### PR TITLE
[api-runners] Prevent duplicate launches for adopted idle runners

### DIFF
--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -448,11 +448,18 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
-  it('counts rebound installation capacity against the remaining grant budget', async () => {
+  it.each([
+    ['template capacity', 5, 2],
+    ['global reservation budget', 2, 5],
+  ])('counts rebound installation capacity against the %s', async (_case, maxReservations, availableSlots) => {
     const reboundWorkspaceId = crypto.randomUUID();
     const launchWorkspaceId = crypto.randomUUID();
     await pendingJobFactory.create({
       workspaceId: reboundWorkspaceId,
+      requiredLabels: ['linux'],
+    });
+    await pendingJobFactory.create({
+      workspaceId: launchWorkspaceId,
       requiredLabels: ['linux'],
     });
     await pendingJobFactory.create({
@@ -471,9 +478,9 @@ describe('pollDemandAndReserve', () => {
 
     const result = await pollInstallationDemandAndReserve({
       provisionerId,
-      maxReservations: 1,
+      maxReservations,
       ttlSeconds: 60,
-      templates: [template('linux', ['linux'], 1)],
+      templates: [template('linux', ['linux'], availableSlots)],
       capabilityWindowSeconds: 60,
       eligibleWorkspaceIds: new Set([reboundWorkspaceId, launchWorkspaceId]),
     });
@@ -482,16 +489,15 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(reservations)
       .where(eq(reservations.provisionerId, provisionerId));
-    expect(result.reservations).toEqual([]);
-    expect(storedReservations).toHaveLength(1);
-    expect(storedReservations[0]).toMatchObject({
-      workspaceId: reboundWorkspaceId,
-      kind: 'bound',
-      count: 1,
-    });
-    expect(
-      storedReservations.some((reservation) => reservation.workspaceId === launchWorkspaceId),
-    ).toBe(false);
+    expect(result.reservations).toEqual([
+      expect.objectContaining({workspaceId: launchWorkspaceId, count: 1}),
+    ]);
+    expect(storedReservations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({workspaceId: reboundWorkspaceId, kind: 'bound', count: 1}),
+        expect.objectContaining({workspaceId: launchWorkspaceId, kind: 'launch', count: 1}),
+      ]),
+    );
   });
 
   it('does not rebind a released runner after its reservation expires', async () => {


### PR DESCRIPTION
The reservation poll now separates demand reservation units from new-runner launch units. Idle runners adopted by a reservation reduce the count sent to the provisioner, while the database reservation keeps its full count for demand suppression and assignment accounting. Fully adopted grants are omitted from the response because the DTO requires positive counts.

This fixes surplus launches when prewarmed runners already satisfy queued demand. The patch Changeset is included for `@shipfox/api-runners`. Follow-up coverage verifies installation fan-out budgets after full adoption and documents the launch-count contract.

Validation: full API runners test suite (44 files, 546 tests), affected package Biome and TypeScript checks, affected dependency build, and API database-boundary verification.

Closes ENG-1500