### PR TITLE
[provisioner-core] Let provisioner adapters declare reservation TTL

### DIFF
--- a/.changeset/declare-reservation-ttl.md
+++ b/.changeset/declare-reservation-ttl.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/provisioner-core': minor
+---
+
+Let provisioner adapters request provider-specific reservation TTLs during demand polling. `startProvisioner` rejects an adapter whose `reservationTtlSeconds` is not a positive integer.

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -36,6 +36,43 @@ describe('runProvisionerIteration', () => {
     vi.clearAllMocks();
   });
 
+  it('forwards the adapter reservation TTL to demand polling', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      reservationTtlSeconds: 300,
+      launch: () => Promise.resolve(),
+    };
+
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+    });
+
+    expect(pollBodies[0]).toMatchObject({reservation_ttl_seconds: 300});
+  });
+
+  it('omits the reservation TTL when the adapter does not declare one', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+    };
+
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+    });
+
+    expect(pollBodies[0]).not.toHaveProperty('reservation_ttl_seconds');
+  });
+
   it('runs onTick before polling demand', async () => {
     const events: string[] = [];
     const {client} = harness({
@@ -462,6 +499,29 @@ describe('split demand and converge loops', () => {
 });
 
 describe('startProvisioner', () => {
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects an invalid adapter reservation TTL of %s', async (reservationTtlSeconds) => {
+    const onConfigure = vi.fn();
+
+    await expect(
+      startProvisioner({
+        adapter: {
+          loadTemplates: () => Promise.resolve([template]),
+          reservationTtlSeconds,
+          launch: () => Promise.resolve(),
+          onConfigure,
+        },
+      }),
+    ).rejects.toThrow('reservationTtlSeconds');
+
+    expect(onConfigure).not.toHaveBeenCalled();
+  });
+
   it('rejects more than 1000 templates with a clear error', async () => {
     const templates = Array.from({length: 1001}, (_, index) => ({
       ...template,

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -103,6 +103,15 @@ export async function startProvisioner<Spec>(
       `Provisioner has ${templates.length} templates; the demand poll accepts at most ${MAX_TEMPLATES_PER_POLL}. Reduce the configured templates.`,
     );
   }
+  if (
+    options.adapter.reservationTtlSeconds !== undefined &&
+    (!Number.isInteger(options.adapter.reservationTtlSeconds) ||
+      options.adapter.reservationTtlSeconds < 1)
+  ) {
+    throw new Error(
+      `Provisioner adapter reservationTtlSeconds is ${options.adapter.reservationTtlSeconds}; the demand poll accepts a whole number of seconds of at least 1. Set a positive integer.`,
+    );
+  }
 
   const providerConfiguration = (await options.adapter.onConfigure?.({templates})) ?? {};
   logger().info(
@@ -318,6 +327,9 @@ export async function runDemandIteration<Spec>(
         : deps.adapter.terminate
           ? {terminate: deps.adapter.terminate}
           : {}),
+      ...(deps.adapter.reservationTtlSeconds !== undefined
+        ? {reservationTtlSeconds: deps.adapter.reservationTtlSeconds}
+        : {}),
       buildRunnerEnv,
       reservationLimit,
       launchBudget,

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -36,6 +36,8 @@ export interface ProvisionerTickDeps<Spec> {
   readonly launch: LaunchRunner<Spec>;
   readonly terminate?: TerminateRunners;
   readonly buildRunnerEnv: RunnerEnvFactory<Spec>;
+  /** Optional reservation lifetime requested for the demand poll, in seconds. */
+  readonly reservationTtlSeconds?: number;
   readonly reservationLimit: number;
   readonly launchBudget: number | (() => number);
   readonly waitSeconds: number;
@@ -106,6 +108,9 @@ export async function runProvisionerTick<Spec>(
   const response = await deps.client.pollDemand(
     {
       wait_seconds: deps.waitSeconds,
+      ...(deps.reservationTtlSeconds !== undefined
+        ? {reservation_ttl_seconds: deps.reservationTtlSeconds}
+        : {}),
       max_reservations: pollReservationLimit,
       templates: advertisements,
     },

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -80,6 +80,8 @@ export interface ProvisionerRuntime {
  */
 export interface ProvisionerAdapter<Spec = unknown> {
   loadTemplates(): Promise<readonly ProvisionerTemplate<Spec>[]>;
+  /** Optional reservation lifetime requested for each demand poll, in seconds. */
+  readonly reservationTtlSeconds?: number;
   /** Optional provider details added to the startup configuration record. */
   onConfigure?(args: {
     templates: readonly ProvisionerTemplate<Spec>[];


### PR DESCRIPTION
Provisioner adapters can now optionally declare `reservationTtlSeconds` for demand polling.

The core forwards the value as `reservation_ttl_seconds` when configured and omits the field otherwise, preserving existing adapter behavior. Invalid configured values are rejected during startup before provider configuration, preventing repeated API 400 responses from wedging the demand loop. Regression coverage and a package changeset are included.

Closes ENG-1496

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adapters can request a reservation TTL for demand polls. `@shipfox/provisioner-core` forwards it to providers and validates it at startup to prevent bad polls. Closes ENG-1496.

- New Features
  - Optional adapter field `reservationTtlSeconds` (seconds) to control reservation lifetime per poll.
  - Forwarded as `reservation_ttl_seconds` during demand polling; omitted when unset. Invalid values (non-integer, <= 0, NaN, Infinity) are rejected before provider configuration to avoid repeated 400s.

<sup>Written for commit ad38717e4a0ce2daafc66e764643d232aef2941d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

