### PR TITLE
Add run-scoped workflow detail navigation

### DIFF
--- a/.changeset/run-detail-tab-strip.md
+++ b/.changeset/run-detail-tab-strip.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-workflows": patch
+"@shipfox/react-ui": patch
+---
+
+Add URL-backed run detail tabs for Summary, Jobs, Annotations, and Source.

--- a/libs/client/shell/src/components/nav-tabs.test.tsx
+++ b/libs/client/shell/src/components/nav-tabs.test.tsx
@@ -30,6 +30,15 @@ function WorkspaceTabs() {
   return <NavTabs entries={entries} scope="workspace" />;
 }
 
+const projectEntries: readonly NavTabEntry[] = [
+  {
+    id: 'runs',
+    scope: 'project',
+    label: 'Runs',
+    to: '/w/$workspaceSlug/p/$projectSlug/runs',
+  },
+];
+
 describe('NavTabs', () => {
   test('distinguishes active and inactive workspace tabs', async () => {
     const rootRoute = createRootRoute({component: Outlet});
@@ -52,9 +61,36 @@ describe('NavTabs', () => {
 
     const projectsTab = await screen.findByRole('tab', {name: 'Projects'});
     const settingsTab = screen.getByRole('tab', {name: 'Settings'});
-    expect(projectsTab).toHaveClass('text-foreground-neutral-muted');
+    expect(projectsTab).toHaveClass(
+      'text-foreground-neutral-subtle',
+      'hover:text-foreground-neutral-base',
+    );
     expect(projectsTab).toHaveAttribute('aria-selected', 'false');
     expect(settingsTab).toHaveClass('text-foreground-neutral-base');
     expect(settingsTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('uses a quiet branded marker for the active project section', async () => {
+    const rootRoute = createRootRoute({component: Outlet});
+    const runsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/w/$workspaceSlug/p/$projectSlug/runs',
+      component: () => <NavTabs entries={projectEntries} scope="project" />,
+    });
+    const router = createRouter({
+      history: createMemoryHistory({initialEntries: ['/w/workspace/p/project/runs']}),
+      routeTree: rootRoute.addChildren([runsRoute]),
+    });
+
+    render(<RouterProvider router={router} />);
+
+    const runsTab = await screen.findByRole('tab', {name: 'Runs'});
+    expect(screen.getByRole('tablist', {name: 'Project sections'})).toHaveClass(
+      'overflow-x-auto',
+      'whitespace-nowrap',
+    );
+    expect(runsTab).toHaveClass('shrink-0', 'whitespace-nowrap');
+    expect(runsTab).toHaveClass('border-b', 'border-border-highlights-interactive');
+    expect(runsTab).not.toHaveClass('border-b-2');
   });
 });

--- a/libs/client/shell/src/components/nav-tabs.tsx
+++ b/libs/client/shell/src/components/nav-tabs.tsx
@@ -13,13 +13,16 @@ export function NavTabs({
   const params = useRouteParams(parseWorkspaceProjectParams);
   const reduced = useReducedMotion();
   const tabs = entries.filter((entry) => entry.scope === scope);
-  const tabClassName = `h-40 inline-flex items-center px-4 text-sm font-medium transition-colors ${reduced ? '' : 'transition-[border-color]'}`;
+  const projectScoped = scope === 'project';
+  const tabClassName = `h-40 inline-flex shrink-0 items-center whitespace-nowrap px-4 ${projectScoped ? 'text-xs' : 'text-sm'} font-medium transition-colors ${reduced ? '' : 'transition-[border-color]'}`;
   const activeProps = {
-    className: 'border-b-2 border-border-highlights-interactive text-foreground-neutral-base',
+    className: projectScoped
+      ? 'border-b border-border-highlights-interactive text-foreground-neutral-base'
+      : 'border-b-2 border-border-highlights-interactive text-foreground-neutral-base',
     'aria-selected': 'true' as const,
   };
   const inactiveProps = {
-    className: 'border-b-2 border-transparent text-foreground-neutral-muted',
+    className: `${projectScoped ? 'border-b' : 'border-b-2'} border-transparent text-foreground-neutral-subtle hover:text-foreground-neutral-base`,
     'aria-selected': 'false' as const,
   };
 
@@ -27,7 +30,7 @@ export function NavTabs({
     <div
       role="tablist"
       aria-label={`${scope === 'project' ? 'Project' : 'Workspace'} sections`}
-      className="sticky top-56 z-20 h-40 px-16 flex items-end gap-12 bg-background-subtle-base border-b border-border-neutral-base"
+      className="sticky top-56 z-20 flex h-40 items-end gap-12 overflow-x-auto whitespace-nowrap border-b border-border-neutral-base bg-background-subtle-base px-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       {tabs.map((entry) => (
         <Link

--- a/libs/client/workflows/src/components/job-graph/job-duration-label.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-duration-label.tsx
@@ -22,7 +22,11 @@ function LiveDurationText({fromIso}: {fromIso: string}) {
 function DurationText({children}: {children: string}) {
   // The status icon names the state; the node aria-label carries the verb.
   return (
-    <Code as="span" variant="label" className="shrink-0 tabular-nums text-foreground-neutral-muted">
+    <Code
+      as="span"
+      variant="label"
+      className="shrink-0 tabular-nums text-foreground-neutral-subtle"
+    >
       {children}
     </Code>
   );

--- a/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
@@ -81,7 +81,7 @@ export function JobGraphContent({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <div className="min-h-0 overflow-auto bg-background-neutral-base">
+      <div className="min-h-0 overflow-auto bg-background-neutral-background">
         <div className="relative" style={{width: contentWidth, minHeight: contentHeight}}>
           <GraphEdges model={model} hoveredJobId={hoveredJobId} />
           <div

--- a/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
@@ -7,6 +7,7 @@ import type {WorkflowRunDetail} from '#core/workflow-run.js';
 import type {JobGraphModel, JobGraphNavigationKey} from './graph-model.js';
 import {nextJobGraphNodeId} from './graph-model.js';
 import {JobNode, TriggerNode} from './job-node.js';
+import type {JobGraphSelectionSource} from './types.js';
 
 const NODE_WIDTH = 208;
 const NODE_HEIGHT = 48;
@@ -27,7 +28,7 @@ export function JobGraphContent({
     'triggerDisplayLabel' | 'triggerLabel' | 'triggerProvider' | 'triggerSource'
   >;
   selectedJobId?: string | undefined;
-  onSelectJob: (jobId: string | undefined) => void;
+  onSelectJob: (jobId: string | undefined, source?: JobGraphSelectionSource) => void;
 }) {
   const nodeRefs = useRef(new Map<string, HTMLButtonElement>());
   const [hoveredJobId, setHoveredJobId] = useState<string | undefined>();
@@ -74,7 +75,7 @@ export function JobGraphContent({
     if (!nextNodeId) return;
 
     event.preventDefault();
-    onSelectJob(nextNodeId);
+    onSelectJob(nextNodeId, 'keyboard');
     nodeRefs.current.get(nextNodeId)?.focus();
   }
 
@@ -101,7 +102,9 @@ export function JobGraphContent({
                   node={node}
                   selected={node.id === selectedJobId}
                   ref={setNodeRef(node.id)}
-                  onSelect={() => onSelectJob(node.id === selectedJobId ? undefined : node.id)}
+                  onSelect={() =>
+                    onSelectJob(node.id === selectedJobId ? undefined : node.id, 'pointer')
+                  }
                   onKeyDown={handleKeyDown}
                   onHoverStart={() => setHoveredJobId(node.id)}
                   onHoverEnd={() =>

--- a/libs/client/workflows/src/components/job-graph/job-graph-view.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-view.tsx
@@ -3,6 +3,7 @@ import {useState} from 'react';
 import type {WorkflowRunDetail} from '#core/workflow-run.js';
 import type {JobGraphModel} from './graph-model.js';
 import {JobGraphContent} from './job-graph-content.js';
+import type {JobGraphSelectionSource} from './types.js';
 
 export function JobGraphView({
   model,
@@ -19,7 +20,9 @@ export function JobGraphView({
   >;
   selectedJobId?: string | undefined;
   defaultSelectedJobId?: string | undefined;
-  onSelectedJobChange?: ((jobId: string | undefined) => void) | undefined;
+  onSelectedJobChange?:
+    | ((jobId: string | undefined, source?: JobGraphSelectionSource) => void)
+    | undefined;
   className?: string | undefined;
 }) {
   const [localSelectedJobId, setLocalSelectedJobId] = useState<string | undefined>(
@@ -27,9 +30,9 @@ export function JobGraphView({
   );
   const selected = selectedJobId ?? localSelectedJobId;
 
-  function selectJob(jobId: string | undefined) {
+  function selectJob(jobId: string | undefined, source?: JobGraphSelectionSource) {
     setLocalSelectedJobId(jobId);
-    onSelectedJobChange?.(jobId);
+    onSelectedJobChange?.(jobId, source);
   }
 
   return (

--- a/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {layout: 'centered'},
   decorators: [
     (Story) => (
-      <div className="h-520 w-900 overflow-auto bg-background-neutral-base p-16">
+      <div className="h-520 w-900 overflow-auto bg-background-neutral-background p-16">
         <Story />
       </div>
     ),

--- a/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   parameters: {layout: 'centered'},
   decorators: [
     (Story) => (
-      <div className="bg-background-neutral-base p-16">
+      <div className="bg-background-neutral-background p-16">
         <Story />
       </div>
     ),

--- a/libs/client/workflows/src/components/job-graph/job-node.test.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.test.tsx
@@ -52,11 +52,14 @@ function makeNode(overrides: NodeOverrides): JobGraphNode {
   });
 }
 
-function renderNode(node: JobGraphNode, {live = false}: {live?: boolean} = {}) {
+function renderNode(
+  node: JobGraphNode,
+  {live = false, selected = false}: {live?: boolean; selected?: boolean} = {},
+) {
   const element = (
     <JobNode
       node={node}
-      selected={false}
+      selected={selected}
       onSelect={() => undefined}
       onKeyDown={() => undefined}
       onHoverStart={() => undefined}
@@ -90,6 +93,28 @@ function setMatchMedia(reduced: boolean) {
 function setVisibility(state: 'visible' | 'hidden') {
   Object.defineProperty(document, 'visibilityState', {configurable: true, value: state});
 }
+
+describe('JobNode interaction', () => {
+  test('presents the selectable node as an elevated interactive surface', () => {
+    renderNode(makeNode({name: 'build', status: 'pending'}));
+
+    expect(screen.getByRole('button', {name: 'build, Pending'})).toHaveClass(
+      'cursor-pointer',
+      'bg-background-neutral-base',
+      'shadow-button-neutral',
+      'hover:bg-background-components-hover',
+    );
+  });
+
+  test('uses a quiet neutral surface for the selected node', () => {
+    renderNode(makeNode({name: 'build', status: 'pending'}), {selected: true});
+
+    expect(screen.getByRole('button', {name: 'build, Pending'})).toHaveClass(
+      'bg-background-components-hover',
+      'hover:bg-background-components-pressed',
+    );
+  });
+});
 
 describe('JobNode duration', () => {
   beforeEach(() => {

--- a/libs/client/workflows/src/components/job-graph/job-node.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.tsx
@@ -40,14 +40,14 @@ export function TriggerNode({
         <button
           type="button"
           aria-label={label}
-          className="flex items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none"
+          className="flex cursor-help items-center justify-center rounded-full bg-background-neutral-base shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
           style={{width: TRIGGER_SIZE, height: TRIGGER_SIZE}}
         >
           <TriggerSourceIcon
             provider={trigger.triggerProvider}
             source={trigger.triggerSource}
             aria-hidden
-            className="size-14 shrink-0 text-foreground-neutral-muted"
+            className="size-14 shrink-0 text-foreground-neutral-subtle"
           />
         </button>
       </TooltipTrigger>
@@ -106,15 +106,15 @@ export function JobNode({
       onPointerEnter={onHoverStart}
       onPointerLeave={onHoverEnd}
       className={cn(
-        'group relative flex h-48 w-208 items-center gap-8 rounded-8 border border-border-neutral-base bg-background-components-base px-10 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
-        selected && 'bg-background-components-hover',
+        'group relative flex h-48 w-208 cursor-pointer items-center gap-8 rounded-8 bg-background-neutral-base px-10 text-left shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+        selected && 'bg-background-components-hover hover:bg-background-components-pressed',
         node.carriedOver && 'opacity-[0.55]',
       )}
     >
       {selected ? (
         <span
           aria-hidden="true"
-          className="absolute inset-y-6 left-0 w-3 rounded-full bg-border-highlights-interactive"
+          className="absolute inset-y-6 left-0 w-px rounded-full bg-border-highlights-interactive"
         />
       ) : null}
       <div className="flex min-w-0 flex-1 items-center gap-8">
@@ -136,7 +136,7 @@ function ExecutionCountText({executions}: {executions: JobExecution[]}) {
       <TooltipTrigger asChild>
         <span
           aria-hidden="true"
-          className="inline-flex h-20 min-w-28 shrink-0 items-center justify-end gap-4 text-foreground-neutral-muted"
+          className="inline-flex h-20 min-w-28 shrink-0 items-center justify-end gap-4 text-foreground-neutral-subtle"
         >
           <Icon name="loopRightLine" className="size-12" />
           <Code as="span" variant="label" className="text-current">

--- a/libs/client/workflows/src/components/job-graph/types.ts
+++ b/libs/client/workflows/src/components/job-graph/types.ts
@@ -1,9 +1,13 @@
 import type {WorkflowRunDetail} from '#core/workflow-run.js';
 
+export type JobGraphSelectionSource = 'pointer' | 'keyboard';
+
 export interface JobGraphProps {
   run: WorkflowRunDetail;
   selectedJobId?: string | undefined;
   defaultSelectedJobId?: string | undefined;
-  onSelectedJobChange?: ((jobId: string | undefined) => void) | undefined;
+  onSelectedJobChange?:
+    | ((jobId: string | undefined, source?: JobGraphSelectionSource) => void)
+    | undefined;
   className?: string | undefined;
 }

--- a/libs/client/workflows/src/components/workflow-run-duration-label.tsx
+++ b/libs/client/workflows/src/components/workflow-run-duration-label.tsx
@@ -86,7 +86,7 @@ function DurationText({
       variant="label"
       aria-label={ariaLabel}
       className={cn(
-        'inline-flex shrink-0 items-center gap-4 tabular-nums text-foreground-neutral-muted',
+        'inline-flex shrink-0 items-center gap-4 tabular-nums text-foreground-neutral-subtle',
         className,
       )}
     >

--- a/libs/client/workflows/src/components/workflow-run-number-label.tsx
+++ b/libs/client/workflows/src/components/workflow-run-number-label.tsx
@@ -32,7 +32,7 @@ export function WorkflowRunNumberLabel({run}: {run: WorkflowRunNumberLabelRun}) 
         <Code
           as="span"
           variant="label"
-          className="min-w-0 max-w-[240px] truncate text-foreground-neutral-muted"
+          className="min-w-0 max-w-[240px] truncate text-foreground-neutral-subtle"
         >
           {visibleLabel}
         </Code>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-attempt-switcher.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-attempt-switcher.tsx
@@ -52,7 +52,7 @@ export function WorkflowRunAttemptSwitcher({
           size="2xs"
           iconRight="arrowDownSLine"
           aria-label={`Switch attempt, currently ${run.runAttempt.attempt} of ${maxAttempt}`}
-          className="h-20 px-4 text-foreground-neutral-muted hover:text-foreground-neutral-base"
+          className="h-20 px-4 text-foreground-neutral-subtle hover:text-foreground-neutral-base"
         >
           <Text as="span" size="xs" className="text-inherit">
             Attempt {run.runAttempt.attempt} of {maxAttempt}
@@ -139,7 +139,7 @@ function AttemptItem({
         </Code>
         <RelativeTime
           value={attempt.createdAt}
-          className="shrink-0 whitespace-nowrap font-code text-xs leading-20 text-foreground-neutral-muted"
+          className="shrink-0 whitespace-nowrap font-code text-xs leading-20 text-foreground-neutral-subtle"
         />
       </Link>
     </DropdownMenuItem>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -56,10 +56,10 @@ const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({
 });
 
 const withFrame: Decorator = (Story) => (
-  <div className="min-h-screen bg-background-neutral-base">
+  <div className="min-h-screen bg-background-neutral-background">
     <div className="mx-auto flex min-h-screen w-full max-w-[1120px] flex-col overflow-hidden border-x border-border-neutral-base bg-background-subtle-base">
       <Story />
-      <div className="min-h-0 flex-1 bg-background-neutral-base p-16" />
+      <div className="min-h-0 flex-1 bg-background-neutral-background p-16" />
     </div>
   </div>
 );
@@ -381,5 +381,25 @@ export const LongTriggerMetadata: Story = {
       trigger_source: 'github-enterprise-cloud-production-organization',
       trigger_event: 'workflow_dispatch_with_release_candidate_payload',
     }),
+  },
+};
+
+export const NarrowLongContent: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-[360px] max-w-full overflow-hidden border-x border-border-neutral-base">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    run: workflowRunDetail({
+      status: 'running',
+      name: 'release-production-multi-region-with-canary-and-post-deploy-validation',
+      trigger_provider: 'github',
+      trigger_source: 'github-enterprise-cloud-production-organization',
+      trigger_event: 'workflow_dispatch_with_release_candidate_payload',
+    }),
+    onCancel: noop,
   },
 };

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -160,30 +160,6 @@ const ATTEMPT_SUMMARY_ARGS = {
 
 export const Playground: Story = {};
 
-export const WithSourceButton: Story = {
-  args: {
-    run: workflowRunDetail({
-      status: 'succeeded',
-      source_snapshot: {format: 'yaml', content: 'jobs:\n  build:\n    steps: []'},
-    }),
-    sourceAvailable: true,
-    sourceOpen: false,
-    sourcePanelId: 'workflow-source-panel',
-  },
-};
-
-export const SourceOpen: Story = {
-  args: {
-    run: workflowRunDetail({
-      status: 'succeeded',
-      source_snapshot: {format: 'yaml', content: 'jobs:\n  build:\n    steps: []'},
-    }),
-    sourceAvailable: true,
-    sourceOpen: true,
-    sourcePanelId: 'workflow-source-panel',
-  },
-};
-
 export const WithAttempts: Story = {
   decorators: [withAttemptApi],
   args: ATTEMPT_SUMMARY_ARGS,
@@ -323,7 +299,7 @@ const ACTION_VARIANTS = [
   >;
 }>;
 
-export const ActionVariantsWithSource: Story = {
+export const ActionVariants: Story = {
   render: () => (
     <div className="flex flex-col">
       {ACTION_VARIANTS.map(({label, run, props}, index) => (
@@ -333,9 +309,6 @@ export const ActionVariantsWithSource: Story = {
             ...run,
             id: `22222222-2222-4222-8222-${String(index + 2).padStart(12, '0')}`,
           }}
-          sourceAvailable
-          sourceOpen={label === 'Running'}
-          sourcePanelId={`workflow-source-panel-${index}`}
           {...props}
         />
       ))}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -128,27 +128,6 @@ describe('WorkflowRunSummary', () => {
     );
   });
 
-  test('renders source control only when source is available', async () => {
-    const user = userEvent.setup();
-    const onSourceToggle = vi.fn();
-    renderSummary(
-      {source_snapshot: {format: 'yaml', content: 'name: deploy-web'}},
-      {
-        sourceAvailable: true,
-        sourceOpen: false,
-        sourcePanelId: 'workflow-source-panel',
-        onSourceToggle,
-      },
-    );
-
-    const sourceButton = await screen.findByRole('button', {name: 'View source'});
-    await user.click(sourceButton);
-
-    expect(sourceButton).toHaveAttribute('aria-controls', 'workflow-source-panel');
-    expect(sourceButton).toHaveAttribute('aria-expanded', 'false');
-    expect(onSourceToggle).toHaveBeenCalledTimes(1);
-  });
-
   test('shows the selected attempt duration, not the top-level run duration', async () => {
     renderSummary({
       started_at: '2026-05-07T00:00:00.000Z',
@@ -193,7 +172,7 @@ describe('WorkflowRunSummary', () => {
     expect(duration).toHaveAttribute('aria-label', 'running 2m 14s');
   });
 
-  test('omits source control when source is unavailable', async () => {
+  test('does not render a whole-run source control', async () => {
     renderSummary();
 
     await screen.findByRole('region', {name: 'deploy-web'});

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -34,6 +34,8 @@ describe('WorkflowRunSummary', () => {
 
     const summary = await screen.findByRole('region', {name: 'deploy-web'});
 
+    expect(summary).toHaveClass('bg-background-neutral-background', 'px-16');
+    expect(summary.firstElementChild).not.toHaveClass('max-w-[1120px]');
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(within(summary).getAllByText('Running')).not.toHaveLength(0);
     expect(within(summary).getByText('CI #5184')).toBeInTheDocument();

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuTrigger,
 } from '@shipfox/react-ui/dropdown-menu';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
-import {Icon} from '@shipfox/react-ui/icon';
 import {RelativeTime} from '@shipfox/react-ui/relative-time';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
@@ -58,6 +57,7 @@ export function WorkflowRunSummary({
   const headingId = useId();
   const status = getWorkflowStatusVisual(run.runAttempt.status);
   const action = workflowRunActionForRun(run);
+  const hasAction = canRenderWorkflowRunAction(action, onCancel, onRerun);
   const attemptSwitcher =
     latestAttempt && latestAttempt > 1 && workspaceSlug && projectSlug
       ? {workspaceSlug, projectSlug, latestAttempt}
@@ -68,66 +68,77 @@ export function WorkflowRunSummary({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <section
-        aria-labelledby={headingId}
-        className="border-b border-border-neutral-base bg-background-subtle-base px-16 py-8"
-      >
-        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-4 overflow-hidden">
-          <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-8">
-            {workspaceSlug && projectSlug ? (
-              <Link
-                to="/w/$workspaceSlug/p/$projectSlug/runs"
-                params={{workspaceSlug, projectSlug}}
-                search={
-                  ((previous: Record<string, unknown>) =>
-                    workflowRunListSearchParams(validateWorkflowRunsSearch(previous))) as never
-                }
-                aria-label="Back to runs"
-                className="inline-flex shrink-0 items-center gap-4 rounded-4 text-xs font-medium text-foreground-neutral-muted outline-none hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
-              >
-                <Icon name="arrowLeftLine" className="size-14" aria-hidden="true" />
-                <span>Runs</span>
-              </Link>
-            ) : null}
-            <Badge variant={status.badge} size="xs">
-              <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
-                {status.label}
-              </span>
-            </Badge>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Header id={headingId} variant="h3" className="min-w-0 truncate">
-                  <span
-                    ref={headingTextRef}
-                    title={isHeadingTruncated ? run.name : undefined}
-                    className="block min-w-0 truncate"
+      <section aria-labelledby={headingId} className="bg-background-neutral-background px-16 py-12">
+        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-8 overflow-hidden max-[480px]:grid-cols-1">
+          <nav
+            aria-label="Breadcrumb"
+            className="col-start-1 row-start-1 min-w-0 max-[480px]:col-start-auto max-[480px]:row-start-auto"
+          >
+            <ol className="flex min-w-0 items-center gap-8">
+              {workspaceSlug && projectSlug ? (
+                <li className="shrink-0">
+                  <Link
+                    to="/w/$workspaceSlug/p/$projectSlug/runs"
+                    params={{workspaceSlug, projectSlug}}
+                    search={
+                      ((previous: Record<string, unknown>) =>
+                        workflowRunListSearchParams(validateWorkflowRunsSearch(previous))) as never
+                    }
+                    className="rounded-4 text-xs font-medium text-foreground-neutral-subtle underline decoration-border-neutral-strong underline-offset-4 outline-none hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
                   >
-                    {run.name}
-                  </span>
-                </Header>
-              </TooltipTrigger>
-              {isHeadingTruncated ? (
-                <TooltipContent>
-                  <Text as="span" size="xs" className="max-w-[360px] break-words">
-                    {run.name}
-                  </Text>
-                </TooltipContent>
+                    Runs
+                  </Link>
+                </li>
               ) : null}
-            </Tooltip>
-          </div>
+              {workspaceSlug && projectSlug ? (
+                <li aria-hidden="true" className="shrink-0 text-xs text-foreground-neutral-subtle">
+                  /
+                </li>
+              ) : null}
+              <li aria-current="page" className="flex min-w-0 items-center gap-8">
+                <Badge variant={status.badge} size="xs">
+                  <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
+                    {status.label}
+                  </span>
+                </Badge>
 
-          <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end">
-            <WorkflowRunActionSlot
-              action={action}
-              cancelling={cancelling}
-              onCancel={onCancel}
-              rerunPending={rerunPending}
-              onRerun={onRerun}
-            />
-          </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Header id={headingId} variant="h3" className="min-w-0 truncate">
+                      <span
+                        ref={headingTextRef}
+                        title={isHeadingTruncated ? run.name : undefined}
+                        className="block min-w-0 truncate"
+                      >
+                        {run.name}
+                      </span>
+                    </Header>
+                  </TooltipTrigger>
+                  {isHeadingTruncated ? (
+                    <TooltipContent>
+                      <Text as="span" size="xs" className="max-w-[360px] break-words">
+                        {run.name}
+                      </Text>
+                    </TooltipContent>
+                  ) : null}
+                </Tooltip>
+              </li>
+            </ol>
+          </nav>
 
-          <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-muted">
+          {hasAction ? (
+            <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end max-[480px]:col-start-auto max-[480px]:row-start-auto max-[480px]:justify-self-start">
+              <WorkflowRunActionSlot
+                action={action}
+                cancelling={cancelling}
+                onCancel={onCancel}
+                rerunPending={rerunPending}
+                onRerun={onRerun}
+              />
+            </div>
+          ) : null}
+
+          <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-subtle max-[480px]:col-span-1 max-[480px]:row-start-auto">
             {run.number !== null ? (
               <>
                 <WorkflowRunNumberLabel run={run} />
@@ -153,7 +164,7 @@ export function WorkflowRunSummary({
                       <button
                         type="button"
                         aria-label={run.triggerLabel}
-                        className="inline-flex max-w-full min-w-0 items-center gap-4 rounded-6 border-0 bg-transparent p-0 text-left text-foreground-neutral-muted outline-none focus-visible:shadow-button-neutral-focus"
+                        className="inline-flex max-w-full min-w-0 cursor-help items-center gap-4 rounded-6 border-0 bg-transparent p-0 text-left text-foreground-neutral-subtle outline-none focus-visible:shadow-button-neutral-focus"
                       >
                         <TriggerSourceIcon
                           provider={run.triggerProvider}
@@ -181,7 +192,7 @@ export function WorkflowRunSummary({
             ) : null}
             <RelativeTime
               value={run.runAttempt.createdAt}
-              className="shrink-0 whitespace-nowrap text-xs leading-20 text-foreground-neutral-muted"
+              className="shrink-0 whitespace-nowrap text-xs leading-20 text-foreground-neutral-subtle"
             />
 
             {displayDuration ? (
@@ -189,7 +200,7 @@ export function WorkflowRunSummary({
                 <MetadataSeparator />
                 <WorkflowRunDurationLabel
                   duration={displayDuration}
-                  className="text-foreground-neutral-muted"
+                  className="text-foreground-neutral-subtle"
                 />
               </>
             ) : null}
@@ -282,6 +293,16 @@ function workflowRunActionForRun(run: WorkflowRunDetail): WorkflowRunAction {
   if (!isWorkflowRunTerminal(run.runAttempt.status)) return 'cancel';
   if (run.runAttempt.status === 'succeeded' || !hasFailedOrCancelledJobs(run)) return 'rerun-all';
   return 'rerun-menu';
+}
+
+function canRenderWorkflowRunAction(
+  action: WorkflowRunAction,
+  onCancel: (() => void) | undefined,
+  onRerun: ((mode: WorkflowRunRerunMode) => void) | undefined,
+): boolean {
+  if (action === 'cancel') return onCancel !== undefined;
+  if (action === 'rerun-all' || action === 'rerun-menu') return onRerun !== undefined;
+  return false;
 }
 
 function hasFailedOrCancelledJobs(run: WorkflowRunDetail): boolean {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -8,11 +8,12 @@ import {
   DropdownMenuTrigger,
 } from '@shipfox/react-ui/dropdown-menu';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
+import {Icon} from '@shipfox/react-ui/icon';
 import {RelativeTime} from '@shipfox/react-ui/relative-time';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import type {Ref} from 'react';
+import {Link} from '@tanstack/react-router';
 import {useId} from 'react';
 import {WorkflowRunNumberLabel} from '#components/workflow-run-number-label.js';
 import {
@@ -22,6 +23,7 @@ import {
   type WorkflowRunDetail,
   type WorkflowRunRerunMode,
 } from '#core/workflow-run.js';
+import {validateWorkflowRunsSearch, workflowRunListSearchParams} from '#routes/inputs.js';
 import {WorkflowRunDurationLabel} from '../workflow-run-duration-label.js';
 import {getWorkflowStatusVisual} from '../workflow-status/status-visuals.js';
 import {WorkflowRunAttemptSwitcher} from './workflow-run-attempt-switcher.js';
@@ -36,11 +38,6 @@ export interface WorkflowRunSummaryProps {
   workspaceSlug?: string | undefined;
   projectSlug?: string | undefined;
   run: WorkflowRunDetail;
-  sourceAvailable?: boolean | undefined;
-  sourceOpen?: boolean | undefined;
-  sourcePanelId?: string | undefined;
-  sourceButtonRef?: Ref<HTMLButtonElement> | undefined;
-  onSourceToggle?: (() => void) | undefined;
   cancelling?: boolean | undefined;
   onCancel?: (() => void) | undefined;
   rerunPending?: boolean | undefined;
@@ -52,11 +49,6 @@ export function WorkflowRunSummary({
   workspaceSlug,
   projectSlug,
   run,
-  sourceAvailable = false,
-  sourceOpen = false,
-  sourcePanelId,
-  sourceButtonRef,
-  onSourceToggle,
   cancelling = false,
   onCancel,
   rerunPending = false,
@@ -82,6 +74,21 @@ export function WorkflowRunSummary({
       >
         <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-4 overflow-hidden">
           <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-8">
+            {workspaceSlug && projectSlug ? (
+              <Link
+                to="/w/$workspaceSlug/p/$projectSlug/runs"
+                params={{workspaceSlug, projectSlug}}
+                search={
+                  ((previous: Record<string, unknown>) =>
+                    workflowRunListSearchParams(validateWorkflowRunsSearch(previous))) as never
+                }
+                aria-label="Back to runs"
+                className="inline-flex shrink-0 items-center gap-4 rounded-4 text-xs font-medium text-foreground-neutral-muted outline-none hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
+              >
+                <Icon name="arrowLeftLine" className="size-14" aria-hidden="true" />
+                <span>Runs</span>
+              </Link>
+            ) : null}
             <Badge variant={status.badge} size="xs">
               <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
                 {status.label}
@@ -118,19 +125,6 @@ export function WorkflowRunSummary({
               rerunPending={rerunPending}
               onRerun={onRerun}
             />
-            {sourceAvailable ? (
-              <Button
-                ref={sourceButtonRef}
-                type="button"
-                variant="secondary"
-                size="xs"
-                aria-controls={sourcePanelId}
-                aria-expanded={sourceOpen}
-                onClick={onSourceToggle}
-              >
-                View source
-              </Button>
-            ) : null}
           </div>
 
           <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-muted">
@@ -300,6 +294,6 @@ function workflowRunHasJobs(run: WorkflowRunDetail): run is WorkflowRunDetail & 
   return 'jobs' in run && Array.isArray(run.jobs);
 }
 
-function MetadataSeparator() {
+export function MetadataSeparator() {
   return <span aria-hidden="true" className="h-12 w-px shrink-0 bg-border-neutral-base" />;
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/index.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/index.ts
@@ -1,0 +1,5 @@
+export {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
+export {RunAnnotationsEmpty} from './run-annotations-empty.js';
+export {RunJobsList} from './run-jobs-list.js';
+export {RunTabCount} from './run-tab-count.js';
+export {RunTabStrip} from './run-tab-strip.js';

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.test.tsx
@@ -1,0 +1,69 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {act, render, screen} from '@testing-library/react';
+import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import type {WorkflowRunsSearch} from '#routes/inputs.js';
+import {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
+
+const ANNOTATION_SUMMARY: RunAnnotationSummary = {
+  total: 5,
+  error: 2,
+  warning: 1,
+  info: 2,
+  success: 0,
+};
+
+describe('RunAnnotationSummaryLine', () => {
+  test('links the severity breakdown into the Annotations panel', async () => {
+    await renderSummaryLine();
+
+    expect(screen.getByText('5 annotations')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
+      'href',
+      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
+    );
+  });
+
+  test('clears a stale annotation when linking to a severity', async () => {
+    await renderSummaryLine({annotation: 'annotation-old'});
+
+    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
+      'href',
+      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
+    );
+  });
+});
+
+async function renderSummaryLine(search: WorkflowRunsSearch = {}) {
+  const rootRoute = createRootRoute({component: Outlet});
+  const runRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
+    component: () => (
+      <RunAnnotationSummaryLine
+        summary={ANNOTATION_SUMMARY}
+        workspaceSlug="acme"
+        projectSlug="project"
+        workflowRunId="run-1"
+        search={search}
+      />
+    ),
+  });
+  const router = createRouter({
+    history: createMemoryHistory({initialEntries: ['/w/acme/p/project/runs/run-1']}),
+    routeTree: rootRoute.addChildren([runRoute]),
+  });
+  await router.load();
+  let result: ReturnType<typeof render> | undefined;
+  await act(() => {
+    result = render(<RouterProvider router={router} />);
+  });
+  if (!result) throw new Error('Run annotation summary did not render.');
+  return result;
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
@@ -31,8 +31,8 @@ export function RunAnnotationSummaryLine({
   );
 
   return (
-    <div className="flex h-32 min-h-32 shrink-0 items-center justify-end gap-8 overflow-x-auto whitespace-nowrap px-16 text-foreground-neutral-muted min-[768px]:px-0">
-      <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-muted">
+    <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-foreground-neutral-subtle">
+      <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-subtle">
         {summary.total} {pluralize('annotation', summary.total)}
       </Text>
       {visibleSeverities.map((severity) => (

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
@@ -1,0 +1,89 @@
+import {Text} from '@shipfox/react-ui/typography';
+import {Link} from '@tanstack/react-router';
+import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import {
+  WORKFLOW_RUN_ANNOTATION_SEVERITIES,
+  type WorkflowRunAnnotationSeverity,
+  type WorkflowRunsSearch,
+  workflowRunSearchParams,
+} from '#routes/inputs.js';
+import {MetadataSeparator} from '../workflow-run-summary/workflow-run-summary.js';
+
+export interface RunAnnotationSummaryLineProps {
+  summary?: RunAnnotationSummary | undefined;
+  workspaceSlug?: string | undefined;
+  projectSlug?: string | undefined;
+  workflowRunId?: string | undefined;
+  search?: WorkflowRunsSearch | undefined;
+}
+
+export function RunAnnotationSummaryLine({
+  summary,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  search = {},
+}: RunAnnotationSummaryLineProps) {
+  if (!summary) return null;
+
+  const visibleSeverities = WORKFLOW_RUN_ANNOTATION_SEVERITIES.filter(
+    (severity) => summary[severity] > 0,
+  );
+
+  return (
+    <div className="flex h-32 min-h-32 shrink-0 items-center justify-end gap-8 overflow-x-auto whitespace-nowrap px-16 text-foreground-neutral-muted min-[768px]:px-0">
+      <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-muted">
+        {summary.total} {pluralize('annotation', summary.total)}
+      </Text>
+      {visibleSeverities.map((severity) => (
+        <span key={severity} className="inline-flex shrink-0 items-center gap-8">
+          <MetadataSeparator />
+          <SeverityLink
+            count={summary[severity]}
+            severity={severity}
+            workspaceSlug={workspaceSlug}
+            projectSlug={projectSlug}
+            workflowRunId={workflowRunId}
+            search={search}
+          />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function SeverityLink({
+  count,
+  severity,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  search,
+}: {
+  count: number;
+  severity: WorkflowRunAnnotationSeverity;
+  workspaceSlug?: string | undefined;
+  projectSlug?: string | undefined;
+  workflowRunId?: string | undefined;
+  search: WorkflowRunsSearch;
+}) {
+  const label = `${count} ${pluralize(severity, count)}`;
+  if (!workspaceSlug || !projectSlug || !workflowRunId) {
+    return <span className="text-foreground-highlight-interactive">{label}</span>;
+  }
+
+  return (
+    <Link
+      to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
+      params={{workspaceSlug, projectSlug, workflowRunId}}
+      search={workflowRunSearchParams({...search, tab: 'annotations', severity}, search) as never}
+      className="text-foreground-highlight-interactive outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
+    >
+      {label}
+    </Link>
+  );
+}
+
+function pluralize(word: string, count: number): string {
+  return count === 1 ? word : `${word}s`;
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
@@ -72,11 +72,19 @@ function SeverityLink({
     return <span className="text-foreground-highlight-interactive">{label}</span>;
   }
 
+  const searchWithoutAnnotation = {...search};
+  delete searchWithoutAnnotation.annotation;
+
   return (
     <Link
       to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
       params={{workspaceSlug, projectSlug, workflowRunId}}
-      search={workflowRunSearchParams({...search, tab: 'annotations', severity}, search) as never}
+      search={
+        workflowRunSearchParams(
+          {...searchWithoutAnnotation, tab: 'annotations', severity},
+          search,
+        ) as never
+      }
       className="text-foreground-highlight-interactive outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
     >
       {label}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations-empty.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations-empty.tsx
@@ -1,0 +1,11 @@
+import {EmptyState} from '@shipfox/react-ui/empty-state';
+
+export function RunAnnotationsEmpty() {
+  return (
+    <EmptyState
+      icon="fileDamageLine"
+      title="No annotations"
+      description="This run has no annotations to show."
+    />
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-jobs-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-jobs-list.tsx
@@ -1,0 +1,132 @@
+import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {defaultJobExecution, deriveJobDisplayStatus, type Job} from '#core/workflow-run.js';
+import {formatJobDurationAccessibleLabel} from '../job-graph/job-duration-format.js';
+import {JobDurationLabel} from '../job-graph/job-duration-label.js';
+import {JobCard} from '../workflow-run-view/job-card.js';
+import {WorkflowStatusIcon} from '../workflow-status/workflow-status-icon.js';
+
+export interface RunJobsListProps {
+  jobs: Job[];
+  selectedJobId?: string | undefined;
+  onSelectedJobChange: (jobId: string | undefined) => void;
+  workspaceSlug?: string | undefined;
+  selectedJobExecution: ReturnType<typeof defaultJobExecution>;
+  selectedAttemptId: string | null | undefined;
+  onSelectedJobExecutionChange: ((jobExecutionId: string | undefined) => void) | undefined;
+  onSelectedAttemptChange: ((attemptId: string | undefined) => void) | undefined;
+  sourcePanelId?: string | undefined;
+  sourceAvailable?: boolean | undefined;
+  focusedSourceStepId?: string | null | undefined;
+  onOpenStepSource?: Parameters<typeof JobCard>[0]['onOpenStepSource'];
+}
+
+export function RunJobsList({
+  jobs,
+  selectedJobId,
+  onSelectedJobChange,
+  workspaceSlug,
+  selectedJobExecution,
+  selectedAttemptId,
+  onSelectedJobExecutionChange,
+  onSelectedAttemptChange,
+  sourcePanelId,
+  sourceAvailable,
+  focusedSourceStepId,
+  onOpenStepSource,
+}: RunJobsListProps) {
+  if (jobs.length === 0) {
+    return (
+      <section
+        aria-label="Workflow jobs"
+        className="rounded-8 border border-border-neutral-base bg-background-components-base"
+      >
+        <div className="min-h-160">
+          <RunJobsEmptyState />
+        </div>
+      </section>
+    );
+  }
+
+  const orderedJobs = [...jobs].sort(compareJobs);
+
+  return (
+    <section aria-label="Workflow jobs" className="flex min-w-0 flex-col gap-8">
+      <ul aria-label="Run jobs" className="m-0 flex min-w-0 list-none flex-col gap-8 p-0">
+        {orderedJobs.map((job) => {
+          const selected = job.id === selectedJobId;
+          const status = deriveJobDisplayStatus(job);
+          const execution = defaultJobExecution(job);
+          const durationLabel = formatJobDurationAccessibleLabel(
+            job.displayDuration,
+            execution ? execution.status : undefined,
+          );
+          const rowLabel = [
+            job.displayName,
+            statusLabel(status),
+            durationLabel,
+            job.carriedOver ? 'reused' : undefined,
+          ]
+            .filter((part): part is string => Boolean(part))
+            .join(', ');
+
+          return (
+            <li key={job.id} className="min-w-0">
+              <button
+                type="button"
+                aria-expanded={selected}
+                aria-controls={`job-card-${job.id}`}
+                aria-label={rowLabel}
+                onClick={() => onSelectedJobChange(selected ? undefined : job.id)}
+                className="flex min-h-44 w-full min-w-0 items-center gap-8 rounded-8 border border-border-neutral-base bg-background-components-base px-12 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active"
+              >
+                <WorkflowStatusIcon status={status} size={14} tooltip={false} />
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground-neutral-base">
+                  {job.displayName}
+                </span>
+                <JobDurationLabel duration={job.displayDuration} />
+              </button>
+              {selected ? (
+                <div id={`job-card-${job.id}`} className="mt-8">
+                  <JobCard
+                    workspaceSlug={workspaceSlug}
+                    job={job}
+                    selectedJobExecution={selectedJobExecution}
+                    selectedAttemptId={job.carriedOver ? undefined : selectedAttemptId}
+                    onSelectedJobExecutionChange={onSelectedJobExecutionChange}
+                    onSelectedAttemptChange={onSelectedAttemptChange}
+                    sourcePanelId={sourcePanelId}
+                    sourceAvailable={sourceAvailable}
+                    focusedSourceStepId={focusedSourceStepId}
+                    onOpenStepSource={onOpenStepSource}
+                  />
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function RunJobsEmptyState() {
+  return (
+    <EmptyState
+      icon="componentLine"
+      title="No jobs yet"
+      description="This run has not materialized jobs."
+    />
+  );
+}
+
+function compareJobs(left: Job, right: Job): number {
+  return (
+    left.position - right.position ||
+    left.displayName.localeCompare(right.displayName) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function statusLabel(status: ReturnType<typeof deriveJobDisplayStatus>): string {
+  return status === 'listening' ? 'Listening' : status.charAt(0).toUpperCase() + status.slice(1);
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-jobs-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-jobs-list.tsx
@@ -1,5 +1,11 @@
 import {EmptyState} from '@shipfox/react-ui/empty-state';
-import {defaultJobExecution, deriveJobDisplayStatus, type Job} from '#core/workflow-run.js';
+import {useTimeTick} from '@shipfox/react-ui/time-ticker';
+import {
+  defaultJobExecution,
+  deriveJobDisplayStatus,
+  deriveJobExecutionDisplayStatus,
+  type Job,
+} from '#core/workflow-run.js';
 import {formatJobDurationAccessibleLabel} from '../job-graph/job-duration-format.js';
 import {JobDurationLabel} from '../job-graph/job-duration-label.js';
 import {JobCard} from '../workflow-run-view/job-card.js';
@@ -34,6 +40,8 @@ export function RunJobsList({
   focusedSourceStepId,
   onOpenStepSource,
 }: RunJobsListProps) {
+  useTimeTick();
+
   if (jobs.length === 0) {
     return (
       <section
@@ -58,7 +66,7 @@ export function RunJobsList({
           const execution = defaultJobExecution(job);
           const durationLabel = formatJobDurationAccessibleLabel(
             job.displayDuration,
-            execution ? execution.status : undefined,
+            execution ? deriveJobExecutionDisplayStatus(execution) : undefined,
           );
           const rowLabel = [
             job.displayName,
@@ -74,7 +82,7 @@ export function RunJobsList({
               <button
                 type="button"
                 aria-expanded={selected}
-                aria-controls={`job-card-${job.id}`}
+                aria-controls={selected ? `job-card-${job.id}` : undefined}
                 aria-label={rowLabel}
                 onClick={() => onSelectedJobChange(selected ? undefined : job.id)}
                 className="flex min-h-44 w-full min-w-0 items-center gap-8 rounded-8 border border-border-neutral-base bg-background-components-base px-12 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active"

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-jobs-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-jobs-list.tsx
@@ -1,5 +1,6 @@
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {useTimeTick} from '@shipfox/react-ui/time-ticker';
+import {cn} from '@shipfox/react-ui/utils';
 import {
   defaultJobExecution,
   deriveJobDisplayStatus,
@@ -85,8 +86,18 @@ export function RunJobsList({
                 aria-controls={selected ? `job-card-${job.id}` : undefined}
                 aria-label={rowLabel}
                 onClick={() => onSelectedJobChange(selected ? undefined : job.id)}
-                className="flex min-h-44 w-full min-w-0 items-center gap-8 rounded-8 border border-border-neutral-base bg-background-components-base px-12 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active"
+                className={cn(
+                  'relative flex min-h-44 w-full min-w-0 items-center gap-8 rounded-8 bg-background-neutral-base px-12 text-left shadow-button-neutral outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
+                  selected &&
+                    'bg-background-components-hover hover:bg-background-components-pressed',
+                )}
               >
+                {selected ? (
+                  <span
+                    aria-hidden="true"
+                    className="absolute inset-y-6 left-0 w-px rounded-full bg-border-highlights-interactive"
+                  />
+                ) : null}
                 <WorkflowStatusIcon status={status} size={14} tooltip={false} />
                 <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground-neutral-base">
                   {job.displayName}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-count.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-count.tsx
@@ -1,0 +1,17 @@
+import {Badge} from '@shipfox/react-ui/badge';
+
+export function RunTabCount({
+  count,
+  hasFailures,
+}: {
+  count: number | undefined;
+  hasFailures: boolean;
+}) {
+  if (count === undefined) return null;
+
+  return (
+    <Badge size="2xs" variant={hasFailures ? 'error' : 'neutral'} aria-hidden="true">
+      {count}
+    </Badge>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-count.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-count.tsx
@@ -2,16 +2,27 @@ import {Badge} from '@shipfox/react-ui/badge';
 
 export function RunTabCount({
   count,
-  hasFailures,
+  alertCount = 0,
+  alertLabel,
 }: {
   count: number | undefined;
-  hasFailures: boolean;
+  alertCount?: number | undefined;
+  alertLabel: string;
 }) {
-  if (count === undefined) return null;
+  if (count === undefined && alertCount <= 0) return null;
 
   return (
-    <Badge size="2xs" variant={hasFailures ? 'error' : 'neutral'} aria-hidden="true">
-      {count}
-    </Badge>
+    <>
+      {count === undefined ? null : (
+        <Badge size="2xs" variant="neutral" aria-hidden="true">
+          {count}
+        </Badge>
+      )}
+      {alertCount > 0 ? (
+        <Badge size="2xs" variant="error" aria-hidden="true">
+          {alertCount} {alertLabel}
+        </Badge>
+      ) : null}
+    </>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.stories.tsx
@@ -1,13 +1,5 @@
 import {Tabs} from '@shipfox/react-ui/tabs';
-import type {Decorator, Meta, StoryObj} from '@storybook/react';
-import {
-  createMemoryHistory,
-  createRootRoute,
-  createRoute,
-  createRouter,
-  Outlet,
-  RouterProvider,
-} from '@tanstack/react-router';
+import type {Meta, StoryObj} from '@storybook/react';
 import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
 import {RunTabStrip} from './run-tab-strip.js';
 
@@ -19,28 +11,12 @@ const ANNOTATION_SUMMARY: RunAnnotationSummary = {
   success: 1,
 };
 
-const withRouter: Decorator = (Story) => {
-  const rootRoute = createRootRoute({component: Outlet});
-  const runRoute = createRoute({
-    getParentRoute: () => rootRoute,
-    path: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
-    component: () => <Story />,
-  });
-  const router = createRouter({
-    history: createMemoryHistory({initialEntries: ['/w/acme/p/project/runs/run-1']}),
-    routeTree: rootRoute.addChildren([runRoute]),
-  });
-
-  return <RouterProvider router={router} />;
-};
-
 const meta = {
   title: 'Workflows/RunTabStrip',
   component: RunTabStrip,
   parameters: {layout: 'fullscreen'},
-  decorators: [withRouter],
   render: (args) => (
-    <div className="bg-background-subtle-base">
+    <div className="bg-background-neutral-background">
       <Tabs defaultValue="summary">
         <RunTabStrip {...args} />
       </Tabs>
@@ -50,10 +26,6 @@ const meta = {
     jobCount: 6,
     jobsFailed: 1,
     annotationSummary: ANNOTATION_SUMMARY,
-    workspaceSlug: 'acme',
-    projectSlug: 'project',
-    workflowRunId: 'run-1',
-    search: {},
   },
 } satisfies Meta<typeof RunTabStrip>;
 

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.stories.tsx
@@ -1,0 +1,81 @@
+import {Tabs} from '@shipfox/react-ui/tabs';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import {RunTabStrip} from './run-tab-strip.js';
+
+const ANNOTATION_SUMMARY: RunAnnotationSummary = {
+  total: 8,
+  error: 2,
+  warning: 3,
+  info: 2,
+  success: 1,
+};
+
+const withRouter: Decorator = (Story) => {
+  const rootRoute = createRootRoute({component: Outlet});
+  const runRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
+    component: () => <Story />,
+  });
+  const router = createRouter({
+    history: createMemoryHistory({initialEntries: ['/w/acme/p/project/runs/run-1']}),
+    routeTree: rootRoute.addChildren([runRoute]),
+  });
+
+  return <RouterProvider router={router} />;
+};
+
+const meta = {
+  title: 'Workflows/RunTabStrip',
+  component: RunTabStrip,
+  parameters: {layout: 'fullscreen'},
+  decorators: [withRouter],
+  render: (args) => (
+    <div className="bg-background-subtle-base">
+      <Tabs defaultValue="summary">
+        <RunTabStrip {...args} />
+      </Tabs>
+    </div>
+  ),
+  args: {
+    jobCount: 6,
+    jobsFailed: 1,
+    annotationSummary: ANNOTATION_SUMMARY,
+    workspaceSlug: 'acme',
+    projectSlug: 'project',
+    workflowRunId: 'run-1',
+    search: {},
+  },
+} satisfies Meta<typeof RunTabStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const NoCounts: Story = {
+  args: {
+    jobCount: undefined,
+    annotationSummary: undefined,
+  },
+};
+
+export const NarrowLayout: Story = {
+  decorators: [
+    withRouter,
+    (Story) => (
+      <div className="w-[360px] max-w-full overflow-hidden border">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.stories.tsx
@@ -71,7 +71,6 @@ export const NoCounts: Story = {
 
 export const NarrowLayout: Story = {
   decorators: [
-    withRouter,
     (Story) => (
       <div className="w-[360px] max-w-full overflow-hidden border">
         <Story />

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.test.tsx
@@ -10,6 +10,7 @@ import {
 import {act, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import type {WorkflowRunsSearch} from '#routes/inputs.js';
 import {RunTabStrip} from './run-tab-strip.js';
 
 const ANNOTATION_SUMMARY: RunAnnotationSummary = {
@@ -47,18 +48,48 @@ describe('RunTabStrip', () => {
   test('keeps count slots stable when data is absent', async () => {
     await renderStrip({annotationSummary: undefined, jobCount: undefined});
 
-    expect(screen.getByRole('tab', {name: 'Jobs'})).toBeInTheDocument();
-    expect(screen.getByRole('tab', {name: 'Annotations'})).toBeInTheDocument();
+    const jobsTab = screen.getByRole('tab', {name: 'Jobs'});
+    const annotationsTab = screen.getByRole('tab', {name: 'Annotations'});
+
+    expect(jobsTab).toBeInTheDocument();
+    expect(annotationsTab).toBeInTheDocument();
+    expect(jobsTab.querySelector('.min-w-24')).not.toBeNull();
+    expect(annotationsTab.querySelector('.min-w-24')).not.toBeNull();
     expect(screen.queryByText('5 annotations')).not.toBeInTheDocument();
+  });
+
+  test('singularizes accessible count labels', async () => {
+    await renderStrip({
+      annotationSummary: {total: 1, error: 1, warning: 0, info: 0, success: 0},
+      jobCount: 1,
+    });
+
+    expect(screen.getByRole('tab', {name: 'Jobs, 1 job'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Annotations, 1 annotation'})).toBeInTheDocument();
+  });
+
+  test('clears a stale annotation when linking to a severity', async () => {
+    await renderStrip({
+      annotationSummary: ANNOTATION_SUMMARY,
+      jobCount: 3,
+      search: {annotation: 'annotation-old'},
+    });
+
+    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
+      'href',
+      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
+    );
   });
 });
 
 async function renderStrip({
   annotationSummary,
   jobCount,
+  search,
 }: {
   annotationSummary?: RunAnnotationSummary | undefined;
   jobCount?: number | undefined;
+  search?: WorkflowRunsSearch | undefined;
 } = {}) {
   const rootRoute = createRootRoute({component: Outlet});
   const runRoute = createRoute({
@@ -73,7 +104,7 @@ async function renderStrip({
           workspaceSlug="acme"
           projectSlug="project"
           workflowRunId="run-1"
-          search={{}}
+          search={search}
         />
       </Tabs>
     ),

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.test.tsx
@@ -7,10 +7,9 @@ import {
   Outlet,
   RouterProvider,
 } from '@tanstack/react-router';
-import {act, render, screen} from '@testing-library/react';
+import {act, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
-import type {WorkflowRunsSearch} from '#routes/inputs.js';
 import {RunTabStrip} from './run-tab-strip.js';
 
 const ANNOTATION_SUMMARY: RunAnnotationSummary = {
@@ -22,30 +21,39 @@ const ANNOTATION_SUMMARY: RunAnnotationSummary = {
 };
 
 describe('RunTabStrip', () => {
-  test('exposes tab counts, severity links, and keyboard navigation', async () => {
+  test('exposes tab counts and keyboard navigation', async () => {
     const user = userEvent.setup();
 
-    await renderStrip({annotationSummary: ANNOTATION_SUMMARY, jobCount: 3});
+    await renderStrip({annotationSummary: ANNOTATION_SUMMARY, jobCount: 3, jobsFailed: 1});
 
-    expect(screen.getByRole('tab', {name: 'Jobs, 3 jobs'})).toBeInTheDocument();
-    expect(screen.getByRole('tab', {name: 'Annotations, 5 annotations'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
-      'href',
-      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
+    const jobsTab = screen.getByRole('tab', {name: 'Jobs, 3 jobs, 1 failed'});
+    const annotationsTab = screen.getByRole('tab', {
+      name: 'Annotations, 5 annotations, 2 errors',
+    });
+    expect(within(jobsTab).getByText('3')).toHaveClass('bg-tag-neutral-bg');
+    expect(within(jobsTab).getByText('1 failed')).toHaveClass('bg-tag-error-bg');
+    expect(within(annotationsTab).getByText('5')).toHaveClass('bg-tag-neutral-bg');
+    expect(within(annotationsTab).getByText('2 errors')).toHaveClass('bg-tag-error-bg');
+    expect(screen.queryByRole('link', {name: '2 errors'})).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Source'})).toHaveClass(
+      'data-[state=inactive]:text-foreground-neutral-subtle',
+      'data-[state=inactive]:hover:text-foreground-neutral-base',
     );
 
     const summary = screen.getByRole('tab', {name: 'Summary'});
+    expect(screen.getByRole('tablist', {name: 'Run sections'})).toHaveClass('min-w-full', 'px-16');
+    expect(summary.parentElement?.parentElement).toHaveClass('bg-background-neutral-background');
     summary.focus();
     await user.keyboard('{ArrowRight}');
 
-    expect(screen.getByRole('tab', {name: 'Jobs, 3 jobs'})).toHaveAttribute(
+    expect(screen.getByRole('tab', {name: 'Jobs, 3 jobs, 1 failed'})).toHaveAttribute(
       'aria-selected',
       'true',
     );
     expect(screen.getByRole('tab', {name: 'Summary'})).toHaveAttribute('tabindex', '-1');
   });
 
-  test('keeps count slots stable when data is absent', async () => {
+  test('does not reserve count space when data is absent', async () => {
     await renderStrip({annotationSummary: undefined, jobCount: undefined});
 
     const jobsTab = screen.getByRole('tab', {name: 'Jobs'});
@@ -53,8 +61,8 @@ describe('RunTabStrip', () => {
 
     expect(jobsTab).toBeInTheDocument();
     expect(annotationsTab).toBeInTheDocument();
-    expect(jobsTab.querySelector('.min-w-24')).not.toBeNull();
-    expect(annotationsTab.querySelector('.min-w-24')).not.toBeNull();
+    expect(jobsTab.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(annotationsTab.querySelector('[data-slot="badge"]')).toBeNull();
     expect(screen.queryByText('5 annotations')).not.toBeInTheDocument();
   });
 
@@ -62,34 +70,24 @@ describe('RunTabStrip', () => {
     await renderStrip({
       annotationSummary: {total: 1, error: 1, warning: 0, info: 0, success: 0},
       jobCount: 1,
+      jobsFailed: 1,
     });
 
-    expect(screen.getByRole('tab', {name: 'Jobs, 1 job'})).toBeInTheDocument();
-    expect(screen.getByRole('tab', {name: 'Annotations, 1 annotation'})).toBeInTheDocument();
-  });
-
-  test('clears a stale annotation when linking to a severity', async () => {
-    await renderStrip({
-      annotationSummary: ANNOTATION_SUMMARY,
-      jobCount: 3,
-      search: {annotation: 'annotation-old'},
-    });
-
-    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
-      'href',
-      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
-    );
+    expect(screen.getByRole('tab', {name: 'Jobs, 1 job, 1 failed'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', {name: 'Annotations, 1 annotation, 1 error'}),
+    ).toBeInTheDocument();
   });
 });
 
 async function renderStrip({
   annotationSummary,
   jobCount,
-  search,
+  jobsFailed = 0,
 }: {
   annotationSummary?: RunAnnotationSummary | undefined;
   jobCount?: number | undefined;
-  search?: WorkflowRunsSearch | undefined;
+  jobsFailed?: number | undefined;
 } = {}) {
   const rootRoute = createRootRoute({component: Outlet});
   const runRoute = createRoute({
@@ -99,12 +97,8 @@ async function renderStrip({
       <Tabs defaultValue="summary">
         <RunTabStrip
           jobCount={jobCount}
-          jobsFailed={1}
+          jobsFailed={jobsFailed}
           annotationSummary={annotationSummary}
-          workspaceSlug="acme"
-          projectSlug="project"
-          workflowRunId="run-1"
-          search={search}
         />
       </Tabs>
     ),

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.test.tsx
@@ -1,0 +1,92 @@
+import {Tabs} from '@shipfox/react-ui/tabs';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import {RunTabStrip} from './run-tab-strip.js';
+
+const ANNOTATION_SUMMARY: RunAnnotationSummary = {
+  total: 5,
+  error: 2,
+  warning: 1,
+  info: 2,
+  success: 0,
+};
+
+describe('RunTabStrip', () => {
+  test('exposes tab counts, severity links, and keyboard navigation', async () => {
+    const user = userEvent.setup();
+
+    await renderStrip({annotationSummary: ANNOTATION_SUMMARY, jobCount: 3});
+
+    expect(screen.getByRole('tab', {name: 'Jobs, 3 jobs'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Annotations, 5 annotations'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
+      'href',
+      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
+    );
+
+    const summary = screen.getByRole('tab', {name: 'Summary'});
+    summary.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('tab', {name: 'Jobs, 3 jobs'})).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', {name: 'Summary'})).toHaveAttribute('tabindex', '-1');
+  });
+
+  test('keeps count slots stable when data is absent', async () => {
+    await renderStrip({annotationSummary: undefined, jobCount: undefined});
+
+    expect(screen.getByRole('tab', {name: 'Jobs'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Annotations'})).toBeInTheDocument();
+    expect(screen.queryByText('5 annotations')).not.toBeInTheDocument();
+  });
+});
+
+async function renderStrip({
+  annotationSummary,
+  jobCount,
+}: {
+  annotationSummary?: RunAnnotationSummary | undefined;
+  jobCount?: number | undefined;
+} = {}) {
+  const rootRoute = createRootRoute({component: Outlet});
+  const runRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
+    component: () => (
+      <Tabs defaultValue="summary">
+        <RunTabStrip
+          jobCount={jobCount}
+          jobsFailed={1}
+          annotationSummary={annotationSummary}
+          workspaceSlug="acme"
+          projectSlug="project"
+          workflowRunId="run-1"
+          search={{}}
+        />
+      </Tabs>
+    ),
+  });
+  const router = createRouter({
+    history: createMemoryHistory({initialEntries: ['/w/acme/p/project/runs/run-1']}),
+    routeTree: rootRoute.addChildren([runRoute]),
+  });
+  await router.load();
+  let result: ReturnType<typeof render> | undefined;
+  await act(() => {
+    result = render(<RouterProvider router={router} />);
+  });
+  if (!result) throw new Error('Run tab strip did not render.');
+  return result;
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.tsx
@@ -1,0 +1,88 @@
+import {TabsList, TabsTrigger} from '@shipfox/react-ui/tabs';
+import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import type {WorkflowRunsSearch} from '#routes/inputs.js';
+import {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
+import {RunTabCount} from './run-tab-count.js';
+
+export interface RunTabStripProps {
+  jobCount?: number | undefined;
+  jobsFailed?: number | undefined;
+  annotationSummary?: RunAnnotationSummary | undefined;
+  workspaceSlug?: string | undefined;
+  projectSlug?: string | undefined;
+  workflowRunId?: string | undefined;
+  search?: WorkflowRunsSearch | undefined;
+}
+
+export function RunTabStrip({
+  jobCount,
+  jobsFailed = 0,
+  annotationSummary,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  search,
+}: RunTabStripProps) {
+  const annotationCount = annotationSummary?.total;
+
+  return (
+    <div className="flex min-w-0 flex-col border-b border-border-neutral-base bg-background-subtle-base min-[768px]:h-32 min-[768px]:flex-row min-[768px]:items-center">
+      <div className="order-2 min-w-0 flex-1 overflow-x-auto min-[768px]:order-1">
+        <TabsList
+          aria-label="Run sections"
+          activeClassName="h-1"
+          className="h-32 min-h-32 gap-12 overflow-x-auto px-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+        >
+          <TabsTrigger
+            value="summary"
+            className="h-32 min-h-32 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+          >
+            Summary
+          </TabsTrigger>
+          <TabsTrigger
+            value="jobs"
+            aria-label={jobCount === undefined ? 'Jobs' : `Jobs, ${jobCount} jobs`}
+            className="h-32 min-h-32 gap-6 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+          >
+            <span>Jobs</span>
+            <span className="inline-flex min-w-24 justify-center">
+              <RunTabCount count={jobCount} hasFailures={jobsFailed > 0} />
+            </span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="annotations"
+            aria-label={
+              annotationCount === undefined
+                ? 'Annotations'
+                : `Annotations, ${annotationCount} annotations`
+            }
+            className="h-32 min-h-32 gap-6 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+          >
+            <span>Annotations</span>
+            <span className="inline-flex min-w-24 justify-center">
+              <RunTabCount
+                count={annotationCount}
+                hasFailures={(annotationSummary?.error ?? 0) > 0}
+              />
+            </span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="source"
+            className="h-32 min-h-32 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+          >
+            Source
+          </TabsTrigger>
+        </TabsList>
+      </div>
+      <div className="order-1 min-w-0 min-[768px]:order-2 min-[768px]:shrink-0 min-[768px]:pr-16">
+        <RunAnnotationSummaryLine
+          summary={annotationSummary}
+          workspaceSlug={workspaceSlug}
+          projectSlug={projectSlug}
+          workflowRunId={workflowRunId}
+          search={search}
+        />
+      </div>
+    </div>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.tsx
@@ -26,7 +26,7 @@ export function RunTabStrip({
   const annotationCount = annotationSummary?.total;
 
   return (
-    <div className="flex min-w-0 flex-col border-b border-border-neutral-base bg-background-subtle-base min-[768px]:h-32 min-[768px]:flex-row min-[768px]:items-center">
+    <div className="flex min-w-0 flex-col border-b border-border-neutral-base bg-background-subtle-base min-[768px]:min-h-32 min-[768px]:flex-row min-[768px]:items-center">
       <div className="order-2 min-w-0 flex-1 overflow-x-auto min-[768px]:order-1">
         <TabsList
           aria-label="Run sections"
@@ -41,7 +41,11 @@ export function RunTabStrip({
           </TabsTrigger>
           <TabsTrigger
             value="jobs"
-            aria-label={jobCount === undefined ? 'Jobs' : `Jobs, ${jobCount} jobs`}
+            aria-label={
+              jobCount === undefined
+                ? 'Jobs'
+                : `Jobs, ${jobCount} ${jobCount === 1 ? 'job' : 'jobs'}`
+            }
             className="h-32 min-h-32 gap-6 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
           >
             <span>Jobs</span>
@@ -54,7 +58,7 @@ export function RunTabStrip({
             aria-label={
               annotationCount === undefined
                 ? 'Annotations'
-                : `Annotations, ${annotationCount} annotations`
+                : `Annotations, ${annotationCount} ${annotationCount === 1 ? 'annotation' : 'annotations'}`
             }
             className="h-32 min-h-32 gap-6 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
           >

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-tab-strip.tsx
@@ -1,92 +1,97 @@
 import {TabsList, TabsTrigger} from '@shipfox/react-ui/tabs';
 import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
-import type {WorkflowRunsSearch} from '#routes/inputs.js';
-import {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
 import {RunTabCount} from './run-tab-count.js';
 
 export interface RunTabStripProps {
   jobCount?: number | undefined;
   jobsFailed?: number | undefined;
   annotationSummary?: RunAnnotationSummary | undefined;
-  workspaceSlug?: string | undefined;
-  projectSlug?: string | undefined;
-  workflowRunId?: string | undefined;
-  search?: WorkflowRunsSearch | undefined;
 }
 
-export function RunTabStrip({
-  jobCount,
-  jobsFailed = 0,
-  annotationSummary,
-  workspaceSlug,
-  projectSlug,
-  workflowRunId,
-  search,
-}: RunTabStripProps) {
+export function RunTabStrip({jobCount, jobsFailed = 0, annotationSummary}: RunTabStripProps) {
   const annotationCount = annotationSummary?.total;
+  const annotationErrors = annotationSummary?.error ?? 0;
 
   return (
-    <div className="flex min-w-0 flex-col border-b border-border-neutral-base bg-background-subtle-base min-[768px]:min-h-32 min-[768px]:flex-row min-[768px]:items-center">
-      <div className="order-2 min-w-0 flex-1 overflow-x-auto min-[768px]:order-1">
-        <TabsList
-          aria-label="Run sections"
-          activeClassName="h-1"
-          className="h-32 min-h-32 gap-12 overflow-x-auto px-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+    <div className="min-w-0 overflow-x-auto border-b border-border-neutral-base bg-background-neutral-background [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <TabsList
+        aria-label="Run sections"
+        className="h-40 min-h-40 w-max min-w-full gap-16 px-16 [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+      >
+        <TabsTrigger
+          value="summary"
+          className="h-40 min-h-40 py-0 text-xs data-[state=inactive]:text-foreground-neutral-subtle data-[state=inactive]:hover:text-foreground-neutral-base [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
         >
-          <TabsTrigger
-            value="summary"
-            className="h-32 min-h-32 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
-          >
-            Summary
-          </TabsTrigger>
-          <TabsTrigger
-            value="jobs"
-            aria-label={
-              jobCount === undefined
-                ? 'Jobs'
-                : `Jobs, ${jobCount} ${jobCount === 1 ? 'job' : 'jobs'}`
-            }
-            className="h-32 min-h-32 gap-6 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
-          >
-            <span>Jobs</span>
-            <span className="inline-flex min-w-24 justify-center">
-              <RunTabCount count={jobCount} hasFailures={jobsFailed > 0} />
-            </span>
-          </TabsTrigger>
-          <TabsTrigger
-            value="annotations"
-            aria-label={
-              annotationCount === undefined
-                ? 'Annotations'
-                : `Annotations, ${annotationCount} ${annotationCount === 1 ? 'annotation' : 'annotations'}`
-            }
-            className="h-32 min-h-32 gap-6 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
-          >
-            <span>Annotations</span>
-            <span className="inline-flex min-w-24 justify-center">
-              <RunTabCount
-                count={annotationCount}
-                hasFailures={(annotationSummary?.error ?? 0) > 0}
-              />
-            </span>
-          </TabsTrigger>
-          <TabsTrigger
-            value="source"
-            className="h-32 min-h-32 py-0 text-xs [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
-          >
-            Source
-          </TabsTrigger>
-        </TabsList>
-      </div>
-      <div className="order-1 min-w-0 min-[768px]:order-2 min-[768px]:shrink-0 min-[768px]:pr-16">
-        <RunAnnotationSummaryLine
-          summary={annotationSummary}
-          workspaceSlug={workspaceSlug}
-          projectSlug={projectSlug}
-          workflowRunId={workflowRunId}
-          search={search}
-        />
-      </div>
+          Summary
+        </TabsTrigger>
+        <TabsTrigger
+          value="jobs"
+          aria-label={runTabAccessibleName({
+            label: 'Jobs',
+            total: jobCount,
+            totalSingular: 'job',
+            totalPlural: 'jobs',
+            alertCount: jobsFailed,
+            alertSingular: 'failed',
+            alertPlural: 'failed',
+          })}
+          className="h-40 min-h-40 gap-6 py-0 text-xs data-[state=inactive]:text-foreground-neutral-subtle data-[state=inactive]:hover:text-foreground-neutral-base [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+        >
+          <span>Jobs</span>
+          <RunTabCount count={jobCount} alertCount={jobsFailed} alertLabel="failed" />
+        </TabsTrigger>
+        <TabsTrigger
+          value="annotations"
+          aria-label={runTabAccessibleName({
+            label: 'Annotations',
+            total: annotationCount,
+            totalSingular: 'annotation',
+            totalPlural: 'annotations',
+            alertCount: annotationErrors,
+            alertSingular: 'error',
+            alertPlural: 'errors',
+          })}
+          className="h-40 min-h-40 gap-6 py-0 text-xs data-[state=inactive]:text-foreground-neutral-subtle data-[state=inactive]:hover:text-foreground-neutral-base [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+        >
+          <span>Annotations</span>
+          <RunTabCount
+            count={annotationCount}
+            alertCount={annotationErrors}
+            alertLabel={annotationErrors === 1 ? 'error' : 'errors'}
+          />
+        </TabsTrigger>
+        <TabsTrigger
+          value="source"
+          className="h-40 min-h-40 py-0 text-xs data-[state=inactive]:text-foreground-neutral-subtle data-[state=inactive]:hover:text-foreground-neutral-base [@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:min-h-44"
+        >
+          Source
+        </TabsTrigger>
+      </TabsList>
     </div>
   );
+}
+
+function runTabAccessibleName({
+  label,
+  total,
+  totalSingular,
+  totalPlural,
+  alertCount,
+  alertSingular,
+  alertPlural,
+}: {
+  label: string;
+  total: number | undefined;
+  totalSingular: string;
+  totalPlural: string;
+  alertCount: number;
+  alertSingular: string;
+  alertPlural: string;
+}): string {
+  const parts = [label];
+
+  if (total !== undefined) parts.push(`${total} ${total === 1 ? totalSingular : totalPlural}`);
+  if (alertCount > 0) parts.push(`${alertCount} ${alertCount === 1 ? alertSingular : alertPlural}`);
+
+  return parts.join(', ');
 }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.test.ts
@@ -82,6 +82,29 @@ describe('resolveWorkflowRunSelection', () => {
     expect(resolved.selectedAttemptId).toBeNull();
   });
 
+  test('finds a job from a legacy job execution selection', () => {
+    const execution = workflowJobExecutionDto({id: 'execution-deploy', sequence: 1});
+    const run = workflowRunDetail({
+      jobs: [
+        workflowJobDto({id: 'job-build', name: 'build'}),
+        workflowJobDto({
+          id: 'job-deploy',
+          name: 'deploy',
+          position: 1,
+          job_executions: [execution],
+        }),
+      ],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {jobExecutionId: 'execution-deploy'},
+    });
+
+    expect(resolved.job?.id).toBe('job-deploy');
+    expect(resolved.jobExecution?.id).toBe('execution-deploy');
+  });
+
   test('falls back from an invalid job execution id to the running execution', () => {
     const run = workflowRunDetail({
       jobs: [
@@ -154,6 +177,31 @@ describe('resolveWorkflowRunSelection', () => {
 
     expect(resolved.attempt?.id).toBe('attempt-2');
     expect(resolved.selectedAttemptId).toBe('attempt-2');
+  });
+
+  test('finds the step owner from a legacy step attempt selection', () => {
+    const attempt = workflowStepAttemptDto({id: 'attempt-deploy', step_id: 'step-deploy'});
+    const step = workflowStepDto({
+      id: 'step-deploy',
+      current_attempt: 1,
+      attempts: [attempt],
+    });
+    const run = workflowRunDetail({
+      jobs: [
+        workflowJobDto({id: 'job-build', name: 'build'}),
+        workflowJobDto({id: 'job-deploy', name: 'deploy', position: 1, steps: [step]}),
+      ],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {stepAttemptId: 'attempt-deploy'},
+    });
+
+    expect(resolved.job?.id).toBe('job-deploy');
+    expect(resolved.step?.id).toBe('step-deploy');
+    expect(resolved.attempt?.id).toBe('attempt-deploy');
+    expect(resolved.selectedAttemptId).toBe('attempt-deploy');
   });
 
   test('lets a valid step override a mismatched job id', () => {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.ts
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.ts
@@ -25,6 +25,8 @@ export function resolveWorkflowRunSelection({
 }): ResolvedWorkflowRunSelection {
   const jobById = new Map(run.jobs.map((job) => [job.id, job]));
   const stepMatch = findStep(run, selection.stepId);
+  const jobExecutionMatch = findJobExecution(run, selection.jobExecutionId);
+  const stepAttemptMatch = findStepAttempt(run, selection.stepAttemptId);
 
   if (stepMatch) {
     const attempt = resolveStepAttempt(stepMatch.step, selection.stepAttemptId);
@@ -37,7 +39,20 @@ export function resolveWorkflowRunSelection({
     };
   }
 
-  const job = (selection.jobId ? jobById.get(selection.jobId) : undefined) ?? run.jobs.at(0);
+  if (stepAttemptMatch) {
+    return {
+      job: stepAttemptMatch.job,
+      jobExecution: stepAttemptMatch.jobExecution,
+      step: stepAttemptMatch.step,
+      attempt: stepAttemptMatch.attempt,
+      selectedAttemptId: stepAttemptMatch.attempt.id,
+    };
+  }
+
+  const job =
+    (selection.jobId ? jobById.get(selection.jobId) : undefined) ??
+    jobExecutionMatch?.job ??
+    run.jobs.at(0);
   const jobExecution = job ? resolveJobExecution(job, selection.jobExecutionId) : undefined;
 
   return {
@@ -47,6 +62,38 @@ export function resolveWorkflowRunSelection({
     attempt: undefined,
     selectedAttemptId: null,
   };
+}
+
+function findJobExecution(
+  run: WorkflowRunDetail,
+  jobExecutionId: string | undefined,
+): {job: Job; jobExecution: JobExecution} | undefined {
+  if (!jobExecutionId) return undefined;
+
+  for (const job of run.jobs) {
+    const jobExecution = job.jobExecutions.find((candidate) => candidate.id === jobExecutionId);
+    if (jobExecution) return {job, jobExecution};
+  }
+
+  return undefined;
+}
+
+function findStepAttempt(
+  run: WorkflowRunDetail,
+  stepAttemptId: string | undefined,
+): {job: Job; jobExecution: JobExecution; step: Step; attempt: StepAttempt} | undefined {
+  if (!stepAttemptId) return undefined;
+
+  for (const job of run.jobs) {
+    for (const jobExecution of job.jobExecutions) {
+      for (const step of jobExecution.steps) {
+        const attempt = step.attempts.find((candidate) => candidate.id === stepAttemptId);
+        if (attempt) return {job, jobExecution, step, attempt};
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function findStep(

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
@@ -31,6 +31,17 @@ export function WorkflowRunSkeleton() {
   );
 }
 
+export function WorkflowRunContentSkeleton() {
+  return (
+    <section
+      aria-label="Loading workflow run content"
+      className="min-h-160 rounded-8 border border-border-neutral-base bg-background-components-base p-16"
+    >
+      <Skeleton className="h-160 w-full rounded-6" />
+    </section>
+  );
+}
+
 export function WorkflowRunNotFound() {
   return (
     <EmptyState

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
@@ -9,7 +9,7 @@ export function WorkflowRunSkeleton() {
   return (
     <section
       aria-label="Loading workflow run"
-      className="border-b border-border-neutral-base bg-background-subtle-base px-16 py-12"
+      className="bg-background-neutral-background px-16 py-12"
     >
       <div className="flex min-w-0 flex-wrap items-center gap-x-12 gap-y-8">
         <div className="flex min-w-0 items-center gap-8">

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -66,6 +66,11 @@ describe('WorkflowRunView', () => {
     expect(await screen.findByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: BUILD_JOB_BUTTON_NAME})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: DEPLOY_JOB_BUTTON_NAME})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: BUILD_JOB_BUTTON_NAME})).toHaveClass(
+      'bg-background-components-hover',
+      'hover:bg-background-components-pressed',
+    );
+    expect(screen.getByRole('tabpanel')).toHaveClass('max-w-[1120px]', 'px-24');
     expect(screen.getByRole('region', {name: 'build'})).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}),

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -26,6 +26,8 @@ const DEPLOY_JOB_ID = '88888888-8888-4888-8888-888888888888';
 const CHECKOUT_STEP_ID = '99999999-9999-4999-8999-999999999999';
 const CHECKOUT_ATTEMPT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const RERUN_BUTTON_NAME = /^Re-run/;
+const BUILD_JOB_BUTTON_NAME = 'build, Succeeded';
+const DEPLOY_JOB_BUTTON_NAME = 'deploy, Running';
 const ATTEMPT_2_PATTERN = /Attempt 2/;
 const COPY_RUN_BUTTON_NAME = /Copy run/;
 const EXECUTION_ONE_MENU_ITEM_PATTERN = /#1/;
@@ -34,7 +36,19 @@ const LISTENING_EXECUTION_SWITCHER_NAME =
 const JOB_TEMPLATE_NAME = ['Implement $', '{{ event.issue.identifier }}'].join('');
 
 describe('WorkflowRunView', () => {
-  test('renders the run summary, jobs graph, and selected job step attempts when a run loads', async () => {
+  test('keeps the real tab strip visible while the run is loading', async () => {
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    renderView({tab: 'summary'});
+
+    expect(await screen.findByRole('tab', {name: 'Summary'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Jobs'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Annotations'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Source'})).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Loading workflow run content'})).toBeInTheDocument();
+  });
+
+  test('renders the run summary, jobs list, and selected job step attempts when a run loads', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
     });
@@ -50,8 +64,8 @@ describe('WorkflowRunView', () => {
       within(summary).queryByRole('button', {name: COPY_RUN_BUTTON_NAME}),
     ).not.toBeInTheDocument();
     expect(await screen.findByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'build, Succeeded'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'deploy, Running'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: BUILD_JOB_BUTTON_NAME})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: DEPLOY_JOB_BUTTON_NAME})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'build'})).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}),
@@ -685,8 +699,7 @@ describe('WorkflowRunView', () => {
     ).toBeInTheDocument();
   });
 
-  test('opens and closes workflow source without resetting the selected job', async () => {
-    const user = userEvent.setup();
+  test('renders the full workflow source in the Source tab', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() =>
         Promise.resolve(
@@ -702,38 +715,20 @@ describe('WorkflowRunView', () => {
       ),
     });
 
-    renderView();
+    renderView({tab: 'source'});
 
-    const deployNode = await screen.findByRole('button', {name: 'deploy, Running'});
-    await user.click(deployNode);
-    expect(deployNode).toHaveAttribute('aria-pressed', 'true');
-
-    const sourceButton = within(screen.getByRole('region', {name: 'deploy-web'})).getByRole(
-      'button',
-      {name: 'View source'},
+    expect(await screen.findByRole('tab', {name: 'Source'})).toHaveAttribute(
+      'aria-selected',
+      'true',
     );
-    const panelId = sourceButton.getAttribute('aria-controls');
-    expect(panelId).toBeTruthy();
-    expect(sourceButton).toHaveAttribute('aria-expanded', 'false');
-
-    await user.click(sourceButton);
-
-    const sourcePanel = screen.getByRole('dialog', {name: 'Workflow source'});
-    expect(sourceButton).toHaveAttribute('aria-expanded', 'true');
-    expect(sourcePanel).toHaveAttribute('id', panelId);
-    expect(sourcePanel).toHaveTextContent('pnpm test');
-
-    await user.click(screen.getByRole('button', {name: 'Close source'}));
-
-    await waitFor(() => expect(sourceButton).toHaveFocus());
-    expect(sourceButton).toHaveAttribute('aria-expanded', 'false');
-    expect(deployNode).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('region', {name: 'deploy'})).toBeInTheDocument();
+    expect(await screen.findByText('pnpm test')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', {name: 'Workflow source'})).not.toBeInTheDocument();
   });
 
   test('highlights selected step source lines when the source panel opens', async () => {
     const user = userEvent.setup();
     const stepId = '99999999-9999-4999-8999-000000000003';
+    const stepAttemptId = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000003';
     configureApiClient({
       fetchImpl: vi.fn(() =>
         Promise.resolve(
@@ -749,13 +744,27 @@ describe('WorkflowRunView', () => {
                   run_attempt_id: RUN_ID,
                   name: 'deploy',
                   status: 'running',
-                  steps: [
-                    workflowStepDto({
-                      id: stepId,
-                      key: 'deploy',
+                  job_executions: [
+                    workflowJobExecutionDto({
+                      job_id: DEPLOY_JOB_ID,
                       name: 'deploy',
-                      source_location: {start_line: 2, end_line: 3},
                       status: 'running',
+                      steps: [
+                        workflowStepDto({
+                          id: stepId,
+                          key: 'deploy',
+                          name: 'deploy',
+                          source_location: {start_line: 2, end_line: 3},
+                          status: 'running',
+                          attempts: [
+                            workflowStepAttemptDto({
+                              id: stepAttemptId,
+                              step_id: stepId,
+                              status: 'running',
+                            }),
+                          ],
+                        }),
+                      ],
                     }),
                   ],
                 }),
@@ -766,29 +775,29 @@ describe('WorkflowRunView', () => {
       ),
     });
 
-    renderView({selection: {stepId}});
-    const summary = await screen.findByRole('region', {name: 'deploy-web'});
-    await user.click(within(summary).getByRole('button', {name: 'View source'}));
+    renderView({tab: 'jobs', selection: {stepId, stepAttemptId}});
+    const jobRegion = await screen.findByRole('region', {name: 'deploy'});
+    await user.click(within(jobRegion).getByRole('button', {name: 'View source'}));
 
-    await screen.findByRole('dialog', {name: 'Workflow source'});
-    const highlightedLines = document.body.querySelectorAll('.line.highlighted-line');
+    const sourceDialog = await screen.findByRole('dialog', {name: 'Workflow source'});
+    const highlightedLines = sourceDialog.querySelectorAll('.line.highlighted-line');
     expect(highlightedLines).toHaveLength(2);
     expect(highlightedLines[0]).toHaveTextContent('deploy:');
     expect(highlightedLines[1]).toHaveTextContent('steps:');
   });
 
-  test('does not render a source control when the run has no source snapshot', async () => {
+  test('explains when the run has no source snapshot', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() =>
         Promise.resolve(jsonResponse(workflowRunViewDetailDto({source_snapshot: null}))),
       ),
     });
 
-    renderView();
+    renderView({tab: 'source'});
 
     await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(screen.queryByRole('button', {name: 'View source'})).not.toBeInTheDocument();
+    expect(await screen.findByText('Source snapshot unavailable')).toBeInTheDocument();
   });
 
   test('opens the source panel highlighting a step from the job header Source button', async () => {
@@ -802,25 +811,17 @@ describe('WorkflowRunView', () => {
     const jobRegion = await screen.findByRole('region', {name: 'build'});
     await user.click(screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}));
     const jobSourceButton = within(jobRegion).getByRole('button', {name: 'View source'});
-    const summaryButton = within(screen.getByRole('region', {name: 'deploy-web'})).getByRole(
-      'button',
-      {name: 'View source'},
-    );
     expect(jobSourceButton).toHaveAttribute('aria-expanded', 'false');
-    expect(jobSourceButton).toHaveAttribute(
-      'aria-controls',
-      summaryButton.getAttribute('aria-controls'),
-    );
+    expect(jobSourceButton).toHaveAttribute('aria-controls');
 
     await user.click(jobSourceButton);
 
-    await screen.findByRole('dialog', {name: 'Workflow source'});
-    const highlighted = document.body.querySelectorAll('.line.highlighted-line');
+    const sourceDialog = await screen.findByRole('dialog', {name: 'Workflow source'});
+    const highlighted = sourceDialog.querySelectorAll('.line.highlighted-line');
     expect(highlighted).toHaveLength(2);
     expect(highlighted[0]).toHaveTextContent('build:');
     expect(highlighted[1]).toHaveTextContent('steps:');
     expect(jobSourceButton).toHaveAttribute('aria-expanded', 'true');
-    expect(summaryButton).toHaveAttribute('aria-expanded', 'false');
   });
 
   test('returns focus to the job Source button on close and preserves the selected job', async () => {
@@ -844,7 +845,7 @@ describe('WorkflowRunView', () => {
     expect(screen.getByRole('region', {name: 'build'})).toBeInTheDocument();
   });
 
-  test('falls back to the summary Source button when refetch removes the focused step source', async () => {
+  test('closes the source panel when refetch removes the focused step source', async () => {
     const user = userEvent.setup();
     let detailRequests = 0;
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
@@ -893,10 +894,6 @@ describe('WorkflowRunView', () => {
     const jobRegion = await screen.findByRole('region', {name: 'build'});
     await user.click(screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}));
     const jobSourceButton = within(jobRegion).getByRole('button', {name: 'View source'});
-    const summaryButton = within(screen.getByRole('region', {name: 'deploy-web'})).getByRole(
-      'button',
-      {name: 'View source'},
-    );
     await user.click(jobSourceButton);
     await screen.findByRole('dialog', {name: 'Workflow source'});
 
@@ -906,10 +903,7 @@ describe('WorkflowRunView', () => {
         within(jobRegion).queryByRole('button', {name: 'View source'}),
       ).not.toBeInTheDocument(),
     );
-    await user.click(screen.getByRole('button', {name: 'Close source'}));
-
-    await waitFor(() => expect(summaryButton).toHaveFocus());
-    expect(summaryButton).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('dialog', {name: 'Workflow source'})).not.toBeInTheDocument();
   });
 
   test('re-runs all jobs from a succeeded run and navigates to the new run', async () => {
@@ -1127,7 +1121,7 @@ describe('WorkflowRunView', () => {
     expect(
       await screen.findByRole('button', {name: 'build, Succeeded, reused'}),
     ).toBeInTheDocument();
-    expect(screen.getAllByText('reused')).toHaveLength(2);
+    expect(screen.getAllByText('reused')).toHaveLength(1);
     await user.click(screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}));
 
     expect(await screen.findByText('Not executed in this run.')).toBeInTheDocument();
@@ -1144,6 +1138,7 @@ function renderView(props: Partial<Parameters<typeof WorkflowRunView>[0]> = {}, 
       workspaceSlug={PROJECT_TEST_WSLUG}
       projectSlug="project"
       workflowRunId={RUN_ID}
+      tab="jobs"
       {...props}
     />
   ));

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -26,7 +26,12 @@ import {WORKFLOW_RUN_TABS, type WorkflowRunTab} from '#routes/inputs.js';
 import {JobGraph} from '../job-graph/index.js';
 import type {JobGraphSelectionSource} from '../job-graph/types.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
-import {RunAnnotationsEmpty, RunJobsList, RunTabStrip} from '../workflow-run-tabs/index.js';
+import {
+  RunAnnotationSummaryLine,
+  RunAnnotationsEmpty,
+  RunJobsList,
+  RunTabStrip,
+} from '../workflow-run-tabs/index.js';
 import {WorkflowSourceContent, WorkflowSourcePanel} from '../workflow-source-panel/index.js';
 import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
 import {
@@ -340,16 +345,12 @@ function RunViewContent({
           jobCount={runData?.jobs.length}
           jobsFailed={runData?.jobs.filter((job) => job.status === 'failed').length}
           annotationSummary={annotationSummary}
-          workspaceSlug={workspaceSlug}
-          projectSlug={projectSlug}
-          workflowRunId={runData?.id}
-          search={selection}
         />
-        <TabsContents className="min-h-0 flex-1 overflow-auto bg-background-neutral-base p-16">
+        <TabsContents className="min-h-0 flex-1 overflow-auto bg-background-neutral-background pb-24 pt-16">
           <TabsContent
             value="summary"
             tabIndex={-1}
-            className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 outline-none"
+            className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24 outline-none"
           >
             {runData ? (
               <JobGraph
@@ -364,7 +365,7 @@ function RunViewContent({
           <TabsContent
             value="jobs"
             tabIndex={-1}
-            className="mx-auto w-full max-w-[1120px] outline-none"
+            className="mx-auto w-full max-w-[1120px] px-24 outline-none"
           >
             {runData ? (
               <RunJobsList
@@ -388,15 +389,28 @@ function RunViewContent({
           <TabsContent
             value="annotations"
             tabIndex={-1}
-            className="mx-auto w-full max-w-[1120px] outline-none"
+            className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24 outline-none"
           >
-            {runData ? <RunAnnotationsEmpty /> : tabState}
+            {runData ? (
+              <>
+                <RunAnnotationSummaryLine
+                  summary={annotationSummary}
+                  workspaceSlug={workspaceSlug}
+                  projectSlug={projectSlug}
+                  workflowRunId={runData.id}
+                  search={selection}
+                />
+                <RunAnnotationsEmpty />
+              </>
+            ) : (
+              tabState
+            )}
           </TabsContent>
           <TabsContent
             value="source"
             keepMounted={sourceSnapshot !== null}
             tabIndex={-1}
-            className="mx-auto flex min-h-full w-full max-w-[1120px] outline-none"
+            className="mx-auto flex min-h-full w-full max-w-[1120px] px-24 outline-none"
           >
             {runData ? (
               sourceSnapshot ? (

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,6 +1,8 @@
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
+import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {RelativeTimeProvider} from '@shipfox/react-ui/relative-time';
+import {Tabs, TabsContent, TabsContents} from '@shipfox/react-ui/tabs';
 import {toast} from '@shipfox/react-ui/toast';
 import {useNavigate} from '@tanstack/react-router';
 import {useEffect, useId, useRef, useState} from 'react';
@@ -10,6 +12,7 @@ import {
   type StepSourceLocation,
   type WorkflowRunRerunMode,
 } from '#core/workflow-run.js';
+import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
 import {
   type WorkflowRunSelectionInput,
   withoutWorkflowRunSelectionSearch,
@@ -19,12 +22,15 @@ import {
   useRerunWorkflowRunMutation,
   useWorkflowRunAttemptQuery,
 } from '#hooks/api/workflow-runs.js';
+import {WORKFLOW_RUN_TABS, type WorkflowRunTab} from '#routes/inputs.js';
 import {JobGraph} from '../job-graph/index.js';
+import type {JobGraphSelectionSource} from '../job-graph/types.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
-import {WorkflowSourcePanel} from '../workflow-source-panel/index.js';
-import {JobCard} from './job-card.js';
+import {RunAnnotationsEmpty, RunJobsList, RunTabStrip} from '../workflow-run-tabs/index.js';
+import {WorkflowSourceContent, WorkflowSourcePanel} from '../workflow-source-panel/index.js';
 import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
 import {
+  WorkflowRunContentSkeleton,
   WorkflowRunNotFound,
   WorkflowRunSkeleton,
   WorkflowRunStaleError,
@@ -42,12 +48,14 @@ export interface WorkflowRunViewProps {
   workflowRunId?: string | undefined;
   selection?: WorkflowRunSelectionInput | undefined;
   onSelectionChange?: ((selection: WorkflowRunSelectionInput) => void) | undefined;
+  tab?: WorkflowRunTab | undefined;
+  onTabChange?: ((tab: WorkflowRunTab) => void) | undefined;
+  annotationSummary?: RunAnnotationSummary | undefined;
 }
 
 /**
- * Renders the run for `workflowRunId`, or a skeleton while `workflowRunId` is still unknown (the page is
- * resolving which run to show) or the run is loading, so the page never branches on the
- * loading state itself.
+ * Renders the run for `workflowRunId`, keeping the local tab strip mounted while the run
+ * request is pending so polling never inserts navigation under the user's cursor.
  */
 export function WorkflowRunView({
   projectId,
@@ -56,6 +64,9 @@ export function WorkflowRunView({
   workflowRunId,
   selection,
   onSelectionChange,
+  tab,
+  onTabChange,
+  annotationSummary,
 }: WorkflowRunViewProps) {
   const runQuery = useWorkflowRunAttemptQuery({workflowRunId, runAttempt: selection?.runAttempt});
   const rerunMutation = useRerunWorkflowRunMutation(projectId);
@@ -70,6 +81,9 @@ export function WorkflowRunView({
           rerunMutation={rerunMutation}
           selection={selection}
           onSelectionChange={onSelectionChange}
+          tab={tab}
+          onTabChange={onTabChange}
+          annotationSummary={annotationSummary}
         />
       </div>
     </RelativeTimeProvider>
@@ -83,6 +97,9 @@ function RunViewContent({
   rerunMutation,
   selection,
   onSelectionChange,
+  tab,
+  onTabChange,
+  annotationSummary,
 }: {
   workspaceSlug: string | undefined;
   projectSlug: string | undefined;
@@ -90,18 +107,22 @@ function RunViewContent({
   rerunMutation: ReturnType<typeof useRerunWorkflowRunMutation>;
   selection: WorkflowRunSelectionInput | undefined;
   onSelectionChange: ((selection: WorkflowRunSelectionInput) => void) | undefined;
+  tab: WorkflowRunTab | undefined;
+  onTabChange: ((tab: WorkflowRunTab) => void) | undefined;
+  annotationSummary: RunAnnotationSummary | undefined;
 }) {
   const navigate = useNavigate();
   const [selectedJobId, setSelectedJobId] = useState<string | undefined>();
   const [selectedJobExecutionId, setSelectedJobExecutionId] = useState<string | undefined>();
+  const [localTab, setLocalTab] = useState<WorkflowRunTab>(tab ?? 'summary');
   const [sourcePanelOpen, setSourcePanelOpen] = useState(false);
   const [sourceFocus, setSourceFocus] = useState<WorkflowSourceFocus | null>(null);
   const sourcePanelId = useId();
-  const sourceButtonRef = useRef<HTMLButtonElement>(null);
-  // The button that last opened the panel (summary or a step detail), so Escape /
-  // Close returns focus to whoever opened it.
+  // The step Source button that last opened the panel, so Escape / Close returns focus to it.
   const lastSourceTriggerRef = useRef<HTMLButtonElement | null>(null);
   const selectionControlled = selection !== undefined;
+  const tabControlled = onTabChange !== undefined;
+  const activeTab = tabControlled ? (tab ?? 'summary') : localTab;
   const sourceAvailable =
     query.data?.sourceSnapshot !== null && query.data?.sourceSnapshot !== undefined;
   const cancelMutation = useCancelWorkflowRunMutation(query.data);
@@ -113,8 +134,8 @@ function RunViewContent({
     }
   }, [sourceAvailable]);
 
-  // If a refetch drops the focused step or its location, degrade to whole-workflow
-  // focus so the panel never points at an unmounted Source button.
+  // If a refetch drops the focused step or its location, close the panel so it never points at
+  // an unmounted Source button.
   useEffect(() => {
     if (!sourceFocus) return;
     const stillLocated = query.data?.jobs.some((job) =>
@@ -124,31 +145,24 @@ function RunViewContent({
     );
     if (!stillLocated) {
       setSourceFocus(null);
-      lastSourceTriggerRef.current = sourceButtonRef.current;
+      setSourcePanelOpen(false);
     }
   }, [sourceFocus, query.data]);
 
-  if (query.isPending) return <WorkflowRunSkeleton />;
-
-  // Only show the full error placeholder when nothing ever loaded. A refetch that fails after
-  // a prior success keeps the loaded run on screen (see below) instead of wiping the pane,
-  // since active-run polling can hit a transient API error.
-  if (query.isError && query.data === undefined) {
-    if (query.error instanceof ApiError && query.error.status === 404) {
-      return <WorkflowRunNotFound />;
-    }
-    return <QueryLoadError query={query} subject="workflow run" icon="pulseLine" />;
-  }
-
-  if (query.data === undefined) return <WorkflowRunSkeleton />;
-
   const runData = query.data;
-  const resolvedSelection = selectionControlled
-    ? resolveWorkflowRunSelection({run: runData, selection})
-    : undefined;
+  const resolvedSelection =
+    selectionControlled && runData
+      ? resolveWorkflowRunSelection({
+          run: runData,
+          selection: selection as WorkflowRunSelectionInput,
+        })
+      : undefined;
+  const hasExplicitJobSelection = Boolean(selection?.jobId || selection?.stepId);
   const selectedJob = selectionControlled
-    ? resolvedSelection?.job
-    : (runData.jobs.find((job) => job.id === selectedJobId) ?? runData.jobs.at(0));
+    ? hasExplicitJobSelection
+      ? resolvedSelection?.job
+      : undefined
+    : (runData?.jobs.find((job) => job.id === selectedJobId) ?? runData?.jobs.at(0));
   const selectedJobExecution = selectionControlled
     ? resolvedSelection?.jobExecution
     : selectedJob
@@ -157,13 +171,32 @@ function RunViewContent({
   const selectedAttemptId = selectionControlled
     ? (resolvedSelection?.selectedAttemptId ?? null)
     : undefined;
-  // Explicit per-step focus wins; fall back to the URL-selected step so deep links
-  // still pre-highlight when the summary opens the whole-workflow source.
+  // Explicit per-step focus wins; fall back to the URL-selected step so deep links still
+  // pre-highlight source in the Source tab.
   const highlightedLineRange =
     sourceFocus?.location ?? resolvedSelection?.step?.sourceLocation ?? null;
-  const sourceSnapshot = runData.sourceSnapshot;
+  const sourceSnapshot = runData?.sourceSnapshot ?? null;
+
+  function changeTab(nextTab: WorkflowRunTab) {
+    if (!tabControlled) {
+      setLocalTab(nextTab);
+    } else if (activeTab !== nextTab) {
+      onTabChange?.(nextTab);
+    }
+
+    if (nextTab !== 'jobs') {
+      setSourcePanelOpen(false);
+      setSourceFocus(null);
+    }
+  }
+
+  function handleTabChange(nextTab: string) {
+    if (!WORKFLOW_RUN_TABS.some((value) => value === nextTab)) return;
+    changeTab(nextTab as WorkflowRunTab);
+  }
+
   async function rerun(mode: WorkflowRunRerunMode) {
-    if (!workspaceSlug || !projectSlug) {
+    if (!runData || !workspaceSlug || !projectSlug) {
       toast.error('Could not start re-run from this route.');
       return;
     }
@@ -185,12 +218,16 @@ function RunViewContent({
     }
   }
 
-  function selectJob(jobId: string | undefined) {
+  function selectJob(jobId: string | undefined, source: JobGraphSelectionSource = 'pointer') {
+    if (source === 'pointer') changeTab('jobs');
     if (!selectionControlled) {
       setSelectedJobId(jobId);
       setSelectedJobExecutionId(undefined);
       return;
     }
+    // Keyboard roving focus is an interaction within the Summary graph. Keep that panel mounted
+    // and let JobGraphView own the visual selection so focus is not moved to a different tab.
+    if (source === 'keyboard') return;
 
     onSelectionChange?.(
       jobId ? {jobId, runAttempt: selection?.runAttempt} : {runAttempt: selection?.runAttempt},
@@ -235,20 +272,6 @@ function RunViewContent({
     });
   }
 
-  function openWholeWorkflowSource() {
-    setSourceFocus(null);
-    lastSourceTriggerRef.current = sourceButtonRef.current;
-    setSourcePanelOpen(true);
-  }
-
-  function toggleWholeWorkflowSource() {
-    if (sourcePanelOpen && sourceFocus === null) {
-      closeSourcePanel();
-      return;
-    }
-    openWholeWorkflowSource();
-  }
-
   function openStepSource(
     stepId: string,
     location: StepSourceLocation,
@@ -261,13 +284,11 @@ function RunViewContent({
 
   function closeSourcePanel() {
     const trigger = lastSourceTriggerRef.current;
-    const fallbackTrigger = sourceButtonRef.current;
     setSourcePanelOpen(false);
-    // Defer so focus lands after the panel unmounts; clear the focus only after
-    // focusing so the opener button is still expanded (force-visible) on return.
+    // Defer so focus lands after the panel unmounts; clear the focus only after focusing so the
+    // opener button is still expanded (force-visible) on return.
     window.setTimeout(() => {
-      const focusTarget = trigger?.isConnected ? trigger : fallbackTrigger;
-      focusTarget?.focus();
+      if (trigger?.isConnected) trigger.focus();
       setSourceFocus(null);
     }, 0);
   }
@@ -280,38 +301,77 @@ function RunViewContent({
     });
   }
 
+  const fatalError = query.isError && runData === undefined;
+  const tabState = fatalError ? (
+    query.error instanceof ApiError && query.error.status === 404 ? (
+      <WorkflowRunNotFound />
+    ) : (
+      <QueryLoadError query={query} subject="workflow run" icon="pulseLine" />
+    )
+  ) : query.isPending || runData === undefined ? (
+    <WorkflowRunContentSkeleton />
+  ) : null;
+
   return (
     <>
-      <div className="flex min-w-0 flex-1 flex-col">
-        <WorkflowRunSummary
+      <Tabs
+        value={activeTab}
+        onValueChange={handleTabChange}
+        className="flex min-w-0 flex-1 flex-col gap-0"
+      >
+        {runData ? (
+          <WorkflowRunSummary
+            workspaceSlug={workspaceSlug}
+            projectSlug={projectSlug}
+            run={runData}
+            cancelling={cancelMutation.isPending}
+            onCancel={cancelRun}
+            rerunPending={rerunMutation.isPending}
+            onRerun={(mode) => void rerun(mode)}
+            latestAttempt={runData.latestAttempt}
+          />
+        ) : (
+          <WorkflowRunSkeleton />
+        )}
+        {runData && query.isError ? <WorkflowRunStaleError query={query} /> : null}
+        <RunTabStrip
+          jobCount={runData?.jobs.length}
+          jobsFailed={runData?.jobs.filter((job) => job.status === 'failed').length}
+          annotationSummary={annotationSummary}
           workspaceSlug={workspaceSlug}
           projectSlug={projectSlug}
-          run={runData}
-          sourceAvailable={sourceAvailable}
-          sourceOpen={sourcePanelOpen && sourceFocus === null}
-          sourcePanelId={sourcePanelId}
-          sourceButtonRef={sourceButtonRef}
-          onSourceToggle={toggleWholeWorkflowSource}
-          cancelling={cancelMutation.isPending}
-          onCancel={cancelRun}
-          rerunPending={rerunMutation.isPending}
-          onRerun={(mode) => void rerun(mode)}
-          latestAttempt={runData.latestAttempt}
+          workflowRunId={runData?.id}
+          search={selection}
         />
-        {query.isError ? <WorkflowRunStaleError query={query} /> : null}
-        <div className="min-h-0 flex-1 overflow-auto bg-background-neutral-base p-16">
-          <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16">
-            <JobGraph
-              run={runData}
-              selectedJobId={selectedJob?.id}
-              onSelectedJobChange={selectJob}
-            />
-            {selectedJob ? (
-              <JobCard
+        <TabsContents className="min-h-0 flex-1 overflow-auto bg-background-neutral-base p-16">
+          <TabsContent
+            value="summary"
+            tabIndex={-1}
+            className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 outline-none"
+          >
+            {runData ? (
+              <JobGraph
+                run={runData}
+                selectedJobId={selectedJob?.id}
+                onSelectedJobChange={selectJob}
+              />
+            ) : (
+              tabState
+            )}
+          </TabsContent>
+          <TabsContent
+            value="jobs"
+            tabIndex={-1}
+            className="mx-auto w-full max-w-[1120px] outline-none"
+          >
+            {runData ? (
+              <RunJobsList
+                jobs={runData.jobs}
+                selectedJobId={selectedJob?.id}
+                onSelectedJobChange={selectJob}
                 workspaceSlug={workspaceSlug}
-                job={selectedJob}
                 selectedJobExecution={selectedJobExecution}
-                selectedAttemptId={selectedJob.carriedOver ? undefined : selectedAttemptId}
+                selectedAttemptId={selectedAttemptId}
                 onSelectedJobExecutionChange={selectJobExecution}
                 onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
                 sourcePanelId={sourcePanelId}
@@ -319,10 +379,48 @@ function RunViewContent({
                 focusedSourceStepId={sourceFocus?.stepId ?? null}
                 onOpenStepSource={openStepSource}
               />
-            ) : null}
-          </div>
-        </div>
-      </div>
+            ) : (
+              tabState
+            )}
+          </TabsContent>
+          <TabsContent
+            value="annotations"
+            tabIndex={-1}
+            className="mx-auto w-full max-w-[1120px] outline-none"
+          >
+            {runData ? <RunAnnotationsEmpty /> : tabState}
+          </TabsContent>
+          <TabsContent
+            value="source"
+            keepMounted={sourceSnapshot !== null}
+            tabIndex={-1}
+            className="mx-auto flex min-h-full w-full max-w-[1120px] outline-none"
+          >
+            {runData ? (
+              sourceSnapshot ? (
+                <WorkflowSourceContent
+                  source={sourceSnapshot}
+                  highlightedLineRange={highlightedLineRange}
+                  scrollHighlightedIntoView
+                />
+              ) : (
+                <EmptyState
+                  className="min-h-160 w-full"
+                  icon="fileDamageLine"
+                  title="Source snapshot unavailable"
+                  description={
+                    runData.isTemporary
+                      ? 'Temporary runs do not capture workflow source.'
+                      : 'This run was created before workflow source snapshots were captured.'
+                  }
+                />
+              )
+            ) : (
+              tabState
+            )}
+          </TabsContent>
+        </TabsContents>
+      </Tabs>
       <WorkflowSourcePanel
         id={sourcePanelId}
         source={sourceSnapshot}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -157,7 +157,9 @@ function RunViewContent({
           selection: selection as WorkflowRunSelectionInput,
         })
       : undefined;
-  const hasExplicitJobSelection = Boolean(selection?.jobId || selection?.stepId);
+  const hasExplicitJobSelection = Boolean(
+    selection?.jobId || selection?.jobExecutionId || selection?.stepId || selection?.stepAttemptId,
+  );
   const selectedJob = selectionControlled
     ? hasExplicitJobSelection
       ? resolvedSelection?.job

--- a/libs/client/workflows/src/components/workflow-source-panel/index.ts
+++ b/libs/client/workflows/src/components/workflow-source-panel/index.ts
@@ -1,1 +1,2 @@
+export * from './workflow-source-content.js';
 export * from './workflow-source-panel.js';

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-content.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-content.tsx
@@ -1,0 +1,84 @@
+import {
+  CodeBlock,
+  CodeBlockBody,
+  CodeBlockContent,
+  CodeBlockCopyButton,
+  CodeBlockFilename,
+  CodeBlockFiles,
+  CodeBlockHeader,
+  type CodeBlockHighlightedLineRange,
+  CodeBlockItem,
+} from '@shipfox/react-ui/code-block';
+import {cn} from '@shipfox/react-ui/utils';
+import type {ReactNode} from 'react';
+import type {WorkflowSourceSnapshot} from '#core/workflow-run.js';
+
+const WORKFLOW_SOURCE_FILENAME = 'workflow.yaml';
+const WORKFLOW_SOURCE_CODE_THEMES = {
+  light: 'vitesse-dark',
+  dark: 'vitesse-dark',
+};
+
+export interface WorkflowSourceContentProps {
+  source: WorkflowSourceSnapshot;
+  highlightedLineRange?: CodeBlockHighlightedLineRange | null | undefined;
+  scrollHighlightedIntoView?: boolean | undefined;
+  headerAction?: ReactNode;
+  className?: string | undefined;
+}
+
+export function WorkflowSourceContent({
+  source,
+  highlightedLineRange,
+  scrollHighlightedIntoView,
+  headerAction,
+  className,
+}: WorkflowSourceContentProps) {
+  const data = [
+    {
+      language: 'yaml',
+      filename: WORKFLOW_SOURCE_FILENAME,
+      code: source.content,
+    },
+  ];
+
+  return (
+    <CodeBlock
+      data={data}
+      className={cn(
+        'flex size-full flex-col rounded-none bg-background-contrast-base shadow-none',
+        className,
+      )}
+    >
+      <CodeBlockHeader className="shrink-0 border-b border-border-contrast-base bg-background-contrast-base">
+        <CodeBlockFiles>
+          {(item) => <CodeBlockFilename value={item.filename}>{item.filename}</CodeBlockFilename>}
+        </CodeBlockFiles>
+        <CodeBlockCopyButton />
+        {headerAction}
+      </CodeBlockHeader>
+      <CodeBlockBody className="flex min-h-0 flex-1 overflow-auto scrollbar">
+        {(item) => (
+          <CodeBlockItem
+            value={item.filename}
+            className={cn(
+              'min-h-full px-0 pb-0',
+              '[&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base [&>div]:dark:bg-background-contrast-base',
+              '[&_code]:!text-sm [&_code]:!text-foreground-neutral-on-inverted [&_.line]:!text-sm [&_.line]:before:!text-sm [&_.line]:before:!text-foreground-neutral-muted',
+            )}
+          >
+            <CodeBlockContent
+              language="yaml"
+              themes={WORKFLOW_SOURCE_CODE_THEMES}
+              syntaxHighlighting
+              highlightedLineRange={highlightedLineRange}
+              scrollHighlightedIntoView={scrollHighlightedIntoView}
+            >
+              {item.code}
+            </CodeBlockContent>
+          </CodeBlockItem>
+        )}
+      </CodeBlockBody>
+    </CodeBlock>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.tsx
@@ -1,24 +1,9 @@
 import {Button} from '@shipfox/react-ui/button';
-import {
-  CodeBlock,
-  CodeBlockBody,
-  CodeBlockContent,
-  CodeBlockCopyButton,
-  CodeBlockFilename,
-  CodeBlockFiles,
-  CodeBlockHeader,
-  type CodeBlockHighlightedLineRange,
-  CodeBlockItem,
-} from '@shipfox/react-ui/code-block';
+import type {CodeBlockHighlightedLineRange} from '@shipfox/react-ui/code-block';
 import {Sheet, SheetClose, SheetContent, SheetTitle} from '@shipfox/react-ui/sheet';
 import {cn} from '@shipfox/react-ui/utils';
 import type {WorkflowSourceSnapshot} from '#core/workflow-run.js';
-
-const WORKFLOW_SOURCE_FILENAME = 'workflow.yaml';
-const WORKFLOW_SOURCE_CODE_THEMES = {
-  light: 'vitesse-dark',
-  dark: 'vitesse-dark',
-};
+import {WorkflowSourceContent} from './workflow-source-content.js';
 
 export interface WorkflowSourcePanelProps {
   id: string;
@@ -61,76 +46,24 @@ export function WorkflowSourcePanel({
           )}
         >
           <SheetTitle className="sr-only">Workflow source</SheetTitle>
-          <WorkflowSourcePanelContent
+          <WorkflowSourceContent
             source={source}
             highlightedLineRange={highlightedLineRange}
             scrollHighlightedIntoView={scrollHighlightedIntoView}
+            headerAction={
+              <SheetClose asChild>
+                <Button
+                  type="button"
+                  variant="transparentMuted"
+                  size="sm"
+                  iconLeft="close"
+                  aria-label="Close source"
+                />
+              </SheetClose>
+            }
           />
         </SheetContent>
       ) : null}
     </Sheet>
-  );
-}
-
-function WorkflowSourcePanelContent({
-  source,
-  highlightedLineRange,
-  scrollHighlightedIntoView,
-}: {
-  source: WorkflowSourceSnapshot;
-  highlightedLineRange: CodeBlockHighlightedLineRange | null | undefined;
-  scrollHighlightedIntoView: boolean | undefined;
-}) {
-  const data = [
-    {
-      language: 'yaml',
-      filename: WORKFLOW_SOURCE_FILENAME,
-      code: source.content,
-    },
-  ];
-
-  return (
-    <CodeBlock
-      data={data}
-      className="flex size-full flex-col rounded-none bg-background-contrast-base shadow-none"
-    >
-      <CodeBlockHeader className="shrink-0 border-b border-border-contrast-base bg-background-contrast-base">
-        <CodeBlockFiles>
-          {(item) => <CodeBlockFilename value={item.filename}>{item.filename}</CodeBlockFilename>}
-        </CodeBlockFiles>
-        <CodeBlockCopyButton />
-        <SheetClose asChild>
-          <Button
-            type="button"
-            variant="transparentMuted"
-            size="sm"
-            iconLeft="close"
-            aria-label="Close source"
-          />
-        </SheetClose>
-      </CodeBlockHeader>
-      <CodeBlockBody className="flex min-h-0 flex-1 overflow-auto scrollbar">
-        {(item) => (
-          <CodeBlockItem
-            value={item.filename}
-            className={cn(
-              'min-h-full px-0 pb-0',
-              '[&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base [&>div]:dark:bg-background-contrast-base',
-              '[&_code]:!text-sm [&_code]:!text-foreground-neutral-on-inverted [&_.line]:!text-sm [&_.line]:before:!text-sm [&_.line]:before:!text-foreground-neutral-muted',
-            )}
-          >
-            <CodeBlockContent
-              language="yaml"
-              themes={WORKFLOW_SOURCE_CODE_THEMES}
-              syntaxHighlighting
-              highlightedLineRange={highlightedLineRange}
-              scrollHighlightedIntoView={scrollHighlightedIntoView}
-            >
-              {item.code}
-            </CodeBlockContent>
-          </CodeBlockItem>
-        )}
-      </CodeBlockBody>
-    </CodeBlock>
   );
 }

--- a/libs/client/workflows/src/core/workflow-run-tabs.ts
+++ b/libs/client/workflows/src/core/workflow-run-tabs.ts
@@ -1,0 +1,8 @@
+/** Counts used by the run detail tab strip before the annotations query owns the data. */
+export interface RunAnnotationSummary {
+  total: number;
+  error: number;
+  warning: number;
+  info: number;
+  success: number;
+}

--- a/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
@@ -56,7 +56,7 @@ export function WorkflowRunDetailPage({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-neutral-base">
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-neutral-background">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
@@ -2,7 +2,13 @@ import {useNavigate} from '@tanstack/react-router';
 import {useCallback} from 'react';
 import {WorkflowRunView} from '#components/workflow-run-view/index.js';
 import type {WorkflowRunSelectionInput} from '#core/workflow-run-url-state.js';
-import {type WorkflowRunsSearch, workflowRunSearchParams} from '#routes/inputs.js';
+import {
+  validateWorkflowRunsSearch,
+  type WorkflowRunsSearch,
+  type WorkflowRunTab,
+  workflowRunSearchParams,
+  workflowRunTab,
+} from '#routes/inputs.js';
 
 interface WorkflowRunDetailPageProps {
   projectId: string;
@@ -24,10 +30,25 @@ export function WorkflowRunDetailPage({
   const onSelectionChange = useCallback(
     (nextSelection: WorkflowRunSelectionInput) => {
       navigate({
-        search: workflowRunSearchParams(search, nextSelection) as never,
+        search: ((previous: Record<string, unknown>) => {
+          const current = validateWorkflowRunsSearch(previous);
+          return workflowRunSearchParams(current, nextSelection);
+        }) as never,
+        replace: true,
       });
     },
-    [navigate, search],
+    [navigate],
+  );
+  const onTabChange = useCallback(
+    (nextTab: WorkflowRunTab) => {
+      navigate({
+        search: ((previous: Record<string, unknown>) => {
+          const current = validateWorkflowRunsSearch(previous);
+          return workflowRunSearchParams({...current, tab: nextTab}, current);
+        }) as never,
+      });
+    },
+    [navigate],
   );
 
   return (
@@ -39,6 +60,8 @@ export function WorkflowRunDetailPage({
         workflowRunId={workflowRunId}
         selection={selection}
         onSelectionChange={onSelectionChange}
+        tab={workflowRunTab(search)}
+        onTabChange={onTabChange}
       />
     </div>
   );

--- a/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
@@ -44,7 +44,11 @@ export function WorkflowRunDetailPage({
       navigate({
         search: ((previous: Record<string, unknown>) => {
           const current = validateWorkflowRunsSearch(previous);
-          return workflowRunSearchParams({...current, tab: nextTab}, current);
+          const nextSearch = workflowRunSearchParams({...current, tab: nextTab}, current);
+          return nextTab === 'summary' &&
+            (current.jobId || current.jobExecutionId || current.stepId || current.stepAttemptId)
+            ? {...nextSearch, tab: nextTab}
+            : nextSearch;
         }) as never,
       });
     },

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -178,7 +178,7 @@ describe('WorkflowRunPages', () => {
     renderRunPath('?tab=jobs');
 
     expect(await screen.findByRole('button', {name: DEPLOY_JOB_BUTTON_NAME})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Back to runs'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Runs'})).toHaveAttribute(
       'href',
       `/w/${PROJECT_TEST_WSLUG}/p/project/runs`,
     );
@@ -190,7 +190,7 @@ describe('WorkflowRunPages', () => {
 
     renderRunPath(`?search=deploy-web&status=running&tab=jobs&job=${DEPLOY_JOB_ID}`);
 
-    expect(await screen.findByRole('link', {name: 'Back to runs'})).toHaveAttribute(
+    expect(await screen.findByRole('link', {name: 'Runs'})).toHaveAttribute(
       'href',
       `/w/${PROJECT_TEST_WSLUG}/p/project/runs?search=deploy-web&status=running`,
     );

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -40,6 +40,9 @@ const INTEGRATION_TESTS_RE = /integration-tests/u;
 const BUILD_IMAGE_RE = /build-image/u;
 const STATUS_FILTER_RE = /^Status\b.*filter$/u;
 const EXECUTION_ONE_MENU_ITEM = /Execution #1: deploy review #1/u;
+const JOBS_TAB_NAME = /^Jobs/u;
+const BUILD_JOB_BUTTON_NAME = 'build, Succeeded';
+const DEPLOY_JOB_BUTTON_NAME = 'deploy, Running';
 const RUN_DETAIL_PATH_RE = /^\/workflows\/runs\/([^/]+)$/u;
 const RUN_OVERRIDES = {
   id: RUN_ID,
@@ -171,25 +174,129 @@ describe('WorkflowRunPages', () => {
   test('renders the detail route without mounting the run list', async () => {
     configureApiClient({fetchImpl: createRunDetailFetch()});
 
-    renderRunPath();
+    renderRunPath('?tab=jobs');
 
-    expect(await screen.findByRole('button', {name: 'deploy, Running'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: DEPLOY_JOB_BUTTON_NAME})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Back to runs'})).toHaveAttribute(
+      'href',
+      `/w/${PROJECT_TEST_WSLUG}/p/project/runs`,
+    );
     expect(screen.queryByLabelText('Workflow runs')).not.toBeInTheDocument();
+  });
+
+  test('back to runs preserves list filters and drops run detail state', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderRunPath(`?search=deploy-web&status=running&tab=jobs&job=${DEPLOY_JOB_ID}`);
+
+    expect(await screen.findByRole('link', {name: 'Back to runs'})).toHaveAttribute(
+      'href',
+      `/w/${PROJECT_TEST_WSLUG}/p/project/runs?search=deploy-web&status=running`,
+    );
+  });
+
+  test('defaults the detail route to the Summary tab', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    const {router} = renderRunPath();
+
+    expect(await screen.findByRole('region', {name: 'deploy-web'})).toBeInTheDocument();
+    const summaryTab = screen.getByRole('tab', {name: 'Summary'});
+    expect(summaryTab).toHaveAttribute('aria-selected', 'true');
+    expect(summaryTab).toHaveAttribute('aria-controls', screen.getByRole('tabpanel').id);
+    expect(screen.queryByRole('list', {name: 'Run jobs'})).not.toBeInTheDocument();
+    expect(currentSearch(router).tab).toBeUndefined();
+  });
+
+  test('opens legacy selection-only detail URLs on the Jobs tab', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderRunPath(`?job=${DEPLOY_JOB_ID}`);
+
+    expect(await screen.findByRole('list', {name: 'Run jobs'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: JOBS_TAB_NAME})).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('pushes tab changes and restores them with browser history', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    const {router} = renderRunPath();
+    const initialHistoryLength = router.history.length;
+
+    await user.click(await screen.findByRole('tab', {name: JOBS_TAB_NAME}));
+
+    await waitFor(() => expect(currentSearch(router).tab).toBe('jobs'));
+    expect(router.history.length).toBe(initialHistoryLength + 1);
+    expect(screen.getByRole('tab', {name: JOBS_TAB_NAME})).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('list', {name: 'Run jobs'})).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Summary'}));
+
+    await waitFor(() => expect(currentSearch(router).tab).toBeUndefined());
+    expect(router.history.length).toBe(initialHistoryLength + 2);
+
+    await act(() => {
+      router.history.back();
+    });
+    await waitFor(() => expect(currentSearch(router).tab).toBe('jobs'));
+    expect(screen.getByRole('list', {name: 'Run jobs'})).toBeInTheDocument();
+  });
+
+  test('opens the Jobs tab and selects a job from the Summary graph', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    const {router} = renderRunPath();
+    const initialHistoryLength = router.history.length;
+
+    await user.click(await screen.findByRole('button', {name: 'deploy, Running'}));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toMatchObject({tab: 'jobs', job: DEPLOY_JOB_ID});
+    });
+    expect(router.history.length).toBe(initialHistoryLength + 1);
+    expect(screen.getByRole('button', {name: 'deploy, Running'})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', {name: 'deploy, Running'})).toHaveAttribute(
+      'aria-controls',
+      `job-card-${DEPLOY_JOB_ID}`,
+    );
+  });
+
+  test('keeps Summary active while keyboard navigation moves graph focus', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    const {router} = renderRunPath();
+    const build = await screen.findByRole('button', {name: BUILD_JOB_BUTTON_NAME});
+    const deploy = screen.getByRole('button', {name: DEPLOY_JOB_BUTTON_NAME});
+
+    build.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(deploy).toHaveFocus();
+    expect(deploy).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('tab', {name: 'Summary'})).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('list', {name: 'Run jobs'})).not.toBeInTheDocument();
+    expect(currentSearch(router).job).toBeUndefined();
   });
 
   test('restores a deep-linked job and exact attempt after data loads', async () => {
     configureApiClient({fetchImpl: createRunDetailFetch()});
 
     renderRunPath(
-      `?job=${BUILD_JOB_ID}&step=${DEPLOY_STEP_ID}&stepAttempt=${DEPLOY_ATTEMPT_TWO_ID}`,
+      `?tab=jobs&job=${BUILD_JOB_ID}&step=${DEPLOY_STEP_ID}&stepAttempt=${DEPLOY_ATTEMPT_TWO_ID}`,
     );
 
-    const deployJob = await screen.findByRole('button', {name: 'deploy, Running'});
+    const deployJob = await screen.findByRole('button', {name: DEPLOY_JOB_BUTTON_NAME});
     const deployAttempt = await screen.findByRole('button', {
       name: 'deploy, Running, attempt 2',
     });
 
-    expect(deployJob).toHaveAttribute('aria-pressed', 'true');
+    expect(deployJob).toHaveAttribute('aria-expanded', 'true');
     expect(deployAttempt).toHaveAttribute('aria-expanded', 'true');
     expect(await screen.findByText('attempt two log')).toBeInTheDocument();
   });
@@ -198,14 +305,17 @@ describe('WorkflowRunPages', () => {
     const user = userEvent.setup();
     configureApiClient({fetchImpl: createRunDetailFetch()});
     const {router} = renderRunPath(
-      `?step=${DEPLOY_STEP_ID}&stepAttempt=${DEPLOY_ATTEMPT_TWO_ID}&runAttempt=1`,
+      `?tab=jobs&step=${DEPLOY_STEP_ID}&stepAttempt=${DEPLOY_ATTEMPT_TWO_ID}&runAttempt=1`,
     );
+    const initialHistoryLength = router.history.length;
 
-    await user.click(await screen.findByRole('button', {name: 'build, Succeeded'}));
+    await user.click(await screen.findByRole('button', {name: BUILD_JOB_BUTTON_NAME}));
 
     await waitFor(() => {
       expect(currentSearch(router)).toMatchObject({job: BUILD_JOB_ID});
     });
+    expect(currentSearch(router).tab).toBe('jobs');
+    expect(router.history.length).toBe(initialHistoryLength);
     expect(currentSearch(router).step).toBeUndefined();
     expect(currentSearch(router).stepAttempt).toBeUndefined();
     expect(screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'})).toHaveAttribute(
@@ -217,7 +327,7 @@ describe('WorkflowRunPages', () => {
   test('selecting an attempt writes job, step, and attempt search state', async () => {
     const user = userEvent.setup();
     configureApiClient({fetchImpl: createRunDetailFetch()});
-    const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
+    const {router} = renderRunPath(`?tab=jobs&job=${DEPLOY_JOB_ID}`);
 
     await user.click(await screen.findByRole('button', {name: 'deploy, Running, attempt 2'}));
 
@@ -235,7 +345,7 @@ describe('WorkflowRunPages', () => {
     configureApiClient({
       fetchImpl: createRunDetailFetch({details: {[RUN_ID]: retryRunDetailDto()}}),
     });
-    const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
+    const {router} = renderRunPath(`?tab=jobs&job=${DEPLOY_JOB_ID}`);
 
     await user.click(
       await screen.findByRole('button', {
@@ -273,7 +383,9 @@ describe('WorkflowRunPages', () => {
   test('collapsing an attempt removes step and attempt while preserving job', async () => {
     const user = userEvent.setup();
     configureApiClient({fetchImpl: createRunDetailFetch()});
-    const {router} = renderRunPath(`?step=${DEPLOY_STEP_ID}&stepAttempt=${DEPLOY_ATTEMPT_TWO_ID}`);
+    const {router} = renderRunPath(
+      `?tab=jobs&step=${DEPLOY_STEP_ID}&stepAttempt=${DEPLOY_ATTEMPT_TWO_ID}`,
+    );
 
     const deployAttempt = await screen.findByRole('button', {
       name: 'deploy, Running, attempt 2',
@@ -286,41 +398,6 @@ describe('WorkflowRunPages', () => {
     expect(currentSearch(router).step).toBeUndefined();
     expect(currentSearch(router).stepAttempt).toBeUndefined();
     expect(deployAttempt).toHaveAttribute('aria-expanded', 'false');
-  });
-
-  test('back and forward navigation restores prior selections', async () => {
-    const user = userEvent.setup();
-    configureApiClient({fetchImpl: createRunDetailFetch()});
-    const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
-
-    await user.click(await screen.findByRole('button', {name: 'deploy, Running, attempt 2'}));
-    await waitFor(() => {
-      expect(currentSearch(router).stepAttempt).toBe(DEPLOY_ATTEMPT_TWO_ID);
-    });
-
-    await act(() => {
-      router.history.back();
-    });
-    await waitFor(() => {
-      expect(currentSearch(router)).toMatchObject({job: DEPLOY_JOB_ID});
-    });
-    expect(currentSearch(router).step).toBeUndefined();
-    expect(currentSearch(router).stepAttempt).toBeUndefined();
-    expect(screen.getByRole('button', {name: 'deploy, Running, attempt 2'})).toHaveAttribute(
-      'aria-expanded',
-      'false',
-    );
-
-    await act(() => {
-      router.history.forward();
-    });
-    await waitFor(() => {
-      expect(currentSearch(router).stepAttempt).toBe(DEPLOY_ATTEMPT_TWO_ID);
-    });
-    expect(screen.getByRole('button', {name: 'deploy, Running, attempt 2'})).toHaveAttribute(
-      'aria-expanded',
-      'true',
-    );
   });
 
   test('run list links navigate to detail and back restores list filters', async () => {

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -43,6 +43,7 @@ const EXECUTION_ONE_MENU_ITEM = /Execution #1: deploy review #1/u;
 const JOBS_TAB_NAME = /^Jobs/u;
 const BUILD_JOB_BUTTON_NAME = 'build, Succeeded';
 const DEPLOY_JOB_BUTTON_NAME = 'deploy, Running';
+const LIVE_DEPLOY_JOB_BUTTON_NAME = /^deploy, Running, running /u;
 const RUN_DETAIL_PATH_RE = /^\/workflows\/runs\/([^/]+)$/u;
 const RUN_OVERRIDES = {
   id: RUN_ID,
@@ -217,6 +218,49 @@ describe('WorkflowRunPages', () => {
     expect(screen.getByRole('tab', {name: JOBS_TAB_NAME})).toHaveAttribute('aria-selected', 'true');
   });
 
+  test('opens a legacy job execution URL with its owning job selected', async () => {
+    configureApiClient({
+      fetchImpl: createRunDetailFetch({details: {[RUN_ID]: retryRunDetailDto()}}),
+    });
+
+    renderRunPath(`?jobExecution=${DEPLOY_EXECUTION_TWO_ID}`);
+
+    expect(await screen.findByRole('region', {name: 'deploy review #2'})).toBeInTheDocument();
+  });
+
+  test('uses the derived execution status in a live job duration label', async () => {
+    configureApiClient({
+      fetchImpl: createRunDetailFetch({
+        details: {
+          [RUN_ID]: defaultRunDetailDto({
+            jobs: [
+              workflowJobDto({
+                id: DEPLOY_JOB_ID,
+                run_attempt_id: RUN_ID,
+                name: 'deploy',
+                status: 'running',
+                job_executions: [
+                  workflowJobExecutionDto({
+                    job_id: DEPLOY_JOB_ID,
+                    status: 'pending',
+                    started_at: '2026-08-04T00:00:00.000Z',
+                    steps: [workflowStepDto({status: 'running'})],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        },
+      }),
+    });
+
+    renderRunPath(`?tab=jobs&job=${DEPLOY_JOB_ID}`);
+
+    expect(
+      await screen.findByRole('button', {name: LIVE_DEPLOY_JOB_BUTTON_NAME}),
+    ).toBeInTheDocument();
+  });
+
   test('pushes tab changes and restores them with browser history', async () => {
     const user = userEvent.setup();
     configureApiClient({fetchImpl: createRunDetailFetch()});
@@ -264,6 +308,25 @@ describe('WorkflowRunPages', () => {
       'aria-controls',
       `job-card-${DEPLOY_JOB_ID}`,
     );
+    expect(screen.getByRole('button', {name: BUILD_JOB_BUTTON_NAME})).not.toHaveAttribute(
+      'aria-controls',
+    );
+  });
+
+  test('preserves an explicit Summary tab with a selected job', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    const {router} = renderRunPath(`?tab=jobs&job=${DEPLOY_JOB_ID}`);
+
+    await screen.findByRole('button', {name: DEPLOY_JOB_BUTTON_NAME});
+    await user.click(screen.getByRole('tab', {name: 'Summary'}));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toMatchObject({tab: 'summary', job: DEPLOY_JOB_ID});
+    });
+    expect(screen.getByRole('tab', {name: 'Summary'})).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('list', {name: 'Run jobs'})).not.toBeInTheDocument();
   });
 
   test('keeps Summary active while keyboard navigation moves graph focus', async () => {

--- a/libs/client/workflows/src/routes/inputs.test.ts
+++ b/libs/client/workflows/src/routes/inputs.test.ts
@@ -6,7 +6,9 @@ import {
   validateWorkflowRunsSearch,
   type WorkflowRunsSearch,
   workflowRouteParams,
+  workflowRunListSearchParams,
   workflowRunSearchParams,
+  workflowRunTab,
 } from './inputs.js';
 
 /** Everything a filter change writes, then reads back, exactly as the router would. */
@@ -21,6 +23,8 @@ describe('validateWorkflowRunsSearch', () => {
       validateWorkflowRunsSearch({
         search: ['unexpected'],
         status: 'unknown',
+        tab: 'unknown',
+        severity: 'critical',
         after: 'yesterday',
         before: '2026-13-01',
       }),
@@ -65,6 +69,28 @@ describe('validateWorkflowRunsSearch', () => {
       jobId: 'job-1',
     });
   });
+
+  test('accepts known tabs and annotation severities while dropping unknown values', () => {
+    expect(
+      validateWorkflowRunsSearch({tab: 'annotations', annotation: 'run-1', severity: 'error'}),
+    ).toEqual({tab: 'annotations', annotation: 'run-1', severity: 'error'});
+    expect(validateWorkflowRunsSearch({tab: 'unknown', severity: 'critical'})).toEqual({});
+    expect(workflowRunTab({})).toBe('summary');
+    expect(workflowRunTab({tab: 'source'})).toBe('source');
+  });
+
+  test.each([
+    ['job', {jobId: 'job-1'}],
+    ['job execution', {jobExecutionId: 'execution-1'}],
+    ['step', {stepId: 'step-1'}],
+    ['step attempt', {stepAttemptId: 'attempt-1'}],
+  ])('defaults a legacy %s selection URL to Jobs', (_selection, search) => {
+    expect(workflowRunTab(search)).toBe('jobs');
+  });
+
+  test('keeps an explicit Summary tab ahead of legacy selection inference', () => {
+    expect(workflowRunTab({tab: 'summary', jobId: 'job-1'})).toBe('summary');
+  });
 });
 
 describe('the run list URL contract', () => {
@@ -88,6 +114,9 @@ describe('the run list URL contract', () => {
       event: ['push'],
       after: '2026-05-01',
       before: '2026-05-31',
+      tab: 'annotations',
+      annotation: 'annotation-1',
+      severity: 'warning',
     };
 
     expect(roundTrip(search)).toEqual(search);
@@ -117,6 +146,24 @@ describe('the run list URL contract', () => {
 
   test('writes nothing for an unfiltered list', () => {
     expect(stringifyAppSearch(workflowRunSearchParams({}, {}))).toBe('');
+  });
+
+  test('omits the default Summary tab from the URL', () => {
+    expect(stringifyAppSearch(workflowRunSearchParams({tab: 'summary'}, {}))).toBe('');
+    expect(stringifyAppSearch(workflowRunSearchParams({tab: 'jobs'}, {}))).toBe('?tab=jobs');
+  });
+
+  test('serializes only list filters for the detail back link', () => {
+    expect(
+      workflowRunListSearchParams({
+        search: 'deploy',
+        status: ['running'],
+        tab: 'jobs',
+        annotation: 'annotation-1',
+        severity: 'error',
+        jobId: 'job-1',
+      }),
+    ).toEqual({search: 'deploy', status: ['running']});
   });
 
   test('has no page or cursor parameter to carry', () => {

--- a/libs/client/workflows/src/routes/inputs.ts
+++ b/libs/client/workflows/src/routes/inputs.ts
@@ -8,6 +8,14 @@ export const WORKFLOW_RUN_LIST_STATUSES = ['succeeded', 'failed', 'running', 'ca
 
 export type WorkflowRunListStatus = (typeof WORKFLOW_RUN_LIST_STATUSES)[number];
 
+export const WORKFLOW_RUN_TABS = ['summary', 'jobs', 'annotations', 'source'] as const;
+
+export type WorkflowRunTab = (typeof WORKFLOW_RUN_TABS)[number];
+
+export const WORKFLOW_RUN_ANNOTATION_SEVERITIES = ['error', 'warning', 'info', 'success'] as const;
+
+export type WorkflowRunAnnotationSeverity = (typeof WORKFLOW_RUN_ANNOTATION_SEVERITIES)[number];
+
 export interface WorkflowRunsSearch extends WorkflowRunSelectionInput {
   search?: string;
   status?: WorkflowRunListStatus[];
@@ -18,9 +26,14 @@ export interface WorkflowRunsSearch extends WorkflowRunSelectionInput {
   after?: string;
   /** Inclusive upper bound on the run's local calendar date, `YYYY-MM-DD`. */
   before?: string;
+  tab?: WorkflowRunTab;
+  annotation?: string;
+  severity?: WorkflowRunAnnotationSeverity;
 }
 
 const STATUS_VALUES = new Set<string>(WORKFLOW_RUN_LIST_STATUSES);
+const TAB_VALUES = new Set<string>(WORKFLOW_RUN_TABS);
+const ANNOTATION_SEVERITY_VALUES = new Set<string>(WORKFLOW_RUN_ANNOTATION_SEVERITIES);
 const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
 /**
@@ -39,6 +52,14 @@ export function validateWorkflowRunsSearch(input: Record<string, unknown>): Work
   const after = calendarDate(input.after);
   const before = calendarDate(input.before);
   const runAttempt = positiveInteger(input.runAttempt);
+  const tabValue = string(input.tab);
+  const tab = tabValue && TAB_VALUES.has(tabValue) ? (tabValue as WorkflowRunTab) : undefined;
+  const annotation = string(input.annotation);
+  const severityValue = string(input.severity);
+  const severity =
+    severityValue && ANNOTATION_SEVERITY_VALUES.has(severityValue)
+      ? (severityValue as WorkflowRunAnnotationSeverity)
+      : undefined;
 
   return {
     ...(search ? {search} : {}),
@@ -48,6 +69,9 @@ export function validateWorkflowRunsSearch(input: Record<string, unknown>): Work
     ...(event.length > 0 ? {event} : {}),
     ...(after ? {after} : {}),
     ...(before ? {before} : {}),
+    ...(tab ? {tab} : {}),
+    ...(annotation ? {annotation} : {}),
+    ...(severity ? {severity} : {}),
     ...(string(input.job) ? {jobId: string(input.job)} : {}),
     ...(string(input.jobExecution) ? {jobExecutionId: string(input.jobExecution)} : {}),
     ...(string(input.step) ? {stepId: string(input.step)} : {}),
@@ -74,12 +98,33 @@ export function workflowRunSearchParams(
     ...(search.event?.length ? {event: search.event} : {}),
     ...(search.after ? {after: search.after} : {}),
     ...(search.before ? {before: search.before} : {}),
+    ...(search.tab && search.tab !== 'summary' ? {tab: search.tab} : {}),
+    ...(search.annotation ? {annotation: search.annotation} : {}),
+    ...(search.severity ? {severity: search.severity} : {}),
     ...(selection.jobId ? {job: selection.jobId} : {}),
     ...(selection.jobExecutionId ? {jobExecution: selection.jobExecutionId} : {}),
     ...(selection.stepId ? {step: selection.stepId} : {}),
     ...(selection.stepAttemptId ? {stepAttempt: selection.stepAttemptId} : {}),
     ...(selection.runAttempt ? {runAttempt: String(selection.runAttempt)} : {}),
   };
+}
+
+/**
+ * Resolves the detail surface for a URL. Explicit tabs win; legacy selection-only URLs belong
+ * to Jobs so their selected detail remains visible instead of silently landing on Summary.
+ */
+export function workflowRunTab(
+  search: Pick<WorkflowRunsSearch, 'tab' | 'jobId' | 'jobExecutionId' | 'stepId' | 'stepAttemptId'>,
+): WorkflowRunTab {
+  if (search.tab) return search.tab;
+  if (search.jobId || search.jobExecutionId || search.stepId || search.stepAttemptId) return 'jobs';
+  return 'summary';
+}
+
+/** Serializes only list filters when leaving a run detail page for the run list. */
+export function workflowRunListSearchParams(search: WorkflowRunsSearch) {
+  const {tab: _tab, annotation: _annotation, severity: _severity, ...listSearch} = search;
+  return workflowRunSearchParams(listSearch, {});
 }
 
 /**

--- a/libs/shared/react/ui/src/components/tabs/tabs.test.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.test.tsx
@@ -1,0 +1,91 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Tabs, TabsContent, TabsContents, TabsList, TabsTrigger} from './tabs.js';
+
+describe('Tabs', () => {
+  test('connects the active tab to its tabpanel', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultValue="summary">
+        <TabsList>
+          <TabsTrigger value="summary">Summary</TabsTrigger>
+          <TabsTrigger value="jobs">Jobs</TabsTrigger>
+        </TabsList>
+        <TabsContents>
+          <TabsContent value="summary">Summary content</TabsContent>
+          <TabsContent value="jobs">Jobs content</TabsContent>
+        </TabsContents>
+      </Tabs>,
+    );
+
+    const summaryTab = screen.getByRole('tab', {name: 'Summary'});
+    expect(summaryTab.getAttribute('aria-controls')).toBe(screen.getByRole('tabpanel').id);
+    expect(screen.getByText('Summary content')).toBeDefined();
+
+    await user.click(screen.getByRole('tab', {name: 'Jobs'}));
+
+    expect(screen.getByRole('tab', {name: 'Jobs'}).getAttribute('aria-controls')).toBe(
+      screen.getByRole('tabpanel').id,
+    );
+    expect(screen.getByText('Jobs content')).toBeDefined();
+    expect(screen.queryByText('Summary content')).toBeNull();
+  });
+
+  test('scopes tab and panel ids to each Tabs instance', () => {
+    render(
+      <>
+        <Tabs defaultValue="summary">
+          <TabsList>
+            <TabsTrigger value="summary">First summary</TabsTrigger>
+          </TabsList>
+          <TabsContents>
+            <TabsContent value="summary">First content</TabsContent>
+          </TabsContents>
+        </Tabs>
+        <Tabs defaultValue="summary">
+          <TabsList>
+            <TabsTrigger value="summary">Second summary</TabsTrigger>
+          </TabsList>
+          <TabsContents>
+            <TabsContent value="summary">Second content</TabsContent>
+          </TabsContents>
+        </Tabs>
+      </>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+    const panels = screen.getAllByRole('tabpanel');
+
+    expect(tabs[0]?.getAttribute('aria-controls')).toBe(panels[0]?.id);
+    expect(tabs[1]?.getAttribute('aria-controls')).toBe(panels[1]?.id);
+    expect(panels[0]?.id).not.toBe(panels[1]?.id);
+  });
+
+  test('keeps an opted-in tab panel mounted while inactive', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultValue="summary">
+        <TabsList>
+          <TabsTrigger value="summary">Summary</TabsTrigger>
+          <TabsTrigger value="source">Source</TabsTrigger>
+        </TabsList>
+        <TabsContents>
+          <TabsContent value="summary">Summary content</TabsContent>
+          <TabsContent value="source" keepMounted>
+            Source content
+          </TabsContent>
+        </TabsContents>
+      </Tabs>,
+    );
+
+    const sourcePanel = screen.getByText('Source content').closest('[role="tabpanel"]');
+    expect(sourcePanel).toBeDefined();
+    expect(sourcePanel?.getAttribute('hidden')).toBeDefined();
+
+    await user.click(screen.getByRole('tab', {name: 'Source'}));
+
+    expect(sourcePanel?.getAttribute('hidden')).toBeNull();
+  });
+});

--- a/libs/shared/react/ui/src/components/tabs/tabs.test.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.test.tsx
@@ -73,7 +73,7 @@ describe('Tabs', () => {
         </TabsList>
         <TabsContents>
           <TabsContent value="summary">Summary content</TabsContent>
-          <TabsContent value="source" keepMounted>
+          <TabsContent value="source" keepMounted className="flex">
             Source content
           </TabsContent>
         </TabsContents>
@@ -81,11 +81,11 @@ describe('Tabs', () => {
     );
 
     const sourcePanel = screen.getByText('Source content').closest('[role="tabpanel"]');
-    expect(sourcePanel).toBeDefined();
-    expect(sourcePanel?.getAttribute('hidden')).toBeDefined();
+    if (!(sourcePanel instanceof HTMLElement)) throw new Error('Source panel did not render.');
+    expect(sourcePanel.style.display).toBe('none');
 
     await user.click(screen.getByRole('tab', {name: 'Source'}));
 
-    expect(sourcePanel?.getAttribute('hidden')).toBeNull();
+    expect(sourcePanel.style.display).toBe('');
   });
 });

--- a/libs/shared/react/ui/src/components/tabs/tabs.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import {type HTMLMotionProps, motion, type Transition} from 'framer-motion';
+import {type HTMLMotionProps, motion, type Transition, useReducedMotion} from 'framer-motion';
 import {
-  Children,
   type ComponentProps,
   createContext,
   forwardRef,
-  isValidElement,
-  type ReactElement,
   type ReactNode,
   useCallback,
   useContext,
   useEffect,
+  useId,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -22,6 +20,7 @@ import {debounce} from '#utils/debounce.js';
 
 type TabsContextType<T extends string = string> = {
   activeValue: T;
+  id: string;
   handleValueChange: (value: T) => void;
   registerTrigger: (value: string, node: HTMLElement | null) => void;
   getTriggerElement: (value: string) => HTMLElement | undefined;
@@ -65,6 +64,7 @@ function Tabs<T extends string = string>({
   ...props
 }: TabsProps<T>) {
   const [activeValue, setActiveValue] = useState<T | undefined>(defaultValue ?? undefined);
+  const id = useId();
   const triggersRef = useRef(new Map<string, HTMLElement>());
   const initialSet = useRef(false);
   const isControlled = value !== undefined;
@@ -124,6 +124,7 @@ function Tabs<T extends string = string>({
     <TabsContext.Provider
       value={{
         activeValue: resolvedActiveValue as string,
+        id,
         handleValueChange: handleValueChange as (value: string) => void,
         registerTrigger,
         getTriggerElement,
@@ -147,18 +148,20 @@ type TabsListProps = ComponentProps<'div'> & {
   transition?: Transition;
 };
 
+const defaultTabsIndicatorTransition: Transition = {
+  duration: 0.2,
+  ease: 'easeOut',
+};
+
 function TabsList({
   children,
   className,
   activeClassName,
-  transition = {
-    type: 'spring',
-    stiffness: 400,
-    damping: 30,
-  },
+  transition = defaultTabsIndicatorTransition,
   ...props
 }: TabsListProps) {
   const {activeValue, getTriggerElement} = useTabs();
+  const reducedMotion = useReducedMotion();
   const [indicatorStyle, setIndicatorStyle] = useState<{
     left: number;
     width: number;
@@ -208,7 +211,7 @@ function TabsList({
             left: indicatorStyle.left,
             width: indicatorStyle.width,
           }}
-          transition={transition}
+          transition={reducedMotion ? {duration: 0} : transition}
         />
       )}
     </div>
@@ -228,6 +231,7 @@ const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
       registerTrigger,
       getAllTriggerValues,
       getTriggerElement,
+      id,
     } = useTabs();
 
     const localRef = useRef<HTMLButtonElement | null>(null);
@@ -294,13 +298,12 @@ const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
         data-slot="tabs-trigger"
         role="tab"
         tabIndex={isActive ? 0 : -1}
-        whileTap={{scale: 0.95}}
         onClick={() => handleValueChange(value)}
         onKeyDown={handleKeyDown}
         data-state={isActive ? 'active' : 'inactive'}
         aria-selected={isActive}
-        aria-controls={`tabpanel-${value}`}
-        id={`tab-${value}`}
+        aria-controls={`${id}-tabpanel-${value}`}
+        id={`${id}-tab-${value}`}
         className={cn(
           'relative inline-flex cursor-pointer items-center justify-center whitespace-nowrap px-0 py-10 text-sm font-medium transition-colors outline-none focus-visible:shadow-border-interactive-with-active focus-visible:rounded-2 disabled:pointer-events-none disabled:opacity-50',
           isActive ? 'text-foreground-neutral-base' : 'text-foreground-neutral-muted',
@@ -321,21 +324,9 @@ type TabsContentsProps = ComponentProps<'div'> & {
 };
 
 function TabsContents({children, className, ...props}: TabsContentsProps) {
-  const {activeValue} = useTabs();
-  const childrenArray = Children.toArray(children);
-
-  const activeChild = childrenArray.find(
-    (child): child is ReactElement<{value: string}> =>
-      isValidElement(child) &&
-      typeof child.props === 'object' &&
-      child.props !== null &&
-      'value' in child.props &&
-      child.props.value === activeValue,
-  );
-
   return (
     <div data-slot="tabs-contents" className={cn(className)} {...(props as ComponentProps<'div'>)}>
-      {activeChild}
+      {children}
     </div>
   );
 }
@@ -343,13 +334,20 @@ function TabsContents({children, className, ...props}: TabsContentsProps) {
 type TabsContentProps = ComponentProps<'div'> & {
   value: string;
   children: ReactNode;
+  keepMounted?: boolean;
 };
 
-function TabsContent({children, value, className, ...props}: TabsContentProps) {
-  const {activeValue} = useTabs();
+function TabsContent({
+  children,
+  value,
+  className,
+  keepMounted = false,
+  ...props
+}: TabsContentProps) {
+  const {activeValue, id} = useTabs();
   const isActive = activeValue === value;
 
-  if (!isActive) {
+  if (!isActive && !keepMounted) {
     return null;
   }
 
@@ -357,7 +355,9 @@ function TabsContent({children, value, className, ...props}: TabsContentProps) {
     <div
       role="tabpanel"
       data-slot="tabs-content"
-      aria-labelledby={`tab-${value}`}
+      aria-labelledby={`${id}-tab-${value}`}
+      id={`${id}-tabpanel-${value}`}
+      hidden={!isActive}
       className={cn(className)}
       {...props}
     >

--- a/libs/shared/react/ui/src/components/tabs/tabs.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.tsx
@@ -342,6 +342,7 @@ function TabsContent({
   value,
   className,
   keepMounted = false,
+  style,
   ...props
 }: TabsContentProps) {
   const {activeValue, id} = useTabs();
@@ -360,6 +361,7 @@ function TabsContent({
       hidden={!isActive}
       className={cn(className)}
       {...props}
+      style={!isActive ? {...style, display: 'none'} : style}
     >
       {children}
     </div>


### PR DESCRIPTION
Give workflow run details a local, URL-backed navigation surface. The run header now sits above Summary, Jobs, Annotations, and Source tabs, with counts, severity links, and preserved run/list selection state. The shared tabs primitive keeps inactive panels mounted for stable source rendering, while legacy job and step URLs continue to land on the Jobs tab.

Closes ENG-1362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds run-scoped, URL-backed tabs (Summary, Jobs, Annotations, Source) to the workflow run detail. Preserves run list filters and keeps the real tab strip visible while runs load and poll. Closes ENG-1362.

- **New Features**
  - Tab strip synced to a `tab` query param; shows job counts (with failed alerts) and annotation totals with severity deep‑links; remains visible during loading.
  - Jobs tab adds a collapsible, selectable job list with durations and `JobCard`; integrates with the graph (pointer clicks switch to Jobs, keyboard stays on Summary).
  - Source tab renders the full workflow via `WorkflowSourceContent` with line highlights; job/step “View source” still opens the sheet; “Back to runs” preserves list filters.

- **Refactors**
  - `@shipfox/react-ui/tabs`: scoped tab/tabpanel ARIA ids with correct `aria-controls`, reduced‑motion indicator, optional keepMounted panels, and tests.
  - Validated `tab`, `annotation`, and `severity` search params; selection resolver now handles legacy job execution and step attempt IDs with safe fallbacks.
  - Project‑scoped shell tabs use compact styling and clearer states; extracted `WorkflowSourceContent`; refined neutral text/backgrounds and added a content skeleton.

<sup>Written for commit 8e095bdb701d6123b39e9331297ae3527fdc34b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

