### PR TITLE
[api-runners] Count runner reservation promotion failures during enrollment

### DIFF
--- a/.changeset/count-runner-promotion-failures.md
+++ b/.changeset/count-runner-promotion-failures.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": minor
+---
+
+Count bounded runner reservation promotion failures during enrollment.

--- a/libs/api/runners/src/core/runner-control-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.test.ts
@@ -1,6 +1,8 @@
-import {vi} from '@shipfox/vitest/vi';
+import {afterEach, vi} from '@shipfox/vitest/vi';
+import {inArray} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {reservations} from '#db/schema/reservations.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {
@@ -8,6 +10,29 @@ import {
   runnerReservationPromotionFailureCount,
 } from '#metrics/instance.js';
 import {enrollRunnerControlSession} from './runner-control-sessions.js';
+
+const createdReservationIds = new Set<string>();
+const createdRunnerInstanceIds = new Set<string>();
+
+afterEach(async () => {
+  const runnerInstanceIds = [...createdRunnerInstanceIds];
+  const reservationIds = [...createdReservationIds];
+
+  if (runnerInstanceIds.length > 0) {
+    await db()
+      .delete(runnerActivationTokens)
+      .where(inArray(runnerActivationTokens.runnerInstanceId, runnerInstanceIds));
+    await db()
+      .delete(runnerControlSessions)
+      .where(inArray(runnerControlSessions.runnerInstanceId, runnerInstanceIds));
+    await db().delete(providerRunners).where(inArray(providerRunners.id, runnerInstanceIds));
+  }
+  if (reservationIds.length > 0)
+    await db().delete(reservations).where(inArray(reservations.id, reservationIds));
+
+  createdRunnerInstanceIds.clear();
+  createdReservationIds.clear();
+});
 
 describe('enrollRunnerControlSession', () => {
   it('counts expired reservation promotion failures', async () => {
@@ -176,6 +201,7 @@ async function createReservation(params: {
     })
     .returning();
   if (!reservation) throw new Error('Expected reservation');
+  createdReservationIds.add(reservation.id);
   return reservation;
 }
 
@@ -198,6 +224,7 @@ async function createRunner(params: {
     })
     .returning({id: providerRunners.id});
   if (!runner) throw new Error('Expected runner instance');
+  createdRunnerInstanceIds.add(runner.id);
 
   await db()
     .insert(runnerControlSessions)

--- a/libs/api/runners/src/core/runner-control-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.test.ts
@@ -1,0 +1,212 @@
+import {vi} from '@shipfox/vitest/vi';
+import {db} from '#db/db.js';
+import {reservations} from '#db/schema/reservations.js';
+import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
+import {providerRunners} from '#db/schema/runner-instances.js';
+import {
+  type RunnerReservationPromotionFailureReason,
+  runnerReservationPromotionFailureCount,
+} from '#metrics/instance.js';
+import {enrollRunnerControlSession} from './runner-control-sessions.js';
+
+describe('enrollRunnerControlSession', () => {
+  it('counts expired reservation promotion failures', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({
+      provisionerId,
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+
+    await expectPromotionFailure({
+      provisionerId,
+      intendedReservationId: reservation.id,
+      reason: 'reservation-expired',
+    });
+  });
+
+  it('counts missing reservation promotion failures', async () => {
+    await expectPromotionFailure({
+      provisionerId: crypto.randomUUID(),
+      intendedReservationId: crypto.randomUUID(),
+      reason: 'reservation-not-found',
+    });
+  });
+
+  it('counts already-assigned reservation promotion failures', async () => {
+    const provisionerId = crypto.randomUUID();
+    const intendedReservation = await createReservation({provisionerId});
+    const assignedReservation = await createReservation({provisionerId});
+
+    await expectPromotionFailure({
+      provisionerId,
+      intendedReservationId: intendedReservation.id,
+      reservationId: assignedReservation.id,
+      reason: 'already-assigned',
+    });
+  });
+
+  it('counts not-assignable reservation promotion failures', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({
+      provisionerId,
+      requiredLabels: ['gpu'],
+    });
+
+    await expectPromotionFailure({
+      provisionerId,
+      intendedReservationId: reservation.id,
+      labels: ['linux'],
+      reason: 'not-assignable',
+    });
+  });
+
+  it('does not count successful reservation promotion', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({provisionerId});
+    const runnerInstanceId = await createRunner({
+      provisionerId,
+      intendedReservationId: reservation.id,
+    });
+    const addSpy = vi.spyOn(runnerReservationPromotionFailureCount, 'add');
+
+    try {
+      const activationToken = await enrollRunnerControlSession({
+        runnerInstanceId,
+        provisionerId,
+        labels: ['linux'],
+        providerKind: 'docker',
+        protocolVersion: '1',
+      });
+
+      expect(activationToken).toEqual(expect.any(String));
+      expect(addSpy).not.toHaveBeenCalled();
+    } finally {
+      addSpy.mockRestore();
+    }
+  });
+
+  it('keeps unexpected promotion failures on the error-log path', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({provisionerId});
+    const runnerInstanceId = await createRunner({
+      provisionerId,
+      intendedReservationId: reservation.id,
+    });
+    const unexpectedError = new Error('database unavailable');
+    const debugLog = vi.fn();
+    const errorLog = vi.fn();
+
+    vi.resetModules();
+    vi.doMock('@shipfox/node-opentelemetry', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@shipfox/node-opentelemetry')>()),
+      logger: () => ({debug: debugLog, error: errorLog}),
+    }));
+    vi.doMock('#db/runner-assignments.js', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('#db/runner-assignments.js')>()),
+      assignRunnerInstancesTx: vi.fn().mockRejectedValue(unexpectedError),
+    }));
+
+    const {closePostgresClient, createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+
+    try {
+      const {enrollRunnerControlSession: enroll} = await import('./runner-control-sessions.js');
+      const result = await enroll({
+        runnerInstanceId,
+        provisionerId,
+        labels: ['linux'],
+        providerKind: 'docker',
+        protocolVersion: '1',
+      });
+
+      expect(result).toBeNull();
+      expect(debugLog).not.toHaveBeenCalled();
+      expect(errorLog).toHaveBeenCalledWith(
+        expect.objectContaining({err: unexpectedError}),
+        'Unexpected failure promoting runner reservation during enrollment',
+      );
+    } finally {
+      await closePostgresClient();
+      vi.doUnmock('@shipfox/node-opentelemetry');
+      vi.doUnmock('#db/runner-assignments.js');
+      vi.resetModules();
+    }
+  });
+});
+
+async function expectPromotionFailure(params: {
+  provisionerId: string;
+  intendedReservationId: string;
+  reservationId?: string;
+  labels?: string[];
+  reason: RunnerReservationPromotionFailureReason;
+}): Promise<void> {
+  const runnerInstanceId = await createRunner(params);
+  const addSpy = vi.spyOn(runnerReservationPromotionFailureCount, 'add');
+
+  try {
+    const result = await enrollRunnerControlSession({
+      runnerInstanceId,
+      provisionerId: params.provisionerId,
+      labels: params.labels ?? ['linux'],
+      providerKind: 'docker',
+      protocolVersion: '1',
+    });
+
+    expect(result).toBeNull();
+    expect(addSpy).toHaveBeenCalledWith(1, {reason: params.reason});
+  } finally {
+    addSpy.mockRestore();
+  }
+}
+
+async function createReservation(params: {
+  provisionerId: string;
+  requiredLabels?: string[];
+  expiresAt?: Date;
+}) {
+  const [reservation] = await db()
+    .insert(reservations)
+    .values({
+      workspaceId: crypto.randomUUID(),
+      provisionerId: params.provisionerId,
+      requiredLabels: params.requiredLabels ?? ['linux'],
+      count: 1,
+      expiresAt: params.expiresAt ?? new Date(Date.now() + 60_000),
+    })
+    .returning();
+  if (!reservation) throw new Error('Expected reservation');
+  return reservation;
+}
+
+async function createRunner(params: {
+  provisionerId: string;
+  intendedReservationId: string;
+  reservationId?: string;
+  labels?: string[];
+}): Promise<string> {
+  const [runner] = await db()
+    .insert(providerRunners)
+    .values({
+      provisionerId: params.provisionerId,
+      intendedReservationId: params.intendedReservationId,
+      reservationId: params.reservationId ?? null,
+      providerRunnerId: crypto.randomUUID(),
+      labels: params.labels ?? [],
+      state: 'starting',
+      reportedAt: new Date(),
+    })
+    .returning({id: providerRunners.id});
+  if (!runner) throw new Error('Expected runner instance');
+
+  await db()
+    .insert(runnerControlSessions)
+    .values({
+      runnerInstanceId: runner.id,
+      provisionerId: params.provisionerId,
+      hashedToken: crypto.randomUUID(),
+      prefix: 'test',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+  return runner.id;
+}

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -17,6 +17,10 @@ import {terminalStates} from '#db/runner-instances.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
+import {
+  type RunnerReservationPromotionFailureReason,
+  recordRunnerReservationPromotionFailure,
+} from '#metrics/index.js';
 import {issueRunnerActivationTokenTx} from './runner-activation.js';
 
 export class RunnerBootstrapTokenInvalidError extends Error {
@@ -198,27 +202,35 @@ export async function enrollRunnerControlSession(params: {
         });
       });
     } catch (error) {
-      const expectedFailure =
-        error instanceof ReservationExpiredError ||
-        error instanceof ReservationNotFoundError ||
-        error instanceof RunnerInstanceAlreadyAssignedError ||
-        error instanceof RunnerInstanceNotAssignableError;
+      const expectedFailureReason = getRunnerReservationPromotionFailureReason(error);
       const details = {
         err: error,
         runnerInstanceId: params.runnerInstanceId,
         provisionerId: params.provisionerId,
         reservationId: intendedReservationId,
       };
-      if (expectedFailure)
+      if (expectedFailureReason) {
+        recordRunnerReservationPromotionFailure(expectedFailureReason);
         logger().debug(details, 'Runner reservation could not be promoted during enrollment');
-      else
+      } else {
         logger().error(
           details,
           'Unexpected failure promoting runner reservation during enrollment',
         );
+      }
       return null;
     }
   });
