### PR TITLE
[e2e-client-workspaces] Remove returning-user home screenshot capture

### DIFF
--- a/e2e/suites/client/workspaces/tests/workspace-switching.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/workspace-switching.e2e.ts
@@ -1,4 +1,3 @@
-import {stableScreenshot} from '@shipfox/e2e-kit/ui';
 import {expect, test} from './test.js';
 import {ONBOARDING_URL_RE, workspaceUrlRe} from './workspace-urls.js';
 
@@ -79,6 +78,5 @@ test.describe('workspace switching', () => {
         ONBOARDING_URL_RE,
       );
     }
-    await stableScreenshot(page, 'workspaces/returning-user-home');
   });
 });


### PR DESCRIPTION
Remove the returning-user home screenshot from the client workspaces E2E suite so visual coverage can be owned by Storybook. The test still verifies direct routing to the workspace and prevents an onboarding URL from flashing during navigation.

Validation: `mise exec -- turbo check type depcruise --filter=@shipfox/e2e-client-workspaces...` (371 tasks successful)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the returning-user home screenshot capture from the client workspaces E2E test so Storybook owns visual coverage. The test still verifies direct routing to the workspace and ensures the onboarding URL does not flash during navigation.

<sup>Written for commit 1a5645adc8553714932e0419055c155b87538114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

