### PR TITLE
[api-runners] Reserve labels for installation-scope provisioners

### DIFF
--- a/.changeset/reserve-installation-labels.md
+++ b/.changeset/reserve-installation-labels.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Reserve configured runner labels for installation-scope provisioners.

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -26,6 +26,15 @@ describe('RUNNER_RESERVED_LABELS', () => {
     expect(config.RUNNER_RESERVED_LABELS).toBe(' ShipFox-Managed, Linux,shipfox-managed ');
     expect(runnerReservedLabels).toEqual(['linux', 'shipfox-managed']);
   });
+
+  it('rejects invalid runner labels', async () => {
+    vi.stubEnv('RUNNER_RESERVED_LABELS', 'linux,has space');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'RUNNER_RESERVED_LABELS contains invalid runner label(s): has space',
+    );
+  });
 });
 
 describe('EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS validation', () => {

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -1,6 +1,33 @@
 import {RUNNER_ASSIGNMENT_POLL_DEFAULT_WAIT_SECONDS} from '@shipfox/api-runners-dto';
 import {vi} from '@shipfox/vitest/vi';
 
+describe('RUNNER_RESERVED_LABELS', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('defaults to no reserved labels', async () => {
+    vi.stubEnv('RUNNER_RESERVED_LABELS', undefined);
+    vi.resetModules();
+
+    const {config, runnerReservedLabels} = await import('#config.js');
+
+    expect(config.RUNNER_RESERVED_LABELS).toBe('');
+    expect(runnerReservedLabels).toEqual([]);
+  });
+
+  it('parses comma-separated labels for case-insensitive matching', async () => {
+    vi.stubEnv('RUNNER_RESERVED_LABELS', ' ShipFox-Managed, Linux,shipfox-managed ');
+    vi.resetModules();
+
+    const {config, runnerReservedLabels} = await import('#config.js');
+
+    expect(config.RUNNER_RESERVED_LABELS).toBe(' ShipFox-Managed, Linux,shipfox-managed ');
+    expect(runnerReservedLabels).toEqual(['linux', 'shipfox-managed']);
+  });
+});
+
 describe('EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS validation', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -1,5 +1,6 @@
 import {RUNNER_ASSIGNMENT_POLL_DEFAULT_WAIT_SECONDS} from '@shipfox/api-runners-dto';
-import {bool, createConfig, num} from '@shipfox/config';
+import {bool, createConfig, num, str} from '@shipfox/config';
+import {parseLabelList} from '@shipfox/runner-labels';
 import {STUCK_JOB_THRESHOLD_SECONDS} from '#core/maintenance-policy.js';
 
 const EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS = 3600;
@@ -26,6 +27,10 @@ export const config = createConfig({
   RUNNER_ASSIGNMENT_POLL_INTERVAL_MS: num({
     desc: 'Delay between durable assignment reads while a runner-control session waits for an assignment, in milliseconds.',
     default: 250,
+  }),
+  RUNNER_RESERVED_LABELS: str({
+    desc: 'Comma-separated labels that only installation-scope provisioners may advertise. Any other provisioner or runner has them removed.',
+    default: '',
   }),
   EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS: num({
     desc: `Lifetime of a provisioner-minted runner registration token, in seconds. The token can be exchanged once by a runner before this time passes. Set this between 1 and ${EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS}.`,
@@ -132,6 +137,8 @@ export const config = createConfig({
     default: false,
   }),
 });
+
+export const runnerReservedLabels = parseLabelList(config.RUNNER_RESERVED_LABELS);
 
 if (
   !Number.isInteger(config.EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS) ||

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -1,6 +1,6 @@
 import {RUNNER_ASSIGNMENT_POLL_DEFAULT_WAIT_SECONDS} from '@shipfox/api-runners-dto';
 import {bool, createConfig, num, str} from '@shipfox/config';
-import {parseLabelList} from '@shipfox/runner-labels';
+import {findInvalidLabels, parseLabelList} from '@shipfox/runner-labels';
 import {STUCK_JOB_THRESHOLD_SECONDS} from '#core/maintenance-policy.js';
 
 const EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS = 3600;
@@ -138,7 +138,16 @@ export const config = createConfig({
   }),
 });
 
-export const runnerReservedLabels = parseLabelList(config.RUNNER_RESERVED_LABELS);
+const parsedRunnerReservedLabels = parseLabelList(config.RUNNER_RESERVED_LABELS);
+const invalidRunnerReservedLabels = findInvalidLabels(parsedRunnerReservedLabels);
+
+if (invalidRunnerReservedLabels.length > 0) {
+  throw new Error(
+    `RUNNER_RESERVED_LABELS contains invalid runner label(s): ${invalidRunnerReservedLabels.join(', ')}`,
+  );
+}
+
+export const runnerReservedLabels = parsedRunnerReservedLabels;
 
 if (
   !Number.isInteger(config.EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS) ||

--- a/libs/api/runners/src/core/errors.ts
+++ b/libs/api/runners/src/core/errors.ts
@@ -40,6 +40,15 @@ export class EmptyRunnerLabelsError extends Error {
   }
 }
 
+export class RunnerLabelsReservedError extends Error {
+  constructor(public readonly labels: string[]) {
+    super(
+      `All supplied runner labels are reserved for installation-scope provisioners: ${labels.join(', ')}`,
+    );
+    this.name = 'RunnerLabelsReservedError';
+  }
+}
+
 export class EmptyRequiredLabelsError extends Error {
   constructor() {
     super('Required labels cannot be empty');

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -25,6 +25,7 @@ export {
   ProvisionerTokenNotFoundError,
   RegistrationTokenConsumedError,
   RegistrationTokenExpiredError,
+  RunnerLabelsReservedError,
   RunnerSessionExhaustedError,
   RunningJobExecutionNotFoundError,
 } from './errors.js';

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -2,7 +2,6 @@ import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import type {NodePgDatabase} from '@shipfox/node-drizzle';
 import {logger} from '@shipfox/node-opentelemetry';
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
-import {canonicalizeLabels} from '@shipfox/runner-labels';
 import {and, eq, gt, isNull, notInArray, or, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import {
@@ -11,6 +10,7 @@ import {
   RunnerInstanceAlreadyAssignedError,
   RunnerInstanceNotAssignableError,
 } from '#core/errors.js';
+import {sanitizeRunnerLabels} from '#core/runner-labels.js';
 import {db, type schema, type Tx} from '#db/db.js';
 import {assignRunnerInstancesTx} from '#db/runner-assignments.js';
 import {terminalStates} from '#db/runner-instances.js';
@@ -141,8 +141,12 @@ export async function enrollRunnerControlSession(params: {
 }): Promise<string | null> {
   return await db().transaction(async (tx) => {
     const [current] = await tx
-      .select({intendedReservationId: providerRunners.intendedReservationId})
+      .select({
+        intendedReservationId: providerRunners.intendedReservationId,
+        provisionerScope: provisionerTokens.scope,
+      })
       .from(providerRunners)
+      .innerJoin(provisionerTokens, eq(provisionerTokens.id, providerRunners.provisionerId))
       .where(
         and(
           eq(providerRunners.id, params.runnerInstanceId),
@@ -158,7 +162,10 @@ export async function enrollRunnerControlSession(params: {
     const [updated] = await tx
       .update(providerRunners)
       .set({
-        labels: [...canonicalizeLabels(params.labels)],
+        labels: sanitizeRunnerLabels(params.labels, {
+          scope: current.provisionerScope,
+          source: 'runner control enrollment',
+        }),
         providerKind: params.providerKind,
         protocolVersion: params.protocolVersion,
         capabilities: params.capabilities ?? null,

--- a/libs/api/runners/src/core/runner-instances.ts
+++ b/libs/api/runners/src/core/runner-instances.ts
@@ -23,6 +23,7 @@ import {
 import {config} from '../config.js';
 
 export interface ReportRunnerInstancesParams {
+  scope: 'installation' | 'workspace';
   workspaceId: string | null;
   provisionerId: string;
   events: RunnerInstanceReportEvent[];

--- a/libs/api/runners/src/core/runner-labels.test.ts
+++ b/libs/api/runners/src/core/runner-labels.test.ts
@@ -1,0 +1,53 @@
+import {RunnerLabelsReservedError} from './errors.js';
+import {sanitizeRunnerLabels, sanitizeRunnerLabelsOrThrow} from './runner-labels.js';
+
+describe('sanitizeRunnerLabels', () => {
+  it('strips reserved labels from non-installation sources', () => {
+    const labels = sanitizeRunnerLabels([' Linux ', 'shipfox-managed', 'linux'], {
+      scope: 'workspace',
+      source: 'test',
+      reservedLabels: ['Shipfox-Managed'],
+    });
+
+    expect(labels).toEqual(['linux']);
+  });
+
+  it('preserves reserved labels for installation sources', () => {
+    const labels = sanitizeRunnerLabels([' Linux ', 'shipfox-managed'], {
+      scope: 'installation',
+      source: 'test',
+      reservedLabels: ['shipfox-managed'],
+    });
+
+    expect(labels).toEqual(['linux', 'shipfox-managed']);
+  });
+
+  it('does not change labels when no reserved labels are configured', () => {
+    const labels = sanitizeRunnerLabels([' Linux ', 'linux'], {
+      scope: 'manual',
+      source: 'test',
+      reservedLabels: [],
+    });
+
+    expect(labels).toEqual(['linux']);
+  });
+
+  it('uses the configured reserved labels when none are provided explicitly', () => {
+    const labels = sanitizeRunnerLabels(['linux', 'shipfox-managed'], {
+      scope: 'workspace',
+      source: 'test',
+    });
+
+    expect(labels).toEqual(['linux']);
+  });
+
+  it('throws when sanitization removes every canonical label', () => {
+    expect(() =>
+      sanitizeRunnerLabelsOrThrow([' Shipfox-Managed '], {
+        scope: 'workspace',
+        source: 'test',
+        reservedLabels: ['shipfox-managed'],
+      }),
+    ).toThrow(RunnerLabelsReservedError);
+  });
+});

--- a/libs/api/runners/src/core/runner-labels.ts
+++ b/libs/api/runners/src/core/runner-labels.ts
@@ -1,0 +1,51 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import {canonicalizeLabels} from '@shipfox/runner-labels';
+import {runnerReservedLabels} from '#config.js';
+import {RunnerLabelsReservedError} from './errors.js';
+
+export type RunnerLabelScope = 'installation' | 'workspace' | 'manual';
+
+type SanitizeRunnerLabelsParams = {
+  scope: RunnerLabelScope;
+  source: string;
+  logLevel?: 'debug' | 'warn';
+  reservedLabels?: readonly string[];
+};
+
+function sanitizeCanonicalRunnerLabels(
+  canonicalLabels: readonly string[],
+  params: SanitizeRunnerLabelsParams,
+): string[] {
+  if (params.scope === 'installation') return [...canonicalLabels];
+
+  const reservedLabels = new Set(canonicalizeLabels(params.reservedLabels ?? runnerReservedLabels));
+  if (reservedLabels.size === 0) return [...canonicalLabels];
+
+  const removedLabels = canonicalLabels.filter((label) => reservedLabels.has(label));
+  if (removedLabels.length === 0) return [...canonicalLabels];
+
+  const details = {source: params.source, removedLabels};
+  if (params.logLevel === 'debug')
+    logger().debug(details, 'Removed reserved runner labels from a non-installation source');
+  else logger().warn(details, 'Removed reserved runner labels from a non-installation source');
+  return canonicalLabels.filter((label) => !reservedLabels.has(label));
+}
+
+export function sanitizeRunnerLabels(
+  labels: readonly string[],
+  params: SanitizeRunnerLabelsParams,
+): string[] {
+  return sanitizeCanonicalRunnerLabels([...canonicalizeLabels(labels)], params);
+}
+
+export function sanitizeRunnerLabelsOrThrow(
+  labels: readonly string[],
+  params: SanitizeRunnerLabelsParams,
+): string[] {
+  const canonicalLabels = [...canonicalizeLabels(labels)];
+  const sanitizedLabels = sanitizeCanonicalRunnerLabels(canonicalLabels, params);
+  if (sanitizedLabels.length === 0 && canonicalLabels.length > 0) {
+    throw new RunnerLabelsReservedError(canonicalLabels);
+  }
+  return sanitizedLabels;
+}

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -9,12 +9,14 @@ import {
   getRunnerSessionTokenClaims,
   manualRegistrationTokenFactory,
   providerRunnerFactory,
+  provisionerTokenFactory,
   runnersTestAuthClient,
 } from '#test/index.js';
 import {
   EmptyRunnerLabelsError,
   RegistrationTokenConsumedError,
   RegistrationTokenWorkspaceMismatchError,
+  RunnerLabelsReservedError,
 } from './errors.js';
 import {issueRunnerActivationToken} from './runner-activation.js';
 import {registerRunnerSession} from './runner-sessions.js';
@@ -64,6 +66,15 @@ describe('registerRunnerSession', () => {
         labels: [' ', '\t'],
       }),
     ).rejects.toBeInstanceOf(EmptyRunnerLabelsError);
+  });
+
+  it('names labels removed by the reserved-label policy', () => {
+    const error = new RunnerLabelsReservedError(['shipfox-managed']);
+
+    expect(error.message).toBe(
+      'All supplied runner labels are reserved for installation-scope provisioners: shipfox-managed',
+    );
+    expect(error.labels).toEqual(['shipfox-managed']);
   });
 
   it('consumes an ephemeral token and creates a one-claim session', async () => {
@@ -223,7 +234,8 @@ describe('activation runner sessions', () => {
 
   beforeEach(async () => {
     workspaceId = crypto.randomUUID();
-    provisionerId = crypto.randomUUID();
+    const provisioner = await provisionerTokenFactory.create({workspaceId});
+    provisionerId = provisioner.id;
     const runner = await providerRunnerFactory.create({workspaceId, provisionerId});
     runnerInstanceId = runner.id;
   });
@@ -295,5 +307,26 @@ describe('activation runner sessions', () => {
     );
     expect(storedToken?.consumedAt).toBeInstanceOf(Date);
     expect(sessions).toHaveLength(1);
+  });
+
+  it('strips reserved labels from workspace activation registration', async () => {
+    const rawToken = await issueRunnerActivationToken({
+      runnerInstanceId,
+      provisionerId,
+      ttlSeconds: 60,
+    });
+    const [activationToken] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.runnerInstanceId, runnerInstanceId));
+    if (!rawToken || !activationToken) throw new Error('Activation token was not created');
+
+    const result = await registerRunnerSession({
+      auth: runnersTestAuthClient,
+      credential: {kind: 'activation', activationTokenId: activationToken.id, workspaceId},
+      labels: ['linux', 'shipfox-managed'],
+    });
+
+    expect(result.session.labels).toEqual(['linux']);
   });
 });

--- a/libs/api/runners/src/core/runner-sessions.ts
+++ b/libs/api/runners/src/core/runner-sessions.ts
@@ -8,6 +8,7 @@ import {
 } from '#db/runner-sessions.js';
 import type {RunnerSession} from './entities/runner-session.js';
 import {EmptyRunnerLabelsError} from './errors.js';
+import {sanitizeRunnerLabelsOrThrow} from './runner-labels.js';
 
 export interface RegisterRunnerSessionResult {
   session: RunnerSession;
@@ -38,7 +39,13 @@ export async function registerRunnerSession(params: {
   labels: string[];
   toolCapabilities?: RunnerToolCapabilitiesDto | null;
 }): Promise<RegisterRunnerSessionResult> {
-  const labels = [...canonicalizeLabels(params.labels)];
+  const labels =
+    params.credential.kind === 'manual'
+      ? sanitizeRunnerLabelsOrThrow(params.labels, {
+          scope: 'manual',
+          source: 'manual runner registration',
+        })
+      : [...canonicalizeLabels(params.labels)];
   if (labels.length === 0) throw new EmptyRunnerLabelsError();
 
   const mode = params.credential.kind;

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -4,6 +4,7 @@ import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registra
 import {
   ActiveEphemeralRegistrationTokenExistsError,
   ActiveEphemeralRegistrationTokensExistError,
+  EmptyRunnerLabelsError,
   RegistrationTokenBatchExceedsReservationError,
   RegistrationTokenConsumedError,
   RegistrationTokenExpiredError,
@@ -11,11 +12,13 @@ import {
   ReservationExpiredError,
   ReservationNotFoundError,
 } from '#core/errors.js';
+import {sanitizeRunnerLabelsOrThrow} from '#core/runner-labels.js';
 import {db} from './db.js';
 import {
   ephemeralRegistrationTokens,
   toEphemeralRegistrationToken,
 } from './schema/ephemeral-registration-tokens.js';
+import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
 import {providerRunners} from './schema/runner-instances.js';
 import {runnerSessions, toRunnerSession} from './schema/runner-sessions.js';
@@ -307,6 +310,17 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
       );
     }
 
+    const [provisioner] = await tx
+      .select({scope: provisionerTokens.scope})
+      .from(provisionerTokens)
+      .where(eq(provisionerTokens.id, consumed[0].provisionerId))
+      .limit(1);
+    const labels = sanitizeRunnerLabelsOrThrow(params.labels, {
+      scope: provisioner?.scope ?? 'workspace',
+      source: 'ephemeral runner registration',
+    });
+    if (labels.length === 0) throw new EmptyRunnerLabelsError();
+
     const [session] = await tx
       .insert(runnerSessions)
       .values({
@@ -316,7 +330,7 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
         registrationTokenKind: 'ephemeral',
         provisionerId: consumed[0].provisionerId,
         providerRunnerId: consumed[0].providerRunnerId,
-        labels: params.labels,
+        labels,
         toolCapabilities: params.toolCapabilities ?? null,
         toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
         maxClaims: params.maxClaims,

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -10,7 +10,7 @@ import {
   listProvisionerTerminateIntents,
   reapStaleRunnerInstances,
   reconcileRunnerInstances,
-  reportRunnerInstances,
+  reportRunnerInstances as reportRunnerInstancesDb,
 } from '#db/runner-instances.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {reservations} from '#db/schema/reservations.js';
@@ -24,6 +24,12 @@ import {
   reservationFactory,
   runnerSessionFactory,
 } from '#test/index.js';
+
+type ReportRunnerInstancesTestParams = Parameters<typeof reportRunnerInstancesDb>[0];
+
+function reportRunnerInstances(params: ReportRunnerInstancesTestParams) {
+  return reportRunnerInstancesDb(params);
+}
 
 function providerRunnerRowsFor(params: {workspaceId: string; provisionerId: string}) {
   return db()
@@ -93,6 +99,7 @@ describe('reportRunnerInstances', () => {
     const reportedAt = new Date();
 
     const report = await reportRunnerInstances({
+      scope: 'installation',
       workspaceId: null,
       provisionerId,
       events: [event({providerRunnerId: 'installation-runner', reportedAt})],
@@ -118,6 +125,7 @@ describe('reportRunnerInstances', () => {
     const reportedAt = new Date();
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -140,6 +148,7 @@ describe('reportRunnerInstances', () => {
     const reportedAt = new Date();
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -160,6 +169,7 @@ describe('reportRunnerInstances', () => {
   it('accepts delayed events that move the lifecycle forward', async () => {
     const newest = new Date();
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -168,6 +178,7 @@ describe('reportRunnerInstances', () => {
     });
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -188,6 +199,7 @@ describe('reportRunnerInstances', () => {
   it('rejects older out-of-order events in the same lifecycle state', async () => {
     const newest = new Date();
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -201,6 +213,7 @@ describe('reportRunnerInstances', () => {
     });
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -222,6 +235,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(1);
     const reportedAt = new Date('2025-01-01T00:00:00.000Z');
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -235,6 +249,7 @@ describe('reportRunnerInstances', () => {
     });
 
     const terminal = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -247,6 +262,7 @@ describe('reportRunnerInstances', () => {
       ],
     });
     const revived = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -270,6 +286,7 @@ describe('reportRunnerInstances', () => {
 
   it('clamps future reported times so they do not pin provisioned runner state', async () => {
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -282,6 +299,7 @@ describe('reportRunnerInstances', () => {
     });
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -305,6 +323,7 @@ describe('reportRunnerInstances', () => {
     const terminatedAt = new Date('2025-01-01T00:03:00.000Z');
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -346,6 +365,7 @@ describe('reportRunnerInstances', () => {
     const terminatedAt = new Date('2025-01-01T00:03:00.000Z');
     const startedAt = new Date('2025-01-01T00:00:00.000Z');
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -358,6 +378,7 @@ describe('reportRunnerInstances', () => {
     });
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -378,6 +399,7 @@ describe('reportRunnerInstances', () => {
 
   it('uses server update time for active provisioned runner windows', async () => {
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -401,6 +423,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(2);
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: 'provisioned-runner-1', reservationId, state: 'failed'})],
@@ -429,6 +452,7 @@ describe('reportRunnerInstances', () => {
     if (!runner.providerRunnerId) throw new Error('Runner instance provider id missing');
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: runner.providerRunnerId, state: 'failed'})],
@@ -479,6 +503,7 @@ describe('reportRunnerInstances', () => {
     });
 
     const result = await reportRunnerInstances({
+      scope: 'installation',
       workspaceId: null,
       provisionerId: installationProvisioner.id,
       events: [event({providerRunnerId: 'installation-pre-enrollment-runner', state: 'failed'})],
@@ -521,6 +546,7 @@ describe('reportRunnerInstances', () => {
     });
 
     const result = await reportRunnerInstances({
+      scope: 'installation',
       workspaceId: null,
       provisionerId: installationProvisioner.id,
       events: [
@@ -552,6 +578,7 @@ describe('reportRunnerInstances', () => {
     });
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -581,11 +608,13 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(2);
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: 'provisioned-runner-1', reservationId, state: 'failed'})],
     });
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: 'provisioned-runner-1', reservationId, state: 'failed'})],
@@ -600,6 +629,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(2);
     const failedAt = new Date();
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -613,6 +643,7 @@ describe('reportRunnerInstances', () => {
     });
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -636,6 +667,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(2);
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -656,6 +688,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(3);
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -673,6 +706,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(1);
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: 'provisioned-runner-1', reservationId, state: 'failed'})],
@@ -695,6 +729,7 @@ describe('reportRunnerInstances', () => {
     if (!reservation) throw new Error('Expected reservation');
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -715,6 +750,7 @@ describe('reportRunnerInstances', () => {
     const reservationId = await createReservation(1);
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -750,6 +786,7 @@ describe('reportRunnerInstances', () => {
     });
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -776,6 +813,7 @@ describe('reportRunnerInstances', () => {
     const reportedAt = new Date('2025-01-01T00:00:00.000Z');
 
     const result = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -819,11 +857,13 @@ describe('reportRunnerInstances', () => {
     });
 
     const first = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: 'provisioned-runner-1', state: 'terminated'})],
     });
     const second = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [event({providerRunnerId: 'provisioned-runner-1', state: 'terminated'})],
@@ -1365,6 +1405,7 @@ describe('reapStaleRunnerInstances', () => {
 
     await lockHolderReady.promise;
     const report = reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -1845,6 +1886,7 @@ describe('reconcileRunnerInstances', () => {
     });
 
     await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -1877,6 +1919,7 @@ describe('reconcileRunnerInstances', () => {
 
     await lockHolderReady.promise;
     const report = reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -2026,6 +2069,7 @@ describe('runner instance provider attachment', () => {
       providerRunnerId,
     });
     await reportRunnerInstances({
+      scope: 'installation',
       workspaceId: null,
       provisionerId,
       events: [

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -1,5 +1,4 @@
 import {logger} from '@shipfox/node-opentelemetry';
-import {canonicalizeLabels} from '@shipfox/runner-labels';
 import {
   and,
   asc,
@@ -19,6 +18,7 @@ import {
 } from 'drizzle-orm';
 import {alias} from 'drizzle-orm/pg-core';
 import type {RunnerInstance, RunnerInstanceState} from '#core/entities/runner-instance.js';
+import {sanitizeRunnerLabels} from '#core/runner-labels.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {
@@ -74,6 +74,7 @@ export interface RunnerInstanceReportEvent {
 }
 
 export interface ReportRunnerInstancesParams {
+  scope: 'installation' | 'workspace';
   workspaceId: string | null;
   provisionerId: string;
   events: RunnerInstanceReportEvent[];
@@ -165,7 +166,11 @@ export async function reportRunnerInstances(params: ReportRunnerInstancesParams)
       providerRunnerId: event.providerRunnerId,
       reservationId: event.reservationId,
       templateKey: event.templateKey,
-      labels: [...canonicalizeLabels(event.labels)],
+      labels: sanitizeRunnerLabels(event.labels, {
+        scope: params.scope,
+        logLevel: 'debug',
+        source: 'runner instance report',
+      }),
       state: event.state,
       reason: event.reason,
       runnerSessionId: event.runnerSessionId,

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -1,7 +1,10 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {and, asc, eq, gt, inArray, isNull, lt, notExists, or, sql} from 'drizzle-orm';
 import type {RunnerSession} from '#core/entities/runner-session.js';
+import {EmptyRunnerLabelsError} from '#core/errors.js';
+import {sanitizeRunnerLabelsOrThrow} from '#core/runner-labels.js';
 import {db} from './db.js';
+import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {runnerActivationTokens} from './schema/runner-activation-tokens.js';
 import {runnerControlSessions} from './schema/runner-control-sessions.js';
 import {providerRunners} from './schema/runner-instances.js';
@@ -79,6 +82,16 @@ export async function createRunnerSessionConsumingActivationToken(params: {
       .for('update');
     if (!token?.workspaceId || !token.providerRunnerId)
       throw new Error('Runner activation token is invalid, expired, or has already been used');
+    const [provisioner] = await tx
+      .select({scope: provisionerTokens.scope})
+      .from(provisionerTokens)
+      .where(eq(provisionerTokens.id, token.provisionerId))
+      .limit(1);
+    const labels = sanitizeRunnerLabelsOrThrow(params.labels, {
+      scope: provisioner?.scope ?? 'workspace',
+      source: 'activation runner registration',
+    });
+    if (labels.length === 0) throw new EmptyRunnerLabelsError();
     const [session] = await tx
       .insert(runnerSessions)
       .values({
@@ -89,7 +102,7 @@ export async function createRunnerSessionConsumingActivationToken(params: {
         runnerInstanceId: token.runnerInstanceId,
         provisionerId: token.provisionerId,
         providerRunnerId: token.providerRunnerId,
-        labels: params.labels,
+        labels,
         toolCapabilities: params.toolCapabilities ?? null,
         toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
         maxClaims: 1,

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -173,6 +173,39 @@ describe('POST /provisioners/demand/poll', () => {
     expect(clearedSnapshots).toEqual([]);
   });
 
+  it('strips reserved labels from workspace template advertisements', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        wait_seconds: 0,
+        max_reservations: 0,
+        templates: [
+          {
+            template_key: 'linux',
+            labels: ['linux', 'shipfox-managed'],
+            available_slots: 1,
+            starting: 0,
+            running: 0,
+          },
+        ],
+      },
+    });
+
+    const snapshots = await db()
+      .select()
+      .from(provisionerCapabilitySnapshots)
+      .where(eq(provisionerCapabilitySnapshots.provisionerId, provisionerTokenId));
+
+    expect(res.statusCode).toBe(200);
+    expect(snapshots).toEqual([
+      expect.objectContaining({
+        labels: ['linux'],
+      }),
+    ]);
+  });
+
   it('returns terminate intent ids for active provisioned runners with cancelled latest jobs', async () => {
     await providerRunnerFactory.create({
       workspaceId,

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -9,6 +9,7 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {pollDemand, releaseReservationGrants} from '#core/demand.js';
+import {sanitizeRunnerLabels} from '#core/runner-labels.js';
 import {publishWorkspaceProvisionerCapabilitySnapshot} from '#db/provisioner-capability-snapshots.js';
 import {
   listQueuedDemandWorkspaceIds,
@@ -21,10 +22,17 @@ import {toPollDemandResponseDto} from '#presentation/dto/index.js';
 
 const TERMINATE_INTENT_LIMIT = 1000;
 
-function toReservationTemplates(templates: PollDemandTemplateDto[]): ReservationTemplate[] {
+function toReservationTemplates(
+  templates: PollDemandTemplateDto[],
+  scope: 'installation' | 'workspace',
+): ReservationTemplate[] {
   return templates.map((template) => ({
     templateKey: template.template_key,
-    labels: template.labels,
+    labels: sanitizeRunnerLabels(template.labels, {
+      scope,
+      logLevel: 'debug',
+      source: 'provisioner template advertisement',
+    }),
     availableSlots: template.available_slots,
     starting: template.starting,
     running: template.running,
@@ -81,7 +89,7 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
           await options.installationProvisioning.policy.filterEligibleWorkspaceIds(
             candidateWorkspaceIds,
           );
-        const templates = toReservationTemplates(request.body.templates);
+        const templates = toReservationTemplates(request.body.templates, 'installation');
         const result = await pollInstallationDemandAndReserve({
           provisionerId: provisionerContext.provisionerTokenId,
           maxReservations: request.body.max_reservations,
@@ -101,7 +109,7 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
       }
       const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
 
-      const templates = toReservationTemplates(request.body.templates);
+      const templates = toReservationTemplates(request.body.templates, 'workspace');
       await publishWorkspaceProvisionerCapabilitySnapshot({
         workspaceId,
         provisionerId: provisionerTokenId,

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -202,7 +202,10 @@ describe('POST /runners/register', () => {
 
   it('strips reserved labels from ephemeral registration', async () => {
     const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
-    const provisioner = await provisionerTokenFactory.create({workspaceId});
+    const provisioner = await provisionerTokenFactory.create({
+      scope: 'workspace',
+      workspaceId,
+    });
     const token = await ephemeralRegistrationTokenFactory.create(
       {workspaceId, provisionerId: provisioner.id},
       {transient: {rawToken: ephemeralRawToken}},
@@ -225,6 +228,34 @@ describe('POST /runners/register', () => {
       id: res.json().session_id,
       provisionerId: token.provisionerId,
       labels: ['linux'],
+    });
+  });
+
+  it('preserves reserved labels for installation-scope ephemeral registration', async () => {
+    const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
+    const provisioner = await provisionerTokenFactory.create({scope: 'installation'});
+    const token = await ephemeralRegistrationTokenFactory.create(
+      {workspaceId, provisionerId: provisioner.id},
+      {transient: {rawToken: ephemeralRawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${ephemeralRawToken}`},
+      payload: {labels: ['linux', 'shipfox-managed']},
+    });
+
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, res.json().session_id));
+
+    expect(res.statusCode).toBe(200);
+    expect(session).toMatchObject({
+      id: res.json().session_id,
+      provisionerId: token.provisionerId,
+      labels: ['linux', 'shipfox-managed'],
     });
   });
 

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -1,11 +1,12 @@
 import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
-import {closeApp, createApp} from '@shipfox/node-fastify';
+import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
 import {eq, sql} from 'drizzle-orm';
-import type {FastifyInstance} from 'fastify';
+import type {FastifyInstance, FastifyReply, FastifyRequest} from 'fastify';
 import {config} from '#config.js';
+import {RunnerLabelsReservedError} from '#core/errors.js';
 import {hashRunnersRateLimitIdentifier} from '#core/rate-limit.js';
 import {db} from '#db/db.js';
 import {revokeManualRegistrationToken} from '#db/manual-registration-tokens.js';
@@ -19,9 +20,11 @@ import {
   fakeRunnerSessionAuthMethod,
   getRunnerSessionTokenClaims,
   manualRegistrationTokenFactory,
+  provisionerTokenFactory,
   runnersTestAuthClient,
 } from '#test/index.js';
 import {createRunnerRoutes} from './index.js';
+import {createRegisterRoute} from './register.js';
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -123,6 +126,38 @@ describe('POST /runners/register', () => {
     expect(session?.toolCapabilitiesReportedAt).toBeInstanceOf(Date);
   });
 
+  it('strips reserved labels from manual registration', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['linux', 'shipfox-managed', 'x64']},
+    });
+
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, res.json().session_id));
+
+    expect(res.statusCode).toBe(200);
+    expect(session?.labels).toEqual(['linux', 'x64']);
+  });
+
+  it('returns a distinct error when all manual registration labels are reserved', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['shipfox-managed']},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      code: 'runner-labels-reserved',
+      details: {labels: ['shipfox-managed']},
+    });
+  });
+
   it('exchanges an ephemeral registration token for a one-claim runner session', async () => {
     const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
     const token = await ephemeralRegistrationTokenFactory.create(
@@ -163,6 +198,34 @@ describe('POST /runners/register', () => {
       .where(eq(ephemeralRegistrationTokens.id, token.id));
     expect(consumed?.consumedAt).toBeInstanceOf(Date);
     expect(consumed?.consumedSessionId).toBe(body.session_id);
+  });
+
+  it('strips reserved labels from ephemeral registration', async () => {
+    const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
+    const provisioner = await provisionerTokenFactory.create({workspaceId});
+    const token = await ephemeralRegistrationTokenFactory.create(
+      {workspaceId, provisionerId: provisioner.id},
+      {transient: {rawToken: ephemeralRawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${ephemeralRawToken}`},
+      payload: {labels: ['linux', 'shipfox-managed']},
+    });
+
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, res.json().session_id));
+
+    expect(res.statusCode).toBe(200);
+    expect(session).toMatchObject({
+      id: res.json().session_id,
+      provisionerId: token.provisionerId,
+      labels: ['linux'],
+    });
   });
 
   it('rejects malformed capability reports without creating a runner session', async () => {
@@ -416,6 +479,26 @@ describe('POST /runners/register', () => {
     });
 
     expect(res.statusCode).toBe(200);
+  });
+
+  it('maps reserved-label-only registration failures to a public error code', () => {
+    const route = createRegisterRoute(runnersTestAuthClient);
+
+    try {
+      route.errorHandler?.(
+        new RunnerLabelsReservedError(['shipfox-managed']),
+        {} as FastifyRequest,
+        {} as FastifyReply,
+      );
+      throw new Error('Expected register route error handler to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError);
+      expect(error).toMatchObject({
+        code: 'runner-labels-reserved',
+        details: {labels: ['shipfox-managed']},
+        status: 400,
+      });
+    }
   });
 
   async function seedEphemeralRegisterRateLimit(

--- a/libs/api/runners/src/presentation/routes/register.ts
+++ b/libs/api/runners/src/presentation/routes/register.ts
@@ -5,6 +5,7 @@ import {
   EmptyRunnerLabelsError,
   RegistrationTokenConsumedError,
   RegistrationTokenExpiredError,
+  RunnerLabelsReservedError,
 } from '#core/errors.js';
 import {registerRunnerSession} from '#core/runner-sessions.js';
 import {getRunnerContext} from '#presentation/auth/index.js';
@@ -23,6 +24,12 @@ export function createRegisterRoute(auth: AuthInterModuleClient) {
     },
     preHandler: createEphemeralRegisterRateLimitPreHandler(),
     errorHandler: (error, request) => {
+      if (error instanceof RunnerLabelsReservedError) {
+        throw new ClientError(error.message, 'runner-labels-reserved', {
+          details: {labels: error.labels},
+          status: 400,
+        });
+      }
       if (error instanceof EmptyRunnerLabelsError) {
         throw new ClientError(error.message, 'empty-runner-labels', {status: 400});
       }

--- a/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
@@ -113,6 +113,39 @@ describe('POST /provisioners/runner-instances/report', () => {
     expect(rows[0]?.reportedAt.toISOString()).toBe(reportedAt);
   });
 
+  it('strips reserved labels from workspace runner reports', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: 'provisioned-runner-reserved-label',
+            labels: ['linux', 'shipfox-managed'],
+            state: 'starting',
+            reported_at: new Date('2025-01-01T00:00:00.000Z').toISOString(),
+            provider_kind: 'docker',
+          },
+        ],
+      },
+    });
+
+    const [row] = await db()
+      .select()
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.workspaceId, workspaceId),
+          eq(providerRunners.provisionerId, provisionerTokenId),
+          eq(providerRunners.providerRunnerId, 'provisioned-runner-reserved-label'),
+        ),
+      );
+
+    expect(res.statusCode).toBe(200);
+    expect(row?.labels).toEqual(['linux']);
+  });
+
   it('returns 400 when the batch exceeds the DTO limit', async () => {
     const event = {
       provider_runner_id: 'provisioned-runner-1',

--- a/libs/api/runners/src/presentation/routes/report-runner-instances.ts
+++ b/libs/api/runners/src/presentation/routes/report-runner-instances.ts
@@ -20,6 +20,7 @@ export const reportRunnerInstancesRoute = defineRoute({
   handler: async (request) => {
     const context = requireProvisionerContext(request);
     const result = await reportRunnerInstances({
+      scope: context.scope,
       workspaceId: context.scope === 'workspace' ? context.workspaceId : null,
       provisionerId: context.provisionerTokenId,
       events: request.body.events.map((event) => ({

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   fakeLeaseTokenAuthMethod,
   fakeRunnerSessionAuthMethod,
+  provisionerTokenFactory,
   runnersTestAuthClient,
 } from '#test/index.js';
 import {createRunnerRoutes} from './index.js';
@@ -29,15 +30,26 @@ import {
 } from './runner-enrollment.js';
 
 const token = 'provisioner-test-token';
+const workspaceToken = 'workspace-provisioner-test-token';
 const fakeUserAuth: AuthMethod = {name: AUTH_USER, authenticate: () => Promise.resolve()};
 
 describe('runner enrollment control plane', () => {
   let app: FastifyInstance;
   let provisionerId: string;
+  let workspaceProvisionerId: string;
   const provisionerAuth: AuthMethod = {
     name: AUTH_PROVISIONER_TOKEN,
     authenticate: (request: FastifyRequest) => {
-      if (extractBearerToken(request.headers.authorization) !== token)
+      const rawToken = extractBearerToken(request.headers.authorization);
+      if (rawToken === workspaceToken) {
+        setProvisionerContext(request, {
+          scope: 'workspace',
+          workspaceId: crypto.randomUUID(),
+          provisionerTokenId: workspaceProvisionerId,
+        });
+        return Promise.resolve();
+      }
+      if (rawToken !== token)
         throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
       setProvisionerContext(request, {scope: 'installation', provisionerTokenId: provisionerId});
       return Promise.resolve();
@@ -64,8 +76,13 @@ describe('runner enrollment control plane', () => {
     await closeApp();
   });
 
-  beforeEach(() => {
-    provisionerId = crypto.randomUUID();
+  beforeEach(async () => {
+    const provisioner = await provisionerTokenFactory.create({scope: 'installation'});
+    const workspaceProvisioner = await provisionerTokenFactory.create({
+      scope: 'workspace',
+    });
+    provisionerId = provisioner.id;
+    workspaceProvisionerId = workspaceProvisioner.id;
   });
 
   it('uses the requested assignment wait below the server cap and caps larger requests', () => {
@@ -112,7 +129,11 @@ describe('runner enrollment control plane', () => {
       method: 'POST',
       url: '/runner-control/enrollment',
       headers: {authorization: `Bearer ${controlToken}`},
-      payload: {labels: ['Linux', 'linux'], provider_kind: 'docker', protocol_version: '1'},
+      payload: {
+        labels: ['Linux', 'linux', 'shipfox-managed'],
+        provider_kind: 'docker',
+        protocol_version: '1',
+      },
     });
     expect(enrolled.statusCode).toBe(200);
     expect(enrolled.json()).toEqual({activation_token: null});
@@ -131,7 +152,7 @@ describe('runner enrollment control plane', () => {
       .where(eq(providerRunners.id, runner.runner_instance_id));
     expect(instance).toMatchObject({
       provisionerId,
-      labels: ['linux'],
+      labels: ['linux', 'shipfox-managed'],
       providerRunnerId: 'container-1',
       state: 'running',
       protocolVersion: '1',
@@ -148,6 +169,40 @@ describe('runner enrollment control plane', () => {
       headers: {authorization: `Bearer ${controlToken}`},
     });
     expect(jobs.statusCode).toBe(401);
+  });
+
+  it('strips reserved labels when a workspace provisioner enrolls a runner', async () => {
+    const created = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${workspaceToken}`},
+      payload: {runner_instances: [{}]},
+    });
+    const runner = created.json().runner_instances[0];
+    const exchanged = await app.inject({
+      method: 'POST',
+      url: '/runner-enrollment/exchange',
+      payload: {bootstrap_token: runner.bootstrap_token},
+    });
+
+    const enrolled = await app.inject({
+      method: 'POST',
+      url: '/runner-control/enrollment',
+      headers: {authorization: `Bearer ${exchanged.json().control_session_token}`},
+      payload: {
+        labels: ['linux', 'shipfox-managed'],
+        provider_kind: 'docker',
+        protocol_version: '1',
+      },
+    });
+
+    const [instance] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.runner_instance_id));
+
+    expect(enrolled.statusCode).toBe(200);
+    expect(instance?.labels).toEqual(['linux']);
   });
 
   it('promotes an intended reservation during enrollment and returns its activation token', async () => {

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -37,6 +37,7 @@ describe('runner enrollment control plane', () => {
   let app: FastifyInstance;
   let provisionerId: string;
   let workspaceProvisionerId: string;
+  let workspaceProvisionerWorkspaceId: string;
   const provisionerAuth: AuthMethod = {
     name: AUTH_PROVISIONER_TOKEN,
     authenticate: (request: FastifyRequest) => {
@@ -44,7 +45,7 @@ describe('runner enrollment control plane', () => {
       if (rawToken === workspaceToken) {
         setProvisionerContext(request, {
           scope: 'workspace',
-          workspaceId: crypto.randomUUID(),
+          workspaceId: workspaceProvisionerWorkspaceId,
           provisionerTokenId: workspaceProvisionerId,
         });
         return Promise.resolve();
@@ -81,8 +82,12 @@ describe('runner enrollment control plane', () => {
     const workspaceProvisioner = await provisionerTokenFactory.create({
       scope: 'workspace',
     });
+    if (workspaceProvisioner.scope !== 'workspace') {
+      throw new Error('Expected a workspace provisioner token');
+    }
     provisionerId = provisioner.id;
     workspaceProvisionerId = workspaceProvisioner.id;
+    workspaceProvisionerWorkspaceId = workspaceProvisioner.workspaceId;
   });
 
   it('uses the requested assignment wait below the server cap and caps larger requests', () => {

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -1,18 +1,3 @@
-import {
-  deleteExpiredEphemeralRegistrationTokens,
-  deleteExpiredRunnerReservations,
-  deleteExpiredRunnerSessions,
-  detectAndExpireStuckJobs,
-  reapStaleRunnerInstances,
-} from '#core/maintenance.js';
-import {
-  deleteExpiredEphemeralRegistrationTokensActivity,
-  deleteExpiredReservationsActivity,
-  deleteExpiredRunnerSessionsActivity,
-  detectAndExpireStuckJobsActivity,
-  reapStaleRunnerInstancesActivity,
-} from './maintenance-activities.js';
-
 vi.mock('#core/maintenance.js', () => ({
   deleteExpiredEphemeralRegistrationTokens: vi.fn(),
   deleteExpiredRunnerReservations: vi.fn(),
@@ -21,46 +6,52 @@ vi.mock('#core/maintenance.js', () => ({
   reapStaleRunnerInstances: vi.fn(),
 }));
 
-beforeEach(() => {
+let maintenance: typeof import('#core/maintenance.js');
+let activities: typeof import('./maintenance-activities.js');
+
+beforeEach(async () => {
+  vi.resetModules();
+  maintenance = await import('#core/maintenance.js');
+  activities = await import('./maintenance-activities.js');
   vi.clearAllMocks();
 });
 
 describe('detectAndExpireStuckJobsActivity', () => {
   it('delegates to core maintenance', async () => {
-    vi.mocked(detectAndExpireStuckJobs).mockResolvedValueOnce({expired: 2});
+    vi.mocked(maintenance.detectAndExpireStuckJobs).mockResolvedValueOnce({expired: 2});
 
-    const result = await detectAndExpireStuckJobsActivity({thresholdSeconds: 180});
+    const result = await activities.detectAndExpireStuckJobsActivity({thresholdSeconds: 180});
 
     expect(result).toEqual({expired: 2});
-    expect(detectAndExpireStuckJobs).toHaveBeenCalledWith({thresholdSeconds: 180});
+    expect(maintenance.detectAndExpireStuckJobs).toHaveBeenCalledWith({thresholdSeconds: 180});
   });
 });
 
 describe('deleteExpiredReservationsActivity', () => {
   it('delegates to core maintenance', async () => {
-    vi.mocked(deleteExpiredRunnerReservations).mockResolvedValueOnce({deleted: 3});
+    vi.mocked(maintenance.deleteExpiredRunnerReservations).mockResolvedValueOnce({deleted: 3});
 
-    const result = await deleteExpiredReservationsActivity({limit: 50});
+    const result = await activities.deleteExpiredReservationsActivity({limit: 50});
 
     expect(result).toEqual({deleted: 3});
-    expect(deleteExpiredRunnerReservations).toHaveBeenCalledWith({limit: 50});
+    expect(maintenance.deleteExpiredRunnerReservations).toHaveBeenCalledWith({limit: 50});
   });
 });
 
 describe('reapStaleRunnerInstancesActivity', () => {
   it('delegates to core maintenance', async () => {
-    vi.mocked(reapStaleRunnerInstances).mockResolvedValueOnce({
+    vi.mocked(maintenance.reapStaleRunnerInstances).mockResolvedValueOnce({
       reaped: 4,
       reservationsReleased: 2,
     });
 
-    const result = await reapStaleRunnerInstancesActivity({
+    const result = await activities.reapStaleRunnerInstancesActivity({
       thresholdSeconds: 300,
       limit: 100,
     });
 
     expect(result).toEqual({reaped: 4, reservationsReleased: 2});
-    expect(reapStaleRunnerInstances).toHaveBeenCalledWith({
+    expect(maintenance.reapStaleRunnerInstances).toHaveBeenCalledWith({
       thresholdSeconds: 300,
       limit: 100,
     });
@@ -69,16 +60,16 @@ describe('reapStaleRunnerInstancesActivity', () => {
 
 describe('deleteExpiredRunnerSessionsActivity', () => {
   it('delegates to core maintenance', async () => {
-    vi.mocked(deleteExpiredRunnerSessions).mockResolvedValueOnce({deleted: 4});
+    vi.mocked(maintenance.deleteExpiredRunnerSessions).mockResolvedValueOnce({deleted: 4});
 
-    const result = await deleteExpiredRunnerSessionsActivity({
+    const result = await activities.deleteExpiredRunnerSessionsActivity({
       manualRetentionDays: 30,
       ephemeralRetentionDays: 7,
       limit: 25,
     });
 
     expect(result).toEqual({deleted: 4});
-    expect(deleteExpiredRunnerSessions).toHaveBeenCalledWith({
+    expect(maintenance.deleteExpiredRunnerSessions).toHaveBeenCalledWith({
       manualRetentionDays: 30,
       ephemeralRetentionDays: 7,
       limit: 25,
@@ -88,15 +79,17 @@ describe('deleteExpiredRunnerSessionsActivity', () => {
 
 describe('deleteExpiredEphemeralRegistrationTokensActivity', () => {
   it('delegates to core maintenance', async () => {
-    vi.mocked(deleteExpiredEphemeralRegistrationTokens).mockResolvedValueOnce({deleted: 6});
+    vi.mocked(maintenance.deleteExpiredEphemeralRegistrationTokens).mockResolvedValueOnce({
+      deleted: 6,
+    });
 
-    const result = await deleteExpiredEphemeralRegistrationTokensActivity({
+    const result = await activities.deleteExpiredEphemeralRegistrationTokensActivity({
       retentionDays: 7,
       limit: 25,
     });
 
     expect(result).toEqual({deleted: 6});
-    expect(deleteExpiredEphemeralRegistrationTokens).toHaveBeenCalledWith({
+    expect(maintenance.deleteExpiredEphemeralRegistrationTokens).toHaveBeenCalledWith({
       retentionDays: 7,
       limit: 25,
     });

--- a/libs/api/runners/test/env.ts
+++ b/libs/api/runners/test/env.ts
@@ -4,6 +4,7 @@ process.env.POSTGRES_USERNAME ??= 'shipfox';
 process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
+process.env.RUNNER_RESERVED_LABELS ??= 'shipfox-managed';
 process.env.WORKSPACE_JWT_SECRET = 'test-secret';
 process.env.AUTH_ROOT_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 process.env.TZ = 'UTC';


### PR DESCRIPTION
Reserve configured runner labels for installation-scope provisioners.

This adds `RUNNER_RESERVED_LABELS` handling across runner advertisement and registration paths, preserves installation-scope labels, strips reserved labels from workspace-scope runners, and returns the public `runner-labels-reserved` error when registration contains only reserved labels. It also makes runner scope explicit at report/control boundaries and hardens the maintenance activity tests against shared Vitest module state.

Validation passed:
- `mise exec -- turbo type test check depcruise --filter=@shipfox/api-runners...`
- 157 tasks successful; 41 test files and 500 tests passed
- forced zero-cache validation passed

Closes ENG-1482

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve installation-only runner labels and enforce them across provisioner ads, runner reports, control enrollment, and all registration paths. Reject invalid config and return a clear error when a registration contains only reserved labels. Implements ENG-1482.

- New Features
  - Added `RUNNER_RESERVED_LABELS` in `@shipfox/api-runners`; parsed case-insensitively and now validated, rejecting invalid labels.
  - Applied label sanitization by provisioner scope: preserve on installation, strip on workspace/manual; used in template ads, runner reports, control enrollment, and manual/activation/ephemeral registrations (reads provisioner scope for activation/ephemeral).
  - Mapped reserved-label-only registrations to a public error: code `runner-labels-reserved` (HTTP 400) with offending labels in `details`.

- Migration
  - Set `RUNNER_RESERVED_LABELS` (comma-separated, e.g. "shipfox-managed") to activate the policy; invalid labels will fail startup.
  - Use installation-scope provisioners when advertising or registering reserved labels; workspace/manual sources will have them dropped.
  - Handle `runner-labels-reserved` errors when all provided labels are reserved.

<sup>Written for commit a7b31aee9889b58ad9c5313bb4d6f80920f22a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

