### PR TITLE
Pin intended reservation compatibility discriminator

### DIFF
--- a/libs/api/runners-dto/src/schemas/reconcile-runner-instances.test.ts
+++ b/libs/api/runners-dto/src/schemas/reconcile-runner-instances.test.ts
@@ -60,8 +60,8 @@ describe('reconcileRunnerInstancesBodySchema', () => {
 });
 
 describe('reconcileRunnerInstancesResponseSchema', () => {
-  it('accepts responses from servers before intended reservation support', () => {
-    const result = reconcileRunnerInstancesResponseSchema.safeParse({
+  it('keeps the optional field absent for responses from older servers', () => {
+    const result = reconcileRunnerInstancesResponseSchema.parse({
       runners: [
         {
           provider_runner_id: 'provisioned-runner-1',
@@ -75,11 +75,13 @@ describe('reconcileRunnerInstancesResponseSchema', () => {
       terminated_absent_provider_runner_ids: [],
     });
 
-    expect(result.success).toBe(true);
+    const runner = result.runners[0];
+    if (!runner) throw new Error('Expected one parsed runner');
+    expect(Object.hasOwn(runner, 'intended_reservation_id')).toBe(false);
   });
 
-  it('parses reconciled provisioned runner responses', () => {
-    const result = reconcileRunnerInstancesResponseSchema.safeParse({
+  it('keeps an explicit null field present for current responses', () => {
+    const result = reconcileRunnerInstancesResponseSchema.parse({
       runners: [
         {
           provider_runner_id: 'provisioned-runner-1',
@@ -99,6 +101,9 @@ describe('reconcileRunnerInstancesResponseSchema', () => {
       terminated_absent_provider_runner_ids: ['provisioned-runner-2'],
     });
 
-    expect(result.success).toBe(true);
+    const runner = result.runners[0];
+    if (!runner) throw new Error('Expected one parsed runner');
+    expect(Object.hasOwn(runner, 'intended_reservation_id')).toBe(true);
+    expect(runner.intended_reservation_id).toBeNull();
   });
 });

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -458,6 +458,8 @@ function syncCanonicalReservationIds(
 ): void {
   context.canonicalReservationIdsByRunner.clear();
   for (const runner of runners) {
+    // Absence means a legacy response; explicit null means current canonical state is
+    // unassigned, so only the former may fall back to the launch tag.
     if (!Object.hasOwn(runner, 'intended_reservation_id') && runner.reservation_id === null)
       continue;
     context.canonicalReservationIdsByRunner.set(


### PR DESCRIPTION
The EC2 reconcile client uses the presence of `intended_reservation_id` to distinguish legacy server responses from current canonical state. This change exercises the real parsed DTO output so absent and explicit `null` remain distinct, and documents why explicit `null` must suppress the launch-tag fallback.

Closes ENG-1518

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the difference between an absent and an explicit null `intended_reservation_id` in reconcile responses so legacy servers still use the launch-tag fallback, while current servers with null do not. Addresses ENG-1518.

- **Bug Fixes**
  - Parser tests now assert field absence vs explicit null for `intended_reservation_id`.
  - EC2 lifecycle: only fall back to launch tag when the field is absent and `reservation_id` is null; explicit null suppresses fallback.

<sup>Written for commit 128768c9019b9edd4a14c168921e624ff2809e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

