### PR TITLE
[node-log] Preserve error cause chains in logs

### DIFF
--- a/.changeset/trace-error-causes.md
+++ b/.changeset/trace-error-causes.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-log": patch
+---
+
+Preserves nested error cause details in local and OpenTelemetry logs for both `err` and `error` fields.

--- a/libs/shared/node/log/README.md
+++ b/libs/shared/node/log/README.md
@@ -12,7 +12,8 @@ Typed logging for Shipfox Node services. It wraps `pino` with shared defaults, e
 Defaults include:
 
 - ISO timestamps.
-- Standard serializers for `err`, `error`, `errors`, `req`, and `res`.
+- Standard serializers for `err`, `errors`, `req`, and `res`, preserving `cause` chains.
+- An `error` field holding an `Error` is normalized to `err` so it reaches the same serializer.
 - Output control through environment variables.
 
 Environment variables (via `@shipfox/config`):

--- a/libs/shared/node/log/src/log.test.ts
+++ b/libs/shared/node/log/src/log.test.ts
@@ -11,6 +11,55 @@ afterEach(() => {
 });
 
 describe('log destination thresholds', () => {
+  it('preserves cause chains and accepts both error field names', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'shipfox-node-log-'));
+    const file = join(directory, 'application.log');
+
+    try {
+      vi.stubEnv('LOG_LEVEL', 'info');
+      vi.stubEnv('LOG_STDOUT', 'false');
+      vi.stubEnv('LOG_FILE', file);
+      vi.stubEnv('LOG_PRETTY', 'false');
+      vi.resetModules();
+
+      const {createLogger} = await import('./log.js');
+      const logger = createLogger({});
+      const cause = Object.assign(new Error('permission denied'), {
+        name: 'UnauthorizedOperation',
+        requestId: 'request-123',
+      });
+      const error = new Error('Cannot launch runner', {cause});
+
+      logger.error({err: error}, 'err field');
+      logger.error({error}, 'error field');
+      await new Promise<void>((resolve, reject) =>
+        logger.flush((flushError?: Error) => (flushError ? reject(flushError) : resolve())),
+      );
+
+      await vi.waitFor(async () => {
+        const records = (await readFile(file, 'utf8'))
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line));
+        expect(records).toHaveLength(2);
+        for (const record of records) {
+          expect(record).not.toHaveProperty('error');
+          expect(record.err).toMatchObject({
+            message: 'Cannot launch runner: permission denied',
+            cause: {
+              name: 'UnauthorizedOperation',
+              message: 'permission denied',
+              requestId: 'request-123',
+            },
+          });
+          expect(record.err.stack).toContain('caused by: UnauthorizedOperation: permission denied');
+        }
+      });
+    } finally {
+      await rm(directory, {recursive: true, force: true});
+    }
+  });
+
   it('applies the configured file threshold through the shared logger transport', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'shipfox-node-log-'));
     const file = join(directory, 'application.log');

--- a/libs/shared/node/log/src/log.test.ts
+++ b/libs/shared/node/log/src/log.test.ts
@@ -30,8 +30,10 @@ describe('log destination thresholds', () => {
       });
       const error = new Error('Cannot launch runner', {cause});
 
-      logger.error({err: error}, 'err field');
-      logger.error({error}, 'error field');
+      logger.error({err: error});
+      logger.error({error});
+      logger.error({error}, 'explicit message');
+      logger.child({component: 'child'}).error({error});
       await new Promise<void>((resolve, reject) =>
         logger.flush((flushError?: Error) => (flushError ? reject(flushError) : resolve())),
       );
