### PR TITLE
[runner-image] Start runner lifecycle units after network readiness

### DIFF
--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -17,7 +17,15 @@ Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host ope
 
 ## Environment contract
 
-Cloud-init writes `/etc/shipfox/runner.env`. The provider owns the values and must never bake them into the image:
+The provider owns the values and must never bake them into the image. It must publish
+`/etc/shipfox/runner.env` atomically: stage the complete file at
+`/etc/shipfox/runner.env.tmp`, then rename it into place on the same filesystem. The
+image watches the final path and starts the lifecycle target when it appears, so this
+contract does not depend on cloud-init's systemd units or stage ordering. Cloud-init
+uses `write_files` for the temporary file and a final-stage `runcmd` rename; an off-cloud
+provisioner must provide the same temp-plus-rename behavior.
+
+The provider-rendered environment contains:
 
 - `SHIPFOX_API_URL`: API base URL.
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`: one-use managed-runner bootstrap token.
@@ -32,7 +40,7 @@ The image derives its tool capabilities from its baked runner runtime and sends 
 enrollment. Providers do not inject capabilities, workspace IDs, workspace registration tokens,
 or activation tokens into user data.
 
-`shipfox-runner.service` powers off immediately when the runner exits. Its SIGTERM drain budget is 90 seconds, after which systemd can force-kill the process and the backend re-reserves the job. `shipfox-max-lifetime.service` schedules a forced poweroff and falls back to a baked 3600-second limit when the configured value is missing or malformed. AWS builds also enable a Spot IMDSv2 watcher that stops the runner, allows it to drain briefly, then powers off.
+`shipfox-runner.service` powers off immediately when the runner exits. Its SIGTERM drain budget is 90 seconds, after which systemd can force-kill the process and the backend re-reserves the job. Once the environment file is published, `shipfox-max-lifetime.service` schedules a forced poweroff and falls back to a baked 3600-second limit when the configured value is missing or malformed. The configured lifetime therefore includes boot and enrollment skew and must remain comfortably above one job's maximum duration. AWS builds also enable a Spot IMDSv2 watcher that stops the runner, allows it to drain briefly, then powers off.
 
 With `InstanceInitiatedShutdownBehavior=terminate` and Spot `InstanceInterruptionBehavior=terminate`, provider-side settings convert these poweroffs into EC2 termination. The in-guest watchdog is the fast path. The durable backstop remains tagged-instance reconciliation, the backend staleness reaper, and terminate-on-shutdown because privileged job steps or a wedged kernel can defeat an in-guest timer.
 

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -21,9 +21,10 @@ The provider owns the values and must never bake them into the image. It must pu
 `/etc/shipfox/runner.env` atomically: stage the complete file at
 `/etc/shipfox/runner.env.tmp`, then rename it into place on the same filesystem. The
 image watches the final path and starts the lifecycle target when it appears, so this
-contract does not depend on cloud-init's systemd units or stage ordering. Cloud-init
-uses `write_files` for the temporary file and a final-stage `runcmd` rename; an off-cloud
-provisioner must provide the same temp-plus-rename behavior.
+contract does not depend on cloud-init's systemd units or stage ordering. The path unit
+pulls the environment gate, which in turn pulls the lifecycle target after its check
+passes. Cloud-init uses `write_files` for the temporary file and a final-stage `runcmd`
+rename; an off-cloud provisioner must provide the same temp-plus-rename behavior.
 
 The provider-rendered environment contains:
 

--- a/infra/images/runner/assets/shipfox-max-lifetime.service
+++ b/infra/images/runner/assets/shipfox-max-lifetime.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Shipfox runner hard maximum lifetime watchdog
-After=cloud-final.service shipfox-runner-env.service
-Wants=cloud-final.service
+After=network-online.target shipfox-runner-env.service
+Wants=network-online.target
 Requires=shipfox-runner-env.service
 
 [Service]
@@ -9,4 +9,4 @@ Type=oneshot
 ExecStart=/opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh
 
 [Install]
-WantedBy=cloud-init.target
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-max-lifetime.service
+++ b/infra/images/runner/assets/shipfox-max-lifetime.service
@@ -7,6 +7,3 @@ Requires=shipfox-runner-env.service
 [Service]
 Type=oneshot
 ExecStart=/opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh
-
-[Install]
-WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-runner-env.path
+++ b/infra/images/runner/assets/shipfox-runner-env.path
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start the Shipfox runner lifecycle when its environment is ready
+After=network-online.target
+Wants=network-online.target
+
+[Path]
+PathExists=/etc/shipfox/runner.env
+Unit=shipfox-runner.target
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-runner-env.path
+++ b/infra/images/runner/assets/shipfox-runner-env.path
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Path]
 PathExists=/etc/shipfox/runner.env
-Unit=shipfox-runner.target
+Unit=shipfox-runner-env.service
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Validate Shipfox runner environment file
-After=cloud-final.service
-Wants=cloud-final.service
+After=network-online.target cloud-config.service
+Wants=network-online.target cloud-config.service
 
 [Service]
 Type=oneshot

--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Validate Shipfox runner environment file
 After=network-online.target
-Wants=network-online.target
+Wants=network-online.target shipfox-runner.target
 
 [Service]
 Type=oneshot

--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Validate Shipfox runner environment file
-After=network-online.target cloud-config.service
-Wants=network-online.target cloud-config.service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Shipfox platform runner
-After=cloud-final.service shipfox-runner-env.service
-Wants=cloud-final.service
+After=network-online.target shipfox-runner-env.service
+Wants=network-online.target
 Requires=shipfox-runner-env.service
 SuccessAction=poweroff-immediate
 FailureAction=poweroff-immediate
@@ -22,4 +22,4 @@ StandardError=journal
 SyslogIdentifier=shipfox-runner
 
 [Install]
-WantedBy=cloud-init.target
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Shipfox platform runner
-After=network-online.target shipfox-runner-env.service
+After=network-online.target time-sync.target shipfox-runner-env.service
 Wants=network-online.target
 Requires=shipfox-runner-env.service
 SuccessAction=poweroff-immediate
@@ -20,6 +20,3 @@ TimeoutStopSec=90s
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=shipfox-runner
-
-[Install]
-WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Shipfox platform runner
 After=network-online.target time-sync.target shipfox-runner-env.service
-Wants=network-online.target
+Wants=network-online.target time-sync.target
 Requires=shipfox-runner-env.service
 SuccessAction=poweroff-immediate
 FailureAction=poweroff-immediate

--- a/infra/images/runner/assets/shipfox-runner.target
+++ b/infra/images/runner/assets/shipfox-runner.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Shipfox runner lifecycle
+After=network-online.target shipfox-runner-env.service
+Wants=network-online.target shipfox-runner.service shipfox-max-lifetime.service
+Requires=shipfox-runner-env.service

--- a/infra/images/runner/assets/shipfox-spot-watchdog.service
+++ b/infra/images/runner/assets/shipfox-spot-watchdog.service
@@ -10,4 +10,4 @@ Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy=cloud-init.target
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-spot-watchdog.service
+++ b/infra/images/runner/assets/shipfox-spot-watchdog.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Shipfox runner Spot interruption watchdog
-After=network-online.target shipfox-runner.service
+After=network-online.target shipfox-runner.service shipfox-runner-env.service
 Wants=network-online.target
+Requires=shipfox-runner-env.service
 
 [Service]
 Type=simple
@@ -10,4 +11,4 @@ Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=shipfox-runner.target

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -30,13 +30,15 @@ build {
   provisioner "shell" {
     inline = [
       "sudo install -d -m 0755 /etc/shipfox /opt/shipfox-runner/scripts/runtime/helpers",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.target /etc/systemd/system/shipfox-runner.target",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.path /etc/systemd/system/shipfox-runner-env.path",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.service /etc/systemd/system/shipfox-runner.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",
       "sudo systemctl daemon-reload",
-      "sudo systemctl enable shipfox-runner.service shipfox-max-lifetime.service"
+      "sudo systemctl enable shipfox-runner-env.path"
     ]
   }
 

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -843,7 +843,7 @@ describe('spot watchdog runtime script', () => {
 });
 
 describe('systemd boot activation', () => {
-  it('activates every installable Shipfox service after cloud-init', async () => {
+  it('activates every installable Shipfox service after network readiness', async () => {
     const assets = new URL('../assets/', import.meta.url);
     const unitNames = (await readdir(assets)).filter((name) => name.endsWith('.service'));
 
@@ -851,7 +851,21 @@ describe('systemd boot activation', () => {
       const unit = await readFile(new URL(unitName, assets), 'utf8');
       if (!unit.includes('[Install]')) continue;
 
-      expect(unit, unitName).toContain('WantedBy=cloud-init.target');
+      expect(unit, unitName).toContain('After=network-online.target');
+      expect(unit, unitName).toContain('Wants=network-online.target');
+      expect(unit, unitName).toContain('WantedBy=multi-user.target');
+      expect(unit, unitName).not.toContain('cloud-final.service');
     }
+  });
+
+  it('validates runner environment after cloud-config without waiting for cloud-final', async () => {
+    const unit = await readFile(
+      new URL('../assets/shipfox-runner-env.service', import.meta.url),
+      'utf8',
+    );
+
+    expect(unit).toContain('After=network-online.target cloud-config.service');
+    expect(unit).toContain('Wants=network-online.target cloud-config.service');
+    expect(unit).not.toContain('cloud-final.service');
   });
 });

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -886,16 +886,19 @@ describe('systemd boot activation', () => {
       {
         name: 'shipfox-runner.service',
         after: 'network-online.target time-sync.target shipfox-runner-env.service',
+        wants: 'network-online.target time-sync.target',
         wantedBy: undefined,
       },
       {
         name: 'shipfox-max-lifetime.service',
         after: 'network-online.target shipfox-runner-env.service',
+        wants: 'network-online.target',
         wantedBy: undefined,
       },
       {
         name: 'shipfox-spot-watchdog.service',
         after: 'network-online.target shipfox-runner.service shipfox-runner-env.service',
+        wants: 'network-online.target',
         wantedBy: 'shipfox-runner.target',
       },
     ] as const;
@@ -904,9 +907,7 @@ describe('systemd boot activation', () => {
       const unit = await readUnit(expectation.name);
 
       expect(systemdDirective(unit, 'Unit', 'After'), expectation.name).toBe(expectation.after);
-      expect(systemdDirective(unit, 'Unit', 'Wants'), expectation.name).toBe(
-        'network-online.target',
-      );
+      expect(systemdDirective(unit, 'Unit', 'Wants'), expectation.name).toBe(expectation.wants);
       expect(systemdDirective(unit, 'Unit', 'Requires'), expectation.name).toBe(
         'shipfox-runner-env.service',
       );

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -867,7 +867,7 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe('network-online.target');
     expect(systemdDirective(pathUnit, 'Unit', 'Wants')).toBe('network-online.target');
     expect(systemdDirective(pathUnit, 'Path', 'PathExists')).toBe('/etc/shipfox/runner.env');
-    expect(systemdDirective(pathUnit, 'Path', 'Unit')).toBe('shipfox-runner.target');
+    expect(systemdDirective(pathUnit, 'Path', 'Unit')).toBe('shipfox-runner-env.service');
     expect(systemdDirective(pathUnit, 'Install', 'WantedBy')).toBe('multi-user.target');
     expect(pathUnit).not.toContain('cloud-config.service');
     expect(pathUnit).not.toContain('cloud-final.service');
@@ -922,7 +922,9 @@ describe('systemd boot activation', () => {
     const unit = await readUnit('shipfox-runner-env.service');
 
     expect(systemdDirective(unit, 'Unit', 'After')).toBe('network-online.target');
-    expect(systemdDirective(unit, 'Unit', 'Wants')).toBe('network-online.target');
+    expect(systemdDirective(unit, 'Unit', 'Wants')).toBe(
+      'network-online.target shipfox-runner.target',
+    );
     expect(systemdDirective(unit, 'Service', 'Type')).toBe('oneshot');
     expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
       '/usr/bin/test -s /etc/shipfox/runner.env',

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,5 +1,5 @@
 import {execFileSync} from 'node:child_process';
-import {readdir, readFile} from 'node:fs/promises';
+import {readFile} from 'node:fs/promises';
 import {findProducedAmiId, parsePackerAmiArtifact} from '#aws.js';
 import {parseBuildRunnerImageArgs} from '#build-runner-image.js';
 import {buildRunnerImageCandidate, parseRunnerImageCandidateArgs} from '#candidate.js';
@@ -842,30 +842,94 @@ describe('spot watchdog runtime script', () => {
   });
 });
 
+function systemdSection(unit: string, section: string): string | undefined {
+  return unit.match(new RegExp(`\\[${section}\\]\\n([\\s\\S]*?)(?=\\n\\[[^\\n]+\\]|$)`))?.[1];
+}
+
+function systemdDirective(unit: string, section: string, name: string): string | undefined {
+  const sectionBody = systemdSection(unit, section);
+  if (!sectionBody) return undefined;
+  const line = sectionBody.split('\n').find((candidate) => candidate.startsWith(`${name}=`));
+  return line?.slice(name.length + 1);
+}
+
 describe('systemd boot activation', () => {
-  it('activates every installable Shipfox service after network readiness', async () => {
-    const assets = new URL('../assets/', import.meta.url);
-    const unitNames = (await readdir(assets)).filter((name) => name.endsWith('.service'));
+  const assets = new URL('../assets/', import.meta.url);
 
-    for (const unitName of unitNames) {
-      const unit = await readFile(new URL(unitName, assets), 'utf8');
-      if (!unit.includes('[Install]')) continue;
+  function readUnit(name: string): Promise<string> {
+    return readFile(new URL(name, assets), 'utf8');
+  }
 
-      expect(unit, unitName).toContain('After=network-online.target');
-      expect(unit, unitName).toContain('Wants=network-online.target');
-      expect(unit, unitName).toContain('WantedBy=multi-user.target');
-      expect(unit, unitName).not.toContain('cloud-final.service');
+  it('starts the lifecycle target when the complete environment file appears', async () => {
+    const pathUnit = await readUnit('shipfox-runner-env.path');
+    const targetUnit = await readUnit('shipfox-runner.target');
+
+    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe('network-online.target');
+    expect(systemdDirective(pathUnit, 'Unit', 'Wants')).toBe('network-online.target');
+    expect(systemdDirective(pathUnit, 'Path', 'PathExists')).toBe('/etc/shipfox/runner.env');
+    expect(systemdDirective(pathUnit, 'Path', 'Unit')).toBe('shipfox-runner.target');
+    expect(systemdDirective(pathUnit, 'Install', 'WantedBy')).toBe('multi-user.target');
+    expect(pathUnit).not.toContain('cloud-config.service');
+    expect(pathUnit).not.toContain('cloud-final.service');
+
+    expect(systemdDirective(targetUnit, 'Unit', 'After')).toBe(
+      'network-online.target shipfox-runner-env.service',
+    );
+    expect(systemdDirective(targetUnit, 'Unit', 'Wants')).toBe(
+      'network-online.target shipfox-runner.service shipfox-max-lifetime.service',
+    );
+    expect(systemdDirective(targetUnit, 'Unit', 'Requires')).toBe('shipfox-runner-env.service');
+  });
+
+  it('keeps lifecycle units behind the fail-closed environment gate', async () => {
+    const expectations = [
+      {
+        name: 'shipfox-runner.service',
+        after: 'network-online.target time-sync.target shipfox-runner-env.service',
+        wantedBy: undefined,
+      },
+      {
+        name: 'shipfox-max-lifetime.service',
+        after: 'network-online.target shipfox-runner-env.service',
+        wantedBy: undefined,
+      },
+      {
+        name: 'shipfox-spot-watchdog.service',
+        after: 'network-online.target shipfox-runner.service shipfox-runner-env.service',
+        wantedBy: 'shipfox-runner.target',
+      },
+    ] as const;
+
+    for (const expectation of expectations) {
+      const unit = await readUnit(expectation.name);
+
+      expect(systemdDirective(unit, 'Unit', 'After'), expectation.name).toBe(expectation.after);
+      expect(systemdDirective(unit, 'Unit', 'Wants'), expectation.name).toBe(
+        'network-online.target',
+      );
+      expect(systemdDirective(unit, 'Unit', 'Requires'), expectation.name).toBe(
+        'shipfox-runner-env.service',
+      );
+      expect(systemdDirective(unit, 'Install', 'WantedBy'), expectation.name).toBe(
+        expectation.wantedBy,
+      );
+      expect(unit, expectation.name).not.toContain('cloud-config.service');
+      expect(unit, expectation.name).not.toContain('cloud-final.service');
     }
   });
 
-  it('validates runner environment after cloud-config without waiting for cloud-final', async () => {
-    const unit = await readFile(
-      new URL('../assets/shipfox-runner-env.service', import.meta.url),
-      'utf8',
-    );
+  it('keeps the environment gate as a persistent non-empty-file check', async () => {
+    const unit = await readUnit('shipfox-runner-env.service');
 
-    expect(unit).toContain('After=network-online.target cloud-config.service');
-    expect(unit).toContain('Wants=network-online.target cloud-config.service');
+    expect(systemdDirective(unit, 'Unit', 'After')).toBe('network-online.target');
+    expect(systemdDirective(unit, 'Unit', 'Wants')).toBe('network-online.target');
+    expect(systemdDirective(unit, 'Service', 'Type')).toBe('oneshot');
+    expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
+      '/usr/bin/test -s /etc/shipfox/runner.env',
+    );
+    expect(systemdDirective(unit, 'Service', 'RemainAfterExit')).toBe('yes');
+    expect(systemdDirective(unit, 'Install', 'WantedBy')).toBeUndefined();
+    expect(unit).not.toContain('cloud-config.service');
     expect(unit).not.toContain('cloud-final.service');
   });
 });

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -13,12 +13,12 @@ const options: RunnerBootstrapUserDataOptions = {
 };
 
 describe('renderRunnerBootstrapUserData', () => {
-  it('writes the managed runner environment contract for cloud-init', () => {
+  it('atomically publishes the managed runner environment contract for cloud-init', () => {
     const userData = renderRunnerBootstrapUserData(options);
 
     expect(userData).toBe(`#cloud-config
 write_files:
