### PR TITLE
[provisioner-ec2] Register service metrics and reconcile absence telemetry

### DIFF
--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -1010,14 +1010,29 @@ describe('createEc2Lifecycle', () => {
 
   it('logs backend absent ids while reconciling an empty observed set', async () => {
     const client = fakeClient({
-      reconcileResponse: {runners: [], terminated_absent_provider_runner_ids: ['vanished-runner']},
+      reconcileResponse: {
+        runners: [],
+        terminated_absent_provider_runner_ids: ['vanished-runner-1', 'vanished-runner-2'],
+      },
     });
     const lifecycle = makeLifecycle({client});
 
     await lifecycle.reconcile();
 
     expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: []}]);
-    expect(observability.recordEc2ReconcileAbsent).toHaveBeenCalledOnce();
+    expect(observability.recordEc2ReconcileAbsent).toHaveBeenCalledWith(2);
+    expect(observability.recordEc2ReconcileAbsent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not record reconcile absence when the backend reports no absent ids', async () => {
+    const client = fakeClient({
+      reconcileResponse: {runners: [], terminated_absent_provider_runner_ids: []},
+    });
+    const lifecycle = makeLifecycle({client});
+
+    await lifecycle.reconcile();
+
+    expect(observability.recordEc2ReconcileAbsent).not.toHaveBeenCalled();
   });
 
   it('terminates only managed instances matching requested ids', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -13,12 +13,14 @@ import type {Ec2TemplateSpec} from '#templates.js';
 const observability = vi.hoisted(() => ({
   logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
   recordEc2Launch: vi.fn(),
+  recordEc2ReconcileAbsent: vi.fn(),
   recordEc2Termination: vi.fn(),
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
 vi.mock('#metrics/instance.js', () => ({
   recordEc2Launch: observability.recordEc2Launch,
+  recordEc2ReconcileAbsent: observability.recordEc2ReconcileAbsent,
   recordEc2Termination: observability.recordEc2Termination,
 }));
 
@@ -1015,6 +1017,7 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.reconcile();
 
     expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: []}]);
+    expect(observability.recordEc2ReconcileAbsent).toHaveBeenCalledOnce();
   });
 
   it('terminates only managed instances matching requested ids', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -20,6 +20,7 @@ import {buildInstanceTags, parseInstanceIdentity} from '#instance-identity.js';
 import {
   type Ec2TerminationReason,
   recordEc2Launch,
+  recordEc2ReconcileAbsent,
   recordEc2Termination,
 } from '#metrics/instance.js';
 import type {Ec2TemplateSpec} from '#templates.js';
@@ -223,6 +224,7 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
       .map((runner) => runner.provider_runner_id),
   );
   if (response.terminated_absent_provider_runner_ids.length > 0) {
+    recordEc2ReconcileAbsent();
     logger().info(
       {providerRunnerIds: response.terminated_absent_provider_runner_ids},
       'Backend terminated provisioned runners absent from EC2',

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -224,7 +224,7 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
       .map((runner) => runner.provider_runner_id),
   );
   if (response.terminated_absent_provider_runner_ids.length > 0) {
-    recordEc2ReconcileAbsent();
+    recordEc2ReconcileAbsent(response.terminated_absent_provider_runner_ids.length);
     logger().info(
       {providerRunnerIds: response.terminated_absent_provider_runner_ids},
       'Backend terminated provisioned runners absent from EC2',

--- a/libs/provisioner/ec2/src/metrics/instance.test.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.test.ts
@@ -45,9 +45,9 @@ describe('EC2 provisioner metrics', () => {
     });
   });
 
-  it('records reconcile absence without labels', () => {
-    metrics.recordEc2ReconcileAbsent();
+  it('records the reconcile absence count without labels', () => {
+    metrics.recordEc2ReconcileAbsent(2);
 
-    expect(counterAdd('ec2_provisioner_reconcile_absent')).toHaveBeenCalledWith(1);
+    expect(counterAdd('ec2_provisioner_reconcile_absent')).toHaveBeenCalledWith(2);
   });
 });

--- a/libs/provisioner/ec2/src/metrics/instance.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.ts
@@ -39,6 +39,6 @@ export function recordEc2Termination(reason: Ec2TerminationReason): void {
   terminateCount.add(1, {reason});
 }
 
-export function recordEc2ReconcileAbsent(): void {
-  reconcileAbsentCount.add(1);
+export function recordEc2ReconcileAbsent(count: number): void {
+  reconcileAbsentCount.add(count);
 }

--- a/libs/provisioner/ec2/src/provisioner.test.ts
+++ b/libs/provisioner/ec2/src/provisioner.test.ts
@@ -1,4 +1,16 @@
-import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
+const observability = vi.hoisted(() => ({
+  registerEc2ServiceMetrics: vi.fn(),
+}));
+
+vi.mock('#metrics/service.js', () => ({
+  registerEc2ServiceMetrics: observability.registerEc2ServiceMetrics,
+}));
+
+import type {
+  ProviderRunnerTracker,
+  ProvisionerClient,
+  ProvisionerTemplate,
+} from '@shipfox/provisioner-core';
 import type {Ec2Engine} from '#ec2-engine.js';
 import {createEc2ProvisionerAdapter} from '#provisioner.js';
 import type {Ec2TemplateSpec} from '#templates.js';
@@ -28,6 +40,10 @@ const engine: Ec2Engine = {
 };
 
 describe('createEc2ProvisionerAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it.each([
     [300_000, 330],
     [600_000, 630],
@@ -43,5 +59,33 @@ describe('createEc2ProvisionerAdapter', () => {
     });
 
     expect(adapter.reservationTtlSeconds).toBe(reservationTtlSeconds);
+  });
+
+  it('registers service metrics with the authenticated provisioner identity', async () => {
+    const adapter = createEc2ProvisionerAdapter({
+      engine,
+      templates: [template],
+      registrationDeadlineMs: 300_000,
+      launchHeadroomMs: 30_000,
+      reconcileIntervalMs: 60_000,
+    });
+
+    await adapter.onStart?.({
+      client: {
+        reconcileRunnerInstances: vi.fn().mockResolvedValue({
+          runners: [],
+          terminated_absent_provider_runner_ids: [],
+        }),
+      } as unknown as ProvisionerClient,
+      identity: {id: 'provisioner-1', workspaceId: null},
+      tracker: {
+        replaceAll: vi.fn(),
+      } as unknown as ProviderRunnerTracker,
+    });
+
+    expect(observability.registerEc2ServiceMetrics).toHaveBeenCalledWith({
+      engine,
+      provisionerId: 'provisioner-1',
+    });
   });
 });

