### PR TITLE
[biome] Enforce semantic spacing in className literals

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -210,6 +210,10 @@
       ]
     },
     {
+      "path": "./tools/biome/plugins/client-architecture/no-raw-spacing.grit",
+      "includes": []
+    },
+    {
       "path": "./tools/biome/plugins/database-boundaries/no-direct-table-declaration.grit",
       "includes": [
         "**/libs/api/**/src/db/**",

--- a/tools/biome/plugins/client-architecture/fixtures/biome.fixture.json
+++ b/tools/biome/plugins/client-architecture/fixtures/biome.fixture.json
@@ -61,11 +61,16 @@
     {
       "path": "../no-direct-browser-storage.grit",
       "includes": ["**/browser-storage/**"]
+    },
+    {
+      "path": "../no-raw-spacing.grit",
+      "includes": ["**/no-raw-spacing/**"]
     }
   ],
   "files": {
     "includes": [
       "**/*.ts",
+      "**/*.tsx",
       "!**/*.test.ts",
       "!**/*.test.tsx",
       "!**/*.stories.ts",

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/allowed.tsx
@@ -1,0 +1,18 @@
+declare function cn(...values: unknown[]): string;
+
+export function AllowedSpacing() {
+  const templateClassName = `p-4`;
+
+  return (
+    <>
+      <div className="gap-tight gap-inline gap-cluster gap-group gap-section gap-region" />
+      <div className="p-tight px-row py-row p-panel-compact p-panel px-frame py-frame" />
+      <div className="p-0 gap-0 mt-0 first:pt-0 last:pb-0 p-[15%] pl-[2ch]" />
+      <div className="p-0" />
+      <div className={`p-4`} />
+      <div className={templateClassName} />
+      <div className={cn('p-4')} />
+      <div data-className="p-4" />
+    </>
+  );
+}

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/rejected.tsx
@@ -1,0 +1,14 @@
+export function RejectedSpacing() {
+  return (
+    <>
+      <div className="p-1 px-2 py-3 pt-4 pr-5 pb-6 pl-7" />
+      <div className="m-8 mx-9 my-10 mt-11 mr-12 mb-13 ml-14" />
+      <div className="ps-15 pe-16 ms-17 me-18" />
+      <div className="gap-0.5 gap-x-16 gap-y-17 space-x-18 space-y-1.5 p-2.5" />
+      <div className="-m-20 -mt-21 p-row p-frame" />
+      <div className="p-4" />
+      <div className="p-row" />
+      <div className="sm:p-4" />
+    </>
+  );
+}

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/rejected.tsx
@@ -9,6 +9,11 @@ export function RejectedSpacing() {
       <div className="p-4" />
       <div className="p-row" />
       <div className="sm:p-4" />
+      <div
+        className="
+          p-4
+        "
+      />
     </>
   );
 }

--- a/tools/biome/plugins/client-architecture/no-raw-spacing.grit
+++ b/tools/biome/plugins/client-architecture/no-raw-spacing.grit
@@ -1,0 +1,12 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+// The optional prefix consumes only whitespace or a variant colon, so the raw
+// spacing token is checked independently of its position in the class list.
+JsxAttribute() as $attribute where {
+  $attribute <: r"className\s*=\s*(?:\x22|\x27)(?:.*(?:\s|:))?(?:-)?(?:p-(?:row|frame)|(?:p|px|py|pt|pr|pb|pl|ps|pe|m|mx|my|mt|mr|mb|ml|ms|me|gap|gap-x|gap-y|space-x|space-y)-(?:[1-9][0-9]*(?:\.[0-9]+)?|0\.[0-9]+))(?:\x22|\x27|\s|:).*",
+  register_diagnostic(
+    span=$attribute,
+    message="client-architecture/no-raw-spacing: use an approved semantic spacing role such as `gap-inline`, `p-panel`, `px-row`, or `py-row`; raw numeric utilities and `p-row`/`p-frame` are not allowed."
+  )
+}

--- a/tools/biome/plugins/client-architecture/no-raw-spacing.grit
+++ b/tools/biome/plugins/client-architecture/no-raw-spacing.grit
@@ -4,7 +4,7 @@ language js(typescript, jsx)
 // The optional prefix consumes only whitespace or a variant colon, so the raw
 // spacing token is checked independently of its position in the class list.
 JsxAttribute() as $attribute where {
-  $attribute <: r"className\s*=\s*(?:\x22|\x27)(?:.*(?:\s|:))?(?:-)?(?:p-(?:row|frame)|(?:p|px|py|pt|pr|pb|pl|ps|pe|m|mx|my|mt|mr|mb|ml|ms|me|gap|gap-x|gap-y|space-x|space-y)-(?:[1-9][0-9]*(?:\.[0-9]+)?|0\.[0-9]+))(?:\x22|\x27|\s|:).*",
+  $attribute <: r"className\s*=\s*(?:\x22|\x27)(?:[\s\S]*(?:\s|:))?(?:-)?(?:p-(?:row|frame)|(?:p|px|py|pt|pr|pb|pl|ps|pe|m|mx|my|mt|mr|mb|ml|ms|me|gap|gap-x|gap-y|space-x|space-y)-(?:[1-9][0-9]*(?:\.[0-9]+)?|0\.[0-9]+))(?:\x22|\x27|\s|:)[\s\S]*",
   register_diagnostic(
     span=$attribute,
     message="client-architecture/no-raw-spacing: use an approved semantic spacing role such as `gap-inline`, `p-panel`, `px-row`, or `py-row`; raw numeric utilities and `p-row`/`p-frame` are not allowed."

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -160,7 +160,7 @@ describe('client-architecture Biome plugins', () => {
         const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
         assert.match(output, rawSpacingRulePattern);
         assert.match(output, rawSpacingRejectedLocationPattern);
-        assert.equal(output.match(rawSpacingDiagnosticPattern)?.length, 8);
+        assert.equal(output.match(rawSpacingDiagnosticPattern)?.length, 9);
         return true;
       },
     );

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {execFile} from 'node:child_process';
-import {rm, writeFile} from 'node:fs/promises';
+import {readFile, rm, writeFile} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {promisify} from 'node:util';
@@ -23,12 +23,19 @@ const browserStorageFixtureRoot = resolve(
   workspaceRoot,
   'tools/biome/plugins/client-architecture/fixtures/browser-storage',
 );
+const rawSpacingFixtureRoot = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/client-architecture/fixtures/no-raw-spacing',
+);
 const rejectedLocationPattern = /rejected\.ts:3/u;
 const testFixturePattern = /ignored\.test\.ts/u;
 const storyFixturePattern = /ignored\.stories\.ts/u;
 const generatedFixturePattern = /rejected\.gen\.ts/u;
 const routeInputRulePattern = /client-architecture\/no-raw-route-inputs/u;
 const storageRulePattern = /client-architecture\/no-direct-browser-storage/u;
+const rawSpacingRulePattern = /client-architecture\/no-raw-spacing/u;
+const rawSpacingDiagnosticPattern = /client-architecture\/no-raw-spacing/g;
+const rawSpacingRejectedLocationPattern = /rejected\.tsx:/u;
 
 const fixtureRuleNames = [
   'fixture-boundary',
@@ -134,6 +141,52 @@ describe('client-architecture Biome plugins', () => {
       {cwd: workspaceRoot},
     );
     assert.doesNotMatch(`${stdout}${stderr}`, storageRulePattern);
+  });
+
+  test('rejects raw numeric and asymmetric spacing in className string literals', async () => {
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          biomeCheck,
+          '--config-path',
+          fixtureConfig,
+          resolve(rawSpacingFixtureRoot, 'rejected.tsx'),
+        ],
+        {cwd: workspaceRoot},
+      ),
+      (error: unknown) => {
+        const commandError = error as {stdout?: string; stderr?: string};
+        const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+        assert.match(output, rawSpacingRulePattern);
+        assert.match(output, rawSpacingRejectedLocationPattern);
+        assert.equal(output.match(rawSpacingDiagnosticPattern)?.length, 8);
+        return true;
+      },
+    );
+  });
+
+  test('allows semantic, zero, arbitrary, and non-literal className spacing', async () => {
+    const {stdout, stderr} = await execFileAsync(
+      process.execPath,
+      [biomeCheck, '--config-path', fixtureConfig, resolve(rawSpacingFixtureRoot, 'allowed.tsx')],
+      {cwd: workspaceRoot},
+    );
+    assert.doesNotMatch(`${stdout}${stderr}`, rawSpacingRulePattern);
+  });
+
+  test('registers no-raw-spacing with an empty rollout glob list', async () => {
+    const rootConfig = JSON.parse(await readFile(resolve(workspaceRoot, 'biome.json'), 'utf8')) as {
+      plugins: {includes: string[]; path: string}[];
+    };
+    const rawSpacingPlugin = rootConfig.plugins.find(({path}) =>
+      path.endsWith('/no-raw-spacing.grit'),
+    );
+
+    assert.deepEqual(rawSpacingPlugin, {
+      path: './tools/biome/plugins/client-architecture/no-raw-spacing.grit',
+      includes: [],
+    });
   });
 
   // The fixture config scopes each rule to its fixture directory. These tests run


