### PR TITLE
Fix published React UI subpath resolution

### DIFF
--- a/.changeset/eng-1474-storybook-react-ui-exports.md
+++ b/.changeset/eng-1474-storybook-react-ui-exports.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-ui": patch
+"@shipfox/client-workflows": patch
+"@shipfox/react-ui": patch
+---
+
+Publish the shared UI component artifacts and release `@shipfox/client-ui` with the updated shared UI dependency so fresh consumers and Storybook resolve component subpaths without configuration overrides.

--- a/libs/client/ui/src/react-ui-package-exports.test.ts
+++ b/libs/client/ui/src/react-ui-package-exports.test.ts
@@ -1,0 +1,38 @@
+import {execFileSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from '@shipfox/vitest/vi';
+
+const calloutRuntimePath = /dist\/components\/callout\/index\.js$/;
+const markdownRuntimePath = /dist\/components\/markdown\/index\.js$/;
+const lineBreak = /\r?\n/;
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+
+describe('@shipfox/react-ui published subpath exports', () => {
+  it('resolves Callout and Markdown through Node package exports', () => {
+    const resolutions = execFileSync(
+      process.execPath,
+      [
+        '--conditions=default',
+        '--input-type=module',
+        '-e',
+        [
+          "import {createRequire} from 'node:module';",
+          "const require = createRequire(process.cwd() + '/package.json');",
+          "await import('@shipfox/client-ui');",
+          "console.log(require.resolve('@shipfox/react-ui/callout'));",
+          "console.log(require.resolve('@shipfox/react-ui/markdown'));",
+        ].join('\n'),
+      ],
+      {
+        cwd: packageRoot,
+        encoding: 'utf8',
+        env: {...process.env, NODE_OPTIONS: ''},
+      },
+    );
+
+    expect(resolutions.trim().split(lineBreak)).toEqual([
+      expect.stringMatching(calloutRuntimePath),
+      expect.stringMatching(markdownRuntimePath),
+    ]);
+  });
+});

--- a/libs/client/workflows/.storybook/main.ts
+++ b/libs/client/workflows/.storybook/main.ts
@@ -1,1 +1,16 @@
-export {default} from '../../.storybook/main.ts';
+import type {StorybookConfig} from '@storybook/react-vite';
+import sharedConfig from '../../.storybook/main.ts';
+import {withWorkspaceSource} from './workspace-source.ts';
+
+const config: StorybookConfig = {
+  ...sharedConfig,
+  viteFinal: async (viteConfig, options) => {
+    const sharedViteConfig = sharedConfig.viteFinal
+      ? await sharedConfig.viteFinal(viteConfig, options)
+      : viteConfig;
+
+    return withWorkspaceSource(sharedViteConfig);
+  },
+};
+
+export default config;

--- a/libs/client/workflows/.storybook/workspace-source.ts
+++ b/libs/client/workflows/.storybook/workspace-source.ts
@@ -1,0 +1,31 @@
+import {workspaceSourceResolver} from '@shipfox/vite/workspace-source';
+import type {InlineConfig} from 'vite';
+import {defaultClientConditions, defaultServerConditions} from 'vite';
+
+function withCondition(conditions: readonly string[] | undefined, defaults: readonly string[]) {
+  const resolvedConditions = [...(conditions ?? defaults)];
+
+  if (!resolvedConditions.includes('workspace-source')) {
+    resolvedConditions.push('workspace-source');
+  }
+
+  return resolvedConditions;
+}
+
+export function withWorkspaceSource(config: InlineConfig): InlineConfig {
+  return {
+    ...config,
+    plugins: [...(config.plugins ?? []), workspaceSourceResolver()],
+    resolve: {
+      ...config.resolve,
+      conditions: withCondition(config.resolve?.conditions, defaultClientConditions),
+    },
+    ssr: {
+      ...config.ssr,
+      resolve: {
+        ...config.ssr?.resolve,
+        conditions: withCondition(config.ssr?.resolve?.conditions, defaultServerConditions),
+      },
+    },
+  };
+}

--- a/libs/client/workflows/package.json
+++ b/libs/client/workflows/package.json
@@ -88,6 +88,7 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
+    "@shipfox/vite": "workspace:*",
     "@shipfox/vitest": "workspace:*",
     "@storybook/addon-vitest": "catalog:",
     "@storybook/react": "catalog:",

--- a/libs/client/workflows/src/storybook-config.test.ts
+++ b/libs/client/workflows/src/storybook-config.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from '@shipfox/vitest/vi';
+import {withWorkspaceSource} from '../.storybook/workspace-source';
+
+describe('client-workflows Storybook Vite configuration', () => {
+  it('keeps workspace-source active for client and SSR package resolution', () => {
+    const config = withWorkspaceSource({
+      resolve: {conditions: ['browser']},
+      ssr: {resolve: {conditions: ['node']}},
+    });
+
+    expect(config.resolve?.conditions).toEqual(['browser', 'workspace-source']);
+    expect(config.ssr?.resolve?.conditions).toEqual(['node', 'workspace-source']);
+    expect(config.plugins?.map((plugin) => plugin && 'name' in plugin && plugin.name)).toContain(
+      'shipfox:workspace-source-resolver',
+    );
+  });
+
+  it('does not duplicate an existing workspace-source condition', () => {
+    const config = withWorkspaceSource({
+      resolve: {conditions: ['browser', 'workspace-source']},
+      ssr: {resolve: {conditions: ['node', 'workspace-source']}},
+    });
+
+    expect(config.resolve?.conditions).toEqual(['browser', 'workspace-source']);
+    expect(config.ssr?.resolve?.conditions).toEqual(['node', 'workspace-source']);
+  });
+});

--- a/libs/client/workflows/tsconfig.test.json
+++ b/libs/client/workflows/tsconfig.test.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "include": [
+    "src",
+    "test",
+    ".storybook/workspace-source.ts",
+    "vitest.config.ts",
+    "node_modules/@shipfox/vitest/globals.d.ts"
+  ],
   "exclude": ["**/*.stories.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6144,6 +6144,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+      '@shipfox/vite':
+        specifier: workspace:*
+        version: link:../../../tools/vite
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest


### PR DESCRIPTION
## Summary

Republish the existing generic @shipfox/react-ui component export map with its compiled artifacts and release @shipfox/client-ui with the updated shared UI dependency. The affected client-workflows Storybook now enables the workspace-source condition and resolver so clean workspace builds use the same package graph.

The resolution remains generic through the existing component wildcard; this adds no Callout/Markdown-specific exports and requires no consumer aliases, overrides, or patches. Storybook still reports the existing non-fatal package.json discovery warning, which is outside this fix.

Validated with the client-ui and client-workflows test/type/build scopes, Storybook build, packed artifact inspection, dependency/lockfile checks, and published-artifact verification.

Closes ENG-1474

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subpath resolution for `@shipfox/react-ui` by republishing compiled artifacts with the existing wildcard export map and updating `@shipfox/client-ui` to consume it. Storybook in `client-workflows` now resolves workspace sources consistently via Vite, addressing ENG-1474.

- **Bug Fixes**
  - Republished `@shipfox/react-ui` so subpaths like `/callout` and `/markdown` resolve via package exports without aliases.
  - Updated `@shipfox/client-ui` to depend on the new shared UI build for clean installs.
  - Enabled `workspace-source` in `client-workflows` Storybook by adding the `@shipfox/vite` resolver and `workspace-source` conditions for client and SSR; added tests for both export resolution and Vite config.

<sup>Written for commit ec6fffe5ab1ed1b6157f4967779893a68a539f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

