### PR TITLE
Centralize Shipfox Conductor workspace setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,22 +2,7 @@
 
 [scripts]
 run_mode = "concurrent"
-setup = """
-set -e
-mise trust
-mise install
-if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
-  if [ -n "${CONDUCTOR_ROOT_PATH:-}" ]; then
-    mise -C "$CONDUCTOR_ROOT_PATH" trust
-    mise -C "$CONDUCTOR_ROOT_PATH" install
-  fi
-fi
-mise exec -- pnpm -r install --frozen-lockfile
-if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
-  mise run ollama:up
-  mise exec -- pnpm dev:services:up
-fi
-"""
+setup = "mise run --yes workspace:setup"
 archive = """
 if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
   mise exec -- pnpm dev:services:destroy


### PR DESCRIPTION
Use the repository-owned `workspace:setup` command as the Conductor entrypoint so tool installation, dependency installation, and required services follow the shared workspace contract. Keep the existing local archive cleanup behavior unchanged.

Closes ENG-1545

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Conductor setup through the repository `workspace:setup` task so tool/dependency installs and required services follow the shared workspace contract. Keeps local archive cleanup unchanged and addresses ENG-1545.

<sup>Written for commit e996e6c7792994ed724bb24bae7bdbd37cf4fb2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

