### PR TITLE
Keep only the latest pending main CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,17 @@ permissions:
   contents: read
   pull-requests: read
 
-# Give every main push one FIFO slot before checks start. Pull requests use
-# independent groups, while the preview workflow owns its own stale-run
-# cancellation.
+# Keep the current main run and the newest pending run. A newer main push
+# replaces an older pending run without canceling the run already in progress.
+# Pull requests use independent groups, while the preview workflow owns its
+# own stale-run cancellation.
 concurrency:
   group: >-
     ${{ github.ref == 'refs/heads/main' &&
     format('{0}-main', github.workflow) ||
     format('{0}-pr-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: false
-  queue: max
+  queue: single
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
Update the CI concurrency policy so main keeps the workflow already in progress but replaces stale pending runs when newer merges arrive.

`queue: single` limits the main concurrency group to one pending run, and `cancel-in-progress: false` preserves the active build. Pull-request groups remain independent.

Validation: YAML parse, concurrency-policy assertion, and `git diff --check` passed. `actionlint` was unavailable locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI concurrency so `main` keeps the in-progress run and only the newest pending run. New pushes replace older queued runs, and pull request groups stay independent (`queue: single`, `cancel-in-progress: false` in `.github/workflows/ci.yml`).

<sup>Written for commit ceceba91688aa7b8f09aa1ee04ad3bb0d7b0972e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

