### PR TITLE
Preserve GitHub provider errors in integration agent tools

### DIFF
--- a/.changeset/calm-provider-rejections.md
+++ b/.changeset/calm-provider-rejections.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-integration-spi": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-core": patch
+---
+
+Preserve GitHub provider rejection details and classify terminal agent-tool failures without reporting them as provider outages.

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
+import {IntegrationProviderError} from '#core/errors.js';
 import {
   agentStepConfig,
   catalogTool,
@@ -18,6 +19,36 @@ import {
   registryWithAgentTools,
 } from '#test/agent-tools-gateway-helpers.js';
 import {createAgentToolsGatewayRoutes} from './index.js';
+
+const gatewayMocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  reportError: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-error-monitoring', () => ({
+  reportError: gatewayMocks.reportError,
+}));
+vi.mock('@shipfox/node-opentelemetry', () => {
+  const metric = {add: vi.fn(), record: vi.fn()};
+  const meter = {
+    createCounter: () => metric,
+    createGauge: () => metric,
+    createHistogram: () => metric,
+    createUpDownCounter: () => metric,
+  };
+
+  return {
+    getFastifyInstrumentation: () => undefined,
+    instanceMetrics: {getMeter: () => meter},
+    logger: () => ({
+      error: gatewayMocks.loggerError,
+      info: gatewayMocks.loggerInfo,
+      warn: gatewayMocks.loggerWarn,
+    }),
+  };
+});
 
 let leases = new Map<string, LeasedJobContext>();
 
@@ -43,6 +74,10 @@ describe('agent tools gateway route', () => {
   beforeEach(async () => {
     await closeApp();
     leases = new Map();
+    gatewayMocks.loggerError.mockReset();
+    gatewayMocks.loggerInfo.mockReset();
+    gatewayMocks.loggerWarn.mockReset();
+    gatewayMocks.reportError.mockReset();
   });
 
   afterEach(async () => {
@@ -227,13 +262,19 @@ describe('agent tools gateway route', () => {
     });
   });
 
-  it('returns bounded MCP errors when provider dispatch fails', async () => {
+  it('returns the provider message and terminal code for rejected calls', async () => {
     const lease = leaseContext({workspaceId: 'workspace-1'});
     const integration = materializedIntegration({connectionId: 'connection-1'});
     leases.set('provider-error-lease', lease);
+    const providerError = new IntegrationProviderError(
+      'provider-rejected',
+      'commit_id is missing',
+      undefined,
+      422,
+    );
     const app = await createGatewayApp({
       registry: registryWithAgentTools([catalogTool()], {
-        callError: new Error('remote provider leaked implementation detail'),
+        callError: providerError,
       }),
       loadLeasedAgentStep: async () => ({
         workspaceId: lease.workspaceId,
@@ -269,8 +310,50 @@ describe('agent tools gateway route', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Integration provider call failed'}],
-      structuredContent: {code: 'provider-unavailable'},
+      content: [{type: 'text', text: 'commit_id is missing'}],
+      structuredContent: {code: 'provider-rejected', status: 422},
+    });
+    expect(gatewayMocks.loggerError).not.toHaveBeenCalled();
+    expect(gatewayMocks.reportError).not.toHaveBeenCalled();
+  });
+
+  it('reports provider unavailability while preserving its message and status', async () => {
+    const lease = leaseContext({workspaceId: 'workspace-1'});
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    leases.set('provider-unavailable-lease', lease);
+    const providerError = new IntegrationProviderError(
+      'provider-unavailable',
+      'GitHub returned HTTP 503',
+      undefined,
+      503,
+    );
+    const app = await createGatewayApp({
+      registry: registryWithAgentTools([catalogTool()], {callError: providerError}),
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([integration])},
+      }),
+      getIntegrationConnectionById: async () =>
+        connection({
+          id: integration.connectionId,
+          workspaceId: lease.workspaceId,
+          slug: integration.connectionSlug,
+        }),
+    });
+
+    const result = await callIssueReadTool(app, 'provider-unavailable-lease');
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'GitHub returned HTTP 503'}],
+      structuredContent: {code: 'provider-unavailable', status: 503},
+    });
+    expect(gatewayMocks.loggerError).toHaveBeenCalledWith(
+      {err: providerError, provider: 'github'},
+      'Integration agent tool provider was unavailable',
+    );
+    expect(gatewayMocks.reportError).toHaveBeenCalledWith(providerError, {
+      boundary: 'integration.agent-tool',
     });
   });
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
@@ -20,36 +20,6 @@ import {
 } from '#test/agent-tools-gateway-helpers.js';
 import {createAgentToolsGatewayRoutes} from './index.js';
 
