### PR TITLE
Keep Drizzle migrations visible to Cubic reviews

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+version: 1
+
+reviews:
+  ignore:
+    files:
+      - '**/drizzle/meta/**'


### PR DESCRIPTION
Configure Cubic to ignore generated Drizzle metadata under any `drizzle/meta/` directory.

This removes snapshot and journal noise from AI reviews while keeping the actual SQL migrations reviewable.

Validation: YAML structure parsing and `git diff --check origin/main...HEAD` passed. The Prettier check was unavailable because this workspace does not have a Prettier executable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cubic.yaml` to ignore generated Drizzle metadata under `**/drizzle/meta/**`. This keeps Cubic reviews focused on actual SQL migrations and removes snapshot/journal noise.

<sup>Written for commit dcf1959efd5b4962077331aa667a35d19b1c6fe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

