### PR TITLE
[@shipfox/api-runners] Deduct only pending launch units from capacity

### DIFF
--- a/.changeset/pending-launch-capacity.md
+++ b/.changeset/pending-launch-capacity.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-runners': patch
+---
+
+Deduct only pending launch units from provisioner capacity across reservation polls.

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -16,7 +16,7 @@ import {
   assignRunnerInstancesTx,
   validateRunnerReservationCapacityTx,
 } from '#db/runner-assignments.js';
-import {terminalStates} from '#db/runner-instances.js';
+import {terminalStates} from '#db/runner-states.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';

--- a/libs/api/runners/src/db/reservation-locks.ts
+++ b/libs/api/runners/src/db/reservation-locks.ts
@@ -1,0 +1,22 @@
+import {sql} from 'drizzle-orm';
+import type {Tx} from './db.js';
+
+export async function lockRunnerReservationAdvisoryKeysTx(
+  tx: Tx,
+  params: {provisionerId: string; reservationIds: readonly string[]},
+): Promise<void> {
+  const reservationIds = [...new Set(params.reservationIds)].sort();
+  if (reservationIds.length === 0) return;
+
+  const lockKeys = sql.join(
+    reservationIds.map(
+      (reservationId) => sql`(${`runners_assignment:${params.provisionerId}:${reservationId}`})`,
+    ),
+    sql`, `,
+  );
+  await tx.execute(sql`
+    select pg_advisory_xact_lock(hashtext(lock_key))
+    from (values ${lockKeys}) as reservation_locks(lock_key)
+    order by lock_key
+  `);
+}

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -1,6 +1,7 @@
 import {pgClient} from '@shipfox/node-postgres';
 import {vi} from '@shipfox/vitest/vi';
 import {and, eq, inArray, or, sql, sum} from 'drizzle-orm';
+import type {RunnerInstanceState} from '#core/entities/runner-instance.js';
 import {db} from '#db/db.js';
 import {
   deleteExpiredReservations,
@@ -184,15 +185,24 @@ describe('pollDemandAndReserve', () => {
     ).toHaveLength(1);
   });
 
