### PR TITLE
[api-integration-github] Prepare for stateless installation tokens

### DIFF
--- a/.changeset/calm-tokens-travel.md
+++ b/.changeset/calm-tokens-travel.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-integration-github': patch
+---
+
+Request stateless GitHub App installation tokens during the format rollout.

--- a/.changeset/calm-tokens-travel.md
+++ b/.changeset/calm-tokens-travel.md
@@ -2,4 +2,4 @@
 '@shipfox/api-integration-github': patch
 ---
 
-Request stateless GitHub App installation tokens during the format rollout.
+Support both stateless and stateful GitHub App installation token formats.

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -196,6 +196,8 @@ export function e2eEnv(sourceEnv) {
     GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
     HOST: sourceEnv.HOST ?? '0.0.0.0',
     GITHUB_API_BASE_URL: githubApiBaseUrl,
+    GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE:
+      sourceEnv.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE ?? 'enabled',
     GITHUB_APP_CLIENT_ID: sourceEnv.GITHUB_APP_CLIENT_ID ?? 'e2e-github-client-id',
     GITHUB_APP_CLIENT_SECRET: sourceEnv.GITHUB_APP_CLIENT_SECRET ?? 'e2e-github-client-secret',
     GITHUB_APP_ID: sourceEnv.GITHUB_APP_ID ?? '1',

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -75,6 +75,7 @@ describe('e2eEnv', () => {
       'This E2E deployment does not accept new accounts.',
     );
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:55361/');
+    assert.equal(env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE, 'enabled');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:55362/');
     assert.match(env.GITHUB_APP_PRIVATE_KEY, /BEGIN PRIVATE KEY/u);
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:55360/mcp');
@@ -92,6 +93,7 @@ describe('e2eEnv', () => {
       GITEA_CLONE_BASE_URL: 'http://localhost:3000',
       LINEAR_MCP_ENDPOINT: 'http://127.0.0.1:16120/mcp',
       GITHUB_API_BASE_URL: 'http://127.0.0.1:16121',
+      GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE: 'disabled',
       SLACK_API_BASE_URL: 'http://127.0.0.1:16122',
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
@@ -107,6 +109,7 @@ describe('e2eEnv', () => {
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:3000');
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:16120/mcp');
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
+    assert.equal(env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE, 'disabled');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:16122');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
     assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'false');

--- a/e2e/suites/flow/workflows/src/github-api.test.ts
+++ b/e2e/suites/flow/workflows/src/github-api.test.ts
@@ -12,7 +12,11 @@ describe('GitHub API mock', () => {
     try {
       const mint = await fetch(new URL('/app/installations/1234/access_tokens', mock.endpoint), {
         method: 'POST',
-        headers: {authorization: 'Bearer app-jwt', 'content-type': 'application/json'},
+        headers: {
+          authorization: 'Bearer app-jwt',
+          'content-type': 'application/json',
+          'x-github-stateless-s2s-token': 'enabled',
+        },
         body: '{}',
       });
       const read = await fetch(new URL('/repos/shipfox/e2e/issues/1', mock.endpoint), {
@@ -28,6 +32,7 @@ describe('GitHub API mock', () => {
       });
 
       expect(mint.status).toBe(201);
+      expect(GITHUB_INSTALLATION_TOKEN).toHaveLength(520);
       await expect(mint.json()).resolves.toMatchObject({
         token: GITHUB_INSTALLATION_TOKEN,
         permissions: {issues: 'write'},
@@ -38,6 +43,7 @@ describe('GitHub API mock', () => {
         {
           kind: 'mint-token',
           authorization: 'Bearer app-jwt',
+          tokenFormatOverride: 'enabled',
           installationId: 1234,
           body: {},
         },

--- a/e2e/suites/flow/workflows/src/github-api.test.ts
+++ b/e2e/suites/flow/workflows/src/github-api.test.ts
@@ -1,13 +1,30 @@
 import {
-  GITHUB_INSTALLATION_TOKEN,
   GITHUB_READ_RESULT_MARKER,
+  GITHUB_STATEFUL_INSTALLATION_TOKEN,
+  GITHUB_STATELESS_INSTALLATION_TOKEN,
   GITHUB_WRITE_RESULT_MARKER,
   startGithubApiMock,
 } from './github-api.js';
 
+const GITHUB_INSTALLATION_TOKEN_PATTERN = /^ghs_[A-Za-z0-9._-]{36,}$/u;
+
 describe('GitHub API mock', () => {
-  it('serves installation-token, issue-read, and issue-write requests', async () => {
-    const mock = await startGithubApiMock(new URL('http://127.0.0.1:0'));
+  it.each([
+    {
+      format: 'stateless',
+      token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+      authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+    },
+    {
+      format: 'stateful',
+      token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
+      authorization: `token ${GITHUB_STATEFUL_INSTALLATION_TOKEN}`,
+    },
+  ])('serves $format installation-token and issue requests', async ({token, authorization}) => {
+    const mock = await startGithubApiMock({
+      endpoint: new URL('http://127.0.0.1:0'),
+      installationToken: token,
+    });
 
     try {
       const mint = await fetch(new URL('/app/installations/1234/access_tokens', mock.endpoint), {
@@ -20,21 +37,21 @@ describe('GitHub API mock', () => {
         body: '{}',
       });
       const read = await fetch(new URL('/repos/shipfox/e2e/issues/1', mock.endpoint), {
-        headers: {authorization: `token ${GITHUB_INSTALLATION_TOKEN}`},
+        headers: {authorization},
       });
       const write = await fetch(new URL('/repos/shipfox/e2e/issues', mock.endpoint), {
         method: 'POST',
         headers: {
-          authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+          authorization,
           'content-type': 'application/json',
         },
         body: JSON.stringify({title: 'Synthetic issue'}),
       });
 
       expect(mint.status).toBe(201);
-      expect(GITHUB_INSTALLATION_TOKEN).toHaveLength(520);
+      expect(token).toMatch(GITHUB_INSTALLATION_TOKEN_PATTERN);
       await expect(mint.json()).resolves.toMatchObject({
-        token: GITHUB_INSTALLATION_TOKEN,
+        token,
         permissions: {issues: 'write'},
       });
       await expect(read.json()).resolves.toMatchObject({marker: GITHUB_READ_RESULT_MARKER});
@@ -49,14 +66,14 @@ describe('GitHub API mock', () => {
         },
         {
           kind: 'read-issue',
-          authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+          authorization,
           owner: 'shipfox',
           repo: 'e2e',
           issueNumber: 1,
         },
         {
           kind: 'create-issue',
-          authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+          authorization,
           owner: 'shipfox',
           repo: 'e2e',
           body: {title: 'Synthetic issue'},

--- a/e2e/suites/flow/workflows/src/github-api.ts
+++ b/e2e/suites/flow/workflows/src/github-api.ts
@@ -6,7 +6,12 @@ import {
   type ServerResponse,
 } from 'node:http';
 
-export const GITHUB_INSTALLATION_TOKEN = 'github-e2e-installation-token';
+const JWT_SEGMENT_LENGTH = 169;
+
+export const GITHUB_INSTALLATION_TOKEN =
+  `ghs_123456_${'a'.repeat(JWT_SEGMENT_LENGTH)}` +
+  `.${'b'.repeat(JWT_SEGMENT_LENGTH)}` +
+  `.${'c'.repeat(JWT_SEGMENT_LENGTH)}`;
 export const GITHUB_READ_RESULT_MARKER = 'github-read-result-marker';
 export const GITHUB_WRITE_RESULT_MARKER = 'github-write-result-marker';
 
@@ -18,6 +23,7 @@ export type GithubApiMockCall =
   | {
       kind: 'mint-token';
       authorization: string | undefined;
+      tokenFormatOverride: string | undefined;
       installationId: number;
       body: Record<string, unknown>;
     }
@@ -86,6 +92,7 @@ async function handleGithubRequest(params: {
     params.calls.push({
       kind: 'mint-token',
       authorization,
+      tokenFormatOverride: singleHeader(params.request.headers['x-github-stateless-s2s-token']),
       installationId: Number(mintMatch[1]),
       body: await readJsonBody(params.request),
     });
@@ -130,6 +137,10 @@ async function handleGithubRequest(params: {
   }
 
   sendJson(params.response, 404, {message: 'Not Found'});
+}
+
+function singleHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value.join(', ') : value;
 }
 
 function requiredGithubApiBaseUrl(): string {

--- a/e2e/suites/flow/workflows/src/github-api.ts
+++ b/e2e/suites/flow/workflows/src/github-api.ts
@@ -8,10 +8,11 @@ import {
 
 const JWT_SEGMENT_LENGTH = 169;
 
-export const GITHUB_INSTALLATION_TOKEN =
+export const GITHUB_STATELESS_INSTALLATION_TOKEN =
   `ghs_123456_${'a'.repeat(JWT_SEGMENT_LENGTH)}` +
   `.${'b'.repeat(JWT_SEGMENT_LENGTH)}` +
   `.${'c'.repeat(JWT_SEGMENT_LENGTH)}`;
+export const GITHUB_STATEFUL_INSTALLATION_TOKEN = `ghs_${'d'.repeat(36)}`;
 export const GITHUB_READ_RESULT_MARKER = 'github-read-result-marker';
 export const GITHUB_WRITE_RESULT_MARKER = 'github-write-result-marker';
 
@@ -48,13 +49,26 @@ export interface GithubApiMock {
   stop(): Promise<void>;
 }
 
+export interface GithubApiMockOptions {
+  endpoint?: URL | undefined;
+  installationToken?: string | undefined;
+}
+
 export async function startGithubApiMock(
-  endpoint = new URL(requiredGithubApiBaseUrl()),
+  options: GithubApiMockOptions = {},
 ): Promise<GithubApiMock> {
   const calls: GithubApiMockCall[] = [];
+  const installationToken = options.installationToken ?? GITHUB_STATELESS_INSTALLATION_TOKEN;
+  const endpoint = options.endpoint ?? new URL(requiredGithubApiBaseUrl());
   let boundEndpoint = endpoint;
   const server = createServer((request, response) => {
-    void handleGithubRequest({calls, endpoint: boundEndpoint, request, response});
+    void handleGithubRequest({
+      calls,
+      endpoint: boundEndpoint,
+      installationToken,
+      request,
+      response,
+    });
   });
 
   try {
@@ -79,6 +93,7 @@ export async function startGithubApiMock(
 async function handleGithubRequest(params: {
   calls: GithubApiMockCall[];
   endpoint: URL;
+  installationToken: string;
   request: IncomingMessage;
   response: ServerResponse;
 }): Promise<void> {
@@ -97,7 +112,7 @@ async function handleGithubRequest(params: {
       body: await readJsonBody(params.request),
     });
     sendJson(params.response, 201, {
-      token: GITHUB_INSTALLATION_TOKEN,
+      token: params.installationToken,
       expires_at: '2099-01-01T00:00:00.000Z',
       permissions: {issues: 'write'},
       repository_selection: 'all',

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -9,8 +9,9 @@ import {
   fetchLogAttachment,
 } from '#attachments.js';
 import {
-  GITHUB_INSTALLATION_TOKEN,
   GITHUB_READ_RESULT_MARKER,
+  GITHUB_STATEFUL_INSTALLATION_TOKEN,
+  GITHUB_STATELESS_INSTALLATION_TOKEN,
   GITHUB_WRITE_RESULT_MARKER,
   startGithubApiMock,
 } from '#github-api.js';
@@ -23,149 +24,165 @@ import {expect, test} from './fixtures.js';
 const CLAUDE_AGENT_MODEL = 'deterministic-github-tools-agent';
 const TERMINAL_TIMEOUT_MS = 60_000;
 const BEARER_AUTHORIZATION = /^bearer /iu;
+const GITHUB_TOKEN_CASES = [
+  {
+    format: 'stateless',
+    token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+    authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+  },
+  {
+    format: 'stateful',
+    token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
+    authorization: `token ${GITHUB_STATEFUL_INSTALLATION_TOKEN}`,
+  },
+] as const;
 
 test.describe.configure({mode: 'serial'});
 
-test('runs selected GitHub tools and denies unselected authority', async ({suite}, testInfo) => {
-  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
-  const installationId = Number.parseInt(uniqueId.slice(0, 7), 16) + 1;
-  const githubApi = await startGithubApiMock();
-  let fakeModelProvider: Awaited<ReturnType<typeof startFakeOpenAiModelProvider>> | undefined;
+for (const tokenCase of GITHUB_TOKEN_CASES) {
+  test(`runs selected GitHub tools with a ${tokenCase.format} token`, async ({suite}, testInfo) => {
+    const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+    const installationId = Number.parseInt(uniqueId.slice(0, 7), 16) + 1;
+    const githubApi = await startGithubApiMock({installationToken: tokenCase.token});
+    let fakeModelProvider: Awaited<ReturnType<typeof startFakeOpenAiModelProvider>> | undefined;
 
-  try {
-    const scriptId = `${suite.runId}-github-agent-tools-${uniqueId}`;
-    fakeModelProvider = await startFakeOpenAiModelProvider({
-      runId: `${suite.runId}-github-agent-tools-${uniqueId}`,
-    });
-    const connection = await createGithubConnection({
-      workspaceId: suite.workspaceId,
-      installationId,
-      accountLogin: `e${uniqueId.slice(0, 5)}`,
-      displayName: `GitHub E2E ${uniqueId}`,
-      installerUserId: crypto.randomUUID(),
-    });
-    const issueReadTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_read`;
-    const issueWriteTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_write`;
-    const addIssueCommentTool = `mcp__shipfox_integration_tools__${connection.slug}__add_issue_comment`;
-    const fakeAnthropic = await createAnthropicFakeModelProviderConfig({
-      workspaceId: suite.workspaceId,
-      fakeModelProvider,
-      scriptId,
-      model: CLAUDE_AGENT_MODEL,
-      responses: [
-        toolCall(issueReadTool, {
-          method: 'get',
-          owner: 'shipfox',
-          repo: 'e2e',
-          issue_number: 1,
-        }),
-        toolCall(issueWriteTool, {
-          method: 'create',
-          owner: 'shipfox',
-          repo: 'e2e',
-          title: 'Synthetic GitHub issue',
-        }),
-        toolCall(issueReadTool, {
-          method: 'get_comments',
-          owner: 'shipfox',
-          repo: 'e2e',
-          issue_number: 1,
-        }),
-        toolCall(addIssueCommentTool, {
-          owner: 'shipfox',
-          repo: 'e2e',
-          issue_number: 1,
-          body: 'This tool was not selected',
-        }),
-        message('done'),
-      ],
-      assertions: [
-        {kind: 'model', equals: CLAUDE_AGENT_MODEL},
-        {kind: 'tool_present', name: issueReadTool},
-        {kind: 'tool_present', name: issueWriteTool},
-        {kind: 'tool_absent', name: addIssueCommentTool},
-        {
-          kind: 'message_content_includes',
-          value: GITHUB_READ_RESULT_MARKER,
-          minRequestIndex: 1,
-        },
-        {
-          kind: 'message_content_includes',
-          value: GITHUB_WRITE_RESULT_MARKER,
-          minRequestIndex: 2,
-        },
-        {
-          kind: 'message_content_includes',
-          value: 'Unauthorized integration tool method: get_comments',
-          minRequestIndex: 3,
-        },
-        {
-          kind: 'message_content_includes',
-          value: 'No such tool available:',
-          minRequestIndex: 4,
-        },
-      ],
-      setAsDefault: true,
-    });
-
-    const terminal = await runGithubToolsWorkflow({
-      suite,
-      testInfo,
-      uniqueId,
-      connectionSlug: connection.slug,
-      runnerEnv: fakeAnthropic.runnerEnv,
-    });
-
-    expect(terminal.status).toBe('succeeded');
-    expect(terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
-    const providerRequests = await fakeModelProvider.getRequests(scriptId);
-    expect(providerRequests).toHaveLength(6);
-    expect(providerRequests[0]).toMatchObject({
-      model: `${CLAUDE_AGENT_MODEL}-small-fast`,
-      served_response: 'message:non_consuming_model',
-    });
-    expect(providerRequests.filter((request) => request.model === CLAUDE_AGENT_MODEL)).toHaveLength(
-      5,
-    );
-    expect(providerRequests.every((request) => request.assertion_failures.length === 0)).toBe(true);
-    expect(githubApi.calls).toEqual([
-      {
-        kind: 'mint-token',
-        authorization: expect.stringMatching(BEARER_AUTHORIZATION),
-        tokenFormatOverride: 'enabled',
+    try {
+      const scriptId = `${suite.runId}-github-agent-tools-${uniqueId}`;
+      fakeModelProvider = await startFakeOpenAiModelProvider({
+        runId: `${suite.runId}-github-agent-tools-${uniqueId}`,
+      });
+      const connection = await createGithubConnection({
+        workspaceId: suite.workspaceId,
         installationId,
-        body: {},
-      },
-      {
-        kind: 'read-issue',
-        authorization: `bearer ${GITHUB_INSTALLATION_TOKEN}`,
-        owner: 'shipfox',
-        repo: 'e2e',
-        issueNumber: 1,
-      },
-      {
-        kind: 'create-issue',
-        authorization: `bearer ${GITHUB_INSTALLATION_TOKEN}`,
-        owner: 'shipfox',
-        repo: 'e2e',
-        body: {title: 'Synthetic GitHub issue'},
-      },
-    ]);
-  } finally {
-    await Promise.all([
-      fakeModelProvider?.stop()?.catch((error: unknown) => {
-        process.stderr.write(
-          `github-agent-tools-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
-        );
-      }) ?? Promise.resolve(),
-      githubApi.stop().catch((error: unknown) => {
-        process.stderr.write(
-          `github-agent-tools-e2e: stopGithubApiMock failed: ${String(error)}\n`,
-        );
-      }),
-    ]);
-  }
-});
+        accountLogin: `e${uniqueId.slice(0, 5)}`,
+        displayName: `GitHub E2E ${uniqueId}`,
+        installerUserId: crypto.randomUUID(),
+      });
+      const issueReadTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_read`;
+      const issueWriteTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_write`;
+      const addIssueCommentTool = `mcp__shipfox_integration_tools__${connection.slug}__add_issue_comment`;
+      const fakeAnthropic = await createAnthropicFakeModelProviderConfig({
+        workspaceId: suite.workspaceId,
+        fakeModelProvider,
+        scriptId,
+        model: CLAUDE_AGENT_MODEL,
+        responses: [
+          toolCall(issueReadTool, {
+            method: 'get',
+            owner: 'shipfox',
+            repo: 'e2e',
+            issue_number: 1,
+          }),
+          toolCall(issueWriteTool, {
+            method: 'create',
+            owner: 'shipfox',
+            repo: 'e2e',
+            title: 'Synthetic GitHub issue',
+          }),
+          toolCall(issueReadTool, {
+            method: 'get_comments',
+            owner: 'shipfox',
+            repo: 'e2e',
+            issue_number: 1,
+          }),
+          toolCall(addIssueCommentTool, {
+            owner: 'shipfox',
+            repo: 'e2e',
+            issue_number: 1,
+            body: 'This tool was not selected',
+          }),
+          message('done'),
+        ],
+        assertions: [
+          {kind: 'model', equals: CLAUDE_AGENT_MODEL},
+          {kind: 'tool_present', name: issueReadTool},
+          {kind: 'tool_present', name: issueWriteTool},
+          {kind: 'tool_absent', name: addIssueCommentTool},
+          {
+            kind: 'message_content_includes',
+            value: GITHUB_READ_RESULT_MARKER,
+            minRequestIndex: 1,
+          },
+          {
+            kind: 'message_content_includes',
+            value: GITHUB_WRITE_RESULT_MARKER,
+            minRequestIndex: 2,
+          },
+          {
+            kind: 'message_content_includes',
+            value: 'Unauthorized integration tool method: get_comments',
+            minRequestIndex: 3,
+          },
+          {
+            kind: 'message_content_includes',
+            value: 'No such tool available:',
+            minRequestIndex: 4,
+          },
+        ],
+        setAsDefault: true,
+      });
+
+      const terminal = await runGithubToolsWorkflow({
+        suite,
+        testInfo,
+        uniqueId,
+        connectionSlug: connection.slug,
+        runnerEnv: fakeAnthropic.runnerEnv,
+      });
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
+      const providerRequests = await fakeModelProvider.getRequests(scriptId);
+      expect(providerRequests).toHaveLength(6);
+      expect(providerRequests[0]).toMatchObject({
+        model: `${CLAUDE_AGENT_MODEL}-small-fast`,
+        served_response: 'message:non_consuming_model',
+      });
+      expect(
+        providerRequests.filter((request) => request.model === CLAUDE_AGENT_MODEL),
+      ).toHaveLength(5);
+      expect(providerRequests.every((request) => request.assertion_failures.length === 0)).toBe(
+        true,
+      );
+      expect(githubApi.calls).toEqual([
+        {
+          kind: 'mint-token',
+          authorization: expect.stringMatching(BEARER_AUTHORIZATION),
+          tokenFormatOverride: 'enabled',
+          installationId,
+          body: {},
+        },
+        {
+          kind: 'read-issue',
+          authorization: tokenCase.authorization,
+          owner: 'shipfox',
+          repo: 'e2e',
+          issueNumber: 1,
+        },
+        {
+          kind: 'create-issue',
+          authorization: tokenCase.authorization,
+          owner: 'shipfox',
+          repo: 'e2e',
+          body: {title: 'Synthetic GitHub issue'},
+        },
+      ]);
+    } finally {
+      await Promise.all([
+        fakeModelProvider?.stop()?.catch((error: unknown) => {
+          process.stderr.write(
+            `github-agent-tools-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
+          );
+        }) ?? Promise.resolve(),
+        githubApi.stop().catch((error: unknown) => {
+          process.stderr.write(
+            `github-agent-tools-e2e: stopGithubApiMock failed: ${String(error)}\n`,
+          );
+        }),
+      ]);
+    }
+  });
+}
 
 async function runGithubToolsWorkflow(params: {
   suite: SuiteContext;

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -132,19 +132,20 @@ test('runs selected GitHub tools and denies unselected authority', async ({suite
       {
         kind: 'mint-token',
         authorization: expect.stringMatching(BEARER_AUTHORIZATION),
+        tokenFormatOverride: 'enabled',
         installationId,
         body: {},
       },
       {
         kind: 'read-issue',
-        authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+        authorization: `bearer ${GITHUB_INSTALLATION_TOKEN}`,
         owner: 'shipfox',
         repo: 'e2e',
         issueNumber: 1,
       },
       {
         kind: 'create-issue',
-        authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+        authorization: `bearer ${GITHUB_INSTALLATION_TOKEN}`,
         owner: 'shipfox',
         repo: 'e2e',
         body: {title: 'Synthetic GitHub issue'},

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -1,6 +1,11 @@
 import {GithubIntegrationProviderError} from '#core/errors.js';
-import {GITHUB_STATELESS_INSTALLATION_TOKEN} from '#test/index.js';
+import {
+  GITHUB_STATEFUL_INSTALLATION_TOKEN,
+  GITHUB_STATELESS_INSTALLATION_TOKEN,
+} from '#test/index.js';
 import {createGithubApiClient, mapGithubError} from './client.js';
+
+const GITHUB_INSTALLATION_TOKEN_PATTERN = /^ghs_[A-Za-z0-9._-]{36,}$/u;
 
 const {createInstallationAccessTokenMock, RequestErrorMock} = vi.hoisted(() => {
   class RequestErrorMock extends Error {
@@ -23,6 +28,9 @@ vi.mock('octokit', () => ({
     };
   },
   Octokit: {
+    plugin() {
+      return this;
+    },
     defaults(options: unknown) {
       return {defaults: options};
     },
@@ -79,32 +87,37 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
       token: GITHUB_STATELESS_INSTALLATION_TOKEN,
       expiresAt: new Date('2026-06-10T12:00:00.000Z'),
     });
-    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toHaveLength(520);
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toMatch(GITHUB_INSTALLATION_TOKEN_PATTERN);
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN.slice(4).split('.')).toHaveLength(3);
     expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
       installation_id: 1,
       repository_ids: [42],
       permissions: {contents: 'read'},
-      headers: {'X-GitHub-Stateless-S2S-Token': 'enabled'},
     });
   });
 
-  it('mints a repository-scoped write installation token when requested', async () => {
+  it('passes through a stateful repository-scoped write token', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
-      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+      data: {
+        token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
     });
     const client = createGithubApiClient();
 
-    await client.createInstallationAccessToken({
+    const result = await client.createInstallationAccessToken({
       installationId: 1,
       repositoryId: 42,
       permissions: {contents: 'write'},
     });
 
+    expect(result.token).toBe(GITHUB_STATEFUL_INSTALLATION_TOKEN);
+    expect(GITHUB_STATEFUL_INSTALLATION_TOKEN).toMatch(GITHUB_INSTALLATION_TOKEN_PATTERN);
+    expect(GITHUB_STATEFUL_INSTALLATION_TOKEN).not.toContain('.');
     expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
       installation_id: 1,
       repository_ids: [42],
       permissions: {contents: 'write'},
-      headers: {'X-GitHub-Stateless-S2S-Token': 'enabled'},
     });
   });
 

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -1,4 +1,5 @@
 import {GithubIntegrationProviderError} from '#core/errors.js';
+import {GITHUB_STATELESS_INSTALLATION_TOKEN} from '#test/index.js';
 import {createGithubApiClient, mapGithubError} from './client.js';
 
 const {createInstallationAccessTokenMock, RequestErrorMock} = vi.hoisted(() => {
@@ -62,7 +63,10 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
 
   it('mints a repository-scoped, read-only installation token', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
-      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
     });
     const client = createGithubApiClient();
 
@@ -72,13 +76,15 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
     });
 
     expect(result).toEqual({
-      token: 'ghs_installationtoken',
+      token: GITHUB_STATELESS_INSTALLATION_TOKEN,
       expiresAt: new Date('2026-06-10T12:00:00.000Z'),
     });
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toHaveLength(520);
     expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
       installation_id: 1,
       repository_ids: [42],
       permissions: {contents: 'read'},
+      headers: {'X-GitHub-Stateless-S2S-Token': 'enabled'},
     });
   });
 
@@ -98,6 +104,7 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
       installation_id: 1,
       repository_ids: [42],
       permissions: {contents: 'write'},
+      headers: {'X-GitHub-Stateless-S2S-Token': 'enabled'},
     });
   });
 

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -4,10 +4,11 @@ import ky, {HTTPError, TimeoutError} from 'ky';
 import {App, Octokit, RequestError} from 'octokit';
 import {config, normalizedGithubApiBaseUrl, normalizedGithubPrivateKey} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
-
-export const STATELESS_INSTALLATION_TOKEN_HEADERS = {
-  'X-GitHub-Stateless-S2S-Token': 'enabled',
-};
+import {recordInstallationTokenFormat} from '#metrics/index.js';
+import {
+  getGithubInstallationOctokit,
+  githubInstallationTokenFormatPlugin,
+} from './github-octokit.js';
 
 const NEXT_PAGE_RE = /[?&]page=(\d+)/;
 const TRAILING_SLASHES_RE = /\/+$/;
@@ -190,7 +191,9 @@ class OctokitGithubApiClient implements GithubApiClient {
     limit: number;
     cursor?: string | undefined;
   }): Promise<GithubRepositoryPage> {
-    const octokit = await this.getApp().getInstallationOctokit(input.installationId);
+    const octokit = await mapGithubError(() =>
+      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    );
     const page = cursorToPage(input.cursor);
     const response = await mapGithubError(() =>
       octokit.rest.apps.listReposAccessibleToInstallation({
@@ -209,7 +212,9 @@ class OctokitGithubApiClient implements GithubApiClient {
     installationId: number;
     repositoryId: number;
   }): Promise<GithubRepository> {
-    const octokit = await this.getApp().getInstallationOctokit(input.installationId);
+    const octokit = await mapGithubError(() =>
+      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    );
     const response = await mapGithubError(() =>
       octokit.request('GET /repositories/{repository_id}', {
         repository_id: input.repositoryId,
@@ -227,7 +232,9 @@ class OctokitGithubApiClient implements GithubApiClient {
     limit: number;
     cursor?: string | undefined;
   }): Promise<GithubFilePage> {
-    const octokit = await this.getApp().getInstallationOctokit(input.installationId);
+    const octokit = await mapGithubError(() =>
+      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    );
     const repository = await this.getRepository({
       installationId: input.installationId,
       repositoryId: input.repositoryId,
@@ -307,7 +314,9 @@ class OctokitGithubApiClient implements GithubApiClient {
     ref: string;
     path: string;
   }): Promise<GithubFileContent> {
-    const octokit = await this.getApp().getInstallationOctokit(input.installationId);
+    const octokit = await mapGithubError(() =>
+      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    );
     const repository = await this.getRepository({
       installationId: input.installationId,
       repositoryId: input.repositoryId,
@@ -357,7 +366,6 @@ class OctokitGithubApiClient implements GithubApiClient {
         installation_id: input.installationId,
         repository_ids: [input.repositoryId],
         permissions: input.permissions ?? {contents: 'read'},
-        headers: STATELESS_INSTALLATION_TOKEN_HEADERS,
       }),
     );
 
@@ -367,6 +375,8 @@ class OctokitGithubApiClient implements GithubApiClient {
         'GitHub installation access token response did not include a token',
       );
     }
+
+    recordInstallationTokenFormat(response.data.token);
 
     const expiresAt = new Date(response.data.expires_at);
     if (Number.isNaN(expiresAt.getTime())) {
@@ -388,7 +398,9 @@ class OctokitGithubApiClient implements GithubApiClient {
       this.app = new App({
         appId: config.GITHUB_APP_ID,
         privateKey: normalizedGithubPrivateKey(),
-        Octokit: Octokit.defaults({baseUrl: normalizedGithubApiBaseUrl()}),
+        Octokit: Octokit.plugin(githubInstallationTokenFormatPlugin).defaults({
+          baseUrl: normalizedGithubApiBaseUrl(),
+        }),
       });
     }
     return this.app;

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -5,6 +5,10 @@ import {App, Octokit, RequestError} from 'octokit';
 import {config, normalizedGithubApiBaseUrl, normalizedGithubPrivateKey} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 
+export const STATELESS_INSTALLATION_TOKEN_HEADERS = {
+  'X-GitHub-Stateless-S2S-Token': 'enabled',
+};
+
 const NEXT_PAGE_RE = /[?&]page=(\d+)/;
 const TRAILING_SLASHES_RE = /\/+$/;
 const MAX_TREE_WALK_DEPTH = 10;
@@ -353,6 +357,7 @@ class OctokitGithubApiClient implements GithubApiClient {
         installation_id: input.installationId,
         repository_ids: [input.repositoryId],
         permissions: input.permissions ?? {contents: 'read'},
+        headers: STATELESS_INSTALLATION_TOKEN_HEADERS,
       }),
     );
 

--- a/libs/api/integration/github/src/api/github-octokit.test.ts
+++ b/libs/api/integration/github/src/api/github-octokit.test.ts
@@ -1,0 +1,115 @@
+import {generateKeyPairSync} from 'node:crypto';
+import {once} from 'node:events';
+import {createServer} from 'node:http';
+import {App, Octokit} from 'octokit';
+import {
+  GITHUB_STATEFUL_INSTALLATION_TOKEN,
+  GITHUB_STATELESS_INSTALLATION_TOKEN,
+} from '#test/index.js';
+import {
+  createGithubInstallationTokenFormatPlugin,
+  getGithubInstallationOctokit,
+} from './github-octokit.js';
+
+const {privateKey} = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {type: 'spki', format: 'pem'},
+  privateKeyEncoding: {type: 'pkcs8', format: 'pem'},
+});
+const BEARER_AUTHORIZATION = /^bearer /iu;
+
+describe('GitHub installation Octokit', () => {
+  it.each([
+    {
+      format: 'stateless',
+      token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+      override: 'enabled' as const,
+      authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+    },
+    {
+      format: 'stateful',
+      token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
+      override: 'disabled' as const,
+      authorization: `token ${GITHUB_STATEFUL_INSTALLATION_TOKEN}`,
+    },
+    {
+      format: 'stateful without an override',
+      token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
+      override: undefined,
+      authorization: `token ${GITHUB_STATEFUL_INSTALLATION_TOKEN}`,
+    },
+  ])('requests and authenticates with a $format token', async ({
+    token,
+    override,
+    authorization,
+  }) => {
+    const calls: Array<{
+      method: string | undefined;
+      path: string | undefined;
+      authorization: string | undefined;
+      tokenFormatOverride: string | undefined;
+    }> = [];
+    const server = createServer((request, response) => {
+      calls.push({
+        method: request.method,
+        path: request.url,
+        authorization: request.headers.authorization,
+        tokenFormatOverride: request.headers['x-github-stateless-s2s-token'] as string | undefined,
+      });
+
+      if (request.method === 'POST' && request.url === '/app/installations/123/access_tokens') {
+        response.writeHead(201, {'content-type': 'application/json'}).end(
+          JSON.stringify({
+            token,
+            expires_at: '2099-01-01T00:00:00.000Z',
+            permissions: {metadata: 'read'},
+            repository_selection: 'all',
+          }),
+        );
+        return;
+      }
+
+      if (request.method === 'GET' && request.url === '/installation/repositories') {
+        response
+          .writeHead(200, {'content-type': 'application/json'})
+          .end(JSON.stringify({total_count: 0, repositories: []}));
+        return;
+      }
+
+      response.writeHead(404, {'content-type': 'application/json'}).end('{"message":"Not Found"}');
+    });
+    server.listen({host: '127.0.0.1', port: 0});
+    await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP server address.');
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const InstallationTokenOctokit = Octokit.plugin(
+        createGithubInstallationTokenFormatPlugin(override),
+      ).defaults({baseUrl});
+      const app = new App({appId: 1, privateKey, Octokit: InstallationTokenOctokit});
+      const octokit = await getGithubInstallationOctokit(app, 123, baseUrl);
+
+      await octokit.rest.apps.listReposAccessibleToInstallation();
+
+      expect(calls).toEqual([
+        {
+          method: 'POST',
+          path: '/app/installations/123/access_tokens',
+          authorization: expect.stringMatching(BEARER_AUTHORIZATION),
+          tokenFormatOverride: override,
+        },
+        {
+          method: 'GET',
+          path: '/installation/repositories',
+          authorization,
+          tokenFormatOverride: undefined,
+        },
+      ]);
+    } finally {
+      server.close();
+      await once(server, 'close');
+    }
+  });
+});

--- a/libs/api/integration/github/src/api/github-octokit.ts
+++ b/libs/api/integration/github/src/api/github-octokit.ts
@@ -1,0 +1,49 @@
+import {type App, Octokit} from 'octokit';
+import {config, normalizedGithubApiBaseUrl} from '#config.js';
+import {GithubIntegrationProviderError} from '#core/errors.js';
+import {recordInstallationTokenFormat} from '#metrics/index.js';
+
+const INSTALLATION_TOKEN_REQUEST_PATH = /\/app\/installations\/[^/]+\/access_tokens(?:\?|$)/u;
+type GithubInstallationTokenFormatOverride = 'enabled' | 'disabled' | undefined;
+
+export function createGithubInstallationTokenFormatPlugin(
+  override: GithubInstallationTokenFormatOverride,
+): Parameters<typeof Octokit.plugin>[0] {
+  return (octokit) => {
+    octokit.hook.before('request', (options) => {
+      if (
+        !override ||
+        options.method !== 'POST' ||
+        !INSTALLATION_TOKEN_REQUEST_PATH.test(options.url)
+      ) {
+        return;
+      }
+
+      options.headers['x-github-stateless-s2s-token'] = override;
+    });
+  };
+}
+
+export const githubInstallationTokenFormatPlugin: Parameters<typeof Octokit.plugin>[0] =
+  createGithubInstallationTokenFormatPlugin(config.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE);
+
+export async function getGithubInstallationOctokit(
+  app: App,
+  installationId: number,
+  baseUrl = normalizedGithubApiBaseUrl(),
+): Promise<Octokit> {
+  const authentication = (await app.octokit.auth({
+    type: 'installation',
+    installationId,
+  })) as {token?: unknown};
+
+  if (typeof authentication.token !== 'string') {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub installation authentication did not include a token',
+    );
+  }
+
+  recordInstallationTokenFormat(authentication.token);
+  return new Octokit({auth: authentication.token, baseUrl});
+}

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -1,6 +1,6 @@
 import type {GetIntegrationConnectionByIdFn} from '@shipfox/api-integration-spi';
 import {GithubIntegrationProviderError} from '#core/errors.js';
-import {githubInstallationFactory} from '#test/index.js';
+import {GITHUB_STATELESS_INSTALLATION_TOKEN, githubInstallationFactory} from '#test/index.js';
 import {encodeInstallationTokenEnvelope} from './installation-token-envelope.js';
 import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
 
@@ -47,18 +47,23 @@ describe('GithubInstallationTokenProvider', () => {
 
   it('mints a broad installation token on a cache miss', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
-      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
     });
     const provider = createGithubInstallationTokenProvider();
 
     const result = await provider.getInstallationAccessToken(1);
 
     expect(result).toEqual({
-      token: 'ghs_installationtoken',
+      token: GITHUB_STATELESS_INSTALLATION_TOKEN,
       expiresAt: new Date('2026-06-10T12:00:00.000Z'),
     });
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toHaveLength(520);
     expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
       installation_id: 1,
+      headers: {'X-GitHub-Stateless-S2S-Token': 'enabled'},
     });
   });
 
@@ -66,7 +71,10 @@ describe('GithubInstallationTokenProvider', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
     createInstallationAccessTokenMock.mockResolvedValue({
-      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
     });
     const provider = createGithubInstallationTokenProvider();
 
@@ -151,7 +159,10 @@ describe('GithubInstallationTokenProvider', () => {
         updatedAt: new Date(),
       });
     createInstallationAccessTokenMock.mockResolvedValue({
-      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
     });
     const provider = createGithubInstallationTokenProvider({
       getIntegrationConnectionById,
@@ -174,6 +185,10 @@ describe('GithubInstallationTokenProvider', () => {
     const second = await provider.getInstallationAccessToken(installationId);
 
     expect(first).toEqual(second);
+    expect(first.token).toBe(GITHUB_STATELESS_INSTALLATION_TOKEN);
+    expect(values.get(`${workspaceId}:${installationId}`)).toContain(
+      GITHUB_STATELESS_INSTALLATION_TOKEN,
+    );
     expect(lockCalls).toBe(1);
     expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
   });

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -1,8 +1,14 @@
 import type {GetIntegrationConnectionByIdFn} from '@shipfox/api-integration-spi';
 import {GithubIntegrationProviderError} from '#core/errors.js';
-import {GITHUB_STATELESS_INSTALLATION_TOKEN, githubInstallationFactory} from '#test/index.js';
+import {
+  GITHUB_STATEFUL_INSTALLATION_TOKEN,
+  GITHUB_STATELESS_INSTALLATION_TOKEN,
+  githubInstallationFactory,
+} from '#test/index.js';
 import {encodeInstallationTokenEnvelope} from './installation-token-envelope.js';
 import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
+
+const GITHUB_INSTALLATION_TOKEN_PATTERN = /^ghs_[A-Za-z0-9._-]{36,}$/u;
 
 const {appOptions, createInstallationAccessTokenMock, RequestErrorMock} = vi.hoisted(() => ({
   appOptions: [] as unknown[],
@@ -28,6 +34,9 @@ vi.mock('octokit', () => ({
     }
   },
   Octokit: {
+    plugin() {
+      return this;
+    },
     defaults(options: unknown) {
       return {defaults: options};
     },
@@ -60,11 +69,26 @@ describe('GithubInstallationTokenProvider', () => {
       token: GITHUB_STATELESS_INSTALLATION_TOKEN,
       expiresAt: new Date('2026-06-10T12:00:00.000Z'),
     });
-    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toHaveLength(520);
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toMatch(GITHUB_INSTALLATION_TOKEN_PATTERN);
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN.slice(4).split('.')).toHaveLength(3);
     expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
       installation_id: 1,
-      headers: {'X-GitHub-Stateless-S2S-Token': 'enabled'},
     });
+  });
+
+  it('passes through a stateful broad installation token', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {
+        token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
+    });
+    const provider = createGithubInstallationTokenProvider();
+
+    const result = await provider.getInstallationAccessToken(1);
+
+    expect(result.token).toBe(GITHUB_STATEFUL_INSTALLATION_TOKEN);
+    expect(GITHUB_STATEFUL_INSTALLATION_TOKEN).not.toContain('.');
   });
 
   it('returns a cached token without a second mint', async () => {

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -4,12 +4,9 @@ import {config, normalizedGithubApiBaseUrl, normalizedGithubPrivateKey} from '#c
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {withInstallationTokenLock} from '#db/installation-token-lock.js';
 import {getGithubInstallationByInstallationId} from '#db/installations.js';
-import {recordInstallationTokenLookup} from '#metrics/index.js';
-import {
-  type GithubInstallationAccessToken,
-  mapGithubError,
-  STATELESS_INSTALLATION_TOKEN_HEADERS,
-} from './client.js';
+import {recordInstallationTokenFormat, recordInstallationTokenLookup} from '#metrics/index.js';
+import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
+import {githubInstallationTokenFormatPlugin} from './github-octokit.js';
 import {
   githubInstallationTokenNamespace,
   TOKEN_REFRESH_MARGIN_MS,
@@ -59,7 +56,6 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
       () =>
         this.getApp().octokit.rest.apps.createInstallationAccessToken({
           installation_id: installationId,
-          headers: STATELESS_INSTALLATION_TOKEN_HEADERS,
         }),
       'installation-not-found',
     );
@@ -70,6 +66,8 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
         'GitHub installation access token response did not include a token',
       );
     }
+
+    recordInstallationTokenFormat(response.data.token);
 
     const expiresAt = new Date(response.data.expires_at);
     if (Number.isNaN(expiresAt.getTime())) {
@@ -91,7 +89,7 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
       this.app = new App({
         appId: config.GITHUB_APP_ID,
         privateKey: normalizedGithubPrivateKey(),
-        Octokit: Octokit.defaults({
+        Octokit: Octokit.plugin(githubInstallationTokenFormatPlugin).defaults({
           baseUrl: normalizedGithubApiBaseUrl(),
           throttle: {
             onRateLimit: (

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -5,7 +5,11 @@ import {GithubIntegrationProviderError} from '#core/errors.js';
 import {withInstallationTokenLock} from '#db/installation-token-lock.js';
 import {getGithubInstallationByInstallationId} from '#db/installations.js';
 import {recordInstallationTokenLookup} from '#metrics/index.js';
-import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
+import {
+  type GithubInstallationAccessToken,
+  mapGithubError,
+  STATELESS_INSTALLATION_TOKEN_HEADERS,
+} from './client.js';
 import {
   githubInstallationTokenNamespace,
   TOKEN_REFRESH_MARGIN_MS,
@@ -55,6 +59,7 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
       () =>
         this.getApp().octokit.rest.apps.createInstallationAccessToken({
           installation_id: installationId,
+          headers: STATELESS_INSTALLATION_TOKEN_HEADERS,
         }),
       'installation-not-found',
     );

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -29,6 +29,11 @@ export const config = createConfig({
     desc: 'Base URL used for GitHub REST API requests. Set this only for GitHub Enterprise Server or a compatible test server.',
     default: 'https://api.github.com',
   }),
+  GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE: str({
+    desc: 'Temporary GitHub installation token format override. Set this to enabled to request stateless tokens, disabled to request stateful tokens, or leave it unset to follow the GitHub rollout.',
+    choices: ['enabled', 'disabled'] as const,
+    default: undefined,
+  }),
   GITHUB_INSTALL_STATE_SECRET: str({
     desc: 'Secret used to sign the state token that protects the GitHub App install flow. Required.',
   }),

--- a/libs/api/integration/github/src/metrics/instance.ts
+++ b/libs/api/integration/github/src/metrics/instance.ts
@@ -1,6 +1,7 @@
 import type {IntegrationProviderErrorReason} from '@shipfox/api-integration-spi';
 import {instanceMetrics} from '@shipfox/node-opentelemetry';
 import type {MintErrorClass} from '#api/installation-token-envelope.js';
+import {config} from '#config.js';
 
 const meter = instanceMetrics.getMeter('github');
 
@@ -31,6 +32,13 @@ const installationTokenMintDuration = meter.createHistogram<Record<string, never
     advice: {explicitBucketBoundaries: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000]},
   },
 );
+
+const installationTokenFormatCount = meter.createCounter<{
+  format: 'stateless' | 'stateful' | 'unknown';
+  override: 'enabled' | 'disabled' | 'absent';
+}>('github_installation_token_format', {
+  description: 'GitHub installation tokens observed by format and requested override',
+});
 
 const installationTokenLockWaitDuration = meter.createHistogram<Record<string, never>>(
   'github_installation_token_lock_wait_duration',
@@ -70,6 +78,15 @@ export function recordInstallationTokenMint(params: {
   });
 }
 
+export function recordInstallationTokenFormat(token: string): void {
+  recordMetric(() => {
+    installationTokenFormatCount.add(1, {
+      format: installationTokenFormat(token),
+      override: config.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE ?? 'absent',
+    });
+  });
+}
+
 export function recordInstallationTokenLockWait(durationMs: number): void {
   recordMetric(() => installationTokenLockWaitDuration.record(durationMs));
 }
@@ -79,4 +96,12 @@ export function recordInstallationTokenBackoff(params: {
   class: MintErrorClass;
 }): void {
   recordMetric(() => installationTokenBackoffCount.add(1, params));
+}
+
+function installationTokenFormat(token: string): 'stateless' | 'stateful' | 'unknown' {
+  if (!token.startsWith('ghs_')) return 'unknown';
+  const dotCount = token.slice(4).split('.').length - 1;
+  if (dotCount === 2) return 'stateless';
+  if (dotCount === 0) return 'stateful';
+  return 'unknown';
 }

--- a/libs/api/integration/github/test/env.ts
+++ b/libs/api/integration/github/test/env.ts
@@ -14,3 +14,4 @@ process.env.GITHUB_APP_SLUG = 'shipfox-test';
 process.env.GITHUB_APP_USERNAME = 'shipfox-test';
 process.env.GITHUB_INSTALL_STATE_SECRET = 'test-install-state-secret';
 process.env.GITHUB_API_BASE_URL = 'https://api.github.com';
+process.env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE = 'enabled';

--- a/libs/api/integration/github/test/fixtures/github-installation-token.ts
+++ b/libs/api/integration/github/test/fixtures/github-installation-token.ts
@@ -1,0 +1,6 @@
+const JWT_SEGMENT_LENGTH = 169;
+
+export const GITHUB_STATELESS_INSTALLATION_TOKEN =
+  `ghs_123456_${'a'.repeat(JWT_SEGMENT_LENGTH)}` +
+  `.${'b'.repeat(JWT_SEGMENT_LENGTH)}` +
+  `.${'c'.repeat(JWT_SEGMENT_LENGTH)}`;

--- a/libs/api/integration/github/test/fixtures/github-installation-token.ts
+++ b/libs/api/integration/github/test/fixtures/github-installation-token.ts
@@ -4,3 +4,5 @@ export const GITHUB_STATELESS_INSTALLATION_TOKEN =
   `ghs_123456_${'a'.repeat(JWT_SEGMENT_LENGTH)}` +
   `.${'b'.repeat(JWT_SEGMENT_LENGTH)}` +
   `.${'c'.repeat(JWT_SEGMENT_LENGTH)}`;
+
+export const GITHUB_STATEFUL_INSTALLATION_TOKEN = `ghs_${'d'.repeat(36)}`;

--- a/libs/api/integration/github/test/index.ts
+++ b/libs/api/integration/github/test/index.ts
@@ -1,3 +1,6 @@
 export {githubInstallationFactory} from './factories/github-installation.js';
-export {GITHUB_STATELESS_INSTALLATION_TOKEN} from './fixtures/github-installation-token.js';
+export {
+  GITHUB_STATEFUL_INSTALLATION_TOKEN,
+  GITHUB_STATELESS_INSTALLATION_TOKEN,
+} from './fixtures/github-installation-token.js';
 export {type GithubPushPayloadOptions, githubPushPayload} from './fixtures/github-webhook.js';

--- a/libs/api/integration/github/test/index.ts
+++ b/libs/api/integration/github/test/index.ts
@@ -1,2 +1,3 @@
 export {githubInstallationFactory} from './factories/github-installation.js';
+export {GITHUB_STATELESS_INSTALLATION_TOKEN} from './fixtures/github-installation-token.js';
 export {type GithubPushPayloadOptions, githubPushPayload} from './fixtures/github-webhook.js';

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -72,6 +72,8 @@ function queueFetchFailure(stderr: string) {
 }
 
 const BASE = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main', cwd: '/work/job-1'};
+const GITHUB_INSTALLATION_TOKEN_PATTERN = /^ghs_[A-Za-z0-9._-]{36,}$/u;
+const GITHUB_STATEFUL_INSTALLATION_TOKEN = `ghs_${'d'.repeat(36)}`;
 const GITHUB_STATELESS_INSTALLATION_TOKEN =
   `ghs_123456_${'a'.repeat(169)}` + `.${'b'.repeat(169)}` + `.${'c'.repeat(169)}`;
 
@@ -223,19 +225,22 @@ describe('checkoutRepository argv', () => {
     expect(fetchOptions.env.GIT_CONFIG_VALUE_99).toBeUndefined();
   });
 
-  it('injects a stateless GitHub token as a basic header and registers both secrets', async () => {
+  it.each([
+    {format: 'stateful', token: GITHUB_STATEFUL_INSTALLATION_TOKEN},
+    {format: 'stateless', token: GITHUB_STATELESS_INSTALLATION_TOKEN},
+  ])('injects a $format GitHub token as a basic header and registers both secrets', async ({
+    token,
+  }) => {
     queueSuccessfulCheckout();
     const onSecrets = vi.fn();
-    const expected = Buffer.from(`x-access-token:${GITHUB_STATELESS_INSTALLATION_TOKEN}`).toString(
-      'base64',
-    );
+    const expected = Buffer.from(`x-access-token:${token}`).toString('base64');
 
     await checkoutRepository({
       ...BASE,
       auth: {
         kind: 'basic',
         username: 'x-access-token',
-        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        token,
         expires_at: '2026-01-01T00:00:00Z',
         carry: 'header',
         host: 'github.com',
@@ -246,10 +251,10 @@ describe('checkoutRepository argv', () => {
 
     const fetchArgs = spawnMock.mock.calls[2]?.[1] as string[];
     const fetchOptions = spawnMock.mock.calls[2]?.[2] as {env: Record<string, string>};
-    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toHaveLength(520);
+    expect(token).toMatch(GITHUB_INSTALLATION_TOKEN_PATTERN);
     expect(fetchArgs[0]).toBe('fetch');
     expect(fetchOptions.env.GIT_CONFIG_VALUE_0).toBe(`Authorization: Basic ${expected}`);
-    expect(onSecrets).toHaveBeenCalledWith([GITHUB_STATELESS_INSTALLATION_TOKEN, expected]);
+    expect(onSecrets).toHaveBeenCalledWith([token, expected]);
   });
 
   it('disables interactive credential prompts on every git process', async () => {

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -72,6 +72,8 @@ function queueFetchFailure(stderr: string) {
 }
 
 const BASE = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main', cwd: '/work/job-1'};
+const GITHUB_STATELESS_INSTALLATION_TOKEN =
+  `ghs_123456_${'a'.repeat(169)}` + `.${'b'.repeat(169)}` + `.${'c'.repeat(169)}`;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -221,17 +223,19 @@ describe('checkoutRepository argv', () => {
     expect(fetchOptions.env.GIT_CONFIG_VALUE_99).toBeUndefined();
   });
 
-  it('injects a basic credential as a base64 Authorization header and registers both secrets', async () => {
+  it('injects a stateless GitHub token as a basic header and registers both secrets', async () => {
     queueSuccessfulCheckout();
     const onSecrets = vi.fn();
-    const expected = Buffer.from('x-token:tok-123').toString('base64');
+    const expected = Buffer.from(`x-access-token:${GITHUB_STATELESS_INSTALLATION_TOKEN}`).toString(
+      'base64',
+    );
 
     await checkoutRepository({
       ...BASE,
       auth: {
         kind: 'basic',
-        username: 'x-token',
-        token: 'tok-123',
+        username: 'x-access-token',
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
         expires_at: '2026-01-01T00:00:00Z',
         carry: 'header',
         host: 'github.com',
@@ -242,9 +246,10 @@ describe('checkoutRepository argv', () => {
 
     const fetchArgs = spawnMock.mock.calls[2]?.[1] as string[];
     const fetchOptions = spawnMock.mock.calls[2]?.[2] as {env: Record<string, string>};
+    expect(GITHUB_STATELESS_INSTALLATION_TOKEN).toHaveLength(520);
     expect(fetchArgs[0]).toBe('fetch');
     expect(fetchOptions.env.GIT_CONFIG_VALUE_0).toBe(`Authorization: Basic ${expected}`);
-    expect(onSecrets).toHaveBeenCalledWith(['tok-123', expected]);
+    expect(onSecrets).toHaveBeenCalledWith([GITHUB_STATELESS_INSTALLATION_TOKEN, expected]);
   });
 
   it('disables interactive credential prompts on every git process', async () => {


### PR DESCRIPTION
## Summary

GitHub is moving App installation tokens to a longer stateless format. Opt both broad and repository-scoped token minting into the rollout format with GitHub's per-request override header.

Exercise a representative 520-character dotted token through token caching, agent-tool requests, runner checkout credentials, and secret registration. The end-to-end contract also captures Octokit's expected switch from the legacy `token` authorization scheme to `bearer` for the new shape.

The repository's GitHub Actions token consumers were audited for hardcoded format or length assumptions. The pinned GitHub-owned token action does not expose the temporary override header, so those workflows remain unchanged.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/api-integration-github... --filter=@shipfox/runner-workspace... --filter=@shipfox/e2e-flow-workflows... --concurrency=4`
- `mise exec -- turbo depcruise --filter=@shipfox/api-integration-github... --concurrency=4`
- `mise run e2e -- --filter=@shipfox/e2e-flow-workflows` (40 passed)
- `mise exec -- pnpm exec changeset status`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full support for both stateless and stateful GitHub App installation tokens. Apply an optional per-request override when minting, auto-select the right auth scheme based on token shape, and record the observed format.

- **New Features**
  - Add `GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE` config and apply it to all Octokit installation-token mints via a plugin (`githubInstallationTokenFormatPlugin`).
  - Keep App JWT as `Bearer`; use `bearer` for stateless tokens and `token` for stateful tokens; runner checkout uses `x-access-token:<token>` in the basic header.
  - Record token format with `github_installation_token_format` metric; test both formats end-to-end without fixed-length assumptions across caching, agent-tools, checkout, and secret registration in `@shipfox/api-integration-github`.

<sup>Written for commit 7d8e3aa5af7e00a70c2dd59f9f855db45602cb23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

