### PR TITLE
Add project settings and live slug availability

### DIFF
--- a/.changeset/project-settings-slug-availability.md
+++ b/.changeset/project-settings-slug-availability.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/client-auth": minor
+"@shipfox/client-projects": minor
+"@shipfox/client-shell": minor
+"@shipfox/client-ui": minor
+"@shipfox/client-workspace-settings": minor
+---
+
+Add project settings, shared slug rename warnings, and live slug availability checks.

--- a/libs/client/auth/src/core/auth.ts
+++ b/libs/client/auth/src/core/auth.ts
@@ -33,6 +33,12 @@ export interface WorkspaceCreateCommand {
   slug: string;
 }
 
+export interface WorkspaceUpdateCommand {
+  workspaceId: string;
+  name?: string;
+  slug?: string;
+}
+
 export interface Workspace {
   id: string;
   name: string;

--- a/libs/client/auth/src/core/auth.ts
+++ b/libs/client/auth/src/core/auth.ts
@@ -33,11 +33,15 @@ export interface WorkspaceCreateCommand {
   slug: string;
 }
 
-export interface WorkspaceUpdateCommand {
-  workspaceId: string;
-  name?: string;
-  slug?: string;
-}
+type WorkspaceUpdateBody =
+  | {name: string; slug?: never}
+  | {name?: never; slug: string}
+  | {
+      name: string;
+      slug: string;
+    };
+
+export type WorkspaceUpdateCommand = {workspaceId: string} & WorkspaceUpdateBody;
 
 export interface Workspace {
   id: string;

--- a/libs/client/auth/src/hooks/api/workspace-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.test.ts
@@ -91,12 +91,13 @@ describe('checkWorkspaceSlugAvailability', () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({available: true}));
     configureApiClient({fetchImpl});
 
-    await expect(checkWorkspaceSlugAvailability('acme-labs')).resolves.toBe(true);
+    const slug = 'acme/labs?region=eu';
+    await expect(checkWorkspaceSlugAvailability(slug)).resolves.toBe(true);
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
     const url = new URL(request.url);
     expect(url.pathname).toBe('/workspaces/slug-availability');
-    expect(url.searchParams.get('slug')).toBe('acme-labs');
+    expect(url.search).toBe(`?slug=${encodeURIComponent(slug)}`);
     expect(request.method).toBe('GET');
   });
 });

--- a/libs/client/auth/src/hooks/api/workspace-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.test.ts
@@ -1,5 +1,9 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {createWorkspace} from './workspace-auth.js';
+import {
+  checkWorkspaceSlugAvailability,
+  createWorkspace,
+  updateWorkspace,
+} from './workspace-auth.js';
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -38,5 +42,61 @@ describe('createWorkspace', () => {
     expect(request.url).toBe('https://api.example.test/workspaces');
     expect(request.method).toBe('POST');
     expect(requestBody).toEqual({name: 'Acme', slug: 'acme'});
+  });
+});
+
+describe('updateWorkspace', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('patches the workspace body', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({
+        id: '33333333-3333-4333-8333-333333333333',
+        name: 'Acme Labs',
+        slug: 'acme-labs',
+        status: 'active',
+        settings: {},
+        created_at: '2026-04-27T00:00:00.000Z',
+        updated_at: '2026-04-27T00:00:00.000Z',
+      });
+    });
+    configureApiClient({fetchImpl});
+
+    const result = await updateWorkspace({
+      workspaceId: '33333333-3333-4333-8333-333333333333',
+      name: 'Acme Labs',
+      slug: 'acme-labs',
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.slug).toBe('acme-labs');
+    expect(request.url).toBe(
+      'https://api.example.test/workspaces/33333333-3333-4333-8333-333333333333',
+    );
+    expect(request.method).toBe('PATCH');
+    expect(requestBody).toEqual({name: 'Acme Labs', slug: 'acme-labs'});
+  });
+});
+
+describe('checkWorkspaceSlugAvailability', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('encodes the slug and returns the server result', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({available: true}));
+    configureApiClient({fetchImpl});
+
+    await expect(checkWorkspaceSlugAvailability('acme-labs')).resolves.toBe(true);
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    const url = new URL(request.url);
+    expect(url.pathname).toBe('/workspaces/slug-availability');
+    expect(url.searchParams.get('slug')).toBe('acme-labs');
+    expect(request.method).toBe('GET');
   });
 });

--- a/libs/client/auth/src/hooks/api/workspace-auth.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.ts
@@ -1,12 +1,18 @@
-import {workspaceResponseSchema} from '@shipfox/api-workspaces-dto';
+import {
+  updateWorkspaceBodySchema,
+  workspaceResponseSchema,
+  workspaceSlugAvailabilityResponseSchema,
+} from '@shipfox/api-workspaces-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {
   listUserWorkspaces,
   userWorkspacesQueryKey,
   userWorkspacesQueryOptions,
 } from '@shipfox/client-shell/runtime';
-import {useMutation} from '@tanstack/react-query';
-import type {WorkspaceCreateCommand} from '#core/auth.js';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {useSetAtom} from 'jotai';
+import type {WorkspaceCreateCommand, WorkspaceUpdateCommand} from '#core/auth.js';
+import {authStateAtom} from '#state/auth.js';
 import {useRefreshAuth} from './refresh-auth.js';
 import {toWorkspace} from './workspace-mapper.js';
 
@@ -16,6 +22,24 @@ export async function createWorkspace(command: WorkspaceCreateCommand) {
     body: {name: command.name, slug: command.slug},
   });
   return toWorkspace(response);
+}
+
+export async function updateWorkspace(command: WorkspaceUpdateCommand) {
+  const body = updateWorkspaceBodySchema.parse({name: command.name, slug: command.slug});
+  const response = await checkedApiRequest(
+    workspaceResponseSchema,
+    `/workspaces/${command.workspaceId}`,
+    {method: 'PATCH', body},
+  );
+  return toWorkspace(response);
+}
+
+export async function checkWorkspaceSlugAvailability(slug: string): Promise<boolean> {
+  const response = await checkedApiRequest(
+    workspaceSlugAvailabilityResponseSchema,
+    `/workspaces/slug-availability?slug=${encodeURIComponent(slug)}`,
+  );
+  return response.available;
 }
 
 export {listUserWorkspaces, userWorkspacesQueryKey, userWorkspacesQueryOptions};
@@ -30,6 +54,29 @@ export function useCreateWorkspaceAuth() {
       // doesn't carry. Refresh so the next request includes it in the JWT
       // claim and passes the in-memory canAccess() check on the server.
       await refreshAuth();
+    },
+  });
+}
+
+export function useUpdateWorkspaceMutation() {
+  const queryClient = useQueryClient();
+  const setAuthState = useSetAtom(authStateAtom);
+
+  return useMutation({
+    mutationFn: updateWorkspace,
+    onSuccess: async (workspace) => {
+      setAuthState((previous) => {
+        if (previous.status !== 'authenticated') return previous;
+        return {
+          ...previous,
+          workspaces: (previous.workspaces ?? []).map((candidate) =>
+            candidate.id === workspace.id
+              ? {...candidate, name: workspace.name, slug: workspace.slug, status: workspace.status}
+              : candidate,
+          ),
+        };
+      });
+      await queryClient.invalidateQueries({queryKey: userWorkspacesQueryKey});
     },
   });
 }

--- a/libs/client/auth/src/hooks/index.ts
+++ b/libs/client/auth/src/hooks/index.ts
@@ -7,7 +7,12 @@ export {
 export {useRefreshAuth} from './api/refresh-auth.js';
 export {useSignupAuth} from './api/signup-auth.js';
 export {useResendEmailVerificationAuth, useVerifyEmailAuth} from './api/verify-email-auth.js';
-export {useCreateWorkspaceAuth} from './api/workspace-auth.js';
+export {
+  checkWorkspaceSlugAvailability,
+  updateWorkspace,
+  useCreateWorkspaceAuth,
+  useUpdateWorkspaceMutation,
+} from './api/workspace-auth.js';
 export {useActiveWorkspace, useMaybeActiveWorkspace} from './use-active-workspace.js';
 export type {AuthStateValue} from './use-auth-state.js';
 export {useAuthState} from './use-auth-state.js';

--- a/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
@@ -120,6 +120,47 @@ describe('WorkspaceOnboardingPage', () => {
     expect(screen.getByText(`${window.location.origin}/w/custom-workspace`)).toBeInTheDocument();
   });
 
+  test('checks a manually edited workspace slug for availability', async () => {
+    const user = pageUserFactory.build({email: 'workspace-availability@example.com'});
+    const availabilityRequests: string[] = [];
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      const url = request.url;
+      if (url.includes('/auth/refresh')) {
+        return Promise.resolve(jsonResponse({token: 'access-token', user}));
+      }
+      if (url.includes('/workspaces/slug-availability')) {
+        availabilityRequests.push(url);
+        return Promise.resolve(jsonResponse({available: true}));
+      }
+      if (url.endsWith('/workspaces')) {
+        return Promise.resolve(jsonResponse({memberships: []}));
+      }
+      return Promise.resolve(
+        jsonResponse({code: 'not-found', message: 'Not found'}, {status: 404}),
+      );
+    });
+    configureApiClient({fetchImpl});
+
+    renderAuthPage(
+      '/',
+      <AuthGuard>
+        <WorkspaceGuard>
+          <h1>Authenticated home</h1>
+        </WorkspaceGuard>
+      </AuthGuard>,
+    );
+    fireEvent.change(await screen.findByLabelText('Workspace slug'), {
+      target: {value: 'custom-workspace'},
+    });
+
+    await waitFor(() => expect(availabilityRequests).toHaveLength(1));
+    expect(new URL(availabilityRequests[0] ?? '').searchParams.get('slug')).toBe(
+      'custom-workspace',
+    );
+    expect(await screen.findByText('Slug is available.')).toBeInTheDocument();
+  });
+
   test('shows a duplicate slug error on the slug field', async () => {
     const user = pageUserFactory.build({email: 'workspace-conflict@example.com'});
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -1,6 +1,6 @@
-import {slugifyName} from '@shipfox/api-common-dto';
+import {slugifyName, slugSchema} from '@shipfox/api-common-dto';
 import {createWorkspaceBodySchema} from '@shipfox/api-workspaces-dto';
-import {displayNameFieldError} from '@shipfox/client-ui';
+import {displayNameFieldError, SlugField} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@shipfox/react-ui/card';
@@ -12,7 +12,7 @@ import {useForm} from '@tanstack/react-form';
 import {useNavigate} from '@tanstack/react-router';
 import {useSetAtom} from 'jotai';
 import {useState} from 'react';
-import {useCreateWorkspaceAuth} from '#hooks/api/workspace-auth.js';
+import {checkWorkspaceSlugAvailability, useCreateWorkspaceAuth} from '#hooks/api/workspace-auth.js';
 import {useAuthState} from '#hooks/use-auth-state.js';
 import {lastWorkspaceIdAtom, rememberLastWorkspaceId} from '#state/last-workspace.js';
 import {workspaceOnboardingErrorToFormError} from './form-errors.js';
@@ -33,6 +33,10 @@ const previewBars = [
   {id: 'runs-late-low', height: 44},
   {id: 'runs-late-high', height: 74},
 ];
+
+function isSlugValid(value: string): boolean {
+  return slugSchema.safeParse(value).success;
+}
 
 export function WorkspaceOnboardingPage() {
   const createWorkspace = useCreateWorkspaceAuth();
@@ -161,29 +165,27 @@ export function WorkspaceOnboardingPage() {
                   }}
                 >
                   {(field) => (
-                    <FormField
-                      label="Workspace slug"
+                    <SlugField
                       id="workspace-slug"
+                      label="Workspace slug"
+                      name="slug"
+                      value={field.state.value}
+                      onChange={(value) => {
+                        setSlugTouched(true);
+                        field.handleChange(value);
+                      }}
+                      onBlur={field.handleBlur}
+                      error={fieldError(field)}
                       description={
-                        <span className="break-all font-code" aria-live="polite">
+                        <span className="break-all font-code">
                           {`${window.location.origin}/w/${field.state.value || 'acme'}`}
                         </span>
                       }
-                      error={fieldError(field)}
-                    >
-                      <FormFieldInput
-                        autoComplete="off"
-                        name="slug"
-                        placeholder="acme"
-                        type="text"
-                        value={field.state.value}
-                        onChange={(event) => {
-                          setSlugTouched(true);
-                          field.handleChange(event.target.value);
-                        }}
-                        onBlur={field.handleBlur}
-                      />
-                    </FormField>
+                      placeholder="acme"
+                      checkEnabled={slugTouched}
+                      isValid={isSlugValid}
+                      checkAvailability={checkWorkspaceSlugAvailability}
+                    />
                   )}
                 </form.Field>
               </CardContent>

--- a/libs/client/features/src/index.test.ts
+++ b/libs/client/features/src/index.test.ts
@@ -46,6 +46,8 @@ describe('defaultFeatures', () => {
       'nav.settings',
     ]);
     expect(composition.settingsSections.map(({id}) => id)).toEqual([
+      'settings.project-general',
+      'settings.general',
       'settings.members',
       'settings.runners',
       'settings.provisioners',

--- a/libs/client/projects/src/core/project.ts
+++ b/libs/client/projects/src/core/project.ts
@@ -25,6 +25,12 @@ export interface CreateProjectCommand {
   source: ProjectSource;
 }
 
+export interface UpdateProjectCommand {
+  projectId: string;
+  name?: string;
+  slug?: string;
+}
+
 const REPOSITORY_NAME_SPLIT_RE = /[/-]/;
 
 export function projectNameFromRepository(repositoryId: string): string {

--- a/libs/client/projects/src/feature.ts
+++ b/libs/client/projects/src/feature.ts
@@ -11,6 +11,17 @@ export const projectsNavigation = [
   },
 ] as const satisfies readonly NavTabEntry[];
 
+export const projectSettingsSections = [
+  {
+    id: 'settings.project-general',
+    scope: 'project',
+    pathSegment: 'general',
+    label: 'General',
+    icon: 'settings3Line',
+    order: 50,
+  },
+] as const;
+
 export const projectsFeature = defineClientFeature({
   id: 'shipfox.projects',
   routes: [
@@ -29,6 +40,17 @@ export const projectsFeature = defineClientFeature({
       parent: 'projectLayout',
       impl: '@shipfox/client-projects/routes/project-index',
     },
+    {
+      path: '/w/$workspaceSlug/p/$projectSlug/settings',
+      parent: 'projectSettings',
+      impl: '@shipfox/client-projects/routes/project-settings-index',
+    },
+    {
+      path: '/w/$workspaceSlug/p/$projectSlug/settings/general',
+      parent: 'projectSettings',
+      impl: '@shipfox/client-projects/routes/project-settings',
+    },
   ],
   navigation: projectsNavigation,
+  settingsSections: projectSettingsSections,
 });

--- a/libs/client/projects/src/hooks/api/projects.test.ts
+++ b/libs/client/projects/src/hooks/api/projects.test.ts
@@ -2,11 +2,13 @@ import {configureApiClient} from '@shipfox/client-api';
 import {QueryClient} from '@tanstack/react-query';
 import {
   createProject,
+  isProjectSlugAvailable,
   listProjects,
   projectSlugQueryOptions,
   projectsInfiniteQueryOptions,
   projectsQueryKeys,
   resolveProjectSlug,
+  updateProject,
 } from './projects.js';
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -93,6 +95,66 @@ describe('createProject', () => {
         external_repository_id: body.source.externalRepositoryId,
       },
     });
+  });
+});
+
+describe('updateProject', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('patches the project body', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse(projectResponse('renamed-project'));
+    });
+    configureApiClient({fetchImpl});
+
+    const result = await updateProject({
+      projectId: '33333333-3333-4333-8333-333333333333',
+      name: 'Renamed project',
+      slug: 'renamed-project',
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.slug).toBe('renamed-project');
+    expect(request.url).toBe(
+      'https://api.example.test/projects/33333333-3333-4333-8333-333333333333',
+    );
+    expect(request.method).toBe('PATCH');
+    expect(requestBody).toEqual({name: 'Renamed project', slug: 'renamed-project'});
+  });
+});
+
+describe('isProjectSlugAvailable', () => {
+  test('uses cached project lists without making a request', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(projectsQueryKeys.list(workspaceId, 'taken'), {
+      pages: [
+        {
+          projects: [projectResponse('taken-project')],
+          nextCursor: null,
+        },
+      ],
+      pageParams: [undefined],
+    });
+
+    expect(isProjectSlugAvailable({queryClient, workspaceId, projectSlug: 'taken-project'})).toBe(
+      false,
+    );
+    expect(
+      isProjectSlugAvailable({
+        queryClient,
+        workspaceId,
+        projectSlug: 'taken-project',
+        currentProjectId: '33333333-3333-4333-8333-333333333333',
+      }),
+    ).toBe(true);
+    expect(isProjectSlugAvailable({queryClient, workspaceId, projectSlug: 'new-project'})).toBe(
+      true,
+    );
   });
 });
 

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -2,6 +2,7 @@ import {
   createProjectBodySchema,
   listProjectsResponseSchema,
   projectResponseSchema,
+  updateProjectBodySchema,
 } from '@shipfox/api-projects-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {
