### PR TITLE
[client-integrations] Fix page interaction after closing usage modal

### DIFF
--- a/.changeset/quiet-modal-exit.md
+++ b/.changeset/quiet-modal-exit.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-integrations": patch
+---
+
+Restores page interaction immediately after closing the integration usage modal.

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -15,6 +15,8 @@ import {
   Outlet,
   RouterProvider,
 } from '@tanstack/react-router';
+import {screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {createStore, Provider as JotaiProvider} from 'jotai';
 import {useMemo} from 'react';
 import {IntegrationGallery} from './integration-gallery.js';
@@ -146,6 +148,25 @@ export const NoProvidersAvailable: Story = {
 
 export const LongNames: Story = {
   args: {scenario: 'long-names'},
+};
+
+export const UsageModalCloseRestoresInteraction: Story = {
+  play: async ({canvasElement}) => {
+    const user = userEvent.setup();
+    const canvas = within(canvasElement);
+    const actionsButton = await canvas.findByRole('button', {
+      name: 'Open acme-corp integration actions',
+    });
+
+    await user.click(actionsButton);
+    await user.click(await screen.findByRole('menuitem', {name: 'Use this integration'}));
+    await screen.findByRole('dialog', {name: 'Use acme-corp'});
+    await user.click(await screen.findByRole('button', {name: 'Done'}));
+    expect(screen.queryByRole('dialog', {name: 'Use acme-corp'})).not.toBeInTheDocument();
+    expect(document.body.style.pointerEvents).not.toBe('none');
+    await user.click(actionsButton);
+    await screen.findByRole('menuitem', {name: 'Use this integration'});
+  },
 };
 
 function fetchForScenario(scenario: Scenario): typeof fetch {

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -15,10 +15,9 @@ import {
   Outlet,
   RouterProvider,
 } from '@tanstack/react-router';
-import {screen, within} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import {createStore, Provider as JotaiProvider} from 'jotai';
 import {useMemo} from 'react';
+import {expect, screen, userEvent, within} from 'storybook/test';
 import {IntegrationGallery} from './integration-gallery.js';
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -367,6 +367,27 @@ describe('IntegrationGallery — installed section', () => {
     expect(screen.getByText(webhookConnectionDto.inbound_url)).toBeVisible();
   });
 
+  test('restores page interactivity after closing the usage modal', async () => {
+    renderGallery({}, {connections: [webhookConnection]});
+
+    await openActions('Open Stripe production integration actions');
+    expect(document.body.style.pointerEvents).toBe('none');
+    fireEvent.click(screen.getByRole('menuitem', {name: 'Use this integration'}));
+    expect(await screen.findByRole('dialog', {name: 'Use Stripe production'})).toBeVisible();
+    expect(document.body.style.pointerEvents).toBe('none');
+
+    const usageDialog = screen.getByRole('dialog', {name: 'Use Stripe production'});
+    fireEvent.click(within(usageDialog).getByRole('button', {name: 'Done'}));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Use Stripe production'})).not.toBeInTheDocument();
+      expect(document.body).not.toHaveStyle({pointerEvents: 'none'});
+    });
+
+    await openActions('Open Stripe production integration actions');
+    expect(screen.getByRole('menuitem', {name: 'Use this integration'})).toBeVisible();
+  });
+
   test('opens the usage modal with a GitHub event selector', async () => {
     renderGallery({}, {connections: [githubConnection]});
 

--- a/libs/client/integrations/src/components/integration-usage-modal.tsx
+++ b/libs/client/integrations/src/components/integration-usage-modal.tsx
@@ -71,8 +71,10 @@ export function IntegrationUsageModal({
   );
   const title = connection ? `Use ${connection.displayName}` : 'Use integration';
 
+  if (!open || connection === null) return null;
+
   return (
-    <Modal open={open && connection !== null} onOpenChange={onOpenChange}>
+    <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent aria-describedby={undefined} className="max-h-[calc(100vh-32px)] max-w-[640px]">
         <ModalTitle className="sr-only">{title}</ModalTitle>
         <ModalHeader>


### PR DESCRIPTION
The integration usage modal remained mounted during Radix's closing lifecycle after its controlled open state was cleared. That kept focus and scroll isolation active, so the gallery could not be clicked.

The modal now unmounts when closed, allowing Radix cleanup to run immediately. Regression coverage verifies both DOM cleanup and immediate reopening of the actions menu in Storybook.

The change includes a patch Changeset for @shipfox/client-integrations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmounts the integration usage modal immediately on close so Radix focus/scroll locks are cleared and the gallery becomes clickable again.

- **Bug Fixes**
  - Return `null` when closed or `connection` is `null`; pass `open` directly to `Modal`.
  - Restore body pointer events immediately after close.
  - Use `storybook/test` in the gallery story to verify cleanup and actions menu reopening; publish a patch for `@shipfox/client-integrations`.

<sup>Written for commit 587850a55bb32721f35fa685ad9912231d014d40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

