### PR TITLE
Add safe explicit checkout targeting

### DIFF
--- a/.changeset/runner-checkout-destination-errors.md
+++ b/.changeset/runner-checkout-destination-errors.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows-dto": minor
+"@shipfox/client-workflows": minor
+---
+
+Add typed step errors for invalid checkout paths and occupied checkout destinations.

--- a/apps/client/turbo.json
+++ b/apps/client/turbo.json
@@ -5,7 +5,7 @@
     "generate": {
       "cache": true,
       "outputs": ["src/shipfox-app.gen.ts"],
-      "dependsOn": ["^type:emit"]
+      "dependsOn": ["^build", "^type:emit"]
     },
     "build": {
       "dependsOn": ["generate", "^build"],

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -26,6 +26,9 @@ const jobStatusSchema = z.enum([
 const jobStatusReasonSchema = z.enum([
   'dependency_not_completed',
   'condition_false',
+  'default_gate_rejected',
+  'condition_rejected',
+  'condition_errored',
   'user_cancelled',
   'run_cancelled',
   'timed_out',
@@ -45,6 +48,8 @@ const stepErrorReasonSchema = z.enum([
   'checkout_failed',
   'checkout_auth_failed',
   'checkout_unavailable',
+  'checkout_path_invalid',
+  'checkout_destination_occupied',
   'git_unavailable',
   'workspace_prep_failed',
   'setup_aborted',
@@ -59,14 +64,17 @@ type AssertExact<Actual, Expected> = [Actual] extends [Expected]
     ? true
     : never
   : never;
-export type _ExpectJobStatusReasonSchemaMatchesDto = AssertExact<
+// Assigned to a value so a mismatch is a compile error: a bare `type X = AssertExact<…>`
+// alias resolves to `never` without failing the build, which lets the DTO add a reason
+// this suite silently cannot assert.
+const _expectJobStatusReasonSchemaMatchesDto: AssertExact<
   z.infer<typeof jobStatusReasonSchema>,
   JobStatusReasonDto
->;
-export type _ExpectStepErrorReasonSchemaMatchesDto = AssertExact<
+> = true;
+const _expectStepErrorReasonSchemaMatchesDto: AssertExact<
   z.infer<typeof stepErrorReasonSchema>,
   StepErrorReasonDto
->;
+> = true;
 
 const logsExpectationSchema = z
   .object({

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -61,6 +61,18 @@ describe('stepErrorDtoSchema', () => {
     });
   });
 
+  it.each([
+    'checkout_path_invalid',
+    'checkout_destination_occupied',
+  ] as const)('accepts the runner checkout destination reason %s', (reason) => {
+    const result = stepErrorDtoSchema.parse({
+      message: 'Checkout destination policy rejected the step.',
+      reason,
+    });
+
+    expect(result?.reason).toBe(reason);
+  });
+
   it('rejects unknown agent config issues', () => {
     const result = stepErrorDtoSchema.safeParse({
       message: 'Model provider credentials are not configured',

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 // Machine-readable cause of a step failure, for DB troubleshooting. The runner
 // reports it and the server stores it as-is. The `checkout_*`, `git_unavailable`,
-// `workspace_prep_failed`, and `setup_aborted` values cover setup-phase failures.
+// `workspace_prep_failed`, and `setup_aborted` values cover checkout/setup failures.
 // For agent steps the cause is split three ways: `agent_config_invalid` is a user-fixable
 // configuration error and carries an `agent_config_issue`; `agent_invocation_failed`
 // covers a provider/API failure once the configuration is valid; and
@@ -13,6 +13,8 @@ export const stepErrorReasonSchema = z.enum([
   'checkout_failed',
   'checkout_auth_failed',
   'checkout_unavailable',
+  'checkout_path_invalid',
+  'checkout_destination_occupied',
   'git_unavailable',
   'workspace_prep_failed',
   'setup_aborted',

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -4,6 +4,8 @@ export type StepErrorReason =
   | 'checkout_failed'
   | 'checkout_auth_failed'
   | 'checkout_unavailable'
+  | 'checkout_path_invalid'
+  | 'checkout_destination_occupied'
   | 'git_unavailable'
   | 'workspace_prep_failed'
   | 'setup_aborted'
@@ -23,6 +25,8 @@ export const STEP_ERROR_REASONS = new Set<StepErrorReason>([
   'checkout_failed',
   'checkout_auth_failed',
   'checkout_unavailable',
+  'checkout_path_invalid',
+  'checkout_destination_occupied',
   'git_unavailable',
   'workspace_prep_failed',
   'setup_aborted',

--- a/libs/runner/execution/src/core/checkout-execution.ts
+++ b/libs/runner/execution/src/core/checkout-execution.ts
@@ -1,0 +1,330 @@
+import type {CheckoutTokenResponseDto, StepErrorReasonDto} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {HTTPError, requestCheckoutToken} from '@shipfox/runner-protocol';
+import {
+  type CheckoutCommandStartMetadata,
+  CheckoutError,
+  type CheckoutFailureKind,
+  type CheckoutOutputSink,
+  type CheckoutPhase,
+  checkoutRepository,
+  writeAmbientGitCredential,
+} from '@shipfox/runner-workspace';
+import type {KyInstance} from 'ky';
+import type {StepResult} from '#core/step-result.js';
+
+const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
+
+export interface CheckoutLogSink {
+  writeGroupStart(name: string): void;
+  writeGroupEnd(): void;
+  writeGroup(options: {name: string; lines: readonly string[]; source?: 'stdout' | 'stderr'}): void;
+  writeOutputLine(line: string, source?: 'stdout' | 'stderr'): void;
+  write(chunk: Buffer, source: 'stdout' | 'stderr'): void;
+  addSecrets(secrets: string[]): void;
+}
+
+export type CheckoutFailureScope = 'setup' | 'checkout';
+
+export type CheckoutPhaseResult<T> = {ok: true; value: T} | {ok: false; result: StepResult};
+
+export async function requestCheckoutCredentials(params: {
+  leaseClient: KyInstance;
+  signal: AbortSignal;
+  stepId: string;
+  attempt: number;
+  log?: CheckoutLogSink | undefined;
+  scope: CheckoutFailureScope;
+}): Promise<CheckoutPhaseResult<CheckoutTokenResponseDto>> {
+  const {leaseClient, signal, stepId, attempt, log, scope} = params;
+  try {
+    log?.writeGroup({
+      name: 'Request repository access',
+      lines: ['Requesting short-lived repository access from Shipfox.'],
+    });
+    const checkout = await requestCheckoutToken(leaseClient, {stepId, attempt, signal});
+    log?.writeGroup({
+      name: 'Repository access granted',
+      lines: credentialLines(checkout.auth),
+    });
+    return {ok: true, value: checkout};
+  } catch (error) {
+    const reason = classifyCheckoutTokenError(error);
+    writeFailure(
+      log,
+      scope === 'setup'
+        ? 'Setup failed because Shipfox could not grant repository access.'
+        : 'Checkout step failed because Shipfox could not grant repository access.',
+      checkoutTokenFailureHelp(reason),
+      error,
+    );
+    return {ok: false, result: fail(error, reason)};
+  }
+}
+
+export async function checkoutRepositoryAt(params: {
+  destination: string;
+  gitConfigPath: string;
+  checkout: CheckoutTokenResponseDto;
+  signal: AbortSignal;
+  log?: CheckoutLogSink | undefined;
+  scope: CheckoutFailureScope;
+}): Promise<
+  CheckoutPhaseResult<{
+    ambientGitConfigPath?: string | undefined;
+    checkout: NonNullable<StepResult['checkout']>;
+  }>
+> {
+  const {destination, gitConfigPath, checkout, signal, log, scope} = params;
+  try {
+    log?.writeGroup({
+      name: 'Repository details',
+      lines: [
+        `Repository: ${safeRepositoryUrl(checkout.repository_url)}`,
+        `Requested ref: ${checkout.ref}`,
+        `Path: ${destination}`,
+      ],
+    });
+    const commit = await checkoutRepository({
+      repositoryUrl: checkout.repository_url,
+      ref: checkout.ref,
+      fetchDepth: checkout.fetch_depth,
+      auth: checkout.auth,
+      cwd: destination,
+      signal,
+      onSecrets: (secrets) => log?.addSecrets(secrets),
+      onCommandStart: (metadata) => writeCheckoutCommand(log, metadata),
+      onOutput: checkoutOutput(log),
+    });
+    log?.writeGroup({name: 'Checkout complete', lines: [`Checked out commit: ${commit}`]});
+    const ambientGitConfigPath = await persistAmbientGitCredential({
+      gitConfigPath,
+      checkout,
+      log,
+      scope,
+    });
+    return {
+      ok: true,
+      value: {
+        checkout: {
+          repository: checkout.repository_url,
+          ref: checkout.ref,
+          commit,
+          path: destination,
+        },
+        ...(ambientGitConfigPath ? {ambientGitConfigPath} : {}),
+      },
+    };
+  } catch (error) {
+    const reason =
+      error instanceof CheckoutError ? CHECKOUT_KIND_REASON[error.kind] : 'checkout_failed';
+    if (error instanceof CheckoutError && error.phase) {
+      writeFailure(
+        log,
+        `${scope === 'setup' ? 'Setup' : 'Checkout step'} failed while ${checkoutPhaseAction(error.phase)}.`,
+        checkoutFailureHelp(reason),
+        error,
+      );
+    } else {
+      writeFailure(
+        log,
+        `${scope === 'setup' ? 'Setup' : 'Checkout step'} failed while checking out the repository.`,
+        checkoutFailureHelp(reason),
+        error,
+      );
+    }
+    return {ok: false, result: fail(error, reason)};
+  }
+}
+
+async function persistAmbientGitCredential(params: {
+  gitConfigPath: string;
+  checkout: CheckoutTokenResponseDto;
+  log?: CheckoutLogSink | undefined;
+  scope: CheckoutFailureScope;
+}): Promise<string | undefined> {
+  const {gitConfigPath, checkout, log, scope} = params;
+  if (!checkout.auth?.persist || checkout.auth.carry !== 'header') return undefined;
+
+  try {
+    await writeAmbientGitCredential({
+      configPath: gitConfigPath,
+      repositoryUrl: checkout.repository_url,
+      auth: checkout.auth,
+      ...(checkout.git_author ? {gitAuthor: checkout.git_author} : {}),
+    });
+    return gitConfigPath;
+  } catch (error) {
+    writeWarning(
+      log,
+      'Repository access was not persisted',
+      [
+        `The checkout succeeded, but agent steps will run without ambient git authentication. Details: ${messageOf(error)}`,
+        'Git commands in later steps may need their own credentials.',
+      ],
+      scope,
+    );
+    return undefined;
+  }
+}
+
+const CHECKOUT_KIND_REASON: Record<CheckoutFailureKind, StepErrorReasonDto> = {
+  auth: 'checkout_auth_failed',
+  unavailable: 'checkout_unavailable',
+  failed: 'checkout_failed',
+  aborted: 'setup_aborted',
+};
+
+// Maps a checkout-token endpoint failure to a reason. Auth denial and the backend's
+// retryable provider signals (429/503, or their typed `code`) get distinct reasons; a
+// missing checkout intent (404) and everything else fold into the generic failure.
+// CheckoutError messages are already redacted in the workspace layer; the token-fetch
+// error never carries credential material.
+function classifyCheckoutTokenError(error: unknown): StepErrorReasonDto {
+  if (!(error instanceof HTTPError)) return 'checkout_failed';
+
+  const {status} = error.response;
+  const code = readErrorCode(error);
+
+  if (status === 401 || status === 403 || code === 'access-denied' || code === 'forbidden') {
+    return 'checkout_auth_failed';
+  }
+  if (
+    status === 429 ||
+    status === 503 ||
+    code === 'rate-limited' ||
+    code === 'timeout' ||
+    code === 'provider-unavailable'
+  ) {
+    return 'checkout_unavailable';
+  }
+  return 'checkout_failed';
+}
+
+// ky consumes the response body to populate `error.data` before throwing, so the body
+// is already read here: `error.response.json()` would throw "Body has already been
+// consumed". Read ky's pre-parsed `data` instead.
+function readErrorCode(error: HTTPError): string | undefined {
+  const body = error.data;
+  if (body && typeof body === 'object' && 'code' in body && typeof body.code === 'string') {
+    return body.code;
+  }
+  return undefined;
+}
+
+function fail(error: unknown, reason: StepErrorReasonDto): StepResult {
+  return {
+    success: false,
+    error: {message: messageOf(error), reason},
+    exit_code: null,
+  };
+}
+
+function writeCheckoutCommand(
+  log: CheckoutLogSink | undefined,
+  metadata: CheckoutCommandStartMetadata,
+): void {
+  log?.writeGroup({
+    name: checkoutPhaseTitle(metadata.phase),
+    lines: [`Command: ${metadata.command}`, `Working directory: ${metadata.cwd}`],
+  });
+}
+
+function checkoutOutput(log: CheckoutLogSink | undefined): CheckoutOutputSink | undefined {
+  if (!log) return undefined;
+  return (chunk, source) => log.write(chunk, source);
+}
+
+function credentialLines(auth: CheckoutTokenResponseDto['auth']): string[] {
+  if (!auth) return ['No repository credential was required.'];
+  return [
+    auth.kind === 'bearer'
+      ? 'Using a short-lived repository token.'
+      : 'Using a short-lived username/password repository credential.',
+    auth.expires_at ? `Expires at: ${auth.expires_at}` : 'No expiration was provided.',
+  ];
+}
+
+function checkoutPhaseTitle(phase: CheckoutPhase): string {
+  switch (phase) {
+    case 'init':
+      return 'Initialize repository';
+    case 'remote':
+      return 'Add repository remote';
+    case 'fetch':
+      return 'Fetch requested ref';
+    case 'checkout':
+      return 'Check out commit';
+    case 'resolve':
+      return 'Read checked-out commit';
+  }
+}
+
+function checkoutPhaseAction(phase: CheckoutPhase): string {
+  switch (phase) {
+    case 'init':
+      return 'initializing the local Git repository';
+    case 'remote':
+      return 'adding the repository remote';
+    case 'fetch':
+      return 'fetching the requested ref';
+    case 'checkout':
+      return 'checking out the fetched commit';
+    case 'resolve':
+      return 'reading the checked-out commit';
+  }
+}
+
+function checkoutTokenFailureHelp(reason: StepErrorReasonDto): string {
+  if (reason === 'checkout_auth_failed') {
+    return 'Check that the runner is connected to this workspace and the job is allowed to read this repository.';
+  }
+  if (reason === 'checkout_unavailable') {
+    return 'Retry the job; Shipfox or the repository provider may be temporarily unavailable.';
+  }
+  return 'Check the repository connection and job permissions in Shipfox, then retry the job.';
+}
+
+function checkoutFailureHelp(reason: StepErrorReasonDto): string {
+  if (reason === 'checkout_auth_failed') {
+    return 'Check the repository connection in Shipfox and confirm it has permission to read this repository.';
+  }
+  if (reason === 'checkout_unavailable') {
+    return 'Check the runner network and DNS access to the Git provider, then retry the job.';
+  }
+  if (reason === 'setup_aborted') {
+    return 'The job was cancelled or timed out before checkout completed.';
+  }
+  return 'Check that the repository URL and requested ref are valid. The git output above may include provider details.';
+}
+
+function writeFailure(
+  log: CheckoutLogSink | undefined,
+  summary: string,
+  nextStep: string,
+  error: unknown,
+): void {
+  log?.writeOutputLine(`${summary} Details: ${messageOf(error)}`, 'stderr');
+  log?.writeOutputLine(`Next step: ${nextStep}`, 'stderr');
+}
+
+function writeWarning(
+  log: CheckoutLogSink | undefined,
+  name: string,
+  lines: readonly string[],
+  scope: CheckoutFailureScope,
+): void {
+  if (log) {
+    log.writeGroup({name, lines, source: 'stderr'});
+    return;
+  }
+  logger().warn({name, lines}, scope === 'setup' ? 'Setup warning' : 'Checkout warning');
+}
+
+function safeRepositoryUrl(repositoryUrl: string): string {
+  return repositoryUrl.replace(URL_CREDENTIAL_RE, '$1***@');
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/runner/execution/src/core/checkout-execution.ts
+++ b/libs/runner/execution/src/core/checkout-execution.ts
@@ -321,7 +321,7 @@ function writeWarning(
   logger().warn({name, lines}, scope === 'setup' ? 'Setup warning' : 'Checkout warning');
 }
 
-function safeRepositoryUrl(repositoryUrl: string): string {
+export function safeRepositoryUrl(repositoryUrl: string): string {
   return repositoryUrl.replace(URL_CREDENTIAL_RE, '$1***@');
 }
 

--- a/libs/runner/execution/src/core/checkout-step.test.ts
+++ b/libs/runner/execution/src/core/checkout-step.test.ts
@@ -1,0 +1,280 @@
+import {mkdir, mkdtemp, readFile, realpath, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import type {StepDto} from '@shipfox/api-workflows-dto';
+import {HTTPError} from 'ky';
+
+const requestCheckoutTokenMock = vi.fn();
+const checkoutRepositoryMock = vi.fn();
+const writeAmbientGitCredentialMock = vi.fn();
+
+vi.mock('@shipfox/runner-protocol', () => ({
+  requestCheckoutToken: (...args: unknown[]) => requestCheckoutTokenMock(...args),
+  HTTPError,
+}));
+
+vi.mock('@shipfox/runner-workspace', async () => {
+  const actual = await vi.importActual<typeof import('@shipfox/runner-workspace')>(
+    '@shipfox/runner-workspace',
+  );
+  return {
+    ...actual,
+    checkoutRepository: (...args: unknown[]) => checkoutRepositoryMock(...args),
+    writeAmbientGitCredential: (...args: unknown[]) => writeAmbientGitCredentialMock(...args),
+  };
+});
+
+const {executeCheckoutStep} = await import('#core/checkout-step.js');
+
+const JOB_EXECUTION_ID = '00000000-0000-0000-0000-0000000000a1';
+const GIT_CONFIG_PATH = '/tmp/shipfox-checkout-test/git-cred.config';
+const signal = new AbortController().signal;
+const leaseClient = {} as never;
+
+function checkoutResponse(repository = 'repo-a', ref = 'main') {
+  return {
+    repository_url: `https://github.com/acme/${repository}.git`,
+    ref,
+    fetch_depth: 1,
+  };
+}
+
+function checkoutStep(config: Record<string, unknown> = {}): StepDto {
+  return {
+    id: crypto.randomUUID(),
+    job_execution_id: JOB_EXECUTION_ID,
+    key: null,
+    name: 'Checkout',
+    source_location: null,
+    status: 'running',
+    type: 'checkout',
+    config: {checkout: config},
+    error: null,
+    position: 1,
+    current_attempt: 1,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function fakeLog() {
+  return {
+    writeGroupStart: vi.fn(),
+    writeGroupEnd: vi.fn(),
+    writeGroup: vi.fn(),
+    writeOutputLine: vi.fn(),
+    write: vi.fn(),
+    addSecrets: vi.fn(),
+  };
+}
+
+describe('executeCheckoutStep', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await realpath(await mkdtemp(join(tmpdir(), 'shipfox-checkout-executor-')));
+    vi.clearAllMocks();
+    requestCheckoutTokenMock.mockResolvedValue(checkoutResponse());
+    checkoutRepositoryMock.mockResolvedValue('abc123');
+    writeAmbientGitCredentialMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await rm(workspace, {recursive: true, force: true});
+  });
+
+  function run(config: Record<string, unknown> = {}, destinations = new Map(), log = fakeLog()) {
+    return executeCheckoutStep({
+      cwd: workspace,
+      gitConfigPath: GIT_CONFIG_PATH,
+      leaseClient,
+      signal,
+      step: checkoutStep(config),
+      attempt: 1,
+      destinations,
+      log,
+    });
+  }
+
+  it('checks out into a missing explicit path and reports the resolved destination', async () => {
+    const destinations = new Map();
+
+    const result = await run({path: 'services/api'}, destinations);
+
+    const destination = resolve(workspace, 'services/api');
+    expect(checkoutRepositoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({cwd: destination, fetchDepth: 1}),
+    );
+    expect(result).toEqual({
+      result: {
+        success: true,
+        error: null,
+        exit_code: 0,
+        checkout: {
+          repository: 'https://github.com/acme/repo-a.git',
+          ref: 'main',
+          commit: 'abc123',
+          path: destination,
+        },
+      },
+    });
+    expect(destinations.get(destination)?.repository).toBe('https://github.com/acme/repo-a.git');
+  });
+
+  it.each(['missing', 'empty'])('checks out into a %s destination', async (state) => {
+    const destination = join(workspace, 'repo');
+    if (state === 'empty') await mkdir(destination);
+
+    const result = await run({path: 'repo'});
+
+    expect(result.result.success).toBe(true);
+    expect(checkoutRepositoryMock).toHaveBeenCalledOnce();
+  });
+
+  it.each(['missing', 'empty'])('checks out into a %s destination with force', async (state) => {
+    const destination = join(workspace, 'repo');
+    if (state === 'empty') await mkdir(destination);
+
+    const result = await run({path: 'repo', force: true});
+
+    expect(result.result.success).toBe(true);
+    expect(checkoutRepositoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({cwd: destination}),
+    );
+  });
+
+  it('re-checks out the same target at an owned path with force, discarding changes', async () => {
+    const destinations = new Map();
+    await run({path: 'repo'}, destinations);
+    const destination = resolve(workspace, 'repo');
+    await writeFile(join(destination, 'agent-change.txt'), 'discard me');
+    checkoutRepositoryMock.mockClear();
+
+    const result = await run({path: 'repo', force: true}, destinations);
+
+    expect(result.result.success).toBe(true);
+    expect(checkoutRepositoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({cwd: destination}),
+    );
+    await expect(readFile(join(destination, 'agent-change.txt'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect(destinations.get(destination)?.repository).toBe('https://github.com/acme/repo-a.git');
+  });
+
+  it('refuses to overwrite an occupied destination by default', async () => {
+    const destination = join(workspace, 'repo');
+    await mkdir(destination);
+    await writeFile(join(destination, 'agent-change.txt'), 'keep me');
+
+    const result = await run({path: 'repo'});
+
+    expect(result.result).toEqual({
+      success: false,
+      error: {
+        message: expect.stringContaining('Checkout destination is occupied'),
+        reason: 'checkout_destination_occupied',
+      },
+      exit_code: null,
+    });
+    expect(checkoutRepositoryMock).not.toHaveBeenCalled();
+    await expect(readFile(join(destination, 'agent-change.txt'), 'utf8')).resolves.toBe('keep me');
+  });
+
+  it('replaces an occupied destination only when force is set', async () => {
+    const destination = join(workspace, 'repo');
+    await mkdir(destination);
+    await writeFile(join(destination, 'agent-change.txt'), 'discard me');
+
+    const result = await run({path: 'repo', force: true});
+
+    expect(result.result.success).toBe(true);
+    expect(checkoutRepositoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({cwd: destination}),
+    );
+    await expect(readFile(join(destination, 'agent-change.txt'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('does not invoke Git when a gate restart repeats the same target at the same path', async () => {
+    const destinations = new Map();
+    const first = await run({path: 'repo'}, destinations);
+    const destination = resolve(workspace, 'repo');
+    await writeFile(join(destination, 'agent-change.txt'), 'preserve me');
+    checkoutRepositoryMock.mockClear();
+
+    const second = await run({path: 'repo'}, destinations);
+
+    expect(first.result.success).toBe(true);
+    expect(second).toEqual(first);
+    expect(checkoutRepositoryMock).not.toHaveBeenCalled();
+    await expect(readFile(join(destination, 'agent-change.txt'), 'utf8')).resolves.toBe(
+      'preserve me',
+    );
+  });
+
+  it('refuses a different target at an owned path without force', async () => {
+    const destinations = new Map();
+    await run({path: 'shared'}, destinations);
+    requestCheckoutTokenMock.mockResolvedValue(checkoutResponse('repo-b'));
+    checkoutRepositoryMock.mockClear();
+
+    const result = await run({path: 'shared'}, destinations);
+
+    expect(result.result.error?.reason).toBe('checkout_destination_occupied');
+    expect(checkoutRepositoryMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces a different target at an owned path with force', async () => {
+    const destinations = new Map();
+    await run({path: 'shared'}, destinations);
+    requestCheckoutTokenMock.mockResolvedValue(checkoutResponse('repo-b'));
+
+    const result = await run({path: 'shared', force: true}, destinations);
+
+    expect(result.result.success).toBe(true);
+    expect(checkoutRepositoryMock).toHaveBeenCalledTimes(2);
+    expect(destinations.get(resolve(workspace, 'shared'))?.repository).toContain('repo-b');
+  });
+
+  it('releases nested ownership when force replaces an ancestor', async () => {
+    const destinations = new Map();
+    await run({path: 'lib-a'}, destinations);
+    requestCheckoutTokenMock.mockResolvedValue(checkoutResponse('repo-b'));
+    await run({path: '.', force: true}, destinations);
+    requestCheckoutTokenMock.mockResolvedValue(checkoutResponse('repo-a'));
+    checkoutRepositoryMock.mockClear();
+
+    const result = await run({path: 'lib-a'}, destinations);
+
+    expect(result.result.success).toBe(true);
+    expect(checkoutRepositoryMock).toHaveBeenCalledOnce();
+    expect(destinations.get(resolve(workspace, 'lib-a'))?.repository).toContain('repo-a');
+  });
+
+  it('uses the job root for the first default checkout and the repository name thereafter', async () => {
+    const destinations = new Map();
+    const first = await run({}, destinations);
+    requestCheckoutTokenMock.mockResolvedValue(checkoutResponse('repo-b'));
+    const second = await run({}, destinations);
+
+    expect(first.result.checkout?.path).toBe(workspace);
+    expect(second.result.checkout?.path).toBe(join(workspace, 'repo-b'));
+  });
+
+  it.each([
+    '../outside',
+    '/tmp/outside',
+    'C:outside',
+    'C:\\outside',
+    '.git',
+    'src/.git',
+  ])('rejects an unsafe path before requesting repository access: %s', async (path) => {
+    const result = await run({path});
+
+    expect(result.result.error?.reason).toBe('checkout_path_invalid');
+    expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
+    expect(checkoutRepositoryMock).not.toHaveBeenCalled();
+  });
+});

--- a/libs/runner/execution/src/core/checkout-step.test.ts
+++ b/libs/runner/execution/src/core/checkout-step.test.ts
@@ -5,6 +5,7 @@ import type {StepDto} from '@shipfox/api-workflows-dto';
 import {HTTPError} from 'ky';
 
 const requestCheckoutTokenMock = vi.fn();
+const assertGitAvailableMock = vi.fn();
 const checkoutRepositoryMock = vi.fn();
 const writeAmbientGitCredentialMock = vi.fn();
 
@@ -19,6 +20,7 @@ vi.mock('@shipfox/runner-workspace', async () => {
   );
   return {
     ...actual,
+    assertGitAvailable: (...args: unknown[]) => assertGitAvailableMock(...args),
     checkoutRepository: (...args: unknown[]) => checkoutRepositoryMock(...args),
     writeAmbientGitCredential: (...args: unknown[]) => writeAmbientGitCredentialMock(...args),
   };
@@ -74,6 +76,7 @@ describe('executeCheckoutStep', () => {
   beforeEach(async () => {
     workspace = await realpath(await mkdtemp(join(tmpdir(), 'shipfox-checkout-executor-')));
     vi.clearAllMocks();
+    assertGitAvailableMock.mockResolvedValue('git version 2.51.0');
     requestCheckoutTokenMock.mockResolvedValue(checkoutResponse());
     checkoutRepositoryMock.mockResolvedValue('abc123');
     writeAmbientGitCredentialMock.mockResolvedValue(undefined);
@@ -140,6 +143,31 @@ describe('executeCheckoutStep', () => {
     expect(result.result.success).toBe(true);
     expect(checkoutRepositoryMock).toHaveBeenCalledWith(
       expect.objectContaining({cwd: destination}),
+    );
+  });
+
+  it('reports Git as unavailable before requesting checkout credentials', async () => {
+    const log = fakeLog();
+    assertGitAvailableMock.mockRejectedValue(new Error('git is not available on the runner host'));
+
+    const result = await run({}, new Map(), log);
+
+    expect(result.result).toEqual({
+      success: false,
+      error: {
+        message: 'git is not available on the runner host',
+        reason: 'git_unavailable',
+      },
+      exit_code: null,
+    });
+    expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Checkout step failed because Git is not available on the runner. Details: git is not available on the runner host',
+      'stderr',
+    );
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Next step: Install Git in the runner image or use a runner image that includes Git.',
+      'stderr',
     );
   });
 
@@ -212,6 +240,27 @@ describe('executeCheckoutStep', () => {
     await expect(readFile(join(destination, 'agent-change.txt'), 'utf8')).resolves.toBe(
       'preserve me',
     );
+  });
+
+  it('redacts credentials in the repeated-checkout log', async () => {
+    const destinations = new Map();
+    const log = fakeLog();
+    requestCheckoutTokenMock.mockResolvedValue({
+      ...checkoutResponse(),
+      repository_url: 'https://user:secret@example.test/repo.git',
+    });
+
+    await run({path: 'repo'}, destinations, log);
+    log.writeGroup.mockClear();
+    await run({path: 'repo'}, destinations, log);
+
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Checkout skipped',
+      lines: [
+        `Path: ${resolve(workspace, 'repo')}`,
+        'Already checked out https://***@example.test/repo.git at main.',
+      ],
+    });
   });
 
   it('refuses a different target at an owned path without force', async () => {

--- a/libs/runner/execution/src/core/checkout-step.ts
+++ b/libs/runner/execution/src/core/checkout-step.ts
@@ -2,6 +2,7 @@ import {basename, sep} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
 import {
   assertCheckoutPath,
+  assertGitAvailable,
   CheckoutDestinationOccupiedError,
   CheckoutPathInvalidError,
   createCheckoutDestination,
@@ -14,14 +15,13 @@ import {
   type CheckoutLogSink,
   checkoutRepositoryAt,
   requestCheckoutCredentials,
+  safeRepositoryUrl,
 } from '#core/checkout-execution.js';
 import type {StepResult} from '#core/step-result.js';
 
 const URL_QUERY_RE = /[?#]/;
 const TRAILING_SLASH_RE = /\/+$/;
 const GIT_SUFFIX_RE = /\.git$/i;
-const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
-
 export interface CheckoutDestination {
   repository: string;
   ref: string;
@@ -59,6 +59,12 @@ export async function executeCheckoutStep(params: {
     } catch (error) {
       return pathFailure(error, log);
     }
+  }
+
+  try {
+    await assertGitAvailable();
+  } catch (error) {
+    return gitUnavailableFailure(error, log);
   }
 
   log?.writeGroupStart('Checkout');
@@ -224,8 +230,26 @@ function occupiedFailure(
   };
 }
 
-function safeRepositoryUrl(repositoryUrl: string): string {
-  return repositoryUrl.replace(URL_CREDENTIAL_RE, '$1***@');
+function gitUnavailableFailure(
+  error: unknown,
+  log: CheckoutLogSink | undefined,
+): CheckoutStepExecution {
+  const message = messageOf(error);
+  log?.writeOutputLine(
+    `Checkout step failed because Git is not available on the runner. Details: ${message}`,
+    'stderr',
+  );
+  log?.writeOutputLine(
+    'Next step: Install Git in the runner image or use a runner image that includes Git.',
+    'stderr',
+  );
+  return {
+    result: {
+      success: false,
+      error: {message, reason: 'git_unavailable'},
+      exit_code: null,
+    },
+  };
 }
 
 function messageOf(error: unknown): string {

--- a/libs/runner/execution/src/core/checkout-step.ts
+++ b/libs/runner/execution/src/core/checkout-step.ts
@@ -1,0 +1,233 @@
+import {basename, sep} from 'node:path';
+import type {StepDto} from '@shipfox/api-workflows-dto';
+import {
+  assertCheckoutPath,
+  CheckoutDestinationOccupiedError,
+  CheckoutPathInvalidError,
+  createCheckoutDestination,
+  inspectCheckoutDestination,
+  replaceCheckoutDestination,
+  resolveCheckoutPath,
+} from '@shipfox/runner-workspace';
+import type {KyInstance} from 'ky';
+import {
+  type CheckoutLogSink,
+  checkoutRepositoryAt,
+  requestCheckoutCredentials,
+} from '#core/checkout-execution.js';
+import type {StepResult} from '#core/step-result.js';
+
+const URL_QUERY_RE = /[?#]/;
+const TRAILING_SLASH_RE = /\/+$/;
+const GIT_SUFFIX_RE = /\.git$/i;
+const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
+
+export interface CheckoutDestination {
+  repository: string;
+  ref: string;
+  result: NonNullable<StepResult['checkout']>;
+}
+
+export type CheckoutDestinations = Map<string, CheckoutDestination>;
+
+export interface CheckoutStepExecution {
+  result: StepResult;
+  ambientGitConfigPath?: string | undefined;
+}
+
+/**
+ * Executes an explicit checkout after applying the runner-local destination policy. The
+ * server-resolved repository/ref arrive through the token response, so the ownership
+ * decision is made before any Git command can touch the destination.
+ */
+export async function executeCheckoutStep(params: {
+  cwd: string;
+  gitConfigPath: string;
+  leaseClient: KyInstance;
+  signal: AbortSignal;
+  step: StepDto;
+  attempt: number;
+  destinations: CheckoutDestinations;
+  log?: CheckoutLogSink | undefined;
+}): Promise<CheckoutStepExecution> {
+  const {cwd, gitConfigPath, leaseClient, signal, step, attempt, destinations, log} = params;
+  const config = readCheckoutConfig(step.config.checkout);
+
+  if (config.path !== undefined) {
+    try {
+      assertCheckoutPath(config.path);
+    } catch (error) {
+      return pathFailure(error, log);
+    }
+  }
+
+  log?.writeGroupStart('Checkout');
+  try {
+    const requested = await requestCheckoutCredentials({
+      leaseClient,
+      signal,
+      stepId: step.id,
+      attempt,
+      ...(log ? {log} : {}),
+      scope: 'checkout',
+    });
+    if (!requested.ok) return {result: requested.result};
+
+    const requestedPath =
+      config.path ?? defaultCheckoutPath(requested.value.repository_url, destinations.size === 0);
+    const destination = await resolveCheckoutPath(cwd, requestedPath);
+    const target = {
+      repository: requested.value.repository_url,
+      ref: requested.value.ref,
+    };
+    const previous = destinations.get(destination);
+
+    if (previous !== undefined) {
+      if (sameTarget(previous, target) && !config.force) {
+        log?.writeGroup({
+          name: 'Checkout skipped',
+          lines: [
+            `Path: ${destination}`,
+            `Already checked out ${safeRepositoryUrl(target.repository)} at ${target.ref}.`,
+          ],
+        });
+        return {result: {success: true, error: null, exit_code: 0, checkout: previous.result}};
+      }
+      if (!config.force) throw new CheckoutDestinationOccupiedError(destination);
+      releaseDestinationSubtree(destinations, destination);
+      await replaceCheckoutDestination(destination);
+    } else {
+      const state = await inspectCheckoutDestination(destination);
+      if (state === 'occupied' && !config.force) {
+        throw new CheckoutDestinationOccupiedError(destination);
+      }
+      if (state === 'occupied' && config.force) {
+        releaseDestinationSubtree(destinations, destination);
+        await replaceCheckoutDestination(destination);
+      } else {
+        await createCheckoutDestination(destination);
+      }
+    }
+
+    const checkout = await checkoutRepositoryAt({
+      destination,
+      gitConfigPath,
+      checkout: requested.value,
+      signal,
+      ...(log ? {log} : {}),
+      scope: 'checkout',
+    });
+    if (!checkout.ok) return {result: checkout.result};
+
+    const result = checkout.value.checkout;
+    destinations.set(destination, {
+      repository: result.repository,
+      ref: result.ref,
+      result,
+    });
+    return {
+      result: {success: true, error: null, exit_code: 0, checkout: result},
+      ...(checkout.value.ambientGitConfigPath
+        ? {ambientGitConfigPath: checkout.value.ambientGitConfigPath}
+        : {}),
+    };
+  } catch (error) {
+    if (error instanceof CheckoutPathInvalidError) return pathFailure(error, log);
+    if (error instanceof CheckoutDestinationOccupiedError) {
+      return occupiedFailure(error, log);
+    }
+    return {
+      result: {
+        success: false,
+        error: {message: messageOf(error), reason: 'checkout_failed'},
+        exit_code: null,
+      },
+    };
+  } finally {
+    log?.writeGroupEnd();
+  }
+}
+
+function readCheckoutConfig(value: unknown): {path?: unknown; force: boolean} {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return {force: false};
+  }
+  const config = value as Record<string, unknown>;
+  return {
+    ...(Object.hasOwn(config, 'path') ? {path: config.path} : {}),
+    force: config.force === true,
+  };
+}
+
+function defaultCheckoutPath(repositoryUrl: string, firstCheckout: boolean): string {
+  if (firstCheckout) return '.';
+
+  const withoutQuery = repositoryUrl.split(URL_QUERY_RE, 1)[0] ?? repositoryUrl;
+  const lastSegment = basename(withoutQuery.replace(TRAILING_SLASH_RE, ''));
+  const repositoryName = lastSegment.replace(GIT_SUFFIX_RE, '');
+  assertCheckoutPath(repositoryName);
+  return repositoryName;
+}
+
+function sameTarget(
+  previous: Pick<CheckoutDestination, 'repository' | 'ref'>,
+  target: Pick<CheckoutDestination, 'repository' | 'ref'>,
+): boolean {
+  return previous.repository === target.repository && previous.ref === target.ref;
+}
+
+function releaseDestinationSubtree(destinations: CheckoutDestinations, destination: string): void {
+  const prefix = destination.endsWith(sep) ? destination : `${destination}${sep}`;
+  for (const tracked of destinations.keys()) {
+    if (tracked === destination || tracked.startsWith(prefix)) destinations.delete(tracked);
+  }
+}
+
+function pathFailure(error: unknown, log: CheckoutLogSink | undefined): CheckoutStepExecution {
+  const message = messageOf(error);
+  log?.writeOutputLine(
+    `Checkout step failed because its destination path is invalid. Details: ${message}`,
+    'stderr',
+  );
+  log?.writeOutputLine(
+    'Next step: Use a relative checkout path without .. or .git, and keep it inside the job workspace.',
+    'stderr',
+  );
+  return {
+    result: {
+      success: false,
+      error: {message, reason: 'checkout_path_invalid'},
+      exit_code: null,
+    },
+  };
+}
+
+function occupiedFailure(
+  error: CheckoutDestinationOccupiedError,
+  log: CheckoutLogSink | undefined,
+): CheckoutStepExecution {
+  const message = error.message;
+  log?.writeOutputLine(
+    `Checkout step failed because its destination is occupied. Details: ${message}`,
+    'stderr',
+  );
+  log?.writeOutputLine(
+    'Next step: Choose an empty destination or set force to replace its contents.',
+    'stderr',
+  );
+  return {
+    result: {
+      success: false,
+      error: {message, reason: 'checkout_destination_occupied'},
+      exit_code: null,
+    },
+  };
+}
+
+function safeRepositoryUrl(repositoryUrl: string): string {
+  return repositoryUrl.replace(URL_CREDENTIAL_RE, '$1***@');
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -1,3 +1,4 @@
+import type {StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError} from 'ky';
 
@@ -53,17 +54,35 @@ function checkoutResponse(auth?: unknown, gitAuthor?: unknown) {
   };
 }
 
-function run(log?: ReturnType<typeof fakeLog>) {
+function run(log?: ReturnType<typeof fakeLog>, step = buildSetupStep()) {
   return executeSetupStep({
     cwd: CWD,
     gitConfigPath: GIT_CONFIG_PATH,
     leaseClient,
     signal,
-    stepId: STEP_ID,
+    step,
     attempt: STEP_ATTEMPT,
     ...(log ? {log} : {}),
     jobContext,
   });
+}
+
+function buildSetupStep(config: Record<string, unknown> = {checkout: {}}): StepDto {
+  return {
+    id: STEP_ID,
+    job_execution_id: '00000000-0000-0000-0000-0000000000b1',
+    key: null,
+    name: 'Set up job',
+    source_location: null,
+    status: 'running',
+    type: 'setup',
+    config,
+    error: null,
+    position: 0,
+    current_attempt: STEP_ATTEMPT,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
 }
 
 function fakeLog() {
@@ -117,6 +136,22 @@ afterEach(() => {
 });
 
 describe('executeSetupStep', () => {
+  it('prepares a checkout-disabled job without requiring Git or cloning', async () => {
+    const log = fakeLog();
+
+    const result = await run(log, buildSetupStep({}));
+
+    expect(assertGitAvailableMock).not.toHaveBeenCalled();
+    expect(createJobDirMock).toHaveBeenCalledWith(CWD);
+    expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
+    expect(checkoutRepositoryMock).not.toHaveBeenCalled();
+    expect(result).toEqual({result: {success: true, error: null, exit_code: 0}});
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Checkout skipped',
+      lines: ['No repository checkout was requested for this job.'],
+    });
+  });
+
   it('prepares the workspace, checks out the repo, and succeeds', async () => {
     requestCheckoutTokenMock.mockResolvedValue(
       checkoutResponse(

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -5,6 +5,7 @@ import {HTTPError} from 'ky';
 const requestCheckoutTokenMock = vi.fn();
 const assertGitAvailableMock = vi.fn();
 const createJobDirMock = vi.fn();
+const normalizeCheckoutDestinationMock = vi.fn();
 const checkoutRepositoryMock = vi.fn();
 const writeAmbientGitCredentialMock = vi.fn();
 
@@ -23,6 +24,7 @@ vi.mock('@shipfox/runner-workspace', async () => {
     ...actual,
     assertGitAvailable: (...args: unknown[]) => assertGitAvailableMock(...args),
     createJobDir: (...args: unknown[]) => createJobDirMock(...args),
+    normalizeCheckoutDestination: (...args: unknown[]) => normalizeCheckoutDestinationMock(...args),
     checkoutRepository: (...args: unknown[]) => checkoutRepositoryMock(...args),
     writeAmbientGitCredential: (...args: unknown[]) => writeAmbientGitCredentialMock(...args),
   };
@@ -125,6 +127,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   assertGitAvailableMock.mockResolvedValue('git version 2.51.0');
   createJobDirMock.mockResolvedValue(undefined);
+  normalizeCheckoutDestinationMock.mockResolvedValue(CWD);
   requestCheckoutTokenMock.mockResolvedValue(checkoutResponse());
   checkoutRepositoryMock.mockResolvedValue('abc123');
   writeAmbientGitCredentialMock.mockResolvedValue(undefined);
@@ -174,6 +177,7 @@ describe('executeSetupStep', () => {
 
     expect(assertGitAvailableMock).toHaveBeenCalledOnce();
     expect(createJobDirMock).toHaveBeenCalledWith(CWD);
+    expect(normalizeCheckoutDestinationMock).toHaveBeenCalledWith(CWD, CWD);
     expect(requestCheckoutTokenMock).toHaveBeenCalledWith(leaseClient, {
       stepId: STEP_ID,
       attempt: STEP_ATTEMPT,

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -1,7 +1,11 @@
 import {arch, platform, release} from 'node:os';
 import type {StepDto, StepErrorReasonDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {assertGitAvailable, createJobDir} from '@shipfox/runner-workspace';
+import {
+  assertGitAvailable,
+  createJobDir,
+  normalizeCheckoutDestination,
+} from '@shipfox/runner-workspace';
 import type {KyInstance} from 'ky';
 import {
   type CheckoutLogSink,
@@ -135,11 +139,12 @@ async function runCheckoutSetup(params: {
   const {log} = params;
   log?.writeGroupStart('Checkout');
   try {
+    const destination = await normalizeCheckoutDestination(params.cwd, params.cwd);
     const checkout = await requestCheckoutCredentials({...params, scope: 'setup'});
     if (!checkout.ok) return checkout;
 
     return await checkoutRepositoryAt({
-      destination: params.cwd,
+      destination,
       gitConfigPath: params.gitConfigPath,
       checkout: checkout.value,
       signal: params.signal,

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -1,31 +1,17 @@
 import {arch, platform, release} from 'node:os';
-import type {CheckoutTokenResponseDto, StepErrorReasonDto} from '@shipfox/api-workflows-dto';
+import type {StepDto, StepErrorReasonDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {HTTPError, requestCheckoutToken} from '@shipfox/runner-protocol';
-import {
-  assertGitAvailable,
-  type CheckoutCommandStartMetadata,
-  CheckoutError,
-  type CheckoutFailureKind,
-  type CheckoutOutputSink,
-  type CheckoutPhase,
-  checkoutRepository,
-  createJobDir,
-  writeAmbientGitCredential,
-} from '@shipfox/runner-workspace';
+import {assertGitAvailable, createJobDir} from '@shipfox/runner-workspace';
 import type {KyInstance} from 'ky';
+import {
+  type CheckoutLogSink,
+  type CheckoutPhaseResult,
+  checkoutRepositoryAt,
+  requestCheckoutCredentials,
+} from '#core/checkout-execution.js';
 import type {StepResult} from '#core/step-result.js';
 
-const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
-
-interface SetupLogSink {
-  writeGroupStart(name: string): void;
-  writeGroupEnd(): void;
-  writeGroup(options: {name: string; lines: readonly string[]; source?: 'stdout' | 'stderr'}): void;
-  writeOutputLine(line: string, source?: 'stdout' | 'stderr'): void;
-  write(chunk: Buffer, source: 'stdout' | 'stderr'): void;
-  addSecrets(secrets: string[]): void;
-}
+type SetupLogSink = CheckoutLogSink;
 
 export interface SetupJobContext {
   workflowRunId: string;
@@ -51,23 +37,35 @@ export async function executeSetupStep(params: {
   gitConfigPath: string;
   leaseClient: KyInstance;
   signal: AbortSignal;
-  stepId: string;
+  step: StepDto;
   attempt: number;
   log?: SetupLogSink | undefined;
   jobContext?: SetupJobContext | undefined;
 }): Promise<SetupStepExecution> {
-  const {cwd, log, jobContext} = params;
+  const {cwd, log, jobContext, step} = params;
 
   logger().info(setupLogFields(jobContext), 'Setup step started');
   writeJobContext(log, jobContext);
 
-  const gitFailure = await checkGit(log);
-  if (gitFailure) return logSetupFailure(gitFailure, jobContext);
+  if (step.config.checkout !== undefined) {
+    const gitFailure = await checkGit(log);
+    if (gitFailure) return logSetupFailure(gitFailure, jobContext);
+  }
 
   const workspaceFailure = await prepareWorkspace({cwd, log});
   if (workspaceFailure) return logSetupFailure(workspaceFailure, jobContext);
 
-  const checkout = await runCheckoutSetup({...params, log});
+  if (step.config.checkout === undefined) {
+    log?.writeGroup({
+      name: 'Checkout skipped',
+      lines: ['No repository checkout was requested for this job.'],
+    });
+    log?.writeOutputLine('Setup completed successfully. The job is ready to run.');
+    logger().info(setupLogFields(jobContext), 'Setup step completed');
+    return {result: {success: true, error: null, exit_code: 0}};
+  }
+
+  const checkout = await runCheckoutSetup({...params, stepId: step.id, log});
   if (!checkout.ok) return logSetupFailure(checkout.result, jobContext);
 
   log?.writeOutputLine('Setup completed successfully. The job is ready to run.');
@@ -129,7 +127,7 @@ async function runCheckoutSetup(params: {
   attempt: number;
   log?: SetupLogSink | undefined;
 }): Promise<
-  SetupPhaseResult<{
+  CheckoutPhaseResult<{
     ambientGitConfigPath?: string | undefined;
     checkout: NonNullable<StepResult['checkout']>;
   }>
@@ -137,187 +135,20 @@ async function runCheckoutSetup(params: {
   const {log} = params;
   log?.writeGroupStart('Checkout');
   try {
-    const checkout = await requestCheckoutCredentials(params);
+    const checkout = await requestCheckoutCredentials({...params, scope: 'setup'});
     if (!checkout.ok) return checkout;
 
-    return await checkoutRepositoryForSetup({...params, checkout: checkout.value});
+    return await checkoutRepositoryAt({
+      destination: params.cwd,
+      gitConfigPath: params.gitConfigPath,
+      checkout: checkout.value,
+      signal: params.signal,
+      ...(log ? {log} : {}),
+      scope: 'setup',
+    });
   } finally {
     log?.writeGroupEnd();
   }
-}
-
-type SetupPhaseResult<T> = {ok: true; value: T} | {ok: false; result: StepResult};
-
-async function requestCheckoutCredentials(params: {
-  leaseClient: KyInstance;
-  signal: AbortSignal;
-  stepId: string;
-  attempt: number;
-  log?: SetupLogSink | undefined;
-}): Promise<SetupPhaseResult<CheckoutTokenResponseDto>> {
-  const {leaseClient, signal, stepId, attempt, log} = params;
-  try {
-    log?.writeGroup({
-      name: 'Request repository access',
-      lines: ['Requesting short-lived repository access from Shipfox.'],
-    });
-    const checkout = await requestCheckoutToken(leaseClient, {stepId, attempt, signal});
-    log?.writeGroup({
-      name: 'Repository access granted',
-      lines: credentialLines(checkout.auth),
-    });
-    return {ok: true, value: checkout};
-  } catch (error) {
-    const reason = classifyCheckoutTokenError(error);
-    writeFailure(
-      log,
-      'Setup failed because Shipfox could not grant repository access.',
-      checkoutTokenFailureHelp(reason),
-      error,
-    );
-    return {ok: false, result: fail(error, reason)};
-  }
-}
-
-async function checkoutRepositoryForSetup(params: {
-  cwd: string;
-  gitConfigPath: string;
-  checkout: CheckoutTokenResponseDto;
-  signal: AbortSignal;
-  log?: SetupLogSink | undefined;
-}): Promise<
-  SetupPhaseResult<{
-    ambientGitConfigPath?: string | undefined;
-    checkout: NonNullable<StepResult['checkout']>;
-  }>
-> {
-  const {cwd, gitConfigPath, checkout, signal, log} = params;
-  try {
-    log?.writeGroup({
-      name: 'Repository details',
-      lines: [
-        `Repository: ${safeRepositoryUrl(checkout.repository_url)}`,
-        `Requested ref: ${checkout.ref}`,
-      ],
-    });
-    const commit = await checkoutRepository({
-      repositoryUrl: checkout.repository_url,
-      ref: checkout.ref,
-      fetchDepth: checkout.fetch_depth,
-      auth: checkout.auth,
-      cwd,
-      signal,
-      onSecrets: (secrets) => log?.addSecrets(secrets),
-      onCommandStart: (metadata) => writeCheckoutCommand(log, metadata),
-      onOutput: checkoutOutput(log),
-    });
-    log?.writeGroup({name: 'Checkout complete', lines: [`Checked out commit: ${commit}`]});
-    const ambientGitConfigPath = await persistAmbientGitCredential({
-      gitConfigPath,
-      checkout,
-      log,
-    });
-    return {
-      ok: true,
-      value: {
-        checkout: {
-          repository: checkout.repository_url,
-          ref: checkout.ref,
-          commit,
-          path: cwd,
-        },
-        ...(ambientGitConfigPath ? {ambientGitConfigPath} : {}),
-      },
-    };
-  } catch (error) {
-    const reason =
-      error instanceof CheckoutError ? CHECKOUT_KIND_REASON[error.kind] : 'checkout_failed';
-    if (error instanceof CheckoutError && error.phase) {
-      writeFailure(
-        log,
-        `Setup failed while ${checkoutPhaseAction(error.phase)}.`,
-        checkoutFailureHelp(reason),
-        error,
-      );
-    } else {
-      writeFailure(
-        log,
-        'Setup failed while checking out the repository.',
-        checkoutFailureHelp(reason),
-        error,
-      );
-    }
-    return {ok: false, result: fail(error, reason)};
-  }
-}
-
-async function persistAmbientGitCredential(params: {
-  gitConfigPath: string;
-  checkout: CheckoutTokenResponseDto;
-  log?: SetupLogSink | undefined;
-}): Promise<string | undefined> {
-  const {gitConfigPath, checkout, log} = params;
-  if (!checkout.auth?.persist || checkout.auth.carry !== 'header') return undefined;
-
-  try {
-    await writeAmbientGitCredential({
-      configPath: gitConfigPath,
-      repositoryUrl: checkout.repository_url,
-      auth: checkout.auth,
-      ...(checkout.git_author ? {gitAuthor: checkout.git_author} : {}),
-    });
-    return gitConfigPath;
-  } catch (error) {
-    writeWarning(log, 'Repository access was not persisted', [
-      `The checkout succeeded, but agent steps will run without ambient git authentication. Details: ${messageOf(error)}`,
-      'Git commands in later steps may need their own credentials.',
-    ]);
-    return undefined;
-  }
-}
-
-const CHECKOUT_KIND_REASON: Record<CheckoutFailureKind, StepErrorReasonDto> = {
-  auth: 'checkout_auth_failed',
-  unavailable: 'checkout_unavailable',
-  failed: 'checkout_failed',
-  aborted: 'setup_aborted',
-};
-
-// Maps a checkout-token endpoint failure to a reason. Auth denial and the backend's
-// retryable provider signals (429/503, or their typed `code`) get distinct reasons; a
-// missing checkout intent (404) and everything else fold into the generic failure.
-// CheckoutError messages are already redacted in the workspace layer; the token-fetch
-// error never carries credential material.
-function classifyCheckoutTokenError(error: unknown): StepErrorReasonDto {
-  if (!(error instanceof HTTPError)) return 'checkout_failed';
-
-  const {status} = error.response;
-  const code = readErrorCode(error);
-
-  if (status === 401 || status === 403 || code === 'access-denied' || code === 'forbidden') {
-    return 'checkout_auth_failed';
-  }
-  if (
-    status === 429 ||
-    status === 503 ||
-    code === 'rate-limited' ||
-    code === 'timeout' ||
-    code === 'provider-unavailable'
-  ) {
-    return 'checkout_unavailable';
-  }
-  return 'checkout_failed';
-}
-
-// ky consumes the response body to populate `error.data` before throwing, so the body
-// is already read here: `error.response.json()` would throw "Body has already been
-// consumed". Read ky's pre-parsed `data` instead.
-function readErrorCode(error: HTTPError): string | undefined {
-  const body = error.data;
-  if (body && typeof body === 'object' && 'code' in body && typeof body.code === 'string') {
-    return body.code;
-  }
-  return undefined;
 }
 
 function fail(error: unknown, reason: StepErrorReasonDto): StepResult {
@@ -393,84 +224,6 @@ function buildMetadataLines(): string[] {
   return lines;
 }
 
-function writeCheckoutCommand(
-  log: SetupLogSink | undefined,
-  metadata: CheckoutCommandStartMetadata,
-): void {
-  log?.writeGroup({
-    name: checkoutPhaseTitle(metadata.phase),
-    lines: [`Command: ${metadata.command}`, `Working directory: ${metadata.cwd}`],
-  });
-}
-
-function checkoutOutput(log: SetupLogSink | undefined): CheckoutOutputSink | undefined {
-  if (!log) return undefined;
-  return (chunk, source) => log.write(chunk, source);
-}
-
-function credentialLines(auth: CheckoutTokenResponseDto['auth']): string[] {
-  if (!auth) return ['No repository credential was required.'];
-  return [
-    auth.kind === 'bearer'
-      ? 'Using a short-lived repository token.'
-      : 'Using a short-lived username/password repository credential.',
-    auth.expires_at ? `Expires at: ${auth.expires_at}` : 'No expiration was provided.',
-  ];
-}
-
-function checkoutPhaseTitle(phase: CheckoutPhase): string {
-  switch (phase) {
-    case 'init':
-      return 'Initialize repository';
-    case 'remote':
-      return 'Add repository remote';
-    case 'fetch':
-      return 'Fetch requested ref';
-    case 'checkout':
-      return 'Check out commit';
-    case 'resolve':
-      return 'Read checked-out commit';
-  }
-}
-
-function checkoutPhaseAction(phase: CheckoutPhase): string {
-  switch (phase) {
-    case 'init':
-      return 'initializing the local Git repository';
-    case 'remote':
-      return 'adding the repository remote';
-    case 'fetch':
-      return 'fetching the requested ref';
-    case 'checkout':
-      return 'checking out the fetched commit';
-    case 'resolve':
-      return 'reading the checked-out commit';
-  }
-}
-
-function checkoutTokenFailureHelp(reason: StepErrorReasonDto): string {
-  if (reason === 'checkout_auth_failed') {
-    return 'Check that the runner is connected to this workspace and the job is allowed to read this repository.';
-  }
-  if (reason === 'checkout_unavailable') {
-    return 'Retry the job; Shipfox or the repository provider may be temporarily unavailable.';
-  }
-  return 'Check the repository connection and job permissions in Shipfox, then retry the job.';
-}
-
-function checkoutFailureHelp(reason: StepErrorReasonDto): string {
-  if (reason === 'checkout_auth_failed') {
-    return 'Check the repository connection in Shipfox and confirm it has permission to read this repository.';
-  }
-  if (reason === 'checkout_unavailable') {
-    return 'Check the runner network and DNS access to the Git provider, then retry the job.';
-  }
-  if (reason === 'setup_aborted') {
-    return 'The job was cancelled or timed out before checkout completed.';
-  }
-  return 'Check that the repository URL and requested ref are valid. The git output above may include provider details.';
-}
-
 function writeFailure(
   log: SetupLogSink | undefined,
   summary: string,
@@ -479,18 +232,6 @@ function writeFailure(
 ): void {
   log?.writeOutputLine(`${summary} Details: ${messageOf(error)}`, 'stderr');
   log?.writeOutputLine(`Next step: ${nextStep}`, 'stderr');
-}
-
-function writeWarning(log: SetupLogSink | undefined, name: string, lines: readonly string[]): void {
-  if (log) {
-    log.writeGroup({name, lines, source: 'stderr'});
-    return;
-  }
-  logger().warn({name, lines}, 'Setup warning');
-}
-
-function safeRepositoryUrl(repositoryUrl: string): string {
-  return repositoryUrl.replace(URL_CREDENTIAL_RE, '$1***@');
 }
 
 function messageOf(error: unknown): string {

--- a/libs/runner/execution/src/core/step-result.ts
+++ b/libs/runner/execution/src/core/step-result.ts
@@ -11,7 +11,7 @@ export interface StepResult {
   outputs?: Record<string, string>;
   // Run-step annotations posted before reporting the step result.
   annotations?: LeasedWriteAnnotationOperationDto[];
-  // Resolved checkout details reported by the setup step.
+  // Resolved checkout details reported by setup or an explicit checkout step.
   checkout?: CheckoutResult;
   // Populated when success is false. Null on success.
   error: StepErrorDto;

--- a/libs/runner/execution/src/index.ts
+++ b/libs/runner/execution/src/index.ts
@@ -1,4 +1,10 @@
 export {
+  type CheckoutDestination,
+  type CheckoutDestinations,
+  type CheckoutStepExecution,
+  executeCheckoutStep,
+} from '#core/checkout-step.js';
+export {
   type CommandShellMetadata,
   type CommandStartMetadata,
   type CommandStartSink,

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -45,6 +45,7 @@ const writeStepAnnotationsMock = vi.fn();
 const integrationToolsGatewayUrlMock = vi.fn();
 const executeRunStepMock = vi.fn();
 const executeSetupStepMock = vi.fn();
+const executeCheckoutStepMock = vi.fn();
 const createStepLogStreamMock = vi.fn();
 const createSessionLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
@@ -66,6 +67,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
 vi.mock('@shipfox/runner-execution', () => ({
   executeRunStep: (...args: unknown[]) => executeRunStepMock(...args),
   executeSetupStep: (...args: unknown[]) => executeSetupStepMock(...args),
+  executeCheckoutStep: (...args: unknown[]) => executeCheckoutStepMock(...args),
 }));
 
 vi.mock('@shipfox/runner-logs', async () => {
@@ -212,6 +214,7 @@ describe('runJobSteps', () => {
     integrationToolsGatewayUrlMock.mockReset();
     executeRunStepMock.mockReset();
     executeSetupStepMock.mockReset();
+    executeCheckoutStepMock.mockReset();
     createStepLogStreamMock.mockReset();
     createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
@@ -240,6 +243,9 @@ describe('runJobSteps', () => {
     });
     // Setup succeeds by default; tests that exercise setup failure override it.
     executeSetupStepMock.mockResolvedValue({
+      result: {success: true, error: null, exit_code: 0},
+    });
+    executeCheckoutStepMock.mockResolvedValue({
       result: {success: true, error: null, exit_code: 0},
     });
     createJobLogsDirMock.mockResolvedValue(undefined);
@@ -274,7 +280,7 @@ describe('runJobSteps', () => {
       gitConfigPath: GIT_CONFIG_PATH,
       leaseClient,
       signal: ac.signal,
-      stepId: setup.id,
+      step: setup,
       attempt: 1,
       log: expect.any(Object),
       jobContext: JOB_CONTEXT,
@@ -296,6 +302,73 @@ describe('runJobSteps', () => {
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('dispatches an explicit checkout step through its executor and reports checkout details', async () => {
+    const setup = buildSetupStep();
+    const checkout = buildCheckoutStep({config: {checkout: {path: 'services/api'}}});
+    const checkoutResult = {
+      repository: 'https://github.com/acme/api.git',
+      ref: 'main',
+      commit: 'abc123',
+      path: '/work/services/api',
+    };
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(checkout, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeCheckoutStepMock.mockResolvedValueOnce({
+      result: {success: true, checkout: checkoutResult, error: null, exit_code: 0},
+    });
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeCheckoutStepMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/work',
+        step: checkout,
+        attempt: 1,
+        destinations: expect.any(Map),
+        log: expect.any(Object),
+      }),
+    );
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({stepId: checkout.id, checkout: checkoutResult}),
+    );
+  });
+
+  it('keeps checkout ownership across a repeated checkout dispatch', async () => {
+    const setup = buildSetupStep();
+    const checkout = buildCheckoutStep({config: {checkout: {path: 'repo'}}});
+    const checkoutResult = {
+      repository: 'https://github.com/acme/repo.git',
+      ref: 'main',
+      commit: 'abc123',
+      path: '/work/repo',
+    };
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(checkout, 1))
+      .mockResolvedValueOnce(stepResponse(checkout, 2))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeCheckoutStepMock.mockResolvedValue({
+      result: {success: true, checkout: checkoutResult, error: null, exit_code: 0},
+    });
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeCheckoutStepMock).toHaveBeenCalledTimes(2);
+    const firstDestinations = executeCheckoutStepMock.mock.calls[0]?.[0].destinations;
+    const secondDestinations = executeCheckoutStepMock.mock.calls[1]?.[0].destinations;
+    expect(secondDestinations).toBe(firstDestinations);
+    expect(secondDestinations.get('/work/repo')).toEqual({
+      repository: checkoutResult.repository,
+      ref: checkoutResult.ref,
+      result: checkoutResult,
+    });
   });
 
   it('reports run step outputs', async () => {
@@ -1775,6 +1848,17 @@ function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
     name: 'implement',
     type: 'agent',
     config: {model: 'claude-opus-4-8', thinking: 'high', prompt: 'Fix it.'},
+    position: 1,
+    ...overrides,
+  });
+}
+
+function buildCheckoutStep(overrides: Partial<StepDto> = {}): StepDto {
+  return buildStep({
+    id: '00000000-0000-0000-0000-0000000000d0',
+    name: 'Checkout',
+    type: 'checkout',
+    config: {checkout: {path: 'repo'}},
     position: 1,
     ...overrides,
   });

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1,4 +1,3 @@
-import {realpath} from 'node:fs/promises';
 import {
   type MaterializedSecretBindingDto,
   materializedSecretBindingSchema,
@@ -132,7 +131,7 @@ export async function runJobSteps(params: {
       if (execution.preparedWorkspace) workspacePrepared = true;
       if (execution.ambientGitConfigPath) ambientGitConfigPath = execution.ambientGitConfigPath;
       if (execution.result.success && execution.result.checkout) {
-        await rememberCheckoutDestination(checkoutDestinations, execution.result.checkout);
+        rememberCheckoutDestination(checkoutDestinations, execution.result.checkout);
       }
 
       if (signal.aborted) return;
@@ -176,12 +175,11 @@ export async function runJobSteps(params: {
   }
 }
 
-async function rememberCheckoutDestination(
+function rememberCheckoutDestination(
   destinations: CheckoutDestinations,
   checkout: NonNullable<StepResult['checkout']>,
-): Promise<void> {
-  const destination = await realpath(checkout.path).catch(() => checkout.path);
-  destinations.set(destination, {
+): void {
+  destinations.set(checkout.path, {
     repository: checkout.repository,
     ref: checkout.ref,
     result: checkout,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1,3 +1,4 @@
+import {realpath} from 'node:fs/promises';
 import {
   type MaterializedSecretBindingDto,
   materializedSecretBindingSchema,
@@ -8,7 +9,9 @@ import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets} from '@shipfox/redact';
 import {executeAgentStep} from '@shipfox/runner-agent';
 import {
+  type CheckoutDestinations,
   type CommandStartMetadata,
+  executeCheckoutStep,
   executeRunStep,
   executeSetupStep,
   type SetupJobContext,
@@ -73,6 +76,7 @@ export async function runJobSteps(params: {
   let workspacePrepared = false;
   let logsPrepared = false;
   let ambientGitConfigPath: string | undefined;
+  const checkoutDestinations: CheckoutDestinations = new Map();
 
   // The most recent step's stream, kept until the next
   // iteration settles it (or the finally does at job end). The step loop is sequential, so
@@ -115,6 +119,7 @@ export async function runJobSteps(params: {
         ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
         signal,
         workspacePrepared,
+        checkoutDestinations,
         ambientGitConfigPath,
         jobId,
         stepLabel,
@@ -126,6 +131,9 @@ export async function runJobSteps(params: {
       activeStream = execution.stream;
       if (execution.preparedWorkspace) workspacePrepared = true;
       if (execution.ambientGitConfigPath) ambientGitConfigPath = execution.ambientGitConfigPath;
+      if (execution.result.success && execution.result.checkout) {
+        await rememberCheckoutDestination(checkoutDestinations, execution.result.checkout);
+      }
 
       if (signal.aborted) return;
 
@@ -166,6 +174,18 @@ export async function runJobSteps(params: {
     // cuts the wait short. Whatever did not drain is timeout-closed server-side.
     await settleStream({stream: activeStream, signal});
   }
+}
+
+async function rememberCheckoutDestination(
+  destinations: CheckoutDestinations,
+  checkout: NonNullable<StepResult['checkout']>,
+): Promise<void> {
+  const destination = await realpath(checkout.path).catch(() => checkout.path);
+  destinations.set(destination, {
+    repository: checkout.repository,
+    ref: checkout.ref,
+    result: checkout,
+  });
 }
 
 export interface PulledStep {
@@ -228,6 +248,7 @@ export async function executeStep(params: {
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
   signal: AbortSignal;
   workspacePrepared: boolean;
+  checkoutDestinations?: CheckoutDestinations | undefined;
   ambientGitConfigPath?: string | undefined;
   gitConfigPath: string;
   jobId: string;
@@ -246,6 +267,7 @@ export async function executeStep(params: {
     subscribeSecrets,
     signal,
     workspacePrepared,
+    checkoutDestinations = new Map(),
     ambientGitConfigPath,
     gitConfigPath,
     jobId,
@@ -323,7 +345,7 @@ export async function executeStep(params: {
         gitConfigPath,
         leaseClient,
         signal,
-        stepId: step.id,
+        step,
         attempt,
         ...(setupStream ? {log: setupStream} : {}),
         jobContext,
@@ -349,6 +371,46 @@ export async function executeStep(params: {
         },
         logOutcome: 'drained',
         preparedWorkspace: false,
+      };
+    }
+
+    if (step.type === 'checkout') {
+      let checkoutStream: StepLogStream | undefined;
+      try {
+        checkoutStream = createStepLogStream({
+          logsDir,
+          stepId: step.id,
+          attempt,
+          secrets,
+          append,
+        });
+      } catch (error) {
+        logger().error(
+          {err: error, jobId, stepId: step.id, attempt},
+          'Failed to open checkout log capture; running checkout without it',
+        );
+      }
+      stream = checkoutStream;
+      registerStreamSecrets(checkoutStream);
+
+      const checkout = await executeCheckoutStep({
+        cwd,
+        gitConfigPath,
+        leaseClient,
+        signal,
+        step,
+        attempt,
+        destinations: checkoutDestinations,
+        ...(checkoutStream ? {log: checkoutStream} : {}),
+      });
+      return {
+        result: checkout.result,
+        stream,
+        logOutcome: checkoutStream ? undefined : 'abandoned',
+        preparedWorkspace: false,
+        ...(checkout.ambientGitConfigPath
+          ? {ambientGitConfigPath: checkout.ambientGitConfigPath}
+          : {}),
       };
     }
 

--- a/libs/runner/workspace/src/checkout-path.test.ts
+++ b/libs/runner/workspace/src/checkout-path.test.ts
@@ -56,8 +56,9 @@ describe('checkout destination paths', () => {
     await mkdir(join(workspace, '.GIT', 'nested'), {recursive: true});
     await symlink(join('.GIT', 'nested'), join(workspace, 'alias'));
 
-    await expect(resolveCheckoutPath(workspace, 'alias')).rejects.toMatchObject({
-      name: 'CheckoutPathInvalidError',
+    const rejection = resolveCheckoutPath(workspace, 'alias');
+    await expect(rejection).rejects.toBeInstanceOf(CheckoutPathInvalidError);
+    await expect(rejection).rejects.toMatchObject({
       checkoutPath: 'alias',
     });
   });

--- a/libs/runner/workspace/src/checkout-path.test.ts
+++ b/libs/runner/workspace/src/checkout-path.test.ts
@@ -45,9 +45,18 @@ describe('checkout destination paths', () => {
     'C:outside',
     'C:\\outside',
     '.git',
+    '.GIT',
     'src/.git',
+    'src/.Git',
   ])('rejects unsafe checkout path syntax: %s', (checkoutPath) => {
     expect(() => assertCheckoutPath(checkoutPath)).toThrow(CheckoutPathInvalidError);
+  });
+
+  it('rejects a symlink whose resolved destination contains a case-variant Git directory', async () => {
+    await mkdir(join(workspace, '.GIT', 'nested'), {recursive: true});
+    await symlink(join('.GIT', 'nested'), join(workspace, 'alias'));
+
+    await expect(resolveCheckoutPath(workspace, 'alias')).rejects.toThrow(CheckoutPathInvalidError);
   });
 
   it('rejects a symlink that resolves outside the job workspace', async () => {

--- a/libs/runner/workspace/src/checkout-path.test.ts
+++ b/libs/runner/workspace/src/checkout-path.test.ts
@@ -56,7 +56,10 @@ describe('checkout destination paths', () => {
     await mkdir(join(workspace, '.GIT', 'nested'), {recursive: true});
     await symlink(join('.GIT', 'nested'), join(workspace, 'alias'));
 
-    await expect(resolveCheckoutPath(workspace, 'alias')).rejects.toThrow(CheckoutPathInvalidError);
+    await expect(resolveCheckoutPath(workspace, 'alias')).rejects.toMatchObject({
+      name: 'CheckoutPathInvalidError',
+      checkoutPath: 'alias',
+    });
   });
 
   it('rejects a symlink that resolves outside the job workspace', async () => {

--- a/libs/runner/workspace/src/checkout-path.test.ts
+++ b/libs/runner/workspace/src/checkout-path.test.ts
@@ -1,0 +1,118 @@
+import {mkdir, mkdtemp, realpath, rm, symlink, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {
+  assertCheckoutPath,
+  CheckoutDestinationOccupiedError,
+  CheckoutPathInvalidError,
+  createCheckoutDestination,
+  inspectCheckoutDestination,
+  replaceCheckoutDestination,
+  resolveCheckoutPath,
+} from '#checkout-path.js';
+
+describe('checkout destination paths', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'shipfox-checkout-path-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, {recursive: true, force: true});
+  });
+
+  it.each(['.', 'src/api'])('resolves safe relative paths: %s', async (checkoutPath) => {
+    await expect(resolveCheckoutPath(workspace, checkoutPath)).resolves.toBe(
+      checkoutPath === '.'
+        ? await realpath(workspace)
+        : join(await realpath(workspace), checkoutPath),
+    );
+  });
+
+  it('resolves a destination whose final directory does not exist yet', async () => {
+    await expect(resolveCheckoutPath(workspace, 'services/api')).resolves.toBe(
+      join(await realpath(workspace), 'services/api'),
+    );
+  });
+
+  it.each([
+    '',
+    '   ',
+    '../outside',
+    'src/../outside',
+    '/tmp/outside',
+    'C:outside',
+    'C:\\outside',
+    '.git',
+    'src/.git',
+  ])('rejects unsafe checkout path syntax: %s', (checkoutPath) => {
+    expect(() => assertCheckoutPath(checkoutPath)).toThrow(CheckoutPathInvalidError);
+  });
+
+  it('rejects a symlink that resolves outside the job workspace', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'shipfox-checkout-outside-'));
+    try {
+      await symlink(outside, join(workspace, 'escape'));
+
+      await expect(resolveCheckoutPath(workspace, 'escape')).rejects.toThrow(
+        CheckoutPathInvalidError,
+      );
+    } finally {
+      await rm(outside, {recursive: true, force: true});
+    }
+  });
+
+  it('rejects a missing destination below an outside symlink', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'shipfox-checkout-outside-'));
+    try {
+      await symlink(outside, join(workspace, 'escape'));
+
+      await expect(resolveCheckoutPath(workspace, 'escape/new')).rejects.toThrow(
+        CheckoutPathInvalidError,
+      );
+    } finally {
+      await rm(outside, {recursive: true, force: true});
+    }
+  });
+
+  it('resolves an existing symlink that stays inside the job workspace', async () => {
+    await mkdir(join(workspace, 'real-target'));
+    await symlink('real-target', join(workspace, 'alias'));
+
+    await expect(resolveCheckoutPath(workspace, 'alias')).resolves.toBe(
+      await realpath(join(workspace, 'real-target')),
+    );
+  });
+
+  it.each([
+    {name: 'missing', expected: 'missing'},
+    {name: 'empty', expected: 'empty'},
+    {name: 'occupied', expected: 'occupied'},
+  ] as const)('classifies a $name destination', async ({name, expected}) => {
+    const destination = join(workspace, name);
+    if (name === 'empty') await mkdir(destination);
+    if (name === 'occupied') {
+      await mkdir(destination);
+      await writeFile(join(destination, 'agent-change.txt'), 'keep me');
+    }
+
+    await expect(inspectCheckoutDestination(destination)).resolves.toBe(expected);
+  });
+
+  it('creates a missing destination and force replacement removes all content', async () => {
+    const destination = join(workspace, 'repo');
+    await createCheckoutDestination(destination);
+    await writeFile(join(destination, 'agent-change.txt'), 'discard me');
+
+    await expect(inspectCheckoutDestination(destination)).resolves.toBe('occupied');
+    await replaceCheckoutDestination(destination);
+    await expect(inspectCheckoutDestination(destination)).resolves.toBe('empty');
+  });
+
+  it('exposes the occupied-destination error used by the executor', () => {
+    expect(new CheckoutDestinationOccupiedError('/job/repo').message).toContain(
+      'Checkout destination is occupied',
+    );
+  });
+});

--- a/libs/runner/workspace/src/checkout-path.ts
+++ b/libs/runner/workspace/src/checkout-path.ts
@@ -1,0 +1,155 @@
+import {lstat, mkdir, readdir, realpath, rm} from 'node:fs/promises';
+import {basename, dirname, isAbsolute, relative, resolve, sep} from 'node:path';
+
+const WINDOWS_DRIVE_PATH_RE = /^[A-Za-z]:/;
+
+/** Thrown when a checkout path cannot be safely placed inside the job workspace. */
+export class CheckoutPathInvalidError extends Error {
+  constructor(public readonly checkoutPath: unknown) {
+    super(
+      `Checkout path is invalid: ${String(checkoutPath)}. Paths must be relative, must not contain '..' or '.git', and must remain inside the job workspace.`,
+    );
+    this.name = 'CheckoutPathInvalidError';
+  }
+}
+
+/** Thrown when a checkout would overwrite content that this job does not own. */
+export class CheckoutDestinationOccupiedError extends Error {
+  constructor(public readonly checkoutPath: string) {
+    super(
+      `Checkout destination is occupied: ${checkoutPath}. Set force to replace the existing contents.`,
+    );
+    this.name = 'CheckoutDestinationOccupiedError';
+  }
+}
+
+export type CheckoutDestinationState = 'missing' | 'empty' | 'occupied';
+
+/**
+ * Checks the lexical part of a checkout path before it is joined to the workspace.
+ * Backslashes are rejected as well as POSIX separators so a path has one portable
+ * interpretation on every runner image.
+ */
+export function assertCheckoutPath(checkoutPath: unknown): asserts checkoutPath is string {
+  if (typeof checkoutPath !== 'string' || checkoutPath.trim() === '') {
+    throw new CheckoutPathInvalidError(checkoutPath);
+  }
+
+  if (
+    checkoutPath.includes('\\') ||
+    checkoutPath.includes('\0') ||
+    checkoutPath.startsWith('/') ||
+    checkoutPath.startsWith('\\') ||
+    WINDOWS_DRIVE_PATH_RE.test(checkoutPath) ||
+    isAbsolute(checkoutPath)
+  ) {
+    throw new CheckoutPathInvalidError(checkoutPath);
+  }
+
+  const segments = checkoutPath.split('/');
+  if (segments.some((segment) => segment === '..' || segment === '.git')) {
+    throw new CheckoutPathInvalidError(checkoutPath);
+  }
+}
+
+/**
+ * Resolves a checkout destination under the real job workspace. The destination itself
+ * may not exist yet, so realpath is walked up to the nearest existing ancestor. This
+ * still catches a symlinked ancestor that would place a new checkout outside the job.
+ */
+export async function resolveCheckoutPath(
+  jobWorkspace: string,
+  checkoutPath: unknown,
+): Promise<string> {
+  assertCheckoutPath(checkoutPath);
+
+  const resolvedWorkspace = await realpath(jobWorkspace);
+  const lexicalCandidate = resolve(jobWorkspace, checkoutPath);
+  const resolvedCandidate = await resolveExistingPrefix(lexicalCandidate);
+
+  if (
+    !isWithin(resolvedWorkspace, resolvedCandidate) ||
+    containsGitSegment(resolvedWorkspace, resolvedCandidate)
+  ) {
+    throw new CheckoutPathInvalidError(checkoutPath);
+  }
+
+  return resolvedCandidate;
+}
+
+export async function inspectCheckoutDestination(
+  checkoutPath: string,
+): Promise<CheckoutDestinationState> {
+  let candidate: Awaited<ReturnType<typeof lstat>>;
+  try {
+    candidate = await lstat(checkoutPath);
+  } catch (error) {
+    if (isFileSystemError(error, 'ENOENT')) return 'missing';
+    throw error;
+  }
+
+  if (!candidate.isDirectory()) return 'occupied';
+  const entries = await readdir(checkoutPath);
+  return entries.length === 0 ? 'empty' : 'occupied';
+}
+
+/** Creates a missing destination without touching existing contents. */
+export async function createCheckoutDestination(checkoutPath: string): Promise<void> {
+  await mkdir(checkoutPath, {recursive: true});
+}
+
+/** Replaces a destination after the executor has applied the never-overwrite rule. */
+export async function replaceCheckoutDestination(checkoutPath: string): Promise<void> {
+  await rm(checkoutPath, {recursive: true, force: true});
+  await mkdir(checkoutPath, {recursive: true});
+}
+
+async function resolveExistingPrefix(candidate: string): Promise<string> {
+  const missingSegments: string[] = [];
+  let current = candidate;
+
+  while (true) {
+    try {
+      const existing = await realpath(current);
+      return resolve(existing, ...missingSegments.reverse());
+    } catch (error) {
+      if (isFileSystemError(error, 'ENOTDIR')) {
+        throw new CheckoutPathInvalidError(candidate);
+      }
+      if (!isFileSystemError(error, 'ENOENT')) throw error;
+
+      // A dangling symlink is not a missing checkout destination. Treating it as one
+      // would allow mkdir/rm to follow an unexpected link during a later operation.
+      try {
+        const entry = await lstat(current);
+        if (entry.isSymbolicLink()) throw new CheckoutPathInvalidError(candidate);
+      } catch (lstatError) {
+        if (!isFileSystemError(lstatError, 'ENOENT')) throw lstatError;
+      }
+
+      const parent = dirname(current);
+      if (parent === current) throw new CheckoutPathInvalidError(candidate);
+      missingSegments.push(basename(current));
+      current = parent;
+    }
+  }
+}
+
+function containsGitSegment(parent: string, candidate: string): boolean {
+  const distance = relative(parent, candidate);
+  return distance.split(sep).some((segment) => segment === '.git');
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+  const distance = relative(parent, candidate);
+  return (
+    distance === '' ||
+    (!distance.startsWith(`..${sep}`) && distance !== '..' && !isAbsolute(distance))
+  );
+}
+
+function isFileSystemError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/libs/runner/workspace/src/checkout-path.ts
+++ b/libs/runner/workspace/src/checkout-path.ts
@@ -56,6 +56,7 @@ export function assertCheckoutPath(checkoutPath: unknown): asserts checkoutPath 
 export async function normalizeCheckoutDestination(
   jobWorkspace: string,
   destination: string,
+  invalidPath: unknown = destination,
 ): Promise<string> {
   const resolvedWorkspace = await realpath(jobWorkspace);
   const resolvedCandidate = await resolveExistingPrefix(destination);
@@ -64,7 +65,7 @@ export async function normalizeCheckoutDestination(
     !isWithin(resolvedWorkspace, resolvedCandidate) ||
     containsGitSegment(resolvedWorkspace, resolvedCandidate)
   ) {
-    throw new CheckoutPathInvalidError(destination);
+    throw new CheckoutPathInvalidError(invalidPath);
   }
 
   return resolvedCandidate;
@@ -79,7 +80,7 @@ export function resolveCheckoutPath(jobWorkspace: string, checkoutPath: unknown)
   assertCheckoutPath(checkoutPath);
 
   const lexicalCandidate = resolve(jobWorkspace, checkoutPath);
-  return normalizeCheckoutDestination(jobWorkspace, lexicalCandidate);
+  return normalizeCheckoutDestination(jobWorkspace, lexicalCandidate, checkoutPath);
 }
 
 export async function inspectCheckoutDestination(

--- a/libs/runner/workspace/src/checkout-path.ts
+++ b/libs/runner/workspace/src/checkout-path.ts
@@ -47,9 +47,27 @@ export function assertCheckoutPath(checkoutPath: unknown): asserts checkoutPath 
   }
 
   const segments = checkoutPath.split('/');
-  if (segments.some((segment) => segment === '..' || segment === '.git')) {
+  if (segments.some((segment) => segment === '..' || isGitSegment(segment))) {
     throw new CheckoutPathInvalidError(checkoutPath);
   }
+}
+
+/** Resolves an absolute checkout destination and enforces the workspace boundary. */
+export async function normalizeCheckoutDestination(
+  jobWorkspace: string,
+  destination: string,
+): Promise<string> {
+  const resolvedWorkspace = await realpath(jobWorkspace);
+  const resolvedCandidate = await resolveExistingPrefix(destination);
+
+  if (
+    !isWithin(resolvedWorkspace, resolvedCandidate) ||
+    containsGitSegment(resolvedWorkspace, resolvedCandidate)
+  ) {
+    throw new CheckoutPathInvalidError(destination);
+  }
+
+  return resolvedCandidate;
 }
 
 /**
@@ -57,24 +75,11 @@ export function assertCheckoutPath(checkoutPath: unknown): asserts checkoutPath 
  * may not exist yet, so realpath is walked up to the nearest existing ancestor. This
  * still catches a symlinked ancestor that would place a new checkout outside the job.
  */
-export async function resolveCheckoutPath(
-  jobWorkspace: string,
-  checkoutPath: unknown,
-): Promise<string> {
+export function resolveCheckoutPath(jobWorkspace: string, checkoutPath: unknown): Promise<string> {
   assertCheckoutPath(checkoutPath);
 
-  const resolvedWorkspace = await realpath(jobWorkspace);
   const lexicalCandidate = resolve(jobWorkspace, checkoutPath);
-  const resolvedCandidate = await resolveExistingPrefix(lexicalCandidate);
-
-  if (
-    !isWithin(resolvedWorkspace, resolvedCandidate) ||
-    containsGitSegment(resolvedWorkspace, resolvedCandidate)
-  ) {
-    throw new CheckoutPathInvalidError(checkoutPath);
-  }
-
-  return resolvedCandidate;
+  return normalizeCheckoutDestination(jobWorkspace, lexicalCandidate);
 }
 
 export async function inspectCheckoutDestination(
@@ -137,7 +142,11 @@ async function resolveExistingPrefix(candidate: string): Promise<string> {
 
 function containsGitSegment(parent: string, candidate: string): boolean {
   const distance = relative(parent, candidate);
-  return distance.split(sep).some((segment) => segment === '.git');
+  return distance.split(sep).some(isGitSegment);
+}
+
+function isGitSegment(segment: string): boolean {
+  return segment.toLowerCase() === '.git';
 }
 
 function isWithin(parent: string, candidate: string): boolean {

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -17,6 +17,7 @@ export {
   CheckoutPathInvalidError,
   createCheckoutDestination,
   inspectCheckoutDestination,
+  normalizeCheckoutDestination,
   replaceCheckoutDestination,
   resolveCheckoutPath,
 } from '#checkout-path.js';

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -11,6 +11,16 @@ export {
   writeAmbientGitCredential,
 } from '#checkout.js';
 export {
+  assertCheckoutPath,
+  CheckoutDestinationOccupiedError,
+  type CheckoutDestinationState,
+  CheckoutPathInvalidError,
+  createCheckoutDestination,
+  inspectCheckoutDestination,
+  replaceCheckoutDestination,
+  resolveCheckoutPath,
+} from '#checkout-path.js';
+export {
   resolveWorkingDirectory,
   WorkingDirectoryEscapeError,
   WorkingDirectoryNotDirectoryError,


### PR DESCRIPTION
Adds explicit checkout execution with runner-local destination safety for side-by-side repositories. Checkout paths are validated and resolved under the job workspace, while the per-job ownership map enforces the never-overwrite policy, gate-restart no-ops, and force replacement. Forced ancestor replacement also releases nested ownership so deleted repositories cannot be reported as still present.

The setup step now skips cloning when no checkout descriptor is dispatched. Typed path and occupied-destination errors are exposed through the DTO/client contracts, with synchronized e2e assertion vocabularies and a Changeset for the published packages.

Validation passed: runner execution (122 tests), runner workspace (99 tests), runner orchestration (95 tests), workflows DTO (120 tests), focused check/type tasks, and e2e workflow check/type.

Closes ENG-1440

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe, explicit checkout executor with path normalization and a never-overwrite policy, wired into the step loop. Setup only checks for Git and clones when a `checkout` is requested, and both paths now share the same rules and credential redaction (ENG-1440).

- **New Features**
  - Added `executeCheckoutStep` with runner-local destination safety and per-job ownership tracking across the step loop.
  - One path policy across setup and checkout: relative-only (no `..`, no absolute paths, not `.git`), resolved under the workspace, and symlink-safe.
  - Error messages for invalid checkout paths now reference the originally requested path for clearer diagnostics.
  - Enforces never-overwrite: same target = no-op; occupied = fail unless `force`; `force` replaces and releases nested ownership.
  - Defaults: first checkout uses the job root; later default uses the repository name; Git availability is checked only when a checkout is requested.
  - Added step error reasons in `@shipfox/api-workflows-dto` and `@shipfox/client-workflows`: `checkout_path_invalid`, `checkout_destination_occupied`; logs redact credentials in repository URLs.
  - Reports checkout details from setup or explicit checkout steps; the server receives the resolved path, repo, ref, and commit.
  - CI: the client composition generator waits for dependency `build`s to finish on clean runners.

- **Migration**
  - If you assert on step error reasons, handle the two new values.
  - To skip setup-time cloning, omit the `checkout` config from the setup step.
  - For explicit checkout, use a relative `path` inside the job workspace and set `force: true` only when replacing existing contents.
  - Update to the latest minor versions of `@shipfox/api-workflows-dto` and `@shipfox/client-workflows`.

<sup>Written for commit 2276aefe1ce1c47f7161dacd98707208e8d830f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

