### PR TITLE
[runner-image] Optimize ephemeral runner boot

### DIFF
--- a/.github/workflows/runner-image-freshness.yml
+++ b/.github/workflows/runner-image-freshness.yml
@@ -1,0 +1,95 @@
+name: Runner image freshness
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: runner-image-freshness
+  cancel-in-progress: false
+
+env:
+  RUNNER_IMAGE_FRESHNESS_MAX_DAYS: '7'
+
+jobs:
+  check:
+    name: Check runner image freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check the latest successful candidate publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          max_age_days="$RUNNER_IMAGE_FRESHNESS_MAX_DAYS"
+          case "$max_age_days" in
+            ''|*[!0-9]*)
+              echo "RUNNER_IMAGE_FRESHNESS_MAX_DAYS must be a positive integer." >&2
+              exit 1
+              ;;
+          esac
+          if (( max_age_days < 1 )); then
+            echo "RUNNER_IMAGE_FRESHNESS_MAX_DAYS must be a positive integer." >&2
+            exit 1
+          fi
+
+          latest_run_id=''
+          latest_created_at=''
+          while IFS=$'\t' read -r run_id created_at; do
+            jobs_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100")"
+            if jq -e '
+              ([
+                .jobs[]
+                | select(.name | startswith("Publish runner image candidate ("))
+                | select(.conclusion == "success")
+                | .name
+              ] | unique | length == 2)
+              and (
+                [.jobs[] | select(.name == "Publish runner image candidate manifest") | .conclusion]
+                | any(. == "success")
+              )
+            ' >/dev/null <<< "$jobs_json"; then
+              latest_run_id="$run_id"
+              latest_created_at="$created_at"
+              break
+            fi
+          done < <(
+            gh run list \
+              --workflow ci.yml \
+              --branch main \
+              --status success \
+              --limit 100 \
+              --json databaseId,createdAt \
+              --jq '.[] | [.databaseId, .createdAt] | @tsv'
+          )
+
+          if [ -z "$latest_run_id" ]; then
+            echo 'No successful runner image candidate publication was found.' >&2
+            exit 1
+          fi
+
+          now_epoch="$(date -u +%s)"
+          created_epoch="$(date -u --date="$latest_created_at" +%s)"
+          age_seconds=$((now_epoch - created_epoch))
+          max_age_seconds=$((max_age_days * 24 * 60 * 60))
+          age_days=$((age_seconds / 24 / 60 / 60))
+
+          {
+            echo '## Runner image freshness'
+            echo "- Last successful candidate publication: workflow run $latest_run_id ($latest_created_at)"
+            echo "- Candidate age: ${age_days}d"
+            echo "- Maximum allowed age: ${max_age_days}d"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if (( age_seconds > max_age_seconds )); then
+            echo "Runner image candidate publication is ${age_days}d old. The maximum allowed age is ${max_age_days}d." >&2
+            exit 1
+          fi

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -23,6 +23,49 @@ The image is checked during the bake and launched with a fresh ephemeral root vo
 
 The IPv6 duplicate-address detection setting is a drop-in for the netplan-generated primary interface configuration. Netplan remains responsible for DHCP, addresses, routes, and online requirements.
 
+The image is built for one job and one instance lifetime. The bake applies
+filesystem and network boot policy in `configure-boot.sh`, and disposable
+service and journal policy in
+[`configure-ephemeral-boot.sh`](scripts/build/configure-ephemeral-boot.sh).
+
+### Boot composition gate
+
+The bake checks that every unit in the mask inventory exists before it masks the
+unit. It checks the effective `systemd` state after masking. It also checks the
+effective journald configuration after writing the drop-in. A base-image change
+that removes a unit or overrides the drop-in fails the image build.
+
+### AppArmor decision
+
+The runner keeps `apparmor.service` enabled. It also keeps
+`snapd.apparmor.service` enabled when the base image provides it. This preserves
+the image security profile while snapd remains installed. This change does not
+mask or socket-activate either unit. ENG-1530 owns removing snapd.
+
+### Journal retention
+
+The host journal uses volatile storage with a `64M` runtime limit. Journald
+allows `1000` messages per service in a `30s` interval. Higher-volume host
+diagnostics can be rate-limited. Job output and runner telemetry remain the
+durable source of truth.
+
+The image writes `/var/lib/shipfox/boot-complete` after the environment path gate
+has validated the runner environment and activated the lifecycle. The marker
+survives a reboot while the instance volume exists. Host journal data and the
+marker disappear when the instance is terminated with its root volume.
+
+### Image freshness
+
+The image does not update packages after the bake. CI builds a candidate on each
+successful normal merge to `main`, and candidates expire after 14 days. The
+[`runner-image-freshness.yml`](../../../.github/workflows/runner-image-freshness.yml)
+workflow alerts when both architecture candidates and their manifest have not
+been published successfully within seven days.
+
+Release promotion should happen at least weekly. When the alert fires, rebuild
+or republish the candidate and investigate the release promotion path before
+using an older image.
+
 ## Environment contract
 
 The provider owns the values and must never bake them into the image. It must publish

--- a/infra/images/runner/assets/shipfox-runner-boot-complete.service
+++ b/infra/images/runner/assets/shipfox-runner-boot-complete.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Record a successful Shipfox runner boot
+After=network-online.target time-sync.target shipfox-runner-env.service
+Wants=network-online.target time-sync.target
+Requires=shipfox-runner-env.service
+Before=shipfox-runner.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'install -d -m 0755 /var/lib/shipfox && date --iso-8601=seconds > /var/lib/shipfox/boot-complete'
+RemainAfterExit=yes

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Shipfox platform runner
-After=network-online.target time-sync.target shipfox-runner-env.service
+After=network-online.target time-sync.target shipfox-runner-env.service shipfox-runner-boot-complete.service
 Wants=network-online.target time-sync.target
-Requires=shipfox-runner-env.service
+Requires=shipfox-runner-env.service shipfox-runner-boot-complete.service
 SuccessAction=poweroff-immediate
 FailureAction=poweroff-immediate
 

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -54,6 +54,7 @@ build {
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.path /etc/systemd/system/shipfox-runner-env.path",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.service /etc/systemd/system/shipfox-runner.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-boot-complete.service /etc/systemd/system/shipfox-runner-boot-complete.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -19,7 +19,8 @@ build {
       "${path.root}/scripts/build/setup-runner.sh",
       "${path.root}/scripts/build/install-node.sh",
       "${path.root}/scripts/build/install-runner.sh",
-      "${path.root}/scripts/build/configure-boot.sh"
+      "${path.root}/scripts/build/configure-boot.sh",
+      "${path.root}/scripts/build/configure-ephemeral-boot.sh"
     ]
   }
 

