### PR TITLE
[@shipfox/runner-execution] Raise step output caps to 64 KiB per value and 256 KiB total

### DIFF
--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -170,6 +170,36 @@ describe('OutputCollector', () => {
     });
   });
 
+  it('accepts a value at the per-value cap', () => {
+    const collector = new OutputCollector(undefined);
+    const value = 'x'.repeat(MAX_OUTPUT_VALUE_BYTES);
+
+    const result = collector.trySet('large', value);
+
+    expect(result).toEqual({ok: true});
+    expect(collector.snapshot()).toEqual({large: value});
+  });
+
+  it('accepts output maps at the total cap', () => {
+    const collector = new OutputCollector(undefined);
+    const keys = ['one', 'two', 'three', 'four'];
+    const lineOverhead = keys.reduce(
+      (total, key) => total + Buffer.byteLength(`${key}=\n`, 'utf8'),
+      0,
+    );
+    const valueBytes = Math.floor((MAX_OUTPUT_TOTAL_BYTES - lineOverhead) / keys.length);
+    const remainder = MAX_OUTPUT_TOTAL_BYTES - (lineOverhead + valueBytes * keys.length);
+    const values = Object.fromEntries(
+      keys.map((key, index) => [key, 'x'.repeat(valueBytes + (index === 0 ? remainder : 0))]),
+    );
+
+    for (const [key, value] of Object.entries(values)) {
+      expect(collector.trySet(key, value)).toEqual({ok: true});
+    }
+
+    expect(collector.snapshot()).toEqual(values);
+  });
+
   it('rejects output maps over the total cap', () => {
     const collector = new OutputCollector(undefined);
     const firstValue = 'x'.repeat(MAX_OUTPUT_VALUE_BYTES - 20);

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -4,7 +4,7 @@ import {basename, isAbsolute, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {type CommandStartMetadata, executeRunStep, type OutputSink} from '#core/run-step.js';
-import {MAX_OUTPUT_TOTAL_BYTES} from '#core/step-output.js';
+import {MAX_OUTPUT_TOTAL_BYTES, MAX_OUTPUT_VALUE_BYTES} from '#core/step-output.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const READY_REGEX = /READY/;
@@ -292,6 +292,38 @@ describe('executeRunStep', () => {
     if (!summary || !dir) throw new Error('Expected annotation spool output paths');
     await expect(access(summary)).rejects.toThrow();
     await expect(access(dir)).rejects.toThrow();
+  });
+
+  it('accepts output at the total byte cap', async () => {
+    expect(MAX_OUTPUT_TOTAL_BYTES).toBe(256 * 1024);
+    expect(MAX_OUTPUT_VALUE_BYTES).toBe(64 * 1024);
+    const keys = ['one', 'two', 'three', 'four'];
+    const lineOverhead = keys.reduce(
+      (total, key) => total + Buffer.byteLength(`${key}=\n`, 'utf8'),
+      0,
+    );
+    const valueBytes = Math.floor((MAX_OUTPUT_TOTAL_BYTES - lineOverhead) / keys.length);
+    const remainder = MAX_OUTPUT_TOTAL_BYTES - (lineOverhead + valueBytes * keys.length);
+    const values = Object.fromEntries(
+      keys.map((key, index) => [key, 'x'.repeat(valueBytes + (index === 0 ? remainder : 0))]),
+    );
+    expect(
+      Math.max(...Object.values(values).map((value) => Buffer.byteLength(value, 'utf8'))),
+    ).toBeLessThanOrEqual(MAX_OUTPUT_VALUE_BYTES);
+    const script = [
+      "const fs = require('node:fs');",
+      `const keys = ${JSON.stringify(keys)};`,
+      `const valueBytes = ${valueBytes};`,
+      `const remainder = ${remainder};`,
+      "const output = keys.map((key, index) => key + '=' + 'x'.repeat(valueBytes + (index === 0 ? remainder : 0)) + '\\n').join('');",
+      'fs.writeFileSync(process.env.SHIPFOX_OUTPUT, output);',
+    ].join(' ');
+    const step = buildStep({config: {run: `node -e ${JSON.stringify(script)}`}});
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.outputs).toEqual(values);
   });
 
   it('fails a succeeded step when emitted output exceeds the total byte cap', async () => {

--- a/libs/runner/execution/src/core/step-output.test.ts
+++ b/libs/runner/execution/src/core/step-output.test.ts
@@ -55,6 +55,15 @@ describe('parseStepOutput', () => {
     expect(result).toEqual({'build-sha': 'abc123'});
   });
 
+  it('accepts a value at the per-value byte cap', () => {
+    expect(MAX_OUTPUT_VALUE_BYTES).toBe(64 * 1024);
+    const value = 'x'.repeat(MAX_OUTPUT_VALUE_BYTES);
+
+    const result = parseStepOutput(`payload=${value}`);
+
+    expect(result).toEqual({payload: value});
+  });
+
   it('throws when a value exceeds the per-value byte cap', () => {
     const measuredBytes = MAX_OUTPUT_VALUE_BYTES + 1;
     const value = 'x'.repeat(measuredBytes);

--- a/libs/runner/execution/src/core/step-output.ts
+++ b/libs/runner/execution/src/core/step-output.ts
@@ -1,5 +1,5 @@
-export const MAX_OUTPUT_TOTAL_BYTES = 64 * 1024;
-export const MAX_OUTPUT_VALUE_BYTES = 16 * 1024;
+export const MAX_OUTPUT_TOTAL_BYTES = 256 * 1024;
+export const MAX_OUTPUT_VALUE_BYTES = 64 * 1024;
 
 export const OUTPUT_KEY_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
 const OUTPUT_LINE_SPLIT_REGEX = /\r?\n/;


### PR DESCRIPTION
Raise the runner-side step output limits now that the server-side caps are in place. Agent `set_output` and shell `SHIPFOX_OUTPUT` can now carry the larger review documents without shrinking them to the old 16 KiB boundary.

The output guidance and report transport remain unchanged.

Validation: `mise exec -- turbo test check type --filter=@shipfox/runner-execution... --filter=@shipfox/runner-agent...` (122 tasks successful).

Closes ENG-1552

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised step output caps in `@shipfox/runner-execution` to 64 KiB per value and 256 KiB total, matching server limits. This satisfies ENG-1552 and lets agent `set_output` and `SHIPFOX_OUTPUT` carry larger review documents without truncation.

<sup>Written for commit affbb14ac61cab2371697524e49b8ee42804aa20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

