### PR TITLE
Document client URL and resource identity decisions

### DIFF
--- a/apps/docs/WRITING.md
+++ b/apps/docs/WRITING.md
@@ -41,6 +41,21 @@ workflow identifier. Keep the schema field name as `connection` in code.
 before it. Use a prepositional phrase instead: write "the slug of your GitHub
 integration connection", not "your GitHub integration connection slug".
 
+### Identifier terms
+
+Qualify `slug` at first use in each document. Use these terms consistently:
+
+| Term | Meaning |
+| --- | --- |
+| Workspace slug | A mutable, globally unique value used in client URLs. |
+| Project slug | A mutable value unique within a workspace and used in client URLs. |
+| Slug of an integration connection | The workflow `source` value for an integration connection. It is not a client URL identifier. |
+| Feature id | A stable namespaced composition identifier such as `shipfox.workflows`. Do not call it a feature slug. |
+
+After the first qualified use, shorten a term only when the surrounding section
+still makes its owner clear. Keep `integration connection` qualified in product
+documentation, even when the page already discusses integrations.
+
 ### Choose the type before writing
 
 Write one sentence that names the reader need before drafting:

--- a/apps/docs/WRITING.md
+++ b/apps/docs/WRITING.md
@@ -34,8 +34,8 @@ page. Split a page when its subject requires more than one reader mode.
 Use **integration connection** for the workspace resource created when an
 integration is connected. Do not use **connection** by itself for this resource,
 especially in titles, navigation, prerequisites, and other text that readers may
-see without surrounding context. Use **integration connection slug** for its
-workflow identifier. Keep the schema field name as `connection` in code.
+see without surrounding context. Use **the slug of an integration connection**
+for its workflow identifier. Keep the schema field name as `connection` in code.
 
 `integration connection` is a fixed compound. Do not put another noun directly
 before it. Use a prepositional phrase instead: write "the slug of your GitHub
@@ -82,7 +82,7 @@ needs it. Link to the task that creates the missing starting state.
 ### One canonical home per fact
 
 Every exact fact lives on one reference page: field tables and accepted values
-in `reference/workflow-schema.mdx`, provider IDs in
+in `reference/workflow-schema.mdx`, provider ids in
 `reference/model-providers.mdx`, numbers and defaults in
 `reference/limits.mdx`, and environment variables in the matching reference
 page. Other pages use only the facts needed to serve their reader and link to

--- a/apps/docs/content/docs/how-to/set-up-work/create-project.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/create-project.mdx
@@ -36,11 +36,18 @@ one, [connect GitHub](/integrations/github/setup) first.
   </Step>
   <Step>
 
-    **Name and create the project**
+    **Name the project and set its slug**
 
-    Keep the suggested name or enter a clearer one. Select **Create project**.
+    Keep the suggested name or enter a clearer one. The form fills **Project slug**
+    from the name. Edit the slug when the URL should use a different value.
+    Select **Create project**.
   </Step>
 </Steps>
+
+The project slug is unique within the workspace. Shipfox uses it in client URLs
+such as `/w/acme/p/checkout-api/runs`. If you rename the project later, links and
+bookmarks that use the old slug stop working. The old slug becomes available for
+another project.
 
 ## Verify workflow discovery
 

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -37,6 +37,17 @@ if: ${{ trigger.event == "push" }}
 `vars` and `secrets` accept a literal key only. `vars["API_URL"]` is valid and a
 computed key such as `vars[inputs.name]` is not.
 
+## Run identifiers
+
+The `run` context has a UUID `id` and a sequential `number`. The UUID identifies
+the run in API and client routes. The number is scoped to the workflow
+definition and is available for labels, predicates, and display text. It is not
+resolved as a route address.
+
+```yaml
+execution_name: 'Deploy #${{ run.number }}'
+```
+
 ## Types
 
 | Type | Written as |

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -65,6 +65,10 @@ Job name must be literal. Move runtime interpolation to execution_name.
 metadata, trigger event data, workflow inputs, referenced workflow variables,
 and stable run facts that already exist at creation time.
 
+The allocated `run.number` is one of those run facts. It is a positive,
+sequential number scoped to the workflow definition. Use it in a dynamic field
+when the field can read the `run` context.
+
 It cannot use job, execution, step, or job-output values that do not exist when
 the run is created. A rerun keeps the original resolved run name.
 
@@ -95,6 +99,24 @@ diagnostic without changing execution status.
 Dynamic-name expressions that use unavailable context or invalid syntax are
 definition validation errors. Rerunning a workflow keeps its resolved run
 name. Rerunning a job execution keeps its resolved execution name.
+
+### Run number
+
+`run.number` is a display label for the current run. It starts at `1` for each
+workflow definition and increases for later runs of that definition. It is not
+a URL or API identifier. Run routes continue to use the run UUID.
+
+For example, a job execution can include the number in its display name:
+
+```yaml
+# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
+name: Deploy
+jobs:
+  deploy:
+    execution_name: 'Deploy #${{ run.number }}'
+    steps:
+      - run: ./deploy.sh
+```
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json

--- a/apps/docs/content/docs/understand/workspaces-and-projects.mdx
+++ b/apps/docs/content/docs/understand/workspaces-and-projects.mdx
@@ -18,6 +18,20 @@ A workspace answers who shares. A project answers which code owns the work.
 This keeps team setup broad and run history narrow.
 The split can grow with the team.
 
