### PR TITLE
[runner-image] Shorten boot by removing the image staging tree

### DIFF
--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
-workspace=/tmp/shipfox-runner-workspace
+root_dir=${RUNNER_IMAGE_ROOT:-/}
+workspace="$root_dir/tmp/shipfox-runner-workspace"
 lockfile="$(find "$workspace" -name pnpm-lock.yaml -print -quit)"
 if [ -z "$lockfile" ]; then
   echo 'Pruned runner workspace has no pnpm lockfile.' >&2
@@ -15,3 +16,12 @@ pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-depend
 # published. This runs against the deployed flat layout, not the pnpm development tree.
 node /opt/runner/dist/verify-installation.js
 chown -R shipfox:shipfox /opt/runner
+
+# Ubuntu's tmpfiles.d/tmp.conf applies `D /tmp 1777 root root 30d` during boot.
+# Remove the dependency tree before the AMI is snapshotted so tmpfiles does not
+# recursively walk the build staging area on every runner start.
+rm -rf "$workspace"
+if [ -e "$workspace" ]; then
+  echo "Runner image staging workspace remains after cleanup: $workspace" >&2
+  exit 1
+fi

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1185,6 +1185,27 @@ describe('runner image composition', () => {
   });
 });
 
+describe('runner installation', () => {
+  it('removes the dependency tree from the image build staging area', async () => {
+    const script = new URL('../scripts/build/install-runner.sh', import.meta.url);
+    const fixture = await createRunnerInstallFixture();
+
+    try {
+      execFileSync('/bin/sh', [script.pathname], {
+        env: fixture.environment,
+        stdio: 'pipe',
+      });
+
+      expect(await pathExists(fixture.workspace)).toBe(false);
+      expect(await readFile(fixture.commandLog, 'utf8')).toContain(
+        'pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner',
+      );
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+});
+
 async function createBootFixture(fstab: string) {
   const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-boot-'));
   const commandDirectory = join(root, 'commands');
@@ -1320,6 +1341,39 @@ done
       RUNNER_IMAGE_ROOT: root,
     },
     root,
+  };
+}
+
+async function createRunnerInstallFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-install-'));
+  const commandDirectory = join(root, 'commands');
+  const workspace = join(root, 'tmp/shipfox-runner-workspace');
+  const commandLog = join(root, 'command.log');
+
+  await mkdir(join(workspace, 'package'), {recursive: true});
+  await mkdir(commandDirectory, {recursive: true});
+  await writeFile(join(workspace, 'package/pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+  await writeExecutable(join(commandDirectory, 'corepack'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(
+    join(commandDirectory, 'pnpm'),
+    `#!/bin/sh
+set -eu
+printf 'pnpm %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+`,
+  );
+  await writeExecutable(join(commandDirectory, 'node'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(join(commandDirectory, 'chown'), '#!/bin/sh\nexit 0\n');
+
+  return {
+    commandLog,
+    environment: {
+      ...process.env,
+      PATH: `${commandDirectory}:${process.env.PATH ?? ''}`,
+      RUNNER_IMAGE_COMMAND_LOG: commandLog,
+      RUNNER_IMAGE_ROOT: root,
+    },
+    root,
+    workspace,
   };
 }
 


### PR DESCRIPTION
## Summary

Ubuntu's `systemd-tmpfiles-setup.service` recursively processes `/tmp` during boot. The runner image bake left the pruned pnpm workspace and dependency tree there, making that cleanup scan a cold-boot cost.

This removes the staging workspace after the runner is deployed and verified, while keeping the standard tmpfiles service enabled for system directories. A fixture-backed runner-image regression test covers the cleanup.

## Validation

- `mise exec -- sh -n infra/images/runner/scripts/build/install-runner.sh`
- `mise exec -- turbo check --filter=@shipfox/runner-image...`
- `mise exec -- turbo type --filter=@shipfox/runner-image...`
- `mise exec -- turbo test --filter=@shipfox/runner-image...` (68 runner-image tests passed)
- `mise exec -- pnpm --filter=@shipfox/runner-image verify`

Real AMI boot timing and I/O-vs-CPU measurement remain to be confirmed on AWS.

Refs ENG-1564

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens runner cold boot by deleting the image build staging workspace in /tmp after install and verification, preventing `systemd-tmpfiles-setup.service` from recursively scanning it on startup. Adds a regression test to verify the cleanup and addresses ENG-1564.

<sup>Written for commit 1a50345fa127f3beb79da1b42c21792ee31cefb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

