### PR TITLE
[api-workflows] Re-resolve checkout policy on reruns

### DIFF
--- a/.changeset/rerun-checkout-target.md
+++ b/.changeset/rerun-checkout-target.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Re-materialize checkout policy from the workflow model when re-running a job.

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -203,7 +203,7 @@ describe('workflow run queries', () => {
       expect(rerunAttempt?.agentToolMaterialization).toEqual(snapshot);
     });
 
-    test('reruns preserve each source job checkout policy', async () => {
+    test('reruns re-materialize each job checkout policy from the model', async () => {
       const source = await createWorkflowRun({
         workspaceId,
         projectId,
@@ -227,6 +227,12 @@ describe('workflow run queries', () => {
         },
       });
       const sourceJobs = await getJobsByWorkflowRunId(source.id);
+      const sourceJob = sourceJobs[0];
+      if (!sourceJob) throw new Error('Missing source job');
+      await db()
+        .update(jobs)
+        .set({checkoutPersistCredentials: true, checkoutPermissionsContents: 'read'})
+        .where(eq(jobs.id, sourceJob.id));
       await markJob(sourceJobs, 'build', 'failed');
       await updateWorkflowRunStatus({
         workflowRunId: source.id,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -193,6 +193,8 @@ function materializeRerunGraphJobs(params: {
 
   return params.sourceJobs.map((sourceJob) => {
     const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
+    const modelJob = sourceModelJobByKey.get(sourceJob.key);
+    const modelCheckout = modelJob?.checkout;
 
     return {
       job: {
@@ -202,8 +204,10 @@ function materializeRerunGraphJobs(params: {
         status: carriedOver ? ('succeeded' as const) : ('pending' as const),
         statusReason: null,
         carriedOver,
-        checkoutPersistCredentials: sourceJob.checkoutPersistCredentials,
-        checkoutPermissionsContents: sourceJob.checkoutPermissionsContents,
+        checkoutPersistCredentials:
+          modelCheckout?.persistCredentials ?? sourceJob.checkoutPersistCredentials,
+        checkoutPermissionsContents:
+          modelCheckout?.permissions?.contents ?? sourceJob.checkoutPermissionsContents,
         success: sourceJob.success,
         executionTimeoutMs: sourceJob.executionTimeoutMs,
         listeningTimeoutMs: sourceJob.listeningTimeoutMs,
@@ -225,7 +229,6 @@ function materializeRerunGraphJobs(params: {
         if (job.mode === 'listening') return undefined;
 
         const sourceExecution = params.sourceJobExecutionByJobId.get(sourceJob.id);
-        const modelJob = sourceModelJobByKey.get(job.key);
         const nameOverride = sourceExecution?.name ?? null;
         const executionName = nameOverride ?? job.name ?? job.key;
         const runner =


### PR DESCRIPTION
Reruns now re-materialize checkout policy from the persisted workflow model by job key, so stale job projection columns do not override the model. Legacy or mismatched models retain the existing database-row fallback.

The regression test deliberately changes the source job's stored checkout columns before rerunning and verifies that the model policy is restored.

Validation: `mise exec -- pnpm turbo type test --filter=@shipfox/api-workflows` (64 files, 712 tests)

Closes ENG-1438

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reruns now re-materialize each job’s checkout policy from the workflow model by job key, instead of copying values from prior job rows. This fixes stale checkout settings on rerun and aligns behavior with the model. Closes ENG-1438.

- **Bug Fixes**
  - Read `persistCredentials` and `permissions.contents` from the model; fall back to stored job values for legacy/mismatched models.
  - Added a regression test that mutates the source job’s checkout columns and verifies reruns restore the model policy.

<sup>Written for commit 0e4b72f9b364bcc0ff80c2f297f28085c54ece97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

