### PR TITLE
Migrate apps/docs to semantic spacing roles

### DIFF
--- a/.changeset/eng-1464-semantic-composition-spacing.md
+++ b/.changeset/eng-1464-semantic-composition-spacing.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": minor
 ---
 
-Adds semantic composition-margin, `ms-inline` badge-separation, and horizontal-padding roles to the shared UI stylesheet.
+Adds the `my-region`, `mt-page`, `ms-inline`, `-mt-inline`, `-mr-inline`, and `px-tight` utilities to the shared UI stylesheet.

--- a/.changeset/eng-1464-semantic-composition-spacing.md
+++ b/.changeset/eng-1464-semantic-composition-spacing.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds semantic composition-margin and horizontal-padding roles to the shared UI stylesheet.

--- a/.changeset/eng-1464-semantic-composition-spacing.md
+++ b/.changeset/eng-1464-semantic-composition-spacing.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": minor
 ---
 
-Adds semantic composition-margin and horizontal-padding roles to the shared UI stylesheet.
+Adds semantic composition-margin, inline-separation, and horizontal-padding roles to the shared UI stylesheet.

--- a/.changeset/eng-1464-semantic-composition-spacing.md
+++ b/.changeset/eng-1464-semantic-composition-spacing.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": minor
 ---
 
-Adds semantic composition-margin, inline-separation, and horizontal-padding roles to the shared UI stylesheet.
+Adds semantic composition-margin, `ms-inline` badge-separation, and horizontal-padding roles to the shared UI stylesheet.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -325,6 +325,14 @@ Anyone arriving from a tutorial or another repo gets this wrong on day one; flag
 in review. Use the scale (2, 4, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 64) and do
 not invent values between the steps.
 
+**Semantic composition roles.** Use `my-region` for a 32px block margin around a
+standalone region and `mt-page` for a 48px separation before page-level feedback
+or similar trailing content. Use `px-tight` when a compact control needs horizontal
+padding without changing its vertical size. The `-mt-inline` and `-mr-inline` roles
+are reserved for preserving a touch target's optical alignment with a containing
+surface. These roles keep composition spacing explicit without reopening raw margin
+utilities across product code.
+
 **Density posture.** Default button height `h-32` with `px-10`; table rows 36 to
 44px; form row gap `gap-16`; card padding `p-24`. A surface is at the wrong density
 when a table needs horizontal scroll from cell padding, when an app page shows more

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -328,10 +328,11 @@ not invent values between the steps.
 **Semantic composition roles.** Use `my-region` for a 32px block margin around a
 standalone region and `mt-page` for a 48px separation before page-level feedback
 or similar trailing content. Use `px-tight` when a compact control needs horizontal
-padding without changing its vertical size. The `-mt-inline` and `-mr-inline` roles
-are reserved for preserving a touch target's optical alignment with a containing
-surface. These roles keep composition spacing explicit without reopening raw margin
-utilities across product code.
+padding without changing its vertical size. Use `ms-inline` for inline badge
+separation. The `-mt-inline` and `-mr-inline` roles are reserved for preserving a
+touch target's optical alignment with a containing surface. These roles keep
+composition spacing explicit without reopening raw margin utilities across product
+code.
 
 **Density posture.** Default button height `h-32` with `px-10`; table rows 36 to
 44px; form row gap `gap-16`; card padding `p-24`. A surface is at the wrong density

