### PR TITLE
[runner-orchestration] Request the first job immediately

### DIFF
--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -401,7 +401,7 @@ describe('startRunner', () => {
 
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(1);
     expect(mockRequestJob).toHaveBeenCalledTimes(1);
-    expect(mockInterruptibleSleep).not.toHaveBeenCalled();
+    expect(mockInterruptibleSleep).toHaveBeenCalledTimes(1);
   });
 
   it('enrolls, waits, activates, and uses the activation session for managed runners', async () => {
@@ -439,8 +439,25 @@ describe('startRunner', () => {
       capabilities: {harnesses: {pi: {tools: ['read']}}},
       registrationToken: 'activation-token',
     });
-    expect(mockRequestJob).toHaveBeenCalledWith('session-token');
+    expect(mockRequestJob).toHaveBeenCalledWith('session-token', expect.any(AbortSignal));
     expect(mockInterruptibleSleep).not.toHaveBeenCalled();
+  });
+
+  it('backs off between empty direct polls', async () => {
+    setPollConfig({maxDuration: 0});
+    mockRequestJob
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JOB)
+      .mockRejectedValueOnce(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockRequestJob).toHaveBeenCalledTimes(3);
+    expect(mockRunJobSteps).toHaveBeenCalledTimes(1);
+    expect(mockInterruptibleSleep).toHaveBeenCalledTimes(2);
+    expect(mockInterruptibleSleep.mock.invocationCallOrder[1]).toBeLessThan(
+      mockRequestJob.mock.invocationCallOrder[1] ?? Infinity,
+    );
   });
 
   it('backs off before retrying a managed assignment poll that returns no token', async () => {
@@ -552,6 +569,19 @@ describe('startRunner', () => {
 
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(2);
     expect(mockRequestJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a claimed job after shutdown during the first request', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    mockRequestJob.mockImplementation(() => {
+      process.emit('SIGTERM');
+      return Promise.resolve(JOB);
+    });
+
+    await startRunner();
+
+    expect(mockRequestJob).toHaveBeenCalledWith('session-token', expect.any(AbortSignal));
+    expect(mockRunJobSteps).not.toHaveBeenCalled();
   });
 
   it('exits cleanly when shutdown aborts the managed assignment poll', async () => {

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -401,6 +401,7 @@ describe('startRunner', () => {
 
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(1);
     expect(mockRequestJob).toHaveBeenCalledTimes(1);
+    expect(mockInterruptibleSleep).not.toHaveBeenCalled();
   });
 
   it('enrolls, waits, activates, and uses the activation session for managed runners', async () => {
@@ -439,7 +440,7 @@ describe('startRunner', () => {
       registrationToken: 'activation-token',
     });
     expect(mockRequestJob).toHaveBeenCalledWith('session-token');
-    expect(mockInterruptibleSleep).toHaveBeenCalledTimes(1);
+    expect(mockInterruptibleSleep).not.toHaveBeenCalled();
   });
 
   it('backs off before retrying a managed assignment poll that returns no token', async () => {
@@ -456,7 +457,7 @@ describe('startRunner', () => {
     await startRunner();
 
     expect(mockPollRunnerAssignment).toHaveBeenCalledTimes(2);
-    expect(mockInterruptibleSleep.mock.calls.map(([ms]) => ms)).toEqual([1, 0]);
+    expect(mockInterruptibleSleep.mock.calls.map(([ms]) => ms)).toEqual([1]);
   });
 
   it('retries a timed-out managed assignment poll and activates after a later assignment', async () => {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -87,6 +87,8 @@ export async function startRunner(): Promise<void> {
   if (startupMode === 'managed') {
     runnerSession = await initializeManagedRunnerSession();
     if (!runnerSession) return;
+  } else {
+    await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
   }
   let pollDeadline = nextPollDeadline();
 
@@ -97,7 +99,7 @@ export async function startRunner(): Promise<void> {
         logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session registered');
       }
 
-      const job = await requestJob(runnerSession.session_token);
+      const job = await requestJob(runnerSession.session_token, shutdownController.signal);
 
       if (!job) {
         if (hasPollDeadlinePassed(pollDeadline)) {
@@ -109,6 +111,8 @@ export async function startRunner(): Promise<void> {
         await interruptableSleep(withJitter(currentInterval));
         continue;
       }
+
+      if (!running) return;
 
       logger().info(
         {
@@ -124,6 +128,8 @@ export async function startRunner(): Promise<void> {
       currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
       pollDeadline = nextPollDeadline();
     } catch (pollError) {
+      if (!running) return;
+
       if (isUnauthorized(pollError)) {
         if (startupMode === 'managed') {
           logger().info('Activated runner session rejected; runner exiting');

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -88,7 +88,6 @@ export async function startRunner(): Promise<void> {
     runnerSession = await initializeManagedRunnerSession();
     if (!runnerSession) return;
   }
-  await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
   let pollDeadline = nextPollDeadline();
 
   while (running) {

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -45,7 +45,13 @@ const TOOL_CAPABILITIES: RunnerToolCapabilitiesDto = {
   },
 };
 
-let calls: Array<{url: string; method: string; authorization: string | null; body: string}>;
+let calls: Array<{
+  url: string;
+  method: string;
+  authorization: string | null;
+  body: string;
+  signal: AbortSignal;
+}>;
 let originalFetch: typeof globalThis.fetch;
 
 beforeAll(() => {
@@ -220,6 +226,17 @@ describe('api-client auth contexts', () => {
     const job = await requestJob('session-abc');
 
     expect(job).toBeNull();
+  });
+
+  it('requestJob forwards the shutdown signal to the claim request', async () => {
+    stubFetch(() => new Response(null, {status: 204}));
+    const controller = new AbortController();
+
+    await requestJob('session-abc', controller.signal);
+
+    expect(calls[0]?.signal.aborted).toBe(false);
+    controller.abort();
+    expect(calls[0]?.signal.aborted).toBe(true);
   });
 
   it('requestJob treats the session-exhausted 409 code as terminal', async () => {
@@ -970,6 +987,7 @@ function stubFetch(handler: (url: string) => Response | Promise<Response>): void
       method: request.method,
       authorization: request.headers.get('authorization'),
       body: await request.clone().text(),
+      signal: request.signal,
     });
     return handler(request.url);
   }) as unknown as typeof globalThis.fetch;

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -248,10 +248,13 @@ function createRunnerSessionClient(sessionToken: string): KyInstance {
 
 // Scheduling is step-less: the claim returns only the job/run ids and the lease
 // token. Steps are pulled one at a time from the step API using that token.
-export async function requestJob(sessionToken: string): Promise<ClaimedJobResponseDto | null> {
+export async function requestJob(
+  sessionToken: string,
+  signal?: AbortSignal,
+): Promise<ClaimedJobResponseDto | null> {
   logger().debug('Polling for job');
 
-  const response = await postJobRequest(sessionToken);
+  const response = await postJobRequest(sessionToken, signal);
 
   if (response.status === 204) {
     return null;
@@ -260,9 +263,12 @@ export async function requestJob(sessionToken: string): Promise<ClaimedJobRespon
   return claimedJobResponseSchema.parse(await response.json());
 }
 
-async function postJobRequest(sessionToken: string): Promise<Response> {
+async function postJobRequest(sessionToken: string, signal?: AbortSignal): Promise<Response> {
   try {
-    return await createRunnerSessionClient(sessionToken).post('runners/jobs/request');
+    return await createRunnerSessionClient(sessionToken).post(
+      'runners/jobs/request',
+      signal ? {signal} : undefined,
+    );
   } catch (error) {
     if (!(error instanceof HTTPError) || error.response.status !== 409) throw error;
 


### PR DESCRIPTION
Managed runner sessions now request their first job immediately after activation, while unmanaged runners retain their jittered startup stagger. The first claim observes shutdown and avoids starting a claimed job after shutdown is requested; direct idle polling retains its backoff.

Closes ENG-1527