### PR TITLE
[api-runners] Preserve committed runner assignments during enrollment

### DIFF
--- a/.changeset/protect-runner-metadata.md
+++ b/.changeset/protect-runner-metadata.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Preserves committed runner assignment metadata during enrollment.

--- a/libs/api/runners/src/core/runner-control-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.test.ts
@@ -1,6 +1,8 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {afterEach, vi} from '@shipfox/vitest/vi';
-import {inArray} from 'drizzle-orm';
+import {eq, inArray} from 'drizzle-orm';
 import {db} from '#db/db.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {reservations} from '#db/schema/reservations.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
@@ -12,6 +14,7 @@ import {
 import {enrollRunnerControlSession} from './runner-control-sessions.js';
 
 const createdReservationIds = new Set<string>();
+const createdProvisionerTokenIds = new Set<string>();
 const createdRunnerInstanceIds = new Set<string>();
 
 afterEach(async () => {
@@ -29,9 +32,14 @@ afterEach(async () => {
   }
   if (reservationIds.length > 0)
     await db().delete(reservations).where(inArray(reservations.id, reservationIds));
+  if (createdProvisionerTokenIds.size > 0)
+    await db()
+      .delete(provisionerTokens)
+      .where(inArray(provisionerTokens.id, [...createdProvisionerTokenIds]));
 
   createdRunnerInstanceIds.clear();
   createdReservationIds.clear();
+  createdProvisionerTokenIds.clear();
 });
 
 describe('enrollRunnerControlSession', () => {
@@ -108,6 +116,139 @@ describe('enrollRunnerControlSession', () => {
     } finally {
       addSpy.mockRestore();
     }
+  });
+
+  it('preserves committed assignment metadata during a later enrollment', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({provisionerId});
+    const committedCapabilities: RunnerToolCapabilitiesDto = {
+      harnesses: {pi: {tools: ['read']}},
+    };
+    const runnerInstanceId = await createRunner({
+      provisionerId,
+      intendedReservationId: reservation.id,
+      reservationId: reservation.id,
+      workspaceId: reservation.workspaceId,
+      assignedAt: new Date(),
+      labels: ['linux'],
+      providerKind: 'ec2',
+      protocolVersion: '1',
+      capabilities: committedCapabilities,
+    });
+
+    const activationToken = await enrollRunnerControlSession({
+      runnerInstanceId,
+      provisionerId,
+      labels: ['gpu'],
+      capabilities: {harnesses: {claude: {tools: ['bash']}}},
+      providerKind: 'docker',
+      protocolVersion: '2',
+    });
+    const [runner] = await db()
+      .select({
+        reservationId: providerRunners.reservationId,
+        labels: providerRunners.labels,
+        providerKind: providerRunners.providerKind,
+        protocolVersion: providerRunners.protocolVersion,
+        capabilities: providerRunners.capabilities,
+        state: providerRunners.state,
+      })
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runnerInstanceId));
+
+    expect(activationToken).toEqual(expect.any(String));
+    expect(runner).toEqual({
+      reservationId: reservation.id,
+      labels: ['linux'],
+      providerKind: 'ec2',
+      protocolVersion: '1',
+      capabilities: committedCapabilities,
+      state: 'running',
+    });
+  });
+
+  it('updates metadata when a provider report precedes assignment commit', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({provisionerId});
+    const capabilities: RunnerToolCapabilitiesDto = {
+      harnesses: {pi: {tools: ['read']}},
+    };
+    const runnerInstanceId = await createRunner({
+      provisionerId,
+      intendedReservationId: reservation.id,
+      reservationId: reservation.id,
+      assignedAt: null,
+    });
+
+    const activationToken = await enrollRunnerControlSession({
+      runnerInstanceId,
+      provisionerId,
+      labels: ['linux'],
+      capabilities,
+      providerKind: 'ec2',
+      protocolVersion: '1',
+    });
+    const [runner] = await db()
+      .select({
+        reservationId: providerRunners.reservationId,
+        assignedAt: providerRunners.assignedAt,
+        labels: providerRunners.labels,
+        providerKind: providerRunners.providerKind,
+        protocolVersion: providerRunners.protocolVersion,
+        capabilities: providerRunners.capabilities,
+        state: providerRunners.state,
+      })
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runnerInstanceId));
+
+    expect(activationToken).toBeNull();
+    expect(runner).toEqual({
+      reservationId: reservation.id,
+      assignedAt: null,
+      labels: ['linux'],
+      providerKind: 'ec2',
+      protocolVersion: '1',
+      capabilities,
+      state: 'running',
+    });
+  });
+
+  it('updates metadata during enrollment for an unassigned runner', async () => {
+    const provisionerId = crypto.randomUUID();
+    const capabilities: RunnerToolCapabilitiesDto = {
+      harnesses: {pi: {tools: ['read']}},
+    };
+    const runnerInstanceId = await createRunner({provisionerId});
+
+    const activationToken = await enrollRunnerControlSession({
+      runnerInstanceId,
+      provisionerId,
+      labels: ['linux'],
+      capabilities,
+      providerKind: 'docker',
+      protocolVersion: '1',
+    });
+    const [runner] = await db()
+      .select({
+        reservationId: providerRunners.reservationId,
+        labels: providerRunners.labels,
+        providerKind: providerRunners.providerKind,
+        protocolVersion: providerRunners.protocolVersion,
+        capabilities: providerRunners.capabilities,
+        state: providerRunners.state,
+      })
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runnerInstanceId));
+
+    expect(activationToken).toBeNull();
+    expect(runner).toEqual({
+      reservationId: null,
+      labels: ['linux'],
+      providerKind: 'docker',
+      protocolVersion: '1',
+      capabilities,
+      state: 'running',
+    });
   });
 
   it('keeps unexpected promotion failures on the error-log path', async () => {
@@ -207,18 +348,42 @@ async function createReservation(params: {
 
 async function createRunner(params: {
   provisionerId: string;
-  intendedReservationId: string;
-  reservationId?: string;
+  intendedReservationId?: string | null;
+  reservationId?: string | null;
+  workspaceId?: string | null;
   labels?: string[];
+  providerKind?: string | null;
+  protocolVersion?: string | null;
+  capabilities?: RunnerToolCapabilitiesDto | null;
+  assignedAt?: Date | null;
 }): Promise<string> {
+  const defaultAssignedAt = params.reservationId ? new Date() : null;
+
+  if (!createdProvisionerTokenIds.has(params.provisionerId)) {
+    await db().insert(provisionerTokens).values({
+      id: params.provisionerId,
+      scope: 'installation',
+      workspaceId: null,
+      hashedToken: crypto.randomUUID(),
+      prefix: 'test',
+      createdByUserId: crypto.randomUUID(),
+    });
+    createdProvisionerTokenIds.add(params.provisionerId);
+  }
+
   const [runner] = await db()
     .insert(providerRunners)
     .values({
       provisionerId: params.provisionerId,
-      intendedReservationId: params.intendedReservationId,
+      intendedReservationId: params.intendedReservationId ?? null,
       reservationId: params.reservationId ?? null,
+      workspaceId: params.workspaceId ?? null,
       providerRunnerId: crypto.randomUUID(),
       labels: params.labels ?? [],
+      providerKind: params.providerKind ?? null,
+      protocolVersion: params.protocolVersion ?? null,
+      capabilities: params.capabilities ?? null,
+      assignedAt: params.assignedAt === undefined ? defaultAssignedAt : params.assignedAt,
       state: 'starting',
       reportedAt: new Date(),
     })

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -163,7 +163,9 @@ export async function enrollRunnerControlSession(params: {
         sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${current.intendedReservationId}`}))`,
       );
 
-    const [updated] = await tx
+    // Provider reports may populate reservationId before the assignment commits. assignedAt is
+    // written by the assignment transaction, so keep the guard on that write boundary.
+    const [metadataUpdated] = await tx
       .update(providerRunners)
       .set({
         labels: sanitizeRunnerLabels(params.labels, {
@@ -173,6 +175,25 @@ export async function enrollRunnerControlSession(params: {
         providerKind: params.providerKind,
         protocolVersion: params.protocolVersion,
         capabilities: params.capabilities ?? null,
+      })
+      .where(
+        and(
+          eq(providerRunners.id, params.runnerInstanceId),
+          eq(providerRunners.provisionerId, params.provisionerId),
+          isNull(providerRunners.assignedAt),
+          notInArray(providerRunners.state, [...terminalStates]),
+        ),
+      )
+      .returning({id: providerRunners.id});
+    if (!metadataUpdated)
+      logger().debug(
+        {runnerInstanceId: params.runnerInstanceId, provisionerId: params.provisionerId},
+        'Runner enrollment metadata update skipped for assigned or terminal runner',
+      );
+
+    const [updated] = await tx
+      .update(providerRunners)
+      .set({
         state: 'running',
         reportedAt: sql`now()`,
         updatedAt: sql`now()`,


### PR DESCRIPTION
Enrollment can receive a reservation ID from a provider report before the assignment transaction commits. Using reservationId as the metadata guard can discard the enrolling runner's labels, provider metadata, protocol version, and capabilities.

This change uses assignedAt as the assignment boundary, keeps liveness updates independent, and records skipped metadata writes. Regression coverage covers committed assignments, early provider reports, and unassigned runners.

Closes ENG-1505


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves committed runner assignment metadata during enrollment by guarding metadata writes on `assignedAt`. Fixes cases where early provider reports could overwrite labels, provider data, protocol version, and capabilities (ENG-1505).

- **Bug Fixes**
  - Update `enrollRunnerControlSession` to only write metadata when `assignedAt` is null; preserve committed assignment data.
  - Keep liveness updates (`state`, `reportedAt`, `updatedAt`) independent of assignment.
  - Add regression tests for committed assignments, early provider reports, and unassigned runners; log skipped metadata updates.

<sup>Written for commit 99367e986aef71bc9f75cbd3f4e1be02ff909ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

