### PR TITLE
Add EC2 launch headroom to reservation TTL

### DIFF
--- a/.changeset/ec2-launch-headroom.md
+++ b/.changeset/ec2-launch-headroom.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Raise the default runner reservation TTL ceiling to admit provider launch headroom.

--- a/.changeset/ec2-launch-headroom.md
+++ b/.changeset/ec2-launch-headroom.md
@@ -2,4 +2,4 @@
 "@shipfox/api-runners": patch
 ---
 
-Raise the default runner reservation TTL ceiling to admit provider launch headroom.
+Raise the default runner reservation TTL ceiling to 600 seconds so longer EC2 launch budgets are accepted while the cap still limits unreleased-reservation demand.

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -41,6 +41,7 @@ overlap across families; lower `cost` wins when more than one template matches.
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | N/A | Path to the EC2 template YAML file. |
 | `AWS_REGION` | yes | N/A | AWS region where the provider launches instances. |
 | `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time an EC2 instance may remain pending without runner enrollment. |
+| `SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS` | no | `30000` | Extra time for the API response and EC2 launch call before EC2 records the instance launch time. Added to the registration deadline to derive the requested reservation lifetime. |
 | `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval between full EC2/backend reconciliation passes. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Demand long-poll duration. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Delay between healthy demand polls. |

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -104,12 +104,12 @@ describe('reservation TTL ceiling validation', () => {
     await expect(import('#config.js')).rejects.toThrow('RESERVATION_TTL_MAX_SECONDS');
   });
 
-  it('defaults high enough for the EC2 registration deadline', async () => {
+  it('defaults high enough for provider registration deadlines and launch headroom', async () => {
     vi.resetModules();
 
     const {config} = await import('#config.js');
 
-    expect(config.RESERVATION_TTL_MAX_SECONDS).toBe(300);
+    expect(config.RESERVATION_TTL_MAX_SECONDS).toBe(600);
   });
 
   it('accepts a whole-second ceiling inside the hard maximum', async () => {

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -66,8 +66,8 @@ export const config = createConfig({
     default: 60,
   }),
   RESERVATION_TTL_MAX_SECONDS: num({
-    desc: `Server-side ceiling for a count-based runner reservation lifetime and activation grace period, in seconds. Set it at least as high as every provider registration deadline so provider-specific values can cover boot and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
-    default: 300,
+    desc: `Server-side ceiling for a count-based runner reservation lifetime and activation grace period, in seconds. Set it at least as high as every provider registration deadline plus its launch headroom so provider-specific values can cover the launch gap, boot, and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
+    default: 600,
   }),
   RESERVATION_LONG_POLL_MAX_WAIT_SECONDS: num({
     desc: 'Maximum time the provisioner demand poll endpoint waits for reservable demand before returning, in seconds.',

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -116,13 +116,30 @@ describe('POST /provisioners/demand/poll', () => {
       method: 'POST',
       url: '/provisioners/demand/poll',
       headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
-      payload: body({max_reservations: 1, reservation_ttl_seconds: 600}),
+      payload: body({max_reservations: 1, reservation_ttl_seconds: 601}),
     });
 
     expect(res.statusCode).toBe(200);
     const expiresAt = Date.parse(res.json().reservations[0].expires_at);
-    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 295_000);
-    expect(expiresAt).toBeLessThan(requestStartedAt + 305_000);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 595_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 605_000);
+  });
+
+  it('accepts a slow-boot reservation TTL below the raised ceiling', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const requestStartedAt = Date.now();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1, reservation_ttl_seconds: 540}),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const expiresAt = Date.parse(res.json().reservations[0].expires_at);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 535_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 545_000);
   });
 
   it('applies a requested reservation TTL below the ceiling', async () => {
@@ -528,13 +545,13 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
       method: 'POST',
       url: '/provisioners/demand/poll',
       headers: {authorization: `Bearer ${INSTALLATION_PROVISIONER_TOKEN}`},
-      payload: body({max_reservations: 1, reservation_ttl_seconds: 600}),
+      payload: body({max_reservations: 1, reservation_ttl_seconds: 601}),
     });
 
     expect(res.statusCode).toBe(200);
     const expiresAt = Date.parse(res.json().reservations[0].expires_at);