-const gatewayMocks = vi.hoisted(() => ({
-  loggerError: vi.fn(),
-  loggerInfo: vi.fn(),
-  loggerWarn: vi.fn(),
-  reportError: vi.fn(),
-}));
-
-vi.mock('@shipfox/node-error-monitoring', () => ({
-  reportError: gatewayMocks.reportError,
-}));
-vi.mock('@shipfox/node-opentelemetry', () => {
-  const metric = {add: vi.fn(), record: vi.fn()};
-  const meter = {
-    createCounter: () => metric,
-    createGauge: () => metric,
-    createHistogram: () => metric,
-    createUpDownCounter: () => metric,
-  };
-
-  return {
-    getFastifyInstrumentation: () => undefined,
-    instanceMetrics: {getMeter: () => meter},
-    logger: () => ({
-      error: gatewayMocks.loggerError,
-      info: gatewayMocks.loggerInfo,
-      warn: gatewayMocks.loggerWarn,
-    }),
-  };
-});
-
 let leases = new Map<string, LeasedJobContext>();
 
 const fakeLeaseAuth: AuthMethod = {
@@ -74,10 +44,6 @@ describe('agent tools gateway route', () => {
   beforeEach(async () => {
     await closeApp();
     leases = new Map();
-    gatewayMocks.loggerError.mockReset();
-    gatewayMocks.loggerInfo.mockReset();
-    gatewayMocks.loggerWarn.mockReset();
-    gatewayMocks.reportError.mockReset();
   });
 
   afterEach(async () => {
@@ -312,48 +278,6 @@ describe('agent tools gateway route', () => {
       isError: true,
       content: [{type: 'text', text: 'commit_id is missing'}],
       structuredContent: {code: 'provider-rejected', status: 422},
-    });
-    expect(gatewayMocks.loggerError).not.toHaveBeenCalled();
-    expect(gatewayMocks.reportError).not.toHaveBeenCalled();
-  });
-
-  it('reports provider unavailability while preserving its message and status', async () => {
-    const lease = leaseContext({workspaceId: 'workspace-1'});
-    const integration = materializedIntegration({connectionId: 'connection-1'});
-    leases.set('provider-unavailable-lease', lease);
-    const providerError = new IntegrationProviderError(
-      'provider-unavailable',
-      'GitHub returned HTTP 503',
-      undefined,
-      503,
-    );
-    const app = await createGatewayApp({
-      registry: registryWithAgentTools([catalogTool()], {callError: providerError}),
-      loadLeasedAgentStep: async () => ({
-        workspaceId: lease.workspaceId,
-        step: {type: 'agent', config: agentStepConfig([integration])},
-      }),
-      getIntegrationConnectionById: async () =>
-        connection({
-          id: integration.connectionId,
-          workspaceId: lease.workspaceId,
-          slug: integration.connectionSlug,
-        }),
-    });
-
-    const result = await callIssueReadTool(app, 'provider-unavailable-lease');
-
-    expect(result).toEqual({
-      isError: true,
-      content: [{type: 'text', text: 'GitHub returned HTTP 503'}],
-      structuredContent: {code: 'provider-unavailable', status: 503},
-    });
-    expect(gatewayMocks.loggerError).toHaveBeenCalledWith(
-      {err: providerError, provider: 'github'},
-      'Integration agent tool provider was unavailable',
-    );
-    expect(gatewayMocks.reportError).toHaveBeenCalledWith(providerError, {
-      boundary: 'integration.agent-tool',
     });
   });
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.test.ts
@@ -1,0 +1,107 @@
+import type {reportError as reportErrorType} from '@shipfox/node-error-monitoring';
+import type {logger as loggerFactoryType} from '@shipfox/node-opentelemetry';
+import {IntegrationProviderError} from '#core/errors.js';
+import {
+  catalogTool,
+  connection,
+  materializedIntegration,
+  materializedTool,
+  registryWithAgentTools,
+} from '#test/agent-tools-gateway-helpers.js';
+import {createIntegrationToolDispatcher} from './dispatch.js';
+import type {AuthorizedIntegrationTool} from './resolve-authorized-tools.js';
+
+const dispatchMocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  reportError: vi.fn(),
+}));
+
+const loggerFactory = (() => ({
+  error: dispatchMocks.loggerError,
+})) as unknown as typeof loggerFactoryType;
+const reportError = dispatchMocks.reportError as unknown as typeof reportErrorType;
+
+describe('createIntegrationToolDispatcher', () => {
+  beforeEach(() => {
+    dispatchMocks.loggerError.mockReset();
+    dispatchMocks.reportError.mockReset();
+  });
+
+  it('preserves terminal provider errors without reporting them as outages', async () => {
+    const providerError = new IntegrationProviderError(
+      'provider-rejected',
+      'commit_id is missing',
+      undefined,
+      422,
+    );
+    const dispatch = createDispatcher(providerError);
+
+    const result = await dispatch({
+      authorizedTool: authorizedTool(),
+      arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'commit_id is missing'}],
+      structuredContent: {code: 'provider-rejected', status: 422},
+    });
+    expect(dispatchMocks.loggerError).not.toHaveBeenCalled();
+    expect(dispatchMocks.reportError).not.toHaveBeenCalled();
+  });
+
+  it('reports provider outages while preserving their message and status', async () => {
+    const providerError = new IntegrationProviderError(
+      'provider-unavailable',
+      'GitHub returned HTTP 503',
+      undefined,
+      503,
+    );
+    const dispatch = createDispatcher(providerError);
+
+    const result = await dispatch({
+      authorizedTool: authorizedTool(),
+      arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'GitHub returned HTTP 503'}],
+      structuredContent: {code: 'provider-unavailable', status: 503},
+    });
+    expect(dispatchMocks.loggerError).toHaveBeenCalledWith(
+      {err: providerError, provider: 'github'},
+      'Integration agent tool provider was unavailable',
+    );
+    expect(dispatchMocks.reportError).toHaveBeenCalledWith(providerError, {
+      boundary: 'integration.agent-tool',
+    });
+  });
+});
+
+function createDispatcher(callError: IntegrationProviderError) {
+  return createIntegrationToolDispatcher(
+    {
+      registry: registryWithAgentTools([catalogTool()], {callError}),
+    },
+    {logger: loggerFactory, reportError},
+  );
+}
+
+function authorizedTool(): AuthorizedIntegrationTool {
+  const integration = materializedIntegration({connectionId: 'connection-1'});
+  const tool = materializedTool();
+  return {
+    mcpName: 'github_main__issue_read',
+    integration,
+    tool,
+    connection: connection({
+      id: integration.connectionId,
+      workspaceId: 'workspace-1',
+      slug: integration.connectionSlug,
+    }),
+    description: 'Read issue metadata from GitHub.',
+    inputSchema: tool.inputSchema,
+    outputSchema: tool.outputSchema,
+  };
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
@@ -100,11 +100,22 @@ async function closeSession(session: {close?(): Promise<void>} | undefined): Pro
   }
 }
 
