### PR TITLE
[api-integration-core] Stabilize provider database teardown

### DIFF
--- a/.changeset/steady-pool-reset.md
+++ b/.changeset/steady-pool-reset.md
@@ -1,5 +1,0 @@
----
-"@shipfox/api-integration-core": patch
----
-
-Clears provider database handles before shared test pools close.

--- a/.changeset/steady-pool-reset.md
+++ b/.changeset/steady-pool-reset.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Clears provider database handles before shared test pools close.

--- a/libs/api/integration/core/test/env.ts
+++ b/libs/api/integration/core/test/env.ts
@@ -32,3 +32,6 @@ process.env.GITEA_BASE_URL = 'https://gitea.example.com';
 process.env.GITEA_SERVICE_USERNAME = 'shipfox-bot';
 process.env.GITEA_SERVICE_TOKEN = 'test-service-token';
 process.env.GITEA_WEBHOOK_SECRET = 'test-webhook-secret';
+process.env.SENTRY_APP_CLIENT_ID = 'test-client-id';
+process.env.SENTRY_APP_CLIENT_SECRET = 'test-client-secret';
+process.env.SENTRY_APP_SLUG = 'shipfox-test';

--- a/libs/api/integration/core/test/setup.ts
+++ b/libs/api/integration/core/test/setup.ts
@@ -1,5 +1,10 @@
 import './env.js';
+import {closeDb as closeGiteaDb} from '@shipfox/api-integration-gitea';
 import {closeDb as closeGithubDb} from '@shipfox/api-integration-github';
+import {closeDb as closeJiraDb} from '@shipfox/api-integration-jira';
+import {closeDb as closeLinearDb} from '@shipfox/api-integration-linear';
+import {closeDb as closeSentryDb} from '@shipfox/api-integration-sentry';
+import {closeDb as closeSlackDb} from '@shipfox/api-integration-slack';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {afterAll, afterEach, beforeAll, vi} from '@shipfox/vitest/vi';
 import {closeDb} from '#db/db.js';
@@ -15,5 +20,12 @@ afterEach(() => {
 afterAll(async () => {
   closeDb();
   closeGithubDb();
+  // isolate:false shares provider module state across files, so every memoized
+  // Drizzle handle must be cleared before the shared pool is ended.
+  closeLinearDb();
+  closeSlackDb();
+  closeJiraDb();
+  closeSentryDb();
+  closeGiteaDb();
   await closePostgresClient();
 });


### PR DESCRIPTION
Prevents integration-core tests from reusing provider Drizzle handles that still point to a closed PostgreSQL pool when Vitest shares module state across files.

The shared test teardown clears every provider database handle before ending the pool. The core test environment also supplies the Sentry values required by the shared provider imports.

Validation: the core package and dependency closure pass, including 87/87 Turbo tasks; the core suite passes 21 files and 142 tests; and 20 repeated package runs report zero failures and zero pool errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `@shipfox/api-integration-core` test teardown by clearing memoized provider DB handles before the shared PostgreSQL pool closes. Prevents "pool closed" errors when Vitest shares module state.

- **Bug Fixes**
  - Clear provider DB handles before ending the shared pool: `@shipfox/api-integration-github`, `@shipfox/api-integration-linear`, `@shipfox/api-integration-slack`, `@shipfox/api-integration-jira`, `@shipfox/api-integration-sentry`, `@shipfox/api-integration-gitea`.
  - Set required Sentry env vars in the test env (`SENTRY_APP_CLIENT_ID`, `SENTRY_APP_CLIENT_SECRET`, `SENTRY_APP_SLUG`) so shared provider imports initialize safely.
  - Close the `@shipfox/node-postgres` client only after providers are cleared to ensure clean shutdown across files.

<sup>Written for commit bff2b4311635a6bf53dcb31d186cb639fe1dc89e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

