### PR TITLE
Retry workflow syncs when integrations connect

### DIFF
--- a/.changeset/retry-definition-sync-on-connection.md
+++ b/.changeset/retry-definition-sync-on-connection.md
@@ -1,0 +1,9 @@
+---
+'@shipfox/api-definitions': patch
+'@shipfox/api-integration-core': patch
+'@shipfox/api-integration-core-dto': minor
+'@shipfox/api-projects': patch
+'@shipfox/api-projects-dto': minor
+---
+
+Retry workspace workflow definition syncs when an integration connection becomes available.

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -6,6 +6,10 @@ import {
   type DefinitionsEventMap,
   definitionsEventSchemas,
 } from '@shipfox/api-definitions-dto';
+import {
+  INTEGRATION_CONNECTION_AVAILABLE,
+  type IntegrationsEventMap,
+} from '@shipfox/api-integration-core-dto';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {
   PROJECT_SOURCE_BOUND,
@@ -20,6 +24,7 @@ import {db, definitionsOutbox, migrationsPath} from '#db/index.js';
 import {createDefinitionRoutes} from '#presentation/index.js';
 import {createDefinitionsInterModulePresentation} from '#presentation/inter-module.js';
 import {
+  createOnIntegrationConnectionAvailable,
   onProjectSourceBound,
   onProjectSourceCommitObserved,
 } from '#presentation/subscribers/index.js';
@@ -46,7 +51,9 @@ export {db, definitionsOutbox, getDefinitionById, migrationsPath} from '#db/inde
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
-const subscriber = subscriberFactory<DefinitionsEventMap & ProjectsEventMap>();
+const subscriber = subscriberFactory<
+  DefinitionsEventMap & IntegrationsEventMap & ProjectsEventMap
+>();
 
 export interface CreateDefinitionsModuleOptions {
   projects: ProjectsModuleClient;
@@ -73,6 +80,10 @@ export function createDefinitionsModule({
         logger().info({event}, 'Definition resolved');
         return Promise.resolve();
       }),
+      subscriber(
+        INTEGRATION_CONNECTION_AVAILABLE,
+        createOnIntegrationConnectionAvailable(projects),
+      ),
       subscriber(PROJECT_SOURCE_BOUND, onProjectSourceBound),
       subscriber(PROJECT_SOURCE_COMMIT_OBSERVED, onProjectSourceCommitObserved),
     ],

--- a/libs/api/definitions/src/presentation/subscribers/index.ts
+++ b/libs/api/definitions/src/presentation/subscribers/index.ts
@@ -1,2 +1,3 @@
+export {createOnIntegrationConnectionAvailable} from './on-integration-connection-available.js';
 export {onProjectSourceBound} from './on-project-source-bound.js';
 export {onProjectSourceCommitObserved} from './on-project-source-commit-observed.js';

--- a/libs/api/definitions/src/presentation/subscribers/on-integration-connection-available.test.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-integration-connection-available.test.ts
@@ -1,0 +1,104 @@
+import type {IntegrationConnectionAvailableEvent} from '@shipfox/api-integration-core-dto';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {createOnIntegrationConnectionAvailable} from './on-integration-connection-available.js';
+
+const startMock = vi.fn();
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({workflow: {start: startMock}}),
+}));
+
+function project(name: string, workspaceId: string) {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId,
+    sourceConnectionId: crypto.randomUUID(),
+    sourceExternalRepositoryId: `github:${name}`,
+    sourceRepositoryOwner: 'shipfox',
+    name,
+  };
+}
+
+describe('onIntegrationConnectionAvailable', () => {
+  beforeEach(() => {
+    startMock.mockReset();
+    startMock.mockResolvedValue({});
+  });
+
+  it('paginates workspace projects and starts an event-keyed sync for each one', async () => {
+    const workspaceId = crypto.randomUUID();
+    const first = project('first', workspaceId);
+    const second = project('second', workspaceId);
+    const cursor = {createdAt: '2026-08-05T12:00:00.000Z', id: first.id};
+    const listProjectsByWorkspace = vi
+      .fn()
+      .mockResolvedValueOnce({projects: [first], nextCursor: cursor})
+      .mockResolvedValueOnce({projects: [second], nextCursor: null});
+    const handler = createOnIntegrationConnectionAvailable({listProjectsByWorkspace} as never);
+    const payload: IntegrationConnectionAvailableEvent = {
+      provider: 'linear',
+      workspaceId: first.workspaceId,
+      connectionId: crypto.randomUUID(),
+      slug: 'linear_shipfox',
+    };
+    const event: DomainEvent<IntegrationConnectionAvailableEvent> = {
+      id: crypto.randomUUID(),
+      type: 'integrations.connection.available',
+      payload,
+      createdAt: new Date(),
+    };
+
+    await handler(payload, event);
+
+    expect(listProjectsByWorkspace).toHaveBeenNthCalledWith(1, {
+      workspaceId: payload.workspaceId,
+      limit: 100,
+    });
+    expect(listProjectsByWorkspace).toHaveBeenNthCalledWith(2, {
+      workspaceId: payload.workspaceId,
+      limit: 100,
+      cursor,
+    });
+    expect(startMock).toHaveBeenCalledTimes(2);
+    for (const candidate of [first, second]) {
+      expect(startMock).toHaveBeenCalledWith('definitionSyncWorkflow', {
+        taskQueue: 'definitions-sync',
+        workflowId: `definition-sync:${candidate.id}:integration:${event.id}`,
+        workflowIdConflictPolicy: 'USE_EXISTING',
+        workflowIdReusePolicy: 'ALLOW_DUPLICATE',
+        args: [
+          {
+            projectId: candidate.id,
+            workspaceId: candidate.workspaceId,
+            sourceConnectionId: candidate.sourceConnectionId,
+            sourceExternalRepositoryId: candidate.sourceExternalRepositoryId,
+            sourceRef: undefined,
+            sourceCommitSha: undefined,
+          },
+        ],
+      });
+    }
+  });
+
+  it('rethrows project lookup failures so the outbox event can retry', async () => {
+    const failure = new Error('projects unavailable');
+    const handler = createOnIntegrationConnectionAvailable({
+      listProjectsByWorkspace: vi.fn(() => Promise.reject(failure)),
+    } as never);
+    const payload: IntegrationConnectionAvailableEvent = {
+      provider: 'linear',
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      slug: 'linear_shipfox',
+    };
+
+    await expect(
+      handler(payload, {
+        id: crypto.randomUUID(),
+        type: 'integrations.connection.available',
+        payload,
+        createdAt: new Date(),
+      }),
+    ).rejects.toBe(failure);
+  });
+});

