### PR TITLE
Fix inline comments in pending GitHub reviews

### DIFF
--- a/.changeset/calm-bots-comment.md
+++ b/.changeset/calm-bots-comment.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Fix pending GitHub review comments by resolving the caller's pending review through the REST API.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -12,6 +12,8 @@ import {
 } from '#core/agent-tools.js';
 import {createGithubIntegrationProvider} from '#index.js';
 
+const githubAppReviewUser = {login: 'shipfox-test[bot]'};
+
 const expectedCatalogRows = [
   {
     id: 'issue_read',
@@ -857,11 +859,17 @@ describe('github agent tool catalog', () => {
     });
   });
 
-  it('adds a comment to the latest pending review through GraphQL', async () => {
+  it('adds a comment to the latest caller pending review through GraphQL', async () => {
     const request = vi.fn().mockResolvedValueOnce({
       data: [
-        {id: 40, node_id: 'review-older', state: 'PENDING'},
-        {id: 41, node_id: 'review-latest', state: 'PENDING'},
+        {id: 40, node_id: 'review-older', state: 'PENDING', user: githubAppReviewUser},
+        {id: 41, node_id: 'review-latest', state: 'PENDING', user: githubAppReviewUser},
+        {
+          id: 42,
+          node_id: 'another-review',
+          state: 'PENDING',
+          user: {login: 'another-user'},
+        },
       ],
     });
     const graphql = vi.fn().mockResolvedValueOnce({
@@ -890,13 +898,17 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(request).toHaveBeenCalledWith('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
-      owner: 'shipfox',
-      repo: 'platform',
-      pull_number: 2,
-      per_page: 100,
-      page: 1,
-    });
+    expect(request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+      expect.objectContaining({
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        per_page: 100,
+        page: 1,
+      }),
+    );
+    expect(request.mock.calls[0]?.[1]).toHaveProperty('request.signal');
     expect(graphql).toHaveBeenCalledWith(expect.stringContaining('addPullRequestReviewThread'), {
       input: {
         pullRequestReviewId: 'review-latest',
@@ -921,7 +933,16 @@ describe('github agent tool catalog', () => {
   });
 
   it('returns an explicit error when there is no pending review for the caller', async () => {
-    const request = vi.fn().mockResolvedValueOnce({data: []});
+    const request = vi.fn().mockResolvedValueOnce({
+      data: [
+        {
+          id: 41,
+          node_id: 'another-review',
+          state: 'PENDING',
+          user: {login: 'another-user'},
+        },
+      ],
+    });
     const graphql = vi.fn();
     const provider = createAgentToolsProvider({request, graphql});
     const session = await provider.openSession({
@@ -995,7 +1016,7 @@ describe('github agent tool catalog', () => {
 
   it('rejects a pending review without a GraphQL node ID', async () => {
     const request = vi.fn().mockResolvedValueOnce({
-      data: [{id: 41, state: 'PENDING'}],
+      data: [{id: 41, state: 'PENDING', user: githubAppReviewUser}],
     });
     const graphql = vi.fn();
     const provider = createAgentToolsProvider({request, graphql});
@@ -1021,6 +1042,44 @@ describe('github agent tool catalog', () => {
       message: 'GitHub pending pull request review did not include a node ID',
     });
     expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it('skips a malformed newer review for an older valid caller review', async () => {
+    const request = vi.fn().mockResolvedValueOnce({
+      data: [
+        {
+          id: 40,
+          node_id: 'review-valid',
+          state: 'PENDING',
+          user: githubAppReviewUser,
+        },
+        {id: 41, node_id: '   ', state: 'PENDING', user: githubAppReviewUser},
+      ],
+    });
+    const graphql = vi.fn().mockResolvedValueOnce({
+      addPullRequestReviewThread: {thread: {id: 'thread-1'}},
+    });
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pendingReviewTool()],
+      scope: undefined,
+    });
+
+    await session.call({
+      toolId: 'add_comment_to_pending_review',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        path: 'src/agent-tools.ts',
+        body: 'Please handle this error.',
+      },
+    });
+
+    expect(graphql).toHaveBeenCalledWith(expect.stringContaining('addPullRequestReviewThread'), {
+      input: expect.objectContaining({pullRequestReviewId: 'review-valid'}),
+    });
   });
 
   it('rejects a malformed pending review list response', async () => {
@@ -1157,8 +1216,9 @@ describe('github agent tool catalog', () => {
       .mockResolvedValueOnce({
         data: [
           {id: 40, state: 'APPROVED'},
-          {id: 41, state: 'PENDING'},
-          {id: 42, state: 'PENDING'},
+          {id: 41, state: 'PENDING', user: githubAppReviewUser},
+          {id: 42, state: 'PENDING', user: githubAppReviewUser},
+          {id: 43, state: 'PENDING', user: {login: 'another-user'}},
         ],
       })
       .mockResolvedValueOnce({data: testCase.data});
@@ -1176,13 +1236,13 @@ describe('github agent tool catalog', () => {
     expect(request).toHaveBeenNthCalledWith(
       1,
       'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
-      {
+      expect.objectContaining({
         owner: 'shipfox',
         repo: 'platform',
         pull_number: 2,
         per_page: 100,
         page: 1,
-      },
+      }),
     );
     expect(request).toHaveBeenNthCalledWith(2, testCase.route, testCase.parameters);
   });
@@ -1191,9 +1251,17 @@ describe('github agent tool catalog', () => {
     const request = vi
       .fn()
       .mockResolvedValueOnce({
-        data: Array.from({length: 100}, (_, index) => ({id: index + 1, state: 'APPROVED'})),
+        data: [
+          ...Array.from({length: 99}, (_, index) => ({id: index + 1, state: 'APPROVED'})),
+          {id: 100, state: 'PENDING', user: githubAppReviewUser},
+        ],
+        headers: {
+          link: '<https://api.github.com/repositories/1/pulls/2/reviews?per_page=100&page=2>; rel="last"',
+        },
       })
-      .mockResolvedValueOnce({data: [{id: 101, state: 'PENDING'}]})
+      .mockResolvedValueOnce({
+        data: [{id: 101, state: 'PENDING', user: githubAppReviewUser}],
+      })
       .mockResolvedValueOnce({data: {id: 101, state: 'COMMENTED'}});
 
     const result = await callGithubToolWithRequest(
@@ -1216,24 +1284,24 @@ describe('github agent tool catalog', () => {
     expect(request).toHaveBeenNthCalledWith(
       1,
       'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
-      {
+      expect.objectContaining({
         owner: 'shipfox',
         repo: 'platform',
         pull_number: 2,
         per_page: 100,
         page: 1,
-      },
+      }),
     );
     expect(request).toHaveBeenNthCalledWith(
       2,
       'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
-      {
+      expect.objectContaining({
         owner: 'shipfox',
         repo: 'platform',
         pull_number: 2,
         per_page: 100,
         page: 2,
-      },
+      }),
     );
     expect(request).toHaveBeenNthCalledWith(
       3,
@@ -1247,6 +1315,61 @@ describe('github agent tool catalog', () => {
         review_id: 101,
       },
     );
+  });
+
+  it('bounds pending review lookup to the newest review pages', async () => {
+    const request = vi.fn().mockResolvedValue({data: []});
+    request.mockResolvedValueOnce({
+      data: Array.from({length: 100}, (_, index) => ({id: index + 1, state: 'APPROVED'})),
+      headers: {
+        link: '<https://api.github.com/repositories/1/pulls/2/reviews?per_page=100&page=6>; rel="last"',
+      },
+    });
+
+    await expect(
+      callGithubToolWithRequest(
+        'pull_request_review_write',
+        {
+          method: 'submit_pending',
+          owner: 'shipfox',
+          repo: 'platform',
+          pull_number: 2,
+          body: 'Looks good.',
+          event: 'COMMENT',
+        },
+        request,
+      ),
+    ).rejects.toMatchObject({
+      reason: 'content-too-large',
+      message: 'GitHub pull request review history exceeded the pending review lookup limit',
+    });
+    expect(request).toHaveBeenCalledTimes(5);
+    expect(request.mock.calls.map((call) => call[1]?.page)).toEqual([1, 6, 5, 4, 3]);
+  });
+
+  it.each([0, -1])('rejects non-positive pending review ID %s', async (id) => {
+    const request = vi.fn().mockResolvedValueOnce({
+      data: [{id, state: 'PENDING', user: githubAppReviewUser}],
+    });
+
+    await expect(
+      callGithubToolWithRequest(
+        'pull_request_review_write',
+        {
+          method: 'submit_pending',
+          owner: 'shipfox',
+          repo: 'platform',
+          pull_number: 2,
+          body: 'Looks good.',
+          event: 'COMMENT',
+        },
+        request,
+      ),
+    ).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+      message: 'GitHub pending pull request review did not include a numeric ID',
+    });
+    expect(request).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -858,33 +858,15 @@ describe('github agent tool catalog', () => {
   });
 
   it('adds a comment to the latest pending review through GraphQL', async () => {
-    const request = vi.fn();
-    const graphql = vi
-      .fn()
-      .mockResolvedValueOnce({
-        viewer: {login: 'shipfox-ai[bot]'},
-        repository: {
-          pullRequest: {
-            reviews: {
-              nodes: [
-                {
-                  id: 'review-older',
-                  author: {login: 'shipfox-ai[bot]'},
-                  createdAt: '2026-08-09T10:00:00Z',
-                },
-                {
-                  id: 'review-latest',
-                  author: {login: 'shipfox-ai[bot]'},
-                  createdAt: '2026-08-09T10:01:00Z',
-                },
-              ],
-            },
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        addPullRequestReviewThread: {thread: {id: 'thread-1'}},
-      });
+    const request = vi.fn().mockResolvedValueOnce({
+      data: [
+        {id: 40, node_id: 'review-older', state: 'PENDING'},
+        {id: 41, node_id: 'review-latest', state: 'PENDING'},
+      ],
+    });
+    const graphql = vi.fn().mockResolvedValueOnce({
+      addPullRequestReviewThread: {thread: {id: 'thread-1'}},
+    });
     const provider = createAgentToolsProvider({request, graphql});
     const session = await provider.openSession({
       connection: connection(),
@@ -908,28 +890,25 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(request).not.toHaveBeenCalled();
-    expect(graphql).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('reviews(last: 100, states: [PENDING])'),
-      {owner: 'shipfox', repo: 'platform', pullNumber: 2},
-    );
-    expect(graphql).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('addPullRequestReviewThread'),
-      {
-        input: {
-          pullRequestReviewId: 'review-latest',
-          path: 'src/agent-tools.ts',
-          body: 'Please handle this error.',
-          subjectType: 'LINE',
-          line: 42,
-          side: 'RIGHT',
-          startLine: 40,
-          startSide: 'RIGHT',
-        },
+    expect(request).toHaveBeenCalledWith('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
+      owner: 'shipfox',
+      repo: 'platform',
+      pull_number: 2,
+      per_page: 100,
+      page: 1,
+    });
+    expect(graphql).toHaveBeenCalledWith(expect.stringContaining('addPullRequestReviewThread'), {
+      input: {
+        pullRequestReviewId: 'review-latest',
+        path: 'src/agent-tools.ts',
+        body: 'Please handle this error.',
+        subjectType: 'LINE',
+        line: 42,
+        side: 'RIGHT',
+        startLine: 40,
+        startSide: 'RIGHT',
       },
-    );
+    });
     expect(result).toEqual({
       content: [
         {
@@ -942,23 +921,8 @@ describe('github agent tool catalog', () => {
   });
 
   it('returns an explicit error when there is no pending review for the caller', async () => {
-    const request = vi.fn();
-    const graphql = vi.fn().mockResolvedValueOnce({
-      viewer: {login: 'shipfox-ai[bot]'},
-      repository: {
-        pullRequest: {
-          reviews: {
-            nodes: [
-              {
-                id: 'review-other-user',
-                author: {login: 'another-user'},
-                createdAt: '2026-08-09T10:00:00Z',
-              },
-            ],
-          },
-        },
-      },
-    });
+    const request = vi.fn().mockResolvedValueOnce({data: []});
+    const graphql = vi.fn();
     const provider = createAgentToolsProvider({request, graphql});
     const session = await provider.openSession({
       connection: connection(),
@@ -977,8 +941,8 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(graphql).toHaveBeenCalledTimes(1);
-    expect(request).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledOnce();
+    expect(graphql).not.toHaveBeenCalled();
     expect(result).toEqual({
       isError: true,
       content: [
@@ -1027,6 +991,64 @@ describe('github agent tool catalog', () => {
       ],
       structuredContent: {code: 'access-denied'},
     });
+  });
+
+  it('rejects a pending review without a GraphQL node ID', async () => {
+    const request = vi.fn().mockResolvedValueOnce({
+      data: [{id: 41, state: 'PENDING'}],
+    });
+    const graphql = vi.fn();
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pendingReviewTool()],
+      scope: undefined,
+    });
+
+    await expect(
+      session.call({
+        toolId: 'add_comment_to_pending_review',
+        arguments: {
+          owner: 'shipfox',
+          repo: 'platform',
+          pull_number: 2,
+          path: 'src/agent-tools.ts',
+          body: 'Please handle this error.',
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+      message: 'GitHub pending pull request review did not include a node ID',
+    });
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed pending review list response', async () => {
+    const request = vi.fn().mockResolvedValueOnce({data: {reviews: []}});
+    const graphql = vi.fn();
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pendingReviewTool()],
+      scope: undefined,
+    });
+
+    await expect(
+      session.call({
+        toolId: 'add_comment_to_pending_review',
+        arguments: {
+          owner: 'shipfox',
+          repo: 'platform',
+          pull_number: 2,
+          path: 'src/agent-tools.ts',
+          body: 'Please handle this error.',
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+      message: 'GitHub pull request review list response was malformed',
+    });
+    expect(graphql).not.toHaveBeenCalled();
   });
 
   it('maps Octokit 4xx failures to terminal provider errors', async () => {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -13,7 +13,7 @@ import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
 } from '#api/installation-token-provider.js';
-import {normalizedGithubApiBaseUrl} from '#config.js';
+import {config, normalizedGithubApiBaseUrl} from '#config.js';
 import type {GithubInstallation} from '#db/installations.js';
 import {GithubIntegrationProviderError} from './errors.js';
 import {
@@ -59,6 +59,12 @@ const GITHUB_GRAPHQL_ROUTE = 'POST /graphql';
 const GITHUB_ARTIFACT_ARCHIVE_FORMAT = 'zip';
 const GITHUB_ARTIFACT_DOWNLOAD_ROUTE = `GET /repos/{owner}/{repo}/actions/artifacts/{resource_id}/${GITHUB_ARTIFACT_ARCHIVE_FORMAT}`;
 const GITHUB_ARTIFACT_DOWNLOAD_TIMEOUT_MS = 30_000;
+const GITHUB_APP_BOT_SUFFIX = '[bot]';
+const PENDING_REVIEW_PAGE_SIZE = 100;
+const PENDING_REVIEW_MAX_PAGE_REQUESTS = 5;
+const PENDING_REVIEW_LOOKUP_TIMEOUT_MS = 15_000;
+const PENDING_REVIEW_PAGE_TIMEOUT_MS = 5_000;
+const PENDING_REVIEW_PAGE_PATTERN = /[?&]page=(\d+)/u;
 const NO_PENDING_REVIEW_MESSAGE =
   'No pending pull request review found for the authenticated GitHub user.';
 
@@ -394,7 +400,7 @@ async function addCommentToPendingReview(
     );
   }
 
-  const review = await latestPendingReview(client, args);
+  const review = await latestPendingReview(client, args, 'nodeId');
   if (review === undefined) return undefined;
   if (review.nodeId === undefined) {
     throw new GithubIntegrationProviderError(
@@ -442,7 +448,7 @@ async function resolvePendingReviewParameters(
 ): Promise<Record<string, unknown> | undefined> {
   if (!isPendingReviewOperation(toolId, method)) return parameters;
 
-  const review = await latestPendingReview(client, parameters);
+  const review = await latestPendingReview(client, parameters, 'id');
   if (review === undefined) return undefined;
   if (review.id === undefined) {
     throw new GithubIntegrationProviderError(
@@ -465,22 +471,59 @@ interface PendingReviewReference {
   nodeId?: string | undefined;
 }
 
+type PendingReviewIdentifier = keyof PendingReviewReference;
+
+interface PendingReviewPageResult {
+  malformed: boolean;
+  review?: PendingReviewReference | undefined;
+}
+
 async function latestPendingReview(
   client: GithubToolClient,
   parameters: Record<string, unknown>,
+  requiredIdentifier: PendingReviewIdentifier,
 ): Promise<PendingReviewReference | undefined> {
-  const perPage = 100;
-  let page = 1;
-  let pendingReview: PendingReviewReference | undefined;
+  const lookupController = new AbortController();
+  const lookupTimeout = setTimeout(
+    () => lookupController.abort(),
+    PENDING_REVIEW_LOOKUP_TIMEOUT_MS,
+  );
 
-  while (true) {
-    const response = await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
-      owner: parameters.owner,
-      repo: parameters.repo,
-      pull_number: parameters.pull_number,
-      per_page: perPage,
-      page,
-    });
+  try {
+    return await latestPendingReviewBeforeDeadline(
+      client,
+      parameters,
+      requiredIdentifier,
+      lookupController.signal,
+    );
+  } finally {
+    clearTimeout(lookupTimeout);
+  }
+}
+
+async function latestPendingReviewBeforeDeadline(
+  client: GithubToolClient,
+  parameters: Record<string, unknown>,
+  requiredIdentifier: PendingReviewIdentifier,
+  lookupSignal: AbortSignal,
+): Promise<PendingReviewReference | undefined> {
+  const firstPage = await requestPendingReviewPage(client, parameters, 1, lookupSignal);
+  const lastPage = pendingReviewLastPage(firstPage.headers);
+  let requests = 1;
+  let malformed = false;
+
+  for (let page = lastPage; page >= 1; page -= 1) {
+    let response = firstPage;
+    if (page !== 1) {
+      if (requests >= PENDING_REVIEW_MAX_PAGE_REQUESTS) {
+        throw new GithubIntegrationProviderError(
+          'content-too-large',
+          'GitHub pull request review history exceeded the pending review lookup limit',
+        );
+      }
+      response = await requestPendingReviewPage(client, parameters, page, lookupSignal);
+      requests += 1;
+    }
     if (!Array.isArray(response.data)) {
       throw new GithubIntegrationProviderError(
         'malformed-provider-response',
@@ -488,24 +531,101 @@ async function latestPendingReview(
       );
     }
 
-    pendingReview = latestPendingReviewOnPage(response.data) ?? pendingReview;
-    if (response.data.length < perPage) return pendingReview;
-    page += 1;
+    const result = latestPendingReviewOnPage(response.data, requiredIdentifier);
+    if (result.review !== undefined) return result.review;
+    malformed ||= result.malformed;
+  }
+
+  if (malformed) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      requiredIdentifier === 'nodeId'
+        ? 'GitHub pending pull request review did not include a node ID'
+        : 'GitHub pending pull request review did not include a numeric ID',
+    );
+  }
+  return undefined;
+}
+
+async function requestPendingReviewPage(
+  client: GithubToolClient,
+  parameters: Record<string, unknown>,
+  page: number,
+  lookupSignal: AbortSignal,
+): Promise<GithubToolResponse> {
+  const pageController = new AbortController();
+  const abortPage = () => pageController.abort();
+  if (lookupSignal.aborted) abortPage();
+  else lookupSignal.addEventListener('abort', abortPage, {once: true});
+  const pageTimeout = setTimeout(abortPage, PENDING_REVIEW_PAGE_TIMEOUT_MS);
+
+  try {
+    return await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
+      owner: parameters.owner,
+      repo: parameters.repo,
+      pull_number: parameters.pull_number,
+      per_page: PENDING_REVIEW_PAGE_SIZE,
+      page,
+      request: {signal: pageController.signal},
+    });
+  } finally {
+    clearTimeout(pageTimeout);
+    lookupSignal.removeEventListener('abort', abortPage);
   }
 }
 
-function latestPendingReviewOnPage(data: readonly unknown[]): PendingReviewReference | undefined {
+function pendingReviewLastPage(headers: GithubToolResponse['headers']): number {
+  const link = headers?.link;
+  if (typeof link !== 'string') return 1;
+  const lastLink = link.split(',').find((part) => part.includes('rel="last"'));
+  if (lastLink === undefined) return 1;
+  const match = PENDING_REVIEW_PAGE_PATTERN.exec(lastLink);
+  const page = match?.[1] === undefined ? Number.NaN : Number.parseInt(match[1], 10);
+  if (!Number.isSafeInteger(page) || page < 1) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub pull request review pagination response was malformed',
+    );
+  }
+  return page;
+}
+
+function latestPendingReviewOnPage(
+  data: readonly unknown[],
+  requiredIdentifier: PendingReviewIdentifier,
+): PendingReviewPageResult {
+  let malformed = false;
+  const appLogin = githubAppBotLogin().toLowerCase();
   for (let index = data.length - 1; index >= 0; index -= 1) {
     const review = data[index];
     if (!isRecord(review) || review.state !== 'PENDING') continue;
+    const userLogin = isRecord(review.user) ? review.user.login : undefined;
+    if (typeof userLogin !== 'string' || userLogin.trim().length === 0) {
+      malformed = true;
+      continue;
+    }
+    if (userLogin.trim().toLowerCase() !== appLogin) continue;
     const id =
-      typeof review.id === 'number' && Number.isSafeInteger(review.id) ? review.id : undefined;
+      typeof review.id === 'number' && Number.isSafeInteger(review.id) && review.id > 0
+        ? review.id
+        : undefined;
     const nodeId =
-      typeof review.node_id === 'string' && review.node_id.length > 0 ? review.node_id : undefined;
-    return {id, nodeId};
+      typeof review.node_id === 'string' && review.node_id.trim().length > 0
+        ? review.node_id.trim()
+        : undefined;
+    const reference = {id, nodeId};
+    if (reference[requiredIdentifier] !== undefined) return {malformed, review: reference};
+    malformed = true;
   }
 
-  return undefined;
+  return {malformed};
+}
+
+function githubAppBotLogin(): string {
+  const configuredUsername = config.GITHUB_APP_USERNAME?.trim() || config.GITHUB_APP_SLUG.trim();
+  return configuredUsername.toLowerCase().endsWith(GITHUB_APP_BOT_SUFFIX)
+    ? configuredUsername
+    : `${configuredUsername}${GITHUB_APP_BOT_SUFFIX}`;
 }
 
 function githubToolResult(

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -62,27 +62,6 @@ const GITHUB_ARTIFACT_DOWNLOAD_TIMEOUT_MS = 30_000;
 const NO_PENDING_REVIEW_MESSAGE =
   'No pending pull request review found for the authenticated GitHub user.';
 
-const LATEST_PENDING_REVIEW_QUERY = `
-  query LatestPendingPullRequestReview($owner: String!, $repo: String!, $pullNumber: Int!) {
-    viewer {
-      login
-    }
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $pullNumber) {
-        reviews(last: 100, states: [PENDING]) {
-          nodes {
-            id
-            author {
-              login
-            }
-            createdAt
-          }
-        }
-      }
-    }
-  }
-`;
-
 const ADD_PENDING_REVIEW_COMMENT_MUTATION = `
   mutation AddCommentToPendingReview($input: AddPullRequestReviewThreadInput!) {
     addPullRequestReviewThread(input: $input) {
@@ -415,16 +394,17 @@ async function addCommentToPendingReview(
     );
   }
 
-  const reviewLookup = await client.graphql(LATEST_PENDING_REVIEW_QUERY, {
-    owner: args.owner,
-    repo: args.repo,
-    pullNumber: args.pull_number,
-  });
-  const reviewId = latestPendingReviewNodeId(reviewLookup);
-  if (reviewId === undefined) return undefined;
+  const review = await latestPendingReview(client, args);
+  if (review === undefined) return undefined;
+  if (review.nodeId === undefined) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub pending pull request review did not include a node ID',
+    );
+  }
 
   const input: Record<string, unknown> = {
-    pullRequestReviewId: reviewId,
+    pullRequestReviewId: review.nodeId,
     path: args.path,
     body: args.body,
     subjectType: args.subject_type,
@@ -435,31 +415,6 @@ async function addCommentToPendingReview(
   if (args.start_side !== undefined) input.startSide = args.start_side;
 
   return await client.graphql(ADD_PENDING_REVIEW_COMMENT_MUTATION, {input});
-}
-
-function latestPendingReviewNodeId(data: unknown): string | undefined {
-  if (!isRecord(data)) return undefined;
-
-  const viewer = isRecord(data.viewer) ? data.viewer.login : undefined;
-  if (typeof viewer !== 'string') return undefined;
-
-  const repository = isRecord(data.repository) ? data.repository : undefined;
-  const pullRequest =
-    repository && isRecord(repository.pullRequest) ? repository.pullRequest : undefined;
-  const reviews = pullRequest && isRecord(pullRequest.reviews) ? pullRequest.reviews : undefined;
-  const nodes = reviews && Array.isArray(reviews.nodes) ? reviews.nodes : [];
-
-  let latest: {createdAt: string; id: string} | undefined;
-  for (const node of nodes) {
-    if (!isRecord(node)) continue;
-    const author = isRecord(node.author) ? node.author.login : undefined;
-    const id = node.id;
-    const createdAt = node.createdAt;
-    if (author !== viewer || typeof id !== 'string' || typeof createdAt !== 'string') continue;
-    if (latest === undefined || createdAt > latest.createdAt) latest = {createdAt, id};
-  }
-
-  return latest?.id;
 }
 
 export function projectGithubOperationParameters(
@@ -487,8 +442,15 @@ async function resolvePendingReviewParameters(
 ): Promise<Record<string, unknown> | undefined> {
   if (!isPendingReviewOperation(toolId, method)) return parameters;
 
-  const reviewId = await latestPendingReviewId(client, parameters);
-  return reviewId === undefined ? undefined : {...parameters, review_id: reviewId};
+  const review = await latestPendingReview(client, parameters);
+  if (review === undefined) return undefined;
+  if (review.id === undefined) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub pending pull request review did not include a numeric ID',
+    );
+  }
+  return {...parameters, review_id: review.id};
 }
 
 function isPendingReviewOperation(toolId: GithubAgentToolId, method: string | undefined): boolean {
@@ -498,13 +460,18 @@ function isPendingReviewOperation(toolId: GithubAgentToolId, method: string | un
   );
 }
 
-async function latestPendingReviewId(
+interface PendingReviewReference {
+  id?: number | undefined;
+  nodeId?: string | undefined;
+}
+
+async function latestPendingReview(
   client: GithubToolClient,
   parameters: Record<string, unknown>,
-): Promise<number | undefined> {
+): Promise<PendingReviewReference | undefined> {
   const perPage = 100;
   let page = 1;
-  let reviewId: number | undefined;
+  let pendingReview: PendingReviewReference | undefined;
 
   while (true) {
     const response = await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
@@ -514,19 +481,28 @@ async function latestPendingReviewId(
       per_page: perPage,
       page,
     });
-    if (!Array.isArray(response.data)) return undefined;
+    if (!Array.isArray(response.data)) {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub pull request review list response was malformed',
+      );
+    }
 
-    reviewId = latestPendingReviewIdOnPage(response.data) ?? reviewId;
-    if (response.data.length < perPage) return reviewId;
+    pendingReview = latestPendingReviewOnPage(response.data) ?? pendingReview;
+    if (response.data.length < perPage) return pendingReview;
     page += 1;
   }
 }
 
-function latestPendingReviewIdOnPage(data: readonly unknown[]): number | undefined {
+function latestPendingReviewOnPage(data: readonly unknown[]): PendingReviewReference | undefined {
   for (let index = data.length - 1; index >= 0; index -= 1) {
     const review = data[index];
     if (!isRecord(review) || review.state !== 'PENDING') continue;
-    if (typeof review.id === 'number' && Number.isSafeInteger(review.id)) return review.id;
+    const id =
+      typeof review.id === 'number' && Number.isSafeInteger(review.id) ? review.id : undefined;
+    const nodeId =
+      typeof review.node_id === 'string' && review.node_id.length > 0 ? review.node_id : undefined;
+    return {id, nodeId};
   }
 
   return undefined;


### PR DESCRIPTION
## Summary

GitHub's REST and GraphQL APIs can represent GitHub App identities differently, so matching `viewer.login` to the review author caused a newly created pending review to appear missing. Resolve the pending review through the paginated REST listing instead, using its numeric ID for REST submit/delete operations and its node ID for GraphQL line comments.

Add bounded error codes to GitHub tool-error results and integration audit logs. This makes failures searchable without recording argument values or expanding metric label cardinality.

Regression coverage includes inline and multiline comment inputs, missing or malformed pending-review data, stable error classification, and audit-log redaction.

Tracing spans remain follow-up work in ENG-1569.

Related to ENG-1569

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inline comments on pending GitHub reviews by resolving the caller’s pending review via REST, scoped to the app bot, with newest-first pagination, strict validation, and request deadlines. Adds bounded error codes and explicit provider errors to keep failures searchable. Related to ENG-1569.

- **Bug Fixes**
  - Resolve pending review via REST with newest-first paging (read Link last-page, check newest pages first, max 5 page requests).
  - Apply deadlines: 15s overall lookup, 5s per page; abort requests with signals.
  - Scope to the configured app bot login (derived from app username/slug + “[bot]”).
  - Validate identifiers before writes: require positive numeric `review_id` (REST) and non-empty `node_id` (GraphQL); treat malformed list shapes as errors.
  - Return `content-too-large` when history exceeds lookup limit; keep explicit `malformed-provider-response` for bad data.

- **New Features**
  - Include a bounded `errorCode` in tool error `structuredContent` and audit logs (e.g. `unknown-tool`, `unknown-operation`, `access-denied`, `invalid-arguments`, `malformed-provider-response`, `no-pending-review`, `content-too-large`).
  - Enforce a strict code pattern and default to `unclassified`; log codes without arguments to keep metrics stable. Applies to `@shipfox/api-integration-core` and `@shipfox/api-integration-github`.

<sup>Written for commit 60cf4a9154214443fde1b373772eea0b381a70b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

