### PR TITLE
[runner-image] Fix runner boot target and mounts

### DIFF
--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -17,7 +17,9 @@ Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host ope
 
 ## Boot behavior
 
-The image is checked during the bake and launched with a fresh ephemeral root volume. The image skips boot-time filesystem checks, applies `noatime` to `/` and `/boot`, and sets pass 0 for `/boot` and `/boot/efi`.
+The image is checked during the bake and starts with `multi-user.target` as the systemd default. It skips boot-time filesystem checks and applies `noatime` to `/` and `/boot`.
+
+The fstab entries for `/boot` and `/boot/efi` use `noauto` and pass 0. The partitions remain in the image for the bootloader, but systemd does not mount them during runner startup. `configure-ephemeral-boot.sh` masks the image's package, bootloader, and firmware update units so they cannot write to the detached mount-point directories.
 
 `fsck.mode=skip` also suppresses checks for other filesystems with a non-zero pass number. Do not add a durable filesystem with a non-zero pass number without revisiting this image contract.
 
@@ -30,10 +32,12 @@ service and journal policy in
 
 ### Boot composition gate
 
-The bake checks that every unit in the mask inventory exists before it masks the
-unit. It checks the effective `systemd` state after masking. It also checks the
-effective journald configuration after writing the drop-in. A base-image change
-that removes a unit or overrides the drop-in fails the image build.
+The bake checks the default systemd target and re-reads the installed fstab to
+confirm that both boot entries use `noauto` and pass 0. It checks that every unit
+in the mask inventory exists before it masks the unit. It checks the effective
+`systemd` state after masking. It also checks the effective journald configuration
+after writing the drop-in. A base-image change that removes a unit, changes a
+boot entry, or overrides the drop-in fails the image build.
 
 ### AppArmor decision
 

--- a/infra/images/runner/scripts/build/configure-boot.sh
+++ b/infra/images/runner/scripts/build/configure-boot.sh
@@ -16,30 +16,94 @@ if [ ! -r "$grub_config" ] || ! grep -Eq '(^|[[:space:]])fsck\.mode=skip([[:spac
   exit 1
 fi
 
-systemctl set-default multi-user.target
-if [ "$(systemctl get-default)" != 'multi-user.target' ]; then
-  printf '%s\n' 'configure-boot: default target is not multi-user.target' >&2
-  exit 1
-fi
-
-# The image is checked during the bake; running root fsck on every ephemeral boot
-# only adds latency and cannot repair a durable runner volume.
-systemctl mask systemd-fsck-root.service
-
 temporary_fstab="$(mktemp)"
 trap 'rm -f "$temporary_fstab"' EXIT
+
+verify_fstab() {
+  awk '
+  function fail(message) {
+    print "configure-boot: " message > "/dev/stderr"
+    invalid = 1
+  }
+
+  function trim(value) {
+    sub(/^[[:space:]]+/, "", value)
+    sub(/[[:space:]]+$/, "", value)
+    return value
+  }
+
+  function has_option(options, option, values, count, i, value) {
+    count = split(options, values, ",")
+    for (i = 1; i <= count; i++) {
+      value = tolower(trim(values[i]))
+      if (value == option) return 1
+    }
+    return 0
+  }
+
+  /^[[:space:]]*#/ || NF == 0 {
+    next
+  }
+
+  {
+    if ($2 == "/" || $2 == "/boot" || $2 == "/boot/efi") {
+      if (NF < 6) {
+        fail("expected six fields for fstab mount " $2)
+        next
+      }
+      if ($5 !~ /^[0-9]+$/ || $6 !~ /^[0-9]+$/) {
+        fail("expected numeric dump and pass fields for fstab mount " $2)
+        next
+      }
+    }
+    if ($2 == "/boot" || $2 == "/boot/efi") {
+      seen[$2] = 1
+      if (!has_option($4, "noauto")) fail("fstab mount " $2 " is missing noauto")
+      if ($6 != 0) fail("fstab mount " $2 " must use pass 0")
+    }
+  }
+
+  END {
+    if (!seen["/boot"]) fail("missing fstab mount /boot")
+    if (!seen["/boot/efi"]) fail("missing fstab mount /boot/efi")
+    exit invalid
+  }
+  ' "$1"
+}
+
 awk '
 function fail(message) {
   print "configure-boot: " message > "/dev/stderr"
   exit 1
 }
 
