### PR TITLE
[runner-workspace] Preserve credentials across multiple checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,7 @@ apps/client/src/shipfox-app.gen.ts
 .gstack/
 
 # Impeccable local hook cache
-.impeccable/hook.cache.json
+**/.impeccable/hook.cache.json
 
 # Playwright
 test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ apps/client/src/shipfox-app.gen.ts
 # GStack local agent artifacts
 .gstack/
 
+# Impeccable local hook cache
+.impeccable/hook.cache.json
+
 # Playwright
 test-results/
 playwright-report/

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -178,4 +178,122 @@ describe('writeAmbientGitCredential (real git)', () => {
 
     expect(exact).toBe(`Authorization: Bearer ${token}`);
   });
+
+  it('keeps credentials for multiple repository URLs', async () => {
+    const configPath = join(workdir, 'git-cred.config');
+    const firstRepositoryUrl = 'https://github.com/acme/first.git';
+    const secondRepositoryUrl = 'https://github.com/acme/second.git';
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: firstRepositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: secondRepositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'second-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+
+    await expect(
+      gitOutput(
+        ['config', '--file', configPath, '--get-urlmatch', 'http.extraHeader', firstRepositoryUrl],
+        workdir,
+      ),
+    ).resolves.toBe('Authorization: Bearer first-token');
+    await expect(
+      gitOutput(
+        ['config', '--file', configPath, '--get-urlmatch', 'http.extraHeader', secondRepositoryUrl],
+        workdir,
+      ),
+    ).resolves.toBe('Authorization: Bearer second-token');
+  });
+
+  it('replaces an existing credential when the same repository is checked out again', async () => {
+    const configPath = join(workdir, 'git-cred.config');
+    const repositoryUrl = 'https://github.com/acme/repeated.git';
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'second-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+
+    await expect(
+      gitOutput(
+        ['config', '--file', configPath, '--get-urlmatch', 'http.extraHeader', repositoryUrl],
+        workdir,
+      ),
+    ).resolves.toBe('Authorization: Bearer second-token');
+  });
+
+  it('leaves the existing config in place when Git cannot parse its staged copy', async () => {
+    const configPath = join(workdir, 'git-cred.config');
+    const repositoryUrl = 'https://github.com/acme/repeated.git';
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+    const original = await readFile(configPath, 'utf8');
+    const malformed = `${original}[broken\n`;
+    await writeFile(configPath, malformed);
+
+    await expect(
+      writeAmbientGitCredential({
+        configPath,
+        repositoryUrl,
+        auth: {
+          kind: 'bearer',
+          token: 'second-token',
+          expires_at: '2026-01-01T00:00:00Z',
+          carry: 'header',
+          host: 'github.com',
+          persist: true,
+        },
+      }),
+    ).rejects.toThrow();
+    await expect(readFile(configPath, 'utf8')).resolves.toBe(malformed);
+  });
 });

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -223,6 +223,92 @@ describe('writeAmbientGitCredential (real git)', () => {
     ).resolves.toBe('Authorization: Bearer second-token');
   });
 
