### PR TITLE
Allow Jira integrations to be reinstalled after deletion

### DIFF
--- a/.changeset/clean-jira-links.md
+++ b/.changeset/clean-jira-links.md
@@ -1,6 +1,6 @@
 ---
 "@shipfox/api-integration-core": patch
-"@shipfox/api-integration-jira": patch
+"@shipfox/api-integration-jira": minor
 ---
 
 Cleans up Jira installation records and tokens when a workspace deletes an integration so the site can be reinstalled.

--- a/.changeset/clean-jira-links.md
+++ b/.changeset/clean-jira-links.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-jira": patch
+---
+
+Cleans up Jira installation records and tokens when a workspace deletes an integration so the site can be reinstalled.

--- a/libs/api/integration/core/src/providers/jira.test.ts
+++ b/libs/api/integration/core/src/providers/jira.test.ts
@@ -127,11 +127,16 @@ describe('jiraProviderModule', () => {
       headers: {authorization: 'Bearer user'},
     });
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(deleteSecrets).not.toHaveBeenCalled();
-
-    releaseRefreshLock();
-    await expect(refreshLock).resolves.toMatchObject({acquired: true});
+    await vi.waitFor(async () => {
+      await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+    });
+    try {
+      expect(deleteSecrets).not.toHaveBeenCalled();
+    } finally {
+      releaseRefreshLock();
+      await expect(refreshLock).resolves.toMatchObject({acquired: true});
+      await deletion;
+    }
     const res = await deletion;
 
     expect(res.statusCode).toBe(204);

--- a/libs/api/integration/core/src/providers/jira.test.ts
+++ b/libs/api/integration/core/src/providers/jira.test.ts
@@ -1,6 +1,7 @@
 import {
   getJiraInstallationByConnectionId,
   upsertJiraInstallation,
+  withJiraRefreshLock,
 } from '@shipfox/api-integration-jira';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
@@ -64,7 +65,7 @@ describe('jiraProviderModule', () => {
     });
   });
 
