### PR TITLE
[react-ui] Document the four-role surface ladder

### DIFF
--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -11,6 +11,24 @@ Shared React component library for Shipfox apps. It provides design tokens, Tail
 - **Icons**: Custom Shipfox icons plus the icon registry used by the `Icon` component.
 - **CSS entry**: `@shipfox/react-ui/index.css` for fonts, Tailwind, animation utilities, and design tokens.
 
+## Public API
+
+### Surface roles
+
+The `@shipfox/react-ui/index.css` entry defines four surface roles for page and component authors:
+
+| Role | Token | Light | Dark | Used for |
+| --- | --- | --- | --- | --- |
+| Canvas | `background-subtle-base` | `#fafafa` | `#0f0f10` | the page, nav bar, tab strip, rails, object headers, panel header strips |
+| Panel | `background-neutral-base` | `#ffffff` | `#1a1a1b` | panel bodies, rows, popovers, modals |
+| Code | `background-contrast-*` | `#1a1a1b` | `#030303` | code, logs, YAML, agent transcripts |
+| Inline fill | `background-components-base` | `#f4f4f5` | `#27272a` | avatars, badges, kbd, chips inside a panel |
+
+The ladder follows two rules:
+
+- Panel sits one ramp step toward the foreground from canvas in both themes. A panel header strip sits one step below its panel, which is the canvas value.
+- No page, panel, or code surface uses an alpha token, because alpha composites over a parent that varies.
+
 ## Imports
 
 Import from a subpath. Each component has its own entry

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -18,7 +18,7 @@ Shared React component library for Shipfox apps. It provides design tokens, Tail
 The `@shipfox/react-ui/index.css` entry defines four target surface roles for page and component authors.
 The table records the target contract, not every token's current resolution. Until the migration
 lands, light canvas uses `--color-alpha-black-2`, light inline fill resolves to `#fafafa`, and dark
-code resolves to `#27272a`. See [the surface ladder in `DESIGN.md`](../../../DESIGN.md#the-surface-ladder)
+code resolves to `#27272a`. See [the surface ladder in `DESIGN.md`](../../../../DESIGN.md#the-surface-ladder)
 for the current-versus-target mapping.
 
 | Role | Token | Target light | Target dark | Used for |

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -15,9 +15,13 @@ Shared React component library for Shipfox apps. It provides design tokens, Tail
 
 ### Surface roles
 
-The `@shipfox/react-ui/index.css` entry defines four surface roles for page and component authors:
+The `@shipfox/react-ui/index.css` entry defines four target surface roles for page and component authors.
+The table records the target contract, not every token's current resolution. Until the migration
+lands, light canvas uses `--color-alpha-black-2`, light inline fill resolves to `#fafafa`, and dark
+code resolves to `#27272a`. See [the surface ladder in `DESIGN.md`](../../../DESIGN.md#the-surface-ladder)
+for the current-versus-target mapping.
 
-| Role | Token | Light | Dark | Used for |
+| Role | Token | Target light | Target dark | Used for |
 | --- | --- | --- | --- | --- |
 | Canvas | `background-subtle-base` | `#fafafa` | `#0f0f10` | the page, nav bar, tab strip, rails, object headers, panel header strips |
 | Panel | `background-neutral-base` | `#ffffff` | `#1a1a1b` | panel bodies, rows, popovers, modals |
@@ -27,7 +31,7 @@ The `@shipfox/react-ui/index.css` entry defines four surface roles for page and 
 The ladder follows two rules:
 
 - Panel sits one ramp step toward the foreground from canvas in both themes. A panel header strip sits one step below its panel, which is the canvas value.
-- No page, panel, or code surface uses an alpha token, because alpha composites over a parent that varies.
+- Page, panel, or code surfaces should use opaque tokens, because alpha composites over a parent that varies. During migration, light-mode canvas is the current exception: `background-subtle-base` uses `--color-alpha-black-2` and resolves to `#fafafa` over white.
 
 ## Imports
 

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -205,9 +205,9 @@
   --color-alpha-black-88: rgba(24, 24, 27, 0.88);
 
   /*
-   * Surface roles
+   * Target surface roles
    *
-   * | Role | Token | Light | Dark | Used for |
+   * | Role | Token | Target light | Target dark | Used for |
    * | --- | --- | --- | --- | --- |
    * | Canvas | `background-subtle-base` | `#fafafa` | `#0f0f10` | the page, nav bar, tab strip, rails, object headers, panel header strips |
    * | Panel | `background-neutral-base` | `#ffffff` | `#1a1a1b` | panel bodies, rows, popovers, modals |
@@ -216,8 +216,14 @@
    *
    * Panel sits one ramp step toward the foreground from canvas in both themes.
    * A panel header strip sits one step below its panel, which is the canvas value.
-   * No page, panel, or code surface uses an alpha token, because alpha composites
-   * over a parent that varies.
+   * This table records target values. During migration, light canvas uses
+   * `--color-alpha-black-2`, light inline fill resolves to `#fafafa`, and dark code
+   * resolves to `#27272a`. See DESIGN.md#the-surface-ladder for the
+   * current-versus-target mapping.
+   * Page, panel, or code surfaces should use opaque tokens, because alpha
+   * composites over a parent that varies. During migration, light-mode canvas is
+   * the current exception: `background-subtle-base` uses `--color-alpha-black-2`
+   * and resolves to `#fafafa` over white.
    */
   /* Design Token Variables - Light Mode */
   /* Background */

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -204,6 +204,21 @@
   --color-alpha-black-80: rgba(24, 24, 27, 0.8);
   --color-alpha-black-88: rgba(24, 24, 27, 0.88);
 
+  /*
+   * Surface roles
+   *
+   * | Role | Token | Light | Dark | Used for |
+   * | --- | --- | --- | --- | --- |
+   * | Canvas | `background-subtle-base` | `#fafafa` | `#0f0f10` | the page, nav bar, tab strip, rails, object headers, panel header strips |
+   * | Panel | `background-neutral-base` | `#ffffff` | `#1a1a1b` | panel bodies, rows, popovers, modals |
+   * | Code | `background-contrast-*` | `#1a1a1b` | `#030303` | code, logs, YAML, agent transcripts |
+   * | Inline fill | `background-components-base` | `#f4f4f5` | `#27272a` | avatars, badges, kbd, chips inside a panel |
+   *
+   * Panel sits one ramp step toward the foreground from canvas in both themes.
+   * A panel header strip sits one step below its panel, which is the canvas value.
+   * No page, panel, or code surface uses an alpha token, because alpha composites
+   * over a parent that varies.
+   */
   /* Design Token Variables - Light Mode */
   /* Background */
   --background-components-hover: var(--color-neutral-100);


### PR DESCRIPTION
Document the four surface roles and the rules that generate the ladder in the CSS token source and the react-ui public API README. This gives page authors one contract for selecting backgrounds across themes.

Closes ENG-1574

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the four surface roles—canvas, panel, code, inline fill—and the ladder rules in `@shipfox/react-ui/index.css` and the library README, with migration notes that explain current token gaps while keeping the target contract. Rules: panel is one step toward foreground from canvas; header strips use canvas; page/panel/code use opaque tokens, with temporary exceptions for light canvas alpha, light inline fill, and dark code. Closes ENG-1574.

- **Bug Fixes**
  - Point README link to the repository-level `DESIGN.md#the-surface-ladder` so docs validation passes and guidance uses the canonical contract.

<sup>Written for commit 5c48af6e7c45ca66623103812ee729bd03d00873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

