### PR TITLE
[EC2 provisioner] Split boot and workspace volumes

### DIFF
--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -21,6 +21,14 @@ and maximum lifetime. It formats and mounts the separate workspace volume at
 `/var/lib/shipfox/workspaces` before the runner starts. The AMI reads that file and shuts
 down when its watchdog exits.
 
+### AMI migration
+
+The split-volume launch contract requires AMIs to be rebuilt before using the 30 GB boot
+volume in the example defaults. An older AMI can contain more root data than the smaller
+volume accepts, which makes the launch fail. Deploy the provider change before publishing
+the replacement AMI. During the transition, keep `root_volume_gb` at or above the old AMI's
+root snapshot size until every template uses a rebuilt AMI.
+
 ## Template families
 
 The checked-in [`templates.example.yaml`](templates.example.yaml) contains a general

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -16,8 +16,10 @@ Copy [`templates.example.yaml`](templates.example.yaml). Set
 zero to keep ready runners without demand.
 
 The AMI must include the Shipfox runner and its shutdown watchdog. Cloud-init writes
-`/etc/shipfox/runner.env` with the API URL, one-use token, labels, poll time, and
-maximum lifetime. The AMI reads that file and shuts down when its watchdog exits.
+`/etc/shipfox/runner.env` with the API URL, one-use token, labels, workspace root, poll time,
+and maximum lifetime. It formats and mounts the separate workspace volume at
+`/var/lib/shipfox/workspaces` before the runner starts. The AMI reads that file and shuts
+down when its watchdog exits.
 
 ## Template families
 

--- a/apps/provisioner-ec2/templates.example.yaml
+++ b/apps/provisioner-ec2/templates.example.yaml
@@ -35,8 +35,11 @@ defaults:
   security_groups: [sg-runner]
   iam_instance_profile: shipfox-runner
   associate_public_ip: false
-  root_volume_gb: 100
+  # Keep the boot volume small. Job checkouts and logs live on the separate workspace volume.
+  root_volume_gb: 30
   root_device_name: /dev/sda1
+  workspace_volume_gb: 100
+  workspace_device_name: /dev/sdf
   max_concurrency: 50
   target_concurrency: 0
 
@@ -82,6 +85,7 @@ matrix:
       spot_max_price: 1.25
       subnets: [subnet-gpu]
       security_groups: [sg-gpu]
-      root_volume_gb: 200
+      root_volume_gb: 30
+      workspace_volume_gb: 200
       max_concurrency: 10
       cost: 25

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -11,7 +11,7 @@ User=shipfox
 EnvironmentFile=-/etc/environment
 EnvironmentFile=/etc/shipfox/runner.env
 Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
-ExecStartPre=/usr/bin/mountpoint -q /var/lib/shipfox/workspaces
+ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh
 WorkingDirectory=/opt/runner
 ExecStart=/usr/local/bin/node --enable-source-maps dist/index.js
 Restart=no

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -11,6 +11,7 @@ User=shipfox
 EnvironmentFile=-/etc/environment
 EnvironmentFile=/etc/shipfox/runner.env
 Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
