### PR TITLE
[api-runners] Count activation-timeout reaps once across retries

### DIFF
--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -368,7 +368,7 @@ describe('POST /provisioners/demand/poll', () => {
     expect(intentCalls).toHaveLength(1);
   });
 
-  it('returns stale demand-backed runners and records the reap outcome', async () => {
+  it('counts activation-timeout reaps once across terminate-intent retries', async () => {
     const intentSpy = vi.spyOn(providerRunnerTerminateIntentIssuedCount, 'add');
     const outcomeSpy = vi.spyOn(providerRunnerActivationOutcomeCount, 'add');
     await providerRunnerFactory.create({
@@ -383,28 +383,35 @@ describe('POST /provisioners/demand/poll', () => {
     const intentCallsBefore = intentSpy.mock.calls.length;
     const outcomeCallsBefore = outcomeSpy.mock.calls.length;
 
-    const res = await app.inject({
-      method: 'POST',
-      url: '/provisioners/demand/poll',
-      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
-      payload: body({max_reservations: 0}),
-    });
+    const poll = () =>
+      app.inject({
+        method: 'POST',
+        url: '/provisioners/demand/poll',
+        headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+        payload: body({max_reservations: 0}),
+      });
+    const firstResponse = await poll();
+    const retryResponse = await poll();
 
-    expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({
+    expect(firstResponse.statusCode).toBe(200);
+    expect(retryResponse.statusCode).toBe(200);
+    expect(firstResponse.json()).toMatchObject({
       reservations: [],
       terminate_provider_runner_ids: ['stale-demand-runner'],
     });
-    expect(
-      intentSpy.mock.calls
-        .slice(intentCallsBefore)
-        .filter(
-          ([value, attributes]) =>
-            value === 1 &&
-            JSON.stringify(attributes) ===
-              JSON.stringify({surface: 'poll-demand', reason: 'activation-timeout'}),
-        ),
-    ).toHaveLength(1);
+    expect(retryResponse.json()).toMatchObject({
+      reservations: [],
+      terminate_provider_runner_ids: ['stale-demand-runner'],
+    });
+    const intentCalls = intentSpy.mock.calls
+      .slice(intentCallsBefore)
+      .filter(
+        ([value, attributes]) =>
+          value === 1 &&
+          JSON.stringify(attributes) ===
+            JSON.stringify({surface: 'poll-demand', reason: 'activation-timeout'}),
+      );
+    expect(intentCalls).toHaveLength(2);
     expect(
       outcomeSpy.mock.calls
         .slice(outcomeCallsBefore)


### PR DESCRIPTION
Locks in the activation-timeout metric contract across terminate-intent retries.

The regression exercises two demand polls for the same stale runner and verifies that both termination intents are delivered while the `reaped` activation outcome is counted only on first delivery.

Closes ENG-1517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure activation-timeout reaps are counted once across terminate-intent retries in the demand poll route. Adds a regression test that polls twice for the same stale runner: both terminate intents are emitted, but only the first poll increments the `reaped` activation outcome. Closes ENG-1517.

<sup>Written for commit cbf7df4052871cf7014ca977d400c9539b423c61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