+}
+
+function getRunnerReservationPromotionFailureReason(
+  error: unknown,
+): RunnerReservationPromotionFailureReason | null {
+  if (error instanceof ReservationExpiredError) return 'reservation-expired';
+  if (error instanceof ReservationNotFoundError) return 'reservation-not-found';
+  if (error instanceof RunnerInstanceAlreadyAssignedError) return 'already-assigned';
+  if (error instanceof RunnerInstanceNotAssignableError) return 'not-assignable';
+  return null;
 }
 
 export async function attachRunnerControlProviderId(params: {

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -1,3 +1,4 @@
+export type {RunnerReservationPromotionFailureReason} from './instance.js';
 export {
   jobExecutionClaimedCount,
   jobExecutionEnqueuedCount,
@@ -7,6 +8,7 @@ export {
   providerRunnerReconcileCallCount,
   providerRunnerTerminateIntentHonoredCount,
   providerRunnerTerminateIntentIssuedCount,
+  recordRunnerReservationPromotionFailure,
   recordRunnersRateLimitCheck,
   recordRunnersRateLimitPruneFailure,
 } from './instance.js';

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -83,6 +83,18 @@ export const reservationReleasedCount = meter.createCounter<Record<string, never
   {description: 'Reservation units released from terminal provisioned runner reports'},
 );
 
+export type RunnerReservationPromotionFailureReason =
+  | 'reservation-expired'
+  | 'reservation-not-found'
+  | 'already-assigned'
+  | 'not-assignable';
+
+export const runnerReservationPromotionFailureCount = meter.createCounter<{
+  reason: RunnerReservationPromotionFailureReason;
+}>('runners_reservation_promotion_failures', {
+  description: 'Runner reservation promotion failures during enrollment by reason',
+});
+
 export type RunnersRateLimitAction = 'provisioner-mint' | 'ephemeral-register';
 export type RunnersRateLimitScope = 'provisioner' | 'ephemeral-token';
 export type RunnersRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
@@ -105,6 +117,12 @@ function recordMetric(record: () => void): void {
   } catch {
     // Metrics must not affect runner or provisioner request outcomes.
   }
+}
+
+export function recordRunnerReservationPromotionFailure(
+  reason: RunnerReservationPromotionFailureReason,
+): void {
+  recordMetric(() => runnerReservationPromotionFailureCount.add(1, {reason}));
 }
 
 export function recordRunnersRateLimitCheck(params: {


### PR DESCRIPTION
Count bounded runner reservation promotion failures during enrollment so expected assignment failures become alertable without changing enrollment behavior.

The metric uses bounded failure reasons and guarded recording so instrumentation cannot affect the enrollment outcome. Unexpected promotion failures retain the error-log path, while successful promotions remain uncounted.

Closes ENG-1493

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded metric to count runner reservation promotion failures during enrollment so we can alert on expected assignment failures without changing behavior. Also isolates enrollment tests by cleaning up created DB rows. Closes ENG-1493.

- **New Features**
  - New counter `runners_reservation_promotion_failures` with reasons: `reservation-expired`, `reservation-not-found`, `already-assigned`, `not-assignable`.
  - Only counts expected failures; successes are not counted and unexpected errors stay on the error-log path.
  - Tests cover each bounded reason, verify successful promotions are not recorded, and clean up DB rows to keep tests isolated.

<sup>Written for commit f54b9a5f6c5a30e6a0271c0e62df014b5e098f7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

