### PR TITLE
Report in-guest runner boot timings

### DIFF
--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -5,6 +5,6 @@ Wants=network-online.target shipfox-runner.target
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/sh -c '/opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'
+ExecStartPre=/bin/sh -c '/usr/bin/timeout 5s /opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'
 ExecStart=/usr/bin/test -s /etc/shipfox/runner.env
 RemainAfterExit=yes

--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -5,5 +5,6 @@ Wants=network-online.target shipfox-runner.target
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/sh -c '/opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'
 ExecStart=/usr/bin/test -s /etc/shipfox/runner.env
 RemainAfterExit=yes

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -48,8 +48,12 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = ["SHIPFOX_IMAGE_REVISION=${var.revision}"]
+    execute_command  = "sudo -E sh -c '{{ .Vars }} {{ .Path }}'"
     inline = [
       "sudo install -d -m 0755 /etc/shipfox /opt/shipfox-runner/scripts/runtime/helpers",
+      "printf '%s\\n' \"$SHIPFOX_IMAGE_REVISION\" > /etc/shipfox/image-revision",
+      "chmod 0444 /etc/shipfox/image-revision",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.target /etc/systemd/system/shipfox-runner.target",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.path /etc/systemd/system/shipfox-runner-env.path",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.service /etc/systemd/system/shipfox-runner.service",
@@ -57,6 +61,7 @@ build {
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-boot-complete.service /etc/systemd/system/shipfox-runner-boot-complete.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
+      "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/record-boot-io.sh /opt/shipfox-runner/scripts/runtime/record-boot-io.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/verify-workspace-mount.sh /opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",
       "sudo systemctl daemon-reload",

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -49,7 +49,7 @@ build {
 
   provisioner "shell" {
     environment_vars = ["SHIPFOX_IMAGE_REVISION=${var.revision}"]
-    execute_command  = "sudo -E sh -c '{{ .Vars }} {{ .Path }}'"
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline = [
       "sudo install -d -m 0755 /etc/shipfox /opt/shipfox-runner/scripts/runtime/helpers",
       "printf '%s\\n' \"$SHIPFOX_IMAGE_REVISION\" > /etc/shipfox/image-revision",

--- a/infra/images/runner/scripts/runtime/record-boot-io.sh
+++ b/infra/images/runner/scripts/runtime/record-boot-io.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+
+root_source="$(findmnt -no SOURCE /)"
+root_device="$(lsblk -no PKNAME "$root_source" 2>/dev/null || true)"
+if [ -z "$root_device" ]; then
+  root_device="$(basename "$root_source")"
+fi
+
+stat_path="/sys/block/$root_device/stat"
+if [ ! -r "$stat_path" ]; then
+  printf 'runner boot telemetry: root device stats are unavailable: %s\n' "$stat_path" >&2
+  exit 1
+fi
+
+read -r read_ops _ read_sectors _ < "$stat_path"
+uptime_seconds="$(awk '{print $1}' /proc/uptime)"
+
+install -d -m 0755 /run/shipfox
+temporary_path="$(mktemp /run/shipfox/boot-io.XXXXXX)"
+trap 'rm -f "$temporary_path"' EXIT
+cat > "$temporary_path" <<EOF
+root_device=$root_device
+read_ops=$read_ops
+read_sectors=$read_sectors
+uptime_seconds=$uptime_seconds
+EOF
+chmod 0644 "$temporary_path"
+mv -- "$temporary_path" /run/shipfox/boot-io
+trap - EXIT

--- a/infra/images/runner/scripts/runtime/record-boot-io.sh
+++ b/infra/images/runner/scripts/runtime/record-boot-io.sh
@@ -17,6 +17,10 @@ read -r read_ops _ read_sectors _ < "$stat_path"
 uptime_seconds="$(awk '{print $1}' /proc/uptime)"
 
 install -d -m 0755 /run/shipfox
+if [ -e /run/shipfox/boot-io ]; then
+  exit 0
+fi
+
 temporary_path="$(mktemp /run/shipfox/boot-io.XXXXXX)"
 trap 'rm -f "$temporary_path"' EXIT
 cat > "$temporary_path" <<EOF
@@ -26,5 +30,12 @@ read_sectors=$read_sectors
 uptime_seconds=$uptime_seconds
 EOF
 chmod 0644 "$temporary_path"
-mv -- "$temporary_path" /run/shipfox/boot-io
+if ! ln -- "$temporary_path" /run/shipfox/boot-io 2>/dev/null; then
+  if [ -e /run/shipfox/boot-io ]; then
+    exit 0
+  fi
+  printf 'runner boot telemetry: failed to publish the boot I/O sample\n' >&2
+  exit 1
+fi
+rm -f "$temporary_path"
 trap - EXIT

--- a/infra/images/runner/scripts/runtime/record-boot-io.sh
+++ b/infra/images/runner/scripts/runtime/record-boot-io.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
-root_source="$(findmnt -no SOURCE /)"
-root_device="$(lsblk -no PKNAME "$root_source" 2>/dev/null || true)"
+root_source="$(findmnt -no SOURCE / || true)"
+root_device="$(lsblk -no PKNAME "$root_source" 2>/dev/null | head -n1 | tr -d '[:space:]' || true)"
 if [ -z "$root_device" ]; then
   root_device="$(basename "$root_source")"
 fi

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1009,6 +1009,9 @@ describe('systemd boot activation', () => {
       'network-online.target shipfox-runner.target',
     );
     expect(systemdDirective(unit, 'Service', 'Type')).toBe('oneshot');
+    expect(systemdDirective(unit, 'Service', 'ExecStartPre')).toBe(
+      "/bin/sh -c '/opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'",
+    );
     expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
       '/usr/bin/test -s /etc/shipfox/runner.env',
     );
@@ -1016,6 +1019,25 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Install', 'WantedBy')).toBeUndefined();
     expect(unit).not.toContain('cloud-config.service');
     expect(unit).not.toContain('cloud-final.service');
+  });
+
+  it('resolves the root device and publishes a boot I/O sample', async () => {
+    const script = new URL('../scripts/runtime/record-boot-io.sh', import.meta.url);
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+    const source = await readFile(script, 'utf8');
+
+    execFileSync('sh', ['-n', script.pathname], {stdio: 'pipe'});
+
+    expect(source).toContain('findmnt -no SOURCE /');
+    expect(source).toContain('lsblk -no PKNAME "$root_source"');
+    expect(source).toContain('read -r read_ops _ read_sectors _');
+    expect(source).toContain('/sys/block/$root_device/stat');
+    expect(source).toContain('/run/shipfox/boot-io');
+    expect(build).toContain(
+      'record-boot-io.sh /opt/shipfox-runner/scripts/runtime/record-boot-io.sh',
+    );
+    expect(build).toContain('SHIPFOX_IMAGE_REVISION=$' + '{var.revision}');
+    expect(build).toContain('/etc/shipfox/image-revision');
   });
 
   it('records a durable boot marker before starting the runner', async () => {

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1010,7 +1010,7 @@ describe('systemd boot activation', () => {
     );
     expect(systemdDirective(unit, 'Service', 'Type')).toBe('oneshot');
     expect(systemdDirective(unit, 'Service', 'ExecStartPre')).toBe(
-      "/bin/sh -c '/opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'",
+      "/bin/sh -c '/usr/bin/timeout 5s /opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'",
     );
     expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
       '/usr/bin/test -s /etc/shipfox/runner.env',
@@ -1030,6 +1030,8 @@ describe('systemd boot activation', () => {
 
     expect(source).toContain('findmnt -no SOURCE / || true');
     expect(source).toContain('lsblk -no PKNAME "$root_source" 2>/dev/null | head -n1 | tr -d');
+    expect(source).toContain('if [ -e /run/shipfox/boot-io ]; then');
+    expect(source).toContain('ln -- "$temporary_path" /run/shipfox/boot-io');
     expect(source).toContain('read -r read_ops _ read_sectors _');
     expect(source).toContain('/sys/block/$root_device/stat');
     expect(source).toContain('/run/shipfox/boot-io');

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1028,8 +1028,8 @@ describe('systemd boot activation', () => {
 
     execFileSync('sh', ['-n', script.pathname], {stdio: 'pipe'});
 
-    expect(source).toContain('findmnt -no SOURCE /');
-    expect(source).toContain('lsblk -no PKNAME "$root_source"');
+    expect(source).toContain('findmnt -no SOURCE / || true');
+    expect(source).toContain('lsblk -no PKNAME "$root_source" 2>/dev/null | head -n1 | tr -d');
     expect(source).toContain('read -r read_ops _ read_sectors _');
     expect(source).toContain('/sys/block/$root_device/stat');
     expect(source).toContain('/run/shipfox/boot-io');

--- a/infra/images/runner/variable.pkr.hcl
+++ b/infra/images/runner/variable.pkr.hcl
@@ -57,6 +57,10 @@ variable "node_version" {
 variable "revision" {
   type    = string
   default = "local"
+  validation {
+    condition     = can(regex("^[A-Za-z0-9._-]+$", var.revision))
+    error_message = "Revision must contain only letters, numbers, dots, underscores, or hyphens."
+  }
 }
 
 variable "runner_version" {

--- a/libs/runner/orchestration/src/config.ts
+++ b/libs/runner/orchestration/src/config.ts
@@ -1,6 +1,10 @@
-import {createConfig, num} from '@shipfox/config';
+import {createConfig, num, str} from '@shipfox/config';
 
 export const config = createConfig({
+  IMAGE_REVISION: str({
+    desc: 'Optional image revision reported by runners that do not have baked image metadata. Leave it empty when no revision is available.',
+    default: '',
+  }),
   SHIPFOX_POLL_INTERVAL_MS: num({
     desc: 'How often the runner asks the API for new jobs, in milliseconds. The runner backs off toward SHIPFOX_POLL_MAX_INTERVAL_MS while idle or after errors.',
     default: 1000,

--- a/libs/runner/orchestration/src/core/boot-timeline.test.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.test.ts
@@ -1,0 +1,50 @@
+import {createBootTimelineCollector} from '#core/boot-timeline.js';
+
+function systemdStat(startTicks: number): string {
+  return `1 (systemd) S ${Array.from({length: 18}, () => '0').join(' ')} ${startTicks}`;
+}
+
+describe('boot timeline collection', () => {
+  it('builds the boot and runner read breakdown from monotonic samples', () => {
+    const files: Record<string, string> = {
+      '/proc/uptime': '42.5 0.0',
+      '/run/shipfox/boot-io':
+        'root_device=nvme0n1\nread_ops=100\nread_sectors=200\nuptime_seconds=40.0\n',
+      '/sys/block/nvme0n1/stat': '150 0 250 0 0 0 0 0 0 0 0 0 0 0 0 0 0',
+      '/proc/self/stat': systemdStat(4000),
+      '/proc/1/stat': systemdStat(100),
+      '/etc/shipfox/image-revision': '0123456789abcdef0123456789abcdef01234567\n',
+    };
+    const read = vi.fn((path: string) => files[path]);
+    const collector = createBootTimelineCollector(read);
+
+    files['/proc/uptime'] = '60.5 0.0';
+    const event = collector.createEvent(collector.captureEnrollment());
+
+    expect(event).toEqual({
+      uptime_seconds: 42.5,
+      process_start_offset_seconds: 40,
+      enrollment_offset_seconds: 60.5,
+      kernel_seconds: 1,
+      userspace_seconds: 39,
+      image_revision: '0123456789abcdef0123456789abcdef01234567',
+      boot_read_bytes: 102_400,
+      boot_read_ops: 100,
+      boot_read_bytes_per_second: 102_400 / 40,
+      runner_read_bytes: 25_600,
+      runner_read_ops: 50,
+      runner_read_bytes_per_second: 25_600 / 20.5,
+    });
+  });
+
+  it('keeps the event useful when an older image has no telemetry files', () => {
+    const files: Record<string, string> = {'/proc/uptime': '12.25 0.0'};
+    const collector = createBootTimelineCollector((path) => files[path]);
+
+    expect(collector.createEvent(collector.captureEnrollment())).toEqual({
+      uptime_seconds: 12.25,
+      process_start_offset_seconds: 12.25,
+      enrollment_offset_seconds: 12.25,
+    });
+  });
+});

--- a/libs/runner/orchestration/src/core/boot-timeline.test.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.test.ts
@@ -10,7 +10,7 @@ describe('boot timeline collection', () => {
       '/proc/uptime': '42.5 0.0',
       '/run/shipfox/boot-io':
         'root_device=nvme0n1\nread_ops=100\nread_sectors=200\nuptime_seconds=35.5\n',
-      '/sys/block/nvme0n1/stat': '150 0 250 0 0 0 0 0 0 0 0 0 0 0 0 0 0',
+      '/sys/block/nvme0n1/stat': '120 0 220 0 0 0 0 0 0 0 0 0 0 0 0 0 0',
       '/proc/self/stat': systemdStat(4000),
       '/proc/1/stat': systemdStat(100),
       '/etc/shipfox/image-revision': '0123456789abcdef0123456789abcdef01234567\n',
@@ -19,9 +19,12 @@ describe('boot timeline collection', () => {
     const collector = createBootTimelineCollector(read);
 
     files['/proc/uptime'] = '60.5 0.0';
+    files['/sys/block/nvme0n1/stat'] = '150 0 250 0 0 0 0 0 0 0 0 0 0 0 0 0 0';
     const event = collector.createEvent(collector.captureEnrollment());
 
     expect(event).toEqual({
+      boot_timeline_version: 1,
+      telemetry_state: 'complete',
       uptime_seconds: 42.5,
       process_start_offset_seconds: 40,
       enrollment_offset_seconds: 60.5,
@@ -31,9 +34,9 @@ describe('boot timeline collection', () => {
       boot_read_bytes: 102_400,
       boot_read_ops: 100,
       boot_read_bytes_per_second: 102_400 / 35.5,
-      runner_read_bytes: 25_600,
-      runner_read_ops: 50,
-      runner_read_bytes_per_second: 25_600 / 20.5,
+      runner_read_bytes: 15_360,
+      runner_read_ops: 30,
+      runner_read_bytes_per_second: 15_360 / 20.5,
     });
   });
 
@@ -42,6 +45,8 @@ describe('boot timeline collection', () => {
     const collector = createBootTimelineCollector((path) => files[path]);
 
     expect(collector.createEvent(collector.captureEnrollment())).toEqual({
+      boot_timeline_version: 1,
+      telemetry_state: 'unavailable',
       uptime_seconds: 12.25,
       process_start_offset_seconds: 12.25,
       enrollment_offset_seconds: 12.25,

--- a/libs/runner/orchestration/src/core/boot-timeline.test.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.test.ts
@@ -9,7 +9,7 @@ describe('boot timeline collection', () => {
     const files: Record<string, string> = {
       '/proc/uptime': '42.5 0.0',
       '/run/shipfox/boot-io':
-        'root_device=nvme0n1\nread_ops=100\nread_sectors=200\nuptime_seconds=40.0\n',
+        'root_device=nvme0n1\nread_ops=100\nread_sectors=200\nuptime_seconds=35.5\n',
       '/sys/block/nvme0n1/stat': '150 0 250 0 0 0 0 0 0 0 0 0 0 0 0 0 0',
       '/proc/self/stat': systemdStat(4000),
       '/proc/1/stat': systemdStat(100),
@@ -30,7 +30,7 @@ describe('boot timeline collection', () => {
       image_revision: '0123456789abcdef0123456789abcdef01234567',
       boot_read_bytes: 102_400,
       boot_read_ops: 100,
-      boot_read_bytes_per_second: 102_400 / 40,
+      boot_read_bytes_per_second: 102_400 / 35.5,
       runner_read_bytes: 25_600,
       runner_read_ops: 50,
       runner_read_bytes_per_second: 25_600 / 20.5,

--- a/libs/runner/orchestration/src/core/boot-timeline.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.ts
@@ -1,0 +1,203 @@
+import {readFileSync} from 'node:fs';
+
+const BOOT_IO_PATH = '/run/shipfox/boot-io';
+const IMAGE_REVISION_PATH = '/etc/shipfox/image-revision';
+const PROCESS_STAT_PATH = '/proc/self/stat';
+const SYSTEMD_STAT_PATH = '/proc/1/stat';
+const UPTIME_PATH = '/proc/uptime';
+const SYSTEM_CLOCK_TICKS_PER_SECOND = 100;
+const ROOT_DEVICE_PATTERN = /^[a-zA-Z0-9._-]+$/u;
+const WHITESPACE_PATTERN = /\s+/u;
+
+type ReadText = (path: string) => string | undefined;
+
+type DiskReadSample = {
+  readOps: number;
+  readSectors: number;
+};
+
+type BootIoSample = DiskReadSample & {
+  rootDevice: string;
+  uptimeSeconds: number;
+};
+
+type EnrollmentSample = {
+  currentDiskReads?: DiskReadSample;
+  uptimeSeconds?: number;
+};
+
+export type BootTimelineFields = Record<string, number | string>;
+
+function readText(path: string): string | undefined {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function parseNonNegativeNumber(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim() === '') return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function parseUptime(raw: string | undefined): number | undefined {
+  return parseNonNegativeNumber(raw?.trim().split(WHITESPACE_PATTERN)[0]);
+}
+
+function parseKeyValueFile(raw: string | undefined): Record<string, string> {
+  if (raw === undefined) return {};
+
+  return Object.fromEntries(
+    raw
+      .split('\n')
+      .map((line) => line.split('='))
+      .filter(([key, value]) => key !== undefined && value !== undefined)
+      .map(([key, ...value]) => [key, value.join('=')]),
+  );
+}
+
+function parseDiskReadSample(raw: string | undefined): DiskReadSample | undefined {
+  const fields = raw?.trim().split(WHITESPACE_PATTERN);
+  if (!fields || fields.length < 3) return undefined;
+
+  const readOps = parseNonNegativeNumber(fields[0]);
+  const readSectors = parseNonNegativeNumber(fields[2]);
+  if (readOps === undefined || readSectors === undefined) return undefined;
+
+  return {readOps, readSectors};
+}
+
+function parseBootIoSample(raw: string | undefined): BootIoSample | undefined {
+  const values = parseKeyValueFile(raw);
+  const rootDevice = values.root_device;
+  const readOps = parseNonNegativeNumber(values.read_ops);
+  const readSectors = parseNonNegativeNumber(values.read_sectors);
+  const uptimeSeconds = parseNonNegativeNumber(values.uptime_seconds);
+  if (
+    rootDevice === undefined ||
+    !ROOT_DEVICE_PATTERN.test(rootDevice) ||
+    readOps === undefined ||
+    readSectors === undefined ||
+    uptimeSeconds === undefined
+  ) {
+    return undefined;
+  }
+
+  return {rootDevice, readOps, readSectors, uptimeSeconds};
+}
+
+function parseProcessStartSeconds(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+
+  const commandEnd = raw.lastIndexOf(')');
+  if (commandEnd < 0) return undefined;
+
+  const fields = raw
+    .slice(commandEnd + 1)
+    .trim()
+    .split(WHITESPACE_PATTERN);
+  const startTicks = parseNonNegativeNumber(fields[19]);
+  return startTicks === undefined ? undefined : startTicks / SYSTEM_CLOCK_TICKS_PER_SECOND;
+}
+
+function setField(
+  fields: BootTimelineFields,
+  key: string,
+  value: number | string | undefined,
+): void {
+  if (value !== undefined) fields[key] = value;
+}
+
+function readImageRevision(read: ReadText): string | undefined {
+  const bakedRevision = read(IMAGE_REVISION_PATH)?.trim();
+  if (bakedRevision) return bakedRevision;
+
+  const environmentRevision = process.env.IMAGE_REVISION?.trim();
+  return environmentRevision || undefined;
+}
+
+function readEnrollmentSample(read: ReadText): EnrollmentSample {
+  const uptimeSeconds = parseUptime(read(UPTIME_PATH));
+  const bootIo = parseBootIoSample(read(BOOT_IO_PATH));
+  const currentDiskReads =
+    bootIo === undefined
+      ? undefined
+      : parseDiskReadSample(read(`/sys/block/${bootIo.rootDevice}/stat`));
+
+  return {
+    ...(currentDiskReads === undefined ? {} : {currentDiskReads}),
+    ...(uptimeSeconds === undefined ? {} : {uptimeSeconds}),
+  };
+}
+
+function readBootIo(read: ReadText): BootIoSample | undefined {
+  return parseBootIoSample(read(BOOT_IO_PATH));
+}
+
+function addReadFields(
+  fields: BootTimelineFields,
+  processStartSeconds: number | undefined,
+  enrollment: EnrollmentSample,
+  bootIo: BootIoSample | undefined,
+): void {
+  if (bootIo === undefined) return;
+
+  const bootReadBytes = bootIo.readSectors * 512;
+  setField(fields, 'boot_read_bytes', bootReadBytes);
+  setField(fields, 'boot_read_ops', bootIo.readOps);
+
+  if (processStartSeconds !== undefined && processStartSeconds > 0) {
+    setField(fields, 'boot_read_bytes_per_second', bootReadBytes / processStartSeconds);
+  }
+
+  const current = enrollment.currentDiskReads;
+  if (current === undefined) return;
+
+  const runnerReadBytes = Math.max(0, current.readSectors - bootIo.readSectors) * 512;
+  const runnerReadOps = Math.max(0, current.readOps - bootIo.readOps);
+  setField(fields, 'runner_read_bytes', runnerReadBytes);
+  setField(fields, 'runner_read_ops', runnerReadOps);
+
+  const runnerDurationSeconds =
+    processStartSeconds !== undefined && enrollment.uptimeSeconds !== undefined
+      ? enrollment.uptimeSeconds - processStartSeconds
+      : undefined;
+  if (runnerDurationSeconds !== undefined && runnerDurationSeconds > 0) {
+    setField(fields, 'runner_read_bytes_per_second', runnerReadBytes / runnerDurationSeconds);
+  }
+}
+
+export function createBootTimelineCollector(read: ReadText = readText) {
+  const processStartUptimeSeconds = parseUptime(read(UPTIME_PATH));
+  const processStartOffsetSeconds =
+    parseProcessStartSeconds(read(PROCESS_STAT_PATH)) ?? processStartUptimeSeconds;
+
+  return {
+    captureEnrollment(): EnrollmentSample {
+      return readEnrollmentSample(read);
+    },
+
+    createEvent(enrollment: EnrollmentSample): BootTimelineFields {
+      const fields: BootTimelineFields = {};
+      const systemdStartSeconds = parseProcessStartSeconds(read(SYSTEMD_STAT_PATH));
+
+      setField(fields, 'uptime_seconds', processStartUptimeSeconds);
+      setField(fields, 'process_start_offset_seconds', processStartOffsetSeconds);
+      setField(fields, 'enrollment_offset_seconds', enrollment.uptimeSeconds);
+      setField(fields, 'kernel_seconds', systemdStartSeconds);
+      setField(
+        fields,
+        'userspace_seconds',
+        processStartOffsetSeconds !== undefined && systemdStartSeconds !== undefined
+          ? Math.max(0, processStartOffsetSeconds - systemdStartSeconds)
+          : undefined,
+      );
+      setField(fields, 'image_revision', readImageRevision(read));
+      addReadFields(fields, processStartOffsetSeconds, enrollment, readBootIo(read));
+
+      return fields;
+    },
+  };
+}

--- a/libs/runner/orchestration/src/core/boot-timeline.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.ts
@@ -148,8 +148,8 @@ function addReadFields(
   setField(fields, 'boot_read_bytes', bootReadBytes);
   setField(fields, 'boot_read_ops', bootIo.readOps);
 
-  if (processStartSeconds !== undefined && processStartSeconds > 0) {
-    setField(fields, 'boot_read_bytes_per_second', bootReadBytes / processStartSeconds);
+  if (bootIo.uptimeSeconds > 0) {
+    setField(fields, 'boot_read_bytes_per_second', bootReadBytes / bootIo.uptimeSeconds);
   }
 
   const current = enrollment.currentDiskReads;

--- a/libs/runner/orchestration/src/core/boot-timeline.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.ts
@@ -1,4 +1,5 @@
 import {readFileSync} from 'node:fs';
+import {config} from '#config.js';
 
 const BOOT_IO_PATH = '/run/shipfox/boot-io';
 const IMAGE_REVISION_PATH = '/etc/shipfox/image-revision';
@@ -6,7 +7,9 @@ const PROCESS_STAT_PATH = '/proc/self/stat';
 const SYSTEMD_STAT_PATH = '/proc/1/stat';
 const UPTIME_PATH = '/proc/uptime';
 const SYSTEM_CLOCK_TICKS_PER_SECOND = 100;
+const BOOT_TIMELINE_VERSION = 1 as const;
 const ROOT_DEVICE_PATTERN = /^[a-zA-Z0-9._-]+$/u;
+const IMAGE_REVISION_PATTERN = /^[a-zA-Z0-9._-]+$/u;
 const WHITESPACE_PATTERN = /\s+/u;
 
 type ReadText = (path: string) => string | undefined;
@@ -26,7 +29,11 @@ type EnrollmentSample = {
   uptimeSeconds?: number;
 };
 
-export type BootTimelineFields = Record<string, number | string>;
+export type BootTimelineFields = {
+  boot_timeline_version: typeof BOOT_TIMELINE_VERSION;
+  telemetry_state: 'complete' | 'unavailable';
+  [key: string]: number | string;
+};
 
 function readText(path: string): string | undefined {
   try {
@@ -112,19 +119,24 @@ function setField(
 
 function readImageRevision(read: ReadText): string | undefined {
   const bakedRevision = read(IMAGE_REVISION_PATH)?.trim();
-  if (bakedRevision) return bakedRevision;
+  const environmentRevision = config.IMAGE_REVISION?.trim() ?? '';
+  const revision = bakedRevision || environmentRevision;
 
-  const environmentRevision = process.env.IMAGE_REVISION?.trim();
-  return environmentRevision || undefined;
+  if (!revision || revision === 'local' || !IMAGE_REVISION_PATTERN.test(revision)) {
+    return undefined;
+  }
+  return revision;
 }
 
-function readEnrollmentSample(read: ReadText): EnrollmentSample {
+function readDiskReads(read: ReadText, rootDevice: string | undefined): DiskReadSample | undefined {
+  if (rootDevice === undefined) return undefined;
+
+  return parseDiskReadSample(read(`/sys/block/${rootDevice}/stat`));
+}
+
+function readEnrollmentSample(read: ReadText, bootIo: BootIoSample | undefined): EnrollmentSample {
   const uptimeSeconds = parseUptime(read(UPTIME_PATH));
-  const bootIo = parseBootIoSample(read(BOOT_IO_PATH));
-  const currentDiskReads =
-    bootIo === undefined
-      ? undefined
-      : parseDiskReadSample(read(`/sys/block/${bootIo.rootDevice}/stat`));
+  const currentDiskReads = readDiskReads(read, bootIo?.rootDevice);
 
   return {
     ...(currentDiskReads === undefined ? {} : {currentDiskReads}),
@@ -139,6 +151,7 @@ function readBootIo(read: ReadText): BootIoSample | undefined {
 function addReadFields(
   fields: BootTimelineFields,
   processStartSeconds: number | undefined,
+  processStartDiskReads: DiskReadSample | undefined,
   enrollment: EnrollmentSample,
   bootIo: BootIoSample | undefined,
 ): void {
@@ -153,10 +166,11 @@ function addReadFields(
   }
 
   const current = enrollment.currentDiskReads;
-  if (current === undefined) return;
+  if (current === undefined || processStartDiskReads === undefined) return;
 
-  const runnerReadBytes = Math.max(0, current.readSectors - bootIo.readSectors) * 512;
-  const runnerReadOps = Math.max(0, current.readOps - bootIo.readOps);
+  const runnerReadBytes =
+    Math.max(0, current.readSectors - processStartDiskReads.readSectors) * 512;
+  const runnerReadOps = Math.max(0, current.readOps - processStartDiskReads.readOps);
   setField(fields, 'runner_read_bytes', runnerReadBytes);
   setField(fields, 'runner_read_ops', runnerReadOps);
 
@@ -173,14 +187,25 @@ export function createBootTimelineCollector(read: ReadText = readText) {
   const processStartUptimeSeconds = parseUptime(read(UPTIME_PATH));
   const processStartOffsetSeconds =
     parseProcessStartSeconds(read(PROCESS_STAT_PATH)) ?? processStartUptimeSeconds;
+  const bootIo = readBootIo(read);
+  const processStartDiskReads = readDiskReads(read, bootIo?.rootDevice);
 
   return {
     captureEnrollment(): EnrollmentSample {
-      return readEnrollmentSample(read);
+      return readEnrollmentSample(read, bootIo);
     },
 
     createEvent(enrollment: EnrollmentSample): BootTimelineFields {
-      const fields: BootTimelineFields = {};
+      const fields: BootTimelineFields = {
+        boot_timeline_version: BOOT_TIMELINE_VERSION,
+        telemetry_state:
+          bootIo !== undefined &&
+          processStartDiskReads !== undefined &&
+          enrollment.currentDiskReads !== undefined &&
+          enrollment.uptimeSeconds !== undefined
+            ? 'complete'
+            : 'unavailable',
+      };
       const systemdStartSeconds = parseProcessStartSeconds(read(SYSTEMD_STAT_PATH));
 
       setField(fields, 'uptime_seconds', processStartUptimeSeconds);
@@ -195,7 +220,7 @@ export function createBootTimelineCollector(read: ReadText = readText) {
           : undefined,
       );
       setField(fields, 'image_revision', readImageRevision(read));
-      addReadFields(fields, processStartOffsetSeconds, enrollment, readBootIo(read));
+      addReadFields(fields, processStartOffsetSeconds, processStartDiskReads, enrollment, bootIo);
 
       return fields;
     },

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -406,6 +406,7 @@ describe('startRunner', () => {
 
   it('enrolls, waits, activates, and uses the activation session for managed runners', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(0);
+    const info = vi.spyOn(logger(), 'info').mockImplementation(() => undefined);
     vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
     vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
     vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
@@ -441,6 +442,17 @@ describe('startRunner', () => {
     });
     expect(mockRequestJob).toHaveBeenCalledWith('session-token', expect.any(AbortSignal));
     expect(mockInterruptibleSleep).not.toHaveBeenCalled();
+
+    const bootTimelineCalls = info.mock.calls.filter(
+      ([, message]) => message === 'runner.boot_timeline',
+    );
+    expect(bootTimelineCalls).toHaveLength(1);
+    const bootTimelineCallIndex = info.mock.calls.findIndex(
+      ([, message]) => message === 'runner.boot_timeline',
+    );
+    expect(info.mock.invocationCallOrder[bootTimelineCallIndex]).toBeLessThan(
+      mockRequestJob.mock.invocationCallOrder[0] ?? Infinity,
+    );
   });
 
   it('backs off between empty direct polls', async () => {

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -447,6 +447,13 @@ describe('startRunner', () => {
       ([, message]) => message === 'runner.boot_timeline',
     );
     expect(bootTimelineCalls).toHaveLength(1);
+    expect(bootTimelineCalls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        boot_timeline_version: 1,
+        telemetry_state: expect.any(String),
+        provider_kind: 'ec2',
+      }),
+    );
     const bootTimelineCallIndex = info.mock.calls.findIndex(
       ([, message]) => message === 'runner.boot_timeline',
     );

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -45,7 +45,6 @@ import {runJobSteps} from '#core/step-loop.js';
 
 let running = true;
 let warnedAboutUnavailablePiExtensions = false;
-let bootTimelineReported = false;
 const bootTimeline = createBootTimelineCollector();
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
@@ -305,13 +304,7 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
     providerKind: enrollmentConfig.providerKind,
     protocolVersion: enrollmentConfig.protocolVersion,
   });
-  if (!bootTimelineReported) {
-    bootTimelineReported = true;
-    logger().info(
-      bootTimeline.createEvent(bootTimeline.captureEnrollment()),
-      'runner.boot_timeline',
-    );
-  }
+  logger().info(bootTimeline.createEvent(bootTimeline.captureEnrollment()), 'runner.boot_timeline');
   const activationToken =
     enrollmentActivationToken ?? (await waitForRunnerActivation(controlSessionToken));
   if (!activationToken) return undefined;

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -304,7 +304,13 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
     providerKind: enrollmentConfig.providerKind,
     protocolVersion: enrollmentConfig.protocolVersion,
   });
-  logger().info(bootTimeline.createEvent(bootTimeline.captureEnrollment()), 'runner.boot_timeline');
+  logger().info(
+    {
+      ...bootTimeline.createEvent(bootTimeline.captureEnrollment()),
+      provider_kind: enrollmentConfig.providerKind,
+    },
+    'runner.boot_timeline',
+  );
   const activationToken =
     enrollmentActivationToken ?? (await waitForRunnerActivation(controlSessionToken));
   if (!activationToken) return undefined;

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -39,11 +39,14 @@ import {
 } from '@shipfox/runner-workspace';
 import {isTimeoutError} from 'ky';
 import {config} from '#config.js';
+import {createBootTimelineCollector} from '#core/boot-timeline.js';
 import {startHeartbeatLoop} from '#core/heartbeat-loop.js';
 import {runJobSteps} from '#core/step-loop.js';
 
 let running = true;
 let warnedAboutUnavailablePiExtensions = false;
+let bootTimelineReported = false;
+const bootTimeline = createBootTimelineCollector();
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
@@ -302,6 +305,13 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
     providerKind: enrollmentConfig.providerKind,
     protocolVersion: enrollmentConfig.protocolVersion,
   });
+  if (!bootTimelineReported) {
+    bootTimelineReported = true;
+    logger().info(
+      bootTimeline.createEvent(bootTimeline.captureEnrollment()),
+      'runner.boot_timeline',
+    );
+  }
   const activationToken =
     enrollmentActivationToken ?? (await waitForRunnerActivation(controlSessionToken));
   if (!activationToken) return undefined;


### PR DESCRIPTION
Capture the in-guest boot timeline and root-device I/O needed to explain managed runner startup latency.

The runner image records a pre-runner root-device sample and bakes its image revision. Managed runners emit one `runner.boot_timeline` event at enrollment with kernel, userspace, process, and enrollment offsets, boot and runner read counters, and effective rates. This keeps the measurement queryable without changing the enrollment protocol, and the image-side sample is best-effort so it cannot block startup.

Closes ENG-1523

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a single `runner.boot_timeline` event at managed-runner enrollment with in-guest boot timings and root-device reads to explain startup latency. Addresses ENG-1523 and ties metrics to a validated image revision.

- **New Features**
  - Record early boot I/O via `record-boot-io.sh` as systemd `ExecStartPre` (5s timeout); writes `/run/shipfox/boot-io` once and fails gracefully.
  - Bake image revision to `/etc/shipfox/image-revision` from Packer `var.revision` (validated); collector falls back to `IMAGE_REVISION` and ignores `local`.
  - Add `createBootTimelineCollector` to compute kernel/userspace/process/enrollment offsets, correct runner read attribution by capturing process-start disk counters, and report boot/runner bytes|ops and per-second rates with `telemetry_state` and `boot_timeline_version: 1`.
  - Emit `runner.boot_timeline` once at enrollment, before activation/job request, including `provider_kind`; best-effort and non-blocking.
  - Tests cover prestart wiring, script install, parsing/math, missing-telemetry fallback, versioned payload, and event ordering.

<sup>Written for commit 3ee8465603ebca652bb7eec8ab80e464cff631b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