@@ -16,7 +17,13 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import type {CreateProjectCommand, Project, ProjectList} from '#core/project.js';
+import {useCallback} from 'react';
+import type {
+  CreateProjectCommand,
+  Project,
+  ProjectList,
+  UpdateProjectCommand,
+} from '#core/project.js';
 import {toProject, toProjectList} from './mappers.js';
 
 const PROJECT_LIST_STALE_TIME = 30_000;
@@ -211,6 +218,50 @@ export async function createProject(command: CreateProjectCommand): Promise<Proj
   );
 }
 
+export async function updateProject(command: UpdateProjectCommand): Promise<Project> {
+  const body = updateProjectBodySchema.parse({name: command.name, slug: command.slug});
+  return toProject(
+    await checkedApiRequest(projectResponseSchema, `/projects/${command.projectId}`, {
+      method: 'PATCH',
+      body,
+    }),
+  );
+}
+
+export function isProjectSlugAvailable({
+  queryClient,
+  workspaceId,
+  projectSlug,
+  currentProjectId,
+}: {
+  queryClient: QueryClient;
+  workspaceId: string;
+  projectSlug: string;
+  currentProjectId?: string | undefined;
+}): boolean {
+  const cachedLists = queryClient.getQueriesData<InfiniteData<ProjectList, string | undefined>>({
+    queryKey: [...projectsQueryKeys.all, 'list', workspaceId],
+  });
+  const conflict = cachedLists
+    .flatMap(([, data]) => data?.pages.flatMap((page) => page.projects) ?? [])
+    .some((project) => project.slug === projectSlug && project.id !== currentProjectId);
+  return !conflict;
+}
+
+export function useProjectSlugAvailability(
+  workspaceId: string | undefined,
+  currentProjectId?: string,
+): (projectSlug: string) => boolean {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (projectSlug: string) =>
+      workspaceId
+        ? isProjectSlugAvailable({queryClient, workspaceId, projectSlug, currentProjectId})
+        : true,
+    [currentProjectId, queryClient, workspaceId],
+  );
+}
+
 export function projectsInfiniteQueryOptions(
   workspaceId: string | undefined,
   search?: string,
@@ -321,6 +372,19 @@ export function useCreateProjectMutation() {
         refetchType: 'active',
       });
       await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(command.workspaceId)});
+    },
+  });
+}
+
+export function useUpdateProjectMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateProject,
+    onSuccess: async (project) => {
+      queryClient.setQueryData(projectsQueryKeys.detail(project.id), project);
+      queryClient.setQueryData(projectsQueryKeys.slug(project.workspaceId, project.slug), project);
+      await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(project.workspaceId)});
     },
   });
 }

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -251,13 +251,17 @@ export function isProjectSlugAvailable({
 export function useProjectSlugAvailability(
   workspaceId: string | undefined,
   currentProjectId?: string,
-): (projectSlug: string) => boolean {
+): (projectSlug: string) => Promise<boolean> {
   const queryClient = useQueryClient();
   return useCallback(
-    (projectSlug: string) =>
-      workspaceId
-        ? isProjectSlugAvailable({queryClient, workspaceId, projectSlug, currentProjectId})
-        : true,
+    async (projectSlug: string) => {
+      if (!workspaceId) return false;
+      if (!isProjectSlugAvailable({queryClient, workspaceId, projectSlug, currentProjectId})) {
+        return false;
+      }
+      const project = await findProjectBySlug({workspaceId, projectSlug});
+      return project === undefined || project.id === currentProjectId;
+    },
     [currentProjectId, queryClient, workspaceId],
   );
 }
@@ -384,6 +388,9 @@ export function useUpdateProjectMutation() {
     onSuccess: async (project) => {
       queryClient.setQueryData(projectsQueryKeys.detail(project.id), project);
       queryClient.setQueryData(projectsQueryKeys.slug(project.workspaceId, project.slug), project);
+      await queryClient.invalidateQueries({
+        queryKey: [...projectsQueryKeys.all, 'slug', project.workspaceId],
+      });
       await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(project.workspaceId)});
     },
   });

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -6,6 +6,7 @@ export {
   type ProjectSource,
   projectNameFromRepository,
   selectProjectSource,
+  type UpdateProjectCommand,
 } from '#core/project.js';
 export {
   ProjectBreadcrumb,
@@ -21,5 +22,6 @@ export * from './hooks/api/definitions.js';
 export * from './hooks/api/projects.js';
 export * from './pages/create-project-page.js';
 export * from './pages/home-router.js';
+export {ProjectSettingsPage} from './pages/project-settings-page.js';
 export * from './pages/projects-hub-page.js';
 export * from './project-error.js';

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -93,6 +93,31 @@ describe('CreateProjectPage', () => {
     expect(screen.getByText('/w/acme/p/launch-pad')).toBeInTheDocument();
   });
 
+  test('checks project slug availability from memory without an availability request', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
+      }
+      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+        return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}/projects/new`, <CreateProjectPage />);
+    const slugInput = await screen.findByLabelText('Project slug');
+    fireEvent.change(slugInput, {target: {value: 'custom-project'}});
+
+    expect(await screen.findByText('Slug is available.')).toBeInTheDocument();
+    expect(
+      fetchImpl.mock.calls.some(([input]) =>
+        (input as Request).url.includes('/projects/slug-availability'),
+      ),
+    ).toBe(false);
+  });
+
   test('uses the current repository-derived name when submitted before touching the field', async () => {
     let createProjectBody: unknown;
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -1,5 +1,7 @@
 import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient} from '@tanstack/react-query';
 import {fireEvent, screen, waitFor} from '@testing-library/react';
+import {projectsQueryKeys} from '#hooks/api/projects.js';
 import {
   jsonResponse,
   PROJECT_TEST_WID,
@@ -93,7 +95,7 @@ describe('CreateProjectPage', () => {
     expect(screen.getByText('/w/acme/p/launch-pad')).toBeInTheDocument();
   });
 
-  test('checks project slug availability from memory without an availability request', async () => {
+  test('checks project slug availability authoritatively after a cache miss', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       const request = input as Request;
       if (request.url.includes('/integration-connections?')) {
@@ -101,6 +103,9 @@ describe('CreateProjectPage', () => {
       }
       if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
         return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
+      }
+      if (request.url.includes('/projects?')) {
+        return Promise.resolve(jsonResponse({projects: [], next_cursor: null}));
       }
       return Promise.resolve(jsonResponse({}));
     });
@@ -112,9 +117,55 @@ describe('CreateProjectPage', () => {
 
     expect(await screen.findByText('Slug is available.')).toBeInTheDocument();
     expect(
-      fetchImpl.mock.calls.some(([input]) =>
-        (input as Request).url.includes('/projects/slug-availability'),
+      fetchImpl.mock.calls.some(
+        ([input]) =>
+          (input as Request).url.includes('/projects?') &&
+          (input as Request).url.includes('search=custom-project'),
       ),
+    ).toBe(true);
+  });
+
+  test('reports a cached project slug conflict without another availability request', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
+      }
+      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+        return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+    queryClient.setQueryData(projectsQueryKeys.list(PROJECT_TEST_WID, 'custom-project'), {
+      pages: [
+        {
+          projects: [
+            {
+              id: '55555555-5555-4555-8555-555555555555',
+              workspaceId: PROJECT_TEST_WID,
+              name: 'Custom project',
+              slug: 'custom-project',
+              source: {connectionId: CONNECTION_ID, externalRepositoryId: 'custom-project'},
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      pageParams: [undefined],
+    });
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}/projects/new`, <CreateProjectPage />, queryClient);
+    fireEvent.change(await screen.findByLabelText('Project slug'), {
+      target: {value: 'custom-project'},
+    });
+
+    expect(await screen.findByText('This slug is already taken.')).toBeInTheDocument();
+    expect(
+      fetchImpl.mock.calls.some(([input]) => (input as Request).url.includes('/projects?')),
     ).toBe(false);
   });
 