-  it('does not charge adopted runners against later launch capacity', async () => {
+  it('does not charge adopted runners against later overlapping demand', async () => {
     const adoptedRunner = await createIdleRunner({labels: ['linux', 'gpu']});
     await createPendingJobs(1, ['linux', 'gpu']);
-    await createPendingJobs(1, ['linux']);
 
+    const firstPoll = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+    expect(firstPoll.reservations).toEqual([]);
+
+    await createPendingJobs(1, ['linux']);
     const result = await pollDemandAndReserve({
       workspaceId,
       provisionerId,
-      maxReservations: 2,
+      maxReservations: 1,
       ttlSeconds: 60,
       templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
     });
@@ -218,6 +228,128 @@ describe('pollDemandAndReserve', () => {
     ]);
     expect(boundReservation).toMatchObject({kind: 'bound', count: 1});
     expect(storedRunner?.reservationId).toBe(boundReservation?.id);
+  });
+
+  it('deducts only pending launch units from a partially adopted reservation', async () => {
+    await createIdleRunner({labels: ['linux', 'gpu']});
+    await createIdleRunner({labels: ['linux', 'gpu']});
+    await createPendingJobs(3, ['linux', 'gpu']);
+
+    const firstPoll = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 3,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 3)],
+    });
+    expect(firstPoll.reservations).toEqual([expect.objectContaining({count: 1})]);
+
+    await createPendingJobs(1, ['linux']);
+    const secondPoll = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 2)],
+    });
+
+    expect(secondPoll.reservations).toEqual([
+      expect.objectContaining({labels: ['linux'], count: 1}),
+    ]);
+  });
+
+  it('deducts a launch reservation with no adopted units in full', async () => {
+    await createPendingJobs(1, ['linux', 'gpu']);
+
+    const firstPoll = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+    expect(firstPoll.reservations).toEqual([expect.objectContaining({count: 1})]);
+
+    await createPendingJobs(1, ['linux']);
+    const secondPoll = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+
+    expect(secondPoll.reservations).toEqual([]);
+  });
+
+  it('counts an intended runner while its reservation assignment is in flight', async () => {
+    const intendedReservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux', 'gpu'],
+      intendedReservationId: intendedReservation.id,
+    });
+    await createPendingJobs(1, ['linux', 'gpu']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+
+    expect(result.reservations).toEqual([
+      expect.objectContaining({labels: ['gpu', 'linux'], count: 1}),
+    ]);
+  });
+
+  it('deducts a released runner reservation unit as pending', async () => {
+    const reservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: reservation.id,
+      reservationReleasedAt: new Date(Date.now() - 1_000),
+    });
+    await createPendingJobs(1, ['linux', 'gpu']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+
+    expect(result.reservations).toEqual([]);
+  });
+
+  it('deducts a terminal intended runner reservation unit as pending', async () => {
+    const reservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      intendedReservationId: reservation.id,
+      state: 'terminated',
+    });
+    await createPendingJobs(1, ['linux', 'gpu']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
+    });
+
+    expect(result.reservations).toEqual([]);
   });
 
   it('binds a runner whose intended reservation has passed its activation grace period', async () => {
@@ -1536,6 +1668,7 @@ describe('pollDemandAndReserve', () => {
     reservationId?: string | null;
     intendedReservationId?: string | null;
     reservationReleasedAt?: Date | null;
+    state?: RunnerInstanceState;
   }) {
     const createdAt = params.createdAt ?? new Date();
     const [runner] = await db()
@@ -1549,7 +1682,7 @@ describe('pollDemandAndReserve', () => {
         intendedReservationId: params.intendedReservationId,
         reservationReleasedAt: params.reservationReleasedAt,
         labels: params.labels,
-        state: 'running',
+        state: params.state ?? 'running',
         reportedAt: createdAt,
         createdAt,
         updatedAt: createdAt,

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -11,12 +11,15 @@ import {
   isNull,
   lt,
   notExists,
+  notInArray,
   or,
   sql,
 } from 'drizzle-orm';
 import {recordProviderRunnerActivationOutcome} from '#metrics/instance.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
+import {lockRunnerReservationAdvisoryKeysTx} from './reservation-locks.js';
+import {terminalStates} from './runner-states.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
 import {provisionerCapabilitySnapshots} from './schema/provisioner-capability-snapshots.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
@@ -246,20 +249,10 @@ async function pollDemandAndReserveLockedTx(
   const reservedByLabels = new Map(
     activeReservationRows.map((row) => [labelKey(row.requiredLabels), row.reserved]),
   );
-  const activeProvisionerReservationRows = await tx
-    .select({
-      requiredLabels: reservations.requiredLabels,
-      reserved: sql<number>`coalesce(sum(${reservations.count}), 0)::int`,
-    })
-    .from(reservations)
-    .where(
-      and(
-        eq(reservations.workspaceId, params.workspaceId),
-        eq(reservations.provisionerId, params.provisionerId),
-        gt(reservations.expiresAt, sql`now()`),
-      ),
-    )
-    .groupBy(reservations.requiredLabels);
+  const activeProvisionerReservationRows = await listActiveProvisionerReservationRowsTx(tx, {
+    workspaceId: params.workspaceId,
+    provisionerId: params.provisionerId,
+  });
 
   const templates = params.templates.map((template) => ({
     templateKey: template.templateKey,
@@ -370,6 +363,102 @@ async function pollDemandAndReserveLockedTx(
   }
 
   return {stats, reservations: grants, newlyReservedUnits};
+}
+
+async function listActiveProvisionerReservationRowsTx(
+  tx: Tx,
+  params: {workspaceId: string; provisionerId: string},
+): Promise<Array<{requiredLabels: string[]; reserved: number}>> {
+  const candidateRows = await tx
+    .select({id: reservations.id})
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.workspaceId, params.workspaceId),
+        eq(reservations.provisionerId, params.provisionerId),
+        gt(reservations.expiresAt, sql`now()`),
+      ),
+    );
+  const candidateIds = candidateRows.map((row) => row.id);
+  if (candidateIds.length === 0) return [];
+
+  // Assignment and provider-report transactions use this key before changing runner
+  // links. Lock it before counting so an in-flight assignment cannot expose its unit twice.
+  await lockRunnerReservationAdvisoryKeysTx(tx, {
+    provisionerId: params.provisionerId,
+    reservationIds: candidateIds,
+  });
+
+  const activeRows = await tx
+    .select({
+      id: reservations.id,
+      requiredLabels: reservations.requiredLabels,
+      count: reservations.count,
+    })
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.workspaceId, params.workspaceId),
+        eq(reservations.provisionerId, params.provisionerId),
+        gt(reservations.expiresAt, sql`now()`),
+      ),
+    )
+    .orderBy(asc(reservations.id))
+    .for('update');
+  if (activeRows.length === 0) return [];
+
+  const activeIds = activeRows.map((row) => row.id);
+  const activeIdSet = new Set(activeIds);
+  const usedRunnerRows = await tx
+    .select({
+      id: providerRunners.id,
+      reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
+      state: providerRunners.state,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.provisionerId, params.provisionerId),
+        isNull(providerRunners.reservationReleasedAt),
+        or(
+          inArray(providerRunners.reservationId, activeIds),
+          and(
+            inArray(providerRunners.intendedReservationId, activeIds),
+            notInArray(providerRunners.state, [...terminalStates]),
+          ),
+        ),
+      ),
+    );
+  const usedByReservation = new Map<string, Set<string>>();
+  for (const runner of usedRunnerRows) {
+    if (runner.reservationId && activeIdSet.has(runner.reservationId)) {
+      addUsedRunner(usedByReservation, runner.reservationId, runner.id);
+    }
+    if (
+      runner.intendedReservationId &&
+      activeIdSet.has(runner.intendedReservationId) &&
+      !terminalStates.includes(runner.state as (typeof terminalStates)[number])
+    ) {
+      addUsedRunner(usedByReservation, runner.intendedReservationId, runner.id);
+    }
+  }
+
+  return activeRows.flatMap((reservation) => {
+    const used = usedByReservation.get(reservation.id)?.size ?? 0;
+    const pending = Math.max(0, reservation.count - used);
+    return pending > 0 ? [{requiredLabels: reservation.requiredLabels, reserved: pending}] : [];
+  });
+}
+
+function addUsedRunner(
+  usedByReservation: Map<string, Set<string>>,
+  reservationId: string,
+  runnerId: string,
+): void {
+  const runnerIds = usedByReservation.get(reservationId);
+  if (runnerIds) runnerIds.add(runnerId);
+  else usedByReservation.set(reservationId, new Set([runnerId]));
 }
 
 async function listIdleRunnerInstancesTx(

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -7,6 +7,7 @@ import {
 } from '#core/errors.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
+import {lockRunnerReservationAdvisoryKeysTx} from './reservation-locks.js';
 import {terminalStates} from './runner-instances.js';
 import {reservations} from './schema/reservations.js';
 import {runnerControlSessions} from './schema/runner-control-sessions.js';
@@ -186,17 +187,6 @@ export interface RunnerReservationCapacityValidation {
     string,
     {reason: RunnerReservationCapacityFailureReason; count: number}
   >;
-}
-
-export async function lockRunnerReservationAdvisoryKeysTx(
-  tx: Tx,
-  params: {provisionerId: string; reservationIds: readonly string[]},
-): Promise<void> {
-  for (const reservationId of [...new Set(params.reservationIds)].sort()) {
-    await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${reservationId}`}))`,
-    );
-  }
 }
 
 export async function validateRunnerReservationCapacityTx(

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -8,7 +8,7 @@ import {
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {lockRunnerReservationAdvisoryKeysTx} from './reservation-locks.js';
-import {terminalStates} from './runner-instances.js';
+import {terminalStates} from './runner-states.js';
 import {reservations} from './schema/reservations.js';
 import {runnerControlSessions} from './schema/runner-control-sessions.js';
 import {providerRunners} from './schema/runner-instances.js';

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -39,7 +39,6 @@ import {providerRunners, toRunnerInstance} from './schema/runner-instances.js';
 import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
 
-export {terminalStates};
 export const activeStates = [
   'starting',
   'running',

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -27,11 +27,10 @@ import {
   listRunningJobExecutionsByRunnerInstanceTx,
   type RunnerInstanceBoundJobExecution,
 } from './job-executions.js';
+import {lockRunnerReservationAdvisoryKeysTx} from './reservation-locks.js';
 import {releaseReservationUnits} from './reservations.js';
-import {
-  lockRunnerReservationAdvisoryKeysTx,
-  validateRunnerReservationCapacityTx,
-} from './runner-assignments.js';
+import {validateRunnerReservationCapacityTx} from './runner-assignments.js';
+import {terminalStates} from './runner-states.js';
 import {ephemeralRegistrationTokens} from './schema/ephemeral-registration-tokens.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
@@ -40,11 +39,7 @@ import {providerRunners, toRunnerInstance} from './schema/runner-instances.js';
 import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
 
-export const terminalStates = [
-  'stopped',
-  'failed',
-  'terminated',
-] as const satisfies readonly RunnerInstanceState[];
+export {terminalStates};
 export const activeStates = [
   'starting',
   'running',

--- a/libs/api/runners/src/db/runner-states.ts
+++ b/libs/api/runners/src/db/runner-states.ts
@@ -1,0 +1,7 @@
+import type {RunnerInstanceState} from '#core/entities/runner-instance.js';
+
+export const terminalStates = [
+  'stopped',
+  'failed',
+  'terminated',
+] as const satisfies readonly RunnerInstanceState[];


### PR DESCRIPTION
Provisioner polling now deducts only reservation units that still require a launch. Runners already adopted or assigned through the reservation are no longer charged against advertised template capacity a second time, while full reservation counts remain in demand suppression and accounting.

The reservation accounting is synchronized with concurrent runner assignment state, uses transaction-stable expiry checks, and adds real-Postgres regressions for overlapping demand, partial and absent adoption, in-flight intent, released runners, and terminal intended runners.

Closes ENG-1519

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provisioner capacity in `@shipfox/api-runners` by deducting only units that still need a launch across reservation polls. Addresses Linear ENG-1519 and stops double-charging for adopted or intended-and-active runners.

- **Bug Fixes**
  - Count only pending launch units per active reservation; full reservation counts still suppress demand. Treat intended+active runners as used; treat released or terminal-intended as pending.
  - Prevent double-counting during assignment/adoption by locking reservation keys and updating rows before counting. Add Postgres tests for overlapping demand, partial/absent adoption, in-flight intent, released runners, and terminal-intended runners. Extract shared `reservation-locks` and `terminalStates` to break a runner state dependency cycle.

<sup>Written for commit f4755c037c033e751e637471c6066604527d1e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

