### PR TITLE
[provisioner-ec2] Deduplicate terminal instance observations

### DIFF
--- a/.changeset/quiet-ec2-termination.md
+++ b/.changeset/quiet-ec2-termination.md
@@ -2,4 +2,4 @@
 "@shipfox/provisioner-ec2-provider": patch
 ---
 
-Reports each EC2 runner termination once per AWS instance ID.
+EC2 terminal observations now use AWS instance IDs with a one-hour listing-gap grace period.

--- a/.changeset/quiet-ec2-termination.md
+++ b/.changeset/quiet-ec2-termination.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/provisioner-ec2-provider": patch
+---
+
+Reports each EC2 runner termination once per AWS instance ID.

--- a/.changeset/quiet-ec2-termination.md
+++ b/.changeset/quiet-ec2-termination.md
@@ -2,4 +2,4 @@
 "@shipfox/provisioner-ec2-provider": patch
 ---
 
-EC2 terminal observations now use AWS instance IDs with a one-hour listing-gap grace period.
+Reports each EC2 runner termination once instead of on every observation, using AWS instance IDs and a one-hour listing-gap grace period.

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -119,3 +119,12 @@ The provider reads the shared provisioner variables plus these EC2-specific vari
 The API clamps the requested reservation lifetime to its own `RESERVATION_TTL_MAX_SECONDS`
 ceiling and does not report the clamp. Raising the registration deadline past that ceiling
 therefore shortens the reservation relative to the deadline: raise both together.
+
+## Behavior notes
+
+The provider deduplicates terminal observations by AWS instance ID while AWS keeps
+the instance in the managed listing.
+It reports pending, running, stopping, and shutting-down states on each observation.
+Stopped instances remain eligible for termination. Shutting-down and terminated
+instances do not trigger another AWS termination call.
+The in-memory marker resets when the provider restarts.

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -122,9 +122,9 @@ therefore shortens the reservation relative to the deadline: raise both together
 ## Behavior notes
 
 Search for `Observed EC2 runner instance termination` to find one terminal log per AWS
-instance ID. The provider keeps the deduplication marker while the instance is listed
-and for one hour after a listing gap.
-Non-terminal states are reported on ordinary observations.
+instance ID. The provider keeps the marker while AWS lists the instance, and for one
+hour after a listing gap.
+The provider reports non-terminal states on every observation.
 When the provider terminates an instance, it reports `terminated` with either
 `backend-terminate` or `registration-deadline`.
 Stopped instances remain eligible for termination. Shutting-down and terminated

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -124,8 +124,9 @@ therefore shortens the reservation relative to the deadline: raise both together
 Search for `Observed EC2 runner instance termination` to find one terminal log per AWS
 instance ID. The provider keeps the deduplication marker while the instance is listed
 and for one hour after a listing gap.
-Non-terminal states are reported on ordinary observations. An actionable termination
-reports its terminal reason instead.
+Non-terminal states are reported on ordinary observations.
+When the provider terminates an instance, it reports `terminated` with either
+`backend-terminate` or `registration-deadline`.
 Stopped instances remain eligible for termination. Shutting-down and terminated
 instances do not trigger another AWS termination call.
 The in-memory marker resets when the provider restarts.

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -1,9 +1,8 @@
 # @shipfox/provisioner-ec2-provider
 
-The EC2 provider scaffold for the Shipfox provisioner. It currently loads and validates
-EC2 template configuration for the provider-agnostic
-[`@shipfox/provisioner-core`](../core) control loop. The EC2 engine, lifecycle, and app
-wiring land in later issues.
+The EC2 provider loads and validates template configuration, runs the EC2 lifecycle, and
+reports capacity through the provider-agnostic [`@shipfox/provisioner-core`](../core)
+control loop.
 
 ## Public API
 
@@ -122,9 +121,11 @@ therefore shortens the reservation relative to the deadline: raise both together
 
 ## Behavior notes
 
-The provider deduplicates terminal observations by AWS instance ID while AWS keeps
-the instance in the managed listing.
-It reports pending, running, stopping, and shutting-down states on each observation.
+Search for `Observed EC2 runner instance termination` to find one terminal log per AWS
+instance ID. The provider keeps the deduplication marker while the instance is listed
+and for one hour after a listing gap.
+Non-terminal states are reported on ordinary observations. An actionable termination
+reports its terminal reason instead.
 Stopped instances remain eligible for termination. Shutting-down and terminated
 instances do not trigger another AWS termination call.
 The in-memory marker resets when the provider restarts.

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -391,7 +391,7 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies).toHaveLength(1);
   });
 
