### PR TITLE
Preserve first-checkout intent for runner materialization

### DIFF
--- a/.changeset/first-checkout-rule.md
+++ b/.changeset/first-checkout-rule.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-definitions": minor
+"@shipfox/api-workflows": minor
+---
+
+Carry first-checkout intent through workflow normalization and step materialization for the upcoming runner checkout execution, including implicit-checkout suppression, checkout opt-out, and position-based primary checkout placement.

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -87,7 +87,7 @@ export interface WorkflowModelJob {
   readonly mode: 'one_shot' | 'listening';
   readonly runner: readonly string[];
   readonly runnerTemplates?: readonly WorkflowFieldTemplate[];
-  readonly checkout: WorkflowModelJobCheckout;
+  readonly checkout: WorkflowModelJobCheckout | false;
   readonly if?: WorkflowExpression;
   readonly success?: string;
   readonly outputs?: WorkflowOutputTemplates;

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -53,7 +53,6 @@ export type WorkflowModelValidationIssueCode =
   | 'unknown-integration-method'
   | 'unknown-integration-tool'
   | 'unknown-job-dependency'
-  | 'unsupported-checkout'
   | 'untrusted-agent-selection-context';
 
 export type WorkflowModelValidationIssuePathSegment = string | number;

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
@@ -21,19 +21,9 @@ const DEFAULT_CHECKOUT_FETCH_DEPTH = 1;
 
 export function normalizeJobCheckout(params: {
   checkout: WorkflowDocumentJob['checkout'];
-  issues: WorkflowModelValidationIssue[];
-  path: readonly WorkflowModelValidationIssuePathSegment[];
-}): WorkflowModelJobCheckout {
+}): WorkflowModelJobCheckout | false {
   if (params.checkout === false) {
-    params.issues.push(
-      issue({
-        code: 'unsupported-checkout',
-        message: 'checkout: false is not supported by the workflow model yet.',
-        path: params.path,
-      }),
-    );
-
-    return DEFAULT_JOB_CHECKOUT;
+    return false;
   }
 
   const checkout = params.checkout ?? {};

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -209,8 +209,6 @@ function normalizeJob(params: {
   });
   const checkout = normalizeJobCheckout({
     checkout: params.job.checkout,
-    issues: params.issues,
-    path: ['jobs', params.sourceName, 'checkout'],
   });
   const jobEnv = normalizeEnv({
     env: params.job.env,

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1122,8 +1122,8 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.jobs[0]?.checkout).toEqual(DEFAULT_JOB_CHECKOUT);
   });
 
