### PR TITLE
[provisioner-ec2] Initialize OpenTelemetry runtime

### DIFF
--- a/apps/provisioner-ec2/src/index.ts
+++ b/apps/provisioner-ec2/src/index.ts
@@ -1,9 +1,28 @@
-import {logger} from '@shipfox/node-opentelemetry';
-import {startEc2Provisioner} from '@shipfox/provisioner-ec2-provider';
+import {
+  logger,
+  shutdownInstrumentation,
+  startInstanceInstrumentation,
+  startServiceMetrics,
+} from '@shipfox/node-opentelemetry';
 
 try {
+  await startInstanceInstrumentation({
+    serviceName: 'provisioner-ec2',
+    instrumentations: {
+      fastify: false,
+      http: true,
+      undici: true,
+      awsSdk: true,
+      pino: true,
+    },
+  });
+  startServiceMetrics({serviceName: 'provisioner-ec2'});
+
+  const {startEc2Provisioner} = await import('@shipfox/provisioner-ec2-provider');
   await startEc2Provisioner();
 } catch (error) {
   logger().error({error}, 'Fatal provisioner error');
-  process.exit(1);
+  process.exitCode = 1;
+} finally {
+  await shutdownInstrumentation();
 }


### PR DESCRIPTION
## Summary

Initialize instance instrumentation and the service metrics endpoint before loading the EC2 provider so the runtime emits traces, Pino logs, AWS SDK/HTTP telemetry, and Prometheus metrics on port 9474.

The entrypoint now preserves graceful termination while flushing telemetry during shutdown.

## Validation

- `mise exec -- turbo check type build --filter=@shipfox/provisioner-ec2...`
- `mise exec -- turbo test --filter=@shipfox/provisioner-ec2...`
- `mise exec -- turbo depcruise --filter=@shipfox/provisioner-ec2...`
- Built the `provisioner-ec2:ci` image and verified `/metrics` returned 200 in the container.
- Sent SIGTERM to the container and verified exit code 0.

## Follow-up

Image publication must run on CI/main to produce the immutable GHCR digest; the Cloud runtime pin can then be updated to that digest.

Refs ENG-1480

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize OpenTelemetry in the EC2 provisioner and expose Prometheus metrics on port 9474 before starting the provider. This restores ECS health checks and enables traces, Pino logs, and AWS SDK/HTTP telemetry.

- **Bug Fixes**
  - Start `@shipfox/node-opentelemetry` at boot: `startInstanceInstrumentation({ serviceName: 'provisioner-ec2', instrumentations: { http: true, undici: true, awsSdk: true, pino: true } })` and `startServiceMetrics({ serviceName: 'provisioner-ec2' })`.
  - Defer loading `@shipfox/provisioner-ec2-provider` until after instrumentation so startup dependencies are captured; `/metrics` is now available on 9474 for ECS health and the collector scrape (ENG-1480).
  - Preserve graceful shutdown by using `process.exitCode = 1` and `shutdownInstrumentation()` to flush telemetry on exit.

<sup>Written for commit 178a135ea60dd904d8f5f9096680b215e468d0c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

