### PR TITLE
[provisioner-docker-provider] Derive reservation TTL from registration deadline

### DIFF
--- a/.changeset/docker-reservation-ttl.md
+++ b/.changeset/docker-reservation-ttl.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/provisioner-docker-provider': patch
+---
+
+Request a reservation TTL derived from `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` on every demand poll, so reservations live exactly as long as a created container may take to register.

--- a/.changeset/docker-reservation-ttl.md
+++ b/.changeset/docker-reservation-ttl.md
@@ -2,4 +2,4 @@
 '@shipfox/provisioner-docker-provider': patch
 ---
 
-Request a reservation TTL derived from `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` on every demand poll, so reservations live exactly as long as a created container may take to register.
+Derive the requested reservation TTL from `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS`, rounded up to whole seconds.

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -114,7 +114,7 @@ variables:
 | `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | - | JSON object of string-valued driver options. Requires `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER`; option values are never logged. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Retention time for failed runner containers, in milliseconds. Set `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed runner containers. Set `0` to disable retention. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before being reaped as stale. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before being reaped as stale. Also the reservation lifetime the provisioner requests on each demand poll, rounded up to whole seconds; the control plane clamps it to its own `RESERVATION_TTL_MAX_SECONDS`. |
 
 The core `SHIPFOX_RUNNER_API_URL` variable is injected into runner containers as
 `SHIPFOX_API_URL` and defaults to `SHIPFOX_API_URL`. Set it when containers reach the

--- a/libs/provisioner/docker/src/provisioner.test.ts
+++ b/libs/provisioner/docker/src/provisioner.test.ts
@@ -1,0 +1,52 @@
+const mocks = vi.hoisted(() => ({
+  createDockerEngine: vi.fn(() => ({})),
+  createDockerLifecycle: vi.fn(),
+  loadDockerTemplates: vi.fn(() => []),
+  logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
+  startProvisioner: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks.logger}));
+vi.mock('@shipfox/provisioner-core', () => ({startProvisioner: mocks.startProvisioner}));
+vi.mock('#docker-engine.js', () => ({
+  createDockerEngine: mocks.createDockerEngine,
+  DockerEngineError: class extends Error {},
+}));
+vi.mock('#lifecycle.js', () => ({createDockerLifecycle: mocks.createDockerLifecycle}));
+vi.mock('#templates.js', () => ({loadDockerTemplates: mocks.loadDockerTemplates}));
+
+describe('Docker provisioner reservation TTL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('derives the default reservation TTL from the registration deadline', async () => {
+    const {startDockerProvisioner} = await import('#provisioner.js');
+
+    await startDockerProvisioner();
+
+    expect(adapterOptions().reservationTtlSeconds).toBe(120);
+  });
+
+  it('derives a changed reservation TTL from the configured deadline', async () => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS', '180001');
+    vi.resetModules();
+    const {startDockerProvisioner} = await import('#provisioner.js');
+
+    await startDockerProvisioner();
+
+    expect(adapterOptions().reservationTtlSeconds).toBe(181);
+  });
+});
+
+function adapterOptions(): {reservationTtlSeconds: number} {
+  const calls = mocks.startProvisioner.mock.calls as unknown as Array<[unknown]>;
+  const options = calls.at(-1)?.[0];
+  if (!options) throw new Error('Docker provisioner did not start the core provisioner.');
+  return (options as {adapter: {reservationTtlSeconds: number}}).adapter;
+}

--- a/libs/provisioner/docker/src/provisioner.ts
+++ b/libs/provisioner/docker/src/provisioner.ts
@@ -29,6 +29,7 @@ export function startDockerProvisioner(): Promise<void> {
   return startProvisioner<DockerTemplateSpec>({
     adapter: {
       loadTemplates: () => Promise.resolve(templates),
+      reservationTtlSeconds: Math.ceil(config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS / 1000),
       async onConfigure() {
         if (!dockerLogDriver) {
           try {


### PR DESCRIPTION
The Docker provisioner now requests a reservation lifetime derived from `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS`, rounded up to whole seconds so a non-second-aligned deadline is not shortened. This keeps demand reservations aligned with the provider's registration window and documents the server-side clamp and package release metadata.

Closes ENG-1502

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Docker reservation TTL with the registration window by deriving it from `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS`, rounded up to whole seconds. Addresses ENG-1502 and prevents reservations expiring before containers can register.

- **New Features**
  - Provisioner now sets `reservationTtlSeconds` from `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` (rounded up).
  - README and the `@shipfox/provisioner-docker-provider` changeset document the behavior and note the control plane clamp to `RESERVATION_TTL_MAX_SECONDS`.

<sup>Written for commit fa644d7ac94ac32f299d032ba82611bad81e0d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

