### PR TITLE
[runner-image] Apply faster boot settings to runner images

### DIFF
--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -15,6 +15,14 @@ The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `eu-c
 
 Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host operating system before running a QEMU build.
 
+## Boot behavior
+
+The image is checked during the bake and launched with a fresh ephemeral root volume. The image skips boot-time filesystem checks, applies `noatime` to `/` and `/boot`, and sets pass 0 for `/boot` and `/boot/efi`.
+
+`fsck.mode=skip` also suppresses checks for other filesystems with a non-zero pass number. Do not add a durable filesystem with a non-zero pass number without revisiting this image contract.
+
+The IPv6 duplicate-address detection setting is a drop-in for the netplan-generated primary interface configuration. Netplan remains responsible for DHCP, addresses, routes, and online requirements.
+
 ## Environment contract
 
 The provider owns the values and must never bake them into the image. It must publish

--- a/infra/images/runner/assets/shipfox-runner.network
+++ b/infra/images/runner/assets/shipfox-runner.network
@@ -1,9 +1,0 @@
-[Match]
-Name=eth* en*
-
-[Network]
-DHCP=yes
-IPv6DuplicateAddressDetection=0
-
-[Link]
-RequiredForOnline=yes

--- a/infra/images/runner/assets/shipfox-runner.network
+++ b/infra/images/runner/assets/shipfox-runner.network
@@ -1,0 +1,9 @@
+[Match]
+Name=eth* en*
+
+[Network]
+DHCP=yes
+IPv6DuplicateAddressDetection=0
+
+[Link]
+RequiredForOnline=yes

--- a/infra/images/runner/assets/shipfox-runner.networkd.conf
+++ b/infra/images/runner/assets/shipfox-runner.networkd.conf
@@ -1,0 +1,2 @@
+[Network]
+IPv6DuplicateAddressDetection=0

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -30,11 +30,27 @@ build {
 
   provisioner "shell" {
     inline = [
+      "sudo install -d -m 0755 /etc/systemd/network/10-netplan-ens5.network.d",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-ens5.network.d/99-shipfox-runner.conf"
+    ]
+    only = ["amazon-ebs.build_image"]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo install -d -m 0755 /etc/systemd/network/10-netplan-ens3.network.d /etc/systemd/network/10-netplan-enp1s0.network.d /etc/systemd/network/10-netplan-eth0.network.d",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-ens3.network.d/99-shipfox-runner.conf",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-enp1s0.network.d/99-shipfox-runner.conf",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-eth0.network.d/99-shipfox-runner.conf"
+    ]
+    only = ["qemu.build_image"]
+  }
+
+  provisioner "shell" {
+    inline = [
       "sudo install -d -m 0755 /etc/shipfox /opt/shipfox-runner/scripts/runtime/helpers",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.target /etc/systemd/system/shipfox-runner.target",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.path /etc/systemd/system/shipfox-runner-env.path",
-      "sudo install -d -m 0755 /etc/systemd/network",
-      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.network /etc/systemd/network/05-shipfox-runner.network",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.service /etc/systemd/system/shipfox-runner.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -18,7 +18,8 @@ build {
     scripts = [
       "${path.root}/scripts/build/setup-runner.sh",
       "${path.root}/scripts/build/install-node.sh",
-      "${path.root}/scripts/build/install-runner.sh"
+      "${path.root}/scripts/build/install-runner.sh",
+      "${path.root}/scripts/build/configure-boot.sh"
     ]
   }
 
@@ -32,6 +33,8 @@ build {
       "sudo install -d -m 0755 /etc/shipfox /opt/shipfox-runner/scripts/runtime/helpers",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.target /etc/systemd/system/shipfox-runner.target",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.path /etc/systemd/system/shipfox-runner-env.path",
+      "sudo install -d -m 0755 /etc/systemd/network",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.network /etc/systemd/network/05-shipfox-runner.network",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.service /etc/systemd/system/shipfox-runner.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",

--- a/infra/images/runner/scripts/build/configure-boot.sh
+++ b/infra/images/runner/scripts/build/configure-boot.sh
@@ -1,39 +1,51 @@
 #!/usr/bin/env sh
 set -eu
 
-grub_defaults=/etc/default/grub
-if ! grep -Eq '^[^#]*fsck\.mode=skip' "$grub_defaults"; then
-  if grep -Eq '^GRUB_CMDLINE_LINUX_DEFAULT=' "$grub_defaults"; then
-    sed -i -E 's/^(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*)"/\1 fsck.mode=skip"/' "$grub_defaults"
-  else
-    printf '%s\n' 'GRUB_CMDLINE_LINUX_DEFAULT="fsck.mode=skip"' >> "$grub_defaults"
-  fi
-fi
+root_dir=${RUNNER_IMAGE_ROOT:-/}
+grub_dropin_dir="$root_dir/etc/default/grub.d"
+grub_dropin="$grub_dropin_dir/zz-shipfox-runner.cfg"
+grub_config="$root_dir/boot/grub/grub.cfg"
+fstab="$root_dir/etc/fstab"
+
+install -d -m 0755 "$grub_dropin_dir"
+printf '%s\n' 'GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-} fsck.mode=skip"' > "$grub_dropin"
 update-grub
+
+if [ ! -r "$grub_config" ] || ! grep -Eq '(^|[[:space:]])fsck\.mode=skip([[:space:]]|$)' "$grub_config"; then
+  printf '%s\n' 'configure-boot: regenerated grub.cfg does not contain fsck.mode=skip' >&2
+  exit 1
+fi
 
 # The image is checked during the bake; running root fsck on every ephemeral boot
 # only adds latency and cannot repair a durable runner volume.
 systemctl mask systemd-fsck-root.service
 
-fstab=/etc/fstab
 temporary_fstab="$(mktemp)"
 trap 'rm -f "$temporary_fstab"' EXIT
 awk '
-function add_option(options, option, values, count, index) {
+function fail(message) {
+  print "configure-boot: " message > "/dev/stderr"
+  exit 1
+}
+
+function add_option(options, option, values, count, i) {
   count = split(options, values, ",")
-  for (index = 1; index <= count; index++) {
-    if (values[index] == option) return options
+  for (i = 1; i <= count; i++) {
+    if (values[i] == option) return options
   }
   return options == "" ? option : options "," option
 }
 
-/^[[:space:]]*#/ || NF < 4 {
+/^[[:space:]]*#/ || NF == 0 {
   print
   next
 }
 
 {
   changed = 0
+  if ($2 == "/" || $2 == "/boot" || $2 == "/boot/efi") {
+    if (NF < 6) fail("expected six fields for fstab mount " $2)
+  }
   if ($2 == "/" || $2 == "/boot") {
     $4 = add_option($4, "noatime")
     changed = 1
@@ -43,7 +55,7 @@ function add_option(options, option, values, count, index) {
     changed = 1
   }
   if (changed) {
-    print $1, $2, $3, $4, $5, $6
+    print
   } else {
     print
   }

--- a/infra/images/runner/scripts/build/configure-boot.sh
+++ b/infra/images/runner/scripts/build/configure-boot.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+set -eu
+
+grub_defaults=/etc/default/grub
+if ! grep -Eq '^[^#]*fsck\.mode=skip' "$grub_defaults"; then
+  if grep -Eq '^GRUB_CMDLINE_LINUX_DEFAULT=' "$grub_defaults"; then
+    sed -i -E 's/^(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*)"/\1 fsck.mode=skip"/' "$grub_defaults"
+  else
+    printf '%s\n' 'GRUB_CMDLINE_LINUX_DEFAULT="fsck.mode=skip"' >> "$grub_defaults"
+  fi
+fi
+update-grub
+
+# The image is checked during the bake; running root fsck on every ephemeral boot
+# only adds latency and cannot repair a durable runner volume.
+systemctl mask systemd-fsck-root.service
+
+fstab=/etc/fstab
+temporary_fstab="$(mktemp)"
+trap 'rm -f "$temporary_fstab"' EXIT
+awk '
+function add_option(options, option, values, count, index) {
+  count = split(options, values, ",")
+  for (index = 1; index <= count; index++) {
+    if (values[index] == option) return options
+  }
+  return options == "" ? option : options "," option
+}
+
+/^[[:space:]]*#/ || NF < 4 {
+  print
+  next
+}
+
+{
+  changed = 0
+  if ($2 == "/" || $2 == "/boot") {
+    $4 = add_option($4, "noatime")
+    changed = 1
+  }
+  if ($2 == "/boot" || $2 == "/boot/efi") {
+    $6 = 0
+    changed = 1
+  }
+  if (changed) {
+    print $1, $2, $3, $4, $5, $6
+  } else {
+    print
+  }
+}
+' "$fstab" > "$temporary_fstab"
+install -m 0644 "$temporary_fstab" "$fstab"

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -936,3 +936,31 @@ describe('systemd boot activation', () => {
     expect(unit).not.toContain('cloud-final.service');
   });
 });
+
+describe('runner boot configuration', () => {
+  it('applies the filesystem and fsck boot settings during the image build', async () => {
+    const script = await readFile(
+      new URL('../scripts/build/configure-boot.sh', import.meta.url),
+      'utf8',
+    );
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+
+    expect(script).toContain('fsck.mode=skip');
+    expect(script).toContain('systemd-fsck-root.service');
+    expect(script).toContain('noatime');
+    expect(build).toContain('scripts/build/configure-boot.sh');
+  });
+
+  it('disables IPv6 duplicate-address detection for runner interfaces', async () => {
+    const network = await readFile(
+      new URL('../assets/shipfox-runner.network', import.meta.url),
+      'utf8',
+    );
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+
+    expect(network).toContain('Name=eth* en*');
+    expect(network).toContain('DHCP=yes');
+    expect(network).toContain('IPv6DuplicateAddressDetection=0');
+    expect(build).toContain('05-shipfox-runner.network');
+  });
+});

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,5 +1,7 @@
 import {execFileSync} from 'node:child_process';
-import {readFile} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {findProducedAmiId, parsePackerAmiArtifact} from '#aws.js';
 import {parseBuildRunnerImageArgs} from '#build-runner-image.js';
 import {buildRunnerImageCandidate, parseRunnerImageCandidateArgs} from '#candidate.js';
@@ -938,29 +940,121 @@ describe('systemd boot activation', () => {
 });
 
 describe('runner boot configuration', () => {
-  it('applies the filesystem and fsck boot settings during the image build', async () => {
-    const script = await readFile(
-      new URL('../scripts/build/configure-boot.sh', import.meta.url),
-      'utf8',
-    );
-    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+  const script = new URL('../scripts/build/configure-boot.sh', import.meta.url);
 
-    expect(script).toContain('fsck.mode=skip');
-    expect(script).toContain('systemd-fsck-root.service');
-    expect(script).toContain('noatime');
-    expect(build).toContain('scripts/build/configure-boot.sh');
+  it('applies filesystem and fsck settings against a checked image fixture', async () => {
+    const fstab = `# fstab
+UUID=root / ext4 defaults 0 1
+UUID=boot /boot ext4 defaults 0 1 extra-column
+UUID=efi /boot/efi vfat defaults 0 1
+UUID=data /data ext4 defaults 0 2
+`;
+    const fixture = await createBootFixture(fstab);
+
+    try {
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+
+      expect(await readFile(join(fixture.root, 'boot/grub/grub.cfg'), 'utf8')).toContain(
+        'fsck.mode=skip',
+      );
+      expect(await readFile(join(fixture.root, 'etc/systemd/systemctl.log'), 'utf8')).toBe(
+        'mask systemd-fsck-root.service\nmask systemd-fsck-root.service\n',
+      );
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(`# fstab
+UUID=root / ext4 defaults,noatime 0 1
+UUID=boot /boot ext4 defaults,noatime 0 0 extra-column
+UUID=efi /boot/efi vfat defaults 0 0
+UUID=data /data ext4 defaults 0 2
+`);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
   });
 
-  it('disables IPv6 duplicate-address detection for runner interfaces', async () => {
+  it('fails before publishing an image when a target fstab entry is malformed', async () => {
+    const fstab = 'UUID=root / ext4 defaults\n';
+    const fixture = await createBootFixture(fstab);
+
+    try {
+      expect(() =>
+        execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
+      ).toThrow();
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(fstab);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('installs IPv6 tuning as primary-interface netplan drop-ins', async () => {
     const network = await readFile(
-      new URL('../assets/shipfox-runner.network', import.meta.url),
+      new URL('../assets/shipfox-runner.networkd.conf', import.meta.url),
       'utf8',
     );
     const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
 
-    expect(network).toContain('Name=eth* en*');
-    expect(network).toContain('DHCP=yes');
-    expect(network).toContain('IPv6DuplicateAddressDetection=0');
-    expect(build).toContain('05-shipfox-runner.network');
+    expect(network).toBe('[Network]\nIPv6DuplicateAddressDetection=0\n');
+    expect(build).toContain('10-netplan-ens5.network.d/99-shipfox-runner.conf');
+    expect(build).toContain('10-netplan-ens3.network.d/99-shipfox-runner.conf');
+    expect(build).toContain('10-netplan-enp1s0.network.d/99-shipfox-runner.conf');
+    expect(build).toContain('10-netplan-eth0.network.d/99-shipfox-runner.conf');
+    expect(build).not.toContain('DHCP=yes');
+    expect(build).not.toContain('RequiredForOnline=yes');
+    expect(build).not.toContain('05-shipfox-runner.network');
   });
 });
+
+async function createBootFixture(fstab: string) {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-boot-'));
+  const commandDirectory = join(root, 'commands');
+
+  await mkdir(join(root, 'boot/grub'), {recursive: true});
+  await mkdir(join(root, 'etc/default/grub.d'), {recursive: true});
+  await mkdir(join(root, 'etc/systemd'), {recursive: true});
+  await mkdir(commandDirectory, {recursive: true});
+  await writeFile(join(root, 'etc/default/grub'), 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1"\n');
+  await writeFile(
+    join(root, 'etc/default/grub.d/50-cloudimg-settings.cfg'),
+    `GRUB_CMDLINE_LINUX_DEFAULT="\${GRUB_CMDLINE_LINUX_DEFAULT} console=ttyS0"\n`,
+  );
+  await writeFile(join(root, 'etc/fstab'), fstab);
+  await writeFile(
+    join(commandDirectory, 'update-grub'),
+    [
+      '#!/bin/sh',
+      'set -eu',
+      `root_dir=\${RUNNER_IMAGE_ROOT:?}`,
+      '. "$root_dir/etc/default/grub"',
+      'for dropin in "$root_dir"/etc/default/grub.d/*.cfg; do',
+      '  [ -e "$dropin" ] || continue',
+      '  . "$dropin"',
+      'done',
+      `printf "%s\\n" "linux \${GRUB_CMDLINE_LINUX_DEFAULT-}" > "$root_dir/boot/grub/grub.cfg"`,
+      '',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(commandDirectory, 'systemctl'),
+    [
+      '#!/bin/sh',
+      'set -eu',
+      `root_dir=\${RUNNER_IMAGE_ROOT:?}`,
+      '[ "$#" -eq 2 ]',
+      '[ "$1" = mask ]',
+      '[ "$2" = systemd-fsck-root.service ]',
+      'printf "%s\\n" "$*" >> "$root_dir/etc/systemd/systemctl.log"',
+      '',
+    ].join('\n'),
+  );
+  await chmod(join(commandDirectory, 'update-grub'), 0o755);
+  await chmod(join(commandDirectory, 'systemctl'), 0o755);
+
+  return {
+    root,
+    environment: {
+      ...process.env,
+      PATH: `${commandDirectory}:${process.env.PATH ?? ''}`,
+      RUNNER_IMAGE_ROOT: root,
+    },
+  };
+}

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,5 +1,5 @@
 import {execFileSync} from 'node:child_process';
-import {chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {findProducedAmiId, parsePackerAmiArtifact} from '#aws.js';
@@ -950,11 +950,13 @@ UUID=efi /boot/efi vfat defaults 0 1
 UUID=data /data ext4 defaults 0 2
 `;
     const fixture = await createBootFixture(fstab);
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
 
     try {
       execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
       execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
 
+      expect(build).toContain('scripts/build/configure-boot.sh');
       expect(await readFile(join(fixture.root, 'boot/grub/grub.cfg'), 'utf8')).toContain(
         'fsck.mode=skip',
       );


### PR DESCRIPTION
Runner images currently perform filesystem checks and IPv6 duplicate-address detection during every ephemeral boot, adding avoidable startup latency.

This change applies the boot-time settings while baking the runner image so newly launched runners skip repeated filesystem checks and avoid network address-detection delay.

Validated locally with:
- `mise exec -- turbo check --filter=@shipfox/runner-image`
- `mise exec -- turbo type --filter=@shipfox/runner-image`
- `mise exec -- turbo test --filter=@shipfox/runner-image`
- `mise exec -- pnpm --filter=@shipfox/runner-image verify`
- `mise exec -- sh -n infra/images/runner/scripts/build/configure-boot.sh`
- `git diff --check`

Closes ENG-1532

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce cold-boot time by skipping filesystem checks and IPv6 duplicate-address detection. Settings are applied at image bake via `configure-boot.sh` and systemd-networkd drop-ins to satisfy ENG-1532.

- **New Features**
  - Add `fsck.mode=skip` via GRUB drop-in; regenerate and verify `grub.cfg`; mask `systemd-fsck-root.service`; keep configure-boot provisioner wired via test.
  - Tune `fstab`: add `noatime` to `/` and `/boot`; set pass 0 for `/boot` and `/boot/efi`; preserve fields; validate (fail on malformed); idempotent.
  - Disable IPv6 DAD with networkd drop-ins for `ens5`, `ens3`, `enp1s0`, `eth0`; netplan stays owner (no DHCP/online flags, no new `.network`).

<sup>Written for commit d7c87f3cc2a245fb6fa2ea7f69c8515dae91bb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

