### PR TITLE
[provisioner-ec2-provider] Add EC2 launch lifecycle duration metrics

### DIFF
--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -6,6 +6,12 @@ import {
 import {createEc2Engine, type RunInstanceArgs} from '#ec2-engine.js';
 import {SHIPFOX_TAGS} from '#instance-identity.js';
 
+const observability = vi.hoisted(() => ({recordEc2LaunchDuration: vi.fn()}));
+
+vi.mock('#metrics/instance.js', () => ({
+  recordEc2LaunchDuration: observability.recordEc2LaunchDuration,
+}));
+
 const runArgs: RunInstanceArgs = {
   clientToken: 'runner-1',
   tags: {
@@ -26,6 +32,10 @@ const runArgs: RunInstanceArgs = {
 };
 
 describe('createEc2Engine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('runs one atomically tagged instance with launch settings', async () => {
     const ec2 = fakeEc2();
     const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
@@ -141,6 +151,34 @@ describe('createEc2Engine', () => {
       tags: {Name: 'runner-1'},
       state: 'pending',
       launchTime: new Date('2026-07-18T12:00:00.000Z'),
+    });
+  });
+
+  it('records the RunInstances duration with returned instance labels', async () => {
+    const ec2 = fakeEc2({
+      runOutput: {
+        Instances: [
+          instance({
+            Architecture: 'arm64',
+            Placement: {AvailabilityZone: 'eu-west-3b'},
+          }),
+        ],
+      },
+    });
+    const now = vi.fn().mockReturnValueOnce(1_000).mockReturnValueOnce(1_750);
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never, now});
+
+    await engine.runInstance({
+      ...runArgs,
+      tags: {...runArgs.tags, [SHIPFOX_TAGS.templateKey]: 'arm-small'},
+    });
+
+    expect(observability.recordEc2LaunchDuration).toHaveBeenCalledWith({
+      durationMs: 750,
+      templateKey: 'arm-small',
+      market: 'on-demand',
+      architecture: 'arm64',
+      availabilityZone: 'eu-west-3b',
     });
   });
 

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -7,6 +7,7 @@ import {
   TerminateInstancesCommand,
 } from '@aws-sdk/client-ec2';
 import {SHIPFOX_TAGS} from '#instance-identity.js';
