### PR TITLE
[provisioner-ec2] Attribute lifecycle metrics to template pools

### DIFF
--- a/.changeset/ec2-template-metric-labels.md
+++ b/.changeset/ec2-template-metric-labels.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/provisioner-ec2-provider": patch
+---
+
+Attribute EC2 lifecycle metrics and termination diagnostics to template pools.

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -42,9 +42,18 @@ as the GPU `subnets` replaces the default list rather than appending to it. Labe
 overlap across families; lower `cost` wins when more than one template matches.
 
 The EC2 launch and termination counters use the expanded template key as a label.
-The checked-in example expands to 11 keys: one hand-written template, eight general
-variants (`2 × 2 × 2`), and two GPU variants (`2 × 1`). Keep production matrix axes
-bounded because each additional template adds another series to these counters.
+Keys are trimmed and must start with a letter or number, contain only letters, numbers,
+dots, underscores, or hyphens, and be at most 128 characters. The provider accepts at
+most 256 expanded templates; the checked-in example expands to 11 keys: one hand-written
+template, eight general variants (`2 × 2 × 2`), and two GPU variants (`2 × 1`). Keep
+production matrix axes bounded because each additional template adds another series to
+these counters.
+
+Instances with a missing, malformed, or no-longer-configured `shipfox.template_key` use
+the reserved `__unattributed__` series for termination metrics and logs. Do not use that
+key in configuration. Renaming a template intentionally separates its existing launch
+series from later termination series, so preserve keys when historical attribution must
+remain continuous.
 
 ## Configuration
 

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -41,6 +41,11 @@ EC2 operators provide their own AMI and instance-type lookup maps under `vars`.
 as the GPU `subnets` replaces the default list rather than appending to it. Labels may
 overlap across families; lower `cost` wins when more than one template matches.
 
