### PR TITLE
[api-runners] Record why runner activation tokens are not issued

### DIFF
--- a/.changeset/quiet-token-reasons.md
+++ b/.changeset/quiet-token-reasons.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Adds low-cardinality metrics and debug logs that identify why runner activation token issuance stops.

--- a/libs/api/runners/src/core/runner-activation.ts
+++ b/libs/api/runners/src/core/runner-activation.ts
@@ -1,14 +1,22 @@
+import {logger} from '@shipfox/node-opentelemetry';
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
 import {and, eq, isNull, sql} from 'drizzle-orm';
 import type {Tx} from '#db/db.js';
 import {db} from '#db/db.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
+import type {RunnerInstanceDb} from '#db/schema/runner-instances.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
+import {
+  type RunnerActivationTokenNotIssuedReason,
+  type RunnerActivationTokenNotIssuedSurface,
+  recordRunnerActivationTokenNotIssued,
+} from '#metrics/instance.js';
 
 export async function issueRunnerActivationToken(params: {
   runnerInstanceId: string;
   provisionerId: string;
   ttlSeconds: number;
+  surface: RunnerActivationTokenNotIssuedSurface;
 }): Promise<string | null> {
   return await db().transaction(async (tx) => issueRunnerActivationTokenTx(tx, params));
 }
