### PR TITLE
[api-runners] Require launch reservations in provisioner flows

### DIFF
--- a/.changeset/require-launch-reservations.md
+++ b/.changeset/require-launch-reservations.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Require provisioner reservation token and assignment flows to use launch reservations, and classify
+non-launch reservation capacity rejections separately in metrics.

--- a/.changeset/require-launch-reservations.md
+++ b/.changeset/require-launch-reservations.md
@@ -2,5 +2,4 @@
 "@shipfox/api-runners": patch
 ---
 
-Require provisioner reservation token and assignment flows to use launch reservations, and classify
-non-launch reservation capacity rejections separately in metrics.
+Require provisioner reservation token and assignment flows to use launch reservations.

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.test.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.test.ts
@@ -3,6 +3,7 @@ import {and, eq, inArray} from 'drizzle-orm';
 import {
   ActiveEphemeralRegistrationTokensExistError,
   type RegistrationTokenBatchExceedsReservationError,
+  ReservationNotFoundError,
 } from '#core/errors.js';
 import {db} from '#db/db.js';
 import {
@@ -54,6 +55,20 @@ describe('createEphemeralRegistrationTokensBatch', () => {
     expect(
       await resolveEphemeralRegistrationTokenByHash(hashOpaqueToken(rawTokens[0] ?? '')),
     ).toEqual(expect.objectContaining({providerRunnerId: 'provisioned-runner-a'}));
+  });
+
+  it('rejects bound reservations', async () => {
+    const boundReservationId = await createReservation({count: 1, kind: 'bound'});
+
+    await expect(
+      createEphemeralRegistrationTokensBatch({
+        workspaceId,
+        provisionerId,
+        reservationId: boundReservationId,
+        expiresAt: new Date(Date.now() + 300_000),
+        rows: [row('bound-runner', generateOpaqueToken('ephemeralRegistrationToken'))],
+      }),
+    ).rejects.toBeInstanceOf(ReservationNotFoundError);
   });
 
   it('rejects the batch and inserts no rows when any provisioned runner already has an active token', async () => {
@@ -186,7 +201,10 @@ describe('createEphemeralRegistrationTokensBatch', () => {
     } satisfies Partial<RegistrationTokenBatchExceedsReservationError>);
   });
 
-  async function createReservation(params: {count: number}): Promise<string> {
+  async function createReservation(params: {
+    count: number;
+    kind?: 'bound' | 'launch';
+  }): Promise<string> {
     const [reservation] = await db()
       .insert(reservations)
       .values({
@@ -194,6 +212,7 @@ describe('createEphemeralRegistrationTokensBatch', () => {
         provisionerId,
         requiredLabels: ['linux'],
         count: params.count,
+        kind: params.kind ?? 'launch',
         expiresAt: new Date(Date.now() + 60_000),
       })
       .returning({id: reservations.id});

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -133,6 +133,7 @@ export async function createEphemeralRegistrationTokensBatch(
           eq(reservations.id, params.reservationId),
           eq(reservations.workspaceId, params.workspaceId),
           eq(reservations.provisionerId, params.provisionerId),
+          eq(reservations.kind, 'launch'),
         ),
       )
       .limit(1);

--- a/libs/api/runners/src/db/runner-assignments.test.ts
+++ b/libs/api/runners/src/db/runner-assignments.test.ts
@@ -1,6 +1,7 @@
 import {eq} from 'drizzle-orm';
 import {
   ReservationExpiredError,
+  ReservationNotFoundError,
   RunnerInstanceAlreadyAssignedError,
   RunnerInstanceNotAssignableError,
 } from '#core/errors.js';
@@ -124,6 +125,32 @@ describe('assignRunnerInstances', () => {
     expect(assigned).toEqual([runner.id]);
   });
 
+  it('is idempotent for a committed bound reservation assignment', async () => {
+    const reservation = await createReservation({kind: 'bound'});
+    const runner = await createEnrolledRunner();
+    await db()
+      .update(providerRunners)
+      .set({
+        workspaceId,
+        reservationId: reservation.id,
+        assignedAt: new Date(),
+      })
+      .where(eq(providerRunners.id, runner.id));
+
+    const assigned = await assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [runner.id],
+    });
+
+    expect(assigned).toEqual([runner.id]);
+    const [stored] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(stored?.intendedReservationId).toBeNull();
+  });
+
   it('rejects expired reservations', async () => {
     const reservation = await createReservation({expiresAt: new Date(Date.now() - 1_000)});
     const runner = await createEnrolledRunner();
@@ -135,6 +162,19 @@ describe('assignRunnerInstances', () => {
     });
 
     await expect(assignment).rejects.toThrow(ReservationExpiredError);
+  });
+
+  it('rejects bound reservations', async () => {
+    const reservation = await createReservation({kind: 'bound'});
+    const runner = await createEnrolledRunner();
+
+    const assignment = assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [runner.id],
+    });
+
+    await expect(assignment).rejects.toThrow(ReservationNotFoundError);
   });
 
   it('rejects unenrolled or incompatible runners', async () => {
@@ -265,7 +305,7 @@ describe('assignRunnerInstances', () => {
   });
 
   async function createReservation(
-    overrides: Partial<{expiresAt: Date; requiredLabels: string[]}> = {},
+    overrides: Partial<{expiresAt: Date; requiredLabels: string[]; kind: 'bound' | 'launch'}> = {},
   ) {
     const [reservation] = await db()
       .insert(reservations)
@@ -274,6 +314,7 @@ describe('assignRunnerInstances', () => {
         provisionerId,
         requiredLabels: overrides.requiredLabels ?? ['linux'],
         count: 1,
+        kind: overrides.kind ?? 'launch',
         expiresAt: overrides.expiresAt ?? new Date(Date.now() + 60_000),
       })
       .returning();

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -1,4 +1,4 @@
-import {and, eq, inArray, isNull, notInArray, or, sql} from 'drizzle-orm';
+import {and, eq, inArray, isNull, ne, notInArray, or, sql} from 'drizzle-orm';
 import {
   ReservationExpiredError,
   ReservationNotFoundError,
@@ -85,6 +85,7 @@ export async function assignRunnerInstancesTx(
       and(
         eq(reservations.id, params.reservationId),
         eq(reservations.provisionerId, params.provisionerId),
+        eq(reservations.kind, 'launch'),
       ),
     )
     .limit(1)
@@ -177,6 +178,7 @@ export async function assignRunnerInstancesTx(
 
 export type RunnerReservationCapacityFailureReason =
   | 'reservation-not-found'
+  | 'reservation-kind-mismatch'
   | 'reservation-expired'
   | 'capacity-exhausted';
 
@@ -237,11 +239,26 @@ export async function validateRunnerReservationCapacityTx(
       and(
         eq(reservations.provisionerId, params.provisionerId),
         inArray(reservations.id, reservationIds),
+        eq(reservations.kind, 'launch'),
+      ),
+    )
+    .for('update');
+  const nonLaunchReservationRows = await tx
+    .select({id: reservations.id})
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.provisionerId, params.provisionerId),
+        inArray(reservations.id, reservationIds),
+        ne(reservations.kind, 'launch'),
       ),
     )
     .for('update');
   const reservationsById = new Map(
     reservationRows.map((reservation) => [reservation.id, reservation]),
+  );
+  const nonLaunchReservationIds = new Set(
+    nonLaunchReservationRows.map((reservation) => reservation.id),
   );
   const requestedReservationIds = new Set(reservationIds);
   const usedRunnerIdsByReservation = new Map<string, Set<string>>();
@@ -295,7 +312,9 @@ export async function validateRunnerReservationCapacityTx(
     const reservation = reservationsById.get(reservationId);
     if (!reservation) {
       unavailableByReservation.set(reservationId, {
-        reason: 'reservation-not-found',
+        reason: nonLaunchReservationIds.has(reservationId)
+          ? 'reservation-kind-mismatch'
+          : 'reservation-not-found',
         count: requested,
       });
       continue;

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -388,6 +388,36 @@ describe('reportRunnerInstances', () => {
     expect(rows[0]?.reservationId).toBe(reservationId);
   });
 
+  it('does not adopt a bound reservation id from an unclaimed report', async () => {
+    const reservationId = await createReservation(1, {kind: 'bound'});
+    await db()
+      .insert(providerRunners)
+      .values({
+        workspaceId,
+        provisionerId,
+        providerRunnerId: 'bound-reservation-runner',
+        state: 'starting',
+        reportedAt: new Date('2025-01-01T00:00:00.000Z'),
+      });
+
+    await reportRunnerInstances({
+      scope: 'workspace',
+      workspaceId,
+      provisionerId,
+      events: [
+        event({
+          providerRunnerId: 'bound-reservation-runner',
+          reservationId,
+          state: 'running',
+          reportedAt: new Date('2025-01-01T00:01:00.000Z'),
+        }),
+      ],
+    });
+
+    const rows = await providerRunnerRowsFor({workspaceId, provisionerId});
+    expect(rows[0]?.reservationId).toBeNull();
+  });
+
   it('does not let reports exceed reservation capacity when creating projection rows', async () => {
     const reservationId = await createReservation(1);
 
@@ -1136,13 +1166,14 @@ describe('reportRunnerInstances', () => {
 
   async function createReservation(
     count: number,
-    overrides?: {workspaceId?: string; provisionerId?: string},
+    overrides?: {kind?: 'bound' | 'launch'; workspaceId?: string; provisionerId?: string},
   ): Promise<string> {
     await reservationFactory.create({
       workspaceId: overrides?.workspaceId ?? workspaceId,
       provisionerId: overrides?.provisionerId ?? provisionerId,
       requiredLabels: ['linux'],
       count,
+      kind: overrides?.kind ?? 'launch',
       expiresAt: new Date(Date.now() + 60_000),
     });
     const [reservation] = await db()

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -118,6 +118,7 @@ export const runnerReservationPromotionFailureCount = meter.createCounter<{
 
 export type RunnerReservationCapacityFailureReason =
   | 'reservation-not-found'
+  | 'reservation-kind-mismatch'
   | 'reservation-expired'
   | 'capacity-exhausted';
 

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -388,7 +388,22 @@ describe('runner enrollment control plane', () => {
         expiresAt: new Date(Date.now() + 60_000),
       })
       .returning({id: reservations.id});
-    const reservationIds = [expiredReservation[0]?.id, foreignReservation[0]?.id];
+    const boundReservation = await db()
+      .insert(reservations)
+      .values({
+        workspaceId: crypto.randomUUID(),
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        kind: 'bound',
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning({id: reservations.id});
+    const reservationIds = [
+      expiredReservation[0]?.id,
+      foreignReservation[0]?.id,
+      boundReservation[0]?.id,
+    ];
     if (reservationIds.some((reservationId) => !reservationId))
       throw new Error('Reservation insert returned no row');
 
@@ -411,6 +426,7 @@ describe('runner enrollment control plane', () => {
 
       expect(failureSpy).toHaveBeenCalledWith(1, {reason: 'reservation-expired'});
       expect(failureSpy).toHaveBeenCalledWith(1, {reason: 'reservation-not-found'});
+      expect(failureSpy).toHaveBeenCalledWith(1, {reason: 'reservation-kind-mismatch'});
     } finally {
       failureSpy.mockRestore();
     }


### PR DESCRIPTION
Provisioner-facing reservation IDs must refer to launch reservations so rebound capacity cannot be consumed by token, assignment, or report flows.

This change adds launch-kind enforcement across the provisioner reservation lookups, preserves idempotent retries for already committed bound assignments, prevents bound report IDs from being adopted, and classifies owned non-launch capacity rejections as `reservation-kind-mismatch` in metrics without changing the existing assignment 404 behavior.

Validation:
- `mise exec -- pnpm --filter=@shipfox/api-runners test` — 590 passed across 44 files
- `mise exec -- turbo check type depcruise --filter=@shipfox/api-runners...` — 100 successful tasks
- `mise exec -- pnpm check:api-database-boundaries` — passed
- `mise exec -- pnpm exec changeset status` — passed

Closes ENG-1515

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require launch reservations across provisioner flows in `@shipfox/api-runners`. Blocks bound reservations in token, assignment, and report paths to meet ENG-1515.

- **Bug Fixes**
  - Enforce `kind: 'launch'` for token creation and runner assignment; non-launch reservations return not found.
  - Capacity validation ignores non-launch reservations and records `reservation-kind-mismatch` for metrics.
  - Preserve idempotent replays for already-committed bound assignments; reports no longer adopt bound reservation IDs.

<sup>Written for commit 328377cd51898ae69c4aabf8744d201e1e204b91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