--- a/infra/images/runner/scripts/build/configure-ephemeral-boot.sh
+++ b/infra/images/runner/scripts/build/configure-ephemeral-boot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+# Runner instances are ephemeral. These units either repeat work already done while
+# baking the image or write state that has no value after the instance exits.
+systemctl mask \
+  apt-daily.service \
+  apt-daily-upgrade.service \
+  apt-daily.timer \
+  apt-daily-upgrade.timer \
+  unattended-upgrades.service \
+  systemd-fsck-root.service \
+  systemd-fsck@.service \
+  systemd-journal-flush.service
+
+journald_drop_in=/etc/systemd/journald.conf.d/shipfox-volatile.conf
+install -d -m 0755 "$(dirname "$journald_drop_in")"
+cat > "$journald_drop_in" <<'EOF'
+[Journal]
+Storage=volatile
+EOF

--- a/infra/images/runner/scripts/build/configure-ephemeral-boot.sh
+++ b/infra/images/runner/scripts/build/configure-ephemeral-boot.sh
@@ -2,20 +2,179 @@
 set -eu
 
 # Runner instances are ephemeral. These units either repeat work already done while
-# baking the image or write state that has no value after the instance exits.
-systemctl mask \
-  apt-daily.service \
-  apt-daily-upgrade.service \
-  apt-daily.timer \
-  apt-daily-upgrade.timer \
-  unattended-upgrades.service \
-  systemd-fsck-root.service \
-  systemd-fsck@.service \
-  systemd-journal-flush.service
+# baking the image or maintain state that has no value after the instance exits.
+# Keep the inventory explicit. The bake fails when a base image no longer contains
+# one of these units, so a renamed or removed unit cannot silently weaken the gate.
 
