### PR TITLE
[runner] Defer AI imports until jobs

### DIFF
--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -135,9 +135,8 @@ ENV IMAGE_REVISION=$IMAGE_REVISION \
     BUILD_NUMBER=$BUILD_NUMBER \
     RUNNER_VERSION=$RUNNER_VERSION
 
-# tini as PID 1; --enable-source-maps maps stack traces back to TypeScript.
-# OpenTelemetry is started in-process by startRunner(), so it needs no preload
-# flag. The flag stays on the entrypoint command (not NODE_OPTIONS) so it applies
-# to the runner only, not to the user step processes it spawns.
+# tini as PID 1. OpenTelemetry is started in-process by startRunner(), so it
+# needs no preload flag. The runner command is separate from user step
+# processes, which are spawned by the runner.
 ENTRYPOINT ["tini", "--"]
-CMD ["node", "--enable-source-maps", "./dist/index.js"]
+CMD ["node", "./dist/index.js"]

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -1,8 +1,11 @@
-import {logger} from '@shipfox/node-opentelemetry';
-import {startRunner} from '@shipfox/runner-orchestration';
+const processEntryUptimeSeconds = process.uptime();
+const [{logger}, {startRunner}] = await Promise.all([
+  import('@shipfox/node-opentelemetry'),
+  import('@shipfox/runner-orchestration'),
+]);
 
 try {
-  await startRunner();
+  await startRunner({processEntryUptimeSeconds});
 } catch (error) {
   logger().error({error}, 'Fatal runner error');
   process.exit(1);

--- a/apps/runner/src/verify-installation.ts
+++ b/apps/runner/src/verify-installation.ts
@@ -1,4 +1,21 @@
+import {createRequire} from 'node:module';
 import {assertPiHarnessExtensionsAvailable} from '@shipfox/runner-agent/pi-extensions';
+
+const require = createRequire(import.meta.url);
+const RUNNER_AGENT_RUNTIME_EXPORTS = [
+  '@shipfox/runner-agent/pi-extensions',
+  '@shipfox/runner-agent/tool-capabilities',
+  '@shipfox/runner-agent/step',
+] as const;
+
+for (const specifier of RUNNER_AGENT_RUNTIME_EXPORTS) {
+  try {
+    require.resolve(specifier);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to resolve runner agent export "${specifier}": ${reason}`);
+  }
+}
 
 // Runs during the container and AMI image builds, against the deployed production closure rather
 // than the pnpm development tree. Imports the leaf module, not a package barrel: the runner barrels

--- a/apps/runner/src/verify-installation.ts
+++ b/apps/runner/src/verify-installation.ts
@@ -3,7 +3,6 @@ import {assertPiHarnessExtensionsAvailable} from '@shipfox/runner-agent/pi-exten
 
 const require = createRequire(import.meta.url);
 const RUNNER_AGENT_RUNTIME_EXPORTS = [
-  '@shipfox/runner-agent/pi-extensions',
   '@shipfox/runner-agent/tool-capabilities',
   '@shipfox/runner-agent/step',
 ] as const;

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -13,7 +13,7 @@ EnvironmentFile=/etc/shipfox/runner.env
 Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
 ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh
 WorkingDirectory=/opt/runner
-ExecStart=/usr/local/bin/node --enable-source-maps dist/index.js
+ExecStart=/usr/local/bin/node dist/index.js
 Restart=no
 KillSignal=SIGTERM
 KillMode=control-group

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -913,6 +913,10 @@ describe('systemd boot activation', () => {
       'ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh',
     );
     expect(unit).not.toContain('RequiresMountsFor=');
+    expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
+      '/usr/local/bin/node dist/index.js',
+    );
+    expect(unit).not.toContain('--enable-source-maps');
   });
 
   it('ships the provider-gated workspace preflight separately from the runner app', async () => {

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1071,6 +1071,20 @@ describe('systemd boot activation', () => {
   });
 });
 
+describe('runner container entrypoint', () => {
+  it('starts the compiled runner and verifies its production closure', async () => {
+    const dockerfile = await readFile(
+      new URL('../../../../apps/runner/Dockerfile', import.meta.url),
+      'utf8',
+    );
+
+    expect(dockerfile).toContain('RUN node ./dist/verify-installation.js');
+    expect(dockerfile).toContain('ENTRYPOINT ["tini", "--"]');
+    expect(dockerfile).toContain('CMD ["node", "./dist/index.js"]');
+    expect(dockerfile).not.toContain('--enable-source-maps');
+  });
+});
+
 describe('runner boot configuration', () => {
   const script = new URL('../scripts/build/configure-boot.sh', import.meta.url);
 

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -35,6 +35,26 @@
         "types": "./dist/core/pi-extensions.d.ts",
         "default": "./dist/core/pi-extensions.js"
       }
+    },
+    "./tool-capabilities": {
+      "workspace-source": {
+        "types": "./src/core/tool-capabilities.ts",
+        "default": "./src/core/tool-capabilities.ts"
+      },
+      "default": {
+        "types": "./dist/core/tool-capabilities.d.ts",
+        "default": "./dist/core/tool-capabilities.js"
+      }
+    },
+    "./step": {
+      "workspace-source": {
+        "types": "./src/core/step.ts",
+        "default": "./src/core/step.ts"
+      },
+      "default": {
+        "types": "./dist/core/step.d.ts",
+        "default": "./dist/core/step.js"
+      }
     }
   },
   "scripts": {

--- a/libs/runner/orchestration/package.json
+++ b/libs/runner/orchestration/package.json
@@ -55,6 +55,7 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
-    "@shipfox/vitest": "workspace:*"
+    "@shipfox/vitest": "workspace:*",
+    "tsx": "catalog:"
   }
 }

--- a/libs/runner/orchestration/src/core/boot-timeline.test.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.test.ts
@@ -1,4 +1,4 @@
-import {createBootTimelineCollector} from '#core/boot-timeline.js';
+import {createBootTimelineCollector, createRunnerBootPhaseTimeline} from '#core/boot-timeline.js';
 
 function systemdStat(startTicks: number): string {
   return `1 (systemd) S ${Array.from({length: 18}, () => '0').join(' ')} ${startTicks}`;
@@ -38,6 +38,32 @@ describe('boot timeline collection', () => {
       runner_read_ops: 30,
       runner_read_bytes_per_second: 15_360 / 20.5,
     });
+  });
+
+  it('records each runner phase once from a monotonic clock', () => {
+    const now = vi
+      .fn<() => number>()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(11)
+      .mockReturnValueOnce(12)
+      .mockReturnValueOnce(13)
+      .mockReturnValueOnce(14);
+    const timeline = createRunnerBootPhaseTimeline(now);
+
+    timeline.mark('runner_started_offset_seconds');
+    timeline.mark('runner_started_offset_seconds');
+    timeline.mark('bootstrap_exchange_offset_seconds');
+    timeline.mark('activation_offset_seconds');
+    timeline.mark('first_claim_offset_seconds');
+
+    expect(timeline.snapshot()).toEqual({
+      process_entry_offset_seconds: 10,
+      runner_started_offset_seconds: 11,
+      bootstrap_exchange_offset_seconds: 12,
+      activation_offset_seconds: 13,
+      first_claim_offset_seconds: 14,
+    });
+    expect(now).toHaveBeenCalledTimes(5);
   });
 
   it('keeps the event useful when an older image has no telemetry files', () => {

--- a/libs/runner/orchestration/src/core/boot-timeline.test.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.test.ts
@@ -23,7 +23,7 @@ describe('boot timeline collection', () => {
     const event = collector.createEvent(collector.captureEnrollment());
 
     expect(event).toEqual({
-      boot_timeline_version: 1,
+      boot_timeline_version: 2,
       telemetry_state: 'complete',
       uptime_seconds: 42.5,
       process_start_offset_seconds: 40,
@@ -48,22 +48,22 @@ describe('boot timeline collection', () => {
       .mockReturnValueOnce(12)
       .mockReturnValueOnce(13)
       .mockReturnValueOnce(14);
-    const timeline = createRunnerBootPhaseTimeline(now);
+    const timeline = createRunnerBootPhaseTimeline(now, 9);
 
-    timeline.mark('runner_started_offset_seconds');
-    timeline.mark('runner_started_offset_seconds');
-    timeline.mark('bootstrap_exchange_offset_seconds');
-    timeline.mark('activation_offset_seconds');
-    timeline.mark('first_claim_offset_seconds');
+    timeline.mark('runner_started_uptime_seconds');
+    timeline.mark('runner_started_uptime_seconds');
+    timeline.mark('bootstrap_exchange_uptime_seconds');
+    timeline.mark('activation_uptime_seconds');
+    timeline.mark('first_claim_uptime_seconds');
 
     expect(timeline.snapshot()).toEqual({
-      process_entry_offset_seconds: 10,
-      runner_started_offset_seconds: 11,
-      bootstrap_exchange_offset_seconds: 12,
-      activation_offset_seconds: 13,
-      first_claim_offset_seconds: 14,
+      process_entry_uptime_seconds: 9,
+      runner_started_uptime_seconds: 10,
+      bootstrap_exchange_uptime_seconds: 11,
+      activation_uptime_seconds: 12,
+      first_claim_uptime_seconds: 13,
     });
-    expect(now).toHaveBeenCalledTimes(5);
+    expect(now).toHaveBeenCalledTimes(4);
   });
 
   it('keeps the event useful when an older image has no telemetry files', () => {
@@ -71,7 +71,7 @@ describe('boot timeline collection', () => {
     const collector = createBootTimelineCollector((path) => files[path]);
 
     expect(collector.createEvent(collector.captureEnrollment())).toEqual({
-      boot_timeline_version: 1,
+      boot_timeline_version: 2,
       telemetry_state: 'unavailable',
       uptime_seconds: 12.25,
       process_start_offset_seconds: 12.25,

--- a/libs/runner/orchestration/src/core/boot-timeline.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.ts
@@ -7,7 +7,8 @@ const PROCESS_STAT_PATH = '/proc/self/stat';
 const SYSTEMD_STAT_PATH = '/proc/1/stat';
 const UPTIME_PATH = '/proc/uptime';
 const SYSTEM_CLOCK_TICKS_PER_SECOND = 100;
-const BOOT_TIMELINE_VERSION = 1 as const;
+// Version 2 names runner phase samples in the process.uptime() time base.
+const BOOT_TIMELINE_VERSION = 2 as const;
 const ROOT_DEVICE_PATTERN = /^[a-zA-Z0-9._-]+$/u;
 const IMAGE_REVISION_PATTERN = /^[a-zA-Z0-9._-]+$/u;
 const WHITESPACE_PATTERN = /\s+/u;
@@ -30,13 +31,13 @@ type EnrollmentSample = {
 };
 
 type RunnerBootPhase =
-  | 'runner_started_offset_seconds'
-  | 'bootstrap_exchange_offset_seconds'
-  | 'activation_offset_seconds'
-  | 'first_claim_offset_seconds';
+  | 'runner_started_uptime_seconds'
+  | 'bootstrap_exchange_uptime_seconds'
+  | 'activation_uptime_seconds'
+  | 'first_claim_uptime_seconds';
 
 type RunnerBootPhaseFields = {
-  process_entry_offset_seconds: number;
+  process_entry_uptime_seconds: number;
 } & Partial<Record<RunnerBootPhase, number>>;
 
 export type BootTimelineFields = {
@@ -237,10 +238,13 @@ export function createBootTimelineCollector(read: ReadText = readText) {
   };
 }
 
-/** Records process-monotonic offsets for the phases that surround runner enrollment. */
-export function createRunnerBootPhaseTimeline(now: () => number = () => process.uptime()) {
+/** Records process-uptime samples for the phases that surround runner enrollment. */
+export function createRunnerBootPhaseTimeline(
+  now: () => number = () => process.uptime(),
+  processEntryUptimeSeconds = now(),
+) {
   const fields: RunnerBootPhaseFields = {
-    process_entry_offset_seconds: now(),
+    process_entry_uptime_seconds: processEntryUptimeSeconds,
   };
 
   return {

--- a/libs/runner/orchestration/src/core/boot-timeline.ts
+++ b/libs/runner/orchestration/src/core/boot-timeline.ts
@@ -29,6 +29,16 @@ type EnrollmentSample = {
   uptimeSeconds?: number;
 };
 
+type RunnerBootPhase =
+  | 'runner_started_offset_seconds'
+  | 'bootstrap_exchange_offset_seconds'
+  | 'activation_offset_seconds'
+  | 'first_claim_offset_seconds';
+
+type RunnerBootPhaseFields = {
+  process_entry_offset_seconds: number;
+} & Partial<Record<RunnerBootPhase, number>>;
+
 export type BootTimelineFields = {
   boot_timeline_version: typeof BOOT_TIMELINE_VERSION;
   telemetry_state: 'complete' | 'unavailable';
@@ -223,6 +233,24 @@ export function createBootTimelineCollector(read: ReadText = readText) {
       addReadFields(fields, processStartOffsetSeconds, processStartDiskReads, enrollment, bootIo);
 
       return fields;
+    },
+  };
+}
+
+/** Records process-monotonic offsets for the phases that surround runner enrollment. */
+export function createRunnerBootPhaseTimeline(now: () => number = () => process.uptime()) {
+  const fields: RunnerBootPhaseFields = {
+    process_entry_offset_seconds: now(),
+  };
+
+  return {
+    mark(phase: RunnerBootPhase): void {
+      if (fields[phase] !== undefined) return;
+      fields[phase] = now();
+    },
+
+    snapshot(): RunnerBootPhaseFields {
+      return {...fields};
     },
   };
 }

--- a/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
+++ b/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
@@ -8,6 +8,7 @@ import {fileURLToPath} from 'node:url';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const probePath = resolve(packageRoot, 'test/bootstrap-module-set-probe.mjs');
 const moduleTrackerPath = resolve(packageRoot, 'test/module-load-tracker.mjs');
+const commonJsModuleTrackerPath = resolve(packageRoot, 'test/module-load-tracker.cjs');
 const require = createRequire(import.meta.url);
 const tsxLoaderPath = require.resolve('tsx');
 const LINE_BREAK_PATTERN = /\r?\n/u;
@@ -23,6 +24,8 @@ it('keeps heavy agent packages out of the managed bootstrap module set', () => {
       process.execPath,
       [
         '--conditions=workspace-source',
+        '--require',
+        commonJsModuleTrackerPath,
         `--import=${tsxLoaderPath}`,
         '--loader',
         moduleTrackerPath,

--- a/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
+++ b/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
@@ -1,5 +1,6 @@
 import {spawnSync} from 'node:child_process';
-import {existsSync, mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
 import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -7,7 +8,11 @@ import {fileURLToPath} from 'node:url';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const probePath = resolve(packageRoot, 'test/bootstrap-module-set-probe.mjs');
 const moduleTrackerPath = resolve(packageRoot, 'test/module-load-tracker.mjs');
-const tsxLoaderPath = resolve(packageRoot, '../../../apps/runner/node_modules/tsx/dist/loader.mjs');
+const require = createRequire(import.meta.url);
+const tsxLoaderPath = require.resolve('tsx');
+const LINE_BREAK_PATTERN = /\r?\n/u;
+const HEAVY_AGENT_PACKAGE_PATTERN =
+  /\/node_modules\/(?:@anthropic-ai|@earendil-works|@modelcontextprotocol)(?:\/|\+)/u;
 
 it('keeps heavy agent packages out of the managed bootstrap module set', () => {
   const trackerDirectory = mkdtempSync(join(tmpdir(), 'shipfox-runner-module-set-'));
@@ -46,8 +51,11 @@ it('keeps heavy agent packages out of the managed bootstrap module set', () => {
       );
     }
 
-    const loadedHeavyModules = existsSync(trackerFile) ? readFileSync(trackerFile, 'utf8') : '';
-    expect(loadedHeavyModules).toBe('');
+    const loadedModules = readFileSync(trackerFile, 'utf8')
+      .split(LINE_BREAK_PATTERN)
+      .filter(Boolean);
+    expect(loadedModules.length).toBeGreaterThan(0);
+    expect(loadedModules.some((url) => HEAVY_AGENT_PACKAGE_PATTERN.test(url))).toBe(false);
   } finally {
     rmSync(trackerDirectory, {recursive: true, force: true});
   }

--- a/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
+++ b/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
@@ -1,0 +1,54 @@
+import {spawnSync} from 'node:child_process';
+import {existsSync, mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const probePath = resolve(packageRoot, 'test/bootstrap-module-set-probe.mjs');
+const moduleTrackerPath = resolve(packageRoot, 'test/module-load-tracker.mjs');
+const tsxLoaderPath = resolve(packageRoot, '../../../apps/runner/node_modules/tsx/dist/loader.mjs');
+
+it('keeps heavy agent packages out of the managed bootstrap module set', () => {
+  const trackerDirectory = mkdtempSync(join(tmpdir(), 'shipfox-runner-module-set-'));
+  const trackerFile = join(trackerDirectory, 'heavy-modules.txt');
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--conditions=workspace-source',
+        `--import=${tsxLoaderPath}`,
+        '--loader',
+        moduleTrackerPath,
+        probePath,
+      ],
+      {
+        cwd: packageRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          SHIPFOX_MODULE_TRACKER_FILE: trackerFile,
+        },
+      },
+    );
+
+    if (result.error !== undefined || result.status !== 0) {
+      throw new Error(
+        [
+          result.error?.message,
+          `exit status: ${String(result.status)}`,
+          result.stdout,
+          result.stderr,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+      );
+    }
+
+    const loadedHeavyModules = existsSync(trackerFile) ? readFileSync(trackerFile, 'utf8') : '';
+    expect(loadedHeavyModules).toBe('');
+  } finally {
+    rmSync(trackerDirectory, {recursive: true, force: true});
+  }
+});

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -428,13 +428,18 @@ describe('startRunner', () => {
     vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
     mockRunnerStartupMode.mockReturnValue('managed');
 
+    let cleanupSettled = false;
     let finishCleanup!: () => void;
     mockCleanupOrphanedJobLogs.mockReturnValue(
       new Promise<void>((resolve) => {
-        finishCleanup = resolve;
+        finishCleanup = () => {
+          cleanupSettled = true;
+          resolve();
+        };
       }),
     );
     mockExchangeRunnerBootstrapToken.mockImplementation(() => {
+      expect(cleanupSettled).toBe(false);
       finishCleanup();
       return Promise.resolve({controlSessionToken: 'control-token'});
     });
@@ -448,6 +453,27 @@ describe('startRunner', () => {
     expect(mockCleanupOrphanedJobLogs.mock.invocationCallOrder[0]).toBeLessThan(
       mockExchangeRunnerBootstrapToken.mock.invocationCallOrder[0] ?? Infinity,
     );
+  });
+
+  it('warns when orphan log cleanup fails without blocking managed bootstrap', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const cleanupError = new Error('permission denied');
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
+    mockRunnerStartupMode.mockReturnValue('managed');
+    mockCleanupOrphanedJobLogs.mockRejectedValue(cleanupError);
+    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockEnrollRunnerControlSession.mockResolvedValue('activation-token');
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(warn).toHaveBeenCalledWith(
+      {err: cleanupError, workspaceRoot: WORKSPACE_ROOT},
+      'Failed to sweep orphaned job logs',
+    );
+    expect(mockExchangeRunnerBootstrapToken).toHaveBeenCalledWith('sf_rbt_bootstrap-token');
   });
 
   it('enrolls, waits, activates, and uses the activation session for managed runners', async () => {
@@ -496,10 +522,19 @@ describe('startRunner', () => {
     expect(bootTimelineCalls).toHaveLength(1);
     expect(bootTimelineCalls[0]?.[0]).toEqual(
       expect.objectContaining({
-        boot_timeline_version: 1,
+        boot_timeline_version: 2,
         telemetry_state: expect.any(String),
+        process_entry_uptime_seconds: expect.any(Number),
+        runner_started_uptime_seconds: expect.any(Number),
+        bootstrap_exchange_uptime_seconds: expect.any(Number),
         provider_kind: 'ec2',
       }),
+    );
+    const activationCall = info.mock.calls.find(
+      ([, message]) => message === 'Managed runner activated',
+    );
+    expect(activationCall?.[0]).toEqual(
+      expect.objectContaining({activation_uptime_seconds: expect.any(Number)}),
     );
     const bootTimelineCallIndex = info.mock.calls.findIndex(
       ([, message]) => message === 'runner.boot_timeline',

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -38,18 +38,35 @@ vi.mock('#core/step-loop.js', () => ({
   runJobSteps: vi.fn(),
 }));
 
-const {isPiExtensionAvailableMock} = vi.hoisted(() => ({
+const {isPiExtensionAvailableMock, runnerAgentBarrelEvaluated} = vi.hoisted(() => ({
   isPiExtensionAvailableMock: vi.fn((_params: {packageName: string}) => true),
+  runnerAgentBarrelEvaluated: {value: false},
 }));
 
-vi.mock('@shipfox/runner-agent', () => ({
+vi.mock('@shipfox/runner-agent', () => {
+  runnerAgentBarrelEvaluated.value = true;
+  return {
+    isPiExtensionAvailable: isPiExtensionAvailableMock,
+    PI_HARNESS_EXTENSION_PACKAGE_NAMES: ['pi-web-access', 'pi-mcp-adapter'],
+    runnerToolCapabilities: vi.fn(() => ({
+      harnesses: {
+        pi: {tools: ['read']},
+      },
+    })),
+  };
+});
+
+vi.mock('@shipfox/runner-agent/pi-extensions', () => ({
+  isPiExtensionAvailable: isPiExtensionAvailableMock,
+  PI_HARNESS_EXTENSION_PACKAGE_NAMES: ['pi-web-access', 'pi-mcp-adapter'],
+}));
+
+vi.mock('@shipfox/runner-agent/tool-capabilities', () => ({
   runnerToolCapabilities: vi.fn(() => ({
     harnesses: {
       pi: {tools: ['read']},
     },
   })),
-  isPiExtensionAvailable: isPiExtensionAvailableMock,
-  PI_HARNESS_EXTENSION_PACKAGE_NAMES: ['pi-web-access', 'pi-mcp-adapter'],
 }));
 
 vi.mock('@shipfox/runner-protocol', () => ({
@@ -79,7 +96,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
 
 import {logger} from '@shipfox/node-opentelemetry';
 import {interruptibleSleep} from '@shipfox/node-resilient-loop';
-import {runnerToolCapabilities} from '@shipfox/runner-agent';
+import {runnerToolCapabilities} from '@shipfox/runner-agent/tool-capabilities';
 import {
   consumeManagedRunnerBootstrapToken,
   createLeaseClient,
@@ -170,6 +187,7 @@ beforeEach(() => {
   mockJobWorkspacePath.mockReturnValue(JOB_CWD);
   mockJobLogsPath.mockReturnValue(JOB_LOGS_DIR);
   mockJobCredentialsPath.mockReturnValue(JOB_CREDENTIALS_DIR);
+  mockCleanupOrphanedJobLogs.mockResolvedValue(undefined);
   mockRunJobSteps.mockResolvedValue();
 });
 
@@ -404,6 +422,34 @@ describe('startRunner', () => {
     expect(mockInterruptibleSleep).toHaveBeenCalledTimes(1);
   });
 
+  it('does not wait for orphan log cleanup before managed bootstrap', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
+    mockRunnerStartupMode.mockReturnValue('managed');
+
+    let finishCleanup!: () => void;
+    mockCleanupOrphanedJobLogs.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      }),
+    );
+    mockExchangeRunnerBootstrapToken.mockImplementation(() => {
+      finishCleanup();
+      return Promise.resolve({controlSessionToken: 'control-token'});
+    });
+    mockEnrollRunnerControlSession.mockResolvedValue('activation-token');
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockCleanupOrphanedJobLogs).toHaveBeenCalledWith(WORKSPACE_ROOT);
+    expect(mockExchangeRunnerBootstrapToken).toHaveBeenCalledWith('sf_rbt_bootstrap-token');
+    expect(mockCleanupOrphanedJobLogs.mock.invocationCallOrder[0]).toBeLessThan(
+      mockExchangeRunnerBootstrapToken.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+
   it('enrolls, waits, activates, and uses the activation session for managed runners', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(0);
     const info = vi.spyOn(logger(), 'info').mockImplementation(() => undefined);
@@ -423,6 +469,7 @@ describe('startRunner', () => {
 
     await startRunner();
 
+    expect(runnerAgentBarrelEvaluated.value).toBe(false);
     expect(mockConsumeManagedRunnerBootstrapToken).toHaveBeenCalledTimes(1);
     expect(mockExchangeRunnerBootstrapToken).toHaveBeenCalledWith('sf_rbt_bootstrap-token');
     expect(mockEnrollRunnerControlSession).toHaveBeenCalledWith({

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -9,8 +9,8 @@ import {
 import {
   isPiExtensionAvailable,
   PI_HARNESS_EXTENSION_PACKAGE_NAMES,
-  runnerToolCapabilities,
-} from '@shipfox/runner-agent';
+} from '@shipfox/runner-agent/pi-extensions';
+import {runnerToolCapabilities} from '@shipfox/runner-agent/tool-capabilities';
 import {
   consumeManagedRunnerBootstrapToken,
   createLeaseClient,
@@ -39,13 +39,14 @@ import {
 } from '@shipfox/runner-workspace';
 import {isTimeoutError} from 'ky';
 import {config} from '#config.js';
-import {createBootTimelineCollector} from '#core/boot-timeline.js';
+import {createBootTimelineCollector, createRunnerBootPhaseTimeline} from '#core/boot-timeline.js';
 import {startHeartbeatLoop} from '#core/heartbeat-loop.js';
 import {runJobSteps} from '#core/step-loop.js';
 
 let running = true;
 let warnedAboutUnavailablePiExtensions = false;
 const bootTimeline = createBootTimelineCollector();
+const bootPhaseTimeline = createRunnerBootPhaseTimeline();
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
@@ -70,13 +71,17 @@ export async function startRunner(): Promise<void> {
   // Fail fast at startup: a dangerous root should crash the process at deploy,
   // not silently fail every job.
   const workspaceRoot = resolveWorkspaceRootFromEnv();
-  await cleanupOrphanedJobLogs(workspaceRoot);
+  void cleanupOrphanedJobLogs(workspaceRoot).catch((error) => {
+    logger().warn({err: error, workspaceRoot}, 'Failed to sweep orphaned job logs');
+  });
   requireRunnerLabels();
   warnAboutUnavailablePiExtensions();
   const startupMode = runnerStartupMode();
 
+  bootPhaseTimeline.mark('runner_started_offset_seconds');
   logger().info(
     {
+      ...bootPhaseTimeline.snapshot(),
       pollInterval: config.SHIPFOX_POLL_INTERVAL_MS,
       pollMaxDuration: config.SHIPFOX_POLL_MAX_DURATION_MS,
       workspaceRoot,
@@ -116,8 +121,10 @@ export async function startRunner(): Promise<void> {
 
       if (!running) return;
 
+      bootPhaseTimeline.mark('first_claim_offset_seconds');
       logger().info(
         {
+          ...bootPhaseTimeline.snapshot(),
           workflowRunId: job.workflow_run_id,
           workflowRunAttemptId: job.workflow_run_attempt_id,
           jobId: job.job_id,
@@ -296,6 +303,7 @@ export async function runJob(
 async function initializeManagedRunnerSession(): Promise<RunnerSession | undefined> {
   const bootstrapToken = consumeManagedRunnerBootstrapToken();
   const exchanged = await exchangeRunnerBootstrapToken(bootstrapToken);
+  bootPhaseTimeline.mark('bootstrap_exchange_offset_seconds');
   const controlSessionToken = exchanged.controlSessionToken;
   const enrollmentConfig = managedRunnerEnrollmentConfig();
   const enrollmentActivationToken = await enrollRunnerControlSession({
@@ -307,6 +315,7 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
   logger().info(
     {
       ...bootTimeline.createEvent(bootTimeline.captureEnrollment()),
+      ...bootPhaseTimeline.snapshot(),
       provider_kind: enrollmentConfig.providerKind,
     },
     'runner.boot_timeline',
@@ -319,7 +328,11 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
     capabilities: runnerToolCapabilities(),
     registrationToken: activationToken,
   });
-  logger().info({runnerSessionId: runnerSession.session_id}, 'Managed runner activated');
+  bootPhaseTimeline.mark('activation_offset_seconds');
+  logger().info(
+    {...bootPhaseTimeline.snapshot(), runnerSessionId: runnerSession.session_id},
+    'Managed runner activated',
+  );
   return runnerSession;
 }
 

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -46,7 +46,8 @@ import {runJobSteps} from '#core/step-loop.js';
 let running = true;
 let warnedAboutUnavailablePiExtensions = false;
 const bootTimeline = createBootTimelineCollector();
-const bootPhaseTimeline = createRunnerBootPhaseTimeline();
+type RunnerBootPhaseTimeline = ReturnType<typeof createRunnerBootPhaseTimeline>;
+let bootPhaseTimeline: RunnerBootPhaseTimeline | undefined;
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
@@ -63,10 +64,13 @@ const shutdownController = createGracefulShutdownController({
   },
 });
 
-export async function startRunner(): Promise<void> {
+export async function startRunner(
+  options: {processEntryUptimeSeconds?: number} = {},
+): Promise<void> {
   running = true;
   shutdownController.reset();
   shutdownController.start();
+  const runnerBootPhaseTimeline = getRunnerBootPhaseTimeline(options.processEntryUptimeSeconds);
 
   // Fail fast at startup: a dangerous root should crash the process at deploy,
   // not silently fail every job.
@@ -78,10 +82,10 @@ export async function startRunner(): Promise<void> {
   warnAboutUnavailablePiExtensions();
   const startupMode = runnerStartupMode();
 
-  bootPhaseTimeline.mark('runner_started_offset_seconds');
+  runnerBootPhaseTimeline.mark('runner_started_uptime_seconds');
   logger().info(
     {
-      ...bootPhaseTimeline.snapshot(),
+      ...runnerBootPhaseTimeline.snapshot(),
       pollInterval: config.SHIPFOX_POLL_INTERVAL_MS,
       pollMaxDuration: config.SHIPFOX_POLL_MAX_DURATION_MS,
       workspaceRoot,
@@ -92,7 +96,7 @@ export async function startRunner(): Promise<void> {
   let currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
   let runnerSession: RunnerSession | undefined;
   if (startupMode === 'managed') {
-    runnerSession = await initializeManagedRunnerSession();
+    runnerSession = await initializeManagedRunnerSession(runnerBootPhaseTimeline);
     if (!runnerSession) return;
   } else {
     await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
@@ -121,10 +125,10 @@ export async function startRunner(): Promise<void> {
 
       if (!running) return;
 
-      bootPhaseTimeline.mark('first_claim_offset_seconds');
+      runnerBootPhaseTimeline.mark('first_claim_uptime_seconds');
       logger().info(
         {
-          ...bootPhaseTimeline.snapshot(),
+          ...runnerBootPhaseTimeline.snapshot(),
           workflowRunId: job.workflow_run_id,
           workflowRunAttemptId: job.workflow_run_attempt_id,
           jobId: job.job_id,
@@ -300,10 +304,12 @@ export async function runJob(
   }
 }
 
-async function initializeManagedRunnerSession(): Promise<RunnerSession | undefined> {
+async function initializeManagedRunnerSession(
+  runnerBootPhaseTimeline: RunnerBootPhaseTimeline,
+): Promise<RunnerSession | undefined> {
   const bootstrapToken = consumeManagedRunnerBootstrapToken();
   const exchanged = await exchangeRunnerBootstrapToken(bootstrapToken);
-  bootPhaseTimeline.mark('bootstrap_exchange_offset_seconds');
+  runnerBootPhaseTimeline.mark('bootstrap_exchange_uptime_seconds');
   const controlSessionToken = exchanged.controlSessionToken;
   const enrollmentConfig = managedRunnerEnrollmentConfig();
   const enrollmentActivationToken = await enrollRunnerControlSession({
@@ -315,7 +321,7 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
   logger().info(
     {
       ...bootTimeline.createEvent(bootTimeline.captureEnrollment()),
-      ...bootPhaseTimeline.snapshot(),
+      ...runnerBootPhaseTimeline.snapshot(),
       provider_kind: enrollmentConfig.providerKind,
     },
     'runner.boot_timeline',
@@ -328,12 +334,24 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
     capabilities: runnerToolCapabilities(),
     registrationToken: activationToken,
   });
-  bootPhaseTimeline.mark('activation_offset_seconds');
+  runnerBootPhaseTimeline.mark('activation_uptime_seconds');
   logger().info(
-    {...bootPhaseTimeline.snapshot(), runnerSessionId: runnerSession.session_id},
+    {...runnerBootPhaseTimeline.snapshot(), runnerSessionId: runnerSession.session_id},
     'Managed runner activated',
   );
   return runnerSession;
+}
+
+function getRunnerBootPhaseTimeline(
+  processEntryUptimeSeconds: number | undefined,
+): RunnerBootPhaseTimeline {
+  if (bootPhaseTimeline !== undefined) return bootPhaseTimeline;
+
+  bootPhaseTimeline = createRunnerBootPhaseTimeline(
+    () => process.uptime(),
+    processEntryUptimeSeconds,
+  );
+  return bootPhaseTimeline;
 }
 
 async function waitForRunnerActivation(controlSessionToken: string): Promise<string | undefined> {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1,6 +1,7 @@
 import type {AgentConfigIssueDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError} from 'ky';
+import type {RunnerAgentStepModule} from '#core/step-loop.js';
 
 const {AgentRuntimeConfigRequestError, StepSecretsRequestError, resolveWorkingDirectoryMock} =
   vi.hoisted(() => ({
@@ -50,9 +51,6 @@ const createStepLogStreamMock = vi.fn();
 const createSessionLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
 const createJobLogsDirMock = vi.fn();
-const {agentStepModuleEvaluated} = vi.hoisted(() => ({
-  agentStepModuleEvaluated: {value: false},
-}));
 
 vi.mock('@shipfox/runner-protocol', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
@@ -84,7 +82,6 @@ vi.mock('@shipfox/runner-logs', async () => {
 });
 
 vi.mock('@shipfox/runner-agent/step', () => {
-  agentStepModuleEvaluated.value = true;
   return {
     executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
   };
@@ -96,8 +93,14 @@ vi.mock('@shipfox/runner-workspace', () => ({
     resolveWorkingDirectoryMock(cwd, workingDirectory),
 }));
 
-const {executeStep, pullNextStep, publishStepAnnotations, reportStepResult, runJobSteps} =
-  await import('#core/step-loop.js');
+const {
+  createRunnerAgentStepLoader,
+  executeStep,
+  pullNextStep,
+  publishStepAnnotations,
+  reportStepResult,
+  runJobSteps,
+} = await import('#core/step-loop.js');
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
 const RUN_ID = '00000000-0000-0000-0000-0000000000ab';
@@ -269,7 +272,7 @@ describe('runJobSteps', () => {
     vi.restoreAllMocks();
   });
 
-  it('does not load the agent step module for a shell-only job', async () => {
+  it('does not execute the agent module for a shell-only job', async () => {
     const setup = buildSetupStep();
     const run = buildRunStep();
     requestNextStepMock
@@ -281,8 +284,34 @@ describe('runJobSteps', () => {
 
     await runLoop({signal: ac.signal});
 
-    expect(agentStepModuleEvaluated.value).toBe(false);
     expect(executeAgentStepMock).not.toHaveBeenCalled();
+  });
+
+  it('loads the agent module once and reuses the fulfilled promise', async () => {
+    const agentStepModule = {} as RunnerAgentStepModule;
+    const importAgentStep = vi.fn<() => Promise<RunnerAgentStepModule>>();
+    importAgentStep.mockResolvedValue(agentStepModule);
+    const loadRunnerAgentStep = createRunnerAgentStepLoader(importAgentStep);
+
+    await expect(loadRunnerAgentStep()).resolves.toBe(agentStepModule);
+    await expect(loadRunnerAgentStep()).resolves.toBe(agentStepModule);
+
+    expect(importAgentStep).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a rejected agent module import so the next job can retry', async () => {
+    const agentStepModule = {} as RunnerAgentStepModule;
+    const importError = new Error('agent module unavailable');
+    const importAgentStep = vi
+      .fn<() => Promise<RunnerAgentStepModule>>()
+      .mockRejectedValueOnce(importError)
+      .mockResolvedValueOnce(agentStepModule);
+    const loadRunnerAgentStep = createRunnerAgentStepLoader(importAgentStep);
+
+    await expect(loadRunnerAgentStep()).rejects.toBe(importError);
+    await expect(loadRunnerAgentStep()).resolves.toBe(agentStepModule);
+
+    expect(importAgentStep).toHaveBeenCalledTimes(2);
   });
 
   it('runs the setup step then a run step against the prepared cwd, reporting both', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -51,6 +51,9 @@ const createStepLogStreamMock = vi.fn();
 const createSessionLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
 const createJobLogsDirMock = vi.fn();
+const {agentStepModuleEvaluated} = vi.hoisted(() => ({
+  agentStepModuleEvaluated: {value: false},
+}));
 
 vi.mock('@shipfox/runner-protocol', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
@@ -82,6 +85,14 @@ vi.mock('@shipfox/runner-logs', async () => {
 });
 
 vi.mock('@shipfox/runner-agent/step', () => {
+  agentStepModuleEvaluated.value = true;
+  return {
+    executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
+  };
+});
+
+vi.mock('@shipfox/runner-agent', () => {
+  agentStepModuleEvaluated.value = true;
   return {
     executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
   };
@@ -227,6 +238,7 @@ describe('runJobSteps', () => {
     createStepLogStreamMock.mockReset();
     createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
+    agentStepModuleEvaluated.value = false;
     resolveWorkingDirectoryMock.mockReset();
     resolveWorkingDirectoryMock.mockImplementation(
       async (cwd: string, workingDirectory: unknown) =>
@@ -285,6 +297,7 @@ describe('runJobSteps', () => {
     await runLoop({signal: ac.signal});
 
     expect(executeAgentStepMock).not.toHaveBeenCalled();
+    expect(agentStepModuleEvaluated.value).toBe(false);
   });
 
   it('loads the agent module once and reuses the fulfilled promise', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -112,6 +112,7 @@ const {
   reportStepResult,
   runJobSteps,
 } = await import('#core/step-loop.js');
+const agentStepModuleEvaluatedDuringStepLoopImport = agentStepModuleEvaluated.value;
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
 const RUN_ID = '00000000-0000-0000-0000-0000000000ab';
@@ -238,7 +239,6 @@ describe('runJobSteps', () => {
     createStepLogStreamMock.mockReset();
     createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
-    agentStepModuleEvaluated.value = false;
     resolveWorkingDirectoryMock.mockReset();
     resolveWorkingDirectoryMock.mockImplementation(
       async (cwd: string, workingDirectory: unknown) =>
@@ -297,7 +297,7 @@ describe('runJobSteps', () => {
     await runLoop({signal: ac.signal});
 
     expect(executeAgentStepMock).not.toHaveBeenCalled();
-    expect(agentStepModuleEvaluated.value).toBe(false);
+    expect(agentStepModuleEvaluatedDuringStepLoopImport).toBe(false);
   });
 
   it('loads the agent module once and reuses the fulfilled promise', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -50,6 +50,9 @@ const createStepLogStreamMock = vi.fn();
 const createSessionLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
 const createJobLogsDirMock = vi.fn();
+const {agentStepModuleEvaluated} = vi.hoisted(() => ({
+  agentStepModuleEvaluated: {value: false},
+}));
 
 vi.mock('@shipfox/runner-protocol', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
@@ -80,9 +83,12 @@ vi.mock('@shipfox/runner-logs', async () => {
   };
 });
 
-vi.mock('@shipfox/runner-agent', () => ({
-  executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
-}));
+vi.mock('@shipfox/runner-agent/step', () => {
+  agentStepModuleEvaluated.value = true;
+  return {
+    executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
+  };
+});
 
 vi.mock('@shipfox/runner-workspace', () => ({
   createJobLogsDir: (...args: unknown[]) => createJobLogsDirMock(...args),
@@ -261,6 +267,22 @@ describe('runJobSteps', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('does not load the agent step module for a shell-only job', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(agentStepModuleEvaluated.value).toBe(false);
+    expect(executeAgentStepMock).not.toHaveBeenCalled();
   });
 
   it('runs the setup step then a run step against the prepared cwd, reporting both', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -6,7 +6,6 @@ import {
 import type {LogOutcomeDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets} from '@shipfox/redact';
-import {executeAgentStep} from '@shipfox/runner-agent';
 import {
   type CheckoutDestinations,
   type CommandStartMetadata,
@@ -44,6 +43,16 @@ import {createJobLogsDir, resolveWorkingDirectory} from '@shipfox/runner-workspa
 import type {KyInstance} from 'ky';
 
 const WHITESPACE_REGEX = /\s+/;
+type RunnerAgentStepModule = typeof import('@shipfox/runner-agent/step');
+let runnerAgentStepModule: Promise<RunnerAgentStepModule> | undefined;
+
+function loadRunnerAgentStep(): Promise<RunnerAgentStepModule> {
+  if (runnerAgentStepModule !== undefined) return runnerAgentStepModule;
+
+  const pending = import('@shipfox/runner-agent/step');
+  runnerAgentStepModule = pending;
+  return pending;
+}
 
 // Reporting a step before pulling the next one is the safety invariant: a lost report is
 // retried in place (next/report are idempotent), so a step is never re-pulled or
@@ -466,6 +475,7 @@ export async function executeStep(params: {
       }
       stream = sessionStream;
       registerStreamSecrets(sessionStream);
+      const {executeAgentStep} = await loadRunnerAgentStep();
       const result = await executeAgentStep(step, {
         signal,
         cwd: stepCwd,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -43,16 +43,27 @@ import {createJobLogsDir, resolveWorkingDirectory} from '@shipfox/runner-workspa
 import type {KyInstance} from 'ky';
 
 const WHITESPACE_REGEX = /\s+/;
-type RunnerAgentStepModule = typeof import('@shipfox/runner-agent/step');
-let runnerAgentStepModule: Promise<RunnerAgentStepModule> | undefined;
+export type RunnerAgentStepModule = typeof import('@shipfox/runner-agent/step');
 
-function loadRunnerAgentStep(): Promise<RunnerAgentStepModule> {
-  if (runnerAgentStepModule !== undefined) return runnerAgentStepModule;
+export function createRunnerAgentStepLoader(
+  importAgentStep: () => Promise<RunnerAgentStepModule> = () =>
+    import('@shipfox/runner-agent/step'),
+): () => Promise<RunnerAgentStepModule> {
+  let runnerAgentStepModule: Promise<RunnerAgentStepModule> | undefined;
 
-  const pending = import('@shipfox/runner-agent/step');
-  runnerAgentStepModule = pending;
-  return pending;
+  return () => {
+    if (runnerAgentStepModule !== undefined) return runnerAgentStepModule;
+
+    const pending = importAgentStep().catch((error: unknown) => {
+      runnerAgentStepModule = undefined;
+      throw error;
+    });
+    runnerAgentStepModule = pending;
+    return pending;
+  };
 }
+
+const loadRunnerAgentStep = createRunnerAgentStepLoader();
 
 // Reporting a step before pulling the next one is the safety invariant: a lost report is
 // retried in place (next/report are idempotent), so a step is never re-pulled or

--- a/libs/runner/orchestration/test/bootstrap-module-set-probe.mjs
+++ b/libs/runner/orchestration/test/bootstrap-module-set-probe.mjs
@@ -1,0 +1,72 @@
+import {createServer} from 'node:http';
+
+const server = createServer((request, response) => {
+  request.resume();
+  response.setHeader('content-type', 'application/json');
+
+  if (request.method === 'POST' && request.url === '/runner-enrollment/exchange') {
+    response.end(
+      JSON.stringify({
+        runner_instance_id: '00000000-0000-4000-8000-000000000001',
+        control_session_token: 'control-token',
+        expires_at: '2030-01-01T00:00:00.000Z',
+      }),
+    );
+    return;
+  }
+
+  if (request.method === 'POST' && request.url === '/runner-control/enrollment') {
+    response.end(JSON.stringify({activation_token: 'activation-token'}));
+    return;
+  }
+
+  if (request.method === 'POST' && request.url === '/runners/register') {
+    response.end(
+      JSON.stringify({
+        session_token: 'session-token',
+        session_id: '00000000-0000-4000-8000-000000000002',
+        mode: 'activation',
+        max_claims: 1,
+      }),
+    );
+    return;
+  }
+
+  if (request.method === 'POST' && request.url === '/runners/jobs/request') {
+    response.writeHead(409);
+    response.end(JSON.stringify({code: 'runner-session-exhausted'}));
+    return;
+  }
+
+  response.writeHead(404);
+  response.end(JSON.stringify({error: 'not found'}));
+});
+
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+
+const address = server.address();
+if (address === null || typeof address === 'string') {
+  throw new Error('Probe server did not expose a TCP address.');
+}
+
+process.env.SHIPFOX_API_URL = `http://127.0.0.1:${address.port}`;
+process.env.SHIPFOX_RUNNER_REGISTRATION_TOKEN = '';
+process.env.SHIPFOX_RUNNER_BOOTSTRAP_TOKEN = 'sf_rbt_module-set-probe';
+process.env.SHIPFOX_RUNNER_PROVIDER_KIND = 'ec2';
+process.env.SHIPFOX_RUNNER_PROTOCOL_VERSION = '1';
+process.env.SHIPFOX_RUNNER_LABELS = 'local';
+process.env.SHIPFOX_RUNNER_WORKSPACE_ROOT = `/tmp/shipfox-module-set-probe-${process.pid}`;
+
+const processEntryUptimeSeconds = process.uptime();
+
+try {
+  const {startRunner} = await import('#core/runner.js');
+  await startRunner({processEntryUptimeSeconds});
+} finally {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/libs/runner/orchestration/test/module-load-tracker.cjs
+++ b/libs/runner/orchestration/test/module-load-tracker.cjs
@@ -1,0 +1,19 @@
+const {appendFileSync} = require('node:fs');
+const Module = require('node:module');
+
+const originalLoad = Module._load;
+
+Module._load = function trackCommonJsLoad(request, parent, isMain) {
+  let resolved = request;
+  try {
+    resolved = Module._resolveFilename(request, parent, isMain);
+  } catch {
+    resolved = request;
+  }
+
+  if (process.env.SHIPFOX_MODULE_TRACKER_FILE !== undefined) {
+    appendFileSync(process.env.SHIPFOX_MODULE_TRACKER_FILE, `${resolved}\n`);
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};

--- a/libs/runner/orchestration/test/module-load-tracker.mjs
+++ b/libs/runner/orchestration/test/module-load-tracker.mjs
@@ -1,0 +1,15 @@
+import {appendFileSync} from 'node:fs';
+
+const HEAVY_AGENT_PACKAGE_PATTERN =
+  /\/node_modules\/(?:@anthropic-ai|@earendil-works|@modelcontextprotocol)(?:\/|\+)/u;
+
+export function load(url, context, nextLoad) {
+  if (
+    process.env.SHIPFOX_MODULE_TRACKER_FILE !== undefined &&
+    HEAVY_AGENT_PACKAGE_PATTERN.test(url)
+  ) {
+    appendFileSync(process.env.SHIPFOX_MODULE_TRACKER_FILE, `${url}\n`);
+  }
+
+  return nextLoad(url, context);
+}

--- a/libs/runner/orchestration/test/module-load-tracker.mjs
+++ b/libs/runner/orchestration/test/module-load-tracker.mjs
@@ -1,13 +1,7 @@
 import {appendFileSync} from 'node:fs';
 
-const HEAVY_AGENT_PACKAGE_PATTERN =
-  /\/node_modules\/(?:@anthropic-ai|@earendil-works|@modelcontextprotocol)(?:\/|\+)/u;
-
 export function load(url, context, nextLoad) {
-  if (
-    process.env.SHIPFOX_MODULE_TRACKER_FILE !== undefined &&
-    HEAVY_AGENT_PACKAGE_PATTERN.test(url)
-  ) {
+  if (process.env.SHIPFOX_MODULE_TRACKER_FILE !== undefined) {
     appendFileSync(process.env.SHIPFOX_MODULE_TRACKER_FILE, `${url}\n`);
   }
 

--- a/libs/runner/workspace/src/workspace.test.ts
+++ b/libs/runner/workspace/src/workspace.test.ts
@@ -214,6 +214,19 @@ describe('cleanupOrphanedJobLogs', () => {
     await cleanupOrphanedJobLogs(root);
     await expect(stat(orphan)).rejects.toThrow();
   });
+
+  it('reclaims a lock left by a dead or invalid owner', async () => {
+    const logsRoot = join(root, '.shipfox-runner-logs');
+    const orphan = join(logsRoot, 'job-55555555-5555-4555-8555-555555555555');
+    await mkdir(orphan, {recursive: true});
+    await writeFile(`${orphan}.lock`, 'not-a-live-owner');
+
+    await cleanupOrphanedJobLogs(root);
+
+    await expect(stat(orphan)).rejects.toThrow();
+    await expect(stat(`${orphan}.lock`)).rejects.toThrow();
+    await expect(stat(`${orphan}.lock.reclaim`)).rejects.toThrow();
+  });
 });
 
 describe('cleanupWorkspace', () => {

--- a/libs/runner/workspace/src/workspace.test.ts
+++ b/libs/runner/workspace/src/workspace.test.ts
@@ -199,6 +199,21 @@ describe('cleanupOrphanedJobLogs', () => {
   it('does not throw when the runner log root is missing', async () => {
     await expect(cleanupOrphanedJobLogs(root)).resolves.toBeUndefined();
   });
+
+  it('preserves a job directory while the job owns its log lock', async () => {
+    const logsRoot = join(root, '.shipfox-runner-logs');
+    const orphan = join(logsRoot, 'job-44444444-4444-4444-8444-444444444444');
+    await mkdir(orphan, {recursive: true});
+    await writeFile(join(orphan, 'setup.ndjson'), '{}\n');
+    await writeFile(`${orphan}.lock`, `${process.pid}\n`);
+
+    await cleanupOrphanedJobLogs(root);
+
+    expect((await stat(orphan)).isDirectory()).toBe(true);
+    await rm(`${orphan}.lock`, {force: true});
+    await cleanupOrphanedJobLogs(root);
+    await expect(stat(orphan)).rejects.toThrow();
+  });
 });
 
 describe('cleanupWorkspace', () => {

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -1,13 +1,15 @@
 import type {Dirent} from 'node:fs';
-import {mkdir, readdir, rm} from 'node:fs/promises';
+import {mkdir, readdir, readFile, rm, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
-import {join, parse, resolve} from 'node:path';
+import {dirname, join, parse, resolve} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
 import {isUuid} from '@shipfox/regex';
 import {config} from '#config.js';
 
 const RUNNER_LOGS_DIR = '.shipfox-runner-logs';
 const RUNNER_CRED_DIR = '.shipfox-runner-cred';
+const JOB_LOG_LOCK_SUFFIX = '.lock';
+const JOB_LOG_LOCK_RETRY_MS = 10;
 
 /**
  * Thrown when `SHIPFOX_RUNNER_WORKSPACE_ROOT` resolves to a path we refuse to
@@ -111,7 +113,7 @@ export async function createJobDir(cwd: string): Promise<void> {
  * Resets the runner-owned log directory before a job can reuse it after a crash.
  */
 export async function createJobLogsDir(logsDir: string): Promise<void> {
-  await resetDir(logsDir);
+  await withJobLogLock(logsDir, true, () => resetDir(logsDir));
 }
 
 /**
@@ -137,8 +139,69 @@ export async function cleanupOrphanedJobLogs(root: string): Promise<void> {
           entry.name.startsWith('job-') &&
           isUuid(entry.name.slice('job-'.length)),
       )
-      .map((entry) => cleanupJobLogs(join(logsRoot, entry.name))),
+      .map((entry) =>
+        withJobLogLock(join(logsRoot, entry.name), false, () =>
+          cleanupJobLogs(join(logsRoot, entry.name)),
+        ),
+      ),
   );
+}
+
+/**
+ * Coordinates the asynchronous orphan sweep with setup's pre-clean. A sweep
+ * skips an active job, while setup waits for a sweep that already owns the
+ * lock before recreating the directory. The pid makes locks left by a crashed
+ * runner recoverable without weakening the mutual exclusion for live runners.
+ */
+async function withJobLogLock<T>(
+  logsDir: string,
+  waitForLock: boolean,
+  action: () => Promise<T>,
+): Promise<T | undefined> {
+  const lockPath = `${logsDir}${JOB_LOG_LOCK_SUFFIX}`;
+  await mkdir(dirname(logsDir), {recursive: true});
+
+  while (true) {
+    try {
+      await writeFile(lockPath, `${process.pid}\n`, {flag: 'wx'});
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+
+      if (await isStaleJobLogLock(lockPath)) {
+        await rm(lockPath, {force: true});
+        continue;
+      }
+      if (!waitForLock) return undefined;
+
+      await new Promise((resolve) => setTimeout(resolve, JOB_LOG_LOCK_RETRY_MS));
+    }
+  }
+
+  try {
+    return await action();
+  } finally {
+    await rm(lockPath, {force: true});
+  }
+}
+
+async function isStaleJobLogLock(lockPath: string): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await readFile(lockPath, 'utf8');
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT';
+  }
+
+  const pid = Number(raw.trim());
+  if (!Number.isInteger(pid) || pid <= 0) return true;
+
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ESRCH';
+  }
 }
 
 /**

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -1,6 +1,6 @@
 import {randomUUID} from 'node:crypto';
 import type {Dirent} from 'node:fs';
-import {mkdir, readdir, readFile, readlink, rm, symlink, writeFile} from 'node:fs/promises';
+import {link, mkdir, readdir, readFile, readlink, rm, symlink, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {dirname, join, parse, resolve} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -163,26 +163,21 @@ async function withJobLogLock<T>(
   await mkdir(dirname(logsDir), {recursive: true});
 
   while (true) {
-    try {
-      await writeFile(lockPath, `${process.pid}:${randomUUID()}`, {flag: 'wx'});
+    if (await tryAcquireJobLogLock(lockPath)) {
       break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-
-      const existingLock = await readJobLogLock(lockPath);
-      if (existingLock === undefined) {
-        continue;
-      }
-      if (
-        isProcessDead(existingLock.pid) &&
-        (await tryReclaimStaleJobLogLock(lockPath, existingLock.raw))
-      ) {
-        continue;
-      }
-      if (!waitForLock) return undefined;
-
-      await new Promise((resolve) => setTimeout(resolve, JOB_LOG_LOCK_RETRY_MS));
     }
+
+    const existingLock = await readJobLogLock(lockPath);
+    if (existingLock === undefined) continue;
+    if (
+      isProcessDead(existingLock.pid) &&
+      (await tryReclaimStaleJobLogLock(lockPath, existingLock.raw))
+    ) {
+      continue;
+    }
+    if (!waitForLock) return undefined;
+
+    await new Promise((resolve) => setTimeout(resolve, JOB_LOG_LOCK_RETRY_MS));
   }
 
   try {
@@ -196,6 +191,24 @@ type JobLogLock = {
   pid: number;
   raw: string;
 };
+
+async function tryAcquireJobLogLock(lockPath: string): Promise<boolean> {
+  const lockOwner = `${process.pid}:${randomUUID()}`;
+  const temporaryLockPath = `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    await writeFile(temporaryLockPath, lockOwner, {flag: 'wx'});
+    try {
+      await link(temporaryLockPath, lockPath);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      return false;
+    }
+  } finally {
+    await rm(temporaryLockPath, {force: true});
+  }
+}
 
 async function readJobLogLock(lockPath: string): Promise<JobLogLock | undefined> {
   let raw: string;

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -1,5 +1,6 @@
+import {randomUUID} from 'node:crypto';
 import type {Dirent} from 'node:fs';
-import {mkdir, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {mkdir, readdir, readFile, readlink, rm, symlink, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {dirname, join, parse, resolve} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -163,13 +164,19 @@ async function withJobLogLock<T>(
 
   while (true) {
     try {
-      await writeFile(lockPath, `${process.pid}\n`, {flag: 'wx'});
+      await writeFile(lockPath, `${process.pid}:${randomUUID()}`, {flag: 'wx'});
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
 
-      if (await isStaleJobLogLock(lockPath)) {
-        await rm(lockPath, {force: true});
+      const existingLock = await readJobLogLock(lockPath);
+      if (existingLock === undefined) {
+        continue;
+      }
+      if (
+        isProcessDead(existingLock.pid) &&
+        (await tryReclaimStaleJobLogLock(lockPath, existingLock.raw))
+      ) {
         continue;
       }
       if (!waitForLock) return undefined;
@@ -185,15 +192,25 @@ async function withJobLogLock<T>(
   }
 }
 
-async function isStaleJobLogLock(lockPath: string): Promise<boolean> {
+type JobLogLock = {
+  pid: number;
+  raw: string;
+};
+
+async function readJobLogLock(lockPath: string): Promise<JobLogLock | undefined> {
   let raw: string;
   try {
-    raw = await readFile(lockPath, 'utf8');
+    raw = (await readFile(lockPath, 'utf8')).trim();
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'ENOENT';
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
   }
 
-  const pid = Number(raw.trim());
+  const pid = Number(raw.split(':', 1)[0]);
+  return {pid, raw};
+}
+
+function isProcessDead(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return true;
 
   try {
@@ -202,6 +219,53 @@ async function isStaleJobLogLock(lockPath: string): Promise<boolean> {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === 'ESRCH';
   }
+}
+
+/**
+ * Claims stale-lock reclamation with an atomic symlink. The claim records the
+ * reclaimer pid, so another process can safely take over if the reclaimer
+ * crashes; no process unlinks the lock after a separate liveness check.
+ */
+async function tryReclaimStaleJobLogLock(lockPath: string, expectedLock: string): Promise<boolean> {
+  const reclaimPath = `${lockPath}.reclaim`;
+
+  while (true) {
+    try {
+      // A symlink is created atomically, and its target publishes the full
+      // reclaimer token before another process can observe the claim.
+      await symlink(`${process.pid}:${randomUUID()}`, reclaimPath);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (!(await isStaleReclaimer(reclaimPath))) return false;
+      await rm(reclaimPath, {force: true});
+    }
+  }
+
+  try {
+    const currentLock = await readJobLogLock(lockPath);
+    if (currentLock?.raw !== expectedLock) return false;
+
+    try {
+      await rm(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    return true;
+  } finally {
+    await rm(reclaimPath, {force: true});
+  }
+}
+
+async function isStaleReclaimer(reclaimPath: string): Promise<boolean> {
+  let target: string;
+  try {
+    target = await readlink(reclaimPath);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT';
+  }
+
+  return isProcessDead(Number(target.split(':', 1)[0]));
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6677,6 +6677,9 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
 
   libs/runner/protocol:
     dependencies:


### PR DESCRIPTION
Break the runner bootstrap import graph so managed enrollment does not evaluate the AI harness stack on cold EBS reads.

This:
- adds lightweight runner-agent subpath exports for bootstrap metadata;
- lazily imports the agent execution module once on the first agent step;
- moves orphan-log cleanup off the bootstrap critical path;
- records monotonic boot-phase offsets and removes source-map parsing from runner startup.

The bootstrap path stays clear of Anthropic, Earendil, and MCP SDK modules while agent execution remains unchanged.

Closes ENG-1528

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer loading the AI agent until a job runs and harden the bootstrap with atomic log locks, background cleanup, and v2 boot-phase telemetry to cut managed runner boot time. Addresses ENG-1528 by keeping heavy deps off cold-boot and verifying the production closure during image build.

- **Performance**
  - Lazy-load `@shipfox/runner-agent/step` on first agent step; shell-only jobs never import it. Failed imports clear and retry on the next job.
  - Add subpath exports in `@shipfox/runner-agent` for `pi-extensions`, `tool-capabilities`, and `step` to bypass the barrel and keep bootstrap free of `@anthropic-ai/*`, `@earendil-works/*`, and `@modelcontextprotocol/sdk` (asserted via a module-set probe that tracks ESM and CJS loads).
  - Run orphaned log cleanup in the background, guarded by per-job PID locks with atomic publication and stale-lock reclaim; failures warn but never block bootstrap.
  - Remove `--enable-source-maps` from Docker and systemd runner start commands.

- **New Features**
  - Boot timeline v2 with monotonic samples: `process_entry_uptime_seconds`, `runner_started_uptime_seconds`, `bootstrap_exchange_uptime_seconds`, `activation_uptime_seconds`, `first_claim_uptime_seconds` (emitted in logs).
  - Verify production closure during image build by resolving `@shipfox/runner-agent/tool-capabilities` and `@shipfox/runner-agent/step`.

<sup>Written for commit 882d06e0b171876f27622b445604622ca94df231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

