### PR TITLE
[api-workflows] Load runner catalog and resolve job runner labels

### DIFF
--- a/.changeset/runner-catalog-resolution.md
+++ b/.changeset/runner-catalog-resolution.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": minor
+---
+
+Loads configured runner catalog names when materializing workflow runner labels.

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -44,8 +44,9 @@ const run = await runWorkflow(definitions, {
 | `RUNNER_CATALOG_PATH` | empty | Optional path to a YAML file mapping runner catalog names to complete runner label sets. |
 
 The catalog is loaded and validated once when the Workflows module is imported;
-restart the API after changing the file. An empty or comment-only file behaves
-like an unset path. Catalog names and labels are canonicalized to lowercase.
+restart the API after changing the file. An empty YAML document behaves like an
+unset path; a `null` or comment-only document is invalid. Catalog names and
+labels are canonicalized to lowercase.
 Values that do not match a catalog name remain literal labels, so a misspelled
 catalog name can leave a job waiting for a runner that never advertises it.
 

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -37,6 +37,25 @@ const run = await runWorkflow(definitions, {
 });
 ```
 
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RUNNER_CATALOG_PATH` | empty | Optional path to a YAML file mapping runner catalog names to complete runner label sets. |
+
+The catalog is loaded and validated once when the Workflows module is imported;
+restart the API after changing the file. An empty or comment-only file behaves
+like an unset path. Catalog names and labels are canonicalized to lowercase.
+Values that do not match a catalog name remain literal labels, so a misspelled
+catalog name can leave a job waiting for a runner that never advertises it.
+
+```yaml
+# runner-catalog.yaml
+shipfox-4cpu:
+  - arch.amd64
+  - cpu.4
+```
+
 ## Routes / API / Data Model
 
 Workflow routes keep UUIDs in path and query parameters. The run response

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -52,6 +52,7 @@
     "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/api-workspaces-dto": "workspace:*",
+    "@shipfox/config": "workspace:*",
     "@shipfox/inter-module": "workspace:*",
     "@shipfox/expression": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
@@ -67,6 +68,7 @@
     "@temporalio/common": "catalog:",
     "@temporalio/workflow": "catalog:",
     "drizzle-orm": "catalog:",
+    "js-yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
@@ -81,6 +83,7 @@
     "@temporalio/client": "catalog:",
     "@temporalio/testing": "catalog:",
     "@temporalio/worker": "catalog:",
+    "@types/js-yaml": "catalog:",
     "@types/pg": "catalog:",
     "drizzle-kit": "catalog:",
     "fastify": "catalog:",

--- a/libs/api/workflows/src/config.test.ts
+++ b/libs/api/workflows/src/config.test.ts
@@ -25,8 +25,8 @@ describe('loadRunnerCatalog', () => {
     expect(loadRunnerCatalog('')).toEqual({});
   });
 
-  it('treats an empty YAML document as empty', () => {
-    expect(loadRunnerCatalog(writeCatalog(''))).toEqual({});
+  it.each(['', ' \n\t'])('treats an empty YAML document as empty', (contents) => {
+    expect(loadRunnerCatalog(writeCatalog(contents))).toEqual({});
   });
 
   it.each([

--- a/libs/api/workflows/src/config.test.ts
+++ b/libs/api/workflows/src/config.test.ts
@@ -1,0 +1,78 @@
+import {randomUUID} from 'node:crypto';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {loadRunnerCatalog} from './config.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'api-workflows-'));
+});
+
+afterEach(() => {
+  rmSync(dir, {recursive: true, force: true});
+});
+
+function writeCatalog(contents: string): string {
+  const path = join(dir, `${randomUUID()}.yaml`);
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe('loadRunnerCatalog', () => {
+  it('returns an empty catalog when no path is configured', () => {
+    expect(loadRunnerCatalog('')).toEqual({});
+  });
+
+  it.each([
+    '',
+    '# just a comment',
+    '---\n',
+  ])('treats an empty YAML document as empty', (contents) => {
+    expect(loadRunnerCatalog(writeCatalog(contents))).toEqual({});
+  });
+
+  it('loads and validates a YAML catalog', () => {
+    const path = writeCatalog(`
+ShipFox-4CPU:
+  - OS.Ubuntu-Latest
+  - CPU.4
+`);
+
+    expect(loadRunnerCatalog(path)).toEqual({
+      'shipfox-4cpu': ['cpu.4', 'os.ubuntu-latest'],
+    });
+  });
+
+  it('includes the file path when the catalog file is missing', () => {
+    const path = join(dir, 'missing.yaml');
+
+    expect(() => loadRunnerCatalog(path)).toThrow(`Cannot read runner catalog config at ${path}`);
+  });
+
+  it('includes the file path when YAML is malformed', () => {
+    const path = writeCatalog('runner: [unclosed');
+
+    expect(() => loadRunnerCatalog(path)).toThrow(`Cannot parse runner catalog config at ${path}`);
+  });
+
+  it.each([
+    ['bad name', 'label'],
+    ['name', 'not a label'],
+  ])('includes the file path when the catalog contains an invalid %s', (name, value) => {
+    const path = writeCatalog(`${name}:\n  - ${value}\n`);
+
+    expect(() => loadRunnerCatalog(path)).toThrow(`Invalid runner catalog config at ${path}`);
+  });
+
+  it('rejects oversized entries at startup', () => {
+    const path = writeCatalog(
+      `too-many:\n${Array.from({length: 21}, (_, index) => `  - label-${index}`).join('\n')}\n`,
+    );
+
+    expect(() => loadRunnerCatalog(path)).toThrow(
+      `Runner catalog entry "too-many" in ${path} has 21 labels`,
+    );
+  });
+});

--- a/libs/api/workflows/src/config.test.ts
+++ b/libs/api/workflows/src/config.test.ts
@@ -25,12 +25,19 @@ describe('loadRunnerCatalog', () => {
     expect(loadRunnerCatalog('')).toEqual({});
   });
 
+  it('treats an empty YAML document as empty', () => {
+    expect(loadRunnerCatalog(writeCatalog(''))).toEqual({});
+  });
+
   it.each([
-    '',
     '# just a comment',
     '---\n',
-  ])('treats an empty YAML document as empty', (contents) => {
-    expect(loadRunnerCatalog(writeCatalog(contents))).toEqual({});
+    'null\n',
+    '~\n',
+  ])('rejects a null YAML document (%j)', (contents) => {
+    const path = writeCatalog(contents);
+
+    expect(() => loadRunnerCatalog(path)).toThrow(`Invalid runner catalog config at ${path}`);
   });
 
   it('loads and validates a YAML catalog', () => {

--- a/libs/api/workflows/src/config.ts
+++ b/libs/api/workflows/src/config.ts
@@ -31,6 +31,8 @@ export function loadRunnerCatalog(filePath: string): RunnerCatalog {
     );
   }
 
+  if (contents.trim() === '') return {};
+
   let raw: unknown;
   try {
     raw = yaml.load(contents);
@@ -40,8 +42,6 @@ export function loadRunnerCatalog(filePath: string): RunnerCatalog {
       {cause: error},
     );
   }
-
-  if (raw === undefined) return {};
 
   let catalog: RunnerCatalog;
   try {

--- a/libs/api/workflows/src/config.ts
+++ b/libs/api/workflows/src/config.ts
@@ -41,7 +41,7 @@ export function loadRunnerCatalog(filePath: string): RunnerCatalog {
     );
   }
 
-  if (raw === undefined || raw === null) return {};
+  if (raw === undefined) return {};
 
   let catalog: RunnerCatalog;
   try {

--- a/libs/api/workflows/src/config.ts
+++ b/libs/api/workflows/src/config.ts
@@ -1,0 +1,71 @@
+import {readFileSync} from 'node:fs';
+import {createConfig, str} from '@shipfox/config';
+import {MAX_RUNNER_LABELS, parseRunnerCatalog, type RunnerCatalog} from '@shipfox/runner-labels';
+import yaml from 'js-yaml';
+
+export const config = createConfig({
+  RUNNER_CATALOG_PATH: str({
+    desc: 'Path to the YAML file that maps runner catalog names to complete label sets. Leave it empty to use every job runner value as a literal label. The file is loaded at startup; restart the API after changing it.',
+    default: '',
+  }),
+});
+
+/** Raised when the configured runner catalog cannot be read, parsed, or validated. */
+export class RunnerCatalogConfigError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'RunnerCatalogConfigError';
+  }
+}
+
+export function loadRunnerCatalog(filePath: string): RunnerCatalog {
+  if (filePath === '') return {};
+
+  let contents: string;
+  try {
+    contents = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new RunnerCatalogConfigError(
+      `Cannot read runner catalog config at ${filePath}: ${errorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = yaml.load(contents);
+  } catch (error) {
+    throw new RunnerCatalogConfigError(
+      `Cannot parse runner catalog config at ${filePath}: ${errorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  if (raw === undefined || raw === null) return {};
+
+  let catalog: RunnerCatalog;
+  try {
+    catalog = parseRunnerCatalog(raw);
+  } catch (error) {
+    throw new RunnerCatalogConfigError(
+      `Invalid runner catalog config at ${filePath}: ${errorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  for (const [name, labels] of Object.entries(catalog)) {
+    if (labels.length > MAX_RUNNER_LABELS) {
+      throw new RunnerCatalogConfigError(
+        `Runner catalog entry "${name}" in ${filePath} has ${labels.length} labels; the maximum is ${MAX_RUNNER_LABELS}.`,
+      );
+    }
+  }
+
+  return catalog;
+}
+
+export const runnerCatalog = loadRunnerCatalog(config.RUNNER_CATALOG_PATH);
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -134,8 +134,15 @@ export class JobNotFoundError extends Error {
 }
 
 export class InvalidJobRunnerLabelsError extends Error {
-  constructor(readonly labels: readonly string[]) {
-    super(`Job runner labels are invalid: ${labels.join(', ')}`);
+  constructor(
+    readonly labels: readonly string[],
+    readonly requestedLabels: readonly string[] = labels,
+  ) {
+    const requestedSuffix =
+      requestedLabels.join(', ') === labels.join(', ')
+        ? ''
+        : ` (requested: ${requestedLabels.join(', ')})`;
+    super(`Job runner labels are invalid: ${labels.join(', ')}${requestedSuffix}`);
     this.name = 'InvalidJobRunnerLabelsError';
   }
 }

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.catalog.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.catalog.test.ts
@@ -1,0 +1,117 @@
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {workflowModel} from '#test/index.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'api-workflows-runner-catalog-'));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(dir, {recursive: true, force: true});
+});
+
+function template(source: string): string {
+  return `\${{ ${source} }}`;
+}
+
+function writeCatalog(contents: string): string {
+  const path = join(dir, 'runner-catalog.yaml');
+  writeFileSync(path, contents);
+  return path;
+}
+
+function executionContext(runner: string) {
+  return {
+    site: 'execution-creation' as const,
+    values: {
+      run: {
+        id: 'run-1',
+        name: 'Build',
+        definition_id: 'definition-1',
+        project_id: 'project-1',
+        workspace_id: 'workspace-1',
+        created_at: new Date('2026-06-30T12:00:00.000Z'),
+      },
+      trigger: {source: 'manual', event: 'fire'},
+      event: null,
+      inputs: null,
+      execution: {
+        index: 1,
+        name: 'build #1',
+        status: 'pending',
+        started_at: null,
+        finished_at: null,
+        events: [{data: {runner}, source: 'github', event: 'push'}],
+      },
+    },
+  };
+}
+
+describe('materializeJobRunner with a catalog', () => {
+  it('expands an interpolated catalog name and keeps free-form labels', async () => {
+    const path = writeCatalog(`
+shipfox-4cpu:
+  - arch.amd64
+  - cpu.4
+`);
+    vi.stubEnv('RUNNER_CATALOG_PATH', path);
+    vi.resetModules();
+
+    const {materializeJobRunner} = await import('./materialize-workflow-model.js');
+    const model = workflowModel({
+      jobs: {
+        build: {
+          runner: ['internal-network'],
+          runnerTemplates: [template('execution.events[0].data.runner')],
+          steps: [{run: 'npm test'}],
+        },
+      },
+    });
+    const [job] = model.jobs;
+    if (!job) throw new Error('Test model created no jobs');
+
+    const result = materializeJobRunner({
+      job,
+      context: executionContext('SHIPFOX-4CPU'),
+      definitionId: 'definition-1',
+    });
+
+    expect(result).toEqual(['arch.amd64', 'cpu.4', 'internal-network']);
+  });
+
+  it('validates the combined expanded label count', async () => {
+    const labels = (suffix: string) =>
+      Array.from({length: 8}, (_, index) => `  - label-${index}${suffix}`).join('\n');
+    const path = writeCatalog(
+      `first:\n${labels('')}\nsecond:\n${labels('-second')}\nthird:\n${labels('-third')}\n`,
+    );
+    vi.stubEnv('RUNNER_CATALOG_PATH', path);
+    vi.resetModules();
+
+    const {materializeJobRunner} = await import('./materialize-workflow-model.js');
+    const model = workflowModel({
+      jobs: {
+        build: {
+          runner: [],
+          runnerTemplates: [template('"first"'), template('"second"'), template('"third"')],
+          steps: [{run: 'npm test'}],
+        },
+      },
+    });
+    const [job] = model.jobs;
+    if (!job) throw new Error('Test model created no jobs');
+
+    expect(() =>
+      materializeJobRunner({
+        job,
+        context: executionContext('unused'),
+        definitionId: 'definition-1',
+      }),
+    ).toThrow('requested: first, second, third');
+  });
+});

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
@@ -1,5 +1,6 @@
 import {DEFAULT_JOB_CHECKOUT, type WorkflowModel} from '@shipfox/api-definitions-dto';
-import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
+import {findInvalidLabels, MAX_RUNNER_LABELS, resolveRunnerLabels} from '@shipfox/runner-labels';
+import {runnerCatalog} from '#config.js';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
@@ -112,10 +113,11 @@ export function materializeJobRunner(params: {
       definitionId: params.definitionId,
     }),
   );
-  const labels = canonicalizeLabels([...params.job.runner, ...resolvedLabels]);
+  const requestedLabels = [...params.job.runner, ...resolvedLabels];
+  const labels = resolveRunnerLabels(requestedLabels, runnerCatalog);
   const invalidLabels = findInvalidLabels(labels);
   if (labels.length === 0 || labels.length > MAX_RUNNER_LABELS || invalidLabels.length > 0) {
-    throw new InvalidJobRunnerLabelsError(labels);
+    throw new InvalidJobRunnerLabelsError(labels, requestedLabels);
   }
   return labels;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4371,6 +4371,9 @@ importers:
       '@shipfox/api-workspaces-dto':
         specifier: workspace:*
         version: link:../workspaces-dto
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../shared/common/config
       '@shipfox/expression':
         specifier: workspace:*
         version: link:../../shared/expression
@@ -4416,6 +4419,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      js-yaml:
+        specifier: 'catalog:'
+        version: 4.2.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -4453,6 +4459,9 @@ importers:
       '@temporalio/worker':
         specifier: 'catalog:'
         version: 1.18.1(@swc/helpers@0.5.23)(tslib@2.8.1)
+      '@types/js-yaml':
+        specifier: 'catalog:'
+        version: 4.0.9
       '@types/pg':
         specifier: ^8.15.5
         version: 8.20.0


### PR DESCRIPTION
Adds the workflow-owned runner catalog configuration and resolves catalog names when jobs are materialized.

The loader reads the optional YAML catalog at startup, validates entries before serving requests, preserves free-form labels and empty/unset behavior, and documents RUNNER_CATALOG_PATH for self-hosted deployments.

Closes ENG-1484

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load a workflow-owned runner catalog and resolve catalog names to concrete runner labels during job materialization, with startup validation that treats only blank files as empty and rejects null/comment-only docs while preserving literal labels. Aligns with ENG-1484.

- **New Features**
  - Load and validate a YAML runner catalog via `RUNNER_CATALOG_PATH` at startup using `@shipfox/config` and `js-yaml`; reject null/comment-only docs; only blank files are treated as empty.
  - Resolve catalog names in job runner labels, keeping any free-form labels.
  - Enforce label limits and surface clearer errors, including requested vs resolved labels.
  - Update docs and add tests; add deps `@shipfox/config`, `js-yaml`, and `@types/js-yaml`.

- **Migration**
  - Optionally set `RUNNER_CATALOG_PATH` to a YAML file; restart the API after changes.
  - Blank YAML files behave like unset; `null`, `---`, or comment-only files are invalid.
  - Catalog names and labels are lowercased; typos stay as literal labels and may prevent matching runners.

<sup>Written for commit 44bf8d9c4e3a799a10d892ddcd86884578dd0b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