-journald_drop_in=/etc/systemd/journald.conf.d/shipfox-volatile.conf
+# apt-daily.service: package indexes are installed and cleaned during the image bake.
+apt_daily_service='apt-daily.service'
+# apt-daily-upgrade.service: package upgrades are intentionally owned by image release.
+apt_daily_upgrade_service='apt-daily-upgrade.service'
+# apt-daily.timer: package refreshes must not start after the image is published.
+apt_daily_timer='apt-daily.timer'
+# apt-daily-upgrade.timer: package upgrades must not start after the image is published.
+apt_daily_upgrade_timer='apt-daily-upgrade.timer'
+# unattended-upgrades.service: security updates run during the image build instead.
+unattended_upgrades_service='unattended-upgrades.service'
+# systemd-journal-flush.service: the runner journal is volatile and has no disk journal to flush.
+systemd_journal_flush_service='systemd-journal-flush.service'
+# lvm2-monitor.service: runner root disks are direct EBS or QEMU devices, not LVM volumes.
+lvm2_monitor_service='lvm2-monitor.service'
+# multipathd.service: runners do not attach multipath storage.
+multipathd_service='multipathd.service'
+# multipathd.socket: runners do not attach multipath storage.
+multipathd_socket='multipathd.socket'
+# ufw.service: provider network controls own the runner boundary and no host firewall is configured.
+ufw_service='ufw.service'
+# plymouth-read-write.service: runners are headless and do not need a boot splash.
+plymouth_read_write_service='plymouth-read-write.service'
+# plymouth-quit.service: runners are headless and do not need a boot splash.
+plymouth_quit_service='plymouth-quit.service'
+# plymouth-quit-wait.service: runners are headless and do not need a boot splash.
+plymouth_quit_wait_service='plymouth-quit-wait.service'
+# udisks2.service: runners do not manage desktop or removable disks.
+udisks2_service='udisks2.service'
+# ModemManager.service: runners have no modem hardware to manage.
+modem_manager_service='ModemManager.service'
+# apport.service: job logs and runner telemetry replace local crash-report collection.
+apport_service='apport.service'
+# sysstat.service: ephemeral runner accounting has no value after instance termination.
+sysstat_service='sysstat.service'
+# e2scrub_reap.service: runners do not keep long-lived filesystem snapshots to scrub.
+e2scrub_reap_service='e2scrub_reap.service'
+# hibinit-agent.service: runner instances never hibernate and terminate after their work.
+hibinit_agent_service='hibinit-agent.service'
+# grub-common.service: the baked bootloader does not need per-instance maintenance.
+grub_common_service='grub-common.service'
+# grub-initrd-fallback.service: runners do not need an interactive bootloader fallback.
+grub_initrd_fallback_service='grub-initrd-fallback.service'
+# keyboard-setup.service: runners are headless and do not accept local keyboard input.
+keyboard_setup_service='keyboard-setup.service'
+# console-setup.service: runners are headless and do not need a local console layout.
+console_setup_service='console-setup.service'
+# setvtrgb.service: runners are headless and do not need virtual-terminal colors.
+setvtrgb_service='setvtrgb.service'
+# getty@tty1.service: runners are headless and expose no interactive local login.
+getty_tty1_service='getty@tty1.service'
+# motd-news.timer: runner instances do not display a login message.
+motd_news_timer='motd-news.timer'
+# update-notifier-download.timer: runner instances do not need notification metadata.
+update_notifier_download_timer='update-notifier-download.timer'
+# update-notifier-motd.timer: runner instances do not display a login message.
+update_notifier_motd_timer='update-notifier-motd.timer'
+# fwupd-refresh.timer: runner instances do not own firmware updates.
+fwupd_refresh_timer='fwupd-refresh.timer'
+# man-db.timer: runner images do not need to rebuild local manual-page indexes.
+man_db_timer='man-db.timer'
+# logrotate.timer: host logs are volatile and job logs are retained by the job pipeline.
+logrotate_timer='logrotate.timer'
+# e2scrub_all.timer: runners do not keep long-lived filesystem snapshots to scrub.
+e2scrub_all_timer='e2scrub_all.timer'
+# fstrim.timer: the runner root disk is discarded with the instance.
+fstrim_timer='fstrim.timer'
+# dpkg-db-backup.timer: package database backups have no value on a disposable instance.
+dpkg_db_backup_timer='dpkg-db-backup.timer'
+# sysstat-collect.timer: ephemeral runner accounting has no value after instance termination.
+sysstat_collect_timer='sysstat-collect.timer'
+# sysstat-summary.timer: ephemeral runner accounting has no value after instance termination.
+sysstat_summary_timer='sysstat-summary.timer'
+
+masked_units="
+  $apt_daily_service
+  $apt_daily_upgrade_service
+  $apt_daily_timer
+  $apt_daily_upgrade_timer
+  $unattended_upgrades_service
+  $systemd_journal_flush_service
+  $lvm2_monitor_service
+  $multipathd_service
+  $multipathd_socket
+  $ufw_service
+  $plymouth_read_write_service
+  $plymouth_quit_service
+  $plymouth_quit_wait_service
+  $udisks2_service
+  $modem_manager_service
+  $apport_service
+  $sysstat_service
+  $e2scrub_reap_service
+  $hibinit_agent_service
+  $grub_common_service
+  $grub_initrd_fallback_service
+  $keyboard_setup_service
+  $console_setup_service
+  $setvtrgb_service
+  $getty_tty1_service
+  $motd_news_timer
+  $update_notifier_download_timer
+  $update_notifier_motd_timer
+  $fwupd_refresh_timer
+  $man_db_timer
+  $logrotate_timer
+  $e2scrub_all_timer
+  $fstrim_timer
+  $dpkg_db_backup_timer
+  $sysstat_collect_timer
+  $sysstat_summary_timer
+"
+
+# systemctl mask creates a /dev/null alias even for a unit that does not exist.
+# Check the composition before masking so a base-image change fails the bake.
+for unit in $masked_units; do
+  if ! systemctl cat "$unit" >/dev/null 2>&1; then
+    echo "Runner image boot policy requires unit $unit, but it is not installed." >&2
+    exit 1
+  fi
+done
+
+# --now closes an already-running maintenance window before Packer snapshots the image.
+systemctl mask --now $masked_units
+
+# Verify the manager accepted every mask instead of trusting systemctl's exit status alone.
+for unit in $masked_units; do
+  state="$(systemctl is-enabled "$unit" 2>/dev/null || true)"
+  if [ "$state" != 'masked' ]; then
+    echo "Runner image boot policy failed to mask $unit (state: $state)." >&2
+    exit 1
+  fi
+done
+
+# This override is test-only. Production always writes the system drop-in below /etc.
+journald_drop_in="${SHIPFOX_JOURNAL_DROP_IN:-/etc/systemd/journald.conf.d/shipfox-volatile.conf}"
+journal_runtime_max_use='64M'
+journal_rate_limit_interval='30s'
+journal_rate_limit_burst='1000'
 install -d -m 0755 "$(dirname "$journald_drop_in")"
