### PR TITLE
[provisioner-ec2] Derive reservation TTL from registration deadline

### DIFF
--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -113,5 +113,9 @@ The provider reads the shared provisioner variables plus these EC2-specific vari
 | --- | --- | --- | --- |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file with EC2 launch and capacity configuration. |
 | `AWS_REGION` | yes | - | AWS region where runner instances launch. |
-| `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time a launched instance may wait for runner registration. |
+| `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time a launched instance may wait for runner registration. Also sets the reservation lifetime the provider requests on each demand poll. |
 | `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval for a full backend reconcile using EC2 instance tags. |
+
+The API clamps the requested reservation lifetime to its own `RESERVATION_TTL_MAX_SECONDS`
+ceiling and does not report the clamp. Raising the registration deadline past that ceiling
+therefore shortens the reservation relative to the deadline: raise both together.

--- a/libs/provisioner/ec2/src/config.ts
+++ b/libs/provisioner/ec2/src/config.ts
@@ -15,7 +15,7 @@ export const config = createConfig({
     desc: 'AWS region the runner instances launch in, such as us-east-1. Required. Read by the AWS SDK and by the provider.',
   }),
   SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS: num({
-    desc: 'How long a launched instance may run without a runner registering before the provisioner terminates it as stale, in milliseconds.',
+    desc: 'How long a launched instance may run without a runner registering before the provisioner terminates it as stale, in milliseconds. The EC2 provisioner derives the reservation lifetime sent with each demand poll from this setting, so changing it changes both deadlines. The API caps the requested lifetime at RESERVATION_TTL_MAX_SECONDS and does not report the clamp, so raise that ceiling alongside any increase here.',
     default: 300_000,
   }),
   SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS: num({

--- a/libs/provisioner/ec2/src/provisioner.test.ts
+++ b/libs/provisioner/ec2/src/provisioner.test.ts
@@ -1,0 +1,45 @@
+import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
+import type {Ec2Engine} from '#ec2-engine.js';
+import {createEc2ProvisionerAdapter} from '#provisioner.js';
+import type {Ec2TemplateSpec} from '#templates.js';
+
+const template: ProvisionerTemplate<Ec2TemplateSpec> = {
+  key: 'small',
+  labels: ['linux'],
+  maxConcurrency: 1,
+  cost: 1,
+  spec: {
+    ami: 'ami-0123456789abcdef0',
+    instanceType: 't3.small',
+    market: 'on-demand',
+    spotMaxPrice: null,
+    subnets: ['subnet-123'],
+    securityGroups: ['sg-123'],
+    associatePublicIp: false,
+    rootVolumeGb: 20,
+    rootDeviceName: '/dev/sda1',
+  },
+};
+
+const engine: Ec2Engine = {
+  runInstance: () => Promise.reject(new Error('not used')),
+  listManaged: () => Promise.resolve([]),
+  terminate: () => Promise.resolve(),
+};
+
+describe('createEc2ProvisionerAdapter', () => {
+  it.each([
+    [300_000, 300],
+    [300_001, 301],
+    [1, 1],
+  ])('derives a reservation TTL from a %d ms registration deadline', (registrationDeadlineMs, reservationTtlSeconds) => {
+    const adapter = createEc2ProvisionerAdapter({
+      engine,
+      templates: [template],
+      registrationDeadlineMs,
+      reconcileIntervalMs: 60_000,
+    });
+
+    expect(adapter.reservationTtlSeconds).toBe(reservationTtlSeconds);
+  });
+});

--- a/libs/provisioner/ec2/src/provisioner.ts
+++ b/libs/provisioner/ec2/src/provisioner.ts
@@ -29,6 +29,9 @@ export function createEc2ProvisionerAdapter(
 
   return {
     loadTemplates: () => Promise.resolve(options.templates),
+    reservationTtlSeconds: reservationTtlSecondsFromRegistrationDeadline(
+      options.registrationDeadlineMs,
+    ),
     launch: (launch) => requireLifecycle(lifecycle).launch(launch),
     terminate: (ids) => requireLifecycle(lifecycle).terminate(ids),
     async onStart(runtime) {
@@ -53,6 +56,10 @@ export function startEc2Provisioner(): Promise<void> {
       reconcileIntervalMs: config.SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS,
     }),
   });
+}
+
+function reservationTtlSecondsFromRegistrationDeadline(registrationDeadlineMs: number): number {
+  return Math.ceil(registrationDeadlineMs / 1000);
 }
 
 function createLifecycle(


### PR DESCRIPTION
Use `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` as the source of truth for the EC2 adapter's reservation TTL. The adapter converts the configured milliseconds to whole seconds, rounding up, and the EC2 configuration and README document the API ceiling relationship.

Regression coverage verifies the default conversion and changed deadlines. Launch headroom remains a separate follow-up in ENG-1507 because it requires the server-side reservation ceiling to move first.

Closes ENG-1501

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the EC2 reservation TTL from `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS`, rounding up to whole seconds so reservations track the registration deadline. Documents the API ceiling behavior and adds tests. Closes ENG-1501.

- **New Features**
  - Compute and send reservation TTL from the registration deadline (ceil(ms/1000)).
  - Document API clamping to `RESERVATION_TTL_MAX_SECONDS` and update config descriptions.
  - Add tests to verify default and custom deadline conversions.

<sup>Written for commit 74b3f32c83efe2fa12a1da1767f21316dcb75dbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

