### PR TITLE
[api-runners] Report stale enrolled runners

### DIFF
--- a/.changeset/stale-runner-gauge.md
+++ b/.changeset/stale-runner-gauge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Adds a service gauge for enrolled runners without a recent provisioner report after the stale-runner grace window.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -20,14 +20,14 @@ summing the same shared value from every pod.
 
 The runners service exposes `runners_enrolled_without_recent_report` on port
 9474. It counts running runners with a live control session, no workspace, no
-runner session, and an `updated_at` older than the stale-runner grace window.
+runner session, and a `reported_at` older than the stale-runner grace window.
 
 The gauge uses `RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS` as its grace
 window. The default is five minutes. Alert when the value is greater than zero.
 Healthy warm-pool runners stay below the threshold because their provisioner
-refreshes `updated_at` with each running report. A warm-pool runner that remains
-stale after five minutes indicates a reporting or provisioner failure and is
-intentionally included in the alert.
+refreshes `reported_at` with each running report. A warm-pool runner that
+remains stale after five minutes indicates a reporting or provisioner failure
+and is intentionally included in the alert.
 
 ## Initialize in the required order
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -16,6 +16,19 @@ Use service metrics only for a point-in-time value from shared storage, such as
 a queue depth. Observable gauges use port 9474. This stops Prometheus from
 summing the same shared value from every pod.
 
