### PR TITLE
[api-runners] Recover stale runner reservation bindings

### DIFF
--- a/.changeset/idle-runner-reservation-recovery.md
+++ b/.changeset/idle-runner-reservation-recovery.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Allow idle runners with expired or deleted intended or assigned reservations to be rebound on the next demand poll. Runner reports no longer overwrite a committed reservation assignment, and rebinding revokes unconsumed activation tokens before transferring ownership.

--- a/.changeset/idle-runner-reservation-recovery.md
+++ b/.changeset/idle-runner-reservation-recovery.md
@@ -2,4 +2,4 @@
 "@shipfox/api-runners": patch
 ---
 
-Allow idle runners with expired or deleted intended or assigned reservations to be rebound on the next demand poll. Runner reports no longer overwrite a committed reservation assignment, and rebinding revokes unconsumed activation tokens before transferring ownership.
+Allow idle runners with expired or deleted intended or assigned reservations to be rebound on the next demand poll.

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -86,6 +86,216 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
+  it('binds a runner whose intended reservation has expired', async () => {
+    const intendedReservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      intendedReservationId: intendedReservation.id,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: result.reservations[0]?.reservationId,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+  });
+
+  it('binds a runner whose intended reservation was deleted', async () => {
+    const intendedReservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await db().delete(reservations).where(eq(reservations.id, intendedReservation.id));
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      intendedReservationId: intendedReservation.id,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: result.reservations[0]?.reservationId,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+  });
+
+  it('binds a runner whose assigned reservation has expired', async () => {
+    const staleReservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      workspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+    });
+    const [activationToken] = await db()
+      .insert(runnerActivationTokens)
+      .values({
+        runnerInstanceId: runner.id,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!activationToken) throw new Error('Expected activation token');
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    const [storedToken] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.id, activationToken.id));
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: result.reservations[0]?.reservationId,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+    expect(storedToken?.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('binds a runner whose assigned reservation was deleted', async () => {
+    const staleReservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await db().delete(reservations).where(eq(reservations.id, staleReservation.id));
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      workspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: result.reservations[0]?.reservationId,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+  });
+
+  it('does not bind a runner whose assigned reservation is still live', async () => {
+    const liveReservation = await createIntendedReservation({
+      workspaceId: crypto.randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      workspaceId,
+      reservationId: liveReservation.id,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]?.count).toBe(1);
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: liveReservation.id,
+      intendedReservationId: null,
+      assignedAt: null,
+    });
+  });
+
+  it('does not bind a runner whose intended reservation is still live', async () => {
+    const intendedReservation = await createIntendedReservation({
+      workspaceId: crypto.randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      intendedReservationId: intendedReservation.id,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]?.count).toBe(1);
+    expect(storedRunner).toMatchObject({
+      workspaceId: null,
+      reservationId: null,
+      intendedReservationId: intendedReservation.id,
+      assignedAt: null,
+    });
+  });
+
   it('does not bind a running runner without an active control session', async () => {
     const [runner] = await db()
       .insert(providerRunners)
@@ -808,10 +1018,30 @@ describe('pollDemandAndReserve', () => {
     }
   }
 
+  async function createIntendedReservation(params: {
+    workspaceId: string;
+    expiresAt: Date;
+  }): Promise<{id: string}> {
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId: params.workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: params.expiresAt,
+      })
+      .returning({id: reservations.id});
+    if (!reservation) throw new Error('Expected reservation');
+    return reservation;
+  }
+
   async function createIdleRunner(params: {
     labels: string[];
     createdAt?: Date;
     controlSessionExpiresAt?: Date;
+    workspaceId?: string | null;
+    reservationId?: string | null;
     intendedReservationId?: string;
   }) {
     const createdAt = params.createdAt ?? new Date();
@@ -819,8 +1049,10 @@ describe('pollDemandAndReserve', () => {
       .insert(providerRunners)
       .values({
         provisionerId,
-        providerRunnerId: crypto.randomUUID(),
+        workspaceId: params.workspaceId,
+        reservationId: params.reservationId,
         intendedReservationId: params.intendedReservationId,
+        providerRunnerId: crypto.randomUUID(),
         labels: params.labels,
         state: 'running',
         reportedAt: createdAt,

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -10,6 +10,7 @@ import {
   isNotNull,
   isNull,
   lt,
+  notExists,
   or,
   sql,
 } from 'drizzle-orm';
@@ -298,16 +299,49 @@ async function bindIdleRunnerInstancesTx(
     count: number;
   },
 ): Promise<void> {
+  const canBindRunner = () =>
+    and(
+      or(
+        and(isNull(providerRunners.workspaceId), isNull(providerRunners.reservationId)),
+        and(
+          isNotNull(providerRunners.reservationId),
+          notExists(
+            tx
+              .select({id: reservations.id})
+              .from(reservations)
+              .where(
+                and(
+                  eq(reservations.id, providerRunners.reservationId),
+                  gt(reservations.expiresAt, sql`now()`),
+                ),
+              ),
+          ),
+        ),
+      ),
+      or(
+        isNull(providerRunners.intendedReservationId),
+        notExists(
+          tx
+            .select({id: reservations.id})
+            .from(reservations)
+            .where(
+              and(
+                eq(reservations.id, providerRunners.intendedReservationId),
+                gt(reservations.expiresAt, sql`now()`),
+              ),
+            ),
+        ),
+      ),
+      isNull(providerRunners.runnerSessionId),
+    );
+
   const idleRunners = await tx
     .select({id: providerRunners.id})
     .from(providerRunners)
     .where(
       and(
         eq(providerRunners.provisionerId, params.provisionerId),
-        isNull(providerRunners.workspaceId),
-        isNull(providerRunners.reservationId),
-        isNull(providerRunners.intendedReservationId),
-        isNull(providerRunners.runnerSessionId),
+        canBindRunner(),
         isNotNull(providerRunners.providerRunnerId),
         eq(providerRunners.state, 'running'),
         arrayContains(providerRunners.labels, params.requiredLabels),
@@ -333,10 +367,25 @@ async function bindIdleRunnerInstancesTx(
   if (idleRunners.length === 0) return;
 
   await tx
+    .update(runnerActivationTokens)
+    .set({revokedAt: sql`now()`})
+    .where(
+      and(
+        inArray(
+          runnerActivationTokens.runnerInstanceId,
+          idleRunners.map((runner) => runner.id),
+        ),
+        isNull(runnerActivationTokens.consumedAt),
+        isNull(runnerActivationTokens.revokedAt),
+      ),
+    );
+
+  await tx
     .update(providerRunners)
     .set({
       workspaceId: params.workspaceId,
       reservationId: params.reservationId,
+      intendedReservationId: null,
       assignedAt: sql`now()`,
       updatedAt: sql`now()`,
     })
@@ -346,9 +395,7 @@ async function bindIdleRunnerInstancesTx(
           providerRunners.id,
           idleRunners.map((runner) => runner.id),
         ),
-        isNull(providerRunners.workspaceId),
-        isNull(providerRunners.reservationId),
-        isNull(providerRunners.runnerSessionId),
+        canBindRunner(),
       ),
     );
 }

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -238,14 +238,15 @@ describe('reportRunnerInstances', () => {
       .set({expiresAt: new Date(Date.now() - 60_000)})
       .where(eq(reservations.id, staleReservationId));
     const reboundReservationId = await createReservation(2);
-    const reportedAt = new Date('2026-01-01T00:00:00.000Z');
+    const initialReportedAt = new Date(Date.now() - 120_000);
+    const runningReportedAt = new Date(Date.now() - 60_000);
     await providerRunnerFactory.create({
       workspaceId,
       provisionerId,
       providerRunnerId: 'rebound-runner',
       reservationId: reboundReservationId,
       state: 'running',
-      reportedAt,
+      reportedAt: initialReportedAt,
     });
 
     const runningReport = await reportRunnerInstances({
@@ -256,7 +257,7 @@ describe('reportRunnerInstances', () => {
         event({
           providerRunnerId: 'rebound-runner',
           reservationId: staleReservationId,
-          reportedAt,
+          reportedAt: runningReportedAt,
         }),
       ],
     });
@@ -269,7 +270,7 @@ describe('reportRunnerInstances', () => {
           providerRunnerId: 'rebound-runner',
           reservationId: staleReservationId,
           state: 'failed',
-          reportedAt: new Date(reportedAt.getTime() + 1_000),
+          reportedAt: new Date(runningReportedAt.getTime() + 1_000),
         }),
       ],
     });

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -249,6 +249,7 @@ describe('reportRunnerInstances', () => {
     });
 
     const runningReport = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [
@@ -260,6 +261,7 @@ describe('reportRunnerInstances', () => {
       ],
     });
     const terminalReport = await reportRunnerInstances({
+      scope: 'workspace',
       workspaceId,
       provisionerId,
       events: [

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -231,6 +231,74 @@ describe('reportRunnerInstances', () => {
     expect(rows[0]?.reason).toBe('fresh');
   });
 
+  it('preserves a rebound reservation through stale reports and releases it on termination', async () => {
+    const staleReservationId = await createReservation(1);
+    await db()
+      .update(reservations)
+      .set({expiresAt: new Date(Date.now() - 60_000)})
+      .where(eq(reservations.id, staleReservationId));
+    const reboundReservationId = await createReservation(2);
+    const reportedAt = new Date('2026-01-01T00:00:00.000Z');
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'rebound-runner',
+      reservationId: reboundReservationId,
+      state: 'running',
+      reportedAt,
+    });
+
+    const runningReport = await reportRunnerInstances({
+      workspaceId,
+      provisionerId,
+      events: [
+        event({
+          providerRunnerId: 'rebound-runner',
+          reservationId: staleReservationId,
+          reportedAt,
+        }),
+      ],
+    });
+    const terminalReport = await reportRunnerInstances({
+      workspaceId,
+      provisionerId,
+      events: [
+        event({
+          providerRunnerId: 'rebound-runner',
+          reservationId: staleReservationId,
+          state: 'failed',
+          reportedAt: new Date(reportedAt.getTime() + 1_000),
+        }),
+      ],
+    });
+
+    const [runner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.providerRunnerId, 'rebound-runner'));
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    expect(runningReport).toEqual({
+      accepted: 1,
+      reservationsReleased: 0,
+      terminateIntentsHonored: [],
+    });
+    expect(terminalReport).toEqual({
+      accepted: 1,
+      reservationsReleased: 1,
+      terminateIntentsHonored: [],
+    });
+    expect(runner).toMatchObject({
+      reservationId: reboundReservationId,
+      reservationReleasedAt: expect.any(Date),
+    });
+    expect(
+      reservationRows.find((reservation) => reservation.id === reboundReservationId)?.count,
+    ).toBe(1);
+    expect(
+      reservationRows.find((reservation) => reservation.id === staleReservationId)?.count,
+    ).toBe(1);
+  });
+
   it('does not let equal-timestamp lower-priority reports flip terminal state', async () => {
     const reservationId = await createReservation(1);
     const reportedAt = new Date('2025-01-01T00:00:00.000Z');

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -190,7 +190,7 @@ export async function reportRunnerInstances(params: ReportRunnerInstancesParams)
         target: [providerRunners.provisionerId, providerRunners.providerRunnerId],
         targetWhere: isNotNull(providerRunners.providerRunnerId),
         set: {
-          reservationId: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN coalesce(excluded.reservation_id, ${providerRunners.reservationId}) ELSE ${providerRunners.reservationId} END`,
+          reservationId: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN coalesce(${providerRunners.reservationId}, excluded.reservation_id) ELSE ${providerRunners.reservationId} END`,
           templateKey: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN coalesce(excluded.template_key, ${providerRunners.templateKey}) ELSE ${providerRunners.templateKey} END`,
           labels: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN excluded.labels ELSE ${providerRunners.labels} END`,
           state: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN excluded.state ELSE ${providerRunners.state} END`,

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -59,33 +59,44 @@ export async function createRunnerSessionConsumingActivationToken(params: {
   toolCapabilities?: RunnerToolCapabilitiesDto | null;
 }) {
   return await db().transaction(async (tx) => {
-    const [token] = await tx
+    const [runner] = await tx
       .select({
-        id: runnerActivationTokens.id,
-        runnerInstanceId: runnerActivationTokens.runnerInstanceId,
+        activationTokenId: runnerActivationTokens.id,
+        runnerInstanceId: providerRunners.id,
         workspaceId: providerRunners.workspaceId,
         provisionerId: providerRunners.provisionerId,
         providerRunnerId: providerRunners.providerRunnerId,
+        runnerSessionId: providerRunners.runnerSessionId,
       })
       .from(runnerActivationTokens)
       .innerJoin(providerRunners, eq(providerRunners.id, runnerActivationTokens.runnerInstanceId))
+      .where(eq(runnerActivationTokens.id, params.activationTokenId))
+      .limit(1)
+      .for('update', {of: providerRunners});
+    if (!runner?.workspaceId || !runner.providerRunnerId || runner.runnerSessionId)
+      throw new Error('Runner activation token is invalid, expired, or has already been used');
+
+    const [activationToken] = await tx
+      .select({id: runnerActivationTokens.id})
+      .from(runnerActivationTokens)
       .where(
         and(
-          eq(runnerActivationTokens.id, params.activationTokenId),
+          eq(runnerActivationTokens.id, runner.activationTokenId),
+          eq(runnerActivationTokens.runnerInstanceId, runner.runnerInstanceId),
           isNull(runnerActivationTokens.consumedAt),
           isNull(runnerActivationTokens.revokedAt),
           gt(runnerActivationTokens.expiresAt, sql`now()`),
-          isNull(providerRunners.runnerSessionId),
         ),
       )
       .limit(1)
       .for('update');
-    if (!token?.workspaceId || !token.providerRunnerId)
+    if (!activationToken)
       throw new Error('Runner activation token is invalid, expired, or has already been used');
+
     const [provisioner] = await tx
       .select({scope: provisionerTokens.scope})
       .from(provisionerTokens)
-      .where(eq(provisionerTokens.id, token.provisionerId))
+      .where(eq(provisionerTokens.id, runner.provisionerId))
       .limit(1);
     const labels = sanitizeRunnerLabelsOrThrow(params.labels, {
       scope: provisioner?.scope ?? 'workspace',
@@ -95,13 +106,13 @@ export async function createRunnerSessionConsumingActivationToken(params: {
     const [session] = await tx
       .insert(runnerSessions)
       .values({
-        workspaceId: token.workspaceId,
+        workspaceId: runner.workspaceId,
         scope: 'workspace',
-        registrationTokenId: token.id,
+        registrationTokenId: activationToken.id,
         registrationTokenKind: 'activation',
-        runnerInstanceId: token.runnerInstanceId,
-        provisionerId: token.provisionerId,
-        providerRunnerId: token.providerRunnerId,
+        runnerInstanceId: runner.runnerInstanceId,
+        provisionerId: runner.provisionerId,
+        providerRunnerId: runner.providerRunnerId,
         labels,
         toolCapabilities: params.toolCapabilities ?? null,
         toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
@@ -113,13 +124,13 @@ export async function createRunnerSessionConsumingActivationToken(params: {
     await tx
       .update(runnerActivationTokens)
       .set({consumedAt: sql`now()`, consumedSessionId: session.id})
-      .where(eq(runnerActivationTokens.id, token.id));
+      .where(eq(runnerActivationTokens.id, activationToken.id));
     await tx
       .update(providerRunners)
       .set({runnerSessionId: session.id, updatedAt: sql`now()`})
       .where(
         and(
-          eq(providerRunners.id, token.runnerInstanceId),
+          eq(providerRunners.id, runner.runnerInstanceId),
           isNull(providerRunners.runnerSessionId),
         ),
       );
@@ -128,7 +139,7 @@ export async function createRunnerSessionConsumingActivationToken(params: {
       .set({closedAt: sql`now()`, closeReason: 'activated'})
       .where(
         and(
-          eq(runnerControlSessions.runnerInstanceId, token.runnerInstanceId),
+          eq(runnerControlSessions.runnerInstanceId, runner.runnerInstanceId),
           isNull(runnerControlSessions.closedAt),
         ),
       );


### PR DESCRIPTION
## Summary

Idle runners could remain stranded after intended or committed reservations expired or were deleted. This change makes stale bindings recoverable on the next demand poll, clears obsolete intent, revokes unconsumed activation tokens during ownership transfer, and prevents provider reports from replacing a committed reservation with a stale tag.

The follow-up policy and integration work is tracked in ENG-1504, ENG-1505, and ENG-1506.

Validation is complete across the affected package and dependents: tests, type checks, repository checks, dependency-cruiser, database-boundary verification, and changeset validation.

Closes ENG-1491

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
In `@shipfox/api-runners`, safely recover stale runner reservation bindings so idle runners aren’t stranded, while preserving committed assignments. Closes ENG-1491.

- **Bug Fixes**
  - Rebind idle runners on the next demand poll when intended or assigned reservations are expired or deleted; clear obsolete intended bindings.
  - Preserve committed reservation assignments; stale provider reservation tags no longer overwrite them, and reservations are released on termination as expected.
  - Revoke unconsumed activation tokens during rebinding and enforce safe, locked token consumption.

- **Refactors**
  - Aligned tests with provisioner scope and added coverage for stale intended/assigned reservations, rebinding, and reservation preservation.

<sup>Written for commit 33e5eda5e3c3937fa661ec489352d639e1368cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

