### PR TITLE
[api-runners] Define activation grace before stale runner rebinding

### DIFF
--- a/.changeset/steady-runners-rebind.md
+++ b/.changeset/steady-runners-rebind.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Uses provider reservation expiry as the activation grace period before stale runner assignments are rebound.

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -62,11 +62,11 @@ export const config = createConfig({
     default: 250,
   }),
   RESERVATION_TTL_SECONDS: num({
-    desc: 'Default lifetime of a count-based runner reservation, in seconds. Used when a provisioner does not request a provider-specific value. Expired reservations stop counting against queued demand.',
+    desc: 'Default lifetime and activation grace period of a count-based runner reservation, in seconds. A runner without a session can be rebound only after this deadline. Used when a provisioner does not request a provider-specific value. Expired reservations stop counting against queued demand.',
     default: 60,
   }),
   RESERVATION_TTL_MAX_SECONDS: num({
-    desc: `Server-side ceiling for a count-based runner reservation lifetime, in seconds. Set it at least as high as every provider registration deadline so provider-specific values can cover boot and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
+    desc: `Server-side ceiling for a count-based runner reservation lifetime and activation grace period, in seconds. Set it at least as high as every provider registration deadline so provider-specific values can cover boot and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
     default: 300,
   }),
   RESERVATION_LONG_POLL_MAX_WAIT_SECONDS: num({

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -86,7 +86,7 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
-  it('binds a runner whose intended reservation has expired', async () => {
+  it('binds a runner whose intended reservation has passed its activation grace period', async () => {
     const intendedReservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() - 60_000),
@@ -117,7 +117,7 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
-  it('binds a runner whose intended reservation was deleted', async () => {
+  it('binds a runner whose intended reservation was deleted after its grace period', async () => {
     const intendedReservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
@@ -149,7 +149,7 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
-  it('binds a runner whose assigned reservation has expired', async () => {
+  it('binds an assigned runner after its reservation grace period expires', async () => {
     const staleReservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() - 60_000),
@@ -197,7 +197,7 @@ describe('pollDemandAndReserve', () => {
     expect(storedToken?.revokedAt).toBeInstanceOf(Date);
   });
 
-  it('binds a runner whose assigned reservation was deleted', async () => {
+  it('binds an assigned runner whose reservation was deleted', async () => {
     const staleReservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
@@ -231,9 +231,9 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
-  it('does not bind a runner whose assigned reservation is still live', async () => {
+  it('does not bind an assigned runner within its activation grace period', async () => {
     const liveReservation = await createIntendedReservation({
-      workspaceId: crypto.randomUUID(),
+      workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
     });
     const runner = await createIdleRunner({
@@ -241,14 +241,14 @@ describe('pollDemandAndReserve', () => {
       workspaceId,
       reservationId: liveReservation.id,
     });
-    await createPendingJobs(1, ['linux']);
+    await createPendingJobs(2, ['linux']);
 
     const result = await pollDemandAndReserve({
       workspaceId,
       provisionerId,
-      maxReservations: 1,
+      maxReservations: 2,
       ttlSeconds: 60,
-      templates: [template('linux', ['linux'], 1)],
+      templates: [template('linux', ['linux'], 2)],
     });
 
     const [storedRunner] = await db()
@@ -264,7 +264,7 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
-  it('does not bind a runner whose intended reservation is still live', async () => {
+  it('does not bind a runner whose intended reservation is within its activation grace period', async () => {
     const intendedReservation = await createIntendedReservation({
       workspaceId: crypto.randomUUID(),
       expiresAt: new Date(Date.now() + 60_000),
@@ -293,6 +293,140 @@ describe('pollDemandAndReserve', () => {
       reservationId: null,
       intendedReservationId: intendedReservation.id,
       assignedAt: null,
+    });
+  });
+
+  it('does not rebind a stale runner from another workspace in a workspace-scoped poll', async () => {
+    const previousWorkspaceId = crypto.randomUUID();
+    const staleReservation = await createIntendedReservation({
+      workspaceId: previousWorkspaceId,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      workspaceId: previousWorkspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]?.count).toBe(1);
+    expect(storedRunner).toMatchObject({
+      workspaceId: previousWorkspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+    });
+  });
+
+  it('rebinds an unowned runner whose reservation was deleted', async () => {
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      reservationId: crypto.randomUUID(),
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: result.reservations[0]?.reservationId,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+  });
+
+  it('rebinds a stale runner across workspaces for an installation-scoped poll', async () => {
+    const previousWorkspaceId = crypto.randomUUID();
+    const targetWorkspaceId = crypto.randomUUID();
+    const staleReservation = await createIntendedReservation({
+      workspaceId: previousWorkspaceId,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      workspaceId: previousWorkspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+    });
+    await pendingJobFactory.create({workspaceId: targetWorkspaceId, requiredLabels: ['linux']});
+
+    const result = await pollInstallationDemandAndReserve({
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+      capabilityWindowSeconds: 60,
+      eligibleWorkspaceIds: new Set([targetWorkspaceId]),
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]).toMatchObject({workspaceId: targetWorkspaceId, count: 1});
+    expect(storedRunner).toMatchObject({
+      workspaceId: targetWorkspaceId,
+      reservationId: result.reservations[0]?.reservationId,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+  });
+
+  it('does not rebind a released runner after its reservation expires', async () => {
+    const staleReservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const releasedAt = new Date(Date.now() - 30_000);
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      workspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+      reservationReleasedAt: releasedAt,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]?.count).toBe(1);
+    expect(storedRunner).toMatchObject({
+      workspaceId,
+      reservationId: staleReservation.id,
+      intendedReservationId: staleReservation.id,
+      reservationReleasedAt: releasedAt,
     });
   });
 
@@ -1042,7 +1176,8 @@ describe('pollDemandAndReserve', () => {
     controlSessionExpiresAt?: Date;
     workspaceId?: string | null;
     reservationId?: string | null;
-    intendedReservationId?: string;
+    intendedReservationId?: string | null;
+    reservationReleasedAt?: Date | null;
   }) {
     const createdAt = params.createdAt ?? new Date();
     const [runner] = await db()
@@ -1051,8 +1186,9 @@ describe('pollDemandAndReserve', () => {
         provisionerId,
         workspaceId: params.workspaceId,
         reservationId: params.reservationId,
-        intendedReservationId: params.intendedReservationId,
         providerRunnerId: crypto.randomUUID(),
+        intendedReservationId: params.intendedReservationId,
+        reservationReleasedAt: params.reservationReleasedAt,
         labels: params.labels,
         state: 'running',
         reportedAt: createdAt,

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -68,6 +68,12 @@ export interface InstallationPollDemandAndReserveParams {
   onReservations?: (reservations: ReservationGrant[]) => void;
 }
 
+type DemandScope = 'installation' | 'workspace';
+
+type PollDemandAndReserveLockedParams = PollDemandAndReserveParams & {
+  scope: DemandScope;
+};
+
 interface NormalizedTemplate {
   templateKey: string;
   labels: string[];
@@ -93,7 +99,7 @@ export async function pollDemandAndReserveTx(
   params: PollDemandAndReserveParams,
 ): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
   await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId}))`);
-  return await pollDemandAndReserveLockedTx(tx, params);
+  return await pollDemandAndReserveLockedTx(tx, {...params, scope: 'workspace'});
 }
 
 export async function pollInstallationDemandAndReserve(
@@ -127,6 +133,7 @@ export async function pollInstallationDemandAndReserve(
           availableSlots: template.remainingSlots,
         })),
         capabilityWindowSeconds: params.capabilityWindowSeconds,
+        scope: 'installation',
       });
     });
     results.push(result);
@@ -159,7 +166,7 @@ function consumeInstallationTemplateSlots(
 
 async function pollDemandAndReserveLockedTx(
   tx: Tx,
-  params: PollDemandAndReserveParams,
+  params: PollDemandAndReserveLockedParams,
 ): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
   let demandRows = (
     await tx
@@ -266,6 +273,7 @@ async function pollDemandAndReserveLockedTx(
         requiredLabels: demand.requiredLabels,
         count: grant,
         workspaceId: params.workspaceId,
+        scope: params.scope,
       });
       reservedAfterGrant += grant;
       grants.push({
@@ -297,14 +305,23 @@ async function bindIdleRunnerInstancesTx(
     workspaceId: string;
     requiredLabels: string[];
     count: number;
+    scope: DemandScope;
   },
 ): Promise<void> {
+  // Reservation expiry is the activation grace deadline. A live reservation
+  // protects a runner that is still booting; an expired or missing row is stale.
   const canBindRunner = () =>
     and(
       or(
         and(isNull(providerRunners.workspaceId), isNull(providerRunners.reservationId)),
         and(
           isNotNull(providerRunners.reservationId),
+          params.scope === 'installation'
+            ? undefined
+            : or(
+                isNull(providerRunners.workspaceId),
+                eq(providerRunners.workspaceId, params.workspaceId),
+              ),
           notExists(
             tx
               .select({id: reservations.id})
@@ -332,6 +349,7 @@ async function bindIdleRunnerInstancesTx(
             ),
         ),
       ),
+      isNull(providerRunners.reservationReleasedAt),
       isNull(providerRunners.runnerSessionId),
     );
 

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -302,6 +302,68 @@ describe('reportRunnerInstances', () => {
     ).toBe(1);
   });
 
+  it('keeps the stored reservation when a report carries a stale reservation id', async () => {
+    const staleReservationId = await createReservation(1);
+    const boundReservationId = await createReservation(1);
+    await db()
+      .insert(providerRunners)
+      .values({
+        workspaceId,
+        provisionerId,
+        reservationId: boundReservationId,
+        providerRunnerId: 'provisioned-runner-1',
+        state: 'running',
+        reportedAt: new Date('2025-01-01T00:00:00.000Z'),
+      });
+
+    await reportRunnerInstances({
+      scope: 'workspace',
+      workspaceId,
+      provisionerId,
+      events: [
+        event({
+          providerRunnerId: 'provisioned-runner-1',
+          reservationId: staleReservationId,
+          state: 'running',
+          reportedAt: new Date('2025-01-01T00:01:00.000Z'),
+        }),
+      ],
+    });
+
+    const rows = await providerRunnerRowsFor({workspaceId, provisionerId});
+    expect(rows[0]?.reservationId).toBe(boundReservationId);
+  });
+
+  it('adopts a reported reservation id when the runner carries none', async () => {
+    const reservationId = await createReservation(1);
+    await db()
+      .insert(providerRunners)
+      .values({
+        workspaceId,
+        provisionerId,
+        providerRunnerId: 'provisioned-runner-1',
+        state: 'starting',
+        reportedAt: new Date('2025-01-01T00:00:00.000Z'),
+      });
+
+    await reportRunnerInstances({
+      scope: 'workspace',
+      workspaceId,
+      provisionerId,
+      events: [
+        event({
+          providerRunnerId: 'provisioned-runner-1',
+          reservationId,
+          state: 'running',
+          reportedAt: new Date('2025-01-01T00:01:00.000Z'),
+        }),
+      ],
+    });
+
+    const rows = await providerRunnerRowsFor({workspaceId, provisionerId});
+    expect(rows[0]?.reservationId).toBe(reservationId);
+  });
+
   it('does not let equal-timestamp lower-priority reports flip terminal state', async () => {
     const reservationId = await createReservation(1);
     const reportedAt = new Date('2025-01-01T00:00:00.000Z');


### PR DESCRIPTION
Define reservation expiry as the activation grace deadline before stale runner assignments can be rebound. Polling keeps workspace-scoped ownership boundaries while allowing installation-scoped reuse, excludes released runners, and documents the behavior in the @shipfox/api-runners patch changeset.

Closes ENG-1506

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets reservation expiry as the runner activation grace period, controlling when stale assignments can be rebound. Polling respects workspace boundaries, enables installation-scoped reuse, and ignores released runners. Closes ENG-1506.

- **New Features**
  - Treat reservation TTL as activation grace; updated config descriptions.
  - Workspace-scoped polls only rebind owned runners; installation-scoped polls can rebind across workspaces.
  - Skip rebinding runners with `reservationReleasedAt`.
  - Documented in a patch changeset for `@shipfox/api-runners`.

- **Bug Fixes**
  - Keep stored reservation when a runner reports a stale reservation id; adopt reported id only if the runner has none.
  - Expanded tests for grace windows, scoping, and rebinding rules.

<sup>Written for commit eae6f3754c1e06ac3aa83e1e0c95bd882c89a492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

