### PR TITLE
[client-workflows] Show annotations in workflow runs

### DIFF
--- a/.changeset/run-annotations-surface.md
+++ b/.changeset/run-annotations-surface.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/react-ui": minor
+"@shipfox/client-ui": minor
+"@shipfox/client-workflows": minor
+---
+
+Render run annotations in the run workspace. `AnnotationCard` gains an optional context title, provenance, and action, and bounds a long body behind a disclosure. The run's Annotations section is now the only surface that renders an annotation body, ranked by severity and then emission order, with the job page linking to it through a bounded count chip.
+
+`Markdown` tables now size to their content instead of stretching to the container, so a two-column table no longer puts a cell the width of the page away from its row header.

--- a/libs/client/ui/src/annotation-card.test.tsx
+++ b/libs/client/ui/src/annotation-card.test.tsx
@@ -1,12 +1,20 @@
 import {ThemeProvider} from '@shipfox/react-ui/theme';
-import {render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type {ReactNode} from 'react';
-import {AnnotationCard} from './annotation-card.js';
+import {AnnotationCard, type AnnotationCardProps} from './annotation-card.js';
 
 const styles = ['default', 'info', 'success', 'warning', 'error'] as const;
 const stylesWithDefaultGlyph = ['info', 'success', 'warning', 'error'] as const;
+/** Markdown link syntax that reached the DOM as text, which means the source was cut mid-link. */
+const UNPARSED_LINK_PATTERN = /^\[documentation\]/u;
+const OPEN_DOCUMENTATION_PATTERN = /Open documentation/;
 
 describe('AnnotationCard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test.each(styles)('renders %s annotations as callouts', (style) => {
     const {container} = renderAnnotationCard({style, body: `**${style}** body`});
 
@@ -48,12 +56,158 @@ describe('AnnotationCard', () => {
 
     expect(container.firstChild).toBeNull();
   });
+
+  test('renders the context as a heading at the level the caller asks for', () => {
+    renderAnnotationCard({style: 'error', body: 'Body', title: 'smoke check', titleAs: 'h3'});
+
+    expect(screen.getByRole('heading', {level: 3, name: 'smoke check'})).toBeInTheDocument();
+  });
+
+  test('keeps the header when the body is empty', () => {
+    renderAnnotationCard({style: 'info', body: '', title: 'deploy'});
+
+    expect(screen.getByRole('heading', {name: 'deploy'})).toBeInTheDocument();
+  });
+
+  test('leaves a body that fits unbounded and undisclosed', () => {
+    stubRenderedBodyHeight(40);
+    const {container} = renderAnnotationCard({style: 'info', body: 'Short', maxBodyHeight: 320});
+
+    expect(screen.queryByRole('button', {name: 'Show more'})).not.toBeInTheDocument();
+    expect(container.querySelector('[style*="max-height"]')).toBeNull();
+  });
+
+  test('never clips a body that overruns the budget by less than the tolerance', () => {
+    // Without a disclosure to open, a silent clip would hide content with nothing to reveal it.
+    stubRenderedBodyHeight(324);
+    const {container} = renderAnnotationCard({
+      style: 'info',
+      body: 'Just over',
+      maxBodyHeight: 320,
+    });
+
+    expect(screen.queryByRole('button', {name: 'Show more'})).not.toBeInTheDocument();
+    expect(container.querySelector('[style*="max-height"]')).toBeNull();
+  });
+
+  test('parses only a preview of a very large body until it is expanded', async () => {
+    const user = userEvent.setup();
+    stubRenderedBodyHeight(5_000);
+    // Clipping with CSS bounds the layout but not the parse: the whole megabyte would still be
+    // turned into DOM behind `overflow: hidden`.
+    // Lines are padded so the 4,000-character source budget, not the line count, is what
+    // bounds the preview: ~45 characters per line puts roughly 90 of the 700 on screen.
+    const lineCount = 700;
+    const body = Array.from(
+      {length: lineCount},
+      (_unused, index) => `- line ${index} ${'detail '.repeat(5)}`,
+    ).join('\n');
+    renderAnnotationCard({style: 'error', body, maxBodyHeight: 320});
+
+    const items = () => screen.getAllByRole('listitem').length;
+    expect(items()).toBeLessThan(150);
+    expect(screen.queryByText(new RegExp(`line ${lineCount - 1}\\b`, 'u'))).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Show more'}));
+
+    expect(items()).toBe(lineCount);
+    expect(screen.getByText(new RegExp(`line ${lineCount - 1}\\b`, 'u'))).toBeInTheDocument();
+  });
+
+  test('cuts the preview at a line boundary', () => {
+    stubRenderedBodyHeight(5_000);
+    // A mid-line cut can split a link and render the fragment as literal text. An unterminated
+    // fence needs no handling: CommonMark closes one at end of document.
+    const line = `[documentation](https://example.com/${'path/'.repeat(8)}) trailing words here`;
+    renderAnnotationCard({
+      style: 'info',
+      body: Array.from({length: 200}, () => line).join('\n\n'),
+      maxBodyHeight: 320,
+    });
+
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', expect.stringContaining('example.com'));
+    }
+    expect(screen.queryByText(UNPARSED_LINK_PATTERN)).not.toBeInTheDocument();
+  });
+
+  test('discloses a body that arrives after the card mounted empty', async () => {
+    stubRenderedBodyHeight(5_000);
+    const {rerender} = renderAnnotationCard({style: 'warning', body: '', title: 'deploy'});
+
+    expect(screen.queryByRole('button', {name: 'Show more'})).not.toBeInTheDocument();
+
+    rerender(
+      <AnnotationCardTestHost>
+        <AnnotationCard style="warning" body="Appended during the step" title="deploy" />
+      </AnnotationCardTestHost>,
+    );
+
+    // The observer only exists once there is a node to observe, so an empty-to-content
+    // transition has to reinstall it or the body clips with nothing to open it.
+    expect(await screen.findByRole('button', {name: 'Show more'})).toBeInTheDocument();
+  });
+
+  test('clamps a body taller than the budget behind a disclosure', async () => {
+    const user = userEvent.setup();
+    stubRenderedBodyHeight(5_000);
+    const {container} = renderAnnotationCard({style: 'error', body: 'Tall', maxBodyHeight: 320});
+
+    const showMore = screen.getByRole('button', {name: 'Show more'});
+    expect(showMore).toHaveAttribute('aria-expanded', 'false');
+    const clamped = container.querySelector<HTMLElement>(`#${CSS.escape(bodyId(showMore))}`);
+    expect(clamped).toHaveStyle({maxHeight: '320px'});
+
+    await user.click(showMore);
+
+    expect(screen.getByRole('button', {name: 'Show less'})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(clamped).not.toHaveStyle({maxHeight: '320px'});
+  });
+
+  test('reveals a clipped body when focus enters one of its links', async () => {
+    const user = userEvent.setup();
+    stubRenderedBodyHeight(5_000);
+    const {container} = renderAnnotationCard({
+      style: 'info',
+      body: '[Open documentation](https://example.com)',
+      maxBodyHeight: 320,
+    });
+
+    await user.tab();
+
+    expect(screen.getByRole('link', {name: OPEN_DOCUMENTATION_PATTERN})).toHaveFocus();
+    expect(screen.getByRole('button', {name: 'Show less'})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(container.querySelector('[style*="max-height"]')).toBeNull();
+  });
 });
 
-function renderAnnotationCard({style, body}: {style: (typeof styles)[number]; body: string}) {
+/** jsdom performs no layout, so the measured content height is stubbed for the clamp tests. */
+function stubRenderedBodyHeight(height: number) {
+  vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(height);
+}
+
+function bodyId(showMore: HTMLElement): string {
+  const id = showMore.getAttribute('aria-controls');
+  if (!id) throw new Error('Show more is not associated with a body.');
+  return id;
+}
+
+function renderAnnotationCard({
+  style,
+  body,
+  ...props
+}: {style: (typeof styles)[number]; body: string} & Partial<AnnotationCardProps>) {
   return render(
     <AnnotationCardTestHost>
-      <AnnotationCard style={style} body={body} />
+      <AnnotationCard style={style} body={body} {...props} />
     </AnnotationCardTestHost>,
   );
 }

--- a/libs/client/ui/src/annotation-card.test.tsx
+++ b/libs/client/ui/src/annotation-card.test.tsx
@@ -9,6 +9,8 @@ const stylesWithDefaultGlyph = ['info', 'success', 'warning', 'error'] as const;
 /** Markdown link syntax that reached the DOM as text, which means the source was cut mid-link. */
 const UNPARSED_LINK_PATTERN = /^\[documentation\]/u;
 const OPEN_DOCUMENTATION_PATTERN = /Open documentation/;
+const PREFIX_PATTERN = /prefix/u;
+const DOCUMENTATION_PATTERN = /documentation/u;
 
 describe('AnnotationCard', () => {
   afterEach(() => {
@@ -131,6 +133,23 @@ describe('AnnotationCard', () => {
       expect(link).toHaveAttribute('href', expect.stringContaining('example.com'));
     }
     expect(screen.queryByText(UNPARSED_LINK_PATTERN)).not.toBeInTheDocument();
+  });
+
+  test('does not parse a partial first line in an oversized single-line body', async () => {
+    const user = userEvent.setup();
+    stubRenderedBodyHeight(5_000);
+    const body = `${'prefix '.repeat(570)}[documentation](https://example.com/${'path/'.repeat(300)})`;
+    renderAnnotationCard({style: 'info', body, maxBodyHeight: 320});
+
+    expect(screen.queryByText(PREFIX_PATTERN)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'documentation'})).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Show more'}));
+
+    expect(screen.getByRole('link', {name: DOCUMENTATION_PATTERN})).toHaveAttribute(
+      'href',
+      expect.stringContaining('example.com'),
+    );
   });
 
   test('discloses a body that arrives after the card mounted empty', async () => {

--- a/libs/client/ui/src/annotation-card.tsx
+++ b/libs/client/ui/src/annotation-card.tsx
@@ -25,8 +25,6 @@ const OVERFLOW_TOLERANCE = 8;
  */
 const MAX_COLLAPSED_BODY_CHARS = 4_000;
 
-const TRAILING_PARTIAL_LINE = /\n[^\n]*$/u;
-
 /**
  * Cuts Markdown source at a line boundary.
  *
@@ -36,7 +34,9 @@ const TRAILING_PARTIAL_LINE = /\n[^\n]*$/u;
  * code block either way.
  */
 function collapsedPreview(body: string): string {
-  return body.slice(0, MAX_COLLAPSED_BODY_CHARS).replace(TRAILING_PARTIAL_LINE, '');
+  const preview = body.slice(0, MAX_COLLAPSED_BODY_CHARS);
+  const lastLineBreak = preview.lastIndexOf('\n');
+  return lastLineBreak === -1 ? '' : preview.slice(0, lastLineBreak);
 }
 
 /**

--- a/libs/client/ui/src/annotation-card.tsx
+++ b/libs/client/ui/src/annotation-card.tsx
@@ -1,23 +1,189 @@
 import type {AnnotationStyleDto} from '@shipfox/annotations-dto';
+import {Button} from '@shipfox/react-ui/button';
 import {Callout, CalloutContent} from '@shipfox/react-ui/callout';
 import {Markdown} from '@shipfox/react-ui/markdown';
-import {memo} from 'react';
+import {cn} from '@shipfox/react-ui/utils';
+import {type ReactNode, useEffect, useId, useRef, useState} from 'react';
+
+/**
+ * Rendered height of a body before it clamps, in pixels. The server permits 1 MiB per body and
+ * 50 contexts per job execution, so one run can legitimately hold hundreds of megabytes of
+ * Markdown. Nothing here may render unbounded.
+ */
+const DEFAULT_MAX_BODY_HEIGHT = 320;
+
+/** Sub-pixel layout noise must not put a one-line body behind a disclosure. */
+const OVERFLOW_TOLERANCE = 8;
+
+/**
+ * Source characters parsed while collapsed.
+ *
+ * Clipping with CSS bounds the layout but not the work: a 1 MiB body still runs the full
+ * remark/rehype pipeline and mounts every node behind an `overflow: hidden`. Twenty-five of
+ * those is tens of megabytes of DOM nobody can see. This is generous next to a 320px clamp
+ * (roughly 16 lines) so the preview always overfills the visible box.
+ */
+const MAX_COLLAPSED_BODY_CHARS = 4_000;
+
+const TRAILING_PARTIAL_LINE = /\n[^\n]*$/u;
+
+/**
+ * Cuts Markdown source at a line boundary.
+ *
+ * Only the line boundary needs handling: a mid-line cut can split a link or inline code and
+ * render the fragment as literal text. An unterminated fence needs no repair, because
+ * CommonMark closes an open fence at the end of the document, so the preview renders it as a
+ * code block either way.
+ */
+function collapsedPreview(body: string): string {
+  return body.slice(0, MAX_COLLAPSED_BODY_CHARS).replace(TRAILING_PARTIAL_LINE, '');
+}
+
+/**
+ * Prose measure for the body. Tables and code fences opt out: they are scanned column-wise and
+ * want the width, while a 150-character paragraph is simply hard to read.
+ */
+const BODY_MEASURE =
+  '[&>p]:max-w-[75ch] [&>ul]:max-w-[75ch] [&>ol]:max-w-[75ch] [&>blockquote]:max-w-[75ch] [&>h1]:max-w-[75ch] [&>h2]:max-w-[75ch] [&>h3]:max-w-[75ch] [&>h4]:max-w-[75ch]';
 
 type AnnotationCardProps = {
   style: AnnotationStyleDto;
   body: string;
+  /** The annotation's `context`, shown as its title. */
+  title?: string | undefined;
+  /** Heading element for the title. Callers own the document outline. */
+  titleAs?: 'h2' | 'h3' | 'h4' | undefined;
+  /** Where the annotation came from, rendered under the title. */
+  provenance?: ReactNode | undefined;
+  /** A single action, such as a link back to the emitting step. */
+  action?: ReactNode | undefined;
+  maxBodyHeight?: number | undefined;
+  id?: string | undefined;
 };
 
-const AnnotationCard = memo(function AnnotationCard({style, body}: AnnotationCardProps) {
-  if (!body.trim()) return null;
+/**
+ * Deliberately not memoized: `provenance` and `action` are elements the caller builds fresh on
+ * every render, so a shallow compare could never hit. The parse cost that actually matters is
+ * held by `Markdown`, which memoizes on its primitive props.
+ */
+function AnnotationCard({
+  style,
+  body,
+  title,
+  titleAs: TitleTag = 'h3',
+  provenance,
+  action,
+  maxBodyHeight = DEFAULT_MAX_BODY_HEIGHT,
+  id,
+}: AnnotationCardProps) {
+  const bodyId = useId();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [measurement, setMeasurement] = useState<{measured: boolean; overflows: boolean}>({
+    measured: false,
+    overflows: false,
+  });
+  const [expanded, setExpanded] = useState(false);
+  const {measured, overflows} = measurement;
+  const hasBody = Boolean(body.trim());
+  const hasHeader = Boolean(title || provenance || action);
+
+  useEffect(() => {
+    const node = contentRef.current;
+    if (!node || !hasBody) return;
+
+    // Measured on the unclamped inner node so the reading stays true while the outer wrapper is
+    // clipped, and observed rather than measured once because a code fence settles its height
+    // only after syntax highlighting lands.
+    function measure() {
+      if (!node) return;
+      setMeasurement({
+        measured: true,
+        overflows: node.scrollHeight > maxBodyHeight + OVERFLOW_TOLERANCE,
+      });
+    }
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+    // `hasBody` is a dependency because the measured node only exists once there is a body to
+    // measure: an annotation that starts empty and is appended to during its step would
+    // otherwise never install an observer, and would clip with no way to open it. Later edits
+    // to a non-empty body need no re-run, since the observer already reports their height.
+  }, [maxBodyHeight, hasBody]);
+
+  if (!hasBody && !hasHeader) return null;
+
+  // Truncation is known from the source, so an over-budget body needs no measurement to know
+  // it overflows. That keeps the disclosure correct on the very first paint.
+  const truncated = body.length > MAX_COLLAPSED_BODY_CHARS;
+  const disclosable = hasBody && (truncated || overflows);
+
+  // Clamped before the first measurement so a long body never paints full height and then
+  // collapses under the reader, and released once measured within tolerance so a body just
+  // over the budget is never clipped without a disclosure to open it.
+  const collapsed = hasBody && !expanded && (!measured || disclosable);
+  const rendered = collapsed && truncated ? collapsedPreview(body) : body;
 
   return (
-    <Callout type={style}>
-      <CalloutContent>
-        <Markdown>{body}</Markdown>
+    <Callout id={id} type={style}>
+      <CalloutContent className="flex flex-col gap-6">
+        {hasHeader ? (
+          <div className="flex min-w-0 items-start justify-between gap-8">
+            <div className="flex min-w-0 flex-col gap-2">
+              {title ? (
+                <TitleTag className="min-w-0 break-words font-code text-sm font-medium leading-20 text-foreground-neutral-base">
+                  {title}
+                </TitleTag>
+              ) : null}
+              {provenance}
+            </div>
+            {action ? <div className="shrink-0">{action}</div> : null}
+          </div>
+        ) : null}
+
+        {hasBody ? (
+          <div className="flex min-w-0 flex-col gap-4">
+            <div
+              id={bodyId}
+              className={cn('relative min-w-0', collapsed && 'overflow-hidden')}
+              style={collapsed ? {maxHeight: maxBodyHeight} : undefined}
+              // Tabbing to a link inside a clipped body cannot scroll it into view, so reveal the
+              // body rather than move focus somewhere invisible.
+              onFocusCapture={collapsed && disclosable ? () => setExpanded(true) : undefined}
+            >
+              <div ref={contentRef}>
+                <Markdown className={cn(BODY_MEASURE, '[&>*:last-child]:mb-0')}>
+                  {rendered}
+                </Markdown>
+              </div>
+              {collapsed && disclosable ? (
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-x-0 bottom-0 h-48 bg-linear-to-t from-background-components-base to-transparent"
+                />
+              ) : null}
+            </div>
+            {disclosable ? (
+              // The fade above it carries the "there is more" signal, so the control itself
+              // stays quiet rather than competing with the body it reveals.
+              <Button
+                type="button"
+                size="xs"
+                variant="transparent"
+                aria-expanded={expanded}
+                aria-controls={bodyId}
+                onClick={() => setExpanded((current) => !current)}
+                className="-mx-inline self-start [@media(pointer:coarse)]:min-h-44"
+              >
+                {expanded ? 'Show less' : 'Show more'}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
       </CalloutContent>
     </Callout>
   );
-});
+}
 
-export {AnnotationCard, type AnnotationCardProps};
+export {AnnotationCard, type AnnotationCardProps, DEFAULT_MAX_BODY_HEIGHT};

--- a/libs/client/workflows/.storybook/preview.css
+++ b/libs/client/workflows/.storybook/preview.css
@@ -8,3 +8,7 @@
    apps/client/src/styles.css scans every package it renders. */
 @source "../src";
 @source "../../../shared/react/ui/src";
+/* client-ui owns `AnnotationCard`, whose clamp fade and prose measure live nowhere else.
+   Without this the classes are silently dropped and every Argos snapshot of a story that
+   renders one is a picture of unstyled markup, which is worse than no snapshot. */
+@source "../../ui/src";

--- a/libs/client/workflows/package.json
+++ b/libs/client/workflows/package.json
@@ -62,6 +62,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/annotations-dto": "workspace:*",
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",

--- a/libs/client/workflows/src/components/job-detail/job-detail-header.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.test.tsx
@@ -23,6 +23,9 @@ describe('JobDetailHeader', () => {
         job={job}
         selectedJobExecution={execution}
         onSelectedJobExecutionChange={vi.fn()}
+        workspaceSlug="acme"
+        projectSlug="project"
+        workflowRunId="run-1"
       />,
     );
 

--- a/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
@@ -4,6 +4,7 @@ import {Code, Text} from '@shipfox/react-ui/typography';
 import {formatTimestamp} from '@shipfox/react-ui/utils';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
+import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {
   defaultJobExecution,
   deriveJobDisplayStatus,
@@ -11,6 +12,7 @@ import {
   type Job,
   type JobExecution,
 } from '#core/workflow-run.js';
+import {RunAnnotationCountChip} from '../workflow-run-tabs/index.js';
 import {JobExecutionSwitcher} from './job-execution-switcher.js';
 import {JobExecutionTimeText} from './job-execution-time-text.js';
 
@@ -18,12 +20,23 @@ export interface JobDetailHeaderProps {
   job: Job;
   selectedJobExecution: JobExecution | undefined;
   onSelectedJobExecutionChange: (jobExecutionId: string) => void;
+  workspaceSlug: string;
+  projectSlug: string;
+  workflowRunId: string;
+  runAttempt?: number | undefined;
+  /** Counts for this job only. Renders a link into the run's Annotations section, never a body. */
+  annotationSummary?: RunAnnotationSummary | undefined;
 }
 
 export function JobDetailHeader({
   job,
   selectedJobExecution,
   onSelectedJobExecutionChange,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  runAttempt,
+  annotationSummary,
 }: JobDetailHeaderProps) {
   const selectedStatus = selectedExecutionStatus(job, selectedJobExecution);
   const jobStatus = getWorkflowStatusVisual(selectedStatus);
@@ -39,7 +52,7 @@ export function JobDetailHeader({
             ariaLabel={`Job status: ${jobStatus.label}`}
           />
           <Code
-            as="h1"
+            as="h2"
             variant="paragraph"
             bold
             tabIndex={-1}
@@ -50,9 +63,9 @@ export function JobDetailHeader({
           </Code>
         </div>
 
-        {selectedJobExecution ? (
+        {selectedJobExecution || annotationSummary?.total ? (
           <div className="flex min-w-0 flex-wrap items-center gap-10 text-foreground-neutral-muted">
-            {job.executionCountVisible ? (
+            {selectedJobExecution && job.executionCountVisible ? (
               <JobExecutionSwitcher
                 job={job}
                 selectedJobExecution={selectedJobExecution.id}
@@ -60,8 +73,20 @@ export function JobDetailHeader({
                 variant="title"
               />
             ) : null}
-            <JobDurationMeta execution={selectedJobExecution} kind="queue" />
-            <JobDurationMeta execution={selectedJobExecution} kind="run" />
+            {selectedJobExecution ? (
+              <>
+                <JobDurationMeta execution={selectedJobExecution} kind="queue" />
+                <JobDurationMeta execution={selectedJobExecution} kind="run" />
+              </>
+            ) : null}
+            <RunAnnotationCountChip
+              summary={annotationSummary}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              workflowRunId={workflowRunId}
+              runAttempt={runAttempt}
+              jobId={job.id}
+            />
           </div>
         ) : null}
       </div>

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.stories.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.stories.tsx
@@ -7,6 +7,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {type ReactNode, useState} from 'react';
 import type {Job, JobExecution, WorkflowRunDetail} from '#core/workflow-run.js';
+import {runAnnotationsQueryKeys} from '#hooks/api/run-annotations.js';
 import type {useWorkflowRunAttemptQuery} from '#hooks/api/workflow-runs.js';
 import {
   workflowJob,
@@ -170,6 +171,10 @@ function StoryQueryProvider({
       defaultOptions: {queries: {staleTime: Number.POSITIVE_INFINITY}},
     });
     if (run) {
+      client.setQueryData(runAnnotationsQueryKeys.list(run.id, run.runAttempt.attempt), {
+        pages: [{annotations: [], hasMore: false, nextCursor: null}],
+        pageParams: [undefined],
+      });
       for (const job of run.jobs) {
         for (const execution of job.jobExecutions) {
           for (const step of execution.steps) {

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -10,7 +10,9 @@ import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
 import {type RefObject, useEffect, useRef} from 'react';
+import {summarizeJobAnnotations} from '#core/run-annotation.js';
 import type {Job, JobExecution} from '#core/workflow-run.js';
+import {useRunAnnotationsQuery} from '#hooks/api/run-annotations.js';
 import type {useWorkflowRunAttemptQuery} from '#hooks/api/workflow-runs.js';
 import {
   type WorkflowJobSearch,
@@ -66,6 +68,16 @@ export function JobDetailView({
   const pageScrollRef = useRef<HTMLDivElement>(null);
   const landingSelectionRef = useRef<FrozenLandingSelection | undefined>(undefined);
   const hasLoadedData = query.data !== undefined;
+  // Same query key as the run workspace, so this reads the cache instead of fetching again.
+  const annotations = useRunAnnotationsQuery({
+    workflowRunId,
+    runAttempt: query.data?.runAttempt.attempt,
+  });
+  const jobAnnotationSummary = annotations.annotations
+    ? summarizeJobAnnotations(annotations.annotations, jobId, {
+        truncated: annotations.summary?.truncated ?? false,
+      })
+    : undefined;
 
   useEffect(() => {
     if (!jobId || !hasLoadedData) return;
@@ -206,8 +218,13 @@ export function JobDetailView({
                 job={job}
                 selectedJobExecution={selectedJobExecution}
                 onSelectedJobExecutionChange={selectExecution}
+                workspaceSlug={workspaceSlug}
+                projectSlug={projectSlug}
+                workflowRunId={workflowRunId}
+                runAttempt={run.runAttempt.attempt}
+                annotationSummary={jobAnnotationSummary}
               />
-              <Text as="h2" className="sr-only">
+              <Text as="h3" className="sr-only">
                 Logs
               </Text>
               {selectedJobExecution ? (

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -89,7 +89,7 @@ export function WorkflowRunSummary({
 
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Header id={headingId} variant="h3" className="min-w-0 truncate">
+                  <Header as="h1" id={headingId} variant="h3" className="min-w-0 truncate">
                     <span ref={headingTextRef} className="block min-w-0 truncate">
                       {run.name}
                     </span>

--- a/libs/client/workflows/src/components/workflow-run-tabs/index.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/index.ts
@@ -1,2 +1,5 @@
+export {RunAnnotationCountChip} from './run-annotation-count-chip.js';
+export {annotationElementId, RunAnnotationItem} from './run-annotation-item.js';
+export {RunAnnotationList, type RunAnnotationListQuery} from './run-annotation-list.js';
 export {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
 export {RunAnnotationsEmpty} from './run-annotations-empty.js';

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-count-chip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-count-chip.tsx
@@ -1,0 +1,63 @@
+import {Icon} from '@shipfox/react-ui/icon';
+import {cn} from '@shipfox/react-ui/utils';
+import {Link} from '@tanstack/react-router';
+import {highestRunAnnotationSeverity, type RunAnnotationSummary} from '#core/run-annotation.js';
+import {type WorkflowRunsSearch, workflowRunSearchParams} from '#routes/inputs.js';
+import {SEVERITY_CHIP_TONE, SEVERITY_ICON} from './severity-visuals.js';
+
+export interface RunAnnotationCountChipProps {
+  summary: RunAnnotationSummary | undefined;
+  workspaceSlug: string;
+  projectSlug: string;
+  workflowRunId: string;
+  runAttempt?: number | undefined;
+  /** Scopes the destination list to one job. */
+  jobId?: string | undefined;
+}
+
+/**
+ * A bounded reference into the run's Annotations section: a count, its highest severity, and one
+ * link. Never a body, so an annotation is rendered exactly once per page.
+ */
+export function RunAnnotationCountChip({
+  summary,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  runAttempt,
+  jobId,
+}: RunAnnotationCountChipProps) {
+  if (!summary || summary.total === 0) return null;
+
+  const severity = highestRunAnnotationSeverity(summary);
+  const count = `${summary.total}${summary.truncated ? '+' : ''}`;
+  const label = `${count} ${summary.total === 1 && !summary.truncated ? 'annotation' : 'annotations'}`;
+  const accessibleLabel = severity
+    ? `View ${label}, highest severity ${severity}`
+    : `View ${label}`;
+  const search: WorkflowRunsSearch = {tab: 'annotations', ...(runAttempt ? {runAttempt} : {})};
+  if (jobId) search.jobId = jobId;
+
+  return (
+    <Link
+      to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
+      params={{workspaceSlug, projectSlug, workflowRunId}}
+      search={workflowRunSearchParams(search, search) as never}
+      aria-label={accessibleLabel}
+      className={cn(
+        'inline-flex h-20 shrink-0 items-center gap-4 rounded-4 border px-6 font-code text-xs leading-16 tabular-nums outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active',
+        // The chip stays 20px optically so it sits level with the duration metadata beside it;
+        // the hit area grows to the 44px minimum only where the pointer is coarse.
+        '[@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:px-10',
+        severity ? SEVERITY_CHIP_TONE[severity] : 'border-border-neutral-base',
+      )}
+    >
+      <Icon
+        name={severity ? SEVERITY_ICON[severity] : 'fileTextLine'}
+        size={12}
+        aria-hidden="true"
+      />
+      <span className="text-foreground-neutral-base">{count}</span>
+    </Link>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -2,6 +2,7 @@ import {AnnotationCard} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Text} from '@shipfox/react-ui/typography';
+import {cn} from '@shipfox/react-ui/utils';
 import {Link} from '@tanstack/react-router';
 import {useEffect, useRef} from 'react';
 import type {RunAnnotationEntry} from '#core/run-annotation.js';
@@ -51,7 +52,15 @@ export function RunAnnotationItem({
   }, [selected]);
 
   return (
-    <li ref={itemRef} tabIndex={-1} className="outline-none">
+    <li
+      ref={itemRef}
+      tabIndex={-1}
+      aria-current={selected ? 'true' : undefined}
+      className={cn(
+        'rounded-8 outline-none focus-visible:shadow-border-interactive-with-active',
+        selected && 'shadow-border-interactive-with-active',
+      )}
+    >
       <AnnotationCard
         id={annotationElementId(annotation.id)}
         style={annotation.style}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -1,0 +1,114 @@
+import {AnnotationCard} from '@shipfox/client-ui';
+import {Button} from '@shipfox/react-ui/button';
+import {Icon} from '@shipfox/react-ui/icon';
+import {Text} from '@shipfox/react-ui/typography';
+import {Link} from '@tanstack/react-router';
+import {useEffect, useRef} from 'react';
+import type {RunAnnotationEntry} from '#core/run-annotation.js';
+import {workflowJobSearchParams} from '#routes/inputs.js';
+
+export interface RunAnnotationItemProps {
+  entry: RunAnnotationEntry;
+  workspaceSlug?: string | undefined;
+  projectSlug?: string | undefined;
+  workflowRunId: string;
+  runAttempt?: number | undefined;
+  /** Deep-link target from `?annotation=`, which takes focus rather than only being scrolled to. */
+  selected?: boolean | undefined;
+}
+
+/**
+ * One annotation, and the only place in the product that renders an annotation body.
+ *
+ * The title is the annotation's `context`, which is what the emitting step named the block.
+ * Everything below it exists so a reader can get from a diagnostic back to its cause.
+ */
+export function RunAnnotationItem({
+  entry,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  runAttempt,
+  selected = false,
+}: RunAnnotationItemProps) {
+  const {annotation, origin} = entry;
+  const canLink = Boolean(origin && workspaceSlug && projectSlug);
+  const itemRef = useRef<HTMLLIElement>(null);
+  const focusedRef = useRef(false);
+
+  useEffect(() => {
+    if (!selected) {
+      focusedRef.current = false;
+      return;
+    }
+    if (focusedRef.current) return;
+
+    // A deep link that only scrolls leaves a keyboard or screen-reader user at the document
+    // start while the page moves under them.
+    focusedRef.current = true;
+    itemRef.current?.focus({preventScroll: true});
+    itemRef.current?.scrollIntoView({block: 'nearest'});
+  }, [selected]);
+
+  return (
+    <li ref={itemRef} tabIndex={-1} className="outline-none">
+      <AnnotationCard
+        id={annotationElementId(annotation.id)}
+        style={annotation.style}
+        title={annotation.context}
+        titleAs="h3"
+        provenance={<RunAnnotationProvenance entry={entry} />}
+        body={annotation.body}
+        action={
+          canLink && origin ? (
+            <Button
+              asChild
+              size="xs"
+              variant="transparent"
+              className="[@media(pointer:coarse)]:min-h-44"
+            >
+              <Link
+                to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId/jobs/$jobId"
+                params={{
+                  workspaceSlug: workspaceSlug ?? '',
+                  projectSlug: projectSlug ?? '',
+                  workflowRunId,
+                  jobId: origin.jobId,
+                }}
+                search={
+                  workflowJobSearchParams({
+                    jobExecutionId: origin.jobExecutionId,
+                    stepId: origin.stepId,
+                    stepAttemptId: origin.stepAttemptId,
+                    runAttempt,
+                  }) as never
+                }
+              >
+                Open step
+                <Icon name="arrowRightLine" size={12} aria-hidden="true" />
+              </Link>
+            </Button>
+          ) : null
+        }
+      />
+    </li>
+  );
+}
+
+/** `job · execution #2 · run tests · attempt 1`, dropping any part the run no longer resolves. */
+function RunAnnotationProvenance({entry}: {entry: RunAnnotationEntry}) {
+  const parts = [entry.jobName, entry.executionLabel, entry.stepLabel, entry.attemptLabel].filter(
+    (part): part is string => Boolean(part),
+  );
+
+  return (
+    <Text as="p" size="xs" className="min-w-0 break-words font-code text-foreground-neutral-subtle">
+      {parts.join(' · ')}
+    </Text>
+  );
+}
+
+/** Stable element id so `?annotation=<id>` can scroll to and highlight one annotation. */
+export function annotationElementId(annotationId: string): string {
+  return `run-annotation-${annotationId}`;
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -1,0 +1,241 @@
+import {QueryLoadError, type QueryLoadErrorQuery} from '@shipfox/client-ui';
+import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
+import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {Skeleton} from '@shipfox/react-ui/skeleton';
+import {Text} from '@shipfox/react-ui/typography';
+import {useState} from 'react';
+import type {RunAnnotationEntry} from '#core/run-annotation.js';
+import {RunAnnotationItem} from './run-annotation-item.js';
+import {RunAnnotationsEmpty} from './run-annotations-empty.js';
+
+export interface RunAnnotationListQuery extends QueryLoadErrorQuery {
+  isPending: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => unknown;
+}
+
+export interface RunAnnotationListProps {
+  query: RunAnnotationListQuery;
+  entries: RunAnnotationEntry[] | undefined;
+  workflowRunId: string;
+  workspaceSlug?: string | undefined;
+  projectSlug?: string | undefined;
+  runAttempt?: number | undefined;
+  /** Name of the job the list is filtered to, used only for empty-state copy. */
+  filteredJobName?: string | undefined;
+  /** Active severity filter, named in the empty state so the reader knows what to clear. */
+  filteredSeverity?: string | undefined;
+  filtered: boolean;
+  onClearFilters?: (() => void) | undefined;
+  /** Annotation id from `?annotation=`, which the matching card scrolls to and focuses. */
+  selectedAnnotationId?: string | undefined;
+}
+
+/**
+ * How many annotations render at once.
+ *
+ * A page holds up to 500 rows and each one mounts a Markdown pipeline, so the fetch budget is
+ * not a render budget. The window grows on demand and the server page only loads once the
+ * reader has actually seen everything already fetched.
+ */
+const RENDER_WINDOW = 25;
+
+/**
+ * The annotations list.
+ *
+ * Loading, empty, error, and stale are four distinct renderings on purpose: coalescing a failed
+ * fetch into an empty result tells a reader their run is clean when the truth is unknown.
+ */
+export function RunAnnotationList({
+  query,
+  entries,
+  workflowRunId,
+  workspaceSlug,
+  projectSlug,
+  runAttempt,
+  filteredJobName,
+  filteredSeverity,
+  filtered,
+  onClearFilters,
+  selectedAnnotationId,
+}: RunAnnotationListProps) {
+  const [visibleCount, setVisibleCount] = useState(RENDER_WINDOW);
+
+  // A deep-linked annotation past the window would otherwise be unreachable: it is in the data,
+  // absent from the DOM, and nothing on screen says so.
+  const selectedIndex = selectedAnnotationId
+    ? (entries?.findIndex((entry) => entry.annotation.id === selectedAnnotationId) ?? -1)
+    : -1;
+  const renderCount = Math.max(visibleCount, selectedIndex + 1);
+
+  if (query.isPending) return <RunAnnotationListSkeleton />;
+
+  if (query.isError && entries === undefined) {
+    return <QueryLoadError query={query} subject="annotations" icon="fileDamageLine" />;
+  }
+
+  if (entries === undefined) return <RunAnnotationListSkeleton />;
+
+  const visible = entries.slice(0, renderCount);
+  const hiddenCount = entries.length - visible.length;
+
+  return (
+    <div className="flex min-w-0 flex-col gap-12">
+      {query.isError ? <RunAnnotationStaleError query={query} /> : null}
+
+      {entries.length === 0 ? (
+        filtered ? (
+          <RunAnnotationsFilteredEmpty
+            jobName={filteredJobName}
+            severity={filteredSeverity}
+            onClearFilters={onClearFilters}
+          />
+        ) : (
+          <RunAnnotationsEmpty />
+        )
+      ) : (
+        <ol className="flex min-w-0 flex-col gap-12">
+          {visible.map((entry) => (
+            <RunAnnotationItem
+              key={entry.annotation.id}
+              entry={entry}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              workflowRunId={workflowRunId}
+              runAttempt={runAttempt}
+              selected={entry.annotation.id === selectedAnnotationId}
+            />
+          ))}
+        </ol>
+      )}
+
+      {hiddenCount > 0 ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="self-start [@media(pointer:coarse)]:min-h-44"
+          onClick={() => setVisibleCount((current) => current + RENDER_WINDOW)}
+        >
+          Show {Math.min(hiddenCount, RENDER_WINDOW)} more of {entries.length}
+        </Button>
+      ) : query.hasNextPage ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="self-start [@media(pointer:coarse)]:min-h-44"
+          isLoading={query.isFetchingNextPage}
+          onClick={() => {
+            void query.fetchNextPage();
+          }}
+        >
+          Load more annotations
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Names the filters that are actually active.
+ *
+ * Blaming severity for a job-only filter sends the reader to change the wrong control, which
+ * is worse than saying nothing.
+ */
+function filteredEmptyDescription({
+  jobName,
+  severity,
+}: {
+  jobName: string | undefined;
+  severity: string | undefined;
+}): string {
+  if (jobName && severity) {
+    return `This run has annotations, but none from ${jobName} at ${severity} severity.`;
+  }
+  if (jobName) return `This run has annotations, but none from ${jobName}.`;
+  if (severity) return `This run has annotations, but none at ${severity} severity.`;
+  return 'This run has annotations, but none match the current filters.';
+}
+
+function RunAnnotationsFilteredEmpty({
+  jobName,
+  severity,
+  onClearFilters,
+}: {
+  jobName: string | undefined;
+  severity: string | undefined;
+  onClearFilters: (() => void) | undefined;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-12">
+      <EmptyState
+        icon="fileDamageLine"
+        title="No matching annotations"
+        description={filteredEmptyDescription({jobName, severity})}
+      />
+      {onClearFilters ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="[@media(pointer:coarse)]:min-h-44"
+          onClick={onClearFilters}
+        >
+          Clear filters
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A failed poll keeps the annotations already on screen and marks them stale rather than
+ * clearing. Polite rather than assertive: the poll runs every 4s and a flapping API would
+ * otherwise interrupt a screen reader on every cycle.
+ */
+function RunAnnotationStaleError({query}: {query: QueryLoadErrorQuery}) {
+  return (
+    <Callout role="status" aria-live="polite" type="error">
+      <div className="flex w-full items-center justify-between gap-8">
+        <Text size="xs">Could not refresh annotations.</Text>
+        <Button
+          type="button"
+          size="2xs"
+          variant="secondary"
+          className="[@media(pointer:coarse)]:min-h-44"
+          isLoading={query.isFetching}
+          onClick={() => {
+            void query.refetch();
+          }}
+        >
+          Retry
+        </Button>
+      </div>
+    </Callout>
+  );
+}
+
+const ANNOTATION_SKELETON_ROWS = ['first', 'second', 'third'];
+
+function RunAnnotationListSkeleton() {
+  return (
+    <section aria-label="Loading annotations" className="flex flex-col gap-12">
+      {ANNOTATION_SKELETON_ROWS.map((row) => (
+        <div
+          key={row}
+          className="flex gap-12 rounded-8 border border-border-neutral-base bg-background-components-base px-12 py-8"
+        >
+          <Skeleton className="h-40 w-4 rounded-full" />
+          <div className="flex min-w-0 flex-1 flex-col gap-6">
+            <Skeleton className="h-20 w-160 rounded-4" />
+            <Skeleton className="h-16 w-240 rounded-4" />
+            <Skeleton className="h-40 w-full rounded-4" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -90,6 +90,7 @@ export function RunAnnotationList({
           <RunAnnotationsFilteredEmpty
             jobName={filteredJobName}
             severity={filteredSeverity}
+            incomplete={query.hasNextPage}
             onClearFilters={onClearFilters}
           />
         ) : (
@@ -148,10 +149,24 @@ export function RunAnnotationList({
 function filteredEmptyDescription({
   jobName,
   severity,
+  incomplete,
 }: {
   jobName: string | undefined;
   severity: string | undefined;
+  incomplete: boolean;
 }): string {
+  if (incomplete) {
+    if (jobName && severity) {
+      return `None of the loaded annotations are from ${jobName} at ${severity} severity. Load more annotations to continue searching.`;
+    }
+    if (jobName) {
+      return `None of the loaded annotations are from ${jobName}. Load more annotations to continue searching.`;
+    }
+    if (severity) {
+      return `None of the loaded annotations are at ${severity} severity. Load more annotations to continue searching.`;
+    }
+    return 'None of the loaded annotations match the current filters. Load more annotations to continue searching.';
+  }
   if (jobName && severity) {
     return `This run has annotations, but none from ${jobName} at ${severity} severity.`;
   }
@@ -163,18 +178,20 @@ function filteredEmptyDescription({
 function RunAnnotationsFilteredEmpty({
   jobName,
   severity,
+  incomplete,
   onClearFilters,
 }: {
   jobName: string | undefined;
   severity: string | undefined;
+  incomplete: boolean;
   onClearFilters: (() => void) | undefined;
 }) {
   return (
     <div className="flex flex-col items-center gap-12">
       <EmptyState
         icon="fileDamageLine"
-        title="No matching annotations"
-        description={filteredEmptyDescription({jobName, severity})}
+        title={incomplete ? 'No matches in loaded annotations' : 'No matching annotations'}
+        description={filteredEmptyDescription({jobName, severity, incomplete})}
       />
       {onClearFilters ? (
         <Button

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.test.tsx
@@ -7,7 +7,7 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 import {act, render, screen} from '@testing-library/react';
-import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import type {WorkflowRunsSearch} from '#routes/inputs.js';
 import {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
 
@@ -17,7 +17,11 @@ const ANNOTATION_SUMMARY: RunAnnotationSummary = {
   warning: 1,
   info: 2,
   success: 0,
+  truncated: false,
 };
+
+const INFO_OR_SUCCESS_PATTERN = /info|success/;
+const SHOW_ALL_PATTERN = /Show all/;
 
 describe('RunAnnotationSummaryLine', () => {
   test('links the severity breakdown into the Annotations panel', async () => {
@@ -30,6 +34,66 @@ describe('RunAnnotationSummaryLine', () => {
     );
   });
 
+  test('renders every count at one type scale', async () => {
+    // The severity counts previously bypassed `Text` and inherited the ambient 14px, so they
+    // rendered a step larger and heavier than the total they sit beside.
+    await renderSummaryLine();
+
+    const total = screen.getByText('5 annotations');
+    const errors = screen.getByText('2 errors');
+
+    expect(total).toHaveClass('text-xs', 'font-display');
+    expect(errors).toHaveClass('text-xs', 'font-display');
+    expect(errors).not.toHaveClass('text-foreground-highlight-interactive');
+  });
+
+  test('distinguishes severities by glyph rather than by label colour', async () => {
+    const {container} = await renderSummaryLine();
+
+    const tones = [...container.querySelectorAll('svg')].map((glyph) =>
+      glyph.getAttribute('class'),
+    );
+
+    expect(tones.some((tone) => tone?.includes('text-tag-error-icon'))).toBe(true);
+    expect(tones.some((tone) => tone?.includes('text-tag-warning-icon'))).toBe(true);
+  });
+
+  test('names only the severities that need attention', async () => {
+    await renderSummaryLine();
+
+    expect(screen.getByRole('link', {name: '2 errors'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '1 warning'})).toBeInTheDocument();
+    // The 2 info annotations are inside the total; naming them again would give a clean
+    // result the same weight and the same accent as a failure.
+    expect(screen.queryByRole('link', {name: '2 infos'})).not.toBeInTheDocument();
+    expect(screen.queryByText(INFO_OR_SUCCESS_PATTERN)).not.toBeInTheDocument();
+  });
+
+  test('turns the total into the way out of an active severity filter', async () => {
+    await renderSummaryLine({severity: 'error'});
+
+    expect(screen.getByRole('link', {name: 'Show all 5 annotations'})).toHaveAttribute(
+      'href',
+      '/w/acme/p/project/runs/run-1?tab=annotations',
+    );
+  });
+
+  test('leaves the total as plain text when no severity filter is active', async () => {
+    await renderSummaryLine();
+
+    expect(screen.queryByRole('link', {name: SHOW_ALL_PATTERN})).not.toBeInTheDocument();
+  });
+
+  test('falls back to the bare total when nothing needs attention', async () => {
+    await renderSummaryLine(
+      {},
+      {total: 3, error: 0, warning: 0, info: 3, success: 0, truncated: false},
+    );
+
+    expect(screen.getByText('3 annotations')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
   test('clears a stale annotation when linking to a severity', async () => {
     await renderSummaryLine({annotation: 'annotation-old'});
 
@@ -38,16 +102,26 @@ describe('RunAnnotationSummaryLine', () => {
       '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
     );
   });
+
+  test('marks a truncated read as a lower bound', async () => {
+    await renderSummaryLine({}, {...ANNOTATION_SUMMARY, truncated: true});
+
+    expect(screen.getByText('5+ annotations')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '2+ errors'})).toBeInTheDocument();
+  });
 });
 
-async function renderSummaryLine(search: WorkflowRunsSearch = {}) {
+async function renderSummaryLine(
+  search: WorkflowRunsSearch = {},
+  summary: RunAnnotationSummary = ANNOTATION_SUMMARY,
+) {
   const rootRoute = createRootRoute({component: Outlet});
   const runRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
     component: () => (
       <RunAnnotationSummaryLine
-        summary={ANNOTATION_SUMMARY}
+        summary={summary}
         workspaceSlug="acme"
         projectSlug="project"
         workflowRunId="run-1"

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
@@ -1,13 +1,28 @@
+import {Icon} from '@shipfox/react-ui/icon';
 import {Text} from '@shipfox/react-ui/typography';
+import {cn} from '@shipfox/react-ui/utils';
 import {Link} from '@tanstack/react-router';
-import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {
-  WORKFLOW_RUN_ANNOTATION_SEVERITIES,
   type WorkflowRunAnnotationSeverity,
   type WorkflowRunsSearch,
   workflowRunSearchParams,
 } from '#routes/inputs.js';
 import {MetadataSeparator} from '../workflow-run-summary/workflow-run-summary.js';
+import {SEVERITY_ICON, SEVERITY_ICON_TONE} from './severity-visuals.js';
+
+/**
+ * The severities this line names.
+ *
+ * The line exists so a failing run cannot look clean while the explanation sits behind an
+ * inactive section, which makes its subject "what needs attention", not "what happened".
+ * `info` and `success` are already inside the total, and repeating them gives "nothing is
+ * wrong" the same weight and the same accent as "something failed".
+ */
+const ATTENTION_SEVERITIES = [
+  'error',
+  'warning',
+] as const satisfies readonly WorkflowRunAnnotationSeverity[];
 
 export interface RunAnnotationSummaryLineProps {
   summary?: RunAnnotationSummary | undefined;
@@ -24,22 +39,49 @@ export function RunAnnotationSummaryLine({
   workflowRunId,
   search = {},
 }: RunAnnotationSummaryLineProps) {
-  if (!summary) return null;
+  // A run with no annotations says so in its empty state; a "0 annotations" line beside it is
+  // the same fact twice.
+  if (!summary || summary.total === 0) return null;
 
-  const visibleSeverities = WORKFLOW_RUN_ANNOTATION_SEVERITIES.filter(
-    (severity) => summary[severity] > 0,
-  );
+  const visibleSeverities = ATTENTION_SEVERITIES.filter((severity) => summary[severity] > 0);
+
+  const totalLabel = countLabel(summary.total, 'annotation', summary.truncated);
 
   return (
     <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-foreground-neutral-subtle">
-      <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-subtle">
-        {summary.total} {pluralize('annotation', summary.total)}
-      </Text>
+      {search.severity && workspaceSlug && projectSlug && workflowRunId ? (
+        // The severity filter has no control of its own, so while one is active the total is
+        // the way back out. Unfiltered it stays plain text: a link to where you already are
+        // is noise.
+        <Link
+          to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
+          params={{workspaceSlug, projectSlug, workflowRunId}}
+          search={
+            workflowRunSearchParams(
+              {...withoutSeverity(search), tab: 'annotations'},
+              search,
+            ) as never
+          }
+          aria-label={`Show all ${totalLabel}`}
+          className="shrink-0 rounded-4 outline-none focus-visible:shadow-border-interactive-with-active"
+        >
+          {/* Underlined rather than accented: the escape hatch has to read as a link without
+              becoming the loudest thing on a line whose job is to be scannable. */}
+          <Text as="span" size="xs" className="text-foreground-neutral-subtle underline">
+            {totalLabel}
+          </Text>
+        </Link>
+      ) : (
+        <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-subtle">
+          {totalLabel}
+        </Text>
+      )}
       {visibleSeverities.map((severity) => (
         <span key={severity} className="inline-flex shrink-0 items-center gap-8">
           <MetadataSeparator />
           <SeverityLink
             count={summary[severity]}
+            truncated={summary.truncated}
             severity={severity}
             workspaceSlug={workspaceSlug}
             projectSlug={projectSlug}
@@ -54,6 +96,7 @@ export function RunAnnotationSummaryLine({
 
 function SeverityLink({
   count,
+  truncated,
   severity,
   workspaceSlug,
   projectSlug,
@@ -61,19 +104,33 @@ function SeverityLink({
   search,
 }: {
   count: number;
+  truncated: boolean;
   severity: WorkflowRunAnnotationSeverity;
   workspaceSlug?: string | undefined;
   projectSlug?: string | undefined;
   workflowRunId?: string | undefined;
   search: WorkflowRunsSearch;
 }) {
-  const label = `${count} ${pluralize(severity, count)}`;
+  const label = countLabel(count, severity, truncated);
+  const content = (
+    <>
+      <Icon
+        name={SEVERITY_ICON[severity]}
+        size={12}
+        aria-hidden="true"
+        className={cn('shrink-0', SEVERITY_ICON_TONE[severity])}
+      />
+      <Text as="span" size="xs" className="text-foreground-neutral-subtle">
+        {label}
+      </Text>
+    </>
+  );
+
   if (!workspaceSlug || !projectSlug || !workflowRunId) {
-    return <span className="text-foreground-highlight-interactive">{label}</span>;
+    return <span className="inline-flex items-center gap-4">{content}</span>;
   }
 
-  const searchWithoutAnnotation = {...search};
-  delete searchWithoutAnnotation.annotation;
+  const searchWithoutAnnotation = withoutAnnotation(search);
 
   return (
     <Link
@@ -85,13 +142,31 @@ function SeverityLink({
           search,
         ) as never
       }
-      className="text-foreground-highlight-interactive outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
+      className="inline-flex items-center gap-4 rounded-4 outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
     >
-      {label}
+      {content}
     </Link>
   );
 }
 
-function pluralize(word: string, count: number): string {
-  return count === 1 ? word : `${word}s`;
+/** A selected annotation is stale the moment the list it was chosen from is refiltered. */
+function withoutAnnotation(search: WorkflowRunsSearch): WorkflowRunsSearch {
+  const next = {...search};
+  delete next.annotation;
+  return next;
+}
+
+function withoutSeverity(search: WorkflowRunsSearch): WorkflowRunsSearch {
+  const next = withoutAnnotation(search);
+  delete next.severity;
+  return next;
+}
+
+/**
+ * A truncated read renders `500+ annotations`: the counts are a lower bound once the page budget
+ * is hit, and presenting them as exact would understate a run the reader is trying to trust.
+ */
+function countLabel(count: number, word: string, truncated: boolean): string {
+  const plural = count === 1 && !truncated ? word : `${word}s`;
+  return `${count}${truncated ? '+' : ''} ${plural}`;
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
@@ -1,0 +1,293 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import type {ReactNode} from 'react';
+import {
+  buildRunAnnotationList,
+  type RunAnnotationRecord,
+  type RunAnnotationStyle,
+  summarizeRunAnnotations,
+} from '#core/run-annotation.js';
+import type {Job} from '#core/workflow-run.js';
+import {
+  workflowJob,
+  workflowJobExecutionDto,
+  workflowStepAttemptDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
+import {RunAnnotationCountChip} from './run-annotation-count-chip.js';
+import {RunAnnotationList, type RunAnnotationListQuery} from './run-annotation-list.js';
+import {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
+
+const WORKSPACE_SLUG = 'acme';
+const PROJECT_SLUG = 'platform';
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+const BUILD_JOB_ID = '44444444-4444-4444-8444-00000000000b';
+const TEST_JOB_ID = '44444444-4444-4444-8444-00000000000c';
+const BUILD_EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
+const TEST_EXECUTION_ID = '77777777-7777-4777-8777-00000000000c';
+const BUILD_STEP_ID = '55555555-5555-4555-8555-00000000000b';
+const TEST_STEP_ID = '55555555-5555-4555-8555-00000000000c';
+const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
+const TEST_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000c';
+
+const LONG_BODY = [
+  '### Failing specs',
+  '',
+  ...Array.from(
+    {length: 40},
+    (_unused, index) => `- \`packages/web/src/route-${index}.test.ts\` expected 200, received 503`,
+  ),
+].join('\n');
+
+const meta = {
+  title: 'Workflows/RunAnnotations',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: () => {
+    const annotations = [
+      annotation({
+        id: 'a1',
+        context: 'smoke check',
+        style: 'error',
+        sequence: 3,
+        body: 'Task nine failed the smoke check against `https://preview.example.com`.\n\n```sh\ncurl -sSf https://preview.example.com/healthz\n```',
+      }),
+      annotation({
+        id: 'a2',
+        context: 'flaky tests',
+        style: 'warning',
+        sequence: 1,
+        jobId: TEST_JOB_ID,
+        jobExecutionId: TEST_EXECUTION_ID,
+        originStepId: TEST_STEP_ID,
+        body: '2 specs retried before passing.\n\n| Spec | Retries |\n| --- | --- |\n| `checkout.spec.ts` | 1 |\n| `billing.spec.ts` | 2 |',
+      }),
+      annotation({
+        id: 'a3',
+        context: 'deploy',
+        style: 'success',
+        sequence: 2,
+        body: 'Deployed **v42** to staging: [preview](https://preview.example.com)',
+      }),
+      annotation({
+        id: 'a4',
+        context: 'coverage',
+        style: 'info',
+        sequence: 4,
+        body: 'Line coverage held at 87.4%.',
+      }),
+    ];
+
+    return <AnnotationsFrame annotations={annotations} />;
+  },
+};
+
+export const BoundedBody: Story = {
+  // The only story in this package that earns a second Argos mode. The clamp's fade is the one
+  // gradient in the client, and it blends a surface token that flips with the theme, so a
+  // dark-only capture would never catch it breaking on a light card.
+  parameters: {
+    argos: {modes: {dark: {theme: 'dark'}, light: {theme: 'light'}}},
+  },
+  render: () => (
+    <AnnotationsFrame
+      annotations={[
+        annotation({id: 'long', context: 'test results', style: 'error', body: LONG_BODY}),
+      ]}
+    />
+  ),
+};
+
+export const DataStates: Story = {
+  render: () => {
+    const loaded = [annotation({id: 'a1', context: 'deploy', style: 'success'})];
+    return (
+      <div className="grid max-w-[1120px] gap-16 p-16 md:grid-cols-2">
+        <StateExample label="Loading">
+          <AnnotationsList annotations={[]} query={storyQuery({isPending: true})} />
+        </StateExample>
+        <StateExample label="Empty">
+          <AnnotationsList annotations={[]} />
+        </StateExample>
+        <StateExample label="Error">
+          <AnnotationsList
+            annotations={[]}
+            query={storyQuery({isError: true, data: undefined, error: new Error('Storybook')})}
+          />
+        </StateExample>
+        <StateExample label="Stale">
+          <AnnotationsList
+            annotations={loaded}
+            query={storyQuery({isError: true, error: new Error('Storybook')})}
+          />
+        </StateExample>
+        <StateExample label="Filtered miss">
+          <AnnotationsList annotations={[]} filtered filteredJobName="build" />
+        </StateExample>
+        <StateExample label="Truncated counts">
+          <RunAnnotationSummaryLine
+            summary={{...summarizeRunAnnotations(loaded), total: 500, error: 12, truncated: true}}
+            workspaceSlug={WORKSPACE_SLUG}
+            projectSlug={PROJECT_SLUG}
+            workflowRunId={RUN_ID}
+          />
+        </StateExample>
+      </div>
+    );
+  },
+};
+
+export const CountChips: Story = {
+  render: () => (
+    <div className="flex max-w-[1120px] flex-wrap items-center gap-12 p-16">
+      {(['error', 'warning', 'info', 'success'] as const).map((style) => (
+        <RunAnnotationCountChip
+          key={style}
+          summary={summarizeRunAnnotations([annotation({id: style, context: style, style})])}
+          workspaceSlug={WORKSPACE_SLUG}
+          projectSlug={PROJECT_SLUG}
+          workflowRunId={RUN_ID}
+          jobId={BUILD_JOB_ID}
+        />
+      ))}
+      <RunAnnotationCountChip
+        summary={{total: 500, error: 12, warning: 3, info: 0, success: 0, truncated: true}}
+        workspaceSlug={WORKSPACE_SLUG}
+        projectSlug={PROJECT_SLUG}
+        workflowRunId={RUN_ID}
+      />
+    </div>
+  ),
+};
+
+function AnnotationsFrame({annotations}: {annotations: RunAnnotationRecord[]}) {
+  return (
+    <div className="min-h-screen bg-background-neutral-base py-16">
+      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
+        <RunAnnotationSummaryLine
+          summary={summarizeRunAnnotations(annotations)}
+          workspaceSlug={WORKSPACE_SLUG}
+          projectSlug={PROJECT_SLUG}
+          workflowRunId={RUN_ID}
+        />
+        <AnnotationsList annotations={annotations} />
+      </div>
+    </div>
+  );
+}
+
+function AnnotationsList({
+  annotations,
+  query = storyQuery(),
+  filtered = false,
+  filteredJobName,
+}: {
+  annotations: RunAnnotationRecord[];
+  query?: RunAnnotationListQuery;
+  filtered?: boolean;
+  filteredJobName?: string;
+}) {
+  return (
+    <RunAnnotationList
+      query={query}
+      entries={query.data === undefined ? undefined : buildRunAnnotationList({annotations, jobs})}
+      workspaceSlug={WORKSPACE_SLUG}
+      projectSlug={PROJECT_SLUG}
+      workflowRunId={RUN_ID}
+      runAttempt={1}
+      filtered={filtered}
+      filteredJobName={filteredJobName}
+      onClearFilters={() => undefined}
+    />
+  );
+}
+
+function StateExample({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <span className="text-xs font-medium text-foreground-neutral-muted">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function storyQuery(overrides: Partial<RunAnnotationListQuery> = {}): RunAnnotationListQuery {
+  return {
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    data: {pages: []},
+    error: null,
+    refetch: () => undefined,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: () => undefined,
+    ...overrides,
+  };
+}
+
+function annotation(
+  overrides: Partial<RunAnnotationRecord> & {id: string; style: RunAnnotationStyle},
+): RunAnnotationRecord {
+  return {
+    jobId: BUILD_JOB_ID,
+    jobExecutionId: BUILD_EXECUTION_ID,
+    originStepId: BUILD_STEP_ID,
+    originStepAttempt: 1,
+    context: 'default',
+    sequence: 1,
+    body: 'Body',
+    ...overrides,
+  };
+}
+
+const jobs: Job[] = [
+  workflowJob({
+    id: BUILD_JOB_ID,
+    key: 'build',
+    name: 'build',
+    position: 0,
+    job_executions: [
+      workflowJobExecutionDto({
+        id: BUILD_EXECUTION_ID,
+        job_id: BUILD_JOB_ID,
+        steps: [
+          workflowStepDto({
+            id: BUILD_STEP_ID,
+            name: 'run smoke checks',
+            attempts: [
+              workflowStepAttemptDto({id: BUILD_ATTEMPT_ID, step_id: BUILD_STEP_ID, attempt: 1}),
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+  workflowJob({
+    id: TEST_JOB_ID,
+    key: 'test',
+    name: 'test',
+    position: 1,
+    job_executions: [
+      workflowJobExecutionDto({
+        id: TEST_EXECUTION_ID,
+        job_id: TEST_JOB_ID,
+        steps: [
+          workflowStepDto({
+            id: TEST_STEP_ID,
+            name: 'vitest',
+            attempts: [
+              workflowStepAttemptDto({id: TEST_ATTEMPT_ID, step_id: TEST_STEP_ID, attempt: 1}),
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+];

--- a/libs/client/workflows/src/components/workflow-run-tabs/severity-visuals.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/severity-visuals.ts
@@ -1,0 +1,37 @@
+import type {IconName} from '@shipfox/react-ui/icon';
+import type {RunAnnotationSeverity} from '#core/run-annotation.js';
+
+/**
+ * The glyph vocabulary for annotation severity, shared by every count surface.
+ *
+ * Deliberately the same marks the `Callout` uses on the cards themselves, so the glyph beside
+ * `1 error` in the summary is the glyph on the error card below it.
+ */
+export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> = {
+  error: 'closeCircleFill',
+  warning: 'errorWarningFill',
+  info: 'info',
+  success: 'checkboxCircleFill',
+};
+
+/**
+ * Severity tone lives in the glyph, never in the label.
+ *
+ * Coloring the text would make severity compete with the brand accent, which this system
+ * reserves for links, focus, and "you are here". Shape plus tone in a 12px mark distinguishes
+ * an error from a warning without either of them shouting.
+ */
+export const SEVERITY_ICON_TONE: Record<RunAnnotationSeverity, string> = {
+  error: 'text-tag-error-icon',
+  warning: 'text-tag-warning-icon',
+  info: 'text-tag-blue-icon',
+  success: 'text-tag-success-icon',
+};
+
+/** Hairline tone for a bordered count chip, matching the glyph it sits beside. */
+export const SEVERITY_CHIP_TONE: Record<RunAnnotationSeverity, string> = {
+  error: 'border-tag-error-border text-tag-error-icon',
+  warning: 'border-tag-warning-border text-tag-warning-icon',
+  info: 'border-tag-blue-border text-tag-blue-icon',
+  success: 'border-tag-success-border text-tag-success-icon',
+};

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
@@ -27,6 +27,50 @@ describe('RunWorkspaceNav', () => {
     vi.useRealTimers();
   });
 
+  test('announces the annotation count with its unit and marks a truncated read', async () => {
+    const run = workflowRunDetail({
+      id: RUN_ID,
+      jobs: [workflowJobDto({id: CURRENT_JOB_ID, name: 'build', position: 0})],
+    });
+
+    renderWithRouter(
+      <RunWorkspaceNav
+        workspaceSlug="acme"
+        projectSlug="project"
+        run={run}
+        activeSection="summary"
+        annotationSummary={{
+          total: 500,
+          error: 12,
+          warning: 3,
+          info: 0,
+          success: 0,
+          truncated: true,
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('link', {name: 'Annotations 500+ annotations'})).toBeVisible();
+  });
+
+  test('omits the annotation count until the read resolves', async () => {
+    const run = workflowRunDetail({
+      id: RUN_ID,
+      jobs: [workflowJobDto({id: CURRENT_JOB_ID, name: 'build', position: 0})],
+    });
+
+    renderWithRouter(
+      <RunWorkspaceNav
+        workspaceSlug="acme"
+        projectSlug="project"
+        run={run}
+        activeSection="summary"
+      />,
+    );
+
+    expect(await screen.findByRole('link', {name: 'Annotations'})).toBeVisible();
+  });
+
   test('shows the complete run hierarchy and marks the current job', async () => {
     const run = workflowRunDetail({
       id: RUN_ID,

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
@@ -50,7 +50,7 @@ describe('RunWorkspaceNav', () => {
       />,
     );
 
-    expect(await screen.findByRole('link', {name: 'Annotations 500+ annotations'})).toBeVisible();
+    expect(await screen.findByRole('link', {name: 'Annotations, 500 or more'})).toBeVisible();
   });
 
   test('omits the annotation count until the read resolves', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -6,13 +6,13 @@ import {cn} from '@shipfox/react-ui/utils';
 import {Link} from '@tanstack/react-router';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
+import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {
   defaultJobExecution,
   deriveJobDisplayStatus,
   type Job,
   type WorkflowRunDetail,
 } from '#core/workflow-run.js';
-import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
 import {
   type WorkflowJobSearch,
   type WorkflowRunTab,
@@ -224,6 +224,7 @@ function RunWorkspaceNavContent({
               section="annotations"
               current={!currentJobId && activeSection === 'annotations'}
               count={annotationSummary?.total}
+              countTruncated={annotationSummary?.truncated}
               onNavigate={onNavigate}
             />
           </li>
@@ -252,6 +253,7 @@ function RunSectionLink({
   section,
   current,
   count,
+  countTruncated = false,
   onNavigate,
 }: {
   workspaceSlug: string;
@@ -261,6 +263,8 @@ function RunSectionLink({
   section: RunWorkspaceSection;
   current: boolean;
   count?: number | undefined;
+  /** The read hit its page budget, so the count is a lower bound and renders as `N+`. */
+  countTruncated?: boolean | undefined;
   onNavigate?: (() => void) | undefined;
 }) {
   return (
@@ -284,6 +288,9 @@ function RunSectionLink({
       {count ? (
         <span className="ml-auto font-code text-xs text-foreground-neutral-muted tabular-nums">
           {count}
+          {countTruncated ? '+' : ''}
+          {/* A bare number is not an accessible name; the unit rides along for screen readers. */}
+          <span className="sr-only"> {sectionLabel(section).toLowerCase()}</span>
         </span>
       ) : null}
     </Link>

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -279,6 +279,11 @@ function RunSectionLink({
       }
       onClick={onNavigate}
       aria-current={current ? 'page' : undefined}
+      aria-label={
+        count
+          ? `${sectionLabel(section)}, ${countTruncated ? `${count} or more` : count}`
+          : undefined
+      }
       className={cn(
         'flex min-h-32 items-center gap-8 rounded-4 px-8 text-xs font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
         current && 'bg-background-neutral-hover',
@@ -286,11 +291,12 @@ function RunSectionLink({
     >
       {sectionLabel(section)}
       {count ? (
-        <span className="ml-auto font-code text-xs text-foreground-neutral-muted tabular-nums">
+        <span
+          aria-hidden="true"
+          className="ml-auto font-code text-xs text-foreground-neutral-muted tabular-nums"
+        >
           {count}
           {countTruncated ? '+' : ''}
-          {/* A bare number is not an accessible name; the unit rides along for screen readers. */}
-          <span className="sr-only"> {sectionLabel(section).toLowerCase()}</span>
         </span>
       ) : null}
     </Link>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -1,10 +1,13 @@
+import type {AnnotationDto} from '@shipfox/annotations-dto';
 import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   workflowJobDto,
+  workflowJobExecutionDto,
   workflowRunDetailDto,
+  workflowStepAttemptDto,
   workflowStepDto,
 } from '#test/fixtures/workflow-run.js';
 import {jsonResponse, PROJECT_TEST_WSLUG, renderProjectPage} from '#test/pages.js';
@@ -14,6 +17,13 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const BUILD_JOB_ID = '77777777-7777-4777-8777-777777777777';
 const DEPLOY_JOB_ID = '88888888-8888-4888-8888-888888888888';
+const BUILD_EXECUTION_ID = '99999999-9999-4999-8999-000000000001';
+const BUILD_STEP_ID = '55555555-5555-4555-8555-000000000001';
+const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-000000000001';
+const ANNOTATION_ID_ONE = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001';
+const ANNOTATION_ID_TWO = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002';
+const TASK_NINE_PATTERN = /Task nine/;
+const SHOW_MORE_PATTERN = /Show \d+ more/;
 
 describe('WorkflowRunView', () => {
   beforeEach(() => {
@@ -32,9 +42,7 @@ describe('WorkflowRunView', () => {
   });
 
   test('opens the all-jobs Summary on the dependency graph by default', async () => {
-    configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
-    });
+    configureRunFetch();
 
     const {container} = renderView();
 
@@ -59,9 +67,7 @@ describe('WorkflowRunView', () => {
   });
 
   test('treats the removed Jobs tab URL as the graph Summary', async () => {
-    configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
-    });
+    configureRunFetch();
 
     renderView({tab: 'jobs'});
 
@@ -71,9 +77,7 @@ describe('WorkflowRunView', () => {
 
   test('navigates graph and rail jobs to their dedicated job routes', async () => {
     const user = userEvent.setup();
-    configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
-    });
+    configureRunFetch();
 
     const {router} = renderView();
     await user.click(await screen.findByRole('button', {name: 'deploy, Running'}));
@@ -87,9 +91,7 @@ describe('WorkflowRunView', () => {
 
   test('keeps run Annotations and Source in the workspace navigation', async () => {
     const user = userEvent.setup();
-    configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
-    });
+    configureRunFetch();
 
     const {router} = renderView();
     await screen.findByRole('region', {name: 'Workflow jobs'});
@@ -99,17 +101,137 @@ describe('WorkflowRunView', () => {
   });
 
   test('filters the single run-level Annotations page by job', async () => {
-    configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
-    });
+    configureRunFetch();
 
     renderView({tab: 'annotations', selection: {jobId: BUILD_JOB_ID}});
 
     expect(
       await screen.findByRole('combobox', {name: 'Filter annotations by job'}),
     ).toHaveTextContent('build');
-    expect(screen.getByText('build has no annotations to show in this run.')).toBeInTheDocument();
+    expect(await screen.findByText('This run has no annotations to show.')).toBeInTheDocument();
     expect(screen.queryByRole('tab', {name: 'Annotations'})).not.toBeInTheDocument();
+  });
+
+  test('renders annotation bodies once, severity first, with provenance', async () => {
+    configureRunFetch([
+      annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info', sequence: 1}),
+      annotationDto({
+        id: ANNOTATION_ID_TWO,
+        context: 'smoke check',
+        style: 'error',
+        sequence: 2,
+        body: 'Task nine **failed**.',
+      }),
+    ]);
+
+    renderView({tab: 'annotations'});
+
+    const headings = await screen.findAllByRole('heading', {level: 3});
+    expect(headings.map((heading) => heading.textContent)).toEqual(['smoke check', 'coverage']);
+    expect(screen.getByText(TASK_NINE_PATTERN)).toBeInTheDocument();
+    expect(screen.getAllByText('build · checkout · attempt 1')).toHaveLength(2);
+    expect(screen.getByText('2 annotations')).toBeInTheDocument();
+  });
+
+  test('links an annotation back to the step that emitted it', async () => {
+    configureRunFetch([annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage'})]);
+
+    renderView({tab: 'annotations'});
+
+    const href = (await screen.findByRole('link', {name: 'Open step'})).getAttribute('href') ?? '';
+    const [pathname, query = ''] = href.split('?');
+
+    expect(pathname).toBe(`/w/${PROJECT_TEST_WSLUG}/p/project/runs/${RUN_ID}/jobs/${BUILD_JOB_ID}`);
+    expect(Object.fromEntries(new URLSearchParams(query))).toEqual({
+      jobExecution: BUILD_EXECUTION_ID,
+      step: BUILD_STEP_ID,
+      stepAttempt: BUILD_ATTEMPT_ID,
+      runAttempt: '"1"',
+    });
+  });
+
+  test('shows a failed annotations read as an error, never as an empty run', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn((input: RequestInfo | URL) =>
+        Promise.resolve(
+          requestUrl(input).includes('/annotations')
+            ? jsonResponse({code: 'internal'}, {status: 500})
+            : jsonResponse(workflowRunViewDetailDto()),
+        ),
+      ),
+    });
+
+    renderView({tab: 'annotations'});
+
+    expect(await screen.findByRole('button', {name: 'Retry loading annotations'})).toBeVisible();
+    expect(screen.queryByText('This run has no annotations to show.')).not.toBeInTheDocument();
+  });
+
+  test('bounds how many annotation bodies render at once', async () => {
+    configureRunFetch(
+      Array.from({length: 30}, (_unused, index) =>
+        annotationDto({
+          id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(index).padStart(12, '0')}`,
+          context: `context-${index}`,
+          sequence: index + 1,
+        }),
+      ),
+    );
+
+    renderView({tab: 'annotations'});
+
+    expect(await screen.findAllByRole('heading', {level: 3})).toHaveLength(25);
+    const showMore = screen.getByRole('button', {name: 'Show 5 more of 30'});
+
+    await userEvent.click(showMore);
+
+    expect(screen.getAllByRole('heading', {level: 3})).toHaveLength(30);
+    expect(screen.queryByRole('button', {name: SHOW_MORE_PATTERN})).not.toBeInTheDocument();
+  });
+
+  test('focuses a deep-linked annotation beyond the render window', async () => {
+    const deepLinkedId = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000029';
+    configureRunFetch(
+      Array.from({length: 30}, (_unused, index) =>
+        annotationDto({
+          id:
+            index === 29
+              ? deepLinkedId
+              : `aaaaaaaa-aaaa-4aaa-8aaa-${String(index).padStart(12, '0')}`,
+          context: `context-${index}`,
+          sequence: index + 1,
+        }),
+      ),
+    );
+
+    renderView({tab: 'annotations', selection: {annotation: deepLinkedId}});
+
+    const target = await screen.findByRole('heading', {level: 3, name: 'context-29'});
+    await waitFor(() => expect(target.closest('li')).toHaveFocus());
+  });
+
+  test('separates a filtered miss from a run with no annotations', async () => {
+    configureRunFetch([annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info'})]);
+
+    renderView({tab: 'annotations', selection: {severity: 'error'}});
+
+    expect(await screen.findByText('No matching annotations')).toBeInTheDocument();
+    expect(
+      screen.getByText('This run has annotations, but none at error severity.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Clear filters'})).toBeInTheDocument();
+  });
+
+  test('blames only the filters that are actually active', async () => {
+    // The annotation belongs to build, so filtering to deploy is a job-only miss. Naming
+    // severity here would send the reader to change a control they never touched.
+    configureRunFetch([annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info'})]);
+
+    renderView({tab: 'annotations', selection: {jobId: DEPLOY_JOB_ID}});
+
+    expect(
+      await screen.findByText('This run has annotations, but none from deploy.'),
+    ).toBeInTheDocument();
   });
 
   test('renders the captured workflow source in the Source section', async () => {
@@ -132,9 +254,7 @@ describe('WorkflowRunView', () => {
   });
 
   test('explains when the run has no source snapshot', async () => {
-    configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
-    });
+    configureRunFetch();
 
     renderView({tab: 'source'});
 
@@ -164,6 +284,42 @@ function renderView(props: Partial<Parameters<typeof WorkflowRunView>[0]> = {}) 
   ));
 }
 
+/** The API client hands `fetchImpl` a `Request`, whose URL only `.url` exposes. */
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  return input instanceof URL ? input.href : input.url;
+}
+
+/** Routes the run detail and the annotations read, which are two independent fetches. */
+function configureRunFetch(
+  annotations: AnnotationDto[] = [],
+  runOverrides: Partial<WorkflowRunDetailResponseDto> = {},
+) {
+  configureApiClient({
+    fetchImpl: vi.fn((input: RequestInfo | URL) =>
+      Promise.resolve(
+        requestUrl(input).includes('/annotations')
+          ? jsonResponse({annotations, has_more: false, next_cursor: null})
+          : jsonResponse(workflowRunViewDetailDto(runOverrides)),
+      ),
+    ),
+  });
+}
+
+function annotationDto(overrides: Partial<AnnotationDto> & {id: string}): AnnotationDto {
+  return {
+    job_id: BUILD_JOB_ID,
+    job_execution_id: BUILD_EXECUTION_ID,
+    origin_step_id: BUILD_STEP_ID,
+    origin_step_attempt: 1,
+    context: 'default',
+    style: 'default',
+    sequence: 1,
+    body: 'Body',
+    ...overrides,
+  };
+}
+
 function workflowRunViewDetailDto(
   overrides: Partial<WorkflowRunDetailResponseDto> = {},
 ): WorkflowRunDetailResponseDto {
@@ -181,7 +337,28 @@ function workflowRunViewDetailDto(
         run_attempt_id: RUN_ID,
         name: 'build',
         status: 'succeeded',
-        steps: [workflowStepDto({name: 'checkout', status: 'succeeded'})],
+        job_executions: [
+          workflowJobExecutionDto({
+            id: BUILD_EXECUTION_ID,
+            job_id: BUILD_JOB_ID,
+            status: 'succeeded',
+            steps: [
+              workflowStepDto({
+                id: BUILD_STEP_ID,
+                name: 'checkout',
+                status: 'succeeded',
+                attempts: [
+                  workflowStepAttemptDto({
+                    id: BUILD_ATTEMPT_ID,
+                    step_id: BUILD_STEP_ID,
+                    attempt: 1,
+                    status: 'succeeded',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
       }),
       workflowJobDto({
         id: DEPLOY_JOB_ID,

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -207,7 +207,10 @@ describe('WorkflowRunView', () => {
     renderView({tab: 'annotations', selection: {annotation: deepLinkedId}});
 
     const target = await screen.findByRole('heading', {level: 3, name: 'context-29'});
-    await waitFor(() => expect(target.closest('li')).toHaveFocus());
+    const selected = target.closest('li');
+    await waitFor(() => expect(selected).toHaveFocus());
+    expect(selected).toHaveAttribute('aria-current', 'true');
+    expect(selected).toHaveClass('shadow-border-interactive-with-active');
   });
 
   test('separates a filtered miss from a run with no annotations', async () => {
@@ -220,6 +223,46 @@ describe('WorkflowRunView', () => {
       screen.getByText('This run has annotations, but none at error severity.'),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Clear filters'})).toBeInTheDocument();
+  });
+
+  test('does not claim a filtered miss beyond the loaded annotation budget', async () => {
+    configureRunFetch(
+      [annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info'})],
+      {},
+      {has_more: true, next_cursor: 'next-page'},
+    );
+
+    renderView({tab: 'annotations', selection: {severity: 'error'}});
+
+    expect(await screen.findByText('No matches in loaded annotations')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'None of the loaded annotations are at error severity. Load more annotations to continue searching.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Load more annotations'})).toBeInTheDocument();
+    expect(screen.queryByText('No matching annotations')).not.toBeInTheDocument();
+  });
+
+  test('clears annotation filters and legacy step selection together', async () => {
+    const user = userEvent.setup();
+    configureRunFetch([annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info'})]);
+
+    const {router} = renderView({
+      tab: 'annotations',
+      selection: {
+        jobId: DEPLOY_JOB_ID,
+        jobExecutionId: BUILD_EXECUTION_ID,
+        stepId: BUILD_STEP_ID,
+        stepAttemptId: BUILD_ATTEMPT_ID,
+        severity: 'error',
+        annotation: ANNOTATION_ID_ONE,
+      },
+    });
+
+    await user.click(await screen.findByRole('button', {name: 'Clear filters'}));
+
+    await waitFor(() => expect(router.state.location.search).toEqual({tab: 'annotations'}));
   });
 
   test('blames only the filters that are actually active', async () => {
@@ -294,12 +337,18 @@ function requestUrl(input: RequestInfo | URL): string {
 function configureRunFetch(
   annotations: AnnotationDto[] = [],
   runOverrides: Partial<WorkflowRunDetailResponseDto> = {},
+  annotationPageOverrides: Partial<{has_more: boolean; next_cursor: string | null}> = {},
 ) {
   configureApiClient({
     fetchImpl: vi.fn((input: RequestInfo | URL) =>
       Promise.resolve(
         requestUrl(input).includes('/annotations')
-          ? jsonResponse({annotations, has_more: false, next_cursor: null})
+          ? jsonResponse({
+              annotations,
+              has_more: false,
+              next_cursor: null,
+              ...annotationPageOverrides,
+            })
           : jsonResponse(workflowRunViewDetailDto(runOverrides)),
       ),
     ),

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -10,11 +10,13 @@ import {
   SelectValue,
 } from '@shipfox/react-ui/select';
 import {toast} from '@shipfox/react-ui/toast';
+import {Text} from '@shipfox/react-ui/typography';
 import {useNavigate} from '@tanstack/react-router';
-import {type ReactNode, useEffect} from 'react';
-import type {Job, WorkflowRunRerunMode} from '#core/workflow-run.js';
-import type {RunAnnotationSummary} from '#core/workflow-run-tabs.js';
+import {type ReactNode, useEffect, useMemo} from 'react';
+import {buildRunAnnotationList, type RunAnnotationSummary} from '#core/run-annotation.js';
+import {isWorkflowRunTerminal, type Job, type WorkflowRunRerunMode} from '#core/workflow-run.js';
 import {withoutWorkflowRunSelectionSearch} from '#core/workflow-run-url-state.js';
+import {useRunAnnotationsQuery} from '#hooks/api/run-annotations.js';
 import {
   useCancelWorkflowRunMutation,
   useRerunWorkflowRunMutation,
@@ -30,7 +32,7 @@ import {
 import {JobGraph} from '../job-graph/index.js';
 import type {JobGraphSelectionSource} from '../job-graph/types.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
-import {RunAnnotationSummaryLine, RunAnnotationsEmpty} from '../workflow-run-tabs/index.js';
+import {RunAnnotationList, RunAnnotationSummaryLine} from '../workflow-run-tabs/index.js';
 import {WorkflowSourceContent} from '../workflow-source-panel/index.js';
 import {RunWorkspaceNav} from './run-workspace-nav.js';
 import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
@@ -51,7 +53,6 @@ export interface WorkflowRunViewProps {
   runAttempt?: number | undefined;
   selection?: WorkflowRunsSearch | undefined;
   tab?: WorkflowRunTab | undefined;
-  annotationSummary?: RunAnnotationSummary | undefined;
   activeJobId?: string | undefined;
   jobSearch?: WorkflowJobSearch | undefined;
   jobContent?: ReactNode | undefined;
@@ -69,7 +70,6 @@ export function WorkflowRunView({
   runAttempt,
   selection,
   tab,
-  annotationSummary,
   activeJobId,
   jobSearch,
   jobContent,
@@ -79,6 +79,22 @@ export function WorkflowRunView({
     runAttempt: selection?.runAttempt ?? runAttempt,
   });
   const rerunMutation = useRerunWorkflowRunMutation(projectId);
+  // Annotations are read on their own cadence rather than hydrated into the run, so the two
+  // modules stay decoupled. The key is shared, so the job page's count chip costs no extra fetch.
+  //
+  // Polling is scoped to the surface that renders bodies. The read has no counts-only mode, so
+  // every poll transfers whole Markdown bodies; doing that every four seconds behind Summary,
+  // Source, and the job log spends megabytes to keep one rail number warm. Off that surface the
+  // counts still refresh on navigation and on window focus.
+  const annotationsQuery = useRunAnnotationsQuery({
+    workflowRunId,
+    runAttempt: runQuery.data?.runAttempt.attempt,
+    live:
+      runWorkspaceSection(tab) === 'annotations' &&
+      !activeJobId &&
+      Boolean(runQuery.data) &&
+      !isWorkflowRunTerminal(runQuery.data?.runAttempt.status ?? 'pending'),
+  });
 
   return (
     <RelativeTimeProvider>
@@ -87,11 +103,11 @@ export function WorkflowRunView({
           workspaceSlug={workspaceSlug}
           projectSlug={projectSlug}
           query={runQuery}
+          annotations={annotationsQuery}
           rerunMutation={rerunMutation}
           runAttempt={runAttempt}
           selection={selection}
           tab={tab}
-          annotationSummary={annotationSummary}
           activeJobId={activeJobId}
           jobSearch={jobSearch}
           jobContent={jobContent}
@@ -105,11 +121,11 @@ function RunViewContent({
   workspaceSlug,
   projectSlug,
   query,
+  annotations,
   rerunMutation,
   runAttempt,
   selection,
   tab,
-  annotationSummary,
   activeJobId,
   jobSearch,
   jobContent,
@@ -117,17 +133,18 @@ function RunViewContent({
   workspaceSlug: string | undefined;
   projectSlug: string | undefined;
   query: ReturnType<typeof useWorkflowRunAttemptQuery>;
+  annotations: ReturnType<typeof useRunAnnotationsQuery>;
   rerunMutation: ReturnType<typeof useRerunWorkflowRunMutation>;
   runAttempt: number | undefined;
   selection: WorkflowRunsSearch | undefined;
   tab: WorkflowRunTab | undefined;
-  annotationSummary: RunAnnotationSummary | undefined;
   activeJobId: string | undefined;
   jobSearch: WorkflowJobSearch | undefined;
   jobContent: ReactNode | undefined;
 }) {
   const navigate = useNavigate();
   const runData = query.data;
+  const annotationSummary = annotations.summary;
   const activeSection = runWorkspaceSection(tab);
   const cancelMutation = useCancelWorkflowRunMutation(runData);
   const sourceSnapshot = runData?.sourceSnapshot ?? null;
@@ -228,6 +245,21 @@ function RunViewContent({
     });
   }
 
+  function clearAnnotationFilters() {
+    if (!runData || !workspaceSlug || !projectSlug) return;
+    const nextSearch: WorkflowRunsSearch = {...selection, tab: 'annotations'};
+    delete nextSearch.jobId;
+    delete nextSearch.severity;
+    delete nextSearch.annotation;
+
+    void navigate({
+      to: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
+      params: {workspaceSlug, projectSlug, workflowRunId: runData.id},
+      search: workflowRunSearchParams(nextSearch, nextSearch) as never,
+      replace: true,
+    });
+  }
+
   function cancelRun() {
     cancelMutation.mutate(undefined, {
       onError: (error) => toast.error(cancelErrorMessage(error)),
@@ -291,6 +323,7 @@ function RunViewContent({
             <RunSectionContent
               section={activeSection}
               run={runData}
+              annotations={annotations}
               annotationSummary={annotationSummary}
               workspaceSlug={workspaceSlug}
               projectSlug={projectSlug}
@@ -298,6 +331,7 @@ function RunViewContent({
               selectedJobId={selection?.jobId}
               onSelectGraphJob={selectGraphJob}
               onSelectAnnotationJob={selectAnnotationJob}
+              onClearAnnotationFilters={clearAnnotationFilters}
               sourceSnapshot={sourceSnapshot}
               highlightedLineRange={highlightedLineRange}
             />
@@ -313,6 +347,7 @@ function RunViewContent({
 function RunSectionContent({
   section,
   run,
+  annotations,
   annotationSummary,
   workspaceSlug,
   projectSlug,
@@ -320,11 +355,13 @@ function RunSectionContent({
   selectedJobId,
   onSelectGraphJob,
   onSelectAnnotationJob,
+  onClearAnnotationFilters,
   sourceSnapshot,
   highlightedLineRange,
 }: {
   section: RunWorkspaceSection;
   run: NonNullable<ReturnType<typeof useWorkflowRunAttemptQuery>['data']>;
+  annotations: ReturnType<typeof useRunAnnotationsQuery>;
   annotationSummary: RunAnnotationSummary | undefined;
   workspaceSlug: string | undefined;
   projectSlug: string | undefined;
@@ -332,6 +369,7 @@ function RunSectionContent({
   selectedJobId: string | undefined;
   onSelectGraphJob: (jobId: string | undefined, source?: JobGraphSelectionSource) => void;
   onSelectAnnotationJob: (jobId: string | undefined) => void;
+  onClearAnnotationFilters: () => void;
   sourceSnapshot: NonNullable<
     ReturnType<typeof useWorkflowRunAttemptQuery>['data']
   >['sourceSnapshot'];
@@ -343,6 +381,9 @@ function RunSectionContent({
     return (
       <section aria-label="All jobs summary" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
         <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
+          <Text as="h2" className="sr-only">
+            All jobs summary
+          </Text>
           <JobGraph
             run={run}
             selectedJobId={selectedJobId}
@@ -355,33 +396,27 @@ function RunSectionContent({
   }
 
   if (section === 'annotations') {
-    const selectedJob = run.jobs.find((job) => job.id === selectedJobId);
     return (
-      <section aria-label="Run annotations" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
-        <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
-          <div className="flex flex-wrap items-center justify-between gap-8">
-            <RunAnnotationSummaryLine
-              summary={annotationSummary}
-              workspaceSlug={workspaceSlug}
-              projectSlug={projectSlug}
-              workflowRunId={run.id}
-              search={selection}
-            />
-            <AnnotationJobFilter
-              jobs={run.jobs}
-              selectedJobId={selectedJob?.id}
-              onSelect={onSelectAnnotationJob}
-            />
-          </div>
-          <RunAnnotationsEmpty jobName={selectedJob?.displayName} />
-        </div>
-      </section>
+      <RunAnnotationsSection
+        run={run}
+        annotations={annotations}
+        annotationSummary={annotationSummary}
+        workspaceSlug={workspaceSlug}
+        projectSlug={projectSlug}
+        selection={selection}
+        selectedJobId={selectedJobId}
+        onSelectAnnotationJob={onSelectAnnotationJob}
+        onClearAnnotationFilters={onClearAnnotationFilters}
+      />
     );
   }
 
   return (
     <section aria-label="Workflow source" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
-      <div className="mx-auto flex min-h-full w-full max-w-[1120px] px-24">
+      <div className="mx-auto flex min-h-full w-full max-w-[1120px] flex-col px-24">
+        <Text as="h2" className="sr-only">
+          Workflow source
+        </Text>
         {sourceSnapshot ? (
           <WorkflowSourceContent
             source={sourceSnapshot}
@@ -400,6 +435,86 @@ function RunSectionContent({
             }
           />
         )}
+      </div>
+    </section>
+  );
+}
+
+function RunAnnotationsSection({
+  run,
+  annotations,
+  annotationSummary,
+  workspaceSlug,
+  projectSlug,
+  selection,
+  selectedJobId,
+  onSelectAnnotationJob,
+  onClearAnnotationFilters,
+}: {
+  run: NonNullable<ReturnType<typeof useWorkflowRunAttemptQuery>['data']>;
+  annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  annotationSummary: RunAnnotationSummary | undefined;
+  workspaceSlug: string | undefined;
+  projectSlug: string | undefined;
+  selection: WorkflowRunsSearch | undefined;
+  selectedJobId: string | undefined;
+  onSelectAnnotationJob: (jobId: string | undefined) => void;
+  onClearAnnotationFilters: () => void;
+}) {
+  const selectedJob = run.jobs.find((job) => job.id === selectedJobId);
+  const severity = selection?.severity;
+  const records = annotations.annotations;
+
+  const entries = useMemo(
+    () =>
+      records
+        ? buildRunAnnotationList({
+            annotations: records,
+            jobs: run.jobs,
+            severity,
+            jobId: selectedJob?.id,
+          })
+        : undefined,
+    [records, run.jobs, selectedJob?.id, severity],
+  );
+
+  return (
+    <section aria-label="Run annotations" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
+      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
+        <Text as="h2" className="sr-only">
+          Annotations
+        </Text>
+        <div className="flex flex-wrap items-center justify-between gap-8">
+          <RunAnnotationSummaryLine
+            summary={annotationSummary}
+            workspaceSlug={workspaceSlug}
+            projectSlug={projectSlug}
+            workflowRunId={run.id}
+            search={selection}
+          />
+          <AnnotationJobFilter
+            jobs={run.jobs}
+            selectedJobId={selectedJob?.id}
+            onSelect={onSelectAnnotationJob}
+          />
+        </div>
+        <RunAnnotationList
+          // Remounting on a filter change resets the render window, so narrowing to one job
+          // never lands the reader inside a "show more" position from the previous filter.
+          key={`${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
+          query={annotations.query}
+          entries={entries}
+          workspaceSlug={workspaceSlug}
+          projectSlug={projectSlug}
+          workflowRunId={run.id}
+          runAttempt={run.runAttempt.attempt}
+          // A run with no annotations at all offers no filter to clear, whatever the URL says.
+          filtered={Boolean((severity || selectedJob) && (annotationSummary?.total ?? 0) > 0)}
+          filteredJobName={selectedJob?.displayName}
+          filteredSeverity={severity}
+          onClearFilters={onClearAnnotationFilters}
+          selectedAnnotationId={selection?.annotation}
+        />
       </div>
     </section>
   );

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -249,6 +249,9 @@ function RunViewContent({
     if (!runData || !workspaceSlug || !projectSlug) return;
     const nextSearch: WorkflowRunsSearch = {...selection, tab: 'annotations'};
     delete nextSearch.jobId;
+    delete nextSearch.jobExecutionId;
+    delete nextSearch.stepId;
+    delete nextSearch.stepAttemptId;
     delete nextSearch.severity;
     delete nextSearch.annotation;
 
@@ -499,9 +502,9 @@ function RunAnnotationsSection({
           />
         </div>
         <RunAnnotationList
-          // Remounting on a filter change resets the render window, so narrowing to one job
-          // never lands the reader inside a "show more" position from the previous filter.
-          key={`${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
+          // Remounting on a filter or run-attempt change resets the render window, so the next
+          // list never inherits a "show more" position from different data.
+          key={`${run.id}:${run.runAttempt.attempt}:${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
           query={annotations.query}
           entries={entries}
           workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/core/run-annotation.test.ts
+++ b/libs/client/workflows/src/core/run-annotation.test.ts
@@ -1,0 +1,315 @@
+import {
+  workflowJob,
+  workflowJobExecutionDto,
+  workflowStepAttemptDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
+import {
+  buildRunAnnotationList,
+  highestRunAnnotationSeverity,
+  type RunAnnotationRecord,
+  type RunAnnotationStyle,
+  summarizeJobAnnotations,
+  summarizeRunAnnotations,
+} from './run-annotation.js';
+import type {Job} from './workflow-run.js';
+
+const BUILD_JOB_ID = '44444444-4444-4444-8444-00000000000b';
+const TEST_JOB_ID = '44444444-4444-4444-8444-00000000000c';
+const BUILD_EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
+const TEST_EXECUTION_ONE_ID = '77777777-7777-4777-8777-00000000000c';
+const TEST_EXECUTION_TWO_ID = '77777777-7777-4777-8777-00000000000d';
+const BUILD_STEP_ID = '55555555-5555-4555-8555-00000000000b';
+const TEST_STEP_ID = '55555555-5555-4555-8555-00000000000c';
+const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
+
+describe('summarizeRunAnnotations', () => {
+  test('counts every annotation in the total and only severities per severity', () => {
+    const annotations = [
+      annotation({id: 'a', style: 'error'}),
+      annotation({id: 'b', style: 'warning'}),
+      annotation({id: 'c', style: 'default'}),
+      annotation({id: 'd', style: 'error'}),
+    ];
+
+    const summary = summarizeRunAnnotations(annotations);
+
+    expect(summary).toEqual({
+      total: 4,
+      error: 2,
+      warning: 1,
+      info: 0,
+      success: 0,
+      truncated: false,
+    });
+  });
+
+  test('carries truncation so counts read as a lower bound', () => {
+    const summary = summarizeRunAnnotations([annotation({id: 'a', style: 'info'})], {
+      truncated: true,
+    });
+
+    expect(summary.truncated).toBe(true);
+  });
+});
+
+describe('summarizeJobAnnotations', () => {
+  test('counts only the annotations owned by one job', () => {
+    const annotations = [
+      annotation({id: 'a', style: 'error', jobId: BUILD_JOB_ID}),
+      annotation({id: 'b', style: 'warning', jobId: TEST_JOB_ID}),
+      annotation({id: 'c', style: 'info', jobId: TEST_JOB_ID}),
+    ];
+
+    const summary = summarizeJobAnnotations(annotations, TEST_JOB_ID);
+
+    expect(summary.total).toBe(2);
+    expect(summary.error).toBe(0);
+    expect(summary.warning).toBe(1);
+  });
+});
+
+describe('highestRunAnnotationSeverity', () => {
+  test('reports the loudest severity present', () => {
+    const summary = summarizeRunAnnotations([
+      annotation({id: 'a', style: 'success'}),
+      annotation({id: 'b', style: 'warning'}),
+    ]);
+
+    expect(highestRunAnnotationSeverity(summary)).toBe('warning');
+  });
+
+  test('reports nothing when only unstyled annotations exist', () => {
+    const summary = summarizeRunAnnotations([annotation({id: 'a', style: 'default'})]);
+
+    expect(highestRunAnnotationSeverity(summary)).toBeNull();
+  });
+});
+
+describe('buildRunAnnotationList', () => {
+  test('ranks by severity before emission order', () => {
+    const annotations = [
+      annotation({id: 'a', style: 'success', sequence: 1}),
+      annotation({id: 'b', style: 'error', sequence: 2}),
+      annotation({id: 'c', style: 'default', sequence: 3}),
+      annotation({id: 'd', style: 'warning', sequence: 4}),
+      annotation({id: 'e', style: 'info', sequence: 5}),
+    ];
+
+    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+
+    expect(entries.map((entry) => entry.annotation.id)).toEqual(['b', 'd', 'e', 'a', 'c']);
+  });
+
+  test('breaks a severity tie by job position before sequence', () => {
+    // `sequence` restarts per execution, so the later job's lower sequence must not lead.
+    const annotations = [
+      annotation({id: 'late-job', style: 'error', sequence: 1, jobId: TEST_JOB_ID}),
+      annotation({id: 'early-job', style: 'error', sequence: 9, jobId: BUILD_JOB_ID}),
+    ];
+
+    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+
+    expect(entries.map((entry) => entry.annotation.id)).toEqual(['early-job', 'late-job']);
+  });
+
+  test('breaks a job tie by execution sequence', () => {
+    const annotations = [
+      annotation({
+        id: 'second-execution',
+        style: 'error',
+        sequence: 1,
+        jobId: TEST_JOB_ID,
+        jobExecutionId: TEST_EXECUTION_TWO_ID,
+      }),
+      annotation({
+        id: 'first-execution',
+        style: 'error',
+        sequence: 2,
+        jobId: TEST_JOB_ID,
+        jobExecutionId: TEST_EXECUTION_ONE_ID,
+      }),
+    ];
+
+    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+
+    expect(entries.map((entry) => entry.annotation.id)).toEqual([
+      'first-execution',
+      'second-execution',
+    ]);
+  });
+
+  test('resolves provenance and an origin the run can route back to', () => {
+    const annotations = [annotation({id: 'a', style: 'error'})];
+
+    const [entry] = buildRunAnnotationList({annotations, jobs: jobs()});
+
+    expect(entry?.jobName).toBe('build');
+    expect(entry?.stepLabel).toBe('compile');
+    expect(entry?.attemptLabel).toBe('attempt 1');
+    expect(entry?.origin).toEqual({
+      jobId: BUILD_JOB_ID,
+      jobExecutionId: BUILD_EXECUTION_ID,
+      stepId: BUILD_STEP_ID,
+      stepAttemptId: BUILD_ATTEMPT_ID,
+    });
+  });
+
+  test('names an execution only when the job ran more than once', () => {
+    const annotations = [
+      annotation({id: 'single', style: 'info'}),
+      annotation({
+        id: 'multi',
+        style: 'info',
+        jobId: TEST_JOB_ID,
+        jobExecutionId: TEST_EXECUTION_TWO_ID,
+        originStepId: TEST_STEP_ID,
+      }),
+    ];
+
+    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+    const byId = new Map(entries.map((entry) => [entry.annotation.id, entry]));
+
+    expect(byId.get('single')?.executionLabel).toBeNull();
+    expect(byId.get('multi')?.executionLabel).toBe('execution #2');
+  });
+
+  test('keeps an annotation whose step the run attempt no longer holds, without an origin', () => {
+    const annotations = [
+      annotation({
+        id: 'orphan',
+        style: 'error',
+        originStepId: '55555555-5555-4555-8555-0000000000ff',
+      }),
+    ];
+
+    const [entry] = buildRunAnnotationList({annotations, jobs: jobs()});
+
+    expect(entry?.annotation.id).toBe('orphan');
+    expect(entry?.jobName).toBe('build');
+    expect(entry?.stepLabel).toBeNull();
+    expect(entry?.origin).toBeNull();
+  });
+
+  test('sorts an annotation from an unknown job last rather than first', () => {
+    const annotations = [
+      annotation({
+        id: 'unknown-job',
+        style: 'error',
+        jobId: '44444444-4444-4444-8444-0000000000ff',
+      }),
+      annotation({id: 'known-job', style: 'error'}),
+    ];
+
+    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+
+    expect(entries.map((entry) => entry.annotation.id)).toEqual(['known-job', 'unknown-job']);
+  });
+
+  test('filters by severity and by job', () => {
+    const annotations = [
+      annotation({id: 'build-error', style: 'error'}),
+      annotation({id: 'build-info', style: 'info'}),
+      annotation({id: 'test-error', style: 'error', jobId: TEST_JOB_ID}),
+    ];
+
+    expect(
+      buildRunAnnotationList({annotations, jobs: jobs(), severity: 'error'}).map(
+        (entry) => entry.annotation.id,
+      ),
+    ).toEqual(['build-error', 'test-error']);
+    expect(
+      buildRunAnnotationList({annotations, jobs: jobs(), jobId: BUILD_JOB_ID}).map(
+        (entry) => entry.annotation.id,
+      ),
+    ).toEqual(['build-error', 'build-info']);
+  });
+
+  test('never selects an unstyled annotation with a severity filter', () => {
+    const annotations = [annotation({id: 'plain', style: 'default'})];
+
+    expect(buildRunAnnotationList({annotations, jobs: jobs(), severity: 'info'})).toEqual([]);
+  });
+});
+
+function annotation(
+  overrides: Partial<RunAnnotationRecord> & {id: string; style: RunAnnotationStyle},
+): RunAnnotationRecord {
+  return {
+    jobId: BUILD_JOB_ID,
+    jobExecutionId: BUILD_EXECUTION_ID,
+    originStepId: BUILD_STEP_ID,
+    originStepAttempt: 1,
+    context: `context-${overrides.id}`,
+    sequence: 1,
+    body: 'Body',
+    ...overrides,
+  };
+}
+
+function jobs(): Job[] {
+  return [
+    workflowJob({
+      id: BUILD_JOB_ID,
+      key: 'build',
+      name: 'build',
+      position: 0,
+      job_executions: [
+        workflowJobExecutionDto({
+          id: BUILD_EXECUTION_ID,
+          job_id: BUILD_JOB_ID,
+          sequence: 1,
+          steps: [
+            workflowStepDto({
+              id: BUILD_STEP_ID,
+              job_execution_id: BUILD_EXECUTION_ID,
+              name: 'compile',
+              attempts: [
+                workflowStepAttemptDto({
+                  id: BUILD_ATTEMPT_ID,
+                  step_id: BUILD_STEP_ID,
+                  attempt: 1,
+                  status: 'succeeded',
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    }),
+    workflowJob({
+      id: TEST_JOB_ID,
+      key: 'test',
+      name: 'test',
+      position: 1,
+      job_executions: [
+        workflowJobExecutionDto({
+          id: TEST_EXECUTION_ONE_ID,
+          job_id: TEST_JOB_ID,
+          sequence: 1,
+          steps: [
+            workflowStepDto({
+              id: TEST_STEP_ID,
+              job_execution_id: TEST_EXECUTION_ONE_ID,
+              name: 'run tests',
+              attempts: [],
+            }),
+          ],
+        }),
+        workflowJobExecutionDto({
+          id: TEST_EXECUTION_TWO_ID,
+          job_id: TEST_JOB_ID,
+          sequence: 2,
+          steps: [
+            workflowStepDto({
+              id: TEST_STEP_ID,
+              job_execution_id: TEST_EXECUTION_TWO_ID,
+              name: 'run tests',
+              attempts: [],
+            }),
+          ],
+        }),
+      ],
+    }),
+  ];
+}

--- a/libs/client/workflows/src/core/run-annotation.ts
+++ b/libs/client/workflows/src/core/run-annotation.ts
@@ -1,0 +1,238 @@
+import type {Job} from './workflow-run.js';
+
+export type RunAnnotationStyle = 'default' | 'info' | 'success' | 'warning' | 'error';
+
+/**
+ * The severities the run surfaces rank and filter by. The `default` style carries no severity:
+ * it counts toward the total and sorts last, but no severity filter selects it.
+ */
+export const RUN_ANNOTATION_SEVERITIES = ['error', 'warning', 'info', 'success'] as const;
+
+export type RunAnnotationSeverity = (typeof RUN_ANNOTATION_SEVERITIES)[number];
+
+const SEVERITY_RANK: Record<RunAnnotationStyle, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+  success: 3,
+  default: 4,
+};
+
+const SEVERITY_SET = new Set<string>(RUN_ANNOTATION_SEVERITIES);
+
+export interface RunAnnotation {
+  id: string;
+  jobId: string;
+  jobExecutionId: string;
+  originStepId: string;
+  originStepAttempt: number;
+  context: string;
+  style: RunAnnotationStyle;
+  sequence: number;
+}
+
+export interface RunAnnotationRecord extends RunAnnotation {
+  body: string;
+}
+
+/** Counts shown by the run rail and the severity summary line. */
+export interface RunAnnotationSummary {
+  total: number;
+  error: number;
+  warning: number;
+  info: number;
+  success: number;
+  /** True when the read hit its page budget, so every count is a lower bound. */
+  truncated: boolean;
+}
+
+/** Everything the annotations list needs to route back to the step that emitted an annotation. */
+export interface RunAnnotationOrigin {
+  jobId: string;
+  jobExecutionId: string;
+  stepId: string;
+  stepAttemptId: string;
+}
+
+export interface RunAnnotationEntry {
+  annotation: RunAnnotationRecord;
+  jobName: string | null;
+  /** Only set when the job ran more than once, so a single-execution job stays uncluttered. */
+  executionLabel: string | null;
+  stepLabel: string | null;
+  attemptLabel: string;
+  /** `null` when the run attempt no longer contains the emitting step, so no link is offered. */
+  origin: RunAnnotationOrigin | null;
+}
+
+export function annotationSeverity(style: RunAnnotationStyle): RunAnnotationSeverity | null {
+  return SEVERITY_SET.has(style) ? (style as RunAnnotationSeverity) : null;
+}
+
+export function summarizeRunAnnotations(
+  annotations: readonly RunAnnotation[],
+  {truncated = false}: {truncated?: boolean | undefined} = {},
+): RunAnnotationSummary {
+  const summary: RunAnnotationSummary = {
+    total: annotations.length,
+    error: 0,
+    warning: 0,
+    info: 0,
+    success: 0,
+    truncated,
+  };
+
+  for (const annotation of annotations) {
+    const severity = annotationSeverity(annotation.style);
+    if (severity) summary[severity] += 1;
+  }
+
+  return summary;
+}
+
+export interface BuildRunAnnotationListInput {
+  annotations: readonly RunAnnotationRecord[];
+  jobs: readonly Job[];
+  severity?: RunAnnotationSeverity | undefined;
+  jobId?: string | undefined;
+}
+
+/**
+ * Ranks annotations for display.
+ *
+ * Severity leads: emission order is a log affordance, not a summary affordance. `sequence` is
+ * only stable within one job execution, so the tie-break walks down job position and execution
+ * sequence before using it, and ends on the id so the order never depends on input order.
+ */
+export function buildRunAnnotationList({
+  annotations,
+  jobs,
+  severity,
+  jobId,
+}: BuildRunAnnotationListInput): RunAnnotationEntry[] {
+  const index = indexJobs(jobs);
+  const entries: RunAnnotationEntry[] = [];
+
+  for (const annotation of annotations) {
+    if (jobId && annotation.jobId !== jobId) continue;
+    const annotationSeverityValue = annotationSeverity(annotation.style);
+    if (severity && annotationSeverityValue !== severity) continue;
+    entries.push(toEntry(annotation, index));
+  }
+
+  return entries.sort((left, right) => compareEntries(left, right, index));
+}
+
+/** Counts annotations owned by one job, for the job page's bounded reference chip. */
+export function summarizeJobAnnotations(
+  annotations: readonly RunAnnotation[],
+  jobId: string,
+  options: {truncated?: boolean | undefined} = {},
+): RunAnnotationSummary {
+  return summarizeRunAnnotations(
+    annotations.filter((annotation) => annotation.jobId === jobId),
+    options,
+  );
+}
+
+/** The loudest severity present, which tints a count chip. */
+export function highestRunAnnotationSeverity(
+  summary: RunAnnotationSummary,
+): RunAnnotationSeverity | null {
+  return RUN_ANNOTATION_SEVERITIES.find((severity) => summary[severity] > 0) ?? null;
+}
+
+interface JobIndexEntry {
+  position: number;
+  name: string;
+  executionCount: number;
+  executions: Map<string, JobExecutionIndexEntry>;
+}
+
+interface JobExecutionIndexEntry {
+  sequence: number;
+  steps: Map<string, {label: string; attemptIds: Map<number, string>}>;
+}
+
+function indexJobs(jobs: readonly Job[]): Map<string, JobIndexEntry> {
+  const index = new Map<string, JobIndexEntry>();
+
+  for (const job of jobs) {
+    const executions = new Map<string, JobExecutionIndexEntry>();
+    for (const execution of job.jobExecutions) {
+      const steps = new Map<string, {label: string; attemptIds: Map<number, string>}>();
+      for (const step of execution.steps) {
+        const attemptIds = new Map<number, string>();
+        for (const attempt of step.attempts) attemptIds.set(attempt.attempt, attempt.id);
+        steps.set(step.id, {label: step.name || step.key || step.id, attemptIds});
+      }
+      executions.set(execution.id, {sequence: execution.sequence, steps});
+    }
+
+    index.set(job.id, {
+      position: job.position,
+      name: job.displayName,
+      executionCount: job.jobExecutions.length,
+      executions,
+    });
+  }
+
+  return index;
+}
+
+function toEntry(
+  annotation: RunAnnotationRecord,
+  index: Map<string, JobIndexEntry>,
+): RunAnnotationEntry {
+  const job = index.get(annotation.jobId);
+  const execution = job?.executions.get(annotation.jobExecutionId);
+  const step = execution?.steps.get(annotation.originStepId);
+  const stepAttemptId = step?.attemptIds.get(annotation.originStepAttempt);
+
+  return {
+    annotation,
+    jobName: job?.name ?? null,
+    executionLabel:
+      execution && job && job.executionCount > 1 ? `execution #${execution.sequence}` : null,
+    stepLabel: step?.label ?? null,
+    attemptLabel: `attempt ${annotation.originStepAttempt}`,
+    origin: stepAttemptId
+      ? {
+          jobId: annotation.jobId,
+          jobExecutionId: annotation.jobExecutionId,
+          stepId: annotation.originStepId,
+          stepAttemptId,
+        }
+      : null,
+  };
+}
+
+function compareEntries(
+  left: RunAnnotationEntry,
+  right: RunAnnotationEntry,
+  index: Map<string, JobIndexEntry>,
+): number {
+  const bySeverity = SEVERITY_RANK[left.annotation.style] - SEVERITY_RANK[right.annotation.style];
+  if (bySeverity !== 0) return bySeverity;
+
+  const byJob = jobPosition(left, index) - jobPosition(right, index);
+  if (byJob !== 0) return byJob;
+
+  const byExecution = executionSequence(left, index) - executionSequence(right, index);
+  if (byExecution !== 0) return byExecution;
+
+  const bySequence = left.annotation.sequence - right.annotation.sequence;
+  if (bySequence !== 0) return bySequence;
+
+  return left.annotation.id.localeCompare(right.annotation.id);
+}
+
+/** An unmatched job sorts last rather than first, so known provenance leads the list. */
+function jobPosition(entry: RunAnnotationEntry, index: Map<string, JobIndexEntry>): number {
+  return index.get(entry.annotation.jobId)?.position ?? Number.MAX_SAFE_INTEGER;
+}
+
+function executionSequence(entry: RunAnnotationEntry, index: Map<string, JobIndexEntry>): number {
+  const job = index.get(entry.annotation.jobId);
+  return job?.executions.get(entry.annotation.jobExecutionId)?.sequence ?? Number.MAX_SAFE_INTEGER;
+}

--- a/libs/client/workflows/src/core/workflow-run-tabs.ts
+++ b/libs/client/workflows/src/core/workflow-run-tabs.ts
@@ -1,8 +1,0 @@
-/** Counts used by the run detail tab strip before the annotations query owns the data. */
-export interface RunAnnotationSummary {
-  total: number;
-  error: number;
-  warning: number;
-  info: number;
-  success: number;
-}

--- a/libs/client/workflows/src/hooks/api/run-annotation-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/run-annotation-mapper.ts
@@ -1,0 +1,30 @@
+import type {AnnotationDto, ReadAnnotationsResponseDto} from '@shipfox/annotations-dto';
+import type {RunAnnotationRecord} from '#core/run-annotation.js';
+
+export interface RunAnnotationPage {
+  annotations: RunAnnotationRecord[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export function toRunAnnotation(dto: AnnotationDto): RunAnnotationRecord {
+  return {
+    id: dto.id,
+    jobId: dto.job_id,
+    jobExecutionId: dto.job_execution_id,
+    originStepId: dto.origin_step_id,
+    originStepAttempt: dto.origin_step_attempt,
+    context: dto.context,
+    style: dto.style,
+    sequence: dto.sequence,
+    body: dto.body,
+  };
+}
+
+export function toRunAnnotationPage(response: ReadAnnotationsResponseDto): RunAnnotationPage {
+  return {
+    annotations: response.annotations.map(toRunAnnotation),
+    hasMore: response.has_more,
+    nextCursor: response.next_cursor,
+  };
+}

--- a/libs/client/workflows/src/hooks/api/run-annotations.ts
+++ b/libs/client/workflows/src/hooks/api/run-annotations.ts
@@ -1,0 +1,137 @@
+import {READ_ANNOTATIONS_MAX_LIMIT, readAnnotationsResponseSchema} from '@shipfox/annotations-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {
+  type InfiniteData,
+  infiniteQueryOptions,
+  type UseInfiniteQueryOptions,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import {
+  type RunAnnotationRecord,
+  type RunAnnotationSummary,
+  summarizeRunAnnotations,
+} from '#core/run-annotation.js';
+import {type RunAnnotationPage, toRunAnnotationPage} from './run-annotation-mapper.js';
+
+/** Matches the run detail poll, so annotations and run state never disagree by more than a tick. */
+const ACTIVE_POLL_MS = 4_000;
+
+export const runAnnotationsQueryKeys = {
+  all: ['run-annotations'] as const,
+  list: (workflowRunId: string, runAttempt?: number | undefined) =>
+    [...runAnnotationsQueryKeys.all, 'list', workflowRunId, runAttempt ?? null] as const,
+};
+
+type RunAnnotationsQueryKey =
+  | ReturnType<typeof runAnnotationsQueryKeys.list>
+  | readonly ['run-annotations', 'list'];
+
+type RunAnnotationsQueryOptions = UseInfiniteQueryOptions<
+  RunAnnotationPage,
+  Error,
+  InfiniteData<RunAnnotationPage, string | undefined>,
+  RunAnnotationsQueryKey,
+  string | undefined
+>;
+
+async function listRunAnnotations({
+  workflowRunId,
+  runAttempt,
+  cursor,
+  signal,
+}: {
+  workflowRunId: string;
+  runAttempt: number;
+  cursor?: string | undefined;
+  signal?: AbortSignal;
+}): Promise<RunAnnotationPage> {
+  const params = new URLSearchParams({
+    workflow_run_id: workflowRunId,
+    attempt: String(runAttempt),
+    limit: String(READ_ANNOTATIONS_MAX_LIMIT),
+  });
+  if (cursor) params.set('cursor', cursor);
+
+  return toRunAnnotationPage(
+    await checkedApiRequest(readAnnotationsResponseSchema, `/annotations?${params.toString()}`, {
+      signal,
+    }),
+  );
+}
+
+export interface RunAnnotationsQueryInput {
+  workflowRunId: string | undefined;
+  runAttempt: number | undefined;
+  /** Poll while the run attempt is non-terminal, then settle. */
+  live?: boolean | undefined;
+}
+
+export function runAnnotationsQueryOptions({
+  workflowRunId,
+  runAttempt,
+  live = false,
+}: RunAnnotationsQueryInput): RunAnnotationsQueryOptions {
+  const enabled = Boolean(workflowRunId) && runAttempt !== undefined;
+
+  // Polling stops once the reader has paged past the first page: the cursor bounding page 2 was
+  // computed from page 1's last row, so a refetch that shifts that boundary can drop a range of
+  // annotations into a between-pages gap.
+  return infiniteQueryOptions({
+    queryKey: workflowRunId
+      ? runAnnotationsQueryKeys.list(workflowRunId, runAttempt)
+      : ([...runAnnotationsQueryKeys.all, 'list'] as const),
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({pageParam, signal}) =>
+      listRunAnnotations({
+        workflowRunId: workflowRunId ?? '',
+        runAttempt: runAttempt ?? 1,
+        cursor: pageParam,
+        signal,
+      }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: 2_000,
+    refetchOnWindowFocus: true,
+    refetchInterval: (query) => {
+      if (!live) return false;
+      const pages = query.state.data?.pages;
+      return pages && pages.length > 1 ? false : ACTIVE_POLL_MS;
+    },
+    refetchIntervalInBackground: false,
+  });
+}
+
+export interface RunAnnotationsQueryResult {
+  query: ReturnType<
+    typeof useInfiniteQuery<
+      RunAnnotationPage,
+      Error,
+      InfiniteData<RunAnnotationPage, string | undefined>,
+      RunAnnotationsQueryKey,
+      string | undefined
+    >
+  >;
+  /** `undefined` until the first page resolves, so counts never render a speculative zero. */
+  annotations: RunAnnotationRecord[] | undefined;
+  summary: RunAnnotationSummary | undefined;
+}
+
+export function useRunAnnotationsQuery(input: RunAnnotationsQueryInput): RunAnnotationsQueryResult {
+  const query = useInfiniteQuery(runAnnotationsQueryOptions(input));
+  const pages = query.data?.pages;
+
+  const annotations = useMemo(
+    () => (pages ? pages.flatMap((page) => page.annotations) : undefined),
+    [pages],
+  );
+  const summary = useMemo(
+    () =>
+      annotations
+        ? summarizeRunAnnotations(annotations, {truncated: pages?.at(-1)?.hasMore ?? false})
+        : undefined,
+    [annotations, pages],
+  );
+
+  return {query, annotations, summary};
+}

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -33,8 +33,59 @@ const BACK_TO_SUMMARY_PATTERN = /Back to run summary/;
 const RUN_MOVED_ON_PATTERN = /Run moved on to/;
 const LINT_LINK_PATTERN = /lint/;
 const RELEASE_LINK_PATTERN = /release/;
+const ANNOTATION_LINK_PATTERN = /annotation/;
 
 describe('WorkflowJobDetailPage', () => {
+  beforeEach(() => {
+    jobAnnotations.value = [];
+  });
+
+  test('links the job to its annotations without rendering one', async () => {
+    jobAnnotations.value = [
+      {
+        id: 'aaaaaaaa-1111-4aaa-8aaa-000000000001',
+        job_id: JOB_ID,
+        job_execution_id: EXECUTION_ID,
+        origin_step_id: STEP_ID,
+        origin_step_attempt: 2,
+        context: 'smoke check',
+        style: 'error',
+        sequence: 1,
+        body: 'Task nine failed.',
+      },
+      {
+        id: 'aaaaaaaa-1111-4aaa-8aaa-000000000002',
+        job_id: SIBLING_JOB_ID,
+        job_execution_id: EXECUTION_ID,
+        origin_step_id: STEP_ID,
+        origin_step_attempt: 1,
+        context: 'other job',
+        style: 'info',
+        sequence: 2,
+        body: 'Not this job.',
+      },
+    ];
+    configureApiClient({fetchImpl: vi.fn(jobDetailFetch)});
+
+    renderJobPath(`?jobExecution=${EXECUTION_ID}&runAttempt=1`);
+
+    const chip = await screen.findByRole('link', {
+      name: 'View 1 annotation, highest severity error',
+    });
+    expect(chip.getAttribute('href')).toContain(`tab=annotations`);
+    expect(chip.getAttribute('href')).toContain(`job=${JOB_ID}`);
+    expect(screen.queryByText('Task nine failed.')).not.toBeInTheDocument();
+  });
+
+  test('omits the annotation chip when the job produced none', async () => {
+    configureApiClient({fetchImpl: vi.fn(jobDetailFetch)});
+
+    renderJobPath(`?jobExecution=${EXECUTION_ID}&runAttempt=1`);
+
+    await screen.findByRole('heading', {name: 'release'});
+    expect(screen.queryByRole('link', {name: ANNOTATION_LINK_PATTERN})).not.toBeInTheDocument();
+  });
+
   test('resolves an exact job execution and step attempt from a deep link', async () => {
     configureApiClient({fetchImpl: vi.fn(jobDetailFetch)});
 
@@ -247,9 +298,20 @@ function renderJobPath(path = '', jobId = JOB_ID) {
   );
 }
 
+/** Annotations for the job page, which renders their count and never their bodies. */
+const jobAnnotations: {value: unknown[]} = {value: []};
+
+function annotationsResponse() {
+  return {annotations: jobAnnotations.value, has_more: false, next_cursor: null};
+}
+
 function jobDetailFetch(input: RequestInfo | URL) {
   const request = input as Request;
   const url = new URL(request.url);
+
+  if (url.pathname.endsWith('/annotations')) {
+    return Promise.resolve(jsonResponse(annotationsResponse()));
+  }
 
   if (url.pathname.endsWith('/attempts')) {
     return Promise.resolve(
@@ -286,6 +348,10 @@ function jobDetailFetch(input: RequestInfo | URL) {
 function newerAttemptJobDetailFetch(input: RequestInfo | URL) {
   const request = input as Request;
   const url = new URL(request.url);
+
+  if (url.pathname.endsWith('/annotations')) {
+    return Promise.resolve(jsonResponse(annotationsResponse()));
+  }
 
   if (url.pathname.endsWith('/attempts')) {
     return Promise.resolve(

--- a/libs/client/workflows/src/routes/inputs.ts
+++ b/libs/client/workflows/src/routes/inputs.ts
@@ -1,3 +1,4 @@
+import {RUN_ANNOTATION_SEVERITIES, type RunAnnotationSeverity} from '#core/run-annotation.js';
 import type {WorkflowRunSelectionInput} from '#core/workflow-run-url-state.js';
 
 /**
@@ -12,9 +13,13 @@ export const WORKFLOW_RUN_TABS = ['summary', 'jobs', 'annotations', 'source'] as
 
 export type WorkflowRunTab = (typeof WORKFLOW_RUN_TABS)[number];
 
-export const WORKFLOW_RUN_ANNOTATION_SEVERITIES = ['error', 'warning', 'info', 'success'] as const;
+/**
+ * The `severity` parameter's vocabulary is the display severity set, not a second list: a URL
+ * that could name a severity the list cannot rank would be a filter with no matching rows.
+ */
+export const WORKFLOW_RUN_ANNOTATION_SEVERITIES = RUN_ANNOTATION_SEVERITIES;
 
-export type WorkflowRunAnnotationSeverity = (typeof WORKFLOW_RUN_ANNOTATION_SEVERITIES)[number];
+export type WorkflowRunAnnotationSeverity = RunAnnotationSeverity;
 
 export interface WorkflowRunsSearch extends WorkflowRunSelectionInput {
   search?: string;

--- a/libs/shared/react/ui/src/components/markdown/markdown.test.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.test.tsx
@@ -63,7 +63,9 @@ describe('Markdown', () => {
 [docs](https://example.com/docs)
 `);
 
-    expect(getByRole('table')).not.toBeNull();
+    const table = getByRole('table');
+    expect(table.classList.contains('w-auto')).toBe(true);
+    expect(table.classList.contains('min-w-full')).toBe(false);
     expect(getByText('one')).not.toBeNull();
     const link = getByRole('link', {name: DOCS_LINK_NAME});
     expect(link.getAttribute('href')).toBe('https://example.com/docs');

--- a/libs/shared/react/ui/src/components/markdown/markdown.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.tsx
@@ -79,11 +79,13 @@ const markdownComponents = {
       {...props}
     />
   ),
+  // Sized to content, not to the container: a two-column table stretched to full width puts a
+  // cell 700px from its row header. The scroll container still absorbs a table too wide to fit.
   table: ({className, node: _node, ...props}) => (
     <div className="mb-8 overflow-x-auto">
       <table
         className={cn(
-          'min-w-full border-collapse border border-border-neutral-base text-sm tabular-nums',
+          'w-auto border-collapse border border-border-neutral-base text-sm tabular-nums',
           className,
         )}
         {...props}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6110,6 +6110,9 @@ importers:
 
   libs/client/workflows:
     dependencies:
+      '@shipfox/annotations-dto':
+        specifier: workspace:*
+        version: link:../../api/annotations-dto
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../../api/definitions-dto


### PR DESCRIPTION
Run annotations now have a dedicated workspace section so operators can find the most important messages and trace them back to the emitting job. The view ranks annotations by severity and emission order, supports severity and job filtering, makes the 500-row client budget explicit, and links job-level counts into the filtered view.

Annotation bodies render through a reusable bounded card: collapsed cards parse only a line-safe 4,000-character preview, disclose overflow on first paint, and parse the full Markdown only when expanded. Live polling is scoped to the Annotations section so summary, source, and job-log views no longer re-fetch full bodies every four seconds. Markdown tables also size to their content for easier scanning.

This remains a client-side surface over the existing cursor-paged body endpoint. ENG-1479 tracks server-owned counts and filtering, correct global ordering beyond the client budget, and a live paging model that does not trade freshness for cursor safety.

Validation: frozen install; dependency and lockfile policy; packed public artifacts; and `turbo test type type:emit check` across `@shipfox/client-ui...`, `@shipfox/client-workflows...`, and `@shipfox/react-ui...` (230/230 tasks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dedicated Annotations workspace with severity/job filters, job-level links, and a single place that renders bodies. Scoped, smarter polling and lazy Markdown parsing improve performance, and the client makes limits explicit in line with Linear ENG-1479.

- New Features
  - Annotations tab lists entries ranked by severity then emission order; supports severity and job filters; shows a 500-row client budget and labels truncation (“500 or more”).
  - Job pages show an annotation count chip that links into the run’s Annotations tab with filters applied; the nav shows the count only after it loads.
  - `AnnotationCard` accepts context title/provenance/action, clamps long bodies, renders a safe 4k preview, and parses full Markdown on expand.
  - Live polling runs only for the Annotations list, shares cache via `useRunAnnotationsQuery`, and pauses when the run is terminal or the last page is stable.
  - Severity icons are consistent across counts and cards; Markdown tables size to content for easier scanning.

- Dependencies
  - Add `@shipfox/annotations-dto`. Publish minor bumps to `@shipfox/react-ui`, `@shipfox/client-ui`, and `@shipfox/client-workflows`.

<sup>Written for commit e7d889709b9a78eb14799a2540a18e564e1a4de8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

