### PR TITLE
[api-integration-jira] Log Jira webhook registration rejection reasons

### DIFF
--- a/.changeset/jira-webhook-diagnostics.md
+++ b/.changeset/jira-webhook-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-jira": patch
+---
+
+Logs bounded provider reasons when Jira rejects dynamic webhook registration.

--- a/libs/api/integration/jira/src/api/client.test.ts
+++ b/libs/api/integration/jira/src/api/client.test.ts
@@ -2,7 +2,18 @@ import {HTTPError} from 'ky';
 import type {JiraIntegrationProviderError} from '#core/errors.js';
 import {mapJiraError} from './client.js';
 
-const mocks = vi.hoisted(() => ({delete: vi.fn(), post: vi.fn(), request: vi.fn()}));
+const mocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  post: vi.fn(),
+  request: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => ({
+    warn: mocks.warn,
+  }),
+}));
 
 vi.mock('ky', () => {
   class MockHTTPError extends Error {
@@ -77,6 +88,7 @@ describe('Jira dynamic webhook API', () => {
     mocks.delete.mockReset();
     mocks.post.mockReset();
     mocks.request.mockReset();
+    mocks.warn.mockReset();
   });
 
   it('registers the six curated events with the access token', async () => {
@@ -122,6 +134,165 @@ describe('Jira dynamic webhook API', () => {
     {webhookRegistrationResult: [{errors: []}]},
   ])('rejects malformed or errored registration responses', async (response) => {
     mocks.post.mockReturnValue(resolves(response));
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
+  it('logs provider validation errors before rejecting registration', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        webhookRegistrationResult: [
+          {createdWebhookId: 123, errors: ['Webhook URL is not approved', 'Invalid JQL filter']},
+        ],
+      }),
+    );
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {
+        operation: 'register-dynamic-webhook',
+        providerErrors: ['Webhook URL is not approved', 'Invalid JQL filter'],
+        providerErrorCount: 2,
+      },
+      'Jira dynamic webhook registration rejected',
+    );
+  });
+
+  it('limits logged provider errors to five values', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        webhookRegistrationResult: [
+          {
+            errors: ['one', 'two', 'three', 'four', 'five', 'six'],
+          },
+        ],
+      }),
+    );
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {
+        operation: 'register-dynamic-webhook',
+        providerErrors: ['one', 'two', 'three', 'four', 'five'],
+        providerErrorCount: 6,
+      },
+      'Jira dynamic webhook registration rejected',
+    );
+  });
+
+  it('limits each logged provider error to 500 characters', async () => {
+    const longError = 'x'.repeat(501);
+    mocks.post.mockReturnValue(resolves({webhookRegistrationResult: [{errors: [longError]}]}));
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {
+        operation: 'register-dynamic-webhook',
+        providerErrors: ['x'.repeat(500)],
+        providerErrorCount: 1,
+      },
+      'Jira dynamic webhook registration rejected',
+    );
+  });
+
+  it('omits non-string provider errors from the warning', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        webhookRegistrationResult: [
+          {errors: ['valid message', 42, null, {message: 'raw response'}, true]},
+        ],
+      }),
+    );
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {
+        operation: 'register-dynamic-webhook',
+        providerErrors: ['valid message'],
+        providerErrorCount: 5,
+      },
+      'Jira dynamic webhook registration rejected',
+    );
+  });
+
+  it('accepts an empty provider errors array without logging a rejection', async () => {
+    mocks.post.mockReturnValue(
+      resolves({webhookRegistrationResult: [{createdWebhookId: 123, errors: []}]}),
+    );
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).resolves.toEqual({webhookId: 123});
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-array provider errors value without logging it', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        webhookRegistrationResult: [{createdWebhookId: 123, errors: {message: 'do not log me'}}],
+      }),
+    );
+    const {createJiraApiClient} = await import('./client.js');
+
+    await expect(
+      createJiraApiClient().registerDynamicWebhook({
+        accessToken: 'access-token',
+        cloudId: 'cloud-1',
+        url: 'https://shipfox.example.com/webhooks/integrations/jira/connection-1',
+      }),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the malformed provider response reason for a Jira rejection', async () => {
+    mocks.post.mockReturnValue(
+      resolves({webhookRegistrationResult: [{errors: ['Provider rejected the webhook']}]}),
+    );
     const {createJiraApiClient} = await import('./client.js');
 
     await expect(

--- a/libs/api/integration/jira/src/api/client.ts
+++ b/libs/api/integration/jira/src/api/client.ts
@@ -282,7 +282,21 @@ function parseDynamicWebhookRegistration(
     createdWebhookId?: unknown;
     errors?: unknown;
   };
-  if (errors !== undefined && (!Array.isArray(errors) || errors.length > 0)) {
+  if (errors !== undefined && !Array.isArray(errors)) {
+    throw malformed('Jira webhook registration returned errors');
+  }
+  if (Array.isArray(errors) && errors.length > 0) {
+    logger().warn(
+      {
+        operation: 'register-dynamic-webhook',
+        providerErrors: errors
+          .filter((error): error is string => typeof error === 'string')
+          .slice(0, 5)
+          .map((error) => error.slice(0, 500)),
+        providerErrorCount: errors.length,
+      },
+      'Jira dynamic webhook registration rejected',
+    );
     throw malformed('Jira webhook registration returned errors');
   }
   if (


### PR DESCRIPTION
Jira can return HTTP 200 while rejecting dynamic webhook registration. The adapter now records a bounded provider-boundary warning with Jira's string error reasons and original count, then preserves the existing safe malformed-provider-response path.

Non-array response values remain generic, and provider details do not reach the callback or Sentry. The change is limited to the Jira adapter and unit tests, with a patch Changeset for the published package.

After staging deployment, use the captured warning to route the provider-specific remediation. Package check, type, and test validation pass with 118 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs bounded Jira rejection reasons when dynamic webhook registration returns HTTP 200 but is refused. Keeps the existing malformed-provider-response behavior while improving diagnostics in `@shipfox/api-integration-jira`.

- **New Features**
  - Emits a provider-boundary warning via `@shipfox/node-opentelemetry` with up to 5 string errors (each ≤500 chars) and the original error count.
  - Ignores non-string entries; skips logging for empty arrays; still rejects with reason `malformed-provider-response`.
  - Scope limited to the Jira adapter; adds unit tests and a patch changeset for `@shipfox/api-integration-jira`.

<sup>Written for commit 7f1c1423f8ebb000e4bdbe47a5b041d6238c9981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

