### PR TITLE
[@shipfox/api-workflows] Raise job output caps before runner rollout

### DIFF
--- a/.changeset/steady-jobs-expand.md
+++ b/.changeset/steady-jobs-expand.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Raises job output limits to 64 KiB per value and 256 KiB total before runner-side cap changes.

--- a/apps/docs/content/docs/reference/limits.mdx
+++ b/apps/docs/content/docs/reference/limits.mdx
@@ -29,7 +29,7 @@ can change the values marked configurable.
 
 | Limit | Default | Configurable | Details |
 | --- | --- | --- | --- |
-| Output bytes per job | 64 KiB total, 16 KiB per value | No | A job fails with an unknown status reason when materialized outputs exceed the cap. See [Job fields](/reference/workflow-schema#job-fields). |
+| Output bytes per job | 256 KiB total, 64 KiB per value | No | A job fails with an unknown status reason when materialized outputs exceed the cap. See [Job fields](/reference/workflow-schema#job-fields). |
 | Declared outputs per job | 128 entries | No | The `outputs:` map on one job. See [Job fields](/reference/workflow-schema#job-fields). |
 | Structured output nesting | 64 levels | No | Structured values deeper than this fail as non-JSON-safe outputs. |
 

--- a/libs/api/workflows/src/core/step-config/job-output-limits.ts
+++ b/libs/api/workflows/src/core/step-config/job-output-limits.ts
@@ -6,8 +6,8 @@ import {JobOutputNotJsonSafeError} from '#core/errors.js';
 
 export const MAX_JOB_OUTPUT_ENTRIES = WORKFLOW_DOCUMENT_JOB_OUTPUTS_MAX_ENTRIES;
 export const MAX_JOB_OUTPUT_NESTING_DEPTH = WORKFLOW_DOCUMENT_STEP_OUTPUT_SCHEMA_MAX_DEPTH;
-export const MAX_JOB_OUTPUTS_TOTAL_BYTES = 64 * 1024;
-export const MAX_JOB_OUTPUT_VALUE_BYTES = 16 * 1024;
+export const MAX_JOB_OUTPUTS_TOTAL_BYTES = 256 * 1024;
+export const MAX_JOB_OUTPUT_VALUE_BYTES = 64 * 1024;
 
 const textEncoder = new TextEncoder();
 

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -1640,36 +1640,48 @@ describe('materializeJobOutputs', () => {
     expect(materialize).toThrow(JobOutputTooLargeError);
   });
 
-  it('accepts values up to the per-value cap', () => {
-    const payload = 'x'.repeat(MAX_JOB_OUTPUT_VALUE_BYTES);
+  it('accepts a 64 KiB value and rejects one byte over', () => {
+    const maxValueBytes = 64 * 1024;
     const job = outputJob({payload: template('steps.collect.outputs.payload')});
+    const materialize = (payload: string) =>
+      materializeJobOutputs({
+        job,
+        context: outputContext({payload}),
+        definitionId: 'definition-1',
+      });
 
-    const result = materializeJobOutputs({
-      job,
-      context: outputContext({payload}),
-      definitionId: 'definition-1',
-    });
+    const payload = 'x'.repeat(maxValueBytes);
 
-    expect(result).toEqual({payload});
+    expect(materialize(payload)).toEqual({payload});
+    expect(() => materialize(`${payload}x`)).toThrow(JobOutputTooLargeError);
   });
 
-  it('accepts output totals above the previous cap', () => {
-    const keys = ['one', 'two', 'three'];
+  it('accepts a serialized total at 256 KiB and rejects one byte over', () => {
+    const maxTotalBytes = 256 * 1024;
+    const keys = ['one', 'two', 'three', 'four'];
     const outputs = Object.fromEntries(
       keys.map((key) => [key, template(`steps.collect.outputs.${key}`)]),
     );
-    const values = Object.fromEntries(
-      keys.map((key) => [key, 'x'.repeat(MAX_JOB_OUTPUT_VALUE_BYTES)]),
-    );
+    const values = {
+      one: 'x'.repeat(64 * 1024),
+      two: 'x'.repeat(64 * 1024),
+      three: 'x'.repeat(64 * 1024),
+      four: 'x'.repeat(64 * 1024 - 40),
+    };
     const job = outputJob(outputs);
+    const materialize = (contextValues: Record<string, unknown>) =>
+      materializeJobOutputs({
+        job,
+        context: outputContext(contextValues),
+        definitionId: 'definition-1',
+      });
 
-    const result = materializeJobOutputs({
-      job,
-      context: outputContext(values),
-      definitionId: 'definition-1',
-    });
+    expect(Buffer.byteLength(JSON.stringify(values), 'utf8')).toBe(maxTotalBytes);
+    expect(materialize(values)).toEqual(values);
 
-    expect(result).toEqual(values);
+    const overLimitValues = {...values, four: `${values.four}x`};
+    expect(Buffer.byteLength(JSON.stringify(overLimitValues), 'utf8')).toBe(maxTotalBytes + 1);
+    expect(() => materialize(overLimitValues)).toThrow(JobOutputTooLargeError);
   });
 
   it('rejects the total materialized job output cap', () => {

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -1641,7 +1641,8 @@ describe('materializeJobOutputs', () => {
   });
 
   it('accepts a 64 KiB value and rejects one byte over', () => {
-    const maxValueBytes = 64 * 1024;
+    const maxValueBytes = MAX_JOB_OUTPUT_VALUE_BYTES;
+    expect(maxValueBytes).toBe(64 * 1024);
     const job = outputJob({payload: template('steps.collect.outputs.payload')});
     const materialize = (payload: string) =>
       materializeJobOutputs({
@@ -1657,16 +1658,19 @@ describe('materializeJobOutputs', () => {
   });
 
   it('accepts a serialized total at 256 KiB and rejects one byte over', () => {
-    const maxTotalBytes = 256 * 1024;
+    const maxValueBytes = MAX_JOB_OUTPUT_VALUE_BYTES;
+    const maxTotalBytes = MAX_JOB_OUTPUTS_TOTAL_BYTES;
+    expect(maxValueBytes).toBe(64 * 1024);
+    expect(maxTotalBytes).toBe(256 * 1024);
     const keys = ['one', 'two', 'three', 'four'];
     const outputs = Object.fromEntries(
       keys.map((key) => [key, template(`steps.collect.outputs.${key}`)]),
     );
     const values = {
-      one: 'x'.repeat(64 * 1024),
-      two: 'x'.repeat(64 * 1024),
-      three: 'x'.repeat(64 * 1024),
-      four: 'x'.repeat(64 * 1024 - 40),
+      one: 'x'.repeat(maxValueBytes),
+      two: 'x'.repeat(maxValueBytes),
+      three: 'x'.repeat(maxValueBytes),
+      four: 'x'.repeat(maxValueBytes - 40),
     };
     const job = outputJob(outputs);
     const materialize = (contextValues: Record<string, unknown>) =>

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -1640,6 +1640,38 @@ describe('materializeJobOutputs', () => {
     expect(materialize).toThrow(JobOutputTooLargeError);
   });
 
+  it('accepts values up to the per-value cap', () => {
+    const payload = 'x'.repeat(MAX_JOB_OUTPUT_VALUE_BYTES);
+    const job = outputJob({payload: template('steps.collect.outputs.payload')});
+
+    const result = materializeJobOutputs({
+      job,
+      context: outputContext({payload}),
+      definitionId: 'definition-1',
+    });
+
+    expect(result).toEqual({payload});
+  });
+
+  it('accepts output totals above the previous cap', () => {
+    const keys = ['one', 'two', 'three'];
+    const outputs = Object.fromEntries(
+      keys.map((key) => [key, template(`steps.collect.outputs.${key}`)]),
+    );
+    const values = Object.fromEntries(
+      keys.map((key) => [key, 'x'.repeat(MAX_JOB_OUTPUT_VALUE_BYTES)]),
+    );
+    const job = outputJob(outputs);
+
+    const result = materializeJobOutputs({
+      job,
+      context: outputContext(values),
+      definitionId: 'definition-1',
+    });
+
+    expect(result).toEqual(values);
+  });
+
   it('rejects the total materialized job output cap', () => {
     const keys = ['one', 'two', 'three', 'four', 'five'];
     const outputs = Object.fromEntries(

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -148,6 +148,48 @@ describe('workflow run job executions', () => {
     expect(persisted?.outputs).toEqual({findings: [{severity: 'high'}]});
   });
 
+  test('persists job outputs in the raised size band when execution succeeds', async () => {
+    const outputKeys = ['one', 'two', 'three'];
+    const outputValues = Object.fromEntries(outputKeys.map((key) => [key, 'x'.repeat(64 * 1024)]));
+    const outputTemplates = Object.fromEntries(
+      outputKeys.map((key) => [key, template(`steps.collect.outputs.${key}`)]),
+    );
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({
+        jobs: {
+          build: {
+            steps: [{key: 'collect', run: 'echo build'}],
+            outputs: outputTemplates,
+          },
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+    await finishCollectedStep(job.id, outputValues);
+
+    const resolved = await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'succeeded',
+      expectedVersion: execution.version,
+    });
+
+    expect(resolved).toMatchObject({status: 'succeeded', outputs: outputValues});
+    const persisted = await getFirstJobExecutionByJobId(job.id);
+    expect(persisted?.outputs).toEqual(outputValues);
+  });
+
   test('persists JSON-safe typed integer and timestamp outputs when execution succeeds', async () => {
     const run = await createWorkflowRun({
       workspaceId,

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -150,7 +150,9 @@ describe('workflow run job executions', () => {
 
   test('persists job outputs in the raised size band when execution succeeds', async () => {
     const outputKeys = ['one', 'two', 'three'];
-    const outputValues = Object.fromEntries(outputKeys.map((key) => [key, 'x'.repeat(64 * 1024)]));
+    const outputValues = Object.fromEntries(
+      outputKeys.map((key) => [key, 'x'.repeat(MAX_JOB_OUTPUT_VALUE_BYTES)]),
+    );
     const outputTemplates = Object.fromEntries(
       outputKeys.map((key) => [key, template(`steps.collect.outputs.${key}`)]),
     );


### PR DESCRIPTION
Raise the server-side job output limits to 64 KiB per value and 256 KiB total. This lets deployed servers accept larger outputs before the runner-side cap update, avoiding a version-skew window where a runner could emit a value the server rejects.

The canonical Job outputs limits reference now matches this server slice. The Step outputs reference and runner-side limits remain unchanged until ENG-1552. Entry-count and nesting limits remain unchanged.

This PR pins exact per-value and total boundaries and verifies that a roughly 196 KiB output set persists through the database write path. Measured-size rejection wording remains owned by ENG-1548 and is not duplicated here.

Validation: 68 api-workflows test files and 810 tests pass. The affected package and dependencies pass check, type, build, and dependency-cruiser validation. Docs test, check, type, and build also pass.

Closes ENG-1551
