### PR TITLE
[api-workflows] Default checkout ref to trigger commit

### DIFF
--- a/.changeset/trigger-commit-checkout.md
+++ b/.changeset/trigger-commit-checkout.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Defaults same-project checkout steps to the workflow trigger commit while preserving explicit refs and cross-repository defaults.

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -3,6 +3,7 @@ import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module'
 import {projectFactory} from '#test/factories/project.js';
 import {createStepCheckoutSpec} from './checkout.js';
 import type {Step} from './entities/step.js';
+import type {WorkflowRunTriggerReference} from './entities/workflow-run.js';
 import {CheckoutConfigInvalidError, CheckoutIntentUnresolvedError} from './errors.js';
 
 const getProjectById = vi.fn();
@@ -98,6 +99,7 @@ describe('createStepCheckoutSpec', () => {
       step,
       workspaceId: project.workspaceId,
       projectId: project.id,
+      triggerReference: triggerReferenceFor(project.id),
       integrations: integrations as IntegrationsModuleClient,
       projects: projects as ProjectsModuleClient,
     });
@@ -113,6 +115,136 @@ describe('createStepCheckoutSpec', () => {
       externalRepositoryId: 'github:412',
       ref: 'refs/pull/412/head',
       permissions: {contents: 'write'},
+    });
+  });
+
+  it('defaults the ref to the trigger commit for the triggered repository', async () => {
+    const project = projectFactory.build();
+    const triggerReference = triggerReferenceFor(project.id);
+    const step = checkoutStep({permissions: {contents: 'read'}});
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+    });
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      ref: triggerReference.commit,
+    });
+
+    await createStepCheckoutSpec({
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      triggerReference,
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ref: triggerReference.commit,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('preserves an explicit ref when the trigger targets the same project', async () => {
+    const project = projectFactory.build();
+    const explicitRef = 'refs/pull/412/head';
+    const step = checkoutStep({ref: explicitRef, permissions: {contents: 'read'}});
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+    });
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      ref: explicitRef,
+    });
+
+    await createStepCheckoutSpec({
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      triggerReference: triggerReferenceFor(project.id),
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ref: explicitRef,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('uses the provider default when the matching trigger reference has no commit', async () => {
+    const project = projectFactory.build();
+    const triggerReference = {...triggerReferenceFor(project.id), commit: null};
+    const step = checkoutStep({permissions: {contents: 'read'}});
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+    });
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      ref: 'main',
+    });
+
+    await createStepCheckoutSpec({
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      triggerReference,
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('keeps the provider default ref for a cross-repository target', async () => {
+    const project = projectFactory.build();
+    const targetProjectId = crypto.randomUUID();
+    const step = checkoutStep({project: targetProjectId});
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: targetProjectId,
+      connectionId: crypto.randomUUID(),
+      externalRepositoryId: 'github:412',
+    });
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/target.git',
+      ref: 'main',
+    });
+
+    await createStepCheckoutSpec({
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      triggerReference: triggerReferenceFor(project.id),
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: expect.any(String),
+      externalRepositoryId: 'github:412',
+      permissions: {contents: 'read'},
     });
   });
 
@@ -290,5 +422,14 @@ function checkoutStep(checkout: Record<string, unknown>): Step {
     currentAttempt: 1,
     createdAt: now,
     updatedAt: now,
+  };
+}
+
+function triggerReferenceFor(projectId: string): WorkflowRunTriggerReference {
+  return {
+    project: {id: projectId},
+    repository: 'acme/repo',
+    ref: 'refs/heads/feature/checkout',
+    commit: 'a'.repeat(40),
   };
 }

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -431,5 +431,6 @@ function triggerReferenceFor(projectId: string): WorkflowRunTriggerReference {
     repository: 'acme/repo',
     ref: 'refs/heads/feature/checkout',
     commit: 'a'.repeat(40),
+    actor: null,
   };
 }

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -3,6 +3,7 @@ import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module'
 import {checkoutTargetValidationIssues} from '@shipfox/workflow-document';
 import {z} from 'zod';
 import type {Step} from '#core/entities/step.js';
+import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {CheckoutConfigInvalidError, CheckoutIntentUnresolvedError} from './errors.js';
 
 const checkoutConfigSchema = z
@@ -37,12 +38,14 @@ export async function createStepCheckoutSpec({
   step,
   workspaceId,
   projectId,
+  triggerReference,
   integrations,
   projects,
 }: {
   step: Step;
   workspaceId: string;
   projectId: string;
+  triggerReference?: WorkflowRunTriggerReference | null | undefined;
   integrations: IntegrationsModuleClient;
   projects: ProjectsModuleClient;
 }): Promise<{
@@ -76,11 +79,16 @@ export async function createStepCheckoutSpec({
     },
     target,
   });
+  const ref =
+    checkout.ref ??
+    (triggerReference?.project?.id === resolvedTarget.projectId
+      ? (triggerReference.commit ?? undefined)
+      : undefined);
   const response = await integrations.createCheckoutSpec({
     workspaceId,
     connectionId: resolvedTarget.connectionId,
     externalRepositoryId: resolvedTarget.externalRepositoryId,
-    ...(checkout.ref === undefined ? {} : {ref: checkout.ref}),
+    ...(ref === undefined ? {} : {ref}),
     permissions: checkout.permissions ?? {contents: 'read'},
   });
 

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -4,6 +4,7 @@ import {and, asc, desc, eq, inArray, notInArray, sql} from 'drizzle-orm';
 import {isJobTerminal, type Job, type JobStatus, type JobStatusReason} from '#core/entities/job.js';
 import type {JobExecution} from '#core/entities/job-execution.js';
 import type {PersistedEvaluationTraceEntry} from '#core/entities/step.js';
