### PR TITLE
[provisioner-ec2] Stop retrying released reservation assignments

### DIFF
--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -234,6 +234,20 @@ describe('createEc2Lifecycle', () => {
     );
   });
 
+  it('keeps released reservation suppression while its runner remains observed', async () => {
+    const instances = [instance({state: 'running'})];
+    const client = fakeClient({assignmentErrors: [httpError(404)]});
+    const lifecycle = makeLifecycle({engine: fakeEngine({instances}), client});
+
+    await lifecycle.observe();
+    instances[0] = instance({state: 'stopped'});
+    await lifecycle.observe();
+    instances[0] = instance({state: 'running'});
+    await lifecycle.observe();
+
+    expect(client.assignmentBodies).toHaveLength(1);
+  });
+
   it('forgets a released reservation after its runner leaves the observed fleet', async () => {
     const instances = [instance({state: 'running'})];
     const client = fakeClient({assignmentErrors: [httpError(404)]});

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -181,7 +181,7 @@ describe('createEc2Lifecycle', () => {
       ],
     });
     const client = fakeClient({
-      assignmentErrors: [httpError(404)],
+      assignmentErrors: [httpError(503)],
       reconcileResponse: {
         runners: [reconciledRunner('runner-terminate', 'terminate')],
         terminated_absent_provider_runner_ids: [],
@@ -203,9 +203,62 @@ describe('createEc2Lifecycle', () => {
     );
     expect(engine.terminated).toEqual(['i-terminate']);
     expect(observability.logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({reservationId: '00000000-0000-4000-8000-000000000003'}),
-      'Reservation assignment rejected',
+      expect.objectContaining({
+        reservationId: '00000000-0000-4000-8000-000000000003',
+        status: 503,
+        retryable: true,
+      }),
+      'Reservation assignment rejected; will retry',
     );
+  });
+
+  it('stops retrying assignment after the reservation is released', async () => {
+    const client = fakeClient({assignmentErrors: [httpError(404)]});
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(client.assignmentBodies).toHaveLength(1);
+    expect(observability.logger.warn).toHaveBeenCalledTimes(1);
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reservationId: '00000000-0000-4000-8000-000000000003',
+        status: 404,
+        retryable: false,
+      }),
+      'Reservation assignment stopped because reservation was released',
+    );
+  });
+
+  it('forgets a released reservation after its runner leaves the observed fleet', async () => {
+    const instances = [instance({state: 'running'})];
+    const client = fakeClient({assignmentErrors: [httpError(404)]});
+    const lifecycle = makeLifecycle({engine: fakeEngine({instances}), client});
+
+    await lifecycle.observe();
+    instances.length = 0;
+    await lifecycle.observe();
+    instances.push(instance({state: 'running'}));
+    await lifecycle.observe();
+
+    expect(client.assignmentBodies).toHaveLength(2);
+  });
+
+  it('retries a transient assignment failure on a later observation', async () => {
+    const client = fakeClient({assignmentErrors: [httpError(503)]});
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(client.assignmentBodies).toHaveLength(2);
   });
 
   it('reports a Spot-reclaimed terminated instance as failed', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -73,6 +73,7 @@ interface Ec2LifecycleContext {
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
+  readonly releasedReservationIds: Set<string>;
   lastReconciledAt?: Date;
 }
 
@@ -95,6 +96,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
     pendingReports: [],
+    releasedReservationIds: new Set(),
   };
 
   return {
@@ -303,8 +305,15 @@ async function assignEnrolledReservations(
   context: Ec2LifecycleContext,
   candidates: readonly AssignmentCandidate[],
 ): Promise<void> {
+  const candidateReservationIds = new Set(candidates.map(({reservationId}) => reservationId));
+  for (const reservationId of context.releasedReservationIds) {
+    if (!candidateReservationIds.has(reservationId))
+      context.releasedReservationIds.delete(reservationId);
+  }
+
   const assignments = new Map<string, string[]>();
   for (const {reservationId, runnerInstanceId} of candidates) {
+    if (context.releasedReservationIds.has(reservationId)) continue;
     const runnerInstanceIds = assignments.get(reservationId) ?? [];
     runnerInstanceIds.push(runnerInstanceId);
     assignments.set(reservationId, runnerInstanceIds);
@@ -313,9 +322,14 @@ async function assignEnrolledReservations(
     try {
       await context.client.assignRunnerInstances(reservationId, runnerInstanceIds);
     } catch (error) {
+      const status = responseStatus(error);
+      const reservationWasReleased = status === 404;
+      if (reservationWasReleased) context.releasedReservationIds.add(reservationId);
       logger().warn(
-        {reservationId, runnerInstanceIds, err: error},
-        'Reservation assignment rejected',
+        {reservationId, runnerInstanceIds, err: error, status, retryable: !reservationWasReleased},
+        reservationWasReleased
+          ? 'Reservation assignment stopped because reservation was released'
+          : 'Reservation assignment rejected; will retry',
       );
     }
   }

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -73,7 +73,7 @@ interface Ec2LifecycleContext {
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
-  readonly releasedReservationIds: Set<string>;
+  readonly releasedReservationRunnerIds: Map<string, Set<string>>;
   lastReconciledAt?: Date;
 }
 
@@ -96,7 +96,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
     pendingReports: [],
-    releasedReservationIds: new Set(),
+    releasedReservationRunnerIds: new Map(),
   };
 
   return {
@@ -234,11 +234,13 @@ async function applyObservedInstances(
   const events: RunnerInstanceReportEventDto[] = [];
   const assignmentCandidates: AssignmentCandidate[] = [];
   const observedIds = new Set<string>();
+  const observedRunnerInstanceIds = new Set<string>();
   const reapInstances: Ec2InstanceView[] = [];
   const terminateIntentInstances: Ec2InstanceView[] = [];
 
   for (const instance of instances) {
     const identity = parseInstanceIdentity(instance);
+    if (identity.runnerInstanceId) observedRunnerInstanceIds.add(identity.runnerInstanceId);
     if (!identity.providerRunnerId) continue;
     observedIds.add(identity.providerRunnerId);
     context.locallyLaunched.delete(identity.providerRunnerId);
@@ -295,7 +297,7 @@ async function applyObservedInstances(
 
   synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
   context.tracker.replaceAll(trackerRunners);
-  await assignEnrolledReservations(context, assignmentCandidates);
+  await assignEnrolledReservations(context, assignmentCandidates, observedRunnerInstanceIds);
   if (events.length > 0) await reportEvents(context, events);
   await terminateInstances(context, terminateIntentInstances, 'backend-terminate');
   await terminateInstances(context, reapInstances, 'registration-deadline');
@@ -304,16 +306,13 @@ async function applyObservedInstances(
 async function assignEnrolledReservations(
   context: Ec2LifecycleContext,
   candidates: readonly AssignmentCandidate[],
+  observedRunnerInstanceIds: ReadonlySet<string>,
 ): Promise<void> {
-  const candidateReservationIds = new Set(candidates.map(({reservationId}) => reservationId));
-  for (const reservationId of context.releasedReservationIds) {
-    if (!candidateReservationIds.has(reservationId))
-      context.releasedReservationIds.delete(reservationId);
-  }
+  pruneReleasedReservationRunners(context, observedRunnerInstanceIds);
 
   const assignments = new Map<string, string[]>();
   for (const {reservationId, runnerInstanceId} of candidates) {
-    if (context.releasedReservationIds.has(reservationId)) continue;
+    if (context.releasedReservationRunnerIds.has(reservationId)) continue;
     const runnerInstanceIds = assignments.get(reservationId) ?? [];
     runnerInstanceIds.push(runnerInstanceId);
     assignments.set(reservationId, runnerInstanceIds);
@@ -324,7 +323,13 @@ async function assignEnrolledReservations(
     } catch (error) {
       const status = responseStatus(error);
       const reservationWasReleased = status === 404;
-      if (reservationWasReleased) context.releasedReservationIds.add(reservationId);
+      if (reservationWasReleased) {
+        const releasedRunnerInstanceIds =
+          context.releasedReservationRunnerIds.get(reservationId) ?? new Set<string>();
+        for (const runnerInstanceId of runnerInstanceIds)
+          releasedRunnerInstanceIds.add(runnerInstanceId);
+        context.releasedReservationRunnerIds.set(reservationId, releasedRunnerInstanceIds);
+      }
       logger().warn(
         {reservationId, runnerInstanceIds, err: error, status, retryable: !reservationWasReleased},
         reservationWasReleased
@@ -332,6 +337,19 @@ async function assignEnrolledReservations(
           : 'Reservation assignment rejected; will retry',
       );
     }
+  }
+}
+
+function pruneReleasedReservationRunners(
+  context: Ec2LifecycleContext,
+  observedRunnerInstanceIds: ReadonlySet<string>,
+): void {
+  for (const [reservationId, runnerInstanceIds] of context.releasedReservationRunnerIds) {
+    for (const runnerInstanceId of runnerInstanceIds) {
+      if (!observedRunnerInstanceIds.has(runnerInstanceId))
+        runnerInstanceIds.delete(runnerInstanceId);
+    }
+    if (runnerInstanceIds.size === 0) context.releasedReservationRunnerIds.delete(reservationId);
   }
 }
 


### PR DESCRIPTION
Stop EC2 assignment retries once the API has confirmed that the reservation was released.

The lifecycle remembers released reservation IDs across observe ticks, emits explicit retryable context, and prunes IDs when their runner leaves the observed fleet. Transient assignment failures remain retryable.

Closes ENG-1497

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `provisioner-ec2` from retrying reservation assignments after the API confirms the reservation was released. Keeps retries for transient failures and reduces unnecessary calls and logs; addresses ENG-1497.

- **Bug Fixes**
  - Suppress 404 assignment retries per `runnerInstanceId` while the runner remains observed; prune when it leaves the fleet.
  - Distinguish 404 (released) vs 503 (transient) and include status + retryable in logs.
  - Add tests for per-runner suppression, pruning, and transient retries.

<sup>Written for commit a3d1c5b71818fd31564c0d551702afc4481341c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

