### PR TITLE
[api-integration-github] Restore pending pull request review writes

### DIFF
--- a/.changeset/fix-pending-review-resolution.md
+++ b/.changeset/fix-pending-review-resolution.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Resolve the latest pending pull request review before submitting or deleting it.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -591,9 +591,72 @@ describe('github agent tool catalog', () => {
         repo: 'platform',
         pull_number: 2,
         per_page: 100,
+        page: 1,
       },
     );
     expect(request).toHaveBeenNthCalledWith(2, testCase.route, testCase.parameters);
+  });
+
+  it('resolves a pending review from a later review page', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: Array.from({length: 100}, (_, index) => ({id: index + 1, state: 'APPROVED'})),
+      })
+      .mockResolvedValueOnce({data: [{id: 101, state: 'PENDING'}]})
+      .mockResolvedValueOnce({data: {id: 101, state: 'COMMENTED'}});
+
+    const result = await callGithubToolWithRequest(
+      'pull_request_review_write',
+      {
+        method: 'submit_pending',
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        body: 'Looks good.',
+        event: 'COMMENT',
+      },
+      request,
+    );
+
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify({id: 101, state: 'COMMENTED'})}],
+      structuredContent: {id: 101, state: 'COMMENTED'},
+    });
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+      {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        per_page: 100,
+        page: 1,
+      },
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+      {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        per_page: 100,
+        page: 2,
+      },
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      3,
+      'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events',
+      {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        body: 'Looks good.',
+        event: 'COMMENT',
+        review_id: 101,
+      },
+    );
   });
 
   it.each([

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -518,6 +518,110 @@ describe('github agent tool catalog', () => {
 
   it.each([
     {
+      method: 'submit_pending',
+      arguments: {
+        method: 'submit_pending',
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        body: 'Please address this before merging.',
+        event: 'REQUEST_CHANGES',
+      },
+      route: 'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events',
+      parameters: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        body: 'Please address this before merging.',
+        event: 'REQUEST_CHANGES',
+        review_id: 42,
+      },
+      data: {id: 42, state: 'CHANGES_REQUESTED'},
+    },
+    {
+      method: 'delete_pending',
+      arguments: {
+        method: 'delete_pending',
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+      },
+      route: 'DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}',
+      parameters: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        review_id: 42,
+      },
+      data: {id: 42, state: 'PENDING'},
+    },
+  ] satisfies Array<{
+    method: 'submit_pending' | 'delete_pending';
+    arguments: Record<string, unknown>;
+    route: string;
+    parameters: Record<string, unknown>;
+    data: unknown;
+  }>)('$method resolves the latest pending review before writing', async (testCase) => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          {id: 40, state: 'APPROVED'},
+          {id: 41, state: 'PENDING'},
+          {id: 42, state: 'PENDING'},
+        ],
+      })
+      .mockResolvedValueOnce({data: testCase.data});
+
+    const result = await callGithubToolWithRequest(
+      'pull_request_review_write',
+      testCase.arguments,
+      request,
+    );
+
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(testCase.data)}],
+      structuredContent: testCase.data,
+    });
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+      {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        per_page: 100,
+      },
+    );
+    expect(request).toHaveBeenNthCalledWith(2, testCase.route, testCase.parameters);
+  });
+
+  it.each([
+    'submit_pending',
+    'delete_pending',
+  ] as const)('%s reports when no pending review exists', async (method) => {
+    const request = vi.fn(() => Promise.resolve({data: []}));
+
+    const result = await callGithubToolWithRequest(
+      'pull_request_review_write',
+      {method, owner: 'shipfox', repo: 'platform', pull_number: 2},
+      request,
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'No pending pull request review found for the authenticated GitHub user.',
+        },
+      ],
+    });
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
       toolId: 'list_issue_types',
       arguments: {owner: 'shipfox'},
       data: [{id: 1}],