+  it('serializes concurrent updates to one config', async () => {
+    const configPath = join(workdir, 'git-cred.config');
+    const initialRepositoryUrl = 'https://github.com/acme/initial.git';
+    const firstConcurrentRepositoryUrl = 'https://github.com/acme/first.git';
+    const secondConcurrentRepositoryUrl = 'https://github.com/acme/second.git';
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: initialRepositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'initial-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+    await Promise.all([
+      writeAmbientGitCredential({
+        configPath,
+        repositoryUrl: firstConcurrentRepositoryUrl,
+        auth: {
+          kind: 'bearer',
+          token: 'first-token',
+          expires_at: '2026-01-01T00:00:00Z',
+          carry: 'header',
+          host: 'github.com',
+          persist: true,
+        },
+      }),
+      writeAmbientGitCredential({
+        configPath,
+        repositoryUrl: secondConcurrentRepositoryUrl,
+        auth: {
+          kind: 'bearer',
+          token: 'second-token',
+          expires_at: '2026-01-01T00:00:00Z',
+          carry: 'header',
+          host: 'github.com',
+          persist: true,
+        },
+      }),
+    ]);
+
+    await expect(
+      gitOutput(
+        [
+          'config',
+          '--file',
+          configPath,
+          '--get-urlmatch',
+          'http.extraHeader',
+          initialRepositoryUrl,
+        ],
+        workdir,
+      ),
+    ).resolves.toBe('Authorization: Bearer initial-token');
+    await expect(
+      gitOutput(
+        [
+          'config',
+          '--file',
+          configPath,
+          '--get-urlmatch',
+          'http.extraHeader',
+          firstConcurrentRepositoryUrl,
+        ],
+        workdir,
+      ),
+    ).resolves.toBe('Authorization: Bearer first-token');
+    await expect(
+      gitOutput(
+        [
+          'config',
+          '--file',
+          configPath,
+          '--get-urlmatch',
+          'http.extraHeader',
+          secondConcurrentRepositoryUrl,
+        ],
+        workdir,
+      ),
+    ).resolves.toBe('Authorization: Bearer second-token');
+  });
+
   it('replaces an existing credential when the same repository is checked out again', async () => {
     const configPath = join(workdir, 'git-cred.config');
     const repositoryUrl = 'https://github.com/acme/repeated.git';
@@ -258,6 +344,46 @@ describe('writeAmbientGitCredential (real git)', () => {
         workdir,
       ),
     ).resolves.toBe('Authorization: Bearer second-token');
+  });
+
+  it('keeps the first author when the user section has a trailing comment', async () => {
+    const configPath = join(workdir, 'git-cred.config');
+    const repositoryUrl = 'https://github.com/acme/commented.git';
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl,
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {name: 'First Author', email: 'first@example.com'},
+    });
+    const initial = await readFile(configPath, 'utf8');
+    await writeFile(configPath, initial.replace('[user]\n', '[user] ; configured by the job\n'));
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/second-commented.git',
+      auth: {
+        kind: 'bearer',
+        token: 'second-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {name: 'Second Author', email: 'second@example.com'},
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    expect(content.match(/^\[user\].*$/gm)).toHaveLength(1);
+    expect(content).toContain('name = "First Author"');
+    expect(content).not.toContain('name = "Second Author"');
   });
 
   it('leaves the existing config in place when Git cannot parse its staged copy', async () => {

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -394,9 +394,17 @@ describe('writeAmbientGitCredential', () => {
     root = await mkdtemp(join(tmpdir(), 'shipfox-ambient-git-'));
     priorGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
     delete process.env.GIT_CONFIG_GLOBAL;
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1) as (
+        error: null,
+        result: {stdout: string; stderr: string},
+      ) => void;
+      callback(null, {stdout: '', stderr: ''});
+    });
   });
 
   afterEach(async () => {
+    execFileMock.mockReset();
     if (priorGitConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
     else process.env.GIT_CONFIG_GLOBAL = priorGitConfigGlobal;
     await rm(root, {recursive: true, force: true});
@@ -424,6 +432,94 @@ describe('writeAmbientGitCredential', () => {
     expect(content).toContain('[http "https://github.com/acme/repo.git"]');
     expect(content).toContain('extraHeader = "Authorization: Bearer tok-123"');
     expect(content).toContain('[http]\n\tfollowRedirects = false');
+  });
+
+  it('accumulates credentials for multiple repositories in one config', async () => {
+    const configPath = join(root, 'creds', 'git-cred.config');
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/first.git',
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/second.git',
+      auth: {
+        kind: 'bearer',
+        token: 'second-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    const mode = (await stat(configPath)).mode & 0o777;
+    expect(mode).toBe(0o600);
+    expect(content.match(/\[http "/g)).toHaveLength(2);
+    expect(content).toContain(
+      '[http "https://github.com/acme/first.git"]\n\textraHeader = "Authorization: Bearer first-token"',
+    );
+    expect(content).toContain(
+      '[http "https://github.com/acme/second.git"]\n\textraHeader = "Authorization: Bearer second-token"',
+    );
+  });
+
+  it('keeps the first supplied Git author while accumulating later repositories', async () => {
+    const configPath = join(root, 'creds', 'git-cred.config');
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/initial.git',
+      auth: {
+        kind: 'bearer',
+        token: 'initial-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+    });
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/first.git',
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {name: 'First Author', email: 'first@example.com'},
+    });
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/second.git',
+      auth: {
+        kind: 'bearer',
+        token: 'second-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {name: 'Second Author', email: 'second@example.com'},
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    expect(content.match(/\[user\]/g)).toHaveLength(1);
+    expect(content).toContain('name = "First Author"');
+    expect(content).not.toContain('name = "Second Author"');
   });
 
   it('includes the prior global config when it exists', async () => {

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -522,6 +522,45 @@ describe('writeAmbientGitCredential', () => {
     expect(content).not.toContain('name = "Second Author"');
   });
 
+  it('recognizes a commented Git author section while accumulating repositories', async () => {
+    const configPath = join(root, 'creds', 'git-cred.config');
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/first.git',
+      auth: {
+        kind: 'bearer',
+        token: 'first-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {name: 'First Author', email: 'first@example.com'},
+    });
+    const initial = await readFile(configPath, 'utf8');
+    await writeFile(configPath, initial.replace('[user]\n', '[user] # configured by the job\n'));
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/second.git',
+      auth: {
+        kind: 'bearer',
+        token: 'second-token',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {name: 'Second Author', email: 'second@example.com'},
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    expect(content.match(/^\[user\].*$/gm)).toHaveLength(1);
+    expect(content).toContain('name = "First Author"');
+    expect(content).not.toContain('name = "Second Author"');
+  });
+
   it('includes the prior global config when it exists', async () => {
     const baseConfig = join(root, 'base.gitconfig');
     const configPath = join(root, 'git-cred.config');

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -2,7 +2,7 @@ import {execFile, spawn} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
 import {access, appendFile, chmod, mkdir, readFile, rename, rm, writeFile} from 'node:fs/promises';
 import {homedir} from 'node:os';
-import {dirname, join} from 'node:path';
+import {dirname, join, resolve} from 'node:path';
 import {promisify} from 'node:util';
 import type {CheckoutTokenAuthDto} from '@shipfox/api-workflows-dto';
 
@@ -14,6 +14,8 @@ const GIT_VERSION_RE = /^git version (\d+)\.(\d+)\.(\d+)/;
 const CONFIG_LINE_BREAK_RE = /[\r\n]/;
 const MIN_GIT_VERSION = {major: 2, minor: 31, patch: 0};
 const GIT_CONFIG_INDEXED_ENV_RE = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/;
+const ambientGitConfigLocks = new Map<string, Promise<void>>();
+const GIT_USER_SECTION_RE = /^\[user\]\s*(?:[;#].*)?$/i;
 
 /** Thrown when `git` is not on the runner host's PATH; surfaced as `git_unavailable`. */
 export class GitUnavailableError extends Error {
@@ -198,61 +200,85 @@ export async function checkoutRepository(params: {
   }
 }
 
-export async function writeAmbientGitCredential(params: {
+export function writeAmbientGitCredential(params: {
   configPath: string;
   repositoryUrl: string;
   auth: CheckoutTokenAuthDto;
   gitAuthor?: {name: string; email: string} | undefined;
 }): Promise<void> {
   const {configPath, repositoryUrl, auth, gitAuthor} = params;
-  const includePath = await ambientIncludePath();
-  const existing = await readAmbientGitConfig(configPath);
-  const userLines = gitAuthor
-    ? [
-        GIT_USER_SECTION_HEADER,
-        `\tname = ${gitConfigQuotedValue(gitAuthor.name)}`,
-        `\temail = ${gitConfigQuotedValue(gitAuthor.email)}`,
-      ]
-    : [];
-  const repositoryLines = [
-    `[http "${gitConfigSubsection(repositoryUrl)}"]`,
-    `\textraHeader = ${gitConfigQuotedValue(`Authorization: ${authorizationValue(auth)}`)}`,
-  ];
 
-  await mkdir(dirname(configPath), {recursive: true});
-  const temporaryConfigPath = `${configPath}.${randomUUID()}.tmp`;
-  try {
-    if (existing === undefined || existing.trim() === '') {
-      const lines = [
-        ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
-        ...userLines,
-        ...repositoryLines,
-        '[http]',
-        '\tfollowRedirects = false',
-        '',
-      ];
-      await writeFile(temporaryConfigPath, lines.join('\n'), {flag: 'wx', mode: 0o600});
-    } else {
-      await writeFile(temporaryConfigPath, existing, {flag: 'wx', mode: 0o600});
-      await unsetAmbientGitCredential(temporaryConfigPath, repositoryUrl);
+  return withAmbientGitConfigLock(configPath, async () => {
+    const includePath = await ambientIncludePath();
+    const existing = await readAmbientGitConfig(configPath);
+    const userLines = gitAuthor
+      ? [
+          GIT_USER_SECTION_HEADER,
+          `\tname = ${gitConfigQuotedValue(gitAuthor.name)}`,
+          `\temail = ${gitConfigQuotedValue(gitAuthor.email)}`,
+        ]
+      : [];
+    const repositoryLines = [
+      `[http "${gitConfigSubsection(repositoryUrl)}"]`,
+      `\textraHeader = ${gitConfigQuotedValue(`Authorization: ${authorizationValue(auth)}`)}`,
+    ];
 
-      const current = await readFile(temporaryConfigPath, 'utf8');
-      // [user] applies to the whole ambient config. Keep the first author for v1; per-repository
-      // identities need includeIf gitdir: and are intentionally deferred.
-      const additions = [
-        ...(gitAuthor && !hasGitAuthorSection(current) ? userLines : []),
-        ...repositoryLines,
-        '',
-      ].join('\n');
-      await appendFile(temporaryConfigPath, `${current.endsWith('\n') ? '' : '\n'}${additions}`);
+    await mkdir(dirname(configPath), {recursive: true});
+    const temporaryConfigPath = `${configPath}.${randomUUID()}.tmp`;
+    try {
+      if (existing === undefined || existing.trim() === '') {
+        const lines = [
+          ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
+          ...userLines,
+          ...repositoryLines,
+          '[http]',
+          '\tfollowRedirects = false',
+          '',
+        ];
+        await writeFile(temporaryConfigPath, lines.join('\n'), {flag: 'wx', mode: 0o600});
+      } else {
+        await writeFile(temporaryConfigPath, existing, {flag: 'wx', mode: 0o600});
+        await unsetAmbientGitCredential(temporaryConfigPath, repositoryUrl);
+
+        const current = await readFile(temporaryConfigPath, 'utf8');
+        // [user] applies to the whole ambient config. Keep the first author for v1; per-repository
+        // identities need includeIf gitdir: and are intentionally deferred.
+        const additions = [
+          ...(gitAuthor && !hasGitAuthorSection(current) ? userLines : []),
+          ...repositoryLines,
+          '',
+        ].join('\n');
+        await appendFile(temporaryConfigPath, `${current.endsWith('\n') ? '' : '\n'}${additions}`);
+      }
+
+      await chmod(temporaryConfigPath, 0o600);
+      await rename(temporaryConfigPath, configPath);
+    } finally {
+      await rm(temporaryConfigPath, {force: true});
     }
+    await chmod(configPath, 0o600);
+  });
+}
 
-    await chmod(temporaryConfigPath, 0o600);
-    await rename(temporaryConfigPath, configPath);
+async function withAmbientGitConfigLock<T>(
+  configPath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lockKey = resolve(configPath);
+  const previous = ambientGitConfigLocks.get(lockKey) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolvePromise) => {
+    release = resolvePromise;
+  });
+  ambientGitConfigLocks.set(lockKey, current);
+
+  await previous;
+  try {
+    return await operation();
   } finally {
-    await rm(temporaryConfigPath, {force: true});
+    release();
+    if (ambientGitConfigLocks.get(lockKey) === current) ambientGitConfigLocks.delete(lockKey);
   }
-  await chmod(configPath, 0o600);
 }
 
 function basicCredential(auth: {username: string; token: string}): string {
@@ -491,7 +517,7 @@ async function readAmbientGitConfig(configPath: string): Promise<string | undefi
 }
 
 function hasGitAuthorSection(config: string): boolean {
-  return config.split('\n').some((line) => line.trim() === GIT_USER_SECTION_HEADER);
+  return config.split('\n').some((line) => GIT_USER_SECTION_RE.test(line.trim()));
 }
 
 function isFileNotFoundError(error: unknown): boolean {

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -1,5 +1,6 @@
 import {execFile, spawn} from 'node:child_process';
-import {access, chmod, mkdir, writeFile} from 'node:fs/promises';
+import {randomUUID} from 'node:crypto';
+import {access, appendFile, chmod, mkdir, readFile, rename, rm, writeFile} from 'node:fs/promises';
 import {homedir} from 'node:os';
 import {dirname, join} from 'node:path';
 import {promisify} from 'node:util';
@@ -8,6 +9,7 @@ import type {CheckoutTokenAuthDto} from '@shipfox/api-workflows-dto';
 const execFileAsync = promisify(execFile);
 const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
 const SHELL_SAFE_ARG_RE = /^[A-Za-z0-9_./:=@+-]+$/;
+const GIT_USER_SECTION_HEADER = '[user]';
 const GIT_VERSION_RE = /^git version (\d+)\.(\d+)\.(\d+)/;
 const CONFIG_LINE_BREAK_RE = /[\r\n]/;
 const MIN_GIT_VERSION = {major: 2, minor: 31, patch: 0};
@@ -204,24 +206,52 @@ export async function writeAmbientGitCredential(params: {
 }): Promise<void> {
   const {configPath, repositoryUrl, auth, gitAuthor} = params;
   const includePath = await ambientIncludePath();
-  const lines = [
-    ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
-    ...(gitAuthor
-      ? [
-          '[user]',
-          `\tname = ${gitConfigQuotedValue(gitAuthor.name)}`,
-          `\temail = ${gitConfigQuotedValue(gitAuthor.email)}`,
-        ]
-      : []),
+  const existing = await readAmbientGitConfig(configPath);
+  const userLines = gitAuthor
+    ? [
+        GIT_USER_SECTION_HEADER,
+        `\tname = ${gitConfigQuotedValue(gitAuthor.name)}`,
+        `\temail = ${gitConfigQuotedValue(gitAuthor.email)}`,
+      ]
+    : [];
+  const repositoryLines = [
     `[http "${gitConfigSubsection(repositoryUrl)}"]`,
     `\textraHeader = ${gitConfigQuotedValue(`Authorization: ${authorizationValue(auth)}`)}`,
-    '[http]',
-    '\tfollowRedirects = false',
-    '',
   ];
 
   await mkdir(dirname(configPath), {recursive: true});
-  await writeFile(configPath, lines.join('\n'), {mode: 0o600});
+  const temporaryConfigPath = `${configPath}.${randomUUID()}.tmp`;
+  try {
+    if (existing === undefined || existing.trim() === '') {
+      const lines = [
+        ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
+        ...userLines,
+        ...repositoryLines,
+        '[http]',
+        '\tfollowRedirects = false',
+        '',
+      ];
+      await writeFile(temporaryConfigPath, lines.join('\n'), {flag: 'wx', mode: 0o600});
+    } else {
+      await writeFile(temporaryConfigPath, existing, {flag: 'wx', mode: 0o600});
+      await unsetAmbientGitCredential(temporaryConfigPath, repositoryUrl);
+
+      const current = await readFile(temporaryConfigPath, 'utf8');
+      // [user] applies to the whole ambient config. Keep the first author for v1; per-repository
+      // identities need includeIf gitdir: and are intentionally deferred.
+      const additions = [
+        ...(gitAuthor && !hasGitAuthorSection(current) ? userLines : []),
+        ...repositoryLines,
+        '',
+      ].join('\n');
+      await appendFile(temporaryConfigPath, `${current.endsWith('\n') ? '' : '\n'}${additions}`);
+    }
+
+    await chmod(temporaryConfigPath, 0o600);
+    await rename(temporaryConfigPath, configPath);
+  } finally {
+    await rm(temporaryConfigPath, {force: true});
+  }
   await chmod(configPath, 0o600);
 }
 
@@ -232,6 +262,25 @@ function basicCredential(auth: {username: string; token: string}): string {
 function authorizationValue(auth: CheckoutTokenAuthDto): string {
   if (auth.kind === 'bearer') return `Bearer ${auth.token}`;
   return `Basic ${basicCredential(auth)}`;
+}
+
+async function unsetAmbientGitCredential(configPath: string, repositoryUrl: string): Promise<void> {
+  try {
+    await execFileAsync('git', [
+      'config',
+      '--file',
+      configPath,
+      '--unset-all',
+      `http.${gitConfigSubsection(repositoryUrl)}.extraHeader`,
+    ]);
+  } catch (error) {
+    if (isGitConfigKeyMissing(error)) return;
+    throw error;
+  }
+}
+
+function isGitConfigKeyMissing(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 5;
 }
 
 // Every form the credential takes on the wire is secret. For basic auth the raw token is
@@ -430,6 +479,23 @@ function isAtLeastVersion(
 
 function formatVersion(version: {major: number; minor: number; patch: number}): string {
   return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+async function readAmbientGitConfig(configPath: string): Promise<string | undefined> {
+  try {
+    return await readFile(configPath, 'utf8');
+  } catch (error) {
+    if (isFileNotFoundError(error)) return undefined;
+    throw error;
+  }
+}
+
+function hasGitAuthorSection(config: string): boolean {
+  return config.split('\n').some((line) => line.trim() === GIT_USER_SECTION_HEADER);
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
 async function ambientIncludePath(): Promise<string | undefined> {


### PR DESCRIPTION
Runner jobs can persist credentials for more than one checkout in a shared ambient Git config. This keeps each repository's URL-scoped authorization header instead of overwriting credentials from earlier checkouts, while replacing stale credentials when the same repository is checked out again.

Updates are staged in a temporary 0600 file and atomically renamed into place. The v1 global author behavior remains first-writer-wins; per-repository authors would require the planned includeIf gitdir mechanism.

Closes ENG-1442

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve credentials across multiple checkouts by accumulating per-repo `http.extraHeader` entries in the shared ambient Git config, replacing only when the same repo is re-checked out. Adds serialized, atomic updates and keeps the first `[user]` author even when the section header is commented; closes ENG-1442.

- **New Features**
  - Keep credentials per repository via `[http "<repo-url>"].extraHeader`; do not overwrite earlier entries.
  - Replace stale credentials when the same repository is checked out again.
  - Atomic, serialized updates using a temporary file + rename, with 0600 permissions; leave existing config untouched if the staged copy can’t be parsed.
  - Preserve first `[user]` author (v1 behavior), including when the section header has trailing `;` or `#` comments; per-repo authors are deferred.

- **Refactors**
  - Ignore nested Impeccable hook caches via `**/.impeccable/hook.cache.json`.

<sup>Written for commit 8ce3525bd933ab465156492a235e5c77da33041e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

