### PR TITLE
[GitHub integration] Keep pending review comments in pending reviews

### DIFF
--- a/.changeset/fix-pending-review-comment.md
+++ b/.changeset/fix-pending-review-comment.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Add comments to the caller's latest pending pull request review through GitHub GraphQL.

--- a/.changeset/fix-pending-review-comment.md
+++ b/.changeset/fix-pending-review-comment.md
@@ -2,4 +2,4 @@
 "@shipfox/api-integration-github": patch
 ---
 
-Add comments to the caller's latest pending pull request review through GitHub GraphQL.
+Add comments to the caller's latest pending pull request review.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -3,6 +3,7 @@ import {DEFAULT_JOB_LOG_TAIL_LINES} from '#core/actions-logs.js';
 import {
   type GithubAgentToolId,
   GithubAgentToolsProvider,
+  type GithubToolClient,
   githubAgentToolCatalog,
   githubAgentToolSelectionCatalog,
 } from '#core/agent-tools.js';
@@ -369,6 +370,139 @@ describe('github agent tool catalog', () => {
     });
   });
 
+  it('adds a comment to the latest pending review through GraphQL', async () => {
+    const request = vi.fn();
+    const graphql = vi
+      .fn()
+      .mockResolvedValueOnce({
+        viewer: {login: 'shipfox-ai[bot]'},
+        repository: {
+          pullRequest: {
+            reviews: {
+              nodes: [
+                {
+                  id: 'review-older',
+                  author: {login: 'shipfox-ai[bot]'},
+                  createdAt: '2026-08-09T10:00:00Z',
+                },
+                {
+                  id: 'review-latest',
+                  author: {login: 'shipfox-ai[bot]'},
+                  createdAt: '2026-08-09T10:01:00Z',
+                },
+              ],
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        addPullRequestReviewThread: {thread: {id: 'thread-1'}},
+      });
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pendingReviewTool()],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'add_comment_to_pending_review',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        path: 'src/agent-tools.ts',
+        body: 'Please handle this error.',
+        subject_type: 'LINE',
+        line: 42,
+        side: 'RIGHT',
+        start_line: 40,
+        start_side: 'RIGHT',
+      },
+    });
+
+    expect(request).not.toHaveBeenCalled();
+    expect(graphql).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('reviews(last: 100, states: [PENDING])'),
+      {owner: 'shipfox', repo: 'platform', pullNumber: 2},
+    );
+    expect(graphql).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('addPullRequestReviewThread'),
+      {
+        input: {
+          pullRequestReviewId: 'review-latest',
+          path: 'src/agent-tools.ts',
+          body: 'Please handle this error.',
+          subjectType: 'LINE',
+          line: 42,
+          side: 'RIGHT',
+          startLine: 40,
+          startSide: 'RIGHT',
+        },
+      },
+    );
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: '{"addPullRequestReviewThread":{"thread":{"id":"thread-1"}}}',
+        },
+      ],
+      structuredContent: {addPullRequestReviewThread: {thread: {id: 'thread-1'}}},
+    });
+  });
+
+  it('returns an explicit error when there is no pending review for the caller', async () => {
+    const request = vi.fn();
+    const graphql = vi.fn().mockResolvedValueOnce({
+      viewer: {login: 'shipfox-ai[bot]'},
+      repository: {
+        pullRequest: {
+          reviews: {
+            nodes: [
+              {
+                id: 'review-other-user',
+                author: {login: 'another-user'},
+                createdAt: '2026-08-09T10:00:00Z',
+              },
+            ],
+          },
+        },
+      },
+    });
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pendingReviewTool()],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'add_comment_to_pending_review',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        path: 'src/agent-tools.ts',
+        body: 'Please handle this error.',
+      },
+    });
+
+    expect(graphql).toHaveBeenCalledTimes(1);
+    expect(request).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'No pending pull request review found for the authenticated GitHub user.',
+        },
+      ],
+    });
+  });
+
   it('requires a ref for pull request status and check-run reads', async () => {
     const result = await callGithubTool(
       'pull_request_read',
@@ -482,7 +616,20 @@ async function callGithubTool(
 ) {
   const tool = githubAgentToolCatalog.find((entry) => entry.id === toolId);
   if (!tool) throw new Error(`Missing GitHub tool: ${toolId}`);
-  const provider = new GithubAgentToolsProvider({
+  const provider = createAgentToolsProvider({
+    request: vi.fn(() => Promise.resolve({data})),
+  });
+  const session = await provider.openSession({
+    connection: connection(),
+    tools: [tool],
+    scope: undefined,
+  });
+
+  return await session.call({toolId, arguments: arguments_});
+}
+
+function createAgentToolsProvider(client: GithubToolClient) {
+  return new GithubAgentToolsProvider({
     getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
     tokenProvider: {
       getInstallationAccessToken: vi.fn(() =>
@@ -498,15 +645,14 @@ async function callGithubTool(
         }),
       ),
     },
-    createClient: vi.fn(() => ({request: vi.fn(() => Promise.resolve({data}))})),
+    createClient: vi.fn(() => client),
   });
-  const session = await provider.openSession({
-    connection: connection(),
-    tools: [tool],
-    scope: undefined,
-  });
+}
 
-  return await session.call({toolId, arguments: arguments_});
+function pendingReviewTool() {
+  const tool = githubAgentToolCatalog.find((entry) => entry.id === 'add_comment_to_pending_review');
+  if (!tool) throw new Error('Missing add_comment_to_pending_review tool');
+  return tool;
 }
 
 function connection() {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -48,6 +48,41 @@ type GithubToolCallResult = {
   structuredContent?: Record<string, unknown> | undefined;
 };
 
+const GITHUB_GRAPHQL_ROUTE = 'POST /graphql';
+const NO_PENDING_REVIEW_MESSAGE =
+  'No pending pull request review found for the authenticated GitHub user.';
+
+const LATEST_PENDING_REVIEW_QUERY = `
+  query LatestPendingPullRequestReview($owner: String!, $repo: String!, $pullNumber: Int!) {
+    viewer {
+      login
+    }
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pullNumber) {
+        reviews(last: 100, states: [PENDING]) {
+          nodes {
+            id
+            author {
+              login
+            }
+            createdAt
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ADD_PENDING_REVIEW_COMMENT_MUTATION = `
+  mutation AddCommentToPendingReview($input: AddPullRequestReviewThreadInput!) {
+    addPullRequestReviewThread(input: $input) {
+      thread {
+        id
+      }
+    }
+  }
+`;
+
 export class GithubAgentToolsProvider
   implements
     AgentToolsProvider<
@@ -110,6 +145,13 @@ export class GithubAgentToolsProvider
         const client = (this.options.createClient ?? createOctokitClient)(token.token);
 
         try {
+          if (operation.kind === 'graphql') {
+            const data = await addCommentToPendingReview(client, operation.parameters);
+            return data === undefined
+              ? githubToolError(NO_PENDING_REVIEW_MESSAGE)
+              : githubToolResult(tool.id as GithubAgentToolId, data);
+          }
+
           const response = await client.request(operation.route, operation.parameters);
           return githubToolResult(tool.id as GithubAgentToolId, response.data);
         } catch (error) {
@@ -132,6 +174,7 @@ export interface GithubAgentToolsProviderOptions {
 
 export interface GithubToolClient {
   request(route: string, parameters: Record<string, unknown>): Promise<{data: unknown}>;
+  graphql?: ((query: string, variables: Record<string, unknown>) => Promise<unknown>) | undefined;
 }
 
 export type GithubToolClientFactory = (token: string) => GithubToolClient;
@@ -139,6 +182,7 @@ export type GithubToolClientFactory = (token: string) => GithubToolClient;
 interface GithubToolOperation {
   route: string;
   parameters: Record<string, unknown>;
+  kind: 'rest' | 'graphql';
 }
 
 function createOctokitClient(token: string): GithubToolClient {
@@ -149,6 +193,7 @@ function createOctokitClient(token: string): GithubToolClient {
   });
   return {
     request: async (route, parameters) => await octokit.request(route, parameters),
+    graphql: async (query, variables) => await octokit.graphql(query, variables),
   };
 }
 
@@ -167,7 +212,11 @@ function resolveGithubOperation(
   const route = githubOperationRoute(toolId, method, params);
   return route === undefined
     ? undefined
-    : {route, parameters: projectGithubOperationParameters(toolId, method, params)};
+    : {
+        route,
+        parameters: projectGithubOperationParameters(toolId, method, params),
+        kind: route === GITHUB_GRAPHQL_ROUTE ? 'graphql' : 'rest',
+      };
 }
 
 function githubOperationRoute(
@@ -257,7 +306,7 @@ function githubOperationRoute(
     case 'pull_request_review_write.delete_pending':
       return `DELETE ${repoPath}/pulls/${pull}/reviews/{review_id}`;
     case 'add_comment_to_pending_review.':
-      return `POST ${repoPath}/pulls/${pull}/comments`;
+      return GITHUB_GRAPHQL_ROUTE;
     case 'actions_list.list_workflows':
       return `GET ${repoPath}/actions/workflows`;
     case 'actions_list.list_workflow_runs':
@@ -293,6 +342,64 @@ function githubOperationRoute(
     default:
       return undefined;
   }
+}
+
+async function addCommentToPendingReview(
+  client: GithubToolClient,
+  args: Record<string, unknown>,
+): Promise<unknown | undefined> {
+  if (client.graphql === undefined) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub client does not support GraphQL operations',
+    );
+  }
+
+  const reviewLookup = await client.graphql(LATEST_PENDING_REVIEW_QUERY, {
+    owner: args.owner,
+    repo: args.repo,
+    pullNumber: args.pull_number,
+  });
+  const reviewId = latestPendingReviewNodeId(reviewLookup);
+  if (reviewId === undefined) return undefined;
+
+  const input: Record<string, unknown> = {
+    pullRequestReviewId: reviewId,
+    path: args.path,
+    body: args.body,
+    subjectType: args.subject_type,
+  };
+  if (args.line !== undefined) input.line = args.line;
+  if (args.side !== undefined) input.side = args.side;
+  if (args.start_line !== undefined) input.startLine = args.start_line;
+  if (args.start_side !== undefined) input.startSide = args.start_side;
+
+  return await client.graphql(ADD_PENDING_REVIEW_COMMENT_MUTATION, {input});
+}
+
+function latestPendingReviewNodeId(data: unknown): string | undefined {
+  if (!isRecord(data)) return undefined;
+
+  const viewer = isRecord(data.viewer) ? data.viewer.login : undefined;
+  if (typeof viewer !== 'string') return undefined;
+
+  const repository = isRecord(data.repository) ? data.repository : undefined;
+  const pullRequest =
+    repository && isRecord(repository.pullRequest) ? repository.pullRequest : undefined;
+  const reviews = pullRequest && isRecord(pullRequest.reviews) ? pullRequest.reviews : undefined;
+  const nodes = reviews && Array.isArray(reviews.nodes) ? reviews.nodes : [];
+
+  let latest: {createdAt: string; id: string} | undefined;
+  for (const node of nodes) {
+    if (!isRecord(node)) continue;
+    const author = isRecord(node.author) ? node.author.login : undefined;
+    const id = node.id;
+    const createdAt = node.createdAt;
+    if (author !== viewer || typeof id !== 'string' || typeof createdAt !== 'string') continue;
+    if (latest === undefined || createdAt > latest.createdAt) latest = {createdAt, id};
+  }
+
+  return latest?.id;
 }
 
 function projectGithubOperationParameters(

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -670,7 +670,7 @@ export const githubAgentToolCatalog = [
     id: 'add_comment_to_pending_review',
     category: 'pull_requests',
     description:
-      "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this.",
+      "Add a review comment to the requester's latest pending pull request review. The comment remains part of that pending review until it is submitted; a pending review needs to already exist to call this.",
     sensitivity: 'write',
     sensitive: false,
     requiredScope: scopes.pullRequestsWrite,


### PR DESCRIPTION
Route pending review comments through GitHub GraphQL so they remain grouped in the requester's pending review for batch submission. The previous REST endpoint required an undeclared commit_id and created standalone comments instead of updating the pending review. The catalog description, generated documentation, and regression coverage now match the behavior, including a clear no-pending-review error.

Closes ENG-1558

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `add_comment_to_pending_review` through GitHub GraphQL so comments stay in the caller’s pending PR review for batch submission. Adds a clear error when no pending review exists. Aligns with ENG-1558.

- **Bug Fixes**
  - Finds the caller’s latest pending review they authored via GraphQL and adds the comment with `addPullRequestReviewThread`.
  - Returns: “No pending pull request review found for the authenticated GitHub user.” when none exist.
  - Switches operation to `POST /graphql` and adds GraphQL support to the GitHub client; throws a provider error if GraphQL is unavailable.
  - Updates the tool catalog description to clarify the comment remains in the pending review until submission, and adds regression tests.
  - Publishes a patch changeset for `@shipfox/api-integration-github`.

<sup>Written for commit 0befa1287d2548285c8c47908b6df1bc7aad382d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

