### PR TITLE
[api-runners] Avoid provisional bound reservations without rebound runners

### DIFF
--- a/.changeset/quiet-bound-rebind.md
+++ b/.changeset/quiet-bound-rebind.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-runners': patch
+---
+
+Avoid provisional bound reservation writes when no runner can be rebound.

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -1,3 +1,4 @@
+import {pgClient} from '@shipfox/node-postgres';
 import {vi} from '@shipfox/vitest/vi';
 import {and, eq, inArray, or, sql, sum} from 'drizzle-orm';
 import {db} from '#db/db.js';
@@ -39,6 +40,23 @@ describe('pollDemandAndReserve', () => {
     expect(result.reservations).toHaveLength(1);
     expect(result.reservations[0]?.count).toBe(20);
     expect(result.stats[0]).toMatchObject({labels: ['linux'], queued: 50, reserved: 20});
+  });
+
+  it('does not create a bound reservation when no idle runner can be rebound', async () => {
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const storedReservations = await reservationsForTest();
+    expect(result.reservations).toHaveLength(1);
+    expect(storedReservations).toHaveLength(1);
+    expect(storedReservations[0]).toMatchObject({kind: 'launch', count: 1});
   });
 
   it('binds the oldest matching enrolled runners and returns only the launch remainder', async () => {
@@ -524,6 +542,88 @@ describe('pollDemandAndReserve', () => {
       intendedReservationId: null,
       assignedAt: expect.any(Date),
     });
+  });
+
+  it('does not rebind a runner reserved by a concurrent installation poll', async () => {
+    const previousWorkspaceId = crypto.randomUUID();
+    const targetWorkspaceId = crypto.randomUUID();
+    const runner = await createIdleRunner({labels: ['linux']});
+    await pendingJobFactory.create({workspaceId: targetWorkspaceId, requiredLabels: ['linux']});
+
+    const lockClient = await pgClient().connect();
+    let transactionOpen = false;
+    let pollPromise: ReturnType<typeof pollInstallationDemandAndReserve> | undefined;
+    try {
+      await lockClient.query('BEGIN');
+      transactionOpen = true;
+      const lockPidResult = await lockClient.query<{pid: number}>('SELECT pg_backend_pid() AS pid');
+      const lockPid = lockPidResult.rows[0]?.pid;
+      if (lockPid === undefined) throw new Error('Expected lock holder backend pid');
+      await lockClient.query('SELECT id FROM runners_runner_instances WHERE id = $1 FOR UPDATE', [
+        runner.id,
+      ]);
+
+      const reservationId = crypto.randomUUID();
+      await lockClient.query(
+        `INSERT INTO runners_reservations
+          (id, workspace_id, provisioner_id, required_labels, count, kind, expires_at)
+         VALUES ($1, $2, $3, $4, $5, 'bound', $6)`,
+        [
+          reservationId,
+          previousWorkspaceId,
+          provisionerId,
+          ['linux'],
+          1,
+          new Date(Date.now() + 60_000),
+        ],
+      );
+      await lockClient.query(
+        `UPDATE runners_runner_instances
+         SET workspace_id = $1, reservation_id = $2, updated_at = now()
+         WHERE id = $3`,
+        [previousWorkspaceId, reservationId, runner.id],
+      );
+
+      pollPromise = pollInstallationDemandAndReserve({
+        provisionerId,
+        maxReservations: 1,
+        ttlSeconds: 60,
+        templates: [template('linux', ['linux'], 1)],
+        capabilityWindowSeconds: 60,
+        eligibleWorkspaceIds: new Set([targetWorkspaceId]),
+      });
+      // waitForLockWait yields to the macrotask queue, so an early poll rejection would
+      // surface as an unhandled rejection before the finally block attaches its handler.
+      pollPromise.catch(() => undefined);
+      await waitForLockWait({blockingPid: lockPid});
+
+      await lockClient.query('COMMIT');
+      transactionOpen = false;
+      const result = await pollPromise;
+      const [storedRunner] = await db()
+        .select()
+        .from(providerRunners)
+        .where(eq(providerRunners.id, runner.id));
+      const storedReservations = await db()
+        .select()
+        .from(reservations)
+        .where(eq(reservations.provisionerId, provisionerId));
+
+      expect(result.reservations).toHaveLength(1);
+      expect(result.reservations[0]).toMatchObject({workspaceId: targetWorkspaceId, count: 1});
+      expect(storedRunner).toMatchObject({
+        workspaceId: previousWorkspaceId,
+        reservationId,
+      });
+      expect(storedReservations).toHaveLength(2);
+      expect(
+        storedReservations.find((reservation) => reservation.workspaceId === targetWorkspaceId),
+      ).toMatchObject({kind: 'launch', count: 1});
+    } finally {
+      if (transactionOpen) await lockClient.query('ROLLBACK');
+      if (pollPromise) await pollPromise.catch(() => undefined);
+      lockClient.release();
+    }
   });
 
   it.each([
@@ -1495,3 +1595,24 @@ describe('pollDemandAndReserve', () => {
     return {templateKey, labels, availableSlots, starting: 0, running: 0};
   }
 });
+
+async function waitForLockWait(params: {blockingPid: number}) {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await pgClient().query<{count: number}>(
+      `
+        SELECT count(*)::int AS count
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND pid <> pg_backend_pid()
+          AND state = 'active'
+          AND wait_event_type = 'Lock'
+          AND $1::int = ANY(pg_blocking_pids(pid))
+      `,
+      [params.blockingPid],
+    );
+    if ((result.rows[0]?.count ?? 0) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for a backend blocked by pid ${params.blockingPid}`);
+}

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -23,7 +23,7 @@ import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
 import {runnerActivationTokens} from './schema/runner-activation-tokens.js';
 import {runnerControlSessions} from './schema/runner-control-sessions.js';
-import {providerRunners} from './schema/runner-instances.js';
+import {type providerRunnerLaunchKindEnum, providerRunners} from './schema/runner-instances.js';
 
 export interface ReservationTemplate {
   templateKey: string;
@@ -74,6 +74,11 @@ export interface InstallationPollDemandAndReserveParams {
 }
 
 type DemandScope = 'installation' | 'workspace';
+
+interface IdleRunnerCandidate {
+  id: string;
+  launchKind: (typeof providerRunnerLaunchKindEnum.enumValues)[number];
+}
 
 type PollDemandAndReserveLockedParams = PollDemandAndReserveParams & {
   scope: DemandScope;
@@ -288,37 +293,38 @@ async function pollDemandAndReserveLockedTx(
     let reservedAfterGrant = reserved;
 
     if (grant > 0 && params.maxReservations > 0) {
-      const [boundReservation] = await tx
-        .insert(reservations)
-        .values({
-          workspaceId: params.workspaceId,
-          provisionerId: params.provisionerId,
-          requiredLabels: demand.requiredLabels,
-          count: grant,
-          kind: 'bound',
-          expiresAt: sql`now() + (${params.activationGraceSeconds ?? params.ttlSeconds} || ' seconds')::interval`,
-        })
-        .returning({id: reservations.id});
-
-      if (!boundReservation) throw new Error('Insert returned no rows');
-
-      remainingMaxReservations -= grant;
-      const boundCount = await bindIdleRunnerInstancesTx(tx, {
+      const idleRunners = await listIdleRunnerInstancesTx(tx, {
         provisionerId: params.provisionerId,
-        reservationId: boundReservation.id,
         requiredLabels: demand.requiredLabels,
         count: grant,
         workspaceId: params.workspaceId,
         scope: params.scope,
       });
 
-      if (boundCount === 0) {
-        await tx.delete(reservations).where(eq(reservations.id, boundReservation.id));
-      } else if (boundCount < grant) {
-        await tx
-          .update(reservations)
-          .set({count: boundCount})
-          .where(eq(reservations.id, boundReservation.id));
+      remainingMaxReservations -= grant;
+
+      const boundCount = idleRunners.length;
+      if (boundCount > 0) {
+        const [boundReservation] = await tx
+          .insert(reservations)
+          .values({
+            workspaceId: params.workspaceId,
+            provisionerId: params.provisionerId,
+            requiredLabels: demand.requiredLabels,
+            count: boundCount,
+            kind: 'bound',
+            expiresAt: sql`now() + (${params.activationGraceSeconds ?? params.ttlSeconds} || ' seconds')::interval`,
+          })
+          .returning({id: reservations.id});
+
+        if (!boundReservation) throw new Error('Insert returned no rows');
+
+        await bindIdleRunnerInstancesTx(tx, {
+          provisionerId: params.provisionerId,
+          reservationId: boundReservation.id,
+          workspaceId: params.workspaceId,
+          idleRunners,
+        });
       }
 
       const launchCount = grant - boundCount;
@@ -366,17 +372,40 @@ async function pollDemandAndReserveLockedTx(
   return {stats, reservations: grants, newlyReservedUnits};
 }
 
-async function bindIdleRunnerInstancesTx(
+async function listIdleRunnerInstancesTx(
   tx: Tx,
   params: {
     provisionerId: string;
-    reservationId: string;
     workspaceId: string;
     requiredLabels: string[];
     count: number;
     scope: DemandScope;
   },
-): Promise<number> {
+): Promise<IdleRunnerCandidate[]> {
+  const lockedRunners = await selectIdleRunnerInstancesTx(tx, params);
+  if (lockedRunners.length === 0) return lockedRunners;
+
+  // A SELECT ... FOR UPDATE can wake with a fresh target row but the original
+  // statement snapshot for reservation subqueries. Re-check the full predicate
+  // in a new statement while retaining the row locks from the first query.
+  return await selectIdleRunnerInstancesTx(tx, {
+    ...params,
+    runnerIds: lockedRunners.map((runner) => runner.id),
+    count: lockedRunners.length,
+  });
+}
+
+async function selectIdleRunnerInstancesTx(
+  tx: Tx,
+  params: {
+    provisionerId: string;
+    workspaceId: string;
+    requiredLabels: string[];
+    count: number;
+    scope: DemandScope;
+    runnerIds?: string[];
+  },
+): Promise<IdleRunnerCandidate[]> {
   // An expired or missing reservation is stale. A live reservation protects a
   // runner that is still booting or waiting for its activation grace period.
   const canBindRunner = () =>
@@ -428,6 +457,7 @@ async function bindIdleRunnerInstancesTx(
     .where(
       and(
         eq(providerRunners.provisionerId, params.provisionerId),
+        params.runnerIds ? inArray(providerRunners.id, params.runnerIds) : undefined,
         canBindRunner(),
         isNotNull(providerRunners.providerRunnerId),
         eq(providerRunners.state, 'running'),
@@ -451,22 +481,34 @@ async function bindIdleRunnerInstancesTx(
     .limit(params.count)
     .for('update');
 
-  if (idleRunners.length === 0) return 0;
+  return idleRunners;
+}
+
+async function bindIdleRunnerInstancesTx(
+  tx: Tx,
+  params: {
+    provisionerId: string;
+    reservationId: string;
+    workspaceId: string;
+    idleRunners: IdleRunnerCandidate[];
+  },
+): Promise<void> {
+  const idleRunnerIds = params.idleRunners.map((runner) => runner.id);
 
   await tx
     .update(runnerActivationTokens)
     .set({revokedAt: sql`now()`})
     .where(
       and(
-        inArray(
-          runnerActivationTokens.runnerInstanceId,
-          idleRunners.map((runner) => runner.id),
-        ),
+        inArray(runnerActivationTokens.runnerInstanceId, idleRunnerIds),
         isNull(runnerActivationTokens.consumedAt),
         isNull(runnerActivationTokens.revokedAt),
       ),
     );
 
+  // listIdleRunnerInstancesTx re-checks the full eligibility predicate in a fresh statement
+  // after acquiring row locks. Those locks prevent the validated set from changing before this
+  // update runs.
   const boundRunners = await tx
     .update(providerRunners)
     .set({
@@ -478,20 +520,18 @@ async function bindIdleRunnerInstancesTx(
     })
     .where(
       and(
-        inArray(
-          providerRunners.id,
-          idleRunners.map((runner) => runner.id),
-        ),
-        canBindRunner(),
+        inArray(providerRunners.id, idleRunnerIds),
+        eq(providerRunners.provisionerId, params.provisionerId),
       ),
     )
     .returning({id: providerRunners.id, launchKind: providerRunners.launchKind});
 
+  if (boundRunners.length !== params.idleRunners.length)
+    throw new Error('Locked idle runner set changed before binding');
+
   const reboundCount = boundRunners.filter((runner) => runner.launchKind === 'demand').length;
   if (reboundCount > 0)
     recordProviderRunnerActivationOutcome({outcome: 'rebound', count: reboundCount});
-
-  return boundRunners.length;
 }
 
 async function listInstallationDemandWorkspaceIds(eligibleWorkspaceIds: ReadonlySet<string>) {


### PR DESCRIPTION
Demand polling now selects and locks eligible idle runners before creating bound reservations, so zero-bind polls avoid provisional reservation writes while full and partial rebind behavior remains unchanged.

The locked runner set is revalidated in a fresh database statement to prevent concurrent installation polls from rebinding a runner whose live reservation committed while the initial query was waiting. Added database coverage for zero-bind behavior and the concurrent installation race.

Validation: 577 api-runners tests, affected-package type checks, Biome checks, dependency-cruise, database-boundary checks, and diff checks pass.

Closes ENG-1514

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents provisional 'bound' reservations in `@shipfox/api-runners` by creating them only after locking and revalidating idle runners; zero-bind polls now write only 'launch' reservations. Also fixes an installation-poll snapshot race so runners reserved elsewhere aren’t rebound.

- **Bug Fixes**
  - Lock and revalidate idle runner candidates before binding; create 'bound' only for the verified set, and otherwise issue only 'launch' reservations (ENG-1514).
  - Recheck under a fresh DB snapshot while holding row locks to fix the installation-poll race; added tests for zero-bind behavior and the concurrent installation case (with lock-wait coverage).

<sup>Written for commit 2e1209d78486324531e96fc9ad208c811bd3364b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