+ExecStartPre=/usr/bin/mountpoint -q /var/lib/shipfox/workspaces
 WorkingDirectory=/opt/runner
 ExecStart=/usr/local/bin/node --enable-source-maps dist/index.js
 Restart=no

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -55,6 +55,7 @@ build {
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
+      "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/verify-workspace-mount.sh /opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",
       "sudo systemctl daemon-reload",
       "sudo systemctl enable shipfox-runner-env.path"

--- a/infra/images/runner/scripts/build/setup-runner.sh
+++ b/infra/images/runner/scripts/build/setup-runner.sh
@@ -4,7 +4,7 @@ set -eu
 apt-get update
 apt-get install --yes --no-install-recommends \
   ca-certificates curl wget git openssh-client tar gzip xz-utils bzip2 zip unzip jq \
-  build-essential python3 pkg-config ripgrep fd-find sudo
+  build-essential python3 pkg-config ripgrep fd-find sudo amazon-ec2-utils
 rm -rf /var/lib/apt/lists/*
 
 ln -sf "$(command -v fdfind)" /usr/local/bin/fd

--- a/infra/images/runner/scripts/runtime/verify-workspace-mount.sh
+++ b/infra/images/runner/scripts/runtime/verify-workspace-mount.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+# Older AMIs and non-EC2 test images do not receive the split-volume marker.
+# Keep their existing boot contract while requiring the mount for new EC2 boots.
+if [ "${SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED:-}" != "1" ]; then
+  exit 0
+fi
+
+workspace_root="${SHIPFOX_RUNNER_WORKSPACE_ROOT:-/var/lib/shipfox/workspaces}"
+exec /usr/bin/mountpoint -q "$workspace_root"

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -865,7 +865,23 @@ describe('systemd boot activation', () => {
   it('requires the job workspace mount before starting the runner', async () => {
     const unit = await readUnit('shipfox-runner.service');
 
-    expect(unit).toContain('ExecStartPre=/usr/bin/mountpoint -q /var/lib/shipfox/workspaces');
+    expect(unit).toContain(
+      'After=network-online.target time-sync.target shipfox-runner-env.service',
+    );
+    expect(unit).toContain('Wants=network-online.target time-sync.target');
+    expect(unit).toContain(
+      'ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh',
+    );
+  });
+
+  it('gates the workspace mount check on the new user-data marker', () => {
+    const script = new URL('../scripts/runtime/verify-workspace-mount.sh', import.meta.url);
+    const result = execFileSync('sh', [script.pathname], {
+      encoding: 'utf8',
+      env: {...process.env, SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED: ''},
+    });
+
+    expect(result).toBe('');
   });
 
   it('starts the lifecycle target when the complete environment file appears', async () => {

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -862,6 +862,12 @@ describe('systemd boot activation', () => {
     return readFile(new URL(name, assets), 'utf8');
   }
 
+  it('requires the job workspace mount before starting the runner', async () => {
+    const unit = await readUnit('shipfox-runner.service');
+
+    expect(unit).toContain('ExecStartPre=/usr/bin/mountpoint -q /var/lib/shipfox/workspaces');
+  });
+
   it('starts the lifecycle target when the complete environment file appears', async () => {
     const pathUnit = await readUnit('shipfox-runner-env.path');
     const targetUnit = await readUnit('shipfox-runner.target');

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -884,6 +884,20 @@ describe('systemd boot activation', () => {
     expect(result).toBe('');
   });
 
+  it('fails the workspace mount check when the marker requires a missing mount', () => {
+    const script = new URL('../scripts/runtime/verify-workspace-mount.sh', import.meta.url);
+
+    expect(() =>
+      execFileSync('sh', [script.pathname], {
+        env: {
+          ...process.env,
+          SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED: '1',
+          SHIPFOX_RUNNER_WORKSPACE_ROOT: '/definitely/missing/shipfox-workspaces',
+        },
+      }),
+    ).toThrow();
+  });
+
   it('starts the lifecycle target when the complete environment file appears', async () => {
     const pathUnit = await readUnit('shipfox-runner-env.path');
     const targetUnit = await readUnit('shipfox-runner.target');

--- a/infra/images/runner/variable.pkr.hcl
+++ b/infra/images/runner/variable.pkr.hcl
@@ -66,7 +66,7 @@ variable "runner_version" {
 
 variable "os_disk_size_gb" {
   type    = number
-  default = 100
+  default = 30
 }
 
 variable "platform" {

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -13,8 +13,9 @@ control loop.
 - `redactRunnerBootstrapUserData(options)` returns launch metadata that is safe to log.
 
 The user-data renderer writes the API URL, one-use bootstrap token, runner-declared labels,
-managed-runner protocol metadata, poll deadline, and watchdog lifetime. It never renders a
-workspace ID, workspace registration token, or activation token.
+managed-runner protocol metadata, the managed workspace root, poll deadline, and watchdog
+lifetime. It formats and mounts the non-root EBS volume before the runner starts. It never
+renders a workspace ID, workspace registration token, or activation token.
 
 ## Template config
 
@@ -44,7 +45,10 @@ defaults:
   security_groups: [sg-runner]
   iam_instance_profile: shipfox-runner
   associate_public_ip: false
-  root_volume_gb: 100
+  root_volume_gb: 30
+  root_device_name: /dev/sda1
+  workspace_volume_gb: 100
+  workspace_device_name: /dev/sdf
   max_concurrency: 50
   target_concurrency: 0
 
@@ -94,6 +98,12 @@ canonicalized with the shared runner-label rules.
 default. Set `cost` to an explicit unitless ranking where lower values win template
 selection. Give a Spot template a lower cost than its on-demand equivalent so the planner
 prefers Spot before spilling to on-demand capacity.
+
+`root_volume_gb` is the boot volume size. `workspace_volume_gb` is a separate, empty gp3
+volume created for per-job checkouts, logs, and credentials. The provider deletes both
+volumes with the instance. `workspace_device_name` is the EC2 block-device mapping name;
+cloud-init resolves the attached non-root disk to its runtime device before formatting and
+mounting it at `/var/lib/shipfox/workspaces`.
 
 Families are independent. The general and GPU families above use different axes and
 markets; the GPU block's `subnets` replaces the general default list rather than

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -99,11 +99,18 @@ default. Set `cost` to an explicit unitless ranking where lower values win templ
 selection. Give a Spot template a lower cost than its on-demand equivalent so the planner
 prefers Spot before spilling to on-demand capacity.
 
-`root_volume_gb` is the boot volume size. `workspace_volume_gb` is a separate, empty gp3
+`root_volume_gb` is the boot volume size. `workspace_volume_gb` is a separate, encrypted gp3
 volume created for per-job checkouts, logs, and credentials. The provider deletes both
 volumes with the instance. `workspace_device_name` is the EC2 block-device mapping name;
-cloud-init resolves the attached non-root disk to its runtime device before formatting and
-mounting it at `/var/lib/shipfox/workspaces`.
+cloud-init resolves the attached EBS disk to its runtime device before formatting and
+mounting it at `/var/lib/shipfox/workspaces`. It fails closed when the mapping is absent and
+the non-root EBS disk is not unique.
+
+The example defaults change general runner capacity from one 100 GB EBS volume to a 30 GB
+boot volume plus a 100 GB workspace volume (130 GB total). The GPU example uses 30 GB plus
+200 GB (230 GB total). EBS storage cost therefore increases with the extra 30 GB, while the
+exact amount depends on region, runner uptime, gp3 IOPS and throughput, and KMS settings.
+The split keeps job data out of the boot image and its snapshots.
 
 Families are independent. The general and GPU families above use different axes and
 markets; the GPU block's `subnets` replaces the general default list rather than

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -67,7 +67,7 @@ describe('createEc2Engine', () => {
         },
         {
           DeviceName: '/dev/sdf',
-          Ebs: {VolumeSize: 200, VolumeType: 'gp3', DeleteOnTermination: true},
+          Ebs: {VolumeSize: 200, VolumeType: 'gp3', Encrypted: true, DeleteOnTermination: true},
         },
       ],
     });

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -22,6 +22,8 @@ const runArgs: RunInstanceArgs = {
   associatePublicIp: false,
   rootVolumeGb: 100,
   rootDeviceName: '/dev/sda1',
+  workspaceVolumeGb: 200,
+  workspaceDeviceName: '/dev/sdf',
   userData: '#cloud-config',
 };
 
@@ -62,6 +64,10 @@ describe('createEc2Engine', () => {
         {
           DeviceName: '/dev/sda1',
           Ebs: {VolumeSize: 100, VolumeType: 'gp3', DeleteOnTermination: true},
+        },
+        {
+          DeviceName: '/dev/sdf',
+          Ebs: {VolumeSize: 200, VolumeType: 'gp3', DeleteOnTermination: true},
         },
       ],
     });

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -72,6 +72,8 @@ export interface RunInstanceArgs {
   readonly associatePublicIp: boolean;
   readonly rootVolumeGb: number;
   readonly rootDeviceName: string;
+  readonly workspaceVolumeGb: number;
+  readonly workspaceDeviceName: string;
   readonly userData?: string;
 }
 
@@ -120,6 +122,14 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
                 DeviceName: args.rootDeviceName,
                 Ebs: {
                   VolumeSize: args.rootVolumeGb,
+                  VolumeType: 'gp3',
+                  DeleteOnTermination: true,
+                },
+              },
+              {
+                DeviceName: args.workspaceDeviceName,
+                Ebs: {
+                  VolumeSize: args.workspaceVolumeGb,
                   VolumeType: 'gp3',
                   DeleteOnTermination: true,
                 },

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -131,6 +131,7 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
                 Ebs: {
                   VolumeSize: args.workspaceVolumeGb,
                   VolumeType: 'gp3',
+                  Encrypted: true,
                   DeleteOnTermination: true,
                 },
               },

--- a/libs/provisioner/ec2/src/instance-identity.test.ts
+++ b/libs/provisioner/ec2/src/instance-identity.test.ts
@@ -28,6 +28,8 @@ const launch: ProviderRunnerLaunch<Ec2TemplateSpec> = {
       associatePublicIp: false,
       rootVolumeGb: 100,
       rootDeviceName: '/dev/sda1',
+      workspaceVolumeGb: 100,
+      workspaceDeviceName: '/dev/sdf',
     },
   },
 };

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -42,6 +42,8 @@ const template: ProvisionerTemplate<Ec2TemplateSpec> = {
     associatePublicIp: false,
     rootVolumeGb: 100,
     rootDeviceName: '/dev/sda1',
+    workspaceVolumeGb: 100,
+    workspaceDeviceName: '/dev/sdf',
   },
 };
 
@@ -70,6 +72,8 @@ describe('createEc2Lifecycle', () => {
       clientToken: 'runner-1',
       ami: 'ami-0123456789abcdef0',
       market: 'spot',
+      workspaceVolumeGb: 100,
+      workspaceDeviceName: '/dev/sdf',
       tags: {'shipfox.provider_runner_id': 'runner-1'},
     });
     expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'launched');

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -158,6 +158,8 @@ async function launchRunner(
       associatePublicIp: launch.template.spec.associatePublicIp,
       rootVolumeGb: launch.template.spec.rootVolumeGb,
       rootDeviceName: launch.template.spec.rootDeviceName,
+      workspaceVolumeGb: launch.template.spec.workspaceVolumeGb,
+      workspaceDeviceName: launch.template.spec.workspaceDeviceName,
       ...(context.renderUserData ? {userData: context.renderUserData(launch)} : {}),
     });
     context.locallyLaunched.set(launch.providerRunnerId, {

--- a/libs/provisioner/ec2/src/provisioner.test.ts
+++ b/libs/provisioner/ec2/src/provisioner.test.ts
@@ -18,6 +18,8 @@ const template: ProvisionerTemplate<Ec2TemplateSpec> = {
     associatePublicIp: false,
     rootVolumeGb: 20,
     rootDeviceName: '/dev/sda1',
+    workspaceVolumeGb: 100,
+    workspaceDeviceName: '/dev/sdf',
   },
 };
 

--- a/libs/provisioner/ec2/src/provisioner.ts
+++ b/libs/provisioner/ec2/src/provisioner.ts
@@ -92,6 +92,7 @@ function renderUserData(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): string {
     labels: launch.template.labels,
     pollMaxDurationMs: numericRunnerEnv(launch, 'SHIPFOX_POLL_MAX_DURATION_MS'),
     maxLifetimeSeconds: numericRunnerEnv(launch, 'SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS'),
+    workspaceDeviceName: launch.template.spec.workspaceDeviceName,
   });
 }
 

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -281,8 +281,11 @@ describe('loadEc2Templates', () => {
     expect(() => loadEc2Templates(path)).toThrow('root_device_name');
   });
 
-  it('rejects device-name aliases that map root and workspace to the same disk', () => {
-    const path = writeTemplates(template({workspace_device_name: '/dev/xvda1'}));
+  it.each([
+    '/dev/xvda1',
+    '/dev/XVDA1',
+  ])('rejects device-name aliases that map root and workspace to the same disk (%s)', (workspaceDeviceName) => {
+    const path = writeTemplates(template({workspace_device_name: workspaceDeviceName}));
 
     expect(() => loadEc2Templates(path)).toThrow('workspace_device_name');
   });

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -109,6 +109,9 @@ describe('loadEc2Templates', () => {
       spec: {
         market: 'on-demand',
         subnets: ['subnet-general-a', 'subnet-general-b'],
+        rootVolumeGb: 30,
+        workspaceVolumeGb: 100,
+        workspaceDeviceName: '/dev/sdf',
       },
     });
     expect(templates.find(({key}) => key === 'gpu-a10-cuda12')).toMatchObject({
@@ -117,6 +120,9 @@ describe('loadEc2Templates', () => {
         market: 'spot',
         subnets: ['subnet-gpu'],
         securityGroups: ['sg-gpu'],
+        rootVolumeGb: 30,
+        workspaceVolumeGb: 200,
+        workspaceDeviceName: '/dev/sdf',
       },
     });
   });
@@ -273,6 +279,12 @@ describe('loadEc2Templates', () => {
     const path = writeTemplates(template({}, '    root_device_name: "   "\n'));
 
     expect(() => loadEc2Templates(path)).toThrow('root_device_name');
+  });
+
+  it('rejects device-name aliases that map root and workspace to the same disk', () => {
+    const path = writeTemplates(template({workspace_device_name: '/dev/xvda1'}));
+
+    expect(() => loadEc2Templates(path)).toThrow('workspace_device_name');
   });
 
   it('throws when workspace_device_name is blank', () => {

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -45,6 +45,8 @@ templates:
     security_groups: [sg-runner]
     associate_public_ip: false
     root_volume_gb: 100
+    workspace_volume_gb: 100
+    workspace_device_name: /dev/sdf
     max_concurrency: 100
     cost: 5
 `;
@@ -71,6 +73,8 @@ templates:
     iam_instance_profile: shipfox-runner
     associate_public_ip: false
     root_volume_gb: 100
+    workspace_volume_gb: 100
+    workspace_device_name: /dev/sdf
     max_concurrency: 200
     target_concurrency: 2
     cost: 5
@@ -83,6 +87,8 @@ templates:
     security_groups: [sg-runner]
     associate_public_ip: true
     root_volume_gb: 120
+    workspace_volume_gb: 100
+    workspace_device_name: /dev/sdf
     max_concurrency: 50
     cost: 10
 `;
@@ -138,6 +144,8 @@ describe('loadEc2Templates', () => {
           associatePublicIp: false,
           rootVolumeGb: 100,
           rootDeviceName: '/dev/sda1',
+          workspaceVolumeGb: 100,
+          workspaceDeviceName: '/dev/sdf',
         },
       },
       {
@@ -155,6 +163,8 @@ describe('loadEc2Templates', () => {
           associatePublicIp: true,
           rootVolumeGb: 120,
           rootDeviceName: '/dev/sda1',
+          workspaceVolumeGb: 100,
+          workspaceDeviceName: '/dev/sdf',
         },
       },
     ]);
@@ -201,6 +211,16 @@ describe('loadEc2Templates', () => {
     expect(loadEc2Templates(writeTemplates(template()))[0]?.spec.rootDeviceName).toBe('/dev/sda1');
   });
 
+  it('uses workspace volume defaults and preserves explicit values', () => {
+    const explicit = loadEc2Templates(
+      writeTemplates(template({workspace_volume_gb: '250', workspace_device_name: '/dev/sdg'})),
+    )[0]?.spec;
+    const defaults = loadEc2Templates(writeTemplates(template()))[0]?.spec;
+
+    expect(explicit).toMatchObject({workspaceVolumeGb: 250, workspaceDeviceName: '/dev/sdg'});
+    expect(defaults).toMatchObject({workspaceVolumeGb: 100, workspaceDeviceName: '/dev/sdf'});
+  });
+
   it('canonicalizes labels (lowercase, dedupe, sort)', () => {
     const path = writeTemplates(template({labels: '[Ubuntu22, ubuntu22, ubuntu22-4cpu]'}));
 
@@ -234,6 +254,7 @@ describe('loadEc2Templates', () => {
     ['security_groups', {security_groups: '[]'}],
     ['associate_public_ip', {associate_public_ip: '"false"'}],
     ['root_volume_gb', {root_volume_gb: '-1'}],
+    ['workspace_volume_gb', {workspace_volume_gb: '-1'}],
     ['max_concurrency', {max_concurrency: '0'}],
     ['cost', {cost: '0'}],
   ])('throws when %s is invalid', (field, override) => {
@@ -252,6 +273,18 @@ describe('loadEc2Templates', () => {
     const path = writeTemplates(template({}, '    root_device_name: "   "\n'));
 
     expect(() => loadEc2Templates(path)).toThrow('root_device_name');
+  });
+
+  it('throws when workspace_device_name is blank', () => {
+    const path = writeTemplates(template({}, '    workspace_device_name: "   "\n'));
+
+    expect(() => loadEc2Templates(path)).toThrow('workspace_device_name');
+  });
+
+  it('throws when workspace_device_name is the root device', () => {
+    const path = writeTemplates(template({}, '    workspace_device_name: /dev/sda1\n'));
+
+    expect(() => loadEc2Templates(path)).toThrow('workspace_device_name');
   });
 
   it('throws when max_concurrency exceeds the limit', () => {

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -24,6 +24,8 @@ export interface Ec2TemplateSpec {
   readonly associatePublicIp: boolean;
   readonly rootVolumeGb: number;
   readonly rootDeviceName: string;
+  readonly workspaceVolumeGb: number;
+  readonly workspaceDeviceName: string;
 }
 
 /** Raised when the template config file is missing, unparseable, or invalid. */
@@ -52,6 +54,8 @@ const ec2TemplateSchema = z
     associate_public_ip: z.boolean(),
     root_volume_gb: z.number().int().positive(),
     root_device_name: z.string().trim().min(1).optional(),
+    workspace_volume_gb: z.number().int().positive().default(100),
+    workspace_device_name: z.string().trim().min(1).default('/dev/sdf'),
     max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
     target_concurrency: z.number().int().nonnegative().max(MAX_TEMPLATE_CONCURRENCY).optional(),
     cost: z.number().positive(),
@@ -63,6 +67,13 @@ const ec2TemplateSchema = z
         code: z.ZodIssueCode.custom,
         path: ['spot_max_price'],
         message: 'spot_max_price is only valid when market is "spot".',
+      });
+    }
+    if ((spec.root_device_name ?? '/dev/sda1') === spec.workspace_device_name) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['workspace_device_name'],
+        message: 'must differ from root_device_name.',
       });
     }
   });
