### PR TITLE
[api-integration-github] Add GitHub review thread tools

### DIFF
--- a/.changeset/quiet-review-threads.md
+++ b/.changeset/quiet-review-threads.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-integration-github': minor
+---
+
+Add GitHub pull request review-thread inspection and resolution tools.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -83,6 +83,7 @@ const expectedCatalogRows = [
       'get_files',
       'get_commits',
       'get_review_comments',
+      'get_review_threads',
       'get_reviews',
       'get_comments',
       'get_check_runs',
@@ -147,6 +148,14 @@ const expectedCatalogRows = [
     sensitive: false,
     requiredScope: [{permission: 'pull_requests', access: 'write'}],
     methods: ['create', 'submit_pending', 'delete_pending'],
+  },
+  {
+    id: 'pull_request_review_thread_write',
+    category: 'pull_requests',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: [{permission: 'pull_requests', access: 'write'}],
+    methods: ['resolve'],
   },
   {
     id: 'add_comment_to_pending_review',
@@ -353,6 +362,12 @@ const githubOperationRouteCases = [
   },
   {
     toolId: 'pull_request_read',
+    method: 'get_review_threads',
+    args: {pull_number: 1},
+    expectedRoute: 'POST /graphql',
+  },
+  {
+    toolId: 'pull_request_read',
     method: 'get_reviews',
     args: {pull_number: 1},
     expectedRoute: 'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
@@ -428,6 +443,12 @@ const githubOperationRouteCases = [
     args: {pull_number: 1},
     runtimeInjectedProperties: ['review_id'],
     expectedRoute: 'DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}',
+  },
+  {
+    toolId: 'pull_request_review_thread_write',
+    method: 'resolve',
+    args: {thread_id: 'PRRT_kwDOExample'},
+    expectedRoute: 'POST /graphql',
   },
   {
     toolId: 'add_comment_to_pending_review',
@@ -663,6 +684,7 @@ describe('github agent tool catalog', () => {
       {properties: {method: {const: 'get_files'}}, required: []},
       {properties: {method: {const: 'get_commits'}}, required: []},
       {properties: {method: {const: 'get_review_comments'}}, required: []},
+      {properties: {method: {const: 'get_review_threads'}}, required: []},
       {properties: {method: {const: 'get_reviews'}}, required: []},
       {properties: {method: {const: 'get_comments'}}, required: []},
       {properties: {method: {const: 'get_check_runs'}}, required: ['ref']},
@@ -838,6 +860,104 @@ describe('github agent tool catalog', () => {
     expect(result).toEqual({
       content: [{type: 'text', text: '{"result":"diff --git a/file b/file"}'}],
       structuredContent: {result: 'diff --git a/file b/file'},
+    });
+  });
+
+  it('reads pull request review threads through GraphQL', async () => {
+    const request = vi.fn();
+    const data = {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              {
+                id: 'PRRT_kwDOExample',
+                isResolved: false,
+                comments: {
+                  nodes: [
+                    {
+                      id: 'PRRC_kwDOExample',
+                      databaseId: 7,
+                      body: 'Please handle this.',
+                      author: {login: 'reviewer'},
+                      path: 'src/index.ts',
+                      line: 42,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const graphql = vi.fn().mockResolvedValueOnce(data);
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pullRequestReadTool()],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'pull_request_read',
+      arguments: {
+        method: 'get_review_threads',
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+        cursor: 'cursor-1',
+      },
+    });
+
+    expect(request).not.toHaveBeenCalled();
+    expect(graphql).toHaveBeenCalledWith(
+      expect.stringContaining('reviewThreads(first: 100, after: $after)'),
+      {owner: 'shipfox', repo: 'platform', pullNumber: 2, after: 'cursor-1'},
+    );
+    const query = graphql.mock.calls[0]?.[0];
+    expect(query).toContain('isResolved');
+    expect(query).toContain('author');
+    expect(query).toContain('path');
+    expect(query).toContain('line');
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(data)}],
+      structuredContent: data,
+    });
+  });
+
+  it('resolves a pull request review thread through GraphQL', async () => {
+    const request = vi.fn();
+    const data = {
+      resolveReviewThread: {
+        thread: {id: 'PRRT_kwDOExample', isResolved: true},
+      },
+    };
+    const graphql = vi.fn().mockResolvedValueOnce(data);
+    const provider = createAgentToolsProvider({request, graphql});
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [pullRequestReviewThreadWriteTool()],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'pull_request_review_thread_write',
+      arguments: {
+        method: 'resolve',
+        owner: 'shipfox',
+        repo: 'platform',
+        thread_id: 'PRRT_kwDOExample',
+      },
+    });
+
+    expect(request).not.toHaveBeenCalled();
+    expect(graphql).toHaveBeenCalledWith(expect.stringContaining('resolveReviewThread'), {
+      input: {threadId: 'PRRT_kwDOExample'},
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(data)}],
+      structuredContent: data,
     });
   });
 