### PR DESCRIPTION
Add the repository-local client-architecture rule for raw spacing utilities in direct JSX `className` string literals. The rule rejects numeric and asymmetric spacing utilities plus the legacy `p-row` and `p-frame` tokens, while preserving semantic roles, zero values, arbitrary values, and dynamic expressions.

The plugin is registered in the root Biome configuration with an empty rollout list, and its fixtures cover standalone, variant-prefixed, decimal, logical-prefix, and intentionally allowed cases.

Validation passed with `mise exec -- turbo type --filter=@shipfox/biome...`, `mise exec -- turbo verify --filter=@shipfox/biome...`, and `mise exec -- turbo test --filter=@shipfox/biome...`.

Closes ENG-1463

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `client-architecture/no-raw-spacing` Biome rule to enforce semantic spacing in JSX `className` string literals, including multiline strings. Blocks numeric/asymmetric spacing utilities and legacy `p-row`/`p-frame`. Closes ENG-1463.

- **New Features**
  - Rejects numeric/decimal spacing (e.g., `p-1`, `m-2.5`, `gap-x-4`, `space-y-1.5`), including negatives and logical prefixes (`ps`, `pe`, `ms`, `me`), plus `p-row` and `p-frame`.
  - Allows semantic roles (`gap-inline`, `p-panel`, `px-row`, `py-row`), zero values, arbitrary values (`[]`), and non-literal/dynamic `className`.
  - Registers the plugin in root `biome.json` with an empty rollout list; adds TSX fixtures and tests.

- **Bug Fixes**
  - Correctly detects raw spacing in multiline `className` string literals; adds tests to verify.

<sup>Written for commit 83e82d74bbbe2100b88ca68c71134b4bcc01c8d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