-cat > "$journald_drop_in" <<'EOF'
+cat > "$journald_drop_in" <<EOF
 [Journal]
 Storage=volatile
+RuntimeMaxUse=$journal_runtime_max_use
+RateLimitIntervalSec=$journal_rate_limit_interval
+RateLimitBurst=$journal_rate_limit_burst
 EOF
+
+# cat-config includes every applicable drop-in in precedence order. The last value
+# for each key is the effective value, so a later image-provided override fails the bake.
+effective_journald_config="$(systemd-analyze cat-config systemd/journald.conf)"
+config_value() {
+  printf '%s\n' "$effective_journald_config" |
+    sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//p" |
+    tail -n 1
+}
+
+if [ "$(config_value Storage)" != 'volatile' ]; then
+  echo 'Runner image boot policy requires volatile journald storage.' >&2
+  exit 1
+fi
+if [ "$(config_value RuntimeMaxUse)" != "$journal_runtime_max_use" ]; then
+  echo "Runner image boot policy requires RuntimeMaxUse=$journal_runtime_max_use." >&2
+  exit 1
+fi
+if [ "$(config_value RateLimitIntervalSec)" != "$journal_rate_limit_interval" ]; then
+  echo "Runner image boot policy requires RateLimitIntervalSec=$journal_rate_limit_interval." >&2
+  exit 1
+fi
+if [ "$(config_value RateLimitBurst)" != "$journal_rate_limit_burst" ]; then
+  echo "Runner image boot policy requires RateLimitBurst=$journal_rate_limit_burst." >&2
+  exit 1
+fi

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -7,6 +7,46 @@ import {parseBuildRunnerImageArgs} from '#build-runner-image.js';
 import {buildRunnerImageCandidate, parseRunnerImageCandidateArgs} from '#candidate.js';
 import {packerBuildArgs, readMiseNodeVersion} from '#runner-image.js';
 
