### PR TITLE
[runner-agent] Clarify workflow output schema guidance

### DIFF
--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -338,12 +338,13 @@ describe('claudeHarnessAdapter', () => {
   it('registers declared output tools when the Anthropic base URL override is active', async () => {
     configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
     queryMock.mockReturnValue(makeQuery([successMessage, successMessage, successMessage]));
+    const schema = {type: 'array', items: {type: 'string'}};
 
     const result = claudeHarnessAdapter.run(
-      invocation({credentials: {}, outputs: {summary: {type: 'string'}}}),
+      invocation({credentials: {}, outputs: {findings: {type: 'json', schema}}}),
     );
 
-    await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
+    await expect(result).rejects.toThrow('Agent step finished without required outputs: findings');
     expect(assertEgressAllowedMock).toHaveBeenCalledWith(
       'http://127.0.0.1:11434',
       expect.objectContaining({allowPrivateNetworks: true}),
@@ -351,6 +352,7 @@ describe('claudeHarnessAdapter', () => {
     expect(createSdkMcpServerMock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'shipfox_outputs',
+        instructions: expect.stringContaining(JSON.stringify(schema, null, 2)),
         tools: [expect.objectContaining({name: 'set_output'})],
       }),
     );

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -139,6 +139,9 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
           useOutputTools ? collector.guidanceText() : undefined,
         ),
         missingRequired: () => collector.missingRequired(),
+        guidanceForMissing: (missing) => collector.guidanceTextFor(missing),
+        terminalGuidanceForMissing: (missing) =>
+          collector.terminalOutputSpecificationsTextFor(missing),
         runTurn: async (message) => {
           messages?.push(userMessage(message));
           response = (await readClaudeResult({queryIterator, onSessionEntry})).response ?? '';

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -140,8 +140,6 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         ),
         missingRequired: () => collector.missingRequired(),
         guidanceForMissing: (missing) => collector.guidanceTextFor(missing),
-        terminalGuidanceForMissing: (missing) =>
-          collector.terminalOutputSpecificationsTextFor(missing),
         runTurn: async (message) => {
           messages?.push(userMessage(message));
           response = (await readClaudeResult({queryIterator, onSessionEntry})).response ?? '';

--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -205,34 +205,6 @@ describe('OutputCollector', () => {
     expect(collector.guidanceTextFor(['meta'])).not.toContain('Output "summary"');
   });
 
-  it('omits schema descriptions only from the human terminal representation', () => {
-    const collector = new OutputCollector({
-      meta: {
-        type: 'json',
-        schema: {
-          type: 'object',
-          description: 'Top-level help text.',
-          properties: {
-            description: {
-              type: 'string',
-              description: 'Field help text.',
-            },
-          },
-        },
-      },
-    });
-
-    const agentGuidance = collector.guidanceTextFor(['meta']);
-    const terminalGuidance = collector.terminalOutputSpecificationsTextFor(['meta']);
-
-    expect(agentGuidance).toContain('Top-level help text.');
-    expect(agentGuidance).toContain('Field help text.');
-    expect(terminalGuidance).not.toContain('Top-level help text.');
-    expect(terminalGuidance).not.toContain('Field help text.');
-    expect(terminalGuidance).toContain('"description": {');
-    expect(terminalGuidance).toContain('descriptions omitted');
-  });
-
   it('states the full contract for steps without declared outputs', () => {
     const collector = new OutputCollector(undefined);
 
@@ -290,7 +262,7 @@ describe('runOutputTurnLoop', () => {
     expect(runTurn).toHaveBeenCalledOnce();
   });
 
-  it('keeps correction instructions in reprompts but only output schemas in the final error', async () => {
+  it('keeps correction guidance in reprompts but omits it from the final error', async () => {
     const runTurn = vi.fn<Parameters<typeof runOutputTurnLoop>[0]['runTurn']>();
     const controller = new AbortController();
     const outputSpecification = [
@@ -308,14 +280,14 @@ describe('runOutputTurnLoop', () => {
       runTurn,
       missingRequired: () => ['findings'],
       guidanceForMissing: () => guidance,
-      terminalGuidanceForMissing: () => outputSpecification,
     }).catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(RequiredOutputsMissingError);
-    expect(error).toMatchObject({message: expect.stringContaining(outputSpecification)});
     expect(error).toMatchObject({
-      message: expect.not.stringContaining('Workflow output contract:'),
+      message: 'Agent step finished without required outputs: findings',
     });
+    expect(error).toMatchObject({message: expect.not.stringContaining(outputSpecification)});
+    expect(error).toMatchObject({message: expect.not.stringContaining(guidance)});
     expect(runTurn).toHaveBeenLastCalledWith(expect.stringContaining(guidance));
   });
 });

--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -2,7 +2,12 @@ import {
   MAX_OUTPUT_TOTAL_BYTES,
   MAX_OUTPUT_VALUE_BYTES,
 } from '@shipfox/runner-execution/step-output';
-import {MAX_OUTPUT_REPROMPTS, OutputCollector, runOutputTurnLoop} from '#core/output-collector.js';
+import {
+  MAX_OUTPUT_REPROMPTS,
+  OutputCollector,
+  RequiredOutputsMissingError,
+  runOutputTurnLoop,
+} from '#core/output-collector.js';
 
 describe('OutputCollector', () => {
   it('accepts declared scalar outputs as string values', () => {
@@ -21,14 +26,18 @@ describe('OutputCollector', () => {
   });
 
   it('rejects undeclared keys on typed steps', () => {
-    const collector = new OutputCollector({count: {type: 'number'}});
+    const schema = {type: 'number'};
+    const collector = new OutputCollector({count: {type: 'json', schema}});
 
     const result = collector.trySet('extra', 'value');
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: false,
-      feedback: 'Output "extra" is not declared by the step output schema.',
+      feedback: expect.stringContaining(
+        'Output "extra" is not declared by the step output schema. Use one of these exact keys: count.',
+      ),
     });
+    expect(result).toMatchObject({feedback: expect.not.stringContaining(JSON.stringify(schema))});
     expect(collector.snapshot()).toEqual({});
   });
 
@@ -50,14 +59,53 @@ describe('OutputCollector', () => {
     expect(result).toMatchObject({feedback: expect.stringContaining('Output key "bad key"')});
   });
 
+  it('lists declared keys without repeating schemas when a typed step receives an invalid key', () => {
+    const schema = {type: 'array', items: {type: 'string'}};
+    const collector = new OutputCollector({findings: {type: 'json', schema}});
+
+    const result = collector.trySet('bad key', 'value');
+
+    expect(result).toMatchObject({
+      ok: false,
+      feedback: expect.stringContaining(
+        'Output key "bad key" is invalid. Use letters, numbers, underscores, or hyphens, and start with a letter or underscore. Use one of these exact keys: findings.',
+      ),
+    });
+    expect(result).toMatchObject({
+      feedback: expect.not.stringContaining(JSON.stringify(schema, null, 2)),
+    });
+  });
+
+  it('states the accepted encoding for each declared output type', () => {
+    const collector = new OutputCollector({
+      summary: {type: 'string'},
+      count: {type: 'number'},
+      passed: {type: 'boolean'},
+    });
+
+    const guidance = collector.guidanceText();
+
+    expect(guidance).toContain('Output "summary"\n- key: "summary"\n- value: the text value');
+    expect(guidance).toContain('- value: number encoded as a string');
+    expect(guidance).toContain('- value: exactly "true" or "false"');
+  });
+
   it('returns coercion feedback for invalid values without storing them', () => {
     const collector = new OutputCollector({count: {type: 'number'}});
 
     const result = collector.trySet('count', 'not-a-number');
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: false,
-      feedback: 'Output "count" must be a finite number or numeric string.',
+      feedback: expect.stringContaining(
+        'Output "count" must be a finite number or numeric string.',
+      ),
+    });
+    expect(result).toMatchObject({
+      feedback: expect.stringContaining('Retry set_output using this exact contract:'),
+    });
+    expect(result).toMatchObject({
+      feedback: expect.stringContaining('- value: number encoded as a string'),
     });
     expect(collector.missingRequired()).toEqual(['count']);
     expect(collector.snapshot()).toEqual({});
@@ -80,6 +128,32 @@ describe('OutputCollector', () => {
 
     expect(result).toEqual({ok: true});
     expect(collector.snapshot()).toEqual({meta: '{"name":"api"}'});
+  });
+
+  it('returns the validation error and exact JSON Schema for a rejected json output', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'file'],
+        properties: {id: {type: 'string'}, file: {type: 'string'}},
+        additionalProperties: false,
+      },
+    };
+    const collector = new OutputCollector({findings: {type: 'json', schema}});
+
+    const result = collector.trySet('findings', '[{"id":"intent_scope-1"}]');
+
+    expect(result).toMatchObject({
+      ok: false,
+      feedback: expect.stringContaining('Output "findings" does not match its JSON Schema.'),
+    });
+    expect(result).toMatchObject({
+      feedback: expect.stringContaining('Schema validation error:'),
+    });
+    expect(result).toMatchObject({
+      feedback: expect.stringContaining(JSON.stringify(schema, null, 2)),
+    });
   });
 
   it('rejects values over the per-value cap', () => {
@@ -108,17 +182,73 @@ describe('OutputCollector', () => {
     });
   });
 
-  it('lists missing required outputs and describes json-as-text guidance', () => {
+  it('lists required outputs with unambiguous json text guidance', () => {
+    const schema = {type: 'array', items: {type: 'string'}};
     const collector = new OutputCollector({
-      meta: {type: 'json'},
+      meta: {type: 'json', schema},
       summary: {type: 'string'},
     });
 
     collector.trySet('summary', 'done');
 
     expect(collector.missingRequired()).toEqual(['meta']);
-    expect(collector.guidanceText()).toContain('For json outputs, pass value as JSON text.');
-    expect(collector.guidanceText()).toContain('- meta: json as JSON text');
+    expect(collector.guidanceText()).toContain(
+      'The tool input has exactly two string fields: key and value.',
+    );
+    expect(collector.guidanceText()).toContain(
+      'do not wrap it in an object named after the output key.',
+    );
+    expect(collector.guidanceText()).toContain('Output "meta"');
+    expect(collector.guidanceText()).toContain('- key: "meta"');
+    expect(collector.guidanceText()).toContain('- value: JSON text encoded as a string');
+    expect(collector.guidanceText()).toContain(JSON.stringify(schema, null, 2));
+    expect(collector.guidanceTextFor(['meta'])).not.toContain('Output "summary"');
+  });
+
+  it('omits schema descriptions only from the human terminal representation', () => {
+    const collector = new OutputCollector({
+      meta: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          description: 'Top-level help text.',
+          properties: {
+            description: {
+              type: 'string',
+              description: 'Field help text.',
+            },
+          },
+        },
+      },
+    });
+
+    const agentGuidance = collector.guidanceTextFor(['meta']);
+    const terminalGuidance = collector.terminalOutputSpecificationsTextFor(['meta']);
+
+    expect(agentGuidance).toContain('Top-level help text.');
+    expect(agentGuidance).toContain('Field help text.');
+    expect(terminalGuidance).not.toContain('Top-level help text.');
+    expect(terminalGuidance).not.toContain('Field help text.');
+    expect(terminalGuidance).toContain('"description": {');
+    expect(terminalGuidance).toContain('descriptions omitted');
+  });
+
+  it('states the full contract for steps without declared outputs', () => {
+    const collector = new OutputCollector(undefined);
+
+    expect(collector.guidanceText()).toBe(
+      [
+        'Workflow output contract:',
+        '- Before your final response, call set_output once for every required output.',
+        '- The tool input has exactly two string fields: key and value.',
+        '- Use each output name below as key exactly as written.',
+        '- For a json output, JSON-serialize the output value into the value string. ' +
+          'The decoded JSON value itself must match the schema; do not wrap it in an object ' +
+          'named after the output key.',
+        '',
+        'This step has no declared outputs, so any valid output key is accepted.',
+      ].join('\n'),
+    );
   });
 });
 
@@ -158,5 +288,34 @@ describe('runOutputTurnLoop', () => {
 
     await expect(result).rejects.toThrow('Agent step aborted');
     expect(runTurn).toHaveBeenCalledOnce();
+  });
+
+  it('keeps correction instructions in reprompts but only output schemas in the final error', async () => {
+    const runTurn = vi.fn<Parameters<typeof runOutputTurnLoop>[0]['runTurn']>();
+    const controller = new AbortController();
+    const outputSpecification = [
+      'Output "findings"',
+      '- key: "findings"',
+      '```json',
+      '{"type":"array"}',
+      '```',
+    ].join('\n');
+    const guidance = `Workflow output contract:\n- Call set_output.\n\n${outputSpecification}`;
+
+    const error = await runOutputTurnLoop({
+      signal: controller.signal,
+      prompt: 'Review the pull request.',
+      runTurn,
+      missingRequired: () => ['findings'],
+      guidanceForMissing: () => guidance,
+      terminalGuidanceForMissing: () => outputSpecification,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(RequiredOutputsMissingError);
+    expect(error).toMatchObject({message: expect.stringContaining(outputSpecification)});
+    expect(error).toMatchObject({
+      message: expect.not.stringContaining('Workflow output contract:'),
+    });
+    expect(runTurn).toHaveBeenLastCalledWith(expect.stringContaining(guidance));
   });
 });

--- a/libs/runner/agent/src/core/output-collector.ts
+++ b/libs/runner/agent/src/core/output-collector.ts
@@ -15,8 +15,14 @@ export type SetOutputResult = {readonly ok: true} | {readonly ok: false; readonl
 export const MAX_OUTPUT_REPROMPTS = 2;
 
 export class RequiredOutputsMissingError extends Error {
-  constructor(public readonly missing: readonly string[]) {
-    super(`Agent step finished without required outputs: ${missing.join(', ')}`);
+  constructor(
+    public readonly missing: readonly string[],
+    guidance?: string,
+  ) {
+    super(
+      `Agent step finished without required outputs: ${missing.join(', ')}` +
+        (guidance === undefined ? '' : `\n\n${guidance}`),
+    );
     this.name = 'RequiredOutputsMissingError';
   }
 }
@@ -51,7 +57,9 @@ export class OutputCollector {
     const declaration = this.#declarations?.[key];
     if (declaration !== undefined) {
       const coerced = coerceSingleOutput(key, declaration, value);
-      if (!coerced.ok) return {ok: false, feedback: feedbackForCoercionError(coerced.error)};
+      if (!coerced.ok) {
+        return {ok: false, feedback: feedbackForCoercionError(coerced.error, declaration)};
+      }
     }
 
     this.#outputs[key] = value;
@@ -71,20 +79,28 @@ export class OutputCollector {
     return outputGuidanceText(this.#declarations);
   }
 
+  guidanceTextFor(keys: readonly string[]): string {
+    return outputGuidanceText(this.#declarations, keys);
+  }
+
+  terminalOutputSpecificationsTextFor(keys: readonly string[]): string {
+    return outputSpecificationsText(this.#declarations, keys, 'terminal');
+  }
+
   #validateKey(key: string): SetOutputResult {
     if (!OUTPUT_KEY_REGEX.test(key)) {
       return {
         ok: false,
         feedback:
           `Output key "${key}" is invalid. Use letters, numbers, underscores, or hyphens, ` +
-          'and start with a letter or underscore.',
+          `and start with a letter or underscore.${declaredKeysFeedback(this.#declarations)}`,
       };
     }
 
     if (this.#declarations !== undefined && !Object.hasOwn(this.#declarations, key)) {
       return {
         ok: false,
-        feedback: `Output "${key}" is not declared by the step output schema.`,
+        feedback: `Output "${key}" is not declared by the step output schema.${declaredKeysFeedback(this.#declarations)}`,
       };
     }
 
@@ -97,6 +113,8 @@ export async function runOutputTurnLoop(params: {
   prompt: string;
   runTurn: (prompt: string) => Promise<void>;
   missingRequired: () => string[];
+  guidanceForMissing?: (missing: readonly string[]) => string;
+  terminalGuidanceForMissing?: (missing: readonly string[]) => string;
 }): Promise<void> {
   let nextPrompt = params.prompt;
   for (let attempt = 0; attempt <= MAX_OUTPUT_REPROMPTS; attempt += 1) {
@@ -105,30 +123,35 @@ export async function runOutputTurnLoop(params: {
     if (params.signal.aborted) throw new Error('Agent step aborted');
     const missing = params.missingRequired();
     if (missing.length === 0) return;
+    const guidance = params.guidanceForMissing?.(missing);
     if (attempt === MAX_OUTPUT_REPROMPTS) {
-      throw new RequiredOutputsMissingError(missing);
+      const terminalGuidance = params.terminalGuidanceForMissing?.(missing) ?? guidance;
+      throw new RequiredOutputsMissingError(missing, terminalGuidance);
     }
     nextPrompt =
       `The previous turn ended without setting required workflow outputs: ${missing.join(', ')}. ` +
-      'Call set_output for each missing key, then provide your final response.';
+      'Call set_output for each missing key, then provide your final response.' +
+      (guidance === undefined ? '' : `\n\n${guidance}`);
   }
 }
 
-export function outputGuidanceText(declarations: OutputDeclarations | undefined): string {
-  const base =
-    'Use the set_output tool to report step outputs. The tool takes key and value strings. ' +
-    'For json outputs, pass value as JSON text.';
+export function outputGuidanceText(
+  declarations: OutputDeclarations | undefined,
+  keys?: readonly string[],
+): string {
+  const base = [
+    'Workflow output contract:',
+    '- Before your final response, call set_output once for every required output.',
+    '- The tool input has exactly two string fields: key and value.',
+    '- Use each output name below as key exactly as written.',
+    '- For a json output, JSON-serialize the output value into the value string. ' +
+      'The decoded JSON value itself must match the schema; do not wrap it in an object named after the output key.',
+  ].join('\n');
   if (declarations === undefined) {
-    return `${base} This step has no declared output schema, so any valid output key is accepted.`;
+    return `${base}\n\nThis step has no declared outputs, so any valid output key is accepted.`;
   }
 
-  const lines = Object.entries(declarations).map(([key, declaration]) => {
-    const schema =
-      declaration.schema === undefined ? '' : '; value must satisfy the declared JSON schema';
-    return `- ${key}: ${declaration.type}${declaration.type === 'json' ? ' as JSON text' : ''}${schema}`;
-  });
-
-  return `${base} This step requires these outputs before finishing:\n${lines.join('\n')}`;
+  return `${base}\n\nRequired outputs:\n\n${outputSpecificationsText(declarations, keys)}`;
 }
 
 export function withOutputGuidance(prompt: string, guidance: string): string {
@@ -143,8 +166,87 @@ function coerceSingleOutput(
   return coerceStepOutputs({declarations: {[key]: declaration}, output: {[key]: value}});
 }
 
-function feedbackForCoercionError(error: StepOutputCoercionError): string {
-  return error.message;
+function feedbackForCoercionError(
+  error: StepOutputCoercionError,
+  declaration: OutputTypeDeclaration,
+): string {
+  const validationError =
+    error.schemaError === undefined ? '' : `\nSchema validation error: ${error.schemaError}`;
+  return (
+    `${error.message}${validationError}\n\nRetry set_output using this exact contract:\n\n` +
+    outputDeclarationGuidance(error.key, declaration)
+  );
+}
+
+function outputDeclarationGuidance(
+  key: string,
+  declaration: OutputTypeDeclaration,
+  audience: 'agent' | 'terminal' = 'agent',
+): string {
+  const lines = [
+    `Output "${key}"`,
+    `- key: "${key}"`,
+    `- value: ${outputValueGuidance(declaration.type)}`,
+  ];
+  if (declaration.schema !== undefined) {
+    lines.push(
+      audience === 'agent'
+        ? '- The decoded JSON value must match this exact JSON Schema:'
+        : '- The decoded JSON value must match this JSON Schema (descriptions omitted):',
+      '```json',
+      formatJsonSchema(declaration.schema, audience),
+      '```',
+    );
+  }
+  return lines.join('\n');
+}
+
+function outputSpecificationsText(
+  declarations: OutputDeclarations | undefined,
+  keys?: readonly string[],
+  audience: 'agent' | 'terminal' = 'agent',
+): string {
+  if (declarations === undefined) return '';
+  const requestedKeys = keys === undefined ? Object.keys(declarations) : keys;
+  return requestedKeys
+    .flatMap((key) => {
+      const declaration = declarations[key];
+      return declaration === undefined
+        ? []
+        : [outputDeclarationGuidance(key, declaration, audience)];
+    })
+    .join('\n\n');
+}
+
+function formatJsonSchema(schema: unknown, audience: 'agent' | 'terminal'): string {
+  if (audience === 'agent') return JSON.stringify(schema, null, 2);
+  return JSON.stringify(
+    schema,
+    (key, value: unknown) =>
+      key === 'description' && typeof value === 'string' ? undefined : value,
+    2,
+  );
+}
+
+function declaredKeysFeedback(declarations: OutputDeclarations | undefined): string {
+  if (declarations === undefined) return '';
+  const keys = Object.keys(declarations);
+  return keys.length === 0
+    ? ' This step declares no output keys.'
+    : ` Use one of these exact keys: ${keys.join(', ')}.`;
+}
+
+function outputValueGuidance(type: OutputTypeDeclaration['type']): string {
+  switch (type) {
+    case 'string':
+      return 'the text value';
+    case 'number':
+      return 'number encoded as a string';
+    case 'boolean':
+      return 'exactly "true" or "false"';
+    case 'json':
+      return 'JSON text encoded as a string';
+  }
 }
 
 function totalOutputBytes(outputs: Record<string, string>): number {

--- a/libs/runner/agent/src/core/output-collector.ts
+++ b/libs/runner/agent/src/core/output-collector.ts
@@ -15,14 +15,8 @@ export type SetOutputResult = {readonly ok: true} | {readonly ok: false; readonl
 export const MAX_OUTPUT_REPROMPTS = 2;
 
 export class RequiredOutputsMissingError extends Error {
-  constructor(
-    public readonly missing: readonly string[],
-    guidance?: string,
-  ) {
-    super(
-      `Agent step finished without required outputs: ${missing.join(', ')}` +
-        (guidance === undefined ? '' : `\n\n${guidance}`),
-    );
+  constructor(public readonly missing: readonly string[]) {
+    super(`Agent step finished without required outputs: ${missing.join(', ')}`);
     this.name = 'RequiredOutputsMissingError';
   }
 }
@@ -83,10 +77,6 @@ export class OutputCollector {
     return outputGuidanceText(this.#declarations, keys);
   }
 
-  terminalOutputSpecificationsTextFor(keys: readonly string[]): string {
-    return outputSpecificationsText(this.#declarations, keys, 'terminal');
-  }
-
   #validateKey(key: string): SetOutputResult {
     if (!OUTPUT_KEY_REGEX.test(key)) {
       return {
@@ -114,7 +104,6 @@ export async function runOutputTurnLoop(params: {
   runTurn: (prompt: string) => Promise<void>;
   missingRequired: () => string[];
   guidanceForMissing?: (missing: readonly string[]) => string;
-  terminalGuidanceForMissing?: (missing: readonly string[]) => string;
 }): Promise<void> {
   let nextPrompt = params.prompt;
   for (let attempt = 0; attempt <= MAX_OUTPUT_REPROMPTS; attempt += 1) {
@@ -125,8 +114,7 @@ export async function runOutputTurnLoop(params: {
     if (missing.length === 0) return;
     const guidance = params.guidanceForMissing?.(missing);
     if (attempt === MAX_OUTPUT_REPROMPTS) {
-      const terminalGuidance = params.terminalGuidanceForMissing?.(missing) ?? guidance;
-      throw new RequiredOutputsMissingError(missing, terminalGuidance);
+      throw new RequiredOutputsMissingError(missing);
     }
     nextPrompt =
       `The previous turn ended without setting required workflow outputs: ${missing.join(', ')}. ` +
@@ -178,11 +166,7 @@ function feedbackForCoercionError(
   );
 }
 
-function outputDeclarationGuidance(
-  key: string,
-  declaration: OutputTypeDeclaration,
-  audience: 'agent' | 'terminal' = 'agent',
-): string {
+function outputDeclarationGuidance(key: string, declaration: OutputTypeDeclaration): string {
   const lines = [
     `Output "${key}"`,
     `- key: "${key}"`,
@@ -190,11 +174,9 @@ function outputDeclarationGuidance(
   ];
   if (declaration.schema !== undefined) {
     lines.push(
-      audience === 'agent'
-        ? '- The decoded JSON value must match this exact JSON Schema:'
-        : '- The decoded JSON value must match this JSON Schema (descriptions omitted):',
+      '- The decoded JSON value must match this exact JSON Schema:',
       '```json',
-      formatJsonSchema(declaration.schema, audience),
+      JSON.stringify(declaration.schema, null, 2),
       '```',
     );
   }
@@ -204,28 +186,15 @@ function outputDeclarationGuidance(
 function outputSpecificationsText(
   declarations: OutputDeclarations | undefined,
   keys?: readonly string[],
-  audience: 'agent' | 'terminal' = 'agent',
 ): string {
   if (declarations === undefined) return '';
   const requestedKeys = keys === undefined ? Object.keys(declarations) : keys;
   return requestedKeys
     .flatMap((key) => {
       const declaration = declarations[key];
-      return declaration === undefined
-        ? []
-        : [outputDeclarationGuidance(key, declaration, audience)];
+      return declaration === undefined ? [] : [outputDeclarationGuidance(key, declaration)];
     })
     .join('\n\n');
-}
-
-function formatJsonSchema(schema: unknown, audience: 'agent' | 'terminal'): string {
-  if (audience === 'agent') return JSON.stringify(schema, null, 2);
-  return JSON.stringify(
-    schema,
-    (key, value: unknown) =>
-      key === 'description' && typeof value === 'string' ? undefined : value,
-    2,
-  );
 }
 
 function declaredKeysFeedback(declarations: OutputDeclarations | undefined): string {

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -492,14 +492,26 @@ describe('piHarnessAdapter', () => {
   });
 
   it('registers the output tool for steps with declared outputs', async () => {
-    const result = piHarnessAdapter.run(invocation({outputs: {summary: {type: 'string'}}}));
+    const schema = {type: 'array', items: {type: 'string'}};
+    const result = piHarnessAdapter.run(invocation({outputs: {findings: {type: 'json', schema}}}));
 
-    await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
+    await expect(result).rejects.toThrow('Agent step finished without required outputs: findings');
 
     expect(createAgentSessionMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
-        customTools: [expect.objectContaining({name: 'set_output'})],
+        customTools: [
+          expect.objectContaining({
+            name: 'set_output',
+            promptGuidelines: [
+              'Call set_output for each required workflow output; the exact key, value encoding, and JSON Schema for each are in the task prompt.',
+            ],
+          }),
+        ],
       }),
+    );
+    expect(promptMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(JSON.stringify(schema, null, 2)),
     );
   });
 
@@ -646,7 +658,7 @@ describe('piHarnessAdapter', () => {
     const result = piHarnessAdapter.run(invocation({outputs: {summary: {type: 'string'}}}));
 
     await expect(result).rejects.toMatchObject({
-      message: 'Agent step finished without required outputs: summary',
+      message: expect.stringContaining('Agent step finished without required outputs: summary'),
       response: 'final text without output',
     });
     expect(promptMock).toHaveBeenCalledTimes(3);

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -239,6 +239,9 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
             response = piSession.getLastAssistantText() ?? '';
           },
           missingRequired: () => collector.missingRequired(),
+          guidanceForMissing: (missing) => collector.guidanceTextFor(missing),
+          terminalGuidanceForMissing: (missing) =>
+            collector.terminalOutputSpecificationsTextFor(missing),
         });
         const outputs = collector.snapshot();
         return {
@@ -410,8 +413,7 @@ function setOutputTool(collector: OutputCollector) {
     description: 'Set one structured output value for this workflow step.',
     promptSnippet: 'set_output records a workflow step output.',
     promptGuidelines: [
-      'Use set_output once for each required workflow output before your final response.',
-      'Pass all values as strings. For json outputs, pass valid JSON text.',
+      'Call set_output for each required workflow output; the exact key, value encoding, and JSON Schema for each are in the task prompt.',
     ],
     parameters: Type.Object({
       key: Type.String(),

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -240,8 +240,6 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
           },
           missingRequired: () => collector.missingRequired(),
           guidanceForMissing: (missing) => collector.guidanceTextFor(missing),
-          terminalGuidanceForMissing: (missing) =>
-            collector.terminalOutputSpecificationsTextFor(missing),
         });
         const outputs = collector.snapshot();
         return {


### PR DESCRIPTION
Agents with declared workflow outputs currently see the output names and broad types, but not the JSON Schema they must satisfy. In the captured review run, that forced the agent to rediscover the workflow configuration before it could call `set_output` correctly.

This makes the output contract self-contained for both Pi and Claude. Agent prompts, correction turns, and validation failures include the exact formatted schema and explicit string-encoding rules. Key errors remain bounded to valid names, while terminal diagnostics omit descriptive annotations so the useful schema constraints fit the step-error display budget for the reported workflow.

Validated with the runner-agent suite (165 tests) and the full `@shipfox/runner-agent...` dependency closure for check, type, and test (122 tasks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exact JSON Schemas and clear key/value encoding rules to agent prompts, reprompts, and validation feedback so agents can call `set_output` correctly. Final terminal errors stay compact and omit schemas.

- **New Features**
  - Adds a "Workflow output contract" with per-type value encoding and exact JSON Schemas; introduces `guidanceTextFor` on the collector.
  - `Claude` and `Pi` adapters pass targeted guidance to reprompts; `Pi` embeds schemas in the task prompt and updates `set_output` tool guidelines to reference it.
  - Errors include schema validation details and a precise retry contract; invalid keys list allowed keys without repeating schemas; final missing-output errors omit schemas while reprompts include them.

<sup>Written for commit 0a5051d1c2f6e5fed88062cb767a240be2bd59bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