-function add_option(options, option, values, count, i) {
+function trim(value) {
+  sub(/^[[:space:]]+/, "", value)
+  sub(/[[:space:]]+$/, "", value)
+  return value
+}
+
+function merge_option_field(options, value) {
+  value = trim(value)
+  if (options == "" || options ~ /,[[:space:]]*$/) return options value
+  return options "," value
+}
+
+function add_option(options, option, values, count, i, value, normalized, found) {
   count = split(options, values, ",")
+  normalized = ""
+  found = 0
   for (i = 1; i <= count; i++) {
-    if (values[i] == option) return options
+    value = trim(values[i])
+    if (value == "") continue
+    if (tolower(value) == option) {
+      value = option
+      found = 1
+    }
+    normalized = normalized == "" ? value : normalized "," value
   }
-  return options == "" ? option : options "," option
+  if (!found) normalized = normalized == "" ? option : normalized "," option
+  return normalized
 }
 
 /^[[:space:]]*#/ || NF == 0 {
@@ -48,24 +112,51 @@ function add_option(options, option, values, count, i) {
 }
 
 {
-  changed = 0
   if ($2 == "/" || $2 == "/boot" || $2 == "/boot/efi") {
     if (NF < 6) fail("expected six fields for fstab mount " $2)
+    option_field = 5
+    while (option_field <= NF && $option_field !~ /^[0-9]+$/) {
+      $4 = merge_option_field($4, $option_field)
+      option_field++
+    }
+    if (option_field > 5 && option_field + 1 <= NF) {
+      if ($(option_field + 1) ~ /^[0-9]+$/ && $option_field ~ /^[0-9]+$/) {
+        field_shift = option_field - 5
+        for (i = 5; i <= NF - field_shift; i++) $i = $(i + field_shift)
+        NF -= field_shift
+      }
+    }
+    if ($5 !~ /^[0-9]+$/ || $6 !~ /^[0-9]+$/) {
+      fail("expected numeric dump and pass fields for fstab mount " $2)
+    }
   }
   if ($2 == "/" || $2 == "/boot") {
     $4 = add_option($4, "noatime")
-    changed = 1
   }
   if ($2 == "/boot" || $2 == "/boot/efi") {
     $4 = add_option($4, "noauto")
     $6 = 0
-    changed = 1
   }
-  if (changed) {
-    print
-  } else {
-    print
-  }
+  print
 }
 ' "$fstab" > "$temporary_fstab"
+
+if ! verify_fstab "$temporary_fstab"; then
+  exit 1
+fi
+
+systemctl set-default multi-user.target
+if [ "$(systemctl get-default)" != 'multi-user.target' ]; then
+  printf '%s\n' 'configure-boot: default target is not multi-user.target' >&2
+  exit 1
+fi
+
 install -m 0644 "$temporary_fstab" "$fstab"
+
+if ! verify_fstab "$fstab"; then
+  exit 1
+fi
+
+# The image is checked during the bake; running root fsck on every ephemeral boot
+# only adds latency and cannot repair a durable runner volume.
+systemctl mask systemd-fsck-root.service

--- a/infra/images/runner/scripts/build/configure-boot.sh
+++ b/infra/images/runner/scripts/build/configure-boot.sh
@@ -16,6 +16,12 @@ if [ ! -r "$grub_config" ] || ! grep -Eq '(^|[[:space:]])fsck\.mode=skip([[:spac
   exit 1
 fi
 
+systemctl set-default multi-user.target
+if [ "$(systemctl get-default)" != 'multi-user.target' ]; then
+  printf '%s\n' 'configure-boot: default target is not multi-user.target' >&2
+  exit 1
+fi
+
 # The image is checked during the bake; running root fsck on every ephemeral boot
 # only adds latency and cannot repair a durable runner volume.
 systemctl mask systemd-fsck-root.service
@@ -51,6 +57,7 @@ function add_option(options, option, values, count, i) {
     changed = 1
   }
   if ($2 == "/boot" || $2 == "/boot/efi") {
+    $4 = add_option($4, "noauto")
     $6 = 0
     changed = 1
   }

--- a/infra/images/runner/scripts/build/configure-ephemeral-boot.sh
+++ b/infra/images/runner/scripts/build/configure-ephemeral-boot.sh
@@ -3,6 +3,9 @@ set -eu
 
 # Runner instances are ephemeral. These units either repeat work already done while
 # baking the image or maintain state that has no value after the instance exits.
+# configure-boot.sh leaves /boot and /boot/efi detached at runtime. This inventory
+# includes the image's package, bootloader, and firmware writers so they cannot
+# update the root-volume shadow directories behind those detached mounts.
 # Keep the inventory explicit. The bake fails when a base image no longer contains
 # one of these units, so a renamed or removed unit cannot silently weaken the gate.
 

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1075,13 +1075,16 @@ UUID=data /data ext4 defaults 0 2
       expect(await readFile(join(fixture.root, 'boot/grub/grub.cfg'), 'utf8')).toContain(
         'fsck.mode=skip',
       );
+      expect(await readFile(join(fixture.root, 'etc/systemd/default-target'), 'utf8')).toBe(
+        'multi-user.target\n',
+      );
       expect(await readFile(join(fixture.root, 'etc/systemd/systemctl.log'), 'utf8')).toBe(
         'mask systemd-fsck-root.service\nmask systemd-fsck-root.service\n',
       );
       expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(`# fstab
 UUID=root / ext4 defaults,noatime 0 1
-UUID=boot /boot ext4 defaults,noatime 0 0 extra-column
-UUID=efi /boot/efi vfat defaults 0 0
+UUID=boot /boot ext4 defaults,noatime,noauto 0 0 extra-column
+UUID=efi /boot/efi vfat defaults,noauto 0 0
 UUID=data /data ext4 defaults 0 2
 `);
     } finally {
@@ -1265,10 +1268,25 @@ async function createBootFixture(fstab: string) {
       '#!/bin/sh',
       'set -eu',
       `root_dir=\${RUNNER_IMAGE_ROOT:?}`,
-      '[ "$#" -eq 2 ]',
-      '[ "$1" = mask ]',
-      '[ "$2" = systemd-fsck-root.service ]',
-      'printf "%s\\n" "$*" >> "$root_dir/etc/systemd/systemctl.log"',
+      'case "$1" in',
+      '  set-default)',
+      '    [ "$#" -eq 2 ]',
+      '    [ "$2" = multi-user.target ]',
+      '    printf "%s\\n" "$2" > "$root_dir/etc/systemd/default-target"',
+      '    ;;',
+      '  get-default)',
+      '    [ "$#" -eq 1 ]',
+      '    cat "$root_dir/etc/systemd/default-target"',
+      '    ;;',
+      '  mask)',
+      '    [ "$#" -eq 2 ]',
+      '    [ "$2" = systemd-fsck-root.service ]',
+      '    printf "%s\\n" "$*" >> "$root_dir/etc/systemd/systemctl.log"',
+      '    ;;',
+      '  *)',
+      '    exit 1',
+      '    ;;',
+      'esac',
       '',
     ].join('\n'),
   );

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1092,6 +1092,34 @@ UUID=data /data ext4 defaults 0 2
     }
   });
 
