### PR TITLE
[api-runners] Reclaim demand runners that never activate

### DIFF
--- a/.changeset/reclaim-demand-runners.md
+++ b/.changeset/reclaim-demand-runners.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Reclaims demand-backed runners that never activate after their independent recovery window expires.

--- a/libs/api/runners/drizzle/0005_previous_lenny_balinger.sql
+++ b/libs/api/runners/drizzle/0005_previous_lenny_balinger.sql
@@ -1,4 +1,5 @@
 CREATE TYPE "public"."runners_reservation_kind" AS ENUM('bound', 'launch');--> statement-breakpoint
 ALTER TABLE "runners_reservations" ADD COLUMN "kind" "runners_reservation_kind" DEFAULT 'launch' NOT NULL;--> statement-breakpoint
 CREATE TYPE "public"."runners_provider_runner_launch_kind" AS ENUM('demand', 'warm', 'manual');--> statement-breakpoint
-ALTER TABLE "runners_runner_instances" ADD COLUMN "launch_kind" "runners_provider_runner_launch_kind" DEFAULT 'manual' NOT NULL;
+ALTER TABLE "runners_runner_instances" ADD COLUMN "launch_kind" "runners_provider_runner_launch_kind" DEFAULT 'manual' NOT NULL;--> statement-breakpoint
+UPDATE "runners_runner_instances" SET "launch_kind" = 'demand' WHERE "reservation_id" IS NOT NULL OR "intended_reservation_id" IS NOT NULL;

--- a/libs/api/runners/drizzle/0005_previous_lenny_balinger.sql
+++ b/libs/api/runners/drizzle/0005_previous_lenny_balinger.sql
@@ -1,2 +1,4 @@
 CREATE TYPE "public"."runners_reservation_kind" AS ENUM('bound', 'launch');--> statement-breakpoint
-ALTER TABLE "runners_reservations" ADD COLUMN "kind" "runners_reservation_kind" DEFAULT 'launch' NOT NULL;
+ALTER TABLE "runners_reservations" ADD COLUMN "kind" "runners_reservation_kind" DEFAULT 'launch' NOT NULL;--> statement-breakpoint
+CREATE TYPE "public"."runners_provider_runner_launch_kind" AS ENUM('demand', 'warm', 'manual');--> statement-breakpoint
+ALTER TABLE "runners_runner_instances" ADD COLUMN "launch_kind" "runners_provider_runner_launch_kind" DEFAULT 'manual' NOT NULL;

--- a/libs/api/runners/drizzle/meta/0005_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0005_snapshot.json
@@ -1436,6 +1436,14 @@
           "primaryKey": false,
           "notNull": false
         },
+        "launch_kind": {
+          "name": "launch_kind",
+          "type": "runners_provider_runner_launch_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
         "assigned_at": {
           "name": "assigned_at",
           "type": "timestamp with time zone",
@@ -2177,6 +2185,11 @@
       "name": "runners_reservation_kind",
       "schema": "public",
       "values": ["bound", "launch"]
+    },
+    "public.runners_provider_runner_launch_kind": {
+      "name": "runners_provider_runner_launch_kind",
+      "schema": "public",
+      "values": ["demand", "warm", "manual"]
     },
     "public.runners_provider_runner_state": {
       "name": "runners_provider_runner_state",

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -86,6 +86,28 @@ describe('runner assignment polling defaults', () => {
   });
 });
 