-  it('reports the staged job checkout opt-out until model support lands', () => {
-    const error = expectInvalid({
+  it('preserves the job checkout opt-out in the model', () => {
+    const model = normalizeWorkflowDocument({
       name: 'checkout disabled',
       jobs: {
         build: {
@@ -1133,12 +1133,7 @@ describe('normalizeWorkflowDocument', () => {
       },
     });
 
-    expect(error.issues).toContainEqual(
-      expect.objectContaining({
-        code: 'unsupported-checkout',
-        path: ['jobs', 'build', 'checkout'],
-      }),
-    );
+    expect(model.jobs[0]?.checkout).toBe(false);
   });
 
   it('normalizes checkout-step targets from earlier step outputs', () => {

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_INTEGRATION_MCP_TRANSPORT,
 } from '@shipfox/api-agent-dto';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
+import {createWorkflowExpression} from '@shipfox/expression';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {AgentToolCatalogEntry, AgentToolMaterializationContext} from '#core/agent-tools.js';
@@ -29,6 +30,19 @@ function template(source: string): string {
 
 function shellRef(name: string): string {
   return `\${${name}}`;
+}
+
+function checkout(repository: string) {
+  return {
+    repository,
+    fetchDepth: 1,
+    permissions: {contents: 'read' as const},
+    persistCredentials: true,
+  };
+}
+
+function condition(source: string) {
+  return createWorkflowExpression({source, check: {mode: 'syntax'}});
 }
 
 function jobExecutionContext(): WorkflowEvaluationContext {
@@ -208,12 +222,7 @@ describe('materializeJobExecutionSteps', () => {
 
     expect(steps[0]).toMatchObject({
       type: 'setup',
-      config: {
-        checkout: {
-          permissions: {contents: 'read'},
-          persist_credentials: true,
-        },
-      },
+      config: {},
     });
     expect(steps[1]).toEqual({
       key: null,
@@ -234,6 +243,106 @@ describe('materializeJobExecutionSteps', () => {
       },
       authoredConfig: null,
       position: 1,
+    });
+  });
+
+  it('places a leading checkout at the job root when its path is omitted', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [{checkout: checkout('acme/api')}, {run: 'echo use checkout'}],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[0]).toMatchObject({type: 'setup', config: {}});
+    expect(steps[1]).toMatchObject({
+      type: 'checkout',
+      config: {checkout: {repository: 'acme/api', path: '.'}},
+    });
+    expect(steps[2]).toMatchObject({type: 'run', config: {run: 'echo use checkout'}});
+  });
+
+  it('keeps the implicit checkout when an explicit checkout is not leading', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {run: 'echo route'},
+            {checkout: checkout('acme/api')},
+            {run: 'echo use checkout'},
+          ],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[0]).toMatchObject({
+      type: 'setup',
+      config: {
+        checkout: {
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+        },
+      },
+    });
+    expect(steps[2]).toMatchObject({
+      type: 'checkout',
+      config: {
+        checkout: {
+          repository: 'acme/api',
+          fetch_depth: 1,
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+        },
+      },
+    });
+    expect(steps[2]?.config.checkout).not.toHaveProperty('path');
+    expect(steps[3]).toMatchObject({type: 'run', config: {run: 'echo use checkout'}});
+  });
+
+  it('omits the implicit checkout when the job opts out', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          checkout: false,
+          steps: [{run: 'echo no repository'}],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[0]).toMatchObject({type: 'setup', config: {}});
+  });
+
+  it('does not restore the implicit checkout for a leading checkout with a false if', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [{if: condition('false'), checkout: checkout('acme/api')}],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[0]).toMatchObject({type: 'setup', config: {}});
+    expect(steps[1]).toMatchObject({
+      type: 'checkout',
+      condition: expect.any(Object),
+      config: {checkout: {repository: 'acme/api', path: '.'}},
     });
   });
 

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -94,7 +94,11 @@ export async function materializeJobExecutionSteps(
           sourceLocation: step.sourceLocation ?? null,
           status: 'pending' as const,
           type: step.kind,
-          config: resolved.config,
+          config: materializedStepConfig({
+            config: resolved.config,
+            step,
+            stepPosition,
+          }),
           ...(step.if === undefined ? {} : {condition: step.if}),
           authoredConfig: resolved.authoredConfig,
           ...materializedConfigPlan(resolved.configPlan, resolved.trace),
@@ -107,6 +111,10 @@ export async function materializeJobExecutionSteps(
 }
 
 function setupStepForJob(job: WorkflowModelJob): MaterializedWorkflowStep {
+  if (job.checkout === false || job.steps[0]?.kind === 'checkout') {
+    return {...SETUP_STEP, config: {}};
+  }
+
   const checkout = job.checkout ?? DEFAULT_JOB_CHECKOUT;
 
   return {
@@ -118,6 +126,27 @@ function setupStepForJob(job: WorkflowModelJob): MaterializedWorkflowStep {
       },
     },
   };
+}
+
+function materializedStepConfig(params: {
+  readonly config: Readonly<Record<string, unknown>>;
+  readonly step: WorkflowModelStep;
+  readonly stepPosition: number;
+}): Readonly<Record<string, unknown>> {
+  if (
+    params.step.kind !== 'checkout' ||
+    params.stepPosition !== 0 ||
+    params.step.checkout.path !== undefined
+  ) {
+    return params.config;
+  }
+
+  const checkout = params.config.checkout;
+  if (checkout === null || typeof checkout !== 'object' || Array.isArray(checkout)) {
+    throw new Error('Checkout materialization config is missing an object');
+  }
+
+  return {...params.config, checkout: {...checkout, path: '.'}};
 }
 
 function materializedConfigPlan(

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -702,6 +702,7 @@ describe('materializeWorkflowModel', () => {
     expect(rows[0]?.steps[1]?.config).toEqual({
       checkout: {
         fetch_depth: 1,
+        path: '.',
         permissions: {contents: 'read'},
         persist_credentials: true,
       },

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
@@ -1,4 +1,4 @@
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import {DEFAULT_JOB_CHECKOUT, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {
@@ -19,7 +19,7 @@ export interface MaterializedWorkflowJob {
   readonly mode: WorkflowModelJob['mode'];
   readonly success?: string;
   readonly executionTimeoutMs?: number;
-  readonly checkout: WorkflowModelJob['checkout'];
+  readonly checkout: Exclude<WorkflowModelJob['checkout'], false>;
   readonly listening?: WorkflowModelJob['listening'];
   readonly name?: string;
   readonly outputs?: WorkflowModelJob['outputs'];
@@ -61,7 +61,7 @@ export async function materializeWorkflowModel(
         ...(job.executionTimeoutMs === undefined
           ? {}
           : {executionTimeoutMs: job.executionTimeoutMs}),
-        checkout: job.checkout,
+        checkout: job.checkout === false ? DEFAULT_JOB_CHECKOUT : job.checkout,
         ...(job.listening === undefined ? {} : {listening: job.listening}),
         ...(name === undefined ? {} : {name}),
         ...(job.outputs === undefined ? {} : {outputs: job.outputs}),

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -195,6 +195,7 @@ function materializeRerunGraphJobs(params: {
     const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
     const modelJob = sourceModelJobByKey.get(sourceJob.key);
     const modelCheckout = modelJob?.checkout;
+    const resolvedModelCheckout = modelCheckout === false ? undefined : modelCheckout;
 
     return {
       job: {
@@ -205,9 +206,9 @@ function materializeRerunGraphJobs(params: {
         statusReason: null,
         carriedOver,
         checkoutPersistCredentials:
-          modelCheckout?.persistCredentials ?? sourceJob.checkoutPersistCredentials,
+          resolvedModelCheckout?.persistCredentials ?? sourceJob.checkoutPersistCredentials,
         checkoutPermissionsContents:
-          modelCheckout?.permissions?.contents ?? sourceJob.checkoutPermissionsContents,
+          resolvedModelCheckout?.permissions?.contents ?? sourceJob.checkoutPermissionsContents,
         success: sourceJob.success,
         executionTimeoutMs: sourceJob.executionTimeoutMs,
         listeningTimeoutMs: sourceJob.listeningTimeoutMs,


### PR DESCRIPTION
Carries first-checkout intent through workflow normalization and server step materialization, including checkout opt-out, implicit-checkout suppression, and primary-checkout placement.

This PR intentionally stops at model/materialization plumbing. Runner setup still needs to consume the setup config for checkout opt-out, and explicit checkout steps still require a runner executor. That follow-up remains separate from this change.

Validation passed: `mise exec -- turbo type --filter=@shipfox/api-workflows...`, `mise exec -- turbo test --filter=@shipfox/api-definitions --filter=@shipfox/api-workflows`, `mise exec -- turbo check --filter=@shipfox/api-workflows...`, and `mise exec -- git diff --check`.

Refs ENG-1434

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves first-checkout intent across workflow normalization and step materialization: supports checkout opt-out, suppresses implicit checkout, and places a leading checkout at the job root. Supports ENG-1434; runner execution changes will follow.

- New Features
  - Allow `checkout: false` in the job model and remove the unsupported-checkout validation.
  - Setup step: omit implicit checkout when the job opts out or when the first step is an explicit checkout; otherwise keep it.
  - Leading explicit checkout without a path gets `path: '.'` and still suppresses the implicit checkout even if its `if` is false.
  - Materialized jobs backfill the default checkout for persistence; reruns correctly derive checkout credentials/permissions when the model uses `checkout: false`.

<sup>Written for commit b6d921f3a1c0ed6a1437870eb4394d1a07a71192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

