### PR TITLE
Prepare Shipfox workspaces with profile-aware setup

### DIFF
--- a/dev/workspace-setup.sh
+++ b/dev/workspace-setup.sh
@@ -79,6 +79,10 @@ start_worktree_services() {
     die "Docker Compose is required for this setup profile; install or enable the Docker Compose plugin."
   fi
 
+  if ! docker info >/dev/null 2>&1; then
+    die "Docker daemon is unavailable; start Docker before running workspace:setup."
+  fi
+
   require_command pnpm
   pnpm dev:services:up
 }

--- a/dev/workspace-setup.sh
+++ b/dev/workspace-setup.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+die() {
+  printf 'workspace setup: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_profile() {
+  local explicit_profile=${SHIPFOX_SETUP_PROFILE:-}
+
+  if [[ -n "$explicit_profile" ]]; then
+    case "$explicit_profile" in
+      conductor-local|conductor-cloud|workflow|developer)
+        printf '%s\n' "$explicit_profile"
+        return
+        ;;
+      *)
+        die "SHIPFOX_SETUP_PROFILE must be one of conductor-local, conductor-cloud, workflow, or developer (received '$explicit_profile')."
+        ;;
+    esac
+  fi
+
+  case "${CONDUCTOR_IS_LOCAL:-}" in
+    1)
+      printf '%s\n' conductor-local
+      ;;
+    0)
+      printf '%s\n' conductor-cloud
+      ;;
+    '')
+      if [[ -n "${SHIPFOX_WORKSPACE:-}" ]]; then
+        printf '%s\n' workflow
+      else
+        printf '%s\n' developer
+      fi
+      ;;
+    *)
+      die "CONDUCTOR_IS_LOCAL must be 1 or 0 when set (received '${CONDUCTOR_IS_LOCAL}')."
+      ;;
+  esac
+}
+
+require_command() {
+  local command_name=$1
+
+  command -v "$command_name" >/dev/null 2>&1 ||
+    die "'$command_name' is required; install it before running workspace:setup."
+}
+
+prepare_root_tools() {
+  local root_path=${CONDUCTOR_ROOT_PATH:-}
+
+  [[ -z "$root_path" ]] && return
+
+  [[ -d "$root_path" ]] ||
+    die "CONDUCTOR_ROOT_PATH '$root_path' does not exist or is not a directory."
+  [[ -f "$root_path/mise.toml" ]] ||
+    die "CONDUCTOR_ROOT_PATH '$root_path' does not contain mise.toml."
+
+  require_command mise
+  mise -C "$root_path" trust --yes mise.toml
+  mise -C "$root_path" install
+}
+
+install_dependencies() {
+  require_command pnpm
+  pnpm -r install --frozen-lockfile
+  printf 'workspace setup: repository context is tracked; no generated context step is required.\n'
+}
+
+start_worktree_services() {
+  if ! command -v docker >/dev/null 2>&1; then
+    die "Docker is required for this setup profile; install Docker before running workspace:setup."
+  fi
+
+  if ! docker compose version >/dev/null 2>&1; then
+    die "Docker Compose is required for this setup profile; install or enable the Docker Compose plugin."
+  fi
+
+  require_command pnpm
+  pnpm dev:services:up
+}
+
+start_shared_ollama() {
+  require_command mise
+  mise run ollama:up
+}
+
+run_context() {
+  local profile
+  profile=$(resolve_profile)
+
+  if [[ "$profile" == "conductor-local" ]]; then
+    prepare_root_tools
+  fi
+
+  install_dependencies
+}
+
+run_services() {
+  local profile
+  profile=$(resolve_profile)
+
+  case "$profile" in
+    conductor-local|developer)
+      start_worktree_services
+      start_shared_ollama
+      ;;
+    workflow)
+      start_worktree_services
+      ;;
+    conductor-cloud)
+      ;;
+  esac
+
+  printf 'workspace setup: ready (%s).\n' "$profile"
+}
+
+usage() {
+  printf 'Usage: %s <context|services>\n' "${0##*/}" >&2
+  exit 1
+}
+
+main() {
+  case "${1:-}" in
+    context)
+      run_context
+      ;;
+    services)
+      run_services
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,15 @@ else
 fi
 """
 
+[tasks."workspace:setup:context"]
+description = "Install pinned tools, dependencies, and repository context"
+run = "bash dev/workspace-setup.sh context"
+
+[tasks."workspace:setup"]
+description = "Prepare this workspace for development and agent execution"
+depends = ["workspace:setup:context"]
+run = "bash dev/workspace-setup.sh services"
+
 [tasks.e2e]
 description = "Run E2E tests with local API and client dev servers"
 depends = ["e2e:build"]


### PR DESCRIPTION
Adds the upstream workspace setup entrypoint for Conductor and other agent workspaces.

The profile-aware script prepares the pinned toolchain and frozen dependencies, then starts isolated worktree services and shared Ollama only where the resolved profile needs them. Cloud workflows remain service-free, while local Conductor workspaces preserve the root-tool setup path.

Closes ENG-1543

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Profile‑aware workspace setup for Conductor and agent workspaces. Installs pinned tools and frozen deps, validates Docker before bootstrapping, and starts only the services needed per profile. Closes ENG-1543.

- **New Features**
  - Adds `dev/workspace-setup.sh` with `context` and `services` commands.
  - Supports profiles: `conductor-local`, `conductor-cloud`, `workflow`, `developer`; chosen via `SHIPFOX_SETUP_PROFILE` or inferred from `CONDUCTOR_IS_LOCAL` / `SHIPFOX_WORKSPACE`.
  - `context`: installs repo deps with `pnpm -r install --frozen-lockfile`; for `conductor-local`, installs root tools from `CONDUCTOR_ROOT_PATH` using `mise`.
  - `services`: validates `docker`/`Docker Compose` and daemon availability, then starts worktree services via `pnpm dev:services:up`; starts shared `Ollama` via `mise run ollama:up` where required.
  - Adds `mise` tasks: `workspace:setup:context` and `workspace:setup`.

- **Migration**
  - Local: run `mise run workspace:setup`. CI/cloud: run `mise run workspace:setup:context`.
  - To force a profile, set `SHIPFOX_SETUP_PROFILE`. Otherwise use `CONDUCTOR_IS_LOCAL` or `SHIPFOX_WORKSPACE` for detection.

<sup>Written for commit f177a8dab931613a459745df5a25a6cd86ce9047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

