### PR TITLE
Surface materialized output contract failures

### DIFF
--- a/.changeset/invalid-job-output-reason.md
+++ b/.changeset/invalid-job-output-reason.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/client-workflows": minor
+---
+
+Expose actionable status reasons and messages when materialized job outputs cannot be persisted.

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -36,6 +36,7 @@ const jobStatusReasonSchema = z.enum([
   'output_too_large',
   'step_failed',
   'unknown',
+  'output_invalid',
 ]);
 const stepStatusSchema = z.enum([
   'pending',

--- a/libs/api/workflows-dto/src/schemas/job.test.ts
+++ b/libs/api/workflows-dto/src/schemas/job.test.ts
@@ -42,4 +42,17 @@ describe('job DTO schema', () => {
 
     expect(result.status_reason).toBe(statusReason);
   });
+
+  it.each([
+    'output_too_large',
+    'output_invalid',
+  ] as const)('accepts job failure reason "%s"', (statusReason) => {
+    const result = jobDtoSchema.parse({
+      ...baseJob,
+      status: 'failed',
+      status_reason: statusReason,
+    });
+
+    expect(result.status_reason).toBe(statusReason);
+  });
 });

--- a/libs/api/workflows-dto/src/schemas/job.ts
+++ b/libs/api/workflows-dto/src/schemas/job.ts
@@ -29,6 +29,7 @@ export const jobStatusReasonSchema = z.enum([
   'output_too_large',
   'step_failed',
   'unknown',
+  'output_invalid',
 ]);
 
 export const jobDtoSchema = z.object({

--- a/libs/api/workflows/drizzle/0003_output_invalid_reason.sql
+++ b/libs/api/workflows/drizzle/0003_output_invalid_reason.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."workflows_job_status_reason" ADD VALUE IF NOT EXISTS 'output_invalid';

--- a/libs/api/workflows/drizzle/meta/0003_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1719 @@
+{
+  "id": "7fc1dd61-d6c6-445b-a15d-44522482203b",
+  "prevId": "df02992d-d268-4b83-854a-df532a063418",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_job_executions": {
+      "name": "workflows_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason_message": {
+          "name": "status_reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_job_executions_job_id_idx": {
+          "name": "workflows_job_executions_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_running_idx": {
+          "name": "workflows_job_executions_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_executions\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_job_sequence_uq": {
+          "name": "workflows_job_executions_job_sequence_uq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_executions_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_executions_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_executions",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_listener_events": {
+      "name": "workflows_job_listener_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "workflows_job_listener_event_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_ref": {
+          "name": "event_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by_execution_id": {
+          "name": "consumed_by_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_job_listener_events_job_event_ref_unique": {
+          "name": "workflows_job_listener_events_job_event_ref_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_job_received_idx": {
+          "name": "workflows_job_listener_events_job_received_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_listener_events_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_listener_events_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["consumed_by_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "workflows_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over": {
+          "name": "carried_over",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checkout_persist_credentials": {
+          "name": "checkout_persist_credentials",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkout_permissions_contents": {
+          "name": "checkout_permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_timeout_ms": {
+          "name": "execution_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_timeout_ms": {
+          "name": "listening_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions": {
+          "name": "max_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_resolve": {
+          "name": "on_resolve",
+          "type": "workflows_job_on_resolve",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_debounce_ms": {
+          "name": "batch_debounce_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_size": {
+          "name": "batch_max_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_wait_ms": {
+          "name": "batch_max_wait_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listener_status": {
+          "name": "listener_status",
+          "type": "workflows_listener_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "workflows_resolution_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_on": {
+          "name": "listening_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_until": {
+          "name": "listening_until",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_jobs_workflow_run_attempt_id_idx": {
+          "name": "workflows_jobs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_jobs_active_listeners_idx": {
+          "name": "workflows_jobs_active_listeners_idx",
+          "columns": [
+            {
+              "expression": "listener_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_jobs\".\"listener_status\" = 'listening'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_order": {
+          "name": "execution_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_outcome": {
+          "name": "log_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_feedback": {
+          "name": "restart_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        },
+        "workflows_step_attempts_job_execution_id_execution_order_uq": {
+          "name": "workflows_step_attempts_job_execution_id_execution_order_uq",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id", "execution_order"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_execution_order_positive_ck": {
+          "name": "workflows_step_attempts_execution_order_positive_ck",
+          "value": "\"workflows_step_attempts\".\"execution_order\" > 0"
+        },
+        "workflows_step_attempts_status_dispatched_ck": {
+          "name": "workflows_step_attempts_status_dispatched_ck",
+          "value": "\"workflows_step_attempts\".\"status\" NOT IN ('pending', 'skipped')"
+        },
+        "workflows_step_attempts_log_outcome_ck": {
+          "name": "workflows_step_attempts_log_outcome_ck",
+          "value": "\"workflows_step_attempts\".\"log_outcome\" IS NULL OR \"workflows_step_attempts\".\"log_outcome\" IN ('drained', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_step_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_plan": {
+          "name": "config_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authored_config": {
+          "name": "authored_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_execution_id_idx": {
+          "name": "workflows_steps_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_steps_id_job_execution_id_uq": {
+          "name": "workflows_steps_id_job_execution_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_steps_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_steps_current_attempt_positive_ck": {
+          "name": "workflows_steps_current_attempt_positive_ck",
+          "value": "\"workflows_steps\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_attempts": {
+      "name": "workflows_workflow_run_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rerun_mode": {
+          "name": "rerun_mode",
+          "type": "workflows_rerun_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rerun_by_user_id": {
+          "name": "rerun_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_tool_materialization": {
+          "name": "agent_tool_materialization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wra_workflow_run_attempt_unique": {
+          "name": "workflows_wra_workflow_run_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wra_one_active_attempt_unique": {
+          "name": "workflows_wra_one_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows_workflow_run_attempts\".\"status\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_workflow_run_attempts",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["workflow_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wra_attempt_positive_ck": {
+          "name": "workflows_wra_attempt_positive_ck",
+          "value": "\"workflows_workflow_run_attempts\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_counters": {
+      "name": "workflows_workflow_run_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_wrrc_definition_id_unique": {
+          "name": "workflows_wrrc_definition_id_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_provider": {
+          "name": "trigger_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2592000000
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_definition_number_unique": {
+          "name": "workflows_wr_definition_number_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_running_idx": {
+          "name": "workflows_wr_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wr_current_attempt_positive_ck": {
+          "name": "workflows_wr_current_attempt_positive_ck",
+          "value": "\"workflows_workflow_runs\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_job_execution_status": {
+      "name": "workflows_job_execution_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_job_listener_event_disposition": {
+      "name": "workflows_job_listener_event_disposition",
+      "schema": "public",
+      "values": ["fire", "resolve"]
+    },
+    "public.workflows_checkout_contents": {
+      "name": "workflows_checkout_contents",
+      "schema": "public",
+      "values": ["read", "write"]
+    },
+    "public.workflows_job_mode": {
+      "name": "workflows_job_mode",
+      "schema": "public",
+      "values": ["one_shot", "listening"]
+    },
+    "public.workflows_job_on_resolve": {
+      "name": "workflows_job_on_resolve",
+      "schema": "public",
+      "values": ["finish", "cancel"]
+    },
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_job_status_reason": {
+      "name": "workflows_job_status_reason",
+      "schema": "public",
+      "values": [
+        "dependency_not_completed",
+        "condition_false",
+        "default_gate_rejected",
+        "condition_rejected",
+        "condition_errored",
+        "user_cancelled",
+        "run_cancelled",
+        "timed_out",
+        "runner_lost",
+        "output_too_large",
+        "step_failed",
+        "unknown",
+        "output_invalid"
+      ]
+    },
+    "public.workflows_listener_status": {
+      "name": "workflows_listener_status",
+      "schema": "public",
+      "values": ["inactive", "listening", "resolved"]
+    },
+    "public.workflows_resolution_reason": {
+      "name": "workflows_resolution_reason",
+      "schema": "public",
+      "values": ["until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_step_status_reason": {
+      "name": "workflows_step_status_reason",
+      "schema": "public",
+      "values": ["default_gate_rejected", "condition_rejected", "condition_errored"]
+    },
+    "public.workflows_rerun_mode": {
+      "name": "workflows_rerun_mode",
+      "schema": "public",
+      "values": ["all", "failed"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1786203875223,
       "tag": "0002_output_failure_details",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1786266649202,
+      "tag": "0003_output_invalid_reason",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/core/entities/job.ts
+++ b/libs/api/workflows/src/core/entities/job.ts
@@ -28,6 +28,7 @@ export const JOB_STATUS_REASONS = [
   'output_too_large',
   'step_failed',
   'unknown',
+  'output_invalid',
 ] as const;
 
 export type JobStatusReason = (typeof JOB_STATUS_REASONS)[number];

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -1,6 +1,12 @@
 import {WORKFLOWS_JOB_EXECUTION_TIMED_OUT} from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
 import {
+  InterpolationUnresolvableError,
+  JobOutputNotJsonSafeError,
+  JobOutputTooLargeError,
+  JobOutputTooManyEntriesError,
+} from '#core/errors.js';
+import {
   MAX_JOB_OUTPUT_ENTRIES,
   MAX_JOB_OUTPUT_VALUE_BYTES,
 } from '#core/step-config/job-output-limits.js';
@@ -19,6 +25,7 @@ import {
   resolveJobExecutionAfterLeaseExpiry,
   updateJobExecutionStatus,
 } from '../workflow-runs.js';
+import {classifyJobOutputFailure} from './job-executions.js';
 
 describe('workflow run job executions', () => {
   let workspaceId: string;
@@ -278,6 +285,48 @@ describe('workflow run job executions', () => {
     });
   });
 
+  test('fails a successful execution when a materialized job output cannot be resolved', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({
+        jobs: {
+          build: {
+            steps: [{key: 'collect', run: 'echo build'}],
+            outputs: {payload: template('steps.collect.outputs.missing')},
+          },
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+    await finishCollectedStep(job.id, {});
+
+    const resolved = await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'succeeded',
+      expectedVersion: execution.version,
+    });
+
+    expect(resolved).toMatchObject({
+      status: 'failed',
+      statusReason: 'output_invalid',
+      statusReasonMessage: expect.stringContaining(
+        'job.outputs uses `steps.collect.outputs.missing`',
+      ),
+      outputs: null,
+    });
+  });
+
   test('fails a successful execution when the persisted model has too many job outputs', async () => {
     const outputs = Object.fromEntries(
       Array.from({length: MAX_JOB_OUTPUT_ENTRIES + 1}, (_, index) => {
@@ -316,7 +365,52 @@ describe('workflow run job executions', () => {
       expectedVersion: execution.version,
     });
 
-    expect(resolved).toMatchObject({status: 'failed', statusReason: 'unknown', outputs: null});
+    expect(resolved).toMatchObject({
+      status: 'failed',
+      statusReason: 'output_invalid',
+      statusReasonMessage: `Job outputs cannot define more than ${MAX_JOB_OUTPUT_ENTRIES} entries (found ${MAX_JOB_OUTPUT_ENTRIES + 1})`,
+      outputs: null,
+    });
+  });
+});
+
+describe('classifyJobOutputFailure', () => {
+  test.each([
+    [
+      new InterpolationUnresolvableError('definition-1', {
+        field: 'job.outputs',
+        source: 'steps.collect.outputs.payload',
+      }),
+      'output_invalid',
+    ],
+    [new JobOutputNotJsonSafeError('payload', 'undefined is not a JSON value'), 'output_invalid'],
+    [new JobOutputTooManyEntriesError(11, 10), 'output_invalid'],
+    [new JobOutputTooLargeError('payload', 16 * 1024, 16 * 1024 + 1, 'value'), 'output_too_large'],
+  ] as const)('classifies %s with the persisted reason', (error, statusReason) => {
+    expect(classifyJobOutputFailure(error)).toMatchObject({statusReason});
+  });
+
+  test('does not classify interpolation failures outside job outputs', () => {
+    const error = new InterpolationUnresolvableError('definition-1', {
+      field: 'env',
+      source: 'event.ref',
+      envKey: 'REF',
+    });
+
+    expect(classifyJobOutputFailure(error)).toBeNull();
+  });
+
+  test('does not classify unexpected failures', () => {
+    expect(classifyJobOutputFailure(new Error('database unavailable'))).toBeNull();
+  });
+
+  test('bounds the persisted message', () => {
+    const failure = classifyJobOutputFailure(
+      new JobOutputNotJsonSafeError('payload', 'x'.repeat(4096)),
+    );
+
+    expect(failure?.statusReasonMessage).toHaveLength(2048);
+    expect(failure?.statusReasonMessage.endsWith('…')).toBe(true);
   });
 });
 

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -122,6 +122,41 @@ export interface UpdateJobExecutionStatusAtVersionParams {
   secrets?: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'> | undefined;
 }
 
+const MAX_STATUS_REASON_MESSAGE_LENGTH = 2048;
+
+export type JobOutputFailure = {
+  statusReason: Extract<JobStatusReason, 'output_invalid' | 'output_too_large'>;
+  statusReasonMessage: string;
+};
+
+export function classifyJobOutputFailure(error: unknown): JobOutputFailure | null {
+  if (error instanceof JobOutputTooLargeError) {
+    return {
+      statusReason: 'output_too_large',
+      statusReasonMessage: boundedStatusReasonMessage(error.message),
+    };
+  }
+
+  if (
+    (error instanceof InterpolationUnresolvableError && error.field === 'job.outputs') ||
+    error instanceof JobOutputNotJsonSafeError ||
+    error instanceof JobOutputTooManyEntriesError
+  ) {
+    return {
+      statusReason: 'output_invalid',
+      statusReasonMessage: boundedStatusReasonMessage(error.message),
+    };
+  }
+
+  return null;
+}
+
+function boundedStatusReasonMessage(message: string): string {
+  return message.length <= MAX_STATUS_REASON_MESSAGE_LENGTH
+    ? message
+    : `${message.slice(0, MAX_STATUS_REASON_MESSAGE_LENGTH - 1)}…`;
+}
+
 async function resolveJobExecutionOutputs(
   tx: Tx,
   params: {
@@ -215,17 +250,11 @@ async function updateJobExecutionStatusAtVersion(
         secrets: params.secrets,
       });
     } catch (error) {
-      if (
-        !(error instanceof InterpolationUnresolvableError) &&
-        !(error instanceof JobOutputNotJsonSafeError) &&
-        !(error instanceof JobOutputTooLargeError) &&
-        !(error instanceof JobOutputTooManyEntriesError)
-      ) {
-        throw error;
-      }
+      const outputFailure = classifyJobOutputFailure(error);
+      if (outputFailure === null) throw error;
       status = 'failed';
-      statusReason = error instanceof JobOutputTooLargeError ? 'output_too_large' : 'unknown';
-      statusReasonMessage = error instanceof JobOutputTooLargeError ? error.message : null;
+      statusReason = outputFailure.statusReason;
+      statusReasonMessage = outputFailure.statusReasonMessage;
       outputs = null;
     }
   }

--- a/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.test.ts
@@ -278,6 +278,40 @@ describe('failure annotations', () => {
     );
   });
 
+  it('projects an output-invalid job failure with its status message', async () => {
+    const payload = jobTerminatedPayload({
+      statusReason: 'output_invalid',
+      statusReasonMessage: 'Job output "payload" cannot be persisted as JSON: undefined.',
+    });
+    dbMocks.getJobScope.mockResolvedValue({
+      workspaceId: '44444444-4444-4444-8444-444444444444',
+      projectId: '55555555-5555-4555-8555-555555555555',
+      triggerReference: null,
+    });
+    dbMocks.getWorkflowRunAttemptById.mockResolvedValue({attempt: 3});
+    dbMocks.getJobExecutionFailureOrigin.mockResolvedValue({
+      jobExecutionId: payload.jobExecutionId,
+      stepId: '77777777-7777-4777-8777-777777777777',
+      stepName: 'Run tests',
+      stepStatus: 'succeeded',
+      stepAttempt: 1,
+      stepError: null,
+      attemptStatus: 'succeeded',
+      attemptError: null,
+      attemptExitCode: 0,
+    });
+
+    await onJobTerminatedFailureAnnotation(annotations)(payload);
+
+    expect(replaceOrRemoveAnnotation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        annotation: expect.objectContaining({
+          body: expect.stringContaining('Job output "payload" cannot be persisted as JSON'),
+        }),
+      }),
+    );
+  });
+
   it('projects a condition evaluation error from a skipped job', async () => {
     const payload = jobTerminatedPayload({status: 'skipped', statusReason: 'condition_errored'});
     dbMocks.getJobScope.mockResolvedValue({

--- a/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.ts
@@ -21,6 +21,7 @@ const JOB_FAILURE_ANNOTATION_REASONS = new Set([
   'runner_lost',
   'condition_errored',
   'output_too_large',
+  'output_invalid',
 ]);
 
 export function onStepAttemptTerminatedFailureAnnotation(

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -33,6 +33,7 @@ import {
   emptyStateForJob,
   emptyStateForMissingExecution,
   jobSucceededSummary,
+  MaterializedOutputFailureNotice,
 } from './job-empty-states.js';
 import {
   resolveWorkflowJobSelection,
@@ -258,39 +259,42 @@ export function JobDetailView({
                 Logs
               </Text>
               {selectedJobExecution ? (
-                <StepList
-                  job={job}
-                  jobExecution={selectedJobExecution}
-                  selectedAttemptId={selectedAttemptId}
-                  defaultSelectedAttemptId={landingSelection?.attemptId}
-                  onSelectedAttemptChange={selectAttempt}
-                  inspectorOpenAttemptId={inspectorOpenAttemptId}
-                  onInspectorOpenChange={onInspectorOpenChange}
-                  autoSelectActiveAttempt
-                  emptyState={emptyStateForJob(job, selectedJobExecution)}
-                  showHeader={false}
-                  className="rounded-none border-0 bg-transparent"
-                  renderExpandedStep={(context) => (
-                    <ExpandedStep context={context} pageScrollRef={pageScrollRef} />
-                  )}
-                  renderInspector={(entry) => (
-                    <StepInspectorSheet
-                      entry={entry}
-                      open
-                      onOpenChange={(open) => onInspectorOpenChange(open ? entry.id : null)}
-                      workspaceSlug={workspaceSlug}
-                      projectSlug={projectSlug}
-                      workflowRunId={run.id}
-                      runAttempt={run.runAttempt.attempt}
-                      jobId={job.id}
-                      annotationCount={annotationCountForStep(
-                        annotationSummaryQuery.data,
-                        entry.step.id,
-                        entry.attempt,
-                      )}
-                    />
-                  )}
-                />
+                <>
+                  <MaterializedOutputFailureNotice jobExecution={selectedJobExecution} />
+                  <StepList
+                    job={job}
+                    jobExecution={selectedJobExecution}
+                    selectedAttemptId={selectedAttemptId}
+                    defaultSelectedAttemptId={landingSelection?.attemptId}
+                    onSelectedAttemptChange={selectAttempt}
+                    inspectorOpenAttemptId={inspectorOpenAttemptId}
+                    onInspectorOpenChange={onInspectorOpenChange}
+                    autoSelectActiveAttempt
+                    emptyState={emptyStateForJob(job, selectedJobExecution)}
+                    showHeader={false}
+                    className="rounded-none border-0 bg-transparent"
+                    renderExpandedStep={(context) => (
+                      <ExpandedStep context={context} pageScrollRef={pageScrollRef} />
+                    )}
+                    renderInspector={(entry) => (
+                      <StepInspectorSheet
+                        entry={entry}
+                        open
+                        onOpenChange={(open) => onInspectorOpenChange(open ? entry.id : null)}
+                        workspaceSlug={workspaceSlug}
+                        projectSlug={projectSlug}
+                        workflowRunId={run.id}
+                        runAttempt={run.runAttempt.attempt}
+                        jobId={job.id}
+                        annotationCount={annotationCountForStep(
+                          annotationSummaryQuery.data,
+                          entry.step.id,
+                          entry.attempt,
+                        )}
+                      />
+                    )}
+                  />
+                </>
               ) : (
                 <EmptyStateForMissingExecution job={job} />
               )}

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
@@ -3,7 +3,13 @@ import {
   workflowJobExecutionDto,
   workflowStepDto,
 } from '#test/fixtures/workflow-run.js';
-import {jobSucceededSummary, skippedJobDescription} from './job-empty-states.js';
+import {
+  emptyStateForJob,
+  emptyStateForMissingExecution,
+  jobSucceededSummary,
+  outputFailureDescriptionForExecution,
+  skippedJobDescription,
+} from './job-empty-states.js';
 
 describe('jobSucceededSummary', () => {
   test('counts only succeeded steps when skipped steps are present', () => {
@@ -31,5 +37,95 @@ describe('skippedJobDescription', () => {
     expect(skippedJobDescription('output_too_large')).toBe(
       'The materialized job output exceeded its configured size limit.',
     );
+  });
+});
+
+describe('materialized output failure descriptions', () => {
+  const fallback =
+    'A materialized job output could not be persisted: it exceeded a size or entry cap, contained a non-JSON-safe value, or referenced an unresolved value. Check the output mapping and values before re-running the workflow.';
+
+  test('uses the server-authored message for an execution with recorded steps', () => {
+    const job = workflowJob({
+      status: 'failed',
+      status_reason: 'output_invalid',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'failed',
+          status_reason: 'output_invalid',
+          status_reason_message: 'Job output "payload" cannot be persisted as JSON: undefined.',
+          steps: [workflowStepDto({status: 'succeeded'})],
+        }),
+      ],
+    });
+    const execution = job.jobExecutions[0];
+    if (!execution) throw new Error('Expected a job execution');
+
+    expect(outputFailureDescriptionForExecution(execution)).toBe(
+      'Job output "payload" cannot be persisted as JSON: undefined.',
+    );
+  });
+
+  test('keeps the generic fallback for old output-invalid rows without a message', () => {
+    const job = workflowJob({
+      status: 'failed',
+      status_reason: 'output_invalid',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'failed',
+          status_reason: 'output_invalid',
+          steps: [workflowStepDto({status: 'succeeded'})],
+        }),
+      ],
+    });
+    const execution = job.jobExecutions[0];
+    if (!execution) throw new Error('Expected a job execution');
+
+    expect(outputFailureDescriptionForExecution(execution)).toBe(fallback);
+  });
+
+  test('uses the message in the empty state when output materialization failed before steps', () => {
+    const job = workflowJob({
+      status: 'failed',
+      status_reason: 'output_invalid',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'failed',
+          status_reason: 'output_invalid',
+          status_reason_message: 'Job outputs cannot define more than 10 entries (found 11)',
+          steps: [],
+        }),
+      ],
+    });
+    const execution = job.jobExecutions[0];
+    if (!execution) throw new Error('Expected a job execution');
+
+    expect(emptyStateForJob(job, execution)).toMatchObject({
+      description: 'Job outputs cannot define more than 10 entries (found 11)',
+    });
+  });
+
+  test('keeps output failures scoped to the selected execution', () => {
+    const job = workflowJob({
+      status: 'failed',
+      status_reason: 'output_invalid',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'succeeded',
+          status_reason: null,
+          steps: [workflowStepDto({status: 'succeeded'})],
+        }),
+      ],
+    });
+    const execution = job.jobExecutions[0];
+    if (!execution) throw new Error('Expected a job execution');
+
+    expect(outputFailureDescriptionForExecution(execution)).toBeUndefined();
+    expect(
+      emptyStateForMissingExecution(
+        workflowJob({status: 'failed', status_reason: 'output_invalid'}),
+      ),
+    ).toMatchObject({
+      description: fallback,
+    });
   });
 });

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -1,3 +1,4 @@
+import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import type {Job, JobExecution, Step, StepError} from '#core/workflow-run.js';
 import {
@@ -8,6 +9,44 @@ import {
 } from '#core/workflow-run.js';
 import type {StepListEmptyState} from '../step-list/index.js';
 import {formatJobExecutionTime} from './job-execution-time-text.js';
+
+const MATERIALIZED_OUTPUT_FAILURE_DESCRIPTION =
+  'A materialized job output could not be persisted: it exceeded a size or entry cap, contained a non-JSON-safe value, or referenced an unresolved value. Check the output mapping and values before re-running the workflow.';
+const OUTPUT_TOO_LARGE_FAILURE_DESCRIPTION =
+  'The materialized job output exceeded its configured size limit. Review the failure details before re-running the workflow.';
+
+export function outputFailureDescriptionForExecution(
+  jobExecution: JobExecution,
+): string | undefined {
+  if (jobExecution.steps.length === 0) return undefined;
+
+  if (jobExecution.statusReason === 'output_invalid') {
+    return jobExecution.statusReasonMessage || MATERIALIZED_OUTPUT_FAILURE_DESCRIPTION;
+  }
+  if (jobExecution.statusReason === 'output_too_large') {
+    return jobExecution.statusReasonMessage || OUTPUT_TOO_LARGE_FAILURE_DESCRIPTION;
+  }
+  return undefined;
+}
+
+export function MaterializedOutputFailureNotice({jobExecution}: {jobExecution: JobExecution}) {
+  const description = outputFailureDescriptionForExecution(jobExecution);
+  if (!description) return null;
+
+  return (
+    <Callout
+      role="alert"
+      type="error"
+      variant="secondary"
+      className="border-b border-border-neutral-base px-row py-row"
+    >
+      <CalloutContent>
+        <CalloutTitle>Job output could not be persisted</CalloutTitle>
+        <CalloutDescription>{description}</CalloutDescription>
+      </CalloutContent>
+    </Callout>
+  );
+}
 
 export function emptyStateForJob(
   job: Job,
@@ -64,7 +103,11 @@ export function emptyStateForJob(
   if (displayStatus === 'failed') {
     return {
       title: 'Job failed before its first step started',
-      description: preStepFailureDescription(jobExecution.statusReason ?? job.statusReason, runner),
+      description: preStepFailureDescription(
+        jobExecution.statusReason ?? job.statusReason,
+        runner,
+        jobExecution.statusReasonMessage,
+      ),
       status: displayStatus,
     };
   }
@@ -159,6 +202,7 @@ export function skippedJobDescription(reason: Job['statusReason']): string {
     case 'run_cancelled':
     case 'timed_out':
     case 'runner_lost':
+    case 'output_invalid':
     case 'step_failed':
     case 'unknown':
     case null:
@@ -168,7 +212,11 @@ export function skippedJobDescription(reason: Job['statusReason']): string {
   }
 }
 
-function preStepFailureDescription(reason: string | null, runner: string[] | null = null): string {
+function preStepFailureDescription(
+  reason: string | null,
+  runner: string[] | null = null,
+  statusReasonMessage: string | null = null,
+): string {
   const runnerCopy = runner?.length ? ` Required runner labels: ${runner.join(', ')}.` : '';
 
   switch (reason) {
@@ -182,7 +230,9 @@ function preStepFailureDescription(reason: string | null, runner: string[] | nul
     case 'step_failed':
       return `The execution failed before step details were recorded.${runnerCopy} Review run annotations before re-running the workflow.`;
     case 'output_too_large':
-      return 'The materialized job output exceeded its configured size limit. Review the failure details before re-running the workflow.';
+      return statusReasonMessage || OUTPUT_TOO_LARGE_FAILURE_DESCRIPTION;
+    case 'output_invalid':
+      return statusReasonMessage || MATERIALIZED_OUTPUT_FAILURE_DESCRIPTION;
     case 'condition_errored':
       return 'The job condition could not be evaluated. Review run annotations before re-running the workflow.';
     case 'dependency_not_completed':

--- a/libs/client/workflows/src/core/entities/job.ts
+++ b/libs/client/workflows/src/core/entities/job.ts
@@ -22,7 +22,8 @@ export type JobStatusReason =
   | 'runner_lost'
   | 'output_too_large'
   | 'step_failed'
-  | 'unknown';
+  | 'unknown'
+  | 'output_invalid';
 export interface JobListening {
   on: Array<{
     source: string;


### PR DESCRIPTION
Materialized job outputs currently collapse four diagnosed output-contract failures into `unknown`, leaving users without an actionable reason after the workflow has completed its steps.

This change introduces the `output_invalid` job reason, preserves `unknown` for unclassified failures, and gives the job detail view an actionable explanation covering output caps, JSON safety, and unresolved values. The PostgreSQL enum migration and Changeset keep the persisted and published package contracts aligned.

Validation:
- API workflows: 68 test files, 812 tests
- API workflows DTO: 135 tests
- Client workflows: 46 test files, 516 tests
- Affected-package type checks, formatting, and API database-boundary verification

Closes ENG-1550

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies materialized job output failures as `output_invalid`, persists a bounded server message on executions, and surfaces it in the job detail view via a scoped callout and clearer empty states. Satisfies Linear ENG-1550 by failing with a size‑specific or invalid‑output reason and giving users actionable guidance.

- **Bug Fixes**
  - API/DTO (`@shipfox/api-workflows`, `@shipfox/api-workflows-dto`): add `output_invalid`; classify unresolved `job.outputs` interpolation, non‑JSON‑safe values, and too‑many entries as `output_invalid`; keep `output_too_large` for size breaches; persist a bounded `status_reason_message` (max 2048 chars, ellipsis when truncated); expose via DTO and e2e schemas; include `output_invalid` in failure annotations and render its message.
  - Client (`@shipfox/client-workflows`): add an execution‑scoped error callout with the server message when steps exist; use the message in pre‑step empty states (fallback text when missing); keep failure details scoped to the selected execution.

- **Migration**
  - Apply `@shipfox/api-workflows` migration adding `output_invalid` to `workflows_job_status_reason` (`0003_output_invalid_reason`).

<sup>Written for commit 2ed87bd4a5980dfa53515767bcf40bac13ec6357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

