### PR TITLE
[api-integration-github] Assert GitHub agent routes against declared inputs

### DIFF
--- a/.changeset/assert-github-route-placeholders.md
+++ b/.changeset/assert-github-route-placeholders.md
@@ -2,4 +2,4 @@
 "@shipfox/api-integration-github": patch
 ---
 
-Keep GitHub agent routes aligned with their declared and runtime parameters, including artifact downloads.
+GitHub agent artifact downloads now use GitHub's required zip format and return a temporary download URL.

--- a/.changeset/assert-github-route-placeholders.md
+++ b/.changeset/assert-github-route-placeholders.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Keep GitHub agent routes aligned with their declared and runtime parameters, including artifact downloads.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -275,6 +275,11 @@ const githubOperationRouteCases = [
   },
   {
     toolId: 'add_issue_comment',
+    args: {issue_number: 1, reaction: '+1', body: 'Comment'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues/{issue_number}/comments',
+  },
+  {
+    toolId: 'add_issue_comment',
     args: {comment_id: 1, reaction: '+1'},
     expectedRoute: 'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions',
   },
@@ -305,8 +310,8 @@ const githubOperationRouteCases = [
   {
     toolId: 'sub_issue_write',
     method: 'reprioritize',
-    args: {issue_number: 1, sub_issue_id: 2},
-    expectedRoute: 'PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/{sub_issue_id}',
+    args: {issue_number: 1, sub_issue_id: 2, after_id: 3},
+    expectedRoute: 'PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority',
   },
   {
     toolId: 'pull_request_read',
@@ -384,8 +389,13 @@ const githubOperationRouteCases = [
   },
   {
     toolId: 'add_reply_to_pull_request_comment',
-    args: {comment_id: 1},
-    expectedRoute: 'POST /repos/{owner}/{repo}/pulls/{comment_id}/replies',
+    args: {pull_number: 1, comment_id: 2, body: 'Reply'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
+  },
+  {
+    toolId: 'add_reply_to_pull_request_comment',
+    args: {comment_id: 2, reaction: '+1'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions',
   },
   {
     toolId: 'merge_pull_request',
@@ -736,6 +746,113 @@ describe('github agent tool catalog', () => {
     expect(result).toEqual({
       content: [{type: 'text', text: '{"number":1}'}],
       structuredContent: {number: 1},
+    });
+  });
+
+  it('returns artifact download metadata without buffering archive bytes', async () => {
+    const request = vi.fn(() =>
+      Promise.resolve({
+        status: 302,
+        headers: {
+          location: 'https://objects.example/artifact.zip?token=temporary',
+          'content-type': 'application/zip',
+          'content-length': '1234',
+        },
+        data: new ArrayBuffer(1024),
+      }),
+    );
+    const result = await callGithubToolWithRequest(
+      'actions_get',
+      {
+        method: 'download_workflow_run_artifact',
+        owner: 'shipfox',
+        repo: 'platform',
+        resource_id: '42',
+      },
+      request,
+    );
+    const expected = {
+      archive_format: 'zip',
+      download_url: 'https://objects.example/artifact.zip?token=temporary',
+      artifact_id: '42',
+      content_type: 'application/zip',
+      size_bytes: 1234,
+    };
+
+    expect(request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/actions/artifacts/{resource_id}/zip',
+      {owner: 'shipfox', repo: 'platform', resource_id: '42'},
+    );
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(expected)}],
+      structuredContent: expected,
+    });
+  });
+
+  it('fails artifact downloads without a redirect URL instead of returning an empty success', async () => {
+    const result = await callGithubToolWithRequest(
+      'actions_get',
+      {
+        method: 'download_workflow_run_artifact',
+        owner: 'shipfox',
+        repo: 'platform',
+        resource_id: '42',
+      },
+      vi.fn(() =>
+        Promise.resolve({
+          status: 302,
+          headers: {},
+          data: new ArrayBuffer(0),
+        }),
+      ),
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'GitHub artifact download did not return a download URL'}],
+    });
+  });
+
+  it('projects get_diff request headers through the provider session', async () => {
+    const request = vi.fn(() => Promise.resolve({data: 'diff --git a/file b/file'}));
+    const result = await callGithubToolWithRequest(
+      'pull_request_read',
+      {
+        method: 'get_diff',
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+      },
+      request,
+    );
+
+    expect(request).toHaveBeenCalledWith('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+      owner: 'shipfox',
+      repo: 'platform',
+      pull_number: 2,
+      headers: {accept: 'application/vnd.github.diff'},
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: '{"result":"diff --git a/file b/file"}'}],
+      structuredContent: {result: 'diff --git a/file b/file'},
+    });
+  });
+
+  it('projects issue comment reactions through the provider session', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {id: 7}}));
+    const result = await callGithubToolWithRequest(
+      'add_issue_comment',
+      {owner: 'shipfox', repo: 'platform', issue_number: 1, reaction: '+1'},
+      request,
+    );
+
+    expect(request).toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/issues/{issue_number}/reactions',
+      {owner: 'shipfox', repo: 'platform', issue_number: 1, content: '+1'},
+    );
+    expect(result).toEqual({
+      content: [{type: 'text', text: '{"id":7}'}],
+      structuredContent: {id: 7},
     });
   });
 

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -7,6 +7,8 @@ import {
   type GithubToolClient,
   githubAgentToolCatalog,
   githubAgentToolSelectionCatalog,
+  githubOperationRoute,
+  projectGithubOperationParameters,
 } from '#core/agent-tools.js';
 import {createGithubIntegrationProvider} from '#index.js';
 
