### PR TITLE
[api-runners] Align runner reservation lock ordering

### DIFF
--- a/.changeset/steady-runner-locks.md
+++ b/.changeset/steady-runner-locks.md
@@ -1,0 +1,6 @@
+---
+'@shipfox/api-runners': patch
+---
+
+Align demand polling and reservation cleanup runner row lock ordering.
+Recheck runner eligibility before binding after row-lock acquisition.

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -1920,13 +1920,23 @@ async function waitForLockWait(params: {blockingPid: number; minWaiters?: number
   while (Date.now() < deadline) {
     const result = await pgClient().query<{count: number}>(
       `
-        SELECT count(*)::int AS count
-        FROM pg_stat_activity
-        WHERE datname = current_database()
-          AND pid <> pg_backend_pid()
-          AND state = 'active'
-          AND wait_event_type = 'Lock'
-          AND $1::int = ANY(pg_blocking_pids(pid))
+        WITH RECURSIVE lock_waiters(waiter_pid, blocker_pid, path) AS (
+          SELECT activity.pid, blockers.blocker_pid, ARRAY[activity.pid, blockers.blocker_pid]
+          FROM pg_stat_activity AS activity
+          CROSS JOIN LATERAL unnest(pg_blocking_pids(activity.pid)) AS blockers(blocker_pid)
+          WHERE activity.datname = current_database()
+            AND activity.pid <> pg_backend_pid()
+            AND activity.state = 'active'
+            AND activity.wait_event_type = 'Lock'
+          UNION ALL
+          SELECT waiters.waiter_pid, blockers.blocker_pid, waiters.path || blockers.blocker_pid
+          FROM lock_waiters AS waiters
+          CROSS JOIN LATERAL unnest(pg_blocking_pids(waiters.blocker_pid)) AS blockers(blocker_pid)
+          WHERE NOT (blockers.blocker_pid = ANY(waiters.path))
+        )
+        SELECT count(DISTINCT waiter_pid)::int AS count
+        FROM lock_waiters
+        WHERE blocker_pid = $1::int
       `,
       [params.blockingPid],
     );

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -203,8 +203,15 @@ describe('pollDemandAndReserve', () => {
     }
   }, 10_000);
 
-  it('does not bind a runner that becomes ineligible while waiting for its row lock', async () => {
-    const runner = await createIdleRunner({labels: ['linux']});
+  it('refills with the next eligible runner when the oldest becomes ineligible', async () => {
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const replacementRunner = await createIdleRunner({
+      labels: ['linux'],
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
     await createPendingJobs(1, ['linux']);
 
     const lockClient = await pgClient().connect();
@@ -265,12 +272,27 @@ describe('pollDemandAndReserve', () => {
       if (!pollPromise) throw new Error('Expected concurrent poll');
       const result = await pollPromise;
 
-      expect(result.reservations).toEqual([expect.objectContaining({count: 1})]);
-      const [storedRunner] = await db()
-        .select({state: providerRunners.state, reservationId: providerRunners.reservationId})
+      expect(result.reservations).toEqual([]);
+      const rows = await db()
+        .select({
+          id: providerRunners.id,
+          state: providerRunners.state,
+          workspaceId: providerRunners.workspaceId,
+          reservationId: providerRunners.reservationId,
+        })
         .from(providerRunners)
-        .where(eq(providerRunners.id, runner.id));
-      expect(storedRunner).toEqual({state: 'terminated', reservationId: null});
+        .where(inArray(providerRunners.id, [runner.id, replacementRunner.id]));
+      const rowsById = new Map(rows.map((row) => [row.id, row]));
+      expect(rowsById.get(runner.id)).toMatchObject({
+        state: 'terminated',
+        workspaceId: null,
+        reservationId: null,
+      });
+      expect(rowsById.get(replacementRunner.id)).toMatchObject({
+        state: 'running',
+        workspaceId,
+        reservationId: expect.any(String),
+      });
     } finally {
       if (lockTransactionOpen) await lockClient.query('ROLLBACK');
       if (eligibilityTransactionOpen) await eligibilityClient.query('ROLLBACK');

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -120,6 +120,167 @@ describe('pollDemandAndReserve', () => {
     });
   });
 
+  it('does not deadlock polling with expired-reservation cleanup', async () => {
+    const oldestRunnerId = `ffffffff-${crypto.randomUUID().slice(9)}`;
+    const lowestIdRunnerId = `00000000-${crypto.randomUUID().slice(9)}`;
+    const [expiredReservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 2,
+        expiresAt: new Date('2000-01-01T00:00:00.000Z'),
+      })
+      .returning({id: reservations.id});
+    if (!expiredReservation) throw new Error('Expected expired reservation');
+
+    const oldestRunner = await createIdleRunner({
+      id: oldestRunnerId,
+      labels: ['linux'],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      workspaceId,
+      reservationId: expiredReservation.id,
+    });
+    const lowestIdRunner = await createIdleRunner({
+      id: lowestIdRunnerId,
+      labels: ['linux'],
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+      workspaceId,
+      reservationId: expiredReservation.id,
+    });
+    await createPendingJobs(2, ['linux']);
+
+    const lockClient = await pgClient().connect();
+    let transactionOpen = false;
+    let cleanupPromise: Promise<number> | undefined;
+    let pollPromise: ReturnType<typeof pollDemandAndReserve> | undefined;
+    try {
+      await lockClient.query('BEGIN');
+      transactionOpen = true;
+      const lockPidResult = await lockClient.query<{pid: number}>('SELECT pg_backend_pid() AS pid');
+      const lockPid = lockPidResult.rows[0]?.pid;
+      if (lockPid === undefined) throw new Error('Expected lock holder backend pid');
+      await lockClient.query('SELECT id FROM runners_runner_instances WHERE id = $1 FOR UPDATE', [
+        lowestIdRunner.id,
+      ]);
+
+      cleanupPromise = deleteExpiredReservations({limit: 1});
+      // Attach a handler before waiting for the second transaction so a deadlock loser cannot
+      // become an unhandled rejection while the test is coordinating the lock holders.
+      cleanupPromise.catch(() => undefined);
+      await waitForLockWait({blockingPid: lockPid});
+
+      pollPromise = pollDemandAndReserve({
+        workspaceId,
+        provisionerId,
+        maxReservations: 2,
+        ttlSeconds: 60,
+        templates: [template('linux', ['linux'], 2)],
+      });
+      pollPromise.catch(() => undefined);
+      await waitForLockWait({blockingPid: lockPid, minWaiters: 2});
+
+      await lockClient.query('COMMIT');
+      transactionOpen = false;
+
+      if (!cleanupPromise || !pollPromise) throw new Error('Expected concurrent operations');
+      const [deleted, result] = await Promise.all([cleanupPromise, pollPromise]);
+
+      expect(deleted).toBe(1);
+      expect(result.reservations).toEqual([]);
+      const rows = await db()
+        .select({id: providerRunners.id, reservationId: providerRunners.reservationId})
+        .from(providerRunners)
+        .where(inArray(providerRunners.id, [oldestRunner.id, lowestIdRunner.id]));
+      expect(rows).toHaveLength(2);
+      expect(rows.every((row) => row.reservationId !== expiredReservation.id)).toBe(true);
+    } finally {
+      if (transactionOpen) await lockClient.query('ROLLBACK');
+      if (cleanupPromise) await cleanupPromise.catch(() => undefined);
+      if (pollPromise) await pollPromise.catch(() => undefined);
+      lockClient.release();
+    }
+  }, 10_000);
+
+  it('does not bind a runner that becomes ineligible while waiting for its row lock', async () => {
+    const runner = await createIdleRunner({labels: ['linux']});
+    await createPendingJobs(1, ['linux']);
+
+    const lockClient = await pgClient().connect();
+    const eligibilityClient = await pgClient().connect();
+    let lockTransactionOpen = false;
+    let eligibilityTransactionOpen = false;
+    let eligibilityLockPromise: Promise<unknown> | undefined;
+    let pollPromise: ReturnType<typeof pollDemandAndReserve> | undefined;
+    try {
+      await lockClient.query('BEGIN');
+      lockTransactionOpen = true;
+      const lockPidResult = await lockClient.query<{pid: number}>('SELECT pg_backend_pid() AS pid');
+      const lockPid = lockPidResult.rows[0]?.pid;
+      if (lockPid === undefined) throw new Error('Expected lock holder backend pid');
+      await lockClient.query('SELECT id FROM runners_runner_instances WHERE id = $1 FOR UPDATE', [
+        runner.id,
+      ]);
+
+      await eligibilityClient.query('BEGIN');
+      eligibilityTransactionOpen = true;
+      const eligibilityPidResult = await eligibilityClient.query<{pid: number}>(
+        'SELECT pg_backend_pid() AS pid',
+      );
+      const eligibilityPid = eligibilityPidResult.rows[0]?.pid;
+      if (eligibilityPid === undefined) throw new Error('Expected eligibility backend pid');
+      eligibilityLockPromise = eligibilityClient.query(
+        'SELECT id FROM runners_runner_instances WHERE id = $1 FOR UPDATE',
+        [runner.id],
+      );
+      // Attach a handler before starting the poll so cleanup can safely await a failed lock query.
+      eligibilityLockPromise.catch(() => undefined);
+      await waitForLockWait({blockingPid: lockPid});
+
+      pollPromise = pollDemandAndReserve({
+        workspaceId,
+        provisionerId,
+        maxReservations: 1,
+        ttlSeconds: 60,
+        templates: [template('linux', ['linux'], 1)],
+      });
+      pollPromise.catch(() => undefined);
+      await waitForLockWait({blockingPid: eligibilityPid});
+
+      await lockClient.query('COMMIT');
+      lockTransactionOpen = false;
+      await eligibilityLockPromise;
+      await eligibilityClient.query(
+        "UPDATE runners_runner_instances SET state = 'terminated', terminated_at = now(), updated_at = now() WHERE id = $1",
+        [runner.id],
+      );
+      await eligibilityClient.query(
+        "UPDATE runners_runner_control_sessions SET closed_at = now(), close_reason = 'test' WHERE runner_instance_id = $1 AND closed_at IS NULL",
+        [runner.id],
+      );
+      await eligibilityClient.query('COMMIT');
+      eligibilityTransactionOpen = false;
+
+      if (!pollPromise) throw new Error('Expected concurrent poll');
+      const result = await pollPromise;
+
+      expect(result.reservations).toEqual([expect.objectContaining({count: 1})]);
+      const [storedRunner] = await db()
+        .select({state: providerRunners.state, reservationId: providerRunners.reservationId})
+        .from(providerRunners)
+        .where(eq(providerRunners.id, runner.id));
+      expect(storedRunner).toEqual({state: 'terminated', reservationId: null});
+    } finally {
+      if (lockTransactionOpen) await lockClient.query('ROLLBACK');
+      if (eligibilityTransactionOpen) await eligibilityClient.query('ROLLBACK');
+      if (eligibilityLockPromise) await eligibilityLockPromise.catch(() => undefined);
+      if (pollPromise) await pollPromise.catch(() => undefined);
+      lockClient.release();
+      eligibilityClient.release();
+    }
+  }, 10_000);
+
   it('splits rebound and launch capacity with separate reservation lifetimes', async () => {
     const runner = await createIdleRunner({labels: ['linux']});
     await createPendingJobs(2, ['linux']);
@@ -1660,6 +1821,7 @@ describe('pollDemandAndReserve', () => {
   }
 
   async function createIdleRunner(params: {
+    id?: string;
     labels: string[];
     createdAt?: Date;
     controlSessionExpiresAt?: Date;
@@ -1674,6 +1836,7 @@ describe('pollDemandAndReserve', () => {
     const [runner] = await db()
       .insert(providerRunners)
       .values({
+        ...(params.id ? {id: params.id} : {}),
         provisionerId,
         workspaceId: params.workspaceId,
         reservationId: params.reservationId,
@@ -1729,8 +1892,9 @@ describe('pollDemandAndReserve', () => {
   }
 });
 
-async function waitForLockWait(params: {blockingPid: number}) {
-  const deadline = Date.now() + 2_000;
+async function waitForLockWait(params: {blockingPid: number; minWaiters?: number}) {
+  const minWaiters = params.minWaiters ?? 1;
+  const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     const result = await pgClient().query<{count: number}>(
       `
@@ -1744,8 +1908,10 @@ async function waitForLockWait(params: {blockingPid: number}) {
       `,
       [params.blockingPid],
     );
-    if ((result.rows[0]?.count ?? 0) > 0) return;
+    if ((result.rows[0]?.count ?? 0) >= minWaiters) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
-  throw new Error(`Timed out waiting for a backend blocked by pid ${params.blockingPid}`);
+  throw new Error(
+    `Timed out waiting for ${minWaiters} backend(s) blocked by pid ${params.blockingPid}`,
+  );
 }

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -581,27 +581,48 @@ async function selectIdleRunnerInstancesTx(
   }
 
   // Select the oldest candidates first, but leave row locking to a second pass. The cleanup
-  // path locks runner rows by id, so the locking pass must use that same order.
-  const candidateRunners = await tx
-    .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
-    .from(providerRunners)
-    .where(isBindableRunner(tx, params))
-    .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
-    .limit(params.count);
+  // path locks runner rows by id, so the locking pass must use that same order. A skipped row
+  // rolls back only this nested savepoint and retries the bounded candidate scan, allowing the
+  // next-oldest eligible runner to refill the grant without retaining a partial lock set.
+  const retrySelection = Symbol('retry bindable runner selection');
+  const idleRunners = await (async () => {
+    while (true) {
+      try {
+        return await tx.transaction(async (lockTx) => {
+          const candidateRunners = await lockTx
+            .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
+            .from(providerRunners)
+            .where(isBindableRunner(lockTx, params))
+            .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
+            .limit(params.count);
 
-  if (candidateRunners.length === 0) return [];
+          if (candidateRunners.length === 0) return candidateRunners;
 
-  // PostgreSQL can acquire row locks before sorting a multi-row FOR UPDATE result. Lock each
-  // selected candidate individually so both polling and cleanup use id order for acquisition.
-  const idleRunners: typeof candidateRunners = [];
-  for (const candidate of [...candidateRunners].sort(compareRunnerIds)) {
-    const [runner] = await tx
-      .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
-      .from(providerRunners)
-      .where(and(eq(providerRunners.id, candidate.id), isBindableRunner(tx, params)))
-      .for('update');
-    if (runner) idleRunners.push(runner);
-  }
+          // PostgreSQL can acquire row locks before sorting a multi-row FOR UPDATE result. Lock
+          // each selected candidate individually so both polling and cleanup use id order.
+          const lockedRunners: typeof candidateRunners = [];
+          for (const candidate of [...candidateRunners].sort(compareRunnerIds)) {
+            const [runner] = await lockTx
+              .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
+              .from(providerRunners)
+              .where(
+                and(
+                  eq(providerRunners.id, candidate.id),
+                  isBindableRunner(lockTx, params),
+                ),
+              )
+              .for('update');
+            if (runner) lockedRunners.push(runner);
+          }
+
+          if (lockedRunners.length !== candidateRunners.length) throw retrySelection;
+          return lockedRunners;
+        });
+      } catch (error) {
+        if (error !== retrySelection) throw error;
+      }
+    }
+  })();
 
   return idleRunners;
 }

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -570,12 +570,7 @@ async function selectIdleRunnerInstancesTx(
     return await tx
       .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
       .from(providerRunners)
-      .where(
-        and(
-          inArray(providerRunners.id, params.runnerIds),
-          isBindableRunner(tx, params),
-        ),
-      )
+      .where(and(inArray(providerRunners.id, params.runnerIds), isBindableRunner(tx, params)))
       .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
       .limit(params.count);
   }
@@ -605,12 +600,7 @@ async function selectIdleRunnerInstancesTx(
             const [runner] = await lockTx
               .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
               .from(providerRunners)
-              .where(
-                and(
-                  eq(providerRunners.id, candidate.id),
-                  isBindableRunner(lockTx, params),
-                ),
-              )
+              .where(and(eq(providerRunners.id, candidate.id), isBindableRunner(lockTx, params)))
               .for('update');
             if (runner) lockedRunners.push(runner);
           }
@@ -663,12 +653,7 @@ async function bindIdleRunnerInstancesTx(
       assignedAt: sql`now()`,
       updatedAt: sql`now()`,
     })
-    .where(
-      and(
-        inArray(providerRunners.id, idleRunnerIds),
-        isBindableRunner(tx, params),
-      ),
-    )
+    .where(and(inArray(providerRunners.id, idleRunnerIds), isBindableRunner(tx, params)))
     .returning({id: providerRunners.id, launchKind: providerRunners.launchKind});
 
   if (boundRunners.length !== params.idleRunners.length)

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -83,6 +83,17 @@ interface IdleRunnerCandidate {
   launchKind: (typeof providerRunnerLaunchKindEnum.enumValues)[number];
 }
 
+interface BindableRunnerParams {
+  provisionerId: string;
+  workspaceId: string;
+  requiredLabels: string[];
+  scope: DemandScope;
+}
+
+interface IdleRunnerSelectionParams extends BindableRunnerParams {
+  count: number;
+}
+
 type PollDemandAndReserveLockedParams = PollDemandAndReserveParams & {
   scope: DemandScope;
 };
@@ -316,6 +327,8 @@ async function pollDemandAndReserveLockedTx(
           provisionerId: params.provisionerId,
           reservationId: boundReservation.id,
           workspaceId: params.workspaceId,
+          requiredLabels: demand.requiredLabels,
+          scope: params.scope,
           idleRunners,
         });
       }
@@ -461,15 +474,78 @@ function addUsedRunner(
   else usedByReservation.set(reservationId, new Set([runnerId]));
 }
 
+// An expired or missing reservation is stale. A live reservation protects a runner that is
+// still booting or waiting for its activation grace period.
+function canBindRunner(tx: Tx, params: BindableRunnerParams) {
+  return and(
+    or(
+      and(isNull(providerRunners.workspaceId), isNull(providerRunners.reservationId)),
+      and(
+        isNotNull(providerRunners.reservationId),
+        params.scope === 'installation'
+          ? undefined
+          : or(
+              isNull(providerRunners.workspaceId),
+              eq(providerRunners.workspaceId, params.workspaceId),
+            ),
+        notExists(
+          tx
+            .select({id: reservations.id})
+            .from(reservations)
+            .where(
+              and(
+                eq(reservations.id, providerRunners.reservationId),
+                gt(reservations.expiresAt, sql`now()`),
+              ),
+            ),
+        ),
+      ),
+    ),
+    or(
+      isNull(providerRunners.intendedReservationId),
+      notExists(
+        tx
+          .select({id: reservations.id})
+          .from(reservations)
+          .where(
+            and(
+              eq(reservations.id, providerRunners.intendedReservationId),
+              gt(reservations.expiresAt, sql`now()`),
+            ),
+          ),
+      ),
+    ),
+    isNull(providerRunners.reservationReleasedAt),
+    isNull(providerRunners.runnerSessionId),
+  );
+}
+
+function isBindableRunner(tx: Tx, params: BindableRunnerParams) {
+  return and(
+    eq(providerRunners.provisionerId, params.provisionerId),
+    canBindRunner(tx, params),
+    isNotNull(providerRunners.providerRunnerId),
+    eq(providerRunners.state, 'running'),
+    arrayContains(providerRunners.labels, params.requiredLabels),
+    exists(
+      tx
+        .select({id: runnerControlSessions.id})
+        .from(runnerControlSessions)
+        .where(
+          and(
+            eq(runnerControlSessions.runnerInstanceId, providerRunners.id),
+            eq(runnerControlSessions.provisionerId, params.provisionerId),
+            isNull(runnerControlSessions.closedAt),
+            gt(runnerControlSessions.expiresAt, sql`now()`),
+          ),
+        ),
+    ),
+  );
+}
+
 async function listIdleRunnerInstancesTx(
   tx: Tx,
-  params: {
-    provisionerId: string;
-    workspaceId: string;
-    requiredLabels: string[];
-    count: number;
-    scope: DemandScope;
-  },
+  params: IdleRunnerSelectionParams & {count: number},
 ): Promise<IdleRunnerCandidate[]> {
   const lockedRunners = await selectIdleRunnerInstancesTx(tx, params);
   if (lockedRunners.length === 0) return lockedRunners;
@@ -486,89 +562,46 @@ async function listIdleRunnerInstancesTx(
 
 async function selectIdleRunnerInstancesTx(
   tx: Tx,
-  params: {
-    provisionerId: string;
-    workspaceId: string;
-    requiredLabels: string[];
-    count: number;
-    scope: DemandScope;
-    runnerIds?: string[];
-  },
+  params: IdleRunnerSelectionParams & {count: number; runnerIds?: string[]},
 ): Promise<IdleRunnerCandidate[]> {
-  // An expired or missing reservation is stale. A live reservation protects a
-  // runner that is still booting or waiting for its activation grace period.
-  const canBindRunner = () =>
-    and(
-      or(
-        and(isNull(providerRunners.workspaceId), isNull(providerRunners.reservationId)),
+  if (params.runnerIds) {
+    // The first pass retains the row locks. Recheck the full predicate in a fresh statement so
+    // reservation subqueries see the state that was current when the lock was acquired.
+    return await tx
+      .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
+      .from(providerRunners)
+      .where(
         and(
-          isNotNull(providerRunners.reservationId),
-          params.scope === 'installation'
-            ? undefined
-            : or(
-                isNull(providerRunners.workspaceId),
-                eq(providerRunners.workspaceId, params.workspaceId),
-              ),
-          notExists(
-            tx
-              .select({id: reservations.id})
-              .from(reservations)
-              .where(
-                and(
-                  eq(reservations.id, providerRunners.reservationId),
-                  gt(reservations.expiresAt, sql`now()`),
-                ),
-              ),
-          ),
+          inArray(providerRunners.id, params.runnerIds),
+          isBindableRunner(tx, params),
         ),
-      ),
-      or(
-        isNull(providerRunners.intendedReservationId),
-        notExists(
-          tx
-            .select({id: reservations.id})
-            .from(reservations)
-            .where(
-              and(
-                eq(reservations.id, providerRunners.intendedReservationId),
-                gt(reservations.expiresAt, sql`now()`),
-              ),
-            ),
-        ),
-      ),
-      isNull(providerRunners.reservationReleasedAt),
-      isNull(providerRunners.runnerSessionId),
-    );
+      )
+      .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
+      .limit(params.count);
+  }
 
-  const idleRunners = await tx
+  // Select the oldest candidates first, but leave row locking to a second pass. The cleanup
+  // path locks runner rows by id, so the locking pass must use that same order.
+  const candidateRunners = await tx
     .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
     .from(providerRunners)
-    .where(
-      and(
-        eq(providerRunners.provisionerId, params.provisionerId),
-        params.runnerIds ? inArray(providerRunners.id, params.runnerIds) : undefined,
-        canBindRunner(),
-        isNotNull(providerRunners.providerRunnerId),
-        eq(providerRunners.state, 'running'),
-        arrayContains(providerRunners.labels, params.requiredLabels),
-        exists(
-          tx
-            .select({id: runnerControlSessions.id})
-            .from(runnerControlSessions)
-            .where(
-              and(
-                eq(runnerControlSessions.runnerInstanceId, providerRunners.id),
-                eq(runnerControlSessions.provisionerId, params.provisionerId),
-                isNull(runnerControlSessions.closedAt),
-                gt(runnerControlSessions.expiresAt, sql`now()`),
-              ),
-            ),
-        ),
-      ),
-    )
+    .where(isBindableRunner(tx, params))
     .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
-    .limit(params.count)
-    .for('update');
+    .limit(params.count);
+
+  if (candidateRunners.length === 0) return [];
+
+  // PostgreSQL can acquire row locks before sorting a multi-row FOR UPDATE result. Lock each
+  // selected candidate individually so both polling and cleanup use id order for acquisition.
+  const idleRunners: typeof candidateRunners = [];
+  for (const candidate of [...candidateRunners].sort(compareRunnerIds)) {
+    const [runner] = await tx
+      .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
+      .from(providerRunners)
+      .where(and(eq(providerRunners.id, candidate.id), isBindableRunner(tx, params)))
+      .for('update');
+    if (runner) idleRunners.push(runner);
+  }
 
   return idleRunners;
 }
@@ -579,6 +612,8 @@ async function bindIdleRunnerInstancesTx(
     provisionerId: string;
     reservationId: string;
     workspaceId: string;
+    requiredLabels: string[];
+    scope: DemandScope;
     idleRunners: IdleRunnerCandidate[];
   },
 ): Promise<void> {
@@ -610,7 +645,7 @@ async function bindIdleRunnerInstancesTx(
     .where(
       and(
         inArray(providerRunners.id, idleRunnerIds),
-        eq(providerRunners.provisionerId, params.provisionerId),
+        isBindableRunner(tx, params),
       ),
     )
     .returning({id: providerRunners.id, launchKind: providerRunners.launchKind});
@@ -703,7 +738,16 @@ async function deleteReservationsWithCleanupTx(
 ): Promise<number> {
   if (ids.length === 0) return 0;
 
-  const affectedRunners = await tx
+  const isAffectedRunner = () =>
+    or(
+      and(
+        inArray(providerRunners.reservationId, ids),
+        isNull(providerRunners.runnerSessionId),
+        isNull(providerRunners.reservationReleasedAt),
+      ),
+      inArray(providerRunners.intendedReservationId, ids),
+    );
+  const candidateRunners = await tx
     .select({
       id: providerRunners.id,
       reservationId: providerRunners.reservationId,
@@ -712,18 +756,23 @@ async function deleteReservationsWithCleanupTx(
       reservationReleasedAt: providerRunners.reservationReleasedAt,
     })
     .from(providerRunners)
-    .where(
-      or(
-        and(
-          inArray(providerRunners.reservationId, ids),
-          isNull(providerRunners.runnerSessionId),
-          isNull(providerRunners.reservationReleasedAt),
-        ),
-        inArray(providerRunners.intendedReservationId, ids),
-      ),
-    )
-    .orderBy(asc(providerRunners.id))
-    .for('update');
+    .where(isAffectedRunner())
+    .orderBy(asc(providerRunners.id));
+  const affectedRunners: typeof candidateRunners = [];
+  for (const candidate of [...candidateRunners].sort(compareRunnerIds)) {
+    const [runner] = await tx
+      .select({
+        id: providerRunners.id,
+        reservationId: providerRunners.reservationId,
+        intendedReservationId: providerRunners.intendedReservationId,
+        runnerSessionId: providerRunners.runnerSessionId,
+        reservationReleasedAt: providerRunners.reservationReleasedAt,
+      })
+      .from(providerRunners)
+      .where(and(eq(providerRunners.id, candidate.id), isAffectedRunner()))
+      .for('update');
+    if (runner) affectedRunners.push(runner);
+  }
   const reservationRows = await tx
     .select({id: reservations.id})
     .from(reservations)
@@ -863,6 +912,10 @@ function deductProvisionerReservations(
       );
     drawSlots(satisfyingTemplates, reservation.reserved);
   }
+}
+
+function compareRunnerIds(left: {id: string}, right: {id: string}): number {
+  return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
 }
 
 function sortDemandRows(rows: DemandRow[]): DemandRow[] {


### PR DESCRIPTION
Demand polling selected runners by creation order while expired-reservation cleanup locked them by UUID, allowing transactions to deadlock. This aligns runner row lock acquisition in both paths by snapshotting candidates and locking each by UUID order while preserving oldest-first selection. The bind path also rechecks full runner eligibility at candidate scan, row lock, and final update so state or control-session changes while waiting cannot bind stale runners.

Added deterministic Postgres regressions for inverse UUID/creation ordering and lock-time eligibility changes. The lock-wait helper is scoped to runner-table waiters so parallel API suites cannot satisfy the coordination gate vacuously.

Validation: `mise exec -- turbo test type --filter=@shipfox/api-runners...` (121/121 tasks), `mise exec -- pnpm --filter @shipfox/api-runners check`, and `mise exec -- pnpm changeset status`.

Closes ENG-1520

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns runner reservation lock ordering in `@shipfox/api-runners` to prevent deadlocks between demand polling and expired-reservation cleanup (ENG-1520). Adds a bounded retry with eligibility rechecks to refill candidates when a runner loses eligibility during row-lock acquisition, preserving UUID lock order and avoiding stale binds.

- **Bug Fixes**
  - Lock runner rows one-by-one in UUID order for both polling and cleanup while selecting oldest-first.
  - Retry the candidate scan inside a nested savepoint if a selected runner becomes ineligible at lock time; recheck eligibility at scan, lock, and update via a shared predicate.
  - Add deterministic Postgres regressions for deadlock and lock-time eligibility races; scope the lock-wait helper to transitive waiters to keep coordination strict.

<sup>Written for commit a870ef701fb9c34b55ace3a91462854337a66715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