+The EC2 launch and termination counters use the expanded template key as a label.
+The checked-in example expands to 11 keys: one hand-written template, eight general
+variants (`2 × 2 × 2`), and two GPU variants (`2 × 1`). Keep production matrix axes
+bounded because each additional template adds another series to these counters.
+
 ## Configuration
 
 | Variable | Required | Default | Purpose |

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -205,6 +205,7 @@ describe('createEc2Engine', () => {
             {
               Instances: [
                 instance({
+                  ImageId: 'ami-actual',
                   State: {Name: 'terminated'},
                   StateTransitionReason: 'User initiated (2026-07-18 12:01:00 GMT)',
                   StateReason: {
@@ -235,6 +236,7 @@ describe('createEc2Engine', () => {
       stateTransitionReason: 'User initiated (2026-07-18 12:01:00 GMT)',
       stateReasonCode: 'Server.SpotInstanceTermination',
       stateReasonMessage: 'Spot capacity reclaimed',
+      ami: 'ami-actual',
     });
     expect(result[1]?.instanceId).toBe('i-456');
   });

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -8,7 +8,7 @@ import {
 } from '@aws-sdk/client-ec2';
 import {SHIPFOX_TAGS} from '#instance-identity.js';
 import {type Ec2Architecture, recordEc2LaunchDuration} from '#metrics/instance.js';
-import type {Ec2Market} from '#templates.js';
+import {type Ec2Market, UNKNOWN_TEMPLATE_KEY} from '#templates.js';
 
 const TRANSIENT_REASONS = new Set<Ec2EngineErrorReason>([
   'insufficient-capacity',
@@ -52,6 +52,7 @@ export type Ec2InstanceState =
 
 export interface Ec2InstanceView {
   readonly instanceId: string;
+  readonly ami?: string;
   readonly tags: Readonly<Record<string, string>>;
   readonly state: Ec2InstanceState;
   readonly architecture?: Ec2Architecture;
@@ -167,7 +168,7 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
         const view = toInstanceView(instance);
         recordEc2LaunchDuration({
           durationMs: completedAt - startedAt,
-          templateKey: args.tags[SHIPFOX_TAGS.templateKey] ?? 'unknown',
+          templateKey: args.tags[SHIPFOX_TAGS.templateKey] ?? UNKNOWN_TEMPLATE_KEY,
           market: args.market,
           architecture: view.architecture ?? 'unknown',
           availabilityZone: view.availabilityZone ?? 'unknown',
@@ -176,7 +177,7 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
       } catch (error) {
         recordEc2LaunchDuration({
           durationMs: now() - startedAt,
-          templateKey: args.tags[SHIPFOX_TAGS.templateKey] ?? 'unknown',
+          templateKey: args.tags[SHIPFOX_TAGS.templateKey] ?? UNKNOWN_TEMPLATE_KEY,
           market: args.market,
           architecture: 'unknown',
           availabilityZone: 'unknown',
@@ -230,6 +231,7 @@ function toInstanceView(instance: Instance): Ec2InstanceView {
 
   return {
     instanceId: instance.InstanceId,
+    ...(instance.ImageId ? {ami: instance.ImageId} : {}),
     tags: Object.fromEntries(
       (instance.Tags ?? []).flatMap(({Key, Value}) =>
         Key !== undefined && Value !== undefined ? [[Key, Value]] : [],

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -80,7 +80,7 @@ describe('createEc2Lifecycle', () => {
       workspaceDeviceName: '/dev/sdf',
       tags: {'shipfox.provider_runner_id': 'runner-1'},
     });
-    expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'launched');
+    expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'launched', 'spot-small');
     expect(observability.logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
         provisioned_runner_id: 'runner-1',
@@ -112,7 +112,7 @@ describe('createEc2Lifecycle', () => {
       {state: 'starting'},
       {state: 'failed', reason: 'throttled'},
     ]);
-    expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'throttled');
+    expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'throttled', 'spot-small');
   });
 
   it('preserves a just-launched instance in the tracker while DescribeInstances lags', async () => {
@@ -661,7 +661,10 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
       expect.objectContaining({state: 'failed', reason: 'spot-interruption'}),
     ]);
-    expect(observability.recordEc2Termination).toHaveBeenCalledWith('spot-interruption');
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
+      'spot-interruption',
+      'spot-small',
+    );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
@@ -887,7 +890,8 @@ describe('createEc2Lifecycle', () => {
   });
 
   it('terminates and reports instances with backend terminate intent', async () => {
-    const engine = fakeEngine({instances: [instance({state: 'running'})]});
+    const launchTime = new Date('2026-01-01T00:00:00.000Z');
+    const engine = fakeEngine({instances: [instance({state: 'running', launchTime})]});
     const client = fakeClient({
       reconcileResponse: {
         runners: [reconciledRunner('runner-1', 'terminate')],
@@ -906,7 +910,20 @@ describe('createEc2Lifecycle', () => {
         reason: 'backend-terminate',
       }),
     ]);
-    expect(observability.recordEc2Termination).toHaveBeenCalledWith('backend-terminate');
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
+      'backend-terminate',
+      'spot-small',
+    );
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      {
+        instance_id: 'i-123',
+        template_key: 'spot-small',
+        ami: 'ami-0123456789abcdef0',
+        launch_time: launchTime.toISOString(),
+        reason: 'backend-terminate',
+      },
+      'Terminated EC2 runner instance',
+    );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
@@ -1023,7 +1040,10 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.reconcile();
 
     expect(engine.terminated).toEqual(['i-123']);
-    expect(observability.recordEc2Termination).toHaveBeenCalledWith('backend-terminate');
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
+      'backend-terminate',
+      'unknown-template',
+    );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
@@ -1045,7 +1065,10 @@ describe('createEc2Lifecycle', () => {
     await lifecycle.observe();
 
     expect(engine.terminated).toEqual(['i-123']);
-    expect(observability.recordEc2Termination).toHaveBeenCalledWith('registration-deadline');
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
+      'registration-deadline',
+      'unknown-template',
+    );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
@@ -1067,7 +1090,10 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
       expect.objectContaining({state: 'terminated', reason: 'registration-deadline'}),
     ]);
-    expect(observability.recordEc2Termination).toHaveBeenCalledWith('registration-deadline');
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
+      'registration-deadline',
+      'spot-small',
+    );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -8,7 +8,7 @@ import type {
 import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
 import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.js';
 import {createEc2Lifecycle} from '#lifecycle.js';
-import type {Ec2TemplateSpec} from '#templates.js';
+import {type Ec2TemplateSpec, UNKNOWN_TEMPLATE_KEY} from '#templates.js';
 
 const observability = vi.hoisted(() => ({
   logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
@@ -891,7 +891,9 @@ describe('createEc2Lifecycle', () => {
 
   it('terminates and reports instances with backend terminate intent', async () => {
     const launchTime = new Date('2026-01-01T00:00:00.000Z');
-    const engine = fakeEngine({instances: [instance({state: 'running', launchTime})]});
+    const engine = fakeEngine({
+      instances: [instance({state: 'running', launchTime, ami: 'ami-actual'})],
+    });
     const client = fakeClient({
       reconcileResponse: {
         runners: [reconciledRunner('runner-1', 'terminate')],
@@ -916,9 +918,12 @@ describe('createEc2Lifecycle', () => {
     );
     expect(observability.logger.info).toHaveBeenCalledWith(
       {
+        provisioned_runner_id: 'runner-1',
+        runner_instance_id: RUNNER_INSTANCE_ID,
         instance_id: 'i-123',
+        aws_instance_id: 'i-123',
         template_key: 'spot-small',
-        ami: 'ami-0123456789abcdef0',
+        ami: 'ami-actual',
         launch_time: launchTime.toISOString(),
         reason: 'backend-terminate',
       },
@@ -1026,7 +1031,7 @@ describe('createEc2Lifecycle', () => {
 
   it('terminates an instance with backend terminate intent even when its labels are unresolvable', async () => {
     const engine = fakeEngine({
-      instances: [instance({state: 'running', templateKey: 'unknown-template', labels: ''})],
+      instances: [instance({state: 'running', templateKey: null, labels: ''})],
     });
     const client = fakeClient({
       reconcileResponse: {
@@ -1042,7 +1047,20 @@ describe('createEc2Lifecycle', () => {
     expect(engine.terminated).toEqual(['i-123']);
     expect(observability.recordEc2Termination).toHaveBeenCalledWith(
       'backend-terminate',
-      'unknown-template',
+      UNKNOWN_TEMPLATE_KEY,
+    );
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      {
+        provisioned_runner_id: 'runner-1',
+        runner_instance_id: RUNNER_INSTANCE_ID,
+        instance_id: 'i-123',
+        aws_instance_id: 'i-123',
+        template_key: UNKNOWN_TEMPLATE_KEY,
+        ami: 'unknown',
+        launch_time: null,
+        reason: 'backend-terminate',
+      },
+      'Terminated EC2 runner instance',
     );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
@@ -1067,9 +1085,34 @@ describe('createEc2Lifecycle', () => {
     expect(engine.terminated).toEqual(['i-123']);
     expect(observability.recordEc2Termination).toHaveBeenCalledWith(
       'registration-deadline',
-      'unknown-template',
+      UNKNOWN_TEMPLATE_KEY,
     );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+  });
+
+  it('attributes an observed tagless termination to the reserved fallback key', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'terminated', templateKey: null})]});
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.observe();
+
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
+      'observed-terminated',
+      UNKNOWN_TEMPLATE_KEY,
+    );
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      {
+        provisioned_runner_id: 'runner-1',
+        runner_instance_id: RUNNER_INSTANCE_ID,
+        instance_id: 'i-123',
+        aws_instance_id: 'i-123',
+        template_key: UNKNOWN_TEMPLATE_KEY,
+        ami: 'unknown',
+        launch_time: null,
+        reason: 'observed-terminated',
+      },
+      'Observed EC2 runner instance termination',
+    );
   });
 
   it('reaps a pending instance past its registration deadline', async () => {
@@ -1194,15 +1237,17 @@ function instance(args: {
   availabilityZone?: string;
   stateTransitionReason?: string;
   launchTime?: Date;
+  ami?: string;
   instanceId?: string;
   providerRunnerId?: string;
   runnerInstanceId?: string;
-  templateKey?: string;
+  templateKey?: string | null;
   labels?: string;
 }): Ec2InstanceView {
   return {
     instanceId: args.instanceId ?? 'i-123',
     state: args.state,
+    ...(args.ami ? {ami: args.ami} : {}),
     ...(args.architecture ? {architecture: args.architecture} : {}),
     ...(args.availabilityZone ? {availabilityZone: args.availabilityZone} : {}),
     tags: {
@@ -1210,7 +1255,9 @@ function instance(args: {
       'shipfox.provider_runner_id': args.providerRunnerId ?? 'runner-1',
       'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
       'shipfox.reservation_id': '00000000-0000-4000-8000-000000000003',
-      'shipfox.template_key': args.templateKey ?? 'spot-small',
+      ...(args.templateKey === null
+        ? {}
+        : {'shipfox.template_key': args.templateKey ?? 'spot-small'}),
       'shipfox.labels': args.labels ?? 'ubuntu22',
     },
     ...(args.stateTransitionReason ? {stateTransitionReason: args.stateTransitionReason} : {}),

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -24,7 +24,7 @@ import {
   recordEc2ReconcileAbsent,
   recordEc2Termination,
 } from '#metrics/instance.js';
-import type {Ec2TemplateSpec} from '#templates.js';
+import {type Ec2TemplateSpec, UNKNOWN_TEMPLATE_KEY} from '#templates.js';
 
 const MAX_REPORT_BATCH = 1000;
 const MAX_REASON_LENGTH = 500;
@@ -43,6 +43,7 @@ type TrackerSeed = {
 type LocallyLaunchedRunner = {
   runnerInstanceId: string;
   templateKey: string;
+  ami: string;
   launchedAt: Date;
 };
 
@@ -169,6 +170,7 @@ async function launchRunner(
     const locallyLaunched = {
       runnerInstanceId: launch.runnerInstanceId,
       templateKey: launch.template.key,
+      ami: launch.template.spec.ami,
       launchedAt: new Date(context.now()),
     };
     context.locallyLaunched.set(launch.providerRunnerId, locallyLaunched);
@@ -308,7 +310,10 @@ async function applyObservedInstances(
     // separate pending metric candidate through listing gaps after this point.
     context.locallyLaunched.delete(identity.providerRunnerId);
     if (instance.state === 'running' && pendingLaunch) {
-      const templateKey = identity.templateKey ?? pendingLaunch.templateKey;
+      const templateKey = resolveTemplateKey(context, [
+        identity.templateKey,
+        pendingLaunch.templateKey,
+      ]);
       const template = context.templatesByKey.get(templateKey);
       context.pendingLaunches.delete(identity.providerRunnerId);
       if (template) {
@@ -356,17 +361,14 @@ async function applyObservedInstances(
       if (terminalObservation) {
         const terminationReason =
           mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
-        recordEc2Termination(
-          terminationReason,
-          identity.templateKey ?? pendingLaunch?.templateKey ?? 'unknown',
-        );
+        const templateKey = resolveTemplateKey(context, [
+          identity.templateKey,
+          pendingLaunch?.templateKey,
+        ]);
+        const template = context.templatesByKey.get(templateKey);
+        recordEc2Termination(terminationReason, templateKey);
         logger().info(
-          {
-            provisioned_runner_id: identity.providerRunnerId,
-            ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
-            aws_instance_id: instance.instanceId,
-            reason: terminationReason,
-          },
+          terminationLogFields(instance, identity, templateKey, template, terminationReason),
           'Observed EC2 runner instance termination',
         );
       }
@@ -631,20 +633,17 @@ async function terminateInstances(
       ? (context.pendingLaunches.get(identity.providerRunnerId) ??
         context.locallyLaunched.get(identity.providerRunnerId))
       : undefined;
-    const templateKey = identity.templateKey ?? locallyLaunched?.templateKey ?? 'unknown';
+    const templateKey = resolveTemplateKey(context, [
+      identity.templateKey,
+      locallyLaunched?.templateKey,
+    ]);
     const template = context.templatesByKey.get(templateKey);
     await context.engine.terminate([instance.instanceId]);
     const actionedAt = context.now().getTime();
     context.terminationActionedInstanceIds.set(instance.instanceId, actionedAt);
     recordEc2Termination(reason, templateKey);
     logger().info(
-      {
-        instance_id: instance.instanceId,
-        template_key: templateKey,
-        ami: template?.spec.ami ?? 'unknown',
-        launch_time: instance.launchTime?.toISOString() ?? null,
-        reason,
-      },
+      terminationLogFields(instance, identity, templateKey, template, reason, locallyLaunched?.ami),
       'Terminated EC2 runner instance',
     );
   }
@@ -690,6 +689,36 @@ function hasTerminalReport(context: Ec2LifecycleContext, instanceId: string): bo
     context.terminalReportedInstanceIds.has(instanceId) ||
     context.pendingTerminalReportedInstanceIds.has(instanceId)
   );
+}
+
+function resolveTemplateKey(
+  context: Ec2LifecycleContext,
+  candidates: readonly (string | undefined)[],
+): string {
+  for (const candidate of candidates) {
+    if (candidate !== undefined && context.templatesByKey.has(candidate)) return candidate;
+  }
+  return UNKNOWN_TEMPLATE_KEY;
+}
+
+function terminationLogFields(
+  instance: Ec2InstanceView,
+  identity: ReturnType<typeof parseInstanceIdentity>,
+  templateKey: string,
+  template: ProvisionerTemplate<Ec2TemplateSpec> | undefined,
+  reason: string,
+  fallbackAmi?: string,
+) {
+  return {
+    ...(identity.providerRunnerId ? {provisioned_runner_id: identity.providerRunnerId} : {}),
+    ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+    instance_id: instance.instanceId,
+    aws_instance_id: instance.instanceId,
+    template_key: templateKey,
+    ami: instance.ami ?? fallbackAmi ?? template?.spec.ami ?? 'unknown',
+    launch_time: instance.launchTime?.toISOString() ?? null,
+    reason,
+  };
 }
 
 function observedRunnerIds(instances: readonly Ec2InstanceView[]): string[] {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -173,7 +173,7 @@ async function launchRunner(
     };
     context.locallyLaunched.set(launch.providerRunnerId, locallyLaunched);
     context.pendingLaunches.set(launch.providerRunnerId, locallyLaunched);
-    recordEc2Launch(launch.template.spec.market, 'launched');
+    recordEc2Launch(launch.template.spec.market, 'launched', launch.template.key);
     logger().info(
       {
         provisioned_runner_id: launch.providerRunnerId,
@@ -183,7 +183,7 @@ async function launchRunner(
       'Launched EC2 runner instance',
     );
   } catch (error) {
-    recordEc2Launch(launch.template.spec.market, launchOutcome(error));
+    recordEc2Launch(launch.template.spec.market, launchOutcome(error), launch.template.key);
     logger().error(
       {
         err: error,
@@ -356,7 +356,10 @@ async function applyObservedInstances(
       if (terminalObservation) {
         const terminationReason =
           mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
-        recordEc2Termination(terminationReason);
+        recordEc2Termination(
+          terminationReason,
+          identity.templateKey ?? pendingLaunch?.templateKey ?? 'unknown',
+        );
         logger().info(
           {
             provisioned_runner_id: identity.providerRunnerId,
@@ -623,10 +626,27 @@ async function terminateInstances(
     (instance) => !context.terminationActionedInstanceIds.has(instance.instanceId),
   );
   for (const instance of instancesToTerminate) {
+    const identity = parseInstanceIdentity(instance);
+    const locallyLaunched = identity.providerRunnerId
+      ? (context.pendingLaunches.get(identity.providerRunnerId) ??
+        context.locallyLaunched.get(identity.providerRunnerId))
+      : undefined;
+    const templateKey = identity.templateKey ?? locallyLaunched?.templateKey ?? 'unknown';
+    const template = context.templatesByKey.get(templateKey);
     await context.engine.terminate([instance.instanceId]);
     const actionedAt = context.now().getTime();
     context.terminationActionedInstanceIds.set(instance.instanceId, actionedAt);
-    recordEc2Termination(reason);
+    recordEc2Termination(reason, templateKey);
+    logger().info(
+      {
+        instance_id: instance.instanceId,
+        template_key: templateKey,
+        ami: template?.spec.ami ?? 'unknown',
+        launch_time: instance.launchTime?.toISOString() ?? null,
+        reason,
+      },
+      'Terminated EC2 runner instance',
+    );
   }
   const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
   const events = terminableInstances.flatMap((instance) => {

--- a/libs/provisioner/ec2/src/metrics/instance.test.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.test.ts
@@ -54,18 +54,20 @@ describe('EC2 provisioner metrics', () => {
   };
 
   it('records launch outcomes with bounded labels', () => {
-    metrics.recordEc2Launch('spot', 'capacity');
+    metrics.recordEc2Launch('spot', 'capacity', 'spot-small');
 
     expect(counterAdd('ec2_provisioner_launch')).toHaveBeenCalledWith(1, {
+      template_key: 'spot-small',
       market: 'spot',
       outcome: 'capacity',
     });
   });
 
   it('records termination reasons with bounded labels', () => {
-    metrics.recordEc2Termination('spot-interruption');
+    metrics.recordEc2Termination('spot-interruption', 'spot-small');
 
     expect(counterAdd('ec2_provisioner_terminate')).toHaveBeenCalledWith(1, {
+      template_key: 'spot-small',
       reason: 'spot-interruption',
     });
   });

--- a/libs/provisioner/ec2/src/metrics/instance.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.ts
@@ -23,20 +23,22 @@ const ec2DurationAdvice = {
 };
 
 const launchCount = meter.createCounter<{
+  template_key: string;
   market: 'spot' | 'on-demand';
   outcome: 'launched' | 'capacity' | 'throttled' | 'error';
 }>('ec2_provisioner_launch', {
-  description: 'EC2 runner launch attempts by market and outcome',
+  description: 'EC2 runner launch attempts by template, market, and outcome',
 });
 
 const terminateCount = meter.createCounter<{
+  template_key: string;
   reason:
     | 'backend-terminate'
     | 'registration-deadline'
     | 'spot-interruption'
     | 'observed-terminated';
 }>('ec2_provisioner_terminate', {
-  description: 'EC2 runner instance terminations by reason',
+  description: 'EC2 runner instance terminations by template and reason',
 });
 
 const reconcileAbsentCount = meter.createCounter<Record<string, never>>(
@@ -75,12 +77,16 @@ export type Ec2TerminationReason =
   | 'spot-interruption'
   | 'observed-terminated';
 
-export function recordEc2Launch(market: 'spot' | 'on-demand', outcome: Ec2LaunchOutcome): void {
-  launchCount.add(1, {market, outcome});
+export function recordEc2Launch(
+  market: 'spot' | 'on-demand',
+  outcome: Ec2LaunchOutcome,
+  templateKey: string,
+): void {
+  launchCount.add(1, {template_key: templateKey, market, outcome});
 }
 
-export function recordEc2Termination(reason: Ec2TerminationReason): void {
-  terminateCount.add(1, {reason});
+export function recordEc2Termination(reason: Ec2TerminationReason, templateKey: string): void {
+  terminateCount.add(1, {template_key: templateKey, reason});
 }
 
 export function recordEc2ReconcileAbsent(count: number): void {

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -4,7 +4,13 @@ import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
-import {Ec2TemplateConfigError, loadEc2Templates} from '#templates.js';
+import {
+  Ec2TemplateConfigError,
+  loadEc2Templates,
+  MAX_EC2_TEMPLATES,
+  MAX_TEMPLATE_KEY_LENGTH,
+  UNKNOWN_TEMPLATE_KEY,
+} from '#templates.js';
 
 let dir: string;
 
@@ -54,6 +60,10 @@ templates:
       defaults,
     ) + extra
   );
+}
+
+function templateWithKey(key: string): string {
+  return template().replace('  t:', `  ${JSON.stringify(key)}:`);
 }
 
 const VALID = `
@@ -172,10 +182,24 @@ describe('loadEc2Templates', () => {
 
   it('rejects IAM instance profiles because runner instances must not carry AWS credentials', () => {
     const path = writeTemplates(template({}, '    iam_instance_profile: shipfox-runner\n'));
-
     expect(() => loadEc2Templates(path)).toThrow(
       'iam_instance_profile (remove this field; runner instances must not carry AWS credentials)',
     );
+  });
+
+  it('trims template keys before loading them', () => {
+    const [loaded] = loadEc2Templates(writeTemplates(templateWithKey('  trimmed-key  ')));
+
+    expect(loaded?.key).toBe('trimmed-key');
+  });
+
+  it.each([
+    ['blank', '   ', 'must not be blank'],
+    ['invalid characters', 'bad/key', 'must start with a letter or number'],
+    ['too long', 'a'.repeat(MAX_TEMPLATE_KEY_LENGTH + 1), 'must be at most'],
+    ['reserved', UNKNOWN_TEMPLATE_KEY, 'reserved for untagged instances'],
+  ])('rejects a %s template key', (_name, key, message) => {
+    expect(() => loadEc2Templates(writeTemplates(templateWithKey(key)))).toThrow(message);
   });
 
   it('rejects IAM instance profiles inherited from defaults', () => {
@@ -382,6 +406,33 @@ matrix:
       {ami: 'ami-0baa', instanceType: 'm7i.xlarge'},
       {ami: 'ami-0bab', instanceType: 'm7i.xlarge'},
     ]);
+  });
+
+  it('rejects an expanded template set above the metric cardinality limit', () => {
+    const values = Array.from({length: MAX_EC2_TEMPLATES + 1}, (_, index) => index).join(', ');
+    const path = writeTemplates(`
+templates: {}
+matrix:
+  bounded:
+    axes:
+      index: [${values}]
+    template:
+      labels: [ubuntu22]
+      ami: ami-0123456789abcdef0
+      instance_type: m6i.large
+      market: spot
+      spot_max_price: 0.05
+      subnets: [subnet-aaa]
+      security_groups: [sg-runner]
+      associate_public_ip: false
+      root_volume_gb: 100
+      workspace_volume_gb: 100
+      workspace_device_name: /dev/sdf
+      max_concurrency: 100
+      cost: 5
+`);
+
+    expect(() => loadEc2Templates(path)).toThrow(`the maximum is ${MAX_EC2_TEMPLATES}`);
   });
 
   it('aggregates missing lookup keys with matrix bindings and field paths', () => {

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -35,7 +35,22 @@ export class Ec2TemplateConfigError extends Error {
 }
 
 const MAX_TEMPLATE_CONCURRENCY = 100_000;
+export const MAX_EC2_TEMPLATES = 256;
+export const MAX_TEMPLATE_KEY_LENGTH = 128;
+export const UNKNOWN_TEMPLATE_KEY = '__unattributed__';
+const TEMPLATE_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const XVD_DEVICE_ALIAS_PATTERN = /^\/dev\/xvd/i;
+
+const templateKeySchema = z
+  .string()
+  .trim()
+  .min(1, 'must not be blank')
+  .max(MAX_TEMPLATE_KEY_LENGTH, `must be at most ${MAX_TEMPLATE_KEY_LENGTH} characters`)
+  .regex(
+    TEMPLATE_KEY_PATTERN,
+    'must start with a letter or number and contain only letters, numbers, dots, underscores, or hyphens',
+  )
+  .refine((key) => key !== UNKNOWN_TEMPLATE_KEY, `is reserved for untagged instances`);
 
 const ec2TemplateSchema = z
   .object({
@@ -100,7 +115,9 @@ function canonicalEc2DeviceName(deviceName: string): string {
  * not validate, an invalid label, or an empty template set.
  */
 export function loadEc2Templates(filePath: string): ProvisionerTemplate<Ec2TemplateSpec>[] {
-  const parsed = ec2TemplatesSchema.safeParse(renderTemplates(filePath, parseYamlFile(filePath)));
+  const rendered = renderTemplates(filePath, parseYamlFile(filePath));
+  const normalized = normalizeTemplateKeys(filePath, rendered);
+  const parsed = ec2TemplatesSchema.safeParse(normalized);
   if (!parsed.success) {
     throw new Ec2TemplateConfigError(
       `Invalid EC2 template config at ${filePath}: ${formatIssues(parsed.error)}`,
@@ -111,6 +128,11 @@ export function loadEc2Templates(filePath: string): ProvisionerTemplate<Ec2Templ
   if (entries.length === 0) {
     throw new Ec2TemplateConfigError(
       `EC2 template config at ${filePath} declares no templates; add at least one.`,
+    );
+  }
+  if (entries.length > MAX_EC2_TEMPLATES) {
+    throw new Ec2TemplateConfigError(
+      `EC2 template config at ${filePath} declares ${entries.length} templates; the maximum is ${MAX_EC2_TEMPLATES}.`,
     );
   }
 
@@ -128,6 +150,46 @@ function renderTemplates(filePath: string, raw: unknown): unknown {
     }
     throw error;
   }
+}
+
+function normalizeTemplateKeys(filePath: string, rendered: unknown): unknown {
+  if (typeof rendered !== 'object' || rendered === null || Array.isArray(rendered)) {
+    return rendered;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  const originalKeys = new Map<string, string>();
+  const issues: string[] = [];
+  for (const [rawKey, spec] of Object.entries(rendered)) {
+    const parsed = templateKeySchema.safeParse(rawKey);
+    if (!parsed.success) {
+      issues.push(`template key "${rawKey}": ${formatIssues(parsed.error)}`);
+      continue;
+    }
+
+    const key = parsed.data;
+    const previousRawKey = originalKeys.get(key);
+    if (previousRawKey !== undefined) {
+      issues.push(
+        `template keys "${previousRawKey}" and "${rawKey}" normalize to the same key "${key}"`,
+      );
+      continue;
+    }
+    originalKeys.set(key, rawKey);
+    Object.defineProperty(normalized, key, {
+      configurable: true,
+      enumerable: true,
+      value: spec,
+      writable: true,
+    });
+  }
+
+  if (issues.length > 0) {
+    throw new Ec2TemplateConfigError(
+      `Invalid EC2 template config at ${filePath}: ${issues.join('; ')}`,
+    );
+  }
+  return normalized;
 }
 
 function toTemplate(


### PR DESCRIPTION
The EC2 launch and termination counters now include `template_key`, so capacity errors and boot-failure terminations identify the pool that produced them. Provider-initiated termination logs also retain the instance ID, template key, AMI, launch time, and reason for post-reap diagnosis.

The template configuration documentation records the checked-in example's 11-key cardinality bound. The deployed template count remains an operational verification before merge.

Validated with the affected-package check, type, and test graph (82 tasks), including 157 EC2 provider tests, Changeset status, and `git diff --check`.

Closes ENG-1539

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `template_key` to EC2 lifecycle metrics and termination logs so failures and reaps identify the exact template pool, addressing ENG-1539. Also hardens attribution with key validation, a 256-template cap, and a reserved fallback for missing or stale tags.

- **New Features**
  - `ec2_provisioner_launch` now labels with `template_key`, `market`, and `outcome`.
  - `ec2_provisioner_terminate` now labels with `template_key` and `reason`.
  - Termination logs include: `instance_id`, `template_key`, `ami`, `launch_time`, `reason` (plus runner IDs when present), preferring the observed AMI.

- **Migration**
  - Template keys are trimmed and validated: start with a letter/number; only letters, numbers, dots, underscores, or hyphens; max 128 chars. Max 256 expanded templates.
  - Missing, malformed, or no-longer-configured keys are attributed to `__unattributed__` in metrics and logs. Do not use this key in config. Renaming a template splits historical launch vs termination series; keep keys stable when continuity matters.

<sup>Written for commit 312ab49848f7dacd8ea19e494a7dc46e3d158033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->