### PR TITLE
Expose per-template EC2 pool saturation metrics

### DIFF
--- a/.changeset/steady-pools-observe-demand.md
+++ b/.changeset/steady-pools-observe-demand.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/provisioner-core': minor
+---
+
+Expose provider adapter demand snapshots for provider-specific observation.

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   type Variant,
   type VariantBindings,
 } from '#template-file.js';
+export {labelsSatisfiedBy, rankTemplatesForLabels, selectTemplate} from '#template-selection.js';
 export type {ProviderRunnerTracker} from '#tracker.js';
 export type {
   LaunchOutcome,

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -39,7 +39,7 @@ export {
   type Variant,
   type VariantBindings,
 } from '#template-file.js';
-export {labelsSatisfiedBy, rankTemplatesForLabels, selectTemplate} from '#template-selection.js';
+export {rankTemplatesForLabels} from '#template-selection.js';
 export type {ProviderRunnerTracker} from '#tracker.js';
 export type {
   LaunchOutcome,

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -176,6 +176,49 @@ describe('runProvisionerIteration', () => {
     );
   });
 
+  it('preserves an existing provider observation failure across snapshot delivery', async () => {
+    const {client} = harness({response: {stats: [], reservations: []}});
+    const health = createHealthState();
+    health.active = new Map([
+      ['provider_observation', {cause: 'reconciliation unavailable', impact: 'capacity'}],
+    ]);
+    let shouldFail = true;
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onDemandStats: () => {
+        if (shouldFail) throw new Error('metrics cache unavailable');
+      },
+    };
+
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      health,
+    });
+    expect(health.active.get('provider_observation')).toEqual({
+      cause: 'reconciliation unavailable',
+      impact: 'capacity',
+    });
+
+    shouldFail = false;
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      health,
+    });
+    expect(health.active.get('provider_observation')).toEqual({
+      cause: 'reconciliation unavailable',
+      impact: 'capacity',
+    });
+  });
+
   it('runs onTick before polling demand', async () => {
     const events: string[] = [];
     const {client} = harness({

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -73,6 +73,34 @@ describe('runProvisionerIteration', () => {
     expect(pollBodies[0]).not.toHaveProperty('reservation_ttl_seconds');
   });
 
+  it('forwards the latest demand stats to the adapter', async () => {
+    const stats = [
+      {
+        labels: ['ubuntu22'],
+        queued: 3,
+        reserved: 1,
+        oldest_queued_at: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    const {client} = harness({response: {stats, reservations: []}});
+    const onDemandStats = vi.fn();
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onDemandStats,
+    };
+
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+    });
+
+    expect(onDemandStats).toHaveBeenCalledWith(stats);
+  });
+
   it('runs onTick before polling demand', async () => {
     const events: string[] = [];
     const {client} = harness({

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -73,8 +73,8 @@ describe('runProvisionerIteration', () => {
     expect(pollBodies[0]).not.toHaveProperty('reservation_ttl_seconds');
   });
 
-  it('forwards the latest demand stats to the adapter', async () => {
-    const stats = [
+  it('forwards each latest demand snapshot to the adapter', async () => {
+    const firstStats = [
       {
         labels: ['ubuntu22'],
         queued: 3,
@@ -82,7 +82,21 @@ describe('runProvisionerIteration', () => {
         oldest_queued_at: '2026-01-01T00:00:00.000Z',
       },
     ];
-    const {client} = harness({response: {stats, reservations: []}});
+    const secondStats = [
+      {
+        labels: ['ubuntu22', 'gpu'],
+        queued: 1,
+        reserved: 0,
+        oldest_queued_at: '2026-01-01T00:01:00.000Z',
+      },
+    ];
+    const {client} = harness({
+      responses: [
+        {stats: firstStats, reservations: []},
+        {stats: secondStats, reservations: []},
+        {stats: [], reservations: []},
+      ],
+    });
     const onDemandStats = vi.fn();
     const adapter: ProvisionerAdapter<null> = {
       loadTemplates: () => Promise.resolve([template]),
@@ -90,15 +104,76 @@ describe('runProvisionerIteration', () => {
       onDemandStats,
     };
 
-    await runDemandIteration({
+    for (let iteration = 0; iteration < 3; iteration += 1) {
+      await runDemandIteration({
+        adapter,
+        client,
+        templates: [template],
+        tracker: createInMemoryTracker(),
+        currentInterval: 1000,
+      });
+    }
+
+    expect(onDemandStats).toHaveBeenNthCalledWith(1, firstStats);
+    expect(onDemandStats).toHaveBeenNthCalledWith(2, secondStats);
+    expect(onDemandStats).toHaveBeenNthCalledWith(3, []);
+  });
+
+  it('clears the adapter demand snapshot after a failed poll', async () => {
+    const {client} = harness({response: {stats: [], reservations: []}});
+    client.pollDemand = () => Promise.reject(new Error('demand poll unavailable'));
+    const onDemandStats = vi.fn();
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onDemandStats,
+    };
+
+    await expect(
+      runDemandIteration({
+        adapter,
+        client,
+        templates: [template],
+        tracker: createInMemoryTracker(),
+        currentInterval: 1000,
+      }),
+    ).rejects.toThrow('demand poll unavailable');
+
+    expect(onDemandStats).toHaveBeenCalledWith([]);
+  });
+
+  it('contains provider demand snapshot delivery failures and continues the iteration', async () => {
+    const {client} = harness({response: {stats: [], reservations: []}});
+    const health = createHealthState();
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onDemandStats: () => {
+        throw new Error('metrics cache unavailable');
+      },
+    };
+
+    const result = await runDemandIteration({
       adapter,
       client,
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 1000,
+      health,
     });
 
-    expect(onDemandStats).toHaveBeenCalledWith(stats);
+    expect(result).toEqual({nextInterval: 1500, degraded: true});
+    expect(health.active.has('provider_observation')).toBe(true);
+    expect(health.active.get('provider_observation')?.cause).toBe(
+      'Demand snapshot delivery failed: metrics cache unavailable',
+    );
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.demand_stats_delivery_failed',
+        reason: 'metrics cache unavailable',
+      }),
+      'Provider demand snapshot delivery failed',
+    );
   });
 
   it('runs onTick before polling demand', async () => {
@@ -595,13 +670,18 @@ describe('startProvisioner', () => {
 type PollDemandResponseFixture = Omit<PollDemandResponseDto, 'terminate_provider_runner_ids'> &
   Partial<Pick<PollDemandResponseDto, 'terminate_provider_runner_ids'>>;
 
-function harness(options: {response: PollDemandResponseFixture; onPoll?: () => void}): {
+function harness(options: {
+  response?: PollDemandResponseFixture;
+  responses?: readonly PollDemandResponseFixture[];
+  onPoll?: () => void;
+}): {
   client: ProvisionerClient;
   pollBodies: PollDemandBodyDto[];
   createBodies: CreateRunnerInstancesBodyDto[];
 } {
   const pollBodies: PollDemandBodyDto[] = [];
   const createBodies: CreateRunnerInstancesBodyDto[] = [];
+  let responseIndex = 0;
 
   return {
     pollBodies,
@@ -612,9 +692,11 @@ function harness(options: {response: PollDemandResponseFixture; onPoll?: () => v
       pollDemand: (body) => {
         options.onPoll?.();
         pollBodies.push(body);
+        const response = options.responses?.[responseIndex++] ?? options.response;
+        if (!response) return Promise.reject(new Error('poll demand fixture is exhausted'));
         return Promise.resolve({
-          ...options.response,
-          terminate_provider_runner_ids: options.response.terminate_provider_runner_ids ?? [],
+          ...response,
+          terminate_provider_runner_ids: response.terminate_provider_runner_ids ?? [],
         });
       },
       createRunnerInstances: (body) => {

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -691,7 +691,6 @@ function notifyDemandStats<Spec>(
   stats: readonly DemandStatDto[],
   health: HealthState,
 ): void {
-  const previousProviderObservationFailure = health.active.get('provider_observation');
   try {
     adapter.onDemandStats?.(stats);
   } catch (error) {
@@ -700,16 +699,19 @@ function notifyDemandStats<Spec>(
       {event: 'provisioner.demand_stats_delivery_failed', reason},
       'Provider demand snapshot delivery failed',
     );
-    applyHealthEvent(health, {
-      type: 'facet_failed',
-      facet: 'provider_observation',
-      cause: `${DEMAND_STATS_DELIVERY_FAILURE_PREFIX}${reason}`,
-      impact: 'capacity',
-      at: new Date(),
-    });
+    if (!health.active.has('provider_observation')) {
+      applyHealthEvent(health, {
+        type: 'facet_failed',
+        facet: 'provider_observation',
+        cause: `${DEMAND_STATS_DELIVERY_FAILURE_PREFIX}${reason}`,
+        impact: 'capacity',
+        at: new Date(),
+      });
+    }
     return;
   }
-  if (previousProviderObservationFailure?.cause.startsWith(DEMAND_STATS_DELIVERY_FAILURE_PREFIX)) {
+  const providerObservationFailure = health.active.get('provider_observation');
+  if (providerObservationFailure?.cause.startsWith(DEMAND_STATS_DELIVERY_FAILURE_PREFIX)) {
     applyHealthEvent(health, {
       type: 'facet_recovered',
       facet: 'provider_observation',

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -354,6 +354,7 @@ export async function runDemandIteration<Spec>(
     });
     throw error;
   }
+  deps.adapter.onDemandStats?.(result.stats);
 
   if (!deps.deferTermination) {
     if (result.providerTermination.status === 'failed') {

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -1,3 +1,4 @@
+import type {DemandStatDto} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
   withJitter as applyJitter,
@@ -29,6 +30,7 @@ const MAX_TEMPLATES_PER_POLL = 1000;
 const CONFIG_SAMPLE_LIMIT = 20;
 const CONVERGE_BACKOFF_FLOOR_MS = 5000;
 const TERMINATION_DRAIN_TIMEOUT_MS = 1000;
+const DEMAND_STATS_DELIVERY_FAILURE_PREFIX = 'Demand snapshot delivery failed: ';
 
 let running = true;
 let pollAbortController: AbortController | undefined;
@@ -352,9 +354,11 @@ export async function runDemandIteration<Spec>(
       impact: 'control_plane',
       at: new Date(),
     });
+    // Do not let a provider retain a demand snapshot after a failed poll.
+    notifyDemandStats(deps.adapter, [], health);
     throw error;
   }
-  deps.adapter.onDemandStats?.(result.stats);
+  notifyDemandStats(deps.adapter, result.stats, health);
 
   if (!deps.deferTermination) {
     if (result.providerTermination.status === 'failed') {
@@ -680,6 +684,38 @@ function isApiFacet(facet: HealthFacet | undefined): boolean {
 
 function errorReason(error: unknown): string {
   return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
+}
+
+function notifyDemandStats<Spec>(
+  adapter: ProvisionerAdapter<Spec>,
+  stats: readonly DemandStatDto[],
+  health: HealthState,
+): void {
+  const previousProviderObservationFailure = health.active.get('provider_observation');
+  try {
+    adapter.onDemandStats?.(stats);
+  } catch (error) {
+    const reason = errorReason(error);
+    logger().warn(
+      {event: 'provisioner.demand_stats_delivery_failed', reason},
+      'Provider demand snapshot delivery failed',
+    );
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'provider_observation',
+      cause: `${DEMAND_STATS_DELIVERY_FAILURE_PREFIX}${reason}`,
+      impact: 'capacity',
+      at: new Date(),
+    });
+    return;
+  }
+  if (previousProviderObservationFailure?.cause.startsWith(DEMAND_STATS_DELIVERY_FAILURE_PREFIX)) {
+    applyHealthEvent(health, {
+      type: 'facet_recovered',
+      facet: 'provider_observation',
+      at: new Date(),
+    });
+  }
 }
 
 function safeEndpoint(value: string): string {

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -1,3 +1,4 @@
+import type {DemandStatDto} from '@shipfox/api-runners-dto';
 import type {ProvisionerClient} from '#api-client.js';
 import type {ProviderRunnerTracker} from '#tracker.js';
 
@@ -89,6 +90,8 @@ export interface ProvisionerAdapter<Spec = unknown> {
   readonly launch: LaunchRunner<Spec>;
   readonly terminate?: TerminateRunners;
   onStart?(runtime: ProvisionerRuntime): Promise<void>;
+  /** Receives the latest demand snapshot for provider-specific observation. */
+  onDemandStats?(stats: readonly DemandStatDto[]): void;
   onTick?(): Promise<void>;
   onStop?(): Promise<void>;
 }

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -90,7 +90,10 @@ export interface ProvisionerAdapter<Spec = unknown> {
   readonly launch: LaunchRunner<Spec>;
   readonly terminate?: TerminateRunners;
   onStart?(runtime: ProvisionerRuntime): Promise<void>;
-  /** Receives the latest demand snapshot for provider-specific observation. */
+  /**
+   * Receives the latest demand snapshot for provider-specific observation. An empty
+   * snapshot is sent when polling fails so providers do not retain stale demand.
+   */
   onDemandStats?(stats: readonly DemandStatDto[]): void;
   onTick?(): Promise<void>;
   onStop?(): Promise<void>;

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -142,6 +142,29 @@ The API clamps the requested reservation lifetime to its own `RESERVATION_TTL_MA
 ceiling and does not report the clamp. Keep that ceiling at least as high as the derived
 value when changing either EC2 setting.
 
+## Service metrics
+
+The provider exposes per-template saturation gauges on the service metrics endpoint.
+The `template_key` label is the rendered template key, not a raw demand label set.
+
+| Metric | Value |
+| --- | --- |
+| `ec2_provisioner_template_runners{state}` | EC2 instances charged against the template cap. `pending` instances report as `starting`. |
+| `ec2_provisioner_template_max_concurrency` | Configured ceiling for the template. |
+| `ec2_provisioner_template_target_concurrency` | Configured warm-pool floor for the template. |
+| `ec2_provisioner_template_queued_demand` | Queued jobs whose labels match the template. |
+| `ec2_provisioner_template_oldest_queued_age` | Age of the oldest matching queued job in milliseconds. |
+
+The runner count reads `shipfox.template_key` from AWS `DescribeInstances` results.
+The production ECS module keeps one provisioner task, so this fleet count matches the
+per-process `max_concurrency` cap. AWS listings are eventually consistent and can briefly
+undercount a new launch. Queue gauges use the latest demand poll and map each label set to
+every ranked matching template.
+
+Each rendered template creates six time series: two runner states and four single-series
+gauges. Matrix families multiply their axis sizes, so keep the rendered template count
+bounded when adding an axis.
+
 ## Behavior notes
 
 Search for `Observed EC2 runner instance termination` to find one terminal log per AWS

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -149,7 +149,7 @@ The `template_key` label is the rendered template key, not a raw demand label se
 
 | Metric | Value |
 | --- | --- |
-| `ec2_provisioner_template_runners{state}` | EC2 instances charged against the template cap. `pending` instances report as `starting`. |
+| `ec2_provisioner_template_runners{state}` | EC2 instances charged against the template cap. `pending` instances report as `starting`; unknown states report as `running`. |
 | `ec2_provisioner_template_max_concurrency` | Configured ceiling for the template. |
 | `ec2_provisioner_template_target_concurrency` | Configured warm-pool floor for the template. |
 | `ec2_provisioner_template_queued_demand` | Queued jobs whose labels match the template. |
@@ -160,6 +160,8 @@ The production ECS module keeps one provisioner task, so this fleet count matche
 per-process `max_concurrency` cap. AWS listings are eventually consistent and can briefly
 undercount a new launch. Queue gauges use the latest demand poll and map each label set to
 every ranked matching template.
+If a demand poll fails, the core adapter clears the cached snapshot so queue gauges do not
+retain stale saturation values.
 
 Each rendered template creates six time series: two runner states and four single-series
 gauges. Matrix families multiply their axis sizes, so keep the rendered template count

--- a/libs/provisioner/ec2/src/metrics/service.test.ts
+++ b/libs/provisioner/ec2/src/metrics/service.test.ts
@@ -201,5 +201,7 @@ function ec2Spec(): Ec2TemplateSpec {
     associatePublicIp: false,
     rootVolumeGb: 20,
     rootDeviceName: '/dev/sda1',
+    workspaceVolumeGb: 100,
+    workspaceDeviceName: '/dev/sdf',
   };
 }

--- a/libs/provisioner/ec2/src/metrics/service.test.ts
+++ b/libs/provisioner/ec2/src/metrics/service.test.ts
@@ -1,9 +1,24 @@
 const mocks = vi.hoisted(() => {
-  const gauge = {};
+  const gauges = {
+    managedInstances: {},
+    templateMaxConcurrency: {},
+    templateOldestQueuedAge: {},
+    templateQueuedDemand: {},
+    templateRunners: {},
+    templateTargetConcurrency: {},
+  };
+  const gaugeByName: Record<string, object> = {
+    ec2_provisioner_managed_instances: gauges.managedInstances,
+    ec2_provisioner_template_max_concurrency: gauges.templateMaxConcurrency,
+    ec2_provisioner_template_oldest_queued_age: gauges.templateOldestQueuedAge,
+    ec2_provisioner_template_queued_demand: gauges.templateQueuedDemand,
+    ec2_provisioner_template_runners: gauges.templateRunners,
+    ec2_provisioner_template_target_concurrency: gauges.templateTargetConcurrency,
+  };
   return {
     addBatchObservableCallback: vi.fn(),
-    createObservableGauge: vi.fn(() => gauge),
-    gauge,
+    createObservableGauge: vi.fn((name: string) => gaugeByName[name]),
+    gauges,
     getMeter: vi.fn(),
     getServiceMetricsProvider: vi.fn(),
   };
@@ -13,8 +28,30 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
   getServiceMetricsProvider: mocks.getServiceMetricsProvider,
 }));
 
-import type {Ec2Engine} from '#ec2-engine.js';
+import type {DemandStatDto} from '@shipfox/api-runners-dto';
+import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
+import type {Ec2Engine, Ec2InstanceView} from '#ec2-engine.js';
+import type {Ec2TemplateSpec} from '#templates.js';
 import {registerEc2ServiceMetrics} from './service.js';
+
+const templates: readonly ProvisionerTemplate<Ec2TemplateSpec>[] = [
+  {
+    key: 'linux',
+    labels: ['linux'],
+    maxConcurrency: 2,
+    targetConcurrency: 1,
+    cost: 1,
+    spec: ec2Spec(),
+  },
+  {
+    key: 'linux-gpu',
+    labels: ['linux', 'gpu'],
+    maxConcurrency: 5,
+    targetConcurrency: 2,
+    cost: 2,
+    spec: ec2Spec(),
+  },
+];
 
 describe('registerEc2ServiceMetrics', () => {
   beforeEach(() => {
@@ -32,10 +69,19 @@ describe('registerEc2ServiceMetrics', () => {
   it('observes managed instances by bounded EC2 state', async () => {
     const listManaged = vi
       .fn()
-      .mockResolvedValue([{state: 'pending'}, {state: 'running'}, {state: 'running'}]);
+      .mockResolvedValue([
+        instance('i-pending', 'pending', 'linux'),
+        instance('i-running-1', 'running', 'linux'),
+        instance('i-running-2', 'running', 'linux'),
+      ]);
     const engine = {listManaged} as unknown as Ec2Engine;
 
-    registerEc2ServiceMetrics({engine, provisionerId: 'provisioner-1'});
+    registerEc2ServiceMetrics({
+      engine,
+      provisionerId: 'provisioner-1',
+      templates: templates.slice(0, 1),
+      getDemandStats: () => [],
+    });
     const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
     const observer = {observe: vi.fn()};
 
@@ -45,7 +91,115 @@ describe('registerEc2ServiceMetrics', () => {
       description: 'EC2 runner instances currently managed by the provisioner, by EC2 state',
     });
     expect(listManaged).toHaveBeenCalledWith('provisioner-1');
-    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 1, {state: 'pending'});
-    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 2, {state: 'running'});
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.managedInstances, 1, {
+      state: 'pending',
+    });
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.managedInstances, 2, {
+      state: 'running',
+    });
+  });
+
+  it('observes AWS-backed template saturation and matching queued demand', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    const instances: Ec2InstanceView[] = [
+      instance('i-linux-pending', 'pending', 'linux'),
+      instance('i-linux-running', 'running', 'linux'),
+      instance('i-gpu-running', 'running', 'linux-gpu'),
+      instance('i-unknown-running', 'running', 'unconfigured'),
+    ];
+    const stats: DemandStatDto[] = [
+      {
+        labels: ['linux'],
+        queued: 3,
+        reserved: 0,
+        oldest_queued_at: new Date(7_000).toISOString(),
+      },
+      {
+        labels: ['linux', 'gpu'],
+        queued: 2,
+        reserved: 0,
+        oldest_queued_at: new Date(8_000).toISOString(),
+      },
+    ];
+    const engine = {listManaged: vi.fn().mockResolvedValue(instances)} as unknown as Ec2Engine;
+
+    try {
+      registerEc2ServiceMetrics({
+        engine,
+        provisionerId: 'provisioner-1',
+        templates,
+        getDemandStats: () => stats,
+      });
+      const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+      const observer = {observe: vi.fn()};
+
+      await callback?.(observer);
+
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 1, {
+        template_key: 'linux',
+        state: 'starting',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 1, {
+        template_key: 'linux',
+        state: 'running',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 0, {
+        template_key: 'linux-gpu',
+        state: 'starting',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 1, {
+        template_key: 'linux-gpu',
+        state: 'running',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateMaxConcurrency, 2, {
+        template_key: 'linux',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateTargetConcurrency, 2, {
+        template_key: 'linux-gpu',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateQueuedDemand, 3, {
+        template_key: 'linux',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateQueuedDemand, 5, {
+        template_key: 'linux-gpu',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateOldestQueuedAge, 3_000, {
+        template_key: 'linux',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateOldestQueuedAge, 3_000, {
+        template_key: 'linux-gpu',
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });
+
+function instance(
+  instanceId: string,
+  state: Ec2InstanceView['state'],
+  templateKey: string,
+): Ec2InstanceView {
+  return {
+    instanceId,
+    state,
+    tags: {
+      'shipfox.provider_runner_id': instanceId,
+      'shipfox.template_key': templateKey,
+    },
+  };
+}
+
+function ec2Spec(): Ec2TemplateSpec {
+  return {
+    ami: 'ami-0123456789abcdef0',
+    instanceType: 't3.small',
+    market: 'on-demand',
+    spotMaxPrice: null,
+    subnets: ['subnet-123'],
+    securityGroups: ['sg-123'],
+    associatePublicIp: false,
+    rootVolumeGb: 20,
+    rootDeviceName: '/dev/sda1',
+  };
+}

--- a/libs/provisioner/ec2/src/metrics/service.test.ts
+++ b/libs/provisioner/ec2/src/metrics/service.test.ts
@@ -21,11 +21,13 @@ const mocks = vi.hoisted(() => {
     gauges,
     getMeter: vi.fn(),
     getServiceMetricsProvider: vi.fn(),
+    logger: {warn: vi.fn()},
   };
 });
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
   getServiceMetricsProvider: mocks.getServiceMetricsProvider,
+  logger: () => mocks.logger,
 }));
 
 import type {DemandStatDto} from '@shipfox/api-runners-dto';
@@ -59,6 +61,7 @@ describe('registerEc2ServiceMetrics', () => {
     mocks.createObservableGauge.mockClear();
     mocks.getMeter.mockReset();
     mocks.getServiceMetricsProvider.mockReset();
+    mocks.logger.warn.mockReset();
     mocks.getMeter.mockReturnValue({
       createObservableGauge: mocks.createObservableGauge,
       addBatchObservableCallback: mocks.addBatchObservableCallback,
@@ -90,6 +93,14 @@ describe('registerEc2ServiceMetrics', () => {
     expect(mocks.createObservableGauge).toHaveBeenCalledWith('ec2_provisioner_managed_instances', {
       description: 'EC2 runner instances currently managed by the provisioner, by EC2 state',
     });
+    expect(mocks.addBatchObservableCallback).toHaveBeenCalledWith(expect.any(Function), [
+      mocks.gauges.managedInstances,
+      mocks.gauges.templateRunners,
+      mocks.gauges.templateMaxConcurrency,
+      mocks.gauges.templateTargetConcurrency,
+      mocks.gauges.templateQueuedDemand,
+      mocks.gauges.templateOldestQueuedAge,
+    ]);
     expect(listManaged).toHaveBeenCalledWith('provisioner-1');
     expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.managedInstances, 1, {
       state: 'pending',
@@ -104,6 +115,8 @@ describe('registerEc2ServiceMetrics', () => {
     const instances: Ec2InstanceView[] = [
       instance('i-linux-pending', 'pending', 'linux'),
       instance('i-linux-running', 'running', 'linux'),
+      instance('i-linux-unknown-state', 'unknown', 'linux'),
+      instance('i-linux-stopping', 'stopping', 'linux'),
       instance('i-gpu-running', 'running', 'linux-gpu'),
       instance('i-unknown-running', 'running', 'unconfigured'),
     ];
@@ -139,7 +152,7 @@ describe('registerEc2ServiceMetrics', () => {
         template_key: 'linux',
         state: 'starting',
       });
-      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 1, {
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 2, {
         template_key: 'linux',
         state: 'running',
       });
@@ -169,9 +182,72 @@ describe('registerEc2ServiceMetrics', () => {
       expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateOldestQueuedAge, 3_000, {
         template_key: 'linux-gpu',
       });
+      expect(mocks.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'provisioner.ec2.unattributed_managed_instances',
+          count: 1,
+        }),
+        'Some managed EC2 instances do not map to a configured template',
+      );
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  it('observes zero demand and runner counts when no instances or jobs are present', async () => {
+    const engine = {listManaged: vi.fn().mockResolvedValue([])} as unknown as Ec2Engine;
+    registerEc2ServiceMetrics({
+      engine,
+      provisionerId: 'provisioner-1',
+      templates,
+      getDemandStats: () => [],
+    });
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    const observer = {observe: vi.fn()};
+
+    await callback?.(observer);
+
+    for (const template of templates) {
+      const labels = {template_key: template.key};
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 0, {
+        ...labels,
+        state: 'starting',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateRunners, 0, {
+        ...labels,
+        state: 'running',
+      });
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.templateQueuedDemand, 0, labels);
+      expect(observer.observe).toHaveBeenCalledWith(
+        mocks.gauges.templateOldestQueuedAge,
+        0,
+        labels,
+      );
+    }
+  });
+
+  it('logs a structured warning when the EC2 listing fails', async () => {
+    const engine = {
+      listManaged: vi.fn().mockRejectedValue(new Error('AWS unavailable')),
+    } as unknown as Ec2Engine;
+    registerEc2ServiceMetrics({
+      engine,
+      provisionerId: 'provisioner-1',
+      templates,
+      getDemandStats: () => [],
+    });
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+
+    await callback?.({observe: vi.fn()});
+
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.service_metrics_failed',
+        provisionerId: 'provisioner-1',
+        reason: 'AWS unavailable',
+      }),
+      'EC2 service metrics callback failed',
+    );
   });
 });
 

--- a/libs/provisioner/ec2/src/metrics/service.ts
+++ b/libs/provisioner/ec2/src/metrics/service.ts
@@ -1,18 +1,55 @@
+import type {DemandStatDto} from '@shipfox/api-runners-dto';
 import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {type ProvisionerTemplate, rankTemplatesForLabels} from '@shipfox/provisioner-core';
 import type {Ec2Engine, Ec2InstanceState} from '#ec2-engine.js';
+import {parseInstanceIdentity} from '#instance-identity.js';
+import type {Ec2TemplateSpec} from '#templates.js';
+
+type ServiceMetricLabels = {
+  template_key?: string;
+  state?: Ec2InstanceState | 'starting' | 'running';
+};
+type TemplateRunnerCounts = {starting: number; running: number};
+type TemplateDemand = {queued: number; oldestQueuedAtMs?: number};
 
 export interface RegisterEc2ServiceMetricsOptions {
   readonly engine: Ec2Engine;
   readonly provisionerId: string;
+  readonly templates: readonly ProvisionerTemplate<Ec2TemplateSpec>[];
+  readonly getDemandStats: () => readonly DemandStatDto[];
 }
 
 export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOptions): void {
   const meter = getServiceMetricsProvider().getMeter('provisioner-ec2');
-  const managedInstances = meter.createObservableGauge<{
-    state: Ec2InstanceState;
-  }>('ec2_provisioner_managed_instances', {
-    description: 'EC2 runner instances currently managed by the provisioner, by EC2 state',
-  });
+  const managedInstances = meter.createObservableGauge<ServiceMetricLabels>(
+    'ec2_provisioner_managed_instances',
+    {
+      description: 'EC2 runner instances currently managed by the provisioner, by EC2 state',
+    },
+  );
+  const templateRunners = meter.createObservableGauge<ServiceMetricLabels>(
+    'ec2_provisioner_template_runners',
+    {description: 'EC2 runner instances charged against each template concurrency cap'},
+  );
+  const templateMaxConcurrency = meter.createObservableGauge<ServiceMetricLabels>(
+    'ec2_provisioner_template_max_concurrency',
+    {description: 'Configured maximum concurrency for each EC2 runner template'},
+  );
+  const templateTargetConcurrency = meter.createObservableGauge<ServiceMetricLabels>(
+    'ec2_provisioner_template_target_concurrency',
+    {description: 'Configured warm-pool target concurrency for each EC2 runner template'},
+  );
+  const templateQueuedDemand = meter.createObservableGauge<ServiceMetricLabels>(
+    'ec2_provisioner_template_queued_demand',
+    {description: 'Queued jobs matching each EC2 runner template'},
+  );
+  const templateOldestQueuedAge = meter.createObservableGauge<ServiceMetricLabels>(
+    'ec2_provisioner_template_oldest_queued_age',
+    {
+      description: 'Age of the oldest queued job matching each EC2 runner template',
+      unit: 'ms',
+    },
+  );
 
   meter.addBatchObservableCallback(
     async (observer) => {
@@ -21,7 +58,79 @@ export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOpti
       for (const instance of instances)
         counts.set(instance.state, (counts.get(instance.state) ?? 0) + 1);
       for (const [state, count] of counts) observer.observe(managedInstances, count, {state});
+
+      const countsByTemplate = new Map<string, TemplateRunnerCounts>(
+        options.templates.map((template) => [template.key, {starting: 0, running: 0}]),
+      );
+      for (const instance of instances) {
+        const templateKey = parseInstanceIdentity(instance).templateKey;
+        const templateCounts = templateKey ? countsByTemplate.get(templateKey) : undefined;
+        const state = templateRunnerState(instance.state);
+        if (!templateCounts || !state) continue;
+        templateCounts[state] += 1;
+      }
+
+      const demandByTemplate = new Map<string, TemplateDemand>(
+        options.templates.map((template) => [template.key, {queued: 0}]),
+      );
+      for (const stat of options.getDemandStats()) {
+        if (stat.queued === 0) continue;
+        const oldestQueuedAtMs = Date.parse(stat.oldest_queued_at);
+        for (const template of rankTemplatesForLabels(stat.labels, options.templates)) {
+          const demand = demandByTemplate.get(template.key);
+          if (!demand) continue;
+          demand.queued += stat.queued;
+          if (Number.isFinite(oldestQueuedAtMs)) {
+            demand.oldestQueuedAtMs =
+              demand.oldestQueuedAtMs === undefined
+                ? oldestQueuedAtMs
+                : Math.min(demand.oldestQueuedAtMs, oldestQueuedAtMs);
+          }
+        }
+      }
+
+      for (const template of options.templates) {
+        const labels = {template_key: template.key};
+        const countsForTemplate = countsByTemplate.get(template.key) ?? {starting: 0, running: 0};
+        const demand = demandByTemplate.get(template.key) ?? {queued: 0};
+        observer.observe(templateRunners, countsForTemplate.starting, {
+          ...labels,
+          state: 'starting',
+        });
+        observer.observe(templateRunners, countsForTemplate.running, {
+          ...labels,
+          state: 'running',
+        });
+        observer.observe(templateMaxConcurrency, template.maxConcurrency, labels);
+        observer.observe(templateTargetConcurrency, template.targetConcurrency ?? 0, labels);
+        observer.observe(templateQueuedDemand, demand.queued, labels);
+        observer.observe(
+          templateOldestQueuedAge,
+          demand.oldestQueuedAtMs === undefined
+            ? 0
+            : Math.max(0, Date.now() - demand.oldestQueuedAtMs),
+          labels,
+        );
+      }
     },
-    [managedInstances],
+    [
+      managedInstances,
+      templateRunners,
+      templateMaxConcurrency,
+      templateTargetConcurrency,
+      templateQueuedDemand,
+      templateOldestQueuedAge,
+    ],
   );
+}
+
+function templateRunnerState(state: Ec2InstanceState): 'starting' | 'running' | undefined {
+  switch (state) {
+    case 'pending':
+      return 'starting';
+    case 'running':
+      return 'running';
+    default:
+      return undefined;
+  }
 }

--- a/libs/provisioner/ec2/src/metrics/service.ts
+++ b/libs/provisioner/ec2/src/metrics/service.ts
@@ -1,5 +1,5 @@
 import type {DemandStatDto} from '@shipfox/api-runners-dto';
-import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getServiceMetricsProvider, logger} from '@shipfox/node-opentelemetry';
 import {type ProvisionerTemplate, rankTemplatesForLabels} from '@shipfox/provisioner-core';
 import type {Ec2Engine, Ec2InstanceState} from '#ec2-engine.js';
 import {parseInstanceIdentity} from '#instance-identity.js';
@@ -50,66 +50,97 @@ export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOpti
       unit: 'ms',
     },
   );
+  let lastUnattributedCount = 0;
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const instances = await options.engine.listManaged(options.provisionerId);
-      const counts = new Map<Ec2InstanceState, number>();
-      for (const instance of instances)
-        counts.set(instance.state, (counts.get(instance.state) ?? 0) + 1);
-      for (const [state, count] of counts) observer.observe(managedInstances, count, {state});
+      try {
+        const instances = await options.engine.listManaged(options.provisionerId);
+        const counts = new Map<Ec2InstanceState, number>();
+        for (const instance of instances)
+          counts.set(instance.state, (counts.get(instance.state) ?? 0) + 1);
+        for (const [state, count] of counts) observer.observe(managedInstances, count, {state});
 
-      const countsByTemplate = new Map<string, TemplateRunnerCounts>(
-        options.templates.map((template) => [template.key, {starting: 0, running: 0}]),
-      );
-      for (const instance of instances) {
-        const templateKey = parseInstanceIdentity(instance).templateKey;
-        const templateCounts = templateKey ? countsByTemplate.get(templateKey) : undefined;
-        const state = templateRunnerState(instance.state);
-        if (!templateCounts || !state) continue;
-        templateCounts[state] += 1;
-      }
+        const countsByTemplate = new Map<string, TemplateRunnerCounts>(
+          options.templates.map((template) => [template.key, {starting: 0, running: 0}]),
+        );
+        let unattributedCount = 0;
+        for (const instance of instances) {
+          const templateKey = parseInstanceIdentity(instance).templateKey;
+          if (!templateKey || !countsByTemplate.has(templateKey)) {
+            unattributedCount += 1;
+            continue;
+          }
+          const state = templateRunnerState(instance.state);
+          if (!state) continue;
+          const templateCounts = countsByTemplate.get(templateKey);
+          if (templateCounts) templateCounts[state] += 1;
+        }
+        if (unattributedCount !== 0 && unattributedCount !== lastUnattributedCount) {
+          logger().warn(
+            {
+              event: 'provisioner.ec2.unattributed_managed_instances',
+              count: unattributedCount,
+              provisionerId: options.provisionerId,
+            },
+            'Some managed EC2 instances do not map to a configured template',
+          );
+        }
+        lastUnattributedCount = unattributedCount;
 
-      const demandByTemplate = new Map<string, TemplateDemand>(
-        options.templates.map((template) => [template.key, {queued: 0}]),
-      );
-      for (const stat of options.getDemandStats()) {
-        if (stat.queued === 0) continue;
-        const oldestQueuedAtMs = Date.parse(stat.oldest_queued_at);
-        for (const template of rankTemplatesForLabels(stat.labels, options.templates)) {
-          const demand = demandByTemplate.get(template.key);
-          if (!demand) continue;
-          demand.queued += stat.queued;
-          if (Number.isFinite(oldestQueuedAtMs)) {
-            demand.oldestQueuedAtMs =
-              demand.oldestQueuedAtMs === undefined
-                ? oldestQueuedAtMs
-                : Math.min(demand.oldestQueuedAtMs, oldestQueuedAtMs);
+        const demandByTemplate = new Map<string, TemplateDemand>(
+          options.templates.map((template) => [template.key, {queued: 0}]),
+        );
+        for (const stat of options.getDemandStats()) {
+          if (stat.queued === 0) continue;
+          const oldestQueuedAtMs = Date.parse(stat.oldest_queued_at);
+          for (const template of rankTemplatesForLabels(stat.labels, options.templates)) {
+            const demand = demandByTemplate.get(template.key);
+            if (!demand) continue;
+            demand.queued += stat.queued;
+            if (Number.isFinite(oldestQueuedAtMs)) {
+              demand.oldestQueuedAtMs =
+                demand.oldestQueuedAtMs === undefined
+                  ? oldestQueuedAtMs
+                  : Math.min(demand.oldestQueuedAtMs, oldestQueuedAtMs);
+            }
           }
         }
-      }
 
-      for (const template of options.templates) {
-        const labels = {template_key: template.key};
-        const countsForTemplate = countsByTemplate.get(template.key) ?? {starting: 0, running: 0};
-        const demand = demandByTemplate.get(template.key) ?? {queued: 0};
-        observer.observe(templateRunners, countsForTemplate.starting, {
-          ...labels,
-          state: 'starting',
-        });
-        observer.observe(templateRunners, countsForTemplate.running, {
-          ...labels,
-          state: 'running',
-        });
-        observer.observe(templateMaxConcurrency, template.maxConcurrency, labels);
-        observer.observe(templateTargetConcurrency, template.targetConcurrency ?? 0, labels);
-        observer.observe(templateQueuedDemand, demand.queued, labels);
-        observer.observe(
-          templateOldestQueuedAge,
-          demand.oldestQueuedAtMs === undefined
-            ? 0
-            : Math.max(0, Date.now() - demand.oldestQueuedAtMs),
-          labels,
+        for (const template of options.templates) {
+          const labels = {template_key: template.key};
+          const countsForTemplate = countsByTemplate.get(template.key) ?? {
+            starting: 0,
+            running: 0,
+          };
+          const demand = demandByTemplate.get(template.key) ?? {queued: 0};
+          observer.observe(templateRunners, countsForTemplate.starting, {
+            ...labels,
+            state: 'starting',
+          });
+          observer.observe(templateRunners, countsForTemplate.running, {
+            ...labels,
+            state: 'running',
+          });
+          observer.observe(templateMaxConcurrency, template.maxConcurrency, labels);
+          observer.observe(templateTargetConcurrency, template.targetConcurrency ?? 0, labels);
+          observer.observe(templateQueuedDemand, demand.queued, labels);
+          observer.observe(
+            templateOldestQueuedAge,
+            demand.oldestQueuedAtMs === undefined
+              ? 0
+              : Math.max(0, Date.now() - demand.oldestQueuedAtMs),
+            labels,
+          );
+        }
+      } catch (error) {
+        logger().warn(
+          {
+            event: 'provisioner.ec2.service_metrics_failed',
+            provisionerId: options.provisionerId,
+            reason: errorReason(error),
+          },
+          'EC2 service metrics callback failed',
         );
       }
     },
@@ -130,7 +161,13 @@ function templateRunnerState(state: Ec2InstanceState): 'starting' | 'running' | 
       return 'starting';
     case 'running':
       return 'running';
+    case 'unknown':
+      return 'running';
     default:
       return undefined;
   }
+}
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
 }

--- a/libs/provisioner/ec2/src/provisioner.test.ts
+++ b/libs/provisioner/ec2/src/provisioner.test.ts
@@ -85,9 +85,15 @@ describe('createEc2ProvisionerAdapter', () => {
       } as unknown as ProviderRunnerTracker,
     });
 
-    expect(observability.registerEc2ServiceMetrics).toHaveBeenCalledWith({
-      engine,
-      provisionerId: 'provisioner-1',
-    });
+    expect(observability.registerEc2ServiceMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        engine,
+        provisionerId: 'provisioner-1',
+        templates: [template],
+      }),
+    );
+    expect(observability.registerEc2ServiceMetrics.mock.calls[0]?.[0].getDemandStats).toEqual(
+      expect.any(Function),
+    );
   });
 });

--- a/libs/provisioner/ec2/src/provisioner.test.ts
+++ b/libs/provisioner/ec2/src/provisioner.test.ts
@@ -6,6 +6,7 @@ vi.mock('#metrics/service.js', () => ({
   registerEc2ServiceMetrics: observability.registerEc2ServiceMetrics,
 }));
 
+import type {DemandStatDto} from '@shipfox/api-runners-dto';
 import type {
   ProviderRunnerTracker,
   ProvisionerClient,
@@ -95,5 +96,33 @@ describe('createEc2ProvisionerAdapter', () => {
     expect(observability.registerEc2ServiceMetrics.mock.calls[0]?.[0].getDemandStats).toEqual(
       expect.any(Function),
     );
+
+    const getDemandStats = observability.registerEc2ServiceMetrics.mock.calls[0]?.[0]
+      .getDemandStats as () => readonly DemandStatDto[];
+    expect(getDemandStats()).toEqual([]);
+
+    const stats: DemandStatDto[] = [
+      {
+        labels: ['linux'],
+        queued: 2,
+        reserved: 1,
+        oldest_queued_at: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    adapter.onDemandStats?.(stats);
+    expect(getDemandStats()).toEqual(stats);
+
+    stats[0]?.labels.push('gpu');
+    expect(getDemandStats()).toEqual([
+      {
+        labels: ['linux'],
+        queued: 2,
+        reserved: 1,
+        oldest_queued_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    adapter.onDemandStats?.([]);
+    expect(getDemandStats()).toEqual([]);
   });
 });

--- a/libs/provisioner/ec2/src/provisioner.ts
+++ b/libs/provisioner/ec2/src/provisioner.ts
@@ -1,3 +1,4 @@
+import type {DemandStatDto} from '@shipfox/api-runners-dto';
 import {
   type ProviderRunnerLaunch,
   type ProvisionerAdapter,
@@ -28,6 +29,7 @@ export function createEc2ProvisionerAdapter(
   options: CreateEc2ProvisionerAdapterOptions,
 ): ProvisionerAdapter<Ec2TemplateSpec> {
   let lifecycle: Ec2Lifecycle | undefined;
+  let lastDemandStats: readonly DemandStatDto[] = [];
 
   return {
     loadTemplates: () => Promise.resolve(options.templates),
@@ -37,8 +39,17 @@ export function createEc2ProvisionerAdapter(
     ),
     launch: (launch) => requireLifecycle(lifecycle).launch(launch),
     terminate: (ids) => requireLifecycle(lifecycle).terminate(ids),
+    onDemandStats(stats) {
+      lastDemandStats = stats.map((stat) => ({...stat, labels: [...stat.labels]}));
+    },
     async onStart(runtime) {
-      registerEc2ServiceMetrics({engine: options.engine, provisionerId: runtime.identity.id});
+      lastDemandStats = [];
+      registerEc2ServiceMetrics({
+        engine: options.engine,
+        provisionerId: runtime.identity.id,
+        templates: options.templates,
+        getDemandStats: () => lastDemandStats,
+      });
       lifecycle = createLifecycle(options, runtime);
       await lifecycle.reconcile();
     },


### PR DESCRIPTION
Adds service-plane gauges that make each configured EC2 template's pool saturation observable: runner counts by starting/running, max/target concurrency, queued demand, and oldest queued age.

The metrics use AWS-managed instances and `shipfox.template_key` for shared truth, and the latest successful demand poll mapped through configured template matching. The README records the current single-ECS-task deployment assumption and bounded template cardinality.

Validated locally with focused check, type, test, dependency-cruiser, and diff checks.

Closes ENG-1538

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose per-template EC2 pool saturation on the service metrics endpoint to show runner utilization and queued work, with stronger handling of demand snapshot delivery and provider health. Addresses ENG-1538 by making it visible when a template is at or near its cap and whether work is waiting.

- **New Features**
  - Added gauges per template:
    - `ec2_provisioner_template_runners{template_key,state=starting|running}`
    - `ec2_provisioner_template_max_concurrency`, `ec2_provisioner_template_target_concurrency`
    - `ec2_provisioner_template_queued_demand`, `ec2_provisioner_template_oldest_queued_age` (ms)
  - Runner counts come from AWS tags (`shipfox.template_key`); `pending` reports as `starting`, and unknown states report as `running`.
  - Queued demand uses the latest demand poll and maps each label set to every ranked matching template via `rankTemplatesForLabels`; queue age uses `Date.now - oldest_queued_at`. Core (`@shipfox/provisioner-core`) forwards snapshots to providers via `onDemandStats`, and the EC2 adapter caches and exposes them to service metrics via `getDemandStats` (cleared on failed polls).
  - Utilization is derivable in PromQL; README documents the single-replica assumption and bounded template cardinality.

- **Bug Fixes**
  - Contained provider demand snapshot delivery failures: iteration continues, health facet `provider_observation` is marked degraded, and a structured warning is logged. Preserves any existing `provider_observation` outage across snapshot delivery, and only auto-recovers if the outage was caused by snapshot delivery.
  - Service metrics warn on unmanaged-to-template mismatches and safely handle AWS listing errors by logging and continuing.

<sup>Written for commit 2a6a130f24fca652d47824f7b7622ebd3ea385b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