-function errorResult(error: unknown): {code: string; message: string} {
+interface IntegrationToolError {
+  code: string;
+  message: string;
+  retryAfterSeconds?: number | undefined;
+  status?: number | undefined;
+}
+
+function errorResult(error: unknown): IntegrationToolError {
   if (error instanceof IntegrationProviderError) {
     return {
       code: error.reason,
-      message: `Integration provider error: ${error.reason}`,
+      message: error.message,
+      ...(error.retryAfterSeconds === undefined
+        ? {}
+        : {retryAfterSeconds: error.retryAfterSeconds}),
+      ...(error.status === undefined ? {} : {status: error.status}),
     };
   }
 
@@ -142,10 +153,16 @@ function isCredentialError(error: unknown): boolean {
   return credentialErrorNamePattern.test(error.name);
 }
 
-function toolError(params: {code: string; message: string}): CallToolResult {
+function toolError(params: IntegrationToolError): CallToolResult {
   return {
     isError: true,
     content: [{type: 'text', text: params.message}],
-    structuredContent: {code: params.code},
+    structuredContent: {
+      code: params.code,
+      ...(params.retryAfterSeconds === undefined
+        ? {}
+        : {retryAfterSeconds: params.retryAfterSeconds}),
+      ...(params.status === undefined ? {} : {status: params.status}),
+    },
   };
 }

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
@@ -15,17 +15,33 @@ export interface CreateIntegrationToolDispatcherParams {
   registry: IntegrationProviderRegistry;
 }
 
+export interface IntegrationToolDispatcherDependencies {
+  logger?: typeof logger;
+  reportError?: typeof reportError;
+}
+
 const timeoutErrorPattern = /timed?\s*out|timeout/i;
 const credentialErrorNamePattern = /Token|Credential|Secret|AccessToken/;
 
 export function createIntegrationToolDispatcher(
   params: CreateIntegrationToolDispatcherParams,
+  dependencies: IntegrationToolDispatcherDependencies = {},
 ): IntegrationToolDispatcher {
-  return (input) => dispatchIntegrationToolCall({...input, registry: params.registry});
+  return (input) =>
+    dispatchIntegrationToolCall({
+      ...input,
+      registry: params.registry,
+      logger: dependencies.logger ?? logger,
+      reportError: dependencies.reportError ?? reportError,
+    });
 }
 
 async function dispatchIntegrationToolCall(
-  input: IntegrationToolDispatchInput & {registry: IntegrationProviderRegistry},
+  input: IntegrationToolDispatchInput & {
+    registry: IntegrationProviderRegistry;
+    logger: typeof logger;
+    reportError: typeof reportError;
+  },
 ): Promise<CallToolResult> {
   let session: AgentToolSession<CallToolResult> | undefined;
 
@@ -52,15 +68,17 @@ async function dispatchIntegrationToolCall(
   } catch (error) {
     const result = errorResult(error);
     if (result.code === 'provider-unavailable') {
-      logger().error(
-        {err: error, provider: input.authorizedTool.integration.provider},
-        'Integration agent tool provider was unavailable',
-      );
-      reportError(error, {boundary: 'integration.agent-tool'});
+      input
+        .logger()
+        .error(
+          {err: error, provider: input.authorizedTool.integration.provider},
+          'Integration agent tool provider was unavailable',
+        );
+      input.reportError(error, {boundary: 'integration.agent-tool'});
     }
     return toolError(result);
   } finally {
-    await closeSession(session);
+    await closeSession(session, input.logger, input.reportError);
   }
 }
 
@@ -90,13 +108,17 @@ function agentToolCatalogEntry(input: IntegrationToolDispatchInput): AgentToolCa
   };
 }
 
-async function closeSession(session: {close?(): Promise<void>} | undefined): Promise<void> {
+async function closeSession(
+  session: {close?(): Promise<void>} | undefined,
+  loggerFactory: typeof logger,
+  reportErrorFn: typeof reportError,
+): Promise<void> {
   try {
     await session?.close?.();
   } catch (error) {
     // Cleanup must not mask the tool result returned to the runner.
-    logger().error({err: error}, 'Failed to close integration agent tool session');
-    reportError(error, {boundary: 'integration.agent-tool', operation: 'close-session'});
+    loggerFactory().error({err: error}, 'Failed to close integration agent tool session');
+    reportErrorFn(error, {boundary: 'integration.agent-tool', operation: 'close-session'});
   }
 }
 

--- a/libs/api/integration/core/src/presentation/routes/errors.ts
+++ b/libs/api/integration/core/src/presentation/routes/errors.ts
@@ -28,6 +28,7 @@ function isProviderError(error: unknown): error is IntegrationProviderError {
         error.reason === 'rate-limited' ||
         error.reason === 'timeout' ||
         error.reason === 'provider-unavailable' ||
+        error.reason === 'provider-rejected' ||
         error.reason === 'malformed-provider-response' ||
         error.reason === 'content-too-large' ||
         error.reason === 'too-many-files'))

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -1,9 +1,19 @@
 import {GithubIntegrationProviderError} from '#core/errors.js';
-import {createGithubApiClient} from './client.js';
+import {createGithubApiClient, mapGithubError} from './client.js';
 
-const {createInstallationAccessTokenMock} = vi.hoisted(() => ({
-  createInstallationAccessTokenMock: vi.fn(),
-}));
+const {createInstallationAccessTokenMock, RequestErrorMock} = vi.hoisted(() => {
+  class RequestErrorMock extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+    ) {
+      super(message);
+      this.name = 'HttpError';
+    }
+  }
+
+  return {createInstallationAccessTokenMock: vi.fn(), RequestErrorMock};
+});
 
 vi.mock('octokit', () => ({
   App: class App {
@@ -16,8 +26,34 @@ vi.mock('octokit', () => ({
       return {defaults: options};
     },
   },
-  RequestError: class RequestError extends Error {},
+  RequestError: RequestErrorMock,
 }));
+
+describe('mapGithubError', () => {
+  it.each([400, 409, 422])('maps HTTP %i to a terminal provider rejection', async (status) => {
+    const error = new RequestErrorMock(`GitHub rejected request with HTTP ${status}`, status);
+
+    const result = mapGithubError(() => Promise.reject(error));
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: `GitHub rejected request with HTTP ${status}`,
+      status,
+    });
+  });
+
+  it('preserves the status when mapping provider unavailability', async () => {
+    const error = new RequestErrorMock('GitHub is unavailable', 503);
+
+    const result = mapGithubError(() => Promise.reject(error));
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'provider-unavailable',
+      message: 'GitHub is unavailable',
+      status: 503,
+    });
+  });
+});
 
 describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
   beforeEach(() => {

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -433,13 +433,19 @@ export async function mapGithubError<T>(
     if (error instanceof GithubIntegrationProviderError) throw error;
     if (error instanceof RequestError) {
       if (error.status === 404) {
-        throw new GithubIntegrationProviderError(notFoundReason, error.message);
+        throw new GithubIntegrationProviderError(
+          notFoundReason,
+          error.message,
+          undefined,
+          error.status,
+        );
       }
       if (error.status === 429 || isGithubRateLimitError(error)) {
         throw new GithubIntegrationProviderError(
           'rate-limited',
           error.message,
           retryAfterSeconds(error),
+          error.status,
         );
       }
       if (error.status === 401 || error.status === 403) {
@@ -447,10 +453,24 @@ export async function mapGithubError<T>(
           'access-denied',
           error.message,
           retryAfterSeconds(error),
+          error.status,
         );
       }
       if (error.status >= 500) {
-        throw new GithubIntegrationProviderError('provider-unavailable', error.message);
+        throw new GithubIntegrationProviderError(
+          'provider-unavailable',
+          error.message,
+          undefined,
+          error.status,
+        );
+      }
+      if (error.status >= 400) {
+        throw new GithubIntegrationProviderError(
+          'provider-rejected',
+          error.message,
+          undefined,
+          error.status,
+        );
       }
     }
     if (error instanceof Error && error.name === 'AbortError') {

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -26,6 +26,10 @@ const providerErrorReasons = [
 ] as const satisfies readonly IntegrationProviderErrorReason[];
 
 const providerErrorReasonSchema = z.enum(providerErrorReasons);
+const backoffErrorSchema = z.object({
+  message: z.string(),
+  status: z.number().int().optional(),
+});
 const terminalMintErrorReasons = new Set<IntegrationProviderErrorReason>([
   'access-denied',
   'installation-not-found',
@@ -46,6 +50,7 @@ const installationTokenEnvelopeSchema = z.object({
   permissions: z.record(z.string(), z.enum(['read', 'write', 'admin'])).optional(),
   backoffUntil: z.string().datetime().optional(),
   backoffReason: providerErrorReasonSchema.optional(),
+  backoffError: backoffErrorSchema.optional(),
 });
 
 export interface InstallationTokenEnvelope {
@@ -54,6 +59,12 @@ export interface InstallationTokenEnvelope {
   permissions?: Record<string, 'read' | 'write' | 'admin'> | undefined;
   backoffUntil?: Date | undefined;
   backoffReason?: IntegrationProviderErrorReason | undefined;
+  backoffError?:
+    | {
+        message: string;
+        status?: number | undefined;
+      }
+    | undefined;
 }
 
 export type MintErrorClass = 'transient' | 'terminal';
@@ -77,6 +88,7 @@ export function encodeInstallationTokenEnvelope(envelope: InstallationTokenEnvel
       backoffUntil: envelope.backoffUntil.toISOString(),
     }),
     ...(envelope.backoffReason !== undefined && {backoffReason: envelope.backoffReason}),
+    ...(envelope.backoffError !== undefined && {backoffError: envelope.backoffError}),
   });
 }
 
@@ -97,6 +109,7 @@ export function parseInstallationTokenEnvelope(raw: string): InstallationTokenEn
     permissions: result.data.permissions,
     backoffUntil: result.data.backoffUntil ? new Date(result.data.backoffUntil) : undefined,
     backoffReason: result.data.backoffReason,
+    backoffError: result.data.backoffError,
   };
 }
 
@@ -153,11 +166,13 @@ export function backoffMs(classified: ClassifiedMintError): number {
 export function providerErrorFromBackoff(
   reason: IntegrationProviderErrorReason,
   retryAfterMs: number,
+  backoffError?: InstallationTokenEnvelope['backoffError'],
 ): GithubIntegrationProviderError {
   return new GithubIntegrationProviderError(
     reason,
-    `GitHub installation token mint is backed off after ${reason}`,
+    backoffError?.message ?? `GitHub installation token mint is backed off after ${reason}`,
     Math.max(1, Math.ceil(retryAfterMs / 1000)),
+    backoffError?.status,
   );
 }
 

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -19,6 +19,7 @@ const providerErrorReasons = [
   'rate-limited',
   'timeout',
   'provider-unavailable',
+  'provider-rejected',
   'malformed-provider-response',
   'content-too-large',
   'too-many-files',
@@ -28,6 +29,7 @@ const providerErrorReasonSchema = z.enum(providerErrorReasons);
 const terminalMintErrorReasons = new Set<IntegrationProviderErrorReason>([
   'access-denied',
   'installation-not-found',
+  'provider-rejected',
   'malformed-provider-response',
 ]);
 
@@ -162,7 +164,12 @@ export function providerErrorFromBackoff(
 export function toProviderError(error: unknown): GithubIntegrationProviderError {
   if (error instanceof GithubIntegrationProviderError) return error;
   if (error instanceof IntegrationProviderError) {
-    return new GithubIntegrationProviderError(error.reason, error.message, error.retryAfterSeconds);
+    return new GithubIntegrationProviderError(
+      error.reason,
+      error.message,
+      error.retryAfterSeconds,
+      error.status,
+    );
   }
   return new GithubIntegrationProviderError(
     'provider-unavailable',

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -190,6 +190,34 @@ describe('SharedInstallationTokenCache', () => {
     expect(mint).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves terminal provider rejection details through backoff', async () => {
+    const store = createStore();
+    const mint = vi
+      .fn()
+      .mockRejectedValue(
+        new GithubIntegrationProviderError(
+          'provider-rejected',
+          'commit_id is missing',
+          undefined,
+          422,
+        ),
+      );
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: 'commit_id is missing',
+      status: 422,
+    });
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: 'commit_id is missing',
+      status: 422,
+    });
+
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
   it('serves stale when refresh minting fails while the token is still valid', async () => {
     const store = createStore();
     setEnvelope(store, token('ghs_existing', '2026-06-10T11:04:30.000Z'));

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -113,6 +113,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       throw providerErrorFromBackoff(
         envelope?.backoffReason ?? 'provider-unavailable',
         (envelope?.backoffUntil?.getTime() ?? now.getTime()) - now.getTime(),
+        envelope?.backoffError,
       );
     }
 
@@ -131,6 +132,10 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         permissions: envelope?.permissions,
         backoffUntil: until,
         backoffReason: classified.reason,
+        backoffError: {
+          message: providerError.message,
+          ...(providerError.status === undefined ? {} : {status: providerError.status}),
+        },
       }).catch((writeError) => {
         logger().warn(
           {installationId: params.installationId, reason: classified.reason, error: writeError},
@@ -215,6 +220,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       throw providerErrorFromBackoff(
         params.envelope.backoffReason,
         params.envelope.backoffUntil.getTime() - initialNow.getTime(),
+        params.envelope.backoffError,
       );
     }
 
@@ -231,6 +237,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         throw providerErrorFromBackoff(
           envelope?.backoffReason ?? 'provider-unavailable',
           (envelope?.backoffUntil?.getTime() ?? now.getTime()) - now.getTime(),
+          envelope?.backoffError,
         );
       }
     }

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -1,3 +1,4 @@
+import {RequestError} from 'octokit';
 import type {GithubApiClient} from '#api/client.js';
 import {DEFAULT_JOB_LOG_TAIL_LINES} from '#core/actions-logs.js';
 import {
@@ -500,6 +501,47 @@ describe('github agent tool catalog', () => {
           text: 'No pending pull request review found for the authenticated GitHub user.',
         },
       ],
+    });
+  });
+
+  it('maps Octokit 4xx failures to terminal provider errors', async () => {
+    const providerError = new RequestError('commit_id is missing', 422, {
+      request: {
+        method: 'POST',
+        url: 'https://api.github.com/repos/shipfox/platform/issues/1',
+        headers: {},
+      },
+    });
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {
+        getInstallationAccessToken: vi.fn(() =>
+          Promise.resolve({
+            token: 'installation-token',
+            expiresAt: new Date(),
+            permissions: {issues: 'read' as const},
+          }),
+        ),
+      },
+      createClient: vi.fn(() => ({
+        request: vi.fn(() => Promise.reject(providerError)),
+      })),
+    });
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [githubAgentToolCatalog[0]],
+      scope: undefined,
+    });
+
+    await expect(
+      session.call({
+        toolId: 'issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      }),
+    ).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: 'commit_id is missing',
+      status: 422,
     });
   });
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -8,6 +8,7 @@ import type {
   OpenAgentToolsSessionInput,
 } from '@shipfox/api-integration-spi';
 import {Octokit} from 'octokit';
