### PR TITLE
Validate runner reservations before enrollment bootstrap

### DIFF
--- a/.changeset/guard-runner-reservations.md
+++ b/.changeset/guard-runner-reservations.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-runners-dto": minor
+---
+
+Validates reservation capacity before creating or adopting runner rows, reports capacity shortfalls and full reservation units separately from launch grants, and preserves request positions for partial enrollment.

--- a/.changeset/guard-runner-reservations.md
+++ b/.changeset/guard-runner-reservations.md
@@ -3,4 +3,4 @@
 "@shipfox/api-runners-dto": minor
 ---
 
-Validates reservation capacity before creating or adopting runner rows, reports capacity shortfalls and full reservation units separately from launch grants, and preserves request positions for partial enrollment.
+Runners are enrolled only when the reservation still has capacity, and partial-enrollment errors now report reservation shortfalls separately from launch grants.

--- a/libs/api/runners-dto/src/schemas/poll-demand.test.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.test.ts
@@ -67,6 +67,7 @@ describe('pollDemandResponseSchema', () => {
           expires_at: 'not-a-date',
         },
       ],
+      newly_reserved_count: 1,
       terminate_provider_runner_ids: [],
     });
 

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -42,6 +42,14 @@ export const reservationGrantSchema = z.object({
 export const pollDemandResponseSchema = z.object({
   stats: z.array(demandStatSchema),
   reservations: z.array(reservationGrantSchema),
+  newly_reserved_count: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe(
+      'Reservation units created by this poll, including units satisfied by adopted runners.',
+    ),
   terminate_provider_runner_ids: z.array(z.string()),
 });
 

--- a/libs/api/runners-dto/src/schemas/runner-enrollment.ts
+++ b/libs/api/runners-dto/src/schemas/runner-enrollment.ts
@@ -24,8 +24,16 @@ export const createRunnerInstancesBodySchema = z
   .strict();
 export const createRunnerInstancesResponseSchema = z.object({
   runner_instances: z.array(
-    z.object({runner_instance_id: z.string().uuid(), bootstrap_token: z.string().min(1)}),
+    z.object({
+      runner_instance_id: z.string().uuid(),
+      bootstrap_token: z.string().min(1),
+      // Accepted instances retain their request position for short responses.
+      request_index: z.number().int().nonnegative().optional(),
+    }),
   ),
+  // A demand reservation can be consumed or stale between demand polling and launch.
+  // The field is omitted for the normal and warm-launch paths.
+  reservation_unavailable: z.literal(true).optional(),
 });
 export const runnerBootstrapExchangeResponseSchema = z.object({
   runner_instance_id: z.string().uuid(),

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -43,6 +43,12 @@ describe('shouldReturn', () => {
     expect(result).toBe(true);
   });
 
+  it('returns true when demand was fully adopted by idle runners', () => {
+    const result = shouldReturn({...emptyResult, newlyReservedCount: 3}, 1, 3, false);
+
+    expect(result).toBe(true);
+  });
+
   it('returns true when terminate intents exist', () => {
     const result = shouldReturn(
       {...emptyResult, terminateRunnerInstanceIds: ['provisioned-runner-1']},
@@ -251,6 +257,59 @@ describe('pollDemand', () => {
       vi.doUnmock('#db/reservations.js');
       vi.doUnmock('#db/runner-instances.js');
       vi.doUnmock('#metrics/instance.js');
+      vi.resetModules();
+    }
+  });
+
+  it('returns immediately when demand is fully adopted by idle runners', async () => {
+    vi.resetModules();
+    const pollDemandAndReserveTx = vi.fn().mockResolvedValue({
+      stats: [],
+      reservations: [],
+      newlyReservedUnits: [{labels: ['linux'], count: 3}],
+    });
+    const listProvisionerTerminateIntentRowsTx = vi.fn().mockResolvedValue([]);
+    const listActiveRunnerInstanceCountsByTemplateTx = vi.fn().mockResolvedValue([]);
+    vi.doMock('#db/db.js', () => ({
+      db: () => ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}),
+    }));
+    vi.doMock('#db/reservations.js', () => ({
+      deleteReservationsByIds: vi.fn(),
+      pollDemandAndReserveTx,
+    }));
+    vi.doMock('#db/runner-instances.js', () => ({
+      listActiveRunnerInstanceCountsByTemplateTx,
+      listProvisionerTerminateIntentRowsTx,
+    }));
+
+    try {
+      const {pollDemand: mockedPollDemand} = await import('#core/demand.js');
+
+      const result = await mockedPollDemand({
+        workspaceId: crypto.randomUUID(),
+        provisionerId: crypto.randomUUID(),
+        maxReservations: 3,
+        waitSeconds: 60,
+        ttlSeconds: 60,
+        terminateIntentLimit: 1000,
+        templates: [
+          {templateKey: 'linux', labels: ['linux'], availableSlots: 3, starting: 0, running: 3},
+        ],
+        signal: new AbortController().signal,
+      });
+
+      expect(result).toEqual({
+        stats: [],
+        reservations: [],
+        newlyReservedCount: 3,
+        terminateRunnerInstanceIds: [],
+      });
+      expect(pollDemandAndReserveTx).toHaveBeenCalledOnce();
+      expect(listActiveRunnerInstanceCountsByTemplateTx).toHaveBeenCalledOnce();
+    } finally {
+      vi.doUnmock('#db/db.js');
+      vi.doUnmock('#db/reservations.js');
+      vi.doUnmock('#db/runner-instances.js');
       vi.resetModules();
     }
   });

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -158,6 +158,9 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
 }
 
 export async function releaseReservationGrants(reservations: ReservationGrant[]): Promise<void> {
+  // Fully adopted reservations are intentionally absent from this list: deleting
+  // one on disconnect would orphan the runner bound to that reservation. They
+  // remain protected until terminal cleanup or expiry.
   await deleteReservationsByIds(reservations.map((reservation) => reservation.reservationId));
 }
 

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -12,13 +12,17 @@ import {
 } from '#core/errors.js';
 import {sanitizeRunnerLabels} from '#core/runner-labels.js';
 import {db, type schema, type Tx} from '#db/db.js';
-import {assignRunnerInstancesTx} from '#db/runner-assignments.js';
+import {
+  assignRunnerInstancesTx,
+  validateRunnerReservationCapacityTx,
+} from '#db/runner-assignments.js';
 import {terminalStates} from '#db/runner-instances.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {
   type RunnerReservationPromotionFailureReason,
+  recordRunnerReservationCapacityFailure,
   recordRunnerReservationPromotionFailure,
 } from '#metrics/index.js';
 import {issueRunnerActivationTokenTx} from './runner-activation.js';
@@ -45,13 +49,52 @@ export async function createRunnerInstancesWithBootstrapTokens(params: {
     reservationId?: string | null;
   }>;
   ttlSeconds: number;
-}): Promise<Array<{runnerInstanceId: string; bootstrapToken: string}>> {
+}): Promise<{
+  runnerInstances: Array<{
+    runnerInstanceId: string;
+    bootstrapToken: string;
+    requestIndex: number;
+  }>;
+  reservationUnavailable: boolean;
+}> {
   const expiresAt = new Date(Date.now() + params.ttlSeconds * 1000);
   return await db().transaction(async (tx) => {
+    const reservationValidation = await validateRunnerReservationCapacityTx(tx, {
+      provisionerId: params.provisionerId,
+      requests: params.runnerInstances.reduce(
+        (requests, runner) => {
+          if (!runner.reservationId) return requests;
+          const request = requests.find(
+            (candidate) => candidate.reservationId === runner.reservationId,
+          );
+          if (request) request.count += 1;
+          else requests.push({reservationId: runner.reservationId, count: 1});
+          return requests;
+        },
+        [] as Array<{reservationId: string; count: number}>,
+      ),
+    });
+    for (const {reason, count} of reservationValidation.unavailableByReservation.values())
+      recordRunnerReservationCapacityFailure(reason, count);
+    const remainingAcceptedByReservation = new Map(reservationValidation.acceptedByReservation);
+    const runnerInstances = params.runnerInstances.flatMap((runner, requestIndex) => {
+      if (!runner.reservationId) return [{...runner, requestIndex}];
+      const remaining = remainingAcceptedByReservation.get(runner.reservationId) ?? 0;
+      if (remaining === 0) return [];
+      remainingAcceptedByReservation.set(runner.reservationId, remaining - 1);
+      return [{...runner, requestIndex}];
+    });
+
+    if (runnerInstances.length === 0)
+      return {
+        runnerInstances: [],
+        reservationUnavailable: reservationValidation.unavailableByReservation.size > 0,
+      };
+
     const instances = await tx
       .insert(providerRunners)
       .values(
-        params.runnerInstances.map((runner) => ({
+        runnerInstances.map((runner) => ({
           provisionerId: params.provisionerId,
           providerKind: params.providerKind ?? null,
           templateKey: runner.templateKey ?? null,
@@ -63,10 +106,15 @@ export async function createRunnerInstancesWithBootstrapTokens(params: {
         })),
       )
       .returning({id: providerRunners.id});
-    const results = instances.map((instance) => ({
-      runnerInstanceId: instance.id,
-      bootstrapToken: generateOpaqueToken('runnerBootstrapToken'),
-    }));
+    const results = instances.map((instance, index) => {
+      const runner = runnerInstances[index];
+      if (!runner) throw new Error('Runner instance insert returned an unexpected row count');
+      return {
+        runnerInstanceId: instance.id,
+        bootstrapToken: generateOpaqueToken('runnerBootstrapToken'),
+        requestIndex: runner.requestIndex,
+      };
+    });
     await tx.insert(runnerBootstrapTokens).values(
       results.map((result) => ({
         runnerInstanceId: result.runnerInstanceId,
@@ -76,7 +124,10 @@ export async function createRunnerInstancesWithBootstrapTokens(params: {
         expiresAt,
       })),
     );
-    return results;
+    return {
+      runnerInstances: results,
+      reservationUnavailable: reservationValidation.unavailableByReservation.size > 0,
+    };
   });
 }
 

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -527,9 +527,9 @@ describe('pollDemandAndReserve', () => {
   });
 
   it.each([
-    ['template capacity', 5, 2],
-    ['global reservation budget', 2, 5],
-  ])('counts rebound installation capacity against the %s', async (_case, maxReservations, availableSlots) => {
+    ['template capacity', 5, 2, 2],
+    ['global reservation budget', 2, 5, 1],
+  ])('does not overcount rebound units for the %s case', async (_case, maxReservations, availableSlots, expectedLaunchCount) => {
     const reboundWorkspaceId = crypto.randomUUID();
     const launchWorkspaceId = crypto.randomUUID();
     await pendingJobFactory.create({
@@ -568,12 +568,16 @@ describe('pollDemandAndReserve', () => {
       .from(reservations)
       .where(eq(reservations.provisionerId, provisionerId));
     expect(result.reservations).toEqual([
-      expect.objectContaining({workspaceId: launchWorkspaceId, count: 1}),
+      expect.objectContaining({workspaceId: launchWorkspaceId, count: expectedLaunchCount}),
     ]);
     expect(storedReservations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({workspaceId: reboundWorkspaceId, kind: 'bound', count: 1}),
-        expect.objectContaining({workspaceId: launchWorkspaceId, kind: 'launch', count: 1}),
+        expect.objectContaining({
+          workspaceId: launchWorkspaceId,
+          kind: 'launch',
+          count: expectedLaunchCount,
+        }),
       ]),
     );
   });

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -41,7 +41,7 @@ describe('pollDemandAndReserve', () => {
     expect(result.stats[0]).toMatchObject({labels: ['linux'], queued: 50, reserved: 20});
   });
 
-  it('binds the oldest matching enrolled runners to a new reservation', async () => {
+  it('binds the oldest matching enrolled runners and returns only the launch remainder', async () => {
     const olderRunner = await createIdleRunner({
       labels: ['linux'],
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
@@ -54,14 +54,14 @@ describe('pollDemandAndReserve', () => {
       labels: ['macos'],
       createdAt: new Date('2026-01-03T00:00:00.000Z'),
     });
-    await createPendingJobs(2, ['linux']);
+    await createPendingJobs(3, ['linux']);
 
     const result = await pollDemandAndReserve({
       workspaceId,
       provisionerId,
-      maxReservations: 2,
+      maxReservations: 3,
       ttlSeconds: 60,
-      templates: [template('linux', ['linux'], 2)],
+      templates: [template('linux', ['linux'], 3)],
     });
 
     const rows = await db()
@@ -69,14 +69,20 @@ describe('pollDemandAndReserve', () => {
       .from(providerRunners)
       .where(inArray(providerRunners.id, [olderRunner.id, newerRunner.id, unmatchedRunner.id]));
     const rowsById = new Map(rows.map((row) => [row.id, row]));
-    expect(result.reservations).toEqual([]);
-    const reservationId = rowsById.get(olderRunner.id)?.reservationId;
-
-    expect(reservationId).toEqual(expect.any(String));
     const [boundReservation] = await db()
       .select()
       .from(reservations)
-      .where(eq(reservations.id, reservationId as string));
+      .where(and(eq(reservations.workspaceId, workspaceId), eq(reservations.kind, 'bound')));
+    const [launchReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(and(eq(reservations.workspaceId, workspaceId), eq(reservations.kind, 'launch')));
+    const reservationId = boundReservation?.id;
+
+    expect(reservationId).toEqual(expect.any(String));
+    expect(result.reservations).toEqual([
+      expect.objectContaining({reservationId: launchReservation?.id, count: 1}),
+    ]);
     expect(boundReservation).toMatchObject({kind: 'bound', count: 2});
     expect(rowsById.get(olderRunner.id)).toMatchObject({
       workspaceId,
@@ -129,7 +135,6 @@ describe('pollDemandAndReserve', () => {
       launchReservation?.expiresAt.getTime() ?? 0,
     );
     expect(launchReservation?.id).toBe(result.reservations[0]?.reservationId);
-
     const [storedRunner] = await db()
       .select()
       .from(providerRunners)
@@ -159,6 +164,42 @@ describe('pollDemandAndReserve', () => {
             value === 1 && JSON.stringify(attributes) === JSON.stringify({outcome: 'rebound'}),
         ),
     ).toHaveLength(1);
+  });
+
+  it('does not charge adopted runners against later launch capacity', async () => {
+    const adoptedRunner = await createIdleRunner({labels: ['linux', 'gpu']});
+    await createPendingJobs(1, ['linux', 'gpu']);
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 2,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+
+    const storedReservations = await reservationsForTest();
+    const boundReservation = storedReservations.find(
+      (reservation) => reservation.requiredLabels.includes('gpu') && reservation.kind === 'bound',
+    );
+    const launchReservation = storedReservations.find(
+      (reservation) => !reservation.requiredLabels.includes('gpu') && reservation.kind === 'launch',
+    );
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, adoptedRunner.id));
+
+    expect(result.reservations).toEqual([
+      expect.objectContaining({
+        reservationId: launchReservation?.id,
+        labels: ['linux'],
+        count: 1,
+      }),
+    ]);
+    expect(boundReservation).toMatchObject({kind: 'bound', count: 1});
+    expect(storedRunner?.reservationId).toBe(boundReservation?.id);
   });
 
   it('binds a runner whose intended reservation has passed its activation grace period', async () => {
@@ -465,10 +506,21 @@ describe('pollDemandAndReserve', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, runner.id));
+    const [storedReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, targetWorkspaceId),
+          eq(reservations.provisionerId, provisionerId),
+          eq(reservations.kind, 'bound'),
+        ),
+      );
     expect(result.reservations).toEqual([]);
+    expect(storedReservation).toMatchObject({workspaceId: targetWorkspaceId, count: 1});
     expect(storedRunner).toMatchObject({
       workspaceId: targetWorkspaceId,
-      reservationId: expect.any(String),
+      reservationId: storedReservation?.id,
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
@@ -701,6 +753,53 @@ describe('pollDemandAndReserve', () => {
     expect(result.reservations).toEqual([
       expect.objectContaining({workspaceId: olderWorkspaceId, labels: ['linux'], count: 1}),
     ]);
+  });
+
+  it('does not charge adopted installation runners against later launch capacity', async () => {
+    const olderWorkspaceId = crypto.randomUUID();
+    const newerWorkspaceId = crypto.randomUUID();
+    const runner = await createIdleRunner({labels: ['linux', 'gpu']});
+    await pendingJobFactory.create({
+      workspaceId: olderWorkspaceId,
+      requiredLabels: ['linux', 'gpu'],
+    });
+    await pendingJobFactory.create({workspaceId: newerWorkspaceId, requiredLabels: ['linux']});
+
+    const result = await pollInstallationDemandAndReserve({
+      provisionerId,
+      maxReservations: 2,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+      capabilityWindowSeconds: 60,
+      eligibleWorkspaceIds: new Set([olderWorkspaceId, newerWorkspaceId]),
+    });
+
+    const storedReservations = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.provisionerId, provisionerId));
+    const boundReservation = storedReservations.find(
+      (reservation) => reservation.workspaceId === olderWorkspaceId,
+    );
+    const launchReservation = storedReservations.find(
+      (reservation) => reservation.workspaceId === newerWorkspaceId,
+    );
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+
+    expect(result.reservations).toEqual([
+      expect.objectContaining({
+        reservationId: launchReservation?.id,
+        workspaceId: newerWorkspaceId,
+        labels: ['linux'],
+        count: 1,
+      }),
+    ]);
+    expect(boundReservation?.count).toBe(1);
+    expect(storedRunner?.workspaceId).toBe(olderWorkspaceId);
+    expect(storedRunner?.reservationId).toBe(boundReservation?.id);
   });
 
   it('reports committed installation grants before an aborted poll stops allocating', async () => {

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -187,6 +187,8 @@ function consumeInstallationTemplateSlots(
   templates: NormalizedTemplate[],
   launchGrants: ReservationGrant[],
 ): void {
+  // Adopted runners are already included in the running count behind availableSlots.
+  // Only units that still need a launch consume advertised template capacity.
   for (const reservation of launchGrants) {
     const satisfyingTemplates = templates
       .filter((template) => isSubset(reservation.labels, template.labels))

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -123,7 +123,11 @@ export async function pollDemandAndReserveTx(
 
 export async function pollInstallationDemandAndReserve(
   params: InstallationPollDemandAndReserveParams,
-): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
+): Promise<{
+  stats: DemandStat[];
+  reservations: ReservationGrant[];
+  newlyReservedCount?: number;
+}> {
   const candidateWorkspaceIds = await listInstallationDemandWorkspaceIds(
     params.eligibleWorkspaceIds,
   );
@@ -159,24 +163,31 @@ export async function pollInstallationDemandAndReserve(
       });
     });
     results.push(result);
-    consumeInstallationTemplateSlots(remainingTemplates, result.newlyReservedUnits);
+    consumeInstallationTemplateSlots(remainingTemplates, result.reservations);
     params.onReservations?.(result.reservations);
     remainingMaxReservations -= result.newlyReservedUnits.reduce(
       (total, reservation) => total + reservation.count,
       0,
     );
   }
+  const newlyReservedCount = results.reduce(
+    (total, result) =>
+      total +
+      result.newlyReservedUnits.reduce((subtotal, reservation) => subtotal + reservation.count, 0),
+    0,
+  );
   return {
     stats: results.flatMap((result) => result.stats),
     reservations: results.flatMap((result) => result.reservations),
+    ...(newlyReservedCount > 0 ? {newlyReservedCount} : {}),
   };
 }
 
 function consumeInstallationTemplateSlots(
   templates: NormalizedTemplate[],
-  reservations: NewReservationUnits[],
+  launchGrants: ReservationGrant[],
 ): void {
-  for (const reservation of reservations) {
+  for (const reservation of launchGrants) {
     const satisfyingTemplates = templates
       .filter((template) => isSubset(reservation.labels, template.labels))
       .sort(
@@ -290,7 +301,6 @@ async function pollDemandAndReserveLockedTx(
       if (!boundReservation) throw new Error('Insert returned no rows');
 
       remainingMaxReservations -= grant;
-      drawSlots(satisfyingTemplates, grant);
       const boundCount = await bindIdleRunnerInstancesTx(tx, {
         provisionerId: params.provisionerId,
         reservationId: boundReservation.id,
@@ -310,6 +320,7 @@ async function pollDemandAndReserveLockedTx(
       }
 
       const launchCount = grant - boundCount;
+      drawSlots(satisfyingTemplates, launchCount);
       let launchReservation: {id: string; expiresAt: Date} | undefined;
       if (launchCount > 0) {
         const [inserted] = await tx

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -230,6 +230,7 @@ export async function validateRunnerReservationCapacityTx(
       id: reservations.id,
       count: reservations.count,
       expiresAt: reservations.expiresAt,
+      isExpired: sql<boolean>`${reservations.expiresAt} <= now()`,
     })
     .from(reservations)
     .where(
@@ -289,7 +290,6 @@ export async function validateRunnerReservationCapacityTx(
     string,
     {reason: RunnerReservationCapacityFailureReason; count: number}
   >();
-  const now = new Date();
   for (const reservationId of reservationIds) {
     const requested = requestedByReservation.get(reservationId) ?? 0;
     const reservation = reservationsById.get(reservationId);
@@ -300,7 +300,7 @@ export async function validateRunnerReservationCapacityTx(
       });
       continue;
     }
-    if (reservation.expiresAt <= now) {
+    if (reservation.isExpired) {
       unavailableByReservation.set(reservationId, {
         reason: 'reservation-expired',
         count: requested,

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -30,9 +30,10 @@ export async function assignRunnerInstancesTx(
   },
 ): Promise<string[]> {
   const runnerInstanceIds = [...params.runnerInstanceIds].sort();
-  await tx.execute(
-    sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${params.reservationId}`}))`,
-  );
+  await lockRunnerReservationAdvisoryKeysTx(tx, {
+    provisionerId: params.provisionerId,
+    reservationIds: [params.reservationId],
+  });
   const runnerRows = await tx
     .select({
       id: providerRunners.id,
@@ -172,4 +173,151 @@ export async function assignRunnerInstancesTx(
       );
   }
   return params.runnerInstanceIds;
+}
+
+export type RunnerReservationCapacityFailureReason =
+  | 'reservation-not-found'
+  | 'reservation-expired'
+  | 'capacity-exhausted';
+
+export interface RunnerReservationCapacityValidation {
+  acceptedByReservation: Map<string, number>;
+  unavailableByReservation: Map<
+    string,
+    {reason: RunnerReservationCapacityFailureReason; count: number}
+  >;
+}
+
+export async function lockRunnerReservationAdvisoryKeysTx(
+  tx: Tx,
+  params: {provisionerId: string; reservationIds: readonly string[]},
+): Promise<void> {
+  for (const reservationId of [...new Set(params.reservationIds)].sort()) {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${reservationId}`}))`,
+    );
+  }
+}
+
+export async function validateRunnerReservationCapacityTx(
+  tx: Tx,
+  params: {
+    provisionerId: string;
+    requests: readonly {reservationId: string; count: number}[];
+  },
+  options: {advisoryLocksHeld?: boolean} = {},
+): Promise<RunnerReservationCapacityValidation> {
+  const requestedByReservation = new Map<string, number>();
+  for (const request of params.requests) {
+    if (request.count <= 0) continue;
+    requestedByReservation.set(
+      request.reservationId,
+      (requestedByReservation.get(request.reservationId) ?? 0) + request.count,
+    );
+  }
+  const reservationIds = [...requestedByReservation.keys()].sort();
+  if (reservationIds.length === 0)
+    return {acceptedByReservation: new Map(), unavailableByReservation: new Map()};
+
+  if (!options.advisoryLocksHeld)
+    await lockRunnerReservationAdvisoryKeysTx(tx, {
+      provisionerId: params.provisionerId,
+      reservationIds,
+    });
+
+  const reservationRows = await tx
+    .select({
+      id: reservations.id,
+      count: reservations.count,
+      expiresAt: reservations.expiresAt,
+    })
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.provisionerId, params.provisionerId),
+        inArray(reservations.id, reservationIds),
+      ),
+    )
+    .for('update');
+  const reservationsById = new Map(
+    reservationRows.map((reservation) => [reservation.id, reservation]),
+  );
+  const requestedReservationIds = new Set(reservationIds);
+  const usedRunnerIdsByReservation = new Map<string, Set<string>>();
+  const usedRunnerRows = await tx
+    .select({
+      id: providerRunners.id,
+      reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
+      state: providerRunners.state,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.provisionerId, params.provisionerId),
+        isNull(providerRunners.reservationReleasedAt),
+        or(
+          inArray(providerRunners.reservationId, reservationIds),
+          and(
+            inArray(providerRunners.intendedReservationId, reservationIds),
+            notInArray(providerRunners.state, [...terminalStates]),
+          ),
+        ),
+      ),
+    );
+  for (const runner of usedRunnerRows) {
+    if (runner.reservationId && requestedReservationIds.has(runner.reservationId)) {
+      const usedRunnerIds =
+        usedRunnerIdsByReservation.get(runner.reservationId) ?? new Set<string>();
+      usedRunnerIds.add(runner.id);
+      usedRunnerIdsByReservation.set(runner.reservationId, usedRunnerIds);
+    }
+    if (
+      runner.intendedReservationId &&
+      requestedReservationIds.has(runner.intendedReservationId) &&
+      !terminalStates.includes(runner.state as (typeof terminalStates)[number])
+    ) {
+      const usedRunnerIds =
+        usedRunnerIdsByReservation.get(runner.intendedReservationId) ?? new Set<string>();
+      usedRunnerIds.add(runner.id);
+      usedRunnerIdsByReservation.set(runner.intendedReservationId, usedRunnerIds);
+    }
+  }
+
+  const acceptedByReservation = new Map<string, number>();
+  const unavailableByReservation = new Map<
+    string,
+    {reason: RunnerReservationCapacityFailureReason; count: number}
+  >();
+  const now = new Date();
+  for (const reservationId of reservationIds) {
+    const requested = requestedByReservation.get(reservationId) ?? 0;
+    const reservation = reservationsById.get(reservationId);
+    if (!reservation) {
+      unavailableByReservation.set(reservationId, {
+        reason: 'reservation-not-found',
+        count: requested,
+      });
+      continue;
+    }
+    if (reservation.expiresAt <= now) {
+      unavailableByReservation.set(reservationId, {
+        reason: 'reservation-expired',
+        count: requested,
+      });
+      continue;
+    }
+
+    const used = usedRunnerIdsByReservation.get(reservationId)?.size ?? 0;
+    const accepted = Math.min(requested, Math.max(0, reservation.count - used));
+    acceptedByReservation.set(reservationId, accepted);
+    if (accepted < requested) {
+      unavailableByReservation.set(reservationId, {
+        reason: 'capacity-exhausted',
+        count: requested - accepted,
+      });
+    }
+  }
+
+  return {acceptedByReservation, unavailableByReservation};
 }

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -598,8 +598,15 @@ describe('reportRunnerInstances', () => {
     expect(active).toEqual([]);
   });
 
-  it('releases one reservation unit for a terminal unclaimed provisioned runner', async () => {
+  it('releases one reservation unit for a terminal runner with an intended reservation', async () => {
     const reservationId = await createReservation(2);
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
 
     const result = await reportRunnerInstances({
       scope: 'workspace',
@@ -613,6 +620,30 @@ describe('reportRunnerInstances', () => {
     expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
     expect(providerRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not let an unrecognized terminal report consume reservation capacity', async () => {
+    const reservationId = await createReservation(1);
+
+    const result = await reportRunnerInstances({
+      scope: 'workspace',
+      workspaceId,
+      provisionerId,
+      events: [event({providerRunnerId: 'unrecognized-runner', reservationId, state: 'failed'})],
+    });
+
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const providerRunnerRows = await providerRunnerRowsFor({workspaceId, provisionerId});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
+    expect(reservationRows[0]?.count).toBe(1);
+    expect(providerRunnerRows).toHaveLength(1);
+    expect(providerRunnerRows[0]).toMatchObject({
+      providerRunnerId: 'unrecognized-runner',
+      reservationId: null,
+      intendedReservationId: null,
+      reservationReleasedAt: null,
+      state: 'failed',
+    });
   });
 
   it('releases an intended reservation for a runner that dies before enrollment', async () => {
@@ -785,6 +816,13 @@ describe('reportRunnerInstances', () => {
 
   it('releases a reservation only once across repeated terminal reports', async () => {
     const reservationId = await createReservation(2);
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
 
     await reportRunnerInstances({
       scope: 'workspace',
@@ -806,6 +844,13 @@ describe('reportRunnerInstances', () => {
 
   it('does not let a newer running report revive a terminal provisioned runner', async () => {
     const reservationId = await createReservation(2);
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
     const failedAt = new Date();
     await reportRunnerInstances({
       scope: 'workspace',
@@ -844,6 +889,13 @@ describe('reportRunnerInstances', () => {
 
   it('tracks provider cleanup as terminated', async () => {
     const reservationId = await createReservation(2);
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
 
     const result = await reportRunnerInstances({
       scope: 'workspace',
@@ -865,6 +917,20 @@ describe('reportRunnerInstances', () => {
 
   it('releases multiple units from the same reservation in one batch', async () => {
     const reservationId = await createReservation(3);
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-2',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
 
     const result = await reportRunnerInstances({
       scope: 'workspace',
@@ -883,6 +949,13 @@ describe('reportRunnerInstances', () => {
 
   it('deletes a one-unit reservation instead of violating the positive count check', async () => {
     const reservationId = await createReservation(1);
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservationId,
+      state: 'running',
+    });
 
     const result = await reportRunnerInstances({
       scope: 'workspace',
@@ -906,6 +979,13 @@ describe('reportRunnerInstances', () => {
     });
     const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     if (!reservation) throw new Error('Expected reservation');
+    await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      providerRunnerId: 'provisioned-runner-1',
+      intendedReservationId: reservation.id,
+      state: 'running',
+    });
 
     const result = await reportRunnerInstances({
       scope: 'workspace',

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -388,6 +388,28 @@ describe('reportRunnerInstances', () => {
     expect(rows[0]?.reservationId).toBe(reservationId);
   });
 
+  it('does not let reports exceed reservation capacity when creating projection rows', async () => {
+    const reservationId = await createReservation(1);
+
+    await reportRunnerInstances({
+      scope: 'workspace',
+      workspaceId,
+      provisionerId,
+      events: [
+        event({providerRunnerId: 'provisioned-runner-1', reservationId}),
+        event({providerRunnerId: 'provisioned-runner-2', reservationId}),
+      ],
+    });
+
+    const rows = await providerRunnerRowsFor({workspaceId, provisionerId});
+    expect(rows.find((row) => row.providerRunnerId === 'provisioned-runner-1')?.reservationId).toBe(
+      reservationId,
+    );
+    expect(
+      rows.find((row) => row.providerRunnerId === 'provisioned-runner-2')?.reservationId,
+    ).toBeNull();
+  });
+
   it('does not let equal-timestamp lower-priority reports flip terminal state', async () => {
     const reservationId = await createReservation(1);
     const reportedAt = new Date('2025-01-01T00:00:00.000Z');

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -294,20 +294,25 @@ async function guardReportedReservationIdsTx(
 
   const remainingAcceptedByReservation = new Map(validation.acceptedByReservation);
   return events.map((event) => {
+    const existing = existingByProviderRunnerId.get(event.providerRunnerId);
     const reservationId = candidateReservationByProviderRunnerId.get(event.providerRunnerId);
     if (!reservationId) {
-      if (isTerminalState(event.state)) return event;
+      if (event.reservationId && isTerminalState(event.state)) {
+        // Terminal cleanup releases the IDs stored on the projection row. An arbitrary
+        // terminal report must not consume reservation capacity during that cleanup.
+        const matchesExistingReservation =
+          existing !== undefined &&
+          (existing.reservationId === event.reservationId ||
+            existing.intendedReservationId === event.reservationId);
+        if (!matchesExistingReservation) return {...event, reservationId: null};
+      }
       if (
         event.reservationId &&
-        existingByProviderRunnerId.get(event.providerRunnerId)?.intendedReservationId &&
-        existingByProviderRunnerId.get(event.providerRunnerId)?.intendedReservationId !==
-          event.reservationId
+        existing?.intendedReservationId &&
+        existing.intendedReservationId !== event.reservationId
       )
         return {...event, reservationId: null};
-      if (
-        event.reservationId &&
-        existingByProviderRunnerId.get(event.providerRunnerId)?.reservationReleasedAt
-      )
+      if (event.reservationId && existing?.reservationReleasedAt)
         return {...event, reservationId: null};
       return event;
     }

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -20,6 +20,7 @@ import {alias} from 'drizzle-orm/pg-core';
 import {config} from '#config.js';
 import type {RunnerInstance, RunnerInstanceState} from '#core/entities/runner-instance.js';
 import {sanitizeRunnerLabels} from '#core/runner-labels.js';
+import {recordRunnerReservationCapacityFailure} from '#metrics/index.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {
@@ -27,6 +28,10 @@ import {
   type RunnerInstanceBoundJobExecution,
 } from './job-executions.js';
 import {releaseReservationUnits} from './reservations.js';
+import {
+  lockRunnerReservationAdvisoryKeysTx,
+  validateRunnerReservationCapacityTx,
+} from './runner-assignments.js';
 import {ephemeralRegistrationTokens} from './schema/ephemeral-registration-tokens.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
@@ -157,13 +162,14 @@ export async function reportRunnerInstances(params: ReportRunnerInstancesParams)
     }
 
     const events = await hydrateRunnerSessionIdsFromConsumedTokens(tx, params, aggregatedEvents);
+    const reservationSafeEvents = await guardReportedReservationIdsTx(tx, params, events);
     const terminateIntentsHonored = await listTerminateIntentsHonoredByTerminatedReportsTx(
       tx,
       params,
-      events,
+      reservationSafeEvents,
     );
 
-    const values = events.map((event) => ({
+    const values = reservationSafeEvents.map((event) => ({
       workspaceId: params.workspaceId,
       provisionerId: params.provisionerId,
       providerRunnerId: event.providerRunnerId,
@@ -215,10 +221,100 @@ export async function reportRunnerInstances(params: ReportRunnerInstancesParams)
       });
 
     const reservationsReleased = hasTerminalEvent
-      ? await releaseTerminalRunnerInstanceReservations(tx, params, events)
+      ? await releaseTerminalRunnerInstanceReservations(tx, params, reservationSafeEvents)
       : 0;
 
-    return {accepted: events.length, reservationsReleased, terminateIntentsHonored};
+    return {
+      accepted: reservationSafeEvents.length,
+      reservationsReleased,
+      terminateIntentsHonored,
+    };
+  });
+}
+
+async function guardReportedReservationIdsTx(
+  tx: Tx,
+  params: ReportRunnerInstancesParams,
+  events: RunnerInstanceReportRow[],
+): Promise<RunnerInstanceReportRow[]> {
+  const reservationIds = [
+    ...new Set(events.flatMap((event) => (event.reservationId ? [event.reservationId] : []))),
+  ].sort();
+  if (reservationIds.length === 0) return events;
+
+  await lockRunnerReservationAdvisoryKeysTx(tx, {
+    provisionerId: params.provisionerId,
+    reservationIds,
+  });
+  const providerRunnerIds = events.map((event) => event.providerRunnerId);
+  const existingRows = await tx
+    .select({
+      providerRunnerId: providerRunners.providerRunnerId,
+      reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
+      reservationReleasedAt: providerRunners.reservationReleasedAt,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.provisionerId, params.provisionerId),
+        inArray(providerRunners.providerRunnerId, providerRunnerIds),
+      ),
+    )
+    .for('update');
+  const existingByProviderRunnerId = new Map(
+    existingRows.flatMap((row) =>
+      row.providerRunnerId ? [[row.providerRunnerId, row] as const] : [],
+    ),
+  );
+  const candidateReservationByProviderRunnerId = new Map<string, string>();
+  for (const event of events) {
+    if (!event.reservationId) continue;
+    if (isTerminalState(event.state)) continue;
+    const existing = existingByProviderRunnerId.get(event.providerRunnerId);
+    if (existing?.reservationId || existing?.intendedReservationId === event.reservationId)
+      continue;
+    if (existing?.intendedReservationId || existing?.reservationReleasedAt) continue;
+    candidateReservationByProviderRunnerId.set(event.providerRunnerId, event.reservationId);
+  }
+
+  const validation = await validateRunnerReservationCapacityTx(
+    tx,
+    {
+      provisionerId: params.provisionerId,
+      requests: [...candidateReservationByProviderRunnerId.values()].map((reservationId) => ({
+        reservationId,
+        count: 1,
+      })),
+    },
+    {advisoryLocksHeld: true},
+  );
+  for (const {reason, count} of validation.unavailableByReservation.values())
+    recordRunnerReservationCapacityFailure(reason, count);
+
+  const remainingAcceptedByReservation = new Map(validation.acceptedByReservation);
+  return events.map((event) => {
+    const reservationId = candidateReservationByProviderRunnerId.get(event.providerRunnerId);
+    if (!reservationId) {
+      if (isTerminalState(event.state)) return event;
+      if (
+        event.reservationId &&
+        existingByProviderRunnerId.get(event.providerRunnerId)?.intendedReservationId &&
+        existingByProviderRunnerId.get(event.providerRunnerId)?.intendedReservationId !==
+          event.reservationId
+      )
+        return {...event, reservationId: null};
+      if (
+        event.reservationId &&
+        existingByProviderRunnerId.get(event.providerRunnerId)?.reservationReleasedAt
+      )
+        return {...event, reservationId: null};
+      return event;
+    }
+    const remaining = remainingAcceptedByReservation.get(reservationId) ?? 0;
+    if (remaining === 0) return {...event, reservationId: null};
+    remainingAcceptedByReservation.set(reservationId, remaining - 1);
+    return event;
   });
 }
 

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -1,6 +1,7 @@
 export type {
   RunnerActivationTokenNotIssuedReason,
   RunnerActivationTokenNotIssuedSurface,
+  RunnerReservationCapacityFailureReason,
   RunnerReservationPromotionFailureReason,
 } from './instance.js';
 export {
@@ -15,6 +16,7 @@ export {
   providerRunnerTerminateIntentIssuedCount,
   recordProviderRunnerActivationOutcome,
   recordRunnerActivationTokenNotIssued,
+  recordRunnerReservationCapacityFailure,
   recordRunnerReservationPromotionFailure,
   recordRunnersRateLimitCheck,
   recordRunnersRateLimitPruneFailure,

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -116,6 +116,17 @@ export const runnerReservationPromotionFailureCount = meter.createCounter<{
   description: 'Runner reservation promotion failures during enrollment by reason',
 });
 
+export type RunnerReservationCapacityFailureReason =
+  | 'reservation-not-found'
+  | 'reservation-expired'
+  | 'capacity-exhausted';
+
+export const runnerReservationCapacityFailureCount = meter.createCounter<{
+  reason: RunnerReservationCapacityFailureReason;
+}>('runners_reservation_capacity_failures', {
+  description: 'Runner reservation admission shortfalls by reason',
+});
+
 export type RunnersRateLimitAction = 'provisioner-mint' | 'ephemeral-register';
 export type RunnersRateLimitScope = 'provisioner' | 'ephemeral-token';
 export type RunnersRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
@@ -151,6 +162,14 @@ export function recordRunnerActivationTokenNotIssued(params: {
   surface: RunnerActivationTokenNotIssuedSurface;
 }): void {
   recordMetric(() => runnerActivationTokenNotIssuedCount.add(1, params));
+}
+
+export function recordRunnerReservationCapacityFailure(
+  reason: RunnerReservationCapacityFailureReason,
+  count: number,
+): void {
+  if (count <= 0) return;
+  recordMetric(() => runnerReservationCapacityFailureCount.add(count, {reason}));
 }
 
 export function recordRunnersRateLimitCheck(params: {

--- a/libs/api/runners/src/presentation/dto/poll-demand.ts
+++ b/libs/api/runners/src/presentation/dto/poll-demand.ts
@@ -17,6 +17,9 @@ export function toPollDemandResponseDto(result: PollDemandResult): PollDemandRes
       count: reservation.count,
       expires_at: reservation.expiresAt.toISOString(),
     })),
+    ...(result.newlyReservedCount !== undefined
+      ? {newly_reserved_count: result.newlyReservedCount}
+      : {}),
     terminate_provider_runner_ids: result.terminateRunnerInstanceIds,
   };
 }

--- a/libs/api/runners/src/presentation/routes/late-runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/late-runner-enrollment.test.ts
@@ -163,13 +163,27 @@ describe('late runner enrollment recovery', () => {
 
     expect(demand.statusCode).toBe(200);
     expect(demand.json().reservations).toEqual([]);
+    const reboundReservations = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, workspaceId),
+          eq(reservations.provisionerId, provisionerId),
+          eq(reservations.kind, 'bound'),
+        ),
+      );
+    const reboundReservation = reboundReservations.find(
+      (reservation) => reservation.id !== arrangement.reservationId,
+    );
+    const reboundReservationId = reboundReservation?.id;
+    if (!reboundReservationId) throw new Error('Expected rebound reservation');
+    expect(reboundReservationId).toEqual(expect.any(String));
 
     const [reboundRunner] = await db()
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, arrangement.runnerInstanceId));
-    const reboundReservationId = reboundRunner?.reservationId;
-    expect(reboundReservationId).toEqual(expect.any(String));
     expect(reboundRunner).toMatchObject({
       workspaceId,
       reservationId: reboundReservationId,
@@ -309,6 +323,23 @@ describe('late runner enrollment recovery', () => {
 
     expect(demand.statusCode).toBe(200);
     expect(demand.json().reservations).toEqual([]);
+    const reboundReservations = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, workspaceId),
+          eq(reservations.provisionerId, provisionerId),
+          eq(reservations.kind, 'bound'),
+        ),
+      );
+    const reboundReservation = reboundReservations.find(
+      (reservation) => reservation.id !== staleReservation.id,
+    );
+    const reboundReservationId = reboundReservation?.id;
+    if (!reboundReservationId) throw new Error('Expected rebound reservation');
+    expect(reboundReservationId).toEqual(expect.any(String));
+    expect(reboundReservationId).not.toBe(staleReservation.id);
 
     const staleReport = await app.inject({
       method: 'POST',
@@ -336,10 +367,6 @@ describe('late runner enrollment recovery', () => {
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, reportedRunner.id));
-    const reboundReservationId = reboundRunner?.reservationId;
-    expect(reboundReservationId).toEqual(expect.any(String));
-    if (!reboundReservationId) throw new Error('Expected rebound reservation');
-    expect(reboundReservationId).not.toBe(staleReservation.id);
     expect(reboundRunner).toMatchObject({
       workspaceId,
       reservationId: reboundReservationId,

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -100,6 +100,7 @@ describe('POST /provisioners/demand/poll', () => {
     expect(res.json()).toMatchObject({
       stats: [{labels: ['linux'], queued: 1, reserved: 1}],
       reservations: [{labels: ['linux'], count: 1}],
+      newly_reserved_count: 1,
       terminate_provider_runner_ids: [],
     });
     expect(res.json().reservations[0].reservation_id).toEqual(expect.any(String));

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -6,6 +6,7 @@ import {
   createApp,
   extractBearerToken,
 } from '@shipfox/node-fastify';
+import {vi} from '@shipfox/vitest/vi';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
@@ -13,6 +14,7 @@ import {reservations} from '#db/schema/reservations.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
+import {runnerReservationCapacityFailureCount} from '#metrics/instance.js';
 import {
   createRunnerControlSessionAuthMethod,
   createRunnerRegistrationTokenAuthMethod,
@@ -390,19 +392,27 @@ describe('runner enrollment control plane', () => {
     if (reservationIds.some((reservationId) => !reservationId))
       throw new Error('Reservation insert returned no row');
 
-    for (const reservationId of reservationIds) {
-      const response = await app.inject({
-        method: 'POST',
-        url: '/provisioners/runner-instances/batch',
-        headers: {authorization: `Bearer ${token}`},
-        payload: {runner_instances: [{reservation_id: reservationId}]},
-      });
+    const failureSpy = vi.spyOn(runnerReservationCapacityFailureCount, 'add');
+    try {
+      for (const reservationId of reservationIds) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/provisioners/runner-instances/batch',
+          headers: {authorization: `Bearer ${token}`},
+          payload: {runner_instances: [{reservation_id: reservationId}]},
+        });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.json()).toMatchObject({
-        runner_instances: [],
-        reservation_unavailable: true,
-      });
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toMatchObject({
+          runner_instances: [],
+          reservation_unavailable: true,
+        });
+      }
+
+      expect(failureSpy).toHaveBeenCalledWith(1, {reason: 'reservation-expired'});
+      expect(failureSpy).toHaveBeenCalledWith(1, {reason: 'reservation-not-found'});
+    } finally {
+      failureSpy.mockRestore();
     }
 
     const runners = await db()

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -308,6 +308,218 @@ describe('runner enrollment control plane', () => {
     });
   });
 
+  it('does not create a duplicate row or bootstrap token after a reservation is consumed', async () => {
+    const workspaceId = crypto.randomUUID();
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!reservation) throw new Error('Reservation insert returned no row');
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{reservation_id: reservation.id}]},
+    });
+    const firstRunner = first.json().runner_instances[0];
+    expect(first.statusCode).toBe(200);
+    expect(first.json().reservation_unavailable).toBeUndefined();
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{reservation_id: reservation.id}]},
+    });
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json()).toMatchObject({
+      runner_instances: [],
+      reservation_unavailable: true,
+    });
+    const runners = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.intendedReservationId, reservation.id));
+    const bootstrapTokens = await db()
+      .select()
+      .from(runnerBootstrapTokens)
+      .where(eq(runnerBootstrapTokens.runnerInstanceId, firstRunner.runner_instance_id));
+    expect(runners).toHaveLength(1);
+    expect(bootstrapTokens).toHaveLength(1);
+  });
+
+  it('returns a classified shortfall for expired and foreign reservations', async () => {
+    const otherProvisioner = await provisionerTokenFactory.create({scope: 'installation'});
+    const runnersBefore = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.provisionerId, provisionerId));
+    const bootstrapTokensBefore = await db()
+      .select()
+      .from(runnerBootstrapTokens)
+      .where(eq(runnerBootstrapTokens.provisionerId, provisionerId));
+    const expiredReservation = await db()
+      .insert(reservations)
+      .values({
+        workspaceId: crypto.randomUUID(),
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() - 1_000),
+      })
+      .returning({id: reservations.id});
+    const foreignReservation = await db()
+      .insert(reservations)
+      .values({
+        workspaceId: crypto.randomUUID(),
+        provisionerId: otherProvisioner.id,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning({id: reservations.id});
+    const reservationIds = [expiredReservation[0]?.id, foreignReservation[0]?.id];
+    if (reservationIds.some((reservationId) => !reservationId))
+      throw new Error('Reservation insert returned no row');
+
+    for (const reservationId of reservationIds) {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/provisioners/runner-instances/batch',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {runner_instances: [{reservation_id: reservationId}]},
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        runner_instances: [],
+        reservation_unavailable: true,
+      });
+    }
+
+    const runners = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.provisionerId, provisionerId));
+    const bootstrapTokens = await db()
+      .select()
+      .from(runnerBootstrapTokens)
+      .where(eq(runnerBootstrapTokens.provisionerId, provisionerId));
+    expect(runners).toHaveLength(runnersBefore.length);
+    expect(bootstrapTokens).toHaveLength(bootstrapTokensBefore.length);
+  });
+
+  it('returns the remaining reservation capacity with request indexes', async () => {
+    const workspaceId = crypto.randomUUID();
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 2,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!reservation) throw new Error('Reservation insert returned no row');
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{reservation_id: reservation.id}]},
+    });
+    expect(first.statusCode).toBe(200);
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        runner_instances: [
+          {template_key: 'linux', reservation_id: reservation.id},
+          {template_key: 'linux', reservation_id: reservation.id},
+        ],
+      },
+    });
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json()).toMatchObject({
+      runner_instances: [
+        {
+          request_index: 0,
+          runner_instance_id: expect.any(String),
+          bootstrap_token: expect.any(String),
+        },
+      ],
+      reservation_unavailable: true,
+    });
+  });
+
+  it('preserves request indexes when a mixed reservation batch has a shortfall', async () => {
+    const [exhaustedReservation, availableReservation] = await db()
+      .insert(reservations)
+      .values([
+        {
+          workspaceId: crypto.randomUUID(),
+          provisionerId,
+          requiredLabels: ['linux'],
+          count: 1,
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+        {
+          workspaceId: crypto.randomUUID(),
+          provisionerId,
+          requiredLabels: ['linux'],
+          count: 1,
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+      ])
+      .returning();
+    if (!exhaustedReservation || !availableReservation)
+      throw new Error('Reservation insert returned no rows');
+
+    const consumed = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{reservation_id: exhaustedReservation.id}]},
+    });
+    expect(consumed.statusCode).toBe(200);
+
+    const mixed = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        runner_instances: [
+          {template_key: 'linux', reservation_id: exhaustedReservation.id},
+          {template_key: 'linux', reservation_id: availableReservation.id},
+        ],
+      },
+    });
+
+    expect(mixed.statusCode).toBe(200);
+    expect(mixed.json()).toMatchObject({
+      runner_instances: [
+        {
+          request_index: 1,
+          runner_instance_id: expect.any(String),
+          bootstrap_token: expect.any(String),
+        },
+      ],
+      reservation_unavailable: true,
+    });
+  });
+
   it('rejects assignment for a provider-reported runner before enrollment', async () => {
     const workspaceId = crypto.randomUUID();
     const [reservation] = await db()

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.ts
@@ -42,7 +42,7 @@ export const createRunnerInstancesRoute = defineRoute({
   },
   handler: async (request) => {
     const {provisionerTokenId} = requireProvisionerContext(request);
-    const results = await createRunnerInstancesWithBootstrapTokens({
+    const result = await createRunnerInstancesWithBootstrapTokens({
       provisionerId: provisionerTokenId,
       ...(request.body.provider_kind ? {providerKind: request.body.provider_kind} : {}),
       runnerInstances: request.body.runner_instances.map((runner) => ({
@@ -52,10 +52,12 @@ export const createRunnerInstancesRoute = defineRoute({
       ttlSeconds: config.RUNNER_BOOTSTRAP_TOKEN_TTL_SECONDS,
     });
     return {
-      runner_instances: results.map((result) => ({
-        runner_instance_id: result.runnerInstanceId,
-        bootstrap_token: result.bootstrapToken,
+      runner_instances: result.runnerInstances.map((runnerInstance) => ({
+        runner_instance_id: runnerInstance.runnerInstanceId,
+        bootstrap_token: runnerInstance.bootstrapToken,
+        request_index: runnerInstance.requestIndex,
       })),
+      ...(result.reservationUnavailable ? {reservation_unavailable: true as const} : {}),
     };
   },
 });

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -205,6 +205,31 @@ describe('runProvisionerIteration', () => {
     expect(result).toEqual({nextInterval: 1500, degraded: true});
   });
 
+  it('logs but does not degrade when a reservation is consumed or stale', async () => {
+    const {client} = harness({response: {stats: [], reservations: [reservation(1)]}});
+    client.createRunnerInstances = () =>
+      Promise.resolve({runner_instances: [], reservation_unavailable: true});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => Promise.resolve(),
+    };
+
+    const result = await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+    });
+
+    expect(result).toEqual({nextInterval: 1000, degraded: false});
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.reservation_consumed_or_stale', skipped: 1}),
+      'Runner reservation was consumed or stale; skipping unavailable launches',
+    );
+  });
+
   it('uses the next degraded poll as a launch probe and recovers after it succeeds', async () => {
     const {client, pollBodies} = harness({response: {stats: [], reservations: [reservation(1)]}});
     const health = createHealthState();

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -396,6 +396,16 @@ export async function runDemandIteration<Spec>(
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'runner_capacity', at: new Date()});
   }
 
+  if (result.reservationConsumedOrStaleCount > 0) {
+    logger().info(
+      {
+        event: 'runner.reservation_consumed_or_stale',
+        skipped: result.reservationConsumedOrStaleCount,
+      },
+      'Runner reservation was consumed or stale; skipping unavailable launches',
+    );
+  }
+
   if (result.launchedCount > 0) {
     applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
   }

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -81,7 +81,7 @@ describe('runProvisionerTick', () => {
     ]);
   });
 
-  it('counts partial warm runner-instance creation as failed capacity work', async () => {
+  it('counts a warm reservation shortfall without a capacity failure', async () => {
     const client: ProvisionerClient = {
       getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
       pollDemand: async () => ({
@@ -89,7 +89,7 @@ describe('runProvisionerTick', () => {
         reservations: [],
         terminate_provider_runner_ids: [],
       }),
-      createRunnerInstances: async () => ({runner_instances: []}),
+      createRunnerInstances: async () => ({runner_instances: [], reservation_unavailable: true}),
       attachRunnerInstanceProviderId: async () => ({attached: true}),
       assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
         runner_instance_ids: runnerInstanceIds,
@@ -126,9 +126,10 @@ describe('runProvisionerTick', () => {
 
     expect(result).toMatchObject({
       plannedCount: 1,
-      launchAttemptedCount: 1,
+      launchAttemptedCount: 0,
       launchedCount: 0,
-      runnerInstanceCreationFailureCount: 1,
+      runnerInstanceCreationFailureCount: 0,
+      reservationConsumedOrStaleCount: 1,
     });
   });
 

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -19,6 +19,7 @@ describe('runProvisionerTick', () => {
             expires_at: '2026-07-21T12:00:00.000Z',
           },
         ],
+        newly_reserved_count: 2,
         terminate_provider_runner_ids: [],
       }),
       createRunnerInstances: (body) => {
@@ -65,7 +66,11 @@ describe('runProvisionerTick', () => {
 
     expect(calls).toEqual(['create', 'launch']);
     expect(launches).toEqual(['sf_rbt_test']);
-    expect(result).toMatchObject({launchedCount: 1, providerLaunchFailureCount: 0});
+    expect(result).toMatchObject({
+      launchedCount: 1,
+      providerLaunchFailureCount: 0,
+      reservedRunnerCount: 2,
+    });
     expect(result.launchLifecycleIncompleteCount).toBe(1);
     expect(createBodies).toEqual([
       {
@@ -76,19 +81,12 @@ describe('runProvisionerTick', () => {
     ]);
   });
 
-  it('counts partial runner-instance creation as failed capacity work', async () => {
+  it('counts partial warm runner-instance creation as failed capacity work', async () => {
     const client: ProvisionerClient = {
       getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
       pollDemand: async () => ({
         stats: [],
-        reservations: [
-          {
-            reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001',
-            labels: ['linux'],
-            count: 1,
-            expires_at: '2026-07-21T12:00:00.000Z',
-          },
-        ],
+        reservations: [],
         terminate_provider_runner_ids: [],
       }),
       createRunnerInstances: async () => ({runner_instances: []}),
@@ -105,7 +103,16 @@ describe('runProvisionerTick', () => {
 
     const result = await runProvisionerTick({
       client,
-      templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
+      templates: [
+        {
+          key: 'linux',
+          labels: ['linux'],
+          maxConcurrency: 1,
+          targetConcurrency: 1,
+          cost: 1,
+          spec: null,
+        },
+      ],
       tracker: createInMemoryTracker(),
       launch: () => Promise.resolve(),
       buildRunnerEnv: ({bootstrapToken}) => ({
@@ -123,6 +130,61 @@ describe('runProvisionerTick', () => {
       launchedCount: 0,
       runnerInstanceCreationFailureCount: 1,
     });
+  });
+
+  it('keeps a consumed or stale reservation shortfall out of capacity failures for old responses', async () => {
+    let createCalls = 0;
+    const client: ProvisionerClient = {
+      getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
+      pollDemand: async () => ({
+        stats: [],
+        reservations: [
+          {
+            reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001',
+            labels: ['linux'],
+            count: 3,
+            expires_at: '2026-07-21T12:00:00.000Z',
+          },
+        ],
+        terminate_provider_runner_ids: [],
+      }),
+      createRunnerInstances: () => {
+        createCalls += 1;
+        return Promise.resolve({runner_instances: []});
+      },
+      attachRunnerInstanceProviderId: async () => ({attached: true}),
+      assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
+        runner_instance_ids: runnerInstanceIds,
+      }),
+      reportRunnerInstances: async () => ({accepted: 0, reservations_released: 0}),
+      reconcileRunnerInstances: async () => ({
+        runners: [],
+        terminated_absent_provider_runner_ids: [],
+      }),
+    };
+
+    const result = await runProvisionerTick({
+      client,
+      templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 3, cost: 1, spec: null}],
+      tracker: createInMemoryTracker(),
+      launch: () => Promise.resolve(),
+      buildRunnerEnv: ({bootstrapToken}) => ({
+        SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken,
+      }),
+      reservationLimit: 3,
+      launchBudget: 3,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+    });
+
+    expect(result).toMatchObject({
+      plannedCount: 3,
+      launchAttemptedCount: 0,
+      launchedCount: 0,
+      runnerInstanceCreationFailureCount: 0,
+      reservationConsumedOrStaleCount: 3,
+    });
+    expect(createCalls).toBe(1);
   });
 
   it('propagates an aborted runner-instance creation without counting capacity failure', async () => {

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -64,6 +64,7 @@ export interface ProvisionerTickResult {
   readonly launchedCount: number;
   readonly runnerInstanceCreationFailureCount: number;
   readonly runnerInstanceCreationFailureReason?: string;
+  readonly reservationConsumedOrStaleCount: number;
   readonly providerLaunchFailureCount: number;
   readonly providerLaunchFailureReason?: string;
   readonly launchLifecycleIncompleteCount: number;
@@ -170,15 +171,15 @@ async function completeProvisionerTick<Spec>(
   });
 
   let plannedCount = planned.reduce((sum, group) => sum + group.count, 0);
-  const reservedRunnerCount = response.reservations.reduce(
-    (sum, reservation) => sum + reservation.count,
-    0,
-  );
+  const reservedRunnerCount =
+    response.newly_reserved_count ??
+    response.reservations.reduce((sum, reservation) => sum + reservation.count, 0);
 
   let launchAttemptedCount = 0;
   let launchedCount = 0;
   let runnerInstanceCreationFailureCount = 0;
   let runnerInstanceCreationFailureReason: string | undefined;
+  let reservationConsumedOrStaleCount = 0;
   let providerLaunchFailureCount = 0;
   let providerLaunchFailureReason: string | undefined;
   let launchLifecycleIncompleteCount = 0;
@@ -217,6 +218,7 @@ async function completeProvisionerTick<Spec>(
     launchedCount += result.launched;
     runnerInstanceCreationFailureCount += result.runnerInstanceCreationFailureCount;
     runnerInstanceCreationFailureReason ??= result.runnerInstanceCreationFailureReason;
+    reservationConsumedOrStaleCount += result.reservationConsumedOrStaleCount;
     providerLaunchFailureCount += result.providerLaunchFailureCount;
     providerLaunchFailureReason ??= result.providerLaunchFailureReason;
     launchLifecycleIncompleteCount += result.launchLifecycleIncompleteCount;
@@ -229,6 +231,7 @@ async function completeProvisionerTick<Spec>(
     launchedCount += result.launched;
     runnerInstanceCreationFailureCount += result.runnerInstanceCreationFailureCount;
     runnerInstanceCreationFailureReason ??= result.runnerInstanceCreationFailureReason;
+    reservationConsumedOrStaleCount += result.reservationConsumedOrStaleCount;
     providerLaunchFailureCount += result.providerLaunchFailureCount;
     providerLaunchFailureReason ??= result.providerLaunchFailureReason;
     launchLifecycleIncompleteCount += result.launchLifecycleIncompleteCount;
@@ -245,6 +248,7 @@ async function completeProvisionerTick<Spec>(
     launchedCount,
     runnerInstanceCreationFailureCount,
     ...(runnerInstanceCreationFailureReason ? {runnerInstanceCreationFailureReason} : {}),
+    reservationConsumedOrStaleCount,
     providerLaunchFailureCount,
     ...(providerLaunchFailureReason ? {providerLaunchFailureReason} : {}),
     launchLifecycleIncompleteCount,
@@ -264,6 +268,7 @@ async function launchReservation<Spec>(
   launched: number;
   runnerInstanceCreationFailureCount: number;
   runnerInstanceCreationFailureReason?: string;
+  reservationConsumedOrStaleCount: number;
   providerLaunchFailureCount: number;
   providerLaunchFailureReason?: string;
   launchLifecycleIncompleteCount: number;
@@ -286,11 +291,14 @@ async function launchReservation<Spec>(
   let launched = 0;
   let runnerInstanceCreationFailureCount = 0;
   let runnerInstanceCreationFailureReason: string | undefined;
+  let reservationConsumedOrStaleCount = 0;
   let providerLaunchFailureCount = 0;
   let providerLaunchFailureReason: string | undefined;
   let launchLifecycleIncompleteCount = 0;
   let launchLifecycleIncompleteReason: string | undefined;
-  for (const batch of chunk(plannedRunners, deps.runnerInstanceBatchSize)) {
+  const batches = chunk(plannedRunners, deps.runnerInstanceBatchSize);
+  let batchStartIndex = 0;
+  for (const batch of batches) {
     if (deps.signal?.aborted) break;
     let created: CreateRunnerInstancesResponseDto;
     try {
@@ -311,19 +319,28 @@ async function launchReservation<Spec>(
       attempted += batch.length;
       runnerInstanceCreationFailureCount += batch.length;
       runnerInstanceCreationFailureReason ??= instanceCreationFailureReason(error);
+      batchStartIndex += batch.length;
       continue;
     }
 
     const missingCount = Math.max(0, batch.length - created.runner_instances.length);
-    if (missingCount > 0) {
+    // Reservation shortfalls are expected control-plane races. The reservation id
+    // fallback keeps a new provisioner compatible with an older API that returns an
+    // empty runner list without reservation_unavailable when capacity is consumed.
+    const reservationShortfall =
+      missingCount > 0 && (reservationId !== undefined || created.reservation_unavailable === true);
+    if (missingCount > 0 && !reservationShortfall) {
       attempted += missingCount;
       runnerInstanceCreationFailureCount += missingCount;
       runnerInstanceCreationFailureReason ??= `Runner instance creation returned ${created.runner_instances.length} of ${batch.length} requested instances.`;
     }
 
-    for (const [index, createdRunner] of created.runner_instances.entries()) {
+    for (const [responseIndex, createdRunner] of created.runner_instances.entries()) {
       if (deps.signal?.aborted) break;
-      const plannedRunner = batch[index];
+      // New API responses carry the request index. Older responses are accepted
+      // prefixes, so the response position remains a safe compatibility fallback.
+      const requestedIndex = createdRunner.request_index ?? responseIndex;
+      const plannedRunner = batch[requestedIndex];
       if (!plannedRunner) continue;
       const template = templateById.get(plannedRunner.providerRunnerId);
       if (!template) continue;
@@ -366,6 +383,15 @@ async function launchReservation<Spec>(
         providerLaunchFailureReason ??= launchFailureReason(error);
       }
     }
+
+    if (reservationShortfall) {
+      reservationConsumedOrStaleCount +=
+        plannedRunners.length -
+        batchStartIndex -
+        Math.min(created.runner_instances.length, batch.length);
+      break;
+    }
+    batchStartIndex += batch.length;
   }
 
   return {
@@ -373,6 +399,7 @@ async function launchReservation<Spec>(
     launched,
     runnerInstanceCreationFailureCount,
     ...(runnerInstanceCreationFailureReason ? {runnerInstanceCreationFailureReason} : {}),
+    reservationConsumedOrStaleCount,
     providerLaunchFailureCount,
     ...(providerLaunchFailureReason ? {providerLaunchFailureReason} : {}),
     launchLifecycleIncompleteCount,


### PR DESCRIPTION
This hardens demand-backed runner enrollment against stale or exhausted reservations. Reservation ownership, expiry, and capacity are validated inside the reservation transaction before runner rows and bootstrap tokens are created, while invalid report attempts are rejected and observable.

The change also keeps reservation units separate from launch units so adopted idle runners do not inflate launch capacity, preserves positional partial enrollment, and makes the provisioner handle reservation shortfalls and adopted demand correctly.

Validation: affected type and Biome checks pass; API database-boundary verification passes; changeset status and diff checks pass. The affected test graph has 552 passing API tests and 98 passing provisioner-core tests. The two existing `src/metrics/service.test.ts` mock-leak failures remain unchanged.

Closes ENG-1511

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates runner reservations before enrollment so stale or exhausted units don’t create runner rows or bootstrap tokens, and keeps adopted capacity from inflating launch capacity (including installation-wide budgets). Also hardens report ingestion to block unowned terminal releases and uses DB time for expiry; provisioner logs consumed/stale shortfalls without degrading. Closes ENG-1511.

- **New Features**
  - Validate reservation ownership, expiry (DB time), and capacity during enrollment with advisory locks; accept only available units and record capacity shortfalls by reason.
  - Runner enrollment returns reservation_unavailable on shortfalls and preserves request order via request_index; provisioner logs shortfalls, avoids capacity-failure counts, doesn’t degrade, and handles warm-path shortfalls the same.
  - Demand polls include newly_reserved_count (workspace and installation); reservations return only the launch remainder. Provisioner derives reservedRunnerCount from it and returns early when demand is fully adopted.
  - Harden report ingestion so reservation IDs can’t exceed capacity and terminal reports can’t release unowned reservation units.

- **Migration**
  - Read newly_reserved_count in poll responses; if demand is fully adopted (no launch grants), return early.
  - Handle reservation_unavailable from runner enrollment; map instances to requests using request_index (fallback to response order for older APIs).

<sup>Written for commit 482bbedb21c2b4e21696f4a5eb798903897c44a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

