### PR TITLE
[api-runners] Preserve rebound assignments across stale provider reports

### DIFF
--- a/libs/api/runners/src/presentation/routes/late-runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/late-runner-enrollment.test.ts
@@ -7,9 +7,11 @@ import {
   extractBearerToken,
 } from '@shipfox/node-fastify';
 import {vi} from '@shipfox/vitest/vi';
-import {eq} from 'drizzle-orm';
+import {and, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
+import {reservations} from '#db/schema/reservations.js';
+import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {runnerReservationPromotionFailureCount} from '#metrics/instance.js';
@@ -214,6 +216,191 @@ describe('late runner enrollment recovery', () => {
       maxClaims: 1,
       claimsUsed: 1,
     });
+  });
+
+  it('preserves a rebound assignment across stale provider reports and releases it once', async () => {
+    const providerRunnerId = `stale-assignment-${crypto.randomUUID()}`;
+    const firstReportAt = new Date(Date.now() - 2_000);
+    const [staleReservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning({id: reservations.id});
+    if (!staleReservation) throw new Error('Expected stale reservation');
+
+    const initialReport = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${workspaceToken}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: providerRunnerId,
+            reservation_id: staleReservation.id,
+            template_key: 'linux',
+            labels: ['linux'],
+            state: 'running',
+            reported_at: firstReportAt.toISOString(),
+            provider_kind: 'docker',
+          },
+        ],
+      },
+    });
+
+    expect(initialReport.statusCode).toBe(200);
+    expect(initialReport.json()).toEqual({accepted: 1, reservations_released: 0});
+
+    const [reportedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.provisionerId, provisionerId),
+          eq(providerRunners.providerRunnerId, providerRunnerId),
+        ),
+      );
+    if (!reportedRunner) throw new Error('Expected reported runner');
+    expect(reportedRunner).toMatchObject({
+      workspaceId,
+      reservationId: staleReservation.id,
+      state: 'running',
+    });
+
+    await db()
+      .insert(runnerControlSessions)
+      .values({
+        runnerInstanceId: reportedRunner.id,
+        provisionerId,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    await db()
+      .update(reservations)
+      .set({expiresAt: new Date(Date.now() - 1_000)})
+      .where(eq(reservations.id, staleReservation.id));
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const demand = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${workspaceToken}`},
+      payload: {
+        wait_seconds: 0,
+        max_reservations: 1,
+        reservation_ttl_seconds: 60,
+        templates: [
+          {
+            template_key: 'linux',
+            labels: ['linux'],
+            available_slots: 1,
+            starting: 0,
+            running: 1,
+          },
+        ],
+      },
+    });
+
+    expect(demand.statusCode).toBe(200);
+    const reboundReservationId = demand.json().reservations[0]?.reservation_id;
+    expect(reboundReservationId).toEqual(expect.any(String));
+    expect(reboundReservationId).not.toBe(staleReservation.id);
+
+    const staleReport = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${workspaceToken}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: providerRunnerId,
+            reservation_id: staleReservation.id,
+            template_key: 'linux',
+            labels: ['linux'],
+            state: 'running',
+            reported_at: new Date(firstReportAt.getTime() + 1_000).toISOString(),
+            provider_kind: 'docker',
+          },
+        ],
+      },
+    });
+
+    expect(staleReport.statusCode).toBe(200);
+    expect(staleReport.json()).toEqual({accepted: 1, reservations_released: 0});
+
+    const [reboundRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, reportedRunner.id));
+    expect(reboundRunner).toMatchObject({
+      workspaceId,
+      reservationId: reboundReservationId,
+      state: 'running',
+      intendedReservationId: null,
+    });
+
+    const terminalReport = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${workspaceToken}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: providerRunnerId,
+            reservation_id: staleReservation.id,
+            template_key: 'linux',
+            labels: ['linux'],
+            state: 'terminated',
+            reported_at: new Date(firstReportAt.getTime() + 2_000).toISOString(),
+            provider_kind: 'docker',
+          },
+        ],
+      },
+    });
+
+    expect(terminalReport.statusCode).toBe(200);
+    expect(terminalReport.json()).toEqual({accepted: 1, reservations_released: 1});
+
+    const [staleReservationAfterTerminal] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, staleReservation.id));
+    const [reboundReservationAfterTerminal] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, reboundReservationId));
+    expect(staleReservationAfterTerminal).toMatchObject({
+      id: staleReservation.id,
+      count: 1,
+    });
+    expect(reboundReservationAfterTerminal).toBeUndefined();
+
+    const repeatedTerminalReport = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${workspaceToken}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: providerRunnerId,
+            reservation_id: staleReservation.id,
+            template_key: 'linux',
+            labels: ['linux'],
+            state: 'terminated',
+            reported_at: new Date(firstReportAt.getTime() + 3_000).toISOString(),
+            provider_kind: 'docker',
+          },
+        ],
+      },
+    });
+
+    expect(repeatedTerminalReport.statusCode).toBe(200);
+    expect(repeatedTerminalReport.json()).toEqual({accepted: 1, reservations_released: 0});
   });
 
   async function enrollRunner(controlSessionToken: string): Promise<void> {


### PR DESCRIPTION
Exercise the provider-facing lifecycle where a runner reports reservation A, A expires, and the public demand poll rebinds the runner to reservation B. The real-Postgres integration then sends stale running and terminal reports that still carry A, proving B remains committed, A is untouched, and terminal cleanup releases B exactly once.

Closes ENG-1504

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a real-Postgres integration test to verify runner rebinding is preserved when providers send stale reports. It ensures a runner rebinds from expired reservation A to B, stale running/terminal reports with A don’t overwrite B, and terminal cleanup releases B exactly once.

Connects to ENG-1504 by covering the public provider report and demand poll flow so stale metadata can’t clobber the committed reservation or release the wrong one.

<sup>Written for commit 73cd16220f70d66a6930d5337b33e7a4af21226a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

