### PR TITLE
Remove Unicode dash punctuation repository-wide

### DIFF
--- a/.changeset/eng-1456-remove-dashes.md
+++ b/.changeset/eng-1456-remove-dashes.md
@@ -1,0 +1,36 @@
+---
+'@shipfox/api-auth': patch
+'@shipfox/api-auth-dto': patch
+'@shipfox/api-common-dto': patch
+'@shipfox/api-integration-core': patch
+'@shipfox/api-integration-github': patch
+'@shipfox/api-integration-sentry': patch
+'@shipfox/api-integration-sentry-dto': patch
+'@shipfox/api-integration-slack': patch
+'@shipfox/api-logs': patch
+'@shipfox/api-logs-dto': patch
+'@shipfox/api-runners': patch
+'@shipfox/api-triggers': patch
+'@shipfox/api-workflows': patch
+'@shipfox/api-workspaces': patch
+'@shipfox/client-auth': patch
+'@shipfox/client-integrations': patch
+'@shipfox/client-invitations': patch
+'@shipfox/client-logs': patch
+'@shipfox/client-onboarding': patch
+'@shipfox/client-secrets': patch
+'@shipfox/client-ui': patch
+'@shipfox/client-workflows': patch
+'@shipfox/client-workspace-settings': patch
+'@shipfox/cloudflare-pages': patch
+'@shipfox/docker': patch
+'@shipfox/inter-module': patch
+'@shipfox/node-fastify': patch
+'@shipfox/node-module': patch
+'@shipfox/playwright': patch
+'@shipfox/react-ui': patch
+'@shipfox/redact': patch
+'@shipfox/worktree-services': patch
+---
+
+Remove Unicode dash punctuation from package prose and source comments.

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Shared local-development configuration (committed). Per-developer overrides go
 # in .env.local (gitignored).
 
-# Object storage for runner logs — points at the bundled Garage (compose.yml).
+# Object storage for runner logs: points at the bundled Garage (compose.yml).
 # `docker compose up -d` provisions the bucket and key these values reference
 # (see dev/garage/README.md).
 LOG_STORAGE_S3_ENDPOINT=http://localhost:3900

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
+      CLOUDFLARE_PAGES_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       SHIPFOX_TURBO_CONCURRENCY: "4"
       SHIPFOX_VITEST_MAX_WORKERS: "1"
 
@@ -443,6 +444,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      CLOUDFLARE_PAGES_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       # Reserve one of the runner's four CPUs for the API/client processes,
       # Docker services, and Ollama-backed provider validation.
       SHIPFOX_TURBO_CONCURRENCY: "3"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -133,7 +133,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: shipfox
-          # Publish must never populate the shared cache — only read what CI built.
+          # Publish must never populate the shared cache: only read what CI built.
           TURBO_CACHE: local:rw,remote:r
         run: pnpm run release:publish
 

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -20,7 +20,7 @@ CLIENT_BASE_URL=http://localhost:5173
 AUTH_ROOT_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
 AUTH_JWT_EXPIRES_IN=15m
 
-# Job lease capability token (job-scoped, HS256) — minted by Scheduling, verified by Orchestration
+# Job lease capability token (job-scoped, HS256): minted by Scheduling, verified by Orchestration
 # AUTH_JOB_LEASE_TOKEN_EXPIRES_IN=90m
 # AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN=1h
 

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -30,7 +30,7 @@ This page is the canonical reference for configuring the Docker runner provision
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | `5000` | Largest poll backoff interval after repeated errors. |
 | `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | `1000` | Provider observation and reconciliation cadence. Backs off on errors up to the larger of 5000ms and the configured cadence. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | `250` | Most reservations requested in one poll. Also bounded by free template capacity and the API's cap of 1000. |
-| `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1–1000). Must not exceed the API's own batch limit. |
+| `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1 to 1000). Must not exceed the API's own batch limit. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner reaps it as stale. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | `3600000` | How long failed runner containers remain stopped for forensic inspection. Set to `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | `20` | Maximum number of failed runner containers retained per provisioner. Set to `0` to disable retention. |

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -42,13 +42,13 @@ until observation succeeds.
 | --- | --- | --- | --- |
 | `SHIPFOX_API_URL` | no | `https://api.shipfox.io` | Base URL of the Shipfox API. Set it for a self-hosted API. |
 | `SHIPFOX_RUNNER_API_URL` | no | `SHIPFOX_API_URL` | API URL injected into runner containers as `SHIPFOX_API_URL`; set it when containers reach the API through a different address. |
-| `SHIPFOX_PROVISIONER_TOKEN` | yes | — | Long-lived provisioner token (keep it in `.env.local`, never commit it). |
-| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the YAML template file (see `templates.example.yaml`). |
+| `SHIPFOX_PROVISIONER_TOKEN` | yes | N/A | Long-lived provisioner token (keep it in `.env.local`, never commit it). |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | N/A | Path to the YAML template file (see `templates.example.yaml`). |
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
-| `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | — | Docker network attached to runner containers, for example a Compose network that can reach the API. |
-| `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | — | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
+| `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | N/A | Docker network attached to runner containers, for example a Compose network that can reach the API. |
+| `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | N/A | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
 | `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` | no | Docker daemon default | Logging driver for runner containers. |