+import {mapGithubError} from '#api/client.js';
 import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
@@ -146,30 +147,30 @@ export class GithubAgentToolsProvider
         const method =
           typeof call.arguments.method === 'string' ? call.arguments.method : undefined;
 
-        try {
-          if (operation.kind === 'graphql') {
-            const data = await addCommentToPendingReview(client, operation.parameters);
-            return data === undefined
-              ? githubToolError(NO_PENDING_REVIEW_MESSAGE)
-              : githubToolResult(tool.id as GithubAgentToolId, data);
-          }
+        if (operation.kind === 'graphql') {
+          const data = await mapGithubError(() =>
+            addCommentToPendingReview(client, operation.parameters),
+          );
+          return data === undefined
+            ? githubToolError(NO_PENDING_REVIEW_MESSAGE)
+            : githubToolResult(tool.id as GithubAgentToolId, data);
+        }
 
-          const operationParameters = await resolvePendingReviewParameters(
+        const operationParameters = await mapGithubError(() =>
+          resolvePendingReviewParameters(
             client,
             operation.parameters,
             tool.id as GithubAgentToolId,
             method,
-          );
-          if (operationParameters === undefined) {
-            return githubToolError(NO_PENDING_REVIEW_MESSAGE);
-          }
-          const response = await client.request(operation.route, operationParameters);
-          return githubToolResult(tool.id as GithubAgentToolId, response.data);
-        } catch (error) {
-          if (error instanceof GithubIntegrationProviderError)
-            return githubToolError(error.message);
-          throw error;
+          ),
+        );
+        if (operationParameters === undefined) {
+          return githubToolError(NO_PENDING_REVIEW_MESSAGE);
         }
+        const response = await mapGithubError(() =>
+          client.request(operation.route, operationParameters),
+        );
+        return githubToolResult(tool.id as GithubAgentToolId, response.data);
       },
     };
   }

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -253,6 +253,7 @@ export type IntegrationProviderErrorReason =
   | 'rate-limited'
   | 'timeout'
   | 'provider-unavailable'
