### PR TITLE
[@shipfox/react-ui] Add semantic spacing tokens

### DIFF
--- a/.changeset/semantic-spacing-tokens.md
+++ b/.changeset/semantic-spacing-tokens.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds semantic spacing and density tokens to the shared React UI stylesheet.

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -335,6 +335,22 @@
   --alpha-250: var(--color-alpha-black-10);
   --alpha-400: var(--color-alpha-black-24);
 
+  /* Semantic Spacing */
+  --space-tight: 4px;
+  --space-inline: 8px;
+  --space-cluster: 12px;
+  --space-group: 16px;
+  --space-section: 24px;
+  --space-region: 32px;
+
+  --pad-tight: 8px;
+  --pad-row-x: 16px;
+  --pad-row-y: 12px;
+  --pad-panel-compact: 16px;
+  --pad-panel: 24px;
+  --pad-frame-x: 24px;
+  --pad-frame-y: 32px;
+
   /* Shadow */
   --shadow-border-base:
     0 -1px 0 0 var(--color-alpha-white-6), 0 0 0 1px var(--color-alpha-white-6),
@@ -410,6 +426,23 @@
     0 4px 8px 0 var(--color-alpha-black-8);
   --shadow-separator-inset:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.15), inset 0 -1px 0 0 rgba(0, 0, 0, 0.06);
+}
+
+[data-density="compact"] {
+  --space-tight: 2px;
+  --space-inline: 4px;
+  --space-cluster: 8px;
+  --space-group: 12px;
+  --space-section: 16px;
+  --space-region: 24px;
+
+  --pad-tight: 4px;
+  --pad-row-x: 12px;
+  --pad-row-y: 8px;
+  --pad-panel-compact: 12px;
+  --pad-panel: 16px;
+  --pad-frame-x: 16px;
+  --pad-frame-y: 24px;
 }
 
 .dark {
@@ -894,6 +927,17 @@
 
   /* Spacing */
   --spacing: 1px;
+  --spacing-inline: var(--space-inline);
+  --spacing-cluster: var(--space-cluster);
+  --spacing-group: var(--space-group);
+  --spacing-section: var(--space-section);
+  --spacing-region: var(--space-region);
+  --spacing-row-x: var(--pad-row-x);
+  --spacing-row-y: var(--pad-row-y);
+  --spacing-panel-compact: var(--pad-panel-compact);
+  --spacing-panel: var(--pad-panel);
+  --spacing-frame-x: var(--pad-frame-x);
+  --spacing-frame-y: var(--pad-frame-y);
 
   /* Radius */
   --radius-2: 2px;
@@ -967,6 +1011,31 @@
   --shadow-checkbox-indeterminate-focus: var(--checkbox-indeterminate-focus-shadow);
   --shadow-tooltip: var(--shadow-tooltip);
   --shadow-separator-inset: var(--shadow-separator-inset);
+}
+
+/* Tight spacing uses explicit utilities because gap and padding have different values. */
+@utility gap-tight {
+  gap: var(--space-tight);
+}
+
+@utility p-tight {
+  padding: var(--pad-tight);
+}
+
+@utility px-row {
+  padding-inline: var(--pad-row-x);
+}
+
+@utility py-row {
+  padding-block: var(--pad-row-y);
+}
+
+@utility px-frame {
+  padding-inline: var(--pad-frame-x);
+}
+
+@utility py-frame {
+  padding-block: var(--pad-frame-y);
 }
 
 @layer base {

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -927,17 +927,6 @@
 
   /* Spacing */
   --spacing: 1px;
-  --spacing-inline: var(--space-inline);
-  --spacing-cluster: var(--space-cluster);
-  --spacing-group: var(--space-group);
-  --spacing-section: var(--space-section);
-  --spacing-region: var(--space-region);
-  --spacing-row-x: var(--pad-row-x);
-  --spacing-row-y: var(--pad-row-y);
-  --spacing-panel-compact: var(--pad-panel-compact);
-  --spacing-panel: var(--pad-panel);
-  --spacing-frame-x: var(--pad-frame-x);
-  --spacing-frame-y: var(--pad-frame-y);
 
   /* Radius */
   --radius-2: 2px;
@@ -1013,13 +1002,41 @@
   --shadow-separator-inset: var(--shadow-separator-inset);
 }
 
