### PR TITLE
Migrate client surfaces to semantic spacing

### DIFF
--- a/.changeset/client-surfaces-semantic-spacing.md
+++ b/.changeset/client-surfaces-semantic-spacing.md
@@ -1,0 +1,13 @@
+---
+"@shipfox/client-workspace-settings": patch
+"@shipfox/client-invitations": patch
+"@shipfox/client-secrets": patch
+"@shipfox/client-config": patch
+"@shipfox/client-shell": patch
+"@shipfox/client-auth": patch
+"@shipfox/client-logs": patch
+---
+
+Migrates the shell, auth, secrets, logs, workspace-settings, config, and invitations
+surfaces to semantic spacing roles and brings them under the `no-raw-spacing` Biome
+plugin.

--- a/.changeset/client-surfaces-semantic-spacing.md
+++ b/.changeset/client-surfaces-semantic-spacing.md
@@ -1,4 +1,5 @@
 ---
+"@shipfox/react-ui": patch
 "@shipfox/client-workspace-settings": patch
 "@shipfox/client-invitations": patch
 "@shipfox/client-secrets": patch
@@ -10,4 +11,5 @@
 
 Migrates the shell, auth, secrets, logs, workspace-settings, config, and invitations
 surfaces to semantic spacing roles and brings them under the `no-raw-spacing` Biome
-plugin.
+plugin. Adds shared menu-surface and edge-specific panel roles for existing spacing
+contracts.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -319,24 +319,29 @@ the marketing page.
   chrome.
 
 **The Pixel-Spacing Rule.** `index.css` sets `--spacing: 1px`, so in this Tailwind
-v4 setup **utility numbers are pixels**: `p-16` is 16px, `gap-8` is 8px, `h-32` is
-32px. This is *not* stock Tailwind, where `p-4` would be 16px. Here `p-4` is 4px.
-Anyone arriving from a tutorial or another repo gets this wrong on day one; flag it
-in review. Use the scale (2, 4, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 64) and do
-not invent values between the steps.
+v4 setup **utility numbers are pixels**: `p-16` is 16px, `gap-8` is 8px, and `h-32`
+is 32px. This is *not* stock Tailwind, where `p-4` would be 16px. Here `p-4` is
+4px. The raw scale remains useful for token definitions and component internals.
+Product surfaces should use the semantic roles below.
 
-**Semantic composition roles.** Use `my-region` for a 32px block margin around a
-standalone region and `mt-page` for a 48px separation before page-level feedback
-or similar trailing content. Use `px-tight` when a compact control needs horizontal
-padding without changing its vertical size. Use `ms-inline` for inline badge
-separation. The `-mt-inline` and `-mr-inline` roles are reserved for preserving a
-touch target's optical alignment with a containing surface. These roles keep
-composition spacing explicit without reopening raw margin utilities across product
-code.
+**Semantic spacing roles.** Values are listed as `default / compact` pixels.
+Compact values apply below an ancestor with `data-density="compact"`.
 
-**Density posture.** Default button height `h-32` with `px-10`; table rows 36 to
-44px; form row gap `gap-16`; card padding `p-24`. A surface is at the wrong density
-when a table needs horizontal scroll from cell padding, when an app page shows more
+| Family | Roles |
+| --- | --- |
+| Gaps | `gap-tight` 4 / 2, `gap-inline` 8 / 4, `gap-cluster` 12 / 8, `gap-group` 16 / 12, `gap-section` 24 / 16, `gap-region` 32 / 24 |
+| Padding | `p-tight` and `px-tight` 8 / 4, `px-row` 16 / 12, `py-row` 12 / 8, `p-panel-compact` 16 / 12, `p-panel` 24 / 16, `px-frame` 24 / 16, `py-frame` 32 / 24 |
+| Margins | `ms-inline` 8 / 4, `my-region` 32 / 24, `mt-page` 48 / 32, `-mt-inline` and `-mr-inline` -8 / -4 |
+
+Use a parent `gap-*` role before adding a child margin. Use the negative inline
+roles only to preserve a touch target's optical alignment with its containing
+surface. Keep zero utilities for explicit resets. Use arbitrary spacing only for
+a fixed optical offset or reserved control space that has no semantic role.
+
+**Density posture.** The default medium button is `h-32`; component sizing owns its
+padding. Use `gap-group` for form row rhythm, `p-panel` for standard cards, and
+`px-row` or `py-row` for row controls. A surface is at the wrong density when a
+table needs horizontal scroll from cell padding, when an app page shows more
 whitespace than content above the fold, or when a marketing page feels like a
 settings panel.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -330,7 +330,7 @@ Compact values apply below an ancestor with `data-density="compact"`.
 | Family | Roles |
 | --- | --- |
 | Gaps | `gap-tight` 4 / 2, `gap-inline` 8 / 4, `gap-cluster` 12 / 8, `gap-group` 16 / 12, `gap-section` 24 / 16, `gap-region` 32 / 24 |
-| Padding | `p-tight` and `px-tight` 8 / 4, `px-row` 16 / 12, `py-row` 12 / 8, `p-panel-compact` 16 / 12, `p-panel` 24 / 16, `px-frame` 24 / 16, `py-frame` 32 / 24 |
+| Padding | `p-menu-surface` 4 / 2, `p-tight` and `px-tight` 8 / 4, `px-row` 16 / 12, `py-row` 12 / 8, `p-panel-compact` 16 / 12, `p-panel` and `pb-panel` 24 / 16, `px-frame` 24 / 16, `py-frame` 32 / 24 |
 | Margins | `ms-inline` 8 / 4, `my-region` 32 / 24, `mt-page` 48 / 32, `-mt-inline` and `-mr-inline` -8 / -4 |
 
 Use a parent `gap-*` role before adding a child margin. Use the negative inline

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -336,7 +336,8 @@ Compact values apply below an ancestor with `data-density="compact"`.
 Use a parent `gap-*` role before adding a child margin. Use the negative inline
 roles only to preserve a touch target's optical alignment with its containing
 surface. Keep zero utilities for explicit resets. Use arbitrary spacing only for
-a fixed optical offset or reserved control space that has no semantic role.
+a fixed optical offset, reserved control space, or asymmetric component contract
+that has no semantic role.
 
 **Density posture.** The default medium button is `h-32`; component sizing owns its
 padding. Use `gap-group` for form row rhythm, `p-panel` for standard cards, and

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -41,6 +41,7 @@
   --margin-page: 48px;
 
   --pad-tight: 8px;
+  --pad-menu-surface: 4px;
   --pad-row-x: 16px;
   --pad-row-y: 12px;
   --pad-panel-compact: 16px;
@@ -123,12 +124,20 @@ html {
   padding: var(--pad-tight);
 }
 