@@ -1543,6 +1663,20 @@ function createAgentToolsProvider(client: GithubToolClient) {
 function pendingReviewTool() {
   const tool = githubAgentToolCatalog.find((entry) => entry.id === 'add_comment_to_pending_review');
   if (!tool) throw new Error('Missing add_comment_to_pending_review tool');
+  return tool;
+}
+
+function pullRequestReadTool() {
+  const tool = githubAgentToolCatalog.find((entry) => entry.id === 'pull_request_read');
+  if (!tool) throw new Error('Missing pull_request_read tool');
+  return tool;
+}
+
+function pullRequestReviewThreadWriteTool() {
+  const tool = githubAgentToolCatalog.find(
+    (entry) => entry.id === 'pull_request_review_thread_write',
+  );
+  if (!tool) throw new Error('Missing pull_request_review_thread_write tool');
   return tool;
 }
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -78,6 +78,63 @@ const ADD_PENDING_REVIEW_COMMENT_MUTATION = `
   }
 `;
 
+const GET_PULL_REQUEST_REVIEW_THREADS_QUERY = `
+  query GetPullRequestReviewThreads(
+    $owner: String!
+    $repo: String!
+    $pullNumber: Int!
+    $after: String
+  ) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pullNumber) {
+        reviewThreads(first: 100, after: $after) {
+          nodes {
+            id
+            isResolved
+            comments(first: 100) {
+              nodes {
+                id
+                databaseId
+                body
+                author {
+                  login
+                }
+                path
+                line
+                side
+                startLine
+                startSide
+                createdAt
+                updatedAt
+                url
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
+
+const RESOLVE_PULL_REQUEST_REVIEW_THREAD_MUTATION = `
+  mutation ResolvePullRequestReviewThread($input: ResolveReviewThreadInput!) {
+    resolveReviewThread(input: $input) {
+      thread {
+        id
+        isResolved
+      }
+    }
+  }
+`;
+
 export class GithubAgentToolsProvider
   implements
     AgentToolsProvider<
@@ -145,11 +202,17 @@ export class GithubAgentToolsProvider
 
         if (operation.kind === 'graphql') {
           const data = await mapGithubError(() =>
-            addCommentToPendingReview(client, operation.parameters),
+            executeGithubGraphqlOperation(
+              client,
+              tool.id as GithubAgentToolId,
+              method,
+              operation.parameters,
+            ),
           );
-          return data === undefined
-            ? githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected')
-            : githubToolResult(tool.id as GithubAgentToolId, data);
+          if (data === undefined && tool.id === 'add_comment_to_pending_review') {
+            return githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected');
+          }
+          return githubToolResult(tool.id as GithubAgentToolId, data);
         }
 
         const operationParameters = await mapGithubError(() =>
@@ -322,6 +385,8 @@ export function githubOperationRoute(
       return `GET ${repoPath}/pulls/${pull}/commits`;
     case 'pull_request_read.get_review_comments':
       return `GET ${repoPath}/pulls/${pull}/comments`;
+    case 'pull_request_read.get_review_threads':
+      return GITHUB_GRAPHQL_ROUTE;
     case 'pull_request_read.get_reviews':
       return `GET ${repoPath}/pulls/${pull}/reviews`;
     case 'pull_request_read.get_comments':
@@ -350,6 +415,8 @@ export function githubOperationRoute(
       return `POST ${repoPath}/pulls/${pull}/reviews/{review_id}/events`;
     case 'pull_request_review_write.delete_pending':
       return `DELETE ${repoPath}/pulls/${pull}/reviews/{review_id}`;
+    case 'pull_request_review_thread_write.resolve':
+      return GITHUB_GRAPHQL_ROUTE;
     case 'add_comment_to_pending_review.':
       return GITHUB_GRAPHQL_ROUTE;
     case 'actions_list.list_workflows':
@@ -421,6 +488,43 @@ async function addCommentToPendingReview(
   if (args.start_side !== undefined) input.startSide = args.start_side;
 
   return await client.graphql(ADD_PENDING_REVIEW_COMMENT_MUTATION, {input});
+}
+
+async function executeGithubGraphqlOperation(
+  client: GithubToolClient,
+  toolId: GithubAgentToolId,
+  method: string | undefined,
+  parameters: Record<string, unknown>,
+): Promise<unknown | undefined> {
+  if (client.graphql === undefined) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub client does not support GraphQL operations',
+    );
+  }
+
+  switch (`${toolId}.${method ?? ''}`) {
+    case 'pull_request_read.get_review_threads': {
+      const variables: Record<string, unknown> = {
+        owner: parameters.owner,
+        repo: parameters.repo,
+        pullNumber: parameters.pull_number,
+      };
+      if (typeof parameters.cursor === 'string') variables.after = parameters.cursor;
+      return await client.graphql(GET_PULL_REQUEST_REVIEW_THREADS_QUERY, variables);
+    }
+    case 'pull_request_review_thread_write.resolve':
+      return await client.graphql(RESOLVE_PULL_REQUEST_REVIEW_THREAD_MUTATION, {
+        input: {threadId: parameters.thread_id},
+      });
+    case 'add_comment_to_pending_review.':
+      return await addCommentToPendingReview(client, parameters);
+    default:
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub operation does not support GraphQL operations',
+      );
+  }
 }
 
 export function projectGithubOperationParameters(

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -175,6 +175,13 @@ const pullRequestReadMethods = [
     scopes.pullRequestsRead,
   ),
   method(
+    'get_review_threads',
+    'Get review threads, their resolution state, and comments for a specific pull request.',
+    'read',
+    false,
+    scopes.pullRequestsRead,
+  ),
+  method(
     'get_reviews',
     'Get reviews for a specific pull request.',
     'read',
@@ -215,6 +222,16 @@ const pullRequestReviewWriteMethods = [
   method(
     'delete_pending',
     'Delete the latest pending pull request review.',
+    'write',
+    false,
+    scopes.pullRequestsWrite,
+  ),
+] as const satisfies readonly GithubAgentToolCatalogMethod[];
+
+const pullRequestReviewThreadWriteMethods = [
+  method(
+    'resolve',
+    'Resolve a pull request review thread.',
     'write',
     false,
     scopes.pullRequestsWrite,
@@ -472,6 +489,7 @@ export const githubAgentToolCatalog = [
           methodRequiredSchema('get_files', []),
           methodRequiredSchema('get_commits', []),
           methodRequiredSchema('get_review_comments', []),
+          methodRequiredSchema('get_review_threads', []),
           methodRequiredSchema('get_reviews', []),
           methodRequiredSchema('get_comments', []),
           methodRequiredSchema('get_check_runs', ['ref']),
@@ -665,6 +683,23 @@ export const githubAgentToolCatalog = [
       ['method', 'pull_number'],
     ),
     outputSchema: openObjectSchema('Pull request review write result'),
+  }),
+  tool({
+    id: 'pull_request_review_thread_write',
+    category: 'pull_requests',
+    description: 'Resolve review threads on a pull request in a GitHub repository.',
+    methods: pullRequestReviewThreadWriteMethods,
+    inputSchema: repositoryInputSchema(
+      {
+        method: methodSchema(
+          pullRequestReviewThreadWriteMethods,
+          'The write operation to perform on a pull request review thread',
+        ),
+        thread_id: stringSchema('The node ID of the review thread'),
+      },
+      ['method', 'thread_id'],
+    ),
+    outputSchema: openObjectSchema('Pull request review thread write result'),
   }),
   tool({
     id: 'add_comment_to_pending_review',


### PR DESCRIPTION
Add review-thread inspection and resolution to the GitHub agent tool catalogue so agents can understand and manage inline pull request feedback.

The read operation exposes thread IDs, resolution state, comments, authors, and locations with cursor support. The write operation resolves a thread through GitHub GraphQL.

Validation:
- `mise exec -- turbo test --filter=@shipfox/api-integration-github`
- `mise exec -- turbo type check --filter=@shipfox/api-integration-github...`
- `mise exec -- git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds review thread read and resolve tools for GitHub pull requests in `@shipfox/api-integration-github`. Agents can list review threads with comments and mark threads resolved via GraphQL.

- **New Features**
  - `pull_request_read.get_review_threads`: list threads with id, resolution state, and comments (author, body, path, line). Supports cursor pagination.
  - `pull_request_review_thread_write.resolve`: resolve a thread by node ID using GraphQL.
  - Updated tool catalog, schemas, routing, and tests for both operations.

<sup>Written for commit eaed7e42b072a9544736c05e7e85ee6e884a8328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