-    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 295_000);
-    expect(expiresAt).toBeLessThan(requestStartedAt + 305_000);
+    expect(expiresAt).toBeGreaterThanOrEqual(requestStartedAt + 595_000);
+    expect(expiresAt).toBeLessThan(requestStartedAt + 605_000);
   });
 
   function body(params: {max_reservations: number; reservation_ttl_seconds?: number}) {

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -112,12 +112,18 @@ The provider reads the shared provisioner variables plus these EC2-specific vari
 | --- | --- | --- | --- |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file with EC2 launch and capacity configuration. |
 | `AWS_REGION` | yes | - | AWS region where runner instances launch. |
-| `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time a launched instance may wait for runner registration. Also sets the reservation lifetime the provider requests on each demand poll. |
+| `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time a launched instance may wait for runner registration. The provider adds the launch headroom and uses the sum to derive the reservation lifetime it requests on each demand poll. |
+| `SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS` | no | `30000` | Extra time for the API response and EC2 launch call before EC2 records the instance launch time. The provider adds this to the registration deadline before deriving the reservation lifetime. |
 | `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval for a full backend reconcile using EC2 instance tags. |
 
+The reservation clock starts when the API grants demand. The EC2 registration clock starts
+when EC2 records the instance launch time. The provider requests
+`ceil((registration deadline + launch headroom) / 1000)` seconds, so the reservation covers
+the launch gap as well as boot and enrollment.
+
 The API clamps the requested reservation lifetime to its own `RESERVATION_TTL_MAX_SECONDS`
-ceiling and does not report the clamp. Raising the registration deadline past that ceiling
-therefore shortens the reservation relative to the deadline: raise both together.
+ceiling and does not report the clamp. Keep that ceiling at least as high as the derived
+value when changing either EC2 setting.
 
 ## Behavior notes
 

--- a/libs/provisioner/ec2/src/config.test.ts
+++ b/libs/provisioner/ec2/src/config.test.ts
@@ -13,3 +13,27 @@ describe('requirePositiveInteger', () => {
     );
   });
 });
+
+describe('EC2 reservation timing configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses a 30-second launch headroom by default', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS).toBe(30_000);
+  });
+
+  it.each(['0', '-1', '1.5'])('rejects an invalid launch headroom: %s', async (value) => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS',
+    );
+  });
+});

--- a/libs/provisioner/ec2/src/config.ts
+++ b/libs/provisioner/ec2/src/config.ts
@@ -15,8 +15,12 @@ export const config = createConfig({
     desc: 'AWS region the runner instances launch in, such as us-east-1. Required. Read by the AWS SDK and by the provider.',
   }),
   SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS: num({
-    desc: 'How long a launched instance may run without a runner registering before the provisioner terminates it as stale, in milliseconds. The EC2 provisioner derives the reservation lifetime sent with each demand poll from this setting, so changing it changes both deadlines. The API caps the requested lifetime at RESERVATION_TTL_MAX_SECONDS and does not report the clamp, so raise that ceiling alongside any increase here.',
+    desc: 'How long a launched instance may run without a runner registering before the provisioner terminates it as stale, in milliseconds. The EC2 provisioner adds SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS and derives the reservation lifetime sent with each demand poll from the sum, so changing this setting changes both deadlines. The API caps the requested lifetime at RESERVATION_TTL_MAX_SECONDS and does not report the clamp, so raise that ceiling alongside any increase here.',
     default: 300_000,
+  }),
+  SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS: num({
+    desc: 'Extra time for the API response and EC2 launch call between reservation creation and EC2 recording the instance launch time, in milliseconds. The EC2 provisioner adds this value to SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS when deriving the reservation lifetime sent with each demand poll. Set RESERVATION_TTL_MAX_SECONDS at least as high as the resulting value because the API silently clamps larger requests.',
+    default: 30_000,
   }),
   SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS: num({
     desc: 'How often the provisioner runs a full reconcile against the backend, re-deriving truth from EC2 instance tags, in milliseconds.',
@@ -27,6 +31,10 @@ export const config = createConfig({
 requirePositiveInteger(
   'SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS',
   config.SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS,
+);
+requirePositiveInteger(
+  'SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS',
+  config.SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS,
 );
 requirePositiveInteger(
   'SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS',

--- a/libs/provisioner/ec2/src/provisioner.test.ts
+++ b/libs/provisioner/ec2/src/provisioner.test.ts
@@ -29,14 +29,16 @@ const engine: Ec2Engine = {
 
 describe('createEc2ProvisionerAdapter', () => {
   it.each([
-    [300_000, 300],
-    [300_001, 301],
-    [1, 1],
-  ])('derives a reservation TTL from a %d ms registration deadline', (registrationDeadlineMs, reservationTtlSeconds) => {
+    [300_000, 330],
+    [600_000, 630],
+    [300_001, 331],
+    [1, 31],
+  ])('derives a reservation TTL with launch headroom from a %d ms registration deadline', (registrationDeadlineMs, reservationTtlSeconds) => {
     const adapter = createEc2ProvisionerAdapter({
       engine,
       templates: [template],
       registrationDeadlineMs,
+      launchHeadroomMs: 30_000,
       reconcileIntervalMs: 60_000,
     });
 

--- a/libs/provisioner/ec2/src/provisioner.ts
+++ b/libs/provisioner/ec2/src/provisioner.ts
@@ -15,6 +15,7 @@ export interface CreateEc2ProvisionerAdapterOptions {
   readonly engine: Ec2Engine;
   readonly templates: readonly ProvisionerTemplate<Ec2TemplateSpec>[];
   readonly registrationDeadlineMs: number;
+  readonly launchHeadroomMs: number;
   readonly reconcileIntervalMs: number;
 }
 
@@ -29,8 +30,9 @@ export function createEc2ProvisionerAdapter(
 
   return {
     loadTemplates: () => Promise.resolve(options.templates),
-    reservationTtlSeconds: reservationTtlSecondsFromRegistrationDeadline(
+    reservationTtlSeconds: reservationTtlSecondsFromLaunchBudget(
       options.registrationDeadlineMs,
+      options.launchHeadroomMs,
     ),
     launch: (launch) => requireLifecycle(lifecycle).launch(launch),
     terminate: (ids) => requireLifecycle(lifecycle).terminate(ids),
@@ -53,13 +55,17 @@ export function startEc2Provisioner(): Promise<void> {
       engine,
       templates,
       registrationDeadlineMs: config.SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS,
+      launchHeadroomMs: config.SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS,
       reconcileIntervalMs: config.SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS,
     }),
   });
 }
 
-function reservationTtlSecondsFromRegistrationDeadline(registrationDeadlineMs: number): number {
-  return Math.ceil(registrationDeadlineMs / 1000);
+function reservationTtlSecondsFromLaunchBudget(
+  registrationDeadlineMs: number,
+  launchHeadroomMs: number,
+): number {
+  return Math.ceil((registrationDeadlineMs + launchHeadroomMs) / 1000);
 }
 
 function createLifecycle(


### PR DESCRIPTION
## Summary

- Add configurable 30-second EC2 launch headroom before deriving the reservation TTL requested from the API.
- Raise the API-side default reservation TTL ceiling to 600 seconds so the default 330-second EC2 budget is accepted while the ceiling remains meaningful.
- Document the relationship between the registration deadline, launch headroom, and API ceiling, with coverage for defaults, invalid values, derivation, and clamping.

The 600-second default leaves room for the EC2 budget to grow while limiting unreleased-reservation demand starvation. Operators with longer launch or registration budgets can raise both provider and API settings.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/provisioner-ec2-provider...` (113 tests passed)
- `mise exec -- turbo check type test --filter=@shipfox/api-runners...` (532 tests passed)
- `mise exec -- pnpm exec changeset status`
- `mise exec -- git diff --check`

Closes ENG-1507

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable 30‑second EC2 launch headroom to the reservation TTL and raises the API TTL ceiling to 600 seconds so the default 330‑second budget isn’t clamped. This aligns the reservation window with the gap between API grant and EC2 launch and addresses ENG-1507.

- **New Features**
  - `@shipfox/provisioner-ec2`: New `SHIPFOX_PROVISIONER_EC2_LAUNCH_HEADROOM_MS` (default 30,000 ms). The provider requests `ceil((registration deadline + launch headroom)/1000)` seconds.
  - `@shipfox/api-runners`: Default `RESERVATION_TTL_MAX_SECONDS` raised to 600 to accept slow‑boot reservations without clamping.
  - Docs and changelog clarify how the registration deadline, launch headroom, and the 600‑second API ceiling interact.

<sup>Written for commit 53f83e219fbd0873368a199305c502fc7c97f721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

