### PR TITLE
[api-runners] Prevent metrics mock leakage between Vitest files

### DIFF
--- a/libs/api/runners/src/metrics/service.test.ts
+++ b/libs/api/runners/src/metrics/service.test.ts
@@ -33,7 +33,14 @@ vi.mock('#db/runner-instances.js', () => ({
   countStaleEnrolledRunnerInstances: mocks.countStaleEnrolledRunnerInstances,
 }));
 
-import {registerRunnersServiceMetrics} from './service.js';
+let registerRunnersServiceMetrics: typeof import('./service.js').registerRunnersServiceMetrics;
+
+beforeAll(async () => {
+  // This package intentionally runs with isolate: false. Reset the shared module cache before
+  // importing the service so a previous file's real OpenTelemetry module cannot bypass this mock.
+  vi.resetModules();
+  ({registerRunnersServiceMetrics} = await import('./service.js'));
+});
 
 describe('registerRunnersServiceMetrics', () => {
   beforeEach(() => {


### PR DESCRIPTION
The runners Vitest suite intentionally shares one module graph (isolate: false). When poll-demand.test.ts loaded the real OpenTelemetry module before metrics/service.test.ts, the static mock was bypassed and the metrics tests became file-order dependent.

Reset the shared module cache before dynamically importing the metrics service so its existing mocks are applied before dependency capture. The current Vitest configuration and shared-module coverage remain unchanged.

Validation: both explicit file orders pass, the full runners suite passes with 44 files and 548 tests, and dependent check, type, and depcruise gates pass.

Closes ENG-1516

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents metrics mock leakage across `vitest` files by resetting the shared module cache before importing the service, making tests order-independent and stable. Addresses ENG-1516 by ensuring the OpenTelemetry mock is honored under a shared module graph.

- **Bug Fixes**
  - Call `vi.resetModules()` in `beforeAll` and dynamically import `./service.js` so mocks apply before dependency capture.
  - Keep `isolate: false` config; no changes to coverage or test setup.

<sup>Written for commit 27a9354e6915b1ecb72d1c9de06f2cd07c6c26c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