-| `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | — | JSON object of string-valued driver options; requires the driver setting. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | N/A | JSON object of string-valued driver options; requires the driver setting. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Failed-container retention TTL in milliseconds; `0` disables retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed containers; `0` disables retention. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before being reaped as stale. |
@@ -57,7 +57,7 @@ until observation succeeds.
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Backoff ceiling. |
 | `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | no | `1000` | Provider observation and reconciliation cadence; backs off on errors up to the larger of 5000ms and this cadence. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | no | `250` | Most reservations requested per poll (also capped by free capacity and the API's limit of 1000). |
-| `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per request (1–1000). |
+| `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per request (1 to 1000). |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Injected into each runner as `SHIPFOX_POLL_MAX_DURATION_MS`. |
 
 ## Template file

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -37,9 +37,9 @@ overlap across families; lower `cost` wins when more than one template matches.
 | --- | --- | --- | --- |
 | `SHIPFOX_API_URL` | no | `https://api.shipfox.io` | Base URL of the Shipfox API. Set it for a self-hosted API. |
 | `SHIPFOX_RUNNER_API_URL` | no | `SHIPFOX_API_URL` | API URL injected into runner instances when they reach the API through a different address. |
-| `SHIPFOX_PROVISIONER_TOKEN` | yes | — | Long-lived provisioner token. |
-| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the EC2 template YAML file. |
-| `AWS_REGION` | yes | — | AWS region where the provider launches instances. |
+| `SHIPFOX_PROVISIONER_TOKEN` | yes | N/A | Long-lived provisioner token. |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | N/A | Path to the EC2 template YAML file. |
+| `AWS_REGION` | yes | N/A | AWS region where the provider launches instances. |
 | `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time an EC2 instance may remain pending without runner enrollment. |
 | `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval between full EC2/backend reconciliation passes. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Demand long-poll duration. |

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -68,12 +68,12 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `SHIPFOX_API_URL` | — | Base URL of the Shipfox API. |
-| `SHIPFOX_RUNNER_REGISTRATION_TOKEN` | — | Manual (`sf_mrt_...`) or ephemeral (`sf_ert_...`) registration token. Set this or `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, not both. |
-| `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN` | — | One-use managed-runner bootstrap token. The runner enrolls and waits for an assignment before exchanging its activation token for a runner session. Set this or `SHIPFOX_RUNNER_REGISTRATION_TOKEN`, not both. |
-| `SHIPFOX_RUNNER_PROVIDER_KIND` | — | Provider kind the managed runner declares during enrollment, such as `ec2` or `docker`. Required with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`. |
+| `SHIPFOX_API_URL` | N/A | Base URL of the Shipfox API. |
+| `SHIPFOX_RUNNER_REGISTRATION_TOKEN` | N/A | Manual (`sf_mrt_...`) or ephemeral (`sf_ert_...`) registration token. Set this or `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, not both. |
+| `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN` | N/A | One-use managed-runner bootstrap token. The runner enrolls and waits for an assignment before exchanging its activation token for a runner session. Set this or `SHIPFOX_RUNNER_REGISTRATION_TOKEN`, not both. |
+| `SHIPFOX_RUNNER_PROVIDER_KIND` | N/A | Provider kind the managed runner declares during enrollment, such as `ec2` or `docker`. Required with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`. |
 | `SHIPFOX_RUNNER_PROTOCOL_VERSION` | `1` | Protocol version the managed runner declares during enrollment. |
-| `SHIPFOX_RUNNER_LABELS` | — | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
+| `SHIPFOX_RUNNER_LABELS` | N/A | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | Base poll interval when requesting jobs. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Maximum backoff interval when no jobs are available or the API errors. |

--- a/docs/guides/local-development-and-release-workflow.md
+++ b/docs/guides/local-development-and-release-workflow.md
@@ -64,7 +64,7 @@ Temporal, Garage, and Gitea, and writes the app environment to
 
 The repository-level port pool is configured with
 `SHIPFOX_PORT_RANGE_START` and `SHIPFOX_PORT_RANGE_END` in `mise.toml`. This
-checkout reserves `20000–24999`; another repository sharing the same machine
+checkout reserves `20000 to 24999`; another repository sharing the same machine
 should reserve a different range. This checkout supports 250 worktree leases;
 another repository can start at `25000`. All ranges still use 20-port blocks, and
 the shared `~/.shipfox/shipfox-port-leases.json` registry rejects overlapping

--- a/e2e/drivers/gitea/README.md
+++ b/e2e/drivers/gitea/README.md
@@ -12,17 +12,17 @@ the platform's public HTTP surface.
 
 Instance side (admin-credentialed, against `E2E_GITEA_URL`):
 
-- `createOrg(params?)` — org + read-only team (`includes_all_repositories`) + bot
+- `createOrg(params?)`: org + read-only team (`includes_all_repositories`) + bot
   membership + org push webhook, mirroring `dev/gitea/bootstrap.sh`. Returns
   `{org, teamId, webhookId}`. A fresh org per suite run is required because an org can
   only ever be linked to one workspace.
-- `createRepo({org, name, ...})` — create a repo in the org. Returns `{name, fullName,
+- `createRepo({org, name, ...})`: create a repo in the org. Returns `{name, fullName,
   cloneUrl, defaultBranch}`.
-- `commitFiles({org, repo, message, files, branch?})` — one commit for the whole batch
+- `commitFiles({org, repo, message, files, branch?})`: one commit for the whole batch
   through Gitea's change-files contents API. Returns the commit SHA. File `content` is
   UTF-8 text; the helper base64-encodes it. `operation` defaults to `create`; `update`
   and `delete` need the file's current blob `sha`.
-- `deleteRepo({org, repo})`, `deleteOrg({org})` — teardown. `deleteOrg` deletes the org's
+- `deleteRepo({org, repo})`, `deleteOrg({org})`: teardown. `deleteOrg` deletes the org's
   repositories first, then the org (Gitea rejects deleting an org that still owns repos).
 
 `createOrg` and `createConnectedOrg` are self-cleaning: if a step fails after the org is
@@ -31,15 +31,15 @@ rethrowing, so a failed run leaves no orphan org in the shared instance.
 
 Platform side (through the product route):
 
-- `connectGiteaOrg({workspaceId, org, sessionToken})` — `POST
+- `connectGiteaOrg({workspaceId, org, sessionToken})`: `POST
   /integrations/gitea/connections`, authenticated with the suite user's session token.
   Returns the connection DTO.
 
 Convenience:
 
-- `createConnectedOrg({workspaceId, sessionToken, name?})` — `createOrg` then
+- `createConnectedOrg({workspaceId, sessionToken, name?})`: `createOrg` then
   `connectGiteaOrg`, returning `{org, teamId, webhookId, connection}`.
-- `createGiteaHelper()` / `giteaHelper` — the factory and the Playwright fixture
+- `createGiteaHelper()` / `giteaHelper`: the factory and the Playwright fixture
   (`gitea`). Compose it with the other helpers:
 
   ```ts

--- a/e2e/suites/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/suites/client/auth/tests/auth-client.e2e.ts
@@ -71,7 +71,7 @@ test('form login routes a user with workspaces straight to /workspaces/$wid', as
 
   // Record every URL the page transits through. Asserting only the final URL
   // would let a brief flash through /setup/workspaces/new slip past
-  // Playwright auto-wait — that flash is the bug we're guarding against.
+  // Playwright auto-wait: that flash is the bug we're guarding against.
   const urlsSeen: string[] = [];
   page.on('framenavigated', (frame) => {
     if (frame === page.mainFrame()) {

--- a/e2e/suites/client/integrations/tests/install-redirect-helpers.ts
+++ b/e2e/suites/client/integrations/tests/install-redirect-helpers.ts
@@ -12,7 +12,7 @@ export interface InstallRedirectExpectation {
   expectedUrl: string;
   /**
    * Runs inside the install-POST handler, after the body is captured but before
-   * the response is fulfilled — i.e. while the app document is still intact and
+   * the response is fulfilled: i.e. while the app document is still intact and
    * the redirect has not fired. Sentry uses it to read its sessionStorage
    * handoff, which is unreadable once the aborted navigation denies the document.
    */

--- a/e2e/suites/client/integrations/tests/install-redirect.e2e.ts
+++ b/e2e/suites/client/integrations/tests/install-redirect.e2e.ts
@@ -25,7 +25,7 @@ test('Sentry install redirects to Sentry and stores the workspace handoff', asyn
     expectedUrl: SENTRY_INSTALL_URL,
     // Sentry's redirect carries no state param, so the install page stashes the
     // workspace id for the callback to pre-select. Read it before the redirect
-    // fires — once the navigation is aborted the document denies storage access.
+    // fires: once the navigation is aborted the document denies storage access.
     beforeReleaseInstall: async () => {
       const storedWorkspaceId = await page.evaluate(
         (key) => window.sessionStorage.getItem(key),

--- a/e2e/suites/client/integrations/tests/sentry-callback.e2e.ts
+++ b/e2e/suites/client/integrations/tests/sentry-callback.e2e.ts
@@ -8,7 +8,7 @@ const CALLBACK_URL =
 
 // Typed against the real connect response DTO so a contract change fails
 // `turbo type` instead of letting the stub pass on a stale shape (e2e packages
-// import *-dto packages for types only — see settings-catalogue.e2e.ts).
+// import *-dto packages for types only: see settings-catalogue.e2e.ts).
 function sentryConnectionFixture(workspaceId: string): SentryConnectResponseDto {
   return {
     id: '00000000-0000-4000-8000-0000000000ab',
@@ -100,7 +100,7 @@ test('Sentry callback installs to a workspace on success', async ({
   await sentryCallback.installButton().click();
 
   // The stub never persisted a connection, so we assert only the success toast
-  // and the redirect target — not that Sentry appears in the gallery.
+  // and the redirect target. Sentry does not need to appear in the gallery.
   await expect(sentryCallback.message('Sentry installed.')).toBeVisible();
   await expect(page).toHaveURL(
     new RegExp(`/workspaces/${workspace.id}/settings/integrations/?$`, 'u'),

--- a/libs/api/auth-dto/src/schemas/job-lease-token.ts
+++ b/libs/api/auth-dto/src/schemas/job-lease-token.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 /**
  * Audience claim binding a token to the job-lease use case. Distinct from auth
- * tokens (separate secret) — this is defense-in-depth so the two token classes stay
+ * tokens (separate secret): this is defense-in-depth so the two token classes stay
  * non-interchangeable even if a verifier is ever misconfigured.
  */
 export const JOB_LEASE_TOKEN_AUDIENCE = 'runner-job-lease';

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -116,16 +116,16 @@ itself.
 - **Audience:** signed-in users on first-party clients (web app, CLI).
 - **Grants:** the user's own account routes and, downstream, any route that
   authorizes against the membership claims. Its scope is "this user, with these
-  memberships" — never a single resource.
+  memberships", never a single resource.
 - **Lifecycle:**
-  - *Emit* — issued on login, signup verification, and password reset.
-  - *Exchange* — sent on each request; a longer-lived refresh session mints a
+  - *Emit*: issued on login, signup verification, and password reset.
+  - *Exchange*: sent on each request; a longer-lived refresh session mints a
     fresh token when it expires.
-  - *Store* — held in client memory only, never persisted to disk or local
+  - *Store*: held in client memory only, never persisted to disk or local
     storage. Refresh sessions are stored server-side as hashes, never in raw form.
-  - *Discard* — expires at the configured `exp` time. Revoking the refresh
+  - *Discard*: expires at the configured `exp` time. Revoking the refresh
     session blocks renewal but does not invalidate the issued access token.
-- **Tradeoff — stale memberships:** because memberships ride in the claims, a
+- **Tradeoff: stale memberships:** because memberships ride in the claims, a
   membership or workspace-status change only takes effect on the next token
   issuance or refresh. Accepted because the recommended lifetime is 15 minutes,
   so the staleness window is bounded and a per-request membership read is avoided.
@@ -137,7 +137,7 @@ The runner exchanges its long-lived registration token at startup, then uses the
 short-lived session token to claim jobs. Heartbeat and step/report/log operations
 use the per-job lease token instead.
 
-- **Scope — one workspace's runner data plane.** The token names one runner
+- **Scope: one workspace's runner data plane.** The token names one runner
   session, one workspace, the fixed `workspace` scope, and the session's immutable
   label set. It can claim jobs for that workspace. It is not a user identity and
   does not authorize dashboard management routes.
@@ -148,7 +148,7 @@ use the per-job lease token instead.
 - **Mechanics.** Signed with HMAC-SHA256 using the derived runner-session key
   and the `runner-session` audience. The default lifetime is `1h`, short enough
   to bound the residual claim window when a registration token is revoked.
-- **Tradeoff — no per-session revocation in v1.** Claim stays stateless and does
+- **Tradeoff: no per-session revocation in v1.** Claim stays stateless and does
   not check the runner session row on each poll. Revoking the registration token
   blocks new sessions, but an existing session can keep claiming until
   `AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN` elapses. A job execution claimed before
@@ -163,7 +163,7 @@ A single-job **capability** token, not a session. It is the means by which a
 runner proves it is the legitimate holder of one specific job while it reports
 progress and drives that job to completion.
 
-- **Scope — exactly one job execution.** The token authorizes action on the
+- **Scope: exactly one job execution.** The token authorizes action on the
   single job execution it names, for the runner holding it. It is **not** a runner
   identity, it is **not** workspace-wide, and it is **not** a substitute for the
   long-lived runner credential used to claim work in the first place. The
@@ -175,9 +175,9 @@ progress and drives that job to completion.
 - **Trust boundary.** There is exactly one issuer: the scheduling side mints a
   lease when a runner claims a job execution, next-step re-scopes it to the
   dispatched step attempt, and heartbeat re-mints the same narrow capability
-  after server state accepts the heartbeat. Everything
-  downstream only *verifies* — an in-process signature check, with no callback to
-  the issuer. The runner, and the untrusted agent workload it hosts, never mints
+  after server state accepts the heartbeat. Everything downstream only *verifies*
+  the token with an in-process signature check. It makes no callback to the
+  issuer. The runner, and the untrusted agent workload it hosts, never mints
   or modifies a token; it only presents the one it was handed.
 - **Mechanics.** Signed with HMAC-SHA256 using the job-lease key derived from
   `AUTH_ROOT_KEY`. Its claims name the job, job execution, and surrounding
@@ -187,13 +187,13 @@ progress and drives that job to completion.
   execution. The root key is supplied through configuration, never embedded in
   code or committed. The raw token must **never** be written to logs, traces, or
   error payloads. There is no automatic redaction to fall back on.
-- **Defense in depth — server state is the final authority.** A valid token is
+- **Defense in depth: server state is the final authority.** A valid token is
   never sufficient on its own to advance work. On the lease's own request path the
   gate is server-side step and progression state: a report against a step that has
   already reached a terminal state (finished, failed, or cancelled) is ignored, so
   a still-valid token cannot re-drive work that is already done. Job-level
   finalization is enforced outside the lease path. Cancellation flows the other way
-  as well — the server can ask the runner to stop at any point, and that request
+  as well: the server can ask the runner to stop at any point, and that request
   rides on the response to each heartbeat rather than depending on the token.
 - **Log append scope.** A step-scoped lease is a signed membership and attempt
   check for append-log authorization. It is not an active-step proof: until the
@@ -207,7 +207,7 @@ progress and drives that job to completion.
   other workspaces. If `AUTH_ROOT_KEY` leaks, rotate it. This invalidates every
   live token and email challenge derived from the old root, including every live
   lease, and forces fresh claims.
-- **Tradeoff — no per-token revocation.** A single outstanding lease cannot be
+- **Tradeoff: no per-token revocation.** A single outstanding lease cannot be
   revoked on its own by token ID. The claiming runner's credential is not
   re-checked on each request, so a lease for already-claimed work can continue to
   be renewed by heartbeat until server state cancels, completes, times out, or
@@ -217,7 +217,7 @@ progress and drives that job to completion.
 - **Guidelines for future changes.** Keep the authority narrow: do not add claims
   that grant access beyond the single job, keep the lifetime bounded, keep a single
   issuer, and keep every other side verify-only. If the no-revocation window ever
-  proves too wide, the right fix is to bind the lease to live runner or job state —
+  proves too wide, the right fix is to bind the lease to live runner or job state.
   not to broaden what the token itself can authorize.
 
 ## Routes

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -217,7 +217,7 @@ progress and drives that job to completion.
 - **Guidelines for future changes.** Keep the authority narrow: do not add claims
   that grant access beyond the single job, keep the lifetime bounded, keep a single
   issuer, and keep every other side verify-only. If the no-revocation window ever
-  proves too wide, the right fix is to bind the lease to live runner or job state.
+  proves too wide, the right fix is to bind the lease to live runner or job state,
   not to broaden what the token itself can authorize.
 
 ## Routes

--- a/libs/api/auth/src/core/job-lease-token.ts
+++ b/libs/api/auth/src/core/job-lease-token.ts
@@ -66,7 +66,7 @@ export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Prom
   return token;
 }
 
-/** Returns the claims on success, or `null` for any invalid input — never throws. */
+/** Returns the claims on success, or `null` for any invalid input. Never throws. */
 export async function verifyJobLeaseToken(token: string): Promise<JobLeaseTokenClaims | null> {
   try {
     const claims = await verifyHs256({

--- a/libs/api/auth/src/core/runner-session-token.ts
+++ b/libs/api/auth/src/core/runner-session-token.ts
@@ -30,7 +30,7 @@ export async function issueRunnerSessionToken(
   return token;
 }
 
-/** Returns the claims on success, or `null` for any invalid input — never throws. */
+/** Returns the claims on success, or `null` for any invalid input. Never throws. */
 export async function verifyRunnerSessionToken(
   token: string,
 ): Promise<RunnerSessionTokenClaims | null> {

--- a/libs/api/auth/src/db/refresh-tokens.ts
+++ b/libs/api/auth/src/db/refresh-tokens.ts
@@ -61,7 +61,7 @@ export async function createRefreshTokenForActiveUser(
 }
 
 /**
- * Looks up the live session token by hash — one that can still authenticate as
+ * Looks up the live session token by hash. It can still authenticate as
  * the current session. Returns `undefined` for revoked, expired, or already
  * rotated tokens; rotated rows survive in the table only for the grace window
  * and are not "active".
@@ -90,8 +90,8 @@ export async function findActiveRefreshTokenByHash(params: {
 /**
  * Looks up a non-revoked, non-expired token by hash, including ones already
  * rotated. Rotation reads {@link RefreshToken.rotatedAt} to decide whether to
- * rotate, honour the grace window, or reject reuse, so — unlike
- * {@link findActiveRefreshTokenByHash} — it must still see rotated rows.
+ * rotate, honour the grace window, or reject reuse, so, unlike
+ * {@link findActiveRefreshTokenByHash}, it must still see rotated rows.
  */
 export async function findRefreshTokenByHash(params: {
   hashedToken: string;

--- a/libs/api/auth/src/presentation/auth/lease-token-auth.ts
+++ b/libs/api/auth/src/presentation/auth/lease-token-auth.ts
@@ -4,7 +4,7 @@ import {verifyJobLeaseToken} from '#core/job-lease-token.js';
 import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
 /**
- * Trust boundary: the signed token is the sole authority — `claims.jobId` scopes
+ * Trust boundary: the signed token is the sole authority. `claims.jobId` scopes
  * every runner request to exactly one job. `workflowRunId`/`workflowRunAttemptId`/`workspaceId`
  * are carried for consumers but are NOT verified against the database here.
  *

--- a/libs/api/common-dto/src/schemas/slug.test.ts
+++ b/libs/api/common-dto/src/schemas/slug.test.ts
@@ -27,7 +27,9 @@ describe('slugSchema', () => {
 
 describe('slugifyName', () => {
   it('lowercases, folds diacritics, and collapses non-alphanumeric runs', () => {
-    expect(slugifyName('Équipe Renard — API', {fallback: 'workspace'})).toBe('equipe-renard-api');
+    expect(slugifyName('Équipe Renard \u2014 API', {fallback: 'workspace'})).toBe(
+      'equipe-renard-api',
+    );
   });
 
   it('trims hyphens and truncates to 40 characters', () => {

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -10,7 +10,7 @@ import type {IntegrationProvider} from '#core/entities/provider.js';
  * and one-shot boot-time tasks. Providers that own none of these simply omit them.
  *
  * A startup task is run once after modules are initialized (migrations done). The
- * provider owns its own wiring — core runs each task generically and isolates
+ * provider owns its own wiring: core runs each task generically and isolates
  * failures so a task can never gate API boot.
  */
 export interface IntegrationModuleParts {

--- a/libs/api/integration/github/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/install.test.ts
@@ -100,7 +100,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
 
         return Promise.resolve(connection);
       }),
-    // Webhook receiver dependencies — install/OAuth tests don't exercise them.
+    // Webhook receiver dependencies: install/OAuth tests don't exercise them.
     coreDb: vi.fn() as never,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
     publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),

--- a/libs/api/integration/sentry-dto/src/schemas/webhooks.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/webhooks.ts
@@ -33,7 +33,7 @@ export type SentryIssueWebhookDto = z.infer<typeof sentryIssueWebhookSchema>;
 
 // Sentry delivers the installation lifecycle under `data.installation` (issue
 // webhooks instead carry a top-level `installation`). The signed payload carries
-// the same material the browser redirect delivers unauthenticated — the install
+// the same material the browser redirect delivers while unauthenticated. The install
 // uuid, the org slug, and the single-use authorization `code`. Only consumed
 // fields are validated; `status`/`actor` are tolerated-but-optional. The raw
 // `code` is security-sensitive and must never be logged.

--- a/libs/api/integration/sentry/README.md
+++ b/libs/api/integration/sentry/README.md
@@ -76,7 +76,7 @@ The provider mounts these authenticated routes (`AUTH_USER` bearer token):
 
 Sentry has no `state` parameter in its install redirect, so the workspace is
 taken from the request body (`workspace_id`) and authorized against the live
-session. `POST /connect` accepts `{workspace_id, code, installation_id}` only —
+session. `POST /connect` accepts `{workspace_id, code, installation_id}` only.
 the organization slug is derived from Sentry after the code exchange, never
 trusted from the client. The exchanged token is used in-memory for the optional
 verify-install call and then discarded; **no Sentry token is persisted**.

--- a/libs/api/integration/sentry/README.md
+++ b/libs/api/integration/sentry/README.md
@@ -76,7 +76,7 @@ The provider mounts these authenticated routes (`AUTH_USER` bearer token):
 
 Sentry has no `state` parameter in its install redirect, so the workspace is
 taken from the request body (`workspace_id`) and authorized against the live
-session. `POST /connect` accepts `{workspace_id, code, installation_id}` only.
+session. `POST /connect` accepts `{workspace_id, code, installation_id}` only;
 the organization slug is derived from Sentry after the code exchange, never
 trusted from the client. The exchanged token is used in-memory for the optional
 verify-install call and then discarded; **no Sentry token is persisted**.

--- a/libs/api/integration/sentry/src/api/client.ts
+++ b/libs/api/integration/sentry/src/api/client.ts
@@ -103,7 +103,7 @@ export function createSentryApiClient(): SentryApiClient {
 
 // The typed error deliberately drops Sentry's status and body so no token, code,
 // or client secret can leak to the client or the logged error chain. That also
-// strips the one detail a self-hoster needs to fix a misconfigured Sentry app —
+// strips the one detail a self-hoster needs to fix a misconfigured Sentry app.
 // e.g. a 403 on `get-installation` means the app is missing "Organization: Read"
 // (see README "Required permissions"). So we log the upstream status
 // here, the only place it survives, keyed by the operation that failed.

--- a/libs/api/integration/sentry/src/core/errors.ts
+++ b/libs/api/integration/sentry/src/core/errors.ts
@@ -41,7 +41,7 @@ export class SentryVerificationInProgressError extends Error {
 /**
  * Base for issue deliveries we received and authenticated but deliberately do
  * not publish. The webhook layer records them for dedup and acknowledges with a
- * 204 rather than treating them as failures — a sustained non-2xx can make Sentry
+ * 204 rather than treating them as failures: a sustained non-2xx can make Sentry
  * disable the webhook. Carries no HTTP concerns so workers/jobs can reuse it.
  */
 export class SentryIssueDroppedError extends Error {}

--- a/libs/api/integration/sentry/src/core/install.test.ts
+++ b/libs/api/integration/sentry/src/core/install.test.ts
@@ -121,7 +121,7 @@ function run(options: RunOptions = {}) {
   };
 }
 
-describe('handleSentryConnect — browser-first (no row)', () => {
+describe('handleSentryConnect: browser-first (no row)', () => {
   it('exchanges, persists the unclaimed row, then binds and verifies last', async () => {
     const sentry = sentryClient();
     const {connectSentryInstallation, persistVerifiedUnclaimedInstallation, result} = run({sentry});
@@ -179,7 +179,7 @@ describe('handleSentryConnect — browser-first (no row)', () => {
   });
 });
 
-describe('handleSentryConnect — verified, unclaimed row exists (webhook-first)', () => {
+describe('handleSentryConnect: verified, unclaimed row exists (webhook-first)', () => {
   it('binds via same-code race when the exchange is already used and the hash matches', async () => {
     const sentry = sentryClient({
       exchangeAuthorizationCode: vi.fn(() =>
@@ -237,7 +237,7 @@ describe('handleSentryConnect — verified, unclaimed row exists (webhook-first)
   });
 });
 
-describe('handleSentryConnect — already claimed / tombstoned', () => {
+describe('handleSentryConnect: already claimed / tombstoned', () => {
   it('is idempotent for an install already claimed to the same workspace', async () => {
     const existing = connection({workspaceId: WORKSPACE_ID});
     const {sentry, connectSentryInstallation, result} = run({
@@ -272,7 +272,7 @@ describe('handleSentryConnect — already claimed / tombstoned', () => {
   });
 });
 
-describe('handleSentryConnect — simultaneous race', () => {
+describe('handleSentryConnect: simultaneous race', () => {
   it('returns a retryable error when the code is already used and no row is visible yet', async () => {
     const sentry = sentryClient({
       exchangeAuthorizationCode: vi.fn(() =>

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -236,7 +236,7 @@ async function claimBrowserFirst(
 }
 
 // The browser-first exchange got "already used" with no row visible at lookup: a
-// concurrent webhook won the exchange. Re-read once — if its verified row is now
+// concurrent webhook won the exchange. Re-read once: if its verified row is now
 // visible we reconcile through the same proof rules; if it got claimed we resolve
 // it; if it was tombstoned we surface that terminally (matching the top-level
 // check); otherwise it is still mid-flight, so the claim is retryable.

--- a/libs/api/integration/sentry/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.test.ts
@@ -94,7 +94,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
           updatedAt: new Date(),
         }),
       ),
-    // Webhook receiver dependencies — install/connect tests don't exercise them.
+    // Webhook receiver dependencies: install/connect tests don't exercise them.
     coreDb: vi.fn() as never,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),

--- a/libs/api/integration/sentry/test/factories/sentry-installation-webhook.ts
+++ b/libs/api/integration/sentry/test/factories/sentry-installation-webhook.ts
@@ -4,7 +4,7 @@ import {Factory} from 'fishery';
 // over the wire: the lifecycle data nests under `data.installation` and carries
 // the single-use authorization `code`. Tests serialize the built object to form a
 // signed request body; the route parses and validates it with the production Zod
-// schema. Build-only — the payload is never persisted, so there is no onCreate
+// schema. Build-only: the payload is never persisted, so there is no onCreate
 // handler.
 export interface SentryInstallationWebhookPayload {
   action: string;

--- a/libs/api/integration/sentry/test/factories/sentry-issue-webhook.ts
+++ b/libs/api/integration/sentry/test/factories/sentry-issue-webhook.ts
@@ -2,7 +2,7 @@ import {Factory} from 'fishery';
 
 // Raw Sentry issue webhook payload, shaped exactly as Sentry delivers it over
 // the wire. Tests serialize the built object to form a signed request body; the
-// route parses and validates it with the production Zod schema. Build-only — the
+// route parses and validates it with the production Zod schema. Build-only: the
 // payload is never persisted, so there is no onCreate handler.
 export interface SentryIssueWebhookPayload {
   action: string;

--- a/libs/api/integration/slack/src/core/agent-tools.ts
+++ b/libs/api/integration/slack/src/core/agent-tools.ts
@@ -357,7 +357,7 @@ const italicPattern = /\*([^*]+)\*|_([^_]+)_/g;
 const blockquotePattern = /^>\s?/gm;
 // Reserved code spans are wrapped in a delimiter built at runtime (String.fromCharCode) rather than
 // a literal escape in source. A real chat message is vanishingly unlikely to contain a NUL byte, but
-// isn't guaranteed not to, so any that do appear are stripped from the input first — after that, the
+// isn't guaranteed not to, so any that do appear are stripped from the input first. After that, the
 // only NUL bytes left are the ones this function inserts, so restoration can't misfire on user text.
 const codePlaceholderDelimiter = String.fromCharCode(0);
 const codePlaceholderPattern = new RegExp(

--- a/libs/api/logs-dto/src/schemas/append.ts
+++ b/libs/api/logs-dto/src/schemas/append.ts
@@ -4,7 +4,7 @@ import {z} from 'zod';
  * Append endpoint contract: `POST .../steps/:stepId/logs?attempt=N&offset=B`.
  *
  * The body is raw NDJSON bytes (whole records, newline-terminated), not a
- * Zod-validated object — it is parsed line by line against the raw log record
+ * Zod-validated object: it is parsed line by line against the raw log record
  * union (`rawLogRecordSchema`). `offset` is a position in the raw
  * NDJSON spool stream; both `offset` and the returned `committed_length` are
  * bounded far below 2^53 by the accrual budget, so JavaScript `number` is safe.

--- a/libs/api/logs-dto/src/schemas/record.ts
+++ b/libs/api/logs-dto/src/schemas/record.ts
@@ -5,7 +5,7 @@ import {sessionViewRowSchema} from './session-view.js';
  * NDJSON log record contract: one JSON object per line, runner-framed.
  *
  * `offset` / `committed_length` are byte positions in the raw append NDJSON spool stream
- * (envelope included) is the offset-CAS axis the runner tracks. The per-job accrual
+ * (envelope included): the offset-CAS axis the runner tracks. The per-job accrual
  * budget charges the normalized NDJSON bytes the server stores, so framing and control records
  * count against it too. The per-record byte caps below bound each record so a single
  * entry's overhead is known and a runner cannot grow storage without moving the

--- a/libs/api/logs-dto/src/schemas/record.ts
+++ b/libs/api/logs-dto/src/schemas/record.ts
@@ -2,10 +2,10 @@ import {z} from 'zod';
 import {sessionViewRowSchema} from './session-view.js';
 
 /**
- * NDJSON log record contract — one JSON object per line, runner-framed.
+ * NDJSON log record contract: one JSON object per line, runner-framed.
  *
  * `offset` / `committed_length` are byte positions in the raw append NDJSON spool stream
- * (envelope included) — the offset-CAS axis the runner tracks. The per-job accrual
+ * (envelope included) is the offset-CAS axis the runner tracks. The per-job accrual
  * budget charges the normalized NDJSON bytes the server stores, so framing and control records
  * count against it too. The per-record byte caps below bound each record so a single
  * entry's overhead is known and a runner cannot grow storage without moving the
@@ -144,7 +144,7 @@ export function parseLogRecordLine(line: string): LogRecord {
 /**
  * Parses one NDJSON line against the raw write union. A forged
  * server-only `capped` / `runner_lost` record fails here even though it is valid
- * under the read union — this is the write-path forgery guard.
+ * under the read union: this is the write-path forgery guard.
  */
 export function parseRawLogRecordLine(line: string): RawLogRecord {
   return rawLogRecordSchema.parse(JSON.parse(line));

--- a/libs/api/logs/README.md
+++ b/libs/api/logs/README.md
@@ -63,9 +63,9 @@ output; control records are flat by `type`:
 
 Two layers stop a runner from writing what it should not:
 
-1. **Lease scope** — the lease binds writes to the job's own `(step, attempt)`, so cross-job
+1. **Lease scope**: the lease binds writes to the job's own `(step, attempt)`, so cross-job
    injection is structurally impossible.
-2. **Distinct raw/write and stored/read unions** — every line is validated against the **raw**
+2. **Distinct raw/write and stored/read unions**: every line is validated against the **raw**
    record union. The server-only `capped`/`runner_lost` tombstones are members of the read union
    only, not the raw write union, so a forged tombstone append is rejected (400). A forged
    tombstone that is otherwise a valid record is logged as a narrowed audit warning (no payload,
@@ -86,13 +86,13 @@ the live tail and the full history. It is workspace-scoped through the stream ro
 `workspace_id`; a 404 covers both a missing stream and a cross-workspace step, so existence never
 leaks.
 
-- **Hot (open, or closed but not yet compacted)** — inline NDJSON read from the Postgres chunks,
+- **Hot (open, or closed but not yet compacted)**: inline NDJSON read from the Postgres chunks,
   walked by chunk `seq` so server control tombstones interleave with normalized runner records
   exactly as compaction concatenates them, making the inline bytes byte-identical to the
   decompressed object.
   Pages are bounded by `LOG_READ_INLINE_MAX_BYTES`; the client follows `has_more`/`next_cursor` to
   drain the backlog, then tails from the last cursor.
-- **Cold (compacted, `object_key` set)** — a presigned GET URL (`LOG_READ_URL_TTL_SECONDS`) so the
+- **Cold (compacted, `object_key` set)**: a presigned GET URL (`LOG_READ_URL_TTL_SECONDS`) so the
   browser fetches the object directly and API egress is bypassed.
 
 ## Agent-session capture
@@ -124,7 +124,7 @@ rejected with 400, and the runner drops it with a `gap`); the request body limit
 One shared, job-wide, generous accrual budget covers a job's logs. When the job's stored bytes
 cross the budget, the job is capped and further appends are dropped. The append that crosses the
 budget is stored in full, then an in-band `capped` tombstone record is injected once; later appends
-are accepted-and-dropped. The cap is a **job-level** signal — a stream can be byte-complete and
+are accepted-and-dropped. The cap is a **job-level** signal: a stream can be byte-complete and
 still sit under a capped job if a sibling step exhausted the shared budget.
 
 A stream closes on one of four triggers, all converging on the same guarded, exactly-once close:

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -97,7 +97,7 @@ if (config.LOG_READ_INLINE_MAX_BYTES < 1) {
 }
 
 // A whole agent_session line is one record in one body. If the body limit is below the
-// line cap, a legitimate large session line could never fit in one request body — Fastify
+// line cap, a legitimate large session line could never fit in one request body: Fastify
 // would 413 it before the per-line validator runs. Fail fast at startup instead.
 if (config.LOG_APPEND_BODY_LIMIT_BYTES < config.LOG_MAX_SESSION_LINE_BYTES) {
   throw new Error(

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -124,7 +124,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
 
 /**
  * A line that fails the raw write union but is a valid record under the read union
- * can only be a server-only `capped`/`runner_lost` tombstone — i.e. a forgery
+ * can only be a server-only `capped`/`runner_lost` tombstone: i.e. a forgery
  * attempt. Returns its type for the audit warn, or undefined for plain garbage.
  */
 function detectForgedType(line: string): string | undefined {

--- a/libs/api/logs/src/core/budget.ts
+++ b/libs/api/logs/src/core/budget.ts
@@ -7,7 +7,7 @@ export interface AllowedBudgetParams {
 
 /**
  * Accrual budget in stored bytes: `base + rate * elapsedMinutes`, floored to an
- * integer. No hard ceiling — job duration limits bound total volume.
+ * integer. No hard ceiling: job duration limits bound total volume.
  */
 export function allowedBudget({
   baseBytes,

--- a/libs/api/logs/src/core/errors.ts
+++ b/libs/api/logs/src/core/errors.ts
@@ -8,10 +8,10 @@ export class OffsetGapError extends Error {
 
 /**
  * The append body is not whole, newline-terminated records of the raw log
- * record contract. `forgedType` is set only for the detectable forgery case — a
+ * record contract. `forgedType` is set only for the detectable forgery case: a
  * line that is a valid server-only record (`capped`/`runner_lost`) under the read
- * union but is not valid on the raw write path — so the append path can emit a narrowed audit warn
- * without logging the payload.
+ * union but is not valid on the raw write path. The append path can emit a
+ * narrowed audit warning without logging the payload.
  */
 export class MalformedLogChunkError extends Error {
   constructor(
@@ -27,7 +27,7 @@ export class MalformedLogChunkError extends Error {
  * The lease's `(workspaceId, projectId, workflowRunAttemptId)` does not match the values
  * stamped on the existing stream row. Since these are functionally determined
  * by `jobId` via workflows FKs, a mismatch implies a forged token or a
- * cross-job lease confusion — never a legitimate request.
+ * cross-job lease confusion. It is never a legitimate request.
  */
 export class LeaseStreamMismatchError extends Error {
   constructor() {

--- a/libs/api/logs/src/db/schema/attempt-streams.ts
+++ b/libs/api/logs/src/db/schema/attempt-streams.ts
@@ -17,7 +17,7 @@ import {pgTable} from './common.js';
 
 /**
  * One stream per (job, step, attempt). Identity is scoped by `job_id` (from the
- * lease), so a lease can only ever reach its own job's streams — cross-job log
+ * lease), so a lease can only ever reach its own job's streams; cross-job log
  * injection is structurally impossible. `workspace_id`, `project_id`, and `workflow_run_attempt_id`
  * are stamped from the lease at create time; they are functionally determined by
  * `job_id` via workflows FKs, so they are denormalized here for self-contained
@@ -32,7 +32,7 @@ import {pgTable} from './common.js';
  * Per-row `committed_length` and `declared_total_bytes` are bounded by the
  * per-job budget, so `mode: 'number'` is safe on the hot path. Any cross-row
  * aggregate (workspace or system-wide totals) MUST read as bigint at the
- * query site — the global sum is unbounded and would silently lose precision
+ * query site: the global sum is unbounded and would silently lose precision
  * past 2^53 as a JS number.
  */
 export const attemptStreams = pgTable(

--- a/libs/api/logs/src/db/schema/job-accounting.ts
+++ b/libs/api/logs/src/db/schema/job-accounting.ts
@@ -11,7 +11,7 @@ import {pgTable} from './common.js';
  *
  * Per-row `stored_bytes_used` is bounded by the per-job budget, so `mode:
  * 'number'` is safe on the hot path. Any cross-row aggregate (workspace or
- * system-wide totals) MUST read as bigint at the query site — the global sum
+ * system-wide totals) MUST read as bigint at the query site: the global sum
  * is unbounded and would silently lose precision past 2^53 as a JS number.
  */
 export const jobAccounting = pgTable('job_accounting', {

--- a/libs/api/logs/test/globalSetup.ts
+++ b/libs/api/logs/test/globalSetup.ts
@@ -11,7 +11,7 @@ const BUCKET_READY_POLL_INTERVAL_MS = 500;
 
 // `garage-init` exits 0 once it has posted the key/bucket ACLs, but Garage does not guarantee
 // those are immediately usable for S3 uploads. Poll HeadBucket so the suite never starts before
-// the store will accept the configured credentials — without this, the compaction tests race the
+// the store will accept the configured credentials: without this, the compaction tests race the
 // ACL propagation and fail with `AccessDenied: No such key`.
 async function waitForBucketReachable(timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -1546,7 +1546,7 @@ describe('detectAndExpireStuckJobs', () => {
   });
 
   it('skips a row whose heartbeat refreshed before the atomic DELETE re-evaluates the predicate', async () => {
-    // Pre-stale, then refresh, then run — the cutoff is folded into the DELETE's
+    // Pre-stale, then refresh, then run: the cutoff is folded into the DELETE's
     // WHERE so the live row survives even though the iteration SELECT saw it stale.
     const {jobId} = await makeStaleJob(600);
     await db()

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -358,7 +358,7 @@ async function touchRunnerSessionLiveness(params: {
  * Releases a job execution's lease when the orchestration workflow finalizes it: deletes the
  * running-job-execution row AND any lingering pending row for the same execution, in one tx.
  * Idempotent (0-row no-op), no token scope (the workflow is authoritative), and
- * emits no event — the workflow already owns the outcome. Sweeping the pending row
+ * emits no event: the workflow already owns the outcome. Sweeping the pending row
  * too closes the at-least-once window where an enqueue retry left an orphan that a
  * later claim would otherwise pick up for an already-finished job execution.
  */

--- a/libs/api/triggers/README.md
+++ b/libs/api/triggers/README.md
@@ -162,14 +162,14 @@ unique per `(workflow_definition_id, name)`.
 
 ### Words we do not use
 
-- `provider` — reserved for the integration module's identity
+- `provider`: reserved for the integration module's identity
   (`integrations_connections.provider`). Trigger code says `source`.
-- `eventType` / `type` — replaced by `event`. The bare word `type` would
+- `eventType` / `type`: replaced by `event`. The bare word `type` would
   collide with TypeScript discriminators and with the `IntegrationProvider`
   capability `type` field.
-- `triggerContext` — the runtime payload on a run is called
+- `triggerContext`: the runtime payload on a run is called
   `triggerPayload`.
-- `kind` — every trigger is identified by `(source, event)`. There is no
+- `kind`: every trigger is identified by `(source, event)`. There is no
   separate axis.
 
 ## Architecture
@@ -205,17 +205,17 @@ or POST /workflow-definitions/:definitionId/fire-manual → look up manual subsc
                 └─────────────────────────────────────────────────────┘
 ```
 
-### Layer 1 — workflow definition (source of truth)
+### Layer 1: workflow definition (source of truth)
 
 The YAML `triggers` map lives inside `workflow_definitions.definition`
 (JSONB owned by the definitions module). That is the only place trigger
 declarations live in raw form.
 
-### Layer 2 — projection (queryable)
+### Layer 2: projection (queryable)
 
 `triggers_subscriptions` is rebuilt from `DEFINITION_RESOLVED` events,
 which carry the parsed `triggers` map. The triggers module never reads the
-definitions table — the event is the contract.
+definitions table: the event is the contract.
 
 Cron triggers also project into `triggers_cron_schedules`, keyed by
 `subscription_id`. That table stores the resolved cron expression, timezone,
@@ -223,15 +223,15 @@ next fire time, and last fire time used by the cron firing engine.
 
 Indexes:
 
-- `(workflow_definition_id, name)` — unique. One row per YAML trigger.
-- `(workspace_id, source, event)` — the hot path for matching incoming
+- `(workflow_definition_id, name)`: unique. One row per YAML trigger.
+- `(workspace_id, source, event)`: the hot path for matching incoming
   integration events at workspace scope.
-- `(workflow_definition_id)` — used to clean up the projection on
+- `(workflow_definition_id)`: used to clean up the projection on
   `DEFINITION_DELETED`.
-- `triggers_cron_schedules.next_fire_at` — used to drain due cron schedules
+- `triggers_cron_schedules.next_fire_at`: used to drain due cron schedules
   in next-fire order.
 
-### Layer 3 — run history (immutable)
+### Layer 3: run history (immutable)
 
 `workflow_runs.trigger_source` and `trigger_event` are indexed text
 columns. `trigger_payload` is a JSONB column typed by `TriggerPayload`:

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -214,7 +214,7 @@ export class StepNotRunningError extends Error {
 
 // A report whose attempt is ahead of the step's current attempt. The host
 // allocates attempt numbers, so a runner can never report one it was not
-// dispatched — this is a protocol error, not an idempotent no-op.
+// dispatched: this is a protocol error, not an idempotent no-op.
 export class StepAttemptAheadError extends Error {
   constructor(
     readonly stepId: string,

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -468,8 +468,8 @@ async function recordStepResultInTransaction(
     };
   }
 
-  // Evaluate the gate (if any) at the service boundary — the only place the CEL
-  // engine runs — and pass the precomputed outcome into the pure decision.
+  // Evaluate the gate (if any) at the service boundary. This is the only place
+  // the CEL engine runs. Pass the precomputed outcome into the pure decision.
   const shouldEvaluateGate = outputCoercion.kind !== 'failed';
   const gate = shouldEvaluateGate ? readStepGate(target.config) : undefined;
   const vars =

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -27,7 +27,7 @@ export interface StepReport {
 // Precomputed gate evaluation (the CEL engine runs in evaluate-gate.ts, never
 // here). `passed`/`failed` are clean evaluations; `uncheckable` means the gate
 // could not be evaluated (no exit code, or an evaluation error) and is treated
-// as a plain command failure — never a restart.
+// as a plain command failure. It is never a restart.
 export type GateOutcome =
   | {kind: 'no-gate'}
   | {kind: 'passed'; source: string; trace?: readonly PersistedEvaluationTraceEntry[]}
@@ -55,7 +55,7 @@ export interface DecideStepTransitionInput {
   // to DEFAULT_RESTART_ATTEMPT_CAP.
   maxAttempts?: number;
   // The gating step's own execution count (number of its attempts), used for the
-  // cap. Defaults to `reportedAttempt` — correct for a single-gate job, where the
+  // cap. Defaults to `reportedAttempt`: correct for a single-gate job, where the
   // two are equal; the service passes the real count so a downstream gate in a
   // multi-gate job isn't penalized for upstream-induced rewinds.
   gatingAttemptCount?: number;

--- a/libs/api/workflows/src/db/schema/step-attempts.ts
+++ b/libs/api/workflows/src/db/schema/step-attempts.ts
@@ -21,8 +21,8 @@ import {stepStatusEnum, steps} from './steps.js';
 
 // Append-only execution history. One row per dispatched attempt of a step,
 // inserted `running` at dispatch and finalized terminal at report. `steps` holds
-// the fast current projection; this table is the audit trail and — via the
-// unique (step_id, attempt) constraint — the idempotency anchor.
+// the fast current projection; this table is the audit trail. The unique
+// (step_id, attempt) constraint is the idempotency anchor.
 export const stepAttempts = pgTable(
   'step_attempts',
   {

--- a/libs/api/workflows/src/db/workflow-runs/steps.ts
+++ b/libs/api/workflows/src/db/workflow-runs/steps.ts
@@ -379,8 +379,8 @@ export interface RewindStepsToPendingParams {
 // Restart-only: rewind every step at or after `fromPosition` back to pending,
 // clearing its result and bumping both `version` and `current_attempt` so the next
 // dispatch opens a fresh attempt. This DELIBERATELY bypasses the never-downgrade
-// guard used everywhere else — it is the one place that resurrects terminal steps
-// — so it must only be called from the durable-restart path, never the ordinary
+// guard used everywhere else. It is the one place that resurrects terminal steps,
+// so it must only be called from the durable-restart path, never the ordinary
 // report path. It must run in the same transaction as the failed-attempt write.
 export async function rewindStepsToPending(
   params: RewindStepsToPendingParams,
@@ -405,7 +405,7 @@ export async function rewindStepsToPending(
 }
 
 // Count a single step's own attempts. Used to bound the restart cap on the
-// gating step's actual executions — `steps.current_attempt` can't be used for
+// gating step's actual executions: `steps.current_attempt` can't be used for
 // the cap because a rewind also bumps it for downstream steps swept into the
 // rewind range (which would inflate a later gate's cap in a multi-gate job).
 export async function countStepAttempts(stepId: string, tx: Tx): Promise<number> {

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -40,7 +40,7 @@ function toStepErrorDto(
 
 // Inverse of toStepErrorDto: reported wire errors land on the domain row in
 // camelCase so the read path renders them back without a special case. `category`
-// is intentionally NOT persisted — the server derives it from the step type on
+// is intentionally NOT persisted: the server derives it from the step type on
 // read, so a runner-supplied category is ignored here.
 export function fromStepErrorDto(error: StepErrorDto | undefined): Record<string, unknown> | null {
   if (!error) return null;

--- a/libs/api/workflows/src/presentation/routes/report-step.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.ts
@@ -12,7 +12,7 @@ export function createReportStepRoute(runners: RunnersInterModuleClient) {
     method: 'POST',
     path: '/steps/:stepId/report',
     description:
-      'Reports whether a step succeeded or failed. The job is identified by the access token. Reporting the same step more than once is safe: once a step has finished, later reports for it are ignored. The runner does not call a separate job-completion endpoint — finalization is driven server-side from the recorded step results, and the `cancel` flag tells the runner to stop once the job has finished without full success.',
+      'Reports whether a step succeeded or failed. The job is identified by the access token. Reporting the same step more than once is safe: once a step has finished, later reports for it are ignored. The runner does not call a separate job-completion endpoint: finalization is driven server-side from the recorded step results, and the `cancel` flag tells the runner to stop once the job has finished without full success.',
     schema: {
       params: z.object({stepId: z.string().uuid()}),
       body: reportStepBodySchema,

--- a/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.ts
@@ -7,7 +7,7 @@ import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
 // Per-step execution finishes a job inside recordStepResult (no runner /complete
 // call), which enqueues WORKFLOWS_JOB_STEPS_SETTLED in the same transaction. The
 // persisted per-step projection is already terminal, so the workflow only flips
-// the job status — no steps are carried.
+// the job status: no steps are carried.
 export async function onJobStepsSettled(payload: WorkflowsJobStepsSettledEventDto): Promise<void> {
   logger().info(
     {

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
@@ -478,7 +478,7 @@ describe('jobExecutionOrchestration', () => {
     expect(finalStatusesFor('job-timeout-error')).toEqual([]);
   });
 
-  test('no signal — workflow stays blocked indefinitely', async () => {
+  test('no signal: workflow stays blocked indefinitely', async () => {
     setCfg({dag: makeDag([]), jobResults: new Map(), skipSignal: true});
 
     const handle = await testEnv.client.workflow.start('jobExecutionOrchestration', {

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
@@ -26,7 +26,7 @@ import {remainingMs} from './deadline.js';
  * execution pending while it is queued, then performs the versioned pending → running
  * transition after the current claim. One deadline spans both waits; claim never resets
  * it. Signals can arrive in any order, so the precedence is finished > lease expired >
- * claimed > timeout. Lease cleanup remains best-effort — a runners DB outage must never
+ * claimed > timeout. Lease cleanup remains best-effort: a runners DB outage must never
  * block the child workflow from returning the job outcome to run-orchestration.
  */
 

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
@@ -382,7 +382,7 @@ describe('runOrchestration', () => {
     const runAttemptStatuses = setRunAttemptStatusCalls().map((c) => c.params.status);
     expect(runAttemptStatuses).toEqual(['running', 'failed']);
 
-    // A, B, C enqueued — D skipped because B failed
+    // A, B, C enqueued: D skipped because B failed
     expect(callsNamed('enqueueJobExecutionForRunner')).toHaveLength(3);
     const jobStatuses = setJobStatusCalls().map((c) => ({
       id: c.params.jobId,

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -17,7 +17,7 @@ const WORKFLOWS_PATH = resolve(import.meta.dirname, '../../../dist/temporal/work
 export {TASK_QUEUE};
 
 // ---------------------------------------------------------------------------
-// Shared mutable test config — each test sets this before starting a workflow.
+// Shared mutable test config: each test sets this before starting a workflow.
 // Activities read from it via closure. Tests run serially within a describe.
 // ---------------------------------------------------------------------------
 
@@ -29,7 +29,7 @@ export interface TestConfig {
   enqueueError?: string;
   /** If true, enqueueJobExecutionForRunner sends two job-finished signals (for dedup testing) */
   duplicateSignal?: boolean;
-  /** If true, enqueueJobExecutionForRunner does nothing (no signal — for timeout testing) */
+  /** If true, enqueueJobExecutionForRunner does nothing without a signal for timeout testing */
   skipSignal?: boolean;
   /** If true, emit the claim but hold back the terminal outcome (for deadline testing) */
   skipOutcomeSignal?: boolean;
@@ -205,7 +205,7 @@ export async function setupEnv(): Promise<void> {
     activities: createMockActivities(),
   });
 
-  // Run worker in background — it processes tasks until shutdown is called
+  // Run worker in background: it processes tasks until shutdown is called
   workerRunPromise = worker.run();
   workerRunPromise.catch(() => {
     // Suppress unhandled rejection on shutdown

--- a/libs/api/workflows/test/fixtures/job-with-steps.ts
+++ b/libs/api/workflows/test/fixtures/job-with-steps.ts
@@ -3,7 +3,7 @@ import {createWorkflowRun, getJobsByWorkflowRunId, getStepsByJobId} from '#db/wo
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 
-// Jobs and steps have no standalone factory — they only exist as children
+// Jobs and steps have no standalone factory: they only exist as children
 // materialized from a WorkflowModel by createWorkflowRun, which also prepends a
 // synthetic "Set up job" step to every job. This fixture exercises step-execution
 // mechanics in isolation, so it strips that step (see stripSetupStep) to keep the

--- a/libs/api/workspaces/src/core/invitations.ts
+++ b/libs/api/workspaces/src/core/invitations.ts
@@ -100,7 +100,7 @@ export async function previewInvitation(params: {token: string}): Promise<Previe
 
   const workspace = await getWorkspaceById(invitation.workspaceId);
   if (!workspace) {
-    // Workspace cascade-deleted — the invitation row is orphaned. Treat as invalid.
+    // Workspace cascade-deleted: the invitation row is orphaned. Treat as invalid.
     return {status: 'invalid'};
   }
 

--- a/libs/client/auth/src/components/auth-guard.tsx
+++ b/libs/client/auth/src/components/auth-guard.tsx
@@ -29,7 +29,7 @@ export function GuestGuard({children}: PropsWithChildren) {
 
   useEffect(() => {
     if (auth.isAuthenticated && target !== undefined) {
-      // Bypass the typed route matcher — `target` is an arbitrary same-origin
+      // Bypass the typed route matcher: `target` is an arbitrary same-origin
       // path resolved at runtime, so we let the URL change drive route resolution.
       router.history.replace(target);
     }

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -70,7 +70,7 @@ export function SignupPage() {
           try {
             await refreshAuth();
           } catch {
-            // Refresh failures don't block the success message — the next API
+            // Refresh failures don't block the success message: the next API
             // call's 401 handling will re-route the user.
           }
           toast.success(`You joined ${invitationPending.workspaceName}.`);
@@ -118,8 +118,9 @@ export function SignupPage() {
     }
   }, [invitationPending, form, setAuthFormDraft]);
 
-  // Sync form values back to the Jotai draft on unmount (only email + password
-  // — name is intentionally not persisted across navigation). Skipped after a
+  // Sync form values back to the Jotai draft on unmount. The draft stores only
+  // email and password; name is intentionally not persisted across navigation.
+  // Skipped after a
   // successful signup because we just intentionally cleared the draft.
   useEffect(() => {
     return () => {

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -203,11 +203,11 @@ const openActions = async (name: string) => {
 };
 
 const SORTED_NAMES_RE = /acme-(early|late)/;
-// The meta line carries the date only — the provider is named once, by the
+// The meta line carries the date only: the provider is named once, by the
 // icon and the account name, never repeated as body text in the row.
 const ADDED_META_RE = /^Added /;
 
-describe('IntegrationGallery — installed section', () => {
+describe('IntegrationGallery: installed section', () => {
   test('renders two distinct cards for two connections sharing one provider', async () => {
     renderGallery(
       {},
@@ -511,7 +511,7 @@ describe('IntegrationGallery — installed section', () => {
     expect(within(installedRegion()).getByText(ADDED_META_RE)).toBeVisible();
   });
 
-  test('names the provider once per row — not repeated in the meta line', async () => {
+  test('names the provider once per row: not repeated in the meta line', async () => {
     renderGallery({}, {connections: [githubConnection]});
 
     await screen.findByText('acme-corp');
@@ -549,7 +549,7 @@ describe('IntegrationGallery — installed section', () => {
   });
 });
 
-describe('IntegrationGallery — available section', () => {
+describe('IntegrationGallery: available section', () => {
   test('lists every provider with an Install link, including installed ones', async () => {
     renderGallery({}, {connections: [githubConnection]});
 

--- a/libs/client/integrations/src/components/redirect-install-page.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.tsx
@@ -14,7 +14,7 @@ interface RedirectInstallPageProps {
   loadingLabel?: string;
   /**
    * Runs before leaving the app (e.g. to persist the workspace id for a
-   * state-less provider callback). Must not throw — a failed side effect
+   * state-less provider callback. It must not throw. A failed side effect
    * should never block the redirect.
    */
   beforeRedirect?: (workspaceId: string) => void;

--- a/libs/client/integrations/src/hooks/api/integrations.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.ts
@@ -175,7 +175,7 @@ export async function listSourceConnections({
   });
   // The endpoint returns every lifecycle status (the settings hub needs that),
   // but source-control consumers (onboarding redirect, project creation) only
-  // act on usable connections — a disabled/error one must read as "not there".
+  // act on usable connections. A disabled/error one must read as "not there".
   return connections.filter(isUsableConnection);
 }
 

--- a/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
@@ -149,7 +149,7 @@ describe('SentryCallbackPage', () => {
     await waitFor(() => expect(screen.getByRole('button', {name: 'Retry'})).toBeDisabled());
 
     // A second attempt (via the still-enabled workspace Install) fails with no
-    // backoff hint — the lock must clear so the user is not stranded.
+    // backoff hint: the lock must clear so the user is not stranded.
     fireEvent.click(screen.getByRole('button', {name: 'Install'}));
     await waitFor(() => expect(screen.getByRole('button', {name: 'Retry'})).toBeEnabled());
   });

--- a/libs/client/integrations/src/sentry-callback.ts
+++ b/libs/client/integrations/src/sentry-callback.ts
@@ -20,7 +20,7 @@ const sentryInstallWorkspaceStorageKey = {
 } satisfies BrowserStorageKey<string>;
 
 // Storage helpers swallow failures (quota, private mode, disabled storage):
-// the handoff is an optimization, never a requirement — the callback always
+// the handoff is an optimization, never a requirement: the callback always
 // asks for explicit confirmation and only uses the stored id to pre-select.
 export function saveSentryInstallWorkspace(storage: WorkspaceStorage, workspaceId: string): void {
   installWorkspaceStorage(storage).write(workspaceId);
@@ -67,7 +67,7 @@ export type SentryWorkspacePreselection =
   | {kind: 'none'};
 
 // Sentry's redirect carries no state token, so the callback can never prove it
-// belongs to an install the user started — installation always requires an
+// belongs to an install the user started. Installation always requires an
 // explicit click. The stored id (and a sole workspace) only pre-select.
 export function preselectSentryWorkspace(
   storedId: string | undefined,

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -223,7 +223,7 @@ export function InvitationAcceptPage() {
     );
   }
 
-  // Authenticated + matches — auto-accept is in flight or about to render its
+  // Authenticated + matches: auto-accept is in flight or about to render its
   // result. Show either the pending state or the error state.
   if (accept.isError) {
     return (

--- a/libs/client/logs/src/components/log-group.stories.tsx
+++ b/libs/client/logs/src/components/log-group.stories.tsx
@@ -165,7 +165,7 @@ export const Truncated: Story = {
 
 /**
  * A genuine subtree failure (a `runner_lost`) draws an inset red bar on the header (a
- * border, not a fill). stderr alone never triggers it — stderr is a channel, not an error.
+ * border, not a fill). stderr alone never triggers it: stderr is a channel, not an error.
  */
 export const ErrorBar: Story = {
   render: () => (

--- a/libs/client/logs/src/core/log-tree.ts
+++ b/libs/client/logs/src/core/log-tree.ts
@@ -3,7 +3,7 @@ import type {LogRecord} from './log-model.js';
 /**
  * Pure render transform for the step-log read stream. The runner emits a flat,
  * ordered NDJSON record list; `group_start`/`group_end` form a tree that the
- * reader reconstructs here before rendering. No React, no state — one function
+ * reader reconstructs here before rendering. No React, no state: one function
  * over the record array.
  *
  *   records[] ──▶ buildLogTree ──▶ { nodes (forest), terminated, originTs, lineCount }

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -56,7 +56,7 @@ function sourceConnection(overrides: {lifecycle_status?: string} = {}) {
 }
 
 // The query cache stores the mapped domain shape (camelCase), not the wire
-// DTO `sourceConnection()` mocks for fetch responses — keep this seed in sync
+// DTO `sourceConnection()` mocks for fetch responses: keep this seed in sync
 // with `toIntegrationConnection` in client-integrations.
 function cachedSourceConnection() {
   return {

--- a/libs/client/secrets/src/components/copy-key.ts
+++ b/libs/client/secrets/src/components/copy-key.ts
@@ -2,7 +2,7 @@ import {toast} from '@shipfox/react-ui/toast';
 
 /**
  * Copies a bare key name (e.g. `MY_TOKEN`) to the clipboard. Guarded because
- * `navigator.clipboard` is undefined in insecure contexts and older browsers —
+ * `navigator.clipboard` is undefined in insecure contexts and older browsers.
  * a missing API or a rejected write surfaces a toast instead of an unhandled
  * rejection.
  */

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -84,7 +84,7 @@ export function VariableForm({
   }, [needsFullValue, fullValueQuery.data, form]);
 
   // The full value must be loaded before a save is allowed, otherwise submitting would
-  // overwrite the stored value with the truncated preview. Block until it arrives —
+  // overwrite the stored value with the truncated preview. Block until it arrives.
   // whether the fetch is still pending or has failed.
   const awaitingFullValue = needsFullValue && fullValueQuery.data === undefined;
   const loadingFullValue = needsFullValue && fullValueQuery.isPending;

--- a/libs/client/ui/src/load-error-copy.ts
+++ b/libs/client/ui/src/load-error-copy.ts
@@ -14,7 +14,7 @@ export interface LoadErrorCopyOptions {
 // synthesizes `network-error` (transport failure) and `request-failed` (server
 // error body with no code); the server adds `server-error`, `unauthorized`, and
 // `forbidden`. Provider codes (timeout, rate-limited, provider-unavailable, ...)
-// belong to setup flows and stay in projectErrorCopy — mapping them here would be
+// belong to setup flows and stay in projectErrorCopy: mapping them here would be
 // dead code on these surfaces.
 const messageByCode: Record<string, string> = {
   'network-error': "We couldn't reach the server. Check your connection and try again.",

--- a/libs/client/ui/src/query-load-error.tsx
+++ b/libs/client/ui/src/query-load-error.tsx
@@ -4,7 +4,7 @@ import {loadErrorCopy} from './load-error-copy.js';
 
 /**
  * Minimal shape of a React Query result this component reads. Typed structurally
- * so client-ui stays decoupled from react-query's generics — any `UseQueryResult`
+ * so client-ui stays decoupled from react-query's generics: any `UseQueryResult`
  * is assignable. `data` is `undefined` only until the first successful fetch, which
  * is exactly the "errored with nothing loaded" signal we gate on.
  */

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -215,7 +215,7 @@ function WorkflowDefinitionsList({
                 // The workflow-name cell holds a `<button>` so the row is
                 // keyboard-reachable (Tab focuses, Enter/Space activates
                 // via native button semantics). The TableRow itself is no
-                // longer clickable — a row-level onClick would be invisible
+                // longer clickable: a row-level onClick would be invisible
                 // to keyboard users and require custom keydown handling.
                 // The `group` class on the row still drives the Run button
                 // reveal on hover or focus-within.

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -144,7 +144,7 @@ function MemberRow({
 
   return (
     <TableRow className={remove.isPending ? 'opacity-60' : undefined}>
-      <TableCell className="font-medium">{member.name ?? '—'}</TableCell>
+      <TableCell className="font-medium">{member.name ?? 'N/A'}</TableCell>
       <TableCell>
         <Code variant="paragraph">{member.email}</Code>
       </TableCell>
@@ -283,7 +283,7 @@ function InvitationRow({
       <TableCell>
         <Code variant="paragraph">{invitation.email}</Code>
       </TableCell>
-      <TableCell>{invitation.invitedByDisplay ?? '—'}</TableCell>
+      <TableCell>{invitation.invitedByDisplay ?? 'N/A'}</TableCell>
       <TableCell>
         <div className="flex items-center gap-8">
           <Text size="sm">{formatDate(invitation.expiresAt)}</Text>

--- a/libs/provisioner/core/README.md
+++ b/libs/provisioner/core/README.md
@@ -22,13 +22,13 @@ observation, reporting, assignment, or termination handling.
 
 ## Public API
 
-- `startProvisioner({adapter})` — run the loop until a shutdown signal. The adapter
+- `startProvisioner({adapter})`: run the loop until a shutdown signal. The adapter
   supplies the provider's templates and its launcher.
-- `ProvisionerAdapter`, `ProvisionerTemplate`, `LaunchRunner`, `ProviderRunnerLaunch`
-  — the contract a provider implements.
-- `loggingLaunch` — a default launcher that records each planned runner without
+- `ProvisionerAdapter`, `ProvisionerTemplate`, `LaunchRunner`, and `ProviderRunnerLaunch`
+  are the contract a provider implements.
+- `loggingLaunch`: a default launcher that records each planned runner without
   starting it (used until a provider ships a real launcher).
-- `ProvisionerAuthenticationError` — thrown at startup when the token is rejected.
+- `ProvisionerAuthenticationError`: thrown at startup when the token is rejected.
 
 ## Key pieces (internal)
 

--- a/libs/runner/agent/src/core/session-forwarder.ts
+++ b/libs/runner/agent/src/core/session-forwarder.ts
@@ -22,7 +22,7 @@ export interface SessionForwarder {
  * Tails a growing append-only JSONL file by byte offset and forwards each complete line.
  *
  * pi persists each session entry synchronously (appendFileSync) and may defer the first write
- * until the first assistant message, then bulk-write several lines at once — a byte-offset
+ * until the first assistant message, then bulk-write several lines at once: a byte-offset
  * reader handles both, where a line-index reader would not. A poll can observe a partial write
  * (a large entry spans several write() syscalls), so the carry buffer holds raw bytes, not a
  * decoded string: bytes are split on the newline and only whole lines are decoded, so a read

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -123,7 +123,7 @@ function spawnAndCapture(
 
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
-    // parent chain). We don't unref() — output capture still needs `close`.
+    // parent chain). We don't unref(): output capture still needs `close`.
     const child = spawn(shell.executable, shell.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -84,7 +84,7 @@ function expectSetupFailureWarning(
 }
 
 // ky populates `error.data` with the pre-parsed body and consumes `error.response`, so
-// the production classifier reads `error.data` — mirror that here rather than faking a
+// the production classifier reads `error.data`: mirror that here rather than faking a
 // re-readable `response.clone().json()`, which production can never do.
 function httpError(status: number, body?: unknown): HTTPError {
   const response = {status} as unknown as Response;

--- a/libs/runner/logs/src/api/spool.ts
+++ b/libs/runner/logs/src/api/spool.ts
@@ -69,8 +69,8 @@ export class AttemptSpool {
   /**
    * Reads whole NDJSON records starting at `offset`, up to `maxBytes` worth, never
    * past what has been written. The returned buffer ends on a record boundary (a
-   * trailing `\n`), so the uploader never ships — and the server never commits — a
-   * torn last line, and every committed offset stays parseable.
+   * trailing `\n`). The uploader never ships a torn last line. The server never
+   * commits one, so every committed offset stays parseable.
    *
    * Returns empty once caught up. The lone exception to the whole-record guarantee
    * is a single record larger than `maxBytes`: it is returned split rather than

--- a/libs/runner/logs/src/api/uploader.test.ts
+++ b/libs/runner/logs/src/api/uploader.test.ts
@@ -155,7 +155,7 @@ describe('LogUploader.flush', () => {
     await uploader.flush();
 
     expect(uploader.isStopped()).toBe(true);
-    // Probe, then one data send that made no progress, then stop — not an endless re-send.
+    // Probe, then one data send that made no progress, then stop. It is not an endless re-send.
     expect(calls).toBe(2);
   });
 

--- a/libs/runner/logs/src/api/uploader.ts
+++ b/libs/runner/logs/src/api/uploader.ts
@@ -26,7 +26,7 @@ export interface UploaderOptions {
  * scheduled. Real appends are only ever made at offset == committed; on
  * (re)start a zero-length probe learns the server's committed offset first, so a
  * body never straddles the commit point. `capped` (budget exhausted) and
- * `stopped` (endpoint gone / lease rejected) are terminal — server-side stream
+ * `stopped` (endpoint gone / lease rejected) are terminal: server-side stream
  * lifecycle takes over from there.
  */
 export class LogUploader {

--- a/libs/runner/logs/src/core/framing.ts
+++ b/libs/runner/logs/src/core/framing.ts
@@ -145,7 +145,7 @@ export class StreamFramer {
     return encodeRecord(endRecord({ts: this.now(), totalBytes}));
   }
 
-  // One verbatim agent session entry per record — never split (splitting would break the
+  // One verbatim agent session entry per record: never split (splitting would break the
   // entry's JSON). The caller drops an over-cap line before this runs. payloadBytes counts
   // the entry's bytes toward the stream's end total, like output `data`. An empty line frames
   // nothing (the DTO requires `data` non-empty), so it is never emitted as a record.

--- a/libs/runner/logs/src/core/markers.ts
+++ b/libs/runner/logs/src/core/markers.ts
@@ -9,7 +9,7 @@ const GROUP_END_LINE = '::endgroup::';
  * with or without a trailing CR/LF). `::group::<name>` and `::endgroup::` are the only two;
  * everything else returns undefined and stays normal output.
  *
- * The `::` must start the line — GitHub treats workflow commands as line-leading, so a `::`
+ * The `::` must start the line: GitHub treats workflow commands as line-leading, so a `::`
  * mid-line or after whitespace is plain text. `::endgroup::` must match exactly, so a
  * trailing argument (`::endgroup:: x`) is not a marker. The name is returned verbatim;
  * secret masking and the DTO's byte cap are applied downstream (the transform masks it, the

--- a/libs/runner/logs/src/core/session-log-stream.ts
+++ b/libs/runner/logs/src/core/session-log-stream.ts
@@ -37,7 +37,7 @@ export interface SessionLogStream extends LogStreamLifecycle {
 /**
  * Forwards verbatim agent session entries onto the step attempt's log stream as opaque
  * `agent_session` records over the shared `RecordSink`. One entry rides one record (never
- * split — that would break the entry's JSON); masking applies whole-line, so no streaming
+ * split: that would break the entry's JSON); masking applies whole-line, so no streaming
  * lookbehind is needed. An over-window entry is dropped with a gap rather than forwarded.
  */
 export function createSessionLogStream(options: SessionLogStreamOptions): SessionLogStream {

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -357,7 +357,7 @@ describe('createStepLogStream', () => {
 
   it('never writes the secret or any of its wire forms to the spool', async () => {
     // Reserved characters ('/', '+', '=') so the URL-encoded form genuinely differs from the
-    // literal — a base64url-shaped token's URL form equals the literal and would prove nothing.
+    // literal: a base64url-shaped token's URL form equals the literal and would prove nothing.
     const secret = 'sf/rt+SECRET=12';
     const forms = secretWireForms(secret); // the exact set the masker derives, incl. the literal
     const stream = createStepLogStream({
@@ -381,7 +381,7 @@ describe('createStepLogStream', () => {
     expect(forms).toContain(encodeURIComponent(secret));
     expect(encodeURIComponent(secret)).not.toBe(secret);
 
-    // Read the plaintext spool file directly: not one wire form may have reached disk.
+    // Read the plaintext spool file directly. No wire form may have reached disk.
     const raw = await readFile(join(dir, 'logs', `${STEP_ID}-11.ndjson`), 'utf8');
     for (const form of forms) {
       expect(raw).not.toContain(form);

--- a/libs/runner/logs/src/core/transform.test.ts
+++ b/libs/runner/logs/src/core/transform.test.ts
@@ -3,7 +3,7 @@ import {LogTransformer, type TransformEvent} from '#core/transform.js';
 const REPLACEMENT = '�';
 
 // An 18-byte (multiple-of-3) secret so its standalone base64 has no padding and the phase-0
-// wire form equals the full encoding — keeps the encoded-form assertions exact.
+// wire form equals the full encoding: keeps the encoded-form assertions exact.
 const SECRET = 'sf_mrt_SECRET12345';
 
 function outputText(events: TransformEvent[]): string {
@@ -126,7 +126,7 @@ describe('LogTransformer secret masking', () => {
   it('masks a secret straddling a forced no-newline flush boundary', () => {
     const transformer = new LogTransformer([SECRET]);
     // A long unterminated line whose tail is the start of the secret. The lookbehind must hold
-    // the partial secret back, then mask it once the rest arrives — no plaintext on the way out.
+    // the partial secret back, then mask it once the rest arrives: no plaintext on the way out.
     const head = 'x'.repeat(40_000);
 
     const first = transformer.push(Buffer.from(`${head}sf_mrt_SE`), 'stdout');

--- a/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 function buildHTTPError(status: number): HTTPError {
-  // Construct a minimal Response object — ky's HTTPError just reads .response.status
+  // Construct a minimal Response object: ky's HTTPError just reads .response.status
   const response = {status} as Response;
   const request = {} as Request;
   const options = {} as ConstructorParameters<typeof HTTPError>[2];
@@ -36,7 +36,7 @@ describe('startHeartbeatLoop', () => {
       maxStaleMs: 1000,
     });
 
-    // Flush any pending microtasks before asserting the timer has not fired —
+    // Flush any pending microtasks before asserting the timer has not fired.
     // a regression that resolved the first tick synchronously would leak past
     // an immediate `expect` without this.
     await Promise.resolve();

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -274,7 +274,7 @@ export async function runJob(
   } catch (stepLoopError) {
     // A non-retryable error surfaced (e.g. an unexpected throw from the loop).
     // Bail this job; the lease expires server-side and the outer poll moves on.
-    // Do not re-pull (would re-execute). Setup failures do NOT reach here — they
+    // Do not re-pull (would re-execute). Setup failures do NOT reach here: they
     // report through the step protocol and finalize the job.
     logger().error({err: stepLoopError, jobId: job.job_id}, 'Job step loop failed');
   } finally {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -807,7 +807,7 @@ export async function reportStepResult(params: {
     stepId: step.id,
     attempt,
     status: result.success ? 'succeeded' : 'failed',
-    // null on success, the error shape on failure — matches reportStepBodySchema's refine.
+    // null on success, the error shape on failure: matches reportStepBodySchema's refine.
     error: result.error,
     exitCode: result.exit_code,
     ...(result.response === undefined ? {} : {response: result.response}),

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -94,7 +94,7 @@ const baseUrl = config.SHIPFOX_API_URL.endsWith('/')
 
 /**
  * The runner's registration bearer credential, exposed so the log masker can scrub it
- * from captured step output. For masking only — never log this value.
+ * from captured step output. Use it only for masking. Never log this value.
  */
 export function runnerRegistrationToken(): string {
   return config.SHIPFOX_RUNNER_REGISTRATION_TOKEN;
@@ -283,9 +283,9 @@ function hasRunnerSessionExhaustedCode(body: unknown): boolean {
   );
 }
 
-// next/report are idempotent, so we widen ky's retry to POST (off by default): a lost
-// response is retried in place, never re-pulling or re-executing a step. A 404 is not
-// retried — it surfaces so the loop can stop.
+// next/report are idempotent, so we widen ky's retry to POST (off by default).
+// A lost response is retried in place, never re-pulling or re-executing a step. A 404 is not
+// retried: it surfaces so the loop can stop.
 export type LeaseTokenSource = string | (() => string);
 
 export function readLeaseToken(leaseToken: LeaseTokenSource): string {

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -48,7 +48,7 @@ export function resolveWorkspaceRoot(root: string | undefined): string {
   const resolved = resolve(root);
 
   // A filesystem root ('/' on POSIX, 'C:\\' on Windows) has no parent and would
-  // put job dirs at the top level — never manage cleanup there.
+  // put job dirs at the top level. Never manage cleanup there.
   if (resolved === parse(resolved).root) throw new UnsafeWorkspaceRootError(root);
 
   // The home directory holds the operator's files; a stray recursive cleanup

--- a/libs/shared/common/inter-module/README.md
+++ b/libs/shared/common/inter-module/README.md
@@ -10,7 +10,7 @@ This README owns the package API and local constraints for defining and
 consuming inter-module contracts.
 
 This package defines contracts and clients. It never validates JSON safety,
-serializes a call, or dispatches one — that is a transport's job. The in-memory
+serializes a call, or dispatches one. That is a transport's job. The in-memory
 transport lives in `@shipfox/node-module/inter-module`.
 
 ## What it does
@@ -20,8 +20,8 @@ transport lives in `@shipfox/node-module/inter-module`.
   `output` schema, and an optional map of kebab-case error codes to detail
   schemas.
 - **`createInterModuleClient(contract, dispatch)`** builds a typed client over
-  any `dispatch` function. This is the seam a transport author implements —
-  the in-memory transport, a fake test presentation, and a future network
+  any `dispatch` function. This is the seam a transport author implements.
+  The in-memory transport, a fake test presentation, and a future network
   transport all produce a client this same way.
 - **`defineInterModulePresentation(contract, handlers)`** closes a producer's
   domain code over its own contract, one handler per declared method.
@@ -37,7 +37,7 @@ transport lives in `@shipfox/node-module/inter-module`.
 
 Switch on the destructured code, not the `error.code` property access directly.
 TypeScript only narrows a `switch` discriminant to `never` in an exhaustive
-`default` when it is a plain local — a dotted expression narrows each `case`
+`default` when it is a plain local: a dotted expression narrows each `case`
 but never reaches `never`, so a `const exhaustive: never = error.code;` check
 fails to compile even when every code is handled:
 
@@ -59,8 +59,8 @@ if (isInterModuleKnownError(widgetsInterModuleContract.methods.getWidget, error)
 
 ## Error-detail schemas must not reshape their input
 
-`isInterModuleKnownError` re-validates `error.details` — already the code's
-schema *output* — by re-parsing it through that same schema. An error-detail
+`isInterModuleKnownError` re-validates `error.details`, already the code's
+schema *output*. It re-parses it through that same schema. An error-detail
 schema's input and output shapes must therefore stay identical (a plain
 `z.object({...})`, no shape-changing `.transform()`/`.pipe()`).
 `createInterModuleKnownError` enforces this at mint time: it throws
@@ -71,7 +71,7 @@ error that would silently fail to narrow later.
 
 A client and a presentation must be built from the exact same contract object
 returned by `defineInterModuleContract`. Two calls with identical module and
-method names produce two different objects on purpose — a transport's `seal()`
+method names produce two different objects on purpose: a transport's `seal()`
 rejects a presentation that does not reference the same object a client used,
 so a producer and a caller can never silently cross-wire onto a
 same-named-but-different contract.

--- a/libs/shared/common/inter-module/src/client.ts
+++ b/libs/shared/common/inter-module/src/client.ts
@@ -19,7 +19,7 @@ export interface InterModuleDispatchCall {
 
 /**
  * The seam a transport author implements. Given a call description, it resolves
- * with the method's output or rejects — with a known error, a validation
+ * with the method's output or rejects with a known error, a validation
  * rejection, an opaque failure, or the call's `AbortSignal` reason.
  */
 export type InterModuleDispatch = (call: InterModuleDispatchCall) => Promise<unknown>;
@@ -33,8 +33,8 @@ export type InterModuleClient<Def extends InterModuleContractDefinition> = {
 
 /**
  * Builds a typed client over `dispatch`. This is the only seam a transport author
- * needs to implement — the in-memory transport, a fake test presentation, and any
- * future network transport all produce a client this same way.
+ * needs to implement. The in-memory transport, a fake test presentation, and
+ * any future network transport all produce a client this same way.
  */
 export function createInterModuleClient<Def extends InterModuleContractDefinition>(
   contract: InterModuleContract<Def>,

--- a/libs/shared/common/inter-module/src/known-error.ts
+++ b/libs/shared/common/inter-module/src/known-error.ts
@@ -41,7 +41,7 @@ function hasKnownErrorMarker(error: unknown): error is MarkedError {
  * validation. A transport uses this narrow check to tell "never minted as a
  * known error" (an undeclared handler bug) apart from "minted, but fails
  * `isInterModuleKnownError`'s full re-validation" (a forged or malformed known
- * error) — two outcomes `isInterModuleKnownError` alone cannot distinguish.
+ * error). The two outcomes `isInterModuleKnownError` alone cannot distinguish.
  * The marker itself stays this package's implementation detail; callers
  * outside it must not reconstruct the `Symbol.for` key by hand.
  */
@@ -52,7 +52,7 @@ export function hasInterModuleKnownErrorMarker(error: unknown): boolean {
 /**
  * Mints a known error for `code`, validating `details` against the schema that
  * `methodContract` declares for that code. Throws a plain (unmarked) `Error` when
- * `code` is not declared or `details` fails its schema — that throw is a contract
+ * `code` is not declared or `details` fails its schema: that throw is a contract
  * defect at the call site, not a known error, and never carries the marker.
  */
 export function createInterModuleKnownError<
@@ -72,7 +72,7 @@ export function createInterModuleKnownError<
 
   const parsedDetails: unknown = schema.parse(details);
   // Re-validating a known error (`isInterModuleKnownError`) re-parses
-  // `error.details` — already this schema's *output* — through the same
+  // `error.details`, already this schema's *output*, through the same
   // schema. A shape-changing `.transform()`/`.pipe()` would then silently
   // fail that later re-validation. Catch the contract violation loudly here,
   // at the point of minting, instead of leaving it as a silent, documented-
@@ -108,8 +108,8 @@ export function createInterModuleKnownError<
  * code's own details schema instead of trusting `instanceof`, so a forged or
  * cross-method error never narrows.
  *
- * Re-validation re-parses `error.details` — already the code's schema
- * *output* — through that same schema. An error-detail schema must therefore
+ * Re-validation re-parses `error.details`, already the code's schema
+ * *output*, through that same schema. An error-detail schema must therefore
  * keep its input and output shapes identical (the common case for a plain
  * `z.object({...})`); a shape-changing `.transform()`/`.pipe()` makes a
  * legitimately minted known error fail this re-validation and downgrades it to
@@ -131,7 +131,7 @@ export function isInterModuleKnownError<Method extends InterModuleMethodContract
   } catch {
     // A schema that behaves asynchronously makes `safeParse` throw instead of
     // returning `{success: false}` (Zod requires `parseAsync` for those). A
-    // forged or malformed error must never crash this check — treat any
+    // forged or malformed error must never crash this check: treat any
     // unexpected throw the same as a failed match.
     return false;
   }

--- a/libs/shared/common/inter-module/src/presentation.ts
+++ b/libs/shared/common/inter-module/src/presentation.ts
@@ -24,7 +24,7 @@ export type InterModulePresentationHandlers<Def extends InterModuleContractDefin
 
 /**
  * Closes a producer's domain code over its own contract. A transport's `register`
- * requires the exact contract object a client was created from — a presentation
+ * requires the exact contract object a client was created from: a presentation
  * built against a different (even structurally identical) contract object is a
  * mismatch, not a match, so two contexts can never accidentally cross-wire.
  */

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -167,7 +167,7 @@ function base64Encode(bytes: Uint8Array, alphabet: string): string {
  * 0, 1, or 2 (mod 3) inside a larger base64 blob (e.g. a token inside a base64-encoded
  * request body). For each phase we encode `phase` filler bytes followed by the secret,
  * drop the `lead` chars the filler produced, and keep the `keep` chars that depend only on
- * the secret's own bytes — the run that appears no matter what surrounds the secret.
+ * the secret's own bytes: the run that appears no matter what surrounds the secret.
  */
 function base64Alignments(bytes: Uint8Array, alphabet: string): string[] {
   const alignments: string[] = [];

--- a/libs/shared/node/fastify/src/router.test.ts
+++ b/libs/shared/node/fastify/src/router.test.ts
@@ -70,7 +70,7 @@ describe('route mounting', () => {
     expect(res.json()).toEqual({nested: true});
   });
 
-  test('auth inheritance — route inherits group auth', async () => {
+  test('auth inheritance: route inherits group auth', async () => {
     const authCalled: string[] = [];
     const app = await createApp({
       auth: [
@@ -96,7 +96,7 @@ describe('route mounting', () => {
     expect(authCalled).toEqual(['client']);
   });
 
-  test('auth override — route auth replaces group auth', async () => {
+  test('auth override: route auth replaces group auth', async () => {
     const authCalled: string[] = [];
     const app = await createApp({
       auth: [

--- a/libs/shared/node/fastify/src/webhook-raw-body.ts
+++ b/libs/shared/node/fastify/src/webhook-raw-body.ts
@@ -16,8 +16,8 @@ export interface RawBodyPluginOptions {
  * offsets and payload byte counts must match the bytes the runner sent).
  *
  * It removes the inherited content-type parsers within its scope, so register it
- * on a route group dedicated to the raw content type — not one that also serves
- * JSON-parsed routes.
+ * on a route group dedicated to the raw content type. Do not register it on a
+ * group that also serves JSON-parsed routes.
  */
 export function createRawBodyPlugin({
   contentType,

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -128,7 +128,7 @@ transport.seal(); // rejects a client whose module never got a presentation regi
 ```
 
 `createClient`/`register` reject a duplicate or mismatched-contract-object call
-immediately, without recording anything — the rejected call never corrupts the
+immediately, without recording anything: the rejected call never corrupts the
 graph, so fixing the caller and retrying that same call is always enough to
 recover.
 

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -70,7 +70,7 @@ interface StartedModuleService {
 
 /**
  * Initializes modules in array order. Modules are processed sequentially
- * so migration order is deterministic — list modules with shared dependencies first.
+ * so migration order is deterministic: list modules with shared dependencies first.
  *
  * Publishers and subscribers declared on each module are registered automatically
  * into the shared pub/sub registry.

--- a/libs/shared/node/module/src/inter-module/dispatch.test.ts
+++ b/libs/shared/node/module/src/inter-module/dispatch.test.ts
@@ -486,7 +486,7 @@ describe('inter-module dispatch: cancellation', () => {
     expect(called).toBe(false);
   });
 
-  it('rejects with the signal reason even when the input is also invalid — cancellation wins', async () => {
+  it('rejects with the signal reason even when the input is also invalid: cancellation wins', async () => {
     let called = false;
     const client = buildWidgetsHarness({
       getWidget: ({id}) => {
@@ -498,7 +498,7 @@ describe('inter-module dispatch: cancellation', () => {
     const reason = new Error('already aborted');
     controller.abort(reason);
 
-    // @ts-expect-error id must be a string — deliberately invalid, to prove cancellation still wins
+    // @ts-expect-error id must be a string: deliberately invalid, to prove cancellation still wins
     await expect(client.getWidget({id: 42}, {signal: controller.signal})).rejects.toBe(reason);
     expect(called).toBe(false);
   });
@@ -509,7 +509,7 @@ describe('inter-module dispatch: cancellation', () => {
       getWidget: () => {
         controller.abort(new Error('reentrant abort'));
         return new Promise(() => {
-          // Never settles on its own — only the abort race can resolve this call.
+          // Never settles on its own: only the abort race can resolve this call.
         });
       },
     });

--- a/libs/shared/node/module/src/inter-module/dispatch.ts
+++ b/libs/shared/node/module/src/inter-module/dispatch.ts
@@ -35,7 +35,7 @@ export type InterModuleHandlerFn = (input: unknown, context: InterModuleHandlerC
  * Fires `reportInternalError` without ever blocking the caller on it: a
  * reporter that returns a promise that never settles must not hang the
  * dispatch boundary. Any synchronous throw or eventual async rejection is
- * drained — the reporter's own failure never affects the caller's outcome.
+ * drained: the reporter's own failure never affects the caller's outcome.
  */
 function drainReport(
   reportInternalError: InterModuleReportInternalError,
@@ -125,7 +125,7 @@ export function runInterModuleCall(callOptions: RunInterModuleCallOptions): Prom
 
   try {
     // The presentation span is started *inside* this callback (not as a
-    // sibling call) so it activates as the client span's child — a span
+    // sibling call) so it activates as the client span's child. A span
     // merely created via `startSpan` never becomes the parent of a later,
     // separately created span; only an *active* span does. Both callbacks may
     // throw synchronously (e.g. a pre-aborted signal); the surrounding
@@ -238,7 +238,7 @@ type HandlerSettlement =
 /**
  * The producer half of the dispatch boundary: races the handler's settlement
  * against `signal`, revives a declared known error into a fresh copy, and
- * validates and copies a successful output. Never throws — the caller
+ * validates and copies a successful output. Never throws: the caller
  * translates the returned settlement into its own rejection or resolution.
  */
 async function invokeHandlerWithCancellation(params: {
@@ -267,7 +267,7 @@ async function invokeHandlerWithCancellation(params: {
   try {
     const context: InterModuleHandlerContext = {signal: signal ?? new AbortController().signal};
     // `.then(onFulfilled, onRejected)` is attached synchronously, right here, so
-    // the handler's own promise always has a consumer — even if the abort race
+    // the handler's own promise always has a consumer: even if the abort race
     // below settles first, this promise's eventual settlement never surfaces as
     // an unhandled rejection.
     const handlerPromise = invokeHandler(handler, input, context).then(

--- a/libs/shared/node/module/src/inter-module/errors.ts
+++ b/libs/shared/node/module/src/inter-module/errors.ts
@@ -18,7 +18,7 @@ export class InterModuleValidationError extends Error {
 /**
  * Rejects a call that failed for a reason the caller must never see: a bad
  * handler output, a malformed known-error attempt, an undeclared handler
- * exception, or a serialization defect. Carries no `cause` — diagnosis lives in
+ * exception, or a serialization defect. Carries no `cause`: diagnosis lives in
  * `reportInternalError` and traces, never in the value returned to the caller.
  */
 export class InterModuleOpaqueError extends Error {

--- a/libs/shared/node/module/src/inter-module/json.ts
+++ b/libs/shared/node/module/src/inter-module/json.ts
@@ -7,7 +7,7 @@ const ARRAY_INDEX_PATTERN = /^(0|[1-9]\d*)$/;
  *
  * Cycle detection tracks only the active recursion path (the current DFS
  * stack), not every object visited. A value reachable twice through two
- * different branches is not a cycle and is allowed — it becomes two
+ * different branches is not a cycle and is allowed: it becomes two
  * independent copies once `JSON.stringify`/`JSON.parse` runs. Only a value
  * that reappears among its own ancestors is rejected.
  */
@@ -17,7 +17,7 @@ export function isJsonSafeValue(value: unknown): boolean {
   } catch {
     // A hostile Proxy trap (getPrototypeOf/ownKeys/getOwnPropertyDescriptor/get)
     // can throw mid-walk. A value that cannot be safely introspected is not
-    // JSON-safe by definition — treat the throw as "unsafe", never let it
+    // JSON-safe by definition: treat the throw as "unsafe", never let it
     // escape as a raw exception.
     return false;
   }
@@ -60,7 +60,7 @@ function checkJsonSafe(value: unknown, activePath: Set<unknown>): boolean {
     if (typeof key === 'symbol') return false;
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     // `JSON.stringify` silently drops a non-enumerable own property (unlike an
-    // array index, which it always serializes regardless of enumerability) —
+    // array index, which it always serializes regardless of enumerability).
     // reject rather than let the later JSON copy silently lose the field.
     if (!descriptor || descriptor.get || descriptor.set || !descriptor.enumerable) return false;
   }

--- a/libs/shared/node/module/src/inter-module/known-error-revive.ts
+++ b/libs/shared/node/module/src/inter-module/known-error-revive.ts
@@ -17,7 +17,7 @@ export type KnownErrorRevival =
  * error rather than trusting the handler's own error instance. A thrown value
  * with no marker at all is `undeclared` (an ordinary handler bug); one with the
  * marker that fails re-validation (forged code, invalid or non-JSON-safe
- * details) is a `known-error-contract-defect` — a producer bug, not a caller-
+ * details) is a `known-error-contract-defect`: a producer bug, not a caller-
  * visible known error.
  */
 export function reviveThrownKnownError(

--- a/libs/shared/node/module/src/inter-module/testing.ts
+++ b/libs/shared/node/module/src/inter-module/testing.ts
@@ -19,12 +19,12 @@ export type FakeInterModuleClients<Presentations extends FakeInterModulePresenta
 /**
  * Builds one real, fully validated client per named fake presentation, backed by
  * an isolated in-memory transport created and sealed for this call alone. Not
- * coupled to Vitest or any other test framework — any test runner can call this
+ * coupled to Vitest or any other test framework: any test runner can call this
  * to exercise a caller against a fake producer without the transport's
  * composition ceremony (`createClient` → `register` → `seal`).
  *
  * Each presentation is one built with `defineInterModulePresentation`, exactly
- * as a production module would build it — that keeps each entry's contract and
+ * as a production module would build it: that keeps each entry's contract and
  * handlers inferred together, so a fake still gets full type checking.
  *
  * Each test that calls this gets its own transport instance; nothing here is

--- a/libs/shared/node/module/src/inter-module/tracing.ts
+++ b/libs/shared/node/module/src/inter-module/tracing.ts
@@ -33,7 +33,7 @@ export function startActiveInterModuleSpan<T>(
 
 /**
  * Sets only stable, bounded attributes (module, method, transport, outcome, and
- * — for a known error — its code) and ends the span. Never attach payloads,
+ * the code for a known error) and ends the span. Never attach payloads,
  * identifiers, messages, stacks, causes, or raw exception events to a span.
  */
 export function endInterModuleSpan(

--- a/libs/shared/node/module/src/inter-module/transport.ts
+++ b/libs/shared/node/module/src/inter-module/transport.ts
@@ -39,7 +39,7 @@ export interface CreateInMemoryInterModuleTransportOptions {
  * ```
  *
  * `createClient` and `register` reject a duplicate or mismatched-contract-object
- * call immediately, without mutating any state — the rejected call itself never
+ * call immediately, without mutating any state: the rejected call itself never
  * corrupts the graph, so fixing the caller's code and retrying that same call is
  * always enough to recover. `seal()` only has to catch what neither of those can
  * know in advance: a client whose module never got a presentation registered.
@@ -47,7 +47,7 @@ export interface CreateInMemoryInterModuleTransportOptions {
  * Clients may be created before presentations so two modules can call each
  * other without a code import cycle. A client and its presentation must
  * reference the exact same contract object `defineInterModuleContract`
- * returned — matching module/method name strings alone is not enough.
+ * returned: matching module/method name strings alone is not enough.
  */
 export interface InterModuleTransport {
   createClient<Def extends InterModuleContractDefinition>(
@@ -197,9 +197,8 @@ export function createInMemoryInterModuleTransport(
     requireBuilding('seal');
 
     // createClient()/register() already reject a duplicate or mismatched
-    // contract the moment it would occur, so the only issue left to detect
-    // here — only knowable once the caller decides composition is complete —
-    // is a client requirement whose module never got a presentation.
+    // contract the moment it would occur. The only issue left to detect here is
+    // a client requirement whose module never got a presentation.
     const issues: string[] = [];
     for (const moduleName of clientContractByModule.keys()) {
       if (!registrationByModule.has(moduleName)) {

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -38,7 +38,7 @@ export interface WorkflowStart {
   /**
    * Optional Temporal cron expression (e.g. `* * * * *`). When set, the
    * workflow is started with `cronSchedule` so Temporal handles recurrence
-   * natively — no continueAsNew loop or external scheduler needed.
+   * natively: no continueAsNew loop or external scheduler needed.
    */
   cronSchedule?: string;
 }

--- a/libs/shared/node/module/test/fake-tracer.ts
+++ b/libs/shared/node/module/test/fake-tracer.ts
@@ -24,7 +24,7 @@ interface FakeSpan {
  *
  * `startActiveSpan` tracks the "current" span with a plain variable reset in a
  * `finally` block, which only correctly nests spans created synchronously
- * within the active callback (not ones created after an `await`) — sufficient
+ * within the active callback (not ones created after an `await`): sufficient
  * for this transport's own dispatch code, which never awaits before starting
  * its nested presentation span. A real OpenTelemetry SDK uses
  * `AsyncLocalStorage` instead, which nests correctly across `await` too.

--- a/libs/shared/react/ui/.storybook/preview.tsx
+++ b/libs/shared/react/ui/.storybook/preview.tsx
@@ -5,8 +5,8 @@ import {ThemeProvider} from '#components/theme/index.js';
 
 // Proactively trigger font fetches before any story renders. Argos's built-in
 // waitForFonts only checks `document.fonts.status === "loaded"`, which is
-// trivially true before a `font-display: swap` face has started fetching — so
-// the fallback can be captured on cold CI. Calling `document.fonts.load()`
+// trivially true before a `font-display: swap` face has started fetching. The
+// fallback can be captured on cold CI. Calling `document.fonts.load()`
 // flips status to "loading", which Argos then correctly waits on.
 if (typeof document !== 'undefined' && document.fonts) {
   void Promise.all([

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -10,7 +10,7 @@
 
 /* Self-hosted Inter (variable, latin subsets). Vendors the woff2 subsets that
    Google Fonts served so the font is registered synchronously at first paint
-   instead of behind a CDN @import — Argos screenshots no longer race the
+   instead of behind a CDN @import: Argos screenshots no longer race the
    fallback face on cold CI. */
 @font-face {
   font-family: "Inter";

--- a/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
@@ -4,7 +4,7 @@ import {Avatar} from './avatar.js';
 import {AvatarGroup, AvatarGroupTooltip} from './avatar-group.js';
 
 // In Playwright (Argos CI) navigator.webdriver is true. DiceBear image fetches
-// are unreliable in CI — skip them so screenshots are deterministic.
+// are unreliable in CI. Skip them so screenshots are deterministic.
 const isTest = typeof navigator !== 'undefined' && navigator.webdriver === true;
 
 const contentOptions = ['letters', 'logo', 'logoPlaceholder', 'image', 'upload'] as const;

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Single panel that expands and collapses, built on `@radix-ui/react-collapsible`. Use it for "show more" rows, optional/advanced settings, and any place a section should fold away until needed. The three primitives — `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent` — compose with our `Button`, `Icon`, and surface components; the content animates its height with the shared `collapsible-down`/`collapsible-up` keyframes. For several independently toggled rows, compose multiple `Collapsible`s. `CollapsibleContent` stays `overflow-hidden` so the height animation can clip cleanly, so portal any nested overlay (popover, tooltip, dropdown menu) rather than rendering it inline, where it would be clipped.',
+          'Single panel that expands and collapses, built on `@radix-ui/react-collapsible`. Use it for "show more" rows, optional/advanced settings, and any place a section should fold away until needed. The three primitives (`Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent`) compose with our `Button`, `Icon`, and surface components; the content animates its height with the shared `collapsible-down`/`collapsible-up` keyframes. For several independently toggled rows, compose multiple `Collapsible`s. `CollapsibleContent` stays `overflow-hidden` so the height animation can clip cleanly, so portal any nested overlay (popover, tooltip, dropdown menu) rather than rendering it inline, where it would be clipped.',
       },
     },
   },

--- a/libs/shared/react/ui/src/components/form-field/form-field.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.tsx
@@ -45,7 +45,7 @@ export interface FormFieldProps {
   label: ReactNode;
   /** Optional id; auto-generated via useId() when omitted. */
   id?: string | undefined;
-  /** Field-level error message — when truthy, sets aria-invalid on the input. */
+  /** Field-level error message: when truthy, sets aria-invalid on the input. */
   error?: string | undefined;
   /** Helper text shown when there is no error. */
   description?: ReactNode;

--- a/libs/shared/react/ui/src/components/load-error-state/load-error-state.tsx
+++ b/libs/shared/react/ui/src/components/load-error-state/load-error-state.tsx
@@ -18,7 +18,7 @@ export interface LoadErrorStateProps {
 
 /**
  * Calm placeholder for a section that failed to load: an error-toned EmptyState
- * with a single Retry action. Announced via `role="status"` (polite) — a section
+ * with a single Retry action. Announced via `role="status"` (polite): a section
  * load failure is recoverable, not an assertive `role="alert"`. Presentational
  * only: the caller owns `onRetry`/`retrying`, so this stays free of data-layer deps.
  */

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -52,7 +52,7 @@ const Section = ({label, children}: {label: string; children: ReactNode}) => (
 );
 
 /**
- * Controls-driven surface — flip the args to explore timestamps, wrap, and the
+ * Controls-driven surface: flip the args to explore timestamps, wrap, and the
  * gutter. The click- and hook-driven behaviors (switch timestamps, per-line
  * wrap) live in the `Interactive` story, since they own state the args cannot.
  */
@@ -69,7 +69,7 @@ export const Playground: Story = {
           </LogContent>
         </LogRow>
         <LogRow lineNumber={36} timestamp={at(9.7)} tone="warning">
-          <LogContent variant="code">WARN deprecated glob@7 — upgrade to glob@10</LogContent>
+          <LogContent variant="code">WARN deprecated glob@7: upgrade to glob@10</LogContent>
         </LogRow>
         <LogRow lineNumber={37} timestamp={at(9.9)} tone="error">
           <LogContent variant="code">
@@ -120,7 +120,7 @@ export const LineNumbers: Story = {
           </LogRow>
           <LogRow lineNumber={null}>
             <LogContent variant="code" className="text-foreground-neutral-muted">
-              lineNumber=null — a marker row keeps the gutter blank
+              lineNumber=null: a marker row keeps the gutter blank
             </LogContent>
           </LogRow>
           <LogRow lineNumber={3}>
@@ -192,7 +192,7 @@ export const Selected: Story = {
           <LogContent variant="code">a normal row</LogContent>
         </LogRow>
         <LogRow lineNumber={12} selected>
-          <LogContent variant="code">selected — the cursor row (j / k)</LogContent>
+          <LogContent variant="code">selected: the cursor row (j / k)</LogContent>
         </LogRow>
         <LogRow lineNumber={13}>
           <LogContent variant="code">another normal row</LogContent>
@@ -210,19 +210,19 @@ export const Indent: Story = {
     <div className="max-w-3xl">
       <LogRows>
         <LogRow lineNumber={1} indent={0}>
-          <LogContent variant="code">depth 0 — build</LogContent>
+          <LogContent variant="code">depth 0: build</LogContent>
         </LogRow>
         <LogRow lineNumber={2} indent={1}>
-          <LogContent variant="code">depth 1 — typecheck</LogContent>
+          <LogContent variant="code">depth 1: typecheck</LogContent>
         </LogRow>
         <LogRow lineNumber={3} indent={2}>
-          <LogContent variant="code">depth 2 — transform module</LogContent>
+          <LogContent variant="code">depth 2: transform module</LogContent>
         </LogRow>
         <LogRow lineNumber={4} indent={3}>
-          <LogContent variant="code">depth 3 — emit chunk</LogContent>
+          <LogContent variant="code">depth 3: emit chunk</LogContent>
         </LogRow>
         <LogRow lineNumber={5} indent={1}>
-          <LogContent variant="code">depth 1 — bundle</LogContent>
+          <LogContent variant="code">depth 1: bundle</LogContent>
         </LogRow>
       </LogRows>
     </div>
@@ -241,7 +241,7 @@ export const Wrapping: Story = {
       'ERROR  TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)';
     return (
       <div className="flex max-w-md flex-col gap-16">
-        <Section label="wrap=false — the line scrolls; a right fade marks the truncation">
+        <Section label="wrap=false: the line scrolls; a right fade marks the truncation">
           <LogRows wrap={false}>
             <LogRow lineNumber={120} tone="error">
               <LogContent variant="code">{long}</LogContent>
@@ -251,7 +251,7 @@ export const Wrapping: Story = {
             </LogRow>
           </LogRows>
         </Section>
-        <Section label="wrap=true — continuation lines hang-indent under the first">
+        <Section label="wrap=true: continuation lines hang-indent under the first">
           <LogRows wrap>
             <LogRow lineNumber={120} tone="error">
               <LogContent variant="code">{long}</LogContent>
@@ -291,7 +291,7 @@ export const Interactive: Story = {
         id: 4,
         ts: 2.31,
         tone: 'warning',
-        text: 'WARN  deprecated glob@7 — upgrade to glob@10 to avoid the slow recursive walk on large repositories',
+        text: 'WARN  deprecated glob@7: upgrade to glob@10 to avoid the slow recursive walk on large repositories',
       },
       {id: 5, ts: 2.95, text: 'done in 412ms'},
     ];
@@ -299,7 +299,7 @@ export const Interactive: Story = {
     const [exceptions, setExceptions] = useState<ReadonlySet<number>>(() => new Set());
 
     // Toggling the global `wrap` control clears the per-line overrides so the
-    // global wins. Adjusted during render — React's reset-on-prop-change pattern.
+    // global wins. Adjusted during render: React's reset-on-prop-change pattern.
     const lastWrap = useRef(args.wrap);
     if (lastWrap.current !== args.wrap) {
       lastWrap.current = args.wrap;
@@ -372,10 +372,10 @@ export const Hover: Story = {
           <LogContent variant="code">a resting row</LogContent>
         </LogRow>
         <LogRow lineNumber={2} className="story-hovered">
-          <LogContent variant="code">hovered — the row tints to mark the pointer target</LogContent>
+          <LogContent variant="code">hovered: the row tints to mark the pointer target</LogContent>
         </LogRow>
         <LogRow lineNumber={3} className="story-hovered" selected>
-          <LogContent variant="code">selected + hovered — the cursor row stays distinct</LogContent>
+          <LogContent variant="code">selected + hovered: the cursor row stays distinct</LogContent>
         </LogRow>
       </LogRows>
     </div>
@@ -393,24 +393,24 @@ export const Content: Story = {
       <LogRows>
         <LogRow lineNumber={1}>
           <LogContent variant="text">
-            variant="text" — prose in the display font that wraps like normal copy.
+            variant="text": prose in the display font that wraps like normal copy.
           </LogContent>
         </LogRow>
         <LogRow lineNumber={2}>
-          <LogContent variant="code">variant="code" — monospace output</LogContent>
+          <LogContent variant="code">variant="code": monospace output</LogContent>
         </LogRow>
         <LogRow lineNumber={3}>
           <LogContent variant="code">{'  whitespace   and\ttabs   are preserved'}</LogContent>
         </LogRow>
         <LogRow lineNumber={4}>
           <LogContent variant="code" ansi>
-            {`${ESC}[32m✓${ESC}[0m code + ansi — escapes become themed spans`}
+            {`${ESC}[32m✓${ESC}[0m code + ansi: escapes become themed spans`}
           </LogContent>
         </LogRow>
         <LogRow lineNumber={5}>
           <LogContent>
             <span className="inline-flex items-center gap-6">
-              arbitrary children — <Badge variant="neutral">any node</Badge>
+              arbitrary children: <Badge variant="neutral">any node</Badge>
             </span>
           </LogContent>
         </LogRow>
@@ -451,7 +451,7 @@ export const Ansi: Story = {
 
 /**
  * `LogHeader` is an optional band inside a row body: a left cluster plus an
- * optional right-aligned `end` slot. It is pure layout — supply the glyphs,
+ * optional right-aligned `end` slot. It is pure layout: supply the glyphs,
  * badges, and meta yourself.
  */
 export const Header: Story = {
@@ -488,7 +488,7 @@ export const Header: Story = {
 };
 
 /**
- * Composition is the API. The library ships no record components — output
+ * Composition is the API. The library ships no record components: output
  * lines, agent turns, tool results, and timeline markers are all assembled from
  * the four primitives, interleaved in one stream.
  */

--- a/libs/shared/react/ui/src/components/log/use-log-wrap.ts
+++ b/libs/shared/react/ui/src/components/log/use-log-wrap.ts
@@ -15,7 +15,7 @@ export interface UseLogWrapResult {
   globalWrap: boolean;
   /** How many lines currently differ from the global default. */
   overriddenCount: number;
-  /** The `wrap` value for a row — `undefined` inherits the global default. */
+  /** The `wrap` value for a row: `undefined` inherits the global default. */
   rowWrap: (id: LogLineId) => boolean | undefined;
   /** Whether a line currently overrides the global default. */
   isOverridden: (id: LogLineId) => boolean;

--- a/tools/cloudflare-pages/src/cli.ts
+++ b/tools/cloudflare-pages/src/cli.ts
@@ -771,8 +771,8 @@ async function runSummary(options: CliOptions): Promise<void> {
     ...config.apps.map((app) => {
       const deployment = deployments.find((candidate) => candidate.appId === app.id);
       const deploymentUrl =
-        deployment?.url === undefined ? '—' : `[open deployment](${deployment.url})`;
-      const commit = sourceCommit === undefined ? '—' : `\`${sourceCommit.slice(0, 12)}\``;
+        deployment?.url === undefined ? 'N/A' : `[open deployment](${deployment.url})`;
+      const commit = sourceCommit === undefined ? 'N/A' : `\`${sourceCommit.slice(0, 12)}\``;
       return `| ${markdownCell(app.id)} | ${markdownCell(appStatus({plan, report: verificationReport, deployment, appId: app.id}))} | ${deploymentUrl} | ${commit} |`;
     }),
     ...(config.apps.length === 0 ? ['No apps are configured for this deployment.'] : []),

--- a/tools/cloudflare-pages/src/github.ts
+++ b/tools/cloudflare-pages/src/github.ts
@@ -42,8 +42,8 @@ function deploymentEnvironmentName(
   appId: string,
   pullRequest: string,
 ): string {
-  const pullRequestSuffix = environment === 'Preview' && pullRequest ? ` – PR ${pullRequest}` : '';
-  return `${environment} – ${appId}${pullRequestSuffix}`;
+  const pullRequestSuffix = environment === 'Preview' && pullRequest ? `: PR ${pullRequest}` : '';
+  return `${environment}: ${appId}${pullRequestSuffix}`;
 }
 
 function deploymentEnvironmentSettings(environment: string): {

--- a/tools/cloudflare-pages/test/cloudflare-pages.test.mjs
+++ b/tools/cloudflare-pages/test/cloudflare-pages.test.mjs
@@ -960,7 +960,7 @@ test('names app GitHub deployments with a readable preview label', async () => {
     runner,
   });
 
-  assert.equal(requests[0].payload.environment, 'Preview – storybook – PR 42');
+  assert.equal(requests[0].payload.environment, 'Preview: storybook: PR 42');
 });
 
 test('registers successful applications from a partial deployment manifest', async () => {
@@ -981,7 +981,7 @@ test('registers successful applications from a partial deployment manifest', asy
   assert.equal(result.ok, true);
   assert.equal(result.apps.length, 1);
   assert.equal(requests.length, 2);
-  assert.equal(requests[0].payload.environment, 'Preview – storybook');
+  assert.equal(requests[0].payload.environment, 'Preview: storybook');
 });
 
 test('uses the GitHub repository from the CI environment for deployment registration', async () => {
@@ -1021,7 +1021,7 @@ test('marks production GitHub deployments as non-transient production deployment
     runner,
   });
 
-  assert.equal(requests[0].payload.environment, 'Production – storybook');
+  assert.equal(requests[0].payload.environment, 'Production: storybook');
   assert.equal(requests[0].payload.transient_environment, false);
   assert.equal(requests[0].payload.production_environment, true);
 });
@@ -1045,7 +1045,7 @@ test('retains a created GitHub deployment when its in-progress status fails', as
       appId: 'storybook',
       id: '123',
       url: 'https://storybook.pages.dev',
-      environment: 'Preview – storybook',
+      environment: 'Preview: storybook',
       repository: 'ShipfoxHQ/example',
     },
   ]);

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -49,11 +49,11 @@ You can still pass `--tag` explicitly (e.g. for a one-off local build); doing so
 
 ### Environment
 
-- `IMAGE_REGISTRIES` — space-separated registry bases for the derived tags (e.g. `ghcr.io/shipfoxhq docker.io/shipfoxhq`). Each base produces its own tag set; unset means the validation path (one local `<name>:ci` tag, or no tag in GitHub Actions cache-only validation). Read by name, so a credential variable is never mistaken for a registry.
-- `GITHUB_SHA` / `BUILD_NUMBER` / `GITHUB_REF_NAME` — the commit identity for the `sha-<short>`, `build-<number>`, and moving branch tags. The moving tag is `latest` on the default branch (`main`) and the sanitized branch name otherwise. `GITHUB_SHA` also becomes the `IMAGE_REVISION` build-arg.
-- `NODE_VERSION` / `PNPM_VERSION` — forwarded as `--build-arg` for the base image.
-- `GITHUB_ACTIONS` — enables the gha BuildKit cache.
-- `npm_package_name` — the prune target for `--setup-context` (set by the package manager when run through a script).
+- `IMAGE_REGISTRIES`: space-separated registry bases for the derived tags (e.g. `ghcr.io/shipfoxhq docker.io/shipfoxhq`). Each base produces its own tag set; unset means the validation path (one local `<name>:ci` tag, or no tag in GitHub Actions cache-only validation). Read by name, so a credential variable is never mistaken for a registry.
+- `GITHUB_SHA` / `BUILD_NUMBER` / `GITHUB_REF_NAME`: the commit identity for the `sha-<short>`, `build-<number>`, and moving branch tags. The moving tag is `latest` on the default branch (`main`) and the sanitized branch name otherwise. `GITHUB_SHA` also becomes the `IMAGE_REVISION` build-arg.
+- `NODE_VERSION` / `PNPM_VERSION`: forwarded as `--build-arg` for the base image.
+- `GITHUB_ACTIONS`: enables the gha BuildKit cache.
+- `npm_package_name`: the prune target for `--setup-context` (set by the package manager when run through a script).
 
 ## License
 

--- a/tools/docker/src/turbo.ts
+++ b/tools/docker/src/turbo.ts
@@ -15,7 +15,7 @@ export {productionizeImports} from '@shipfox/tool-utils';
  * ingest dist" way. `turbo prune` writes a self-contained workspace into `out/`,
  * then each pruned package's already-built (turbo-cached) `dist/` is overlaid
  * into `out/full/`. The image ingests those `dist/`s plus a real `node_modules`
- * and never recompiles TypeScript — `shipfox-swc` transpiles per file and does
+ * and never recompiles TypeScript: `shipfox-swc` transpiles per file and does
  * not bundle, so the workspace `dist/`s are what the running app needs.
  */
 export function setupContext(packageName: string) {

--- a/tools/playwright/src/index.ts
+++ b/tools/playwright/src/index.ts
@@ -20,7 +20,7 @@ export {
 // `document.fonts.ready` resolves once every font face requested so far has
 // finished loading. Argos's built-in `waitForFonts` only checks
 // `document.fonts.status === "loaded"`, which is satisfied before a
-// `font-display: swap` face has even started fetching — so the fallback can be
+// `font-display: swap` face has even started fetching. The fallback can be
 // captured on cold CI. Awaiting `document.fonts.ready` first closes that window.
 async function waitForFonts(handler: Page | Frame): Promise<void> {
   await handler.evaluate(() => document.fonts.ready);

--- a/tools/worktree-services/README.md
+++ b/tools/worktree-services/README.md
@@ -62,7 +62,7 @@ starts the Compose services selected by the repository config.
 
 ## Port ranges
 
-The default range is `20000–45999`. The package allocates 20-port blocks. Set
+The default range is `20000 to 45999`. The package allocates 20-port blocks. Set
 a different range in the consuming repository's `mise.toml` when several
 repositories run on one machine:
 


### PR DESCRIPTION
## Summary

Repository prose, source comments, and user-facing copy now use contextual replacements instead of literal em dashes and en dashes. The slug fixture keeps its runtime input coverage through a `\u2014` escape, and affected published packages include patch changesets.

The tracked in-scope scan is clean outside generated `CHANGELOG.md` files. Validation completed with the affected-package Turbo graph (595 successful tasks), Changesets status, and `git diff --check`.

Closes ENG-1456

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized punctuation by replacing Unicode em/en dashes with clear, context-appropriate punctuation across docs, comments, tests, and UI copy; Storybook CI now validates against the PR head SHA. Includes follow-up grammar fixes in auth, Sentry, and logs docs/comments with no runtime behavior changes (ENG-1456).

- **Refactors**
  - Replaced literal dashes with colons, “to”, or commas; cleaned up README/auth/Sentry/logs wording.
  - Preserved slug behavior via a `\u2014` in the slug test; updated UI placeholders to `N/A`.
  - Added patch Changesets for all affected `@shipfox/...` packages.
  - CI: pass `CLOUDFLARE_PAGES_COMMIT_SHA` (PR head) to tests and E2E so Storybook metadata matches the checked-out commit.

<sup>Written for commit abf783a72afa2ea41199fecf37654624b5966bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

