### PR TITLE
[api-runners] Require committed runner metadata for assignments

### DIFF
--- a/.changeset/committed-assignment-repair.md
+++ b/.changeset/committed-assignment-repair.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Repairs provider-reported runner assignments before activation and preserves reservation capacity during retries.

--- a/libs/api/runners/src/core/runner-control-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.test.ts
@@ -167,7 +167,7 @@ describe('enrollRunnerControlSession', () => {
     });
   });
 
-  it('updates metadata when a provider report precedes assignment commit', async () => {
+  it('repairs assignment metadata when a provider report precedes assignment commit', async () => {
     const provisionerId = crypto.randomUUID();
     const reservation = await createReservation({provisionerId});
     const capabilities: RunnerToolCapabilitiesDto = {
@@ -190,8 +190,10 @@ describe('enrollRunnerControlSession', () => {
     });
     const [runner] = await db()
       .select({
+        workspaceId: providerRunners.workspaceId,
         reservationId: providerRunners.reservationId,
         assignedAt: providerRunners.assignedAt,
+        intendedReservationId: providerRunners.intendedReservationId,
         labels: providerRunners.labels,
         providerKind: providerRunners.providerKind,
         protocolVersion: providerRunners.protocolVersion,
@@ -201,10 +203,12 @@ describe('enrollRunnerControlSession', () => {
       .from(providerRunners)
       .where(eq(providerRunners.id, runnerInstanceId));
 
-    expect(activationToken).toBeNull();
+    expect(activationToken).toEqual(expect.any(String));
     expect(runner).toEqual({
+      workspaceId: reservation.workspaceId,
       reservationId: reservation.id,
-      assignedAt: null,
+      assignedAt: expect.any(Date),
+      intendedReservationId: null,
       labels: ['linux'],
       providerKind: 'ec2',
       protocolVersion: '1',

--- a/libs/api/runners/src/db/runner-assignments.test.ts
+++ b/libs/api/runners/src/db/runner-assignments.test.ts
@@ -41,6 +41,50 @@ describe('assignRunnerInstances', () => {
     });
   });
 
+  it('repairs a provider-reported reservation before assignment commit', async () => {
+    const reservation = await createReservation();
+    const [runner] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId,
+        intendedReservationId: reservation.id,
+        reservationId: reservation.id,
+        providerRunnerId: crypto.randomUUID(),
+        labels: ['linux'],
+        state: 'running',
+        reportedAt: new Date(),
+      })
+      .returning();
+    if (!runner) throw new Error('Runner instance insert returned no row');
+    await db()
+      .insert(runnerControlSessions)
+      .values({
+        runnerInstanceId: runner.id,
+        provisionerId,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+    const assigned = await assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [runner.id],
+    });
+
+    expect(assigned).toEqual([runner.id]);
+    const [stored] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(stored).toMatchObject({
+      workspaceId,
+      reservationId: reservation.id,
+      intendedReservationId: null,
+      assignedAt: expect.any(Date),
+    });
+  });
+
   it('is idempotent for concurrent retries of the same assignment', async () => {
     const reservation = await createReservation();
     const runner = await createEnrolledRunner();
@@ -129,6 +173,25 @@ describe('assignRunnerInstances', () => {
     const reservation = await createReservation();
     const firstRunner = await createEnrolledRunner();
     const secondRunner = await createEnrolledRunner();
+
+    const assignment = assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [firstRunner.id, secondRunner.id],
+    });
+
+    await expect(assignment).rejects.toThrow(RunnerInstanceNotAssignableError);
+  });
+
+  it('charges capacity for a committed runner replayed alongside a new one', async () => {
+    const reservation = await createReservation();
+    const firstRunner = await createEnrolledRunner();
+    const secondRunner = await createEnrolledRunner();
+    await assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [firstRunner.id],
+    });
 
     const assignment = assignRunnerInstances({
       provisionerId,

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -39,6 +39,7 @@ export async function assignRunnerInstancesTx(
       reservationId: providerRunners.reservationId,
       intendedReservationId: providerRunners.intendedReservationId,
       workspaceId: providerRunners.workspaceId,
+      assignedAt: providerRunners.assignedAt,
       providerRunnerId: providerRunners.providerRunnerId,
       labels: providerRunners.labels,
       state: providerRunners.state,
@@ -53,11 +54,16 @@ export async function assignRunnerInstancesTx(
     .for('update');
 
   // The assignment outlives its short reservation row. A retry after maintenance
-  // cleanup is complete when every owned runner already carries the requested assignment.
+  // cleanup is complete when every owned runner already carries the committed assignment.
   if (
     runnerInstanceIds.length > 0 &&
     runnerRows.length === runnerInstanceIds.length &&
-    runnerRows.every((runner) => runner.reservationId === params.reservationId)
+    runnerRows.every(
+      (runner) =>
+        runner.reservationId === params.reservationId &&
+        runner.assignedAt !== null &&
+        runner.workspaceId !== null,
+    )
   ) {
     await tx
       .update(providerRunners)
@@ -110,13 +116,20 @@ export async function assignRunnerInstancesTx(
   const alreadyAssigned = runners.filter((runner) => runner.reservationId !== null);
   if (alreadyAssigned.some((runner) => runner.reservationId !== reservation.id))
     throw new RunnerInstanceAlreadyAssignedError(alreadyAssigned[0]?.id ?? '');
-  const newRunners = runners.filter((runner) => runner.reservationId === null);
+  const newRunners = runners.filter(
+    (runner) =>
+      runner.reservationId === null ||
+      (runner.reservationId === reservation.id &&
+        (runner.assignedAt === null || runner.workspaceId === null)),
+  );
+  const newRunnerIds = newRunners.map((runner) => runner.id);
   const assignedCount = await tx
     .select({count: sql<number>`count(*)::int`})
     .from(providerRunners)
     .where(
       and(
         eq(providerRunners.provisionerId, params.provisionerId),
+        notInArray(providerRunners.id, newRunnerIds),
         or(
           and(
             eq(providerRunners.reservationId, reservation.id),
@@ -124,7 +137,6 @@ export async function assignRunnerInstancesTx(
           ),
           and(
             eq(providerRunners.intendedReservationId, reservation.id),
-            notInArray(providerRunners.id, runnerInstanceIds),
             isNull(providerRunners.reservationReleasedAt),
             notInArray(providerRunners.state, [...terminalStates]),
           ),

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -210,7 +210,7 @@ describe('runner enrollment control plane', () => {
     expect(instance?.labels).toEqual(['linux']);
   });
 
-  it('promotes an intended reservation during enrollment and returns its activation token', async () => {
+  it('repairs an intended reservation after a provider report and returns its activation token', async () => {
     const workspaceId = crypto.randomUUID();
     const [reservation] = await db()
       .insert(reservations)
@@ -240,13 +240,48 @@ describe('runner enrollment control plane', () => {
     });
     const controlToken = exchanged.json().control_session_token;
 
+    const providerRunnerId = 'container-intended-assignment';
     const attached = await app.inject({
       method: 'POST',
       url: `/provisioners/runner-instances/${runner.runner_instance_id}/provider-runner`,
       headers: {authorization: `Bearer ${token}`},
-      payload: {provider_runner_id: 'container-intended-assignment'},
+      payload: {provider_runner_id: providerRunnerId},
     });
     expect(attached.json()).toEqual({attached: true});
+
+    const reported = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: providerRunnerId,
+            reservation_id: reservation.id,
+            template_key: 'linux',
+            labels: ['linux'],
+            state: 'starting',
+            reported_at: new Date().toISOString(),
+            provider_kind: 'docker',
+          },
+        ],
+      },
+    });
+    expect(reported.statusCode).toBe(200);
+    expect(reported.json()).toEqual({accepted: 1, reservations_released: 0});
+
+    const [reportedInstance] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.runner_instance_id));
+    expect(reportedInstance).toMatchObject({
+      workspaceId: null,
+      reservationId: reservation.id,
+      intendedReservationId: reservation.id,
+      assignedAt: null,
+      state: 'starting',
+      providerRunnerId,
+    });
 
     const enrolled = await app.inject({
       method: 'POST',
@@ -266,9 +301,47 @@ describe('runner enrollment control plane', () => {
       reservationId: reservation.id,
       intendedReservationId: null,
       state: 'running',
-      providerRunnerId: 'container-intended-assignment',
+      providerRunnerId,
       assignedAt: expect.any(Date),
     });
+  });
+
+  it('rejects assignment for a provider-reported runner before enrollment', async () => {
+    const workspaceId = crypto.randomUUID();
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!reservation) throw new Error('Reservation insert returned no row');
+    const [runner] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId,
+        intendedReservationId: reservation.id,
+        reservationId: reservation.id,
+        providerRunnerId: crypto.randomUUID(),
+        labels: ['linux'],
+        state: 'starting',
+        reportedAt: new Date(),
+      })
+      .returning({id: providerRunners.id});
+    if (!runner) throw new Error('Runner instance insert returned no row');
+
+    const assigned = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/assignments',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {reservation_id: reservation.id, runner_instance_ids: [runner.id]},
+    });
+
+    expect(assigned.statusCode).toBe(409);
+    expect(assigned.json()).toMatchObject({code: 'runner-instance-not-assignable'});
   });
 
   it('keeps enrollment successful when an intended reservation cannot be promoted', async () => {


### PR DESCRIPTION
Provider reports can stamp a reservation onto a runner before the assignment metadata is committed, leaving the runner unable to activate on retry.

This repairs provider-reported assignments before activation and treats retries as idempotent only after the assignment is fully committed. Capacity accounting also charges committed replayed runners correctly, while unenrolled provider-reported runners remain explicitly not assignable.

Closes ENG-1508

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require committed runner metadata for assignments in `@shipfox/api-runners`, addressing ENG-1508. We repair provider-reported reservations during enrollment, gate idempotency on committed state, and correct capacity accounting.

- **Bug Fixes**
  - Enrollment promotes intended reservations to committed assignments (sets workspaceId and assignedAt) and returns activation tokens.
  - Retries are idempotent only when assignments are fully committed; otherwise metadata is repaired instead of treated as complete.
  - Capacity accounting charges for committed runners replayed with new ones and rejects assigning unenrolled, provider-reported runners.

<sup>Written for commit 321af0f601ca86448d7544d31dc37dd747a28843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