--- a/apps/docs/src/app/components/docs-video.tsx
+++ b/apps/docs/src/app/components/docs-video.tsx
@@ -124,7 +124,7 @@ export function DocsVideo({
         ref={triggerRef}
         onClick={() => setExpanded(true)}
         aria-label={label ? `${label} (click to enlarge)` : 'Enlarge the video'}
-        className="group relative my-6 block w-full cursor-zoom-in appearance-none border-0 bg-transparent p-0"
+        className="group relative block w-full cursor-zoom-in appearance-none border-0 bg-transparent p-0"
       >
         <ThemedVideo
           key={activeMedia.src}
@@ -133,7 +133,7 @@ export function DocsVideo({
           width={width}
           height={height}
         />
-        <span className="pointer-events-none absolute top-3 right-3 rounded-md border border-fd-border bg-fd-background/80 p-1.5 text-fd-muted-foreground opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100">
+        <span className="pointer-events-none absolute top-3 right-3 rounded-md border border-fd-border bg-fd-background/80 p-tight text-fd-muted-foreground opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100">
           <ExpandIcon />
         </span>
       </button>
@@ -146,7 +146,7 @@ export function DocsVideo({
             aria-label={dialogLabel}
             tabIndex={-1}
             onKeyDown={trapFocus}
-            className="fixed inset-0 z-50 flex items-center justify-center p-4 outline-none"
+            className="fixed inset-0 z-50 flex items-center justify-center p-panel-compact outline-none"
           >
             {/* Full-screen backdrop; a real button so Enter/Space close it too. */}
             <button

--- a/apps/docs/src/app/components/integration-catalog.tsx
+++ b/apps/docs/src/app/components/integration-catalog.tsx
@@ -136,17 +136,14 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
   return (
     <section
       aria-label="Integration catalog"
-      className="not-prose my-8 grid gap-x-8 gap-y-6 lg:grid-cols-[minmax(0,1fr)_240px]"
+      className="not-prose my-region grid gap-region lg:grid-cols-[minmax(0,1fr)_240px]"
     >
-      <div className="lg:col-start-1">
+      <div className="flex flex-col gap-group lg:col-start-1">
         <label htmlFor="integration-catalog-search" className="sr-only">
           Search integrations
         </label>
-        <div className="relative">
-          <Search
-            aria-hidden="true"
-            className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-fd-muted-foreground"
-          />
+        <div className="flex min-h-11 items-center gap-tight rounded-md border border-fd-border bg-fd-background px-row py-row outline-none focus-within:ring-2 focus-within:ring-fd-ring">
+          <Search aria-hidden="true" className="size-4 shrink-0 text-fd-muted-foreground" />
           <input
             id="integration-catalog-search"
             type="search"
@@ -154,14 +151,14 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
             data-ph-no-autocapture=""
             onChange={(event) => setFilters((current) => ({...current, query: event.target.value}))}
             placeholder="Search by provider, type, or related term"
-            className="h-11 w-full rounded-md border border-fd-border bg-fd-background py-2 pr-9 pl-10 text-sm text-fd-foreground outline-none placeholder:text-fd-muted-foreground focus-visible:ring-2 focus-visible:ring-fd-ring"
+            className="min-w-0 flex-1 bg-transparent text-sm text-fd-foreground outline-none placeholder:text-fd-muted-foreground"
           />
           {filters.query.length > 0 ? (
             <button
               type="button"
               aria-label="Clear search"
               onClick={() => setFilters((current) => ({...current, query: ''}))}
-              className="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded text-fd-muted-foreground outline-none hover:text-fd-foreground focus-visible:ring-2 focus-visible:ring-fd-ring"
+              className="inline-flex size-7 shrink-0 items-center justify-center rounded text-fd-muted-foreground outline-none hover:text-fd-foreground focus-visible:ring-2 focus-visible:ring-fd-ring"
             >
               <X aria-hidden="true" className="size-4" />
             </button>
@@ -173,7 +170,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
           aria-controls="integration-catalog-filters"
           aria-expanded={filtersOpen}
           onClick={() => setFiltersOpen((open) => !open)}
-          className="mt-4 min-h-11 w-full rounded-md border border-fd-border px-3 text-sm font-medium text-fd-foreground outline-none hover:bg-fd-muted focus-visible:ring-2 focus-visible:ring-fd-ring lg:hidden"
+          className="min-h-11 w-full rounded-md border border-fd-border p-tight text-sm font-medium text-fd-foreground outline-none hover:bg-fd-muted focus-visible:ring-2 focus-visible:ring-fd-ring lg:hidden"
         >
           {activeFilterCount > 0 ? `Filters (${activeFilterCount})` : 'Filters'}
         </button>
@@ -182,7 +179,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
       <aside
         id="integration-catalog-filters"
         aria-label="Filter integrations"
-        className={`${filtersOpen ? 'block' : 'hidden'} border-t border-fd-border pt-4 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:!block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto lg:border-t-0 lg:border-l lg:pl-8 lg:pt-0`}
+        className={`${filtersOpen ? 'block' : 'hidden'} flex flex-col gap-section border-t border-fd-border p-panel-compact lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:!flex lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto lg:border-t-0 lg:border-l lg:pb-0 lg:pr-0 lg:pt-0 lg:px-frame`}
       >
         <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-fd-foreground">Filters</p>
@@ -196,7 +193,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
             </button>
           ) : null}
         </div>
-        <div className="mt-6 space-y-6">
+        <div className="flex flex-col gap-section">
           <FacetGroup
             label="What it does"
             values={INTEGRATION_CATALOG_CAPABILITIES}
@@ -216,50 +213,54 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
         </div>
       </aside>
 
-      <div className="lg:col-start-1">
-        <p aria-live="polite" className="text-sm text-fd-muted-foreground">
-          {filteredProviders.length}{' '}
-          {filteredProviders.length === 1 ? 'integration' : 'integrations'} found
-        </p>
-        {activeFilterCount > 0 ? (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {filters.capability.map((capability) => (
-              <FilterChip
-                key={capability}
-                label={catalogCapabilityLabels[capability]}
-                onRemove={() => removeCapability(capability)}
-              />
-            ))}
-            {filters.category.map((category) => (
-              <FilterChip
-                key={category}
-                label={catalogCategoryLabels[category]}
-                onRemove={() => removeCategory(category)}
-              />
-            ))}
-          </div>
-        ) : null}
+      <div className="flex flex-col gap-section lg:col-start-1">
+        <div className="flex flex-col gap-cluster">
+          <p aria-live="polite" className="text-sm text-fd-muted-foreground">
+            {filteredProviders.length}{' '}
+            {filteredProviders.length === 1 ? 'integration' : 'integrations'} found
+          </p>
+          {activeFilterCount > 0 ? (
+            <div className="flex flex-wrap gap-inline">
+              {filters.capability.map((capability) => (
+                <FilterChip
+                  key={capability}
+                  label={catalogCapabilityLabels[capability]}
+                  onRemove={() => removeCapability(capability)}
+                />
+              ))}
+              {filters.category.map((category) => (
+                <FilterChip
+                  key={category}
+                  label={catalogCategoryLabels[category]}
+                  onRemove={() => removeCategory(category)}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
 
         {filteredProviders.length === 0 ? (
-          <div className="mt-6 rounded-lg border border-dashed border-fd-border px-6 py-10 text-center">
-            <p className="text-sm font-medium text-fd-foreground">
-              No integrations match these filters
-            </p>
-            <p className="mt-2 text-sm text-fd-muted-foreground">
-              Try another term or remove a filter.
-            </p>
+          <div className="flex flex-col items-center gap-group rounded-lg border border-dashed border-fd-border p-panel text-center">
+            <div className="flex flex-col items-center gap-inline">
+              <p className="text-sm font-medium text-fd-foreground">
+                No integrations match these filters
+              </p>
+              <p className="text-sm text-fd-muted-foreground">
+                Try another term or remove a filter.
+              </p>
+            </div>
             {hasFilters ? (
               <button
                 type="button"
                 onClick={clearFilters}
-                className="mt-4 min-h-11 rounded-md px-3 text-sm font-medium text-fd-primary outline-none hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
+                className="min-h-11 rounded-md p-tight text-sm font-medium text-fd-primary outline-none hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
               >
                 Clear filters
               </button>
             ) : null}
           </div>
         ) : (
-          <div className="mt-6 space-y-8">
+          <div className="flex flex-col gap-region">
             {availabilitySections.map((availability) => {
               const sectionProviders = filteredProviders.filter(
                 (provider) => provider.availability === availability,
@@ -270,7 +271,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
                 <section
                   key={availability}
                   aria-labelledby={`${availability}-integrations`}
-                  className="space-y-3"
+                  className="flex flex-col gap-cluster"
                 >
                   <h2
                     id={`${availability}-integrations`}
@@ -278,7 +279,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
                   >
                     {catalogAvailabilityLabels[availability]}
                   </h2>
-                  <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="grid gap-group sm:grid-cols-2">
                     {sectionProviders.map((provider) => (
                       <IntegrationCard
                         key={provider.slug}
@@ -325,8 +326,8 @@ function FacetGroup<Value extends string>({
   onToggle,
 }: FacetGroupProps<Value>) {
   return (
-    <fieldset>
-      <legend className="mb-2 text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
+    <fieldset className="flex flex-col gap-inline">
+      <legend className="text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
         {label}
       </legend>
       <div>
@@ -338,7 +339,7 @@ function FacetGroup<Value extends string>({
           return (
             <label
               key={value}
-              className={`flex cursor-pointer items-center gap-2 py-1.5 text-sm ${
+              className={`flex cursor-pointer items-center gap-inline p-tight text-sm ${
                 count === 0 ? 'text-fd-muted-foreground' : 'text-fd-foreground'
               }`}
             >
@@ -361,7 +362,7 @@ function FacetGroup<Value extends string>({
 
 function FilterChip({label, onRemove}: {label: string; onRemove: () => void}) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-fd-border bg-fd-muted px-2.5 py-1 text-xs text-fd-foreground">
+    <span className="inline-flex items-center gap-tight rounded-full border border-fd-border bg-fd-muted p-tight text-xs text-fd-foreground">
       {label}
       <button
         type="button"
@@ -383,51 +384,53 @@ function IntegrationCard({
   onNavigate: (target: 'overview' | 'setup') => void;
 }) {
   return (
-    <article className="flex min-h-56 flex-col rounded-lg border border-fd-border bg-fd-card p-5">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
+    <article className="flex min-h-56 flex-col gap-group rounded-lg border border-fd-border bg-fd-card p-panel">
+      <div className="flex items-start justify-between gap-group">
+        <div className="flex min-w-0 flex-col gap-inline">
           <Link
             href={provider.overviewHref}
             onClick={() => onNavigate('overview')}
-            className="flex items-start gap-3 font-semibold text-fd-foreground outline-none hover:text-fd-primary hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
+            className="flex items-start gap-cluster font-semibold text-fd-foreground outline-none hover:text-fd-primary hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
           >
             <ProviderIcon icon={provider.icon} />
             <span>{provider.name}</span>
           </Link>
-          <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{provider.summary}</p>
+          <p className="text-sm leading-6 text-fd-muted-foreground">{provider.summary}</p>
         </div>
         {provider.setupHref ? (
           <Link
             href={provider.setupHref}
             onClick={() => onNavigate('setup')}
-            className="-mt-2 -mr-2 inline-flex min-h-11 shrink-0 items-center rounded-md px-2 text-sm font-medium text-fd-primary outline-none hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
+            className="-mr-inline -mt-inline inline-flex min-h-11 shrink-0 items-center rounded-md px-tight text-sm font-medium text-fd-primary outline-none hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
           >
             Set up
           </Link>
         ) : null}
       </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2">
-        {provider.capabilities.map((capability) => (
-          <span
-            key={capability}
-            className="rounded border border-fd-border bg-fd-muted px-1 py-0 text-[9px] font-medium uppercase tracking-wide text-fd-muted-foreground"
-          >
-            {catalogCapabilityLabels[capability]}
-          </span>
-        ))}
-      </div>
+      <div className="flex flex-col gap-cluster">
+        <div className="flex flex-wrap items-center gap-inline">
+          {provider.capabilities.map((capability) => (
+            <span
+              key={capability}
+              className="rounded border border-fd-border bg-fd-muted p-tight py-0 text-[9px] font-medium uppercase tracking-wide text-fd-muted-foreground"
+            >
+              {catalogCapabilityLabels[capability]}
+            </span>
+          ))}
+        </div>
 
-      {provider.eventCount > 0 || provider.toolCount > 0 ? (
-        <p className="mt-3 text-xs text-fd-muted-foreground">
-          {[
-            provider.eventCount > 0 && `${provider.eventCount} events`,
-            provider.toolCount > 0 && `${provider.toolCount} agent tools`,
-          ]
-            .filter(Boolean)
-            .join(' · ')}
-        </p>
-      ) : null}
+        {provider.eventCount > 0 || provider.toolCount > 0 ? (
+          <p className="text-xs text-fd-muted-foreground">
+            {[
+              provider.eventCount > 0 && `${provider.eventCount} events`,
+              provider.toolCount > 0 && `${provider.toolCount} agent tools`,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
+          </p>
+        ) : null}
+      </div>
     </article>
   );
 }
@@ -442,9 +445,7 @@ function removeFilter<Value>(values: readonly Value[], value: Value): Value[] {
 
 function ProviderIcon({icon}: {icon: CatalogIcon}) {
   if (icon === 'webhooks')
-    return (
-      <Webhook aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-fd-muted-foreground" />
-    );
+    return <Webhook aria-hidden="true" className="size-5 shrink-0 text-fd-muted-foreground" />;
 
   const brandIcon = {
     github: siGithub,
@@ -457,7 +458,7 @@ function ProviderIcon({icon}: {icon: CatalogIcon}) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className="mt-0.5 size-5 shrink-0 fill-current text-fd-muted-foreground"
+      className="size-5 shrink-0 fill-current text-fd-muted-foreground"
     >
       <path d={brandIcon.path} />
     </svg>

--- a/apps/docs/src/app/components/integration-catalog.tsx
+++ b/apps/docs/src/app/components/integration-catalog.tsx
@@ -143,7 +143,10 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
           Search integrations
         </label>
         <div className="flex min-h-11 items-center gap-tight rounded-md border border-fd-border bg-fd-background px-row py-row outline-none focus-within:ring-2 focus-within:ring-fd-ring">
-          <Search aria-hidden="true" className="size-4 shrink-0 text-fd-muted-foreground" />
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none size-4 shrink-0 text-fd-muted-foreground"
+          />
           <input
             id="integration-catalog-search"
             type="search"

--- a/apps/docs/src/app/components/page-feedback.tsx
+++ b/apps/docs/src/app/components/page-feedback.tsx
@@ -14,23 +14,23 @@ export function PageFeedback({pageUrl, filePath}: {pageUrl: string; filePath: st
   };
 
   return (
-    <div className="mt-12 flex flex-wrap items-center justify-between gap-4 border-t pt-6 text-sm text-fd-muted-foreground">
+    <div className="mt-page flex flex-wrap items-center justify-between gap-group border-t p-tight text-sm text-fd-muted-foreground">
       {voted ? (
         <span>Thanks for the feedback!</span>
       ) : (
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-cluster">
           <span>Was this page helpful?</span>
           <button
             type="button"
             onClick={() => vote(true)}
-            className="rounded-md border px-3 py-1 transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+            className="rounded-md border p-tight transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
           >
             Yes
           </button>
           <button
             type="button"
             onClick={() => vote(false)}
-            className="rounded-md border px-3 py-1 transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+            className="rounded-md border p-tight transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
           >
             No
           </button>

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -27,6 +27,26 @@
   --color-fd-accent-foreground: #030303;
   --color-fd-ring: #ff4b00;
   --color-fd-overlay: rgb(3 3 3 / 20%);
+
+  /* Semantic spacing roles mirror @shipfox/react-ui for this standalone app. */
+  --space-tight: 4px;
+  --space-inline: 8px;
+  --space-cluster: 12px;
+  --space-group: 16px;
+  --space-section: 24px;
+  --space-region: 32px;
+
+  --margin-inline: 8px;
+  --margin-region: 32px;
+  --margin-page: 48px;
+
+  --pad-tight: 8px;
+  --pad-row-x: 16px;
+  --pad-row-y: 12px;
+  --pad-panel-compact: 16px;
+  --pad-panel: 24px;
+  --pad-frame-x: 24px;
+  --pad-frame-y: 32px;
 }
 
 html {
@@ -52,6 +72,79 @@ html {
   --color-fd-accent-foreground: #fafafa;
   --color-fd-ring: #ff4b00;
   --color-fd-overlay: rgb(0 0 0 / 50%);
+}
+
+/* Keep gap, margin, and padding roles explicit instead of exposing cross-role utilities. */
+@utility gap-tight {
+  gap: var(--space-tight);
+}
+
+@utility gap-inline {
+  gap: var(--space-inline);
+}
+
+@utility gap-cluster {
+  gap: var(--space-cluster);
+}
+
+@utility gap-group {
+  gap: var(--space-group);
+}
+
+@utility gap-section {
+  gap: var(--space-section);
+}
+
+@utility gap-region {
+  gap: var(--space-region);
+}
+
+@utility my-region {
+  margin-block: var(--margin-region);
+}
+
+@utility mt-page {
+  margin-top: var(--margin-page);
+}
+
+@utility -mt-inline {
+  margin-top: calc(var(--margin-inline) * -1);
+}
+
+@utility -mr-inline {
+  margin-right: calc(var(--margin-inline) * -1);
+}
+
+@utility p-tight {
+  padding: var(--pad-tight);
+}
+
+@utility p-panel-compact {
+  padding: var(--pad-panel-compact);
+}
+
+@utility p-panel {
+  padding: var(--pad-panel);
+}
+
+@utility px-tight {
+  padding-inline: var(--pad-tight);
+}
+
+@utility px-row {
+  padding-inline: var(--pad-row-x);
+}
+
+@utility py-row {
+  padding-block: var(--pad-row-y);
+}
+
+@utility px-frame {
+  padding-inline: var(--pad-frame-x);
+}
+
+@utility py-frame {
+  padding-block: var(--pad-frame-y);
 }
 
 body {

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -107,6 +107,10 @@ html {
   margin-top: var(--margin-page);
 }
 
+@utility ms-inline {
+  margin-inline-start: var(--margin-inline);
+}
+
 @utility -mt-inline {
   margin-top: calc(var(--margin-inline) * -1);
 }

--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -12,7 +12,7 @@ export const baseOptions: BaseLayoutProps = {
   githubUrl: 'https://github.com/ShipfoxHQ/shipfox',
   nav: {
     title: (
-      <div className="flex items-center px-4">
+      <div className="flex items-center px-row">
         <picture className="dark:hidden">
           <img src={`${basePath}/logo-light.svg`} alt="Shipfox" className="max-h-6" />
         </picture>

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -44,7 +44,7 @@ export const source = loader({
           'span',
           {
             className:
-              'inline-flex items-center rounded bg-fd-primary/10 p-tight text-[10px] font-medium uppercase tracking-wide text-fd-primary',
+              'ms-inline inline-flex items-center rounded bg-fd-primary/10 p-tight text-[10px] font-medium uppercase tracking-wide text-fd-primary',
           },
           status === 'soon' ? 'Soon' : status,
         ),

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -44,7 +44,7 @@ export const source = loader({
           'span',
           {
             className:
-              'ms-1.5 rounded bg-fd-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-fd-primary',
+              'inline-flex items-center rounded bg-fd-primary/10 p-tight text-[10px] font-medium uppercase tracking-wide text-fd-primary',
           },
           status === 'soon' ? 'Soon' : status,
         ),

--- a/biome.json
+++ b/biome.json
@@ -211,7 +211,22 @@
     },
     {
       "path": "./tools/biome/plugins/client-architecture/no-raw-spacing.grit",
-      "includes": []
+      "includes": [
+        "**/apps/docs/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
     },
     {
       "path": "./tools/biome/plugins/database-boundaries/no-direct-table-declaration.grit",

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -343,6 +343,10 @@
   --space-section: 24px;
   --space-region: 32px;
 
+  --margin-inline: 8px;
+  --margin-region: 32px;
+  --margin-page: 48px;
+
   --pad-tight: 8px;
   --pad-row-x: 16px;
   --pad-row-y: 12px;
@@ -435,6 +439,10 @@
   --space-group: 12px;
   --space-section: 16px;
   --space-region: 24px;
+
+  --margin-inline: 4px;
+  --margin-region: 24px;
+  --margin-page: 32px;
 
   --pad-tight: 4px;
   --pad-row-x: 12px;
@@ -1002,7 +1010,7 @@
   --shadow-separator-inset: var(--shadow-separator-inset);
 }
 
-/* Semantic spacing utilities are explicit to keep gap and padding roles distinct. */
+/* Semantic spacing utilities are explicit to keep gap, margin, and padding roles distinct. */
 @utility gap-tight {
   gap: var(--space-tight);
 }
@@ -1027,6 +1035,22 @@
   gap: var(--space-region);
 }
 
+@utility my-region {
+  margin-block: var(--margin-region);
+}
+
+@utility mt-page {
+  margin-top: var(--margin-page);
+}
+
+@utility -mt-inline {
+  margin-top: calc(var(--margin-inline) * -1);
+}
+
+@utility -mr-inline {
+  margin-right: calc(var(--margin-inline) * -1);
+}
+
 @utility p-tight {
   padding: var(--pad-tight);
 }
@@ -1037,6 +1061,10 @@
 
 @utility p-panel {
   padding: var(--pad-panel);
+}
+
+@utility px-tight {
+  padding-inline: var(--pad-tight);
 }
 
 @utility px-row {

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -1043,6 +1043,10 @@
   margin-top: var(--margin-page);
 }
 
+@utility ms-inline {
+  margin-inline-start: var(--margin-inline);
+}
+
 @utility -mt-inline {
   margin-top: calc(var(--margin-inline) * -1);
 }

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/allowed.tsx
@@ -6,7 +6,7 @@ export function AllowedSpacing() {
   return (
     <>
       <div className="gap-tight gap-inline gap-cluster gap-group gap-section gap-region" />
-      <div className="my-region mt-page -mt-inline -mr-inline" />
+      <div className="my-region mt-page ms-inline -mt-inline -mr-inline" />
       <div className="p-tight px-tight px-row py-row p-panel-compact p-panel px-frame py-frame" />
       <div className="p-0 gap-0 mt-0 first:pt-0 last:pb-0 p-[15%] pl-[2ch]" />
       <div className="p-0" />

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-spacing/allowed.tsx
@@ -6,7 +6,8 @@ export function AllowedSpacing() {
   return (
     <>
       <div className="gap-tight gap-inline gap-cluster gap-group gap-section gap-region" />
-      <div className="p-tight px-row py-row p-panel-compact p-panel px-frame py-frame" />
+      <div className="my-region mt-page -mt-inline -mr-inline" />
+      <div className="p-tight px-tight px-row py-row p-panel-compact p-panel px-frame py-frame" />
       <div className="p-0 gap-0 mt-0 first:pt-0 last:pb-0 p-[15%] pl-[2ch]" />
       <div className="p-0" />
       <div className={`p-4`} />

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -175,7 +175,7 @@ describe('client-architecture Biome plugins', () => {
     assert.doesNotMatch(`${stdout}${stderr}`, rawSpacingRulePattern);
   });
 
-  test('registers no-raw-spacing with an empty rollout glob list', async () => {
+  test('registers no-raw-spacing for the migrated docs app', async () => {
     const rootConfig = JSON.parse(await readFile(resolve(workspaceRoot, 'biome.json'), 'utf8')) as {
       plugins: {includes: string[]; path: string}[];
     };
@@ -185,7 +185,22 @@ describe('client-architecture Biome plugins', () => {
 
     assert.deepEqual(rawSpacingPlugin, {
       path: './tools/biome/plugins/client-architecture/no-raw-spacing.grit',
-      includes: [],
+      includes: [
+        '**/apps/docs/**',
+        '!**/dist/**',
+        '!**/node_modules/**',
+        '!**/*.test.ts',
+        '!**/*.test.tsx',
+        '!**/*.stories.ts',
+        '!**/*.stories.tsx',
+        '!**/test/**',
+        '!**/tests/**',
+        '!**/__tests__/**',
+        '!**/generated/**',
+        '!**/__generated__/**',
+        '!**/*.gen.ts',
+        '!**/*.gen.tsx',
+      ],
     });
   });
 


### PR DESCRIPTION
## Summary

Migrate `apps/docs` from raw Tailwind spacing utilities to the shared semantic spacing contract. The migration also adds the small set of composition roles needed to preserve the reviewed page and card relationships.

The shared UI stylesheet and standalone docs stylesheet now expose mirrored margin and horizontal-padding roles. The docs catalog and page feedback regain their original separation, and setup links preserve their touch-target alignment. The no-raw-spacing rule fixture and design documentation cover the new contract, with a React UI changeset included for the published CSS surface.

## Validation

Focused docs and React UI Biome checks, the Biome test suite, and `turbo type build test --filter=@shipfox/docs... --filter=@shipfox/react-ui...` passed. Desktop and mobile browser checks covered the catalog spacing, setup-link alignment, feedback separation, and search clear-button containment.

Closes ENG-1464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates `apps/docs` from raw Tailwind spacing to shared semantic spacing roles and restores composition spacing in the catalog and page feedback. Publishes new margin and horizontal-only padding roles in `@shipfox/react-ui` and enables the docs `no-raw-spacing` lint, fulfilling ENG-1464.

- **New Features**
  - Added composition roles in `@shipfox/react-ui`: `my-region`, `mt-page`, `ms-inline`, `px-tight`; reserved `-mt-inline`/`-mr-inline`.
  - Kept `p-tight` at 8px and the `gap-cluster` (12px) vs `gap-group` (16px) distinction.
  - Restored catalog/page-feedback separation and setup-link alignment; fixed search icon click-through; status badges use `ms-inline`.

- **Migration**
  - Replaced numeric gaps/margins/padding in `apps/docs` with semantic roles; updated catalog, videos, page feedback, and layout.
  - Mirrored roles in `apps/docs` `global.css`; updated `DESIGN.md`, fixtures, and tests; added an `@shipfox/react-ui` changeset naming the new utilities.

<sup>Written for commit d983466d8537bfc071e5a2aac747fdf24e0bb526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