-  it('deletes the installation and tokens through the generic route before allowing a reinstall', async () => {
+  it('waits for refresh before deleting tokens and allowing a reinstall', async () => {
     vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
     vi.resetModules();
     const deleteSecrets = vi.fn(() => Promise.resolve(2));
@@ -106,11 +107,32 @@ describe('jiraProviderModule', () => {
       status: 'installed',
     });
 
-    const res = await app.inject({
+    let releaseRefreshLock!: () => void;
+    let refreshLockEntered!: () => void;
+    const refreshLockReady = new Promise<void>((resolve) => {
+      refreshLockEntered = resolve;
+    });
+    const refreshLockReleased = new Promise<void>((resolve) => {
+      releaseRefreshLock = resolve;
+    });
+    const refreshLock = withJiraRefreshLock(connection.id, async () => {
+      refreshLockEntered();
+      await refreshLockReleased;
+    });
+    await refreshLockReady;
+
+    const deletion = app.inject({
       method: 'DELETE',
       url: `/integration-connections/${connection.id}`,
       headers: {authorization: 'Bearer user'},
     });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(deleteSecrets).not.toHaveBeenCalled();
+
+    releaseRefreshLock();
+    await expect(refreshLock).resolves.toMatchObject({acquired: true});
+    const res = await deletion;
 
     expect(res.statusCode).toBe(204);
     await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();

--- a/libs/api/integration/core/src/providers/jira.test.ts
+++ b/libs/api/integration/core/src/providers/jira.test.ts
@@ -4,8 +4,12 @@ import {
 } from '@shipfox/api-integration-jira';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {createTestApp, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('jiraProviderModule', () => {
+  const context = useIntegrationRouteTest();
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
@@ -58,5 +62,140 @@ describe('jiraProviderModule', () => {
       connectionId: connection.id,
       cloudId,
     });
+  });
+
+  it('deletes the installation and tokens through the generic route before allowing a reinstall', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
+    vi.resetModules();
+    const deleteSecrets = vi.fn(() => Promise.resolve(2));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const {createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules({
+      secrets: {jira: scopedSecrets, deleteSecrets},
+    });
+    const jiraPart = parts.find((part) => part.provider.provider === 'jira');
+    if (!jiraPart?.database) throw new Error('Jira provider database is not configured');
+    const cloudId = crypto.randomUUID();
+
+    await runMigrations(
+      jiraPart.database.db(),
+      jiraPart.database.migrationsPath,
+      `__drizzle_migrations_${jiraPart.database.databaseNamespace}`,
+    );
+    const app = await createTestApp([jiraPart.provider]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'jira',
+      externalAccountId: cloudId,
+      slug: 'jira_acme',
+      displayName: 'Jira Acme',
+    });
+    await upsertJiraInstallation({
+      connectionId: connection.id,
+      cloudId,
+      siteUrl: 'https://acme.atlassian.net',
+      siteName: 'Acme',
+      authorizingAccountId: 'user-1',
+      scopes: ['read:jira-work'],
+      status: 'installed',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+    await expect(getJiraInstallationByConnectionId(connection.id)).resolves.toBeUndefined();
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: context.workspaceId,
+      namespace: connection.id,
+    });
+
+    const replacement = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'jira',
+      externalAccountId: cloudId,
+      slug: 'jira_acme_again',
+      displayName: 'Jira Acme',
+    });
+    await upsertJiraInstallation({
+      connectionId: replacement.id,
+      cloudId,
+      siteUrl: 'https://acme.atlassian.net',
+      siteName: 'Acme',
+      authorizingAccountId: 'user-1',
+      scopes: ['read:jira-work'],
+      status: 'installed',
+    });
+
+    await expect(getJiraInstallationByConnectionId(replacement.id)).resolves.toMatchObject({
+      cloudId,
+    });
+  });
+
+  it('rolls back provider record cleanup when its transaction fails', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
+    vi.resetModules();
+    const deleteSecrets = vi.fn(() => Promise.resolve(2));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const {createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules({
+      secrets: {jira: scopedSecrets, deleteSecrets},
+    });
+    const jiraPart = parts.find((part) => part.provider.provider === 'jira');
+    if (!jiraPart?.database) throw new Error('Jira provider database is not configured');
+    const cloudId = crypto.randomUUID();
+
+    await runMigrations(
+      jiraPart.database.db(),
+      jiraPart.database.migrationsPath,
+      `__drizzle_migrations_${jiraPart.database.databaseNamespace}`,
+    );
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'jira',
+      externalAccountId: cloudId,
+      slug: 'jira_acme',
+      displayName: 'Jira Acme',
+    });
+    await upsertJiraInstallation({
+      connectionId: connection.id,
+      cloudId,
+      siteUrl: 'https://acme.atlassian.net',
+      siteName: 'Acme',
+      authorizingAccountId: 'user-1',
+      scopes: ['read:jira-work'],
+      status: 'installed',
+    });
+
+    await expect(
+      db().transaction(async (tx) => {
+        await jiraPart.provider.deleteConnectionRecords?.(connection, {tx});
+        throw new Error('transaction failed');
+      }),
+    ).rejects.toThrow('transaction failed');
+
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toMatchObject({
+      id: connection.id,
+    });
+    await expect(getJiraInstallationByConnectionId(connection.id)).resolves.toMatchObject({
+      connectionId: connection.id,
+    });
+    expect(deleteSecrets).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/core/src/providers/jira.test.ts
+++ b/libs/api/integration/core/src/providers/jira.test.ts
@@ -16,6 +16,50 @@ describe('jiraProviderModule', () => {
     vi.resetModules();
   });
 
+  async function createJiraCleanupFixture() {
+    vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
+    vi.resetModules();
+    const deleteSecrets = vi.fn(() => Promise.resolve(2));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const {createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules({
+      secrets: {jira: scopedSecrets, deleteSecrets},
+    });
+    const jiraPart = parts.find((part) => part.provider.provider === 'jira');
+    if (!jiraPart?.database) throw new Error('Jira provider database is not configured');
+    const cloudId = crypto.randomUUID();
+
+    await runMigrations(
+      jiraPart.database.db(),
+      jiraPart.database.migrationsPath,
+      `__drizzle_migrations_${jiraPart.database.databaseNamespace}`,
+    );
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'jira',
+      externalAccountId: cloudId,
+      slug: 'jira_acme',
+      displayName: 'Jira Acme',
+    });
+    await upsertJiraInstallation({
+      connectionId: connection.id,
+      cloudId,
+      siteUrl: 'https://acme.atlassian.net',
+      siteName: 'Acme',
+      authorizingAccountId: 'user-1',
+      scopes: ['read:jira-work'],
+      status: 'installed',
+    });
+
+    return {connection, deleteSecrets, jiraPart, cloudId};
+  }
+
   it('loads its database descriptor and persists a core connection with its Jira installation', async () => {
     vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
     vi.resetModules();
@@ -66,46 +110,8 @@ describe('jiraProviderModule', () => {
   });
 
   it('waits for refresh before deleting tokens and allowing a reinstall', async () => {
-    vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
-    vi.resetModules();
-    const deleteSecrets = vi.fn(() => Promise.resolve(2));
-    const scopedSecrets = {
-      getSecret: vi.fn(() => Promise.resolve(null)),
-      setSecrets: vi.fn(() => Promise.resolve()),
-      deleteSecrets,
-    };
-    const {createPostgresClient} = await import('@shipfox/node-postgres');
-    createPostgresClient();
-    const {loadEnabledProviderModules} = await import('#providers/modules.js');
-    const parts = await loadEnabledProviderModules({
-      secrets: {jira: scopedSecrets, deleteSecrets},
-    });
-    const jiraPart = parts.find((part) => part.provider.provider === 'jira');
-    if (!jiraPart?.database) throw new Error('Jira provider database is not configured');
-    const cloudId = crypto.randomUUID();
-
-    await runMigrations(
-      jiraPart.database.db(),
-      jiraPart.database.migrationsPath,
-      `__drizzle_migrations_${jiraPart.database.databaseNamespace}`,
-    );
+    const {cloudId, connection, deleteSecrets, jiraPart} = await createJiraCleanupFixture();
     const app = await createTestApp([jiraPart.provider]);
-    const connection = await upsertIntegrationConnection({
-      workspaceId: context.workspaceId,
-      provider: 'jira',
-      externalAccountId: cloudId,
-      slug: 'jira_acme',
-      displayName: 'Jira Acme',
-    });
-    await upsertJiraInstallation({
-      connectionId: connection.id,
-      cloudId,
-      siteUrl: 'https://acme.atlassian.net',
-      siteName: 'Acme',
-      authorizingAccountId: 'user-1',
-      scopes: ['read:jira-work'],
-      status: 'installed',
-    });
 
     let releaseRefreshLock!: () => void;
     let refreshLockEntered!: () => void;
@@ -130,14 +136,14 @@ describe('jiraProviderModule', () => {
     await vi.waitFor(async () => {
       await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
     });
+    let res!: Awaited<ReturnType<typeof app.inject>>;
     try {
       expect(deleteSecrets).not.toHaveBeenCalled();
     } finally {
       releaseRefreshLock();
       await expect(refreshLock).resolves.toMatchObject({acquired: true});
-      await deletion;
+      res = await deletion;
     }
-    const res = await deletion;
 
     expect(res.statusCode).toBe(204);
     await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
@@ -170,45 +176,7 @@ describe('jiraProviderModule', () => {
   });
 
   it('rolls back provider record cleanup when its transaction fails', async () => {
-    vi.stubEnv('INTEGRATIONS_ENABLE_JIRA_PROVIDER', 'true');
-    vi.resetModules();
-    const deleteSecrets = vi.fn(() => Promise.resolve(2));
-    const scopedSecrets = {
-      getSecret: vi.fn(() => Promise.resolve(null)),
-      setSecrets: vi.fn(() => Promise.resolve()),
-      deleteSecrets,
-    };
-    const {createPostgresClient} = await import('@shipfox/node-postgres');
-    createPostgresClient();
-    const {loadEnabledProviderModules} = await import('#providers/modules.js');
-    const parts = await loadEnabledProviderModules({
-      secrets: {jira: scopedSecrets, deleteSecrets},
-    });
-    const jiraPart = parts.find((part) => part.provider.provider === 'jira');
-    if (!jiraPart?.database) throw new Error('Jira provider database is not configured');
-    const cloudId = crypto.randomUUID();
-
-    await runMigrations(
-      jiraPart.database.db(),
-      jiraPart.database.migrationsPath,
-      `__drizzle_migrations_${jiraPart.database.databaseNamespace}`,
-    );
-    const connection = await upsertIntegrationConnection({
-      workspaceId: context.workspaceId,
-      provider: 'jira',
-      externalAccountId: cloudId,
-      slug: 'jira_acme',
-      displayName: 'Jira Acme',
-    });
-    await upsertJiraInstallation({
-      connectionId: connection.id,
-      cloudId,
-      siteUrl: 'https://acme.atlassian.net',
-      siteName: 'Acme',
-      authorizingAccountId: 'user-1',
-      scopes: ['read:jira-work'],
-      status: 'installed',
-    });
+    const {connection, jiraPart} = await createJiraCleanupFixture();
 
     await expect(
       db().transaction(async (tx) => {
@@ -223,6 +191,5 @@ describe('jiraProviderModule', () => {
     await expect(getJiraInstallationByConnectionId(connection.id)).resolves.toMatchObject({
       connectionId: connection.id,
     });
-    expect(deleteSecrets).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/core/src/providers/jira.ts
+++ b/libs/api/integration/core/src/providers/jira.ts
@@ -36,6 +36,7 @@ async function loadJiraModuleParts(
     jiraSecretsNamespace,
     migrationsPath,
     upsertJiraInstallation,
+    withJiraRefreshLockAndWait,
   } = await import('@shipfox/api-integration-jira');
 
   async function getExistingJiraConnection(input: {
@@ -151,11 +152,13 @@ async function loadJiraModuleParts(
         await deleteJiraInstallationByConnectionId(connection.id, {tx});
       },
       deleteConnectionSecrets: async (connection) => {
-        // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
-        await (options.secrets?.jira?.deleteSecrets({
-          workspaceId: connection.workspaceId,
-          namespace: jiraNamespaceSuffix(jiraSecretsNamespace(connection.id)),
-        }) ?? Promise.resolve());
+        await withJiraRefreshLockAndWait(connection.id, async () => {
+          // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
+          await (options.secrets?.jira?.deleteSecrets({
+            workspaceId: connection.workspaceId,
+            namespace: jiraNamespaceSuffix(jiraSecretsNamespace(connection.id)),
+          }) ?? Promise.resolve());
+        });
       },
     },
     routes: {

--- a/libs/api/integration/core/src/providers/jira.ts
+++ b/libs/api/integration/core/src/providers/jira.ts
@@ -30,8 +30,10 @@ async function loadJiraModuleParts(
     createJiraPendingSelectionStore,
     createJiraTokenStore,
     db: jiraDb,
+    deleteJiraInstallationByConnectionId,
     disconnectJiraInstallation: disconnectJiraInstallationRecords,
     getJiraInstallationByCloudId,
+    jiraSecretsNamespace,
     migrationsPath,
     upsertJiraInstallation,
   } = await import('@shipfox/api-integration-jira');
@@ -144,6 +146,18 @@ async function loadJiraModuleParts(
 
   const integrationProvider = createJiraIntegrationProvider({
     agentTools: {tokenStore},
+    cleanup: {
+      deleteConnectionRecords: async (connection, {tx}) => {
+        await deleteJiraInstallationByConnectionId(connection.id, {tx});
+      },
+      deleteConnectionSecrets: async (connection) => {
+        // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
+        await (options.secrets?.jira?.deleteSecrets({
+          workspaceId: connection.workspaceId,
+          namespace: jiraNamespaceSuffix(jiraSecretsNamespace(connection.id)),
+        }) ?? Promise.resolve());
+      },
+    },
     routes: {
       tokenStore,
       pendingStore,

--- a/libs/api/integration/jira/src/index.test.ts
+++ b/libs/api/integration/jira/src/index.test.ts
@@ -31,6 +31,17 @@ describe('createJiraIntegrationProvider', () => {
       }),
     ).toThrow('requires all webhook receiver dependencies');
   });
+
+  it('exposes explicit connection cleanup without requiring routes', () => {
+    const deleteConnectionRecords = vi.fn(() => Promise.resolve());
+    const deleteConnectionSecrets = vi.fn(() => Promise.resolve());
+    const provider = createJiraIntegrationProvider({
+      cleanup: {deleteConnectionRecords, deleteConnectionSecrets},
+    });
+
+    expect(provider.deleteConnectionRecords).toBe(deleteConnectionRecords);
+    expect(provider.deleteConnectionSecrets).toBe(deleteConnectionSecrets);
+  });
 });
 
 describe('createJiraMaintenanceWorker', () => {

--- a/libs/api/integration/jira/src/index.ts
+++ b/libs/api/integration/jira/src/index.ts
@@ -126,6 +126,7 @@ export {
   updateJiraInstallationWebhook,
   upsertJiraInstallation,
   withJiraRefreshLock,
+  withJiraRefreshLockAndWait,
   withJiraWebhookRegistrationLock,
 } from '#db/installations.js';
 export type {CreateJiraWebhookRoutesOptions} from '#presentation/routes/webhooks.js';

--- a/libs/api/integration/jira/src/index.ts
+++ b/libs/api/integration/jira/src/index.ts
@@ -142,6 +142,15 @@ export interface CreateJiraIntegrationProviderOptions {
       }
     | undefined;
   getJiraInstallationByConnectionId?: typeof getJiraInstallationByConnectionId | undefined;
+  cleanup?:
+    | {
+        deleteConnectionRecords?: (
+          connection: {id: string},
+          options: {tx: unknown},
+        ) => Promise<void>;
+        deleteConnectionSecrets?: (connection: {id: string; workspaceId: string}) => Promise<void>;
+      }
+    | undefined;
   routes?: JiraIntegrationProviderRoutesOptions | undefined;
 }
 
@@ -210,6 +219,7 @@ export function createJiraIntegrationProvider(options: CreateJiraIntegrationProv
     async connectionExternalUrl(connection: {id: string}): Promise<string | undefined> {
       return (await getInstallationByConnectionId(connection.id))?.siteUrl;
     },
+    ...options.cleanup,
     routes,
     webhookProcessors: webhookProcessor
       ? [{routeIds: ['jira'] as const, processor: webhookProcessor}]


### PR DESCRIPTION
Jira connection deletion removed the core connection but left the provider installation row and tokens. The next OAuth install then treated the Jira site as already linked.

This adds provider cleanup hooks that delete the installation row transactionally and remove scoped tokens after commit. It also covers delete-then-reinstall and transaction rollback behavior.

Validation: `mise exec -- turbo check type --filter=@shipfox/api-integration-jira --filter=@shipfox/api-integration-core`, `mise exec -- turbo test --filter=@shipfox/api-integration-core`, and `mise exec -- turbo test --filter=@shipfox/api-integration-jira`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira integration deletion so a Jira site can be reinstalled. Cleanup removes installation records and secrets, and waits for token refresh before deleting scoped tokens; tests are deterministic.

- **Bug Fixes**
  - Delete installation rows in a transaction and serialize secret cleanup with `withJiraRefreshLockAndWait`.
  - Use Jira secret namespace helpers for the connection scope so reinstall creates a fresh link.
  - Expose provider cleanup hooks (no routes required) and add tests for delete-then-reinstall, refresh-lock ordering, rollback, and cleanup exposure.

<sup>Written for commit f91eb25f47ffdc1a334035fd0a2d0053c5d2d3a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

