### PR TITLE
[runner-labels] Add runner catalog resolution primitives

### DIFF
--- a/.changeset/runner-catalog-label-resolution.md
+++ b/.changeset/runner-catalog-label-resolution.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-labels": minor
+---
+
+Add runner catalog parsing and one-pass label resolution.

--- a/libs/shared/common/runner-labels/README.md
+++ b/libs/shared/common/runner-labels/README.md
@@ -1,24 +1,47 @@
 # Shipfox Runner Labels
 
-Shared runner label canonicalization and validation helpers.
+Shared runner label canonicalization, validation, and catalog resolution helpers.
 
-## Contract
+## What it does
 
-`canonicalizeLabels(value)` accepts `undefined`, one string, or an array of
-strings. It trims labels, lowercases them, drops empty values, deduplicates, and
-sorts the result. A single string is one label; it is not split on commas.
+- **`RunnerCatalog`** represents a map from a catalog name to a complete list of runner labels.
+- **`parseRunnerCatalog(raw)`** validates an already-parsed catalog, canonicalizes names and labels, and rejects invalid or empty entries.
+- **`resolveRunnerLabels(requested, catalog)`** expands known catalog names once and passes unknown values through as labels.
+- **`canonicalizeLabels(value)`** accepts `undefined`, one string, or an array of strings. It trims, lowercases, drops empty values, deduplicates, and sorts the result.
+- **`parseLabelList(value)`** parses comma-delimited configuration values before canonicalizing them.
+- **`findInvalidLabels(labels)`** returns labels that do not match the supported pattern or exceed 128 characters.
+- **`RUNNER_LABEL_PATTERN`, `MAX_RUNNER_LABEL_LENGTH`, and `MAX_RUNNER_LABELS`** are the shared label limits. A caller that owns a complete label set caps it at `MAX_RUNNER_LABELS`.
 
-`parseLabelList(value)` is for comma-delimited configuration values such as
-`DEFINITION_DEFAULT_RUNNER_LABEL`. It splits on commas, then applies the same
-canonicalization contract.
+## Installation and setup
 
-Post-canonicalization labels must match `/^[a-z0-9][a-z0-9._-]*$/`, so labels
-start with a lowercase ASCII letter or digit and may then contain lowercase
-letters, digits, `.`, `_`, and `-`. A label may be at most 128 characters.
-Callers that own a complete label set should cap it at 20 labels.
+```sh
+pnpm add @shipfox/runner-labels
+```
 
-That comma behavior is deliberate: `runner: ubuntu,gpu` in YAML is one invalid
-label, while `DEFINITION_DEFAULT_RUNNER_LABEL=ubuntu,gpu` configures two labels.
+The package does not read files. A consumer loads and parses its configuration before calling `parseRunnerCatalog`.
+
+## Usage
+
+```ts
+import {parseRunnerCatalog, resolveRunnerLabels} from '@shipfox/runner-labels';
+
+const catalog = parseRunnerCatalog({
+  'shipfox-4cpu': ['os.ubuntu-latest', 'arch.amd64', 'cpu.4'],
+});
+
+const labels = resolveRunnerLabels(['shipfox-4cpu', 'internal-network'], catalog);
+// ['arch.amd64', 'cpu.4', 'internal-network', 'os.ubuntu-latest']
+```
+
+## Behavior notes
+
+Names and labels use `/^[a-z0-9][a-z0-9._-]*$/` and may be at most 128 characters. Names are canonicalized at load time, so catalog lookups are case-insensitive.
+
+Catalog entries contain complete label sets. Resolution runs once, so a label produced by an entry is not resolved as another catalog name.
+
+An unknown catalog name remains a label. With no catalog entries, all requested values pass through unchanged after canonicalization.
+
+`runner: ubuntu,gpu` in YAML is one invalid label. `DEFINITION_DEFAULT_RUNNER_LABEL=ubuntu,gpu` is two configuration labels because `parseLabelList` handles comma-delimited values.
 
 ## Development
 