--- a/libs/api/definitions/src/presentation/subscribers/on-integration-connection-available.test.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-integration-connection-available.test.ts
@@ -65,7 +65,7 @@ describe('onIntegrationConnectionAvailable', () => {
         taskQueue: 'definitions-sync',
         workflowId: `definition-sync:${candidate.id}:integration:${event.id}`,
         workflowIdConflictPolicy: 'USE_EXISTING',
-        workflowIdReusePolicy: 'ALLOW_DUPLICATE',
+        workflowIdReusePolicy: 'REJECT_DUPLICATE',
         args: [
           {
             projectId: candidate.id,
@@ -78,6 +78,34 @@ describe('onIntegrationConnectionAvailable', () => {
         ],
       });
     }
+  });
+
+  it('treats an already-started event-keyed sync as successfully delivered', async () => {
+    const workspaceId = crypto.randomUUID();
+    const candidate = project('first', workspaceId);
+    const alreadyStarted = new Error('Workflow execution already started');
+    alreadyStarted.name = 'WorkflowExecutionAlreadyStartedError';
+    startMock.mockRejectedValue(alreadyStarted);
+    const handler = createOnIntegrationConnectionAvailable({
+      listProjectsByWorkspace: vi.fn(() =>
+        Promise.resolve({projects: [candidate], nextCursor: null}),
+      ),
+    } as never);
+    const payload: IntegrationConnectionAvailableEvent = {
+      provider: 'linear',
+      workspaceId,
+      connectionId: crypto.randomUUID(),
+      slug: 'linear_shipfox',
+    };
+
+    await expect(
+      handler(payload, {
+        id: crypto.randomUUID(),
+        type: 'integrations.connection.available',
+        payload,
+        createdAt: new Date(),
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('rethrows project lookup failures so the outbox event can retry', async () => {

--- a/libs/api/definitions/src/presentation/subscribers/on-integration-connection-available.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-integration-connection-available.ts
@@ -1,0 +1,44 @@
+import type {IntegrationConnectionAvailableEvent} from '@shipfox/api-integration-core-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {boundedMap} from '@shipfox/node-module';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {startDefinitionSync} from './start-definition-sync.js';
+
+const PROJECT_PAGE_SIZE = 100;
+const SYNC_START_CONCURRENCY = 10;
+
+export function createOnIntegrationConnectionAvailable(
+  projects: Pick<ProjectsModuleClient, 'listProjectsByWorkspace'>,
+) {
+  return async function onIntegrationConnectionAvailable(
+    payload: IntegrationConnectionAvailableEvent,
+    event: DomainEvent<IntegrationConnectionAvailableEvent>,
+  ): Promise<void> {
+    let cursor: {createdAt: string; id: string} | undefined;
+
+    do {
+      const page = await projects.listProjectsByWorkspace({
+        workspaceId: payload.workspaceId,
+        limit: PROJECT_PAGE_SIZE,
+        ...(cursor ? {cursor} : {}),
+      });
+
+      await boundedMap(
+        page.projects,
+        SYNC_START_CONCURRENCY,
+        async (project) => {
+          await startDefinitionSync({
+            projectId: project.id,
+            workspaceId: project.workspaceId,
+            sourceConnectionId: project.sourceConnectionId,
+            externalRepositoryId: project.sourceExternalRepositoryId,
+            requestId: `integration:${event.id}`,
+          });
+        },
+        {stopOnError: true},
+      );
+
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor);
+  };
+}

--- a/libs/api/definitions/src/presentation/subscribers/start-definition-sync.ts
+++ b/libs/api/definitions/src/presentation/subscribers/start-definition-sync.ts
@@ -8,6 +8,7 @@ export interface StartDefinitionSyncParams {
   externalRepositoryId: string;
   sourceRef?: string | undefined;
   sourceCommitSha?: string | undefined;
+  requestId?: string | undefined;
 }
 
 export async function startDefinitionSync(params: StartDefinitionSyncParams): Promise<void> {
@@ -32,7 +33,11 @@ export async function startDefinitionSync(params: StartDefinitionSyncParams): Pr
 }
 
 function buildWorkflowId(params: StartDefinitionSyncParams): string {
-  return params.sourceCommitSha
-    ? `definition-sync:${params.projectId}:${params.sourceCommitSha}`
-    : `definition-sync:${params.projectId}:bind`;
+  if (params.sourceCommitSha) {
+    return `definition-sync:${params.projectId}:${params.sourceCommitSha}`;
+  }
+  if (params.requestId) {
+    return `definition-sync:${params.projectId}:${params.requestId}`;
+  }
+  return `definition-sync:${params.projectId}:bind`;
 }

--- a/libs/api/definitions/src/presentation/subscribers/start-definition-sync.ts
+++ b/libs/api/definitions/src/presentation/subscribers/start-definition-sync.ts
@@ -14,22 +14,33 @@ export interface StartDefinitionSyncParams {
 export async function startDefinitionSync(params: StartDefinitionSyncParams): Promise<void> {
   const workflowId = buildWorkflowId(params);
 
-  await temporalClient().workflow.start(DEFINITION_SYNC_WORKFLOW, {
-    taskQueue: DEFINITIONS_TASK_QUEUE,
-    workflowId,
-    workflowIdConflictPolicy: 'USE_EXISTING',
-    workflowIdReusePolicy: 'ALLOW_DUPLICATE',
-    args: [
-      {
-        projectId: params.projectId,
-        workspaceId: params.workspaceId,
-        sourceConnectionId: params.sourceConnectionId,
-        sourceExternalRepositoryId: params.externalRepositoryId,
-        sourceRef: params.sourceRef,
-        sourceCommitSha: params.sourceCommitSha,
-      },
-    ],
-  });
+  try {
+    await temporalClient().workflow.start(DEFINITION_SYNC_WORKFLOW, {
+      taskQueue: DEFINITIONS_TASK_QUEUE,
+      workflowId,
+      workflowIdConflictPolicy: 'USE_EXISTING',
+      workflowIdReusePolicy: params.requestId ? 'REJECT_DUPLICATE' : 'ALLOW_DUPLICATE',
+      args: [
+        {
+          projectId: params.projectId,
+          workspaceId: params.workspaceId,
+          sourceConnectionId: params.sourceConnectionId,
+          sourceExternalRepositoryId: params.externalRepositoryId,
+          sourceRef: params.sourceRef,
+          sourceCommitSha: params.sourceCommitSha,
+        },
+      ],
+    });
+  } catch (error) {
+    if (
+      params.requestId &&
+      error instanceof Error &&
+      error.name === 'WorkflowExecutionAlreadyStartedError'
+    ) {
+      return;
+    }
+    throw error;
+  }
 }
 
 function buildWorkflowId(params: StartDefinitionSyncParams): string {

--- a/libs/api/integration/core-dto/src/events.test.ts
+++ b/libs/api/integration/core-dto/src/events.test.ts
@@ -1,12 +1,21 @@
 import {
+  INTEGRATION_CONNECTION_AVAILABLE,
   INTEGRATION_EVENT_RECEIVED,
   INTEGRATION_SOURCE_COMMIT_PUSHED,
   INTEGRATION_SOURCE_REPOSITORY_UPDATED,
+  integrationConnectionAvailableSchema,
   integrationEventReceivedSchema,
   integrationSourceCommitPushedSchema,
   integrationSourceRepositoryUpdatedSchema,
   integrationsEventSchemas,
 } from './events.js';
+
+const validConnectionAvailable = {
+  provider: 'linear',
+  workspaceId: 'ws-1',
+  connectionId: 'conn-1',
+  slug: 'linear_shipfox',
+};
 
 const validEventReceived = {
   provider: 'github',
@@ -48,6 +57,20 @@ const validRepositoryUpdated = {
     defaultBranch: 'main',
   },
 };
+
+describe('integrationConnectionAvailableSchema', () => {
+  it('parses a valid connection-available payload unchanged', () => {
+    expect(integrationConnectionAvailableSchema.parse(validConnectionAvailable)).toEqual(
+      validConnectionAvailable,
+    );
+  });
+
+  it('rejects a payload without a connection slug', () => {
+    const {slug: _slug, ...withoutSlug} = validConnectionAvailable;
+
+    expect(() => integrationConnectionAvailableSchema.parse(withoutSlug)).toThrow();
+  });
+});
 
 describe('integrationSourceCommitPushedSchema', () => {
   it('parses a valid commit-pushed payload unchanged', () => {
@@ -136,6 +159,7 @@ describe('integrationsEventSchemas', () => {
 
     expect(registeredTypes).toEqual(
       [
+        INTEGRATION_CONNECTION_AVAILABLE,
         INTEGRATION_EVENT_RECEIVED,
         INTEGRATION_SOURCE_COMMIT_PUSHED,
         INTEGRATION_SOURCE_REPOSITORY_UPDATED,

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -1,6 +1,7 @@
 import {z} from 'zod';
 
 export const INTEGRATION_EVENT_RECEIVED = 'integrations.event.received' as const;
+export const INTEGRATION_CONNECTION_AVAILABLE = 'integrations.connection.available' as const;
 
 const nonEmptyStringSchema = z.string().nonempty();
 const isoDateTimeSchema = z.string().datetime();
@@ -21,6 +22,16 @@ export const integrationEventReceivedSchema = z.object({
   payload: requiredUnknownSchema,
 });
 export type IntegrationEventReceivedEvent = z.infer<typeof integrationEventReceivedSchema>;
+
+export const integrationConnectionAvailableSchema = z.object({
+  provider: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  connectionId: nonEmptyStringSchema,
+  slug: nonEmptyStringSchema,
+});
+export type IntegrationConnectionAvailableEvent = z.infer<
+  typeof integrationConnectionAvailableSchema
+>;
 
 // A source-control push, normalized by the producing provider and carried by
 // `INTEGRATION_SOURCE_COMMIT_PUSHED` for domain consumers.
@@ -107,12 +118,14 @@ export const SENTRY_ISSUE_ACTIONS = [
 export type SentryIssueAction = (typeof SENTRY_ISSUE_ACTIONS)[number];
 
 export interface IntegrationsEventMap {
+  [INTEGRATION_CONNECTION_AVAILABLE]: IntegrationConnectionAvailableEvent;
   [INTEGRATION_EVENT_RECEIVED]: IntegrationEventReceivedEvent;
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: IntegrationSourceCommitPushedEvent;
   [INTEGRATION_SOURCE_REPOSITORY_UPDATED]: IntegrationSourceRepositoryUpdatedEvent;
 }
 
 export const integrationsEventSchemas = {
+  [INTEGRATION_CONNECTION_AVAILABLE]: integrationConnectionAvailableSchema,
   [INTEGRATION_EVENT_RECEIVED]: integrationEventReceivedSchema,
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: integrationSourceCommitPushedSchema,
   [INTEGRATION_SOURCE_REPOSITORY_UPDATED]: integrationSourceRepositoryUpdatedSchema,

--- a/libs/api/integration/core/src/db/connections.test.ts
+++ b/libs/api/integration/core/src/db/connections.test.ts
@@ -1,5 +1,7 @@
+import {INTEGRATION_CONNECTION_AVAILABLE} from '@shipfox/api-integration-core-dto';
 import {upsertGithubInstallation} from '@shipfox/api-integration-github';
 import {ConnectionSlugConflictError} from '@shipfox/api-integration-spi';
+import {sql} from 'drizzle-orm';
 import {IntegrationConnectionAlreadyExistsError} from '#core/errors.js';
 import {
   createIntegrationConnection,
@@ -13,6 +15,16 @@ import {
   upsertIntegrationConnection,
 } from './connections.js';
 import {db} from './db.js';
+import {integrationsOutbox} from './schema/outbox.js';
+
+function connectionEvents(connectionId: string) {
+  return db()
+    .select()
+    .from(integrationsOutbox)
+    .where(
+      sql`${integrationsOutbox.eventType} = ${INTEGRATION_CONNECTION_AVAILABLE} AND ${integrationsOutbox.payload}->>'connectionId' = ${connectionId}`,
+    );
+}
 
 describe('integration connection queries', () => {
   let workspaceId: string;
@@ -41,6 +53,31 @@ describe('integration connection queries', () => {
     expect(second.id).toBe(first.id);
     expect(second.displayName).toBe('Renamed Debug');
     expect(second.slug).toBe('gitea_owner');
+    expect(await connectionEvents(first.id)).toHaveLength(1);
+  });
+
+  it('publishes availability when an upsert activates an existing connection', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'linear',
+      externalAccountId: 'linear-acme',
+      slug: 'linear_acme',
+      displayName: 'Linear Acme',
+      lifecycleStatus: 'disabled',
+    });
+
+    expect(await connectionEvents(connection.id)).toHaveLength(0);
+
+    await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'linear',
+      externalAccountId: 'linear-acme',
+      slug: 'linear_acme',
+      displayName: 'Linear Acme',
+      lifecycleStatus: 'active',
+    });
+
+    expect(await connectionEvents(connection.id)).toHaveLength(1);
   });
 
   it('allows multiple same-provider connections when external account differs', async () => {
@@ -148,6 +185,7 @@ describe('integration connection queries', () => {
     expect(connections).toHaveLength(1);
     expect(connections[0]?.id).toBe(first.id);
     expect(connections[0]?.displayName).toBe('Stripe');
+    expect(await connectionEvents(first.id)).toHaveLength(1);
   });
 
   it('reports slug collisions separately from duplicate external accounts', async () => {
@@ -252,6 +290,51 @@ describe('integration connection queries', () => {
     expect(updated?.lifecycleStatus).toBe('disabled');
     const reloaded = await getIntegrationConnectionById(connection.id);
     expect(reloaded?.lifecycleStatus).toBe('disabled');
+    expect(await connectionEvents(connection.id)).toHaveLength(1);
+  });
+
+  it('publishes availability when a disabled connection becomes active', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'linear',
+      externalAccountId: 'linear-acme',
+      slug: 'linear_acme',
+      displayName: 'Linear Acme',
+      lifecycleStatus: 'disabled',
+    });
+
+    expect(await connectionEvents(connection.id)).toHaveLength(0);
+
+    await updateIntegrationConnectionLifecycleStatus({
+      id: connection.id,
+      lifecycleStatus: 'active',
+    });
+
+    const events = await connectionEvents(connection.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toEqual({
+      provider: 'linear',
+      workspaceId,
+      connectionId: connection.id,
+      slug: 'linear_acme',
+    });
+  });
+
+  it('does not republish availability when an active connection stays active', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'linear',
+      externalAccountId: 'linear-acme',
+      slug: 'linear_acme',
+      displayName: 'Linear Acme',
+    });
+
+    await updateIntegrationConnectionLifecycleStatus({
+      id: connection.id,
+      lifecycleStatus: 'active',
+    });
+
+    expect(await connectionEvents(connection.id)).toHaveLength(1);
   });
 
   it('returns undefined when updating the lifecycle status of an unknown connection', async () => {
@@ -310,5 +393,12 @@ describe('integration connection queries', () => {
 
     const connections = await listIntegrationConnections({workspaceId});
     expect(connections).toHaveLength(0);
+    const events = await db()
+      .select()
+      .from(integrationsOutbox)
+      .where(
+        sql`${integrationsOutbox.eventType} = ${INTEGRATION_CONNECTION_AVAILABLE} AND ${integrationsOutbox.payload}->>'workspaceId' = ${workspaceId}`,
+      );
+    expect(events).toHaveLength(0);
   });
 });

--- a/libs/api/integration/core/src/db/connections.ts
+++ b/libs/api/integration/core/src/db/connections.ts
@@ -1,5 +1,10 @@
-import {CONNECTION_SLUG_MAX_LENGTH} from '@shipfox/api-integration-core-dto';
+import {
+  CONNECTION_SLUG_MAX_LENGTH,
+  INTEGRATION_CONNECTION_AVAILABLE,
+  type IntegrationsEventMap,
+} from '@shipfox/api-integration-core-dto';
 import {ConnectionSlugConflictError} from '@shipfox/api-integration-spi';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, eq} from 'drizzle-orm';
 import type {
   IntegrationConnection,
@@ -9,6 +14,7 @@ import type {IntegrationProviderKind} from '#core/entities/provider.js';
 import {IntegrationConnectionAlreadyExistsError} from '#core/errors.js';
 import {db} from './db.js';
 import {integrationConnections, toIntegrationConnection} from './schema/connections.js';
+import {integrationsOutbox} from './schema/outbox.js';
 
 type IntegrationDb = ReturnType<typeof db>;
 type IntegrationTx = Parameters<Parameters<IntegrationDb['transaction']>[0]>[0];
@@ -26,9 +32,13 @@ export async function upsertIntegrationConnection(
   params: UpsertIntegrationConnectionParams,
   options: {tx?: IntegrationDb | IntegrationTx | undefined} = {},
 ): Promise<IntegrationConnection> {
-  const executor = options.tx ?? db();
+  if (options.tx === undefined) {
+    return await db().transaction((tx) => upsertIntegrationConnection(params, {tx}));
+  }
+
+  const executor = options.tx;
   const now = new Date();
-  const [row] = await executor
+  let [row] = await executor
     .insert(integrationConnections)
     .values({
       workspaceId: params.workspaceId,
@@ -38,22 +48,52 @@ export async function upsertIntegrationConnection(
       displayName: params.displayName,
       lifecycleStatus: params.lifecycleStatus ?? 'active',
     })
-    .onConflictDoUpdate({
+    .onConflictDoNothing({
       target: [
         integrationConnections.workspaceId,
         integrationConnections.provider,
         integrationConnections.externalAccountId,
       ],
-      set: {
-        displayName: params.displayName,
-        lifecycleStatus: params.lifecycleStatus ?? 'active',
-        updatedAt: now,
-      },
     })
     .returning();
 
+  let becameAvailable = row?.lifecycleStatus === 'active';
+  if (!row) {
+    const [existing] = await executor
+      .select({
+        id: integrationConnections.id,
+        lifecycleStatus: integrationConnections.lifecycleStatus,
+      })
+      .from(integrationConnections)
+      .where(
+        and(
+          eq(integrationConnections.workspaceId, params.workspaceId),
+          eq(integrationConnections.provider, params.provider),
+          eq(integrationConnections.externalAccountId, params.externalAccountId),
+        ),
+      )
+      .limit(1)
+      .for('update');
+    if (!existing) throw new Error('Integration connection upsert conflict row was not found');
+
+    [row] = await executor
+      .update(integrationConnections)
+      .set({
+        displayName: params.displayName,
+        lifecycleStatus: params.lifecycleStatus ?? 'active',
+        updatedAt: now,
+      })
+      .where(eq(integrationConnections.id, existing.id))
+      .returning();
+    becameAvailable = existing.lifecycleStatus !== 'active' && row?.lifecycleStatus === 'active';
+  }
+
   if (!row) throw new Error('Integration connection upsert returned no rows');
-  return toIntegrationConnection(row);
+  const connection = toIntegrationConnection(row);
+  if (becameAvailable) {
+    await writeConnectionAvailableEvent(executor, connection);
+  }
+  return connection;
 }
 
 export interface CreateIntegrationConnectionParams {
@@ -100,7 +140,11 @@ export async function createIntegrationConnection(
   params: CreateIntegrationConnectionParams,
   options: {tx?: IntegrationDb | IntegrationTx | undefined} = {},
 ): Promise<IntegrationConnection> {
-  const executor = options.tx ?? db();
+  if (options.tx === undefined) {
+    return await db().transaction((tx) => createIntegrationConnection(params, {tx}));
+  }
+
+  const executor = options.tx;
   let rows: (typeof integrationConnections.$inferSelect)[];
   try {
     rows = await executor
@@ -130,7 +174,11 @@ export async function createIntegrationConnection(
 
   const row = rows[0];
   if (!row) throw new Error('Integration connection insert returned no rows');
-  return toIntegrationConnection(row);
+  const connection = toIntegrationConnection(row);
+  if (connection.lifecycleStatus === 'active') {
+    await writeConnectionAvailableEvent(executor, connection);
+  }
+  return connection;
 }
 
 export interface ResolveUniqueConnectionSlugParams {
@@ -225,18 +273,49 @@ export async function updateIntegrationConnectionLifecycleStatus(
   params: UpdateIntegrationConnectionLifecycleStatusParams,
   options: {tx?: IntegrationDb | IntegrationTx | undefined} = {},
 ): Promise<IntegrationConnection | undefined> {
-  const executor = options.tx ?? db();
+  if (options.tx === undefined) {
+    return await db().transaction((tx) => updateIntegrationConnectionLifecycleStatus(params, {tx}));
+  }
+
+  const executor = options.tx;
+  const [existing] = await executor
+    .select({lifecycleStatus: integrationConnections.lifecycleStatus})
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, params.id))
+    .limit(1)
+    .for('update');
+  if (!existing) return undefined;
+
   const [row] = await executor
     .update(integrationConnections)
     .set({lifecycleStatus: params.lifecycleStatus, updatedAt: new Date()})
     .where(eq(integrationConnections.id, params.id))
     .returning();
   if (!row) return undefined;
-  return toIntegrationConnection(row);
+  const connection = toIntegrationConnection(row);
+  if (existing.lifecycleStatus !== 'active' && connection.lifecycleStatus === 'active') {
+    await writeConnectionAvailableEvent(executor, connection);
+  }
+  return connection;
 }
 
 export type UpdateIntegrationConnectionLifecycleStatusFn =
   typeof updateIntegrationConnectionLifecycleStatus;
+
+async function writeConnectionAvailableEvent(
+  executor: IntegrationDb | IntegrationTx,
+  connection: IntegrationConnection,
+): Promise<void> {
+  await writeOutboxEvent<IntegrationsEventMap>(executor, integrationsOutbox, {
+    type: INTEGRATION_CONNECTION_AVAILABLE,
+    payload: {
+      provider: connection.provider,
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      slug: connection.slug,
+    },
+  });
+}
 
 export async function deleteIntegrationConnection(
   params: {id: string},

--- a/libs/api/projects-dto/src/inter-module.test.ts
+++ b/libs/api/projects-dto/src/inter-module.test.ts
@@ -38,6 +38,22 @@ describe('projectsInterModuleContract', () => {
     ).toEqual({connection: connectionId, repository: 'acme/api'});
   });
 
+  test('accepts paginated workspace project source listings', () => {
+    const workspaceId = '00000000-0000-4000-8000-000000000001';
+    const cursor = {
+      createdAt: '2026-08-05T12:00:00.000Z',
+      id: '00000000-0000-4000-8000-000000000002',
+    };
+
+    expect(
+      projectsInterModuleContract.methods.listProjectsByWorkspace.input.parse({
+        workspaceId,
+        limit: 100,
+        cursor,
+      }),
+    ).toEqual({workspaceId, limit: 100, cursor});
+  });
+
   test('defines the checkout authorization failure', () => {
     const details = {};
 

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -14,6 +14,10 @@ const workspaceProjectCountSchema = z.object({
   workspaceId: idSchema,
   count: z.number().int().nonnegative(),
 });
+const projectCursorSchema = z.object({
+  createdAt: z.string().datetime(),
+  id: idSchema,
+});
 const checkoutTargetSchema = z.union([
   z.strictObject({project: idSchema}),
   z.strictObject({
@@ -42,6 +46,17 @@ export const projectsInterModuleContract = defineInterModuleContract({
         sourceExternalRepositoryId: z.string(),
       }),
       output: z.object({project: projectSchema.nullable()}),
+    },
+    listProjectsByWorkspace: {
+      input: z.object({
+        workspaceId: idSchema,
+        limit: z.number().int().min(1).max(100),
+        cursor: projectCursorSchema.optional(),
+      }),
+      output: z.object({
+        projects: z.array(projectSchema),
+        nextCursor: projectCursorSchema.nullable(),
+      }),
     },
     requireProjectForWorkspace: {
       input: z.object({projectId: idSchema, workspaceId: idSchema}),

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -109,9 +109,10 @@ describe('Projects checkout target inter-module presentation', () => {
     });
     expect(secondPage.projects).toHaveLength(1);
     expect(secondPage.nextCursor).toBeNull();
-    expect([...firstPage.projects, ...secondPage.projects].map((project) => project.id)).toEqual(
-      expect.arrayContaining([first.projectId, second.projectId]),
-    );
+    const projectIds = [...firstPage.projects, ...secondPage.projects]
+      .map((project) => project.id)
+      .sort();
+    expect(projectIds).toEqual([first.projectId, second.projectId].sort());
   });
 
   test('resolves a project by its workspace-scoped source repository', async () => {

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -75,6 +75,45 @@ async function expectUnauthorized(
 }
 
 describe('Projects checkout target inter-module presentation', () => {
+  test('lists workspace projects through the paginated inter-module contract', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const first = await insertProject({
+      workspaceId,
+      connectionId: crypto.randomUUID(),
+      owner: 'acme',
+      name: 'first',
+    });
+    const second = await insertProject({
+      workspaceId,
+      connectionId: crypto.randomUUID(),
+      owner: 'acme',
+      name: 'second',
+    });
+    await insertProject({
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      owner: 'other',
+      name: 'excluded',
+    });
+
+    const firstPage = await client.listProjectsByWorkspace({workspaceId, limit: 1});
+    expect(firstPage.projects).toHaveLength(1);
+    expect(firstPage.nextCursor).not.toBeNull();
+    if (!firstPage.nextCursor) expect.fail('Expected a second project page');
+
+    const secondPage = await client.listProjectsByWorkspace({
+      workspaceId,
+      limit: 1,
+      cursor: firstPage.nextCursor,
+    });
+    expect(secondPage.projects).toHaveLength(1);
+    expect(secondPage.nextCursor).toBeNull();
+    expect([...firstPage.projects, ...secondPage.projects].map((project) => project.id)).toEqual(
+      expect.arrayContaining([first.projectId, second.projectId]),
+    );
+  });
+
   test('resolves a project by its workspace-scoped source repository', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -9,6 +9,7 @@ import {
   getProjectById,
   getProjectBySource,
   getWorkspaceProjectCounts,
+  listProjects,
   resolveCheckoutTarget,
   updateProjectSourceMetadata,
 } from '#db/projects.js';
@@ -21,6 +22,19 @@ export function createProjectsInterModulePresentation(params: {
     getProjectBySource: async (input) => ({
       project: (await getProjectBySource(input)) ?? null,
     }),
+    listProjectsByWorkspace: async ({workspaceId, limit, cursor}) => {
+      const result = await listProjects({
+        workspaceId,
+        limit,
+        ...(cursor ? {cursor: {createdAt: new Date(cursor.createdAt), id: cursor.id}} : {}),
+      });
+      return {
+        projects: result.projects,
+        nextCursor: result.nextCursor
+          ? {createdAt: result.nextCursor.createdAt.toISOString(), id: result.nextCursor.id}
+          : null,
+      };
+    },
     requireProjectForWorkspace: async ({projectId, workspaceId}) => {
       const project = await getProjectById(projectId);
       if (project === undefined) {

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -26,6 +26,7 @@ const projects = createFakeInterModuleClients({
   projects: defineInterModulePresentation(projectsInterModuleContract, {
     getProjectById: () => ({project: null}),
     getProjectBySource: () => ({project: null}),
+    listProjectsByWorkspace: () => ({projects: [], nextCursor: null}),
     getWorkspaceProjectCounts: () => ({counts: []}),
     requireProjectForWorkspace: async (input) => await requireProjectForWorkspace(input),
     resolveCheckoutTarget: () => ({

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -160,6 +160,7 @@ describe('defaultModules', () => {
         defineInterModulePresentation(projectsInterModuleContract, {
           getProjectById: () => ({project: null}),
           getProjectBySource: () => ({project: null}),
+          listProjectsByWorkspace: () => ({projects: [], nextCursor: null}),
           getWorkspaceProjectCounts: () => ({counts: []}),
           requireProjectForWorkspace: () => ({
             project: {


### PR DESCRIPTION
## Summary

Workflow definition sync can fail when a referenced integration connection is unavailable. Connecting the missing integration currently leaves that error in place until another source push triggers a sync.

This change publishes a durable connection-available event when a connection is newly active or transitions back to active. Definitions consumes the event and starts an event-keyed sync for every project in the workspace, using paginated project lookup and bounded concurrency. Connection state and the outbox event commit atomically, while idempotent active writes do not repeat the workspace-wide fan-out.

The fan-out is intentionally provider-agnostic because workflow definitions may reference integration connections independently of the project's source provider.

## Validation

- `mise exec -- turbo build test check --filter='...[origin/main]'` (332 tasks passed)
- `mise exec -- pnpm turbo check type --affected` (482 tasks passed)
- `mise exec -- pnpm check:api-database-boundaries`
- Force-run `@shipfox/api-integration-core` tests (140 tests passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically retry workflow definition syncs when a required integration connection becomes available. We emit a durable `integrations.connection.available` event and fan out deduplicated, event-keyed syncs to all projects in the workspace.

- **New Features**
  - `@shipfox/api-integration-core`: Publish `integrations.connection.available` when a connection is created active or reactivated; event and state are atomic; active→active does not republish.
  - `@shipfox/api-definitions`: Subscribe and start a sync for each workspace project (100/page, concurrency 10); deduplicate with event-keyed workflow IDs via `requestId` and treat “already started” as delivered.
  - `@shipfox/api-integration-core-dto`: Add `INTEGRATION_CONNECTION_AVAILABLE` and its schema to `integrationsEventSchemas`.
  - `@shipfox/api-projects-dto` + `@shipfox/api-projects`: Add paginated `listProjectsByWorkspace`.

<sup>Written for commit 031e997e6c1e37578754f51e0782e5fc970ca586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