--- a/libs/provisioner/ec2/src/provisioner.ts
+++ b/libs/provisioner/ec2/src/provisioner.ts
@@ -8,6 +8,7 @@ import {
 import {config} from '#config.js';
 import {createEc2Engine, type Ec2Engine} from '#ec2-engine.js';
 import {createEc2Lifecycle, type Ec2Lifecycle} from '#lifecycle.js';
+import {registerEc2ServiceMetrics} from '#metrics/service.js';
 import {type Ec2TemplateSpec, loadEc2Templates} from '#templates.js';
 import {renderRunnerBootstrapUserData} from '#user-data.js';
 
@@ -37,6 +38,7 @@ export function createEc2ProvisionerAdapter(
     launch: (launch) => requireLifecycle(lifecycle).launch(launch),
     terminate: (ids) => requireLifecycle(lifecycle).terminate(ids),
     async onStart(runtime) {
+      registerEc2ServiceMetrics({engine: options.engine, provisionerId: runtime.identity.id});
       lifecycle = createLifecycle(options, runtime);
       await lifecycle.reconcile();
     },


### PR DESCRIPTION
The EC2 provider already defines its service gauge and reconcile-absence counter, but startup never registered the gauge and reconciliation had no production counter call site. This wires both into the existing lifecycle after the provisioner identity is available.

Validation: the provider test suite (136 tests), affected check/type/build tasks, and direct provisioner app check/type/build all pass.

Closes ENG-1534

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the EC2 service gauge and counts reconcile-absent runners so the provisioner emits real metrics in production. Satisfies ENG-1534 by making `ec2_provisioner_managed_instances` and `ec2_provisioner_reconcile_absent` show up on scrape endpoints.

- **Bug Fixes**
  - Register `registerEc2ServiceMetrics` during `onStart` after identity is available, using `{ engine, provisionerId }`.
  - Record reconcile absence per runner during reconciliation by adding the count of backend-reported absent IDs.
  - Add tests for service metrics registration, counting semantics, and no-op when none are absent.

<sup>Written for commit bdb4fac31c693a2e1f2c10817dd098a6de5140c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

