### PR TITLE
[api-integration-jira] Add Jira REST agent tools

### DIFF
--- a/.changeset/calm-jira-tools.md
+++ b/.changeset/calm-jira-tools.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-jira": minor
+"@shipfox/api-integration-core": patch
+---
+
+Adds the in-process Jira REST agent-tool catalog and write-selection support.

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -69,11 +69,21 @@ const integrationValidationContext = {
         ],
       },
     ],
+    [
+      'jira',
+      {
+        selectors: [
+          {token: 'get_issue', kind: 'standalone', sensitivity: 'read', sensitive: false},
+          {token: 'add_comment', kind: 'standalone', sensitivity: 'write', sensitive: false},
+        ],
+      },
+    ],
   ]),
   workspaceConnectionSnapshot: new Map([
     ['github-main', {id: 'conn_1', provider: 'github', capabilities: ['agent_tools']}],
     ['sentry-main', {id: 'conn_2', provider: 'sentry', capabilities: []}],
     ['linear-main', {id: 'conn_3', provider: 'linear', capabilities: ['agent_tools']}],
+    ['jira-main', {id: 'conn_4', provider: 'jira', capabilities: ['agent_tools']}],
   ]),
   defaultConnectionSlug: 'github-main',
 } satisfies IntegrationValidationContext;