+import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {
   type DeriveJobSuccessResult,
@@ -58,11 +59,16 @@ export async function getJobById(id: string): Promise<Job | undefined> {
 export interface JobScope {
   workspaceId: string;
   projectId: string;
+  triggerReference: WorkflowRunTriggerReference | null;
 }
 
 export async function getJobScope(jobId: string): Promise<JobScope | undefined> {
   const rows = await db()
-    .select({workspaceId: workflowRuns.workspaceId, projectId: workflowRuns.projectId})
+    .select({
+      workspaceId: workflowRuns.workspaceId,
+      projectId: workflowRuns.projectId,
+      triggerReference: workflowRuns.triggerReference,
+    })
     .from(jobs)
     .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
     .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -151,6 +151,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
       repository: 'acme/repo',
       ref: 'refs/heads/feature/checkout',
       commit: 'a'.repeat(40),
+      actor: null,
     } satisfies WorkflowRunTriggerReference;
     await db().update(workflowRuns).set({triggerReference}).where(eq(workflowRuns.id, run.id));
     getProjectById.mockResolvedValue({project});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -12,9 +12,11 @@ import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
 import {eq} from 'drizzle-orm';
 import type {StepStatus} from '#core/entities/step.js';
+import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {db} from '#db/db.js';
 import {jobs as jobsTable} from '#db/schema/jobs.js';
 import {steps as stepsTable} from '#db/schema/steps.js';
+import {workflowRuns} from '#db/schema/workflow-runs.js';
 import {createWorkflowRun, getJobsByWorkflowRunId, getStepsByJobId} from '#db/workflow-runs.js';
 import {projectFactory} from '#test/factories/project.js';
 import {workflowModel} from '#test/factories/workflow-model.js';
@@ -138,6 +140,40 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
       externalRepositoryId: project.sourceExternalRepositoryId,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  test('defaults the checkout ref to the run trigger commit for the same project', async () => {
+    const {run, project, job, step} = await createRunningCheckoutStep();
+    const triggerReference = {
+      project: {id: project.id},
+      repository: 'acme/repo',
+      ref: 'refs/heads/feature/checkout',
+      commit: 'a'.repeat(40),
+    } satisfies WorkflowRunTriggerReference;
+    await db().update(workflowRuns).set({triggerReference}).where(eq(workflowRuns.id, run.id));
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+    });
+    createCheckoutSpec.mockResolvedValue(githubSpec('ghs-trigger-token'));
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: checkoutUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ref: triggerReference.commit,
       permissions: {contents: 'read'},
     });
   });

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -122,7 +122,7 @@ export function createCheckoutTokenRoute(clients: {
     handler: async (request, reply) => {
       const {stepId} = request.params;
       const {attempt} = request.query;
-      const {step, workspaceId, projectId} = await loadRunningLeasedStep({
+      const {step, workspaceId, projectId, triggerReference} = await loadRunningLeasedStep({
         runners: clients.runners,
         request,
         stepId,
@@ -137,6 +137,7 @@ export function createCheckoutTokenRoute(clients: {
         step,
         workspaceId,
         projectId,
+        triggerReference,
         integrations: clients.integrations,
         projects: clients.projects,
       });

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -206,7 +206,11 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
 
     const scope = await getJobScope(job.id);
 
-    expect(scope).toEqual({workspaceId: run.workspaceId, projectId: run.projectId});
+    expect(scope).toEqual({
+      workspaceId: run.workspaceId,
+      projectId: run.projectId,
+      triggerReference: null,
+    });
   });
 });
 

--- a/libs/api/workflows/src/presentation/routes/leased-step.ts
+++ b/libs/api/workflows/src/presentation/routes/leased-step.ts
@@ -2,6 +2,7 @@ import {type LeasedJobContext, requireLeasedJobContext} from '@shipfox/api-auth-
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {Step} from '#core/entities/step.js';
+import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {getJobScope, getStepByIdForJobExecution} from '#db/index.js';
 
 export interface LoadedRunningLeasedStep {
@@ -9,6 +10,7 @@ export interface LoadedRunningLeasedStep {
   step: Step;
   workspaceId: string;
   projectId: string;
+  triggerReference: WorkflowRunTriggerReference | null;
 }
 
 export async function loadRunningLeasedStep(params: {
@@ -51,5 +53,11 @@ export async function loadRunningLeasedStep(params: {
     throw new ClientError('Step is not running', 'step-not-running', {status: 409});
   }
 
-  return {leasedJob, step, workspaceId: scope.workspaceId, projectId: scope.projectId};
+  return {
+    leasedJob,
+    step,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    triggerReference: scope.triggerReference,
+  };
 }


### PR DESCRIPTION
Checkout steps now default to the workflow run's trigger commit when the resolved target is the same project. Explicit `ref` values still win, and cross-repository targets keep provider defaults.

The checkout-token route carries the persisted `triggerReference` through job scope. Regression coverage covers trigger commits, explicit refs, missing commits, and cross-repository targets.

Validation passed: the affected workflow suite ran 64 files and 729 tests, and the filtered package check and type validation passed.

Closes ENG-1437

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default same-project checkout steps to the workflow run’s trigger commit so jobs run the exact triggering code. Explicit `ref` values still win, and cross-repo targets keep provider defaults (ENG-1437).

- **New Features**
  - Persist and expose `triggerReference` in job scope; pass it through leased-step and checkout-token routes.
  - Default the checkout `ref` to the trigger commit in `createStepCheckoutSpec` for same-project targets; keep explicit refs and provider defaults otherwise.
  - Add tests for trigger commit defaults, explicit refs, missing commits, and cross-repo targets; align fixtures to the trigger reference contract.

<sup>Written for commit f0533bb80f1d9ac037d701fdc11bb6fdd5c1aa55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

