### PR TITLE
[expression] Add shared JSON and range CEL functions

### DIFF
--- a/.changeset/shared-expression-functions.md
+++ b/.changeset/shared-expression-functions.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds shared `range()`, `toJson()`, and `fromJson()` functions to workflow expressions.

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -96,6 +96,15 @@ passes.
 | `has(field)` | `has(event.pull_request)` | True when the field is present |
 | `string(value)`, `int(value)`, `double(value)` | `"run-" + string(run.number)` | The value converted to that type |
 | `timestamp(string)` | `timestamp("2026-01-01T00:00:00Z")` | A timestamp from an RFC 3339 string |
+| `range(start, stop, step)` | `range(1, 3, 1)` | An inclusive list of integers |
+| `toJson(value)` | `toJson(event.pull_request.labels)` | The value serialized as compact JSON text |
+| `fromJson(string)` | `fromJson(event.payload)` | The JSON text parsed into a CEL value |
+
+`range()` accepts a positive step and can materialize at most 1,000 values and
+1,000,000 context-byte fan-out units in one evaluation. `toJson()` can produce
+at most 1,000,000 UTF-8 bytes in one evaluation. `fromJson()` expects a valid
+JSON string and converts safe integer numbers to CEL integers. `toJson()` writes
+integers outside the range JSON numbers represent exactly as quoted strings.
 
 The [CEL language
 definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md#standard-definitions)

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -9,14 +9,20 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
 - **`WorkflowExpression`**: Stores the CEL tag, source, and check level.
 - **`ExpressionTypeEnvironment`**: Lists names and field types for typed checks.
 - **`evaluateWorkflowExpression`**: Runs a checked value against caller data.
+- **`createWorkflowEnvironment`**: Creates an isolated evaluator with the shared
+  `range()`, `toJson()`, and `fromJson()` functions.
 - **`evaluateWorkflowExpressionWithEnvironment`**: Runs a checked value against
   a caller-owned CEL environment for explicitly scoped custom functions.
 - **`WorkflowExpressionEnvironment`**: The evaluate-only environment shape
   accepted by the scoped evaluator.
-- **`createRangeEnvironment`**: Creates an opt-in evaluator with the bounded,
-  inclusive `range(start, stop, step)` config-templating function.
+- **`createRangeEnvironment`**: Compatibility alias for
+  `createWorkflowEnvironment`.
 - **`MAX_RANGE_ELEMENTS`**: The per-evaluation range materialization limit,
   currently 1,000 values.
+- **`MAX_RANGE_FANOUT_BYTES`**: The per-evaluation context-sized range fan-out
+  limit, currently 1,000,000 bytes.
+- **`MAX_JSON_OUTPUT_BYTES`**: The per-evaluation `toJson()` output limit,
+  currently 1,000,000 UTF-8 bytes.
 - **`evaluateWorkflowPredicate`**: Returns `true` only for the boolean `true`.
 - **`classifyShellCodePosition`**: Finds named workflow bindings passed directly
   to shell positions that re-evaluate their arguments.
@@ -86,12 +92,18 @@ const passed = evaluateWorkflowPredicate(expression, {
 - Context values can include external data. Interpolatable fields rely on their
   structural sink guarantees, while host and availability checks remain enforced.
 - Evaluation is deterministic and has no side effects.
-- Workflow evaluation does not include config-templating functions. Use a
-  caller-owned environment when a custom function is intentionally needed.
-- The config-templating range evaluator accepts CEL integers and safe integer
-  values from JavaScript contexts. It creates a fresh CEL environment and one
-  materialization budget for each evaluation, shared by nested range calls;
-  each evaluation can materialize at most 1,000 values.
+- Workflow evaluation includes the shared `range()`, `toJson()`, and `fromJson()`
+  functions. Use a caller-owned environment when a custom function is intentionally
+  needed outside that registry.
+- `range()` accepts CEL integers and safe integer values from JavaScript
+  contexts. An environment is built once and reused, and each evaluation gets
+  its own materialization budget, shared by nested range calls and restored when
+  a context accessor re-enters the evaluator; each evaluation can materialize at
+  most 1,000 values and 1,000,000 context-byte fan-out units.
+- `toJson()` writes integers outside the safe-integer range as quoted strings, so
+  a round trip through `fromJson()` returns them as strings rather than numbers.
+  Safe JSON numbers parsed by `fromJson()` become CEL integers, and all
+  `toJson()` output shares a 1,000,000-byte budget per evaluation.
 - Field resolution remains string-based by default. Callers rendering config
   objects may opt into raw values for an exact single expression with
   `preserveSingleExpressionType: true`; mixed literal and expression fields

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -1,4 +1,6 @@
+import {evaluate as evaluateCel} from '@marcbachmann/cel-js';
 import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
+import {MAX_JSON_OUTPUT_BYTES, MAX_RANGE_FANOUT_BYTES} from '../workflow-function-registry.js';
 import {WorkflowExpressionEvaluationError} from './errors.js';
 import {
   evaluateWorkflowExpression,
@@ -49,17 +51,153 @@ describe('evaluateWorkflowExpression', () => {
     expect(result).toBe(expected);
   });
 
-  it('does not add caller-supplied functions to the global evaluator', () => {
+  it('does not add workflow functions to the vendor-global evaluator', () => {
     const expression = createWorkflowExpression({
       source: 'range(2, 32, 2)',
       check: {mode: 'syntax'},
     });
-    // Creating the opt-in evaluator must not register range in the global evaluator.
+    // Creating the workflow evaluator must not register functions in the vendor-global evaluator.
     createRangeEnvironment();
 
-    const evaluateGlobally = () => evaluateWorkflowExpression(expression, {});
+    const evaluateGlobally = () => evaluateCel(expression.source, {});
 
-    expect(evaluateGlobally).toThrow(WorkflowExpressionEvaluationError);
+    expect(evaluateGlobally).toThrow('found no matching overload');
+  });
+
+  it('evaluates the shared JSON functions through the default workflow environment', () => {
+    const expression = createWorkflowExpression({
+      source: 'toJson(fromJson(event.payload))',
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {payload: '{"ready":true,"count":2}'},
+    });
+
+    expect(result).toBe('{"ready":true,"count":2}');
+  });
+
+  it('serializes CEL integers as JSON numbers', () => {
+    const expression = createWorkflowExpression({
+      source: 'toJson([1, 2])',
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {});
+
+    expect(result).toBe('[1,2]');
+  });
+
+  it('evaluates range through the default workflow environment', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(2, 6, 2)',
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {});
+
+    expect(result).toEqual([2n, 4n, 6n]);
+  });
+
+  it('gives each default-environment evaluation a full range budget', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(1, 1000, 1).size()',
+      check: {mode: 'syntax'},
+    });
+
+    const first = evaluateWorkflowExpression(expression, {});
+    const second = evaluateWorkflowExpression(expression, {});
+
+    expect(first).toBe(1000n);
+    expect(second).toBe(1000n);
+  });
+
+  it('enforces the range budget through the default workflow environment', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(1, 1001, 1)',
+      check: {mode: 'syntax'},
+    });
+
+    const evaluateTooLarge = () => evaluateWorkflowExpression(expression, {});
+
+    expect(evaluateTooLarge).toThrow(WorkflowExpressionEvaluationError);
+  });
+
+  it('reports invalid JSON passed to fromJson as an evaluation failure', () => {
+    const expression = createWorkflowExpression({
+      source: 'fromJson(event.payload)',
+      check: {mode: 'syntax'},
+    });
+
+    const evaluateInvalid = () =>
+      evaluateWorkflowExpression(expression, {event: {payload: 'not json'}});
+
+    expect(evaluateInvalid).toThrow(WorkflowExpressionEvaluationError);
+  });
+
+  it('serializes integers beyond the safe range as JSON strings', () => {
+    const expression = createWorkflowExpression({
+      source: 'toJson(9223372036854775807)',
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {});
+
+    expect(result).toBe('"9223372036854775807"');
+  });
+
+  it('parses safe JSON numbers as CEL integers', () => {
+    const expression = createWorkflowExpression({
+      source: 'fromJson(event.payload).count + 1',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {payload: 'string'}},
+        },
+      },
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {payload: '{"count":2}'},
+    });
+
+    expect(result).toBe(3n);
+  });
+
+  it('enforces a shared JSON output budget across range-generated values', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(1, 2, 1).map(index, toJson(event)).size() == 2',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {event: {kind: 'map'}},
+        expectedResultType: 'bool',
+      },
+    });
+    const payload = 'x'.repeat(MAX_JSON_OUTPUT_BYTES / 2);
+
+    const result = evaluateWorkflowPredicateFailClosed(expression, {event: {payload}});
+
+    expect(result).toEqual({value: false, evaluationFailed: true});
+  });
+
+  it('enforces a context-sized range fan-out budget', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(1, 1000, 1).map(index, event.payload.upperAscii()).size() == 1000',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {payload: 'string'}},
+        },
+        expectedResultType: 'bool',
+      },
+    });
+    const payload = 'x'.repeat(MAX_RANGE_FANOUT_BYTES / 2);
+
+    const result = evaluateWorkflowPredicateFailClosed(expression, {
+      event: {payload},
+    });
+
+    expect(result).toEqual({value: false, evaluationFailed: true});
   });
 
   it('evaluates against a caller-supplied environment', () => {

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
@@ -1,17 +1,20 @@
-import {type Environment, evaluate} from '@marcbachmann/cel-js';
+import type {Environment} from '@marcbachmann/cel-js';
 import type {WorkflowExpression} from '../expression/workflow-expression.js';
 import {WorkflowExpressionEvaluationError} from './errors.js';
+import {createWorkflowEnvironment} from './workflow-environment.js';
 
 export type WorkflowExpressionEvaluationContext = Readonly<Record<string, unknown>>;
 export type WorkflowExpressionEvaluationValue = unknown;
 export type WorkflowExpressionEnvironment = Pick<Environment, 'evaluate'>;
+
+const workflowEnvironment = createWorkflowEnvironment();
 
 export function evaluateWorkflowExpression(
   expression: WorkflowExpression,
   context: WorkflowExpressionEvaluationContext,
 ): WorkflowExpressionEvaluationValue {
   try {
-    return evaluate(expression.source, context);
+    return workflowEnvironment.evaluate(expression.source, context);
   } catch (error) {
     throw new WorkflowExpressionEvaluationError(error);
   }
@@ -20,9 +23,8 @@ export function evaluateWorkflowExpression(
 /**
  * Evaluate an expression against a caller-owned CEL environment.
  *
- * Workflow expressions deliberately continue to use the global CEL evaluator.
- * Callers that need custom functions, such as config templating, must opt in
- * by creating and passing their own environment.
+ * The caller-owned environment can provide a narrower or broader function set
+ * when the shared workflow registry is not the right boundary.
  */
 export function evaluateWorkflowExpressionWithEnvironment(
   expression: WorkflowExpression,

--- a/libs/shared/expression/src/evaluator/index.ts
+++ b/libs/shared/expression/src/evaluator/index.ts
@@ -1,3 +1,4 @@
+export {MAX_JSON_OUTPUT_BYTES, MAX_RANGE_FANOUT_BYTES} from '../workflow-function-registry.js';
 export {
   WorkflowExpressionEvaluationError,
   type WorkflowExpressionEvaluationFailureReason,
@@ -18,3 +19,4 @@ export {
   rehydrateJsonExpressionRecord,
   rehydrateJsonExpressionValue,
 } from './rehydrate-json-expression.js';
+export {createWorkflowEnvironment} from './workflow-environment.js';

--- a/libs/shared/expression/src/evaluator/range.ts
+++ b/libs/shared/expression/src/evaluator/range.ts
@@ -1,64 +1,9 @@
-import {type Context, Environment} from '@marcbachmann/cel-js';
 import type {WorkflowExpressionEnvironment} from './evaluate-workflow-expression.js';
+import {createWorkflowEnvironment} from './workflow-environment.js';
 
-/** Maximum number of values a config-template range may materialize. */
-export const MAX_RANGE_ELEMENTS = 1_000;
-const RANGE_FUNCTION_SIGNATURE = 'range(dyn, dyn, dyn): list<int>';
+export {MAX_RANGE_ELEMENTS} from '../workflow-function-registry.js';
 
-interface RangeBudget {
-  remaining: number;
-}
-
-function materializeRange(start: bigint, stop: bigint, step: bigint): bigint[] {
-  const values: bigint[] = [];
-  for (let value = start; value <= stop; value += step) values.push(value);
-  return values;
-}
-
-function rangeElementCount(start: bigint, stop: bigint, step: bigint): bigint {
-  if (step <= 0n) throw new RangeError('range step must be positive');
-  if (start > stop) return 0n;
-
-  return (stop - start) / step + 1n;
-}
-
-function toCelInteger(value: unknown, name: string): bigint {
-  if (typeof value === 'bigint') return value;
-  if (typeof value === 'number' && Number.isSafeInteger(value)) return BigInt(value);
-  throw new RangeError(`${name} must be a safe integer`);
-}
-
-function evaluateRange(
-  budget: RangeBudget,
-  start: unknown,
-  stop: unknown,
-  step: unknown,
-): bigint[] {
-  const startValue = toCelInteger(start, 'range start');
-  const stopValue = toCelInteger(stop, 'range stop');
-  const stepValue = toCelInteger(step, 'range step');
-  const count = rangeElementCount(startValue, stopValue, stepValue);
-  if (count > BigInt(budget.remaining)) {
-    throw new RangeError(
-      `range evaluation budget exceeded; ${count} elements requested with ${budget.remaining} remaining`,
-    );
-  }
-
-  const values = materializeRange(startValue, stopValue, stepValue);
-  budget.remaining -= values.length;
-  return values;
-}
-
-/** Create the opt-in range evaluator for config templating. */
+/** Create a workflow evaluator with the shared CEL function registry. */
 export function createRangeEnvironment(): WorkflowExpressionEnvironment {
-  return {
-    evaluate(expression: string, context?: Context) {
-      const budget = {remaining: MAX_RANGE_ELEMENTS};
-      const environment = new Environment({unlistedVariablesAreDyn: true});
-      environment.registerFunction(RANGE_FUNCTION_SIGNATURE, (start, stop, step) =>
-        evaluateRange(budget, start, stop, step),
-      );
-      return environment.evaluate(expression, context);
-    },
-  };
+  return createWorkflowEnvironment();
 }

--- a/libs/shared/expression/src/evaluator/workflow-environment.ts
+++ b/libs/shared/expression/src/evaluator/workflow-environment.ts
@@ -1,0 +1,16 @@
+import {type Context, Environment} from '@marcbachmann/cel-js';
+import {registerWorkflowFunctions} from '../workflow-function-registry.js';
+import type {WorkflowExpressionEnvironment} from './evaluate-workflow-expression.js';
+
+export function createWorkflowEnvironment(): WorkflowExpressionEnvironment {
+  // Building the CEL environment once and resetting the budget keeps the
+  // per-evaluation materialization limit while avoiding a rebuild per call.
+  const environment = new Environment({unlistedVariablesAreDyn: true});
+  const budgets = registerWorkflowFunctions(environment);
+
+  return {
+    evaluate(expression: string, context?: Context) {
+      return budgets.isolate(context, () => environment.evaluate(expression, context));
+    },
+  };
+}

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -38,6 +38,70 @@ describe('createWorkflowExpression', () => {
     });
   });
 
+  it('type-checks the shared workflow function registry', () => {
+    const jsonExpression = createWorkflowExpression({
+      source: 'toJson(event)',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'map'},
+        },
+      },
+    });
+    const parsedExpression = createWorkflowExpression({
+      source: 'fromJson(event.payload).ready',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {payload: 'string'}},
+        },
+      },
+    });
+    const parsedPredicateExpression = createWorkflowExpression({
+      source: 'fromJson(event.payload).ready',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {payload: 'string'}},
+        },
+        expectedResultType: 'bool',
+      },
+    });
+    const dynamicJsonExpression = createWorkflowExpression({
+      source: 'fromJson(event.payload).items',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {payload: 'string'}},
+        },
+      },
+    });
+    const rangeExpression = createWorkflowExpression({
+      source: 'range(1, 3, 1).size() == 3',
+      check: {mode: 'typed'},
+    });
+
+    expect(jsonExpression.resultType).toBe('string');
+    expect(parsedExpression.check).toBe('typed');
+    expect(parsedPredicateExpression.check).toBe('typed');
+    expect(dynamicJsonExpression.resultType).toBeUndefined();
+    expect(rangeExpression.resultType).toBe('bool');
+  });
+
+  it('does not treat fromJson text in a dynamic expression as a function call', () => {
+    const act = () =>
+      createWorkflowExpression({
+        source: 'event["fromJson("]',
+        check: {
+          mode: 'typed',
+          typeEnvironment: {event: {kind: 'map'}},
+          expectedResultType: 'bool',
+        },
+      });
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
   it('rejects misspelled fields from the typed environment', () => {
     const act = () =>
       createWorkflowExpression({

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -1,4 +1,5 @@
-import {Environment, parse as parseCel} from '@marcbachmann/cel-js';
+import {type ASTNode, Environment, parse as parseCel} from '@marcbachmann/cel-js';
+import {registerWorkflowFunctions} from '../workflow-function-registry.js';
 import {InvalidWorkflowExpressionError} from './errors.js';
 import type {
   CreateWorkflowExpressionParams,
@@ -36,14 +37,7 @@ export function createWorkflowExpression(
     });
   }
 
-  try {
-    parseCel(source);
-  } catch (error) {
-    throw new InvalidWorkflowExpressionError({
-      source,
-      reason: error instanceof Error ? error.message : 'Expression source could not be parsed.',
-    });
-  }
+  const ast = parseWorkflowExpression(source);
 
   if (params.check.mode === 'typed') {
     const environment = createTypeCheckingEnvironment();
@@ -65,7 +59,8 @@ export function createWorkflowExpression(
     }
     if (
       params.check.expectedResultType !== undefined &&
-      typeCheckResult.type !== scalarTypeToCelType[params.check.expectedResultType]
+      typeCheckResult.type !== scalarTypeToCelType[params.check.expectedResultType] &&
+      !(typeCheckResult.type === 'dyn' && containsFromJsonCall(ast))
     ) {
       throw new InvalidWorkflowExpressionError({
         source,
@@ -74,7 +69,7 @@ export function createWorkflowExpression(
     }
     resultType =
       resolveKnownPathType(source, params.check.typeEnvironment) ??
-      fromCelType(typeCheckResult.type);
+      fromCelType(typeCheckResult.type, ast);
   }
 
   return {
@@ -109,6 +104,7 @@ function resolveKnownPathType(
 
 function createTypeCheckingEnvironment(): Environment {
   const environment = new Environment({unlistedVariablesAreDyn: false});
+  registerWorkflowFunctions(environment);
 
   // CEL evaluates numeric equality across types, but its static checker normally
   // rejects the same expression. Match validation to the runtime contract.
@@ -191,7 +187,7 @@ function toCelListElementType(
   return 'dyn';
 }
 
-function fromCelType(type: string | undefined): ExpressionType | undefined {
+function fromCelType(type: string | undefined, ast: ASTNode): ExpressionType | undefined {
   if (type === undefined) return undefined;
 
   switch (type) {
@@ -210,7 +206,8 @@ function fromCelType(type: string | undefined): ExpressionType | undefined {
     case 'map':
       return {kind: 'map'};
     case 'dyn':
-      return 'string';
+      // Preserve legacy string fallback for open-map lookups; JSON values stay unknown.
+      return containsFromJsonCall(ast) ? undefined : 'string';
     default:
       // cel-js currently exposes custom/list element result types as opaque strings.
       // Keep the outer list shape when present, but erase element detail rather than
@@ -218,4 +215,33 @@ function fromCelType(type: string | undefined): ExpressionType | undefined {
       if (type.startsWith('list<')) return {kind: 'list', element: {kind: 'map'}};
       return {kind: 'map'};
   }
+}
+
+function parseWorkflowExpression(source: string): ASTNode {
+  try {
+    return parseCel(source).ast;
+  } catch (error) {
+    throw new InvalidWorkflowExpressionError({
+      source,
+      reason: error instanceof Error ? error.message : 'Expression source could not be parsed.',
+    });
+  }
+}
+
+function containsFromJsonCall(node: ASTNode): boolean {
+  if ((node.op === 'call' || node.op === 'rcall') && node.args[0] === 'fromJson') {
+    return true;
+  }
+
+  return containsFromJsonValue(node.args);
+}
+
+function containsFromJsonValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsFromJsonValue);
+  if (typeof value !== 'object' || value === null) return false;
+
+  const candidate = value as {readonly args?: unknown; readonly op?: unknown};
+  if (candidate.args === undefined || candidate.op === undefined) return false;
+
+  return containsFromJsonCall(candidate as ASTNode);
 }

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -18,6 +18,7 @@ export {
   rehydrateJsonExpressionRecord,
   rehydrateJsonExpressionValue,
 } from './evaluator/rehydrate-json-expression.js';
+export {createWorkflowEnvironment} from './evaluator/workflow-environment.js';
 export {
   createWorkflowExpression,
   unsafeWorkflowExpressionFromSource,
@@ -196,3 +197,7 @@ export {
   type WorkflowContextDoc,
   workflowContextDocs,
 } from './workflow-context/workflow-context-docs.js';
+export {
+  MAX_JSON_OUTPUT_BYTES,
+  MAX_RANGE_FANOUT_BYTES,
+} from './workflow-function-registry.js';

--- a/libs/shared/expression/src/json.ts
+++ b/libs/shared/expression/src/json.ts
@@ -1,0 +1,6 @@
+export function stringifyBigint(_key: string, value: unknown): unknown {
+  if (typeof value !== 'bigint') return value;
+
+  const numberValue = Number(value);
+  return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
+}

--- a/libs/shared/expression/src/resolver/coerce-workflow-value-to-string.ts
+++ b/libs/shared/expression/src/resolver/coerce-workflow-value-to-string.ts
@@ -1,3 +1,5 @@
+import {stringifyBigint} from '../json.js';
+
 export function coerceWorkflowValueToString(value: unknown): string {
   if (value === null || value === undefined) return '';
   if (typeof value === 'string') return value;
@@ -7,11 +9,4 @@ export function coerceWorkflowValueToString(value: unknown): string {
 
   const serialized = JSON.stringify(value, stringifyBigint);
   return serialized ?? '';
-}
-
-function stringifyBigint(_key: string, value: unknown): unknown {
-  if (typeof value !== 'bigint') return value;
-
-  const numberValue = Number(value);
-  return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
 }

--- a/libs/shared/expression/src/workflow-function-registry.ts
+++ b/libs/shared/expression/src/workflow-function-registry.ts
@@ -1,0 +1,199 @@
+import type {Environment, RegisteredFunctionHandler} from '@marcbachmann/cel-js';
+
+/** Maximum number of values one evaluation's range calls may materialize. */
+export const MAX_RANGE_ELEMENTS = 1_000;
+
+/** Maximum context-byte fan-out one evaluation's range calls may represent. */
+export const MAX_RANGE_FANOUT_BYTES = 1_000_000;
+
+/** Maximum UTF-8 bytes returned by toJson() calls in one evaluation. */
+export const MAX_JSON_OUTPUT_BYTES = 1_000_000;
+
+const utf8Encoder = new TextEncoder();
+
+const RANGE_FUNCTION_SIGNATURE = 'range(dyn, dyn, dyn): list<int>';
+const TO_JSON_FUNCTION_SIGNATURE = 'toJson(dyn): string';
+const FROM_JSON_FUNCTION_SIGNATURE = 'fromJson(string): dyn';
+
+interface WorkflowFunctionBudget {
+  remainingRangeElements: number;
+  remainingRangeFanoutBytes: number;
+  remainingJsonOutputBytes: number;
+  context: unknown;
+  contextBytes: number | undefined;
+}
+
+/** Per-evaluation budgets held by the handlers registered on an environment. */
+export interface WorkflowFunctionBudgets {
+  isolate<T>(context: unknown, evaluation: () => T): T;
+}
+
+interface WorkflowFunctionDefinition {
+  readonly signature: string;
+  readonly createHandler: (budget: WorkflowFunctionBudget) => RegisteredFunctionHandler;
+}
+
+const workflowFunctionRegistry = [
+  {
+    signature: RANGE_FUNCTION_SIGNATURE,
+    createHandler:
+      (budget: WorkflowFunctionBudget): RegisteredFunctionHandler =>
+      (start: unknown, stop: unknown, step: unknown) =>
+        evaluateRange(budget, start, stop, step),
+  },
+  {
+    signature: TO_JSON_FUNCTION_SIGNATURE,
+    createHandler:
+      (budget: WorkflowFunctionBudget): RegisteredFunctionHandler =>
+      (value: unknown) =>
+        serializeJson(budget, value),
+  },
+  {
+    signature: FROM_JSON_FUNCTION_SIGNATURE,
+    createHandler: (): RegisteredFunctionHandler => (value: unknown) => {
+      if (typeof value !== 'string') throw new TypeError('fromJson() expects a JSON string');
+      return JSON.parse(value, reviveJsonNumber) as unknown;
+    },
+  },
+] satisfies readonly WorkflowFunctionDefinition[];
+
+/**
+ * Register the shared functions and return the budgets their handlers close over.
+ *
+ * Callers that reuse one environment across evaluations must wrap each evaluation
+ * in `isolate` so it gets a full budget without consuming an enclosing one. A
+ * context accessor can re-enter the evaluator, so the enclosing budget is
+ * restored rather than reset.
+ */
+export function registerWorkflowFunctions(environment: Environment): WorkflowFunctionBudgets {
+  const budget: WorkflowFunctionBudget = {
+    remainingRangeElements: MAX_RANGE_ELEMENTS,
+    remainingRangeFanoutBytes: MAX_RANGE_FANOUT_BYTES,
+    remainingJsonOutputBytes: MAX_JSON_OUTPUT_BYTES,
+    context: undefined,
+    contextBytes: undefined,
+  };
+  for (const definition of workflowFunctionRegistry) {
+    environment.registerFunction(definition.signature, definition.createHandler(budget));
+  }
+
+  return {
+    isolate<T>(context: unknown, evaluation: () => T): T {
+      const enclosing = {
+        rangeElements: budget.remainingRangeElements,
+        rangeFanoutBytes: budget.remainingRangeFanoutBytes,
+        jsonOutputBytes: budget.remainingJsonOutputBytes,
+        context: budget.context,
+        contextBytes: budget.contextBytes,
+      };
+      budget.remainingRangeElements = MAX_RANGE_ELEMENTS;
+      budget.remainingRangeFanoutBytes = MAX_RANGE_FANOUT_BYTES;
+      budget.remainingJsonOutputBytes = MAX_JSON_OUTPUT_BYTES;
+      budget.context = context;
+      budget.contextBytes = undefined;
+      try {
+        return evaluation();
+      } finally {
+        budget.remainingRangeElements = enclosing.rangeElements;
+        budget.remainingRangeFanoutBytes = enclosing.rangeFanoutBytes;
+        budget.remainingJsonOutputBytes = enclosing.jsonOutputBytes;
+        budget.context = enclosing.context;
+        budget.contextBytes = enclosing.contextBytes;
+      }
+    },
+  };
+}
+
+function materializeRange(start: bigint, stop: bigint, step: bigint): bigint[] {
+  const values: bigint[] = [];
+  for (let value = start; value <= stop; value += step) values.push(value);
+  return values;
+}
+
+function rangeElementCount(start: bigint, stop: bigint, step: bigint): bigint {
+  if (step <= 0n) throw new RangeError('range step must be positive');
+  if (start > stop) return 0n;
+
+  return (stop - start) / step + 1n;
+}
+
+function toCelInteger(value: unknown, name: string): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return BigInt(value);
+  throw new RangeError(`${name} must be a safe integer`);
+}
+
+function evaluateRange(
+  budget: WorkflowFunctionBudget,
+  start: unknown,
+  stop: unknown,
+  step: unknown,
+): bigint[] {
+  const startValue = toCelInteger(start, 'range start');
+  const stopValue = toCelInteger(stop, 'range stop');
+  const stepValue = toCelInteger(step, 'range step');
+  const count = rangeElementCount(startValue, stopValue, stepValue);
+  if (count > BigInt(budget.remainingRangeElements)) {
+    throw new RangeError(
+      `range evaluation budget exceeded; ${count} elements requested with ${budget.remainingRangeElements} remaining`,
+    );
+  }
+
+  const contextBytes = getContextBytes(budget);
+  const fanoutBytes = count * BigInt(contextBytes);
+  if (fanoutBytes > BigInt(budget.remainingRangeFanoutBytes)) {
+    throw new RangeError(
+      `range fan-out budget exceeded; ${count} elements requested for ${contextBytes} context bytes with ${budget.remainingRangeFanoutBytes} remaining`,
+    );
+  }
+
+  const values = materializeRange(startValue, stopValue, stepValue);
+  budget.remainingRangeElements -= values.length;
+  budget.remainingRangeFanoutBytes -= Number(fanoutBytes);
+  return values;
+}
+
+function getContextBytes(budget: WorkflowFunctionBudget): number {
+  if (budget.contextBytes !== undefined) return budget.contextBytes;
+
+  try {
+    const json = JSON.stringify(budget.context, stringifyBigint);
+    if (json === undefined) {
+      budget.contextBytes = 0;
+      return 0;
+    }
+
+    budget.contextBytes = Math.min(MAX_RANGE_FANOUT_BYTES + 1, utf8Encoder.encode(json).byteLength);
+    return budget.contextBytes;
+  } catch {
+    // A context that cannot be serialized is not safe to fan out over.
+    budget.contextBytes = MAX_RANGE_FANOUT_BYTES + 1;
+    return budget.contextBytes;
+  }
+}
+
+function serializeJson(budget: WorkflowFunctionBudget, value: unknown): string {
+  const json = JSON.stringify(value, stringifyBigint);
+  if (json === undefined) throw new TypeError('toJson() value must be JSON-serializable');
+
+  const outputBytes = utf8Encoder.encode(json).byteLength;
+  if (outputBytes > budget.remainingJsonOutputBytes) {
+    throw new RangeError(
+      `toJson evaluation budget exceeded; ${outputBytes} bytes requested with ${budget.remainingJsonOutputBytes} remaining`,
+    );
+  }
+
+  budget.remainingJsonOutputBytes -= outputBytes;
+  return json;
+}
+
+function reviveJsonNumber(_key: string, value: unknown): unknown {
+  return typeof value === 'number' && Number.isSafeInteger(value) ? BigInt(value) : value;
+}
+
+function stringifyBigint(_key: string, value: unknown): unknown {
+  if (typeof value !== 'bigint') return value;
+
+  const numberValue = Number(value);
+  return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
+}

--- a/libs/shared/expression/src/workflow-function-registry.ts
+++ b/libs/shared/expression/src/workflow-function-registry.ts
@@ -1,4 +1,5 @@
 import type {Environment, RegisteredFunctionHandler} from '@marcbachmann/cel-js';
+import {stringifyBigint} from './json.js';
 
 /** Maximum number of values one evaluation's range calls may materialize. */
 export const MAX_RANGE_ELEMENTS = 1_000;
@@ -189,11 +190,4 @@ function serializeJson(budget: WorkflowFunctionBudget, value: unknown): string {
 
 function reviveJsonNumber(_key: string, value: unknown): unknown {
   return typeof value === 'number' && Number.isSafeInteger(value) ? BigInt(value) : value;
-}
-
-function stringifyBigint(_key: string, value: unknown): unknown {
-  if (typeof value !== 'bigint') return value;
-
-  const numberValue = Number(value);
-  return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
 }


### PR DESCRIPTION
Adds a shared workflow CEL function registry and default evaluator environment for bounded `range()`, `toJson()`, and `fromJson()` functions.

The implementation keeps vendor-global CEL state isolated, resets budgets per evaluation, charges range fan-out against serialized context size before materialization, and preserves symmetric BigInt JSON behavior. Type validation uses an AST walk to distinguish real `fromJson()` calls from source text while retaining typed-path recovery from main.

Validation completed locally: expression tests (599), expression type/check/dependency-cruise, docs tests (28 including workflow-schema checks), and docs check all pass.

Closes ENG-1489

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared CEL functions `range()`, `toJson()`, and `fromJson()` to workflow expressions via a single registry and default evaluator. Implements ENG-1489 with safe JSON parsing/serialization, bounded ranges, and a unified BigInt JSON serializer used by `toJson()`, context fan-out sizing, and string coercion.

- **New Features**
  - Shared function registry used by type-checking and runtime (`createWorkflowEnvironment`).
  - Default evaluator includes `range()`, `toJson()`, `fromJson()`; `createRangeEnvironment` is a compatibility alias.
  - Budgets per evaluation: `MAX_RANGE_ELEMENTS` (1,000), `MAX_RANGE_FANOUT_BYTES` (1,000,000), `MAX_JSON_OUTPUT_BYTES` (1,000,000).
  - `fromJson(string)` parses valid JSON; safe numbers become CEL integers.
  - `toJson(value)` serializes BigInt outside the safe range as quoted strings; shared replacer used across JSON and string paths.
  - Keeps the vendor-global `@marcbachmann/cel-js` environment unmodified.
  - Updates docs and adds a changeset for `@shipfox/expression`.

<sup>Written for commit 312f398c8a788415b1582ac94928fc3ee22754bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

