### PR TITLE
Prepare workspaces for browser-backed verification

### DIFF
--- a/dev/workspace-setup.sh
+++ b/dev/workspace-setup.sh
@@ -70,11 +70,24 @@ install_dependencies() {
   printf 'workspace setup: repository context is tracked; no generated context step is required.\n'
 }
 
+has_linux_dependency_privileges() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    return 0
+  fi
+
+  command -v sudo >/dev/null 2>&1 || return 1
+  sudo -n -v >/dev/null 2>&1
+}
+
 install_test_browser() {
   local args=(install chromium)
 
   if [[ "$(uname -s)" == Linux ]]; then
-    args=(install --with-deps chromium)
+    if has_linux_dependency_privileges; then
+      args=(install --with-deps chromium)
+    else
+      printf 'workspace setup: passwordless sudo is unavailable; installing Chromium without Linux dependencies.\n' >&2
+    fi
   fi
 
   require_command pnpm

--- a/dev/workspace-setup.sh
+++ b/dev/workspace-setup.sh
@@ -70,6 +70,17 @@ install_dependencies() {
   printf 'workspace setup: repository context is tracked; no generated context step is required.\n'
 }
 
+install_test_browser() {
+  local args=(install chromium)
+
+  if [[ "$(uname -s)" == Linux ]]; then
+    args=(install --with-deps chromium)
+  fi
+
+  require_command pnpm
+  pnpm --filter=@shipfox/playwright exec playwright "${args[@]}"
+}
+
 start_worktree_services() {
   if ! command -v docker >/dev/null 2>&1; then
     die "Docker is required for this setup profile; install Docker before running workspace:setup."
@@ -119,6 +130,7 @@ run_services() {
       ;;
   esac
 
+  install_test_browser
   printf 'workspace setup: ready (%s).\n' "$profile"
 }
 


### PR DESCRIPTION
Fresh workspace setup now installs the lockfile-pinned Chromium browser required by browser-backed verification. The repository-owned adapter selects `--with-deps` on Linux and browser-only installation elsewhere, while `workspace:setup:context` remains lightweight and unchanged. This keeps Shipfox's `@shipfox/playwright` detail behind the shared `mise run --yes workspace:setup` contract for Cloud consumers.

Validation completed with `bash -n`, `mise tasks` discovery, `git diff --check`, the full setup entrypoint on macOS, and the same setup script in an Ubuntu 24.04 Playwright container with `CI=true`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workspace setup now installs the lockfile-pinned Playwright Chromium required for browser-backed verification, so fresh workspaces are ready to run. On Linux we add `--with-deps` only when running as root or with passwordless sudo; otherwise we install the browser only, keeping `workspace:setup:context` unchanged behind `mise run --yes workspace:setup` via `@shipfox/playwright`.

<sup>Written for commit 1caf30af4630fc63b8b973ca775c87b48eeb7abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