@@ -19,6 +27,7 @@ export async function issueRunnerActivationTokenTx(
     runnerInstanceId: string;
     provisionerId: string;
     ttlSeconds: number;
+    surface: RunnerActivationTokenNotIssuedSurface;
   },
 ): Promise<string | null> {
   await tx.execute(
@@ -39,7 +48,11 @@ export async function issueRunnerActivationTokenTx(
     )
     .limit(1)
     .for('update');
-  if (!runner?.workspaceId || runner.runnerSessionId || runner.state !== 'running') return null;
+  const notIssuedReason = getRunnerActivationTokenNotIssuedReason(runner);
+  if (notIssuedReason) {
+    recordRunnerActivationTokenNotIssuedWithLog(notIssuedReason, params);
+    return null;
+  }
 
   await tx
     .update(runnerActivationTokens)
@@ -69,6 +82,7 @@ export async function getRunnerAssignment(params: {
     .select({
       workspaceId: providerRunners.workspaceId,
       runnerSessionId: providerRunners.runnerSessionId,
+      state: providerRunners.state,
     })
     .from(providerRunners)
     .where(
@@ -78,5 +92,37 @@ export async function getRunnerAssignment(params: {
       ),
     )
     .limit(1);
-  return runner?.workspaceId && !runner.runnerSessionId ? runner : null;
+  return runner?.workspaceId && !runner.runnerSessionId && runner.state === 'running'
+    ? {workspaceId: runner.workspaceId, runnerSessionId: runner.runnerSessionId}
+    : null;
+}
+
+function getRunnerActivationTokenNotIssuedReason(
+  runner: Pick<RunnerInstanceDb, 'workspaceId' | 'runnerSessionId' | 'state'> | undefined,
+): RunnerActivationTokenNotIssuedReason | null {
+  if (!runner) return 'runner-not-found';
+  if (!runner.workspaceId) return 'missing-workspace';
+  if (runner.runnerSessionId) return 'existing-session';
+  if (runner.state !== 'running') return 'not-running';
+  return null;
+}
+
+function recordRunnerActivationTokenNotIssuedWithLog(
+  reason: RunnerActivationTokenNotIssuedReason,
+  params: {
+    runnerInstanceId: string;
+    provisionerId: string;
+    surface: RunnerActivationTokenNotIssuedSurface;
+  },
+): void {
+  recordRunnerActivationTokenNotIssued({reason, surface: params.surface});
+  logger().debug(
+    {
+      runnerInstanceId: params.runnerInstanceId,
+      provisionerId: params.provisionerId,
+      reason,
+      surface: params.surface,
+    },
+    'Runner activation token was not issued',
+  );
 }

--- a/libs/api/runners/src/core/runner-control-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.test.ts
@@ -9,6 +9,7 @@ import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {
   type RunnerReservationPromotionFailureReason,
+  runnerActivationTokenNotIssuedCount,
   runnerReservationPromotionFailureCount,
 } from '#metrics/instance.js';
 import {enrollRunnerControlSession} from './runner-control-sessions.js';
@@ -215,6 +216,62 @@ describe('enrollRunnerControlSession', () => {
       capabilities,
       state: 'running',
     });
+  });
+
+  it('records an activation-token reason when enrollment sees an existing runner session', async () => {
+    const provisionerId = crypto.randomUUID();
+    const reservation = await createReservation({provisionerId});
+    const runnerInstanceId = await createRunner({
+      provisionerId,
+      intendedReservationId: reservation.id,
+    });
+    await db()
+      .update(providerRunners)
+      .set({runnerSessionId: crypto.randomUUID()})
+      .where(eq(providerRunners.id, runnerInstanceId));
+    const addSpy = vi.spyOn(runnerActivationTokenNotIssuedCount, 'add');
+
+    try {
+      const activationToken = await enrollRunnerControlSession({
+        runnerInstanceId,
+        provisionerId,
+        labels: ['linux'],
+        providerKind: 'docker',
+        protocolVersion: '1',
+      });
+      const [runner] = await db()
+        .select({
+          workspaceId: providerRunners.workspaceId,
+          reservationId: providerRunners.reservationId,
+          assignedAt: providerRunners.assignedAt,
+          intendedReservationId: providerRunners.intendedReservationId,
+          runnerSessionId: providerRunners.runnerSessionId,
+          state: providerRunners.state,
+        })
+        .from(providerRunners)
+        .where(eq(providerRunners.id, runnerInstanceId));
+
+      expect(activationToken).toBeNull();
+      expect(runner).toEqual({
+        workspaceId: reservation.workspaceId,
+        reservationId: reservation.id,
+        assignedAt: expect.any(Date),
+        intendedReservationId: null,
+        runnerSessionId: expect.any(String),
+        state: 'running',
+      });
+      // The test setup uses a shared NoopMeter counter; count only this metric's label shape.
+      const activationTokenCalls = addSpy.mock.calls.filter(
+        ([value, attributes]) =>
+          value === 1 &&
+          (attributes as {reason?: string; surface?: string} | undefined)?.reason ===
+            'existing-session' &&
+          (attributes as {reason?: string; surface?: string} | undefined)?.surface === 'enrollment',
+      );
+      expect(activationTokenCalls).toHaveLength(1);
+    } finally {
+      addSpy.mockRestore();
+    }
   });
 
   it('updates metadata during enrollment for an unassigned runner', async () => {

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -227,6 +227,7 @@ export async function enrollRunnerControlSession(params: {
           runnerInstanceId: params.runnerInstanceId,
           provisionerId: params.provisionerId,
           ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
+          surface: 'enrollment',
         });
       });
     } catch (error) {

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -1,9 +1,15 @@
+import {vi} from '@shipfox/vitest/vi';
 import {and, eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
+import type {RunnerInstanceInsertDb} from '#db/schema/runner-instances.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
+import {
+  type RunnerActivationTokenNotIssuedReason,
+  runnerActivationTokenNotIssuedCount,
+} from '#metrics/instance.js';
 import {
   ephemeralRegistrationTokenFactory,
   getRunnerSessionTokenClaims,
@@ -18,8 +24,33 @@ import {
   RegistrationTokenWorkspaceMismatchError,
   RunnerLabelsReservedError,
 } from './errors.js';
-import {issueRunnerActivationToken} from './runner-activation.js';
+import {getRunnerAssignment, issueRunnerActivationToken} from './runner-activation.js';
 import {registerRunnerSession} from './runner-sessions.js';
+
+const activationTokenNotIssuedCases: Array<{
+  reason: RunnerActivationTokenNotIssuedReason;
+  update: Partial<RunnerInstanceInsertDb>;
+  provisionerId?: string;
+}> = [
+  {reason: 'runner-not-found', update: {}, provisionerId: crypto.randomUUID()},
+  {reason: 'missing-workspace', update: {workspaceId: null}},
+  {reason: 'existing-session', update: {runnerSessionId: crypto.randomUUID()}},
+  {reason: 'not-running', update: {state: 'starting'}},
+];
+
+function activationTokenMetricCalls(spy: {mock: {calls: unknown[][]}}): unknown[][] {
+  // The test setup uses a shared NoopMeter counter, so filter calls to this metric before counting.
+  return spy.mock.calls.filter(([, attributes]) => {
+    if (typeof attributes !== 'object' || attributes === null) return false;
+    const reason = (attributes as {reason?: unknown}).reason;
+    const surface = (attributes as {surface?: unknown}).surface;
+    return (
+      ['runner-not-found', 'missing-workspace', 'existing-session', 'not-running'].includes(
+        String(reason),
+      ) && ['enrollment', 'poll'].includes(String(surface))
+    );
+  });
+}
 
 describe('registerRunnerSession', () => {
   let workspaceId: string;
@@ -245,11 +276,13 @@ describe('activation runner sessions', () => {
       runnerInstanceId,
       provisionerId,
       ttlSeconds: 60,
+      surface: 'poll',
     });
     const replacementToken = await issueRunnerActivationToken({
       runnerInstanceId,
       provisionerId,
       ttlSeconds: 60,
+      surface: 'poll',
     });
 
     const tokens = await db()
@@ -265,11 +298,97 @@ describe('activation runner sessions', () => {
     expect(tokens.filter((token) => token.revokedAt !== null)).toHaveLength(1);
   });
 
+  it.each(
+    activationTokenNotIssuedCases,
+  )('records $reason when direct activation-token issuance is skipped', async ({
+    reason,
+    update,
+    provisionerId: caseProvisionerId,
+  }) => {
+    const addSpy = vi.spyOn(runnerActivationTokenNotIssuedCount, 'add');
+
+    try {
+      if (Object.keys(update).length > 0) {
+        await db()
+          .update(providerRunners)
+          .set(update)
+          .where(eq(providerRunners.id, runnerInstanceId));
+      }
+
+      const activationToken = await issueRunnerActivationToken({
+        runnerInstanceId,
+        provisionerId: caseProvisionerId ?? provisionerId,
+        ttlSeconds: 60,
+        surface: 'poll',
+      });
+
+      expect(activationToken).toBeNull();
+      expect(activationTokenMetricCalls(addSpy)).toEqual([[1, {reason, surface: 'poll'}]]);
+    } finally {
+      addSpy.mockRestore();
+    }
+  });
+
+  it('does not record a metric when assignment polling finds no assignment', async () => {
+    const addSpy = vi.spyOn(runnerActivationTokenNotIssuedCount, 'add');
+
+    try {
+      await db()
+        .update(providerRunners)
+        .set({workspaceId: null})
+        .where(eq(providerRunners.id, runnerInstanceId));
+
+      const assignment = await getRunnerAssignment({runnerInstanceId, provisionerId});
+
+      expect(assignment).toBeNull();
+      expect(activationTokenMetricCalls(addSpy)).toHaveLength(0);
+    } finally {
+      addSpy.mockRestore();
+    }
+  });
+
+  it('does not poll for an assignment while the runner is not running', async () => {
+    const addSpy = vi.spyOn(runnerActivationTokenNotIssuedCount, 'add');
+
+    try {
+      await db()
+        .update(providerRunners)
+        .set({state: 'starting'})
+        .where(eq(providerRunners.id, runnerInstanceId));
+
+      const assignment = await getRunnerAssignment({runnerInstanceId, provisionerId});
+
+      expect(assignment).toBeNull();
+      expect(activationTokenMetricCalls(addSpy)).toHaveLength(0);
+    } finally {
+      addSpy.mockRestore();
+    }
+  });
+
+  it('does not record a metric when activation-token issuance succeeds', async () => {
+    const addSpy = vi.spyOn(runnerActivationTokenNotIssuedCount, 'add');
+
+    try {
+      const activationToken = await issueRunnerActivationToken({
+        runnerInstanceId,
+        provisionerId,
+        ttlSeconds: 60,
+        surface: 'poll',
+      });
+
+      expect(activationToken).toEqual(expect.any(String));
+      expect(activationTokenMetricCalls(addSpy)).toHaveLength(0);
+    } finally {
+      addSpy.mockRestore();
+    }
+  });
+
   it('allows only one concurrent registration to consume an activation token', async () => {
     const rawToken = await issueRunnerActivationToken({
       runnerInstanceId,
       provisionerId,
       ttlSeconds: 60,
+      surface: 'poll',
     });
     const [activationToken] = await db()
       .select()
@@ -314,6 +433,7 @@ describe('activation runner sessions', () => {
       runnerInstanceId,
       provisionerId,
       ttlSeconds: 60,
+      surface: 'poll',
     });
     const [activationToken] = await db()
       .select()

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -1,4 +1,8 @@
-export type {RunnerReservationPromotionFailureReason} from './instance.js';
+export type {
+  RunnerActivationTokenNotIssuedReason,
+  RunnerActivationTokenNotIssuedSurface,
+  RunnerReservationPromotionFailureReason,
+} from './instance.js';
 export {
   jobExecutionClaimedCount,
   jobExecutionEnqueuedCount,
@@ -8,6 +12,7 @@ export {
   providerRunnerReconcileCallCount,
   providerRunnerTerminateIntentHonoredCount,
   providerRunnerTerminateIntentIssuedCount,
+  recordRunnerActivationTokenNotIssued,
   recordRunnerReservationPromotionFailure,
   recordRunnersRateLimitCheck,
   recordRunnersRateLimitPruneFailure,

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -31,6 +31,21 @@ export const runnerBootstrapExchangeCount = meter.createCounter<{
   description: 'Runner bootstrap-token exchanges by outcome',
 });
 
+export type RunnerActivationTokenNotIssuedReason =
+  | 'runner-not-found'
+  | 'missing-workspace'
+  | 'existing-session'
+  | 'not-running';
+
+export type RunnerActivationTokenNotIssuedSurface = 'enrollment' | 'poll';
+
+export const runnerActivationTokenNotIssuedCount = meter.createCounter<{
+  reason: RunnerActivationTokenNotIssuedReason;
+  surface: RunnerActivationTokenNotIssuedSurface;
+}>('runners_runner_activation_token_not_issued', {
+  description: 'Runner activation token issuance skips by reason and surface',
+});
+
 export const runnerControlHeartbeatCount = meter.createCounter<Record<string, never>>(
   'runners_runner_control_heartbeat',
   {description: 'Pre-workspace runner-control heartbeats accepted'},
@@ -123,6 +138,13 @@ export function recordRunnerReservationPromotionFailure(
   reason: RunnerReservationPromotionFailureReason,
 ): void {
   recordMetric(() => runnerReservationPromotionFailureCount.add(1, {reason}));
+}
+
+export function recordRunnerActivationTokenNotIssued(params: {
+  reason: RunnerActivationTokenNotIssuedReason;
+  surface: RunnerActivationTokenNotIssuedSurface;
+}): void {
+  recordMetric(() => runnerActivationTokenNotIssuedCount.add(1, params));
 }
 
 export function recordRunnersRateLimitCheck(params: {

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.ts
@@ -173,7 +173,7 @@ type RunnerAssignmentPollParams = {
   deadline: number;
   intervalMs: number;
   signal: AbortSignal;
-  getAssignment: () => Promise<unknown | null>;
+  getAssignment: () => Promise<{workspaceId: string | null; runnerSessionId: string | null} | null>;
   issueActivationToken: () => Promise<string | null>;
 };
 
@@ -229,6 +229,7 @@ export const runnerAssignmentPollRoute = defineRoute({
         issueRunnerActivationToken({
           ...session,
           ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
+          surface: 'poll',
         }),
     });
     return {activation_token: activationToken};


### PR DESCRIPTION
Runner activation token issuance previously returned null without explaining why. This adds bounded reason and surface instrumentation at the write sites, keeps assignment polling from producing cadence-driven signal, and records explicit runner and provisioner context in debug logs. The tests cover all reason buckets and enrollment and poll behavior; no database migration is required.

Validation: `mise exec -- pnpm turbo test --filter=@shipfox/api-runners` (44 files, 559 tests), `mise exec -- pnpm turbo check --filter=@shipfox/api-runners`, `mise exec -- pnpm turbo type:emit --filter=@shipfox/api-runners`, and `mise exec -- pnpm turbo depcruise --filter=@shipfox/api-runners...`.

Closes ENG-1510