@@ -41,7 +43,14 @@ describe('log destination thresholds', () => {
           .trim()
           .split('\n')
           .map((line) => JSON.parse(line));
-        expect(records).toHaveLength(2);
+        expect(records).toHaveLength(4);
+        expect(records.map((record) => record.msg)).toEqual([
+          'Cannot launch runner',
+          'Cannot launch runner',
+          'explicit message',
+          'Cannot launch runner',
+        ]);
+        expect(records[3]).toMatchObject({component: 'child'});
         for (const record of records) {
           expect(record).not.toHaveProperty('error');
           expect(record.err).toMatchObject({

--- a/libs/shared/node/log/src/log.test.ts
+++ b/libs/shared/node/log/src/log.test.ts
@@ -69,6 +69,47 @@ describe('log destination thresholds', () => {
     }
   });
 
+  it('composes error normalization with a custom log method hook', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'shipfox-node-log-'));
+    const file = join(directory, 'application.log');
+
+    try {
+      vi.stubEnv('LOG_LEVEL', 'info');
+      vi.stubEnv('LOG_STDOUT', 'false');
+      vi.stubEnv('LOG_FILE', file);
+      vi.stubEnv('LOG_PRETTY', 'false');
+      vi.resetModules();
+
+      const {createLogger} = await import('./log.js');
+      let hookCalled = false;
+      const logger = createLogger({
+        hooks: {
+          logMethod(args, method) {
+            hookCalled = true;
+            Reflect.apply(method, this, args);
+          },
+        },
+      });
+
+      logger.error({error: new Error('Cannot launch runner')});
+      await new Promise<void>((resolve, reject) =>
+        logger.flush((flushError?: Error) => (flushError ? reject(flushError) : resolve())),
+      );
+
+      await vi.waitFor(async () => {
+        const record = JSON.parse((await readFile(file, 'utf8')).trim());
+        expect(hookCalled).toBe(true);
+        expect(record).toMatchObject({
+          msg: 'Cannot launch runner',
+          err: {message: 'Cannot launch runner'},
+        });
+        expect(record).not.toHaveProperty('error');
+      });
+    } finally {
+      await rm(directory, {recursive: true, force: true});
+    }
+  });
+
   it('applies the configured file threshold through the shared logger transport', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'shipfox-node-log-'));
     const file = join(directory, 'application.log');

--- a/libs/shared/node/log/src/log.ts
+++ b/libs/shared/node/log/src/log.ts
@@ -79,7 +79,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export const settings: LoggerOptions = {
   level: config.LOG_LEVEL,
   transport: {targets: transports},
-  formatters: {log: normalizeErrorKey},
+  hooks: {
+    logMethod(args, method) {
+      const [object, ...rest] = args;
+      const normalizedArgs = isRecord(object)
+        ? ([normalizeErrorKey(object), ...rest] as Parameters<LogFn>)
+        : args;
+      Reflect.apply(method, this, normalizedArgs);
+    },
+  },
   get timestamp() {
     return getPino().stdTimeFunctions.isoTime;
   },

--- a/libs/shared/node/log/src/log.ts
+++ b/libs/shared/node/log/src/log.ts
@@ -53,22 +53,57 @@ function createTransportStream() {
   );
 }
 
