### PR TITLE
Remove SSM and snapd from EC2 runner images

### DIFF
--- a/apps/provisioner-ec2/templates.example.yaml
+++ b/apps/provisioner-ec2/templates.example.yaml
@@ -33,7 +33,6 @@ defaults:
   labels: [ec2]
   subnets: [subnet-general-a, subnet-general-b]
   security_groups: [sg-runner]
-  iam_instance_profile: shipfox-runner
   associate_public_ip: false
   # Keep the boot volume small. Job checkouts and logs live on the separate workspace volume.
   root_volume_gb: 30

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -38,9 +38,10 @@ that removes a unit or overrides the drop-in fails the image build.
 ### AppArmor decision
 
 The runner keeps `apparmor.service` enabled. It also keeps
-`snapd.apparmor.service` enabled when the base image provides it. This preserves
-the image security profile while snapd remains installed. This change does not
-mask or socket-activate either unit. ENG-1530 owns removing snapd.
+the base image's AppArmor profiles without changing the security posture. The image
+purges `snapd` and removes `/var/lib/snapd` and `/snap` during setup, so the seeded
+`amazon-ssm-agent` snap and `snapd.apparmor.service` are absent. This change does not
+mask or socket-activate `apparmor.service`.
 
 ### Journal retention
 

--- a/infra/images/runner/scripts/build/setup-runner.sh
+++ b/infra/images/runner/scripts/build/setup-runner.sh
@@ -5,6 +5,10 @@ apt-get update
 apt-get install --yes --no-install-recommends \
   ca-certificates curl wget git openssh-client tar gzip xz-utils bzip2 zip unzip jq \
   build-essential python3 pkg-config ripgrep fd-find sudo amazon-ec2-utils
