### PR TITLE
[react-ui] Show one-sided date ranges

### DIFF
--- a/.changeset/partial-date-ranges.md
+++ b/.changeset/partial-date-ranges.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Shows one-sided date ranges in DateRangePicker values.

--- a/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.stories.tsx
+++ b/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.stories.tsx
@@ -70,6 +70,25 @@ export const WithSelectedRange: Story = {
   render: (args) => <ControlledPicker {...args} initialRange={seededRange} />,
 };
 
+export const PartialRanges: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-16">
+      <div className="grid gap-8">
+        <Label htmlFor="start-only-picker">Start only</Label>
+        <ControlledPicker
+          {...args}
+          id="start-only-picker"
+          initialRange={{start: seededRange.start}}
+        />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="end-only-picker">End only</Label>
+        <ControlledPicker {...args} id="end-only-picker" initialRange={{end: seededRange.end}} />
+      </div>
+    </div>
+  ),
+};
+
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex flex-col gap-12">

--- a/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.tsx
@@ -82,8 +82,7 @@ export function DateRangePicker({
   const endDate = dateRange?.end && isValid(dateRange.end) ? dateRange.end : undefined;
   const hasSelection = Boolean(startDate || endDate);
 
-  const displayValue =
-    startDate && endDate ? `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}` : '';
+  const displayValue = formatDateRange(startDate, endDate, dateFormat);
 
   const dayPickerRange: DayPickerDateRange | undefined =
     startDate || endDate ? {from: startDate, to: endDate} : undefined;
@@ -211,4 +210,17 @@ export function DateRangePicker({
       </PopoverContent>
     </Popover>
   );
+}
+
+function formatDateRange(
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  dateFormat: string,
+): string {
+  if (startDate && endDate) {
+    return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`;
+  }
+  if (startDate) return `From ${format(startDate, dateFormat)}`;
+  if (endDate) return `Until ${format(endDate, dateFormat)}`;
+  return '';
 }


### PR DESCRIPTION
Show partial `DateRangePicker` values with `From` and `Until` labels so active filters no longer appear unset. Complete ranges keep their existing format and partial selections retain the clear action.

Add Storybook coverage for start-only and end-only ranges, plus a patch Changeset for `@shipfox/react-ui`.

Closes ENG-1471

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show one-sided date ranges in `DateRangePicker` using clear "From" and "Until" labels so partial filters no longer look unset. Full ranges stay the same. Closes ENG-1471.

- **New Features**
  - Display "From <date>" when only a start date is set, and "Until <date>" when only an end date is set.
  - Added Storybook examples for start-only and end-only ranges.
  - Added a patch Changeset for `@shipfox/react-ui`.

<sup>Written for commit 7b15d3c53601eba21077c3d7c8c2e013c41f6a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