+@utility p-menu-surface {
+  padding: var(--pad-menu-surface);
+}
+
 @utility p-panel-compact {
   padding: var(--pad-panel-compact);
 }
 
 @utility p-panel {
   padding: var(--pad-panel);
+}
+
+@utility pb-panel {
+  padding-bottom: var(--pad-panel);
 }
 
 @utility px-tight {

--- a/biome.json
+++ b/biome.json
@@ -213,6 +213,13 @@
       "path": "./tools/biome/plugins/client-architecture/no-raw-spacing.grit",
       "includes": [
         "**/apps/docs/**",
+        "**/libs/client/shell/**",
+        "**/libs/client/auth/**",
+        "**/libs/client/secrets/**",
+        "**/libs/client/logs/**",
+        "**/libs/client/workspace-settings/**",
+        "**/libs/client/config/**",
+        "**/libs/client/invitations/**",
         "!**/dist/**",
         "!**/node_modules/**",
         "!**/*.test.ts",

--- a/libs/client/auth/src/components/email-code-verification.tsx
+++ b/libs/client/auth/src/components/email-code-verification.tsx
@@ -127,7 +127,7 @@ export function EmailCodeVerification({
           This verification code has expired. Use another email to try again.
         </Callout>
       ) : null}
-      <form className="flex flex-col gap-8" noValidate onSubmit={submit}>
+      <form className="flex flex-col gap-inline" noValidate onSubmit={submit}>
         <FormField label="Verification code" id="verification-code" error={codeError}>
           <FormFieldInput
             autoComplete="one-time-code"

--- a/libs/client/auth/src/components/password-login-form.tsx
+++ b/libs/client/auth/src/components/password-login-form.tsx
@@ -74,7 +74,7 @@ export function PasswordLoginForm({children, invitationEmail}: PasswordLoginForm
 
   return (
     <form
-      className="flex flex-col gap-18"
+      className="flex flex-col gap-group"
       noValidate
       onSubmit={(event) => {
         event.preventDefault();

--- a/libs/client/auth/src/components/workspace-switcher.tsx
+++ b/libs/client/auth/src/components/workspace-switcher.tsx
@@ -45,7 +45,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
     <Command>
       <CommandInput placeholder="Search workspaces..." />
       <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
-        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-[4px] scrollbar">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-menu-surface scrollbar">
           <CommandEmpty>No workspaces found.</CommandEmpty>
           <CommandGroup heading="Workspaces">
             {workspaces.map((workspace) => (
@@ -67,7 +67,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
           </CommandGroup>
         </div>
         <CommandSeparator alwaysRender className="mx-0" />
-        <CommandGroup forceMount className="p-[4px]">
+        <CommandGroup forceMount className="p-menu-surface">
           <CommandItem value="__create" onSelect={handleCreate} forceMount>
             <Icon name="addLine" className="size-16" />
             Create workspace

--- a/libs/client/auth/src/components/workspace-switcher.tsx
+++ b/libs/client/auth/src/components/workspace-switcher.tsx
@@ -45,7 +45,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
     <Command>
       <CommandInput placeholder="Search workspaces..." />
       <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
-        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-4 scrollbar">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-tight scrollbar">
           <CommandEmpty>No workspaces found.</CommandEmpty>
           <CommandGroup heading="Workspaces">
             {workspaces.map((workspace) => (
@@ -57,7 +57,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
               >
                 <Icon
                   name="check"
-                  className={`size-16 mr-8 ${
+                  className={`size-16 ${
                     activeWorkspaceId === workspace.id ? 'opacity-100' : 'opacity-0'
                   }`}
                 />
@@ -67,7 +67,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
           </CommandGroup>
         </div>
         <CommandSeparator alwaysRender className="mx-0" />
-        <CommandGroup forceMount className="p-4">
+        <CommandGroup forceMount className="p-tight">
           <CommandItem value="__create" onSelect={handleCreate} forceMount>
             <Icon name="addLine" className="size-16" />
             Create workspace

--- a/libs/client/auth/src/components/workspace-switcher.tsx
+++ b/libs/client/auth/src/components/workspace-switcher.tsx
@@ -45,7 +45,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
     <Command>
       <CommandInput placeholder="Search workspaces..." />
       <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
-        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-tight scrollbar">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-[4px] scrollbar">
           <CommandEmpty>No workspaces found.</CommandEmpty>
           <CommandGroup heading="Workspaces">
             {workspaces.map((workspace) => (
@@ -67,7 +67,7 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
           </CommandGroup>
         </div>
         <CommandSeparator alwaysRender className="mx-0" />
-        <CommandGroup forceMount className="p-tight">
+        <CommandGroup forceMount className="p-[4px]">
           <CommandItem value="__create" onSelect={handleCreate} forceMount>
             <Icon name="addLine" className="size-16" />
             Create workspace

--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -28,7 +28,7 @@ export function LoginPage() {
   return (
     <AuthShell title={headerTitle} description={headerDescription}>
       <PasswordLoginForm invitationEmail={invitationPending?.email}>
-        <ButtonLink asChild variant="subtle" className="-mt-8 self-end">
+        <ButtonLink asChild variant="subtle" className="-mt-inline self-end">
           <Link to="/auth/reset">Forgot password?</Link>
         </ButtonLink>
       </PasswordLoginForm>

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -95,7 +95,7 @@ function PasswordResetRequest() {
   return (
     <AuthShell title="Reset your password" description="Enter your email to get a reset link.">
       <form
-        className="flex flex-col gap-18"
+        className="flex flex-col gap-group"
         noValidate
         onSubmit={(event) => {
           event.preventDefault();
@@ -174,7 +174,7 @@ function PasswordResetConfirm({token}: {token: string}) {
   return (
     <AuthShell title="Set a new password" description="Choose a password for your Shipfox account.">
       <form
-        className="flex flex-col gap-18"
+        className="flex flex-col gap-group"
         noValidate
         onSubmit={(event) => {
           event.preventDefault();

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -206,7 +206,7 @@ export function SignupPage() {
         description="Your account was created, but we could not finish signing you in."
       >
         <Callout role="alert" type="error">
-          <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-inline">
             <Text size="sm">
               Try again to finish joining your workspace. You can safely retry this step.
             </Text>
@@ -285,7 +285,7 @@ export function SignupPage() {
   return (
     <AuthShell title={headerTitle} description={headerDescription}>
       <form
-        className="flex flex-col gap-18"
+        className="flex flex-col gap-group"
         noValidate
         onSubmit={(event) => {
           event.preventDefault();

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -78,10 +78,10 @@ export function WorkspaceOnboardingPage() {
   });
 
   return (
-    <main className="min-h-screen bg-background-subtle-base px-24 py-32 max-[520px]:px-16">
-      <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full max-w-[1120px] flex-col gap-24">
+    <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
+      <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full max-w-[1120px] flex-col gap-section">
         <header className="flex items-center justify-between">
-          <div className="flex items-center gap-10">
+          <div className="flex items-center gap-inline">
             <div className="flex size-36 items-center justify-center rounded-8 border border-border-neutral-base bg-background-neutral-base shadow-button-neutral">
               <Icon name="shipfox" className="size-24 text-background-highlight-interactive" />
             </div>
@@ -91,7 +91,7 @@ export function WorkspaceOnboardingPage() {
           </div>
         </header>
 
-        <section className="grid flex-1 items-center gap-32 lg:grid-cols-[minmax(0,440px)_minmax(0,1fr)]">
+        <section className="grid flex-1 items-center gap-region lg:grid-cols-[minmax(0,440px)_minmax(0,1fr)]">
           <form
             className="relative z-10 w-full"
             noValidate
@@ -102,8 +102,8 @@ export function WorkspaceOnboardingPage() {
               void form.handleSubmit();
             }}
           >
-            <Card className="gap-20 p-24 shadow-button-neutral">
-              <CardHeader className="gap-8">
+            <Card className="gap-section p-panel shadow-button-neutral">
+              <CardHeader className="gap-inline">
                 <CardTitle id="workspace-onboarding-title" variant="h1">
                   Create your workspace
                 </CardTitle>
@@ -116,7 +116,7 @@ export function WorkspaceOnboardingPage() {
                 </Callout>
               ) : null}
 
-              <CardContent className="flex flex-col gap-8">
+              <CardContent className="flex flex-col gap-inline">
                 <form.Field
                   name="name"
                   validators={{
@@ -201,11 +201,11 @@ export function WorkspaceOnboardingPage() {
             </Card>
           </form>
 
-          <div className="hidden flex-col gap-18 lg:flex" aria-hidden="true">
-            <div className="grid grid-cols-4 gap-12">
+          <div className="hidden flex-col gap-group lg:flex" aria-hidden="true">
+            <div className="grid grid-cols-4 gap-cluster">
               {previewMetrics.map((metric) => (
                 <div
-                  className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-14 shadow-button-neutral"
+                  className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral"
                   key={metric.label}
                 >
                   <Text size="xs" className="text-foreground-neutral-muted">
@@ -217,18 +217,18 @@ export function WorkspaceOnboardingPage() {
                 </div>
               ))}
             </div>
-            <div className="grid grid-cols-2 gap-18">
+            <div className="grid grid-cols-2 gap-group">
               <PreviewPanel title="Performance over time" />
               <PreviewPanel title="Duration distribution" bars />
             </div>
-            <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-16 shadow-button-neutral">
+            <div className="flex flex-col gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral">
               <Text size="sm" bold>
                 Jobs breakdown
               </Text>
-              <div className="mt-14 flex flex-col gap-10">
+              <div className="flex flex-col gap-inline">
                 {[0, 1, 2, 3].map((row) => (
                   <div
-                    className="grid grid-cols-[1fr_80px_80px] gap-12 border-t border-border-neutral-base pt-10"
+                    className="grid grid-cols-[1fr_80px_80px] gap-cluster border-t border-border-neutral-base pt-[10px]"
                     key={row}
                   >
                     <div className="h-12 rounded-full bg-background-neutral-disabled" />
@@ -247,11 +247,11 @@ export function WorkspaceOnboardingPage() {
 
 function PreviewPanel({title, bars = false}: {title: string; bars?: boolean}) {
   return (
-    <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-16 shadow-button-neutral">
+    <div className="flex flex-col gap-group rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral">
       <Text size="sm" bold>
         {title}
       </Text>
-      <div className="mt-16 flex h-[220px] items-end gap-8 border-b border-l border-border-neutral-base px-12 pb-10">
+      <div className="flex h-[220px] items-end gap-inline border-b border-l border-border-neutral-base px-row pb-[10px]">
         {previewBars.map((bar) => (
           <div
             className={

--- a/libs/client/config/src/config-error-screen.tsx
+++ b/libs/client/config/src/config-error-screen.tsx
@@ -21,10 +21,10 @@ export interface ConfigErrorScreenProps {
  */
 export function ConfigErrorScreen({errors, docsUrl}: ConfigErrorScreenProps) {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background-subtle-base px-24 py-32">
+    <main className="flex min-h-screen items-center justify-center bg-background-subtle-base px-frame py-frame">
       <Card className="w-full max-w-[512px]">
         <CardHeader>
-          <div className="flex items-center gap-8">
+          <div className="flex items-center gap-inline">
             <Icon name="errorWarningLine" className="size-20 text-tag-error-icon" />
             <CardTitle variant="h2">Configuration error</CardTitle>
           </div>
@@ -38,7 +38,7 @@ export function ConfigErrorScreen({errors, docsUrl}: ConfigErrorScreenProps) {
           {errors.map((error) => (
             <div
               key={error.key}
-              className="flex flex-col gap-4 border-t border-border-neutral-base py-12 first:border-t-0 first:pt-0"
+              className="flex flex-col gap-tight border-t border-border-neutral-base py-row first:border-t-0 first:pt-0"
             >
               <Code variant="label" bold className="text-foreground-neutral-base">
                 {error.key}

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -222,7 +222,7 @@ export function InvitationAcceptPage() {
     const loginHref = `/auth/login?redirect=${encodeURIComponent(redirect)}`;
     return (
       <AuthShell title={data.workspaceName} description={inviterLine}>
-        <div className="flex flex-col gap-16">
+        <div className="flex flex-col gap-group">
           <Button asChild className="w-full">
             <Link to={signupHref}>Create account</Link>
           </Button>
@@ -247,7 +247,7 @@ export function InvitationAcceptPage() {
         <Callout role="alert" type="warning">
           You're signed in as {auth.user?.email}, but this invitation is for {data.email}.
         </Callout>
-        <div className="flex flex-col gap-16">
+        <div className="flex flex-col gap-group">
           <Button asChild className="w-full">
             <Link to={logoutHref}>Log out and continue</Link>
           </Button>
@@ -315,7 +315,7 @@ export function InvitationAcceptPage() {
 
   return (
     <AuthShell title={data.workspaceName} description={inviterLine}>
-      <div className="flex flex-col items-center gap-12" aria-live="polite">
+      <div className="flex flex-col items-center gap-cluster" aria-live="polite">
         <ShipfoxLoader />
         <Text size="sm" className="text-foreground-neutral-subtle">
           Adding you to {data.workspaceName}…
@@ -327,7 +327,7 @@ export function InvitationAcceptPage() {
 
 function CenteredLoader() {
   return (
-    <div className="flex justify-center py-16" aria-busy="true">
+    <div className="flex justify-center py-row" aria-busy="true">
       <ShipfoxLoader />
     </div>
   );

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -65,10 +65,10 @@ function AgentSessionRowView({
           data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
         >
           <LogContent className="text-foreground-neutral-base">
-            <span className="flex min-w-0 items-start gap-8">
+            <span className="flex min-w-0 items-start gap-inline">
               <MessageIcon role={row.role} terminalFailure={row.terminalFailure} />
-              <span className="flex min-w-0 flex-1 flex-col gap-2">
-                <span className="flex min-w-0 items-center gap-8">
+              <span className="flex min-w-0 flex-1 flex-col gap-tight">
+                <span className="flex min-w-0 items-center gap-inline">
                   <MessageRoleLabel label={row.label} terminalFailure={row.terminalFailure} />
                   <RowMetadata meta={row.meta} className="ml-auto flex-none" />
                 </span>
@@ -106,7 +106,7 @@ function AgentSessionRowView({
             summary={compactPreview(row.summary ?? row.input)}
             trailing={
               awaitingResult ? (
-                <span className="inline-flex items-center gap-4">
+                <span className="inline-flex items-center gap-tight">
                   <Icon
                     name="loader4Line"
                     className="size-12 motion-safe:animate-spin"
@@ -117,7 +117,7 @@ function AgentSessionRowView({
               ) : null
             }
           >
-            <span className="inline-flex min-w-0 items-center gap-6">
+            <span className="inline-flex min-w-0 items-center gap-inline">
               <Icon name="terminalBoxLine" className="size-14 flex-none" aria-hidden="true" />
               <span className="truncate">tool {row.name}</span>
             </span>
@@ -155,7 +155,7 @@ function AgentSessionRowView({
             trailing={
               <span
                 className={cn(
-                  'inline-flex items-center gap-4',
+                  'inline-flex items-center gap-tight',
                   row.isError ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
                 )}
               >
@@ -168,7 +168,7 @@ function AgentSessionRowView({
               </span>
             }
           >
-            <span className="inline-flex min-w-0 items-center gap-6">
+            <span className="inline-flex min-w-0 items-center gap-inline">
               <Icon name="terminalWindowLine" className="size-14 flex-none" aria-hidden="true" />
               <span className="truncate">result {toolName}</span>
             </span>
@@ -194,7 +194,7 @@ function AgentSessionRowView({
           data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
         >
           <LogContent className="text-foreground-neutral-muted">
-            <span className="inline-flex w-full items-center gap-8">
+            <span className="inline-flex w-full items-center gap-inline">
               <Icon name="informationLine" className="size-14 flex-none" aria-hidden="true" />
               <span className="min-w-0">
                 <span className="font-medium">{row.label}</span>
@@ -222,7 +222,7 @@ function AgentSessionRowView({
             summary={compactPreview(row.raw)}
             className="text-orange-600 dark:text-orange-400"
           >
-            <span className="inline-flex min-w-0 items-center gap-6">
+            <span className="inline-flex min-w-0 items-center gap-inline">
               <Icon name="errorWarningLine" className="size-14 flex-none" aria-hidden="true" />
               <span className="truncate">{row.label}</span>
             </span>
@@ -252,7 +252,7 @@ function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: bo
     <Icon
       name={name}
       className={cn(
-        'mt-2 size-14 flex-none',
+        'mt-[2px] size-14 flex-none',
         terminalFailure ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
       )}
       aria-hidden="true"
@@ -307,8 +307,8 @@ function MetadataTrigger({meta}: {meta: readonly SessionViewRowMeta[]}) {
           <Icon name="informationLine" className="size-12" aria-hidden="true" />
         </button>
       </TooltipTrigger>
-      <TooltipContent align="end" variant="inverted" className="max-w-360 px-8 py-6">
-        <span className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-8 gap-y-2 font-code text-xs">
+      <TooltipContent align="end" variant="inverted" className="max-w-360 p-tight">
+        <span className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-[var(--space-inline)] gap-y-[var(--space-tight)] font-code text-xs">
           {meta.map((item) => (
             <Fragment key={`${item.label}-${item.value}`}>
               <span className="text-foreground-contrast-secondary">{item.label}</span>
@@ -335,7 +335,7 @@ function PreviewText({text}: {text: string}) {
         <button
           type="button"
           aria-expanded={expanded}
-          className="ml-8 inline-flex min-h-24 items-center rounded-4 px-6 font-display text-xs text-foreground-highlight-interactive focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)]"
+          className="ms-inline inline-flex min-h-24 items-center rounded-4 px-tight font-display text-xs text-foreground-highlight-interactive focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)]"
           onClick={() => setExpanded((value) => !value)}
         >
           {expanded ? 'show less' : 'show more'}

--- a/libs/client/logs/src/components/log-group.tsx
+++ b/libs/client/logs/src/components/log-group.tsx
@@ -46,7 +46,7 @@ function GroupStatus({node, terminated}: {node: GroupLogNode; terminated: boolea
   }
 
   return (
-    <span className="inline-flex items-center gap-4 text-foreground-neutral-muted">
+    <span className="inline-flex items-center gap-tight text-foreground-neutral-muted">
       <Icon name="loader4Line" className="size-12 motion-safe:animate-spin" aria-hidden="true" />
       running
     </span>

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -110,7 +110,7 @@ export function LogViewSkeleton({
       {skeletonRows.map((row) => (
         <LogRow key={row.id} lineNumber={row.lineNumber}>
           <Skeleton
-            className={`my-4 h-12 ${widths[(row.lineNumber - 1) % widths.length] ?? 'w-[48%]'}`}
+            className={`my-[4px] h-12 ${widths[(row.lineNumber - 1) % widths.length] ?? 'w-[48%]'}`}
           />
         </LogRow>
       ))}
@@ -155,7 +155,7 @@ function NoOutputRow({state}: {state: NonNullable<LogViewProps['emptyState']>}) 
   return (
     <LogRow lineNumber={null}>
       <LogContent className="text-foreground-neutral-muted">
-        <span className="inline-flex min-w-0 items-center gap-8">
+        <span className="inline-flex min-w-0 items-center gap-inline">
           <Icon name="info" className="size-14 flex-none" aria-hidden="true" />
           <span className="min-w-0">
             <span className="font-medium">{copy.title}</span>

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -52,7 +52,7 @@ function LogMarkerRow({
       data-log-terminal-failure={terminalFailure ? 'true' : undefined}
     >
       <LogContent className={cn('block', toneText[tone])}>
-        <span className="inline-flex w-full items-center gap-8">
+        <span className="inline-flex w-full items-center gap-inline">
           <Icon name={icon} className="size-14 flex-none" aria-hidden="true" />
           {/* Label, detail, and figures share one text cluster joined by a literal
               " · ". Flex `gap` is visual only and would copy with no separator, so the

--- a/libs/client/secrets/src/components/delete-entry-dialog.tsx
+++ b/libs/client/secrets/src/components/delete-entry-dialog.tsx
@@ -33,7 +33,7 @@ export function DeleteEntryDialog({
             Delete <strong>{entryKey}</strong>?
           </ModalTitle>
         </ModalHeader>
-        <ModalBody className="gap-16">
+        <ModalBody className="gap-group">
           <Text size="sm">
             Workflows that reference <strong>{entryKey}</strong> will fail at their next run.
           </Text>

--- a/libs/client/secrets/src/components/form-shell.tsx
+++ b/libs/client/secrets/src/components/form-shell.tsx
@@ -10,7 +10,7 @@ export function FormBody({children, className}: {children: ReactNode; className?
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start gap-16 bg-background-neutral-base px-24 pt-16 pb-24',
+        'flex w-full flex-col items-start gap-group bg-background-neutral-base p-panel',
         className,
       )}
     >
@@ -23,7 +23,7 @@ export function FormFooter({children}: {children: ReactNode}) {
   return (
     <div className="flex w-full shrink-0 flex-col">
       <div className="h-[1px] w-full bg-border-neutral-strong" />
-      <div className="flex w-full items-center justify-end gap-16 bg-background-neutral-base px-24 py-16">
+      <div className="flex w-full items-center justify-end gap-group bg-background-neutral-base px-frame py-row">
         {children}
       </div>
     </div>

--- a/libs/client/secrets/src/components/form-shell.tsx
+++ b/libs/client/secrets/src/components/form-shell.tsx
@@ -10,7 +10,7 @@ export function FormBody({children, className}: {children: ReactNode; className?
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start gap-group bg-background-neutral-base px-frame pt-[16px] pb-[24px]',
+        'flex w-full flex-col items-start gap-group bg-background-neutral-base px-frame pt-[16px] pb-panel',
         className,
       )}
     >

--- a/libs/client/secrets/src/components/form-shell.tsx
+++ b/libs/client/secrets/src/components/form-shell.tsx
@@ -10,7 +10,7 @@ export function FormBody({children, className}: {children: ReactNode; className?
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start gap-group bg-background-neutral-base px-frame pt-[16px] pb-panel',
+        'flex w-full flex-col items-start gap-group bg-background-neutral-base px-frame pt-[16px] pb-[24px]',
         className,
       )}
     >

--- a/libs/client/secrets/src/components/form-shell.tsx
+++ b/libs/client/secrets/src/components/form-shell.tsx
@@ -10,7 +10,7 @@ export function FormBody({children, className}: {children: ReactNode; className?
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start gap-group bg-background-neutral-base p-panel',
+        'flex w-full flex-col items-start gap-group bg-background-neutral-base px-frame pt-[16px] pb-panel',
         className,
       )}
     >
@@ -23,7 +23,7 @@ export function FormFooter({children}: {children: ReactNode}) {
   return (
     <div className="flex w-full shrink-0 flex-col">
       <div className="h-[1px] w-full bg-border-neutral-strong" />
-      <div className="flex w-full items-center justify-end gap-group bg-background-neutral-base px-frame py-row">
+      <div className="flex w-full items-center justify-end gap-group bg-background-neutral-base px-frame py-[16px]">
         {children}
       </div>
     </div>

--- a/libs/client/secrets/src/components/secret-form.tsx
+++ b/libs/client/secrets/src/components/secret-form.tsx
@@ -76,7 +76,7 @@ export function SecretForm({
       <FormBody>
         <form
           id={SECRET_FORM_ID}
-          className="flex w-full flex-col gap-16"
+          className="flex w-full flex-col gap-group"
           noValidate
           onSubmit={(event) => {
             event.preventDefault();
@@ -125,7 +125,9 @@ export function SecretForm({
                 <div className="relative">
                   <FormFieldTextarea
                     className={
-                      showValue ? 'pr-32 font-code' : 'pr-32 font-code [-webkit-text-security:disc]'
+                      showValue
+                        ? 'pr-[32px] font-code'
+                        : 'pr-[32px] font-code [-webkit-text-security:disc]'
                     }
                     autoComplete="off"
                     spellCheck={false}

--- a/libs/client/secrets/src/components/store-section-shell.tsx
+++ b/libs/client/secrets/src/components/store-section-shell.tsx
@@ -10,7 +10,7 @@ export function StoreRowsSkeleton({label}: {label: string}) {
     <div role="status" aria-label={label} className={STORE_SURFACE_CLASS}>
       <ul className="divide-y divide-border-neutral-base">
         {[0, 1, 2].map((row) => (
-          <li key={row} className="flex items-center gap-12 px-16 py-12">
+          <li key={row} className="flex items-center gap-cluster px-row py-row">
             <Skeleton className="h-16 w-140" />
             <Skeleton className="h-16 w-96" />
             <Skeleton className="ml-auto h-14 w-80 shrink-0" />

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -94,7 +94,7 @@ export function VariableForm({
       <FormBody>
         <form
           id={VARIABLE_FORM_ID}
-          className="flex w-full flex-col gap-16"
+          className="flex w-full flex-col gap-group"
           noValidate
           onSubmit={(event) => {
             event.preventDefault();

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -54,9 +54,9 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
 
   return (
     <RelativeTimeProvider>
-      <section className="flex flex-col gap-16" aria-label="Secrets">
-        <div className="flex items-start justify-between gap-16">
-          <div className="flex flex-col gap-4">
+      <section className="flex flex-col gap-group" aria-label="Secrets">
+        <div className="flex items-start justify-between gap-group">
+          <div className="flex flex-col gap-tight">
             <Header variant="h3">Secrets</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
               {SECRETS_DESCRIPTION}
@@ -70,13 +70,13 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
         {secretsQuery.isPending ? <StoreRowsSkeleton label="Loading secrets" /> : null}
 
         {secretsQuery.isError && secretsQuery.data === undefined ? (
-          <StoreSurface className="px-16">
+          <StoreSurface className="px-row">
             <QueryLoadError query={secretsQuery} subject="secrets" />
           </StoreSurface>
         ) : null}
 
         {secretsQuery.data !== undefined && secrets.length === 0 ? (
-          <StoreSurface className="px-16">
+          <StoreSurface className="px-row">
             <EmptyState
               icon="keyLine"
               title="No secrets yet"

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -54,9 +54,9 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
 
   return (
     <RelativeTimeProvider>
-      <section className="flex flex-col gap-16" aria-label="Variables">
-        <div className="flex items-start justify-between gap-16">
-          <div className="flex flex-col gap-4">
+      <section className="flex flex-col gap-group" aria-label="Variables">
+        <div className="flex items-start justify-between gap-group">
+          <div className="flex flex-col gap-tight">
             <Header variant="h3">Variables</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
               {VARIABLES_DESCRIPTION}
@@ -70,13 +70,13 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
         {variablesQuery.isPending ? <StoreRowsSkeleton label="Loading variables" /> : null}
 
         {variablesQuery.isError && variablesQuery.data === undefined ? (
-          <StoreSurface className="px-16">
+          <StoreSurface className="px-row">
             <QueryLoadError query={variablesQuery} subject="variables" />
           </StoreSurface>
         ) : null}
 
         {variablesQuery.data !== undefined && variables.length === 0 ? (
-          <StoreSurface className="px-16">
+          <StoreSurface className="px-row">
             <EmptyState
               icon="bracesLine"
               title="No variables yet"

--- a/libs/client/shell/src/components/auth-shell.tsx
+++ b/libs/client/shell/src/components/auth-shell.tsx
@@ -20,7 +20,7 @@ export function AuthShell({
   headingRef,
 }: AuthShellProps) {
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background-subtle-base px-24 py-32 max-[520px]:items-start max-[520px]:px-20 max-[520px]:pb-32 max-[520px]:pt-56">
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background-subtle-base px-frame py-frame max-[520px]:items-start max-[520px]:px-row max-[520px]:pt-[56px]">
       <div
         className="pointer-events-none absolute left-1/2 top-0 h-[380px] w-full max-w-[880px] -translate-x-1/2 -translate-y-[120px] opacity-55 max-[520px]:-translate-y-[170px] max-[520px]:opacity-35"
         aria-hidden="true"
@@ -34,14 +34,16 @@ export function AuthShell({
         <div className="h-full w-full bg-[radial-gradient(circle,rgba(230,62,0,0.48)_1.6px,transparent_1.8px)] bg-[length:44px_44px]" />
       </div>
       <section
-        className={className ?? 'relative flex w-full max-w-[384px] flex-col items-stretch gap-28'}
+        className={
+          className ?? 'relative flex w-full max-w-[384px] flex-col items-stretch gap-region'
+        }
         aria-labelledby="auth-title"
       >
-        <div className="flex flex-col items-center gap-16">
-          <div className="flex size-64 items-center justify-center rounded-12 border border-border-neutral-base bg-background-neutral-base p-10 shadow-button-neutral">
+        <div className="flex flex-col items-center gap-group">
+          <div className="flex size-64 items-center justify-center rounded-12 border border-border-neutral-base bg-background-neutral-base p-tight shadow-button-neutral">
             <Icon name="shipfox" className="size-42 text-background-highlight-interactive" />
           </div>
-          <div className="flex min-w-[128px] flex-col items-center gap-4 text-center">
+          <div className="flex min-w-[128px] flex-col items-center gap-tight text-center">
             <Header
               id="auth-title"
               variant="h1"
@@ -63,5 +65,5 @@ export function AuthShell({
 }
 
 export function AuthActions({children}: PropsWithChildren) {
-  return <div className="flex flex-col gap-20">{children}</div>;
+  return <div className="flex flex-col gap-section">{children}</div>;
 }

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -39,7 +39,7 @@ export function MainLayout({
         </main>
       ) : (
         <main className={`flex-1 overflow-auto ${appContentHeight}`}>
-          <div className="max-w-[1120px] mx-auto px-24 py-32">
+          <div className="max-w-[1120px] mx-auto px-frame py-frame">
             <Outlet />
           </div>
         </main>

--- a/libs/client/shell/src/components/nav-bar.tsx
+++ b/libs/client/shell/src/components/nav-bar.tsx
@@ -9,7 +9,7 @@ export function NavBar({hideProjectNavigation = false}: {hideProjectNavigation?:
   const workspace = useActiveWorkspace();
   const {ProjectBreadcrumb} = useChrome();
   return (
-    <header className="sticky top-0 z-30 h-56 px-16 flex items-center gap-12 bg-background-subtle-base border-b border-border-neutral-base shrink-0">
+    <header className="sticky top-0 z-30 h-56 px-row flex items-center gap-cluster bg-background-subtle-base border-b border-border-neutral-base shrink-0">
       <Link
         to="/"
         aria-label="Shipfox home"

--- a/libs/client/shell/src/components/nav-tabs.tsx
+++ b/libs/client/shell/src/components/nav-tabs.tsx
@@ -14,7 +14,7 @@ export function NavTabs({
   const reduced = useReducedMotion();
   const tabs = entries.filter((entry) => entry.scope === scope);
   const projectScoped = scope === 'project';
-  const tabClassName = `h-40 inline-flex shrink-0 items-center whitespace-nowrap px-4 ${projectScoped ? 'text-xs' : 'text-sm'} font-medium transition-colors ${reduced ? '' : 'transition-[border-color]'}`;
+  const tabClassName = `h-40 inline-flex shrink-0 items-center whitespace-nowrap px-tight ${projectScoped ? 'text-xs' : 'text-sm'} font-medium transition-colors ${reduced ? '' : 'transition-[border-color]'}`;
   const activeProps = {
     className: projectScoped
       ? 'border-b border-border-highlights-interactive text-foreground-neutral-base'
@@ -30,7 +30,7 @@ export function NavTabs({
     <div
       role="tablist"
       aria-label={`${scope === 'project' ? 'Project' : 'Workspace'} sections`}
-      className="sticky top-56 z-20 flex h-40 items-end gap-12 overflow-x-auto whitespace-nowrap border-b border-border-neutral-base bg-background-subtle-base px-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="sticky top-56 z-20 flex h-40 items-end gap-cluster overflow-x-auto whitespace-nowrap border-b border-border-neutral-base bg-background-subtle-base px-row [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       {tabs.map((entry) => (
         <Link

--- a/libs/client/shell/src/components/not-found-page.tsx
+++ b/libs/client/shell/src/components/not-found-page.tsx
@@ -3,7 +3,7 @@ import {Link} from '@tanstack/react-router';
 
 export function NotFoundPage() {
   return (
-    <main className="mx-auto max-w-[960px] px-24 py-48">
+    <main className="mx-auto max-w-[960px] px-frame py-[48px]">
       <Header variant="h1">Page not found</Header>
       <Text size="md" className="text-foreground-neutral-muted">
         This Shipfox page does not exist.

--- a/libs/client/shell/src/components/settings-nav.tsx
+++ b/libs/client/shell/src/components/settings-nav.tsx
@@ -33,7 +33,7 @@ export function SettingsNav({
   return (
     <nav
       aria-label={`${scope === 'workspace' ? 'Workspace' : 'Project'} settings`}
-      className="flex flex-col gap-4"
+      className="flex flex-col gap-tight"
     >
       {scopedEntries.map((entry) => {
         const to = `${settingsPath}/${entry.pathSegment}`;

--- a/libs/client/shell/src/components/workspace-crumb.tsx
+++ b/libs/client/shell/src/components/workspace-crumb.tsx
@@ -13,12 +13,12 @@ export interface WorkspaceCrumbProps {
 export function WorkspaceCrumb({workspace, compact = false}: WorkspaceCrumbProps) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="flex items-center">
+    <div className="flex items-center gap-tight">
       <Link
         to="/w/$workspaceSlug"
         params={{workspaceSlug: workspace.slug}}
         aria-current="page"
-        className={`inline-block text-md font-medium text-foreground-neutral-base px-6 py-4 rounded-6 hover:bg-background-components-hover transition-colors truncate ${compact ? 'max-w-[120px] sm:max-w-[200px]' : 'max-w-[200px]'}`}
+        className={`inline-block text-md font-medium text-foreground-neutral-base p-tight rounded-6 hover:bg-background-components-hover transition-colors truncate ${compact ? 'max-w-[120px] sm:max-w-[200px]' : 'max-w-[200px]'}`}
       >
         {workspace.name}
       </Link>
@@ -29,7 +29,7 @@ export function WorkspaceCrumb({workspace, compact = false}: WorkspaceCrumbProps
             aria-label="Switch workspace"
             aria-haspopup="listbox"
             aria-expanded={open}
-            className="ml-2 grid place-items-center size-24 rounded-4 text-foreground-neutral-muted hover:bg-background-components-hover hover:text-foreground-neutral-base transition-colors"
+            className="grid place-items-center size-24 rounded-4 text-foreground-neutral-muted hover:bg-background-components-hover hover:text-foreground-neutral-base transition-colors"
           >
             <Icon name="arrowDownSLine" className="size-16" />
           </button>

--- a/libs/client/shell/src/components/workspace-switcher.tsx
+++ b/libs/client/shell/src/components/workspace-switcher.tsx
@@ -39,7 +39,7 @@ export function WorkspaceSwitcher({
     <Command>
       <CommandInput placeholder="Search workspaces..." />
       <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
-        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-4 scrollbar">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-tight scrollbar">
           <CommandEmpty>No workspaces found.</CommandEmpty>
           <CommandGroup heading="Workspaces">
             {workspaces.map((workspace) => (
@@ -51,7 +51,7 @@ export function WorkspaceSwitcher({
               >
                 <Icon
                   name="check"
-                  className={`size-16 mr-8 ${activeWorkspaceId === workspace.id ? 'opacity-100' : 'opacity-0'}`}
+                  className={`size-16 ${activeWorkspaceId === workspace.id ? 'opacity-100' : 'opacity-0'}`}
                 />
                 {workspace.name}
               </CommandItem>
@@ -59,7 +59,7 @@ export function WorkspaceSwitcher({
           </CommandGroup>
         </div>
         <CommandSeparator alwaysRender className="mx-0" />
-        <CommandGroup forceMount className="p-4">
+        <CommandGroup forceMount className="p-tight">
           <CommandItem
             value="__create"
             onSelect={() => {

--- a/libs/client/shell/src/components/workspace-switcher.tsx
+++ b/libs/client/shell/src/components/workspace-switcher.tsx
@@ -39,7 +39,7 @@ export function WorkspaceSwitcher({
     <Command>
       <CommandInput placeholder="Search workspaces..." />
       <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
-        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-tight scrollbar">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-[4px] scrollbar">
           <CommandEmpty>No workspaces found.</CommandEmpty>
           <CommandGroup heading="Workspaces">
             {workspaces.map((workspace) => (
@@ -59,7 +59,7 @@ export function WorkspaceSwitcher({
           </CommandGroup>
         </div>
         <CommandSeparator alwaysRender className="mx-0" />
-        <CommandGroup forceMount className="p-tight">
+        <CommandGroup forceMount className="p-[4px]">
           <CommandItem
             value="__create"
             onSelect={() => {

--- a/libs/client/shell/src/components/workspace-switcher.tsx
+++ b/libs/client/shell/src/components/workspace-switcher.tsx
@@ -39,7 +39,7 @@ export function WorkspaceSwitcher({
     <Command>
       <CommandInput placeholder="Search workspaces..." />
       <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
-        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-[4px] scrollbar">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-menu-surface scrollbar">
           <CommandEmpty>No workspaces found.</CommandEmpty>
           <CommandGroup heading="Workspaces">
             {workspaces.map((workspace) => (
@@ -59,7 +59,7 @@ export function WorkspaceSwitcher({
           </CommandGroup>
         </div>
         <CommandSeparator alwaysRender className="mx-0" />
-        <CommandGroup forceMount className="p-[4px]">
+        <CommandGroup forceMount className="p-menu-surface">
           <CommandItem
             value="__create"
             onSelect={() => {

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -162,15 +162,15 @@ function SettingsAnchorLayout({
   if (!params.workspaceSlug || (scope === 'project' && !params.projectSlug)) return null;
 
   return (
-    <div className="flex w-full flex-col gap-24">
-      <header className="flex flex-col gap-6">
+    <div className="flex w-full flex-col gap-section">
+      <header className="flex flex-col gap-inline">
         <Header variant="h2">{title}</Header>
         <Text size="sm" className="text-foreground-neutral-muted">
           {description}
         </Text>
       </header>
 
-      <div className="grid grid-cols-[180px_minmax(0,1fr)] gap-32 max-[760px]:grid-cols-1">
+      <div className="grid grid-cols-[180px_minmax(0,1fr)] gap-region max-[760px]:grid-cols-1">
         <SettingsNav entries={settingsSections} scope={scope} />
         <Outlet />
       </div>

--- a/libs/client/shell/src/runtime/workspace-setup.tsx
+++ b/libs/client/shell/src/runtime/workspace-setup.tsx
@@ -32,8 +32,8 @@ export function WorkspaceSetupPending() {
 
 export function WorkspaceUnavailablePage({workspaceName}: {workspaceName?: string | undefined}) {
   return (
-    <main className="min-h-screen bg-background-subtle-base px-24 py-32 max-[520px]:px-16">
-      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-12">
+    <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
+      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-cluster">
         <Header variant="h1">Workspace unavailable</Header>
         <Text size="md" className="text-foreground-neutral-muted">
           {workspaceName
@@ -59,11 +59,11 @@ export function WorkspaceLayoutErrorRoute({error, reset}: ErrorComponentProps) {
         ? error.cause.message
         : 'Try again in a moment.';
   return (
-    <main className="min-h-screen bg-background-subtle-base px-24 py-32 max-[520px]:px-16">
-      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-24">
+    <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
+      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-section">
         <Header variant="h1">{setupError ? 'Workspace setup' : 'Workspace'}</Header>
         <Callout role="alert" type="error">
-          <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-inline">
             <Text size="sm" bold>
               {setupError ? 'Could not load workspace setup' : 'Could not load workspace'}
             </Text>

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -52,7 +52,7 @@ export function WorkspaceMembersSettingsSection({
   workspaceName: string;
 }) {
   return (
-    <div className="flex min-w-0 flex-col gap-32">
+    <div className="flex min-w-0 flex-col gap-region">
       <MembersSection workspaceId={workspaceId} workspaceName={workspaceName} />
       <PendingInvitationsSection workspaceId={workspaceId} workspaceName={workspaceName} />
     </div>
@@ -71,8 +71,8 @@ function MembersSection({
   const members = query.data ?? [];
 
   return (
-    <section className="flex flex-col gap-16">
-      <div className="flex flex-col gap-4">
+    <section className="flex flex-col gap-group">
+      <div className="flex flex-col gap-tight">
         <Header variant="h3">Members</Header>
         <Text size="sm" className="text-foreground-neutral-muted">
           {query.isPending
@@ -206,9 +206,9 @@ function PendingInvitationsSection({
   const [inviteOpen, setInviteOpen] = useState(false);
 
   return (
-    <section className="flex flex-col gap-16">
-      <div className="flex items-center justify-between gap-16">
-        <div className="flex flex-col gap-4">
+    <section className="flex flex-col gap-group">
+      <div className="flex items-center justify-between gap-group">
+        <div className="flex flex-col gap-tight">
           <Header variant="h3">Pending invitations</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
             {query.isPending
@@ -285,7 +285,7 @@ function InvitationRow({
       </TableCell>
       <TableCell>{invitation.invitedByDisplay ?? 'N/A'}</TableCell>
       <TableCell>
-        <div className="flex items-center gap-8">
+        <div className="flex items-center gap-inline">
           <Text size="sm">{formatDate(invitation.expiresAt)}</Text>
           {expiry === 'expires-soon' ? <Badge variant="warning">Soon</Badge> : null}
           {expiry === 'expired' ? <Badge variant="error">Expired</Badge> : null}
@@ -390,7 +390,7 @@ function InviteMemberModal({
         <ModalHeader>
           <Text size="lg">Invite a member</Text>
         </ModalHeader>
-        <ModalBody className="gap-16">
+        <ModalBody className="gap-group">
           {formError ? (
             <Callout role="alert" type="error">
               {formError}
@@ -398,7 +398,7 @@ function InviteMemberModal({
           ) : null}
           <form
             id="invite-member-form"
-            className="flex flex-col gap-16"
+            className="flex flex-col gap-group"
             noValidate
             onSubmit={(event) => {
               event.preventDefault();
@@ -459,10 +459,10 @@ function EmptyInvitations() {
 
 function TableSkeleton({rows, cols}: {rows: number; cols: number}) {
   return (
-    <div className="flex flex-col gap-12">
+    <div className="flex flex-col gap-cluster">
       {Array.from({length: rows}).map((_, rowIdx) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder rows
-        <div key={rowIdx} className="grid grid-cols-3 gap-16">
+        <div key={rowIdx} className="grid grid-cols-3 gap-group">
           {Array.from({length: cols}).map((__, colIdx) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder cells
             <Skeleton key={colIdx} className="h-20" />

--- a/libs/client/workspace-settings/src/pages/general-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/general-settings-page.tsx
@@ -94,8 +94,8 @@ function WorkspaceGeneralForm({workspace}: {workspace: ReturnType<typeof useActi
 
   return (
     <>
-      <div className="flex min-w-0 flex-col gap-24">
-        <header className="flex flex-col gap-6">
+      <div className="flex min-w-0 flex-col gap-section">
+        <header className="flex flex-col gap-inline">
           <Header variant="h1">General</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
             Update the workspace name and the slug used in its URLs.
@@ -109,7 +109,7 @@ function WorkspaceGeneralForm({workspace}: {workspace: ReturnType<typeof useActi
         ) : null}
 
         <form
-          className="flex max-w-[560px] flex-col gap-16"
+          className="flex max-w-[560px] flex-col gap-group"
           noValidate
           onSubmit={(event) => {
             event.preventDefault();

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -348,6 +348,7 @@
   --margin-page: 48px;
 
   --pad-tight: 8px;
+  --pad-menu-surface: 4px;
   --pad-row-x: 16px;
   --pad-row-y: 12px;
   --pad-panel-compact: 16px;
@@ -445,6 +446,7 @@
   --margin-page: 32px;
 
   --pad-tight: 4px;
+  --pad-menu-surface: 2px;
   --pad-row-x: 12px;
   --pad-row-y: 8px;
   --pad-panel-compact: 12px;
@@ -1059,12 +1061,20 @@
   padding: var(--pad-tight);
 }
 
+@utility p-menu-surface {
+  padding: var(--pad-menu-surface);
+}
+
 @utility p-panel-compact {
   padding: var(--pad-panel-compact);
 }
 
 @utility p-panel {
   padding: var(--pad-panel);
+}
+
+@utility pb-panel {
+  padding-bottom: var(--pad-panel);
 }
 
 @utility px-tight {

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -175,7 +175,7 @@ describe('client-architecture Biome plugins', () => {
     assert.doesNotMatch(`${stdout}${stderr}`, rawSpacingRulePattern);
   });
 
-  test('registers no-raw-spacing for the migrated docs app', async () => {
+  test('registers no-raw-spacing for the migrated client surfaces', async () => {
     const rootConfig = JSON.parse(await readFile(resolve(workspaceRoot, 'biome.json'), 'utf8')) as {
       plugins: {includes: string[]; path: string}[];
     };
@@ -187,6 +187,13 @@ describe('client-architecture Biome plugins', () => {
       path: './tools/biome/plugins/client-architecture/no-raw-spacing.grit',
       includes: [
         '**/apps/docs/**',
+        '**/libs/client/shell/**',
+        '**/libs/client/auth/**',
+        '**/libs/client/secrets/**',
+        '**/libs/client/logs/**',
+        '**/libs/client/workspace-settings/**',
+        '**/libs/client/config/**',
+        '**/libs/client/invitations/**',
         '!**/dist/**',
         '!**/node_modules/**',
         '!**/*.test.ts',


### PR DESCRIPTION
Migrate the seven tier 2 client surfaces from raw numeric spacing utilities to the shared semantic spacing roles.

The PR also enables `no-raw-spacing` for those packages, updates its configuration test, documents the spacing taxonomy and compact-density behavior in `DESIGN.md`, and includes the required Changeset for the published client group.

Validation passed through the scoped check, type, and test closure, including the Biome plugin suite and Storybook coverage. The prose verifier completed with zero errors.

Closes ENG-1466

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates seven client surfaces to shared semantic spacing with compact‑aware menu/panel roles and enforces `no-raw-spacing`, while preserving secret form and workspace switcher spacing. Addresses ENG-1466.

- **Refactors**
  - Replaced raw spacing with semantic roles across `@shipfox/client-shell`, `@shipfox/client-auth`, `@shipfox/client-secrets`, `@shipfox/client-logs`, `@shipfox/client-workspace-settings`, `@shipfox/client-config`, and `@shipfox/client-invitations`.
  - Added `p-menu-surface`, `p-panel`, `pb-panel`, and `p-panel-compact`; documented full role matrix and compact values in DESIGN.md; updated `@shipfox/react-ui` and docs styles.
  - Expanded Biome `no-raw-spacing` includes to these packages and updated the plugin test.
  - Preserved spacing parity in secret forms and workspace switchers using semantic roles and bracketed pixels only where necessary.
  - Added a Changeset with patch releases for the seven client packages and `@shipfox/react-ui`.

- **Migration**
  - Use roles like `gap-tight/inline/cluster/group/section/region`, `p-menu-surface`, `p/pb-panel`, `px/py-row`, `p-panel-compact`, `px/py-frame`, `ms-inline`, `my-region`, `mt-page`; raw spacing utilities now fail linting.
  - Set `data-density="compact"` on a parent to apply compact values automatically.
  - Prefer parent `gap-*` over child margins; use `-mt-inline`/`-mr-inline` only for optical alignment. Use bracketed pixel values only for fixed offsets or to preserve existing dimensions.

<sup>Written for commit 922a9cf43e6135bce4d685a133aae52bf032c350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