-/* Tight spacing uses explicit utilities because gap and padding have different values. */
+/* Semantic spacing utilities are explicit to keep gap and padding roles distinct. */
 @utility gap-tight {
   gap: var(--space-tight);
 }
 
+@utility gap-inline {
+  gap: var(--space-inline);
+}
+
+@utility gap-cluster {
+  gap: var(--space-cluster);
+}
+
+@utility gap-group {
+  gap: var(--space-group);
+}
+
+@utility gap-section {
+  gap: var(--space-section);
+}
+
+@utility gap-region {
+  gap: var(--space-region);
+}
+
 @utility p-tight {
   padding: var(--pad-tight);
+}
+
+@utility p-panel-compact {
+  padding: var(--pad-panel-compact);
+}
+
+@utility p-panel {
+  padding: var(--pad-panel);
 }
 
 @utility px-row {

--- a/libs/shared/react/ui/src/spacing/spacing.stories.tsx
+++ b/libs/shared/react/ui/src/spacing/spacing.stories.tsx
@@ -14,7 +14,7 @@ function SpacingPreview() {
   return (
     <div className="min-h-screen bg-background-neutral-background text-foreground-neutral-base">
       <div className="mx-auto flex max-w-[1120px] flex-col gap-region px-frame py-frame">
-        <header className="flex items-center justify-between gap-cluster border-b border-border-neutral-base pb-panel">
+        <header className="flex items-center justify-between gap-cluster border-b border-border-neutral-base p-panel">
           <div className="flex items-center gap-inline">
             <div className="size-24 rounded-full bg-background-contrast-base" />
             <div className="flex flex-col gap-tight">

--- a/libs/shared/react/ui/src/spacing/spacing.stories.tsx
+++ b/libs/shared/react/ui/src/spacing/spacing.stories.tsx
@@ -1,0 +1,142 @@
+import type {Meta, StoryObj} from '@storybook/react';
+
+const meta = {
+  title: 'Foundations/Semantic Spacing',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SpacingPreview() {
+  return (
+    <div className="min-h-screen bg-background-neutral-background text-foreground-neutral-base">
+      <div className="mx-auto flex max-w-[1120px] flex-col gap-region px-frame py-frame">
+        <header className="flex items-center justify-between gap-cluster border-b border-border-neutral-base pb-panel">
+          <div className="flex items-center gap-inline">
+            <div className="size-24 rounded-full bg-background-contrast-base" />
+            <div className="flex flex-col gap-tight">
+              <p className="text-sm font-semibold">Acme Cloud</p>
+              <p className="text-xs text-foreground-neutral-muted">Operations workspace</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-cluster">
+            <span className="rounded-4 bg-background-subtle-base p-tight text-xs text-foreground-neutral-muted">
+              Healthy
+            </span>
+            <button
+              type="button"
+              className="rounded-6 bg-background-button-inverted-default px-row py-row text-xs font-medium text-foreground-contrast-primary"
+            >
+              Open runbook
+            </button>
+          </div>
+        </header>
+
+        <main className="flex flex-col gap-region">
+          <section className="flex flex-col gap-section">
+            <div className="flex flex-col gap-tight">
+              <p className="text-xs font-medium uppercase tracking-wider text-foreground-neutral-muted">
+                Overview
+              </p>
+              <h1 className="text-2xl font-semibold">Production operations</h1>
+            </div>
+
+            <div className="grid grid-cols-3 gap-cluster">
+              {[
+                ['Active workflows', '24', '2 started today'],
+                ['Runner capacity', '82%', 'Across 3 regions'],
+                ['Open incidents', '03', '1 needs attention'],
+              ].map(([label, value, detail]) => (
+                <article
+                  key={label}
+                  className="flex flex-col gap-group rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact"
+                >
+                  <p className="text-xs text-foreground-neutral-muted">{label}</p>
+                  <div className="flex items-end justify-between gap-inline">
+                    <p className="text-xl font-semibold">{value}</p>
+                    <p className="text-xs text-foreground-neutral-muted">{detail}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="grid grid-cols-[minmax(0,2fr)_minmax(280px,1fr)] gap-section">
+            <article className="overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+              <div className="flex items-center justify-between gap-inline border-b border-border-neutral-base p-panel">
+                <div className="flex flex-col gap-tight">
+                  <h2 className="text-sm font-semibold">Recent workflow runs</h2>
+                  <p className="text-xs text-foreground-neutral-muted">Last 24 hours</p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-4 border border-border-neutral-base px-row py-row text-xs font-medium"
+                >
+                  View all
+                </button>
+              </div>
+              <div className="flex flex-col">
+                {[
+                  ['Deploy production', 'Succeeded', '2 min ago'],
+                  ['Nightly verification', 'Running', '18 min ago'],
+                  ['Release candidate', 'Failed', '42 min ago'],
+                ].map(([name, status, time]) => (
+                  <div
+                    key={name}
+                    className="flex items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
+                  >
+                    <div className="flex min-w-0 flex-col gap-tight">
+                      <p className="truncate text-xs font-medium">{name}</p>
+                      <p className="text-xs text-foreground-neutral-muted">{time}</p>
+                    </div>
+                    <span className="shrink-0 rounded-4 bg-background-subtle-base p-tight text-xs text-foreground-neutral-muted">
+                      {status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </article>
+
+            <aside className="flex flex-col gap-group rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel">
+              <div className="flex flex-col gap-tight">
+                <h2 className="text-sm font-semibold">Deployment settings</h2>
+                <p className="text-xs text-foreground-neutral-muted">
+                  Keep production changes safe and observable.
+                </p>
+              </div>
+              <div className="flex flex-col gap-inline">
+                {['Require approval', 'Notify on failure', 'Retain run logs'].map((setting) => (
+                  <label key={setting} className="flex items-center gap-inline text-xs">
+                    <input type="checkbox" defaultChecked />
+                    {setting}
+                  </label>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="rounded-6 bg-background-button-inverted-default px-row py-row text-xs font-medium text-foreground-contrast-primary"
+              >
+                Save settings
+              </button>
+            </aside>
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export const Comfortable: Story = {
+  render: () => <SpacingPreview />,
+};
+
+export const CompactDensity: Story = {
+  render: () => (
+    <div data-density="compact">
+      <SpacingPreview />
+    </div>
+  ),
+};


### PR DESCRIPTION
Adds semantic gap and padding roles to the shared React UI stylesheet, including compact-density overrides and a Storybook preview for both density modes. Explicit tight utilities keep the distinct gap and padding values from colliding with Tailwind's generated spacing utilities.

Closes ENG-1462

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add semantic spacing and padding tokens to `@shipfox/react-ui`, with compact density support and explicit utilities that don’t collide with Tailwind. Closes ENG-1462 by standardizing spacing across components.

- **New Features**
  - Tokens: --space-(tight|inline|cluster|group|section|region) and --pad-(tight|row-x|row-y|panel-compact|panel|frame-x|frame-y), with compact overrides via [data-density="compact"].
  - Utilities (explicit namespace): gap-tight/inline/cluster/group/section/region; p-tight/panel-compact/panel; px-row/py-row; px-frame/py-frame.
  - Storybook: “Foundations/Semantic Spacing” with comfortable and compact demos.

<sup>Written for commit d7fc11d03d692744dd78e02f2041702c789e2db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

