### PR TITLE
Accept per-poll reservation TTLs and clamp them server-side

### DIFF
--- a/.changeset/fair-runners-poll.md
+++ b/.changeset/fair-runners-poll.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": patch
+"@shipfox/api-runners-dto": patch
+---
+
+Accept provider-specific reservation TTLs in runner demand polling and enforce a server-side ceiling.

--- a/libs/api/runners-dto/src/schemas/poll-demand.test.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.test.ts
@@ -26,6 +26,26 @@ describe('pollDemandBodySchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('accepts an optional positive reservation TTL', () => {
+    const result = pollDemandBodySchema.safeParse({
+      max_reservations: 0,
+      reservation_ttl_seconds: 300,
+      templates: [],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([0, -1, 1.5])('rejects an invalid reservation TTL of %s', (value) => {
+    const result = pollDemandBodySchema.safeParse({
+      max_reservations: 0,
+      reservation_ttl_seconds: value,
+      templates: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('pollDemandResponseSchema', () => {

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -12,6 +12,7 @@ export const pollDemandTemplateSchema = z.object({
 
 export const pollDemandBodySchema = z.object({
   wait_seconds: z.number().int().min(0).optional(),
+  reservation_ttl_seconds: z.number().int().min(1).optional(),
   max_reservations: z.number().int().min(0).max(1000),
   templates: z.array(pollDemandTemplateSchema).max(1000),
 });

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -49,6 +49,51 @@ describe('runner assignment polling defaults', () => {
     await expect(import('#config.js')).rejects.toThrow('RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS');
   });
 });
+
+describe('reservation TTL ceiling validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each([
+    '0',
+    '-5',
+    '1.5',
+    '3601',
+  ])('fails startup when RESERVATION_TTL_MAX_SECONDS is %s', async (value) => {
+    vi.stubEnv('RESERVATION_TTL_MAX_SECONDS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('RESERVATION_TTL_MAX_SECONDS');
+  });
+
+  it('defaults high enough for the EC2 registration deadline', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.RESERVATION_TTL_MAX_SECONDS).toBe(300);
+  });
+
+  it('accepts a whole-second ceiling inside the hard maximum', async () => {
+    vi.stubEnv('RESERVATION_TTL_MAX_SECONDS', '600');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.RESERVATION_TTL_MAX_SECONDS).toBe(600);
+  });
+
+  it('fails startup when the default reservation TTL is above the ceiling', async () => {
+    vi.stubEnv('RESERVATION_TTL_SECONDS', '600');
+    vi.stubEnv('RESERVATION_TTL_MAX_SECONDS', '300');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('RESERVATION_TTL_SECONDS');
+  });
+});
+
 describe('REGISTRATION_TOKEN_BATCH_MAX validation', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -5,6 +5,7 @@ import {STUCK_JOB_THRESHOLD_SECONDS} from '#core/maintenance-policy.js';
 const EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS = 3600;
 const REGISTRATION_TOKEN_BATCH_HARD_MAX = 1000;
 const RUNNER_CONTROL_PLANE_TOKEN_TTL_HARD_MAX_SECONDS = 3600;
+const RESERVATION_TTL_HARD_MAX_SECONDS = 3600;
 
 export const config = createConfig({
   RUNNER_BOOTSTRAP_TOKEN_TTL_SECONDS: num({
@@ -56,8 +57,12 @@ export const config = createConfig({
     default: 250,
   }),
   RESERVATION_TTL_SECONDS: num({
-    desc: 'Lifetime of a count-based runner reservation, in seconds. Expired reservations stop counting against queued demand.',
+    desc: 'Default lifetime of a count-based runner reservation, in seconds. Used when a provisioner does not request a provider-specific value. Expired reservations stop counting against queued demand.',
     default: 60,
+  }),
+  RESERVATION_TTL_MAX_SECONDS: num({
+    desc: `Server-side ceiling for a count-based runner reservation lifetime, in seconds. Set it at least as high as every provider registration deadline so provider-specific values can cover boot and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
+    default: 300,
   }),
   RESERVATION_LONG_POLL_MAX_WAIT_SECONDS: num({
     desc: 'Maximum time the provisioner demand poll endpoint waits for reservable demand before returning, in seconds.',
@@ -206,6 +211,22 @@ for (const [name, value] of [
 if (!Number.isInteger(config.RESERVATION_TTL_SECONDS) || config.RESERVATION_TTL_SECONDS < 1) {
   throw new Error(
     `RESERVATION_TTL_SECONDS (${config.RESERVATION_TTL_SECONDS}) must be a whole number of seconds >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RESERVATION_TTL_MAX_SECONDS) ||
+  config.RESERVATION_TTL_MAX_SECONDS < 1 ||
+  config.RESERVATION_TTL_MAX_SECONDS > RESERVATION_TTL_HARD_MAX_SECONDS
+) {
+  throw new Error(
+    `RESERVATION_TTL_MAX_SECONDS (${config.RESERVATION_TTL_MAX_SECONDS}) must be a whole number of seconds between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
+  );
+}
+
+if (config.RESERVATION_TTL_SECONDS > config.RESERVATION_TTL_MAX_SECONDS) {
+  throw new Error(
+    `RESERVATION_TTL_SECONDS (${config.RESERVATION_TTL_SECONDS}) must not be greater than RESERVATION_TTL_MAX_SECONDS (${config.RESERVATION_TTL_MAX_SECONDS}).`,
   );
 }
 

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -87,6 +87,7 @@ describe('POST /provisioners/demand/poll', () => {
   it('returns demand stats and reservations when matching demand exists', async () => {
     await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
 
+    const requestStartedAt = Date.now();
     const res = await app.inject({
       method: 'POST',
       url: '/provisioners/demand/poll',
@@ -102,6 +103,43 @@ describe('POST /provisioners/demand/poll', () => {
     });
     expect(res.json().reservations[0].reservation_id).toEqual(expect.any(String));
     expect(res.json().reservations[0].expires_at).toEqual(expect.any(String));
+    const expiresAt = Date.parse(res.json().reservations[0].expires_at);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 55_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 65_000);
+  });
+
+  it('clamps a requested reservation TTL for workspace provisioners', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const requestStartedAt = Date.now();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1, reservation_ttl_seconds: 600}),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const expiresAt = Date.parse(res.json().reservations[0].expires_at);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 295_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 305_000);
+  });
+
+  it('applies a requested reservation TTL below the ceiling', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const requestStartedAt = Date.now();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1, reservation_ttl_seconds: 120}),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const expiresAt = Date.parse(res.json().reservations[0].expires_at);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 115_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 125_000);
   });
 
   it('rejects installation provisioner credentials from workspace demand polling', async () => {
@@ -330,10 +368,13 @@ describe('POST /provisioners/demand/poll', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  function body(params: {max_reservations: number}) {
+  function body(params: {max_reservations: number; reservation_ttl_seconds?: number}) {
     return {
       wait_seconds: 0,
       max_reservations: params.max_reservations,
+      ...(params.reservation_ttl_seconds === undefined
+        ? {}
+        : {reservation_ttl_seconds: params.reservation_ttl_seconds}),
       templates: [
         {
           template_key: 'linux',
@@ -377,6 +418,7 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
   let app: FastifyInstance;
   let workspaceId: string;
   let provisionerTokenId: string;
+  const filterEligibleWorkspaceIds = vi.fn().mockResolvedValue(new Set<string>());
 
   const fakeProvisionerAuth: AuthMethod = {
     name: AUTH_PROVISIONER_TOKEN,
@@ -402,7 +444,7 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
       ],
       routes: createRunnerRoutes(runnersTestAuthClient, {
         installationProvisioning: {
-          policy: {filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set())},
+          policy: {filterEligibleWorkspaceIds},
         },
       }),
       swagger: false,
@@ -444,10 +486,31 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
     expect(res.statusCode).toBe(200);
   });
 
-  function body(params: {max_reservations: number}) {
+  it('clamps a requested reservation TTL for installation provisioners', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+    filterEligibleWorkspaceIds.mockResolvedValueOnce(new Set([workspaceId]));
+
+    const requestStartedAt = Date.now();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${INSTALLATION_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1, reservation_ttl_seconds: 600}),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const expiresAt = Date.parse(res.json().reservations[0].expires_at);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 295_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 305_000);
+  });
+
+  function body(params: {max_reservations: number; reservation_ttl_seconds?: number}) {
     return {
       wait_seconds: 0,
       max_reservations: params.max_reservations,
+      ...(params.reservation_ttl_seconds === undefined
+        ? {}
+        : {reservation_ttl_seconds: params.reservation_ttl_seconds}),
       templates: [
         {
           template_key: 'linux',

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -66,6 +66,10 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
         }
       });
       const provisionerContext = requireProvisionerContext(request);
+      const ttlSeconds = Math.min(
+        request.body.reservation_ttl_seconds ?? config.RESERVATION_TTL_SECONDS,
+        config.RESERVATION_TTL_MAX_SECONDS,
+      );
       if (provisionerContext.scope === 'installation') {
         if (!options.installationProvisioning) {
           throw new ClientError(
@@ -85,7 +89,7 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
         const result = await pollInstallationDemandAndReserve({
           provisionerId: provisionerContext.provisionerTokenId,
           maxReservations: request.body.max_reservations,
-          ttlSeconds: config.RESERVATION_TTL_SECONDS,
+          ttlSeconds,
           templates,
           capabilityWindowSeconds: config.PROVISIONER_ACTIVE_WINDOW_SECONDS,
           eligibleWorkspaceIds,
@@ -113,7 +117,7 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
         provisionerId: provisionerTokenId,
         maxReservations: request.body.max_reservations,
         waitSeconds: request.body.wait_seconds,
-        ttlSeconds: config.RESERVATION_TTL_SECONDS,
+        ttlSeconds,
         terminateIntentLimit: TERMINATE_INTENT_LIMIT,
         templates,
         signal: abortController.signal,


### PR DESCRIPTION
## Summary

Allow each provisioner demand poll to request a reservation TTL that matches its provider registration deadline. The runners API now validates a configurable ceiling, uses the existing 60-second default when the field is omitted, and clamps larger requests for both workspace and installation polling.

This keeps provider-specific boot and enrollment time inside the reservation window while preserving server-side control over the maximum lifetime.

Closes ENG-1492

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept per-poll reservation TTLs in runner demand polling and clamp them to a server-side ceiling. Addresses ENG-1492 by keeping provider boot/enrollment within the reservation window; defaults to 60s when not provided and applies to both workspace and installation polling.

- New Features
  - Added optional `reservation_ttl_seconds` to poll body (int ≥ 1).
  - Introduced `RESERVATION_TTL_MAX_SECONDS` (default 300, range 1–3600) with startup validation and a check that `RESERVATION_TTL_SECONDS` ≤ ceiling.
  - Route uses min(requested TTL or default, ceiling) for reservation expiry across both polling scopes.
  - Added tests for schema validation, config validation, and TTL clamping.

<sup>Written for commit b594aa2e714232ac7e0e36db59ebd67affe36b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