+# Runner instances have no host-management credentials. Remove snapd and its seeded
+# snaps instead of carrying a failed host-management path into every boot.
+apt-get purge --yes snapd
+rm -rf /var/lib/snapd /snap
 rm -rf /var/lib/apt/lists/*
 
 ln -sf "$(command -v fdfind)" /usr/local/bin/fd

--- a/infra/images/runner/scripts/build/setup-runner.sh
+++ b/infra/images/runner/scripts/build/setup-runner.sh
@@ -1,20 +1,49 @@
 #!/usr/bin/env sh
 set -eu
 
+root_dir=${RUNNER_IMAGE_ROOT:-/}
+
 apt-get update
 apt-get install --yes --no-install-recommends \
   ca-certificates curl wget git openssh-client tar gzip xz-utils bzip2 zip unzip jq \
   build-essential python3 pkg-config ripgrep fd-find sudo amazon-ec2-utils
 # Runner instances have no host-management credentials. Remove snapd and its seeded
 # snaps instead of carrying a failed host-management path into every boot.
+# Stop snapd before unmounting its seeded loop-backed squashfs filesystems. The base
+# image can have these mounts live even after the snapd package is purged.
+systemctl stop snapd.seeded.service snapd.service snapd.socket 2>/dev/null || true
+for snap_mount in "$root_dir"/snap/* "$root_dir/snap"; do
+  if [ -e "$snap_mount" ]; then
+    umount "$snap_mount" 2>/dev/null || umount -l "$snap_mount" 2>/dev/null || true
+  fi
+done
 apt-get purge --yes snapd
-rm -rf /var/lib/snapd /snap
-rm -rf /var/lib/apt/lists/*
+rm -rf "$root_dir/var/lib/snapd" "$root_dir/snap"
 
-ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+if command -v snap >/dev/null 2>&1 || command -v snapd >/dev/null 2>&1; then
+  printf '%s\n' 'runner image setup: snap or snapd is still available after purge' >&2
+  exit 1
+fi
+
+for removed_path in \
+  "$root_dir/var/lib/snapd" \
+  "$root_dir/snap" \
+  "$root_dir/usr/bin/snap" \
+  "$root_dir/usr/lib/snapd/snapd" \
+  "$root_dir/lib/systemd/system/snapd.service" \
+  "$root_dir/lib/systemd/system/snapd.seeded.service"; do
+  if [ -e "$removed_path" ]; then
+    printf 'runner image setup: removed snap path still exists: %s\n' "$removed_path" >&2
+    exit 1
+  fi
+done
+
+rm -rf "$root_dir/var/lib/apt/lists/"*
+
+ln -sf "$(command -v fdfind)" "$root_dir/usr/local/bin/fd"
 groupadd --system shipfox || true
 id shipfox >/dev/null 2>&1 || useradd --system --gid shipfox --create-home --home-dir /home/shipfox shipfox
-printf '%s\n' 'shipfox ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/shipfox
-chmod 0440 /etc/sudoers.d/shipfox
-printf '%s\n' 'LANG=C.UTF-8' > /etc/default/locale
-install -d -o shipfox -g shipfox /opt/runner
+printf '%s\n' 'shipfox ALL=(ALL) NOPASSWD:ALL' > "$root_dir/etc/sudoers.d/shipfox"
+chmod 0440 "$root_dir/etc/sudoers.d/shipfox"
+printf '%s\n' 'LANG=C.UTF-8' > "$root_dir/etc/default/locale"
+install -d -o shipfox -g shipfox "$root_dir/opt/runner"

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1104,7 +1104,7 @@ describe('runner image composition', () => {
     const fixture = await createRunnerImageSetupFixture();
 
     try {
-      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+      execFileSync('/bin/sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
 
       const events = (await readFile(fixture.commandLog, 'utf8')).trim().split('\n');
       const stopIndex = events.indexOf(
@@ -1132,7 +1132,7 @@ describe('runner image composition', () => {
 
     try {
       expect(() =>
-        execFileSync('sh', [script.pathname], {
+        execFileSync('/bin/sh', [script.pathname], {
           env: {...fixture.environment, RUNNER_IMAGE_FAIL_PURGE: '1'},
           stdio: 'pipe',
         }),
@@ -1153,7 +1153,7 @@ describe('runner image composition', () => {
       await writeExecutable(join(fixture.root, 'usr/bin/snap'), '#!/bin/sh\nexit 0\n');
 
       expect(() =>
-        execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
+        execFileSync('/bin/sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
       ).toThrow();
       expect(await pathExists(join(fixture.root, 'usr/bin/snap'))).toBe(true);
     } finally {
@@ -1291,7 +1291,7 @@ done
     commandLog,
     environment: {
       ...process.env,
-      PATH: `${commandDirectory}:/bin`,
+      PATH: commandDirectory,
       RUNNER_IMAGE_COMMAND_LOG: commandLog,
       RUNNER_IMAGE_ROOT: root,
     },

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1104,7 +1104,13 @@ describe('runner image composition', () => {
     const fixture = await createRunnerImageSetupFixture();
 
     try {
-      execFileSync('/bin/sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+      execFileSync('/bin/sh', [script.pathname], {
+        env: {
+          ...fixture.environment,
+          RUNNER_IMAGE_FAIL_UMOUNT: join(fixture.root, 'snap/amazon-ssm-agent'),
+        },
+        stdio: 'pipe',
+      });
 
       const events = (await readFile(fixture.commandLog, 'utf8')).trim().split('\n');
       const stopIndex = events.indexOf(
@@ -1116,7 +1122,8 @@ describe('runner image composition', () => {
       expect(build).toContain('scripts/build/setup-runner.sh');
       expect(stopIndex).toBeGreaterThanOrEqual(0);
       expect(purgeIndex).toBeGreaterThan(stopIndex);
-      expect(unmountEvents).toHaveLength(4);
+      expect(unmountEvents).toHaveLength(5);
+      expect(unmountEvents).toContain(`umount -l ${join(fixture.root, 'snap/amazon-ssm-agent')}`);
       expect(unmountEvents.every((event) => events.indexOf(event) < purgeIndex)).toBe(true);
       expect(await pathExists(join(fixture.root, 'snap'))).toBe(false);
       expect(await pathExists(join(fixture.root, 'snap/amazon-ssm-agent'))).toBe(false);
@@ -1156,6 +1163,22 @@ describe('runner image composition', () => {
         execFileSync('/bin/sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
       ).toThrow();
       expect(await pathExists(join(fixture.root, 'usr/bin/snap'))).toBe(true);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('fails the image bake when snap remains available on PATH', async () => {
+    const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
+    const fixture = await createRunnerImageSetupFixture();
+
+    try {
+      await writeExecutable(join(fixture.commandDirectory, 'snap'), '#!/bin/sh\nexit 0\n');
+
+      expect(() =>
+        execFileSync('/bin/sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
+      ).toThrow();
+      expect(await pathExists(join(fixture.root, 'snap'))).toBe(false);
     } finally {
       await rm(fixture.root, {force: true, recursive: true});
     }
@@ -1289,6 +1312,7 @@ done
 
   return {
     commandLog,
+    commandDirectory,
     environment: {
       ...process.env,
       PATH: commandDirectory,

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,5 +1,5 @@
 import {execFileSync} from 'node:child_process';
-import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {findProducedAmiId, parsePackerAmiArtifact} from '#aws.js';
@@ -1098,15 +1098,67 @@ UUID=data /data ext4 defaults 0 2
 });
 
 describe('runner image composition', () => {
-  it('purges snapd and its seeded SSM agent from the image', async () => {
-    const setup = await readFile(
-      new URL('../scripts/build/setup-runner.sh', import.meta.url),
-      'utf8',
-    );
+  it('unmounts seeded snaps, purges snapd, and removes its image state', async () => {
+    const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+    const fixture = await createRunnerImageSetupFixture();
 
-    expect(setup).toContain('apt-get purge --yes snapd');
-    expect(setup).toContain('rm -rf /var/lib/snapd /snap');
-    expect(setup).not.toContain('amazon-ssm-agent');
+    try {
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+
+      const events = (await readFile(fixture.commandLog, 'utf8')).trim().split('\n');
+      const stopIndex = events.indexOf(
+        'systemctl stop snapd.seeded.service snapd.service snapd.socket',
+      );
+      const purgeIndex = events.indexOf('apt-get purge --yes snapd');
+      const unmountEvents = events.filter((event) => event.startsWith('umount '));
+
+      expect(build).toContain('scripts/build/setup-runner.sh');
+      expect(stopIndex).toBeGreaterThanOrEqual(0);
+      expect(purgeIndex).toBeGreaterThan(stopIndex);
+      expect(unmountEvents).toHaveLength(4);
+      expect(unmountEvents.every((event) => events.indexOf(event) < purgeIndex)).toBe(true);
+      expect(await pathExists(join(fixture.root, 'snap'))).toBe(false);
+      expect(await pathExists(join(fixture.root, 'snap/amazon-ssm-agent'))).toBe(false);
+      expect(await pathExists(join(fixture.root, 'var/lib/snapd'))).toBe(false);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('fails the image bake when the snapd purge fails', async () => {
+    const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
+    const fixture = await createRunnerImageSetupFixture();
+
+    try {
+      expect(() =>
+        execFileSync('sh', [script.pathname], {
+          env: {...fixture.environment, RUNNER_IMAGE_FAIL_PURGE: '1'},
+          stdio: 'pipe',
+        }),
+      ).toThrow();
+
+      expect(await pathExists(join(fixture.root, 'snap'))).toBe(true);
+      expect(await readFile(fixture.commandLog, 'utf8')).not.toContain('rm -rf');
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('fails the image bake when snapd artifacts remain after purge', async () => {
+    const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
+    const fixture = await createRunnerImageSetupFixture();
+
+    try {
+      await writeExecutable(join(fixture.root, 'usr/bin/snap'), '#!/bin/sh\nexit 0\n');
+
+      expect(() =>
+        execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
+      ).toThrow();
+      expect(await pathExists(join(fixture.root, 'usr/bin/snap'))).toBe(true);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
   });
 });
 
@@ -1163,6 +1215,97 @@ async function createBootFixture(fstab: string) {
       RUNNER_IMAGE_ROOT: root,
     },
   };
+}
+
+async function createRunnerImageSetupFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-setup-'));
+  const commandDirectory = join(root, 'commands');
+  const commandLog = join(root, 'command.log');
+
+  await mkdir(join(root, 'snap/amazon-ssm-agent'), {recursive: true});
+  await mkdir(join(root, 'snap/core22'), {recursive: true});
+  await mkdir(join(root, 'snap/snapd'), {recursive: true});
+  await mkdir(join(root, 'var/lib/snapd'), {recursive: true});
+  await mkdir(join(root, 'var/lib/apt/lists'), {recursive: true});
+  await mkdir(join(root, 'usr/bin'), {recursive: true});
+  await mkdir(join(root, 'usr/local/bin'), {recursive: true});
+  await mkdir(join(root, 'etc/default'), {recursive: true});
+  await mkdir(join(root, 'etc/sudoers.d'), {recursive: true});
+  await mkdir(commandDirectory, {recursive: true});
+
+  await writeExecutable(
+    join(commandDirectory, 'apt-get'),
+    `#!/bin/sh
+set -eu
+printf 'apt-get %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+if [ "$1" = purge ] && [ -n "\${RUNNER_IMAGE_FAIL_PURGE:-}" ]; then
+  exit 1
+fi
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'systemctl'),
+    `#!/bin/sh
+set -eu
+printf 'systemctl %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+[ "$1" = stop ]
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'umount'),
+    `#!/bin/sh
+set -eu
+printf 'umount %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+if [ "\${RUNNER_IMAGE_FAIL_UMOUNT:-}" = "$1" ]; then
+  exit 1
+fi
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'rm'),
+    `#!/bin/sh
+set -eu
+printf 'rm %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+exec /bin/rm "$@"
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'install'),
+    `#!/bin/sh
+set -eu
+last=''
+for argument; do
+  last="$argument"
+done
+/bin/mkdir -p "$last"
+`,
+  );
+  await writeExecutable(join(commandDirectory, 'ln'), '#!/bin/sh\nexec /bin/ln "$@"\n');
+  await writeExecutable(join(commandDirectory, 'chmod'), '#!/bin/sh\nexec /bin/chmod "$@"\n');
+  await writeExecutable(join(commandDirectory, 'groupadd'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(join(commandDirectory, 'id'), '#!/bin/sh\nexit 1\n');
+  await writeExecutable(join(commandDirectory, 'useradd'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(join(commandDirectory, 'fdfind'), '#!/bin/sh\nexit 0\n');
+
+  return {
+    commandLog,
+    environment: {
+      ...process.env,
+      PATH: `${commandDirectory}:/bin`,
+      RUNNER_IMAGE_COMMAND_LOG: commandLog,
+      RUNNER_IMAGE_ROOT: root,
+    },
+    root,
+  };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 describe('ephemeral boot configuration', () => {
   it('masks disposable boot services and stores the journal in memory', async () => {

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1097,6 +1097,19 @@ UUID=data /data ext4 defaults 0 2
   });
 });
 
+describe('runner image composition', () => {
+  it('purges snapd and its seeded SSM agent from the image', async () => {
+    const setup = await readFile(
+      new URL('../scripts/build/setup-runner.sh', import.meta.url),
+      'utf8',
+    );
+
+    expect(setup).toContain('apt-get purge --yes snapd');
+    expect(setup).toContain('rm -rf /var/lib/snapd /snap');
+    expect(setup).not.toContain('amazon-ssm-agent');
+  });
+});
+
 async function createBootFixture(fstab: string) {
   const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-boot-'));
   const commandDirectory = join(root, 'commands');

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -94,10 +94,12 @@ canonicalized with the shared runner-label rules.
 
 Runner instances deliberately do not accept an IAM instance profile: job code has passwordless
 root and unrestricted access to IMDS, so an instance profile would expose its credentials to the
-job. Host access uses EC2 Instance Connect. For Spot templates, `spot_max_price: null` caps the
-request at the on-demand price and is the recommended default. Set `cost` to an explicit unitless
-ranking where lower values win template selection. Give a Spot template a lower cost than its
-on-demand equivalent so the planner prefers Spot before spilling to on-demand capacity.
+job. This change intentionally leaves no host-shell access until ENG-1541 provisions the EC2
+Instance Connect Endpoint; the base image's deb-backed EC2 Instance Connect and SSH socket are
+kept for that follow-up. For Spot templates, `spot_max_price: null` caps the request at the
+on-demand price and is the recommended default. Set `cost` to an explicit unitless ranking where
+lower values win template selection. Give a Spot template a lower cost than its on-demand
+equivalent so the planner prefers Spot before spilling to on-demand capacity.
 
 `root_volume_gb` is the boot volume size. `workspace_volume_gb` is a separate, encrypted gp3
 volume created for per-job checkouts, logs, and credentials. The provider deletes both

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -43,7 +43,6 @@ defaults:
   labels: [ec2]
   subnets: [subnet-general-a, subnet-general-b]
   security_groups: [sg-runner]
-  iam_instance_profile: shipfox-runner
   associate_public_ip: false
   root_volume_gb: 30
   root_device_name: /dev/sda1
@@ -93,11 +92,12 @@ Loading fails fast with a clear, file-scoped error on a missing file, malformed 
 invalid or unknown field, an unusable label, or an empty template set. Labels are
 canonicalized with the shared runner-label rules.
 
-`iam_instance_profile` is the IAM instance-profile name, not its ARN. For Spot templates,
-`spot_max_price: null` caps the request at the on-demand price and is the recommended
-default. Set `cost` to an explicit unitless ranking where lower values win template
-selection. Give a Spot template a lower cost than its on-demand equivalent so the planner
-prefers Spot before spilling to on-demand capacity.
+Runner instances deliberately do not accept an IAM instance profile: job code has passwordless
+root and unrestricted access to IMDS, so an instance profile would expose its credentials to the
+job. Host access uses EC2 Instance Connect. For Spot templates, `spot_max_price: null` caps the
+request at the on-demand price and is the recommended default. Set `cost` to an explicit unitless
+ranking where lower values win template selection. Give a Spot template a lower cost than its
+on-demand equivalent so the planner prefers Spot before spilling to on-demand capacity.
 
 `root_volume_gb` is the boot volume size. `workspace_volume_gb` is a separate, encrypted gp3
 volume created for per-job checkouts, logs, and credentials. The provider deletes both

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -43,7 +43,7 @@ describe('createEc2Engine', () => {
     const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
     const expectedTags = Object.entries(runArgs.tags).map(([Key, Value]) => ({Key, Value}));
 
-    await engine.runInstance({...runArgs, iamInstanceProfile: 'runner-profile'});
+    await engine.runInstance(runArgs);
 
     expect(commandInput<RunInstancesCommand>(ec2.commands[0])).toMatchObject({
       MinCount: 1,
@@ -52,7 +52,7 @@ describe('createEc2Engine', () => {
       ImageId: runArgs.ami,
       InstanceType: runArgs.instanceType,
       InstanceInitiatedShutdownBehavior: 'terminate',
-      IamInstanceProfile: {Name: 'runner-profile'},
+      MetadataOptions: {HttpTokens: 'required', HttpPutResponseHopLimit: 1},
       UserData: Buffer.from('#cloud-config').toString('base64'),
       TagSpecifications: [
         {
@@ -81,14 +81,6 @@ describe('createEc2Engine', () => {
         },
       ],
     });
-  });
-
-  it('omits an absent IAM instance profile', async () => {
-    const ec2 = fakeEc2();
-    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
-
-    await engine.runInstance(runArgs);
-
     expect(commandInput<RunInstancesCommand>(ec2.commands[0])).not.toHaveProperty(
       'IamInstanceProfile',
     );

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -71,7 +71,6 @@ export interface RunInstanceArgs {
   readonly spotMaxPrice: number | null;
   readonly subnetId: string;
   readonly securityGroupIds: readonly string[];
-  readonly iamInstanceProfile?: string;
   readonly associatePublicIp: boolean;
   readonly rootVolumeGb: number;
   readonly rootDeviceName: string;
@@ -112,6 +111,10 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
               Tags: Object.entries(args.tags).map(([Key, Value]) => ({Key, Value})),
             })),
             InstanceInitiatedShutdownBehavior: 'terminate',
+            MetadataOptions: {
+              HttpTokens: 'required',
+              HttpPutResponseHopLimit: 1,
+            },
             // A network interface is required for AssociatePublicIpAddress to work consistently.
             NetworkInterfaces: [
               {
@@ -142,9 +145,6 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
                 },
               },
             ],
-            ...(args.iamInstanceProfile
-              ? {IamInstanceProfile: {Name: args.iamInstanceProfile}}
-              : {}),
             ...(args.market === 'spot'
               ? {
                   InstanceMarketOptions: {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -159,9 +159,6 @@ async function launchRunner(
       spotMaxPrice: launch.template.spec.spotMaxPrice,
       subnetId: selectSubnet(launch),
       securityGroupIds: launch.template.spec.securityGroups,
-      ...(launch.template.spec.iamInstanceProfile
-        ? {iamInstanceProfile: launch.template.spec.iamInstanceProfile}
-        : {}),
       associatePublicIp: launch.template.spec.associatePublicIp,
       rootVolumeGb: launch.template.spec.rootVolumeGb,
       rootDeviceName: launch.template.spec.rootDeviceName,

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -6,14 +6,10 @@ import {fileURLToPath} from 'node:url';
 import {MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import {Ec2TemplateConfigError, loadEc2Templates} from '#templates.js';
 
-const observability = vi.hoisted(() => ({logger: {warn: vi.fn()}}));
-vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
-
 let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'provisioner-ec2-'));
-  observability.logger.warn.mockReset();
 });
 
 afterEach(() => {
@@ -70,7 +66,6 @@ templates:
     spot_max_price: 0.05
     subnets: [subnet-aaa, subnet-bbb]
     security_groups: [sg-runner]
-    iam_instance_profile: shipfox-runner
     associate_public_ip: false
     root_volume_gb: 100
     workspace_volume_gb: 100
@@ -146,7 +141,6 @@ describe('loadEc2Templates', () => {
           spotMaxPrice: 0.05,
           subnets: ['subnet-aaa', 'subnet-bbb'],
           securityGroups: ['sg-runner'],
-          iamInstanceProfile: 'shipfox-runner',
           associatePublicIp: false,
           rootVolumeGb: 100,
           rootDeviceName: '/dev/sda1',
@@ -176,28 +170,10 @@ describe('loadEc2Templates', () => {
     ]);
   });
 
-  it('warns when a template has no IAM instance profile', () => {
-    const path = writeTemplates(template());
-
-    loadEc2Templates(path);
-
-    expect(observability.logger.warn).toHaveBeenCalledWith(
-      {
-        event: 'provisioner.ec2_template_missing_iam_instance_profile',
-        filePath: path,
-        templateKey: 't',
-        capability: 'host_debugging_over_aws_systems_manager',
-      },
-      'EC2 template "t" has no IAM instance profile; host debugging over AWS Systems Manager is unavailable',
-    );
-  });
-
-  it('does not warn when a template has an IAM instance profile', () => {
+  it('rejects IAM instance profiles because runner instances must not carry AWS credentials', () => {
     const path = writeTemplates(template({}, '    iam_instance_profile: shipfox-runner\n'));
 
-    loadEc2Templates(path);
-
-    expect(observability.logger.warn).not.toHaveBeenCalled();
+    expect(() => loadEc2Templates(path)).toThrow('iam_instance_profile');
   });
 
   it('accepts a null spot price', () => {
@@ -267,12 +243,6 @@ describe('loadEc2Templates', () => {
     const path = writeTemplates(template(override));
 
     expect(() => loadEc2Templates(path)).toThrow(field);
-  });
-
-  it('throws when iam_instance_profile is blank', () => {
-    const path = writeTemplates(template({}, '    iam_instance_profile: "   "\n'));
-
-    expect(() => loadEc2Templates(path)).toThrow('iam_instance_profile');
   });
 
   it('throws when root_device_name is blank', () => {

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -173,7 +173,20 @@ describe('loadEc2Templates', () => {
   it('rejects IAM instance profiles because runner instances must not carry AWS credentials', () => {
     const path = writeTemplates(template({}, '    iam_instance_profile: shipfox-runner\n'));
 
-    expect(() => loadEc2Templates(path)).toThrow('iam_instance_profile');
+    expect(() => loadEc2Templates(path)).toThrow(
+      'iam_instance_profile (remove this field; runner instances must not carry AWS credentials)',
+    );
+  });
+
+  it('rejects IAM instance profiles inherited from defaults', () => {
+    const path = writeTemplates(`
+defaults:
+  iam_instance_profile: shipfox-runner
+${template().trimStart()}`);
+
+    expect(() => loadEc2Templates(path)).toThrow(
+      'iam_instance_profile (remove this field; runner instances must not carry AWS credentials)',
+    );
   });
 
   it('accepts a null spot price', () => {

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -198,6 +198,16 @@ function formatIssues(error: z.ZodError): string {
   return error.issues
     .map((issue) => {
       const path = issue.path.join('.');
+      if (issue.code === z.ZodIssueCode.unrecognized_keys) {
+        const keys = issue.keys
+          .map((key) =>
+            key === 'iam_instance_profile'
+              ? `${key} (remove this field; runner instances must not carry AWS credentials)`
+              : key,
+          )
+          .join(', ');
+        return `${path ? `${path}: ` : ''}unrecognized key(s): ${keys}`;
+      }
       return path ? `${path}: ${issue.message}` : issue.message;
     })
     .join('; ');

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import {logger} from '@shipfox/node-opentelemetry';
 import {
   type ProvisionerTemplate,
   ProvisionerTemplateFileError,
@@ -20,7 +19,6 @@ export interface Ec2TemplateSpec {
   readonly spotMaxPrice: number | null;
   readonly subnets: readonly string[];
   readonly securityGroups: readonly string[];
-  readonly iamInstanceProfile?: string;
   readonly associatePublicIp: boolean;
   readonly rootVolumeGb: number;
   readonly rootDeviceName: string;
@@ -51,7 +49,6 @@ const ec2TemplateSchema = z
     spot_max_price: z.number().positive().nullish(),
     subnets: z.array(z.string().trim().min(1)).min(1),
     security_groups: z.array(z.string().trim().min(1)).min(1),
-    iam_instance_profile: z.string().trim().min(1).optional(),
     associate_public_ip: z.boolean(),
     root_volume_gb: z.number().int().positive(),
     root_device_name: z
@@ -156,18 +153,6 @@ function toTemplate(
     );
   }
 
-  if (spec.iam_instance_profile === undefined) {
-    logger().warn(
-      {
-        event: 'provisioner.ec2_template_missing_iam_instance_profile',
-        filePath,
-        templateKey: key,
-        capability: 'host_debugging_over_aws_systems_manager',
-      },
-      `EC2 template "${key}" has no IAM instance profile; host debugging over AWS Systems Manager is unavailable`,
-    );
-  }
-
   return {
     key,
     labels,
@@ -181,9 +166,6 @@ function toTemplate(
       spotMaxPrice: spec.spot_max_price ?? null,
       subnets: spec.subnets,
       securityGroups: spec.security_groups,
-      ...(spec.iam_instance_profile === undefined
-        ? {}
-        : {iamInstanceProfile: spec.iam_instance_profile}),
       associatePublicIp: spec.associate_public_ip,
       rootVolumeGb: spec.root_volume_gb,
       rootDeviceName: spec.root_device_name ?? '/dev/sda1',


### PR DESCRIPTION
Remove the failed host-management path from ephemeral EC2 runners.

The runner image now stops snapd, unmounts seeded loop-backed snap filesystems before purging, and fails the bake if snap state remains. EC2 templates reject IAM instance profiles with actionable remediation, while RunInstances explicitly requires IMDSv2 tokens with a one-hop metadata hop limit. Documentation records that host-shell access is intentionally unavailable until ENG-1541 provisions the EC2 Instance Connect Endpoint.

Validation passed: affected-package Turbo check/type/test ladders, runner-image tests (66), EC2 provider tests (147), Packer validation, shell syntax, and diff checks. Runtime AMI/QEMU boot validation was not available locally; the automated QEMU boot suite remains tracked by ENG-1022.

Closes ENG-1530
