### PR TITLE
[api-workflows] Scope checkout credential persistence per checkout

### DIFF
--- a/.changeset/primary-checkout-credentials.md
+++ b/.changeset/primary-checkout-credentials.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Materialize primary checkout credential persistence on the setup step.

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -202,6 +202,15 @@ describe('materializeJobExecutionSteps', () => {
 
     const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
 
+    expect(steps[0]).toMatchObject({
+      type: 'setup',
+      config: {
+        checkout: {
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+        },
+      },
+    });
     expect(steps[1]).toEqual({
       key: null,
       name: 'Checkout',
@@ -221,6 +230,61 @@ describe('materializeJobExecutionSteps', () => {
       },
       authoredConfig: null,
       position: 1,
+    });
+  });
+
+  it('propagates a non-default job checkout policy into the setup step config', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          checkout: {
+            permissions: {contents: 'write'},
+            persistCredentials: false,
+          },
+          steps: [{run: 'echo hello'}],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[0]).toMatchObject({
+      type: 'setup',
+      config: {
+        checkout: {
+          permissions: {contents: 'write'},
+          persist_credentials: false,
+        },
+      },
+    });
+  });
+
+  it('falls back to the default checkout policy for legacy jobs', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {steps: [{run: 'echo hello'}]},
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+    const legacyJob = {...job, checkout: undefined} as unknown as typeof job;
+
+    const steps = await materializeJobExecutionSteps({
+      model,
+      job: legacyJob,
+      context: jobExecutionContext(),
+    });
+
+    expect(steps[0]).toMatchObject({
+      type: 'setup',
+      config: {
+        checkout: {
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+        },
+      },
     });
   });
 
@@ -250,7 +314,12 @@ describe('materializeJobExecutionSteps', () => {
         sourceLocation: null,
         status: 'pending',
         type: 'setup',
-        config: {},
+        config: {
+          checkout: {
+            permissions: {contents: 'read'},
+            persist_credentials: true,
+          },
+        },
         authoredConfig: null,
         position: 0,
       },

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -1,4 +1,4 @@
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import {DEFAULT_JOB_CHECKOUT, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import type {WorkflowExpression} from '@shipfox/expression';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {
@@ -41,15 +41,14 @@ export interface MaterializeJobExecutionStepsParams {
 
 // Synthetic "Set up job" step prepended when a job execution's steps are materialized.
 // The runner prepares the workspace here; failures report through the normal step
-// protocol instead of hanging the job until the lease/timeout fires. Its config is
-// credential-free.
-const SETUP_STEP: MaterializedWorkflowStep = {
+// protocol instead of hanging the job until the lease/timeout fires. Its config carries
+// checkout policy, never credential material.
+const SETUP_STEP: Omit<MaterializedWorkflowStep, 'config'> = {
   key: null,
   name: 'Set up job',
   sourceLocation: null,
   status: 'pending',
   type: 'setup',
-  config: {},
   authoredConfig: null,
   position: 0,
 };
@@ -68,7 +67,7 @@ export async function materializeJobExecutionSteps(
   } = params;
 
   return [
-    SETUP_STEP,
+    setupStepForJob(job),
     ...(await Promise.all(
       job.steps.map(async (step, stepPosition) => {
         const stepContext = {
@@ -105,6 +104,20 @@ export async function materializeJobExecutionSteps(
       }),
     )),
   ];
+}
+
+function setupStepForJob(job: WorkflowModelJob): MaterializedWorkflowStep {
+  const checkout = job.checkout ?? DEFAULT_JOB_CHECKOUT;
+
+  return {
+    ...SETUP_STEP,
+    config: {
+      checkout: {
+        permissions: checkout.permissions,
+        persist_credentials: checkout.persistCredentials,
+      },
+    },
+  };
 }
 
 function materializedConfigPlan(

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -132,7 +132,12 @@ describe('materializeWorkflowModel', () => {
       sourceLocation: null,
       status: 'pending',
       type: 'setup',
-      config: {},
+      config: {
+        checkout: {
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+        },
+      },
       authoredConfig: null,
       position: 0,
     };
@@ -477,7 +482,12 @@ describe('materializeWorkflowModel', () => {
 
     const rows = await materializeWorkflowModel({model});
 
-    expect(rows[0]?.steps[0]?.config).toEqual({});
+    expect(rows[0]?.steps[0]?.config).toEqual({
+      checkout: {
+        permissions: {contents: 'read'},
+        persist_credentials: true,
+      },
+    });
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: 'npm test',
       env: {
@@ -1276,7 +1286,12 @@ describe('materializeWorkflowModel', () => {
         sourceLocation: null,
         status: 'pending',
         type: 'setup',
-        config: {},
+        config: {
+          checkout: {
+            permissions: {contents: 'read'},
+            persist_credentials: true,
+          },
+        },
         authoredConfig: null,
         position: 0,
       },

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -316,7 +316,12 @@ describe('workflow run queries', () => {
         type: 'setup',
         name: 'Set up job',
         position: 0,
-        config: {},
+        config: {
+          checkout: {
+            permissions: {contents: 'read'},
+            persist_credentials: true,
+          },
+        },
       });
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
     });


### PR DESCRIPTION
Checkout credential persistence is now carried by each materialized checkout policy. The synthetic primary checkout setup step receives the job's checkout settings, explicit checkout steps retain their own settings, and legacy persisted job models without `checkout` fall back to the default read-and-persist policy.

This moves the credential-persistence boundary from the job execution to each checkout while keeping older listening-job models materializable. The runner/token route migration remains in the linked follow-up work.

Closes ENG-1439

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope credential persistence to each checkout and materialize the primary checkout policy on the setup step. This lets multiple checkouts control `persist-credentials` independently while keeping legacy jobs working.

- **New Features**
  - The "Set up job" step now includes checkout policy (permissions and `persist-credentials`) derived from the job’s `checkout` or a safe default.
  - Job-level `checkout` config controls the primary checkout only; explicit checkout steps keep their own settings.
  - Legacy jobs without `checkout` use the default policy: `contents: read` with credentials persisted.

Aligns with ENG-1439: move `persist-credentials` from the job to each checkout.

<sup>Written for commit 0486ee5b614d4f02474e694e49f98b618585acc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

