### PR TITLE
[client-workflows] Migrate workflow surfaces to semantic spacing

### DIFF
--- a/.changeset/workflows-semantic-spacing.md
+++ b/.changeset/workflows-semantic-spacing.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Migrates the workflow client surfaces to semantic spacing roles.

--- a/biome.json
+++ b/biome.json
@@ -225,6 +225,7 @@
         "**/libs/client/runners/**",
         "**/libs/client/projects/**",
         "**/libs/client/agent/**",
+        "**/libs/client/workflows/**",
         "!**/dist/**",
         "!**/node_modules/**",
         "!**/*.test.ts",

--- a/libs/client/workflows/src/components/identifier/identifier.tsx
+++ b/libs/client/workflows/src/components/identifier/identifier.tsx
@@ -112,7 +112,7 @@ export function Identifier({
             onClick={() => {
               void handleCopy();
             }}
-            className="inline-flex h-20 min-w-0 shrink-0 items-center gap-tight rounded-4 px-[2px] text-foreground-neutral-muted outline-none transition-colors hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
+            className="inline-flex h-20 min-w-0 shrink-0 items-center gap-tight rounded-4 px-[var(--pad-menu-surface)] text-foreground-neutral-muted outline-none transition-colors hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
           >
             <Icon name="copy" aria-hidden="true" className="size-12 shrink-0" />
             <Code as="span" variant="label" className="truncate">

--- a/libs/client/workflows/src/components/identifier/identifier.tsx
+++ b/libs/client/workflows/src/components/identifier/identifier.tsx
@@ -112,7 +112,7 @@ export function Identifier({
             onClick={() => {
               void handleCopy();
             }}
-            className="inline-flex h-20 min-w-0 shrink-0 items-center gap-4 rounded-4 px-2 text-foreground-neutral-muted outline-none transition-colors hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
+            className="inline-flex h-20 min-w-0 shrink-0 items-center gap-tight rounded-4 px-[2px] text-foreground-neutral-muted outline-none transition-colors hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
           >
             <Icon name="copy" aria-hidden="true" className="size-12 shrink-0" />
             <Code as="span" variant="label" className="truncate">
@@ -167,7 +167,7 @@ function CopyFeedbackPortal({
             : `translate(-50%, ${COPY_FEEDBACK_OFFSET_PX}px)`,
       }}
       className={cn(
-        'pointer-events-none fixed z-50 whitespace-nowrap rounded-8 bg-background-components-base px-8 py-4 text-xs font-display font-medium leading-20 shadow-tooltip',
+        'pointer-events-none fixed z-50 whitespace-nowrap rounded-8 bg-background-components-base px-tight py-[4px] text-xs font-display font-medium leading-20 shadow-tooltip',
         kind === 'failed' ? 'text-foreground-highlight-error' : 'text-foreground-neutral-base',
       )}
     >

--- a/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.tsx
@@ -24,7 +24,7 @@ export function AgentConfigFailureCallout({
     <Alert
       variant="warning"
       animated={false}
-      className="rounded-none border-x-0 border-t-0 border-b border-tag-warning-border bg-transparent px-0 py-8"
+      className="rounded-none border-x-0 border-t-0 border-b border-tag-warning-border bg-transparent px-0 py-row"
     >
       <AlertContent>
         <AlertTitle>{copy.title}</AlertTitle>

--- a/libs/client/workflows/src/components/job-detail/job-context-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-context-panel.tsx
@@ -85,7 +85,7 @@ function JobContextSheet({
             Execution #{execution.sequence} · {execution.displayName}
           </SheetDescription>
         </SheetHeader>
-        <SheetBody className="gap-20">
+        <SheetBody className="gap-section">
           <div className="grid w-full min-w-0 gap-group min-[640px]:grid-cols-2">
             {runner?.length ? <ContextList label="Runner" values={runner} mono /> : null}
             {execution.queueTime || execution.runTime ? (

--- a/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
@@ -45,10 +45,10 @@ export function JobDetailHeader({
   const jobStatus = getWorkflowStatusVisual(selectedStatus);
 
   return (
-    <header className="border-b border-border-neutral-base px-16 py-12">
-      <div className="flex min-w-0 items-start justify-between gap-12">
-        <div className="flex min-w-0 flex-col gap-8">
-          <div className="flex min-w-0 items-center gap-8">
+    <header className="border-b border-border-neutral-base px-row py-row">
+      <div className="flex min-w-0 items-start justify-between gap-cluster">
+        <div className="flex min-w-0 flex-col gap-inline">
+          <div className="flex min-w-0 items-center gap-inline">
             <WorkflowStatusIcon
               status={selectedStatus}
               size={14}
@@ -68,7 +68,7 @@ export function JobDetailHeader({
           </div>
 
           {selectedJobExecution || annotationSummary?.total ? (
-            <div className="flex min-w-0 flex-wrap items-center gap-10 text-foreground-neutral-muted">
+            <div className="flex min-w-0 flex-wrap items-center gap-inline text-foreground-neutral-muted">
               {selectedJobExecution && job.executionCountVisible ? (
                 <JobExecutionSwitcher
                   job={job}
@@ -122,7 +122,7 @@ function JobDurationMeta({execution, kind}: {execution: JobExecution; kind: 'que
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex items-center gap-4 whitespace-nowrap font-code text-xs leading-20 tabular-nums">
+        <span className="inline-flex items-center gap-tight whitespace-nowrap font-code text-xs leading-20 tabular-nums">
           <Icon
             name={kind === 'queue' ? 'hourglassLine' : 'timerLine'}
             size={12}

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -236,7 +236,7 @@ export function JobDetailView({
             attempt={newerAttempt}
           />
         ) : null}
-        <div ref={pageScrollRef} className="@container min-h-0 flex-1 overflow-auto pb-24">
+        <div ref={pageScrollRef} className="@container min-h-0 flex-1 overflow-auto pb-panel">
           <section aria-label={`${job.displayName} logs`} className="flex w-full flex-col">
             <section className="min-w-0 overflow-hidden">
               <JobDetailHeader
@@ -299,7 +299,7 @@ export function JobDetailView({
               <div
                 role="status"
                 aria-live="polite"
-                className="flex min-w-0 items-center justify-between gap-8 border-t border-border-neutral-base px-16 py-8"
+                className="flex min-w-0 items-center justify-between gap-inline border-t border-border-neutral-base px-row py-row"
               >
                 <Text size="xs" className="min-w-0 text-foreground-neutral-muted">
                   Run moved on to{' '}
@@ -310,7 +310,7 @@ export function JobDetailView({
                 </Text>
                 <button
                   type="button"
-                  className="shrink-0 rounded-4 px-6 py-4 text-xs font-medium text-foreground-highlight-interactive outline-none focus-visible:shadow-border-interactive-with-active"
+                  className="shrink-0 rounded-4 px-tight py-[4px] text-xs font-medium text-foreground-highlight-interactive outline-none focus-visible:shadow-border-interactive-with-active"
                   onClick={retargetToRunningStep}
                 >
                   Jump to it
@@ -318,7 +318,7 @@ export function JobDetailView({
               </div>
             ) : null}
             {succeededSummary ? (
-              <Text size="xs" className="px-16 py-8 text-foreground-neutral-muted">
+              <Text size="xs" className="px-row py-row text-foreground-neutral-muted">
                 {succeededSummary}
               </Text>
             ) : null}
@@ -361,7 +361,7 @@ function EmptyStateForMissingExecution({job}: {job: Job}) {
   const emptyState = emptyStateForMissingExecution(job);
   return (
     <EmptyState
-      className="min-h-120 px-16 py-20"
+      className="min-h-120 p-panel"
       icon="componentLine"
       title={emptyState.title}
       description={emptyState.description}
@@ -382,7 +382,7 @@ function JobNotFoundState({
   search: WorkflowJobSearch;
 }) {
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-12 p-24">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-cluster p-panel">
       <EmptyState
         icon="componentLine"
         title="Job not found"
@@ -397,7 +397,7 @@ function JobNotFoundState({
             {runAttempt: search.runAttempt},
           ) as never
         }
-        className="inline-flex items-center gap-6 rounded-6 px-8 py-6 text-sm text-foreground-highlight-interactive outline-none focus-visible:shadow-border-interactive-with-active"
+        className="inline-flex items-center gap-inline rounded-6 px-tight py-[6px] text-sm text-foreground-highlight-interactive outline-none focus-visible:shadow-border-interactive-with-active"
       >
         <Icon name="arrowLeftLine" size={14} aria-hidden="true" />
         Back to run summary
@@ -420,8 +420,8 @@ function NewerAttemptNotice({
   attempt: number;
 }) {
   return (
-    <div role="status" className="border-b border-border-neutral-base px-16 py-8">
-      <div className="flex items-center justify-between gap-8">
+    <div role="status" className="border-b border-border-neutral-base px-row py-row">
+      <div className="flex items-center justify-between gap-inline">
         <Text size="xs" className="text-foreground-neutral-muted">
           A newer run attempt is available.
         </Text>
@@ -429,7 +429,7 @@ function NewerAttemptNotice({
           to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId/jobs/$jobId"
           params={{workspaceSlug, projectSlug, workflowRunId: runId, jobId}}
           search={workflowJobSearchParams({runAttempt: attempt}) as never}
-          className="shrink-0 rounded-4 px-6 py-4 text-xs font-medium text-foreground-highlight-interactive outline-none focus-visible:shadow-border-interactive-with-active"
+          className="shrink-0 rounded-4 px-tight py-[4px] text-xs font-medium text-foreground-highlight-interactive outline-none focus-visible:shadow-border-interactive-with-active"
         >
           View attempt #{attempt}
         </Link>
@@ -475,19 +475,19 @@ function annotationCountForStep(
 
 function JobDetailSkeleton() {
   return (
-    <div className="min-h-0 min-w-0 flex-1 overflow-auto pb-24">
+    <div className="min-h-0 min-w-0 flex-1 overflow-auto pb-panel">
       <div className="w-full">
-        <header className="flex items-center gap-12 border-b border-border-neutral-base px-16 py-12">
+        <header className="flex items-center gap-cluster border-b border-border-neutral-base px-row py-row">
           <Skeleton className="size-20 rounded-full" />
           <Skeleton className="h-20 w-160 rounded-4" />
           <Skeleton className="h-24 w-72 rounded-6" />
           <Skeleton className="h-24 w-180 rounded-4" />
         </header>
-        <div className="p-16">
+        <div className="p-panel-compact">
           {JOB_DETAIL_SKELETON_ROWS.map((row) => (
             <div
               key={row}
-              className="flex min-h-44 items-center gap-8 border-b border-border-neutral-base last:border-b-0"
+              className="flex min-h-44 items-center gap-inline border-b border-border-neutral-base last:border-b-0"
             >
               <Skeleton className="size-14 rounded-full" />
               <Skeleton className="h-16 w-180 rounded-4" />

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -202,7 +202,7 @@ function humanizeFailureReason(reason: string): string {
 export function CarriedOverStepPanel() {
   return (
     <EmptyState
-      className="min-h-120 rounded-8 border border-border-neutral-base bg-background-components-base px-16 py-20"
+      className="min-h-120 rounded-8 border border-border-neutral-base bg-background-components-base p-panel"
       icon="componentLine"
       title="Carried over from a previous attempt"
       description="Not executed in this run."

--- a/libs/client/workflows/src/components/job-detail/job-execution-switcher.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-execution-switcher.tsx
@@ -44,7 +44,7 @@ export function JobExecutionSwitcher({
     return (
       <div
         className={cn(
-          'flex min-w-0 items-center gap-6 text-sm leading-20 text-foreground-neutral-subtle',
+          'flex min-w-0 items-center gap-inline text-sm leading-20 text-foreground-neutral-subtle',
           className,
         )}
       >
@@ -59,8 +59,8 @@ export function JobExecutionSwitcher({
         className={cn(
           'inline-flex min-w-0 max-w-full items-center rounded-6 text-left transition-colors focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
           variant === 'title'
-            ? '-mx-6 -my-4 gap-8 px-6 py-4 hover:bg-background-components-hover'
-            : 'min-h-28 gap-6 px-8 py-4 text-sm leading-20 text-foreground-neutral-subtle hover:bg-background-components-hover',
+            ? '-mx-inline -my-[4px] gap-inline px-tight py-[4px] hover:bg-background-components-hover'
+            : 'min-h-28 gap-inline px-tight py-[4px] text-sm leading-20 text-foreground-neutral-subtle hover:bg-background-components-hover',
           className,
         )}
         aria-label={`Switch job execution, currently execution ${selected.sequence}: ${selected.displayName}`}
@@ -141,7 +141,7 @@ function executionAccessibleLabel(execution: JobExecution): string {
 
 function TitleExecutionSummary({execution}: {execution: JobExecution}) {
   return (
-    <span className="flex min-w-0 items-center gap-8">
+    <span className="flex min-w-0 items-center gap-inline">
       <Text as="span" size="sm" bold className="shrink-0 text-foreground-neutral-base">
         #{execution.sequence}
       </Text>
@@ -156,7 +156,7 @@ function ExecutionSummary({execution}: {execution: JobExecution}) {
   const displayStatus = deriveJobExecutionDisplayStatus(execution);
 
   return (
-    <span className="flex min-w-0 items-center gap-6">
+    <span className="flex min-w-0 items-center gap-inline">
       <WorkflowStatusIcon status={displayStatus} size={14} tooltip={false} />
       <span className="shrink-0 font-code text-xs leading-20 text-foreground-neutral-base tabular-nums">
         Execution #{execution.sequence}

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -100,15 +100,15 @@ export function StepAttemptLogPanel({
   }
 
   return (
-    <div className="flex min-w-0 flex-col gap-8">
+    <div className="flex min-w-0 flex-col gap-inline">
       {staleError ? (
         <Callout
           role="alert"
           type="warning"
           variant="secondary"
-          className="rounded-none border-b border-border-neutral-base px-0 py-8 shadow-none"
+          className="rounded-none border-b border-border-neutral-base px-0 py-row shadow-none"
         >
-          <div className="flex min-w-0 flex-1 items-center justify-between gap-8">
+          <div className="flex min-w-0 flex-1 items-center justify-between gap-inline">
             <Text size="xs">Could not refresh logs.</Text>
             <Button
               type="button"
@@ -144,7 +144,7 @@ function StepLogsLoadingSurface({label, className}: {label: string; className: s
 function StepLogsWaitingSurface({startedAt, className}: {startedAt: string; className: string}) {
   return (
     <div role="status" aria-label="Waiting for logs" className={className}>
-      <Text size="xs" className="px-10 py-12 text-foreground-neutral-muted">
+      <Text size="xs" className="px-tight py-row text-foreground-neutral-muted">
         Waiting for output ·{' '}
         <span className="font-code tabular-nums" aria-hidden="true">
           <JobExecutionTimeText time={{state: 'live', fromIso: startedAt}} />
@@ -184,9 +184,9 @@ function StepLogsError({retrying, onRetry}: {retrying: boolean; onRetry: () => v
       role="alert"
       type="error"
       variant="secondary"
-      className="rounded-none border-b border-border-neutral-base px-0 py-8 shadow-none"
+      className="rounded-none border-b border-border-neutral-base px-0 py-row shadow-none"
     >
-      <div className="flex min-w-0 flex-1 items-center justify-between gap-8">
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-inline">
         <Text size="xs">Could not load logs.</Text>
         <Button type="button" size="2xs" variant="secondary" isLoading={retrying} onClick={onRetry}>
           Retry

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -64,7 +64,7 @@ export function StepInspectorSheet({
             Attempt #{entry.attempt} · {humanizeStatus(entry.statusVisual.kind)}
           </SheetDescription>
         </SheetHeader>
-        <SheetBody className="gap-20">
+        <SheetBody className="gap-section">
           <StepInspector
             step={entry.step}
             attempt={entry}
@@ -120,7 +120,7 @@ function StepFailureCallout({
       role="alert"
       type="error"
       variant="secondary"
-      className="rounded-8 border border-tag-error-border px-12 py-10 shadow-none"
+      className="rounded-8 border border-tag-error-border p-panel-compact shadow-none"
     >
       <CalloutContent>
         <CalloutTitle>{title}</CalloutTitle>
@@ -195,7 +195,7 @@ function StepInspector({
   const detailCount = Number(hasInputs) + Number(hasOutputs) + Number(hasTrace);
 
   return (
-    <div className="flex min-w-0 flex-col gap-20">
+    <div className="flex min-w-0 flex-col gap-section">
       {showFailure ? (
         <StepFailureCallout
           step={step}
@@ -213,7 +213,7 @@ function StepInspector({
           role="alert"
           type="warning"
           variant="secondary"
-          className="rounded-8 border border-tag-warning-border px-12 py-10 shadow-none"
+          className="rounded-8 border border-tag-warning-border p-panel-compact shadow-none"
         >
           <CalloutContent>
             <CalloutTitle>Details unavailable</CalloutTitle>

--- a/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
@@ -36,7 +36,7 @@ export function JobGraphContent({
   if (model.nodes.length === 0) {
     return (
       <EmptyState
-        className="min-h-160 px-16 py-24"
+        className="min-h-160 p-panel"
         icon="componentLine"
         title="No jobs yet"
         description="This run has not materialized jobs."
@@ -93,7 +93,7 @@ export function JobGraphContent({
           {model.columns.map((column, columnIndex) => (
             <div
               key={column.map((node) => node.id).join(':')}
-              className="absolute flex flex-col gap-20"
+              className="absolute flex flex-col gap-section"
               style={{left: jobLeft(columnIndex), top: PADDING}}
             >
               {column.map((node) => (

--- a/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
@@ -12,6 +12,7 @@ import type {JobGraphSelectionSource} from './types.js';
 const NODE_WIDTH = 208;
 const NODE_HEIGHT = 48;
 const COLUMN_GAP = 64;
+/** Fixed graph spacing shared by the DOM rows and the edge geometry below. */
 const ROW_GAP = 20;
 const TRIGGER_WIDTH = 36;
 const PADDING = 16;
@@ -93,8 +94,8 @@ export function JobGraphContent({
           {model.columns.map((column, columnIndex) => (
             <div
               key={column.map((node) => node.id).join(':')}
-              className="absolute flex flex-col gap-[20px]"
-              style={{left: jobLeft(columnIndex), top: PADDING}}
+              className="absolute flex flex-col"
+              style={{left: jobLeft(columnIndex), top: PADDING, rowGap: ROW_GAP}}
             >
               {column.map((node) => (
                 <JobNode

--- a/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
@@ -93,7 +93,7 @@ export function JobGraphContent({
           {model.columns.map((column, columnIndex) => (
             <div
               key={column.map((node) => node.id).join(':')}
-              className="absolute flex flex-col gap-section"
+              className="absolute flex flex-col gap-[20px]"
               style={{left: jobLeft(columnIndex), top: PADDING}}
             >
               {column.map((node) => (

--- a/libs/client/workflows/src/components/job-graph/job-node.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.tsx
@@ -106,7 +106,7 @@ export function JobNode({
       onPointerEnter={onHoverStart}
       onPointerLeave={onHoverEnd}
       className={cn(
-        'group relative flex h-48 w-208 cursor-pointer items-center gap-inline rounded-8 bg-background-neutral-base px-tight text-left shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+        'group relative flex h-48 w-208 cursor-pointer items-center gap-inline rounded-8 bg-background-neutral-base px-[10px] text-left shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
         selected && 'bg-background-components-hover hover:bg-background-components-pressed',
         node.carriedOver && 'opacity-[0.55]',
       )}

--- a/libs/client/workflows/src/components/job-graph/job-node.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.tsx
@@ -106,7 +106,7 @@ export function JobNode({
       onPointerEnter={onHoverStart}
       onPointerLeave={onHoverEnd}
       className={cn(
-        'group relative flex h-48 w-208 cursor-pointer items-center gap-8 rounded-8 bg-background-neutral-base px-10 text-left shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+        'group relative flex h-48 w-208 cursor-pointer items-center gap-inline rounded-8 bg-background-neutral-base px-tight text-left shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
         selected && 'bg-background-components-hover hover:bg-background-components-pressed',
         node.carriedOver && 'opacity-[0.55]',
       )}
@@ -117,7 +117,7 @@ export function JobNode({
           className="absolute inset-y-6 left-0 w-px rounded-full bg-border-highlights-interactive"
         />
       ) : null}
-      <div className="flex min-w-0 flex-1 items-center gap-8">
+      <div className="flex min-w-0 flex-1 items-center gap-inline">
         <WorkflowStatusIcon status={status} size={14} />
         <JobLabel label={node.displayName} />
       </div>
@@ -136,7 +136,7 @@ function ExecutionCountText({executions}: {executions: JobExecution[]}) {
       <TooltipTrigger asChild>
         <span
           aria-hidden="true"
-          className="inline-flex h-20 min-w-28 shrink-0 items-center justify-end gap-4 text-foreground-neutral-subtle"
+          className="inline-flex h-20 min-w-28 shrink-0 items-center justify-end gap-tight text-foreground-neutral-subtle"
         >
           <Icon name="loopRightLine" className="size-12" />
           <Code as="span" variant="label" className="text-current">

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -228,7 +228,7 @@ function StepListContent({
         )}
       >
         {showHeader ? (
-          <div className="flex min-h-40 items-center border-b border-border-neutral-base px-16 py-8">
+          <div className="flex min-h-40 items-center border-b border-border-neutral-base px-row py-row">
             <Text as="h2" id={titleId} size="sm" bold className="text-foreground-neutral-base">
               {model.jobName}
             </Text>
@@ -307,7 +307,7 @@ function StepListEmptyStateView({
   if (!emptyState.status) {
     return (
       <EmptyState
-        className="min-h-120 px-16 py-20"
+        className="min-h-120 p-panel"
         icon="componentLine"
         title={emptyState.title}
         description={emptyState.description}
@@ -317,7 +317,7 @@ function StepListEmptyStateView({
   }
 
   return (
-    <div className="flex min-h-120 flex-col items-center justify-center gap-10 px-16 py-20">
+    <div className="flex min-h-120 flex-col items-center justify-center gap-inline p-panel">
       <StepListEmptyStateIcon status={emptyState.status} />
       <div className="text-center">
         <Text size="sm" className="text-foreground-neutral-subtle">
@@ -334,14 +334,14 @@ function StepListEmptyStateView({
 function StepListEmptyStateIcon({status}: {status: JobDisplayStatus}) {
   if (status !== 'running') {
     return (
-      <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8">
+      <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-tight">
         <WorkflowStatusIcon status={status} size={20} tooltip={false} />
       </div>
     );
   }
 
   return (
-    <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8 text-foreground-neutral-muted">
+    <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-tight text-foreground-neutral-muted">
       <Icon name="timerLine" size={18} aria-hidden="true" />
     </div>
   );
@@ -377,7 +377,7 @@ function StepRow({
       />
       <StepStatusIcon entry={entry} />
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-8">
+        <div className="flex min-w-0 items-center gap-inline">
           <Text size="sm" bold className="truncate text-foreground-neutral-base">
             {entry.step.label}
           </Text>
@@ -389,7 +389,7 @@ function StepRow({
     </>
   );
   const rowClasses = cn(
-    'group flex min-h-44 min-w-0 flex-1 items-center gap-x-8 bg-transparent px-12 py-6 text-left transition-colors hover:bg-transparent active:bg-transparent focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
+    'group flex min-h-44 min-w-0 flex-1 items-center gap-x-inline bg-transparent px-row py-row text-left transition-colors hover:bg-transparent active:bg-transparent focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
     entry.carriedOver && 'opacity-[0.55]',
   );
   const button = hasExpandedContent ? (
@@ -425,7 +425,7 @@ function StepRow({
     <>
       <div
         className={cn(
-          'group flex min-w-0 items-center transition-colors hover:bg-background-components-hover active:bg-background-components-pressed',
+          'group flex min-w-0 items-center gap-inline pr-[8px] transition-colors hover:bg-background-components-hover active:bg-background-components-pressed',
           selected && 'bg-background-components-hover',
           !hasExpandedContent && ['border-b border-border-neutral-base', isLast && 'border-b-0'],
         )}
@@ -438,7 +438,7 @@ function StepRow({
                 type="button"
                 aria-label={`Inspect ${entry.step.label}, attempt ${entry.attempt}`}
                 onClick={onInspect}
-                className="mr-8 flex size-28 shrink-0 items-center justify-center rounded-4 bg-transparent text-foreground-neutral-muted outline-none transition-colors hover:bg-transparent hover:text-foreground-neutral-base active:bg-transparent focus-visible:shadow-button-neutral-focus"
+                className="flex size-28 shrink-0 items-center justify-center rounded-4 bg-transparent text-foreground-neutral-muted outline-none transition-colors hover:bg-transparent hover:text-foreground-neutral-base active:bg-transparent focus-visible:shadow-button-neutral-focus"
               >
                 <Icon name="informationLine" size={14} aria-hidden="true" />
               </button>
@@ -535,10 +535,10 @@ const attemptChipClasses: Record<NonNullable<BadgeVariant>, string> = {
 
 function StepAttemptChip({attempt}: {attempt: StepAttemptModel}) {
   return (
-    <div className="flex shrink-0 items-center gap-4" aria-hidden="true">
+    <div className="flex shrink-0 items-center gap-tight" aria-hidden="true">
       <span
         className={cn(
-          'inline-flex h-18 min-w-24 items-center justify-center rounded-4 border px-6 font-code text-xs leading-16 text-foreground-neutral-base',
+          'inline-flex h-18 min-w-24 items-center justify-center rounded-4 border px-tight font-code text-xs leading-16 text-foreground-neutral-base',
           attemptChipClasses[attempt.statusVisual.badge ?? 'neutral'],
         )}
       >

--- a/libs/client/workflows/src/components/workflow-run-duration-label.tsx
+++ b/libs/client/workflows/src/components/workflow-run-duration-label.tsx
@@ -121,7 +121,7 @@ function DurationText({
       variant="label"
       aria-label={ariaLabel}
       className={cn(
-        'inline-flex shrink-0 items-center gap-4 tabular-nums text-foreground-neutral-subtle',
+        'inline-flex shrink-0 items-center gap-tight tabular-nums text-foreground-neutral-subtle',
         className,
       )}
     >

--- a/libs/client/workflows/src/components/workflow-run-list/job-status-strip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/job-status-strip.tsx
@@ -74,9 +74,9 @@ export function JobStatusStrip({jobs, className}: JobStatusStripProps) {
         <span
           role="img"
           aria-label={summary}
-          className={cn('inline-flex items-center gap-3', className)}
+          className={cn('inline-flex items-center gap-[3px]', className)}
         >
-          <span aria-hidden="true" className="inline-flex items-center gap-3">
+          <span aria-hidden="true" className="inline-flex items-center gap-[3px]">
             {visible.map((job) => (
               <WorkflowStatusIcon
                 key={job.id}
@@ -89,7 +89,7 @@ export function JobStatusStrip({jobs, className}: JobStatusStripProps) {
               />
             ))}
             {hiddenCount > 0 && overflowStatus ? (
-              <span className="inline-flex items-center gap-2">
+              <span className="inline-flex items-center gap-[2px]">
                 <WorkflowStatusIcon
                   status={overflowStatus}
                   size={GLYPH_SIZE}
@@ -127,17 +127,17 @@ function JobStatusStripTooltip({jobs, summary}: {jobs: WorkflowRunJobs; summary:
   const remaining = notableTotal - named.length;
 
   return (
-    <span className="block max-w-[280px]">
+    <span className="flex max-w-[280px] flex-col gap-tight">
       <Text as="span" size="xs" className="block">
         {summary}
       </Text>
       {named.map((job) => (
-        <Code as="span" variant="label" key={job.id} className="mt-2 block truncate">
+        <Code as="span" variant="label" key={job.id} className="block truncate">
           {getWorkflowStatusVisual(job.status).label.toLowerCase()} · {job.name ?? job.key}
         </Code>
       ))}
       {remaining > 0 ? (
-        <Text as="span" size="xs" className="mt-2 block text-foreground-neutral-muted">
+        <Text as="span" size="xs" className="block text-foreground-neutral-muted">
           and {remaining} more
         </Text>
       ) : null}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-filter-menu.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-filter-menu.tsx
@@ -65,7 +65,7 @@ export function WorkflowRunFilterMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="max-h-[320px] w-[240px] overflow-y-auto">
         {options.length === 0 ? (
-          <Text as="p" size="xs" className="px-8 py-6 text-foreground-neutral-muted">
+          <Text as="p" size="xs" className="px-tight py-[6px] text-foreground-neutral-muted">
             {emptyMessage}
           </Text>
         ) : (

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
@@ -53,7 +53,7 @@ export function WorkflowRunFilters({
   const [sheetOpen, setSheetOpen] = useState(false);
 
   return (
-    <div className="flex flex-wrap items-center gap-8">
+    <div className="flex flex-wrap items-center gap-inline">
       <Input
         value={search.search ?? ''}
         onChange={(event) => onChange({search: event.target.value})}
@@ -64,7 +64,7 @@ export function WorkflowRunFilters({
         iconLeft={<Icon name="searchLine" className="size-14 text-foreground-neutral-muted" />}
       />
 
-      <div className="hidden flex-wrap items-center gap-8 md:flex">
+      <div className="hidden flex-wrap items-center gap-inline md:flex">
         <WorkflowRunFilterControls search={search} facets={facets} onChange={onChange} />
         {hasActiveFilters ? <ClearFiltersButton onClear={onClear} /> : null}
       </div>
@@ -85,7 +85,7 @@ export function WorkflowRunFilters({
           <SheetHeader>
             <SheetTitle>Filter runs</SheetTitle>
           </SheetHeader>
-          <SheetBody className="flex flex-col gap-12">
+          <SheetBody className="flex flex-col gap-cluster">
             <WorkflowRunFilterControls
               search={search}
               facets={facets}
@@ -161,7 +161,7 @@ function WorkflowRunFilterControls({
         className={controlClassName}
       />
       {stacked ? (
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-inline">
           <Label>Created between</Label>
           <RunDateRangeFilter search={search} onChange={onChange} />
         </div>

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -24,7 +24,7 @@ export function WorkflowRunListSkeleton() {
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton row, stable position
           key={index}
-          className="flex items-center gap-10 px-12 py-8 @min-[976px]:h-44 @min-[976px]:py-0"
+          className="flex items-center gap-inline px-row py-row @min-[976px]:h-44 @min-[976px]:py-0"
         >
           <Skeleton className="size-14 shrink-0 rounded-full" />
           <Skeleton className="h-12 w-[220px] max-w-[40%]" />
@@ -44,9 +44,9 @@ export function WorkflowRunListSkeleton() {
  */
 export function WorkflowRunListStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
-    <div className="pb-8">
+    <div className="pb-[8px]">
       <Callout role="alert" type="error">
-        <div className="flex items-center justify-between gap-8">
+        <div className="flex items-center justify-between gap-inline">
           <Text size="xs">Could not refresh workflow runs.</Text>
           <Button
             type="button"
@@ -116,7 +116,7 @@ export function WorkflowRunListNoMatches({
   onLoadMore?: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-inline">
       {isFetchNextPageError ? (
         <Callout role="alert" type="error">
           Could not load more workflow runs. Try again to continue searching older runs.
@@ -131,7 +131,7 @@ export function WorkflowRunListNoMatches({
             : 'No run matches these filters.'
         }
         action={
-          <div className="flex flex-wrap justify-center gap-8">
+          <div className="flex flex-wrap justify-center gap-inline">
             {hasNextPage && onLoadMore ? (
               <Button
                 type="button"
@@ -167,7 +167,7 @@ export function WorkflowRunListLoadMore({
   if (!hasNextPage || !onLoadMore) return null;
 
   return (
-    <div className="flex flex-col items-center gap-8 border-t border-border-neutral-base py-12">
+    <div className="flex flex-col items-center gap-inline border-t border-border-neutral-base py-row">
       {isFetchNextPageError ? (
         <Callout role="alert" type="error">
           Could not load more workflow runs. Try again.

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
@@ -58,7 +58,7 @@ export function WorkflowRunListView({
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
       <section
         aria-labelledby={headingId}
-        className={cn('flex min-h-0 min-w-0 flex-1 flex-col gap-12', className)}
+        className={cn('flex min-h-0 min-w-0 flex-1 flex-col gap-cluster', className)}
       >
         {/* The tab strip above already reads "Runs", so the page heading is for structure and
             assistive tech rather than a second visible title competing with it. */}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -164,7 +164,7 @@ function TriggerLabel({run}: {run: WorkflowRunListItem}) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="flex min-w-0 max-w-[140px] items-center gap-inline outline-none">
+        <span className="flex min-w-0 max-w-[140px] items-center gap-tight outline-none">
           <TriggerSourceIcon
             provider={run.triggerProvider}
             source={run.triggerSource}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -81,15 +81,15 @@ export function WorkflowRunRow({
     <>
       <WorkflowStatusIcon status={display.status} size={14} className="shrink-0" />
 
-      <div className="flex min-w-0 flex-1 flex-col gap-2 @min-[976px]:flex-row @min-[976px]:items-center @min-[976px]:gap-12">
-        <span className="flex min-w-0 items-center gap-8 @min-[976px]:flex-1">
+      <div className="flex min-w-0 flex-1 flex-col gap-tight @min-[976px]:flex-row @min-[976px]:items-center @min-[976px]:gap-cluster">
+        <span className="flex min-w-0 items-center gap-inline @min-[976px]:flex-1">
           <Code variant="label" bold className="truncate text-foreground-neutral-base">
             {run.name}
           </Code>
           {run.number !== null ? <WorkflowRunNumberLabel run={run} /> : null}
         </span>
 
-        <span className="flex min-w-0 flex-wrap items-center gap-10 text-foreground-neutral-subtle @min-[976px]:flex-nowrap @min-[976px]:shrink-0">
+        <span className="flex min-w-0 flex-wrap items-center gap-inline text-foreground-neutral-subtle @min-[976px]:flex-nowrap @min-[976px]:shrink-0">
           {run.triggerDisplayLabel ? <TriggerLabel run={run} /> : null}
           {branch ? <BranchLabel branch={branch} isPullRequest={branch.startsWith('#')} /> : null}
           {commit ? <CommitLabel commit={commit} /> : null}
@@ -97,7 +97,7 @@ export function WorkflowRunRow({
         </span>
       </div>
 
-      <span className="flex shrink-0 items-center gap-12">
+      <span className="flex shrink-0 items-center gap-cluster">
         {/* Fixed at the strip's worst case (see MAX_VISIBLE_JOBS) so the overflow count cannot
             paint over the duration, and kept even when a run has no jobs planned yet, so the
             numerics stay in line down the list instead of stepping in and out. */}
@@ -120,7 +120,7 @@ export function WorkflowRunRow({
   // Rows run edge to edge inside the list's scroll container, which would clip the standard
   // outset focus ring, so this one is inset per the design system's focus-ring rule.
   const rowClassName =
-    'flex w-full min-w-0 items-center gap-10 px-12 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] focus-visible:outline-none @min-[976px]:h-44 @min-[976px]:py-0';
+    'flex w-full min-w-0 items-center gap-inline px-row py-row text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] focus-visible:outline-none @min-[976px]:h-44 @min-[976px]:py-0';
 
   // Optimistic manual runs (temp-<uuid>) have no detail page until the canonical row
   // replaces them on the next poll, so they render non-interactively instead of as a link
@@ -164,7 +164,7 @@ function TriggerLabel({run}: {run: WorkflowRunListItem}) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="flex min-w-0 max-w-[140px] items-center gap-6 outline-none">
+        <span className="flex min-w-0 max-w-[140px] items-center gap-inline outline-none">
           <TriggerSourceIcon
             provider={run.triggerProvider}
             source={run.triggerSource}
@@ -235,7 +235,7 @@ function MetadataChip({
   children: string;
 }) {
   return (
-    <span className={cn('flex min-w-0 shrink-0 items-center gap-4', className)} title={title}>
+    <span className={cn('flex min-w-0 shrink-0 items-center gap-tight', className)} title={title}>
       <Icon name={icon} className="size-12 shrink-0 text-foreground-neutral-muted" aria-hidden />
       <Code as="span" variant="label" className="min-w-0 truncate">
         {children}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-attempt-switcher.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-attempt-switcher.tsx
@@ -52,7 +52,7 @@ export function WorkflowRunAttemptSwitcher({
           size="2xs"
           iconRight="arrowDownSLine"
           aria-label={`Switch attempt, currently ${run.runAttempt.attempt} of ${maxAttempt}`}
-          className="h-20 px-4 text-foreground-neutral-subtle hover:text-foreground-neutral-base"
+          className="h-20 px-[4px] text-foreground-neutral-subtle hover:text-foreground-neutral-base"
         >
           <Text as="span" size="xs" className="text-inherit">
             Attempt {run.runAttempt.attempt} of {maxAttempt}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -38,7 +38,7 @@ describe('WorkflowRunSummary', () => {
 
     const summary = await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(summary).toHaveClass('bg-background-neutral-background', 'px-16');
+    expect(summary).toHaveClass('bg-background-neutral-background', 'px-row', 'py-row');
     expect(summary.firstElementChild).not.toHaveClass('max-w-[1120px]');
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(within(summary).getAllByText('Running')).not.toHaveLength(0);

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -78,10 +78,13 @@ export function WorkflowRunSummary({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <section aria-labelledby={headingId} className="bg-background-neutral-background px-16 py-12">
-        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-8 overflow-hidden max-[480px]:grid-cols-1">
+      <section
+        aria-labelledby={headingId}
+        className="bg-background-neutral-background px-row py-row"
+      >
+        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-cluster gap-y-inline overflow-hidden max-[480px]:grid-cols-1">
           <div className="col-start-1 row-start-1 min-w-0 max-[480px]:col-start-auto max-[480px]:row-start-auto">
-            <div className="flex min-w-0 items-center gap-8">
+            <div className="flex min-w-0 items-center gap-inline">
               <Badge variant={status.badge} size="xs">
                 <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
                   {status.label}
@@ -108,7 +111,7 @@ export function WorkflowRunSummary({
           </div>
 
           {hasAction ? (
-            <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end max-[480px]:col-start-auto max-[480px]:row-start-auto max-[480px]:justify-self-start">
+            <div className="col-start-2 row-start-1 flex min-w-max items-center gap-inline justify-self-end max-[480px]:col-start-auto max-[480px]:row-start-auto max-[480px]:justify-self-start">
               <WorkflowRunActionSlot
                 action={action}
                 cancelling={cancelling}
@@ -119,7 +122,7 @@ export function WorkflowRunSummary({
             </div>
           ) : null}
 
-          <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-subtle max-[480px]:col-span-1 max-[480px]:row-start-auto">
+          <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-cluster overflow-hidden text-foreground-neutral-subtle max-[480px]:col-span-1 max-[480px]:row-start-auto">
             {run.number !== null ? (
               <>
                 <WorkflowRunNumberLabel run={run} />
@@ -145,7 +148,7 @@ export function WorkflowRunSummary({
                       <button
                         type="button"
                         aria-label={run.triggerLabel}
-                        className="inline-flex max-w-full min-w-0 cursor-help items-center gap-4 rounded-6 border-0 bg-transparent p-0 text-left text-foreground-neutral-subtle outline-none focus-visible:shadow-button-neutral-focus"
+                        className="inline-flex max-w-full min-w-0 cursor-help items-center gap-tight rounded-6 border-0 bg-transparent p-0 text-left text-foreground-neutral-subtle outline-none focus-visible:shadow-button-neutral-focus"
                       >
                         <TriggerSourceIcon
                           provider={run.triggerProvider}
@@ -189,7 +192,7 @@ export function WorkflowRunSummary({
             {blockingJob ? (
               <>
                 <MetadataSeparator />
-                <span className="flex min-w-0 items-center gap-4">
+                <span className="flex min-w-0 items-center gap-tight">
                   <Text as="span" size="xs" className="shrink-0">
                     waiting on
                   </Text>

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-count-chip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-count-chip.tsx
@@ -45,10 +45,10 @@ export function RunAnnotationCountChip({
       search={workflowRunSearchParams(search, search) as never}
       aria-label={accessibleLabel}
       className={cn(
-        'inline-flex h-20 shrink-0 items-center gap-4 rounded-4 border px-6 font-code text-xs leading-16 tabular-nums outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active',
+        'inline-flex h-20 shrink-0 items-center gap-tight rounded-4 border px-tight font-code text-xs leading-16 tabular-nums outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active',
         // The chip stays 20px optically so it sits level with the duration metadata beside it;
         // the hit area grows to the 44px minimum only where the pointer is coarse.
-        '[@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:px-10',
+        '[@media(pointer:coarse)]:h-44 [@media(pointer:coarse)]:px-[10px]',
         severity ? SEVERITY_CHIP_TONE[severity] : 'border-border-neutral-base',
       )}
     >

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -92,7 +92,7 @@ export function RunAnnotationList({
   const hasContent = entries.length > 0 || derivedAnnotations.length > 0;
 
   return (
-    <div className="flex min-w-0 flex-col gap-12">
+    <div className="flex min-w-0 flex-col gap-cluster">
       {query.isError ? <RunAnnotationStaleError query={query} /> : null}
 
       {!hasContent ? (
@@ -107,7 +107,7 @@ export function RunAnnotationList({
           <RunAnnotationsEmpty />
         )
       ) : (
-        <ol className="flex min-w-0 flex-col gap-12">
+        <ol className="flex min-w-0 flex-col gap-cluster">
           {visible.map((entry) => (
             <RunAnnotationItem
               key={entry.annotation.id}
@@ -202,7 +202,7 @@ function RunAnnotationsFilteredEmpty({
   onClearFilters: (() => void) | undefined;
 }) {
   return (
-    <div className="flex flex-col items-center gap-12">
+    <div className="flex flex-col items-center gap-cluster">
       <EmptyState
         icon="fileDamageLine"
         title={incomplete ? 'No matches in loaded annotations' : 'No matching annotations'}
@@ -231,7 +231,7 @@ function RunAnnotationsFilteredEmpty({
 function RunAnnotationStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
     <Callout role="status" aria-live="polite" type="error">
-      <div className="flex w-full items-center justify-between gap-8">
+      <div className="flex w-full items-center justify-between gap-inline">
         <Text size="xs">Could not refresh annotations.</Text>
         <Button
           type="button"
@@ -254,14 +254,14 @@ const ANNOTATION_SKELETON_ROWS = ['first', 'second', 'third'];
 
 function RunAnnotationListSkeleton() {
   return (
-    <section aria-label="Loading annotations" className="flex flex-col gap-12">
+    <section aria-label="Loading annotations" className="flex flex-col gap-cluster">
       {ANNOTATION_SKELETON_ROWS.map((row) => (
         <div
           key={row}
-          className="flex gap-12 rounded-8 border border-border-neutral-base bg-background-components-base px-12 py-8"
+          className="flex gap-cluster rounded-8 border border-border-neutral-base bg-background-components-base px-[12px] py-[8px]"
         >
           <Skeleton className="h-40 w-4 rounded-full" />
-          <div className="flex min-w-0 flex-1 flex-col gap-6">
+          <div className="flex min-w-0 flex-1 flex-col gap-inline">
             <Skeleton className="h-20 w-160 rounded-4" />
             <Skeleton className="h-16 w-240 rounded-4" />
             <Skeleton className="h-40 w-full rounded-4" />

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
@@ -48,7 +48,7 @@ export function RunAnnotationSummaryLine({
   const totalLabel = countLabel(summary.total, 'annotation', summary.truncated);
 
   return (
-    <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-foreground-neutral-subtle">
+    <div className="flex flex-wrap items-center gap-x-inline gap-y-tight text-foreground-neutral-subtle">
       {search.severity && workspaceSlug && projectSlug && workflowRunId ? (
         // The severity filter has no control of its own, so while one is active the total is
         // the way back out. Unfiltered it stays plain text: a link to where you already are
@@ -77,7 +77,7 @@ export function RunAnnotationSummaryLine({
         </Text>
       )}
       {visibleSeverities.map((severity) => (
-        <span key={severity} className="inline-flex shrink-0 items-center gap-8">
+        <span key={severity} className="inline-flex shrink-0 items-center gap-inline">
           <MetadataSeparator />
           <SeverityLink
             count={summary[severity]}
@@ -127,7 +127,7 @@ function SeverityLink({
   );
 
   if (!workspaceSlug || !projectSlug || !workflowRunId) {
-    return <span className="inline-flex items-center gap-4">{content}</span>;
+    return <span className="inline-flex items-center gap-tight">{content}</span>;
   }
 
   const searchWithoutAnnotation = withoutAnnotation(search);
@@ -142,7 +142,7 @@ function SeverityLink({
           search,
         ) as never
       }
-      className="inline-flex items-center gap-4 rounded-4 outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
+      className="inline-flex items-center gap-tight rounded-4 outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
     >
       {content}
     </Link>

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -58,7 +58,7 @@ export function RunWorkspaceNav({
           <CollapsibleTrigger asChild>
             <button
               type="button"
-              className="flex min-h-44 w-full items-center justify-between gap-12 px-16 text-left outline-none focus-visible:shadow-border-interactive-with-active min-[768px]:hidden"
+              className="flex min-h-44 w-full items-center justify-between gap-cluster px-row text-left outline-none focus-visible:shadow-border-interactive-with-active min-[768px]:hidden"
               aria-label="Toggle run navigation"
             >
               <span className="min-w-0">
@@ -82,7 +82,7 @@ export function RunWorkspaceNav({
           </CollapsibleTrigger>
           <div
             className={cn(
-              'max-h-[50vh] overflow-y-auto p-8 min-[768px]:block min-[768px]:max-h-none min-[768px]:p-12',
+              'max-h-[50vh] overflow-y-auto p-tight min-[768px]:block min-[768px]:max-h-none min-[768px]:p-panel-compact',
               !mobileOpen && 'hidden',
             )}
           >
@@ -136,7 +136,7 @@ function RunWorkspaceNavContent({
   }, [currentJobId, mobileOpen]);
 
   return (
-    <nav aria-label="Run workspace" className="flex min-w-0 flex-col gap-16">
+    <nav aria-label="Run workspace" className="flex min-w-0 flex-col gap-group">
       <ul>
         <li>
           <RunSectionLink
@@ -152,7 +152,7 @@ function RunWorkspaceNavContent({
       </ul>
 
       <section aria-labelledby="run-workspace-jobs-heading" className="min-w-0">
-        <div className="flex items-center justify-between gap-8 px-8 pb-6">
+        <div className="flex items-center justify-between gap-inline px-tight pb-[6px]">
           <Text
             as="h2"
             id="run-workspace-jobs-heading"
@@ -182,7 +182,7 @@ function RunWorkspaceNavContent({
                   onClick={onNavigate}
                   aria-current={current ? 'page' : undefined}
                   className={cn(
-                    'flex min-h-32 min-w-0 items-center gap-8 rounded-4 px-8 text-left outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
+                    'flex min-h-32 min-w-0 items-center gap-inline rounded-4 px-tight text-left outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
                     current && 'bg-background-neutral-hover',
                   )}
                 >
@@ -210,7 +210,7 @@ function RunWorkspaceNavContent({
           id="run-workspace-details-heading"
           size="xs"
           bold
-          className="px-8 pb-6 text-foreground-neutral-muted"
+          className="px-tight pb-[6px] text-foreground-neutral-muted"
         >
           Run details
         </Text>
@@ -285,7 +285,7 @@ function RunSectionLink({
           : undefined
       }
       className={cn(
-        'flex min-h-32 items-center gap-8 rounded-4 px-8 text-xs font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
+        'flex min-h-32 items-center gap-inline rounded-4 px-tight text-xs font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
         current && 'bg-background-neutral-hover',
       )}
     >

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -82,7 +82,7 @@ export function RunWorkspaceNav({
           </CollapsibleTrigger>
           <div
             className={cn(
-              'max-h-[50vh] overflow-y-auto p-tight min-[768px]:block min-[768px]:max-h-none min-[768px]:p-panel-compact',
+              'max-h-[50vh] overflow-y-auto p-tight min-[768px]:block min-[768px]:max-h-none min-[768px]:p-[12px]',
               !mobileOpen && 'hidden',
             )}
           >

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
@@ -9,10 +9,10 @@ export function WorkflowRunSkeleton() {
   return (
     <section
       aria-label="Loading workflow run"
-      className="bg-background-neutral-background px-16 py-12"
+      className="bg-background-neutral-background px-row py-row"
     >
-      <div className="flex min-w-0 flex-wrap items-center gap-x-12 gap-y-8">
-        <div className="flex min-w-0 items-center gap-8">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-cluster gap-y-inline">
+        <div className="flex min-w-0 items-center gap-inline">
           <Skeleton className="size-8 rounded-full" />
           <Skeleton className="h-24 w-180 rounded-6" />
         </div>
@@ -35,7 +35,7 @@ export function WorkflowRunContentSkeleton() {
   return (
     <section
       aria-label="Loading workflow run content"
-      className="min-h-160 rounded-8 border border-border-neutral-base bg-background-components-base p-16"
+      className="min-h-160 rounded-8 border border-border-neutral-base bg-background-components-base p-panel-compact"
     >
       <Skeleton className="h-160 w-full rounded-6" />
     </section>
@@ -59,9 +59,9 @@ export function WorkflowRunNotFound() {
  */
 export function WorkflowRunStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
-    <div className="border-b border-border-neutral-base p-8">
+    <div className="border-b border-border-neutral-base p-tight">
       <Callout role="alert" type="error">
-        <div className="flex items-center justify-between gap-8">
+        <div className="flex items-center justify-between gap-inline">
           <Text size="xs">Could not refresh this run.</Text>
           <Button
             type="button"

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -348,7 +348,7 @@ function RunViewContent({
               highlightedLineRange={highlightedLineRange}
             />
           ) : (
-            <div className="min-h-0 flex-1 overflow-auto p-24">{loadingOrError}</div>
+            <div className="min-h-0 flex-1 overflow-auto p-panel">{loadingOrError}</div>
           )}
         </div>
       </div>
@@ -391,8 +391,11 @@ function RunSectionContent({
 }) {
   if (section === 'summary') {
     return (
-      <section aria-label="All jobs summary" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
-        <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
+      <section
+        aria-label="All jobs summary"
+        className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
+      >
+        <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-group px-frame">
           <Text as="h2" className="sr-only">
             All jobs summary
           </Text>
@@ -424,8 +427,11 @@ function RunSectionContent({
   }
 
   return (
-    <section aria-label="Workflow source" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
-      <div className="mx-auto flex min-h-full w-full max-w-[1120px] flex-col px-24">
+    <section
+      aria-label="Workflow source"
+      className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
+    >
+      <div className="mx-auto flex min-h-full w-full max-w-[1120px] flex-col px-frame">
         <Text as="h2" className="sr-only">
           Workflow source
         </Text>
@@ -516,12 +522,15 @@ function RunAnnotationsSection({
   );
 
   return (
-    <section aria-label="Run annotations" className="min-h-0 flex-1 overflow-auto pb-24 pt-16">
-      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
+    <section
+      aria-label="Run annotations"
+      className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
+    >
+      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-group px-frame">
         <Text as="h2" className="sr-only">
           Annotations
         </Text>
-        <div className="flex flex-wrap items-center justify-between gap-8">
+        <div className="flex flex-wrap items-center justify-between gap-inline">
           <RunAnnotationSummaryLine
             summary={annotationSummary}
             workspaceSlug={workspaceSlug}
@@ -657,11 +666,11 @@ function RunWorkspaceNavSkeleton() {
   return (
     <aside
       aria-label="Loading run navigation"
-      className="hidden w-240 shrink-0 border-r border-border-neutral-base bg-background-neutral-background p-12 min-[768px]:block"
+      className="hidden w-240 shrink-0 border-r border-border-neutral-base bg-background-neutral-background p-panel-compact min-[768px]:block"
     >
-      <div className="flex flex-col gap-16">
+      <div className="flex flex-col gap-group">
         <div className="h-32 rounded-4 bg-background-components-subtle" />
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-inline">
           <div className="h-16 w-64 rounded-4 bg-background-components-subtle" />
           <div className="h-32 rounded-4 bg-background-components-subtle" />
           <div className="h-32 rounded-4 bg-background-components-subtle" />

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -66,9 +66,9 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
   }
 
   return (
-    <div className="flex w-full flex-col gap-24">
+    <div className="flex w-full flex-col gap-section">
       {projectQuery.isPending ? (
-        <div className="flex flex-col gap-12">
+        <div className="flex flex-col gap-cluster">
           <Skeleton className="h-28 w-1/3" />
           <Skeleton className="h-18 w-1/2" />
         </div>
@@ -88,7 +88,7 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
 
       {projectQuery.data ? (
         <>
-          <header className="flex flex-col gap-4">
+          <header className="flex flex-col gap-tight">
             <Header variant="h2">Workflows</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
               Synced workflow definitions for this project source.
@@ -170,7 +170,7 @@ function WorkflowDefinitionsList({
 }) {
   if (isPending) {
     return (
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-inline">
         <Skeleton className="h-40 w-full" />
         <Skeleton className="h-40 w-full" />
         <Skeleton className="h-40 w-full" />
@@ -228,11 +228,11 @@ function WorkflowDefinitionsList({
                     />
                   </TableCell>
                   <TableCell className="max-w-260">
-                    <div className="flex min-w-0 flex-col gap-2">
+                    <div className="flex min-w-0 flex-col gap-tight">
                       <button
                         type="button"
                         onClick={() => onOpenDefinition(definition)}
-                        className="flex min-w-0 flex-col gap-2 text-left outline-none focus-visible:shadow-border-interactive-with-active rounded-4"
+                        className="flex min-w-0 flex-col gap-tight text-left outline-none focus-visible:shadow-border-interactive-with-active rounded-4"
                       >
                         <Text size="sm" bold className="truncate">
                           {definition.name}
@@ -276,11 +276,11 @@ function WorkflowDefinitionsList({
           return (
             <div
               key={definition.id}
-              className="flex flex-col gap-10 border-b border-border-neutral-base p-12 last:border-b-0"
+              className="flex flex-col gap-inline border-b border-border-neutral-base p-panel-compact last:border-b-0"
             >
               <button
                 type="button"
-                className="flex min-w-0 items-start gap-10 text-left"
+                className="flex min-w-0 items-start gap-inline text-left"
                 onClick={() => onOpenDefinition(definition)}
               >
                 <Icon
@@ -288,7 +288,7 @@ function WorkflowDefinitionsList({
                   className="size-16 shrink-0 text-foreground-neutral-muted"
                   aria-hidden="true"
                 />
-                <div className="flex min-w-0 flex-col gap-4">
+                <div className="flex min-w-0 flex-col gap-tight">
                   <Text size="sm" bold className="break-words">
                     {definition.name}
                   </Text>
@@ -297,7 +297,7 @@ function WorkflowDefinitionsList({
                   </Code>
                 </div>
               </button>
-              <div className="flex items-center justify-between gap-8">
+              <div className="flex items-center justify-between gap-inline">
                 <Text size="xs" className="text-foreground-neutral-muted">
                   Updated <RelativeTime value={definition.updatedAt} />
                 </Text>
@@ -319,7 +319,7 @@ function WorkflowDefinitionsList({
 
       {isFetchNextPageError ? (
         <Callout role="alert" type="error">
-          <div className="flex items-center justify-between gap-12">
+          <div className="flex items-center justify-between gap-cluster">
             <Text size="sm">Could not load more workflows.</Text>
             <Button size="sm" variant="secondary" onClick={onLoadMore}>
               Retry
@@ -363,7 +363,7 @@ function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummary | null | undefin
 
   return (
     <Callout role="alert" type="error">
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-tight">
         <Text size="sm" bold>
           Workflow sync failed
         </Text>
@@ -388,11 +388,11 @@ function WorkflowSyncWarnings({sync}: {sync: DefinitionSyncSummary | null | unde
 
   return (
     <Callout role="status" type="warning">
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-inline">
         <Text size="sm" bold>
           Workflow definition warnings
         </Text>
-        <ul className="flex flex-col gap-4">
+        <ul className="flex flex-col gap-tight">
           {warningItems.map(({key, warning}) => (
             <li key={key}>
               <Text size="sm">{warning.message}</Text>
@@ -436,18 +436,18 @@ function DefinitionSheet({
                 {definition.configPath ?? 'Manual workflow definition'}
               </SheetDescription>
             </SheetHeader>
-            <SheetBody className="gap-18">
-              <div className="grid w-full gap-10">
+            <SheetBody className="gap-group">
+              <div className="grid w-full gap-inline">
                 <Metadata label="Definition id" value={definition.id} />
                 <Metadata label="Source" value={definition.source} />
                 <Metadata label="Ref" value={definition.ref ?? 'Not set'} />
                 <Metadata label="SHA" value={definition.sha ?? 'Not set'} />
               </div>
-              <div className="flex w-full flex-col gap-8">
+              <div className="flex w-full flex-col gap-inline">
                 <Text size="sm" bold>
                   Normalized definition
                 </Text>
-                <pre className="max-h-[52vh] w-full overflow-auto rounded-8 border border-border-neutral-base bg-background-neutral-subtle p-12 scrollbar">
+                <pre className="max-h-[52vh] w-full overflow-auto rounded-8 border border-border-neutral-base bg-background-neutral-subtle p-panel-compact scrollbar">
                   <Code as="code" className="whitespace-pre text-foreground-neutral-base">
                     {normalizedJson}
                   </Code>
@@ -463,7 +463,7 @@ function DefinitionSheet({
 
 function Metadata({label, value}: {label: string; value: string}) {
   return (
-    <div className="min-w-0 py-12 first:pt-0 last:pb-0">
+    <div className="min-w-0 py-row first:pt-0 last:pb-0">
       <Text size="xs" className="text-foreground-neutral-muted">
         {label}
       </Text>

--- a/libs/client/workflows/src/pages/workflow-run-list-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-list-page.tsx
@@ -50,7 +50,7 @@ export function WorkflowRunsPage({
 
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden bg-background-neutral-base">
-      <div className="mx-auto flex min-h-0 w-full max-w-[1120px] flex-1 flex-col px-24 py-24">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1120px] flex-1 flex-col px-frame py-frame">
         <WorkflowRunList
           projectId={projectId}
           workspaceSlug={workspaceSlug}

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -199,6 +199,7 @@ describe('client-architecture Biome plugins', () => {
         '**/libs/client/runners/**',
         '**/libs/client/projects/**',
         '**/libs/client/agent/**',
+        '**/libs/client/workflows/**',
         '!**/dist/**',
         '!**/node_modules/**',
         '!**/*.test.ts',


### PR DESCRIPTION
Migrates the published @shipfox/client-workflows surfaces to the semantic spacing roles defined by the design system, removing the package's remaining non-zero raw spacing utilities.

The PR also enables no-raw-spacing for the package, updates the enforcement test, adds the required patch Changeset, and preserves the fixed layout contracts identified during review: the status-strip width budget, coarse-pointer chip padding, annotation skeleton padding, and step-row trailing inset.

Validation passed: turbo check/type for the client-workflows dependency closure, the full client-workflows test suite (46 files / 514 tests), Biome plugin tests, the raw-spacing audit, and git diff --check. Argos visual sign-off remains the final landing check.

Closes ENG-1469

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `@shipfox/client-workflows` to semantic spacing roles and removed remaining raw spacing utilities. Preserved fixed graph/node geometry and centralized row spacing to keep DOM rows and edges in sync. Closes ENG-1469.

- **Refactors**
  - Rolled out semantic spacing tokens across workflow surfaces; kept layout contracts (status-strip width, step-row trailing inset, coarse-pointer chip padding, annotation skeleton padding).
  - Preserved job graph and node geometry; introduced shared `ROW_GAP` for graph rows so DOM layout and edge geometry use the same source without raw spacing utilities.
  - Enforcement and validation: enabled no-raw-spacing, expanded Biome plugin coverage to `libs/client/workflows/**`, updated enforcement tests, added a patch Changeset; type checks and test suites pass, raw-spacing audit and diff checks pass; Argos visual sign-off remains the final check.

<sup>Written for commit 05ab1c649f72bfa0681903b700d27dc4876457bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