@@ -614,11 +718,21 @@ async function callGithubTool(
   arguments_: Record<string, unknown>,
   data: unknown,
 ) {
+  return await callGithubToolWithRequest(
+    toolId,
+    arguments_,
+    vi.fn(() => Promise.resolve({data})),
+  );
+}
+
+async function callGithubToolWithRequest(
+  toolId: GithubAgentToolId,
+  arguments_: Record<string, unknown>,
+  request: GithubToolClient['request'],
+) {
   const tool = githubAgentToolCatalog.find((entry) => entry.id === toolId);
   if (!tool) throw new Error(`Missing GitHub tool: ${toolId}`);
-  const provider = createAgentToolsProvider({
-    request: vi.fn(() => Promise.resolve({data})),
-  });
+  const provider = createAgentToolsProvider({request});
   const session = await provider.openSession({
     connection: connection(),
     tools: [tool],

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -143,6 +143,8 @@ export class GithubAgentToolsProvider
           );
         }
         const client = (this.options.createClient ?? createOctokitClient)(token.token);
+        const method =
+          typeof call.arguments.method === 'string' ? call.arguments.method : undefined;
 
         try {
           if (operation.kind === 'graphql') {
@@ -152,7 +154,16 @@ export class GithubAgentToolsProvider
               : githubToolResult(tool.id as GithubAgentToolId, data);
           }
 
-          const response = await client.request(operation.route, operation.parameters);
+          const operationParameters = await resolvePendingReviewParameters(
+            client,
+            operation.parameters,
+            tool.id as GithubAgentToolId,
+            method,
+          );
+          if (operationParameters === undefined) {
+            return githubToolError(NO_PENDING_REVIEW_MESSAGE);
+          }
+          const response = await client.request(operation.route, operationParameters);
           return githubToolResult(tool.id as GithubAgentToolId, response.data);
         } catch (error) {
           if (error instanceof GithubIntegrationProviderError)
@@ -417,6 +428,43 @@ function projectGithubOperationParameters(
     parameters.headers = {accept: 'application/vnd.github.diff'};
   }
   return parameters;
+}
+
+async function resolvePendingReviewParameters(
+  client: GithubToolClient,
+  parameters: Record<string, unknown>,
+  toolId: GithubAgentToolId,
+  method: string | undefined,
+): Promise<Record<string, unknown> | undefined> {
+  if (!isPendingReviewOperation(toolId, method)) return parameters;
+
+  const response = await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
+    owner: parameters.owner,
+    repo: parameters.repo,
+    pull_number: parameters.pull_number,
+    per_page: 100,
+  });
+  const reviewId = latestPendingReviewId(response.data);
+  return reviewId === undefined ? undefined : {...parameters, review_id: reviewId};
+}
+
+function isPendingReviewOperation(toolId: GithubAgentToolId, method: string | undefined): boolean {
+  return (
+    toolId === 'pull_request_review_write' &&
+    (method === 'submit_pending' || method === 'delete_pending')
+  );
+}
+
+function latestPendingReviewId(data: unknown): number | undefined {
+  if (!Array.isArray(data)) return undefined;
+
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const review = data[index];
+    if (!isRecord(review) || review.state !== 'PENDING') continue;
+    if (typeof review.id === 'number' && Number.isSafeInteger(review.id)) return review.id;
+  }
+
+  return undefined;
 }
 
 function githubToolResult(toolId: GithubAgentToolId, data: unknown): GithubToolCallResult {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -438,13 +438,7 @@ async function resolvePendingReviewParameters(
 ): Promise<Record<string, unknown> | undefined> {
   if (!isPendingReviewOperation(toolId, method)) return parameters;
 
-  const response = await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
-    owner: parameters.owner,
-    repo: parameters.repo,
-    pull_number: parameters.pull_number,
-    per_page: 100,
-  });
-  const reviewId = latestPendingReviewId(response.data);
+  const reviewId = await latestPendingReviewId(client, parameters);
   return reviewId === undefined ? undefined : {...parameters, review_id: reviewId};
 }
 
@@ -455,9 +449,31 @@ function isPendingReviewOperation(toolId: GithubAgentToolId, method: string | un
   );
 }
 
-function latestPendingReviewId(data: unknown): number | undefined {
-  if (!Array.isArray(data)) return undefined;
+async function latestPendingReviewId(
+  client: GithubToolClient,
+  parameters: Record<string, unknown>,
+): Promise<number | undefined> {
+  const perPage = 100;
+  let page = 1;
+  let reviewId: number | undefined;
 
+  while (true) {
+    const response = await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
+      owner: parameters.owner,
+      repo: parameters.repo,
+      pull_number: parameters.pull_number,
+      per_page: perPage,
+      page,
+    });
+    if (!Array.isArray(response.data)) return undefined;
+
+    reviewId = latestPendingReviewIdOnPage(response.data) ?? reviewId;
+    if (response.data.length < perPage) return reviewId;
+    page += 1;
+  }
+}
+
+function latestPendingReviewIdOnPage(data: readonly unknown[]): number | undefined {
   for (let index = data.length - 1; index >= 0; index -= 1) {
     const review = data[index];
     if (!isRecord(review) || review.state !== 'PENDING') continue;


### PR DESCRIPTION
## Summary

Restore pending pull request review writes by resolving the latest pending review before calling GitHub's submit or delete endpoint. When no pending review exists, return an explicit tool error instead of sending an unresolved route placeholder.

The public tool schema remains unchanged; review ID resolution stays server-side.

## Validation

- `mise exec -- pnpm --filter=@shipfox/api-integration-github check`
- `mise exec -- turbo test --filter=@shipfox/api-integration-github...`
- `mise exec -- turbo type --filter=@shipfox/api-integration-github...`

Closes ENG-1557

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores pending pull request review writes by resolving the latest pending review ID server-side before submit/delete, with clear errors when none exists (ENG-1557). Adds pagination so this works on PRs with more than 100 reviews.

- **Bug Fixes**
  - Resolve `review_id` by paging PR reviews and picking the latest `PENDING` one.
  - Use that `review_id` for `submit_pending`/`delete_pending`; no placeholders sent.
  - Public tool schema unchanged; ID resolution stays server-side.

<sup>Written for commit ab8792c9615948791fe2330dc9366fca3abcf6f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

