### PR TITLE
Preserve CEL types across workflow context boundaries

### DIFF
--- a/.changeset/cel-native-execution-context.md
+++ b/.changeset/cel-native-execution-context.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-workflows": patch
+"@shipfox/api-triggers": patch
+---
+
+Expose execution and run numeric fields as CEL integers, preserve zero-based execution indices,
+and keep listener filter snapshots aligned with live CEL values after persistence.

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
@@ -374,6 +374,45 @@ describe('routeEventToJobListeners', () => {
     const result = await route({workspaceId});
 
     expect(deliverEventToListener).toHaveBeenCalledTimes(1);
+    expect(listenerFilterErrored).not.toHaveBeenCalled();
+    expect(result).toMatchObject({engagedCount: 1, matchedJobCount: 1, acceptedJobCount: 1});
+  });
+
+  it.each([
+    'on',
+    'until',
+  ] as const)('rehydrates CEL scalar values in %s listener filter snapshots', async (kind) => {
+    const workspaceId = crypto.randomUUID();
+    await jobListenerSubscriptionFactory.create({
+      workspaceId,
+      kind,
+      source: 'github',
+      event: 'pull_request_review',
+      config: {
+        filter:
+          'run.number + 1 == 2 && run.created_at < timestamp("2026-07-01T00:00:00Z") && jobs.build.executions[0].index + 1 == 1 && jobs.build.executions[0].started_at < timestamp("2026-07-01T00:00:00Z") && jobs.build.executions[0].events[0].received_at < timestamp("2026-07-01T00:00:00Z")',
+        filter_snapshot: {
+          run: {number: 1, created_at: '2026-06-30T12:00:00.000Z'},
+          jobs: {
+            build: {
+              executions: [
+                {
+                  index: 0,
+                  started_at: '2026-06-30T12:00:00.000Z',
+                  finished_at: null,
+                  events: [{received_at: '2026-06-30T12:00:00.000Z'}],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await route({workspaceId});
+
+    expect(deliverEventToListener).toHaveBeenCalledTimes(1);
+    expect(listenerFilterErrored).not.toHaveBeenCalled();
     expect(result).toMatchObject({engagedCount: 1, matchedJobCount: 1, acceptedJobCount: 1});
   });
 

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.ts
@@ -13,6 +13,8 @@ import {
   type WorkflowsModuleClient,
 } from './workflows-client.js';
 
+const LISTENER_INTEGER_PATTERN = /^-?\d+$/;
+
 export interface RouteEventToJobListenersParams {
   workflows: WorkflowsModuleClient;
   history: TriggerHistoryRecorder;
@@ -217,43 +219,115 @@ function rehydrateListenerFilterSnapshot(
   snapshot: Record<string, unknown>,
   outputTypes: ListenerFilterOutputTypes | undefined,
 ): Record<string, unknown> {
-  if (outputTypes === undefined || !isRecord(snapshot.jobs)) return snapshot;
+  let result = snapshot;
+  if (outputTypes !== undefined && isRecord(snapshot.jobs)) {
+    const jobs = Object.fromEntries(
+      Object.entries(snapshot.jobs).map(([jobKey, jobContext]) => {
+        const jobOutputTypes = Object.hasOwn(outputTypes, jobKey) ? outputTypes[jobKey] : undefined;
+        if (jobOutputTypes === undefined || !isRecord(jobContext)) {
+          return [jobKey, jobContext];
+        }
 
-  const jobs = Object.fromEntries(
-    Object.entries(snapshot.jobs).map(([jobKey, jobContext]) => {
-      const jobOutputTypes = Object.hasOwn(outputTypes, jobKey) ? outputTypes[jobKey] : undefined;
-      if (jobOutputTypes === undefined || !isRecord(jobContext)) {
-        return [jobKey, jobContext];
-      }
+        const outputs = isRecord(jobContext.outputs)
+          ? rehydrateJsonExpressionRecord(jobContext.outputs, jobOutputTypes)
+          : jobContext.outputs;
+        const executions = Array.isArray(jobContext.executions)
+          ? jobContext.executions.map((execution) => {
+              if (!isRecord(execution) || !isRecord(execution.outputs)) return execution;
+              return {
+                ...execution,
+                outputs: rehydrateJsonExpressionRecord(execution.outputs, jobOutputTypes),
+              };
+            })
+          : jobContext.executions;
 
-      const outputs = isRecord(jobContext.outputs)
-        ? rehydrateJsonExpressionRecord(jobContext.outputs, jobOutputTypes)
-        : jobContext.outputs;
-      const executions = Array.isArray(jobContext.executions)
-        ? jobContext.executions.map((execution) => {
-            if (!isRecord(execution) || !isRecord(execution.outputs)) return execution;
-            return {
-              ...execution,
-              outputs: rehydrateJsonExpressionRecord(execution.outputs, jobOutputTypes),
-            };
-          })
-        : jobContext.executions;
+        return [
+          jobKey,
+          {
+            ...jobContext,
+            outputs,
+            executions,
+          },
+        ];
+      }),
+    );
+    result = {...snapshot, jobs};
+  }
 
-      return [
-        jobKey,
-        {
-          ...jobContext,
-          outputs,
-          executions,
-        },
-      ];
-    }),
-  );
-  return {...snapshot, jobs};
+  const rehydrated = {...result};
+  if (isRecord(result.run)) rehydrated.run = rehydrateRunSnapshot(result.run);
+  if (isRecord(result.jobs)) rehydrated.jobs = rehydrateJobsSnapshot(result.jobs);
+  return rehydrated;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function rehydrateRunSnapshot(run: Record<string, unknown>): Record<string, unknown> {
+  const result = {...run};
+  if ('number' in run) result.number = rehydrateListenerInt(run.number);
+  if ('created_at' in run) result.created_at = rehydrateListenerTimestamp(run.created_at);
+  return result;
+}
+
+function rehydrateJobsSnapshot(jobs: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(jobs).map(([jobKey, value]) => [
+      jobKey,
+      isRecord(value) ? rehydrateJobSnapshot(value) : value,
+    ]),
+  );
+}
+
+function rehydrateJobSnapshot(job: Record<string, unknown>): Record<string, unknown> {
+  if (!Array.isArray(job.executions)) return job;
+
+  return {
+    ...job,
+    executions: job.executions.map((value) =>
+      isRecord(value) ? rehydrateExecutionSnapshot(value) : value,
+    ),
+  };
+}
+
+function rehydrateExecutionSnapshot(execution: Record<string, unknown>): Record<string, unknown> {
+  const result = {...execution};
+  if ('index' in execution) result.index = rehydrateListenerInt(execution.index);
+  if ('started_at' in execution) {
+    result.started_at = rehydrateListenerTimestamp(execution.started_at);
+  }
+  if ('finished_at' in execution) {
+    result.finished_at = rehydrateListenerTimestamp(execution.finished_at);
+  }
+  if (Array.isArray(execution.events)) {
+    result.events = execution.events.map((value) =>
+      isRecord(value) ? rehydrateExecutionEventSnapshot(value) : value,
+    );
+  }
+  return result;
+}
+
+function rehydrateExecutionEventSnapshot(event: Record<string, unknown>): Record<string, unknown> {
+  if (!('received_at' in event)) return event;
+  return {...event, received_at: rehydrateListenerTimestamp(event.received_at)};
+}
+
+function rehydrateListenerInt(value: unknown): unknown {
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return BigInt(value);
+  if (typeof value !== 'string' || !LISTENER_INTEGER_PATTERN.test(value)) return value;
+
+  try {
+    return BigInt(value);
+  } catch {
+    return value;
+  }
+}
+
+function rehydrateListenerTimestamp(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date;
 }
 
 function listenerDisposition(subscription: JobListenerSubscription): 'fire' | 'resolve' {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -132,7 +132,7 @@ describe('assembleWorkflowRunContext', () => {
       },
       run: {
         id: 'run-1',
-        number: 1,
+        number: 1n,
         name: 'Build',
         project_id: 'proj-1',
         workspace_id: 'workspace-1',
@@ -308,16 +308,16 @@ describe('assembleExecutionCreationContext', () => {
         }),
         executions: [
           {
-            index: 0,
+            index: 0n,
             name: 'Build #1',
             status: 'failed',
             started_at: date,
             finished_at: date,
-            events: prior.triggerEvents,
+            events: prior.triggerEvents.map((event) => ({...event, received_at: date})),
             outputs: {},
           },
           {
-            index: 1,
+            index: 1n,
             name: 'Build #2',
             status: 'pending',
             started_at: null,
@@ -327,7 +327,7 @@ describe('assembleExecutionCreationContext', () => {
                 source: 'github',
                 event: 'deployment',
                 delivery_id: 'delivery-2',
-                received_at: '2026-06-30T12:01:00.000Z',
+                received_at: new Date('2026-06-30T12:01:00.000Z'),
                 project: null,
                 repository: null,
                 ref: null,
@@ -340,7 +340,7 @@ describe('assembleExecutionCreationContext', () => {
         ],
         job: {key: 'build', name: 'Build'},
         execution: {
-          index: 1,
+          index: 1n,
           name: 'Build #2',
           status: 'pending',
           started_at: null,
@@ -350,7 +350,7 @@ describe('assembleExecutionCreationContext', () => {
               source: 'github',
               event: 'deployment',
               delivery_id: 'delivery-2',
-              received_at: '2026-06-30T12:01:00.000Z',
+              received_at: new Date('2026-06-30T12:01:00.000Z'),
               project: null,
               repository: null,
               ref: null,
@@ -430,12 +430,15 @@ describe('assembleJobActivationContext', () => {
             outputs: {image: 'app:123'},
             executions: [
               {
-                index: 0,
+                index: 0n,
                 name: 'Build #1',
                 status: 'succeeded',
                 started_at: date,
                 finished_at: null,
-                events: buildExecution.triggerEvents,
+                events: buildExecution.triggerEvents.map((event) => ({
+                  ...event,
+                  received_at: date,
+                })),
                 outputs: {sha: 'abc123'},
               },
             ],
@@ -454,12 +457,15 @@ describe('assembleJobActivationContext', () => {
             outputs: {image: 'app:123'},
             executions: [
               {
-                index: 0,
+                index: 0n,
                 name: 'Build #1',
                 status: 'succeeded',
                 started_at: date,
                 finished_at: null,
-                events: buildExecution.triggerEvents,
+                events: buildExecution.triggerEvents.map((event) => ({
+                  ...event,
+                  received_at: date,
+                })),
                 outputs: {sha: 'abc123'},
               },
             ],
@@ -743,6 +749,39 @@ describe('listener filter snapshots', () => {
       },
     });
   });
+
+  it('keeps snapshots JSON-serializable so they survive the outbox payload', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.executions[0].index == 0 && run.number == 1',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {}},
+          executions: [jobExecution({id: 'exec-build', jobId: 'job-build'})],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+    const jobs = matcher?.filter_snapshot?.jobs as Record<string, {executions: {index: unknown}[]}>;
+    const snapshotRun = matcher?.filter_snapshot?.run as {number: unknown};
+
+    expect(typeof jobs.build?.executions[0]?.index).toBe('number');
+    expect(typeof snapshotRun.number).toBe('number');
+    expect(() => JSON.stringify(matcher?.filter_snapshot)).not.toThrow();
+  });
 });
 
 describe('assembleStepDispatchContext', () => {
@@ -779,7 +818,7 @@ describe('assembleStepDispatchContext', () => {
       site: 'step-dispatch',
       values: {
         execution: {
-          index: 2,
+          index: 1n,
           name: 'Deploy',
           status: 'running',
           failed: false,
@@ -790,7 +829,7 @@ describe('assembleStepDispatchContext', () => {
               source: 'github',
               event: 'push',
               delivery_id: 'delivery-1',
-              received_at: '2026-06-30T12:00:00.000Z',
+              received_at: date,
               project: null,
               repository: null,
               ref: null,
@@ -1117,7 +1156,7 @@ describe('assembleJobResolutionContext', () => {
         vars: {},
         executions: [
           {
-            index: 0,
+            index: 0n,
             name: 'First',
             status: 'failed',
             started_at: date,
@@ -1127,7 +1166,7 @@ describe('assembleJobResolutionContext', () => {
                 source: 'github',
                 event: 'push',
                 delivery_id: 'delivery-1',
-                received_at: '2026-06-30T12:00:00.000Z',
+                received_at: date,
                 project: null,
                 repository: null,
                 ref: null,
@@ -1138,7 +1177,7 @@ describe('assembleJobResolutionContext', () => {
             outputs: {},
           },
           {
-            index: 1,
+            index: 1n,
             name: 'Second',
             status: 'succeeded',
             started_at: date,
@@ -1148,7 +1187,7 @@ describe('assembleJobResolutionContext', () => {
                 source: 'github',
                 event: 'push',
                 delivery_id: 'delivery-1',
-                received_at: '2026-06-30T12:00:00.000Z',
+                received_at: date,
                 project: null,
                 repository: null,
                 ref: null,
@@ -1206,14 +1245,50 @@ describe('assembleExecutionResolutionContext', () => {
     });
 
     expect(context.values.execution).toEqual({
-      index: 0,
+      index: 0n,
       name: 'Build #2',
       status: 'running',
       started_at: date,
       finished_at: null,
-      events: targetExecution.triggerEvents,
+      events: targetExecution.triggerEvents.map((event) => ({...event, received_at: date})),
       outputs: {sha: 'target'},
     });
+  });
+
+  it('exposes execution indices and event timestamps as CEL-native values', () => {
+    const targetExecution = jobExecution({
+      id: 'exec-2',
+      sequence: 2,
+      outputs: {sha: 'target'},
+    });
+
+    const context = assembleExecutionResolutionContext({
+      run,
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: 'sub-1',
+        userId: 'user-1',
+      },
+      job: {key: 'build'},
+      jobExecution: targetExecution,
+      executions: [targetExecution],
+      steps: [],
+      attempts: [],
+    });
+
+    const expressions = [
+      'executions[0].index + 1 == 1',
+      'execution.index + 1 == 1',
+      'run.number + 1 == 2',
+      'executions[0].events[0].received_at < timestamp("2026-07-01T00:00:00Z")',
+    ];
+
+    for (const source of expressions) {
+      const expression = createWorkflowExpression({source, check: {mode: 'syntax'}});
+
+      expect(evaluateWorkflowExpression(expression, context.values)).toBe(true);
+    }
   });
 });
 

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -8,7 +8,7 @@ import {
   type WorkflowPredicateContextRoot,
 } from '@shipfox/expression';
 import type {Job, JobListeningTrigger} from '#core/entities/job.js';
-import type {JobExecution} from '#core/entities/job-execution.js';
+import type {JobExecution, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import type {Step, StepAttempt, StepStatus} from '#core/entities/step.js';
 import type {
   TriggerPayload,
@@ -25,6 +25,7 @@ export interface JobContextInput {
 
 export interface AssembleJobsContextOptions {
   readonly skipTypedOutputRehydration?: boolean;
+  readonly skipCelNativeRehydration?: boolean;
 }
 
 export interface AssembleWorkflowRunContextParams {
@@ -44,8 +45,11 @@ export interface AssembleWorkflowRunContextParams {
   readonly vars?: Record<string, string> | undefined;
 }
 
+interface AssembleContextOptions extends AssembleJobsContextOptions {}
+
 export function assembleWorkflowRunContext(
   params: AssembleWorkflowRunContextParams,
+  options: AssembleContextOptions = {},
 ): WorkflowExpressionEvaluationContext {
   const triggerReference = params.run.triggerReference;
   return {
@@ -55,7 +59,8 @@ export function assembleWorkflowRunContext(
     },
     run: {
       id: params.run.id,
-      number: params.run.number,
+      number:
+        options.skipCelNativeRehydration === true ? params.run.number : BigInt(params.run.number),
       name: params.run.name,
       project_id: params.run.projectId,
       workspace_id: params.run.workspaceId,
@@ -136,10 +141,11 @@ export function assembleExecutionCreationContext(
 export function assembleExecutionsContext(
   executions: readonly JobExecution[],
   outputTypes?: Readonly<Record<string, ExpressionType>>,
+  options: AssembleContextOptions = {},
 ): WorkflowExpressionEvaluationContext {
   return {
     executions: executions.map((execution, index) =>
-      assembleExecutionContext(execution, index, outputTypes),
+      assembleExecutionContext(execution, index, outputTypes, options),
     ),
   };
 }
@@ -148,15 +154,37 @@ function assembleExecutionContext(
   execution: JobExecution,
   index: number,
   outputTypes?: Readonly<Record<string, ExpressionType>>,
+  options: AssembleContextOptions = {},
 ): Record<string, unknown> {
+  const skipCelNativeRehydration = options.skipCelNativeRehydration === true;
   return {
-    index,
+    index: skipCelNativeRehydration ? index : BigInt(index),
     name: execution.name,
     status: execution.status,
     started_at: execution.startedAt,
     finished_at: execution.finishedAt,
-    events: execution.triggerEvents,
-    outputs: rehydrateJsonExpressionRecord(execution.outputs, outputTypes),
+    events: skipCelNativeRehydration
+      ? execution.triggerEvents
+      : execution.triggerEvents.map(assembleExecutionEventContext),
+    outputs:
+      options.skipTypedOutputRehydration === true
+        ? (execution.outputs ?? {})
+        : rehydrateJsonExpressionRecord(execution.outputs, outputTypes),
+  };
+}
+
+function assembleExecutionEventContext(event: WorkflowExecutionEvent): Record<string, unknown> {
+  const receivedAt = new Date(event.received_at);
+  /**
+   * An unparseable stored timestamp would become an `Invalid Date`, which compares
+   * false against every CEL `timestamp` and throws on `toISOString` during template
+   * resolution. Keeping the raw value fails loudly as a type mismatch instead.
+   */
+  if (Number.isNaN(receivedAt.getTime())) return {...event};
+
+  return {
+    ...event,
+    received_at: receivedAt,
   };
 }
 
@@ -281,12 +309,15 @@ export function assembleListenerSnapshotContext(params: {
     params.plan.roots.has('run') ||
     params.plan.roots.has('trigger')
   ) {
-    const runContext = assembleWorkflowRunContext({
-      run: params.run,
-      triggerPayload: params.triggerPayload,
-      inputs: params.inputs,
-      vars: params.vars,
-    });
+    const runContext = assembleWorkflowRunContext(
+      {
+        run: params.run,
+        triggerPayload: params.triggerPayload,
+        inputs: params.inputs,
+        vars: params.vars,
+      },
+      {skipCelNativeRehydration: true},
+    );
     if (params.plan.roots.has('workflow')) context.workflow = runContext.workflow;
     if (params.plan.roots.has('run')) context.run = runContext.run;
     if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
@@ -316,13 +347,17 @@ function requestedJobsContext(
   jobKeys: ReadonlySet<string>,
 ): Record<string, unknown> {
   // Listener snapshots cross a JSON outbox boundary; their type metadata is persisted separately.
+  const options: AssembleJobsContextOptions = {
+    skipCelNativeRehydration: true,
+    skipTypedOutputRehydration: true,
+  };
   if (jobKeys.size === 0) {
-    return assembleJobsContext(dependencyJobs, {skipTypedOutputRehydration: true}).jobs;
+    return assembleJobsContext(dependencyJobs, options).jobs;
   }
 
   const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
 
-  return assembleJobsContext(filtered, {skipTypedOutputRehydration: true}).jobs;
+  return assembleJobsContext(filtered, options).jobs;
 }
 
 export type ListenerTriggerWithSnapshot = JobListeningTrigger & {
@@ -429,6 +464,7 @@ function assembleJobContext(
     executions: assembleExecutionsContext(
       executions,
       options.skipTypedOutputRehydration === true ? undefined : outputTypes,
+      options,
     ).executions,
   };
 }
@@ -516,14 +552,8 @@ export function assembleStepDispatchContext(params: {
         ? {}
         : {
             execution: {
-              index: params.jobExecution.sequence,
-              name: params.jobExecution.name,
-              status: params.jobExecution.status,
+              ...assembleExecutionContext(params.jobExecution, params.jobExecution.sequence - 1),
               failed: stepAttemptContext.stepsFailed,
-              started_at: params.jobExecution.startedAt,
-              finished_at: params.jobExecution.finishedAt,
-              events: params.jobExecution.triggerEvents,
-              outputs: params.jobExecution.outputs ?? {},
             },
           }),
       ...(targetStep === undefined


### PR DESCRIPTION
## Summary

Workflow context values declared as CEL `int` and `timestamp` now remain CEL-native during live execution and after listener filter snapshots are persisted and read back. Snapshot writes stay JSON-safe, and execution indexes remain zero-based at step dispatch.

The changeset covers `@shipfox/api-workflows` and `@shipfox/api-triggers` as patches. Validation passed for the focused package checks, type graph, full workflows and triggers test suites, affected-package builds, and `git diff --check`.

Closes ENG-1487

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves CEL-native ints and timestamps across workflow evaluation contexts and when reading listener filter snapshots, while keeping snapshot writes JSON-safe. Maintains zero-based execution indexing at step dispatch. Closes ENG-1487.

- **Bug Fixes**
  - `@shipfox/api-workflows`: Expose `run.number`, execution `index`, and event `received_at` as CEL-native values (`BigInt`/`Date`) across all contexts; safely parse timestamps; keep listener snapshot contexts JSON-serializable.
  - `@shipfox/api-triggers`: Rehydrate listener filter snapshots to CEL-native types for run and execution scalars (ints to `BigInt`, timestamps to `Date`) and typed outputs, with persisted JSON unchanged.

<sup>Written for commit c183d08efa76bdabbf5450587312c73e138fcfed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

