### PR TITLE
[api-workspaces-dto] Reject blank workspace administration reasons

### DIFF
--- a/.changeset/meaningful-workspace-administration-reasons.md
+++ b/.changeset/meaningful-workspace-administration-reasons.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workspaces-dto": patch
+---
+
+Reject whitespace-only workspace administration reasons and normalize surrounding whitespace before enforcing the 512-character bound.

--- a/libs/api/workspaces-dto/src/schemas/workspace.test.ts
+++ b/libs/api/workspaces-dto/src/schemas/workspace.test.ts
@@ -1,0 +1,45 @@
+import {workspaceAdministrationMutationBodySchema} from './workspace.js';
+
+const parseReason = (reason: string) =>
+  workspaceAdministrationMutationBodySchema.safeParse({reason});
+
+describe('workspaceAdministrationMutationBodySchema', () => {
+  it.each(['', '   ', '\u00a0\u2003'])('rejects a %j reason', (reason) => {
+    expect(parseReason(reason).success).toBe(false);
+  });
+
+  it('trims surrounding whitespace from a meaningful reason', () => {
+    expect(parseReason('  Requested by the support operator  ')).toEqual({
+      success: true,
+      data: {reason: 'Requested by the support operator'},
+    });
+  });
+
+  it('preserves ordinary internal whitespace', () => {
+    expect(parseReason('Requested  by the support operator')).toEqual({
+      success: true,
+      data: {reason: 'Requested  by the support operator'},
+    });
+  });
+
+  it('accepts 512 characters after surrounding whitespace is normalized', () => {
+    const result = parseReason(`  ${'a'.repeat(512)}  `);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.reason).toHaveLength(512);
+  });
+
+  it('rejects more than 512 characters after surrounding whitespace is normalized', () => {
+    expect(parseReason(`  ${'a'.repeat(513)}  `).success).toBe(false);
+  });
+
+  it.each([
+    ['control', 'Reason\nwith control'],
+    ['format', 'Reason\u202ewith format character'],
+    ['zero-width', 'Reason\u200dwith format character'],
+  ])('rejects %s characters', (_kind, reason) => {
+    expect(() => workspaceAdministrationMutationBodySchema.parse({reason})).toThrow(
+      'must not contain control or format characters',
+    );
+  });
+});

--- a/libs/api/workspaces-dto/src/schemas/workspace.ts
+++ b/libs/api/workspaces-dto/src/schemas/workspace.ts
@@ -66,11 +66,11 @@ export type WorkspaceAdminLookupQueryDto = z.infer<typeof workspaceAdminLookupQu
 const CONTROL_OR_FORMAT_CHARACTER_RE = /[\p{Cc}\p{Cf}]/u;
 const workspaceAdministrationReasonSchema = z
   .string()
-  .min(1)
-  .max(512)
   .refine((value) => !CONTROL_OR_FORMAT_CHARACTER_RE.test(value), {
     message: 'must not contain control or format characters',
-  });
+  })
+  .transform((value) => value.trim())
+  .pipe(z.string().min(1).max(512));
 
 export const workspaceAdministrationMutationBodySchema = z.object({
   reason: workspaceAdministrationReasonSchema,


### PR DESCRIPTION
Require meaningful workspace administration reasons in the shared DTO contract.

The workspace suspend/reactivate body schema now rejects whitespace-only reasons, trims surrounding whitespace before applying the 512-character bound, preserves ordinary internal whitespace, and continues rejecting control and format characters. Focused schema coverage exercises the normalization and validation boundary, and a patch Changeset releases `@shipfox/api-workspaces-dto` for downstream Cloud adoption.

Closes ENG-1472


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires meaningful workspace administration reasons in `@shipfox/api-workspaces-dto`. Trims surrounding whitespace, rejects whitespace-only input, and enforces the 512‑char limit after normalization (aligned with ENG-1472).

- **Bug Fixes**
  - Treat whitespace-only reasons as invalid; apply length check after trim.
  - Preserve internal spaces; continue rejecting control/format characters with a clear error.
  - Add focused schema tests and ship a patch release of `@shipfox/api-workspaces-dto`.

<sup>Written for commit 899111d4b0b4bc6de0897493db14ca5be50a1170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