-  it('deduplicates a terminal report after the API rejects it as invalid', async () => {
+  it('does not deduplicate a terminal report that the API rejects as invalid', async () => {
     const client = fakeClient({reportErrors: [httpError(400)]});
     const lifecycle = makeLifecycle({
       engine: fakeEngine({instances: [instance({state: 'terminated'})]}),
@@ -401,9 +401,9 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.observe();
     await lifecycle.observe();
 
-    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(1);
-    expect(observability.logger.info).toHaveBeenCalledTimes(1);
-    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(2);
+    expect(observability.logger.info).toHaveBeenCalledTimes(2);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(2);
   });
 
   it('keeps authentication report failures fatal', async () => {
@@ -600,6 +600,32 @@ describe('createEc2Lifecycle', () => {
     ]);
     expect(observability.recordEc2Termination).toHaveBeenCalledWith('backend-terminate');
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps successful termination actions when a later instance fails', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({state: 'running'}),
+        instance({state: 'running', instanceId: 'i-456', providerRunnerId: 'runner-2'}),
+      ],
+      terminateErrors: [undefined, new Error('EC2 unavailable')],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [
+          reconciledRunner('runner-1', 'terminate'),
+          reconciledRunner('runner-2', 'terminate'),
+        ],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.reconcile()).rejects.toThrow('EC2 unavailable');
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual(['i-123', 'i-456']);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(2);
   });
 
   it('reports the first terminal observation before handling backend terminate intent', async () => {
@@ -838,10 +864,16 @@ function instance(args: {
 }
 
 function fakeEngine(
-  options: {instances?: Ec2InstanceView[]; runError?: Error; listError?: Error} = {},
+  options: {
+    instances?: Ec2InstanceView[];
+    runError?: Error;
+    listError?: Error;
+    terminateErrors?: Array<Error | undefined>;
+  } = {},
 ): Ec2Engine & {runArgs: Parameters<Ec2Engine['runInstance']>[0][]; terminated: string[]} {
   const runArgs: Parameters<Ec2Engine['runInstance']>[0][] = [];
   const terminated: string[] = [];
+  const terminateErrors = [...(options.terminateErrors ?? [])];
   return {
     runArgs,
     terminated,
@@ -856,6 +888,8 @@ function fakeEngine(
         ? Promise.reject(options.listError)
         : Promise.resolve(options.instances ?? []),
     terminate: (instanceIds) => {
+      const error = terminateErrors.shift();
+      if (error) return Promise.reject(error);
       terminated.push(...instanceIds);
       return Promise.resolve();
     },

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -391,7 +391,7 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies).toHaveLength(1);
   });
 
-  it('does not deduplicate a terminal report that the API rejects as invalid', async () => {
+  it('deduplicates a terminal report after the API rejects it as invalid', async () => {
     const client = fakeClient({reportErrors: [httpError(400)]});
     const lifecycle = makeLifecycle({
       engine: fakeEngine({instances: [instance({state: 'terminated'})]}),
@@ -401,9 +401,9 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.observe();
     await lifecycle.observe();
 
-    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(2);
-    expect(observability.logger.info).toHaveBeenCalledTimes(2);
-    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(2);
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(1);
+    expect(observability.logger.info).toHaveBeenCalledTimes(1);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
   it('keeps authentication report failures fatal', async () => {
@@ -426,6 +426,21 @@ describe('createEc2Lifecycle', () => {
     await expect(lifecycle.observe()).rejects.toThrow(ProvisionerAuthenticationError);
 
     expect(engine.terminated).toEqual(['i-123']);
+  });
+
+  it('reaps an overdue instance before a failed reconcile request from tick', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
+    });
+    const reconcileError = new ProvisionerAuthenticationError(401);
+    const client = fakeClient({reconcileErrors: [reconcileError, reconcileError]});
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await expect(lifecycle.tick()).rejects.toThrow(ProvisionerAuthenticationError);
+    await expect(lifecycle.tick()).rejects.toThrow(ProvisionerAuthenticationError);
+
+    expect(engine.terminated).toEqual(['i-123']);
+    expect(client.reconcileBodies).toHaveLength(2);
   });
 
   it('reports a failed launch and does not launch when provider identity attachment is rejected', async () => {
@@ -671,8 +686,11 @@ describe('createEc2Lifecycle', () => {
     const lifecycle = makeLifecycle({engine, client});
 
     await lifecycle.reconcile();
+    await lifecycle.reconcile();
 
     expect(engine.terminated).toEqual(['i-123']);
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith('backend-terminate');
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
   it('reaps a pending instance past its registration deadline even when its labels are unresolvable', async () => {
@@ -690,8 +708,11 @@ describe('createEc2Lifecycle', () => {
     const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
     await lifecycle.observe();
+    await lifecycle.observe();
 
     expect(engine.terminated).toEqual(['i-123']);
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith('registration-deadline');
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
   it('reaps a pending instance past its registration deadline', async () => {
@@ -845,6 +866,7 @@ function fakeClient(
   options: {
     reportErrors?: Error[];
     assignmentErrors?: Error[];
+    reconcileErrors?: Error[];
     attachResult?: {attached: boolean};
     reconcileResponse?: Awaited<ReturnType<ProvisionerClient['reconcileRunnerInstances']>>;
   } = {},
@@ -860,6 +882,7 @@ function fakeClient(
   const attachments: Array<{runnerInstanceId: string; providerRunnerId: string}> = [];
   const reportErrors = [...(options.reportErrors ?? [])];
   const assignmentErrors = [...(options.assignmentErrors ?? [])];
+  const reconcileErrors = [...(options.reconcileErrors ?? [])];
   return {
     reportBodies,
     reconcileBodies,
@@ -872,6 +895,8 @@ function fakeClient(
     createRunnerInstances: () => Promise.resolve({runner_instances: []}),
     reconcileRunnerInstances: (body) => {
       reconcileBodies.push(body);
+      const error = reconcileErrors.shift();
+      if (error) return Promise.reject(error);
       return Promise.resolve(
         options.reconcileResponse ?? {
           runners: [],

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -24,6 +24,7 @@ vi.mock('#metrics/instance.js', () => ({
 
 const NOW = new Date('2026-01-01T00:10:00.000Z');
 const RECONCILE_INTERVAL_MS = 60_000;
+const TERMINAL_REPORT_ABSENCE_GRACE_MS = 60 * 60 * 1000;
 const RUNNER_INSTANCE_ID = '00000000-0000-4000-8000-000000000004';
 
 const template: ProvisionerTemplate<Ec2TemplateSpec> = {
@@ -171,13 +172,35 @@ describe('createEc2Lifecycle', () => {
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
-  it('reports a terminal instance again after it leaves and re-enters the listing', async () => {
+  it('keeps terminal deduplication through a transient listing gap', async () => {
     const instances = [instance({state: 'terminated'})];
     const client = fakeClient();
     const lifecycle = makeLifecycle({engine: fakeEngine({instances}), client});
 
     await lifecycle.observe();
     instances.length = 0;
+    await lifecycle.observe();
+    instances.push(instance({state: 'terminated'}));
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(1);
+    expect(observability.logger.info).toHaveBeenCalledTimes(1);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a terminal instance again after the listing-gap grace period', async () => {
+    const now = new Date(NOW);
+    const instances = [instance({state: 'terminated'})];
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances}),
+      client,
+      now: () => now,
+    });
+
+    await lifecycle.observe();
+    instances.length = 0;
+    now.setTime(now.getTime() + TERMINAL_REPORT_ABSENCE_GRACE_MS + 1);
     await lifecycle.observe();
     instances.push(instance({state: 'terminated'}));
     await lifecycle.observe();
@@ -368,12 +391,41 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies).toHaveLength(1);
   });
 
+  it('does not deduplicate a terminal report that the API rejects as invalid', async () => {
+    const client = fakeClient({reportErrors: [httpError(400)]});
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'terminated'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(2);
+    expect(observability.logger.info).toHaveBeenCalledTimes(2);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps authentication report failures fatal', async () => {
     const lifecycle = makeLifecycle({
       client: fakeClient({reportErrors: [new ProvisionerAuthenticationError(401)]}),
     });
 
     await expect(lifecycle.launch(launch())).rejects.toThrow(ProvisionerAuthenticationError);
+  });
+
+  it('terminates an overdue instance before authentication failures can block reporting', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
+    });
+    const client = fakeClient({
+      reportErrors: [new ProvisionerAuthenticationError(401)],
+    });
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await expect(lifecycle.observe()).rejects.toThrow(ProvisionerAuthenticationError);
+
+    expect(engine.terminated).toEqual(['i-123']);
   });
 
   it('reports a failed launch and does not launch when provider identity attachment is rejected', async () => {
@@ -524,16 +576,13 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.reconcile();
 
     expect(engine.terminated).toEqual(['i-123']);
-    expect(client.reportBodies.flatMap((body) => body.events)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({provider_runner_id: 'runner-1', state: 'running'}),
-        expect.objectContaining({
-          provider_runner_id: 'runner-1',
-          state: 'terminated',
-          reason: 'backend-terminate',
-        }),
-      ]),
-    );
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({
+        provider_runner_id: 'runner-1',
+        state: 'terminated',
+        reason: 'backend-terminate',
+      }),
+    ]);
   });
 
   it('reports the first terminal observation before handling backend terminate intent', async () => {
@@ -644,21 +693,23 @@ describe('createEc2Lifecycle', () => {
   });
 
   it('reaps a pending instance past its registration deadline', async () => {
+    const instances = [
+      instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')}),
+    ];
     const engine = fakeEngine({
-      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
+      instances,
     });
     const client = fakeClient();
     const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
     await lifecycle.observe();
+    instances[0] = instance({state: 'terminated'});
+    await lifecycle.observe();
 
     expect(engine.terminated).toEqual(['i-123']);
-    expect(client.reportBodies.flatMap((body) => body.events)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({state: 'starting'}),
-        expect.objectContaining({state: 'terminated', reason: 'registration-deadline'}),
-      ]),
-    );
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({state: 'terminated', reason: 'registration-deadline'}),
+    ]);
   });
 
   it('periodically reconciles and otherwise observes', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -145,11 +145,46 @@ describe('createEc2Lifecycle', () => {
     });
 
     await lifecycle.observe();
+    await lifecycle.observe();
 
     expect(tracker.countsByTemplate()).toEqual(
       new Map([['spot-small', {starting: 0, running: 1}]]),
     );
-    expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'running'});
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({state: 'running'}),
+      expect.objectContaining({state: 'running'}),
+    ]);
+  });
+
+  it('reports a terminal instance once across observation passes', async () => {
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'terminated'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(1);
+    expect(observability.logger.info).toHaveBeenCalledTimes(1);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a terminal instance again after it leaves and re-enters the listing', async () => {
+    const instances = [instance({state: 'terminated'})];
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine: fakeEngine({instances}), client});
+
+    await lifecycle.observe();
+    instances.length = 0;
+    await lifecycle.observe();
+    instances.push(instance({state: 'terminated'}));
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(2);
+    expect(observability.logger.info).toHaveBeenCalledTimes(2);
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(2);
   });
 
   it('assigns an enrolled observed runner through its EC2 identity', async () => {
@@ -275,7 +310,7 @@ describe('createEc2Lifecycle', () => {
     expect(client.assignmentBodies).toHaveLength(2);
   });
 
-  it('reports a Spot-reclaimed terminated instance as failed', async () => {
+  it('reports a Spot-reclaimed terminated instance as failed once', async () => {
     const client = fakeClient();
     const lifecycle = makeLifecycle({
       engine: fakeEngine({
@@ -290,12 +325,13 @@ describe('createEc2Lifecycle', () => {
     });
 
     await lifecycle.observe();
+    await lifecycle.observe();
 
-    expect(client.reportBodies[0]?.events[0]).toMatchObject({
-      state: 'failed',
-      reason: 'spot-interruption',
-    });
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({state: 'failed', reason: 'spot-interruption'}),
+    ]);
     expect(observability.recordEc2Termination).toHaveBeenCalledWith('spot-interruption');
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
   it('propagates observation failures so the core loop degrades capacity to zero', async () => {
@@ -488,8 +524,86 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.reconcile();
 
     expect(engine.terminated).toEqual(['i-123']);
-    expect(client.reportBodies.flatMap((body) => body.events)).toMatchObject([
-      {provider_runner_id: 'runner-1', state: 'terminated', reason: 'backend-terminate'},
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({provider_runner_id: 'runner-1', state: 'running'}),
+        expect.objectContaining({
+          provider_runner_id: 'runner-1',
+          state: 'terminated',
+          reason: 'backend-terminate',
+        }),
+      ]),
+    );
+  });
+
+  it('reports the first terminal observation before handling backend terminate intent', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'terminated'})]});
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual([]);
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({provider_runner_id: 'runner-1', state: 'terminated'}),
+    ]);
+  });
+
+  it('does not terminate or re-report an already-terminated instance with backend intent', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'terminated'})]});
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual([]);
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(1);
+  });
+
+  it('reports a stopped instance once and still terminates it under backend intent', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'stopped'})]});
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual(['i-123']);
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({provider_runner_id: 'runner-1', state: 'terminated'}),
+    ]);
+  });
+
+  it('reports shutting-down instances without calling terminate again', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'shutting-down'})]});
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual([]);
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({provider_runner_id: 'runner-1', state: 'stopping'}),
     ]);
   });
 