+## Slugs separate URLs from identity
+
+Each workspace has a required workspace slug. It is unique across the
+installation. Each project has a required project slug. It is unique within its
+workspace.
+
+The client uses these slugs in readable URLs such as
+`/w/acme/p/checkout-api/runs`. The API continues to identify the workspace and
+project with UUIDs. A slug is a navigation and display value, not a replacement
+for the resource identity.
+
+Slugs can change. A rename frees the old value and breaks links that still use
+the old URL. Shipfox warns before a rename so shared links can be updated.
+
 ## Shared resources belong to the workspace
 
 Many resources can serve more than one project. These include integration connections,

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ names it and links to it; it does not restate it.
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
+| Changes client URL identifiers, route prefixes, or slug and UUID boundaries. | [ADR 0009](adr/0009-client-url-prefix-invariants.md) | Client URL prefixes, resource identity, settings scopes, and run-number display semantics. |
 | Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
 | Changes database ownership, cross-module persistence access, or namespace rules. | [ADR 0006](adr/0006-database-ownership-boundaries.md) | The decision and tradeoffs behind owner-only database access. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ names it and links to it; it does not restate it.
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
-| Changes client URL identifiers, route prefixes, or slug and UUID boundaries. | [ADR 0009](adr/0009-client-url-prefix-invariants.md) | Client URL prefixes, resource identity, settings scopes, and run-number display semantics. |
+| Changes client URL identifiers, route prefixes, or slug and UUID boundaries. | [ADR 0009](adr/0009-client-urls-resource-identity.md) | Client URL prefixes, resource identity, settings scopes, and run-number display semantics. |
 | Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
 | Changes database ownership, cross-module persistence access, or namespace rules. | [ADR 0006](adr/0006-database-ownership-boundaries.md) | The decision and tradeoffs behind owner-only database access. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -5,6 +5,7 @@
 - **Decision owners:** E1 platform composition seams
 - **Linear issue:** [ENG-959](https://linear.app/shipfox/issue/ENG-959/author-the-client-composition-adr)
 - **Implementation issue:** [ENG-938](https://linear.app/shipfox/issue/ENG-938/implement-and-publish-the-client-composition-seam)
+- **Amended by:** [ADR 0009: Client URLs and resource identity](0009-client-url-prefix-invariants.md)
 
 ## Context
 
@@ -47,9 +48,10 @@ feature modules.
 
 ### Stable identifiers
 
-Every feature has a stable namespaced slug such as `shipfox.workflows` or `acme.sso`. Feature ids are
-part of the public compatibility surface. Applications must not derive them from display names or
-package versions.
+Every feature has a stable namespaced feature id such as `shipfox.workflows` or `acme.sso`. Feature
+ids are part of the public compatibility surface. Applications must not derive them from display
+names or package versions. A feature id is not a workspace slug, project slug, or integration
+connection slug.
 
 Provider, navigation, and settings contributions also have stable ids. Their ids stay stable when
 labels, icons, routes, or implementations change. Checks compare ids within each contribution kind
@@ -74,7 +76,8 @@ export type AnchorId =
   | 'root'
   | 'workspaceLayout'
   | 'projectLayout'
-  | 'workspaceSettings';
+  | 'workspaceSettings'
+  | 'projectSettings';
 
 export type RouteParentId = AnchorId | (string & {});
 
@@ -118,6 +121,7 @@ export interface SettingsSectionEntry {
   pathSegment: string;
   label: string;
   icon: IconName;
+  scope?: 'workspace' | 'project';
   order?: number;
 }
 
@@ -170,14 +174,16 @@ route supplies its path, parent, and router context.
 Route manifests use full paths. Composition removes trailing slashes from non-root paths before any
 comparison. `/` remains `/`. Navigation targets use the same normalization.
 
-The shell owns four anchors:
+The shell owns the following anchors. These paths are contract values; the
+composition diagnostics quote them verbatim when reporting an anchor violation.
 
-| Anchor | Purpose |
-| --- | --- |
-| `root` | Root document and global error boundary |
-| `workspaceLayout` | Routes scoped to a workspace |
-| `projectLayout` | Routes scoped to a project |
-| `workspaceSettings` | Routes rendered inside workspace settings |
+| Anchor | Path | Purpose |
+| --- | --- | --- |
+| `root` | `/` | Root document and global error boundary |
+| `workspaceLayout` | `/w/$workspaceSlug` | Routes scoped to a workspace |
+| `projectLayout` | `/w/$workspaceSlug/p/$projectSlug` | Routes scoped to a project |
+| `workspaceSettings` | `/w/$workspaceSlug/settings` | Routes rendered inside workspace settings |
+| `projectSettings` | `/w/$workspaceSlug/p/$projectSlug/settings` | Routes rendered inside project settings |
 
 Features may also declare layout contributions. A layout has a stable id, a full path, a parent, and
 a public route implementation. A route from any composed feature can name that layout id as its
@@ -217,7 +223,7 @@ The generated file:
 
 - starts with a generated-file warning;
 - statically imports every route implementation;
-- creates code-based routes below the four anchors;
+- creates code-based routes below the shell anchors;
 - exports `routeTree` and `router`;
 - augments TanStack Router's `Register` with the consumer's router type; and
 - checks that each implementation is a `defineRoute()` result.
@@ -307,8 +313,10 @@ composition check accepts non-empty strings and rejects malformed role metadata.
 or define a role policy.
 
 A settings section adds navigation data only. The feature contributes its page as a normal route. A
-section with `pathSegment: 'sso'` requires `/workspaces/$wid/settings/sso`. Section ids must be
-unique. The settings index redirects to the first sorted section.
+workspace section with `pathSegment: 'sso'` requires `/w/$workspaceSlug/settings/sso`. Section ids
+must be unique. The optional `scope` defaults to `workspace`; project sections use
+`/w/$workspaceSlug/p/$projectSlug/settings/<pathSegment>`. The settings index redirects to the
+first sorted section for its scope.
 
 ### Runtime configuration
 
@@ -468,12 +476,12 @@ export const workflowsFeature = defineClientFeature({
   id: 'shipfox.workflows',
   routes: [
     {
-      path: '/workspaces/$wid/projects/$pid/workflows',
+      path: '/w/$workspaceSlug/p/$projectSlug/workflows',
       parent: 'projectLayout',
       impl: '@shipfox/client-workflows/routes/workflows-index',
     },
     {
-      path: '/workspaces/$wid/projects/$pid/workflows/$workflowId',
+      path: '/w/$workspaceSlug/p/$projectSlug/workflows/$workflowId',
       parent: 'projectLayout',
       impl: '@shipfox/client-workflows/routes/workflow-detail',
     },
@@ -483,7 +491,7 @@ export const workflowsFeature = defineClientFeature({
       id: 'workflows',
       scope: 'project',
       label: 'Workflows',
-      to: '/workspaces/$wid/projects/$pid/workflows',
+      to: '/w/$workspaceSlug/p/$projectSlug/workflows',
       order: 200,
     },
   ],
@@ -500,7 +508,7 @@ export const ssoFeature = defineClientFeature({
   id: 'acme.sso',
   routes: [
     {
-      path: '/workspaces/$wid/settings/sso',
+      path: '/w/$workspaceSlug/settings/sso',
       parent: 'workspaceSettings',
       impl: '@acme/shipfox-sso-client/routes/settings',
     },
@@ -511,6 +519,7 @@ export const ssoFeature = defineClientFeature({
       pathSegment: 'sso',
       label: 'Single sign-on',
       icon: 'keyLine',
+      scope: 'workspace',
       order: 450,
     },
   ],
@@ -606,7 +615,7 @@ Both the linked iteration gate and packed-tarball gate passed on 2026-07-16. The
 and installed a 12-package `@shipfox/*` runtime closure outside the workspace.
 
 The consumer's `tsc --noEmit` accepted typed `Link` and `useSearch` for the added
-`/workspaces/$wid/insights` route. It resolved emitted `defineRoute()` declarations, anchor return
+`/w/$workspaceSlug/insights` route. It resolved emitted `defineRoute()` declarations, anchor return
 types, and the generated `Register` augmentation from `dist`.
 
 The proof found two package issues:
@@ -675,8 +684,7 @@ Translate the routes under `libs/client/router/src/routes/**`:
 | Workspace settings | `@shipfox/client-workspace-settings` |
 | Integration callbacks and settings | `@shipfox/client-integrations` |
 
-The four structural routes become shell anchors. The router package dissolves after the last route
-moves.
+The structural routes become shell anchors. The router package dissolves after the last route moves.
 
 ### 4. Replace hardcoded registries
 

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -5,7 +5,7 @@
 - **Decision owners:** E1 platform composition seams
 - **Linear issue:** [ENG-959](https://linear.app/shipfox/issue/ENG-959/author-the-client-composition-adr)
 - **Implementation issue:** [ENG-938](https://linear.app/shipfox/issue/ENG-938/implement-and-publish-the-client-composition-seam)
-- **Amended by:** [ADR 0009: Client URLs and resource identity](0009-client-url-prefix-invariants.md)
+- **Amended by:** [ADR 0009: Client URLs and resource identity](0009-client-urls-resource-identity.md)
 
 ## Context
 
@@ -360,6 +360,13 @@ id, key, or feature id.
 | Invalid anchor nesting | `Route "<path>" must be nested under anchor "<anchor>" (<anchor-path>).` |
 | Invalid layout nesting | `Route "<path>" must be nested under layout "<layout>" (<layout-path>).` |
 | Root parent inside protected anchor | `Route "<path>" in feature "<feature>" cannot use root parent inside reserved anchor "<anchor>" (<anchor-path>). Use parent "<anchor>".` |
+| Legacy workspace path | `Route "<path>" must use the slug-based workspace prefix "w" instead of the legacy "/workspaces" path.` |
+| Prefix without slug parameter | `Route "<path>" uses prefix "<prefix>" without a dynamic parameter immediately after it.` |
+| Slug outside prefix | `Route "<path>" places slug parameter "<param>" outside prefix "<prefix>".` |
+| Repeated slug parameter | `Route "<path>" repeats slug parameter "<param>".` |
+| Workspace prefix not first | `Route "<path>" must place workspace prefix "w" at the start of the path.` |
+| Inverted entity prefixes | `Route "<path>" must place workspace prefix "w" before project prefix "p".` |
+| UUID parameter after entity prefix | `Route "<path>" must place UUID parameter "<param>" after a page segment.` |
 | Route module not found | `Could not resolve route implementation "<specifier>" for "<path>".` |
 | Invalid route export | `Route implementation "<specifier>" for "<path>" must export default defineRoute(...).` |
 | Feature evaluation | `Failed to evaluate features module "<file>". Features modules must be Node-safe: <cause>` |
@@ -615,7 +622,7 @@ Both the linked iteration gate and packed-tarball gate passed on 2026-07-16. The
 and installed a 12-package `@shipfox/*` runtime closure outside the workspace.
 
 The consumer's `tsc --noEmit` accepted typed `Link` and `useSearch` for the added
-`/w/$workspaceSlug/insights` route. It resolved emitted `defineRoute()` declarations, anchor return
+`/workspaces/$wid/insights` route. It resolved emitted `defineRoute()` declarations, anchor return
 types, and the generated `Register` augmentation from `dist`.
 
 The proof found two package issues:

--- a/docs/adr/0003-client-state-and-domain-architecture.md
+++ b/docs/adr/0003-client-state-and-domain-architecture.md
@@ -139,6 +139,7 @@ export interface Project {
   id: string;
   workspaceId: string;
   name: string;
+  slug: string;
   source: ProjectSource;
 }
 
@@ -157,10 +158,16 @@ export function toProject(dto: ProjectResponseDto): Project {
     id: dto.id,
     workspaceId: dto.workspace_id,
     name: dto.name,
+    slug: dto.slug,
     source: toProjectSource(dto.source),
   };
 }
 ```
+
+The project model carries both values on purpose. `id` is the stable resource
+identity used by API requests and query keys. `slug` is the mutable navigation
+and display identifier used by client URLs. The mapper keeps the distinction at
+the DTO boundary so pages do not infer identity from a URL segment.
 
 **React Query stores domain models by default.** Mapping in `queryFn` creates one canonical cached
 shape. A component-level `select` can create a local projection, but it cannot be the only place that

--- a/docs/adr/0009-client-url-prefix-invariants.md
+++ b/docs/adr/0009-client-url-prefix-invariants.md
@@ -1,60 +1,212 @@
-# ADR 0009: Client URL prefix invariants
+# ADR 0009: Client URLs and resource identity
 
 - **Status:** Accepted
-- **Date:** 2026-08-01
-- **Decision owners:** E1 platform composition seams
-- **Linear issue:** [ENG-1449](https://linear.app/shipfox/issue/ENG-1449/client-shell-move-client-urls-to)
+- **Date:** 2026-08-03
+- **Decision owners:** E1 platform composition seams and resource boundaries
+- **Linear issue:** [ENG-1452](https://linear.app/shipfox/issue/ENG-1452/docs-record-the-url-and-identifier-decisions-in-adr-0009)
+- **Related:** [ENG-1449](https://linear.app/shipfox/issue/ENG-1449/client-shell-move-client-urls-to) established the initial prefix decision.
 - **Amends:** [ADR 0001: Public client composition contract](0001-client-composition-contract.md)
+
+ADR 0001 remains canonical for the anchor path table, root-parented route
+protection, and exact composition diagnostics. This amendment records the URL
+and resource-identity decisions those anchors implement.
 
 ## Context
 
-The client URL migration replaces UUID-bearing workspace and project paths with readable slugs:
+Workspaces and projects have mutable, URL-safe slugs. Their UUIDs remain the
+stable identity used by the API and stored relationships. The client needs a
+readable URL, while the API needs an identity that does not change when a slug
+is renamed.
 
-- `/workspaces/$wid` becomes `/w/$workspaceSlug`;
-- `/workspaces/$wid/projects/$pid` becomes `/w/$workspaceSlug/p/$projectSlug`.
+The client URL migration also introduces entity prefixes. Without a prefix, a
+slug such as `settings` or `new` could collide with a page segment. The route
+contract therefore needs a durable owner for the prefix registry and the rules
+that keep it safe.
 
-The old path shape is not a compatibility surface. Keeping it in a feature manifest or navigation
-target allows a route tree to describe URLs that the shell cannot safely scope to its workspace and
-project guards.
+The run number is a second human-facing identifier. It helps a person refer to
+a run, but it must not become a second address for a run. The API and client
+need one record of which identifiers route, which identify resources, and which
+exist only for display.
 
 ## Decision
 
-The prefixes `w` and `p` are registered entity prefixes. Their required dynamic parameters are
-`workspaceSlug` and `projectSlug`, respectively. Composition validates every supplied layout and
-route path before building the generated route tree.
+### Identity and URL boundary
 
-The following rules are part of the public composition contract:
+The UUID is the identity of every workspace, project, run, and job. A client
+URL may carry a workspace slug or project slug as a navigation reference. An
+HTTP route keeps using the corresponding UUID when it identifies a resource.
+The API may accept a `slug` field when a workspace or project is created or
+renamed, but it never treats that field as a replacement for an identity
+parameter.
 
-- workspace-scoped paths begin with `/w/$workspaceSlug`;
-- project-scoped paths begin with `/w/$workspaceSlug/p/$projectSlug`;
-- `/w` and `/p` must be followed immediately by their registered slug parameter;
-- a registered slug parameter may not appear outside its prefix or more than once;
-- a project prefix must appear at index 2, after the workspace prefix pair;
-- a workspace prefix, when present, must be the first path segment;
-- other dynamic parameters must follow a page segment, not an entity prefix;
-- legacy `/workspaces/$wid/...` paths fail composition-time validation.
+| Identifier | Client URL | API identity | Purpose |
+| --- | --- | --- | --- |
+| Workspace slug | Yes | `workspaceId` UUID | Navigation and display |
+| Project slug | Yes | `projectId` UUID | Navigation and display |
+| Run UUID | Yes, under `runs/` | `workflowRunId` UUID | Resource identity |
+| Job UUID | Yes, under a run | `jobId` UUID | Resource identity |
+| Run number | No | Not resolved | Display and workflow context |
 
-The prefix registry is the source of truth for these checks. Feature authors should use the shell
-anchor paths and the current route examples in implementation documentation rather than reproducing
-the old UUID path shape.
+The old UUID-bearing client paths are replaced by short slug paths. This is a
+breaking URL change. Old paths return 404 and do not redirect. Slugs are
+mutable, and a renamed slug is immediately available for another resource.
 
-## Diagnostics
+### Client anchors and URL scheme
 
-These route-path diagnostics are stable contract messages:
+The URL forms associated with the shell anchors are:
 
-| Failure | Exact message template |
-| --- | --- |
-| Legacy workspace path | `Route "<path>" must use the slug-based workspace prefix "w" instead of the legacy "/workspaces" path.` |
-| Prefix without slug parameter | `Route "<path>" uses prefix "<prefix>" without a dynamic parameter immediately after it.` |
-| Slug outside prefix | `Route "<path>" places slug parameter "<param>" outside prefix "<prefix>".` |
-| Repeated slug parameter | `Route "<path>" repeats slug parameter "<param>".` |
-| Workspace prefix not first | `Route "<path>" must place workspace prefix "w" at the start of the path.` |
-| Inverted entity prefixes | `Route "<path>" must place workspace prefix "w" before project prefix "p".` |
-| UUID parameter after entity prefix | `Route "<path>" must place UUID parameter "<param>" after a page segment.` |
+| Anchor | Path | Scope |
+| --- | --- | --- |
+| `workspaceLayout` | `/w/$workspaceSlug` | Workspace |
+| `projectLayout` | `/w/$workspaceSlug/p/$projectSlug` | Project |
+| `workspaceSettings` | `/w/$workspaceSlug/settings` | Workspace settings |
+| `projectSettings` | `/w/$workspaceSlug/p/$projectSlug/settings` | Project settings |
+
+Examples below the anchors use the same prefixes:
+
+```text
+/w/acme/p/checkout-api/runs
+/w/acme/p/checkout-api/runs/$workflowRunId
+/w/acme/p/checkout-api/runs/$workflowRunId/jobs/$jobId
+/w/acme/p/checkout-api/settings/general
+```
+
+The `projectSettings` anchor is a shell anchor rather than a route owned by the
+projects feature. It gives project settings the same shell and contribution
+point as workspace settings.
+
+### Entity-prefix registry
+
+Single-letter static path segments are reserved for entity-type prefixes. The
+registry currently contains:
+
+| Prefix | Entity | Required parameter |
+| --- | --- | --- |
+| `w` | Workspace | `$workspaceSlug` |
+| `p` | Project | `$projectSlug` |
+
+Two invariants enforce the registry:
+
+1. A single-letter static segment must be followed immediately by its registered
+   dynamic slug parameter.
+2. A slug parameter must be preceded by its registered prefix. A UUID parameter
+   must follow a page segment such as `runs`, not an entity prefix.
+
+The workspace prefix must be first. The project prefix must follow the workspace
+prefix pair. A registered slug parameter cannot appear twice or outside its
+prefix. Composition checks these rules before it builds the generated route
+tree.
+
+UUID references deliberately have no prefix. Runs keep
+`runs/$workflowRunId`, and jobs keep their page segment below the run. An earlier
+proposal added `r` for runs and planned more prefixes for nested entities. It
+saved three characters on a URL that still contains a 36-character UUID, split
+the `runs` list from its detail page, and added a prefix for every future UUID
+resource. UUIDs do not need a slug namespace, so the extra prefix has no useful
+work to do.
+
+### No reserved-slug list
+
+The URL scheme does not maintain a reserved-word list. A workspace slug is only
+compared with workspace slugs after the `w` prefix. A project slug is only
+compared with project slugs after the `p` prefix. Values such as `settings` and
+`new` therefore cannot occupy a page-name position.
+
+The unprefixed alternative, `/$workspaceSlug/$projectSlug`, would require a list
+that grows whenever a page is added. A stale list would create silent route
+shadowing. The prefix invariant is the source of truth instead.
+
+### Client resolution and API requests
+
+The workspace anchor resolves `$workspaceSlug` from the authenticated workspace
+summaries. The project anchor resolves `$projectSlug` from the workspace's
+project list. Resolution happens at the anchor boundary, before feature pages
+make requests.
+
+After resolution, client adapters and query keys use UUIDs. The slug remains in
+the route for navigation and display. Renaming a slug therefore changes the URL
+without changing the cached resource identity or any API request.
+
+Slug resolution never enters the API request path. `requireWorkspaceAccess`
+continues to receive a UUID and remains stateless. Session token claims remain
+unchanged, and no slug is stored as a foreign reference or token identity.
+
+The authenticated workspace slug-availability endpoint is not a resource
+resolver. It accepts a candidate slug and returns only whether the namespace is
+available. It never returns a workspace or authorizes access to one.
+
+### Settings section scope
+
+`settingsSections` entries have an optional `scope` discriminator with the
+values `workspace` and `project`. Existing entries default to `workspace`. The
+project settings anchor renders project-scoped entries, while the workspace
+settings anchor renders workspace-scoped entries. A section that belongs in
+both surfaces contributes once for each scope.
+
+The discriminator prevents every existing workspace section from appearing in
+project settings when the new anchor is assembled. A feature that needs both
+surfaces contributes separate entries, one per scope. The project settings
+general section owns the project name and slug rename surface. Moving other
+workspace resources to project scope is separate work.
+
+### Run number
+
+Each workflow definition owns a monotonic run counter. The first run starts at
+one, and the `(definitionId, number)` pair is unique. Allocation occurs inside
+the run-creation transaction after trigger idempotency is resolved. A duplicate
+trigger returns the existing run without consuming a number.
+
+Gaps are acceptable because the number is a label and monotonicity matters more
+than density. Counter rows are not cleaned up when a definition is removed, and
+reruns create another attempt on the same run instead of consuming another
+number.
+
+`run.number` is available in workflow expressions after allocation. It is a
+display label and a context value, never a route parameter or an API lookup
+key. Run URLs continue to use the run UUID.
 
 ## Consequences
 
-Route migrations are intentionally breaking at the URL level. Deep links, feature manifests,
-navigation targets, Storybook memory routers, E2E fixtures, and external composition examples must
-use the slug-based paths. The shell rejects malformed or legacy paths while composing, so invalid
-feature contributions fail before a generated route tree is emitted.
+- Client links are readable and can be renamed without changing API identity.
+- A shared client link breaks when its slug changes. The client warns before a
+  rename, and no redirect or alias history is maintained.
+- The API authorization boundary stays UUID-based. It does not need to decide
+  whether an incoming string is a slug or a UUID.
+- Route composition rejects a malformed prefix or slug placement before it can
+  produce a generated route tree.
+- Run numbers repeat across workflow definitions. The workflow name must remain
+  next to the number in lists and headers so the label is meaningful.
+- The project settings surface has the same shell boundary as workspace settings
+  and can filter contributed sections by scope.
+
+## Rejected alternatives
+
+### Use slugs in API resource routes
+
+This would make a rename an API identity concern and move slug resolution into
+authorization. It would also require token and request-boundary changes. Keeping
+UUIDs in the API leaves `requireWorkspaceAccess` stateless.
+
+### Use unprefixed slug paths
+
+`/$workspaceSlug/$projectSlug` is shorter, but it requires a reserved-slug list.
+The list would be easy to miss when adding a page and would fail through route
+shadowing. The explicit `w` and `p` namespaces make the invariant structural.
+
+### Prefix every entity reference
+
+Adding `r` and more prefixes for UUID resources makes the URL look symmetric but
+does not protect a user-chosen slug. It also makes every future nested UUID route
+carry a new registration. Page segments already disambiguate UUID references.
+
+### Route runs by number
+
+Run numbers are scoped to a workflow definition and can repeat in a project. A
+number-only route would need a server lookup, a second authorization path, and a
+policy for counter resets. The UUID remains the run address.
+
+### Keep a slug alias or redirect history
+
+Aliases would make old URLs look stable while creating extra namespace state and
+authorization behavior. The product accepts broken old links and warns before a
+rename instead.

--- a/docs/adr/0009-client-urls-resource-identity.md
+++ b/docs/adr/0009-client-urls-resource-identity.md
@@ -8,8 +8,9 @@
 - **Amends:** [ADR 0001: Public client composition contract](0001-client-composition-contract.md)
 
 ADR 0001 remains canonical for the anchor path table, root-parented route
-protection, and exact composition diagnostics. This amendment records the URL
-and resource-identity decisions those anchors implement.
+protection, and exact composition diagnostics, including the prefix-specific
+messages. This amendment records the URL and resource-identity decisions those
+anchors implement.
 
 ## Context
 
@@ -53,14 +54,10 @@ mutable, and a renamed slug is immediately available for another resource.
 
 ### Client anchors and URL scheme
 
-The URL forms associated with the shell anchors are:
-
-| Anchor | Path | Scope |
-| --- | --- | --- |
-| `workspaceLayout` | `/w/$workspaceSlug` | Workspace |
-| `projectLayout` | `/w/$workspaceSlug/p/$projectSlug` | Project |
-| `workspaceSettings` | `/w/$workspaceSlug/settings` | Workspace settings |
-| `projectSettings` | `/w/$workspaceSlug/p/$projectSlug/settings` | Project settings |
+The [anchor path table in ADR 0001](0001-client-composition-contract.md#paths-and-anchors)
+is canonical. This ADR records the URL scheme encoded by those anchors: client
+workspace and project navigation uses slug segments, while resource requests
+continue to use UUIDs after resolution.
 
 Examples below the anchors use the same prefixes:
 
@@ -95,7 +92,8 @@ Two invariants enforce the registry:
 The workspace prefix must be first. The project prefix must follow the workspace
 prefix pair. A registered slug parameter cannot appear twice or outside its
 prefix. Composition checks these rules before it builds the generated route
-tree.
+tree. The exact messages for these checks remain in the Diagnostics section of
+ADR 0001.
 
 UUID references deliberately have no prefix. Runs keep
 `runs/$workflowRunId`, and jobs keep their page segment below the run. An earlier

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,7 +18,7 @@ documentation model and other engineering sources, start with the
 | [0006: Database ownership boundaries](0006-database-ownership-boundaries.md) | Accepted; amends ADR 0002 | Owner-only database access and stable database namespaces. |
 | [0007: Cross-repository architecture validation](0007-cross-repository-architecture-validation.md) | Accepted | Validation layers, shared policy distribution, and downstream package metadata. |
 | [0008: Administration controls](0008-administration-controls.md) | Accepted | Fixed instance-administrator roles, module-owned administration behavior, and suspension semantics. |
-| [0009: Client URL prefix invariants](0009-client-url-prefix-invariants.md) | Accepted; supersedes ADR 0001 for route paths | Slug-based client URL prefixes and composition-time route-path validation. |
+| [0009: Client URLs and resource identity](0009-client-url-prefix-invariants.md) | Accepted; amends ADR 0001 | Slug-based client URL prefixes, UUID API identities, scoped settings anchors, run-number display semantics, and composition-time route-path validation. |
 | [0010: Prose standard and enforcement](0010-prose-standard-and-enforcement.md) | Accepted | The repository prose standard, its sources, accepted divergences, and enforcement model. |
 
 When a decision changes, add a new ADR that supersedes or amends the earlier

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,7 +18,7 @@ documentation model and other engineering sources, start with the
 | [0006: Database ownership boundaries](0006-database-ownership-boundaries.md) | Accepted; amends ADR 0002 | Owner-only database access and stable database namespaces. |
 | [0007: Cross-repository architecture validation](0007-cross-repository-architecture-validation.md) | Accepted | Validation layers, shared policy distribution, and downstream package metadata. |
 | [0008: Administration controls](0008-administration-controls.md) | Accepted | Fixed instance-administrator roles, module-owned administration behavior, and suspension semantics. |
-| [0009: Client URLs and resource identity](0009-client-url-prefix-invariants.md) | Accepted; amends ADR 0001 | Slug-based client URL prefixes, UUID API identities, scoped settings anchors, run-number display semantics, and composition-time route-path validation. |
+| [0009: Client URLs and resource identity](0009-client-urls-resource-identity.md) | Accepted; amends ADR 0001 | Slug-based client URL prefixes, UUID API identities, scoped settings anchors, run-number display semantics, and composition-time route-path validation. |
 | [0010: Prose standard and enforcement](0010-prose-standard-and-enforcement.md) | Accepted | The repository prose standard, its sources, accepted divergences, and enforcement model. |
 
 When a decision changes, add a new ADR that supersedes or amends the earlier

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -74,6 +74,26 @@ when practical. An outbox event is a public producer contract. Define its name
 and payload in the producer DTO package. Write it in the same transaction as
 the state change. Register its publisher table in the module declaration.
 
+## Resource identity and human identifiers
+
+HTTP routes identify workspaces, projects, runs, and jobs with UUID path
+parameters. Request DTOs and inter-module contracts keep those UUIDs when they
+refer to an existing resource. A workspace or project `slug` is a mutable
+navigation and display field. It can be set or changed through its resource
+contract, but it does not replace the UUID in an identity position.
+
+The client resolves workspace and project slugs before it calls these routes.
+The server therefore does not resolve a slug during `requireWorkspaceAccess` or
+`requireProjectAccess`, and session claims do not carry slugs. The workspace
+slug-availability route is a namespace check that returns only a boolean. It does
+not identify or authorize a workspace.
+
+Workflow run numbers follow the same boundary. The number is allocated per
+workflow definition and is exposed for display and workflow expressions. It is
+never resolved by an HTTP route. Run and job addresses remain UUIDs. See
+[ADR 0009](../adr/0009-client-url-prefix-invariants.md) for the decision and
+rejected alternatives.
+
 For contract primitives and transport-specific behavior, read the
 [inter-module package README](../../libs/shared/common/inter-module/README.md).
 It owns that package's public API and constraints.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -91,7 +91,7 @@ not identify or authorize a workspace.
 Workflow run numbers follow the same boundary. The number is allocated per
 workflow definition and is exposed for display and workflow expressions. It is
 never resolved by an HTTP route. Run and job addresses remain UUIDs. See
-[ADR 0009](../adr/0009-client-url-prefix-invariants.md) for the decision and
+[ADR 0009](../adr/0009-client-urls-resource-identity.md) for the decision and
 rejected alternatives.
 
 For contract primitives and transport-specific behavior, read the

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -70,7 +70,7 @@ Settings contributions declare an optional `scope` of `workspace` or `project`.
 Entries without a scope remain workspace settings; project-scoped entries render
 under the `projectSettings` anchor.
 
-This split is the client side of [ADR 0009](../adr/0009-client-url-prefix-invariants.md).
+This split is the client side of [ADR 0009](../adr/0009-client-urls-resource-identity.md).
 The API remains slug-free in resource identity positions, so
 `requireWorkspaceAccess` continues to authorize the UUID selected by the client.
 

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -53,6 +53,27 @@ Components do not build snake_case transport payloads. Empty responses,
 redirect URLs, health checks, and opaque acknowledgements can remain transport
 values when they have no domain meaning.
 
+## Resource identity and client URLs
+
+Client route params use `workspaceSlug` and `projectSlug` for workspace and
+project navigation. The shell resolves those slugs at the workspace and project
+anchor boundaries. Feature pages receive the resolved resource context before
+they build requests.
+
+Adapters keep using `workspaceId` and `projectId` UUIDs. Query keys also use the
+UUID identity, not the URL slug. A rename therefore changes navigation without
+creating a second cache entry or changing the API authorization input. Run and
+job routes keep their UUID params below the `runs` page segment. The displayed
+run number is not a route identifier.
+
+Settings contributions declare an optional `scope` of `workspace` or `project`.
+Entries without a scope remain workspace settings; project-scoped entries render
+under the `projectSettings` anchor.
+
+This split is the client side of [ADR 0009](../adr/0009-client-url-prefix-invariants.md).
+The API remains slug-free in resource identity positions, so
+`requireWorkspaceAccess` continues to authorize the UUID selected by the client.
+
 Each server-backed resource exposes a package-owned named
 `*QueryOptions` or `*InfiniteQueryOptions` factory from `hooks/api/`. The
 factory owns its key, request, mapping, cache policy, and pagination. Hooks,

--- a/libs/api/projects/README.md
+++ b/libs/api/projects/README.md
@@ -1,0 +1,83 @@
+# Shipfox API Projects
+
+Shipfox API Projects manages project resources and their source repository bindings.
+
+## What it does
+
+- **`createProjectFromSource`**: Creates a project from a repository in an integration connection.
+- **`updateProjectDetails`**: Changes a project's name or slug and writes the update event.
+- **`createProjectRoutes`**: Mounts project and administrator HTTP routes.
+- **`Project`**: Represents the project identity, URL slug, source repository, and timestamps.
+
+## Installation / Setup
+
+```sh
+pnpm add @shipfox/api-projects
+```
+
+The module needs an integrations client to resolve the source integration
+connection and an Auth client for module setup.
+
+## Usage
+
+```ts
+import {createProjectFromSource} from '@shipfox/api-projects';
+
+const project = await createProjectFromSource({
+  actorId,
+  workspaceId,
+  name: 'Checkout API',
+  slug: 'checkout-api',
+  sourceConnectionId,
+  sourceExternalRepositoryId,
+  integrations,
+});
+```
+
+## Routes / API / Data Model
+
+Routes mount under `/projects` and use UUIDs for resource identity:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/projects` | Create a project from a source repository. |
+| `GET` | `/projects?workspace_id=<workspaceId>` | List projects in a workspace. |
+| `GET` | `/projects/<projectId>` | Read one project. |
+| `PATCH` | `/projects/<projectId>` | Update a project's name or slug. |
+
+The create and update bodies carry the mutable `slug` field. A project slug is
+unique within its workspace. A duplicate returns `409 slug-conflict`, while a
+repository already bound to a project returns the separate
+`409 project-already-exists` error.
+
+| Field | Constraint | Use |
+| --- | --- | --- |
+| `id` | UUID, stable | API resource identity |
+| `workspace_id` | UUID | Workspace ownership |
+| `name` | Required display text | Project label |
+| `slug` | Required, unique within `workspace_id` | Client navigation and display |
+| `source` | Integration connection and repository identifiers | Source binding |
+
+Project slugs are navigation values. The API does not resolve a project from a
+slug in a resource path or query. The client resolves a project slug from its
+workspace project list, then sends the UUID to the API.
+
+## Behavior Notes
+
+The create form derives an editable default slug from the project name. The API
+requires an explicit slug and never adds a suffix when the value is taken. A
+rename frees the old slug immediately and emits a project-updated outbox event.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/api-projects
+turbo type --filter=@shipfox/api-projects
+turbo test --filter=@shipfox/api-projects
+```
+
+For repository test conventions, read the [testing guide](../../../docs/guides/testing.md).
+
+## License
+
+MIT

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -1,0 +1,75 @@
+# Shipfox API Workflows
+
+Shipfox API Workflows creates and runs workflow definitions, jobs, executions, steps, and run history.
+
+## What it does
+
+- **`createWorkflowsModule`**: Registers workflow routes, persistence, events, subscribers, and orchestration.
+- **`runWorkflow`**: Loads a definition and creates a run with its initial graph.
+- **`WorkflowRun`**: Represents a run with UUID identity, status, trigger data, and display fields.
+- **`loadRunningLeasedStep`**: Loads the step state available to a leased runner.
+
+## Installation / Setup
+
+```sh
+pnpm add @shipfox/api-workflows
+```
+
+The module requires the Auth, Definitions, Integrations, Projects, Runners,
+Secrets, Workspaces, Annotations, and Agent inter-module clients.
+
+## Usage
+
+```ts
+import {runWorkflow} from '@shipfox/api-workflows';
+
+const run = await runWorkflow(definitions, {
+  agent,
+  workspaceId,
+  projectId,
+  definitionId,
+  triggerPayload: {
+    source: 'manual',
+    event: 'fire',
+    subscriptionId,
+    userId,
+  },
+});
+```
+
+## Routes / API / Data Model
+
+Workflow routes keep UUIDs in path and query parameters. The run response
+includes both `id` and `number`. The UUID identifies the run. The number is a
+display label and workflow expression value.
+
+## Behavior Notes
+
+Run numbers are sequential within one workflow definition, start at `1`, and
+are unique for `(definition_id, number)`. The Workflows module allocates the
+number with a per-definition counter inside the run-creation transaction. It
+resolves trigger idempotency before allocation, so a duplicate delivery returns
+the original run without consuming another number.
+
+Gaps are acceptable because the number is a label and monotonicity matters more
+than density. Counter rows stay after a definition is removed, and reruns create
+another attempt on the same run without consuming a number.
+
+Run numbers are never addresses. No route resolves a run by its number, and run
+URLs continue to use the run UUID. A run number is useful in workflow
+expressions as `run.number` and should appear beside the workflow name when it is
+shown in a list.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/api-workflows
+turbo type --filter=@shipfox/api-workflows
+turbo test --filter=@shipfox/api-workflows
+```
+
+DB-backed workflow tests need local Postgres from `docker compose up -d`.
+
+## License
+
+MIT

--- a/libs/api/workspaces/README.md
+++ b/libs/api/workspaces/README.md
@@ -60,6 +60,18 @@ summaries. Supporting count failures are represented as `unknown`. `POST
 status, correlation_id}`. Both write a redacted `administration.action.performed`
 outbox event and record their result for idempotent retries.
 
+Workspace identity fields are:
+
+| Field | Constraint | Use |
+| --- | --- | --- |
+| `id` | UUID, stable | API resource identity and foreign references |
+| `name` | Required display text | Workspace label |
+| `slug` | Required, globally unique resource slug | Client navigation and display |
+
+The API keeps `id` in resource path parameters. `slug` is accepted on create and
+update, and a duplicate returns `409 slug-conflict`. A slug change frees the old
+value immediately. No API resource route resolves a workspace from its slug.
+
 The module creates these tables:
 
 - `workspaces`


### PR DESCRIPTION
## Summary

Record the client URL and resource-identity contract in ADR 0009 while keeping ADR 0001 as the canonical owner of anchor paths, protected-anchor rules, and composition diagnostics.

Document the slug/UUID boundary, entity-prefix invariants, project-settings scope, run-number semantics, and the terminology distinction across the architecture, package, and product documentation surfaces that own those facts.

## Validation

- `mise exec -- turbo verify --filter=@shipfox/repository-documentation-policy`
- `mise exec -- turbo test --filter=@shipfox/docs`
- `mise exec -- turbo check --filter=@shipfox/docs`
- `mise exec -- git diff --check`

The requested `pnpm check:documentation` script is not defined in this checkout; the repository's documented documentation-policy verifier passed.

Closes ENG-1452

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents slug-based client URLs and UUID-based API identity, restores prefix diagnostics in ADR 0001, adds the `projectSettings` anchor and `scope` for settings sections, and defines per-definition run-number semantics. ADR 0009 now records the URL/identity decisions while ADR 0001 remains the canonical owner of anchor paths and diagnostics; updates ADRs, architecture and product docs, and adds READMEs for `@shipfox/api-projects`, `@shipfox/api-workflows`, and `@shipfox/api-workspaces` to implement ENG-1452.

- **Migration**
  - Use slug paths: `/w/$workspaceSlug` and `/w/$workspaceSlug/p/$projectSlug`; legacy `/workspaces/$wid` paths fail composition.
  - Add `scope` to `settingsSections` and use the project settings anchor (`/w/$workspaceSlug/p/$projectSlug/settings`).
  - Keep UUIDs for API requests and routes under resource pages (e.g., `runs/$workflowRunId` and `jobs/$jobId`); `run.number` is display-only.

<sup>Written for commit e512ee0a95d71e20e4b93e1a3b4b221d87cba0f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