@@ -27,3 +50,7 @@ turbo check --filter=@shipfox/runner-labels
 turbo type --filter=@shipfox/runner-labels
 turbo test --filter=@shipfox/runner-labels
 ```
+
+## License
+
+MIT

--- a/libs/shared/common/runner-labels/src/index.test.ts
+++ b/libs/shared/common/runner-labels/src/index.test.ts
@@ -3,6 +3,8 @@ import {
   findInvalidLabels,
   MAX_RUNNER_LABEL_LENGTH,
   parseLabelList,
+  parseRunnerCatalog,
+  resolveRunnerLabels,
 } from './index.js';
 
 describe('canonicalizeLabels', () => {
@@ -58,5 +60,128 @@ describe('findInvalidLabels', () => {
     const invalid = findInvalidLabels(['ci,gpu', 'has space', 'has\nnewline', overLength]);
 
     expect(invalid).toEqual(['ci,gpu', 'has space', 'has\nnewline', overLength]);
+  });
+});
+
+describe('parseRunnerCatalog', () => {
+  it('canonicalizes names and labels', () => {
+    const catalog = parseRunnerCatalog({
+      ' ShipFox-4CPU ': [' OS.Ubuntu-Latest ', 'CPU.4'],
+    });
+
+    expect(catalog).toEqual({
+      'shipfox-4cpu': ['cpu.4', 'os.ubuntu-latest'],
+    });
+  });
+
+  it('accepts an empty catalog', () => {
+    const catalog = parseRunnerCatalog({});
+
+    expect(catalog).toEqual({});
+  });
+
+  it('rejects an invalid name', () => {
+    const parse = () => parseRunnerCatalog({'not a name': ['label']});
+
+    expect(parse).toThrow('invalid name');
+  });
+
+  it('rejects a name that canonicalizes to nothing', () => {
+    const parse = () => parseRunnerCatalog({'   ': ['label']});
+
+    expect(parse).toThrow('must not be empty');
+  });
+
+  it('rejects a name over the length limit', () => {
+    const overLength = 'a'.repeat(MAX_RUNNER_LABEL_LENGTH + 1);
+    const parse = () => parseRunnerCatalog({[overLength]: ['label']});
+
+    expect(parse).toThrow('invalid name');
+  });
+
+  it('rejects two names that canonicalize to the same value', () => {
+    const parse = () => parseRunnerCatalog({'ShipFox-4CPU': ['cpu.4'], 'shipfox-4cpu': ['cpu.8']});
+
+    expect(parse).toThrow('duplicate name');
+  });
+
+  it('rejects an invalid label', () => {
+    const parse = () => parseRunnerCatalog({name: ['not a label']});
+
+    expect(parse).toThrow('invalid label');
+  });
+
+  it('rejects a label over the length limit', () => {
+    const overLength = 'a'.repeat(MAX_RUNNER_LABEL_LENGTH + 1);
+    const parse = () => parseRunnerCatalog({name: [overLength]});
+
+    expect(parse).toThrow('invalid label');
+  });
+
+  it('rejects an entry with no labels', () => {
+    const parse = () => parseRunnerCatalog({name: []});
+
+    expect(parse).toThrow('at least one label');
+  });
+
+  it('rejects non-object input', () => {
+    const parse = () => parseRunnerCatalog(null);
+
+    expect(parse).toThrow('must be an object');
+  });
+
+  it('rejects an entry whose labels are not strings', () => {
+    const parse = () => parseRunnerCatalog({name: ['label', 1]});
+
+    expect(parse).toThrow('list of labels');
+  });
+});
+
+describe('resolveRunnerLabels', () => {
+  const catalog = parseRunnerCatalog({
+    'shipfox-4cpu': ['os.ubuntu-latest', 'cpu.4'],
+    'shipfox-arm64-4cpu': ['arch.arm64', 'cpu.4'],
+  });
+
+  it('resolves a known catalog name', () => {
+    const labels = resolveRunnerLabels(['SHIPFOX-4CPU'], catalog);
+
+    expect(labels).toEqual(['cpu.4', 'os.ubuntu-latest']);
+  });
+
+  it('passes an unknown name through as a label', () => {
+    const labels = resolveRunnerLabels(['custom-runner'], catalog);
+
+    expect(labels).toEqual(['custom-runner']);
+  });
+
+  it('keeps a free-form label alongside a catalog name', () => {
+    const labels = resolveRunnerLabels(['shipfox-4cpu', 'internal-network'], catalog);
+
+    expect(labels).toEqual(['cpu.4', 'internal-network', 'os.ubuntu-latest']);
+  });
+
+  it('unions labels from two catalog names', () => {
+    const labels = resolveRunnerLabels(['shipfox-4cpu', 'shipfox-arm64-4cpu'], catalog);
+
+    expect(labels).toEqual(['arch.arm64', 'cpu.4', 'os.ubuntu-latest']);
+  });
+
+  it('passes labels through with an empty catalog', () => {
+    const labels = resolveRunnerLabels(['constructor'], {});
+
+    expect(labels).toEqual(['constructor']);
+  });
+
+  it('returns no labels for an empty request', () => {
+    const labels = resolveRunnerLabels([], catalog);
+
+    expect(labels).toEqual([]);
+  });
+
+  it('resolves catalog entries once without recursion', () => {
+    const labels = resolveRunnerLabels(['outer'], {outer: ['inner'], inner: ['label']});
+
+    expect(labels).toEqual(['inner']);
   });
 });

--- a/libs/shared/common/runner-labels/src/index.test.ts
+++ b/libs/shared/common/runner-labels/src/index.test.ts
@@ -130,8 +130,21 @@ describe('parseRunnerCatalog', () => {
     expect(parse).toThrow('must be an object');
   });
 
+  it.each([new Map(), new Date()])('rejects non-plain object input', (value) => {
+    const parse = () => parseRunnerCatalog(value);
+
+    expect(parse).toThrow('must be an object');
+  });
+
   it('rejects an entry whose labels are not strings', () => {
     const parse = () => parseRunnerCatalog({name: ['label', 1]});
+
+    expect(parse).toThrow('list of labels');
+  });
+
+  it('rejects sparse label arrays', () => {
+    const sparseLabels = new Array<string>(1);
+    const parse = () => parseRunnerCatalog({name: sparseLabels});
 
     expect(parse).toThrow('list of labels');
   });

--- a/libs/shared/common/runner-labels/src/index.ts
+++ b/libs/shared/common/runner-labels/src/index.ts
@@ -2,6 +2,8 @@ export const RUNNER_LABEL_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
 export const MAX_RUNNER_LABEL_LENGTH = 128;
 export const MAX_RUNNER_LABELS = 20;
 
+export type RunnerCatalog = Readonly<Record<string, readonly string[]>>;
+
 export function canonicalizeLabels(
   value: string | readonly string[] | undefined,
 ): readonly string[] {
@@ -19,4 +21,69 @@ export function findInvalidLabels(labels: readonly string[]): readonly string[] 
   return labels.filter(
     (label) => label.length > MAX_RUNNER_LABEL_LENGTH || !RUNNER_LABEL_PATTERN.test(label),
   );
+}
+
+export function parseRunnerCatalog(raw: unknown): RunnerCatalog {
+  if (!isRecord(raw)) {
+    throw new Error('Runner catalog must be an object mapping names to label lists.');
+  }
+
+  const catalog = Object.create(null) as Record<string, readonly string[]>;
+
+  for (const [rawName, rawLabels] of Object.entries(raw)) {
+    const name = canonicalizeLabels(rawName)[0];
+    if (name === undefined) {
+      throw new Error('Runner catalog entry names must not be empty.');
+    }
+
+    const invalidName = findInvalidLabels([name]);
+    if (invalidName.length > 0) {
+      throw new Error(`Runner catalog entry "${rawName}" has an invalid name: ${name}.`);
+    }
+
+    if (!isStringArray(rawLabels)) {
+      throw new Error(`Runner catalog entry "${rawName}" must contain a list of labels.`);
+    }
+
+    const labels = canonicalizeLabels(rawLabels);
+    if (labels.length === 0) {
+      throw new Error(`Runner catalog entry "${rawName}" must contain at least one label.`);
+    }
+
+    const invalidLabels = findInvalidLabels(labels);
+    if (invalidLabels.length > 0) {
+      throw new Error(
+        `Runner catalog entry "${rawName}" has invalid label(s): ${invalidLabels.join(', ')}.`,
+      );
+    }
+
+    if (Object.hasOwn(catalog, name)) {
+      throw new Error(`Runner catalog contains duplicate name "${name}".`);
+    }
+
+    catalog[name] = labels;
+  }
+
+  return catalog;
+}
+
+export function resolveRunnerLabels(
+  requested: readonly string[],
+  catalog: RunnerCatalog,
+): readonly string[] {
+  const values = canonicalizeLabels(requested);
+  return canonicalizeLabels(
+    values.flatMap((value) => {
+      const entry = Object.hasOwn(catalog, value) ? catalog[value] : undefined;
+      return entry ?? [value];
+    }),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }

--- a/libs/shared/common/runner-labels/src/index.ts
+++ b/libs/shared/common/runner-labels/src/index.ts
@@ -81,9 +81,12 @@ export function resolveRunnerLabels(
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function isStringArray(value: unknown): value is readonly string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+  return Array.isArray(value) && Array.from(value).every((item) => typeof item === 'string');
 }


### PR DESCRIPTION
Adds the pure runner catalog primitives that downstream workflow loading will consume.

The shared package now parses an already-parsed catalog, canonicalizes case-insensitive names and labels, rejects invalid or empty entries, and resolves catalog names once while passing unknown labels through. It remains browser-safe with no file-system or Node dependencies.

The total runner-label limit remains enforced at workflow materialization after expansion, matching the runner catalog specification and keeping this PR limited to the shared package slice.

Validation: `mise exec -- turbo test type check --filter=@shipfox/runner-labels...`; targeted Vale verification passed with zero errors.

Closes ENG-1481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runner catalog parsing and one-pass label resolution to `@shipfox/runner-labels`, with case-insensitive lookups and hardened input validation. Addresses ENG-1481 by providing shared, browser-safe primitives for already-parsed catalogs.

- **New Features**
  - `parseRunnerCatalog(raw)`: canonicalizes names/labels; rejects invalid/empty entries, duplicates, non-plain objects (e.g., `Map`, `Date`), and non-string or sparse label arrays; enforces `RUNNER_LABEL_PATTERN` and `MAX_RUNNER_LABEL_LENGTH`.
  - `resolveRunnerLabels(requested, catalog)`: expands known catalog names once, passes unknown values through, dedupes and sorts, no recursion.
  - Adds `RunnerCatalog` type, tests, and README examples. Total label count limit still enforced during workflow materialization.

<sup>Written for commit 97164f5d09b99fe9302177a821808568f3650ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