+const WHITESPACE_PATTERN = /\s+/u;
+const EPHEMERAL_BOOT_MASKED_UNITS = [
+  'apt-daily.service',
+  'apt-daily-upgrade.service',
+  'apt-daily.timer',
+  'apt-daily-upgrade.timer',
+  'unattended-upgrades.service',
+  'systemd-journal-flush.service',
+  'lvm2-monitor.service',
+  'multipathd.service',
+  'multipathd.socket',
+  'ufw.service',
+  'plymouth-read-write.service',
+  'plymouth-quit.service',
+  'plymouth-quit-wait.service',
+  'udisks2.service',
+  'ModemManager.service',
+  'apport.service',
+  'sysstat.service',
+  'e2scrub_reap.service',
+  'hibinit-agent.service',
+  'grub-common.service',
+  'grub-initrd-fallback.service',
+  'keyboard-setup.service',
+  'console-setup.service',
+  'setvtrgb.service',
+  'getty@tty1.service',
+  'motd-news.timer',
+  'update-notifier-download.timer',
+  'update-notifier-motd.timer',
+  'fwupd-refresh.timer',
+  'man-db.timer',
+  'logrotate.timer',
+  'e2scrub_all.timer',
+  'fstrim.timer',
+  'dpkg-db-backup.timer',
+  'sysstat-collect.timer',
+  'sysstat-summary.timer',
+] as const;
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -887,21 +927,25 @@ describe('systemd boot activation', () => {
     const expectations = [
       {
         name: 'shipfox-runner.service',
-        after: 'network-online.target time-sync.target shipfox-runner-env.service',
+        after:
+          'network-online.target time-sync.target shipfox-runner-env.service shipfox-runner-boot-complete.service',
         wants: 'network-online.target time-sync.target',
         wantedBy: undefined,
+        requires: 'shipfox-runner-env.service shipfox-runner-boot-complete.service',
       },
       {
         name: 'shipfox-max-lifetime.service',
         after: 'network-online.target shipfox-runner-env.service',
         wants: 'network-online.target',
         wantedBy: undefined,
+        requires: 'shipfox-runner-env.service',
       },
       {
         name: 'shipfox-spot-watchdog.service',
         after: 'network-online.target shipfox-runner.service shipfox-runner-env.service',
         wants: 'network-online.target',
         wantedBy: 'shipfox-runner.target',
+        requires: 'shipfox-runner-env.service',
       },
     ] as const;
 
@@ -911,7 +955,7 @@ describe('systemd boot activation', () => {
       expect(systemdDirective(unit, 'Unit', 'After'), expectation.name).toBe(expectation.after);
       expect(systemdDirective(unit, 'Unit', 'Wants'), expectation.name).toBe(expectation.wants);
       expect(systemdDirective(unit, 'Unit', 'Requires'), expectation.name).toBe(
-        'shipfox-runner-env.service',
+        expectation.requires,
       );
       expect(systemdDirective(unit, 'Install', 'WantedBy'), expectation.name).toBe(
         expectation.wantedBy,
@@ -936,6 +980,17 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Install', 'WantedBy')).toBeUndefined();
     expect(unit).not.toContain('cloud-config.service');
     expect(unit).not.toContain('cloud-final.service');
+  });
+
+  it('records a durable boot marker before starting the runner', async () => {
+    const marker = await readUnit('shipfox-runner-boot-complete.service');
+    const runner = await readUnit('shipfox-runner.service');
+
+    expect(marker).toContain('/var/lib/shipfox/boot-complete');
+    expect(marker).toContain('Before=shipfox-runner.service');
+    expect(runner).toContain('shipfox-runner-boot-complete.service');
+    expect(marker).not.toContain('cloud-config.service');
+    expect(marker).not.toContain('cloud-final.service');
   });
 });
 
@@ -1062,20 +1117,157 @@ async function createBootFixture(fstab: string) {
 }
 describe('ephemeral boot configuration', () => {
   it('masks disposable boot services and stores the journal in memory', async () => {
-    const script = await readFile(
-      new URL('../scripts/build/configure-ephemeral-boot.sh', import.meta.url),
-      'utf8',
-    );
+    const script = new URL('../scripts/build/configure-ephemeral-boot.sh', import.meta.url);
     const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
 
-    expect(script).toContain('apt-daily.service');
-    expect(script).toContain('apt-daily-upgrade.service');
-    expect(script).toContain('unattended-upgrades.service');
-    expect(script).toContain('systemd-fsck-root.service');
-    expect(script).toContain('systemd-fsck@.service');
-    expect(script).toContain('systemd-journal-flush.service');
-    expect(script).toContain('Storage=volatile');
-    expect(script).toContain('/etc/systemd/journald.conf.d/shipfox-volatile.conf');
-    expect(build).toContain('scripts/build/configure-ephemeral-boot.sh');
+    const fixture = await createEphemeralBootFixture();
+
+    try {
+      execFileSync('sh', ['-n', script.pathname], {stdio: 'pipe'});
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+
+      expect((await readFile(fixture.maskLog, 'utf8')).trim().split(WHITESPACE_PATTERN)).toEqual([
+        '--now',
+        ...EPHEMERAL_BOOT_MASKED_UNITS,
+      ]);
+      expect((await readFile(fixture.catLog, 'utf8')).trim().split('\n')).toEqual([
+        ...EPHEMERAL_BOOT_MASKED_UNITS,
+      ]);
+      expect(await readFile(fixture.journalDropIn, 'utf8')).toBe(
+        '[Journal]\nStorage=volatile\nRuntimeMaxUse=64M\nRateLimitIntervalSec=30s\nRateLimitBurst=1000\n',
+      );
+
+      const scriptsStart = build.indexOf('scripts = [');
+      const scriptsEnd = build.indexOf('\n    ]', scriptsStart);
+      expect(scriptsStart).toBeGreaterThanOrEqual(0);
+      expect(scriptsEnd).toBeGreaterThan(scriptsStart);
+      expect(build.slice(scriptsStart, scriptsEnd)).toContain(
+        'scripts/build/configure-ephemeral-boot.sh',
+      );
+      expect(build).toContain(
+        'shipfox-runner-boot-complete.service /etc/systemd/system/shipfox-runner-boot-complete.service',
+      );
+      expect(build).toContain('systemctl enable shipfox-runner-env.path');
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('fails the image bake when a masked unit is missing', async () => {
+    const script = new URL('../scripts/build/configure-ephemeral-boot.sh', import.meta.url);
+    const fixture = await createEphemeralBootFixture();
+
+    try {
+      expect(() =>
+        execFileSync('sh', [script.pathname], {
+          env: {...fixture.environment, SYSTEMCTL_MISSING_UNIT: 'udisks2.service'},
+          stdio: 'pipe',
+        }),
+      ).toThrow();
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('fails the image bake when a higher-precedence journal setting wins', async () => {
+    const script = new URL('../scripts/build/configure-ephemeral-boot.sh', import.meta.url);
+    const fixture = await createEphemeralBootFixture();
+
+    try {
+      expect(() =>
+        execFileSync('sh', [script.pathname], {
+          env: {...fixture.environment, JOURNAL_EFFECTIVE_STORAGE: 'persistent'},
+          stdio: 'pipe',
+        }),
+      ).toThrow();
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
   });
 });
+
+async function createEphemeralBootFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-ephemeral-boot-'));
+  const commandDirectory = join(root, 'commands');
+  const journalDropIn = join(root, 'etc/systemd/journald.conf.d/shipfox-volatile.conf');
+  const maskLog = join(root, 'systemctl-mask.log');
+  const catLog = join(root, 'systemctl-cat.log');
+
+  await mkdir(commandDirectory, {recursive: true});
+  await writeExecutable(
+    join(commandDirectory, 'systemctl'),
+    `#!/bin/sh
+set -eu
+command="$1"
+shift
+case "$command" in
+  cat)
+    unit="$1"
+    printf '%s\\n' "$unit" >> "$SYSTEMCTL_CAT_LOG"
+    if [ "\${SYSTEMCTL_MISSING_UNIT:-}" = "$unit" ]; then
+      exit 1
+    fi
+    ;;
+  mask)
+    printf '%s\\n' "$*" >> "$SYSTEMCTL_MASK_LOG"
+    ;;
+  is-enabled)
+    printf '%s\\n' masked
+    ;;
+  *)
+    echo "unsupported systemctl command: $command" >&2
+    exit 2
+    ;;
+esac
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'install'),
+    `#!/bin/sh
+set -eu
+if [ "$1" != '-d' ]; then
+  echo "unsupported install invocation" >&2
+  exit 2
+fi
+shift
+if [ "$1" = '-m' ]; then
+  shift 2
+fi
+mkdir -p "$1"
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'systemd-analyze'),
+    `#!/bin/sh
+set -eu
+if [ "$1" != 'cat-config' ]; then
+  echo "unsupported systemd-analyze invocation" >&2
+  exit 2
+fi
+if [ -n "\${JOURNAL_EFFECTIVE_STORAGE:-}" ]; then
+  printf '[Journal]\\nStorage=%s\\nRuntimeMaxUse=64M\\nRateLimitIntervalSec=30s\\nRateLimitBurst=1000\\n' "$JOURNAL_EFFECTIVE_STORAGE"
+else
+  cat "$SHIPFOX_JOURNAL_DROP_IN"
+fi
+`,
+  );
+
+  return {
+    catLog,
+    environment: {
+      ...process.env,
+      PATH: `${commandDirectory}:${process.env.PATH ?? ''}`,
+      SHIPFOX_JOURNAL_DROP_IN: journalDropIn,
+      SYSTEMCTL_CAT_LOG: catLog,
+      SYSTEMCTL_MASK_LOG: maskLog,
+    },
+    journalDropIn,
+    maskLog,
+    root,
+  };
+}
+
+async function writeExecutable(path: string, contents: string): Promise<void> {
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+}

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1060,3 +1060,22 @@ async function createBootFixture(fstab: string) {
     },
   };
 }
+describe('ephemeral boot configuration', () => {
+  it('masks disposable boot services and stores the journal in memory', async () => {
+    const script = await readFile(
+      new URL('../scripts/build/configure-ephemeral-boot.sh', import.meta.url),
+      'utf8',
+    );
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+
+    expect(script).toContain('apt-daily.service');
+    expect(script).toContain('apt-daily-upgrade.service');
+    expect(script).toContain('unattended-upgrades.service');
+    expect(script).toContain('systemd-fsck-root.service');
+    expect(script).toContain('systemd-fsck@.service');
+    expect(script).toContain('systemd-journal-flush.service');
+    expect(script).toContain('Storage=volatile');
+    expect(script).toContain('/etc/systemd/journald.conf.d/shipfox-volatile.conf');
+    expect(build).toContain('scripts/build/configure-ephemeral-boot.sh');
+  });
+});


### PR DESCRIPTION
Runner instances are ephemeral, so the image should not spend startup time on package-update timers, filesystem checks, or persistent journal flushes. This change applies that boot policy during the image bake and keeps runner journald output volatile for the lifetime of the instance.

Validation completed locally with:
- `mise exec -- turbo check --filter=@shipfox/runner-image`
- `mise exec -- turbo type --filter=@shipfox/runner-image`
- `mise exec -- turbo test --filter=@shipfox/runner-image`
- `mise exec -- pnpm --filter=@shipfox/runner-image verify`
- `mise exec -- sh -n infra/images/runner/scripts/build/configure-ephemeral-boot.sh`
- `git diff --check`

Closes ENG-1531

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up ephemeral runner boot by masking disposable services, bounding in‑memory journald, and recording a boot-complete marker. Satisfies ENG-1531 by cutting startup work, avoiding disk writes, and enforcing the policy at bake time.

- **New Features**
  - Add `shipfox-runner-boot-complete.service` to write `/var/lib/shipfox/boot-complete` and gate `shipfox-runner.service` with `After`/`Requires`.
  - Configure `journald` via `/etc/systemd/journald.conf.d/shipfox-volatile.conf` with `Storage=volatile`, `RuntimeMaxUse=64M`, `RateLimitIntervalSec=30s`, `RateLimitBurst=1000`.
  - Add `.github/workflows/runner-image-freshness.yml` to fail if the latest candidate and manifest are older than 7 days.

- **Refactors**
  - Add `configure-ephemeral-boot.sh` to mask a strict unit inventory, verify units exist, apply masks, and assert effective `journald` settings; integrate in `infra/images/runner/build.pkr.hcl`.
  - Update tests with systemd fixtures to validate masking, journald limits, failure on missing units or overridden settings, and runner unit dependencies/boot marker.
  - Expand docs on boot policy, AppArmor (kept enabled), journal retention, and image freshness in `infra/images/runner/README.md`.

<sup>Written for commit d321e06f3c397055094bec74ccf641b6ee64b87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