@@ -160,6 +171,8 @@ function toTemplate(
       associatePublicIp: spec.associate_public_ip,
       rootVolumeGb: spec.root_volume_gb,
       rootDeviceName: spec.root_device_name ?? '/dev/sda1',
+      workspaceVolumeGb: spec.workspace_volume_gb,
+      workspaceDeviceName: spec.workspace_device_name,
     },
   };
 }

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -37,6 +37,7 @@ export class Ec2TemplateConfigError extends Error {
 }
 
 const MAX_TEMPLATE_CONCURRENCY = 100_000;
+const XVD_DEVICE_ALIAS_PATTERN = /^\/dev\/xvd/i;
 
 const ec2TemplateSchema = z
   .object({
@@ -53,9 +54,17 @@ const ec2TemplateSchema = z
     iam_instance_profile: z.string().trim().min(1).optional(),
     associate_public_ip: z.boolean(),
     root_volume_gb: z.number().int().positive(),
-    root_device_name: z.string().trim().min(1).optional(),
+    root_device_name: z
+      .string()
+      .trim()
+      .regex(/^\/dev\/[A-Za-z0-9]+$/, 'must be an EC2 device name like "/dev/sda1"')
+      .optional(),
     workspace_volume_gb: z.number().int().positive().default(100),
-    workspace_device_name: z.string().trim().min(1).default('/dev/sdf'),
+    workspace_device_name: z
+      .string()
+      .trim()
+      .regex(/^\/dev\/[A-Za-z0-9]+$/, 'must be an EC2 device name like "/dev/sdf"')
+      .default('/dev/sdf'),
     max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
     target_concurrency: z.number().int().nonnegative().max(MAX_TEMPLATE_CONCURRENCY).optional(),
     cost: z.number().positive(),
@@ -69,7 +78,10 @@ const ec2TemplateSchema = z
         message: 'spot_max_price is only valid when market is "spot".',
       });
     }