+function isErrorLike(value: unknown): value is Error {
+  return (
+    value instanceof Error ||
+    (typeof value === 'object' &&
+      value !== null &&
+      'message' in value &&
+      typeof value.message === 'string' &&
+      'stack' in value &&
+      typeof value.stack === 'string')
+  );
+}
+
+function normalizeErrorKey(object: Record<string, unknown>): Record<string, unknown> {
+  if (object.err !== undefined || !isErrorLike(object.error)) return object;
+
+  const {error, ...rest} = object;
+  return {...rest, err: error};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 export const settings: LoggerOptions = {
   level: config.LOG_LEVEL,
   transport: {targets: transports},
+  formatters: {log: normalizeErrorKey},
   get timestamp() {
     return getPino().stdTimeFunctions.isoTime;
   },
   get serializers() {
     const {stdSerializers} = getPino();
+    const serializeError = (error: unknown): unknown => {
+      const structured = stdSerializers.errWithCause(error as Error);
+      const chained = stdSerializers.err(error as Error);
+      if (!isRecord(structured) || !isRecord(chained)) return structured;
+
+      return {
+        ...structured,
+        ...(typeof chained.message === 'string' ? {message: chained.message} : {}),
+        ...(typeof chained.stack === 'string' ? {stack: chained.stack} : {}),
+      };
+    };
+
     return {
-      error: stdSerializers.errWithCause,
+      error: serializeError,
       errors: (errors: unknown) => {
-        if (Array.isArray(errors))
-          return errors.map((error) => stdSerializers.errWithCause(error as Error));
-        return stdSerializers.errWithCause(errors as Error);
+        if (Array.isArray(errors)) return errors.map(serializeError);
+        return serializeError(errors);
       },
-      err: stdSerializers.errWithCause,
+      err: serializeError,
       req: stdSerializers.req,
       res: stdSerializers.res,
     };

--- a/libs/shared/node/log/src/log.ts
+++ b/libs/shared/node/log/src/log.ts
@@ -76,16 +76,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function normalizeErrorArguments(args: Parameters<LogFn>): Parameters<LogFn> {
+  const [object, ...rest] = args;
+  if (!isRecord(object)) return args;
+
+  const normalizedObject = normalizeErrorKey(object);
+  if (normalizedObject === object) return args;
+
+  return [normalizedObject, ...rest] as Parameters<LogFn>;
+}
+
 export const settings: LoggerOptions = {
   level: config.LOG_LEVEL,
   transport: {targets: transports},
   hooks: {
     logMethod(args, method) {
-      const [object, ...rest] = args;
-      const normalizedArgs = isRecord(object)
-        ? ([normalizeErrorKey(object), ...rest] as Parameters<LogFn>)
-        : args;
-      Reflect.apply(method, this, normalizedArgs);
+      Reflect.apply(method, this, normalizeErrorArguments(args));
     },
   },
   get timestamp() {
@@ -118,6 +124,26 @@ export const settings: LoggerOptions = {
   },
 };
 
+function withSharedSettings(options: LoggerOptions): LoggerOptions {
+  const customLogMethod = options.hooks?.logMethod;
+  return {
+    ...settings,
+    ...options,
+    hooks: {
+      ...settings.hooks,
+      ...options.hooks,
+      logMethod(args, method, level) {
+        const normalizedArgs = normalizeErrorArguments(args);
+        if (customLogMethod) {
+          Reflect.apply(customLogMethod, this, [normalizedArgs, method, level]);
+        } else {
+          Reflect.apply(method, this, normalizedArgs);
+        }
+      },
+    },
+  };
+}
+
 type PinoLogger = Pick<ReturnType<PinoModule>, Level | 'flush'>;
 let logger: PinoLogger | undefined;
 
@@ -128,9 +154,10 @@ function getLogger(): PinoLogger {
 
 export function createLogger(options: LoggerOptions) {
   const pino = getPino();
-  if (options.transport) return pino({...settings, ...options});
+  const configuredOptions = withSharedSettings(options);
+  if (options.transport) return pino(configuredOptions);
 
-  const {transport: _transport, ...loggerOptions} = {...settings, ...options};
+  const {transport: _transport, ...loggerOptions} = configuredOptions;
   return pino(loggerOptions, createTransportStream());
 }
 

--- a/libs/shared/node/opentelemetry/src/instance.test.ts
+++ b/libs/shared/node/opentelemetry/src/instance.test.ts
@@ -48,11 +48,18 @@ describe('Pino log export', () => {
         isRemote: false,
       }),
     } as unknown as Span);
+    const cause = Object.assign(new Error('permission denied'), {
+      name: 'UnauthorizedOperation',
+    });
 
     context.with(activeContext, () => {
       logger.info({organizationId: 'org-123'}, 'info message');
       logger.warn('warn message');
-      logger.error({err: new Error('boom'), operation: 'sync'}, 'error message');
+      logger.error({err: new Error('boom', {cause}), operation: 'sync'}, 'error message');
+      logger.error(
+        {error: new Error('alias boom', {cause}), operation: 'sync-alias'},
+        'aliased error message',
+      );
     });
 
     await new Promise<void>((resolve, reject) =>
@@ -62,11 +69,13 @@ describe('Pino log export', () => {
     const records = [...exporter.getFinishedLogRecords()];
     const firstRecord = records[0];
     const errorRecord = records[2];
-    expect(records).toHaveLength(3);
+    const aliasedErrorRecord = records[3];
+    expect(records).toHaveLength(4);
     expect(records.map((record) => record.body)).toEqual([
       'info message',
       'warn message',
       'error message',
+      'aliased error message',
     ]);
     expect(firstRecord).toMatchObject({
       attributes: {organizationId: 'org-123'},
@@ -78,12 +87,27 @@ describe('Pino log export', () => {
     expect(firstRecord?.attributes).not.toHaveProperty('span_id');
     expect(errorRecord).toMatchObject({
       attributes: {
-        'exception.message': 'boom',
+        'exception.message': 'boom: permission denied',
         'exception.type': 'Error',
         operation: 'sync',
       },
       severityText: 'error',
     });
+    expect(errorRecord?.attributes['exception.stacktrace']).toContain(
+      'caused by: UnauthorizedOperation: permission denied',
+    );
+    expect(aliasedErrorRecord).toMatchObject({
+      attributes: {
+        'exception.message': 'alias boom: permission denied',
+        'exception.type': 'Error',
+        operation: 'sync-alias',
+      },
+      severityText: 'error',
+    });
+    expect(aliasedErrorRecord?.attributes['exception.stacktrace']).toContain(
+      'caused by: UnauthorizedOperation: permission denied',
+    );
+    expect(aliasedErrorRecord?.attributes).not.toHaveProperty('error');
     expect(errorRecord?.hrTime).toBeDefined();
 
     const configuredLogger = context.with(activeContext, () =>
@@ -100,7 +124,7 @@ describe('Pino log export', () => {
       configuredLogger.flush((error?: Error) => (error ? reject(error) : resolve())),
     );
 
-    const contextRecord = exporter.getFinishedLogRecords()[3];
+    const contextRecord = exporter.getFinishedLogRecords()[4];
     expect(contextRecord).toMatchObject({
       attributes: {component: 'context-aware', requestId: 'req-123'},
       spanContext: {traceId},


### PR DESCRIPTION
OpenTelemetry log conversion retains the standard exception message and stack fields but drops nested `Error.cause` objects. Wrapped provider failures therefore appeared in Dash0 as generic outer errors without the underlying permission or provider failure.

Normalize both `err` and `error` Error fields to the canonical `err` field. The shared serializer keeps the structured cause in local Pino output and adds the cause chain to the outer message and stack so OpenTelemetry retains it.

Regression coverage verifies both field names in raw logger output and through the Pino-to-OpenTelemetry export path. This also includes a patch Changeset for `@shipfox/node-log`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves nested error cause chains in local logs and OpenTelemetry, normalizes `error` to the canonical `err`, and composes with custom hooks so messages and stacks include the full chain. Wrapped provider failures now show full cause details in Dash0.

- **Bug Fixes**
  - Normalize `error` to `err` via a `pino` hook, composed with custom `hooks.logMethod`, so normalization runs before message/stack derivation.
  - Serialize errors by merging structured `cause` with the chained message and stack so OpenTelemetry retains the chain and aliased `error` exports cleanly.
  - Expand tests for file logs, child logger, custom hook composition, and the alias `error` path in Pino-to-OpenTelemetry export; include a patch Changeset for `@shipfox/node-log`.

<sup>Written for commit 4242260faa76af8b1e5bbffadc658dbecaafd43f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