-  - path: /etc/shipfox/runner.env
+  - path: /etc/shipfox/runner.env.tmp
     owner: root:root
     permissions: '0600'
     content: |
@@ -29,6 +29,8 @@ write_files:
       SHIPFOX_RUNNER_LABELS="linux,x64,self-hosted"
       SHIPFOX_POLL_MAX_DURATION_MS="300000"
       SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS="3600"
+runcmd:
+  - ['/usr/bin/mv', '--', /etc/shipfox/runner.env.tmp, /etc/shipfox/runner.env]
 `);
   });
 

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -1,5 +1,6 @@
 const CLOUD_INIT_HEADER = '#cloud-config';
 const RUNNER_ENV_PATH = '/etc/shipfox/runner.env';
+const RUNNER_ENV_TEMP_PATH = '/etc/shipfox/runner.env.tmp';
 
 /** Values written into the runner image environment file at EC2 boot. */
 export interface RunnerBootstrapUserDataOptions {
@@ -34,8 +35,9 @@ interface RunnerBootstrapEnvironment {
 
 /**
  * Renders the cloud-init configuration consumed by the prebaked Shipfox runner image.
- * The image's environment gate waits for cloud-config to write this file before lifecycle
- * units start from the network-ready multi-user target. No workspace-scoped credential is included.
+ * Cloud-init stages the file under a temporary path and atomically renames it into place;
+ * the image's path unit starts the lifecycle target when the final path appears. No
+ * workspace-scoped credential is included.
  */
 export function renderRunnerBootstrapUserData(options: RunnerBootstrapUserDataOptions): string {
   const environment = runnerBootstrapEnvironment(options);
@@ -45,11 +47,13 @@ export function renderRunnerBootstrapUserData(options: RunnerBootstrapUserDataOp
 
   return `${CLOUD_INIT_HEADER}
 write_files:
-  - path: ${RUNNER_ENV_PATH}
+  - path: ${RUNNER_ENV_TEMP_PATH}
     owner: root:root
     permissions: '0600'
     content: |
 ${indent(envFile, 6)}
+runcmd:
+  - ['/usr/bin/mv', '--', ${RUNNER_ENV_TEMP_PATH}, ${RUNNER_ENV_PATH}]
 `;
 }
 

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -34,8 +34,8 @@ interface RunnerBootstrapEnvironment {
 
 /**
  * Renders the cloud-init configuration consumed by the prebaked Shipfox runner image.
- * The runner image starts its systemd units after cloud-init and reads the environment
- * file written here. No workspace-scoped credential is included.
+ * The image's environment gate waits for cloud-config to write this file before lifecycle
+ * units start from the network-ready multi-user target. No workspace-scoped credential is included.
  */
 export function renderRunnerBootstrapUserData(options: RunnerBootstrapUserDataOptions): string {
   const environment = runnerBootstrapEnvironment(options);


### PR DESCRIPTION
The runner image now starts its lifecycle target from a systemd path unit when `/etc/shipfox/runner.env` appears. Provisioner user data stages the complete environment in a temporary file and atomically renames it into place, removing the cloud-init service-ordering dependency. Runner, max-lifetime, and Spot units remain behind the persistent fail-closed environment gate, and the runner keeps the time-sync barrier.

Per-unit boot-contract tests and the runner-image documentation cover the path trigger, dependency chain, atomic temp-plus-rename contract, and boot/enrollment skew for the lifetime bound.

Validation passed locally with runner-image and EC2 provider tests/checks, the affected Turbo graphs (161 and 87 tasks), Packer verification, and `git diff --check`. The documented EC2 recovery drill remains pending: this macOS workspace lacks QEMU, xorriso, and `systemd-analyze`, and no AWS resources were launched. The automated QEMU boot/watchdog suite is tracked by ENG-1022.

Refs ENG-1526