### PR TITLE
[api-runners] Prevent rebound runners from creating duplicate launches

### DIFF
--- a/.changeset/quiet-runners-launch.md
+++ b/.changeset/quiet-runners-launch.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-runners': patch
+---
+
+Split rebound and launch reservations so rebinding an idle runner does not create duplicate launch capacity.

--- a/libs/api/runners/drizzle/0005_previous_lenny_balinger.sql
+++ b/libs/api/runners/drizzle/0005_previous_lenny_balinger.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."runners_reservation_kind" AS ENUM('bound', 'launch');--> statement-breakpoint
+ALTER TABLE "runners_reservations" ADD COLUMN "kind" "runners_reservation_kind" DEFAULT 'launch' NOT NULL;

--- a/libs/api/runners/drizzle/meta/0005_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2207 @@
+{
+  "id": "2a126d53-abd8-44c2-9133-39b4906faf9a",
+  "prevId": "5d378e67-a9df-497a-86c0-a70ed6b79e68",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.runners_admin_command_results": {
+      "name": "runners_admin_command_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key_fingerprint": {
+          "name": "idempotency_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_admin_command_results_actor_key_unique": {
+          "name": "runners_admin_command_results_actor_key_unique",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_ephemeral_registration_tokens": {
+      "name": "runners_ephemeral_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_ephemeral_registration_tokens_hashed_token_unique": {
+          "name": "runners_ephemeral_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_reservation_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_active_provider_runner_idx": {
+          "name": "runners_ephemeral_registration_tokens_active_provider_runner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_terminal_idx": {
+          "name": "runners_ephemeral_registration_tokens_terminal_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"consumed_at\", \"expires_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_manual_registration_tokens": {
+      "name": "runners_manual_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_manual_registration_tokens_hashed_token_unique": {
+          "name": "runners_manual_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_manual_registration_tokens_workspace_id_idx": {
+          "name": "runners_manual_registration_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_outbox": {
+      "name": "runners_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_outbox_pending_idx": {
+          "name": "runners_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_outbox_dispatched_retention_idx": {
+          "name": "runners_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_pending_jobs": {
+      "name": "runners_pending_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_pending_jobs_workspace_created_idx": {
+          "name": "runners_pending_jobs_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_pending_jobs_job_id_idx": {
+          "name": "runners_pending_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_pending_jobs_job_execution_id_unique": {
+          "name": "runners_pending_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_capability_snapshots": {
+      "name": "runners_provisioner_capability_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_slots": {
+          "name": "available_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting": {
+          "name": "starting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "running": {
+          "name": "running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "advertised_at": {
+          "name": "advertised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_capability_snapshots_workspace_active_idx": {
+          "name": "runners_provisioner_capability_snapshots_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "advertised_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_capability_snapshots_provisioner_idx": {
+          "name": "runners_provisioner_capability_snapshots_provisioner_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_tokens": {
+      "name": "runners_provisioner_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_provisioner_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_tokens_hashed_token_unique": {
+          "name": "runners_provisioner_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_tokens_workspace_last_seen_idx": {
+          "name": "runners_provisioner_tokens_workspace_last_seen_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_provisioner_tokens_scope_workspace_ck": {
+          "name": "runners_provisioner_tokens_scope_workspace_ck",
+          "value": "(scope = 'workspace' AND workspace_id IS NOT NULL) OR (scope = 'installation' AND workspace_id IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_rate_limits": {
+      "name": "runners_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_rate_limits_window_unique": {
+          "name": "runners_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_rate_limits_expires_at_idx": {
+          "name": "runners_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_reservations": {
+      "name": "runners_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "runners_reservation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'launch'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runners_reservations_workspace_expires_idx": {
+          "name": "runners_reservations_workspace_expires_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_reservations_expires_idx": {
+          "name": "runners_reservations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_reservations_count_positive_ck": {
+          "name": "runners_reservations_count_positive_ck",
+          "value": "\"runners_reservations\".\"count\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_activation_tokens": {
+      "name": "runners_runner_activation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_activation_tokens_hashed_token_unique": {
+          "name": "runners_runner_activation_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_activation_tokens_runner_instance_idx": {
+          "name": "runners_runner_activation_tokens_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_bootstrap_tokens": {
+      "name": "runners_runner_bootstrap_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_bootstrap_tokens_hashed_token_unique": {
+          "name": "runners_runner_bootstrap_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_bootstrap_tokens_runner_instance_idx": {
+          "name": "runners_runner_bootstrap_tokens_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_control_sessions": {
+      "name": "runners_runner_control_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_control_sessions_hashed_token_unique": {
+          "name": "runners_runner_control_sessions_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_control_sessions_active_runner_instance_unique": {
+          "name": "runners_runner_control_sessions_active_runner_instance_unique",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"closed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_control_sessions_runner_instance_idx": {
+          "name": "runners_runner_control_sessions_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_instances": {
+      "name": "runners_runner_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intended_reservation_id": {
+          "name": "intended_reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "state": {
+          "name": "state",
+          "type": "runners_provider_runner_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_claimed_at": {
+          "name": "first_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopping_at": {
+          "name": "stopping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_released_at": {
+          "name": "reservation_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_instances_provisioner_runner_unique": {
+          "name": "runners_runner_instances_provisioner_runner_unique",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runners_runner_instances\".\"provider_runner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_workspace_state_updated_idx": {
+          "name": "runners_runner_instances_workspace_state_updated_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_stale_reaper_idx": {
+          "name": "runners_runner_instances_stale_reaper_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_provisioner_intended_reservation_idx": {
+          "name": "runners_runner_instances_provisioner_intended_reservation_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intended_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"intended_reservation_id\" is not null and \"runners_runner_instances\".\"reservation_released_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_intended_reservation_idx": {
+          "name": "runners_runner_instances_intended_reservation_idx",
+          "columns": [
+            {
+              "expression": "intended_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"intended_reservation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_provisioner_reservation_idx": {
+          "name": "runners_runner_instances_provisioner_reservation_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"reservation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_active_template_counts_idx": {
+          "name": "runners_runner_instances_active_template_counts_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" in ('starting', 'running') and \"template_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_token_kind": {
+          "name": "registration_token_kind",
+          "type": "runners_runner_session_registration_token_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_capabilities": {
+          "name": "tool_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_capabilities_reported_at": {
+          "name": "tool_capabilities_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_claims": {
+          "name": "max_claims",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claims_used": {
+          "name": "claims_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_sessions_provider_runner_updated_idx": {
+          "name": "runners_runner_sessions_provider_runner_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_runner_sessions_claims_ck": {
+          "name": "runners_runner_sessions_claims_ck",
+          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" in ('ephemeral', 'activation') AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NOT NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'activation' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_running_jobs": {
+      "name": "runners_running_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_heartbeat_at": {
+          "name": "first_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_running_jobs_no_first_heartbeat_started_idx": {
+          "name": "runners_running_jobs_no_first_heartbeat_started_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"first_heartbeat_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_last_heartbeat_at_idx": {
+          "name": "runners_running_jobs_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_provider_runner_started_idx": {
+          "name": "runners_running_jobs_provider_runner_started_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_cancellation_requested_idx": {
+          "name": "runners_running_jobs_cancellation_requested_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cancellation_requested_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_job_id_idx": {
+          "name": "runners_running_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_running_jobs_job_execution_id_unique": {
+          "name": "runners_running_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provider_runner_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.runners_provisioner_scope": {
+      "name": "runners_provisioner_scope",
+      "schema": "public",
+      "values": ["workspace", "installation"]
+    },
+    "public.runners_reservation_kind": {
+      "name": "runners_reservation_kind",
+      "schema": "public",
+      "values": ["bound", "launch"]
+    },
+    "public.runners_provider_runner_state": {
+      "name": "runners_provider_runner_state",
+      "schema": "public",
+      "values": ["starting", "running", "stopping", "stopped", "failed", "terminated"]
+    },
+    "public.runners_runner_session_registration_token_kind": {
+      "name": "runners_runner_session_registration_token_kind",
+      "schema": "public",
+      "values": ["manual", "ephemeral", "activation"]
+    },
+    "public.runners_runner_session_scope": {
+      "name": "runners_runner_session_scope",
+      "schema": "public",
+      "values": ["workspace"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/runners/drizzle/meta/_journal.json
+++ b/libs/api/runners/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786017247182,
       "tag": "0004_huge_skreet",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786106547187,
+      "tag": "0005_previous_lenny_balinger",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -62,11 +62,11 @@ export const config = createConfig({
     default: 250,
   }),
   RESERVATION_TTL_SECONDS: num({
-    desc: 'Default lifetime and activation grace period of a count-based runner reservation, in seconds. A runner without a session can be rebound only after this deadline. Used when a provisioner does not request a provider-specific value. Expired reservations stop counting against queued demand.',
+    desc: 'Activation grace period for a rebound runner reservation, in seconds. A runner without a session can be rebound again only after this deadline. It is also the default lifetime for launch reservations when a provisioner does not request a provider-specific value.',
     default: 60,
   }),
   RESERVATION_TTL_MAX_SECONDS: num({
-    desc: `Server-side ceiling for a count-based runner reservation lifetime and activation grace period, in seconds. Set it at least as high as every provider registration deadline plus its launch headroom so provider-specific values can cover the launch gap, boot, and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
+    desc: `Server-side ceiling for a launch reservation lifetime, in seconds. Set it at least as high as every provider registration deadline plus its launch headroom so provider-specific values can cover the launch gap, boot, and enrollment. Set this between 1 and ${RESERVATION_TTL_HARD_MAX_SECONDS}.`,
     default: 600,
   }),
   RESERVATION_LONG_POLL_MAX_WAIT_SECONDS: num({

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -37,6 +37,12 @@ describe('shouldReturn', () => {
     expect(result).toBe(true);
   });
 
+  it('returns true when only a rebound reservation was created', () => {
+    const result = shouldReturn({...emptyResult, newlyReservedCount: 1}, 1, 1, false);
+
+    expect(result).toBe(true);
+  });
+
   it('returns true when terminate intents exist', () => {
     const result = shouldReturn(
       {...emptyResult, terminateRunnerInstanceIds: ['provisioned-runner-1']},
@@ -81,7 +87,9 @@ describe('pollDemand', () => {
 
   it('returns immediately when terminate intents exist without reservation demand', async () => {
     vi.resetModules();
-    const pollDemandAndReserveTx = vi.fn().mockResolvedValue({stats: [], reservations: []});
+    const pollDemandAndReserveTx = vi
+      .fn()
+      .mockResolvedValue({stats: [], reservations: [], newlyReservedUnits: []});
     const listProvisionerTerminateIntentRowsTx = vi
       .fn()
       .mockResolvedValue([{providerRunnerId: 'provisioned-runner-1', reason: 'job-cancelled'}]);
@@ -132,7 +140,9 @@ describe('pollDemand', () => {
   it('does not calculate divergence for a non-returned long-poll retry', async () => {
     vi.resetModules();
     const abortController = new AbortController();
-    const pollDemandAndReserveTx = vi.fn().mockResolvedValue({stats: [], reservations: []});
+    const pollDemandAndReserveTx = vi
+      .fn()
+      .mockResolvedValue({stats: [], reservations: [], newlyReservedUnits: []});
     const listProvisionerTerminateIntentRowsTx = vi.fn().mockImplementation(() => {
       abortController.abort();
       return [];
@@ -180,7 +190,9 @@ describe('pollDemand', () => {
     vi.resetModules();
     vi.stubEnv('PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED', 'true');
     const divergenceAdd = vi.fn();
-    const pollDemandAndReserveTx = vi.fn().mockResolvedValue({stats: [], reservations: []});
+    const pollDemandAndReserveTx = vi
+      .fn()
+      .mockResolvedValue({stats: [], reservations: [], newlyReservedUnits: []});
     const listProvisionerTerminateIntentRowsTx = vi.fn().mockResolvedValue([]);
     const listActiveRunnerInstanceCountsByTemplateTx = vi
       .fn()

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -35,6 +35,8 @@ export interface PollDemandResult {
   stats: DemandStat[];
   reservations: ReservationGrant[];
   terminateRunnerInstanceIds: string[];
+  /** Units reserved this poll. A bound-only allocation carries no launch grant, so this is what ends the long poll. */
+  newlyReservedCount?: number;
 }
 
 export interface RunnerInstanceCountDivergence {
@@ -78,6 +80,7 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
         provisionerId: params.provisionerId,
         maxReservations: params.maxReservations,
         ttlSeconds: params.ttlSeconds,
+        activationGraceSeconds: config.RESERVATION_TTL_SECONDS,
         templates: params.templates,
       });
       const terminateIntents = await listProvisionerTerminateIntentRowsTx(tx, {
@@ -85,8 +88,14 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
         provisionerId: params.provisionerId,
         limit: params.terminateIntentLimit,
       });
+      const newlyReservedCount = demand.newlyReservedUnits.reduce(
+        (total, reservation) => total + reservation.count,
+        0,
+      );
       const result: PollDemandResult = {
-        ...demand,
+        stats: demand.stats,
+        reservations: demand.reservations,
+        ...(newlyReservedCount > 0 ? {newlyReservedCount} : {}),
         terminateRunnerInstanceIds: terminateIntents.map((intent) => intent.providerRunnerId),
       };
 
@@ -145,6 +154,7 @@ export function shouldReturn(
     maxReservations === 0 ||
     totalCapacity === 0 ||
     result.reservations.length > 0 ||
+    (result.newlyReservedCount ?? 0) > 0 ||
     result.terminateRunnerInstanceIds.length > 0 ||
     deadlinePassed
   );

--- a/libs/api/runners/src/core/entities/reservation.ts
+++ b/libs/api/runners/src/core/entities/reservation.ts
@@ -4,6 +4,7 @@ export interface Reservation {
   provisionerId: string;
   requiredLabels: string[];
   count: number;
+  kind: 'bound' | 'launch';
   createdAt: Date;
   expiresAt: Date;
 }

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -7,6 +7,7 @@ import {
   pollInstallationDemandAndReserve,
   releaseReservationUnits,
 } from '#db/reservations.js';
+import {pendingJobExecutions} from '#db/schema/pending-job-executions.js';
 import {reservations} from '#db/schema/reservations.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
@@ -66,9 +67,15 @@ describe('pollDemandAndReserve', () => {
       .from(providerRunners)
       .where(inArray(providerRunners.id, [olderRunner.id, newerRunner.id, unmatchedRunner.id]));
     const rowsById = new Map(rows.map((row) => [row.id, row]));
-    const reservationId = result.reservations[0]?.reservationId;
+    expect(result.reservations).toEqual([]);
+    const reservationId = rowsById.get(olderRunner.id)?.reservationId;
 
     expect(reservationId).toEqual(expect.any(String));
+    const [boundReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, reservationId as string));
+    expect(boundReservation).toMatchObject({kind: 'bound', count: 2});
     expect(rowsById.get(olderRunner.id)).toMatchObject({
       workspaceId,
       reservationId,
@@ -84,6 +91,48 @@ describe('pollDemandAndReserve', () => {
       reservationId: null,
       assignedAt: null,
     });
+  });
+
+  it('splits rebound and launch capacity with separate reservation lifetimes', async () => {
+    const runner = await createIdleRunner({labels: ['linux']});
+    await createPendingJobs(2, ['linux']);
+
+    const before = Date.now();
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 2,
+      ttlSeconds: 120,
+      activationGraceSeconds: 5,
+      templates: [template('linux', ['linux'], 2)],
+    });
+
+    expect(result.reservations).toHaveLength(1);
+    expect(result.reservations[0]).toMatchObject({count: 1});
+    const rows = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, workspaceId),
+          eq(reservations.provisionerId, provisionerId),
+        ),
+      );
+    const boundReservation = rows.find((row) => row.kind === 'bound');
+    const launchReservation = rows.find((row) => row.kind === 'launch');
+    expect(boundReservation).toMatchObject({count: 1});
+    expect(launchReservation).toMatchObject({count: 1});
+    expect(boundReservation?.expiresAt.getTime()).toBeGreaterThan(before + 4_000);
+    expect(boundReservation?.expiresAt.getTime()).toBeLessThan(
+      launchReservation?.expiresAt.getTime() ?? 0,
+    );
+    expect(launchReservation?.id).toBe(result.reservations[0]?.reservationId);
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(storedRunner?.reservationId).toBe(boundReservation?.id);
   });
 
   it('binds a runner whose intended reservation has passed its activation grace period', async () => {
@@ -109,9 +158,10 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations).toEqual([]);
     expect(storedRunner).toMatchObject({
       workspaceId,
-      reservationId: result.reservations[0]?.reservationId,
+      reservationId: expect.any(String),
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
@@ -141,9 +191,10 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations).toEqual([]);
     expect(storedRunner).toMatchObject({
       workspaceId,
-      reservationId: result.reservations[0]?.reservationId,
+      reservationId: expect.any(String),
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
@@ -188,9 +239,10 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(runnerActivationTokens)
       .where(eq(runnerActivationTokens.id, activationToken.id));
+    expect(result.reservations).toEqual([]);
     expect(storedRunner).toMatchObject({
       workspaceId,
-      reservationId: result.reservations[0]?.reservationId,
+      reservationId: expect.any(String),
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
@@ -223,9 +275,10 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations).toEqual([]);
     expect(storedRunner).toMatchObject({
       workspaceId,
-      reservationId: result.reservations[0]?.reservationId,
+      reservationId: expect.any(String),
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
@@ -349,9 +402,10 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations).toEqual([]);
     expect(storedRunner).toMatchObject({
       workspaceId,
-      reservationId: result.reservations[0]?.reservationId,
+      reservationId: expect.any(String),
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
@@ -385,13 +439,59 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
-    expect(result.reservations[0]).toMatchObject({workspaceId: targetWorkspaceId, count: 1});
+    expect(result.reservations).toEqual([]);
     expect(storedRunner).toMatchObject({
       workspaceId: targetWorkspaceId,
-      reservationId: result.reservations[0]?.reservationId,
+      reservationId: expect.any(String),
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
+  });
+
+  it('counts rebound installation capacity against the remaining grant budget', async () => {
+    const reboundWorkspaceId = crypto.randomUUID();
+    const launchWorkspaceId = crypto.randomUUID();
+    await pendingJobFactory.create({
+      workspaceId: reboundWorkspaceId,
+      requiredLabels: ['linux'],
+    });
+    await pendingJobFactory.create({
+      workspaceId: launchWorkspaceId,
+      requiredLabels: ['linux'],
+    });
+    await db()
+      .update(pendingJobExecutions)
+      .set({createdAt: new Date('2026-01-01T00:00:00.000Z')})
+      .where(eq(pendingJobExecutions.workspaceId, reboundWorkspaceId));
+    await db()
+      .update(pendingJobExecutions)
+      .set({createdAt: new Date('2026-01-02T00:00:00.000Z')})
+      .where(eq(pendingJobExecutions.workspaceId, launchWorkspaceId));
+    await createIdleRunner({labels: ['linux']});
+
+    const result = await pollInstallationDemandAndReserve({
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+      capabilityWindowSeconds: 60,
+      eligibleWorkspaceIds: new Set([reboundWorkspaceId, launchWorkspaceId]),
+    });
+
+    const storedReservations = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.provisionerId, provisionerId));
+    expect(result.reservations).toEqual([]);
+    expect(storedReservations).toHaveLength(1);
+    expect(storedReservations[0]).toMatchObject({
+      workspaceId: reboundWorkspaceId,
+      kind: 'bound',
+      count: 1,
+    });
+    expect(
+      storedReservations.some((reservation) => reservation.workspaceId === launchWorkspaceId),
+    ).toBe(false);
   });
 
   it('does not rebind a released runner after its reservation expires', async () => {
@@ -502,9 +602,10 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux', ['linux'], 1)],
     });
 
-    expect(firstResult.reservations).toHaveLength(1);
+    expect(firstResult.reservations).toEqual([]);
     expect(secondResult.reservations).toEqual([]);
     expect(secondResult.stats[0]).toMatchObject({queued: 1, reserved: 1});
+    expect(await activeReservedCount()).toBe(1);
   });
 
   it('allocates overlapping label sets most-specific-first', async () => {
@@ -765,15 +866,25 @@ describe('pollDemandAndReserve', () => {
     const runner = await createIdleRunner({labels: ['linux']});
     await createPendingJobs(1, ['linux']);
 
-    const result = await pollDemandAndReserve({
+    await pollDemandAndReserve({
       workspaceId,
       provisionerId,
       maxReservations: 1,
       ttlSeconds: 60,
       templates: [template('linux', ['linux'], 1)],
     });
-    const reservationId = result.reservations[0]?.reservationId;
-    if (!reservationId) throw new Error('Expected reservation');
+    const [boundReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, workspaceId),
+          eq(reservations.provisionerId, provisionerId),
+          eq(reservations.kind, 'bound'),
+        ),
+      );
+    const reservationId = boundReservation?.id;
+    if (!reservationId) throw new Error('Expected bound reservation');
 
     const [activationToken] = await db()
       .insert(runnerActivationTokens)
@@ -867,15 +978,25 @@ describe('pollDemandAndReserve', () => {
     const runner = await createIdleRunner({labels: ['linux']});
     await createPendingJobs(1, ['linux']);
 
-    const result = await pollDemandAndReserve({
+    await pollDemandAndReserve({
       workspaceId,
       provisionerId,
       maxReservations: 1,
       ttlSeconds: 60,
       templates: [template('linux', ['linux'], 1)],
     });
-    const reservationId = result.reservations[0]?.reservationId;
-    if (!reservationId) throw new Error('Expected reservation');
+    const [boundReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, workspaceId),
+          eq(reservations.provisionerId, provisionerId),
+          eq(reservations.kind, 'bound'),
+        ),
+      );
+    const reservationId = boundReservation?.id;
+    if (!reservationId) throw new Error('Expected bound reservation');
 
     await db()
       .update(reservations)
@@ -963,18 +1084,18 @@ describe('pollDemandAndReserve', () => {
     expect(storedSurvivingRunner?.intendedReservationId).toBe(survivingReservation.id);
 
     await createPendingJobs(1, ['linux']);
-    const result = await pollDemandAndReserve({
+    await pollDemandAndReserve({
       workspaceId,
       provisionerId,
       maxReservations: 1,
       ttlSeconds: 60,
       templates: [template('linux', ['linux'], 1)],
     });
-    const reboundReservationId = result.reservations[0]?.reservationId;
     const [reboundRunner] = await db()
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
+    const reboundReservationId = reboundRunner?.reservationId;
     expect(reboundReservationId).toEqual(expect.any(String));
     expect(reboundRunner).toMatchObject({
       intendedReservationId: null,

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -53,6 +53,8 @@ export interface PollDemandAndReserveParams {
   provisionerId: string;
   maxReservations: number;
   ttlSeconds: number;
+  /** Lifetime of the short reservation that gives rebound runners time to activate. */
+  activationGraceSeconds?: number;
   templates: ReservationTemplate[];
   capabilityWindowSeconds?: number;
 }
@@ -61,6 +63,8 @@ export interface InstallationPollDemandAndReserveParams {
   provisionerId: string;
   maxReservations: number;
   ttlSeconds: number;
+  /** Lifetime of the short reservation that gives rebound runners time to activate. */
+  activationGraceSeconds?: number;
   templates: ReservationTemplate[];
   capabilityWindowSeconds: number;
   eligibleWorkspaceIds: ReadonlySet<string>;
@@ -86,18 +90,32 @@ interface DemandRow {
   oldestQueuedAt: Date;
 }
 
+interface NewReservationUnits {
+  labels: string[];
+  count: number;
+}
+
+interface PollDemandAndReserveResult {
+  stats: DemandStat[];
+  /** Only launch reservations are exposed to the provisioner. */
+  reservations: ReservationGrant[];
+  /** Internal allocation accounting for bound and launch rows together. */
+  newlyReservedUnits: NewReservationUnits[];
+}
+
 export async function pollDemandAndReserve(
   params: PollDemandAndReserveParams,
 ): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     return await pollDemandAndReserveTx(tx, params);
   });
+  return {stats: result.stats, reservations: result.reservations};
 }
 
 export async function pollDemandAndReserveTx(
   tx: Tx,
   params: PollDemandAndReserveParams,
-): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
+): Promise<PollDemandAndReserveResult> {
   await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId}))`);
   return await pollDemandAndReserveLockedTx(tx, {...params, scope: 'workspace'});
 }
@@ -108,7 +126,7 @@ export async function pollInstallationDemandAndReserve(
   const candidateWorkspaceIds = await listInstallationDemandWorkspaceIds(
     params.eligibleWorkspaceIds,
   );
-  const results: Array<{stats: DemandStat[]; reservations: ReservationGrant[]}> = [];
+  const results: PollDemandAndReserveResult[] = [];
   let remainingMaxReservations = params.maxReservations;
   const remainingTemplates = params.templates.map((template) => ({
     ...template,
@@ -122,12 +140,15 @@ export async function pollInstallationDemandAndReserve(
         sql`select pg_try_advisory_xact_lock(hashtext(${workspaceId})) as locked`,
       );
       const locked = lockResult.rows[0];
-      if (!locked?.locked) return {stats: [], reservations: []};
+      if (!locked?.locked) return {stats: [], reservations: [], newlyReservedUnits: []};
       return await pollDemandAndReserveLockedTx(tx, {
         workspaceId,
         provisionerId: params.provisionerId,
         maxReservations: remainingMaxReservations,
         ttlSeconds: params.ttlSeconds,
+        ...(params.activationGraceSeconds !== undefined
+          ? {activationGraceSeconds: params.activationGraceSeconds}
+          : {}),
         templates: remainingTemplates.map((template) => ({
           ...template,
           availableSlots: template.remainingSlots,
@@ -137,9 +158,9 @@ export async function pollInstallationDemandAndReserve(
       });
     });
     results.push(result);
-    consumeInstallationTemplateSlots(remainingTemplates, result.reservations);
+    consumeInstallationTemplateSlots(remainingTemplates, result.newlyReservedUnits);
     params.onReservations?.(result.reservations);
-    remainingMaxReservations -= result.reservations.reduce(
+    remainingMaxReservations -= result.newlyReservedUnits.reduce(
       (total, reservation) => total + reservation.count,
       0,
     );
@@ -152,7 +173,7 @@ export async function pollInstallationDemandAndReserve(
 
 function consumeInstallationTemplateSlots(
   templates: NormalizedTemplate[],
-  reservations: ReservationGrant[],
+  reservations: NewReservationUnits[],
 ): void {
   for (const reservation of reservations) {
     const satisfyingTemplates = templates
@@ -167,7 +188,7 @@ function consumeInstallationTemplateSlots(
 async function pollDemandAndReserveLockedTx(
   tx: Tx,
   params: PollDemandAndReserveLockedParams,
-): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
+): Promise<PollDemandAndReserveResult> {
   let demandRows = (
     await tx
       .select({
@@ -229,6 +250,7 @@ async function pollDemandAndReserveLockedTx(
   deductProvisionerReservations(templates, activeProvisionerReservationRows);
   const stats: DemandStat[] = [];
   const grants: ReservationGrant[] = [];
+  const newlyReservedUnits: NewReservationUnits[] = [];
   let remainingMaxReservations = params.maxReservations;
   const workspaceIdField =
     params.capabilityWindowSeconds === undefined ? {} : {workspaceId: params.workspaceId};
@@ -252,37 +274,70 @@ async function pollDemandAndReserveLockedTx(
     let reservedAfterGrant = reserved;
 
     if (grant > 0 && params.maxReservations > 0) {
-      const [inserted] = await tx
+      const [boundReservation] = await tx
         .insert(reservations)
         .values({
           workspaceId: params.workspaceId,
           provisionerId: params.provisionerId,
           requiredLabels: demand.requiredLabels,
           count: grant,
-          expiresAt: sql`now() + (${params.ttlSeconds} || ' seconds')::interval`,
+          kind: 'bound',
+          expiresAt: sql`now() + (${params.activationGraceSeconds ?? params.ttlSeconds} || ' seconds')::interval`,
         })
-        .returning({id: reservations.id, expiresAt: reservations.expiresAt});
+        .returning({id: reservations.id});
 
-      if (!inserted) throw new Error('Insert returned no rows');
+      if (!boundReservation) throw new Error('Insert returned no rows');
 
       remainingMaxReservations -= grant;
       drawSlots(satisfyingTemplates, grant);
-      await bindIdleRunnerInstancesTx(tx, {
+      const boundCount = await bindIdleRunnerInstancesTx(tx, {
         provisionerId: params.provisionerId,
-        reservationId: inserted.id,
+        reservationId: boundReservation.id,
         requiredLabels: demand.requiredLabels,
         count: grant,
         workspaceId: params.workspaceId,
         scope: params.scope,
       });
+
+      if (boundCount === 0) {
+        await tx.delete(reservations).where(eq(reservations.id, boundReservation.id));
+      } else if (boundCount < grant) {
+        await tx
+          .update(reservations)
+          .set({count: boundCount})
+          .where(eq(reservations.id, boundReservation.id));
+      }
+
+      const launchCount = grant - boundCount;
+      let launchReservation: {id: string; expiresAt: Date} | undefined;
+      if (launchCount > 0) {
+        const [inserted] = await tx
+          .insert(reservations)
+          .values({
+            workspaceId: params.workspaceId,
+            provisionerId: params.provisionerId,
+            requiredLabels: demand.requiredLabels,
+            count: launchCount,
+            kind: 'launch',
+            expiresAt: sql`now() + (${params.ttlSeconds} || ' seconds')::interval`,
+          })
+          .returning({id: reservations.id, expiresAt: reservations.expiresAt});
+
+        if (!inserted) throw new Error('Insert returned no rows');
+        launchReservation = inserted;
+      }
+
+      newlyReservedUnits.push({labels: demand.requiredLabels, count: grant});
       reservedAfterGrant += grant;
-      grants.push({
-        reservationId: inserted.id,
-        ...workspaceIdField,
-        labels: demand.requiredLabels,
-        count: grant,
-        expiresAt: inserted.expiresAt,
-      });
+      if (launchReservation) {
+        grants.push({
+          reservationId: launchReservation.id,
+          ...workspaceIdField,
+          labels: demand.requiredLabels,
+          count: launchCount,
+          expiresAt: launchReservation.expiresAt,
+        });
+      }
     }
 
     stats.push({
@@ -294,7 +349,7 @@ async function pollDemandAndReserveLockedTx(
     });
   }
 
-  return {stats, reservations: grants};
+  return {stats, reservations: grants, newlyReservedUnits};
 }
 
 async function bindIdleRunnerInstancesTx(
@@ -307,9 +362,9 @@ async function bindIdleRunnerInstancesTx(
     count: number;
     scope: DemandScope;
   },
-): Promise<void> {
-  // Reservation expiry is the activation grace deadline. A live reservation
-  // protects a runner that is still booting; an expired or missing row is stale.
+): Promise<number> {
+  // An expired or missing reservation is stale. A live reservation protects a
+  // runner that is still booting or waiting for its activation grace period.
   const canBindRunner = () =>
     and(
       or(
@@ -382,7 +437,7 @@ async function bindIdleRunnerInstancesTx(
     .limit(params.count)
     .for('update');
 
-  if (idleRunners.length === 0) return;
+  if (idleRunners.length === 0) return 0;
 
   await tx
     .update(runnerActivationTokens)
@@ -398,7 +453,7 @@ async function bindIdleRunnerInstancesTx(
       ),
     );
 
-  await tx
+  const reboundRunners = await tx
     .update(providerRunners)
     .set({
       workspaceId: params.workspaceId,
@@ -415,7 +470,10 @@ async function bindIdleRunnerInstancesTx(
         ),
         canBindRunner(),
       ),
-    );
+    )
+    .returning({id: providerRunners.id});
+
+  return reboundRunners.length;
 }
 
 async function listInstallationDemandWorkspaceIds(eligibleWorkspaceIds: ReadonlySet<string>) {

--- a/libs/api/runners/src/db/schema/reservations.ts
+++ b/libs/api/runners/src/db/schema/reservations.ts
@@ -1,8 +1,10 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
-import {check, index, integer, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {check, index, integer, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import type {Reservation} from '#core/entities/reservation.js';
 import {pgTable} from './common.js';
+
+export const reservationKindEnum = pgEnum('runners_reservation_kind', ['bound', 'launch']);
 
 export const reservations = pgTable(
   'reservations',
@@ -12,6 +14,7 @@ export const reservations = pgTable(
     provisionerId: uuid('provisioner_id').notNull(),
     requiredLabels: text('required_labels').array().notNull(),
     count: integer('count').notNull(),
+    kind: reservationKindEnum('kind').notNull().default('launch'),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     expiresAt: timestamp('expires_at', {withTimezone: true}).notNull(),
   },
@@ -32,6 +35,7 @@ export function toReservation(row: ReservationDb): Reservation {
     provisionerId: row.provisionerId,
     requiredLabels: row.requiredLabels,
     count: row.count,
+    kind: row.kind,
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
   };

--- a/libs/api/runners/src/presentation/routes/late-runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/late-runner-enrollment.test.ts
@@ -162,13 +162,14 @@ describe('late runner enrollment recovery', () => {
     });
 
     expect(demand.statusCode).toBe(200);
-    const reboundReservationId = demand.json().reservations[0]?.reservation_id;
-    expect(reboundReservationId).toEqual(expect.any(String));
+    expect(demand.json().reservations).toEqual([]);
 
     const [reboundRunner] = await db()
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, arrangement.runnerInstanceId));
+    const reboundReservationId = reboundRunner?.reservationId;
+    expect(reboundReservationId).toEqual(expect.any(String));
     expect(reboundRunner).toMatchObject({
       workspaceId,
       reservationId: reboundReservationId,
@@ -307,9 +308,7 @@ describe('late runner enrollment recovery', () => {
     });
 
     expect(demand.statusCode).toBe(200);
-    const reboundReservationId = demand.json().reservations[0]?.reservation_id;
-    expect(reboundReservationId).toEqual(expect.any(String));
-    expect(reboundReservationId).not.toBe(staleReservation.id);
+    expect(demand.json().reservations).toEqual([]);
 
     const staleReport = await app.inject({
       method: 'POST',
@@ -337,6 +336,10 @@ describe('late runner enrollment recovery', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, reportedRunner.id));
+    const reboundReservationId = reboundRunner?.reservationId;
+    expect(reboundReservationId).toEqual(expect.any(String));
+    if (!reboundReservationId) throw new Error('Expected rebound reservation');
+    expect(reboundReservationId).not.toBe(staleReservation.id);
     expect(reboundRunner).toMatchObject({
       workspaceId,
       reservationId: reboundReservationId,

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -98,6 +98,7 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
           provisionerId: provisionerContext.provisionerTokenId,
           maxReservations: request.body.max_reservations,
           ttlSeconds,
+          activationGraceSeconds: config.RESERVATION_TTL_SECONDS,
           templates,
           capabilityWindowSeconds: config.PROVISIONER_ACTIVE_WINDOW_SECONDS,
           eligibleWorkspaceIds,

--- a/libs/api/runners/test/factories/reservation.ts
+++ b/libs/api/runners/test/factories/reservation.ts
@@ -7,6 +7,7 @@ interface ReservationAttrs {
   provisionerId: string;
   requiredLabels: string[];
   count: number;
+  kind?: 'bound' | 'launch';
   expiresAt: Date;
 }
 
@@ -19,6 +20,7 @@ export const reservationFactory = Factory.define<ReservationAttrs>(({onCreate}) 
       provisionerId: row.provisionerId,
       requiredLabels: row.requiredLabels,
       count: row.count,
+      kind: row.kind,
       expiresAt: row.expiresAt,
     };
   });


### PR DESCRIPTION
Rebinding an idle runner previously left the full demand grant visible to the provisioner, allowing it to launch capacity that had already been filled by the rebound runner. This change stores rebound and launch capacity separately, returns and releases only launch rows, and preserves full-grant accounting for stats, installation limits, template slots, and long-poll completion.

It adds the reservation-kind migration plus coverage for partial/full rebound, late enrollment, bound-only polling, and multi-workspace installation accounting. The changeset is included for @shipfox/api-runners.

Validation: dependent type checks, runners package checks, focused demand/reservation/late-enrollment tests, dependency-cruise, database-boundary verification, migration catalog inspection, and changeset status all pass. The full runners suite has a pre-existing two-test OpenTelemetry mock-leak failure when poll-demand tests run before metrics tests; the metrics file passes in isolation and ENG-1516 tracks that follow-up.

Follow-up work is tracked in ENG-1514 and ENG-1515.

Closes ENG-1509

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents rebound runners from triggering duplicate capacity launches by splitting reservations into `bound` and `launch`, returning only launch grants to provisioners. Fulfills ENG-1509 by ensuring rebound capacity is hidden from the provisioner while keeping accounting accurate.

- **Bug Fixes**
  - Added reservation `kind` (`'bound' | 'launch'`); create bound rows first, bind idle runners, then create launch rows for any remainder.
  - Provisioners only receive launch grants; rebound allocations are not exposed, eliminating duplicate launches.
  - Long-poll now returns when any units are allocated (including bound-only) via `newlyReservedCount`.
  - Installation polling and template-slot accounting include rebound units in grant budgets.
  - Stats, installation limits, and template slots use full-grant accounting without overprovisioning.

- **Migration**
  - Added enum `runners_reservation_kind` and `reservations.kind` (default `'launch'`).
  - Updated `@shipfox/api-runners` config semantics: `RESERVATION_TTL_SECONDS` is the activation grace for rebound reservations and the default lifetime for launch reservations; routes pass `activationGraceSeconds` accordingly.

<sup>Written for commit 0ea247fb76584d1e6a6c59204727e2ecaf64f9ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