+describe('RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('defaults to a five-minute recovery window', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS).toBe(300);
+  });
+
+  it.each(['0', '-5', '1.5'])('fails startup when the value is %s', async (value) => {
+    vi.stubEnv('RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS');
+  });
+});
+
 describe('reservation TTL ceiling validation', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -85,6 +85,10 @@ export const config = createConfig({
     desc: 'Time window, in seconds, used to list active runners from recent heartbeats and provisioned runner reports.',
     default: 60,
   }),
+  RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS: num({
+    desc: 'Minimum time, in seconds, before a demand-backed runner without a runner session can be reclaimed when neither its current nor intended reservation is live. Set this above the provider registration deadline when startup reservations remain live during boot.',
+    default: 300,
+  }),
   RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS: num({
     desc: 'Time window, in seconds, after which a runner tool capability report is treated as stale. Set this higher than the runner heartbeat interval so active runners keep their advertised tools fresh.',
     default: 60,
@@ -279,6 +283,15 @@ if (
 ) {
   throw new Error(
     `RUNNER_ACTIVE_WINDOW_SECONDS (${config.RUNNER_ACTIVE_WINDOW_SECONDS}) must be a whole number of seconds >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS) ||
+  config.RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS < 1
+) {
+  throw new Error(
+    `RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS (${config.RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS}) must be a whole number of seconds >= 1.`,
   );
 }
 

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -54,6 +54,24 @@ describe('shouldReturn', () => {
     expect(result).toBe(true);
   });
 
+  it('continues waiting for a retry-only activation-timeout intent', () => {
+    const result = shouldReturn(
+      {...emptyResult, terminateRunnerInstanceIds: ['stale-demand-runner']},
+      1,
+      1,
+      false,
+      [
+        {
+          providerRunnerId: 'stale-demand-runner',
+          reason: 'activation-timeout',
+          activationTimeoutRetry: true,
+        },
+      ],
+    );
+
+    expect(result).toBe(false);
+  });
+
   it('returns true when the deadline passed', () => {
     const result = shouldReturn(emptyResult, 1, 1, true);
 
@@ -133,6 +151,75 @@ describe('pollDemand', () => {
       vi.doUnmock('#db/db.js');
       vi.doUnmock('#db/reservations.js');
       vi.doUnmock('#db/runner-instances.js');
+      vi.resetModules();
+    }
+  });
+
+  it('does not return immediately for retry-only activation-timeout intents', async () => {
+    vi.resetModules();
+    const abortController = new AbortController();
+    let listCalls = 0;
+    const pollDemandAndReserveTx = vi
+      .fn()
+      .mockResolvedValue({stats: [], reservations: [], newlyReservedUnits: []});
+    const listProvisionerTerminateIntentRowsTx = vi.fn().mockImplementation(() => {
+      listCalls += 1;
+      if (listCalls === 2) abortController.abort();
+      return [
+        {
+          providerRunnerId: 'stale-demand-runner',
+          reason: 'activation-timeout',
+          activationTimeoutRetry: true,
+        },
+      ];
+    });
+    const listActiveRunnerInstanceCountsByTemplateTx = vi.fn().mockResolvedValue([]);
+    vi.doMock('#db/db.js', () => ({
+      db: () => ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}),
+    }));
+    vi.doMock('#db/reservations.js', () => ({
+      deleteReservationsByIds: vi.fn(),
+      pollDemandAndReserveTx,
+    }));
+    vi.doMock('#db/runner-instances.js', () => ({
+      listActiveRunnerInstanceCountsByTemplateTx,
+      listProvisionerTerminateIntentRowsTx,
+    }));
+    vi.doMock('#metrics/instance.js', () => ({
+      providerRunnerActivationOutcomeCount: {add: vi.fn()},
+      providerRunnerCountDivergenceCount: {add: vi.fn()},
+      providerRunnerTerminateIntentIssuedCount: {add: vi.fn()},
+    }));
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    try {
+      const {pollDemand: mockedPollDemand} = await import('#core/demand.js');
+
+      const result = await mockedPollDemand({
+        workspaceId: crypto.randomUUID(),
+        provisionerId: crypto.randomUUID(),
+        maxReservations: 1,
+        waitSeconds: 60,
+        ttlSeconds: 60,
+        terminateIntentLimit: 1000,
+        templates: [
+          {templateKey: 'linux', labels: ['linux'], availableSlots: 1, starting: 0, running: 0},
+        ],
+        signal: abortController.signal,
+      });
+
+      expect(result).toEqual({
+        stats: [],
+        reservations: [],
+        terminateRunnerInstanceIds: ['stale-demand-runner'],
+      });
+      expect(listProvisionerTerminateIntentRowsTx).toHaveBeenCalledTimes(2);
+    } finally {
+      random.mockRestore();
+      vi.doUnmock('#db/db.js');
+      vi.doUnmock('#db/reservations.js');
+      vi.doUnmock('#db/runner-instances.js');
+      vi.doUnmock('#metrics/instance.js');
       vi.resetModules();
     }
   });

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -72,6 +72,37 @@ describe('shouldReturn', () => {
     expect(result).toBe(false);
   });
 
+  it('returns true for a first-delivery activation-timeout intent', () => {
+    const result = shouldReturn(
+      {...emptyResult, terminateRunnerInstanceIds: ['stale-demand-runner']},
+      1,
+      1,
+      false,
+      [{providerRunnerId: 'stale-demand-runner', reason: 'activation-timeout'}],
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true for a job-cancelled intent alongside a retried activation timeout', () => {
+    const result = shouldReturn(
+      {...emptyResult, terminateRunnerInstanceIds: ['stale-demand-runner', 'cancelled-runner']},
+      1,
+      1,
+      false,
+      [
+        {
+          providerRunnerId: 'stale-demand-runner',
+          reason: 'activation-timeout',
+          activationTimeoutRetry: true,
+        },
+        {providerRunnerId: 'cancelled-runner', reason: 'job-cancelled'},
+      ],
+    );
+
+    expect(result).toBe(true);
+  });
+
   it('returns true when the deadline passed', () => {
     const result = shouldReturn(emptyResult, 1, 1, true);
 

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -16,9 +16,9 @@ import {
   type RunnerInstanceTerminateIntent,
 } from '#db/runner-instances.js';
 import {
-  providerRunnerActivationOutcomeCount,
   providerRunnerCountDivergenceCount,
   providerRunnerTerminateIntentIssuedCount,
+  recordProviderRunnerActivationOutcome,
 } from '#metrics/instance.js';
 
 export interface PollDemandParams {
@@ -252,8 +252,9 @@ function recordPollDemandMetrics(params: PollDemandParams, snapshot: PollDemandS
       surface: 'poll-demand',
       reason: intent.reason,
     });
-    if (intent.reason === 'activation-timeout') {
-      providerRunnerActivationOutcomeCount.add(1, {outcome: 'reaped'});
+    // Retries redeliver an intent already counted on its first emission.
+    if (intent.reason === 'activation-timeout' && !intent.activationTimeoutRetry) {
+      recordProviderRunnerActivationOutcome({outcome: 'reaped'});
     }
   }
 }

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -16,6 +16,7 @@ import {
   type RunnerInstanceTerminateIntent,
 } from '#db/runner-instances.js';
 import {
+  providerRunnerActivationOutcomeCount,
   providerRunnerCountDivergenceCount,
   providerRunnerTerminateIntentIssuedCount,
 } from '#metrics/instance.js';
@@ -99,7 +100,15 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
         terminateRunnerInstanceIds: terminateIntents.map((intent) => intent.providerRunnerId),
       };
 
-      if (!shouldReturn(result, params.maxReservations, totalCapacity, deadlinePassed)) {
+      if (
+        !shouldReturn(
+          result,
+          params.maxReservations,
+          totalCapacity,
+          deadlinePassed,
+          terminateIntents,
+        )
+      ) {
         return {result, terminateIntents, divergences: []};
       }
 
@@ -122,7 +131,15 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
 
     lastSnapshot = snapshot;
 
-    if (shouldReturn(lastSnapshot.result, params.maxReservations, totalCapacity, deadlinePassed)) {
+    if (
+      shouldReturn(
+        lastSnapshot.result,
+        params.maxReservations,
+        totalCapacity,
+        deadlinePassed,
+        lastSnapshot.terminateIntents,
+      )
+    ) {
       recordPollDemandMetrics(params, lastSnapshot);
       return lastSnapshot.result;
     }
@@ -149,13 +166,19 @@ export function shouldReturn(
   maxReservations: number,
   totalCapacity: number,
   deadlinePassed: boolean,
+  terminateIntents?: readonly RunnerInstanceTerminateIntent[],
 ): boolean {
+  const hasImmediateTerminateIntent =
+    terminateIntents?.some(
+      (intent) => intent.reason !== 'activation-timeout' || !intent.activationTimeoutRetry,
+    ) ?? result.terminateRunnerInstanceIds.length > 0;
+
   return (
     maxReservations === 0 ||
     totalCapacity === 0 ||
     result.reservations.length > 0 ||
     (result.newlyReservedCount ?? 0) > 0 ||
-    result.terminateRunnerInstanceIds.length > 0 ||
+    hasImmediateTerminateIntent ||
     deadlinePassed
   );
 }
@@ -229,6 +252,9 @@ function recordPollDemandMetrics(params: PollDemandParams, snapshot: PollDemandS
       surface: 'poll-demand',
       reason: intent.reason,
     });
+    if (intent.reason === 'activation-timeout') {
+      providerRunnerActivationOutcomeCount.add(1, {outcome: 'reaped'});
+    }
   }
 }
 

--- a/libs/api/runners/src/core/entities/runner-instance.ts
+++ b/libs/api/runners/src/core/entities/runner-instance.ts
@@ -6,6 +6,8 @@ export type RunnerInstanceState =
   | 'failed'
   | 'terminated';
 
+export type RunnerInstanceLaunchKind = 'demand' | 'warm' | 'manual';
+
 export interface RunnerInstance {
   id: string;
   workspaceId: string | null;
@@ -13,6 +15,7 @@ export interface RunnerInstance {
   providerRunnerId: string;
   intendedReservationId: string | null;
   reservationId: string | null;
+  launchKind: RunnerInstanceLaunchKind;
   assignedAt?: Date | null;
   templateKey: string | null;
   labels: string[];

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -56,6 +56,7 @@ export async function createRunnerInstancesWithBootstrapTokens(params: {
           providerKind: params.providerKind ?? null,
           templateKey: runner.templateKey ?? null,
           intendedReservationId: runner.reservationId ?? null,
+          launchKind: runner.reservationId ? ('demand' as const) : ('warm' as const),
           state: 'starting' as const,
           labels: [],
           reportedAt: new Date(),

--- a/libs/api/runners/src/core/runner-instances.test.ts
+++ b/libs/api/runners/src/core/runner-instances.test.ts
@@ -84,6 +84,7 @@ function providerRunner(params: {
     providerRunnerId: params.providerRunnerId,
     intendedReservationId: params.intendedReservationId ?? null,
     reservationId: null,
+    launchKind: 'manual' as const,
     templateKey: 'linux',
     labels: ['linux'],
     state: params.state ?? 'running',

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -1,3 +1,4 @@
+import {vi} from '@shipfox/vitest/vi';
 import {and, eq, inArray, or, sql, sum} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {
@@ -12,6 +13,7 @@ import {reservations} from '#db/schema/reservations.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
+import {providerRunnerActivationOutcomeCount} from '#metrics/instance.js';
 import {pendingJobFactory, reservationFactory} from '#test/index.js';
 
 describe('pollDemandAndReserve', () => {
@@ -133,6 +135,30 @@ describe('pollDemandAndReserve', () => {
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
     expect(storedRunner?.reservationId).toBe(boundReservation?.id);
+  });
+
+  it('records a rebound outcome for a demand-backed idle runner', async () => {
+    const outcomeSpy = vi.spyOn(providerRunnerActivationOutcomeCount, 'add');
+    await createIdleRunner({labels: ['linux'], launchKind: 'demand'});
+    await createPendingJobs(1, ['linux']);
+    const callsBefore = outcomeSpy.mock.calls.length;
+
+    await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    expect(
+      outcomeSpy.mock.calls
+        .slice(callsBefore)
+        .filter(
+          ([value, attributes]) =>
+            value === 1 && JSON.stringify(attributes) === JSON.stringify({outcome: 'rebound'}),
+        ),
+    ).toHaveLength(1);
   });
 
   it('binds a runner whose intended reservation has passed its activation grace period', async () => {
@@ -502,6 +528,7 @@ describe('pollDemandAndReserve', () => {
     const releasedAt = new Date(Date.now() - 30_000);
     const runner = await createIdleRunner({
       labels: ['linux'],
+      launchKind: 'demand',
       workspaceId,
       reservationId: staleReservation.id,
       intendedReservationId: staleReservation.id,
@@ -1295,6 +1322,7 @@ describe('pollDemandAndReserve', () => {
     labels: string[];
     createdAt?: Date;
     controlSessionExpiresAt?: Date;
+    launchKind?: 'demand' | 'warm' | 'manual';
     workspaceId?: string | null;
     reservationId?: string | null;
     intendedReservationId?: string | null;
@@ -1308,6 +1336,7 @@ describe('pollDemandAndReserve', () => {
         workspaceId: params.workspaceId,
         reservationId: params.reservationId,
         providerRunnerId: crypto.randomUUID(),
+        launchKind: params.launchKind ?? 'manual',
         intendedReservationId: params.intendedReservationId,
         reservationReleasedAt: params.reservationReleasedAt,
         labels: params.labels,

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -14,6 +14,7 @@ import {
   or,
   sql,
 } from 'drizzle-orm';
+import {providerRunnerActivationOutcomeCount} from '#metrics/instance.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
@@ -409,7 +410,7 @@ async function bindIdleRunnerInstancesTx(
     );
 
   const idleRunners = await tx
-    .select({id: providerRunners.id})
+    .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
     .from(providerRunners)
     .where(
       and(
@@ -453,7 +454,7 @@ async function bindIdleRunnerInstancesTx(
       ),
     );
 
-  const reboundRunners = await tx
+  const boundRunners = await tx
     .update(providerRunners)
     .set({
       workspaceId: params.workspaceId,
@@ -471,9 +472,13 @@ async function bindIdleRunnerInstancesTx(
         canBindRunner(),
       ),
     )
-    .returning({id: providerRunners.id});
+    .returning({id: providerRunners.id, launchKind: providerRunners.launchKind});
 
-  return reboundRunners.length;
+  const reboundCount = boundRunners.filter((runner) => runner.launchKind === 'demand').length;
+  if (reboundCount > 0)
+    providerRunnerActivationOutcomeCount.add(reboundCount, {outcome: 'rebound'});
+
+  return boundRunners.length;
 }
 
 async function listInstallationDemandWorkspaceIds(eligibleWorkspaceIds: ReadonlySet<string>) {

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -14,7 +14,7 @@ import {
   or,
   sql,
 } from 'drizzle-orm';
-import {providerRunnerActivationOutcomeCount} from '#metrics/instance.js';
+import {recordProviderRunnerActivationOutcome} from '#metrics/instance.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
@@ -476,7 +476,7 @@ async function bindIdleRunnerInstancesTx(
 
   const reboundCount = boundRunners.filter((runner) => runner.launchKind === 'demand').length;
   if (reboundCount > 0)
-    providerRunnerActivationOutcomeCount.add(reboundCount, {outcome: 'rebound'});
+    recordProviderRunnerActivationOutcome({outcome: 'rebound', count: reboundCount});
 
   return boundRunners.length;
 }

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -146,6 +146,28 @@ describe('reportRunnerInstances', () => {
     expect(rows[0]?.state).toBe('running');
   });
 
+  it('preserves launch kind when a provider report updates the runner row', async () => {
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'demand-runner',
+      launchKind: 'demand',
+    });
+
+    await reportRunnerInstances({
+      scope: 'workspace',
+      workspaceId,
+      provisionerId,
+      events: [event({providerRunnerId: 'demand-runner', state: 'running'})],
+    });
+
+    const [row] = await db()
+      .select({launchKind: providerRunners.launchKind})
+      .from(providerRunners)
+      .where(eq(providerRunners.providerRunnerId, 'demand-runner'));
+    expect(row?.launchKind).toBe('demand');
+  });
+
   it('uses state progression to dedupe equal-timestamp provisioned runner reports', async () => {
     const reportedAt = new Date();
 
@@ -1157,6 +1179,106 @@ describe('listProvisionerTerminateIntents', () => {
     expect(result).toEqual([{providerRunnerId: 'provisioned-runner-1', reason: 'job-cancelled'}]);
   });
 
+  it('returns an activation-timeout intent for a stale demand-backed runner', async () => {
+    await createRunnerInstance({
+      providerRunnerId: 'stale-demand-runner',
+      launchKind: 'demand',
+      createdAt: new Date(Date.now() - 301_000),
+    });
+
+    const result = await db().transaction((tx) =>
+      listProvisionerTerminateIntentRowsTx(tx, {workspaceId, provisionerId, limit: 1000}),
+    );
+    const [runner] = await providerRunnerRowsFor({workspaceId, provisionerId});
+
+    expect(result).toEqual([
+      {providerRunnerId: 'stale-demand-runner', reason: 'activation-timeout'},
+    ]);
+    expect(runner?.reservationReleasedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not reclaim warm, manual, active, or already-activated runners', async () => {
+    const [liveReservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning({id: reservations.id});
+    if (!liveReservation) throw new Error('Expected live reservation');
+
+    const staleCreatedAt = new Date(Date.now() - 301_000);
+    await createRunnerInstance({
+      providerRunnerId: 'stale-warm-runner',
+      launchKind: 'warm',
+      createdAt: staleCreatedAt,
+    });
+    await createRunnerInstance({
+      providerRunnerId: 'stale-manual-runner',
+      launchKind: 'manual',
+      createdAt: staleCreatedAt,
+    });
+    await createRunnerInstance({
+      providerRunnerId: 'live-demand-runner',
+      launchKind: 'demand',
+      reservationId: liveReservation.id,
+      createdAt: staleCreatedAt,
+    });
+    await db()
+      .insert(providerRunners)
+      .values({
+        workspaceId,
+        provisionerId,
+        intendedReservationId: liveReservation.id,
+        providerRunnerId: 'live-intended-demand-runner',
+        launchKind: 'demand',
+        state: 'running',
+        labels: ['linux'],
+        reportedAt: staleCreatedAt,
+        createdAt: staleCreatedAt,
+        updatedAt: staleCreatedAt,
+      });
+    await createRunnerInstance({
+      providerRunnerId: 'activated-demand-runner',
+      launchKind: 'demand',
+      runnerSessionId: crypto.randomUUID(),
+      createdAt: staleCreatedAt,
+    });
+
+    const result = await listProvisionerTerminateIntents({workspaceId, provisionerId, limit: 1000});
+
+    expect(result).toEqual([]);
+  });
+
+  it('marks activation-timeout retries after releasing the runner reservation', async () => {
+    await createRunnerInstance({
+      providerRunnerId: 'retryable-demand-runner',
+      launchKind: 'demand',
+      createdAt: new Date(Date.now() - 301_000),
+    });
+
+    const first = await db().transaction((tx) =>
+      listProvisionerTerminateIntentRowsTx(tx, {workspaceId, provisionerId, limit: 1000}),
+    );
+    const second = await db().transaction((tx) =>
+      listProvisionerTerminateIntentRowsTx(tx, {workspaceId, provisionerId, limit: 1000}),
+    );
+
+    expect(first).toEqual([
+      {providerRunnerId: 'retryable-demand-runner', reason: 'activation-timeout'},
+    ]);
+    expect(second).toEqual([
+      {
+        providerRunnerId: 'retryable-demand-runner',
+        reason: 'activation-timeout',
+        activationTimeoutRetry: true,
+      },
+    ]);
+  });
+
   it('excludes active provisioned runners whose latest bound job is healthy', async () => {
     await createRunnerInstance({providerRunnerId: 'provisioned-runner-1'});
     await insertRunningJobRow({
@@ -1272,12 +1394,20 @@ describe('listProvisionerTerminateIntents', () => {
     providerRunnerId: string;
     provisionerId?: string;
     state?: 'starting' | 'running' | 'stopping' | 'stopped' | 'failed' | 'terminated';
+    launchKind?: 'demand' | 'warm' | 'manual';
+    createdAt?: Date;
+    reservationId?: string | null;
+    runnerSessionId?: string | null;
   }) {
     return await providerRunnerFactory.create({
       workspaceId,
       provisionerId: params.provisionerId ?? provisionerId,
       providerRunnerId: params.providerRunnerId,
       state: params.state ?? 'running',
+      launchKind: params.launchKind ?? 'manual',
+      createdAt: params.createdAt ?? new Date(),
+      reservationId: params.reservationId ?? null,
+      runnerSessionId: params.runnerSessionId ?? null,
     });
   }
 });

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -17,6 +17,7 @@ import {
   sql,
 } from 'drizzle-orm';
 import {alias} from 'drizzle-orm/pg-core';
+import {config} from '#config.js';
 import type {RunnerInstance, RunnerInstanceState} from '#core/entities/runner-instance.js';
 import {sanitizeRunnerLabels} from '#core/runner-labels.js';
 import type {Tx} from './db.js';
@@ -49,11 +50,12 @@ export const divergenceCountStates = ['starting', 'running'] as const satisfies 
   'starting' | 'running'
 >[];
 
-export type RunnerInstanceTerminateIntentReason = 'job-cancelled';
+export type RunnerInstanceTerminateIntentReason = 'activation-timeout' | 'job-cancelled';
 
 export interface RunnerInstanceTerminateIntent {
   providerRunnerId: string;
   reason: RunnerInstanceTerminateIntentReason;
+  activationTimeoutRetry?: boolean;
 }
 
 export interface ActiveRunnerInstanceTemplateCount {
@@ -336,9 +338,42 @@ export async function listProvisionerTerminateIntentRowsTx(
     );
   }
 
-  return returnedRows.flatMap((row) =>
-    row.providerRunnerId ? [{...row, providerRunnerId: row.providerRunnerId}] : [],
+  const activationTimeoutRunnerIds = returnedRows.flatMap((row) =>
+    row.reason === 'activation-timeout' && row.providerRunnerId ? [row.providerRunnerId] : [],
   );
+  if (activationTimeoutRunnerIds.length > 0) {
+    await tx
+      .update(providerRunners)
+      .set({reservationReleasedAt: sql`now()`, updatedAt: sql`now()`})
+      .where(
+        and(
+          eq(providerRunners.workspaceId, params.workspaceId),
+          eq(providerRunners.provisionerId, params.provisionerId),
+          inArray(providerRunners.providerRunnerId, activationTimeoutRunnerIds),
+          isNull(providerRunners.reservationReleasedAt),
+        ),
+      );
+  }
+
+  return returnedRows.flatMap((row) => toRunnerInstanceTerminateIntent(row));
+}
+
+function toRunnerInstanceTerminateIntent(row: {
+  providerRunnerId: string | null;
+  reason: RunnerInstanceTerminateIntentReason;
+  activationTimeoutRetry: boolean;
+}): RunnerInstanceTerminateIntent[] {
+  if (!row.providerRunnerId) return [];
+
+  return [
+    {
+      providerRunnerId: row.providerRunnerId,
+      reason: row.reason,
+      ...(row.reason === 'activation-timeout' && row.activationTimeoutRetry
+        ? {activationTimeoutRetry: true}
+        : {}),
+    },
+  ];
 }
 
 function provisionerTerminateIntentsQuery(
@@ -346,59 +381,91 @@ function provisionerTerminateIntentsQuery(
   params: {workspaceId: string; provisionerId: string; providerRunnerIds?: string[]},
 ) {
   const newerRunningJobExecutions = alias(runningJobExecutions, 'newer_running_jobs');
-
-  return tx
-    .select({
-      providerRunnerId: providerRunners.providerRunnerId,
-      reason: sql<RunnerInstanceTerminateIntentReason>`'job-cancelled'`,
-    })
-    .from(runningJobExecutions)
-    .innerJoin(
-      providerRunners,
-      and(
-        eq(providerRunners.workspaceId, runningJobExecutions.workspaceId),
-        eq(providerRunners.provisionerId, runningJobExecutions.provisionerId),
-        eq(providerRunners.providerRunnerId, runningJobExecutions.providerRunnerId),
-      ),
-    )
-    .where(
-      and(
-        eq(runningJobExecutions.workspaceId, params.workspaceId),
-        eq(runningJobExecutions.provisionerId, params.provisionerId),
-        isNotNull(providerRunners.providerRunnerId),
-        isNotNull(runningJobExecutions.cancellationRequestedAt),
-        inArray(providerRunners.state, activeStates),
-        params.providerRunnerIds && params.providerRunnerIds.length > 0
-          ? inArray(providerRunners.providerRunnerId, params.providerRunnerIds)
-          : undefined,
-        notExists(
-          tx
-            .select({id: newerRunningJobExecutions.id})
-            .from(newerRunningJobExecutions)
-            .where(
-              and(
-                eq(newerRunningJobExecutions.workspaceId, runningJobExecutions.workspaceId),
-                eq(newerRunningJobExecutions.provisionerId, runningJobExecutions.provisionerId),
-                eq(
-                  newerRunningJobExecutions.providerRunnerId,
-                  runningJobExecutions.providerRunnerId,
-                ),
-                or(
-                  gt(newerRunningJobExecutions.startedAt, runningJobExecutions.startedAt),
-                  and(
-                    eq(newerRunningJobExecutions.startedAt, runningJobExecutions.startedAt),
-                    gt(
-                      newerRunningJobExecutions.jobExecutionId,
-                      runningJobExecutions.jobExecutionId,
+  const latestCancelledJob = exists(
+    tx
+      .select({id: runningJobExecutions.id})
+      .from(runningJobExecutions)
+      .where(
+        and(
+          eq(runningJobExecutions.workspaceId, params.workspaceId),
+          eq(runningJobExecutions.provisionerId, params.provisionerId),
+          eq(runningJobExecutions.providerRunnerId, providerRunners.providerRunnerId),
+          isNotNull(runningJobExecutions.cancellationRequestedAt),
+          notExists(
+            tx
+              .select({id: newerRunningJobExecutions.id})
+              .from(newerRunningJobExecutions)
+              .where(
+                and(
+                  eq(newerRunningJobExecutions.workspaceId, runningJobExecutions.workspaceId),
+                  eq(newerRunningJobExecutions.provisionerId, runningJobExecutions.provisionerId),
+                  eq(
+                    newerRunningJobExecutions.providerRunnerId,
+                    runningJobExecutions.providerRunnerId,
+                  ),
+                  or(
+                    gt(newerRunningJobExecutions.startedAt, runningJobExecutions.startedAt),
+                    and(
+                      eq(newerRunningJobExecutions.startedAt, runningJobExecutions.startedAt),
+                      gt(
+                        newerRunningJobExecutions.jobExecutionId,
+                        runningJobExecutions.jobExecutionId,
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
+          ),
         ),
       ),
-    )
-    .groupBy(providerRunners.providerRunnerId);
+  );
+  const activationTimeout = and(
+    eq(providerRunners.launchKind, 'demand'),
+    isNull(providerRunners.runnerSessionId),
+    lt(
+      providerRunners.createdAt,
+      sql`now() - (${config.RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS} || ' seconds')::interval`,
+    ),
+    notExists(
+      tx
+        .select({id: reservations.id})
+        .from(reservations)
+        .where(
+          and(
+            or(
+              eq(reservations.id, providerRunners.reservationId),
+              eq(reservations.id, providerRunners.intendedReservationId),
+            ),
+            eq(reservations.workspaceId, params.workspaceId),
+            eq(reservations.provisionerId, params.provisionerId),
+            gt(reservations.expiresAt, sql`now()`),
+          ),
+        ),
+    ),
+  );
+
+  return tx
+    .select({
+      providerRunnerId: providerRunners.providerRunnerId,
+      activationTimeoutRetry: sql<boolean>`${providerRunners.reservationReleasedAt} is not null`,
+      reason: sql<RunnerInstanceTerminateIntentReason>`case
+        when ${activationTimeout} then 'activation-timeout'
+        else 'job-cancelled'
+      end`,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.workspaceId, params.workspaceId),
+        eq(providerRunners.provisionerId, params.provisionerId),
+        isNotNull(providerRunners.providerRunnerId),
+        inArray(providerRunners.state, activeStates),
+        params.providerRunnerIds && params.providerRunnerIds.length > 0
+          ? inArray(providerRunners.providerRunnerId, params.providerRunnerIds)
+          : undefined,
+        or(latestCancelledJob, activationTimeout),
+      ),
+    );
 }
 
 async function listTerminateIntentsHonoredByTerminatedReportsTx(
@@ -419,9 +486,7 @@ async function listTerminateIntentsHonoredByTerminatedReportsTx(
     provisionerId: params.provisionerId,
     providerRunnerIds: terminatedRunnerInstanceIds,
   }).orderBy(asc(providerRunners.providerRunnerId));
-  return rows.flatMap((row) =>
-    row.providerRunnerId ? [{...row, providerRunnerId: row.providerRunnerId}] : [],
-  );
+  return rows.flatMap((row) => toRunnerInstanceTerminateIntent(row));
 }
 
 export async function reconcileRunnerInstances(

--- a/libs/api/runners/src/db/schema/runner-instances.ts
+++ b/libs/api/runners/src/db/schema/runner-instances.ts
@@ -14,6 +14,12 @@ export const providerRunnerStateEnum = pgEnum('runners_provider_runner_state', [
   'terminated',
 ]);
 
+export const providerRunnerLaunchKindEnum = pgEnum('runners_provider_runner_launch_kind', [
+  'demand',
+  'warm',
+  'manual',
+]);
+
 export const providerRunners = pgTable(
   'runner_instances',
   {
@@ -25,6 +31,7 @@ export const providerRunners = pgTable(
     providerRunnerId: text('provider_runner_id'),
     intendedReservationId: uuid('intended_reservation_id'),
     reservationId: uuid('reservation_id'),
+    launchKind: providerRunnerLaunchKindEnum('launch_kind').notNull().default('manual'),
     assignedAt: timestamp('assigned_at', {withTimezone: true}),
     templateKey: text('template_key'),
     labels: text('labels').array().notNull().default([]),
@@ -84,6 +91,7 @@ export function toRunnerInstance(row: RunnerInstanceDb): RunnerInstance {
     providerRunnerId: row.providerRunnerId,
     intendedReservationId: row.intendedReservationId,
     reservationId: row.reservationId,
+    launchKind: row.launchKind,
     assignedAt: row.assignedAt,
     templateKey: row.templateKey,
     labels: row.labels,

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -13,6 +13,7 @@ export {
   providerRunnerReconcileCallCount,
   providerRunnerTerminateIntentHonoredCount,
   providerRunnerTerminateIntentIssuedCount,
+  recordProviderRunnerActivationOutcome,
   recordRunnerActivationTokenNotIssued,
   recordRunnerReservationPromotionFailure,
   recordRunnersRateLimitCheck,

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -8,6 +8,7 @@ export {
   jobExecutionEnqueuedCount,
   jobExecutionLeaseExpiredCount,
   providerRunnerAbsentTerminatedCount,
+  providerRunnerActivationOutcomeCount,
   providerRunnerCountDivergenceCount,
   providerRunnerReconcileCallCount,
   providerRunnerTerminateIntentHonoredCount,

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -82,15 +82,21 @@ export const providerRunnerAbsentTerminatedCount = meter.createCounter<Record<st
 
 export const providerRunnerTerminateIntentIssuedCount = meter.createCounter<{
   surface: 'poll-demand' | 'reconcile';
-  reason: 'job-cancelled' | 'terminal-state';
+  reason: 'activation-timeout' | 'job-cancelled' | 'terminal-state';
 }>('runners_provider_runner_terminate_intent_issued', {
   description: 'Provisioned runner terminate intents returned to provisioners',
 });
 
 export const providerRunnerTerminateIntentHonoredCount = meter.createCounter<{
-  reason: 'job-cancelled';
+  reason: 'activation-timeout' | 'job-cancelled';
 }>('runners_provider_runner_terminate_intent_honored', {
   description: 'Provisioned runner terminate intents honored by first transition to terminated',
+});
+
+export const providerRunnerActivationOutcomeCount = meter.createCounter<{
+  outcome: 'reaped' | 'rebound';
+}>('runners_provider_runner_activation_outcome', {
+  description: 'Demand-backed runner activation outcomes by recovery action',
 });
 
 export const reservationReleasedCount = meter.createCounter<Record<string, never>>(

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -170,3 +170,12 @@ export function recordRunnersRateLimitCheck(params: {
 export function recordRunnersRateLimitPruneFailure(): void {
   recordMetric(() => rateLimitPruneFailureCount.add(1));
 }
+
+export function recordProviderRunnerActivationOutcome(params: {
+  outcome: 'reaped' | 'rebound';
+  count?: number;
+}): void {
+  recordMetric(() =>
+    providerRunnerActivationOutcomeCount.add(params.count ?? 1, {outcome: params.outcome}),
+  );
+}

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -20,6 +20,7 @@ import {db} from '#db/db.js';
 import {provisionerCapabilitySnapshots} from '#db/schema/provisioner-capability-snapshots.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {
+  providerRunnerActivationOutcomeCount,
   providerRunnerCountDivergenceCount,
   providerRunnerTerminateIntentIssuedCount,
 } from '#metrics/instance.js';
@@ -365,6 +366,53 @@ describe('POST /provisioners/demand/poll', () => {
       );
     expect(divergenceCalls).toHaveLength(1);
     expect(intentCalls).toHaveLength(1);
+  });
+
+  it('returns stale demand-backed runners and records the reap outcome', async () => {
+    const intentSpy = vi.spyOn(providerRunnerTerminateIntentIssuedCount, 'add');
+    const outcomeSpy = vi.spyOn(providerRunnerActivationOutcomeCount, 'add');
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisionerTokenId,
+      providerRunnerId: 'stale-demand-runner',
+      launchKind: 'demand',
+      createdAt: new Date(Date.now() - 301_000),
+      templateKey: 'linux',
+      state: 'running',
+    });
+    const intentCallsBefore = intentSpy.mock.calls.length;
+    const outcomeCallsBefore = outcomeSpy.mock.calls.length;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 0}),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      reservations: [],
+      terminate_provider_runner_ids: ['stale-demand-runner'],
+    });
+    expect(
+      intentSpy.mock.calls
+        .slice(intentCallsBefore)
+        .filter(
+          ([value, attributes]) =>
+            value === 1 &&
+            JSON.stringify(attributes) ===
+              JSON.stringify({surface: 'poll-demand', reason: 'activation-timeout'}),
+        ),
+    ).toHaveLength(1);
+    expect(
+      outcomeSpy.mock.calls
+        .slice(outcomeCallsBefore)
+        .filter(
+          ([value, attributes]) =>
+            value === 1 && JSON.stringify(attributes) === JSON.stringify({outcome: 'reaped'}),
+        ),
+    ).toHaveLength(1);
   });
 
   it('returns 400 for max reservations above the request bound', async () => {

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -159,6 +159,7 @@ describe('runner enrollment control plane', () => {
       provisionerId,
       labels: ['linux', 'shipfox-managed'],
       providerRunnerId: 'container-1',
+      launchKind: 'warm',
       state: 'running',
       protocolVersion: '1',
     });
@@ -299,6 +300,7 @@ describe('runner enrollment control plane', () => {
     expect(instance).toMatchObject({
       workspaceId,
       reservationId: reservation.id,
+      launchKind: 'demand',
       intendedReservationId: null,
       state: 'running',
       providerRunnerId,

--- a/libs/api/runners/test/factories/runner-instance.ts
+++ b/libs/api/runners/test/factories/runner-instance.ts
@@ -13,6 +13,7 @@ export const providerRunnerFactory = Factory.define<RunnerInstance>(({onCreate})
         providerRunnerId: providerRunner.providerRunnerId,
         intendedReservationId: providerRunner.intendedReservationId,
         reservationId: providerRunner.reservationId,
+        launchKind: providerRunner.launchKind,
         templateKey: providerRunner.templateKey,
         labels: providerRunner.labels,
         state: providerRunner.state,
@@ -26,6 +27,8 @@ export const providerRunnerFactory = Factory.define<RunnerInstance>(({onCreate})
         failedAt: providerRunner.failedAt,
         terminatedAt: providerRunner.terminatedAt,
         reservationReleasedAt: providerRunner.reservationReleasedAt,
+        createdAt: providerRunner.createdAt,
+        updatedAt: providerRunner.updatedAt,
       })
       .returning();
 
@@ -40,6 +43,7 @@ export const providerRunnerFactory = Factory.define<RunnerInstance>(({onCreate})
     providerRunnerId: crypto.randomUUID(),
     intendedReservationId: null,
     reservationId: null,
+    launchKind: 'manual',
     templateKey: 'linux',
     labels: ['linux'],
     state: 'running',


### PR DESCRIPTION
Demand-backed runners can enroll, remain healthy, and never obtain a runner session, which let them evade the existing registration and stale-runner reapers.

This change persists the runner launch kind, issues activation-timeout termination intents only for stale demand launches without a live current or intended reservation, and marks those intents so late delivery cannot make the runner eligible for rebinding. It also preserves retry delivery without making retry-only intents collapse demand long polls, and records activation outcomes for reaped and rebound runners.

Warm and manual runners remain outside the reclaim path. The retry-emission metric deduplication is tracked separately in ENG-1517.

Closes ENG-1512

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclaims demand-backed runners that enroll but never activate by issuing `activation-timeout` termination intents after a short, configurable window. Releases their reservation, records activation outcomes, and preserves long‑poll behavior; warm/manual runners are not affected. Addresses ENG-1512.

- **New Features**
  - Persist runner launch kind (`demand`, `warm`, `manual`); set on creation (`demand` when booted with a reservation, else `warm`) and preserve on provider updates.
  - Add `RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS` (default 300s, whole number ≥1). Reclaim only `demand` runners with no session and no live current or intended reservation; release their reservation on first emission, mark later deliveries with `activationTimeoutRetry`, and keep long‑polling when only retries are pending.
  - Metrics: issue intents with reason `activation-timeout`; record activation outcomes `reaped` (counted only on first intent emission) and `rebound` (idle demand runner bound).

- **Migration**
  - Run DB migrations to add `launch_kind` enum/column and backfill existing rows from reservation fields; optionally tune `RUNNER_DEMAND_ACTIVATION_TIMEOUT_SECONDS`.

<sup>Written for commit 17f8bf641e628e022b2dc8e15203cfd5259989dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