+  | 'provider-rejected'
   | 'malformed-provider-response'
   | 'content-too-large'
   | 'too-many-files';
@@ -262,6 +263,7 @@ export class IntegrationProviderError extends Error {
     public readonly reason: IntegrationProviderErrorReason,
     message: string,
     public readonly retryAfterSeconds?: number | undefined,
+    public readonly status?: number | undefined,
   ) {
     super(message);
     this.name = 'IntegrationProviderError';


### PR DESCRIPTION
GitHub agent-tool calls now preserve provider response messages and HTTP status through the gateway. Deterministic 4xx failures use a terminal provider-rejected code, while 5xx and connection failures remain provider-unavailable and retain reporting behavior.

Focused gateway, GitHub mapping, and agent-tool regression coverage is included, along with the required changeset.

Closes ENG-1559

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves GitHub provider error messages, HTTP status, and retryAfterSeconds end-to-end in integration agent tools and gateway, including through installation token backoff. 4xx map to terminal provider-rejected; 5xx/connection errors stay provider-unavailable and are logged/reported. Addresses ENG-1559.

- New Features
  - Gateway returns provider message, status, and retryAfterSeconds in tool error structuredContent; terminal rejections are not reported, outages are logged/reported.
  - `mapGithubError` maps Octokit errors (404 → not-found with status, other 4xx → provider-rejected, 5xx → provider-unavailable) and preserves status; agent tools wrap REST, GraphQL, and pending-review parameter resolution with this mapping.
  - Installation token envelope/cache persist error details via backoffError {message, status} and surface them on retry; SPI `IntegrationProviderError` adds optional status and schemas updated in `@shipfox/api-integration-spi`, `@shipfox/api-integration-github`, and `@shipfox/api-integration-core`.

<sup>Written for commit 09ab5007179be2e36a67bbd73a20efbb95a9ba64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

