### PR TITLE
[client-workflows] Let the run job rail fill available height

### DIFF
--- a/.changeset/expand-job-rail.md
+++ b/.changeset/expand-job-rail.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Lets the run job rail use available height and exposes overflow when the job list scrolls.

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -53,8 +53,12 @@ export function RunWorkspaceNav({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <aside className="w-full shrink-0 border-b border-border-neutral-base bg-background-neutral-background min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
-        <Collapsible open={mobileOpen} onOpenChange={setMobileOpen}>
+      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base bg-background-neutral-background min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
+        <Collapsible
+          open={mobileOpen}
+          onOpenChange={setMobileOpen}
+          className="flex min-h-0 flex-col min-[768px]:flex-1"
+        >
           <CollapsibleTrigger asChild>
             <button
               type="button"
@@ -82,7 +86,7 @@ export function RunWorkspaceNav({
           </CollapsibleTrigger>
           <div
             className={cn(
-              'max-h-[50vh] overflow-y-auto p-tight min-[768px]:block min-[768px]:max-h-none min-[768px]:p-[12px]',
+              'flex min-h-0 max-h-[50vh] flex-col overflow-y-auto p-tight scrollbar min-[768px]:min-h-0 min-[768px]:flex-1 min-[768px]:overflow-hidden min-[768px]:p-[12px]',
               !mobileOpen && 'hidden',
             )}
           >
@@ -136,7 +140,7 @@ function RunWorkspaceNavContent({
   }, [currentJobId, mobileOpen]);
 
   return (
-    <nav aria-label="Run workspace" className="flex min-w-0 flex-col gap-group">
+    <nav aria-label="Run workspace" className="flex min-h-0 min-w-0 flex-1 flex-col gap-group">
       <ul>
         <li>
           <RunSectionLink
@@ -151,7 +155,10 @@ function RunWorkspaceNavContent({
         </li>
       </ul>
 
-      <section aria-labelledby="run-workspace-jobs-heading" className="min-w-0">
+      <section
+        aria-labelledby="run-workspace-jobs-heading"
+        className="flex min-h-0 min-w-0 flex-1 flex-col"
+      >
         <div className="flex items-center justify-between gap-inline px-tight pb-[6px]">
           <Text
             as="h2"
@@ -166,7 +173,7 @@ function RunWorkspaceNavContent({
             {jobs.length}
           </Text>
         </div>
-        <ol className="max-h-[320px] overflow-y-auto">
+        <ol className="min-h-0 flex-1 overflow-y-auto scrollbar">
           {jobs.map((job) => {
             const current = job.id === currentJobId;
             const execution = defaultJobExecution(job);

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -86,7 +86,7 @@ export function RunWorkspaceNav({
           </CollapsibleTrigger>
           <div
             className={cn(
-              'flex min-h-0 max-h-[50vh] flex-col overflow-y-auto p-tight scrollbar min-[768px]:min-h-0 min-[768px]:flex-1 min-[768px]:flex min-[768px]:overflow-hidden min-[768px]:p-[12px]',
+              'flex min-h-0 max-h-[50vh] flex-col overflow-y-auto p-tight scrollbar min-[768px]:min-h-0 min-[768px]:max-h-none min-[768px]:flex-1 min-[768px]:flex min-[768px]:overflow-hidden min-[768px]:p-[12px]',
               !mobileOpen && 'hidden',
             )}
           >

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -86,7 +86,7 @@ export function RunWorkspaceNav({
           </CollapsibleTrigger>
           <div
             className={cn(
-              'flex min-h-0 max-h-[50vh] flex-col overflow-y-auto p-tight scrollbar min-[768px]:min-h-0 min-[768px]:flex-1 min-[768px]:overflow-hidden min-[768px]:p-[12px]',
+              'flex min-h-0 max-h-[50vh] flex-col overflow-y-auto p-tight scrollbar min-[768px]:min-h-0 min-[768px]:flex-1 min-[768px]:flex min-[768px]:overflow-hidden min-[768px]:p-[12px]',
               !mobileOpen && 'hidden',
             )}
           >


### PR DESCRIPTION
## Summary

Expands the run workspace job rail to use the available height and makes overflowing job lists visibly scrollable.

## Validation

- `mise exec -- pnpm --filter @shipfox/client-workflows test -- src/components/workflow-run-view/run-workspace-nav.test.tsx` (514 tests passed)
- `mise exec -- pnpm turbo check type --filter=@shipfox/client-workflows...`
- Impeccable layout detector
- `mise exec -- pnpm exec changeset status`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the run workspace job rail to fill available height and stay visible on desktop. Removed the desktop height cap and added a visible scrollbar so long job lists scroll.

<sup>Written for commit 9dfb8ed6297d5f1380f348b4e663ec72689760f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