-    if ((spec.root_device_name ?? '/dev/sda1') === spec.workspace_device_name) {
+    if (
+      canonicalEc2DeviceName(spec.root_device_name ?? '/dev/sda1') ===
+      canonicalEc2DeviceName(spec.workspace_device_name)
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['workspace_device_name'],
@@ -79,6 +91,10 @@ const ec2TemplateSchema = z
   });
 
 const ec2TemplatesSchema = z.record(z.string().min(1), ec2TemplateSchema);
+
+function canonicalEc2DeviceName(deviceName: string): string {
+  return deviceName.replace(XVD_DEVICE_ALIAS_PATTERN, '/dev/sd');
+}
 
 /**
  * Read, parse, and validate the local EC2 template config, returning the

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -93,7 +93,7 @@ const ec2TemplateSchema = z
 const ec2TemplatesSchema = z.record(z.string().min(1), ec2TemplateSchema);
 
 function canonicalEc2DeviceName(deviceName: string): string {
-  return deviceName.replace(XVD_DEVICE_ALIAS_PATTERN, '/dev/sd');
+  return deviceName.toLowerCase().replace(XVD_DEVICE_ALIAS_PATTERN, '/dev/sd');
 }
 
 /**

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -27,9 +27,60 @@ write_files:
       SHIPFOX_RUNNER_PROVIDER_KIND="ec2"
       SHIPFOX_RUNNER_PROTOCOL_VERSION="1"
       SHIPFOX_RUNNER_LABELS="linux,x64,self-hosted"
+      SHIPFOX_RUNNER_WORKSPACE_ROOT="/var/lib/shipfox/workspaces"
       SHIPFOX_POLL_MAX_DURATION_MS="300000"
       SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS="3600"
 runcmd:
+  - |
+      set -eu
+      workspace_root='/var/lib/shipfox/workspaces'
+      install -d -o shipfox -g shipfox "$workspace_root"
+
+      # Nitro instances expose EBS volumes as NVMe devices rather than the names used
+      # in the EC2 block-device mapping. Exclude the disk containing / and use the
+      # remaining disk, which is the empty workspace volume attached by the provider.
+      root_source="$(findmnt -n -o SOURCE /)"
+      root_disk="$(lsblk -ndo PKNAME "$root_source" || true)"
+      if [ -z "$root_disk" ]; then
+        root_disk="$(lsblk -ndo NAME "$root_source")"
+      fi
+      if [ -z "$root_disk" ]; then
+        echo 'Unable to identify the root disk.' >&2
+        exit 1
+      fi
+
+      workspace_device=''
+      for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
+        if [ "$candidate" = "/dev/$root_disk" ]; then
+          continue
+        fi
+        model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
+        case "$model" in
+          *'Amazon EC2 NVMe Instance Storage'*) continue ;;
+        esac
+        workspace_device="$candidate"
+        break
+      done
+      if [ -z "$workspace_device" ]; then
+        echo 'Unable to find the EC2 workspace disk.' >&2
+        exit 1
+      fi
+
+      if ! blkid "$workspace_device" >/dev/null 2>&1; then
+        mkfs.ext4 -F -L shipfox-workspace "$workspace_device"
+      fi
+      workspace_uuid="$(blkid -s UUID -o value "$workspace_device")"
+      if [ -z "$workspace_uuid" ]; then
+        echo 'The EC2 workspace disk has no filesystem UUID.' >&2
+        exit 1
+      fi
+      if ! grep -Fq " $workspace_root " /etc/fstab; then
+        printf 'UUID=%s %s auto defaults,nofail 0 0\\n' "$workspace_uuid" "$workspace_root" >> /etc/fstab
+      fi
+      if ! mountpoint -q "$workspace_root"; then
+        mount "$workspace_device" "$workspace_root"
+      fi
+      chown shipfox:shipfox "$workspace_root"
   - ['/usr/bin/mv', '--', /etc/shipfox/runner.env.tmp, /etc/shipfox/runner.env]
 `);
   });
@@ -59,6 +110,7 @@ describe('redactRunnerBootstrapUserData', () => {
       labels: ['linux', 'x64', 'self-hosted'],
       providerKind: 'ec2',
       protocolVersion: '1',
+      workspaceRoot: '/var/lib/shipfox/workspaces',
       pollMaxDurationMs: 300_000,
       maxLifetimeSeconds: 3600,
     });

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -1,3 +1,5 @@
+import {execFileSync} from 'node:child_process';
+
 import {
   type RunnerBootstrapUserDataOptions,
   redactRunnerBootstrapUserData,
@@ -10,6 +12,7 @@ const options: RunnerBootstrapUserDataOptions = {
   labels: ['linux', 'x64', 'self-hosted'],
   pollMaxDurationMs: 300_000,
   maxLifetimeSeconds: 3600,
+  workspaceDeviceName: '/dev/sdf',
 };
 
 describe('renderRunnerBootstrapUserData', () => {
@@ -28,17 +31,34 @@ write_files:
       SHIPFOX_RUNNER_PROTOCOL_VERSION="1"
       SHIPFOX_RUNNER_LABELS="linux,x64,self-hosted"
       SHIPFOX_RUNNER_WORKSPACE_ROOT="/var/lib/shipfox/workspaces"
+      SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED="1"
       SHIPFOX_POLL_MAX_DURATION_MS="300000"
       SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS="3600"
 runcmd:
   - |
       set -eu
       workspace_root='/var/lib/shipfox/workspaces'
+      workspace_device_name='/dev/sdf'
       install -d -o shipfox -g shipfox "$workspace_root"
 
-      # Nitro instances expose EBS volumes as NVMe devices rather than the names used
-      # in the EC2 block-device mapping. Exclude the disk containing / and use the
-      # remaining disk, which is the empty workspace volume attached by the provider.
+      # Xen exposes the configured mapping name directly. Nitro may expose the same
+      # EBS volume as an NVMe device, so resolve it by its EBS model when the mapping
+      # name is not present. Never guess when more than one non-root EBS disk exists.
+      workspace_device=''
+      if [ -b "$workspace_device_name" ]; then
+        workspace_real_device="$(readlink -f "$workspace_device_name")"
+        workspace_model="$(cat "/sys/class/block/$(basename "$workspace_real_device")/device/model" 2>/dev/null || true)"
+        case "$workspace_model" in
+          *'Amazon EC2 NVMe Instance Storage'*)
+            echo "Configured workspace device $workspace_device_name is instance storage." >&2
+            exit 1
+            ;;
+          *)
+            workspace_device="$workspace_device_name"
+            ;;
+        esac
+      fi
+
       root_source="$(findmnt -n -o SOURCE /)"
       root_disk="$(lsblk -ndo PKNAME "$root_source" || true)"
       if [ -z "$root_disk" ]; then
@@ -49,18 +69,40 @@ runcmd:
         exit 1
       fi
 
-      workspace_device=''
-      for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
-        if [ "$candidate" = "/dev/$root_disk" ]; then
-          continue
+      workspace_mapping_tool_available=false
+      if command -v ebsnvme-id >/dev/null 2>&1; then
+        workspace_mapping_tool_available=true
+      fi
+
+      if [ -z "$workspace_device" ]; then
+        configured_device_name="$(printf '%s\\n' "$workspace_device_name" | sed 's#^/dev/##')"
+        workspace_candidate_count=0
+        workspace_candidate=''
+        for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
+          if [ "$candidate" = "/dev/$root_disk" ]; then
+            continue
+          fi
+          model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
+          if [ "$model" != 'Amazon Elastic Block Store' ]; then
+            continue
+          fi
+          if [ "$workspace_mapping_tool_available" = true ]; then
+            mapped_device_name="$(ebsnvme-id -b "$candidate" 2>/dev/null || true)"
+            mapped_device_name="$(printf '%s\\n' "$mapped_device_name" | sed 's#^/dev/##')"
+            if [ "$mapped_device_name" != "$configured_device_name" ]; then
+              continue
+            fi
+          fi
+          workspace_candidate_count=$((workspace_candidate_count + 1))
+          workspace_candidate="$candidate"
+        done
+        if [ "$workspace_candidate_count" -ne 1 ]; then
+          echo "Unable to uniquely resolve EC2 workspace device $workspace_device_name; found $workspace_candidate_count non-root EBS disks." >&2
+          exit 1
         fi
-        model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
-        case "$model" in
-          *'Amazon EC2 NVMe Instance Storage'*) continue ;;
-        esac
-        workspace_device="$candidate"
-        break
-      done
+        workspace_device="$workspace_candidate"
+      fi
+
       if [ -z "$workspace_device" ]; then
         echo 'Unable to find the EC2 workspace disk.' >&2
         exit 1
@@ -90,6 +132,20 @@ runcmd:
 
     expect(userData).not.toContain('SHIPFOX_RUNNER_REGISTRATION_TOKEN');
     expect(userData).not.toContain('WORKSPACE_ID');
+  });
+
+  it('renders a workspace mount script accepted by POSIX sh', () => {
+    const userData = renderRunnerBootstrapUserData(options);
+    const marker = 'runcmd:\n  - |\n';
+    const markerOffset = userData.indexOf(marker);
+    const script = userData
+      .slice(markerOffset + marker.length)
+      .split('\n')
+      .map((line) => (line.startsWith('      ') ? line.slice(6) : line))
+      .join('\n');
+
+    expect(markerOffset).toBeGreaterThanOrEqual(0);
+    expect(() => execFileSync('sh', ['-n', '-c', script])).not.toThrow();
   });
 
   it('rejects unsafe environment values', () => {

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -46,6 +46,11 @@ runcmd:
       # name is not present. Never guess when more than one non-root EBS disk exists.
       workspace_device=''
       if [ -b "$workspace_device_name" ]; then
+        workspace_device_type="$(lsblk -ndo TYPE "$workspace_device_name" || true)"
+        if [ "$workspace_device_type" != 'disk' ]; then
+          echo "Configured workspace device $workspace_device_name is not a disk." >&2
+          exit 1
+        fi
         workspace_real_device="$(readlink -f "$workspace_device_name")"
         workspace_model="$(cat "/sys/class/block/$(basename "$workspace_real_device")/device/model" 2>/dev/null || true)"
         case "$workspace_model" in
@@ -67,6 +72,16 @@ runcmd:
       if [ -z "$root_disk" ]; then
         echo 'Unable to identify the root disk.' >&2
         exit 1
+      fi
+      if [ -n "$workspace_device" ]; then
+        workspace_disk="$(lsblk -ndo PKNAME "$workspace_device" || true)"
+        if [ -z "$workspace_disk" ]; then
+          workspace_disk="$(lsblk -ndo NAME "$workspace_device" || true)"
+        fi
+        if [ "$workspace_disk" = "$root_disk" ]; then
+          echo "Configured workspace device $workspace_device_name resolves to the root disk." >&2
+          exit 1
+        fi
       fi
 
       workspace_mapping_tool_available=false

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -1,6 +1,57 @@
 const CLOUD_INIT_HEADER = '#cloud-config';
 const RUNNER_ENV_PATH = '/etc/shipfox/runner.env';
 const RUNNER_ENV_TEMP_PATH = '/etc/shipfox/runner.env.tmp';
+const RUNNER_WORKSPACE_ROOT = '/var/lib/shipfox/workspaces';
+
+const WORKSPACE_MOUNT_SCRIPT = `set -eu
+workspace_root='${RUNNER_WORKSPACE_ROOT}'
+install -d -o shipfox -g shipfox "$workspace_root"
+
+# Nitro instances expose EBS volumes as NVMe devices rather than the names used
+# in the EC2 block-device mapping. Exclude the disk containing / and use the
+# remaining disk, which is the empty workspace volume attached by the provider.
+root_source="$(findmnt -n -o SOURCE /)"
+root_disk="$(lsblk -ndo PKNAME "$root_source" || true)"
+if [ -z "$root_disk" ]; then
+  root_disk="$(lsblk -ndo NAME "$root_source")"
+fi
+if [ -z "$root_disk" ]; then
+  echo 'Unable to identify the root disk.' >&2
+  exit 1
+fi
+
+workspace_device=''
+for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
+  if [ "$candidate" = "/dev/$root_disk" ]; then
+    continue
+  fi
+  model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
+  case "$model" in
+    *'Amazon EC2 NVMe Instance Storage'*) continue ;;
+  esac
+  workspace_device="$candidate"
+  break
+done
+if [ -z "$workspace_device" ]; then
+  echo 'Unable to find the EC2 workspace disk.' >&2
+  exit 1
+fi
+
+if ! blkid "$workspace_device" >/dev/null 2>&1; then
+  mkfs.ext4 -F -L shipfox-workspace "$workspace_device"
+fi
+workspace_uuid="$(blkid -s UUID -o value "$workspace_device")"
+if [ -z "$workspace_uuid" ]; then
+  echo 'The EC2 workspace disk has no filesystem UUID.' >&2
+  exit 1
+fi
+if ! grep -Fq " $workspace_root " /etc/fstab; then
+  printf 'UUID=%s %s auto defaults,nofail 0 0\\n' "$workspace_uuid" "$workspace_root" >> /etc/fstab
+fi
+if ! mountpoint -q "$workspace_root"; then
+  mount "$workspace_device" "$workspace_root"
+fi
+chown shipfox:shipfox "$workspace_root"`;
 
 /** Values written into the runner image environment file at EC2 boot. */
 export interface RunnerBootstrapUserDataOptions {
@@ -19,6 +70,7 @@ export interface RedactedRunnerBootstrapUserData {
   readonly labels: readonly string[];
   readonly providerKind: string;
   readonly protocolVersion: string;
+  readonly workspaceRoot: string;
   readonly pollMaxDurationMs: number;
   readonly maxLifetimeSeconds: number;
 }
@@ -29,6 +81,7 @@ interface RunnerBootstrapEnvironment {
   readonly SHIPFOX_RUNNER_PROVIDER_KIND: string;
   readonly SHIPFOX_RUNNER_PROTOCOL_VERSION: string;
   readonly SHIPFOX_RUNNER_LABELS: string;
+  readonly SHIPFOX_RUNNER_WORKSPACE_ROOT: string;
   readonly SHIPFOX_POLL_MAX_DURATION_MS: string;
   readonly SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: string;
 }
@@ -53,6 +106,8 @@ write_files:
     content: |
 ${indent(envFile, 6)}
 runcmd:
+  - |
+${indent(WORKSPACE_MOUNT_SCRIPT, 6)}
   - ['/usr/bin/mv', '--', ${RUNNER_ENV_TEMP_PATH}, ${RUNNER_ENV_PATH}]
 `;
 }
@@ -67,6 +122,7 @@ export function redactRunnerBootstrapUserData(
     labels: options.labels,
     providerKind: environment.SHIPFOX_RUNNER_PROVIDER_KIND,
     protocolVersion: environment.SHIPFOX_RUNNER_PROTOCOL_VERSION,
+    workspaceRoot: environment.SHIPFOX_RUNNER_WORKSPACE_ROOT,
     pollMaxDurationMs: options.pollMaxDurationMs,
     maxLifetimeSeconds: options.maxLifetimeSeconds,
   };
@@ -83,6 +139,7 @@ function runnerBootstrapEnvironment(
     SHIPFOX_RUNNER_PROVIDER_KIND: providerKind,
     SHIPFOX_RUNNER_PROTOCOL_VERSION: protocolVersion,
     SHIPFOX_RUNNER_LABELS: options.labels.join(','),
+    SHIPFOX_RUNNER_WORKSPACE_ROOT: RUNNER_WORKSPACE_ROOT,
     SHIPFOX_POLL_MAX_DURATION_MS: String(options.pollMaxDurationMs),
     SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: String(options.maxLifetimeSeconds),
   };
@@ -108,6 +165,6 @@ function indent(value: string, spaces: number): string {
   const padding = ' '.repeat(spaces);
   return value
     .split('\n')
-    .map((line) => `${padding}${line}`)
+    .map((line) => (line.length === 0 ? line : `${padding}${line}`))
     .join('\n');
 }

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -2,14 +2,32 @@ const CLOUD_INIT_HEADER = '#cloud-config';
 const RUNNER_ENV_PATH = '/etc/shipfox/runner.env';
 const RUNNER_ENV_TEMP_PATH = '/etc/shipfox/runner.env.tmp';
 const RUNNER_WORKSPACE_ROOT = '/var/lib/shipfox/workspaces';
+const EC2_DEVICE_NAME_PATTERN = /^\/dev\/[A-Za-z0-9]+$/;
 
-const WORKSPACE_MOUNT_SCRIPT = `set -eu
+function workspaceMountScript(workspaceDeviceName: string): string {
+  return String.raw`set -eu
 workspace_root='${RUNNER_WORKSPACE_ROOT}'
+workspace_device_name='${workspaceDeviceName}'
 install -d -o shipfox -g shipfox "$workspace_root"
 
-# Nitro instances expose EBS volumes as NVMe devices rather than the names used
-# in the EC2 block-device mapping. Exclude the disk containing / and use the
-# remaining disk, which is the empty workspace volume attached by the provider.
+# Xen exposes the configured mapping name directly. Nitro may expose the same
+# EBS volume as an NVMe device, so resolve it by its EBS model when the mapping
+# name is not present. Never guess when more than one non-root EBS disk exists.
+workspace_device=''
+if [ -b "$workspace_device_name" ]; then
+  workspace_real_device="$(readlink -f "$workspace_device_name")"
+  workspace_model="$(cat "/sys/class/block/$(basename "$workspace_real_device")/device/model" 2>/dev/null || true)"
+  case "$workspace_model" in
+    *'Amazon EC2 NVMe Instance Storage'*)
+      echo "Configured workspace device $workspace_device_name is instance storage." >&2
+      exit 1
+      ;;
+    *)
+      workspace_device="$workspace_device_name"
+      ;;
+  esac
+fi
+
 root_source="$(findmnt -n -o SOURCE /)"
 root_disk="$(lsblk -ndo PKNAME "$root_source" || true)"
 if [ -z "$root_disk" ]; then
@@ -20,18 +38,40 @@ if [ -z "$root_disk" ]; then
   exit 1
 fi
 
-workspace_device=''
-for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
-  if [ "$candidate" = "/dev/$root_disk" ]; then
-    continue
+workspace_mapping_tool_available=false
+if command -v ebsnvme-id >/dev/null 2>&1; then
+  workspace_mapping_tool_available=true
+fi
+
+if [ -z "$workspace_device" ]; then
+  configured_device_name="$(printf '%s\n' "$workspace_device_name" | sed 's#^/dev/##')"
+  workspace_candidate_count=0
+  workspace_candidate=''
+  for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
+    if [ "$candidate" = "/dev/$root_disk" ]; then
+      continue
+    fi
+    model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
+    if [ "$model" != 'Amazon Elastic Block Store' ]; then
+      continue
+    fi
+    if [ "$workspace_mapping_tool_available" = true ]; then
+      mapped_device_name="$(ebsnvme-id -b "$candidate" 2>/dev/null || true)"
+      mapped_device_name="$(printf '%s\n' "$mapped_device_name" | sed 's#^/dev/##')"
+      if [ "$mapped_device_name" != "$configured_device_name" ]; then
+        continue
+      fi
+    fi
+    workspace_candidate_count=$((workspace_candidate_count + 1))
+    workspace_candidate="$candidate"
+  done
+  if [ "$workspace_candidate_count" -ne 1 ]; then
+    echo "Unable to uniquely resolve EC2 workspace device $workspace_device_name; found $workspace_candidate_count non-root EBS disks." >&2
+    exit 1
   fi
-  model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
-  case "$model" in
-    *'Amazon EC2 NVMe Instance Storage'*) continue ;;
-  esac
-  workspace_device="$candidate"
-  break
-done
+  workspace_device="$workspace_candidate"
+fi
+
 if [ -z "$workspace_device" ]; then
   echo 'Unable to find the EC2 workspace disk.' >&2
   exit 1
@@ -46,12 +86,13 @@ if [ -z "$workspace_uuid" ]; then
   exit 1
 fi
 if ! grep -Fq " $workspace_root " /etc/fstab; then
-  printf 'UUID=%s %s auto defaults,nofail 0 0\\n' "$workspace_uuid" "$workspace_root" >> /etc/fstab
+  printf 'UUID=%s %s auto defaults,nofail 0 0\n' "$workspace_uuid" "$workspace_root" >> /etc/fstab
 fi
 if ! mountpoint -q "$workspace_root"; then
   mount "$workspace_device" "$workspace_root"
 fi
 chown shipfox:shipfox "$workspace_root"`;
+}
 
 /** Values written into the runner image environment file at EC2 boot. */
 export interface RunnerBootstrapUserDataOptions {
@@ -60,6 +101,7 @@ export interface RunnerBootstrapUserDataOptions {
   readonly labels: readonly string[];
   readonly pollMaxDurationMs: number;
   readonly maxLifetimeSeconds: number;
+  readonly workspaceDeviceName: string;
   readonly providerKind?: string;
   readonly protocolVersion?: string;
 }
@@ -82,6 +124,7 @@ interface RunnerBootstrapEnvironment {
   readonly SHIPFOX_RUNNER_PROTOCOL_VERSION: string;
   readonly SHIPFOX_RUNNER_LABELS: string;
   readonly SHIPFOX_RUNNER_WORKSPACE_ROOT: string;
+  readonly SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED: string;
   readonly SHIPFOX_POLL_MAX_DURATION_MS: string;
   readonly SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: string;
 }
@@ -107,7 +150,7 @@ write_files:
 ${indent(envFile, 6)}
 runcmd:
   - |
-${indent(WORKSPACE_MOUNT_SCRIPT, 6)}
+${indent(workspaceMountScript(options.workspaceDeviceName), 6)}
   - ['/usr/bin/mv', '--', ${RUNNER_ENV_TEMP_PATH}, ${RUNNER_ENV_PATH}]
 `;
 }
@@ -140,6 +183,7 @@ function runnerBootstrapEnvironment(
     SHIPFOX_RUNNER_PROTOCOL_VERSION: protocolVersion,
     SHIPFOX_RUNNER_LABELS: options.labels.join(','),
     SHIPFOX_RUNNER_WORKSPACE_ROOT: RUNNER_WORKSPACE_ROOT,
+    SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED: '1',
     SHIPFOX_POLL_MAX_DURATION_MS: String(options.pollMaxDurationMs),
     SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: String(options.maxLifetimeSeconds),
   };
@@ -153,6 +197,8 @@ function runnerBootstrapEnvironment(
     throw new Error('pollMaxDurationMs must be a non-negative integer.');
   if (!Number.isInteger(options.maxLifetimeSeconds) || options.maxLifetimeSeconds <= 0)
     throw new Error('maxLifetimeSeconds must be a positive integer.');
+  if (!EC2_DEVICE_NAME_PATTERN.test(options.workspaceDeviceName))
+    throw new Error('workspaceDeviceName must be an EC2 device name like /dev/sdf.');
 
   return values;
 }

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -15,6 +15,11 @@ install -d -o shipfox -g shipfox "$workspace_root"
 # name is not present. Never guess when more than one non-root EBS disk exists.
 workspace_device=''
 if [ -b "$workspace_device_name" ]; then
+  workspace_device_type="$(lsblk -ndo TYPE "$workspace_device_name" || true)"
+  if [ "$workspace_device_type" != 'disk' ]; then
+    echo "Configured workspace device $workspace_device_name is not a disk." >&2
+    exit 1
+  fi
   workspace_real_device="$(readlink -f "$workspace_device_name")"
   workspace_model="$(cat "/sys/class/block/$(basename "$workspace_real_device")/device/model" 2>/dev/null || true)"
   case "$workspace_model" in
@@ -36,6 +41,16 @@ fi
 if [ -z "$root_disk" ]; then
   echo 'Unable to identify the root disk.' >&2
   exit 1
+fi
+if [ -n "$workspace_device" ]; then
+  workspace_disk="$(lsblk -ndo PKNAME "$workspace_device" || true)"
+  if [ -z "$workspace_disk" ]; then
+    workspace_disk="$(lsblk -ndo NAME "$workspace_device" || true)"
+  fi
+  if [ "$workspace_disk" = "$root_disk" ]; then
+    echo "Configured workspace device $workspace_device_name resolves to the root disk." >&2
+    exit 1
+  fi
 fi
 
 workspace_mapping_tool_available=false


### PR DESCRIPTION
EC2 runners now keep the AMI-backed boot volume small and put per-job checkouts, logs, and credentials on a separate disposable gp3 volume. The launch path, cloud-init bootstrap, runner startup guard, image defaults, and operator examples share the same contract.

The review follow-up resolves the configured workspace mapping on Nitro with `ebsnvme-id`, accepts only a unique EBS fallback on older AMIs, and fails closed on ambiguous or instance-storage devices. Workspace volumes are encrypted and the rendered mount script is syntax-tested. The runner image gates its mount check on `SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED=1`, keeping older AMIs and QEMU images compatible.

Migration: deploy the provider change before publishing rebuilt runner AMIs. Rebuild AMIs before using the 30 GB boot-volume defaults. Until then, keep `root_volume_gb` at or above the old AMI root snapshot size. The example defaults use 30 GB boot plus 100 GB workspace for general runners (130 GB total), and 30 GB plus 200 GB for GPU runners (230 GB total), so EBS capacity and cost increase by 30 GB per runner before region and gp3 pricing differences.

Validation passed locally: provider `check`, `type`, and 141 tests; runner-image `check`, `type`, and 53 tests; Packer verification; shell syntax checks.

Closes ENG-1536