### PR TITLE
[api-integration-jira] Fix dynamic webhook registration

### DIFF
--- a/.changeset/fix-jira-webhook-filter.md
+++ b/.changeset/fix-jira-webhook-filter.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-jira": patch
+---
+
+Registers Jira dynamic webhooks with a non-empty all-issues JQL filter.

--- a/libs/api/integration/jira/src/api/client.test.ts
+++ b/libs/api/integration/jira/src/api/client.test.ts
@@ -100,7 +100,7 @@ describe('Jira dynamic webhook API', () => {
     mocks.warn.mockReset();
   });
 
-  it('registers the six curated events with the access token', async () => {
+  it('sends the six curated events with the configured JQL filter', async () => {
     mocks.post.mockReturnValue(
       resolves({webhookRegistrationResult: [{createdWebhookId: 123, errors: []}]}),
     );
@@ -130,7 +130,7 @@ describe('Jira dynamic webhook API', () => {
             'comment_updated',
             'comment_deleted',
           ],
-          jqlFilter: '',
+          jqlFilter: 'project != null',
         },
       ],
     });

--- a/libs/api/integration/jira/src/api/client.ts
+++ b/libs/api/integration/jira/src/api/client.ts
@@ -8,7 +8,8 @@ const JIRA_API_TIMEOUT_MS = 10_000;
 const SCOPE_SEPARATOR_RE = /[,\s]+/;
 const TRAILING_SLASHES_RE = /\/+$/;
 export const JIRA_DYNAMIC_WEBHOOK_EVENTS = jiraWebhookEventNames;
-export const JIRA_DYNAMIC_WEBHOOK_JQL = '';
+// Jira rejects an empty dynamic-webhook filter; every issue belongs to a project.
+export const JIRA_DYNAMIC_WEBHOOK_JQL = 'project != null';
 
 export interface JiraAuthorization {
   accessToken: string;


### PR DESCRIPTION
## Summary

Jira Cloud rejects an empty JQL filter when registering dynamic webhooks, causing the OAuth callback to fail after token storage and leaving the installation without a webhook.

Send `project != null` as the all-issues filter. This exact payload was accepted by Jira's live OAuth dynamic-webhook endpoint, and the temporary verification webhook was deleted successfully.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/api-integration-jira...`
- `mise exec -- turbo build --filter=@shipfox/api-integration-jira...`
- `mise exec -- turbo depcruise --filter=@shipfox/api-integration-jira...`
- Live Jira registration and deletion probe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Jira dynamic webhook registration by using a non-empty JQL filter. `@shipfox/api-integration-jira` now sets the filter to 'project != null', preventing OAuth callback failures and ensuring the webhook registers successfully.

<sup>Written for commit ad48e05f8795a9c3cae1b0689c216ad7f4460af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