+## Stale enrolled runner signal
+
+The runners service exposes `runners_enrolled_without_recent_report` on port
+9474. It counts running runners with a live control session, no workspace, no
+runner session, and an `updated_at` older than the stale-runner grace window.
+
+The gauge uses `RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS` as its grace
+window. The default is five minutes. Alert when the value is greater than zero.
+Healthy warm-pool runners stay below the threshold because their provisioner
+refreshes `updated_at` with each running report. A warm-pool runner that remains
+stale after five minutes indicates a reporting or provisioner failure and is
+intentionally included in the alert.
+
 ## Initialize in the required order
 
 Create instance instruments at module load in `src/metrics/instance.ts`. Record

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -90,6 +90,7 @@ export type {
 } from './runner-instances.js';
 export {
   attachRunnerInstanceProviderId,
+  countStaleEnrolledRunnerInstances,
   isTerminalState,
   listActiveRunnerInstanceCountsByTemplateTx,
   listActiveRunnerInstances,

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -4,6 +4,7 @@ import {db} from '#db/db.js';
 import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
 import {
   attachRunnerInstanceProviderId,
+  countStaleEnrolledRunnerInstances,
   listActiveRunnerInstanceCountsByTemplateTx,
   listActiveRunnerInstances,
   listProvisionerTerminateIntentRowsTx,
@@ -14,6 +15,7 @@ import {
 } from '#db/runner-instances.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {reservations} from '#db/schema/reservations.js';
+import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
@@ -2114,6 +2116,94 @@ describe('reconcileRunnerInstances', () => {
       providerKind: 'docker',
       reportedAt: params.reportedAt ?? new Date(),
     };
+  }
+});
+
+describe('countStaleEnrolledRunnerInstances', () => {
+  let provisionerId: string;
+
+  beforeEach(() => {
+    provisionerId = crypto.randomUUID();
+  });
+
+  function staleAt(): Date {
+    return new Date(Date.now() - 120_000);
+  }
+
+  it('counts only stale running runners with a live control session and no assignment', async () => {
+    const baseline = await countStaleEnrolledRunnerInstances({graceSeconds: 60});
+    const stale = await createRunner({updatedAt: staleAt()});
+    await createControlSession(stale);
+
+    const fresh = await createRunner({updatedAt: new Date()});
+    await createControlSession(fresh);
+
+    const assigned = await createRunner({workspaceId: crypto.randomUUID(), updatedAt: staleAt()});
+    await createControlSession(assigned);
+
+    const activated = await createRunner({
+      runnerSessionId: crypto.randomUUID(),
+      updatedAt: staleAt(),
+    });
+    await createControlSession(activated);
+
+    await createRunner({updatedAt: staleAt()});
+    const expiredControlSession = await createRunner({updatedAt: staleAt()});
+    await createControlSession(expiredControlSession, {
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    const closedControlSession = await createRunner({updatedAt: staleAt()});
+    await createControlSession(closedControlSession, {
+      closedAt: new Date(),
+    });
+    const stopped = await createRunner({state: 'stopped', updatedAt: staleAt()});
+    await createControlSession(stopped);
+
+    const count = await countStaleEnrolledRunnerInstances({graceSeconds: 60});
+
+    expect(count - baseline).toBe(1);
+  });
+
+  async function createRunner(params: {
+    state?: 'running' | 'stopped';
+    workspaceId?: string | null;
+    runnerSessionId?: string | null;
+    updatedAt: Date;
+  }) {
+    const [runner] = await db()
+      .insert(providerRunners)
+      .values({
+        workspaceId: params.workspaceId ?? null,
+        provisionerId,
+        providerRunnerId: crypto.randomUUID(),
+        templateKey: 'linux',
+        labels: ['linux'],
+        state: params.state ?? 'running',
+        runnerSessionId: params.runnerSessionId ?? null,
+        providerKind: 'docker',
+        reportedAt: params.updatedAt,
+        updatedAt: params.updatedAt,
+      })
+      .returning({id: providerRunners.id});
+    if (!runner) throw new Error('Expected runner instance');
+    return runner.id;
+  }
+
+  async function createControlSession(
+    runnerInstanceId: string,
+    params: {expiresAt?: Date; closedAt?: Date} = {},
+  ) {
+    await db()
+      .insert(runnerControlSessions)
+      .values({
+        runnerInstanceId,
+        provisionerId,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: params.expiresAt ?? new Date(Date.now() + 60_000),
+        closedAt: params.closedAt,
+        closeReason: params.closedAt ? 'test' : null,
+      });
   }
 });
 

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -2130,13 +2130,19 @@ describe('countStaleEnrolledRunnerInstances', () => {
     return new Date(Date.now() - 120_000);
   }
 
-  it('counts only stale running runners with a live control session and no assignment', async () => {
+  it('counts only stale reported runners with a live control session and no assignment', async () => {
     const baseline = await countStaleEnrolledRunnerInstances({graceSeconds: 60});
     const stale = await createRunner({updatedAt: staleAt()});
     await createControlSession(stale);
 
     const fresh = await createRunner({updatedAt: new Date()});
     await createControlSession(fresh);
+
+    const recentlyMutated = await createRunner({reportedAt: staleAt(), updatedAt: new Date()});
+    await createControlSession(recentlyMutated);
+
+    const freshReport = await createRunner({reportedAt: new Date(), updatedAt: staleAt()});
+    await createControlSession(freshReport);
 
     const assigned = await createRunner({workspaceId: crypto.randomUUID(), updatedAt: staleAt()});
     await createControlSession(assigned);
@@ -2161,15 +2167,17 @@ describe('countStaleEnrolledRunnerInstances', () => {
 
     const count = await countStaleEnrolledRunnerInstances({graceSeconds: 60});
 
-    expect(count - baseline).toBe(1);
+    expect(count - baseline).toBe(2);
   });
 
   async function createRunner(params: {
     state?: 'running' | 'stopped';
     workspaceId?: string | null;
     runnerSessionId?: string | null;
-    updatedAt: Date;
+    reportedAt?: Date;
+    updatedAt?: Date;
   }) {
+    const reportedAt = params.reportedAt ?? params.updatedAt ?? new Date();
     const [runner] = await db()
       .insert(providerRunners)
       .values({
@@ -2181,8 +2189,8 @@ describe('countStaleEnrolledRunnerInstances', () => {
         state: params.state ?? 'running',
         runnerSessionId: params.runnerSessionId ?? null,
         providerKind: 'docker',
-        reportedAt: params.updatedAt,
-        updatedAt: params.updatedAt,
+        reportedAt,
+        updatedAt: params.updatedAt ?? reportedAt,
       })
       .returning({id: providerRunners.id});
     if (!runner) throw new Error('Expected runner instance');

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -259,7 +259,7 @@ export async function countStaleEnrolledRunnerInstances(params: {
         eq(providerRunners.state, 'running'),
         isNull(providerRunners.workspaceId),
         isNull(providerRunners.runnerSessionId),
-        lt(providerRunners.updatedAt, staleRunnerInstanceCutoff(params.graceSeconds)),
+        lt(providerRunners.reportedAt, staleRunnerInstanceCutoff(params.graceSeconds)),
         exists(
           db()
             .select({id: runnerControlSessions.id})

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -29,6 +29,7 @@ import {releaseReservationUnits} from './reservations.js';
 import {ephemeralRegistrationTokens} from './schema/ephemeral-registration-tokens.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
+import {runnerControlSessions} from './schema/runner-control-sessions.js';
 import {providerRunners, toRunnerInstance} from './schema/runner-instances.js';
 import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
@@ -245,6 +246,36 @@ export async function listActiveRunnerInstanceCountsByTemplateTx(
       ? [{templateKey: row.templateKey, state: row.state, count: row.count}]
       : [],
   );
+}
+
+export async function countStaleEnrolledRunnerInstances(params: {
+  graceSeconds: number;
+}): Promise<number> {
+  const [row] = await db()
+    .select({count: sql<number>`count(*)::int`})
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.state, 'running'),
+        isNull(providerRunners.workspaceId),
+        isNull(providerRunners.runnerSessionId),
+        lt(providerRunners.updatedAt, staleRunnerInstanceCutoff(params.graceSeconds)),
+        exists(
+          db()
+            .select({id: runnerControlSessions.id})
+            .from(runnerControlSessions)
+            .where(
+              and(
+                eq(runnerControlSessions.runnerInstanceId, providerRunners.id),
+                isNull(runnerControlSessions.closedAt),
+                gt(runnerControlSessions.expiresAt, sql`now()`),
+              ),
+            ),
+        ),
+      ),
+    );
+
+  return row?.count ?? 0;
 }
 
 export async function listActiveRunnerInstances(params: {

--- a/libs/api/runners/src/metrics/service.test.ts
+++ b/libs/api/runners/src/metrics/service.test.ts
@@ -1,0 +1,87 @@
+const mocks = vi.hoisted(() => {
+  const gauge = {};
+  return {
+    addBatchObservableCallback: vi.fn(),
+    countStaleEnrolledRunnerInstances: vi.fn(),
+    createObservableGauge: vi.fn(() => gauge),
+    gauge,
+    getMeter: vi.fn(),
+    getJobExecutionQueueDepth: vi.fn(),
+    getServiceMetricsProvider: vi.fn(),
+  };
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  getServiceMetricsProvider: mocks.getServiceMetricsProvider,
+}));
+vi.mock('#config.js', () => ({
+  config: {RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS: 300},
+}));
+vi.mock('#db/job-executions.js', () => ({
+  getJobExecutionQueueDepth: mocks.getJobExecutionQueueDepth,
+}));
+vi.mock('#db/runner-instances.js', () => ({
+  countStaleEnrolledRunnerInstances: mocks.countStaleEnrolledRunnerInstances,
+}));
+
+import {registerRunnersServiceMetrics} from './service.js';
+
+describe('registerRunnersServiceMetrics', () => {
+  beforeEach(() => {
+    mocks.addBatchObservableCallback.mockReset();
+    mocks.countStaleEnrolledRunnerInstances.mockReset();
+    mocks.createObservableGauge.mockClear();
+    mocks.getJobExecutionQueueDepth.mockReset();
+    mocks.getMeter.mockReset();
+    mocks.getServiceMetricsProvider.mockReset();
+    mocks.getJobExecutionQueueDepth.mockResolvedValue({
+      pendingJobExecutions: 0,
+      runningJobExecutions: 0,
+    });
+    mocks.getMeter.mockReturnValue({
+      createObservableGauge: mocks.createObservableGauge,
+      addBatchObservableCallback: mocks.addBatchObservableCallback,
+    });
+    mocks.getServiceMetricsProvider.mockReturnValue({getMeter: mocks.getMeter});
+  });
+
+  it('observes enrolled runners without recent reports after the grace window', async () => {
+    mocks.countStaleEnrolledRunnerInstances.mockResolvedValue(2);
+
+    registerRunnersServiceMetrics();
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    if (typeof callback !== 'function') throw new Error('Expected metrics callback');
+    const observer = {observe: vi.fn()};
+
+    await callback(observer);
+
+    expect(mocks.createObservableGauge).toHaveBeenCalledWith(
+      'runners_enrolled_without_recent_report',
+      {
+        description:
+          'Running enrolled runners with a live control session, no workspace or runner session, and no recent provisioner report after the stale-runner grace window',
+      },
+    );
+    expect(mocks.countStaleEnrolledRunnerInstances).toHaveBeenCalledWith({graceSeconds: 300});
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 2);
+  });
+
+  it('keeps queue gauges observable when the enrolled-runner query fails', async () => {
+    mocks.getJobExecutionQueueDepth.mockResolvedValue({
+      pendingJobExecutions: 3,
+      runningJobExecutions: 4,
+    });
+    mocks.countStaleEnrolledRunnerInstances.mockRejectedValue(new Error('database unavailable'));
+
+    registerRunnersServiceMetrics();
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    if (typeof callback !== 'function') throw new Error('Expected metrics callback');
+    const observer = {observe: vi.fn()};
+
+    await callback(observer);
+
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 3);
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 4);
+    expect(observer.observe).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/api/runners/src/metrics/service.test.ts
+++ b/libs/api/runners/src/metrics/service.test.ts
@@ -1,10 +1,19 @@
 const mocks = vi.hoisted(() => {
-  const gauge = {};
+  const gauges = {
+    enrolledRunnersWithoutRecentReport: {},
+    pendingJobExecutions: {},
+    runningJobExecutions: {},
+  };
+  const gaugeByName = {
+    runners_enrolled_without_recent_report: gauges.enrolledRunnersWithoutRecentReport,
+    runners_pending_job_executions: gauges.pendingJobExecutions,
+    runners_running_job_executions: gauges.runningJobExecutions,
+  };
   return {
     addBatchObservableCallback: vi.fn(),
     countStaleEnrolledRunnerInstances: vi.fn(),
-    createObservableGauge: vi.fn(() => gauge),
-    gauge,
+    createObservableGauge: vi.fn((name: string) => gaugeByName[name as keyof typeof gaugeByName]),
+    gauges,
     getMeter: vi.fn(),
     getJobExecutionQueueDepth: vi.fn(),
     getServiceMetricsProvider: vi.fn(),
@@ -63,7 +72,10 @@ describe('registerRunnersServiceMetrics', () => {
       },
     );
     expect(mocks.countStaleEnrolledRunnerInstances).toHaveBeenCalledWith({graceSeconds: 300});
-    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 2);
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.enrolledRunnersWithoutRecentReport,
+      2,
+    );
   });
 
   it('keeps queue gauges observable when the enrolled-runner query fails', async () => {
@@ -80,8 +92,8 @@ describe('registerRunnersServiceMetrics', () => {
 
     await callback(observer);
 
-    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 3);
-    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 4);
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.pendingJobExecutions, 3);
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.runningJobExecutions, 4);
     expect(observer.observe).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/api/runners/src/metrics/service.ts
+++ b/libs/api/runners/src/metrics/service.ts
@@ -1,5 +1,7 @@
 import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {config} from '#config.js';
 import {getJobExecutionQueueDepth} from '#db/job-executions.js';
+import {countStaleEnrolledRunnerInstances} from '#db/runner-instances.js';
 
 export function registerRunnersServiceMetrics(): void {
   const meter = getServiceMetricsProvider().getMeter('runners');
@@ -10,13 +12,31 @@ export function registerRunnersServiceMetrics(): void {
   const runningJobExecutions = meter.createObservableGauge('runners_running_job_executions', {
     description: 'Job executions currently claimed by a runner and in progress',
   });
+  const enrolledRunnersWithoutRecentReport = meter.createObservableGauge(
+    'runners_enrolled_without_recent_report',
+    {
+      description:
+        'Running enrolled runners with a live control session, no workspace or runner session, and no recent provisioner report after the stale-runner grace window',
+    },
+  );
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const depth = await getJobExecutionQueueDepth();
-      observer.observe(pendingJobExecutions, depth.pendingJobExecutions);
-      observer.observe(runningJobExecutions, depth.runningJobExecutions);
+      const [depthResult, staleEnrolledRunnerCountResult] = await Promise.allSettled([
+        getJobExecutionQueueDepth(),
+        countStaleEnrolledRunnerInstances({
+          graceSeconds: config.RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS,
+        }),
+      ]);
+
+      if (depthResult.status === 'fulfilled') {
+        observer.observe(pendingJobExecutions, depthResult.value.pendingJobExecutions);
+        observer.observe(runningJobExecutions, depthResult.value.runningJobExecutions);
+      }
+      if (staleEnrolledRunnerCountResult.status === 'fulfilled') {
+        observer.observe(enrolledRunnersWithoutRecentReport, staleEnrolledRunnerCountResult.value);
+      }
     },
-    [pendingJobExecutions, runningJobExecutions],
+    [pendingJobExecutions, runningJobExecutions, enrolledRunnersWithoutRecentReport],
   );
 }


### PR DESCRIPTION
The runners service now exposes a service-gauge metric for running enrolled runners with a live control session, no workspace or runner session, and no recent provisioner report.

The metric uses the existing stale-runner threshold and documents the five-minute default and warm-pool behavior. Its name distinguishes report staleness from assignment latency, and query failures no longer suppress the existing queue-depth gauges.

Closes ENG-1498

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a service gauge to surface stale enrolled runners and keeps queue metrics resilient. Aligns staleness detection with provisioner report timestamps to better catch stuck warm-pool/provisioner reporting issues (ENG-1498).

- New Features
  - Exposes `runners_enrolled_without_recent_report` on port 9474. Counts running enrolled runners with a live control session, no workspace or runner session, and `reported_at` older than `RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS` (default 5 minutes). Healthy warm-pool runners stay below the threshold; long-stale cases are included.

- Bug Fixes
  - Queue-depth gauges remain observable when the stale-runner query fails.

<sup>Written for commit 4373fd91ef7fbd6b328198ad584c2d60a0edfa0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