@@ -202,6 +204,321 @@ const expectedCatalogRows = [
   },
 ];
 
+type GithubOperationRouteCase = {
+  toolId: GithubAgentToolId;
+  method?: string;
+  args: Record<string, unknown>;
+  expectedRoute: string;
+  runtimeInjectedProperties?: readonly string[];
+};
+
+const githubOperationRouteCases = [
+  {
+    toolId: 'issue_read',
+    method: 'get',
+    args: {issue_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues/{issue_number}',
+  },
+  {
+    toolId: 'issue_read',
+    method: 'get_comments',
+    args: {issue_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues/{issue_number}/comments',
+  },
+  {
+    toolId: 'issue_read',
+    method: 'get_sub_issues',
+    args: {issue_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+  },
+  {
+    toolId: 'issue_read',
+    method: 'get_parent',
+    args: {issue_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues/{issue_number}/parent',
+  },
+  {
+    toolId: 'issue_read',
+    method: 'get_labels',
+    args: {issue_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues/{issue_number}/labels',
+  },
+  {
+    toolId: 'list_issue_types',
+    args: {owner: 'shipfox'},
+    expectedRoute: 'GET /orgs/{owner}/issue-types',
+  },
+  {
+    toolId: 'list_issue_types',
+    args: {owner: 'shipfox', repo: 'platform'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issue-types',
+  },
+  {
+    toolId: 'list_issues',
+    args: {},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues',
+  },
+  {
+    toolId: 'search_issues',
+    args: {},
+    expectedRoute: 'GET /search/issues',
+  },
+  {
+    toolId: 'add_issue_comment',
+    args: {issue_number: 1, body: 'Comment'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues/{issue_number}/comments',
+  },
+  {
+    toolId: 'add_issue_comment',
+    args: {issue_number: 1, reaction: '+1'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues/{issue_number}/reactions',
+  },
+  {
+    toolId: 'add_issue_comment',
+    args: {comment_id: 1, reaction: '+1'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions',
+  },
+  {
+    toolId: 'issue_write',
+    method: 'create',
+    args: {},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues',
+  },
+  {
+    toolId: 'issue_write',
+    method: 'update',
+    args: {issue_number: 1},
+    expectedRoute: 'PATCH /repos/{owner}/{repo}/issues/{issue_number}',
+  },
+  {
+    toolId: 'sub_issue_write',
+    method: 'add',
+    args: {issue_number: 1},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+  },
+  {
+    toolId: 'sub_issue_write',
+    method: 'remove',
+    args: {issue_number: 1, sub_issue_id: 2},
+    expectedRoute: 'DELETE /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/{sub_issue_id}',
+  },
+  {
+    toolId: 'sub_issue_write',
+    method: 'reprioritize',
+    args: {issue_number: 1, sub_issue_id: 2},
+    expectedRoute: 'PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/{sub_issue_id}',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_diff',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_status',
+    args: {pull_number: 1, ref: 'main'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/commits/{ref}/status',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_files',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_commits',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}/commits',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_review_comments',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}/comments',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_reviews',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_comments',
+    args: {pull_number: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/issues/{pull_number}/comments',
+  },
+  {
+    toolId: 'pull_request_read',
+    method: 'get_check_runs',
+    args: {pull_number: 1, ref: 'main'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/commits/{ref}/check-runs',
+  },
+  {
+    toolId: 'list_pull_requests',
+    args: {},
+    expectedRoute: 'GET /repos/{owner}/{repo}/pulls',
+  },
+  {
+    toolId: 'search_pull_requests',
+    args: {},
+    expectedRoute: 'GET /search/issues',
+  },
+  {
+    toolId: 'create_pull_request',
+    args: {},
+    expectedRoute: 'POST /repos/{owner}/{repo}/pulls',
+  },
+  {
+    toolId: 'update_pull_request',
+    args: {pull_number: 1},
+    expectedRoute: 'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+  },
+  {
+    toolId: 'add_reply_to_pull_request_comment',
+    args: {comment_id: 1},
+    expectedRoute: 'POST /repos/{owner}/{repo}/pulls/{comment_id}/replies',
+  },
+  {
+    toolId: 'merge_pull_request',
+    args: {pull_number: 1},
+    expectedRoute: 'PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge',
+  },
+  {
+    toolId: 'update_pull_request_branch',
+    args: {pull_number: 1},
+    expectedRoute: 'PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch',
+  },
+  {
+    toolId: 'pull_request_review_write',
+    method: 'create',
+    args: {pull_number: 1},
+    expectedRoute: 'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+  },
+  {
+    toolId: 'pull_request_review_write',
+    method: 'submit_pending',
+    args: {pull_number: 1},
+    runtimeInjectedProperties: ['review_id'],
+    expectedRoute: 'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events',
+  },
+  {
+    toolId: 'pull_request_review_write',
+    method: 'delete_pending',
+    args: {pull_number: 1},
+    runtimeInjectedProperties: ['review_id'],
+    expectedRoute: 'DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}',
+  },
+  {
+    toolId: 'add_comment_to_pending_review',
+    args: {pull_number: 1, path: 'src/index.ts', body: 'Comment'},
+    expectedRoute: 'POST /graphql',
+  },
+  {
+    toolId: 'actions_list',
+    method: 'list_workflows',
+    args: {},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/workflows',
+  },
+  {
+    toolId: 'actions_list',
+    method: 'list_workflow_runs',
+    args: {resource_id: 'workflow'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/workflows/{resource_id}/runs',
+  },
+  {
+    toolId: 'actions_list',
+    method: 'list_workflow_jobs',
+    args: {resource_id: 'run'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/runs/{resource_id}/jobs',
+  },
+  {
+    toolId: 'actions_list',
+    method: 'list_workflow_run_artifacts',
+    args: {resource_id: 'run'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/runs/{resource_id}/artifacts',
+  },
+  {
+    toolId: 'actions_get',
+    method: 'get_workflow',
+    args: {resource_id: 'workflow'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/workflows/{resource_id}',
+  },
+  {
+    toolId: 'actions_get',
+    method: 'get_workflow_run',
+    args: {resource_id: 'run'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/runs/{resource_id}',
+  },
+  {
+    toolId: 'actions_get',
+    method: 'get_workflow_job',
+    args: {resource_id: 'job'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/jobs/{resource_id}',
+  },
+  {
+    toolId: 'actions_get',
+    method: 'download_workflow_run_artifact',
+    args: {resource_id: 'artifact'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/artifacts/{resource_id}/zip',
+  },
+  {
+    toolId: 'actions_get',
+    method: 'get_workflow_run_usage',
+    args: {resource_id: 'run'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/runs/{resource_id}/timing',
+  },
+  {
+    toolId: 'actions_get',
+    method: 'get_workflow_run_logs_url',
+    args: {resource_id: 'run'},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/runs/{resource_id}/logs',
+  },
+  {
+    toolId: 'actions_run_trigger',
+    method: 'run_workflow',
+    args: {workflow_id: 'ci.yml', ref: 'main'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches',
+  },
+  {
+    toolId: 'actions_run_trigger',
+    method: 'rerun_workflow_run',
+    args: {run_id: 1},
+    expectedRoute: 'POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun',
+  },
+  {
+    toolId: 'actions_run_trigger',
+    method: 'rerun_failed_jobs',
+    args: {run_id: 1},
+    expectedRoute: 'POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs',
+  },
+  {
+    toolId: 'actions_run_trigger',
+    method: 'cancel_workflow_run',
+    args: {run_id: 1},
+    expectedRoute: 'POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel',
+  },
+  {
+    toolId: 'actions_run_trigger',
+    method: 'delete_workflow_run_logs',
+    args: {run_id: 1},
+    expectedRoute: 'DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs',
+  },
+  {
+    toolId: 'get_job_logs',
+    args: {job_id: 1},
+    expectedRoute: 'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+  },
+] satisfies readonly GithubOperationRouteCase[];
+
 describe('github agent tool catalog', () => {
   it('matches the GitHub MCP-style tool rows', () => {
     const rows = githubAgentToolCatalog.map(
@@ -216,6 +533,57 @@ describe('github agent tool catalog', () => {
     );
 
     expect(rows).toEqual(expectedCatalogRows);
+  });
+
+  it('covers every catalog operation with an exact route case', () => {
+    const catalogOperationKeys = githubAgentToolCatalog.flatMap(
+      (entry) =>
+        entry.methods?.map((method) => operationKey(entry.id, method.id)) ?? [
+          operationKey(entry.id),
+        ],
+    );
+    const routeCaseOperationKeys = githubOperationRouteCases.map(({toolId, method}) =>
+      operationKey(toolId, method),
+    );
+
+    expect([...new Set(routeCaseOperationKeys)].sort()).toEqual(
+      [...new Set(catalogOperationKeys)].sort(),
+    );
+  });
+
+  it.each(
+    githubOperationRouteCases,
+  )('asserts the $toolId.$method route and its input placeholders', ({
+    toolId,
+    method,
+    args,
+    expectedRoute,
+    runtimeInjectedProperties = [],
+  }) => {
+    const route = githubOperationRoute(toolId, method, args);
+
+    expect(route).toBe(expectedRoute);
+    if (route === undefined) return;
+
+    const inputProperties = new Set(Object.keys(inputSchemaFor(toolId).properties ?? {}));
+    const undeclaredArguments = Object.keys(args).filter((name) => !inputProperties.has(name));
+    expect(undeclaredArguments).toEqual([]);
+
+    const projectedParameters = projectGithubOperationParameters(toolId, method, args);
+    const injectedProperties = new Set([
+      ...runtimeInjectedProperties,
+      ...Object.keys(projectedParameters).filter(
+        (name) => !inputProperties.has(name) && !Object.hasOwn(args, name),
+      ),
+    ]);
+    const placeholders = Array.from(route.matchAll(/\{([^{}]+)\}/g), (match) => match[1]).filter(
+      (name): name is string => name !== undefined,
+    );
+    const undeclaredPlaceholders = placeholders.filter(
+      (name) => !inputProperties.has(name) && !injectedProperties.has(name),
+    );
+
+    expect(undeclaredPlaceholders).toEqual([]);
   });
 
   it('defines descriptions and schemas for every tool and method', () => {
@@ -939,4 +1307,8 @@ function inputSchemaFor(id: (typeof githubAgentToolCatalog)[number]['id']) {
     anyOf?: unknown[] | undefined;
     oneOf?: unknown[] | undefined;
   };
+}
+
+function operationKey(toolId: GithubAgentToolId, method?: string) {
+  return `${toolId}.${method ?? ''}`;
 }

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -50,6 +50,7 @@ type GithubToolCallResult = {
 };
 
 const GITHUB_GRAPHQL_ROUTE = 'POST /graphql';
+const GITHUB_ARTIFACT_ARCHIVE_FORMAT = 'zip';
 const NO_PENDING_REVIEW_MESSAGE =
   'No pending pull request review found for the authenticated GitHub user.';
 
@@ -231,7 +232,7 @@ function resolveGithubOperation(
       };
 }
 
-function githubOperationRoute(
+export function githubOperationRoute(
   toolId: GithubAgentToolId,
   method: string | undefined,
   args: Record<string, unknown>,
@@ -334,7 +335,7 @@ function githubOperationRoute(
     case 'actions_get.get_workflow_job':
       return `GET ${repoPath}/actions/jobs/${resource}`;
     case 'actions_get.download_workflow_run_artifact':
-      return `GET ${repoPath}/actions/artifacts/${resource}/{archive_format}`;
+      return `GET ${repoPath}/actions/artifacts/${resource}/${GITHUB_ARTIFACT_ARCHIVE_FORMAT}`;
     case 'actions_get.get_workflow_run_usage':
       return `GET ${repoPath}/actions/runs/${resource}/timing`;
     case 'actions_get.get_workflow_run_logs_url':
@@ -414,7 +415,7 @@ function latestPendingReviewNodeId(data: unknown): string | undefined {
   return latest?.id;
 }
 
-function projectGithubOperationParameters(
+export function projectGithubOperationParameters(
   toolId: GithubAgentToolId,
   method: string | undefined,
   args: Record<string, unknown>,

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -51,6 +51,8 @@ type GithubToolCallResult = {
 
 const GITHUB_GRAPHQL_ROUTE = 'POST /graphql';
 const GITHUB_ARTIFACT_ARCHIVE_FORMAT = 'zip';
+const GITHUB_ARTIFACT_DOWNLOAD_ROUTE = `GET /repos/{owner}/{repo}/actions/artifacts/{resource_id}/${GITHUB_ARTIFACT_ARCHIVE_FORMAT}`;
+const GITHUB_ARTIFACT_DOWNLOAD_TIMEOUT_MS = 30_000;
 const NO_PENDING_REVIEW_MESSAGE =
   'No pending pull request review found for the authenticated GitHub user.';
 
@@ -171,7 +173,13 @@ export class GithubAgentToolsProvider
         const response = await mapGithubError(() =>
           client.request(operation.route, operationParameters),
         );
-        return githubToolResult(tool.id as GithubAgentToolId, response.data);
+        return githubToolResult(
+          tool.id as GithubAgentToolId,
+          response.data,
+          response,
+          operationParameters,
+          operation.route,
+        );
       },
     };
   }
@@ -185,8 +193,15 @@ export interface GithubAgentToolsProviderOptions {
   createClient?: GithubToolClientFactory | undefined;
 }
 
+export interface GithubToolResponse {
+  data: unknown;
+  headers?: Record<string, string | number | undefined> | undefined;
+  status?: number | undefined;
+  url?: string | undefined;
+}
+
 export interface GithubToolClient {
-  request(route: string, parameters: Record<string, unknown>): Promise<{data: unknown}>;
+  request(route: string, parameters: Record<string, unknown>): Promise<GithubToolResponse>;
   graphql?: ((query: string, variables: Record<string, unknown>) => Promise<unknown>) | undefined;
 }
 
@@ -205,7 +220,29 @@ function createOctokitClient(token: string): GithubToolClient {
     retry: {enabled: false},
   });
   return {
-    request: async (route, parameters) => await octokit.request(route, parameters),
+    request: async (route, parameters) => {
+      if (route !== GITHUB_ARTIFACT_DOWNLOAD_ROUTE) {
+        return await octokit.request(route, parameters);
+      }
+
+      const abortController = new AbortController();
+      const timeout = setTimeout(
+        () => abortController.abort(),
+        GITHUB_ARTIFACT_DOWNLOAD_TIMEOUT_MS,
+      );
+      try {
+        return await octokit.request(route, {
+          ...parameters,
+          request: {
+            redirect: 'manual',
+            parseSuccessResponseBody: false,
+            signal: abortController.signal,
+          },
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
     graphql: async (query, variables) => await octokit.graphql(query, variables),
   };
 }
@@ -279,7 +316,7 @@ export function githubOperationRoute(
     case 'sub_issue_write.remove':
       return `DELETE ${repoPath}/issues/${issue}/sub_issues/{sub_issue_id}`;
     case 'sub_issue_write.reprioritize':
-      return `PATCH ${repoPath}/issues/${issue}/sub_issues/{sub_issue_id}`;
+      return `PATCH ${repoPath}/issues/${issue}/sub_issues/priority`;
     case 'pull_request_read.get':
       return `GET ${repoPath}/pulls/${pull}`;
     case 'pull_request_read.get_diff':
@@ -307,7 +344,9 @@ export function githubOperationRoute(
     case 'update_pull_request.':
       return `PATCH ${repoPath}/pulls/${pull}`;
     case 'add_reply_to_pull_request_comment.':
-      return `POST ${repoPath}/pulls/{comment_id}/replies`;
+      return args.reaction !== undefined && args.body === undefined
+        ? `POST ${repoPath}/pulls/comments/{comment_id}/reactions`
+        : `POST ${repoPath}/pulls/${pull}/comments/{comment_id}/replies`;
     case 'merge_pull_request.':
       return `PUT ${repoPath}/pulls/${pull}/merge`;
     case 'update_pull_request_branch.':
@@ -335,7 +374,7 @@ export function githubOperationRoute(
     case 'actions_get.get_workflow_job':
       return `GET ${repoPath}/actions/jobs/${resource}`;
     case 'actions_get.download_workflow_run_artifact':
-      return `GET ${repoPath}/actions/artifacts/${resource}/${GITHUB_ARTIFACT_ARCHIVE_FORMAT}`;
+      return GITHUB_ARTIFACT_DOWNLOAD_ROUTE;
     case 'actions_get.get_workflow_run_usage':
       return `GET ${repoPath}/actions/runs/${resource}/timing`;
     case 'actions_get.get_workflow_run_logs_url':
@@ -485,8 +524,17 @@ function latestPendingReviewIdOnPage(data: readonly unknown[]): number | undefin
   return undefined;
 }
 
-function githubToolResult(toolId: GithubAgentToolId, data: unknown): GithubToolCallResult {
-  const structuredContent = projectGithubToolOutput(toolId, data);
+function githubToolResult(
+  toolId: GithubAgentToolId,
+  data: unknown,
+  response?: GithubToolResponse,
+  parameters?: Record<string, unknown>,
+  route?: string,
+): GithubToolCallResult {
+  const structuredContent = projectGithubToolOutput(toolId, data, response, parameters, route);
+  if (structuredContent === undefined) {
+    return githubToolError('GitHub artifact download did not return a download URL');
+  }
   return {
     content: [{type: 'text', text: JSON.stringify(structuredContent)}],
     structuredContent,
@@ -496,7 +544,14 @@ function githubToolResult(toolId: GithubAgentToolId, data: unknown): GithubToolC
 function projectGithubToolOutput(
   toolId: GithubAgentToolId,
   data: unknown,
-): Record<string, unknown> {
+  response?: GithubToolResponse,
+  parameters?: Record<string, unknown>,
+  route?: string,
+): Record<string, unknown> | undefined {
+  if (route === GITHUB_ARTIFACT_DOWNLOAD_ROUTE) {
+    return projectGithubArtifactDownloadOutput(response, parameters);
+  }
+
   switch (toolId) {
     case 'list_issue_types':
       return {issue_types: data};
@@ -516,6 +571,30 @@ function projectGithubToolOutput(
     default:
       return isRecord(data) ? data : {result: data};
   }
+}
+
+function projectGithubArtifactDownloadOutput(
+  response: GithubToolResponse | undefined,
+  parameters: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (response === undefined) return undefined;
+  const downloadUrl = response.headers?.location;
+  if (typeof downloadUrl !== 'string' || downloadUrl.length === 0) return undefined;
+
+  const output: Record<string, unknown> = {
+    archive_format: GITHUB_ARTIFACT_ARCHIVE_FORMAT,
+    download_url: downloadUrl,
+  };
+  if (typeof parameters?.resource_id === 'string') output.artifact_id = parameters.resource_id;
+
+  const contentType = response.headers?.['content-type'];
+  if (typeof contentType === 'string') output.content_type = contentType;
+
+  const contentLength = response.headers?.['content-length'];
+  const sizeBytes = typeof contentLength === 'number' ? contentLength : Number(contentLength);
+  if (Number.isSafeInteger(sizeBytes) && sizeBytes >= 0) output.size_bytes = sizeBytes;
+
+  return output;
 }
 
 function githubSearchItems(data: unknown): unknown {


### PR DESCRIPTION
Closes ENG-1562

Add an exhaustive route contract for every GitHub agent tool operation. The contract checks exact routes, keeps route cases synchronized with the catalog, and verifies that route placeholders are declared or explicitly runtime-injected. It also aligns artifact downloads with GitHub's required zip format and the landed pending-review and GraphQL paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce exact route–input contracts for all GitHub agent tools and switch artifact downloads to the required zip route with redirect metadata. Fulfills ENG-1562 and keeps the catalog and runtime routes in sync.

- **New Features**
  - Added exhaustive route cases and assertions; exported `githubOperationRoute` and `projectGithubOperationParameters`.
  - Validate that route placeholders come from inputs or are runtime-injected (e.g., review_id); covers GraphQL and pending-review paths.
  - Route/behavior fixes: sub-issue reprioritize uses `/priority`; reactions use correct endpoints for issue and PR comments; `get_diff` sets the diff Accept header; artifact downloads use `/zip`, follow manual redirect without buffering, return a temporary URL, and fail with an error if no URL is present.

<sup>Written for commit 94d1319ea9f5a98229373c1e8c8367bdf163f0b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

