### PR TITLE
[provisioner-ec2] Warn when templates lack IAM instance profiles

### DIFF
--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -6,10 +6,14 @@ import {fileURLToPath} from 'node:url';
 import {MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import {Ec2TemplateConfigError, loadEc2Templates} from '#templates.js';
 
+const observability = vi.hoisted(() => ({logger: {warn: vi.fn()}}));
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
+
 let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'provisioner-ec2-'));
+  observability.logger.warn.mockReset();
 });
 
 afterEach(() => {
@@ -154,6 +158,30 @@ describe('loadEc2Templates', () => {
         },
       },
     ]);
+  });
+
+  it('warns when a template has no IAM instance profile', () => {
+    const path = writeTemplates(template());
+
+    loadEc2Templates(path);
+
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      {
+        event: 'provisioner.ec2_template_missing_iam_instance_profile',
+        filePath: path,
+        templateKey: 't',
+        capability: 'host_debugging_over_aws_systems_manager',
+      },
+      'EC2 template "t" has no IAM instance profile; host debugging over AWS Systems Manager is unavailable',
+    );
+  });
+
+  it('does not warn when a template has an IAM instance profile', () => {
+    const path = writeTemplates(template({}, '    iam_instance_profile: shipfox-runner\n'));
+
+    loadEc2Templates(path);
+
+    expect(observability.logger.warn).not.toHaveBeenCalled();
   });
 
   it('accepts a null spot price', () => {

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -1,4 +1,5 @@
 import {readFileSync} from 'node:fs';
+import {logger} from '@shipfox/node-opentelemetry';
 import {
   type ProvisionerTemplate,
   ProvisionerTemplateFileError,
@@ -125,6 +126,18 @@ function toTemplate(
   if (invalid.length > 0) {
     throw new Ec2TemplateConfigError(
       `Template "${key}" in ${filePath} has invalid labels: ${invalid.join(', ')}.`,
+    );
+  }
+
+  if (spec.iam_instance_profile === undefined) {
+    logger().warn(
+      {
+        event: 'provisioner.ec2_template_missing_iam_instance_profile',
+        filePath,
+        templateKey: key,
+        capability: 'host_debugging_over_aws_systems_manager',
+      },
+      `EC2 template "${key}" has no IAM instance profile; host debugging over AWS Systems Manager is unavailable`,
     );
   }
 


### PR DESCRIPTION
Warn during EC2 template loading when `iam_instance_profile` is absent, identifying the template and the unavailable Systems Manager host-debugging capability. Templates with a profile remain silent, and deployments that intentionally omit SSM remain supported.

The self-hosting documentation portion of ENG-1494 is intentionally not included in this PR.

Validation passed: `mise exec -- turbo check type test --filter=@shipfox/provisioner-ec2-provider...` (82/82 tasks, 121 EC2 tests) and `git diff --check`.

Refs ENG-1494

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn during EC2 template load when `iam_instance_profile` is missing to surface that AWS Systems Manager host debugging is unavailable. No behavior changes; templates that omit SSM remain supported. Part of ENG-1494.

- **New Features**
  - Emit a warning via `@shipfox/node-opentelemetry` (`event: provisioner.ec2_template_missing_iam_instance_profile`) with `filePath`, `templateKey`, and `capability`.
  - Tests cover warn on missing profile and no warn when present.

<sup>Written for commit 0d3556d0a1de3f09651524ec38ca65d6655ea683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