@@ -539,10 +653,12 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.observe();
 
     expect(engine.terminated).toEqual(['i-123']);
-    expect(client.reportBodies[0]?.events[0]).toMatchObject({
-      state: 'terminated',
-      reason: 'registration-deadline',
-    });
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({state: 'starting'}),
+        expect.objectContaining({state: 'terminated', reason: 'registration-deadline'}),
+      ]),
+    );
   });
 
   it('periodically reconciles and otherwise observes', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -583,6 +583,8 @@ describe('createEc2Lifecycle', () => {
         reason: 'backend-terminate',
       }),
     ]);
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith('backend-terminate');
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
   it('reports the first terminal observation before handling backend terminate intent', async () => {
@@ -710,6 +712,8 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
       expect.objectContaining({state: 'terminated', reason: 'registration-deadline'}),
     ]);
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith('registration-deadline');
+    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
   it('periodically reconciles and otherwise observes', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -82,6 +82,9 @@ interface Ec2LifecycleContext {
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
   readonly terminalReportedInstanceIds: Map<string, number>;
+  // Keep successful actions across short listing gaps so eventual-consistency reads do not
+  // repeat AWS calls or metrics.
+  readonly terminationActionedInstanceIds: Map<string, number>;
   readonly pendingTerminalReportedInstanceIds: Set<string>;
   readonly terminalReportInstanceIdsByEvent: WeakMap<RunnerInstanceReportEventDto, string>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
@@ -108,6 +111,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
     terminalReportedInstanceIds: new Map(),
+    terminationActionedInstanceIds: new Map(),
     pendingTerminalReportedInstanceIds: new Set(),
     terminalReportInstanceIdsByEvent: new WeakMap(),
     pendingReports: [],
@@ -185,6 +189,7 @@ async function observe(context: Ec2LifecycleContext): Promise<void> {
 
 async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   const instances = await context.engine.listManaged(context.identity.id);
+  await reapRegistrationDeadlineInstances(context, instances);
   const observedProviderRunnerIds = observedRunnerIds(instances);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
     logger().error(
@@ -217,6 +222,16 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   await applyObservedInstances(context, instances, terminateIntentIds);
   await reportEvents(context, []);
   context.lastReconciledAt = new Date(context.now());
+}
+
+async function reapRegistrationDeadlineInstances(
+  context: Ec2LifecycleContext,
+  instances: readonly Ec2InstanceView[],
+): Promise<void> {
+  const instancesToReap = instances.filter(
+    (instance) => isPastRegistrationDeadline(instance, context) && canTerminateInstance(instance),
+  );
+  await terminateInstances(context, instancesToReap, 'registration-deadline');
 }
 
 function tick(context: Ec2LifecycleContext): Promise<void> {
@@ -262,6 +277,9 @@ async function applyObservedInstances(
     observedInstanceIds.add(instance.instanceId);
     if (context.terminalReportedInstanceIds.has(instance.instanceId)) {
       context.terminalReportedInstanceIds.set(instance.instanceId, observedAt);
+    }
+    if (context.terminationActionedInstanceIds.has(instance.instanceId)) {
+      context.terminationActionedInstanceIds.set(instance.instanceId, observedAt);
     }
     if (identity.runnerInstanceId) observedRunnerInstanceIds.add(identity.runnerInstanceId);
     if (!identity.providerRunnerId) continue;
@@ -338,6 +356,7 @@ async function applyObservedInstances(
   }
 
   pruneTerminalReportedInstances(context, observedInstanceIds, context.now().getTime());
+  pruneTerminationActionedInstances(context, observedInstanceIds, context.now().getTime());
   synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
   context.tracker.replaceAll(trackerRunners);
   await assignEnrolledReservations(context, assignmentCandidates, observedRunnerInstanceIds);
@@ -413,6 +432,21 @@ function pruneTerminalReportedInstances(
   }
 }
 
+function pruneTerminationActionedInstances(
+  context: Ec2LifecycleContext,
+  observedInstanceIds: ReadonlySet<string>,
+  nowMs: number,
+): void {
+  for (const [instanceId, actionedAt] of context.terminationActionedInstanceIds) {
+    if (
+      !observedInstanceIds.has(instanceId) &&
+      nowMs - actionedAt >= TERMINAL_REPORT_ABSENCE_GRACE_MS
+    ) {
+      context.terminationActionedInstanceIds.delete(instanceId);
+    }
+  }
+}
+
 function synthesizeAbsentLaunchedRunners(
   context: Ec2LifecycleContext,
   observedIds: ReadonlySet<string>,
@@ -460,8 +494,16 @@ async function terminateInstances(
   if (instances.length === 0) return;
 
   const terminableInstances = instances.filter(canTerminateInstance);
-  if (terminableInstances.length > 0) {
-    await context.engine.terminate(terminableInstances.map((instance) => instance.instanceId));
+  const instancesToTerminate = terminableInstances.filter(
+    (instance) => !context.terminationActionedInstanceIds.has(instance.instanceId),
+  );
+  if (instancesToTerminate.length > 0) {
+    await context.engine.terminate(instancesToTerminate.map((instance) => instance.instanceId));
+    const actionedAt = context.now().getTime();
+    for (const instance of instancesToTerminate) {
+      context.terminationActionedInstanceIds.set(instance.instanceId, actionedAt);
+      recordEc2Termination(reason);
+    }
   }
   const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
   const events = terminableInstances.flatMap((instance) => {
@@ -472,7 +514,6 @@ async function terminateInstances(
     const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
     if (!identity.providerRunnerId || labels.length === 0) return [];
     if (hasTerminalReport(context, instance.instanceId)) return [];
-    recordEc2Termination(reason);
     const event = eventForInstance(context, instance, 'terminated', labels, reason);
     terminalReportInstanceIds.set(event, instance.instanceId);
     return [event];
@@ -537,14 +578,15 @@ async function reportEvents(
     const batch = reports.slice(index, index + MAX_REPORT_BATCH);
     try {
       await context.client.reportRunnerInstances({events: batch});
-      rememberDeliveredTerminalReports(context, batch);
+      rememberTerminalReports(context, batch);
     } catch (error) {
       if (error instanceof ProvisionerAuthenticationError) {
         context.pendingReports.push(...reports.slice(index));
         throw error;
       }
       if (responseStatus(error) === 400) {
-        forgetTerminalReports(context, batch);
+        // A permanent rejection must not reopen the terminal observation loop.
+        rememberTerminalReports(context, batch);
         continue;
       }
       context.pendingReports.push(...reports.slice(index));
@@ -553,7 +595,7 @@ async function reportEvents(
   }
 }
 
-function rememberDeliveredTerminalReports(
+function rememberTerminalReports(
   context: Ec2LifecycleContext,
   reports: readonly RunnerInstanceReportEventDto[],
 ): void {
@@ -561,18 +603,6 @@ function rememberDeliveredTerminalReports(
     const instanceId = context.terminalReportInstanceIdsByEvent.get(report);
     if (!instanceId) continue;
     context.terminalReportedInstanceIds.set(instanceId, context.now().getTime());
-    context.pendingTerminalReportedInstanceIds.delete(instanceId);
-    context.terminalReportInstanceIdsByEvent.delete(report);
-  }
-}
-
-function forgetTerminalReports(
-  context: Ec2LifecycleContext,
-  reports: readonly RunnerInstanceReportEventDto[],
-): void {
-  for (const report of reports) {
-    const instanceId = context.terminalReportInstanceIdsByEvent.get(report);
-    if (!instanceId) continue;
     context.pendingTerminalReportedInstanceIds.delete(instanceId);
     context.terminalReportInstanceIdsByEvent.delete(report);
   }

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -18,6 +18,7 @@ import type {Ec2TemplateSpec} from '#templates.js';
 
 const MAX_REPORT_BATCH = 1000;
 const MAX_REASON_LENGTH = 500;
+const TERMINAL_REPORT_ABSENCE_GRACE_MS = 60 * 60 * 1000;
 const SPOT_INTERRUPTION_REASON =
   /spot|instance-terminated-by-price|instance-terminated-no-capacity/i;
 
@@ -37,6 +38,8 @@ type AssignmentCandidate = {
   reservationId: string;
   runnerInstanceId: string;
 };
+
+type TerminalReportInstanceIds = ReadonlyMap<RunnerInstanceReportEventDto, string>;
 
 export interface Ec2Lifecycle {
   launch(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): Promise<void>;
@@ -72,7 +75,9 @@ interface Ec2LifecycleContext {
   readonly now: () => Date;
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
-  readonly terminalReportedInstanceIds: Set<string>;
+  readonly terminalReportedInstanceIds: Map<string, number>;
+  readonly pendingTerminalReportedInstanceIds: Set<string>;
+  readonly terminalReportInstanceIdsByEvent: Map<RunnerInstanceReportEventDto, string>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
   readonly releasedReservationRunnerIds: Map<string, Set<string>>;
   lastReconciledAt?: Date;
@@ -96,7 +101,9 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     now: options.now ?? (() => new Date()),
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
-    terminalReportedInstanceIds: new Set(),
+    terminalReportedInstanceIds: new Map(),
+    pendingTerminalReportedInstanceIds: new Set(),
+    terminalReportInstanceIdsByEvent: new Map(),
     pendingReports: [],
     releasedReservationRunnerIds: new Map(),
   };
@@ -165,13 +172,12 @@ async function launchRunner(
 }
 
 async function observe(context: Ec2LifecycleContext): Promise<void> {
-  await reportEvents(context, []);
   const instances = await context.engine.listManaged(context.identity.id);
   await applyObservedInstances(context, instances, new Set());
+  await reportEvents(context, []);
 }
 
 async function reconcile(context: Ec2LifecycleContext): Promise<void> {
-  await reportEvents(context, []);
   const instances = await context.engine.listManaged(context.identity.id);
   const observedProviderRunnerIds = observedRunnerIds(instances);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
@@ -183,6 +189,7 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
       'Skipping backend reconcile because observed EC2 runner count exceeds the API limit',
     );
     await applyObservedInstances(context, instances, new Set());
+    await reportEvents(context, []);
     return;
   }
 
@@ -202,6 +209,7 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   }
 
   await applyObservedInstances(context, instances, terminateIntentIds);
+  await reportEvents(context, []);
   context.lastReconciledAt = new Date(context.now());
 }
 
@@ -234,16 +242,21 @@ async function applyObservedInstances(
 ): Promise<void> {
   const trackerRunners: TrackerSeed[] = [];
   const events: RunnerInstanceReportEventDto[] = [];
+  const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
   const assignmentCandidates: AssignmentCandidate[] = [];
   const observedIds = new Set<string>();
   const observedInstanceIds = new Set<string>();
   const observedRunnerInstanceIds = new Set<string>();
   const reapInstances: Ec2InstanceView[] = [];
   const terminateIntentInstances: Ec2InstanceView[] = [];
+  const observedAt = context.now().getTime();
 
   for (const instance of instances) {
     const identity = parseInstanceIdentity(instance);
     observedInstanceIds.add(instance.instanceId);
+    if (context.terminalReportedInstanceIds.has(instance.instanceId)) {
+      context.terminalReportedInstanceIds.set(instance.instanceId, observedAt);
+    }
     if (identity.runnerInstanceId) observedRunnerInstanceIds.add(identity.runnerInstanceId);
     if (!identity.providerRunnerId) continue;
     observedIds.add(identity.providerRunnerId);
@@ -252,9 +265,11 @@ async function applyObservedInstances(
     const hasTerminateIntent = terminateIntentIds.has(identity.providerRunnerId);
     const pastRegistrationDeadline = isPastRegistrationDeadline(instance, context);
     const terminationRequested = hasTerminateIntent || pastRegistrationDeadline;
-    if (hasTerminateIntent && canTerminateInstance(instance)) {
+    const canTerminate = canTerminateInstance(instance);
+    const shouldTerminate = terminationRequested && canTerminate;
+    if (hasTerminateIntent && canTerminate) {
       terminateIntentInstances.push(instance);
-    } else if (pastRegistrationDeadline && canTerminateInstance(instance)) {
+    } else if (pastRegistrationDeadline && canTerminate) {
       reapInstances.push(instance);
     }
 
@@ -266,55 +281,63 @@ async function applyObservedInstances(
 
     const mapped = mapInstanceState(instance);
     const terminalObservation = mapped.state === 'failed' || mapped.state === 'terminated';
-    if (!terminalObservation || !context.terminalReportedInstanceIds.has(instance.instanceId)) {
-      if (terminalObservation) {
-        const terminationReason =
-          mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
-        recordEc2Termination(terminationReason);
-        logger().info(
-          {
-            provisioned_runner_id: identity.providerRunnerId,
-            ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
-            aws_instance_id: instance.instanceId,
-            reason: terminationReason,
-          },
-          'Observed EC2 runner instance termination',
-        );
+    const alreadyReportedTerminal =
+      terminalObservation && hasTerminalReport(context, instance.instanceId);
+    // Actionable termination paths report their terminal reason from terminateInstances below.
+    if (!shouldTerminate) {
+      if (!alreadyReportedTerminal) {
+        if (terminalObservation) {
+          const terminationReason =
+            mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
+          recordEc2Termination(terminationReason);
+          logger().info(
+            {
+              provisioned_runner_id: identity.providerRunnerId,
+              ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+              aws_instance_id: instance.instanceId,
+              reason: terminationReason,
+            },
+            'Observed EC2 runner instance termination',
+          );
+        }
+        const event = eventForInstance(context, instance, mapped.state, labels, mapped.reason);
+        events.push(event);
+        if (terminalObservation) terminalReportInstanceIds.set(event, instance.instanceId);
       }
-      events.push(eventForInstance(context, instance, mapped.state, labels, mapped.reason));
-      if (terminalObservation) context.terminalReportedInstanceIds.add(instance.instanceId);
-    }
-    if (
-      !terminationRequested &&
-      (mapped.state === 'starting' || mapped.state === 'running') &&
-      identity.runnerInstanceId &&
-      identity.reservationId
-    ) {
-      assignmentCandidates.push({
-        runnerInstanceId: identity.runnerInstanceId,
-        reservationId: identity.reservationId,
-      });
-    }
-    if (
-      !terminationRequested &&
-      (mapped.state === 'starting' || mapped.state === 'running') &&
-      identity.templateKey
-    ) {
-      trackerRunners.push({
-        providerRunnerId: identity.providerRunnerId,
-        templateKey: identity.templateKey,
-        state: mapped.state,
-      });
+      if (
+        !terminationRequested &&
+        (mapped.state === 'starting' || mapped.state === 'running') &&
+        identity.runnerInstanceId &&
+        identity.reservationId
+      ) {
+        assignmentCandidates.push({
+          runnerInstanceId: identity.runnerInstanceId,
+          reservationId: identity.reservationId,
+        });
+      }
+      if (
+        !terminationRequested &&
+        (mapped.state === 'starting' || mapped.state === 'running') &&
+        identity.templateKey
+      ) {
+        trackerRunners.push({
+          providerRunnerId: identity.providerRunnerId,
+          templateKey: identity.templateKey,
+          state: mapped.state,
+        });
+      }
     }
   }
 
-  pruneTerminalReportedInstances(context, observedInstanceIds);
+  pruneTerminalReportedInstances(context, observedInstanceIds, context.now().getTime());
   synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
   context.tracker.replaceAll(trackerRunners);
   await assignEnrolledReservations(context, assignmentCandidates, observedRunnerInstanceIds);
-  if (events.length > 0) await reportEvents(context, events);
   await terminateInstances(context, terminateIntentInstances, 'backend-terminate');
   await terminateInstances(context, reapInstances, 'registration-deadline');
+  if (events.length > 0) {
+    await reportEvents(context, events, terminalReportInstanceIds);
+  }
 }
 
 async function assignEnrolledReservations(
@@ -370,10 +393,15 @@ function pruneReleasedReservationRunners(
 function pruneTerminalReportedInstances(
   context: Ec2LifecycleContext,
   observedInstanceIds: ReadonlySet<string>,
+  nowMs: number,
 ): void {
-  for (const instanceId of context.terminalReportedInstanceIds) {
-    if (!observedInstanceIds.has(instanceId))
+  for (const [instanceId, lastObservedAt] of context.terminalReportedInstanceIds) {
+    if (
+      !observedInstanceIds.has(instanceId) &&
+      nowMs - lastObservedAt >= TERMINAL_REPORT_ABSENCE_GRACE_MS
+    ) {
       context.terminalReportedInstanceIds.delete(instanceId);
+    }
   }
 }
 
@@ -427,6 +455,7 @@ async function terminateInstances(
   if (terminableInstances.length > 0) {
     await context.engine.terminate(terminableInstances.map((instance) => instance.instanceId));
   }
+  const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
   const events = terminableInstances.flatMap((instance) => {
     const identity = parseInstanceIdentity(instance);
     const template = identity.templateKey
@@ -434,11 +463,14 @@ async function terminateInstances(
       : undefined;
     const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
     if (!identity.providerRunnerId || labels.length === 0) return [];
-    if (context.terminalReportedInstanceIds.has(instance.instanceId)) return [];
-    context.terminalReportedInstanceIds.add(instance.instanceId);
-    return [eventForInstance(context, instance, 'terminated', labels, reason)];
+    if (hasTerminalReport(context, instance.instanceId)) return [];
+    const event = eventForInstance(context, instance, 'terminated', labels, reason);
+    terminalReportInstanceIds.set(event, instance.instanceId);
+    return [event];
   });
-  if (events.length > 0) await reportEvents(context, events);
+  if (events.length > 0) {
+    await reportEvents(context, events, terminalReportInstanceIds);
+  }
   for (const instance of instances) {
     const identity = parseInstanceIdentity(instance);
     context.locallyLaunched.delete(identity.providerRunnerId);
@@ -448,6 +480,13 @@ async function terminateInstances(
 
 function canTerminateInstance(instance: Ec2InstanceView): boolean {
   return instance.state !== 'shutting-down' && instance.state !== 'terminated';
+}
+
+function hasTerminalReport(context: Ec2LifecycleContext, instanceId: string): boolean {
+  return (
+    context.terminalReportedInstanceIds.has(instanceId) ||
+    context.pendingTerminalReportedInstanceIds.has(instanceId)
+  );
 }
 
 function observedRunnerIds(instances: readonly Ec2InstanceView[]): string[] {
@@ -476,21 +515,55 @@ async function attachProviderIdentity(
 async function reportEvents(
   context: Ec2LifecycleContext,
   events: readonly RunnerInstanceReportEventDto[],
+  terminalReportInstanceIds: TerminalReportInstanceIds = new Map(),
 ): Promise<void> {
+  for (const [event, instanceId] of terminalReportInstanceIds) {
+    context.terminalReportInstanceIdsByEvent.set(event, instanceId);
+    context.pendingTerminalReportedInstanceIds.add(instanceId);
+  }
   const reports = [...context.pendingReports.splice(0), ...events];
   for (let index = 0; index < reports.length; index += MAX_REPORT_BATCH) {
     const batch = reports.slice(index, index + MAX_REPORT_BATCH);
     try {
       await context.client.reportRunnerInstances({events: batch});
+      rememberDeliveredTerminalReports(context, batch);
     } catch (error) {
       if (error instanceof ProvisionerAuthenticationError) {
         context.pendingReports.push(...reports.slice(index));
         throw error;
       }
-      if (responseStatus(error) === 400) continue;
+      if (responseStatus(error) === 400) {
+        forgetTerminalReports(context, batch);
+        continue;
+      }
       context.pendingReports.push(...reports.slice(index));
       return;
     }
+  }
+}
+
+function rememberDeliveredTerminalReports(
+  context: Ec2LifecycleContext,
+  reports: readonly RunnerInstanceReportEventDto[],
+): void {
+  for (const report of reports) {
+    const instanceId = context.terminalReportInstanceIdsByEvent.get(report);
+    if (!instanceId) continue;
+    context.terminalReportedInstanceIds.set(instanceId, context.now().getTime());
+    context.pendingTerminalReportedInstanceIds.delete(instanceId);
+    context.terminalReportInstanceIdsByEvent.delete(report);
+  }
+}
+
+function forgetTerminalReports(
+  context: Ec2LifecycleContext,
+  reports: readonly RunnerInstanceReportEventDto[],
+): void {
+  for (const report of reports) {
+    const instanceId = context.terminalReportInstanceIdsByEvent.get(report);
+    if (!instanceId) continue;
+    context.pendingTerminalReportedInstanceIds.delete(instanceId);
+    context.terminalReportInstanceIdsByEvent.delete(report);
   }
 }
 

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -72,6 +72,7 @@ interface Ec2LifecycleContext {
   readonly now: () => Date;
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
+  readonly terminalReportedInstanceIds: Set<string>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
   readonly releasedReservationRunnerIds: Map<string, Set<string>>;
   lastReconciledAt?: Date;
@@ -95,6 +96,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     now: options.now ?? (() => new Date()),
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
+    terminalReportedInstanceIds: new Set(),
     pendingReports: [],
     releasedReservationRunnerIds: new Map(),
   };
@@ -234,24 +236,26 @@ async function applyObservedInstances(
   const events: RunnerInstanceReportEventDto[] = [];
   const assignmentCandidates: AssignmentCandidate[] = [];
   const observedIds = new Set<string>();
+  const observedInstanceIds = new Set<string>();
   const observedRunnerInstanceIds = new Set<string>();
   const reapInstances: Ec2InstanceView[] = [];
   const terminateIntentInstances: Ec2InstanceView[] = [];
 
   for (const instance of instances) {
     const identity = parseInstanceIdentity(instance);
+    observedInstanceIds.add(instance.instanceId);
     if (identity.runnerInstanceId) observedRunnerInstanceIds.add(identity.runnerInstanceId);
     if (!identity.providerRunnerId) continue;
     observedIds.add(identity.providerRunnerId);
     context.locallyLaunched.delete(identity.providerRunnerId);
 
-    if (terminateIntentIds.has(identity.providerRunnerId)) {
+    const hasTerminateIntent = terminateIntentIds.has(identity.providerRunnerId);
+    const pastRegistrationDeadline = isPastRegistrationDeadline(instance, context);
+    const terminationRequested = hasTerminateIntent || pastRegistrationDeadline;
+    if (hasTerminateIntent && canTerminateInstance(instance)) {
       terminateIntentInstances.push(instance);
-      continue;
-    }
-    if (isPastRegistrationDeadline(instance, context)) {
+    } else if (pastRegistrationDeadline && canTerminateInstance(instance)) {
       reapInstances.push(instance);
-      continue;
     }
 
     const template = identity.templateKey
@@ -261,7 +265,27 @@ async function applyObservedInstances(
     if (labels.length === 0) continue;
 
     const mapped = mapInstanceState(instance);
+    const terminalObservation = mapped.state === 'failed' || mapped.state === 'terminated';
+    if (!terminalObservation || !context.terminalReportedInstanceIds.has(instance.instanceId)) {
+      if (terminalObservation) {
+        const terminationReason =
+          mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
+        recordEc2Termination(terminationReason);
+        logger().info(
+          {
+            provisioned_runner_id: identity.providerRunnerId,
+            ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+            aws_instance_id: instance.instanceId,
+            reason: terminationReason,
+          },
+          'Observed EC2 runner instance termination',
+        );
+      }
+      events.push(eventForInstance(context, instance, mapped.state, labels, mapped.reason));
+      if (terminalObservation) context.terminalReportedInstanceIds.add(instance.instanceId);
+    }
     if (
+      !terminationRequested &&
       (mapped.state === 'starting' || mapped.state === 'running') &&
       identity.runnerInstanceId &&
       identity.reservationId
@@ -271,22 +295,11 @@ async function applyObservedInstances(
         reservationId: identity.reservationId,
       });
     }
-    if (mapped.state === 'failed' || mapped.state === 'terminated') {
-      const terminationReason =
-        mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
-      recordEc2Termination(terminationReason);
-      logger().info(
-        {
-          provisioned_runner_id: identity.providerRunnerId,
-          ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
-          aws_instance_id: instance.instanceId,
-          reason: terminationReason,
-        },
-        'Observed EC2 runner instance termination',
-      );
-    }
-    events.push(eventForInstance(context, instance, mapped.state, labels, mapped.reason));
-    if ((mapped.state === 'starting' || mapped.state === 'running') && identity.templateKey) {
+    if (
+      !terminationRequested &&
+      (mapped.state === 'starting' || mapped.state === 'running') &&
+      identity.templateKey
+    ) {
       trackerRunners.push({
         providerRunnerId: identity.providerRunnerId,
         templateKey: identity.templateKey,
@@ -295,6 +308,7 @@ async function applyObservedInstances(
     }
   }
 
+  pruneTerminalReportedInstances(context, observedInstanceIds);
   synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
   context.tracker.replaceAll(trackerRunners);
   await assignEnrolledReservations(context, assignmentCandidates, observedRunnerInstanceIds);
@@ -353,6 +367,16 @@ function pruneReleasedReservationRunners(
   }
 }
 
+function pruneTerminalReportedInstances(
+  context: Ec2LifecycleContext,
+  observedInstanceIds: ReadonlySet<string>,
+): void {
+  for (const instanceId of context.terminalReportedInstanceIds) {
+    if (!observedInstanceIds.has(instanceId))
+      context.terminalReportedInstanceIds.delete(instanceId);
+  }
+}
+
 function synthesizeAbsentLaunchedRunners(
   context: Ec2LifecycleContext,
   observedIds: ReadonlySet<string>,
@@ -398,14 +422,20 @@ async function terminateInstances(
   reason: string,
 ): Promise<void> {
   if (instances.length === 0) return;
-  await context.engine.terminate(instances.map((instance) => instance.instanceId));
-  const events = instances.flatMap((instance) => {
+
+  const terminableInstances = instances.filter(canTerminateInstance);
+  if (terminableInstances.length > 0) {
+    await context.engine.terminate(terminableInstances.map((instance) => instance.instanceId));
+  }
+  const events = terminableInstances.flatMap((instance) => {
     const identity = parseInstanceIdentity(instance);
     const template = identity.templateKey
       ? context.templatesByKey.get(identity.templateKey)
       : undefined;
     const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
     if (!identity.providerRunnerId || labels.length === 0) return [];
+    if (context.terminalReportedInstanceIds.has(instance.instanceId)) return [];
+    context.terminalReportedInstanceIds.add(instance.instanceId);
     return [eventForInstance(context, instance, 'terminated', labels, reason)];
   });
   if (events.length > 0) await reportEvents(context, events);
@@ -414,6 +444,10 @@ async function terminateInstances(
     context.locallyLaunched.delete(identity.providerRunnerId);
     context.tracker.remove(identity.providerRunnerId);
   }
+}
+
+function canTerminateInstance(instance: Ec2InstanceView): boolean {
+  return instance.state !== 'shutting-down' && instance.state !== 'terminated';
 }
 
 function observedRunnerIds(instances: readonly Ec2InstanceView[]): string[] {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -13,11 +13,17 @@ import type {
 import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
 import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.js';
 import {buildInstanceTags, parseInstanceIdentity} from '#instance-identity.js';
-import {recordEc2Launch, recordEc2Termination} from '#metrics/instance.js';
+import {
+  type Ec2TerminationReason,
+  recordEc2Launch,
+  recordEc2Termination,
+} from '#metrics/instance.js';
 import type {Ec2TemplateSpec} from '#templates.js';
 
 const MAX_REPORT_BATCH = 1000;
 const MAX_REASON_LENGTH = 500;
+// DescribeInstances can retain terminated instances for about an hour. Keep the marker
+// for that long across a listing gap to cover eventual-consistency blips.
 const TERMINAL_REPORT_ABSENCE_GRACE_MS = 60 * 60 * 1000;
 const SPOT_INTERRUPTION_REASON =
   /spot|instance-terminated-by-price|instance-terminated-no-capacity/i;
@@ -77,7 +83,7 @@ interface Ec2LifecycleContext {
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
   readonly terminalReportedInstanceIds: Map<string, number>;
   readonly pendingTerminalReportedInstanceIds: Set<string>;
-  readonly terminalReportInstanceIdsByEvent: Map<RunnerInstanceReportEventDto, string>;
+  readonly terminalReportInstanceIdsByEvent: WeakMap<RunnerInstanceReportEventDto, string>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
   readonly releasedReservationRunnerIds: Map<string, Set<string>>;
   lastReconciledAt?: Date;
@@ -103,7 +109,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     locallyLaunched: new Map(),
     terminalReportedInstanceIds: new Map(),
     pendingTerminalReportedInstanceIds: new Set(),
-    terminalReportInstanceIdsByEvent: new Map(),
+    terminalReportInstanceIdsByEvent: new WeakMap(),
     pendingReports: [],
     releasedReservationRunnerIds: new Map(),
   };
@@ -273,6 +279,11 @@ async function applyObservedInstances(
       reapInstances.push(instance);
     }
 
+    if (shouldTerminate) {
+      // terminateInstances reports the provider-initiated reason: backend-terminate or registration-deadline.
+      continue;
+    }
+
     const template = identity.templateKey
       ? context.templatesByKey.get(identity.templateKey)
       : undefined;
@@ -283,49 +294,46 @@ async function applyObservedInstances(
     const terminalObservation = mapped.state === 'failed' || mapped.state === 'terminated';
     const alreadyReportedTerminal =
       terminalObservation && hasTerminalReport(context, instance.instanceId);
-    // Actionable termination paths report their terminal reason from terminateInstances below.
-    if (!shouldTerminate) {
-      if (!alreadyReportedTerminal) {
-        if (terminalObservation) {
-          const terminationReason =
-            mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
-          recordEc2Termination(terminationReason);
-          logger().info(
-            {
-              provisioned_runner_id: identity.providerRunnerId,
-              ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
-              aws_instance_id: instance.instanceId,
-              reason: terminationReason,
-            },
-            'Observed EC2 runner instance termination',
-          );
-        }
-        const event = eventForInstance(context, instance, mapped.state, labels, mapped.reason);
-        events.push(event);
-        if (terminalObservation) terminalReportInstanceIds.set(event, instance.instanceId);
+    if (!alreadyReportedTerminal) {
+      if (terminalObservation) {
+        const terminationReason =
+          mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
+        recordEc2Termination(terminationReason);
+        logger().info(
+          {
+            provisioned_runner_id: identity.providerRunnerId,
+            ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+            aws_instance_id: instance.instanceId,
+            reason: terminationReason,
+          },
+          'Observed EC2 runner instance termination',
+        );
       }
-      if (
-        !terminationRequested &&
-        (mapped.state === 'starting' || mapped.state === 'running') &&
-        identity.runnerInstanceId &&
-        identity.reservationId
-      ) {
-        assignmentCandidates.push({
-          runnerInstanceId: identity.runnerInstanceId,
-          reservationId: identity.reservationId,
-        });
-      }
-      if (
-        !terminationRequested &&
-        (mapped.state === 'starting' || mapped.state === 'running') &&
-        identity.templateKey
-      ) {
-        trackerRunners.push({
-          providerRunnerId: identity.providerRunnerId,
-          templateKey: identity.templateKey,
-          state: mapped.state,
-        });
-      }
+      const event = eventForInstance(context, instance, mapped.state, labels, mapped.reason);
+      events.push(event);
+      if (terminalObservation) terminalReportInstanceIds.set(event, instance.instanceId);
+    }
+    if (
+      !terminationRequested &&
+      (mapped.state === 'starting' || mapped.state === 'running') &&
+      identity.runnerInstanceId &&
+      identity.reservationId
+    ) {
+      assignmentCandidates.push({
+        runnerInstanceId: identity.runnerInstanceId,
+        reservationId: identity.reservationId,
+      });
+    }
+    if (
+      !terminationRequested &&
+      (mapped.state === 'starting' || mapped.state === 'running') &&
+      identity.templateKey
+    ) {
+      trackerRunners.push({
+        providerRunnerId: identity.providerRunnerId,
+        templateKey: identity.templateKey,
+        state: mapped.state,
+      });
     }
   }
 
@@ -447,7 +455,7 @@ function isPastRegistrationDeadline(
 async function terminateInstances(
   context: Ec2LifecycleContext,
   instances: readonly Ec2InstanceView[],
-  reason: string,
+  reason: Ec2TerminationReason,
 ): Promise<void> {
   if (instances.length === 0) return;
 
@@ -464,6 +472,7 @@ async function terminateInstances(
     const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
     if (!identity.providerRunnerId || labels.length === 0) return [];
     if (hasTerminalReport(context, instance.instanceId)) return [];
+    recordEc2Termination(reason);
     const event = eventForInstance(context, instance, 'terminated', labels, reason);
     terminalReportInstanceIds.set(event, instance.instanceId);
     return [event];
@@ -517,6 +526,8 @@ async function reportEvents(
   events: readonly RunnerInstanceReportEventDto[],
   terminalReportInstanceIds: TerminalReportInstanceIds = new Map(),
 ): Promise<void> {
+  // Pending IDs suppress duplicates without marking delivery. The DTO omits the AWS ID, so
+  // object identity keeps each retry correlated with the instance that produced it.
   for (const [event, instanceId] of terminalReportInstanceIds) {
     context.terminalReportInstanceIdsByEvent.set(event, instanceId);
     context.pendingTerminalReportedInstanceIds.add(instanceId);

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -497,13 +497,11 @@ async function terminateInstances(
   const instancesToTerminate = terminableInstances.filter(
     (instance) => !context.terminationActionedInstanceIds.has(instance.instanceId),
   );
-  if (instancesToTerminate.length > 0) {
-    await context.engine.terminate(instancesToTerminate.map((instance) => instance.instanceId));
+  for (const instance of instancesToTerminate) {
+    await context.engine.terminate([instance.instanceId]);
     const actionedAt = context.now().getTime();
-    for (const instance of instancesToTerminate) {
-      context.terminationActionedInstanceIds.set(instance.instanceId, actionedAt);
-      recordEc2Termination(reason);
-    }
+    context.terminationActionedInstanceIds.set(instance.instanceId, actionedAt);
+    recordEc2Termination(reason);
   }
   const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
   const events = terminableInstances.flatMap((instance) => {
@@ -578,15 +576,14 @@ async function reportEvents(
     const batch = reports.slice(index, index + MAX_REPORT_BATCH);
     try {
       await context.client.reportRunnerInstances({events: batch});
-      rememberTerminalReports(context, batch);
+      rememberDeliveredTerminalReports(context, batch);
     } catch (error) {
       if (error instanceof ProvisionerAuthenticationError) {
         context.pendingReports.push(...reports.slice(index));
         throw error;
       }
       if (responseStatus(error) === 400) {
-        // A permanent rejection must not reopen the terminal observation loop.
-        rememberTerminalReports(context, batch);
+        forgetTerminalReports(context, batch);
         continue;
       }
       context.pendingReports.push(...reports.slice(index));
@@ -595,7 +592,7 @@ async function reportEvents(
   }
 }
 
-function rememberTerminalReports(
+function rememberDeliveredTerminalReports(
   context: Ec2LifecycleContext,
   reports: readonly RunnerInstanceReportEventDto[],
 ): void {
@@ -603,6 +600,18 @@ function rememberTerminalReports(
     const instanceId = context.terminalReportInstanceIdsByEvent.get(report);
     if (!instanceId) continue;
     context.terminalReportedInstanceIds.set(instanceId, context.now().getTime());
+    context.pendingTerminalReportedInstanceIds.delete(instanceId);
+    context.terminalReportInstanceIdsByEvent.delete(report);
+  }
+}
+
+function forgetTerminalReports(
+  context: Ec2LifecycleContext,
+  reports: readonly RunnerInstanceReportEventDto[],
+): void {
+  for (const report of reports) {
+    const instanceId = context.terminalReportInstanceIdsByEvent.get(report);
+    if (!instanceId) continue;
     context.pendingTerminalReportedInstanceIds.delete(instanceId);
     context.terminalReportInstanceIdsByEvent.delete(report);
   }


### PR DESCRIPTION
## Summary

EC2 keeps terminated instances in managed listings for a period after termination, so the converge loop can repeatedly report the same terminal observation and retry termination work. This change reports each termination once instead of on every observation, keyed by AWS instance ID with a one-hour listing-gap grace period.

The provider performs its AWS termination before delivering the associated terminal report, so report authentication failures cannot prevent reaping. It suppresses AWS termination calls only for `shutting-down` and `terminated`; stopped instances remain terminable. Provider-initiated terminal events carry `backend-terminate` or `registration-deadline`, and both reasons now increment the termination metric.

Terminal markers are recorded only after successful report delivery. Retriable failures remain associated with their pending terminal event, while an HTTP 400 batch does not silence a future observation.

The PR includes lifecycle regression coverage, operator behavior notes, and a patch changeset for `@shipfox/provisioner-ec2-provider`.

## Validation

- `mise exec -- turbo test type check --filter=@shipfox/provisioner-ec2-provider... --force` (82 tasks, 117 EC2 tests)
- `mise exec -- turbo check type test --filter=@shipfox/provisioner-ec2-provider...` (82 tasks, 117 EC2 tests)
- `mise exec -- turbo verify --filter=@shipfox/prose-policy` (0 errors; existing warnings and suggestions remain)

This repository has no `lint` Turbo task for the package; `check` is the configured Biome lint-equivalent.