+import {type Ec2Architecture, recordEc2LaunchDuration} from '#metrics/instance.js';
 import type {Ec2Market} from '#templates.js';
 
 const TRANSIENT_REASONS = new Set<Ec2EngineErrorReason>([
@@ -53,6 +54,8 @@ export interface Ec2InstanceView {
   readonly instanceId: string;
   readonly tags: Readonly<Record<string, string>>;
   readonly state: Ec2InstanceState;
+  readonly architecture?: Ec2Architecture;
+  readonly availabilityZone?: string;
   readonly stateTransitionReason?: string;
   readonly stateReasonCode?: string;
   readonly stateReasonMessage?: string;
@@ -84,13 +87,16 @@ export interface Ec2Engine {
 export interface CreateEc2EngineOptions {
   readonly region: string;
   readonly client?: EC2Client;
+  readonly now?: () => number;
 }
 
 export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
   const client = options.client ?? new EC2Client({region: options.region});
+  const now = options.now ?? (() => Date.now());
 
   return {
     async runInstance(args) {
+      const startedAt = now();
       try {
         const output = await client.send(
           new RunInstancesCommand({
@@ -143,11 +149,27 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
             ...(args.userData ? {UserData: Buffer.from(args.userData).toString('base64')} : {}),
           }),
         );
+        const completedAt = now();
         const instance = output.Instances?.[0];
         if (!instance)
           throw new Ec2EngineError('unknown', 'EC2 did not return a launched instance.');
-        return toInstanceView(instance);
+        const view = toInstanceView(instance);
+        recordEc2LaunchDuration({
+          durationMs: completedAt - startedAt,
+          templateKey: args.tags[SHIPFOX_TAGS.templateKey] ?? 'unknown',
+          market: args.market,
+          architecture: view.architecture ?? 'unknown',
+          availabilityZone: view.availabilityZone ?? 'unknown',
+        });
+        return view;
       } catch (error) {
+        recordEc2LaunchDuration({
+          durationMs: now() - startedAt,
+          templateKey: args.tags[SHIPFOX_TAGS.templateKey] ?? 'unknown',
+          market: args.market,
+          architecture: 'unknown',
+          availabilityZone: 'unknown',
+        });
         throw mapEc2Error(error, 'Cannot launch EC2 runner instance.');
       }
     },
@@ -203,6 +225,10 @@ function toInstanceView(instance: Instance): Ec2InstanceView {
       ),
     ),
     state: normalizeState(instance.State?.Name),
+    ...(instance.Architecture ? {architecture: normalizeArchitecture(instance.Architecture)} : {}),
+    ...(instance.Placement?.AvailabilityZone
+      ? {availabilityZone: instance.Placement.AvailabilityZone}
+      : {}),
     ...(instance.StateTransitionReason
       ? {stateTransitionReason: instance.StateTransitionReason}
       : {}),
@@ -210,6 +236,17 @@ function toInstanceView(instance: Instance): Ec2InstanceView {
     ...(instance.StateReason?.Message ? {stateReasonMessage: instance.StateReason.Message} : {}),
     ...(instance.LaunchTime ? {launchTime: instance.LaunchTime} : {}),
   };
+}
+
+function normalizeArchitecture(architecture: string | undefined): Ec2Architecture {
+  switch (architecture) {
+    case 'i386':
+    case 'x86_64':
+    case 'arm64':
+      return architecture;
+    default:
+      return 'unknown';
+  }
 }
 
 function normalizeState(state: string | undefined): Ec2InstanceState {

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -14,6 +14,7 @@ const observability = vi.hoisted(() => ({
   logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
   recordEc2Launch: vi.fn(),
   recordEc2ReconcileAbsent: vi.fn(),
+  recordEc2PendingDuration: vi.fn(),
   recordEc2Termination: vi.fn(),
 }));
 
@@ -21,6 +22,7 @@ vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logge
 vi.mock('#metrics/instance.js', () => ({
   recordEc2Launch: observability.recordEc2Launch,
   recordEc2ReconcileAbsent: observability.recordEc2ReconcileAbsent,
+  recordEc2PendingDuration: observability.recordEc2PendingDuration,
   recordEc2Termination: observability.recordEc2Termination,
 }));
 
@@ -119,6 +121,79 @@ describe('createEc2Lifecycle', () => {
     expect(tracker.countsByTemplate()).toEqual(
       new Map([['spot-small', {starting: 1, running: 0}]]),
     );
+  });
+
+  it('records pending duration once when a locally launched instance first becomes running', async () => {
+    const now = new Date(NOW);
+    const instances = [
+      instance({
+        state: 'pending',
+        architecture: 'x86_64',
+        availabilityZone: 'eu-west-3a',
+      }),
+    ];
+    const lifecycle = makeLifecycle({engine: fakeEngine({instances}), now: () => now});
+
+    await lifecycle.launch(launch());
+    await lifecycle.observe();
+    now.setTime(now.getTime() + 18_000);
+    instances[0] = instance({
+      state: 'running',
+      architecture: 'x86_64',
+      availabilityZone: 'eu-west-3a',
+    });
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(observability.recordEc2PendingDuration).toHaveBeenCalledTimes(1);
+    expect(observability.recordEc2PendingDuration).toHaveBeenCalledWith({
+      durationMs: 18_000,
+      templateKey: 'spot-small',
+      market: 'spot',
+      architecture: 'x86_64',
+      availabilityZone: 'eu-west-3a',
+    });
+  });
+
+  it('retains a pending duration candidate across an EC2 listing gap', async () => {
+    const now = new Date(NOW);
+    const instances = [
+      instance({
+        state: 'pending',
+        architecture: 'x86_64',
+        availabilityZone: 'eu-west-3a',
+      }),
+    ];
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine: fakeEngine({instances}), client, now: () => now});
+
+    await lifecycle.launch(launch());
+    await lifecycle.observe();
+    instances.length = 0;
+    now.setTime(now.getTime() + RECONCILE_INTERVAL_MS + 18_000);
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({state: 'terminated'})]),
+    );
+
+    instances.push(
+      instance({
+        state: 'running',
+        architecture: 'x86_64',
+        availabilityZone: 'eu-west-3a',
+      }),
+    );
+    await lifecycle.observe();
+
+    expect(observability.recordEc2PendingDuration).toHaveBeenCalledTimes(1);
+    expect(observability.recordEc2PendingDuration).toHaveBeenCalledWith({
+      durationMs: RECONCILE_INTERVAL_MS + 18_000,
+      templateKey: 'spot-small',
+      market: 'spot',
+      architecture: 'x86_64',
+      availabilityZone: 'eu-west-3a',
+    });
   });
 
   it('reports a locally launched runner as terminated after the DescribeInstances grace window', async () => {
@@ -1085,6 +1160,8 @@ function launch(): ProviderRunnerLaunch<Ec2TemplateSpec> {
 
 function instance(args: {
   state: Ec2InstanceView['state'];
+  architecture?: Ec2InstanceView['architecture'];
+  availabilityZone?: string;
   stateTransitionReason?: string;
   launchTime?: Date;
   instanceId?: string;
@@ -1096,6 +1173,8 @@ function instance(args: {
   return {
     instanceId: args.instanceId ?? 'i-123',
     state: args.state,
+    ...(args.architecture ? {architecture: args.architecture} : {}),
+    ...(args.availabilityZone ? {availabilityZone: args.availabilityZone} : {}),
     tags: {
       'shipfox.runner_instance_id': args.runnerInstanceId ?? RUNNER_INSTANCE_ID,
       'shipfox.provider_runner_id': args.providerRunnerId ?? 'runner-1',

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -20,6 +20,7 @@ import {buildInstanceTags, parseInstanceIdentity} from '#instance-identity.js';
 import {
   type Ec2TerminationReason,
   recordEc2Launch,
+  recordEc2PendingDuration,
   recordEc2ReconcileAbsent,
   recordEc2Termination,
 } from '#metrics/instance.js';
@@ -87,7 +88,11 @@ interface Ec2LifecycleContext {
   readonly reconcileIntervalMs: number;
   readonly now: () => Date;
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
+  // Newly launched runners that have not appeared in an EC2 listing yet. These entries
+  // retain the existing absence-synthesis grace behavior.
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
+  // Launch timestamps retained after a first pending observation until running or terminal.
+  readonly pendingLaunches: Map<string, LocallyLaunchedRunner>;
   readonly terminalReportedInstanceIds: Map<string, number>;
   // Keep successful actions across short listing gaps so eventual-consistency reads do not
   // repeat AWS calls or metrics.
@@ -118,6 +123,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     now: options.now ?? (() => new Date()),
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
+    pendingLaunches: new Map(),
     terminalReportedInstanceIds: new Map(),
     terminationActionedInstanceIds: new Map(),
     pendingTerminalReportedInstanceIds: new Set(),
@@ -161,11 +167,13 @@ async function launchRunner(
       rootDeviceName: launch.template.spec.rootDeviceName,
       ...(context.renderUserData ? {userData: context.renderUserData(launch)} : {}),
     });
-    context.locallyLaunched.set(launch.providerRunnerId, {
+    const locallyLaunched = {
       runnerInstanceId: launch.runnerInstanceId,
       templateKey: launch.template.key,
       launchedAt: new Date(context.now()),
-    });
+    };
+    context.locallyLaunched.set(launch.providerRunnerId, locallyLaunched);
+    context.pendingLaunches.set(launch.providerRunnerId, locallyLaunched);
     recordEc2Launch(launch.template.spec.market, 'launched');
     logger().info(
       {
@@ -296,7 +304,26 @@ async function applyObservedInstances(
     if (identity.runnerInstanceId) observedRunnerInstanceIds.add(identity.runnerInstanceId);
     if (!identity.providerRunnerId) continue;
     observedIds.add(identity.providerRunnerId);
+    const pendingLaunch = context.pendingLaunches.get(identity.providerRunnerId);
+    // An observed instance is no longer eligible for absent-launch synthesis. Keep the
+    // separate pending metric candidate through listing gaps after this point.
     context.locallyLaunched.delete(identity.providerRunnerId);
+    if (instance.state === 'running' && pendingLaunch) {
+      const templateKey = identity.templateKey ?? pendingLaunch.templateKey;
+      const template = context.templatesByKey.get(templateKey);
+      context.pendingLaunches.delete(identity.providerRunnerId);
+      if (template) {
+        recordEc2PendingDuration({
+          durationMs: context.now().getTime() - pendingLaunch.launchedAt.getTime(),
+          templateKey,
+          market: template.spec.market,
+          architecture: instance.architecture ?? 'unknown',
+          availabilityZone: instance.availabilityZone ?? 'unknown',
+        });
+      }
+    } else if (pendingLaunch && isTerminalPendingState(instance.state)) {
+      context.pendingLaunches.delete(identity.providerRunnerId);
+    }
 
     const hasTerminateIntent = terminateIntentIds.has(identity.providerRunnerId);
     const pastRegistrationDeadline = isPastRegistrationDeadline(instance, context);
@@ -559,6 +586,7 @@ function synthesizeAbsentLaunchedRunners(
       continue;
     }
     context.locallyLaunched.delete(providerRunnerId);
+    context.pendingLaunches.delete(providerRunnerId);
     const template = context.templatesByKey.get(launched.templateKey);
     if (!template) continue;
     events.push({
@@ -620,8 +648,18 @@ async function terminateInstances(
   for (const instance of instances) {
     const identity = parseInstanceIdentity(instance);
     context.locallyLaunched.delete(identity.providerRunnerId);
+    context.pendingLaunches.delete(identity.providerRunnerId);
     context.tracker.remove(identity.providerRunnerId);
   }
+}
+
+function isTerminalPendingState(state: Ec2InstanceView['state']): boolean {
+  return (
+    state === 'shutting-down' ||
+    state === 'stopping' ||
+    state === 'stopped' ||
+    state === 'terminated'
+  );
 }
 
 function canTerminateInstance(instance: Ec2InstanceView): boolean {

--- a/libs/provisioner/ec2/src/metrics/index.ts
+++ b/libs/provisioner/ec2/src/metrics/index.ts
@@ -1,7 +1,12 @@
 export {
+  type Ec2Architecture,
+  type Ec2DurationLabels,
+  type Ec2DurationObservation,
   type Ec2LaunchOutcome,
   type Ec2TerminationReason,
   recordEc2Launch,
+  recordEc2LaunchDuration,
+  recordEc2PendingDuration,
   recordEc2ReconcileAbsent,
   recordEc2Termination,
 } from './instance.js';

--- a/libs/provisioner/ec2/src/metrics/instance.test.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.test.ts
@@ -1,16 +1,27 @@
 const metricMocks = vi.hoisted(() => {
   const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
+  const histograms = new Map<string, {record: ReturnType<typeof vi.fn>}>();
   const createCounter = vi.fn((name: string) => {
     const counter = {add: vi.fn()};
     counters.set(name, counter);
     return counter;
   });
+  const createHistogram = vi.fn((name: string) => {
+    const histogram = {record: vi.fn()};
+    histograms.set(name, histogram);
+    return histogram;
+  });
 
-  return {counters, createCounter};
+  return {counters, createCounter, createHistogram, histograms};
 });
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
-  instanceMetrics: {getMeter: () => ({createCounter: metricMocks.createCounter})},
+  instanceMetrics: {
+    getMeter: () => ({
+      createCounter: metricMocks.createCounter,
+      createHistogram: metricMocks.createHistogram,
+    }),
+  },
 }));
 
 function counterAdd(name: string): ReturnType<typeof vi.fn> {
@@ -19,14 +30,28 @@ function counterAdd(name: string): ReturnType<typeof vi.fn> {
   return counter.add;
 }
 
+function histogramRecord(name: string): ReturnType<typeof vi.fn> {
+  const histogram = metricMocks.histograms.get(name);
+  if (!histogram) throw new Error(`Missing histogram: ${name}`);
+  return histogram.record;
+}
+
 let metrics: typeof import('./instance.js');
 
 describe('EC2 provisioner metrics', () => {
   beforeEach(async () => {
     vi.resetModules();
     metricMocks.counters.clear();
+    metricMocks.histograms.clear();
     metrics = await import('./instance.js');
   });
+
+  const durationLabels = {
+    templateKey: 'spot-small',
+    market: 'spot' as const,
+    architecture: 'x86_64' as const,
+    availabilityZone: 'eu-west-3a',
+  };
 
   it('records launch outcomes with bounded labels', () => {
     metrics.recordEc2Launch('spot', 'capacity');
@@ -49,5 +74,27 @@ describe('EC2 provisioner metrics', () => {
     metrics.recordEc2ReconcileAbsent(2);
 
     expect(counterAdd('ec2_provisioner_reconcile_absent')).toHaveBeenCalledWith(2);
+  });
+
+  it('records EC2 launch duration with bounded labels', () => {
+    metrics.recordEc2LaunchDuration({durationMs: 1_250, ...durationLabels});
+
+    expect(histogramRecord('ec2_provisioner_launch_duration')).toHaveBeenCalledWith(1_250, {
+      template_key: 'spot-small',
+      market: 'spot',
+      architecture: 'x86_64',
+      availability_zone: 'eu-west-3a',
+    });
+  });
+
+  it('records EC2 pending duration with bounded labels', () => {
+    metrics.recordEc2PendingDuration({durationMs: 18_000, ...durationLabels});
+
+    expect(histogramRecord('ec2_provisioner_pending_duration')).toHaveBeenCalledWith(18_000, {
+      template_key: 'spot-small',
+      market: 'spot',
+      architecture: 'x86_64',
+      availability_zone: 'eu-west-3a',
+    });
   });
 });

--- a/libs/provisioner/ec2/src/metrics/instance.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.ts
@@ -2,6 +2,26 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
 const meter = instanceMetrics.getMeter('provisioner-ec2');
 
+export type Ec2Architecture = 'i386' | 'x86_64' | 'arm64' | 'unknown';
+
+export interface Ec2DurationLabels {
+  templateKey: string;
+  market: 'spot' | 'on-demand';
+  architecture: Ec2Architecture;
+  availabilityZone: string;
+}
+
+export interface Ec2DurationObservation extends Ec2DurationLabels {
+  durationMs: number;
+}
+
+const ec2DurationAdvice = {
+  explicitBucketBoundaries: [
+    100, 250, 500, 1_000, 5_000, 10_000, 15_000, 20_000, 30_000, 45_000, 60_000, 90_000, 120_000,
+    300_000,
+  ],
+};
+
 const launchCount = meter.createCounter<{
   market: 'spot' | 'on-demand';
   outcome: 'launched' | 'capacity' | 'throttled' | 'error';
@@ -24,6 +44,30 @@ const reconcileAbsentCount = meter.createCounter<Record<string, never>>(
   {description: 'EC2 runner instances the backend or AWS reported absent during reconciliation'},
 );
 
+const launchDuration = meter.createHistogram<{
+  template_key: string;
+  market: 'spot' | 'on-demand';
+  architecture: Ec2Architecture;
+  availability_zone: string;
+}>('ec2_provisioner_launch_duration', {
+  description:
+    'EC2 RunInstances call duration by template, market, architecture, and availability zone',
+  unit: 'ms',
+  advice: ec2DurationAdvice,
+});
+
+const pendingDuration = meter.createHistogram<{
+  template_key: string;
+  market: 'spot' | 'on-demand';
+  architecture: Ec2Architecture;
+  availability_zone: string;
+}>('ec2_provisioner_pending_duration', {
+  description:
+    'EC2 instance launch return to first observed running state duration by template, market, architecture, and availability zone',
+  unit: 'ms',
+  advice: ec2DurationAdvice,
+});
+
 export type Ec2LaunchOutcome = 'launched' | 'capacity' | 'throttled' | 'error';
 export type Ec2TerminationReason =
   | 'backend-terminate'
@@ -41,4 +85,28 @@ export function recordEc2Termination(reason: Ec2TerminationReason): void {
 
 export function recordEc2ReconcileAbsent(count: number): void {
   reconcileAbsentCount.add(count);
+}
+
+export function recordEc2LaunchDuration(params: Ec2DurationObservation): void {
+  if (params.durationMs < 0) return;
+  launchDuration.record(params.durationMs, toMetricLabels(params));
+}
+
+export function recordEc2PendingDuration(params: Ec2DurationObservation): void {
+  if (params.durationMs < 0) return;
+  pendingDuration.record(params.durationMs, toMetricLabels(params));
+}
+
+function toMetricLabels(params: Ec2DurationLabels): {
+  template_key: string;
+  market: 'spot' | 'on-demand';
+  architecture: Ec2Architecture;
+  availability_zone: string;
+} {
+  return {
+    template_key: params.templateKey,
+    market: params.market,
+    architecture: params.architecture,
+    availability_zone: params.availabilityZone,
+  };
 }


### PR DESCRIPTION
Adds the EC2 cold-launch timing needed to distinguish the AWS launch call from the time spent waiting for the instance to become running.

The provisioner now records millisecond histograms for the `RunInstances` call and the launch-to-first-observed-running interval, using bounded template, market, architecture, and availability-zone labels. Pending observations retain local launch state until the one-time running transition is seen.

Validation passed: package checks and type checks, dependent Turbo type validation, 139 provisioner tests, and `git diff --check`.

Closes ENG-1522

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds EC2 launch and pending duration histograms to separate the AWS `RunInstances` time from the wait until an instance first becomes running. Closes ENG-1522 with bounded labels (template, market, architecture, AZ) and ms units.

- **New Features**
  - Record `ec2_provisioner_launch_duration` around `RunInstances` in `ec2-engine`; records on success and error with labels.
  - Record `ec2_provisioner_pending_duration` once at first observed running; retains candidate across EC2 listing gaps and clears on terminal states.
  - Extend `Ec2InstanceView` with `architecture` and `availabilityZone`; normalize architecture to `i386` | `x86_64` | `arm64` | `unknown`.
  - Define histograms and label helpers in `metrics/instance.ts` with explicit bucket boundaries; export `Ec2Architecture` and duration types; add tests for metrics and engine/lifecycle flows.

<sup>Written for commit 4b5a17a3d1ce2e5302ce072257c1dbde509c45d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

