### PR TITLE
[react-ui] Align light-mode surfaces with the shared ladder

### DIFF
--- a/.changeset/light-surface-values.md
+++ b/.changeset/light-surface-values.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/react-ui': patch
+---
+
+Align light-mode surface tokens with the shared four-role ladder.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,9 +152,9 @@ brought onto it. Read those sections as the target a change should move toward,
 not as a description of what ships today.
 
 Two consequences while the work lands. `Panel` does not exist yet, and `Card`
-still ships in its place. Three surface tokens still resolve to values other than
+still ships in its place. One surface token still resolves to a value other than
 the ones the ladder names, and
-[The surface ladder](#the-surface-ladder) lists each one.
+[The surface ladder](#the-surface-ladder) lists it.
 
 ## Overview
 
@@ -428,13 +428,11 @@ first two surfaces after the same roles, as `colors.canvas` and `colors.panel`.
 | Code | `bg-background-contrast-base` | `#1a1a1b` | `#030303` | Code, logs, YAML, agent transcripts |
 | Inline fill | `bg-background-components-base` | `#f4f4f5` | `#27272a` | Avatars, badges, kbd, chips inside a panel |
 
-**Those hexes are the target, and three tokens do not resolve to them yet.** Read
+**Those hexes are the target, and one token does not resolve to them yet.** Read
 this table as the contract the package is moving to.
 
 | Token | Resolves today | Target |
 | --- | --- | --- |
-| `--background-subtle-base` (light) | `--color-alpha-black-2` | opaque `--color-neutral-50` |
-| `--background-components-base` (light) | `--color-neutral-50` | `--color-neutral-100` |
 | `--background-contrast-base` (dark) | `--color-neutral-800` | `--color-neutral-1000` |
 
 `--background-contrast-subtle` and `--background-contrast-hover` are translucent

--- a/apps/storybook/src/introduction.tsx
+++ b/apps/storybook/src/introduction.tsx
@@ -81,7 +81,7 @@ export function IntroductionPage() {
 
         <section
           aria-labelledby="preview-identity"
-          className="rounded-8 bg-background-subtle-base p-20"
+          className="rounded-8 border border-border-neutral-base bg-background-subtle-base p-20"
         >
           <Code variant="label" bold id="preview-identity">
             Preview identity

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -206,9 +206,9 @@
 
   /* Design Token Variables - Light Mode */
   /* Background */
-  --background-components-hover: var(--color-neutral-100);
+  --background-components-hover: var(--color-neutral-200);
   --background-neutral-base: var(--color-neutral-0);
-  --background-components-pressed: var(--color-neutral-200);
+  --background-components-pressed: var(--color-neutral-300);
   --background-subtle-pressed: var(--color-neutral-200);
   --background-highlight-interactive: var(--color-primary-500);
   --background-subtle-hover: var(--color-neutral-100);

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -218,11 +218,11 @@
   --background-highlight-base: var(--color-primary-50);
   --background-neutral-hover: var(--color-neutral-100);
   --background-neutral-overlay: var(--color-neutral-0);
-  --background-components-base: var(--color-neutral-50);
+  --background-components-base: var(--color-neutral-100);
   --background-field-component: var(--color-neutral-0);
   --background-switch-off-hover: var(--color-neutral-300);
   --background-field-component-hover: var(--color-neutral-50);
-  --background-subtle-base: var(--color-alpha-black-2);
+  --background-subtle-base: var(--color-neutral-50);
   --background-neutral-disabled: var(--color-neutral-100);
   --background-field-hover: var(--color-neutral-100);
   --background-switch-off: var(--color-neutral-200);

--- a/libs/shared/react/ui/src/components/markdown/markdown.test.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.test.tsx
@@ -51,6 +51,14 @@ describe('Markdown', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  test('uses the inline fill for inline code', () => {
+    const {container} = renderMarkdown('Run `pnpm test`.');
+
+    expect(
+      container.querySelector('code')?.classList.contains('bg-background-components-base'),
+    ).toBe(true);
+  });
+
   test('renders GFM tables, lists, and safe external links', () => {
     const {container, getByRole, getByText} = renderMarkdown(`
 - one

--- a/libs/shared/react/ui/src/components/markdown/markdown.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.tsx
@@ -151,7 +151,7 @@ const markdownComponents = {
       return (
         <code
           className={cn(
-            'rounded-2 bg-background-subtle-base px-4 py-2 font-code text-xs text-foreground-neutral-base',
+            'rounded-2 bg-background-components-base px-4 py-2 font-code text-xs text-foreground-neutral-base',
             className,
           )}
           {...props}

--- a/libs/shared/react/ui/src/surface-tokens.test.ts
+++ b/libs/shared/react/ui/src/surface-tokens.test.ts
@@ -1,0 +1,49 @@
+// @ts-expect-error Node built-ins are available in the Vitest Node environment but not part of the UI package's browser type surface.
+import {readFileSync} from 'node:fs';
+
+const css = readFileSync(new URL('../index.css', import.meta.url), 'utf8');
+
+const SEMICOLON_PATTERN = /;$/;
+const TOKEN_REFERENCE_PATTERN = /^var\((--[\w-]+)\)$/;
+const rootBlock = css.slice(css.indexOf(':root {'), css.indexOf('\n.dark {'));
+const darkBlock = css.slice(css.indexOf('\n.dark {'), css.indexOf('\n@theme inline {'));
+
+describe('surface tokens', () => {
+  test('keeps the light ladder opaque and stepped', () => {
+    expect(resolveToken(rootBlock, '--background-subtle-base')).toBe('#fafafa');
+    expect(resolveToken(rootBlock, '--background-components-base')).toBe('#f4f4f5');
+    expect(resolveToken(rootBlock, '--background-components-hover')).toBe('#e4e4e7');
+    expect(resolveToken(rootBlock, '--background-components-pressed')).toBe('#d4d4d8');
+  });
+
+  test('preserves the dark ladder definitions', () => {
+    expect(resolveToken(darkBlock, '--background-subtle-base')).toBe('#0f0f10');
+    expect(resolveToken(darkBlock, '--background-components-base')).toBe('#27272a');
+    expect(resolveToken(darkBlock, '--background-components-hover')).toBe(
+      'rgba(255, 255, 255, 0.1)',
+    );
+    expect(resolveToken(darkBlock, '--background-components-pressed')).toBe(
+      'rgba(255, 255, 255, 0.16)',
+    );
+  });
+});
+
+function readToken(block: string, token: string) {
+  const line = block.split('\n').find((candidate) => candidate.trimStart().startsWith(`${token}:`));
+
+  if (!line) {
+    throw new Error(`Missing token ${token}`);
+  }
+
+  return line
+    .slice(line.indexOf(':') + 1)
+    .trim()
+    .replace(SEMICOLON_PATTERN, '');
+}
+
+function resolveToken(block: string, token: string) {
+  const value = readToken(block, token);
+  const reference = value.match(TOKEN_REFERENCE_PATTERN)?.[1];
+
+  return reference ? readToken(rootBlock, reference) : value;
+}


### PR DESCRIPTION
Align the light-mode surface tokens with the shared four-role ladder so light mode preserves the same visual separation as dark mode.

This makes the canvas token opaque `neutral-50` and moves inline fills to `neutral-100`, giving avatars, badges, and kbd chips a visible shape on panel surfaces. The package changeset records the published token correction.

The companion dark code-surface change and `background-neutral-background` retirement remain tracked separately in ENG-1571 and ENG-1572; those are still required for the complete Phase 1 surface-system rollout.

Part of ENG-1570

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns light-mode surface tokens to the shared four-role ladder so light mode keeps the same visual separation as dark mode. Part of ENG-1570; companion updates in ENG-1571 and ENG-1572 will complete Phase 1.

- **Refactors**
  - Update tokens: set `--background-subtle-base` to `var(--color-neutral-50)` and `--background-components-base` to `var(--color-neutral-100)`; keep light component states stepped (`hover` → `--color-neutral-200`, `pressed` → `--color-neutral-300`).
  - Use the inline fill for Markdown inline code; add token assertions, a visible Storybook boundary, a docs refresh, and a patch changeset for `@shipfox/react-ui`.

<sup>Written for commit dd4847d4b1e78baa13992d9cc3fea20aaedcaf02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