@@ -644,6 +654,56 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.jobs[0]?.steps[0]).toMatchObject({
       kind: 'agent',
       integrations: [{connection: 'linear-main', include: ['save_comment'], allowWrite: true}],
+    });
+  });
+
+  it('requires allow_write for Jira write tools', () => {
+    const document: WorkflowDocument = {
+      name: 'jira write integrations',
+      jobs: {
+        fix: {
+          steps: [
+            {
+              prompt: 'Comment on the issue.',
+              integrations: [{connection: 'jira-main', include: ['add_comment']}],
+            },
+          ],
+        },
+      },
+    };
+
+    const error = expectInvalid(document, {integrationValidationContext});
+
+    expect(error.issues).toMatchObject([
+      {
+        code: 'integration-write-not-allowed',
+        details: {tokens: ['add_comment']},
+      },
+    ]);
+  });
+
+  it('accepts Jira write tools when allow_write is true', () => {
+    const document: WorkflowDocument = {
+      name: 'jira write integrations',
+      jobs: {
+        fix: {
+          steps: [
+            {
+              prompt: 'Comment on the issue.',
+              integrations: [
+                {connection: 'jira-main', include: ['add_comment'], allow_write: true},
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document, {integrationValidationContext});
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      integrations: [{connection: 'jira-main', include: ['add_comment'], allowWrite: true}],
     });
   });
 

--- a/libs/api/integration/core/src/providers/jira.ts
+++ b/libs/api/integration/core/src/providers/jira.ts
@@ -142,6 +142,7 @@ async function loadJiraModuleParts(
   const pendingStore = createJiraPendingSelectionStore({secrets});
 
   const integrationProvider = createJiraIntegrationProvider({
+    agentTools: {tokenStore},
     routes: {
       tokenStore,
       pendingStore,

--- a/libs/api/integration/jira/package.json
+++ b/libs/api/integration/jira/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./agent-tools": {
+      "workspace-source": {
+        "types": "./src/core/agent-tools.ts",
+        "default": "./src/core/agent-tools.ts"
+      },
+      "default": {
+        "types": "./dist/core/agent-tools.d.ts",
+        "default": "./dist/core/agent-tools.js"
+      }
     }
   },
   "scripts": {

--- a/libs/api/integration/jira/src/api/client.test.ts
+++ b/libs/api/integration/jira/src/api/client.test.ts
@@ -2,7 +2,7 @@ import {HTTPError} from 'ky';
 import type {JiraIntegrationProviderError} from '#core/errors.js';
 import {mapJiraError} from './client.js';
 
-const mocks = vi.hoisted(() => ({delete: vi.fn(), post: vi.fn()}));
+const mocks = vi.hoisted(() => ({delete: vi.fn(), post: vi.fn(), request: vi.fn()}));
 
 vi.mock('ky', () => {
   class MockHTTPError extends Error {
@@ -18,7 +18,7 @@ vi.mock('ky', () => {
     }
   }
   return {
-    default: {delete: mocks.delete, post: mocks.post},
+    default: Object.assign(mocks.request, {delete: mocks.delete, post: mocks.post}),
     HTTPError: MockHTTPError,
     TimeoutError: MockTimeoutError,
   };
@@ -58,6 +58,7 @@ describe('Jira dynamic webhook API', () => {
   beforeEach(() => {
     mocks.delete.mockReset();
     mocks.post.mockReset();
+    mocks.request.mockReset();
   });
 
   it('registers the six curated events with the access token', async () => {
@@ -131,5 +132,107 @@ describe('Jira dynamic webhook API', () => {
         json: {webhookIds: [123]},
       }),
     );
+  });
+});
+
+describe('Jira agent-tools REST API', () => {
+  beforeEach(() => {
+    mocks.request.mockReset();
+  });
+
+  it('sends a REST v3 request and parses a JSON response', async () => {
+    mocks.request.mockResolvedValue(
+      new Response(JSON.stringify({id: '1004', key: 'ENG-1004'}), {status: 200}),
+    );
+    const {createJiraAgentToolsClient} = await import('./client.js');
+
+    const result = await createJiraAgentToolsClient().request({
+      accessToken: 'access-token',
+      cloudId: 'cloud-1',
+      method: 'GET',
+      path: '/issue/ENG-1004',
+      query: {fields: ['summary', 'description'], updateHistory: false},
+      operation: 'get_issue',
+    });
+
+    expect(result).toEqual({status: 200, body: {id: '1004', key: 'ENG-1004'}});
+    const [url, options] = mocks.request.mock.calls[0] as [
+      string,
+      {headers: Record<string, string>; searchParams: URLSearchParams},
+    ];
+    expect(url).toBe('http://127.0.0.1:0/ex/jira/cloud-1/rest/api/3/issue/ENG-1004');
+    expect(options.headers).toEqual({authorization: 'Bearer access-token'});
+    expect([...options.searchParams.entries()]).toEqual([
+      ['fields', 'summary'],
+      ['fields', 'description'],
+      ['updateHistory', 'false'],
+    ]);
+  });
+
+  it('maps HTTP 429 Retry-After responses to a rate-limited provider error', async () => {
+    mocks.request.mockRejectedValue(
+      new HTTPError(
+        new Response(null, {status: 429, headers: {'retry-after': '19'}}),
+        new Request('https://jira.example.test'),
+        {} as never,
+      ),
+    );
+    const {createJiraAgentToolsClient} = await import('./client.js');
+
+    await expect(
+      createJiraAgentToolsClient().request({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        method: 'GET',
+        path: '/issue/ENG-1004',
+        operation: 'get_issue',
+      }),
+    ).rejects.toMatchObject({reason: 'rate-limited', retryAfterSeconds: 19});
+  });
+
+  it('preserves Jira validation details from HTTP 400 responses', async () => {
+    mocks.request.mockRejectedValue(
+      new HTTPError(
+        new Response(JSON.stringify({errorMessages: ['The JQL query is invalid']}), {status: 400}),
+        new Request('https://jira.example.test'),
+        {} as never,
+      ),
+    );
+    const {createJiraAgentToolsClient} = await import('./client.js');
+
+    await expect(
+      createJiraAgentToolsClient().request({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        method: 'POST',
+        path: '/search/jql',
+        body: {jql: 'not valid'},
+        operation: 'search_issues',
+      }),
+    ).resolves.toEqual({
+      status: 400,
+      body: {errorMessages: ['The JQL query is invalid']},
+    });
+  });
+
+  it('maps HTTP 401 responses to an access-denied provider error', async () => {
+    mocks.request.mockRejectedValue(
+      new HTTPError(
+        new Response(null, {status: 401}),
+        new Request('https://jira.example.test'),
+        {} as never,
+      ),
+    );
+    const {createJiraAgentToolsClient} = await import('./client.js');
+
+    await expect(
+      createJiraAgentToolsClient().request({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        method: 'GET',
+        path: '/issue/ENG-1004',
+        operation: 'get_issue',
+      }),
+    ).rejects.toMatchObject({reason: 'access-denied'});
   });
 });

--- a/libs/api/integration/jira/src/api/client.ts
+++ b/libs/api/integration/jira/src/api/client.ts
@@ -6,6 +6,7 @@ import {JiraIntegrationProviderError} from '#core/errors.js';
 
 const JIRA_API_TIMEOUT_MS = 10_000;
 const SCOPE_SEPARATOR_RE = /[,\s]+/;
+const TRAILING_SLASHES_RE = /\/+$/;
 export const JIRA_DYNAMIC_WEBHOOK_EVENTS = jiraWebhookEventNames;
 export const JIRA_DYNAMIC_WEBHOOK_JQL = '';
 
@@ -29,6 +30,34 @@ export interface JiraIdentity {
 
 export interface JiraDynamicWebhookRegistration {
   webhookId: number;
+}
+
+export type JiraAgentToolHttpMethod = 'GET' | 'POST' | 'PUT';
+
+export type JiraAgentToolQueryValue =
+  | string
+  | number
+  | boolean
+  | readonly (string | number)[]
+  | undefined;
+
+export interface JiraAgentToolRequest {
+  accessToken: string;
+  cloudId: string;
+  method: JiraAgentToolHttpMethod;
+  path: string;
+  query?: Record<string, JiraAgentToolQueryValue> | undefined;
+  body?: unknown;
+  operation?: string | undefined;
+}
+
+export interface JiraAgentToolResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface JiraAgentToolsClient {
+  request(input: JiraAgentToolRequest): Promise<JiraAgentToolResponse>;
 }
 
 export interface JiraApiClient {
@@ -168,6 +197,67 @@ export function createJiraApiClient(): JiraApiClient {
       );
     },
   };
+}
+
+export function createJiraAgentToolsClient(): JiraAgentToolsClient {
+  return {request: requestJiraRest};
+}
+
+async function requestJiraRest(input: JiraAgentToolRequest): Promise<JiraAgentToolResponse> {
+  return await mapJiraError(input.operation ?? 'agent-tool', async () => {
+    try {
+      const response = await ky(jiraRestUrl(input.cloudId, input.path), {
+        method: input.method,
+        headers: {authorization: `Bearer ${input.accessToken}`},
+        ...(input.query === undefined ? {} : {searchParams: jiraQueryParams(input.query)}),
+        ...(input.body === undefined ? {} : {json: input.body}),
+        timeout: JIRA_API_TIMEOUT_MS,
+      });
+      return {status: response.status, body: await readJiraResponseBody(response)};
+    } catch (error) {
+      if (
+        error instanceof HTTPError &&
+        (error.response.status === 400 || error.response.status === 404)
+      ) {
+        return {
+          status: error.response.status,
+          body: await readJiraResponseBody(error.response),
+        };
+      }
+      throw error;
+    }
+  });
+}
+
+function jiraRestUrl(cloudId: string, path: string): string {
+  const baseUrl = config.JIRA_API_BASE_URL.replace(TRAILING_SLASHES_RE, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${baseUrl}/ex/jira/${encodeURIComponent(cloudId)}/rest/api/3${normalizedPath}`;
+}
+
+function jiraQueryParams(
+  query: Record<string, JiraAgentToolQueryValue>,
+): URLSearchParams | undefined {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, String(item));
+      continue;
+    }
+    params.set(key, String(value));
+  }
+  return params.size > 0 ? params : undefined;
+}
+
+async function readJiraResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
 }
 
 function parseDynamicWebhookRegistration(

--- a/libs/api/integration/jira/src/core/agent-tools-provider.test.ts
+++ b/libs/api/integration/jira/src/core/agent-tools-provider.test.ts
@@ -1,0 +1,299 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-spi';
+import type {JiraAgentToolsClient} from '#api/client.js';
+import {
+  type JiraAgentToolId,
+  jiraAgentToolCatalog,
+  jiraAgentToolSelectionCatalog,
+  jiraPlainTextToAdf,
+} from '#core/agent-tools.js';
+import {JiraAgentToolsProvider} from '#core/agent-tools-provider.js';
+import {JiraIntegrationProviderError} from '#core/errors.js';
+
+function jiraConnection(
+  overrides: Partial<IntegrationConnection<'jira'>> = {},
+): IntegrationConnection<'jira'> {
+  const now = new Date();
+  return {
+    id: 'jira-connection-1',
+    workspaceId: 'workspace-1',
+    provider: 'jira',
+    externalAccountId: 'cloud-1',
+    slug: 'jira-acme',
+    displayName: 'Jira Acme',
+    lifecycleStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function catalogTool(id: JiraAgentToolId) {
+  const tool = jiraAgentToolCatalog.find((candidate) => candidate.id === id);
+  if (!tool) throw new Error(`Unknown test tool: ${id}`);
+  return tool;
+}
+
+function providerOptions(
+  request: JiraAgentToolsClient['request'] = async () => ({status: 200, body: {ok: true}}),
+) {
+  return {
+    jira: {request: vi.fn(request)},
+    tokenStore: {getAccessToken: vi.fn().mockResolvedValue('access-token')},
+  };
+}
+
+async function openSession(
+  options: ReturnType<typeof providerOptions>,
+  toolIds: JiraAgentToolId[],
+  connection = jiraConnection(),
+) {
+  const provider = new JiraAgentToolsProvider(options);
+  return await provider.openSession({
+    connection,
+    tools: toolIds.map(catalogTool),
+    scope: {provider: 'jira'},
+  });
+}
+
+describe('JiraAgentToolsProvider', () => {
+  it('returns the Jira agent tools catalogs', () => {
+    const provider = new JiraAgentToolsProvider(providerOptions());
+
+    expect(provider.catalog()).toBe(jiraAgentToolCatalog);
+    expect(provider.selectionCatalog()).toBe(jiraAgentToolSelectionCatalog);
+    expect(provider.catalog().map((tool) => [tool.id, tool.sensitivity, tool.sensitive])).toEqual([
+      ['get_issue', 'read', false],
+      ['search_issues', 'read', false],
+      ['get_issue_comments', 'read', false],
+      ['get_issue_transitions', 'read', false],
+      ['get_project', 'read', false],
+      ['get_user', 'read', false],
+      ['create_issue', 'write', false],
+      ['update_issue', 'write', false],
+      ['add_comment', 'write', false],
+      ['transition_issue', 'write', false],
+      ['assign_issue', 'write', false],
+    ]);
+  });
+
+  it('reads the stored token before opening a session', async () => {
+    const options = providerOptions();
+    const provider = new JiraAgentToolsProvider(options);
+
+    await provider.openSession({
+      connection: jiraConnection({id: 'jira-connection-7'}),
+      tools: [],
+      scope: {provider: 'jira'},
+    });
+
+    expect(options.tokenStore.getAccessToken).toHaveBeenCalledWith({
+      connectionId: 'jira-connection-7',
+    });
+  });
+
+  it('dispatches a read request with the cloud id and returns structured content', async () => {
+    const body = {id: '1004', key: 'ENG-1004', fields: {summary: 'Jira tools'}};
+    const options = providerOptions(async () => ({status: 200, body}));
+    const session = await openSession(options, ['get_issue']);
+
+    const result = await session.call({
+      toolId: 'get_issue',
+      arguments: {idOrKey: 'ENG-1004', fields: ['summary']},
+    });
+
+    expect(options.jira.request).toHaveBeenCalledWith({
+      accessToken: 'access-token',
+      cloudId: 'cloud-1',
+      method: 'GET',
+      path: '/issue/ENG-1004',
+      query: {fields: ['summary']},
+      operation: 'get_issue',
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(body)}],
+      structuredContent: body,
+    });
+  });
+
+  it('wraps add-comment text in the minimal Jira ADF document', async () => {
+    const options = providerOptions();
+    const session = await openSession(options, ['add_comment']);
+
+    await session.call({
+      toolId: 'add_comment',
+      arguments: {idOrKey: 'ENG-1004', body: 'The adapter is ready.'},
+    });
+
+    expect(options.jira.request).toHaveBeenCalledWith({
+      accessToken: 'access-token',
+      cloudId: 'cloud-1',
+      method: 'POST',
+      path: '/issue/ENG-1004/comment',
+      body: {body: jiraPlainTextToAdf('The adapter is ready.')},
+      operation: 'add_comment',
+    });
+  });
+
+  it('wraps create and update issue descriptions in ADF', async () => {
+    const options = providerOptions();
+    const createSession = await openSession(options, ['create_issue']);
+    const updateSession = await openSession(options, ['update_issue']);
+
+    await createSession.call({
+      toolId: 'create_issue',
+      arguments: {
+        projectKey: 'ENG',
+        summary: 'New issue',
+        issueType: 'Task',
+        body: 'A plain-text description',
+      },
+    });
+    await updateSession.call({
+      toolId: 'update_issue',
+      arguments: {idOrKey: 'ENG-1004', body: 'A replacement description'},
+    });
+
+    expect(options.jira.request).toHaveBeenNthCalledWith(1, {
+      accessToken: 'access-token',
+      cloudId: 'cloud-1',
+      method: 'POST',
+      path: '/issue',
+      body: {
+        fields: {
+          project: {key: 'ENG'},
+          summary: 'New issue',
+          issuetype: {name: 'Task'},
+          description: jiraPlainTextToAdf('A plain-text description'),
+        },
+      },
+      operation: 'create_issue',
+    });
+    expect(options.jira.request).toHaveBeenNthCalledWith(2, {
+      accessToken: 'access-token',
+      cloudId: 'cloud-1',
+      method: 'PUT',
+      path: '/issue/ENG-1004',
+      body: {fields: {description: jiraPlainTextToAdf('A replacement description')}},
+      operation: 'update_issue',
+    });
+  });
+
+  it('maps provider rate limits and preserves Retry-After details', async () => {
+    const options = providerOptions(() =>
+      Promise.reject(new JiraIntegrationProviderError('rate-limited', 'Try again later', 19)),
+    );
+    const session = await openSession(options, ['search_issues']);
+
+    const result = await session.call({
+      toolId: 'search_issues',
+      arguments: {jql: 'project = ENG'},
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [{type: 'text', text: 'Try again later'}],
+      structuredContent: {code: 'rate-limited', retryAfterSeconds: 19},
+    });
+  });
+
+  it('maps Jira authorization failures to access-denied', async () => {
+    const options = providerOptions(() =>
+      Promise.reject(
+        new JiraIntegrationProviderError('access-denied', 'Jira request was rejected'),
+      ),
+    );
+    const session = await openSession(options, ['get_project']);
+
+    const result = await session.call({
+      toolId: 'get_project',
+      arguments: {idOrKey: 'ENG'},
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [{type: 'text', text: 'Jira request was rejected'}],
+      structuredContent: {code: 'access-denied'},
+    });
+  });
+
+  it('returns Jira resource errors as tool errors', async () => {
+    const options = providerOptions(async () => ({
+      status: 404,
+      body: {errorMessages: ['Issue does not exist']},
+    }));
+    const session = await openSession(options, ['get_issue']);
+
+    const result = await session.call({
+      toolId: 'get_issue',
+      arguments: {idOrKey: 'ENG-404'},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Issue does not exist'}],
+    });
+  });
+
+  it('returns Jira validation details for a bad request', async () => {
+    const options = providerOptions(async () => ({
+      status: 400,
+      body: {errorMessages: ['The JQL query is invalid']},
+    }));
+    const session = await openSession(options, ['search_issues']);
+
+    const result = await session.call({
+      toolId: 'search_issues',
+      arguments: {jql: 'not valid'},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'The JQL query is invalid'}],
+    });
+  });
+
+  it('reports successful empty Jira responses with their HTTP status', async () => {
+    const options = providerOptions(async () => ({status: 204, body: undefined}));
+    const session = await openSession(options, ['assign_issue']);
+
+    const result = await session.call({
+      toolId: 'assign_issue',
+      arguments: {idOrKey: 'ENG-1004', accountId: null},
+    });
+
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify({status: 204})}],
+      structuredContent: {status: 204},
+    });
+  });
+
+  it('rejects calls for unselected tools and missing required arguments', async () => {
+    const options = providerOptions();
+    const session = await openSession(options, ['get_issue']);
+
+    await expect(
+      session.call({toolId: 'add_comment', arguments: {idOrKey: 'ENG-1004', body: 'Comment'}}),
+    ).resolves.toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Unknown Jira tool: add_comment'}],
+    });
+    await expect(session.call({toolId: 'get_issue', arguments: {}})).resolves.toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Missing required parameter: idOrKey'}],
+    });
+    expect(options.jira.request).not.toHaveBeenCalled();
+  });
+
+  it('rejects create calls that omit the summary', async () => {
+    const options = providerOptions();
+    const session = await openSession(options, ['create_issue']);
+
+    const result = await session.call({toolId: 'create_issue', arguments: {}});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Missing required parameter: summary'}],
+    });
+    expect(options.jira.request).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/jira/src/core/agent-tools-provider.ts
+++ b/libs/api/integration/jira/src/core/agent-tools-provider.ts
@@ -1,0 +1,175 @@
+import type {
+  AgentToolCatalogEntry,
+  AgentToolSession,
+  AgentToolsProvider,
+  IntegrationConnection,
+  OpenAgentToolsSessionInput,
+} from '@shipfox/api-integration-spi';
+import type {JiraAgentToolResponse, JiraAgentToolsClient} from '#api/client.js';
+import type {JiraTokenStore} from '#core/tokens.js';
+import {
+  JIRA_TOOL_OPERATIONS,
+  type JiraAgentToolRequiredScope,
+  jiraAgentToolCatalog,
+  jiraAgentToolSelectionCatalog,
+} from './agent-tools.js';
+import {JiraIntegrationProviderError} from './errors.js';
+
+type JiraIntegrationConnection = IntegrationConnection<'jira'>;
+
+export type JiraToolCallResult = {
+  isError?: boolean | undefined;
+  content: readonly {type: 'text'; text: string}[];
+  structuredContent?: Record<string, unknown> | undefined;
+};
+
+export interface JiraAgentToolsProviderOptions {
+  jira: Pick<JiraAgentToolsClient, 'request'>;
+  tokenStore: Pick<JiraTokenStore, 'getAccessToken'>;
+}
+
+export class JiraAgentToolsProvider
+  implements
+    AgentToolsProvider<
+      JiraIntegrationConnection,
+      JiraAgentToolRequiredScope,
+      unknown,
+      JiraToolCallResult
+    >
+{
+  constructor(private readonly options: JiraAgentToolsProviderOptions) {}
+
+  catalog() {
+    return jiraAgentToolCatalog;
+  }
+
+  selectionCatalog() {
+    return jiraAgentToolSelectionCatalog;
+  }
+
+  async openSession(
+    input: OpenAgentToolsSessionInput<
+      JiraIntegrationConnection,
+      JiraAgentToolRequiredScope,
+      unknown
+    >,
+  ): Promise<AgentToolSession<JiraToolCallResult>> {
+    const accessToken = await this.options.tokenStore.getAccessToken({
+      connectionId: input.connection.id,
+    });
+    const cloudId = input.connection.externalAccountId;
+
+    return {
+      call: async (call) => {
+        const tool = input.tools.find((candidate) => candidate.id === call.toolId);
+        if (!tool) return jiraToolError(`Unknown Jira tool: ${call.toolId}`);
+
+        const operation = JIRA_TOOL_OPERATIONS[call.toolId as keyof typeof JIRA_TOOL_OPERATIONS];
+        if (!operation) return jiraToolError(`Unknown Jira tool: ${call.toolId}`);
+
+        const missingParameter = missingRequiredParameter(tool, call.arguments);
+        if (missingParameter) {
+          return jiraToolError(`Missing required parameter: ${missingParameter}`);
+        }
+
+        let response: JiraAgentToolResponse;
+        try {
+          response = await this.options.jira.request({
+            accessToken,
+            cloudId,
+            method: operation.method,
+            path: operation.path(call.arguments),
+            ...(operation.query === undefined ? {} : {query: operation.query(call.arguments)}),
+            ...(operation.body === undefined ? {} : {body: operation.body(call.arguments)}),
+            operation: call.toolId,
+          });
+        } catch (error) {
+          if (error instanceof JiraIntegrationProviderError) {
+            return jiraToolError(error.message, {
+              code: error.reason,
+              retryAfterSeconds: error.retryAfterSeconds,
+            });
+          }
+          throw error;
+        }
+
+        if (response.status === 400 || response.status === 404) {
+          return jiraRequestError(
+            response.body,
+            response.status === 404 ? 'Jira resource was not found' : 'Jira request was rejected',
+          );
+        }
+        if (response.status < 200 || response.status >= 300) {
+          return jiraToolError(`Jira request returned HTTP ${response.status}`);
+        }
+        return jiraToolResult(response.body, response.status);
+      },
+      close: () => Promise.resolve(),
+    };
+  }
+}
+
+function missingRequiredParameter(
+  tool: AgentToolCatalogEntry<JiraAgentToolRequiredScope>,
+  args: Record<string, unknown>,
+): string | undefined {
+  const required = tool.inputSchema.required;
+  if (!Array.isArray(required)) return undefined;
+  return required.find(
+    (parameter) => typeof parameter === 'string' && args[parameter] === undefined,
+  );
+}
+
+function jiraToolResult(body: unknown, status: number): JiraToolCallResult {
+  const structuredContent = body === undefined ? {status} : isRecord(body) ? body : {result: body};
+  return {
+    content: [{type: 'text', text: JSON.stringify(structuredContent)}],
+    structuredContent,
+  };
+}
+
+function jiraRequestError(body: unknown, fallbackMessage: string): JiraToolCallResult {
+  return jiraToolError(jiraErrorMessage(body, fallbackMessage));
+}
+
+function jiraErrorMessage(body: unknown, fallbackMessage: string): string {
+  if (typeof body === 'string' && body.length > 0) return body;
+  if (!isRecord(body)) return fallbackMessage;
+
+  const errorMessages = body.errorMessages;
+  if (Array.isArray(errorMessages)) {
+    const message = errorMessages.filter((value): value is string => typeof value === 'string');
+    if (message.length > 0) return message.join('; ');
+  }
+  if (typeof body.message === 'string' && body.message.length > 0) return body.message;
+  const errors = body.errors;
+  if (isRecord(errors)) {
+    const messages = Object.entries(errors).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    );
+    if (messages.length > 0)
+      return messages.map(([field, message]) => `${field}: ${message}`).join('; ');
+  }
+  return fallbackMessage;
+}
+
+function jiraToolError(
+  message: string,
+  options: {code?: string | undefined; retryAfterSeconds?: number | undefined} = {},
+): JiraToolCallResult {
+  const structuredContent = {
+    ...(options.code === undefined ? {} : {code: options.code}),
+    ...(options.retryAfterSeconds === undefined
+      ? {}
+      : {retryAfterSeconds: options.retryAfterSeconds}),
+  };
+  return {
+    isError: true,
+    content: [{type: 'text', text: message}],
+    ...(Object.keys(structuredContent).length === 0 ? {} : {structuredContent}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/libs/api/integration/jira/src/core/agent-tools.ts
+++ b/libs/api/integration/jira/src/core/agent-tools.ts
@@ -1,0 +1,450 @@
+import type {
+  JiraAgentToolId,
+  JiraAgentToolRequiredScope,
+  JiraAgentToolCatalogEntry as JiraDtoAgentToolCatalogEntry,
+} from '@shipfox/api-integration-jira-dto';
+import type {
+  AgentToolCatalogEntry,
+  AgentToolJsonSchema,
+  AgentToolSelectionCatalog,
+  AgentToolSelector,
+} from '@shipfox/api-integration-spi';
+import type {JiraAgentToolHttpMethod, JiraAgentToolQueryValue} from '#api/client.js';
+
+export type JiraAgentToolCatalogEntry = JiraDtoAgentToolCatalogEntry;
+export type {JiraAgentToolId, JiraAgentToolRequiredScope};
+
+interface JiraAgentToolCatalogInput {
+  id: JiraAgentToolId;
+  description: string;
+  sensitivity: 'read' | 'write';
+  sensitive: boolean;
+  requiredScope: JiraAgentToolRequiredScope;
+  inputSchema: AgentToolJsonSchema;
+}
+
+const issueIdOrKeySchema = stringSchema('Jira issue ID or key, such as ENG-123');
+const projectIdOrKeySchema = stringSchema('Jira project ID or key, such as ENG');
+const fieldsSchema = recordSchema('Jira issue fields keyed by their REST API field name');
+const updateSchema = recordSchema('Jira issue field update operations');
+const fieldNamesSchema = arraySchema(stringSchema('Jira field name'));
+const propertiesSchema = arraySchema(stringSchema('Jira issue property key'));
+
+export const jiraAgentToolCatalog = [
+  tool({
+    id: 'get_issue',
+    description: 'Retrieve a Jira issue by its ID or key.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        fields: fieldNamesSchema,
+        fieldsByKeys: booleanSchema('Interpret fields by their keys instead of IDs'),
+        expand: stringSchema('Comma-separated Jira issue expansions'),
+        properties: propertiesSchema,
+        updateHistory: booleanSchema('Record this issue as viewed by the authorizing user'),
+      },
+      ['idOrKey'],
+    ),
+  }),
+  tool({
+    id: 'search_issues',
+    description: 'Search Jira issues with a JQL query.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        jql: stringSchema('Jira Query Language expression'),
+        maxResults: integerSchema('Maximum number of issues to return'),
+        nextPageToken: stringSchema('Pagination token from a previous search'),
+        fields: fieldNamesSchema,
+        fieldsByKeys: booleanSchema('Interpret fields by their keys instead of IDs'),
+        expand: stringSchema('Comma-separated Jira issue expansions'),
+        properties: propertiesSchema,
+        reconcileIssues: arraySchema(integerSchema('Issue ID to reconcile for read-after-write')),
+      },
+      ['jql'],
+    ),
+  }),
+  tool({
+    id: 'get_issue_comments',
+    description: 'List the comments on a Jira issue.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        startAt: integerSchema('Zero-based comment offset'),
+        maxResults: integerSchema('Maximum number of comments to return'),
+        orderBy: stringSchema('Comment ordering expression'),
+        expand: stringSchema('Comma-separated Jira comment expansions'),
+      },
+      ['idOrKey'],
+    ),
+  }),
+  tool({
+    id: 'get_issue_transitions',
+    description: 'List the workflow transitions available for a Jira issue.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        expand: stringSchema('Comma-separated transition expansions, such as transitions.fields'),
+      },
+      ['idOrKey'],
+    ),
+  }),
+  tool({
+    id: 'get_project',
+    description: 'Retrieve a Jira project by its ID or key.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        idOrKey: projectIdOrKeySchema,
+        expand: stringSchema('Comma-separated Jira project expansions'),
+        properties: propertiesSchema,
+      },
+      ['idOrKey'],
+    ),
+  }),
+  tool({
+    id: 'get_user',
+    description: 'Retrieve a Jira user by Atlassian account ID.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        accountId: stringSchema('Atlassian account ID'),
+        expand: stringSchema('Comma-separated Jira user expansions'),
+      },
+      ['accountId'],
+    ),
+  }),
+  tool({
+    id: 'create_issue',
+    description:
+      'Create a Jira issue using Jira REST issue fields. If both a project key and project ID or both an issue type name and issue type ID are supplied, the ID takes precedence.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        projectKey: stringSchema(
+          'Jira project key; projectId takes precedence if both are supplied',
+        ),
+        projectId: stringSchema('Jira project ID; takes precedence over projectKey'),
+        summary: stringSchema('Issue summary'),
+        issueType: stringSchema(
+          'Issue type name; issueTypeId takes precedence if both are supplied',
+        ),
+        issueTypeId: stringSchema('Issue type ID; takes precedence over issueType'),
+        assigneeAccountId: stringSchema('Atlassian account ID to assign'),
+        priority: stringSchema('Jira priority name'),
+        labels: arraySchema(stringSchema('Jira label')),
+        body: stringSchema('Plain-text issue description'),
+        fields: fieldsSchema,
+        update: updateSchema,
+      },
+      ['summary'],
+    ),
+  }),
+  tool({
+    id: 'update_issue',
+    description: 'Update a Jira issue using Jira REST issue fields.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        summary: stringSchema('Replacement issue summary'),
+        issueType: stringSchema(
+          'Replacement issue type name; issueTypeId takes precedence if both are supplied',
+        ),
+        issueTypeId: stringSchema('Replacement issue type ID; takes precedence over issueType'),
+        assigneeAccountId: stringSchema('Atlassian account ID to assign'),
+        priority: stringSchema('Replacement Jira priority name'),
+        labels: arraySchema(stringSchema('Replacement Jira labels')),
+        body: stringSchema('Plain-text replacement issue description'),
+        fields: fieldsSchema,
+        update: updateSchema,
+      },
+      ['idOrKey'],
+    ),
+  }),
+  tool({
+    id: 'add_comment',
+    description: 'Add a plain-text comment to a Jira issue.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        body: stringSchema('Plain-text comment body'),
+      },
+      ['idOrKey', 'body'],
+    ),
+  }),
+  tool({
+    id: 'transition_issue',
+    description: 'Move a Jira issue through a workflow transition.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        transitionId: stringSchema('Jira workflow transition ID'),
+        fields: fieldsSchema,
+        update: updateSchema,
+      },
+      ['idOrKey', 'transitionId'],
+    ),
+  }),
+  tool({
+    id: 'assign_issue',
+    description: 'Assign or unassign a Jira issue by Atlassian account ID.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        idOrKey: issueIdOrKeySchema,
+        accountId: nullableStringSchema('Atlassian account ID, or null to unassign'),
+      },
+      ['idOrKey', 'accountId'],
+    ),
+  }),
+] as const satisfies readonly JiraAgentToolCatalogEntry[];
+
+export const jiraAgentToolSelectionCatalog =
+  buildJiraAgentToolSelectionCatalog(jiraAgentToolCatalog);
+
+export interface JiraToolOperation {
+  method: JiraAgentToolHttpMethod;
+  path: (args: Record<string, unknown>) => string;
+  query?: ((args: Record<string, unknown>) => Record<string, JiraAgentToolQueryValue>) | undefined;
+  body?: ((args: Record<string, unknown>) => unknown) | undefined;
+}
+
+export const JIRA_TOOL_OPERATIONS: Record<JiraAgentToolId, JiraToolOperation> = {
+  get_issue: {
+    method: 'GET',
+    path: (args) => issuePath(args),
+    query: (args) =>
+      definedArguments(args, ['fields', 'fieldsByKeys', 'expand', 'properties', 'updateHistory']),
+  },
+  search_issues: {
+    method: 'POST',
+    path: () => '/search/jql',
+    body: (args) =>
+      definedArguments(args, [
+        'jql',
+        'maxResults',
+        'nextPageToken',
+        'fields',
+        'fieldsByKeys',
+        'expand',
+        'properties',
+        'reconcileIssues',
+      ]),
+  },
+  get_issue_comments: {
+    method: 'GET',
+    path: (args) => issuePath(args, 'comment'),
+    query: (args) => definedArguments(args, ['startAt', 'maxResults', 'orderBy', 'expand']),
+  },
+  get_issue_transitions: {
+    method: 'GET',
+    path: (args) => issuePath(args, 'transitions'),
+    query: (args) => definedArguments(args, ['expand']),
+  },
+  get_project: {
+    method: 'GET',
+    path: (args) => `/project/${encodeURIComponent(stringArgument(args, 'idOrKey'))}`,
+    query: (args) => definedArguments(args, ['expand', 'properties']),
+  },
+  get_user: {
+    method: 'GET',
+    path: () => '/user',
+    query: (args) => definedArguments(args, ['accountId', 'expand']),
+  },
+  create_issue: {
+    method: 'POST',
+    path: () => '/issue',
+    body: (args) => issueWriteBody(args),
+  },
+  update_issue: {
+    method: 'PUT',
+    path: (args) => issuePath(args),
+    body: (args) => issueWriteBody(args),
+  },
+  add_comment: {
+    method: 'POST',
+    path: (args) => issuePath(args, 'comment'),
+    body: (args) => ({body: jiraPlainTextToAdf(stringArgument(args, 'body'))}),
+  },
+  transition_issue: {
+    method: 'POST',
+    path: (args) => issuePath(args, 'transitions'),
+    body: (args) => transitionBody(args),
+  },
+  assign_issue: {
+    method: 'PUT',
+    path: (args) => issuePath(args, 'assignee'),
+    body: (args) => ({accountId: args.accountId}),
+  },
+};
+
+export function jiraPlainTextToAdf(body: string): Record<string, unknown> {
+  return {
+    type: 'doc',
+    version: 1,
+    content: [
+      {
+        type: 'paragraph',
+        content: [{type: 'text', text: body}],
+      },
+    ],
+  };
+}
+
+function buildJiraAgentToolSelectionCatalog(
+  catalog: readonly AgentToolCatalogEntry<JiraAgentToolRequiredScope>[],
+): AgentToolSelectionCatalog {
+  return {
+    selectors: catalog.map(
+      (entry): AgentToolSelector => ({
+        token: entry.id,
+        kind: 'standalone',
+        sensitivity: entry.sensitivity,
+        sensitive: entry.sensitive,
+      }),
+    ),
+  };
+}
+
+function issuePath(args: Record<string, unknown>, suffix = ''): string {
+  return `/issue/${encodeURIComponent(stringArgument(args, 'idOrKey'))}${suffix ? `/${suffix}` : ''}`;
+}
+
+function issueWriteBody(args: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  const fields = issueFields(args);
+  if (Object.keys(fields).length > 0) body.fields = fields;
+  if (isRecord(args.update)) body.update = args.update;
+  return body;
+}
+
+function issueFields(args: Record<string, unknown>): Record<string, unknown> {
+  const fields = isRecord(args.fields) ? {...args.fields} : {};
+  const projectKey = stringArgumentOrUndefined(args, 'projectKey');
+  const projectId = stringArgumentOrUndefined(args, 'projectId');
+  const summary = stringArgumentOrUndefined(args, 'summary');
+  const issueType = stringArgumentOrUndefined(args, 'issueType');
+  const issueTypeId = stringArgumentOrUndefined(args, 'issueTypeId');
+  const assigneeAccountId = args.assigneeAccountId;
+  const priority = stringArgumentOrUndefined(args, 'priority');
+
+  if (projectKey !== undefined) fields.project = {key: projectKey};
+  if (projectId !== undefined) fields.project = {id: projectId};
+  if (summary !== undefined) fields.summary = summary;
+  if (issueType !== undefined) fields.issuetype = {name: issueType};
+  if (issueTypeId !== undefined) fields.issuetype = {id: issueTypeId};
+  if (typeof assigneeAccountId === 'string') fields.assignee = {accountId: assigneeAccountId};
+  if (priority !== undefined) fields.priority = {name: priority};
+  if (Array.isArray(args.labels)) fields.labels = args.labels;
+  if (typeof args.body === 'string') fields.description = jiraPlainTextToAdf(args.body);
+
+  return fields;
+}
+
+function transitionBody(args: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    transition: {id: stringArgument(args, 'transitionId')},
+  };
+  const fields = isRecord(args.fields) ? args.fields : undefined;
+  if (fields !== undefined) body.fields = fields;
+  if (isRecord(args.update)) body.update = args.update;
+  return body;
+}
+
+function definedArguments(
+  args: Record<string, unknown>,
+  names: readonly string[],
+): Record<string, JiraAgentToolQueryValue> {
+  return Object.fromEntries(
+    names.map((name) => [name, args[name]] as const).filter(([, value]) => value !== undefined),
+  ) as Record<string, JiraAgentToolQueryValue>;
+}
+
+function stringArgument(args: Record<string, unknown>, name: string): string {
+  const value = args[name];
+  return typeof value === 'string' ? value : String(value ?? '');
+}
+
+function stringArgumentOrUndefined(
+  args: Record<string, unknown>,
+  name: string,
+): string | undefined {
+  const value = args[name];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function tool(input: JiraAgentToolCatalogInput): JiraAgentToolCatalogEntry {
+  return input;
+}
+
+function objectSchema(
+  properties: Record<string, AgentToolJsonSchema>,
+  required: string[] = [],
+): AgentToolJsonSchema {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties,
+    ...(required.length > 0 ? {required} : {}),
+  };
+}
+
+function recordSchema(description?: string): AgentToolJsonSchema {
+  return {
+    type: 'object',
+    additionalProperties: true,
+    ...(description === undefined ? {} : {description}),
+  };
+}
+
+function stringSchema(description?: string): AgentToolJsonSchema {
+  return {type: 'string', ...(description === undefined ? {} : {description})};
+}
+
+function nullableStringSchema(description?: string): AgentToolJsonSchema {
+  return {type: ['string', 'null'], ...(description === undefined ? {} : {description})};
+}
+
+function integerSchema(description?: string): AgentToolJsonSchema {
+  return {type: 'integer', ...(description === undefined ? {} : {description})};
+}
+
+function booleanSchema(description?: string): AgentToolJsonSchema {
+  return {type: 'boolean', ...(description === undefined ? {} : {description})};
+}
+
+function arraySchema(items: AgentToolJsonSchema): AgentToolJsonSchema {
+  return {type: 'array', items};
+}

--- a/libs/api/integration/jira/src/index.test.ts
+++ b/libs/api/integration/jira/src/index.test.ts
@@ -12,6 +12,16 @@ describe('createJiraIntegrationProvider', () => {
     });
   });
 
+  it('mounts the in-process agent-tools adapter and advertises its capability', () => {
+    const getAccessToken = vi.fn().mockResolvedValue('access-token');
+    const provider = createJiraIntegrationProvider({
+      agentTools: {tokenStore: {getAccessToken}},
+    });
+
+    expect(provider.adapters.agent_tools).toBeDefined();
+    expect(provider.routes).toEqual([]);
+  });
+
   it('rejects incomplete receiver wiring instead of mounting registration without a receiver', () => {
     expect(() =>
       createJiraIntegrationProvider({

--- a/libs/api/integration/jira/src/index.ts
+++ b/libs/api/integration/jira/src/index.ts
@@ -1,6 +1,13 @@
 import {JIRA_PROVIDER} from '@shipfox/api-integration-jira-dto';
-import {createJiraApiClient, type JiraApiClient} from '#api/client.js';
+import {
+  createJiraAgentToolsClient,
+  createJiraApiClient,
+  type JiraAgentToolsClient,
+  type JiraApiClient,
+} from '#api/client.js';
 import {config} from '#config.js';
+import {JiraAgentToolsProvider} from '#core/agent-tools-provider.js';
+import type {JiraTokenStore} from '#core/tokens.js';
 import {createJiraWebhookProcessor} from '#core/webhook-processor.js';
 import {registerJiraWebhook} from '#core/webhook-registration.js';
 import {closeDb, db} from '#db/db.js';
@@ -21,17 +28,38 @@ const TRAILING_SLASHES_RE = /\/+$/;
 export type {JiraProvider} from '@shipfox/api-integration-jira-dto';
 export type {
   JiraAccessibleResource,
+  JiraAgentToolHttpMethod,
+  JiraAgentToolQueryValue,
+  JiraAgentToolRequest,
+  JiraAgentToolResponse,
+  JiraAgentToolsClient,
   JiraApiClient,
   JiraAuthorization,
   JiraDynamicWebhookRegistration,
   JiraIdentity,
 } from '#api/client.js';
 export {
+  createJiraAgentToolsClient,
   createJiraApiClient,
   JIRA_DYNAMIC_WEBHOOK_EVENTS,
   JIRA_DYNAMIC_WEBHOOK_JQL,
   mapJiraError,
 } from '#api/client.js';
+export type {
+  JiraAgentToolCatalogEntry,
+  JiraAgentToolId,
+  JiraAgentToolRequiredScope,
+} from '#core/agent-tools.js';
+export {
+  jiraAgentToolCatalog,
+  jiraAgentToolSelectionCatalog,
+  jiraPlainTextToAdf,
+} from '#core/agent-tools.js';
+export type {
+  JiraAgentToolsProviderOptions,
+  JiraToolCallResult,
+} from '#core/agent-tools-provider.js';
+export {JiraAgentToolsProvider} from '#core/agent-tools-provider.js';
 export type {DisconnectJiraInstallationParams} from '#core/disconnect.js';
 export {disconnectJiraInstallation} from '#core/disconnect.js';
 export {
@@ -105,6 +133,12 @@ export {closeDb, config, db, migrationsPath};
 
 export interface CreateJiraIntegrationProviderOptions {
   jira?: JiraApiClient | undefined;
+  agentTools?:
+    | {
+        tokenStore: Pick<JiraTokenStore, 'getAccessToken'>;
+        jira?: JiraAgentToolsClient | undefined;
+      }
+    | undefined;
   getJiraInstallationByConnectionId?: typeof getJiraInstallationByConnectionId | undefined;
   routes?: JiraIntegrationProviderRoutesOptions | undefined;
 }
@@ -119,6 +153,14 @@ export function createJiraIntegrationProvider(options: CreateJiraIntegrationProv
   const jira = options.jira ?? createJiraApiClient();
   const getInstallationByConnectionId =
     options.getJiraInstallationByConnectionId ?? getJiraInstallationByConnectionId;
+  const adapters = options.agentTools
+    ? {
+        agent_tools: new JiraAgentToolsProvider({
+          jira: options.agentTools.jira ?? createJiraAgentToolsClient(),
+          tokenStore: options.agentTools.tokenStore,
+        }),
+      }
+    : {};
   const webhookOptions = toJiraWebhookOptions(options.routes);
   const webhookProcessor = webhookOptions ? createJiraWebhookProcessor(webhookOptions) : undefined;
   const webhookRoutes = webhookOptions
@@ -136,7 +178,7 @@ export function createJiraIntegrationProvider(options: CreateJiraIntegrationProv
     ? [
         createJiraIntegrationRoutes({
           jira,
-          connectionCapabilities: [],
+          connectionCapabilities: adapters.agent_tools ? ['agent_tools'] : [],
           ...options.routes,
           registerJiraWebhook: (input) =>
             registerJiraWebhook({
@@ -162,7 +204,7 @@ export function createJiraIntegrationProvider(options: CreateJiraIntegrationProv
   return {
     provider: JIRA_PROVIDER,
     displayName: 'Jira',
-    adapters: {},
+    adapters,
     async connectionExternalUrl(connection: {id: string}): Promise<string | undefined> {
       return (await getInstallationByConnectionId(connection.id))?.siteUrl;
     },


### PR DESCRIPTION
Adds the in-process Jira REST v3 agent-tool catalog and provider wiring for Jira connections.

The adapter exposes the read and write tool catalog with `allow_write` selection support, lazy token access, ADF conversion for text bodies, Jira-aware error and rate-limit mapping, and structured success results. The `./agent-tools` export is intentionally kept for convention parity with the existing integration packages; Jira documentation remains a follow-up.

Validation: `mise exec -- turbo test type check --filter='...[origin/main]'` — 698/698 tasks passed. `git diff --check` is clean.

Closes ENG-1004

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-process Jira REST v3 agent tools and provider wiring so agents can call Jira read/write actions via existing connections, with ADF text conversion and Jira-aware error handling. Implements ENG-1004 and advertises the `agent_tools` capability on Jira connections.

- **New Features**
  - Added Jira agent-tool catalog (11 tools) with read/write scopes and selection catalog; write tools require `allow_write`.
  - In-process provider session with lazy token read; one REST v3 request per call; structured results; error mapping for 429 with Retry-After, 401/403 access-denied, 5xx provider-unavailable, and 400/404 pass-through.
  - ADF wrapping for plain-text `description` and `add_comment` bodies.
  - Exposed `./agent-tools` entrypoint in `@shipfox/api-integration-jira` and mounted `agent_tools` adapter when enabled.

- **Migration**
  - Enable by passing `agentTools: { tokenStore }` to `createJiraIntegrationProvider` (optionally override the Jira REST client).
  - For workflows using Jira write tools, set `allow_write: true`; read-only tools continue to work without changes.

<sup>Written for commit ebbe2d40ab8ea81088412760cc79d6f5f0a403c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