+  it('fails before touching fstab when default target verification disagrees', async () => {
+    const fstab = `# fstab
+UUID=root / ext4 defaults 0 1
+UUID=boot /boot ext4 defaults 0 1
+UUID=efi /boot/efi vfat defaults 0 1
+`;
+    const fixture = await createBootFixture(fstab);
+
+    try {
+      expect(() =>
+        execFileSync('sh', [script.pathname], {
+          env: {
+            ...fixture.environment,
+            RUNNER_IMAGE_SYSTEMCTL_DEFAULT_TARGET: 'graphical.target',
+          },
+          stdio: 'pipe',
+        }),
+      ).toThrow();
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(fstab);
+      expect(await readFile(join(fixture.root, 'etc/systemd/default-target'), 'utf8')).toBe(
+        'multi-user.target\n',
+      );
+      expect(await pathExists(join(fixture.root, 'etc/systemd/systemctl.log'))).toBe(false);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
   it('fails before publishing an image when a target fstab entry is malformed', async () => {
     const fstab = 'UUID=root / ext4 defaults\n';
     const fixture = await createBootFixture(fstab);
@@ -1101,6 +1129,70 @@ UUID=data /data ext4 defaults 0 2
         execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
       ).toThrow();
       expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(fstab);
+      expect(await pathExists(join(fixture.root, 'etc/systemd/default-target'))).toBe(false);
+      expect(await pathExists(join(fixture.root, 'etc/systemd/systemctl.log'))).toBe(false);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('fails before publishing an image when a boot fstab entry is missing', async () => {
+    const fstab = `# fstab
+UUID=root / ext4 defaults 0 1
+UUID=efi /boot/efi vfat defaults 0 1
+`;
+    const fixture = await createBootFixture(fstab);
+
+    try {
+      expect(() =>
+        execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'}),
+      ).toThrow();
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(fstab);
+      expect(await pathExists(join(fixture.root, 'etc/systemd/default-target'))).toBe(false);
+      expect(await pathExists(join(fixture.root, 'etc/systemd/systemctl.log'))).toBe(false);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it.each(['NOAUTO', 'NoAuto'])('canonicalizes an existing %s fstab option', async (option) => {
+    const fstab = `# fstab
+UUID=root / ext4 defaults 0 1
+UUID=boot /boot ext4 defaults,noatime,${option} 0 1 extra-column
+UUID=efi /boot/efi vfat defaults,${option} 0 1
+`;
+    const fixture = await createBootFixture(fstab);
+
+    try {
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(`# fstab
+UUID=root / ext4 defaults,noatime 0 1
+UUID=boot /boot ext4 defaults,noatime,noauto 0 0 extra-column
+UUID=efi /boot/efi vfat defaults,noauto 0 0
+`);
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('normalizes space-padded fstab options', async () => {
+    const fstab = `# fstab
+UUID=root / ext4 defaults 0 1
+UUID=boot /boot ext4 defaults, noauto 0 1
+UUID=efi /boot/efi vfat defaults, NoAuto 0 1
+`;
+    const fixture = await createBootFixture(fstab);
+
+    try {
+      execFileSync('sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toBe(`# fstab
+UUID=root / ext4 defaults,noatime 0 1
+UUID=boot /boot ext4 defaults,noauto,noatime 0 0
+UUID=efi /boot/efi vfat defaults,noauto 0 0
+`);
     } finally {
       await rm(fixture.root, {force: true, recursive: true});
     }
@@ -1276,7 +1368,11 @@ async function createBootFixture(fstab: string) {
       '    ;;',
       '  get-default)',
       '    [ "$#" -eq 1 ]',
-      '    cat "$root_dir/etc/systemd/default-target"',
+      `    if [ -n "\${RUNNER_IMAGE_SYSTEMCTL_DEFAULT_TARGET:-}" ]; then`,
+      '      printf "%s\\n" "$RUNNER_IMAGE_SYSTEMCTL_DEFAULT_TARGET"',
+      '    else',
+      '      cat "$root_dir/etc/systemd/default-target"',
+      '    fi',
       '    ;;',
       '  mask)',
       '    [ "$#" -eq 2 ]',


### PR DESCRIPTION
The runner image was still booting through graphical.target and mounting /boot and /boot/efi, adding unnecessary boot latency. This makes the target selection fail closed and marks the unused boot mounts noauto while retaining pass 0.\n\nThe hermetic image fixture covers target verification and idempotent fstab output.\n\nCloses ENG-1566

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the runner image default target to `multi-user.target` and stop mounting `/boot` and `/boot/efi` to cut boot time. Hardened the bake to fail closed on target or `fstab` drift and leave no partial state on errors; aligns with ENG-1566.

- **Bug Fixes**
  - Force default target via `systemctl set-default` and verify with `systemctl get-default`; exit on mismatch.
  - Rewrite and verify `fstab`: add `noauto` and pass `0` for `/boot` and `/boot/efi`, keep `noatime` on `/` and `/boot`, normalize option casing/spacing, ensure both boot entries exist, and make the change idempotent.
  - Fail early without touching disk or `systemd` on malformed `fstab` or target mismatch; extend the composition gate and README to assert the target and detached boot mounts, and document masking of package/bootloader/firmware updaters.

<sup>Written for commit 0526e0a4843b7938c98894f3fd8a750838af5575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