@@ -424,12 +475,12 @@ function repositoryDto() {
   };
 }
 
-function projectDto({id}: {id: string}) {
+function projectDto({id, slug = 'project-detail'}: {id: string; slug?: string}) {
   return {
     id,
     workspace_id: '11111111-1111-4111-8111-111111111111',
     name: 'Project Detail',
-    slug: 'project-detail',
+    slug,
     source: {
       connection_id: CONNECTION_ID,
       external_repository_id: 'platform',

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -81,7 +81,8 @@ export function CreateProjectPage() {
   const defaultProjectSlug = slugifyName(defaultProjectName, {fallback: 'project'});
 
   const [formError, setFormError] = useState<string | undefined>();
-  const [slugTouched, setSlugTouched] = useState(false);
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+  const [slugCheckEnabled, setSlugCheckEnabled] = useState(false);
   const [slugConflict, setSlugConflict] = useState(false);
   const workspaceId = workspace?.id;
   const checkProjectSlugAvailability = useProjectSlugAvailability(workspaceId);
@@ -89,7 +90,9 @@ export function CreateProjectPage() {
   const form = useForm({
     defaultValues: {name: defaultProjectName, slug: defaultProjectSlug},
     onSubmit: async ({value}) => {
-      const projectSlug = slugTouched ? value.slug : slugifyName(value.name, {fallback: 'project'});
+      const projectSlug = slugManuallyEdited
+        ? value.slug
+        : slugifyName(value.name, {fallback: 'project'});
       await createProjectFromForm(nameTouched ? value.name : defaultProjectName, projectSlug);
     },
   });
@@ -97,12 +100,12 @@ export function CreateProjectPage() {
   useEffect(() => {
     if (!nameTouched && form.state.values.name !== defaultProjectName) {
       form.setFieldValue('name', defaultProjectName);
-      if (!slugTouched) {
+      if (!slugManuallyEdited) {
         setSlugConflict(false);
         form.setFieldValue('slug', slugifyName(defaultProjectName, {fallback: 'project'}));
       }
     }
-  }, [defaultProjectName, form, nameTouched, slugTouched]);
+  }, [defaultProjectName, form, nameTouched, slugManuallyEdited]);
 
   function selectConnection(connectionId: string) {
     setSelectedConnectionId(connectionId);
@@ -333,7 +336,8 @@ export function CreateProjectPage() {
                       const nextName = event.target.value;
                       setNameTouched(true);
                       field.handleChange(nextName);
-                      if (!slugTouched) {
+                      if (!slugManuallyEdited) {
+                        setSlugCheckEnabled(true);
                         setSlugConflict(false);
                         form.setFieldValue('slug', slugifyName(nextName, {fallback: 'project'}));
                       }
@@ -359,7 +363,8 @@ export function CreateProjectPage() {
                   name="slug"
                   value={field.state.value}
                   onChange={(value) => {
-                    setSlugTouched(true);
+                    setSlugManuallyEdited(true);
+                    setSlugCheckEnabled(true);
                     setSlugConflict(false);
                     field.handleChange(value);
                   }}
@@ -372,7 +377,7 @@ export function CreateProjectPage() {
                   }
                   placeholder="platform"
                   className="font-code"
-                  checkEnabled={slugTouched}
+                  checkEnabled={slugCheckEnabled}
                   debounceMs={0}
                   isValid={isSlugValid}
                   checkAvailability={checkProjectSlugAvailability}

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -1,4 +1,4 @@
-import {slugifyName} from '@shipfox/api-common-dto';
+import {slugifyName, slugSchema} from '@shipfox/api-common-dto';
 import {createProjectBodySchema} from '@shipfox/api-projects-dto';
 import {useMaybeActiveWorkspace} from '@shipfox/client-auth';
 import {
@@ -9,7 +9,7 @@ import {
   useRepositoriesInfiniteQuery,
   useSourceConnectionsQuery,
 } from '@shipfox/client-integrations';
-import {displayNameFieldError} from '@shipfox/client-ui';
+import {displayNameFieldError, SlugField} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -21,8 +21,16 @@ import {Link, Navigate, useNavigate} from '@tanstack/react-router';
 import {useEffect, useRef, useState} from 'react';
 import {ModelProviderReminderBanner} from '#components/model-provider-reminder-banner.js';
 import {type CreateProjectCommand, projectNameFromRepository} from '#core/project.js';
-import {getProject, useCreateProjectMutation} from '#hooks/api/projects.js';
+import {
+  getProject,
+  useCreateProjectMutation,
+  useProjectSlugAvailability,
+} from '#hooks/api/projects.js';
 import {projectErrorCopy} from '#project-error.js';
+
+function isSlugValid(value: string): boolean {
+  return slugSchema.safeParse(value).success;
+}
 
 export function CreateProjectPage() {
   const workspace = useMaybeActiveWorkspace();
@@ -75,6 +83,8 @@ export function CreateProjectPage() {
   const [formError, setFormError] = useState<string | undefined>();
   const [slugTouched, setSlugTouched] = useState(false);
   const [slugConflict, setSlugConflict] = useState(false);
+  const workspaceId = workspace?.id;
+  const checkProjectSlugAvailability = useProjectSlugAvailability(workspaceId);
 
   const form = useForm({
     defaultValues: {name: defaultProjectName, slug: defaultProjectSlug},
@@ -343,30 +353,30 @@ export function CreateProjectPage() {
               }}
             >
               {(field) => (
-                <FormField
-                  label="Project slug"
+                <SlugField
                   id="project-slug"
+                  label="Project slug"
+                  name="slug"
+                  value={field.state.value}
+                  onChange={(value) => {
+                    setSlugTouched(true);
+                    setSlugConflict(false);
+                    field.handleChange(value);
+                  }}
+                  onBlur={field.handleBlur}
                   error={slugConflict ? 'This project slug is already in use.' : fieldError(field)}
                   description={
-                    <span className="font-code" aria-live="polite">
+                    <span className="font-code">
                       {`/w/${workspace.slug}/p/${field.state.value}`}
                     </span>
                   }
-                >
-                  <FormFieldInput
-                    name="slug"
-                    type="text"
-                    value={field.state.value}
-                    onChange={(event) => {
-                      setSlugTouched(true);
-                      setSlugConflict(false);
-                      field.handleChange(event.target.value);
-                    }}
-                    onBlur={field.handleBlur}
-                    placeholder="platform"
-                    className="font-code"
-                  />
-                </FormField>
+                  placeholder="platform"
+                  className="font-code"
+                  checkEnabled={slugTouched}
+                  debounceMs={0}
+                  isValid={isSlugValid}
+                  checkAvailability={checkProjectSlugAvailability}
+                />
               )}
             </form.Field>
 

--- a/libs/client/projects/src/pages/project-settings-form-errors.ts
+++ b/libs/client/projects/src/pages/project-settings-form-errors.ts
@@ -1,0 +1,17 @@
+import {ApiError} from '@shipfox/client-api';
+
+export type ProjectSettingsField = 'name' | 'slug';
+
+export type ProjectSettingsFormError =
+  | {kind: 'field'; field: ProjectSettingsField; message: string}
+  | {kind: 'form'; message: string};
+
+export function projectSettingsErrorToFormError(error: unknown): ProjectSettingsFormError {
+  if (error instanceof ApiError && error.code === 'slug-conflict') {
+    return {kind: 'field', field: 'slug', message: 'That project slug is already taken.'};
+  }
+  return {
+    kind: 'form',
+    message: error instanceof Error ? error.message : 'Could not update project settings.',
+  };
+}

--- a/libs/client/projects/src/pages/project-settings-page.stories.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.stories.tsx
@@ -1,0 +1,213 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {type AuthState, authStateAtom} from '@shipfox/client-auth';
+import {Toaster} from '@shipfox/react-ui/toast';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {createStore, Provider as JotaiProvider} from 'jotai';
+import {useMemo} from 'react';
+import {expect, screen, userEvent, within} from 'storybook/test';
+import {ProjectSettingsPage} from './project-settings-page.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const PROJECT_ID = '99999999-9999-4999-8999-999999999999';
+const OTHER_PROJECT_ID = '88888888-8888-4888-8888-888888888888';
+
+type Scenario = 'default' | 'long-values' | 'taken-slug';
+
+interface ProjectStoryResponse {
+  id: string;
+  workspace_id: string;
+  name: string;
+  slug: string;
+  source: {
+    connection_id: string;
+    external_repository_id: string;
+  };
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProjectSettingsPageStoryProps {
+  scenario: Scenario;
+}
+
+const authState: AuthState = {
+  status: 'authenticated',
+  token: 'token',
+  user: {
+    id: '22222222-2222-4222-8222-222222222222',
+    email: 'platform@example.com',
+    name: 'Platform Engineer',
+    emailVerifiedAt: '2026-01-01T00:00:00.000Z',
+  },
+  workspaces: [{id: WORKSPACE_ID, name: 'Acme', slug: 'acme', membershipId: 'membership-1'}],
+};
+
+function ProjectSettingsPageStory({scenario}: ProjectSettingsPageStoryProps) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+  const store = useMemo(() => {
+    const nextStore = createStore();
+    nextStore.set(authStateAtom, authState);
+    return nextStore;
+  }, []);
+  const router = useMemo(() => createStoryRouter(scenario), [scenario]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider store={store}>
+        <div className="min-h-screen bg-background-neutral-background px-24 py-32">
+          <div className="mx-auto w-full max-w-[1120px]">
+            <RouterProvider router={router} />
+          </div>
+        </div>
+        <Toaster />
+      </JotaiProvider>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Projects/ProjectSettingsPage',
+  component: ProjectSettingsPageStory,
+  parameters: {layout: 'fullscreen'},
+  args: {scenario: 'default'},
+} satisfies Meta<typeof ProjectSettingsPageStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const LongValues: Story = {
+  args: {scenario: 'long-values'},
+};
+
+export const TakenSlug: Story = {
+  args: {scenario: 'taken-slug'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const slugInput = await canvas.findByLabelText('Project slug');
+    await userEvent.clear(slugInput);
+    await userEvent.type(slugInput, 'taken-platform');
+
+    expect(await canvas.findByText('This slug is already taken.')).toBeInTheDocument();
+  },
+};
+
+export const SlugChangeWarning: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const slugInput = await canvas.findByLabelText('Project slug');
+    await userEvent.clear(slugInput);
+    await userEvent.type(slugInput, 'renamed-platform');
+    await canvas.findByText('Slug is available.');
+    await userEvent.click(canvas.getByRole('button', {name: 'Save changes'}));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('Change project slug?');
+    expect(dialog).toHaveTextContent('Links and bookmarks pointing at the old URL stop working.');
+  },
+};
+
+function createStoryRouter(scenario: Scenario) {
+  const project = projectForScenario(scenario);
+  const rootRoute = createRootRoute({component: Outlet});
+  const projectSettingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug/p/$projectSlug/settings/general',
+    component: ProjectSettingsPage,
+  });
+
+  return createRouter({
+    history: createMemoryHistory({
+      initialEntries: [`/w/acme/p/${project.slug}/settings/general`],
+    }),
+    routeTree: rootRoute.addChildren([projectSettingsRoute]),
+  });
+}
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return async (input, init) => {
+    const url = requestUrl(input);
+    const method = input instanceof Request ? input.method : (init?.method ?? 'GET');
+
+    if (url.pathname === '/projects' && method === 'GET') {
+      const search = url.searchParams.get('search');
+      if (scenario === 'taken-slug' && search === 'taken-platform') {
+        return jsonResponse({
+          projects: [projectForScenario(scenario, {id: OTHER_PROJECT_ID, slug: 'taken-platform'})],
+          next_cursor: null,
+        });
+      }
+      return jsonResponse({projects: [projectForScenario(scenario)], next_cursor: null});
+    }
+
+    if (url.pathname === `/projects/${PROJECT_ID}` && method === 'PATCH') {
+      const body = (await (input as Request).clone().json()) as {
+        name?: string;
+        slug?: string;
+      };
+      const project = projectForScenario(scenario);
+      return jsonResponse({
+        ...project,
+        name: body.name ?? project.name,
+        slug: body.slug ?? project.slug,
+      });
+    }
+
+    return jsonResponse({}, {status: 404});
+  };
+}
+
+function projectForScenario(
+  scenario: Scenario,
+  overrides: Partial<ProjectStoryResponse> = {},
+): ProjectStoryResponse {
+  const project = {
+    id: PROJECT_ID,
+    workspace_id: WORKSPACE_ID,
+    name:
+      scenario === 'long-values'
+        ? 'Infrastructure Control Plane and Workflow Automation'
+        : 'Platform',
+    slug: scenario === 'long-values' ? 'infrastructure-control-plane' : 'platform',
+    source: {
+      connection_id: '33333333-3333-4333-8333-333333333333',
+      external_repository_id: 'platform',
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+  return project;
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) return new URL(input.url);
+  if (input instanceof URL) return input;
+  return new URL(input, 'https://api.example.test');
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}

--- a/libs/client/projects/src/pages/project-settings-page.stories.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.stories.tsx
@@ -122,6 +122,9 @@ export const SlugChangeWarning: Story = {
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toHaveTextContent('Change project slug?');
     expect(dialog).toHaveTextContent('Links and bookmarks pointing at the old URL stop working.');
+    expect(dialog).toHaveTextContent(
+      'Workflows that reference this project slug may stop working.',
+    );
   },
 };
 

--- a/libs/client/projects/src/pages/project-settings-page.test.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.test.tsx
@@ -1,0 +1,74 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {fireEvent, screen, waitFor} from '@testing-library/react';
+import {jsonResponse, renderProjectPage} from '#test/pages.js';
+import {ProjectSettingsPage} from './project-settings-page.js';
+
+describe('ProjectSettingsPage', () => {
+  test('saves a name change without opening the slug warning', async () => {
+    let patchBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === 'PATCH') {
+        patchBody = await request.clone().json();
+        return jsonResponse(projectDto({name: 'Platform API'}));
+      }
+      return jsonResponse({projects: [projectDto()], next_cursor: null});
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProjectPage('/w/acme/p/platform/settings/general', <ProjectSettingsPage />);
+    fireEvent.change(await screen.findByLabelText('Project name'), {
+      target: {value: 'Platform API'},
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    await waitFor(() => expect(patchBody).toEqual({name: 'Platform API'}));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('requires confirmation before saving a slug change', async () => {
+    let patchBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === 'PATCH') {
+        patchBody = await request.clone().json();
+        return jsonResponse(projectDto({slug: 'platform-api'}));
+      }
+      return jsonResponse({projects: [projectDto()], next_cursor: null});
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProjectPage('/w/acme/p/platform/settings/general', <ProjectSettingsPage />);
+    fireEvent.change(await screen.findByLabelText('Project slug'), {
+      target: {value: 'platform-api'},
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('old URL stop working');
+    expect(
+      fetchImpl.mock.calls.some(([input]) =>
+        (input as Request).url.includes('/projects/slug-availability'),
+      ),
+    ).toBe(false);
+    expect(patchBody).toBeUndefined();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Change slug'}));
+    await waitFor(() => expect(patchBody).toEqual({slug: 'platform-api'}));
+  });
+});
+
+function projectDto({name = 'Platform', slug = 'platform'}: {name?: string; slug?: string} = {}) {
+  return {
+    id: '44444444-4444-4444-8444-444444444444',
+    workspace_id: '11111111-1111-4111-8111-111111111111',
+    name,
+    slug,
+    source: {
+      connection_id: '33333333-3333-4333-8333-333333333333',
+      external_repository_id: 'platform',
+    },
+    created_at: '2026-05-07T01:00:00.000Z',
+    updated_at: '2026-05-07T01:00:00.000Z',
+  };
+}

--- a/libs/client/projects/src/pages/project-settings-page.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.tsx
@@ -1,0 +1,192 @@
+import {slugSchema} from '@shipfox/api-common-dto';
+import {createProjectBodySchema} from '@shipfox/api-projects-dto';
+import {useActiveWorkspace} from '@shipfox/client-auth';
+import {displayNameFieldError, SlugChangeWarning, SlugField} from '@shipfox/client-ui';
+import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
+import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
+import {FullPageLoader} from '@shipfox/react-ui/loader';
+import {toast} from '@shipfox/react-ui/toast';
+import {Header, Text} from '@shipfox/react-ui/typography';
+import {useForm} from '@tanstack/react-form';
+import {useNavigate} from '@tanstack/react-router';
+import {useState} from 'react';
+import {useMaybeActiveProject} from '#chrome.js';
+import {useProjectSlugAvailability, useUpdateProjectMutation} from '#hooks/api/projects.js';
+import {projectSettingsErrorToFormError} from './project-settings-form-errors.js';
+
+interface ProjectSettingsValues {
+  name: string;
+  slug: string;
+}
+
+function isSlugValid(value: string): boolean {
+  return slugSchema.safeParse(value).success;
+}
+
+export function ProjectSettingsPage() {
+  const project = useMaybeActiveProject();
+  if (!project) return <FullPageLoader />;
+  return (
+    <ProjectSettingsForm key={`${project.id}:${project.name}:${project.slug}`} project={project} />
+  );
+}
+
+function ProjectSettingsForm({
+  project,
+}: {
+  project: NonNullable<ReturnType<typeof useMaybeActiveProject>>;
+}) {
+  const workspace = useActiveWorkspace();
+  const navigate = useNavigate();
+  const updateProject = useUpdateProjectMutation();
+  const [warningOpen, setWarningOpen] = useState(false);
+  const [pendingValues, setPendingValues] = useState<ProjectSettingsValues>();
+  const [formError, setFormError] = useState<string>();
+
+  const checkProjectSlugAvailability = useProjectSlugAvailability(workspace.id, project.id);
+
+  const form = useForm({
+    defaultValues: {name: project.name, slug: project.slug},
+    onSubmit: async ({value}) => {
+      if (value.slug !== project.slug) {
+        setPendingValues(value);
+        setWarningOpen(true);
+        return;
+      }
+      await save(value);
+    },
+  });
+
+  async function save(values: ProjectSettingsValues) {
+    setFormError(undefined);
+    const nameChanged = values.name !== project.name;
+    const slugChanged = values.slug !== project.slug;
+    if (!nameChanged && !slugChanged) return;
+    const command = {
+      projectId: project.id,
+      ...(nameChanged ? {name: values.name} : {}),
+      ...(slugChanged ? {slug: values.slug} : {}),
+    };
+
+    try {
+      const updated = await updateProject.mutateAsync(command);
+      setPendingValues(undefined);
+      setWarningOpen(false);
+      toast.success('Project settings saved.');
+      await navigate({
+        to: '/w/$workspaceSlug/p/$projectSlug/settings/general',
+        params: {workspaceSlug: workspace.slug, projectSlug: updated.slug},
+      });
+    } catch (error) {
+      setPendingValues(undefined);
+      setWarningOpen(false);
+      const mapped = projectSettingsErrorToFormError(error);
+      if (mapped.kind === 'field') {
+        form.setFieldMeta(mapped.field, (previous) => ({
+          ...previous,
+          errorMap: {...previous.errorMap, onServer: mapped.message},
+        }));
+      } else {
+        setFormError(mapped.message);
+      }
+    }
+  }
+
+  return (
+    <>
+      <div className="flex min-w-0 flex-col gap-24">
+        <header className="flex flex-col gap-6">
+          <Header variant="h1">General</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Update the project name and the slug used in its URLs.
+          </Text>
+        </header>
+
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
+
+        <form
+          className="flex max-w-[560px] flex-col gap-16"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="name"
+            validators={{
+              onBlur: ({value}) =>
+                displayNameFieldError(value, 'Project name', createProjectBodySchema.shape.name),
+              onSubmit: ({value}) =>
+                displayNameFieldError(value, 'Project name', createProjectBodySchema.shape.name),
+            }}
+          >
+            {(field) => (
+              <FormField label="Project name" id="project-settings-name" error={fieldError(field)}>
+                <FormFieldInput
+                  name="name"
+                  type="text"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                  onBlur={field.handleBlur}
+                />
+              </FormField>
+            )}
+          </form.Field>
+
+          <form.Field
+            name="slug"
+            validators={{
+              onBlur: createProjectBodySchema.shape.slug,
+              onSubmit: createProjectBodySchema.shape.slug,
+            }}
+          >
+            {(field) => (
+              <SlugField
+                id="project-settings-slug"
+                label="Project slug"
+                name="slug"
+                value={field.state.value}
+                onChange={(value) => field.handleChange(value)}
+                onBlur={field.handleBlur}
+                error={fieldError(field)}
+                description={
+                  <span className="break-all font-code">
+                    /w/{workspace.slug}/p/{field.state.value}
+                  </span>
+                }
+                placeholder="platform"
+                className="font-code"
+                currentSlug={project.slug}
+                checkEnabled
+                debounceMs={0}
+                isValid={isSlugValid}
+                checkAvailability={checkProjectSlugAvailability}
+              />
+            )}
+          </form.Field>
+
+          <Button type="submit" isLoading={updateProject.isPending} className="self-start">
+            Save changes
+          </Button>
+        </form>
+      </div>
+
+      <SlugChangeWarning
+        open={warningOpen}
+        onOpenChange={setWarningOpen}
+        entityLabel="project"
+        isLoading={updateProject.isPending}
+        onConfirm={() => {
+          if (pendingValues) void save(pendingValues);
+        }}
+      />
+    </>
+  );
+}

--- a/libs/client/projects/src/pages/project-settings-page.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.tsx
@@ -1,9 +1,16 @@
 import {slugSchema} from '@shipfox/api-common-dto';
 import {createProjectBodySchema} from '@shipfox/api-projects-dto';
+import {ApiError} from '@shipfox/client-api';
 import {useActiveWorkspace} from '@shipfox/client-auth';
-import {displayNameFieldError, SlugChangeWarning, SlugField} from '@shipfox/client-ui';
+import {
+  displayNameFieldError,
+  QueryLoadError,
+  SlugChangeWarning,
+  SlugField,
+} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
@@ -11,7 +18,8 @@ import {Header, Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import {useNavigate} from '@tanstack/react-router';
 import {useState} from 'react';
-import {useMaybeActiveProject} from '#chrome.js';
+import {useMaybeActiveProjectQuery} from '#chrome.js';
+import type {Project} from '#core/project.js';
 import {useProjectSlugAvailability, useUpdateProjectMutation} from '#hooks/api/projects.js';
 import {projectSettingsErrorToFormError} from './project-settings-form-errors.js';
 
@@ -25,18 +33,38 @@ function isSlugValid(value: string): boolean {
 }
 
 export function ProjectSettingsPage() {
-  const project = useMaybeActiveProject();
-  if (!project) return <FullPageLoader />;
+  const projectQuery = useMaybeActiveProjectQuery();
+  if (projectQuery.isPending) return <FullPageLoader />;
+  if (projectQuery.isError && projectQuery.data === undefined) {
+    if (projectQuery.error instanceof ApiError && projectQuery.error.status === 404) {
+      return (
+        <EmptyState
+          icon="errorWarningLine"
+          tone="error"
+          title="Project not found"
+          description="This project doesn't exist, or you don't have access to it."
+        />
+      );
+    }
+    return <QueryLoadError query={projectQuery} subject="project" />;
+  }
+  const project = projectQuery.data;
+  if (!project) {
+    return (
+      <EmptyState
+        icon="errorWarningLine"
+        tone="error"
+        title="Project not found"
+        description="This project doesn't exist, or you don't have access to it."
+      />
+    );
+  }
   return (
     <ProjectSettingsForm key={`${project.id}:${project.name}:${project.slug}`} project={project} />
   );
 }
 
-function ProjectSettingsForm({
-  project,
-}: {
-  project: NonNullable<ReturnType<typeof useMaybeActiveProject>>;
-}) {
+function ProjectSettingsForm({project}: {project: Project}) {
   const workspace = useActiveWorkspace();
   const navigate = useNavigate();
   const updateProject = useUpdateProjectMutation();

--- a/libs/client/projects/src/routes/project-settings-index.tsx
+++ b/libs/client/projects/src/routes/project-settings-index.tsx
@@ -1,0 +1,11 @@
+import {defineRoute} from '@shipfox/client-shell/runtime';
+import {redirect} from '@tanstack/react-router';
+
+export default defineRoute({
+  beforeLoad: ({params}: {params: {workspaceSlug: string; projectSlug: string}}) => {
+    throw redirect({
+      to: '/w/$workspaceSlug/p/$projectSlug/settings/general',
+      params,
+    });
+  },
+});

--- a/libs/client/projects/src/routes/project-settings.tsx
+++ b/libs/client/projects/src/routes/project-settings.tsx
@@ -1,0 +1,4 @@
+import {defineRoute} from '@shipfox/client-shell/runtime';
+import {ProjectSettingsPage} from '#pages/project-settings-page.js';
+
+export default defineRoute({component: ProjectSettingsPage});

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -70,6 +70,11 @@ function createTestRouter(path: string, element: ReactElement) {
     path: '/w/$workspaceSlug/settings/agents',
     component: () => <div>Agent settings placeholder</div>,
   });
+  const projectSettingsGeneralRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug/p/$projectSlug/settings/general',
+    component: () => element,
+  });
   const projectDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/w/$workspaceSlug/p/$projectSlug',
@@ -106,6 +111,7 @@ function createTestRouter(path: string, element: ReactElement) {
       workspaceNewProjectRoute,
       integrationsRoute,
       modelProviderSettingsRoute,
+      projectSettingsGeneralRoute,
       projectDetailRoute,
       projectWorkflowsRoute,
     ]),

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -118,8 +118,11 @@ function createTestRouter(path: string, element: ReactElement) {
   });
 }
 
-export function renderProjectPage(path: string, element: ReactElement): RenderResult {
-  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+export function renderProjectPage(
+  path: string,
+  element: ReactElement,
+  queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}}),
+): RenderResult {
   const router = createTestRouter(path, element);
   const store = createStore();
   store.set(authStateAtom, authState);

--- a/libs/client/shell/src/components/settings-nav.tsx
+++ b/libs/client/shell/src/components/settings-nav.tsx
@@ -2,19 +2,42 @@ import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Link, useMatchRoute} from '@tanstack/react-router';
 import type {SettingsSectionEntry} from '#contract.js';
-import {parseWorkspaceParams, useRouteParams} from '#runtime/route-inputs.js';
+import {
+  parseWorkspaceParams,
+  parseWorkspaceProjectParams,
+  useRouteParams,
+} from '#runtime/route-inputs.js';
 
-export function SettingsNav({entries}: {entries: readonly SettingsSectionEntry[]}) {
-  const params = useRouteParams(parseWorkspaceParams);
+export function SettingsNav({
+  entries,
+  scope,
+}: {
+  entries: readonly SettingsSectionEntry[];
+  scope: 'workspace' | 'project';
+}) {
+  const params = useRouteParams((input): {workspaceSlug?: string; projectSlug?: string} =>
+    scope === 'workspace' ? parseWorkspaceParams(input) : parseWorkspaceProjectParams(input),
+  );
   const matchRoute = useMatchRoute();
-  if (!params.workspaceSlug) return null;
+  if (!params.workspaceSlug || (scope === 'project' && !params.projectSlug)) return null;
+  const scopedEntries = entries.filter((entry) => (entry.scope ?? 'workspace') === scope);
+  const settingsPath =
+    scope === 'workspace'
+      ? '/w/$workspaceSlug/settings'
+      : '/w/$workspaceSlug/p/$projectSlug/settings';
+  const paramsForLink =
+    scope === 'workspace'
+      ? {workspaceSlug: params.workspaceSlug}
+      : {workspaceSlug: params.workspaceSlug, projectSlug: params.projectSlug};
+
   return (
-    <nav aria-label="Workspace settings" className="flex flex-col gap-4">
-      {entries.map((entry) => {
-        const to = `/w/$workspaceSlug/settings/${entry.pathSegment}`;
-        const active = Boolean(
-          matchRoute({to: to as never, params: {workspaceSlug: params.workspaceSlug} as never}),
-        );
+    <nav
+      aria-label={`${scope === 'workspace' ? 'Workspace' : 'Project'} settings`}
+      className="flex flex-col gap-4"
+    >
+      {scopedEntries.map((entry) => {
+        const to = `${settingsPath}/${entry.pathSegment}`;
+        const active = Boolean(matchRoute({to: to as never, params: paramsForLink as never}));
         return (
           <Button
             key={entry.id}
@@ -24,7 +47,7 @@ export function SettingsNav({entries}: {entries: readonly SettingsSectionEntry[]
           >
             <Link
               to={to as never}
-              params={{workspaceSlug: params.workspaceSlug} as never}
+              params={paramsForLink as never}
               aria-current={active ? 'page' : undefined}
             >
               <Icon name={entry.icon} className="size-16" />

--- a/libs/client/shell/src/compose/validate-registries.ts
+++ b/libs/client/shell/src/compose/validate-registries.ts
@@ -177,7 +177,10 @@ export function validateSettingsSections(
           [existingFeatureId, feature.id],
         );
       }
-      const path = `/w/$workspaceSlug/settings/${section.pathSegment}`;
+      const path =
+        section.scope === 'project'
+          ? `/w/$workspaceSlug/p/$projectSlug/settings/${section.pathSegment}`
+          : `/w/$workspaceSlug/settings/${section.pathSegment}`;
       const normalizedPath = normalizeRoutePath(path);
       const routeOwner = routes.get(normalizedPath);
       if (routeOwner === undefined && !routes.has(normalizedPath)) {

--- a/libs/client/shell/src/contract.ts
+++ b/libs/client/shell/src/contract.ts
@@ -2,7 +2,12 @@ import type {IconName} from '@shipfox/react-ui/icon';
 import type {ComponentType, PropsWithChildren} from 'react';
 import type {z} from 'zod';
 
-export type AnchorId = 'root' | 'workspaceLayout' | 'projectLayout' | 'workspaceSettings';
+export type AnchorId =
+  | 'root'
+  | 'workspaceLayout'
+  | 'projectLayout'
+  | 'workspaceSettings'
+  | 'projectSettings';
 
 /** A fixed shell anchor or the stable id of a feature-owned layout. */
 export type RouteParentId = AnchorId | (string & {});
@@ -45,6 +50,7 @@ export interface SettingsSectionEntry {
   pathSegment: string;
   label: string;
   icon: IconName;
+  scope?: 'workspace' | 'project';
   order?: number;
 }
 

--- a/libs/client/shell/src/runtime/anchor-paths.test.ts
+++ b/libs/client/shell/src/runtime/anchor-paths.test.ts
@@ -5,6 +5,7 @@ describe('client route path invariants', () => {
     expect(anchorPaths).toMatchObject({
       workspaceLayout: '/w/$workspaceSlug',
       projectLayout: '/w/$workspaceSlug/p/$projectSlug',
+      projectSettings: '/w/$workspaceSlug/p/$projectSlug/settings',
     });
     expect(() =>
       validateRoutePathInvariants('/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId'),

--- a/libs/client/shell/src/runtime/anchor-paths.ts
+++ b/libs/client/shell/src/runtime/anchor-paths.ts
@@ -6,6 +6,7 @@ const anchorPaths = {
   workspaceLayout: '/w/$workspaceSlug',
   projectLayout: '/w/$workspaceSlug/p/$projectSlug',
   workspaceSettings: '/w/$workspaceSlug/settings',
+  projectSettings: '/w/$workspaceSlug/p/$projectSlug/settings',
 } as const;
 
 const entityPrefixRegistry = {

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -8,6 +8,7 @@ import type {NavTabEntry, SettingsSectionEntry} from '#contract.js';
 import {useActiveWorkspace, useMaybeActiveWorkspace} from './active-workspace.js';
 import {anchorPaths} from './anchor-paths.js';
 import {rememberLastWorkspaceId} from './last-workspace.js';
+import {parseWorkspaceParams, parseWorkspaceProjectParams, useRouteParams} from './route-inputs.js';
 import type {RouterContext} from './router-context.js';
 import type {WorkspaceSetupState} from './workspace-setup.js';
 import {
@@ -107,33 +108,72 @@ export function buildAnchorSkeleton({
     },
     component: Outlet,
   });
+  const projectSettings = createRoute({
+    getParentRoute: () => projectLayout,
+    path: '/settings',
+    component: () => (
+      <SettingsAnchorLayout
+        scope="project"
+        title="Project settings"
+        description="Configure this project."
+        settingsSections={settingsSections}
+      />
+    ),
+  });
   const workspaceSettings = createRoute({
     getParentRoute: () => workspaceLayout,
     path: '/settings',
     component: () => {
       const workspace = useActiveWorkspace();
       return (
-        <div className="flex w-full flex-col gap-24">
-          <header className="flex flex-col gap-6">
-            <Header variant="h2">Workspace settings</Header>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              Configure {workspace.name}.
-            </Text>
-          </header>
-
-          <div className="grid grid-cols-[180px_minmax(0,1fr)] gap-32 max-[760px]:grid-cols-1">
-            <SettingsNav entries={settingsSections} />
-            <Outlet />
-          </div>
-        </div>
+        <SettingsAnchorLayout
+          scope="workspace"
+          title="Workspace settings"
+          description={`Configure ${workspace.name}.`}
+          settingsSections={settingsSections}
+        />
       );
     },
   });
   return {
-    anchors: {root: rootRoute, workspaceLayout, projectLayout, workspaceSettings},
+    anchors: {root: rootRoute, workspaceLayout, projectLayout, workspaceSettings, projectSettings},
     rootRoute,
     workspaceLayout,
     projectLayout,
     workspaceSettings,
+    projectSettings,
   };
+}
+
+function SettingsAnchorLayout({
+  scope,
+  title,
+  description,
+  settingsSections,
+}: {
+  scope: 'workspace' | 'project';
+  title: string;
+  description: string;
+  settingsSections: readonly SettingsSectionEntry[];
+}) {
+  const params = useRouteParams((input): {workspaceSlug?: string; projectSlug?: string} =>
+    scope === 'workspace' ? parseWorkspaceParams(input) : parseWorkspaceProjectParams(input),
+  );
+  if (!params.workspaceSlug || (scope === 'project' && !params.projectSlug)) return null;
+
+  return (
+    <div className="flex w-full flex-col gap-24">
+      <header className="flex flex-col gap-6">
+        <Header variant="h2">{title}</Header>
+        <Text size="sm" className="text-foreground-neutral-muted">
+          {description}
+        </Text>
+      </header>
+
+      <div className="grid grid-cols-[180px_minmax(0,1fr)] gap-32 max-[760px]:grid-cols-1">
+        <SettingsNav entries={settingsSections} scope={scope} />
+        <Outlet />
+      </div>
+    </div>
+  );
 }

--- a/libs/client/shell/src/runtime/assemble-route-tree.ts
+++ b/libs/client/shell/src/runtime/assemble-route-tree.ts
@@ -7,7 +7,13 @@ import type {RouteImpl} from '#runtime/define-route.js';
 
 export type ResolveRouteImpl = (specifier: string) => RouteImpl | Promise<RouteImpl>;
 
-const shellAnchors = ['root', 'workspaceLayout', 'projectLayout', 'workspaceSettings'] as const;
+const shellAnchors = [
+  'root',
+  'workspaceLayout',
+  'projectLayout',
+  'workspaceSettings',
+  'projectSettings',
+] as const;
 
 function isShellAnchor(parent: RouteParentId): parent is (typeof shellAnchors)[number] {
   return shellAnchors.includes(parent as (typeof shellAnchors)[number]);
@@ -111,7 +117,13 @@ export async function assembleRouteTree(
     ...routeChildrenFor(parent),
     ...layouts.filter((layout) => layout.parent === parent).map((layout) => layoutTree(layout.id)),
   ];
-  const projectLayout = skeleton.projectLayout.addChildren(childrenFor('projectLayout') as never);
+  const projectSettings = skeleton.projectSettings.addChildren(
+    childrenFor('projectSettings') as never,
+  );
+  const projectLayout = skeleton.projectLayout.addChildren([
+    ...childrenFor('projectLayout'),
+    projectSettings,
+  ] as never);
   const workspaceSettings = skeleton.workspaceSettings.addChildren(
     childrenFor('workspaceSettings') as never,
   );

--- a/libs/client/shell/src/runtime/registries.ts
+++ b/libs/client/shell/src/runtime/registries.ts
@@ -56,5 +56,5 @@ export function settingsEntries(features: readonly ClientFeature[]): SettingsSec
       })),
     )
     .sort(byOrder)
-    .map(({entry}) => entry);
+    .map(({entry}) => ({...entry, scope: entry.scope ?? 'workspace'}));
 }

--- a/libs/client/shell/src/vite/generate.ts
+++ b/libs/client/shell/src/vite/generate.ts
@@ -18,7 +18,13 @@ function indentedLiteral(value: unknown, indentation: number): string {
 }
 
 function isShellAnchor(parent: RouteParentId): boolean {
-  return ['root', 'workspaceLayout', 'projectLayout', 'workspaceSettings'].includes(parent);
+  return [
+    'root',
+    'workspaceLayout',
+    'projectLayout',
+    'workspaceSettings',
+    'projectSettings',
+  ].includes(parent);
 }
 
 function orderedLayouts(layouts: readonly ComposedLayout[]): ComposedLayout[] {
@@ -129,12 +135,19 @@ export function generateAppModule({
   const projectChildren = [
     routeNames(routes, 'projectLayout'),
     ...layoutTreeNames(generatedLayouts, 'projectLayout'),
+    'projectSettings',
   ]
     .filter(Boolean)
     .join(',\n  ');
   const workspaceSettingsChildren = [
     routeNames(routes, 'workspaceSettings'),
     ...layoutTreeNames(generatedLayouts, 'workspaceSettings'),
+  ]
+    .filter(Boolean)
+    .join(',\n  ');
+  const projectSettingsChildren = [
+    routeNames(routes, 'projectSettings'),
+    ...layoutTreeNames(generatedLayouts, 'projectSettings'),
   ]
     .filter(Boolean)
     .join(',\n  ');
@@ -168,6 +181,7 @@ const skeleton = buildAnchorSkeleton({
 
 ${declarations}
 
+const projectSettings = skeleton.projectSettings.addChildren([${projectSettingsChildren}]);
 const projectLayout = skeleton.projectLayout.addChildren([${projectChildren}]);
 const workspaceSettings = skeleton.workspaceSettings.addChildren([${workspaceSettingsChildren}]);
 const workspaceLayout = skeleton.workspaceLayout.addChildren([

--- a/libs/client/shell/test/external/fixture/src/app.fixture.tsx
+++ b/libs/client/shell/test/external/fixture/src/app.fixture.tsx
@@ -85,7 +85,7 @@ test('renders the external route, provider order, navigation, settings, and conf
     [...container.querySelectorAll('[aria-label="Workspace settings"] a')]
       .map((link) => link.textContent?.trim())
       .slice(0, 3),
-  ).toEqual(['Members', 'External', 'Runners']);
+  ).toEqual(['General', 'Members', 'External']);
   expect(container.querySelector('[aria-label="External provider order"]')?.textContent).toBe(
     'outer > inner',
   );

--- a/libs/client/shell/test/typecheck/shipfox-app.gen.ts
+++ b/libs/client/shell/test/typecheck/shipfox-app.gen.ts
@@ -37,7 +37,8 @@ const skeleton = buildAnchorSkeleton({
       "pathSegment": "members",
       "label": "Members",
       "icon": "users",
-      "order": 100
+      "order": 100,
+      "scope": "workspace"
     }
   ],
 });
@@ -60,7 +61,9 @@ const route2 = createRoute({
   ...routeOptions(route2Module.default, "#test/named-route-impl.js", "/w/$workspaceSlug/insights"),
 });
 
-const projectLayout = skeleton.projectLayout.addChildren([route0]);
+const projectSettings = skeleton.projectSettings.addChildren([]);
+const projectLayout = skeleton.projectLayout.addChildren([route0,
+  projectSettings]);
 const workspaceSettings = skeleton.workspaceSettings.addChildren([route1]);
 const workspaceLayout = skeleton.workspaceLayout.addChildren([
   route2,

--- a/libs/client/ui/src/index.ts
+++ b/libs/client/ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './display-name-field-error.js';
 export * from './load-error-copy.js';
 export * from './query-load-error.js';
 export * from './single-flight.js';
+export * from './slug-field.js';

--- a/libs/client/ui/src/slug-field.test.tsx
+++ b/libs/client/ui/src/slug-field.test.tsx
@@ -84,7 +84,7 @@ describe('SlugField', () => {
       'old slug becomes available for someone else to take',
     );
     expect(screen.getByRole('dialog')).toHaveTextContent(
-      'slug has been written down by hand needs updating',
+      'Workflows that reference this project slug may stop working.',
     );
   });
 

--- a/libs/client/ui/src/slug-field.test.tsx
+++ b/libs/client/ui/src/slug-field.test.tsx
@@ -1,0 +1,108 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {SlugChangeWarning, SlugField} from './slug-field.js';
+
+describe('SlugField', () => {
+  test('does not check an untouched or invalid value', async () => {
+    const checkAvailability = vi.fn().mockResolvedValue(true);
+
+    render(
+      <SlugField
+        id="slug"
+        label="Slug"
+        value="derived-value"
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        checkEnabled={false}
+        isValid={() => true}
+        checkAvailability={checkAvailability}
+      />,
+    );
+
+    expect(screen.getByLabelText('Slug')).toHaveValue('derived-value');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(checkAvailability).not.toHaveBeenCalled();
+    expect(screen.queryByText('Slug is available.')).not.toBeInTheDocument();
+  });
+
+  test('shows checking before the availability result and renders a conflict', async () => {
+    let resolveAvailability!: (available: boolean) => void;
+    const checkAvailability = vi.fn(
+      () => new Promise<boolean>((resolve) => (resolveAvailability = resolve)),
+    );
+
+    render(
+      <SlugField
+        id="slug"
+        label="Slug"
+        value="taken-value"
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        debounceMs={5}
+        isValid={() => true}
+        checkAvailability={checkAvailability}
+      />,
+    );
+
+    await waitFor(() => expect(checkAvailability).toHaveBeenCalledWith('taken-value'));
+    expect(screen.getByText('Checking availability…')).toBeInTheDocument();
+    expect(screen.queryByText('Slug is available.')).not.toBeInTheDocument();
+
+    resolveAvailability(false);
+
+    expect(await screen.findByText('This slug is already taken.')).toBeInTheDocument();
+  });
+
+  test('warns about all consequences of changing a slug', () => {
+    render(
+      <SlugChangeWarning open onOpenChange={vi.fn()} entityLabel="project" onConfirm={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('old URL stop working');
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'old slug becomes available for someone else to take',
+    );
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'slug has been written down by hand needs updating',
+    );
+  });
+
+  test('does not check the current entity slug', async () => {
+    const checkAvailability = vi.fn().mockResolvedValue(true);
+
+    render(
+      <SlugField
+        id="slug"
+        label="Slug"
+        value="current-value"
+        currentSlug="current-value"
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        isValid={() => true}
+        checkAvailability={checkAvailability}
+      />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(checkAvailability).not.toHaveBeenCalled();
+    expect(screen.queryByText('Slug is available.')).not.toBeInTheDocument();
+  });
+
+  test('passes input changes through to the form field', () => {
+    const onChange = vi.fn();
+    render(
+      <SlugField
+        id="slug"
+        label="Slug"
+        value="current-value"
+        onChange={onChange}
+        onBlur={vi.fn()}
+        checkEnabled={false}
+        isValid={() => true}
+        checkAvailability={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Slug'), {target: {value: 'next-value'}});
+    expect(onChange).toHaveBeenCalledWith('next-value');
+  });
+});

--- a/libs/client/ui/src/slug-field.test.tsx
+++ b/libs/client/ui/src/slug-field.test.tsx
@@ -24,6 +24,26 @@ describe('SlugField', () => {
     expect(screen.queryByText('Slug is available.')).not.toBeInTheDocument();
   });
 
+  test('does not check an invalid value when checking is enabled', async () => {
+    const checkAvailability = vi.fn().mockResolvedValue(true);
+
+    render(
+      <SlugField
+        id="slug"
+        label="Slug"
+        value="invalid value"
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        isValid={() => false}
+        checkAvailability={checkAvailability}
+      />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(checkAvailability).not.toHaveBeenCalled();
+    expect(screen.queryByText('Checking availability…')).not.toBeInTheDocument();
+  });
+
   test('shows checking before the availability result and renders a conflict', async () => {
     let resolveAvailability!: (available: boolean) => void;
     const checkAvailability = vi.fn(
@@ -49,7 +69,9 @@ describe('SlugField', () => {
 
     resolveAvailability(false);
 
-    expect(await screen.findByText('This slug is already taken.')).toBeInTheDocument();
+    const conflict = await screen.findByText('This slug is already taken.');
+    expect(conflict).toBeInTheDocument();
+    expect(conflict).toHaveAttribute('aria-live', 'polite');
   });
 
   test('warns about all consequences of changing a slug', () => {

--- a/libs/client/ui/src/slug-field.tsx
+++ b/libs/client/ui/src/slug-field.tsx
@@ -1,0 +1,170 @@
+import {Button} from '@shipfox/react-ui/button';
+import {FormField, FormFieldInput} from '@shipfox/react-ui/form-field';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@shipfox/react-ui/modal';
+import {Text} from '@shipfox/react-ui/typography';
+import {type ReactNode, useEffect, useRef, useState} from 'react';
+
+export type SlugAvailabilityStatus = 'unchecked' | 'checking' | 'available' | 'taken';
+
+export interface SlugFieldProps {
+  id: string;
+  label: string;
+  name?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onBlur: () => void;
+  error?: string | undefined;
+  description?: ReactNode;
+  placeholder?: string;
+  className?: string;
+  currentSlug?: string | undefined;
+  checkEnabled?: boolean;
+  debounceMs?: number;
+  isValid: (value: string) => boolean;
+  checkAvailability: (value: string) => Promise<boolean> | boolean;
+}
+
+export function SlugField({
+  id,
+  label,
+  name,
+  value,
+  onChange,
+  onBlur,
+  error,
+  description,
+  placeholder,
+  className,
+  currentSlug,
+  checkEnabled = true,
+  debounceMs = 300,
+  isValid,
+  checkAvailability,
+}: SlugFieldProps) {
+  const [availability, setAvailability] = useState<{
+    value: string;
+    status: SlugAvailabilityStatus;
+  }>({value, status: 'unchecked'});
+  const requestId = useRef(0);
+
+  useEffect(() => {
+    const currentRequestId = ++requestId.current;
+    if (currentSlug !== undefined && value === currentSlug) {
+      setAvailability({value, status: 'unchecked'});
+      return;
+    }
+    if (!checkEnabled || !isValid(value)) {
+      setAvailability({value, status: 'unchecked'});
+      return;
+    }
+
+    setAvailability({value, status: 'checking'});
+    let disposed = false;
+    const timer = window.setTimeout(() => {
+      Promise.resolve(checkAvailability(value)).then(
+        (available) => {
+          if (disposed || requestId.current !== currentRequestId) return;
+          setAvailability({value, status: available ? 'available' : 'taken'});
+        },
+        () => {
+          if (disposed || requestId.current !== currentRequestId) return;
+          setAvailability({value, status: 'unchecked'});
+        },
+      );
+    }, debounceMs);
+
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+    };
+  }, [checkAvailability, checkEnabled, currentSlug, debounceMs, isValid, value]);
+
+  const liveError =
+    error ??
+    (availability.value === value && availability.status === 'taken'
+      ? 'This slug is already taken.'
+      : undefined);
+  const liveStatus =
+    availability.value !== value
+      ? undefined
+      : availability.status === 'checking'
+        ? 'Checking availability…'
+        : availability.status === 'available'
+          ? 'Slug is available.'
+          : undefined;
+
+  return (
+    <FormField
+      label={label}
+      id={id}
+      error={liveError}
+      description={
+        description || liveStatus ? (
+          <span aria-live="polite">
+            {description}
+            {description && liveStatus ? ' ' : null}
+            {liveStatus}
+          </span>
+        ) : undefined
+      }
+    >
+      <FormFieldInput
+        autoComplete="off"
+        className={className}
+        name={name}
+        placeholder={placeholder}
+        type="text"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
+      />
+    </FormField>
+  );
+}
+
+export function SlugChangeWarning({
+  open,
+  onOpenChange,
+  entityLabel,
+  isLoading = false,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entityLabel: string;
+  isLoading?: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>Change {entityLabel} slug?</ModalTitle>
+        </ModalHeader>
+        <ModalBody className="gap-16">
+          <Text size="sm">Changing the slug changes the URL for this {entityLabel}.</Text>
+          <ul className="list-disc pl-20 text-sm text-foreground-neutral-base">
+            <li>Links and bookmarks pointing at the old URL stop working.</li>
+            <li>The old slug becomes available for someone else to take.</li>
+            <li>Any place the slug has been written down by hand needs updating.</li>
+          </ul>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} isLoading={isLoading}>
+            Change slug
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/libs/client/ui/src/slug-field.tsx
+++ b/libs/client/ui/src/slug-field.tsx
@@ -155,7 +155,7 @@ export function SlugChangeWarning({
           <ul className="list-disc pl-20 text-sm text-foreground-neutral-base">
             <li>Links and bookmarks pointing at the old URL stop working.</li>
             <li>The old slug becomes available for someone else to take.</li>
-            <li>Any place the slug has been written down by hand needs updating.</li>
+            <li>Workflows that reference this {entityLabel} slug may stop working.</li>
           </ul>
         </ModalBody>
         <ModalFooter>

--- a/libs/client/ui/src/slug-field.tsx
+++ b/libs/client/ui/src/slug-field.tsx
@@ -68,16 +68,18 @@ export function SlugField({
     setAvailability({value, status: 'checking'});
     let disposed = false;
     const timer = window.setTimeout(() => {
-      Promise.resolve(checkAvailability(value)).then(
-        (available) => {
-          if (disposed || requestId.current !== currentRequestId) return;
-          setAvailability({value, status: available ? 'available' : 'taken'});
-        },
-        () => {
-          if (disposed || requestId.current !== currentRequestId) return;
-          setAvailability({value, status: 'unchecked'});
-        },
-      );
+      Promise.resolve()
+        .then(() => checkAvailability(value))
+        .then(
+          (available) => {
+            if (disposed || requestId.current !== currentRequestId) return;
+            setAvailability({value, status: available ? 'available' : 'taken'});
+          },
+          () => {
+            if (disposed || requestId.current !== currentRequestId) return;
+            setAvailability({value, status: 'unchecked'});
+          },
+        );
     }, debounceMs);
 
     return () => {

--- a/libs/client/workspace-settings/src/components/general/form-errors.ts
+++ b/libs/client/workspace-settings/src/components/general/form-errors.ts
@@ -1,0 +1,17 @@
+import {ApiError} from '@shipfox/client-api';
+
+export type WorkspaceGeneralField = 'name' | 'slug';
+
+export type WorkspaceGeneralFormError =
+  | {kind: 'field'; field: WorkspaceGeneralField; message: string}
+  | {kind: 'form'; message: string};
+
+export function workspaceGeneralErrorToFormError(error: unknown): WorkspaceGeneralFormError {
+  if (error instanceof ApiError && error.code === 'slug-conflict') {
+    return {kind: 'field', field: 'slug', message: 'That workspace slug is already taken.'};
+  }
+  return {
+    kind: 'form',
+    message: error instanceof Error ? error.message : 'Could not update workspace settings.',
+  };
+}

--- a/libs/client/workspace-settings/src/components/workspace-settings-shell.tsx
+++ b/libs/client/workspace-settings/src/components/workspace-settings-shell.tsx
@@ -1,12 +1,14 @@
-import {useActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {useMaybeActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {FullPageLoader} from '@shipfox/react-ui/loader';
 import type {ReactNode} from 'react';
 
 interface WorkspaceSettingsShellProps {
-  children: (workspace: ReturnType<typeof useActiveWorkspace>) => ReactNode;
+  children: (workspace: NonNullable<ReturnType<typeof useMaybeActiveWorkspace>>) => ReactNode;
 }
 
 export function WorkspaceSettingsShell({children}: WorkspaceSettingsShellProps) {
-  const workspace = useActiveWorkspace();
+  const workspace = useMaybeActiveWorkspace();
+  if (!workspace) return <FullPageLoader />;
 
   return children(workspace);
 }

--- a/libs/client/workspace-settings/src/feature.ts
+++ b/libs/client/workspace-settings/src/feature.ts
@@ -16,6 +16,13 @@ export const workspaceSettingsNavigation = [
 
 export const workspaceSettingsSections = [
   {
+    id: 'settings.general',
+    pathSegment: 'general',
+    label: 'General',
+    icon: 'settings3Line',
+    order: 50,
+  },
+  {
     id: 'settings.members',
     pathSegment: 'members',
     label: 'Members',
@@ -36,6 +43,11 @@ export const workspaceSettingsFeature = defineClientFeature({
       path: '/w/$workspaceSlug/settings/members',
       parent: 'workspaceSettings',
       impl: '@shipfox/client-workspace-settings/routes/members',
+    },
+    {
+      path: '/w/$workspaceSlug/settings/general',
+      parent: 'workspaceSettings',
+      impl: '@shipfox/client-workspace-settings/routes/general',
     },
   ],
   navigation: workspaceSettingsNavigation,

--- a/libs/client/workspace-settings/src/pages/general-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/general-settings-page.test.tsx
@@ -1,0 +1,88 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {fireEvent, screen, waitFor} from '@testing-library/react';
+import {jsonResponse, renderWorkspaceSettingsPage} from '#test/pages.js';
+import {GeneralSettingsPage} from './general-settings-page.js';
+
+describe('GeneralSettingsPage', () => {
+  test('saves a name change without opening the slug warning', async () => {
+    let patchBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === 'PATCH') {
+        patchBody = await request.clone().json();
+        return jsonResponse(workspaceDto({name: 'Acme Labs'}));
+      }
+      return jsonResponse({available: true});
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderWorkspaceSettingsPage('/w/acme/settings/general', <GeneralSettingsPage />);
+    fireEvent.change(await screen.findByLabelText('Workspace name'), {
+      target: {value: 'Acme Labs'},
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    await waitFor(() => expect(patchBody).toEqual({name: 'Acme Labs'}));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('requires confirmation before saving a slug change', async () => {
+    let patchBody: unknown;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/slug-availability')) {
+        return jsonResponse({available: true});
+      }
+      if (request.method === 'PATCH') {
+        patchBody = await request.clone().json();
+        return jsonResponse(workspaceDto({slug: 'acme-labs'}));
+      }
+      return jsonResponse({});
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderWorkspaceSettingsPage('/w/acme/settings/general', <GeneralSettingsPage />);
+    fireEvent.change(await screen.findByLabelText('Workspace slug'), {
+      target: {value: 'acme-labs'},
+    });
+    await waitFor(() =>
+      expect(
+        fetchImpl.mock.calls.some(([input]) =>
+          (input as Request).url.includes('/workspaces/slug-availability'),
+        ),
+      ).toBe(true),
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('old URL stop working');
+    expect(
+      fetchImpl.mock.calls.some(([input]) =>
+        (input as Request).url.includes('/workspaces/slug-availability'),
+      ),
+    ).toBe(true);
+    expect(patchBody).toBeUndefined();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Change slug'}));
+    await waitFor(() => expect(patchBody).toEqual({slug: 'acme-labs'}));
+    expect(
+      consoleError.mock.calls.some((args) =>
+        args.some((argument) => String(argument).includes('useActiveWorkspace called outside')),
+      ),
+    ).toBe(false);
+    consoleError.mockRestore();
+  });
+});
+
+function workspaceDto({name = 'Acme', slug = 'acme'}: {name?: string; slug?: string} = {}) {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    name,
+    slug,
+    status: 'active',
+    settings: {},
+    created_at: '2026-04-27T00:00:00.000Z',
+    updated_at: '2026-04-27T00:00:00.000Z',
+  };
+}

--- a/libs/client/workspace-settings/src/pages/general-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/general-settings-page.test.tsx
@@ -29,49 +29,52 @@ describe('GeneralSettingsPage', () => {
   test('requires confirmation before saving a slug change', async () => {
     let patchBody: unknown;
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      const request = input as Request;
-      if (request.url.includes('/slug-availability')) {
-        return jsonResponse({available: true});
-      }
-      if (request.method === 'PATCH') {
-        patchBody = await request.clone().json();
-        return jsonResponse(workspaceDto({slug: 'acme-labs'}));
-      }
-      return jsonResponse({});
-    });
-    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    try {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const request = input as Request;
+        if (request.url.includes('/slug-availability')) {
+          return jsonResponse({available: true});
+        }
+        if (request.method === 'PATCH') {
+          patchBody = await request.clone().json();
+          return jsonResponse(workspaceDto({slug: 'acme-labs'}));
+        }
+        return jsonResponse({});
+      });
+      configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-    renderWorkspaceSettingsPage('/w/acme/settings/general', <GeneralSettingsPage />);
-    fireEvent.change(await screen.findByLabelText('Workspace slug'), {
-      target: {value: 'acme-labs'},
-    });
-    await waitFor(() =>
+      renderWorkspaceSettingsPage('/w/acme/settings/general', <GeneralSettingsPage />);
+      fireEvent.change(await screen.findByLabelText('Workspace slug'), {
+        target: {value: 'acme-labs'},
+      });
+      await waitFor(() =>
+        expect(
+          fetchImpl.mock.calls.some(([input]) =>
+            (input as Request).url.includes('/workspaces/slug-availability'),
+          ),
+        ).toBe(true),
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(dialog).toHaveTextContent('old URL stop working');
       expect(
         fetchImpl.mock.calls.some(([input]) =>
           (input as Request).url.includes('/workspaces/slug-availability'),
         ),
-      ).toBe(true),
-    );
-    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+      ).toBe(true);
+      expect(patchBody).toBeUndefined();
 
-    const dialog = await screen.findByRole('dialog');
-    expect(dialog).toHaveTextContent('old URL stop working');
-    expect(
-      fetchImpl.mock.calls.some(([input]) =>
-        (input as Request).url.includes('/workspaces/slug-availability'),
-      ),
-    ).toBe(true);
-    expect(patchBody).toBeUndefined();
-
-    fireEvent.click(screen.getByRole('button', {name: 'Change slug'}));
-    await waitFor(() => expect(patchBody).toEqual({slug: 'acme-labs'}));
-    expect(
-      consoleError.mock.calls.some((args) =>
-        args.some((argument) => String(argument).includes('useActiveWorkspace called outside')),
-      ),
-    ).toBe(false);
-    consoleError.mockRestore();
+      fireEvent.click(screen.getByRole('button', {name: 'Change slug'}));
+      await waitFor(() => expect(patchBody).toEqual({slug: 'acme-labs'}));
+      expect(
+        consoleError.mock.calls.some((args) =>
+          args.some((argument) => String(argument).includes('useActiveWorkspace called outside')),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });
 

--- a/libs/client/workspace-settings/src/pages/general-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/general-settings-page.tsx
@@ -1,0 +1,198 @@
+import {createWorkspaceBodySchema} from '@shipfox/api-workspaces-dto';
+import {
+  checkWorkspaceSlugAvailability,
+  type useActiveWorkspace,
+  useUpdateWorkspaceMutation,
+} from '@shipfox/client-auth';
+import {displayNameFieldError, SlugChangeWarning, SlugField} from '@shipfox/client-ui';
+import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
+import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
+import {toast} from '@shipfox/react-ui/toast';
+import {Header, Text} from '@shipfox/react-ui/typography';
+import {useForm} from '@tanstack/react-form';
+import {useNavigate} from '@tanstack/react-router';
+import {useState} from 'react';
+import {workspaceGeneralErrorToFormError} from '#components/general/form-errors.js';
+import {WorkspaceSettingsShell} from '#components/workspace-settings-shell.js';
+
+interface WorkspaceGeneralValues {
+  name: string;
+  slug: string;
+}
+
+function isSlugValid(value: string): boolean {
+  return createWorkspaceBodySchema.shape.slug.safeParse(value).success;
+}
+
+export function GeneralSettingsPage() {
+  return (
+    <WorkspaceSettingsShell>
+      {(workspace) => (
+        <WorkspaceGeneralForm
+          key={`${workspace.id}:${workspace.name}:${workspace.slug}`}
+          workspace={workspace}
+        />
+      )}
+    </WorkspaceSettingsShell>
+  );
+}
+
+function WorkspaceGeneralForm({workspace}: {workspace: ReturnType<typeof useActiveWorkspace>}) {
+  const updateWorkspace = useUpdateWorkspaceMutation();
+  const navigate = useNavigate();
+  const [warningOpen, setWarningOpen] = useState(false);
+  const [pendingValues, setPendingValues] = useState<WorkspaceGeneralValues>();
+  const [formError, setFormError] = useState<string>();
+
+  const form = useForm({
+    defaultValues: {name: workspace.name, slug: workspace.slug},
+    onSubmit: async ({value}) => {
+      if (value.slug !== workspace.slug) {
+        setPendingValues(value);
+        setWarningOpen(true);
+        return;
+      }
+      await save(value);
+    },
+  });
+
+  async function save(values: WorkspaceGeneralValues) {
+    setFormError(undefined);
+    const nameChanged = values.name !== workspace.name;
+    const slugChanged = values.slug !== workspace.slug;
+    if (!nameChanged && !slugChanged) return;
+    const command = {
+      workspaceId: workspace.id,
+      ...(nameChanged ? {name: values.name} : {}),
+      ...(slugChanged ? {slug: values.slug} : {}),
+    };
+
+    try {
+      const updated = await updateWorkspace.mutateAsync(command);
+      setPendingValues(undefined);
+      setWarningOpen(false);
+      toast.success('Workspace settings saved.');
+      await navigate({
+        to: '/w/$workspaceSlug/settings/general',
+        params: {workspaceSlug: updated.slug},
+      });
+    } catch (error) {
+      setPendingValues(undefined);
+      setWarningOpen(false);
+      const mapped = workspaceGeneralErrorToFormError(error);
+      if (mapped.kind === 'field') {
+        form.setFieldMeta(mapped.field, (previous) => ({
+          ...previous,
+          errorMap: {...previous.errorMap, onServer: mapped.message},
+        }));
+      } else {
+        setFormError(mapped.message);
+      }
+    }
+  }
+
+  return (
+    <>
+      <div className="flex min-w-0 flex-col gap-24">
+        <header className="flex flex-col gap-6">
+          <Header variant="h1">General</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Update the workspace name and the slug used in its URLs.
+          </Text>
+        </header>
+
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
+
+        <form
+          className="flex max-w-[560px] flex-col gap-16"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="name"
+            validators={{
+              onBlur: ({value}) =>
+                displayNameFieldError(
+                  value,
+                  'Workspace name',
+                  createWorkspaceBodySchema.shape.name,
+                ),
+              onSubmit: ({value}) =>
+                displayNameFieldError(
+                  value,
+                  'Workspace name',
+                  createWorkspaceBodySchema.shape.name,
+                ),
+            }}
+          >
+            {(field) => (
+              <FormField
+                label="Workspace name"
+                id="workspace-settings-name"
+                error={fieldError(field)}
+              >
+                <FormFieldInput
+                  name="name"
+                  type="text"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                  onBlur={field.handleBlur}
+                />
+              </FormField>
+            )}
+          </form.Field>
+
+          <form.Field
+            name="slug"
+            validators={{
+              onBlur: createWorkspaceBodySchema.shape.slug,
+              onSubmit: createWorkspaceBodySchema.shape.slug,
+            }}
+          >
+            {(field) => (
+              <SlugField
+                id="workspace-settings-slug"
+                label="Workspace slug"
+                name="slug"
+                value={field.state.value}
+                onChange={(value) => field.handleChange(value)}
+                onBlur={field.handleBlur}
+                error={fieldError(field)}
+                description={<span className="break-all font-code">/w/{field.state.value}</span>}
+                placeholder="acme"
+                className="font-code"
+                currentSlug={workspace.slug}
+                checkEnabled
+                isValid={isSlugValid}
+                checkAvailability={checkWorkspaceSlugAvailability}
+              />
+            )}
+          </form.Field>
+
+          <Button type="submit" isLoading={updateWorkspace.isPending} className="self-start">
+            Save changes
+          </Button>
+        </form>
+      </div>
+
+      <SlugChangeWarning
+        open={warningOpen}
+        onOpenChange={setWarningOpen}
+        entityLabel="workspace"
+        isLoading={updateWorkspace.isPending}
+        onConfirm={() => {
+          if (pendingValues) void save(pendingValues);
+        }}
+      />
+    </>
+  );
+}

--- a/libs/client/workspace-settings/src/routes/general.tsx
+++ b/libs/client/workspace-settings/src/routes/general.tsx
@@ -1,0 +1,4 @@
+import {defineRoute} from '@shipfox/client-shell/runtime';
+import {GeneralSettingsPage} from '#pages/general-settings-page.js';
+
+export default defineRoute({component: GeneralSettingsPage});

--- a/libs/client/workspace-settings/test/pages.tsx
+++ b/libs/client/workspace-settings/test/pages.tsx
@@ -57,6 +57,11 @@ function createTestRouter(path: string, element: ReactElement) {
     path: '/w/$workspaceSlug/settings/integrations',
     component: () => element,
   });
+  const generalRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug/settings/general',
+    component: () => element,
+  });
 
   return createRouter({
     history: createMemoryHistory({initialEntries: [path]}),
@@ -65,6 +70,7 @@ function createTestRouter(path: string, element: ReactElement) {
       provisionersRoute,
       modelProvidersRoute,
       integrationsRoute,
+      generalRoute,
     ]),
   });
 }

--- a/libs/shared/react/ui/src/components/form-field/form-field.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.tsx
@@ -72,7 +72,7 @@ export function FormField({label, id, error, description, className, children}: 
         <Label htmlFor={fieldId}>{label}</Label>
         {children}
         {error ? (
-          <Text as="p" size="xs" className="text-tag-error-text" id={errorId}>
+          <Text as="p" size="xs" className="text-tag-error-text" id={errorId} aria-live="polite">
             {error}
           </Text>
         ) : description ? (

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -201,7 +201,9 @@ const coordinatorPattern = /\bcoordinator\s*:\s*['"]([^'"]+)['"]/u;
 const routeImplementationPattern = /\bimpl\s*:\s*['"](@shipfox\/client-[^/'"]+)\/routes\//gu;
 const routePathPattern = /\bpath\s*:\s*['"]([^'"]+)['"]/gu;
 const navigationTargetPattern = /\bto\s*:\s*['"]([^'"]+)['"]/gu;
-const settingsPathPattern = /\bpathSegment\s*:\s*['"]([^'"]+)['"]/gu;
+const settingsSectionPattern = /\{[^{}]*\bpathSegment\s*:\s*['"][^'"]+['"][^{}]*\}/gu;
+const settingsPathSegmentPattern = /\bpathSegment\s*:\s*['"]([^'"]+)['"]/u;
+const settingsScopePattern = /\bscope\s*:\s*['"](workspace|project)['"]/u;
 const registryDefinitionPattern = /\b(?:navigation|settingsSections)\s*(?::|=)\s*\[/u;
 const trailingSlashPattern = /\/+$/u;
 const generatedFilePattern = /\.gen\.(?:ts|tsx)$/;
@@ -270,6 +272,24 @@ function capturedMatches(source: string, pattern: RegExp): string[] {
   );
 }
 
+function capturedSettingsSections(
+  source: string,
+): Array<{segment: string; scope: 'workspace' | 'project'}> {
+  return [
+    ...source.matchAll(new RegExp(settingsSectionPattern.source, settingsSectionPattern.flags)),
+  ].flatMap((match) => {
+    const section = match[0];
+    const segment = section.match(settingsPathSegmentPattern)?.[1];
+    if (!segment) return [];
+    return [
+      {
+        segment,
+        scope: section.match(settingsScopePattern)?.[1] === 'project' ? 'project' : 'workspace',
+      },
+    ];
+  });
+}
+
 function normalizeManifestPath(value: string): string {
   return value === '/' ? value : value.replace(trailingSlashPattern, '') || '/';
 }
@@ -293,12 +313,13 @@ function featureContributionOccurrences(file: string, source: string): number {
   for (const target of capturedMatches(source, navigationTargetPattern)) {
     if (!routes.has(normalizeManifestPath(target)) && !hasExplicitCoordinator) occurrences += 1;
   }
-  for (const segment of capturedMatches(source, settingsPathPattern)) {
+  for (const {segment, scope} of capturedSettingsSections(source)) {
     const workspaceTarget = normalizeManifestPath(`/w/$workspaceSlug/settings/${segment}`);
     const projectTarget = normalizeManifestPath(
       `/w/$workspaceSlug/p/$projectSlug/settings/${segment}`,
     );
-    if (!routes.has(workspaceTarget) && !routes.has(projectTarget) && !hasExplicitCoordinator) {
+    const target = scope === 'project' ? projectTarget : workspaceTarget;
+    if (!routes.has(target) && !hasExplicitCoordinator) {
       occurrences += 1;
     }
   }

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -294,8 +294,13 @@ function featureContributionOccurrences(file: string, source: string): number {
     if (!routes.has(normalizeManifestPath(target)) && !hasExplicitCoordinator) occurrences += 1;
   }
   for (const segment of capturedMatches(source, settingsPathPattern)) {
-    const target = normalizeManifestPath(`/w/$workspaceSlug/settings/${segment}`);
-    if (!routes.has(target) && !hasExplicitCoordinator) occurrences += 1;
+    const workspaceTarget = normalizeManifestPath(`/w/$workspaceSlug/settings/${segment}`);
+    const projectTarget = normalizeManifestPath(
+      `/w/$workspaceSlug/p/$projectSlug/settings/${segment}`,
+    );
+    if (!routes.has(workspaceTarget) && !routes.has(projectTarget) && !hasExplicitCoordinator) {
+      occurrences += 1;
+    }
   }
 
   return occurrences;

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -100,6 +100,26 @@ export const projectsFeature = defineClientFeature({
     assert.deepEqual(violations, []);
   });
 
+  test('requires a settings contribution to have a route in the same scope', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/feature.ts',
+      `import {defineClientFeature} from '@shipfox/client-shell';
+export const projectsFeature = defineClientFeature({
+  id: 'shipfox.projects',
+  routes: [{path: '/w/$workspaceSlug/p/$projectSlug/settings/general', parent: 'projectSettings'}],
+  settingsSections: [{pathSegment: 'general', scope: 'workspace'}],
+});`,
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/feature.ts',
+        occurrences: 1,
+        rule: 'non-owning-feature-contribution',
+      },
+    ]);
+  });
+
   test('requires navigation registries to be defined in a feature manifest', () => {
     const violations = auditClientSource(
       'libs/client/projects/src/navigation.ts',

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -86,6 +86,20 @@ export const projectsFeature = defineClientFeature({
     assert.deepEqual(violations, []);
   });
 
+  test('allows project-scoped settings contributions owned by a project route', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/feature.ts',
+      `import {defineClientFeature} from '@shipfox/client-shell';
+export const projectsFeature = defineClientFeature({
+  id: 'shipfox.projects',
+  routes: [{path: '/w/$workspaceSlug/p/$projectSlug/settings/general', parent: 'projectSettings'}],
+  settingsSections: [{pathSegment: 'general', scope: 'project'}],
+});`,
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
   test('requires navigation registries to be defined in a feature manifest', () => {
     const violations = auditClientSource(
       'libs/client/projects/src/navigation.ts',


### PR DESCRIPTION
## Summary

Add project settings and General settings flows for workspaces and projects, with shared slug rename confirmation and availability feedback.

The change establishes the project-settings shell anchor and scope-aware settings registry, uses the workspace availability endpoint and cache-only project checks, and preserves authoritative server conflict handling.

Closes ENG-1450

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project and workspace settings with live slug checks and a shared rename confirmation. Clarifies the slug change warning to note that workflows referencing the old slug may stop working. Implements ENG-1450 with a project-scoped settings anchor, scoped settings nav, and a reusable `SlugField` with instant, authoritative availability feedback.

- **New Features**
  - Project settings: General page to edit name/slug with live availability (cache first, then server) and slug change confirmation. Routes: `/w/$workspaceSlug/p/$projectSlug/settings[/general]`.
  - Workspace settings: General page to edit name/slug with live availability and slug change confirmation at `/w/$workspaceSlug/settings/general`.
  - Shell: new `projectSettings` anchor and scope-aware `SettingsNav`; "General" settings sections registered for workspace and project.
  - Shared UI in `@shipfox/client-ui`: `SlugField` (debounced checks, aria-live) and `SlugChangeWarning` (now also warns that workflows referencing the renamed workspace or project slug may stop working).
  - Storybook: `ProjectSettingsPage` stories for default, long-values, taken-slug, and rename-warning states.

- **Refactors**
  - `@shipfox/client-auth`: added `updateWorkspace`, `checkWorkspaceSlugAvailability`, and `useUpdateWorkspaceMutation`.
  - `@shipfox/client-projects`: added `updateProject`, `useUpdateProjectMutation`, and `useProjectSlugAvailability`.
  - Shell/tooling: settings entries are scope-aware; generator/registries updated; `tools/client-architecture-policy` now enforces a matching scoped route for settings contributions.
  - Create/onboarding forms now use `SlugField` for validation and availability feedback.

<sup>Written for commit b626d0e511300409484eb015d2d9742a98152f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

