### PR TITLE
[react-ui] Remove theme branches from component source

### DIFF
--- a/.changeset/steady-semantic-surfaces.md
+++ b/.changeset/steady-semantic-surfaces.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/react-ui': patch
+---
+
+Use semantic surface and status tokens across code, log, avatar, and keyboard components instead of branching on the active theme.

--- a/.changeset/steady-semantic-surfaces.md
+++ b/.changeset/steady-semantic-surfaces.md
@@ -1,5 +1,8 @@
 ---
 '@shipfox/react-ui': patch
+'@shipfox/client-logs': patch
+'@shipfox/client-triggers': patch
+'@shipfox/client-workflows': patch
 ---
 
-Use semantic surface and status tokens across code, log, avatar, and keyboard components instead of branching on the active theme.
+Use dark contrast surfaces with readable semantic foregrounds across code and log views, preserve status on log-row edge accents, and add shared highlight and tooltip tokens for code and keyboard affordances.

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -156,7 +156,7 @@ function AgentSessionRowView({
               <span
                 className={cn(
                   'inline-flex items-center gap-tight',
-                  row.isError ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
+                  row.isError ? 'text-tag-error-text' : 'text-foreground-neutral-muted',
                 )}
               >
                 <Icon
@@ -174,10 +174,7 @@ function AgentSessionRowView({
             </span>
           </LogDisclosureTrigger>
           <LogDisclosureContent>
-            <LogContent
-              variant="code"
-              className={cn(row.isError && 'text-red-600 dark:text-red-400')}
-            >
+            <LogContent variant="code" className={cn(row.isError && 'text-tag-error-text')}>
               <PreviewText text={row.output} />
             </LogContent>
           </LogDisclosureContent>
@@ -220,7 +217,7 @@ function AgentSessionRowView({
           <LogDisclosureTrigger
             timestamp={new Date(row.timestamp)}
             summary={compactPreview(row.raw)}
-            className="text-orange-600 dark:text-orange-400"
+            className="text-tag-warning-text"
           >
             <span className="inline-flex min-w-0 items-center gap-inline">
               <Icon name="errorWarningLine" className="size-14 flex-none" aria-hidden="true" />
@@ -253,7 +250,7 @@ function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: bo
       name={name}
       className={cn(
         'mt-[2px] size-14 flex-none',
-        terminalFailure ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
+        terminalFailure ? 'text-tag-error-icon' : 'text-foreground-neutral-muted',
       )}
       aria-hidden="true"
     />

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -64,7 +64,7 @@ function AgentSessionRowView({
           tone={row.terminalFailure ? 'error' : 'default'}
           data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
         >
-          <LogContent className="text-foreground-neutral-base">
+          <LogContent className="text-foreground-contrast-primary">
             <span className="flex min-w-0 items-start gap-inline">
               <MessageIcon role={row.role} terminalFailure={row.terminalFailure} />
               <span className="flex min-w-0 flex-1 flex-col gap-tight">
@@ -86,12 +86,12 @@ function AgentSessionRowView({
           <LogDisclosureTrigger
             summary={wordSummary(row.text)}
             timestamp={new Date(row.timestamp)}
-            className="text-foreground-neutral-subtle"
+            className="text-foreground-contrast-secondary"
           >
             thinking
           </LogDisclosureTrigger>
-          <LogDisclosureContent className="text-foreground-neutral-subtle">
-            <LogContent className="text-foreground-neutral-subtle">
+          <LogDisclosureContent className="text-foreground-contrast-secondary">
+            <LogContent className="text-foreground-contrast-secondary">
               <PreviewText text={row.text} />
             </LogContent>
           </LogDisclosureContent>
@@ -156,7 +156,7 @@ function AgentSessionRowView({
               <span
                 className={cn(
                   'inline-flex items-center gap-tight',
-                  row.isError ? 'text-tag-error-text' : 'text-foreground-neutral-muted',
+                  row.isError ? 'text-tag-error-icon' : 'text-foreground-contrast-secondary',
                 )}
               >
                 <Icon
@@ -174,7 +174,7 @@ function AgentSessionRowView({
             </span>
           </LogDisclosureTrigger>
           <LogDisclosureContent>
-            <LogContent variant="code" className={cn(row.isError && 'text-tag-error-text')}>
+            <LogContent variant="code" className="text-foreground-contrast-primary">
               <PreviewText text={row.output} />
             </LogContent>
           </LogDisclosureContent>
@@ -190,7 +190,7 @@ function AgentSessionRowView({
           tone={row.tone}
           data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
         >
-          <LogContent className="text-foreground-neutral-muted">
+          <LogContent className="text-foreground-contrast-secondary">
             <span className="inline-flex w-full items-center gap-inline">
               <Icon name="informationLine" className="size-14 flex-none" aria-hidden="true" />
               <span className="min-w-0">
@@ -198,7 +198,7 @@ function AgentSessionRowView({
                 {row.detail != null ? (
                   <>
                     {' · '}
-                    <span className="text-foreground-neutral-subtle">{row.detail}</span>
+                    <span className="text-foreground-contrast-secondary">{row.detail}</span>
                   </>
                 ) : null}
               </span>
@@ -217,10 +217,14 @@ function AgentSessionRowView({
           <LogDisclosureTrigger
             timestamp={new Date(row.timestamp)}
             summary={compactPreview(row.raw)}
-            className="text-tag-warning-text"
+            className="text-foreground-contrast-primary"
           >
             <span className="inline-flex min-w-0 items-center gap-inline">
-              <Icon name="errorWarningLine" className="size-14 flex-none" aria-hidden="true" />
+              <Icon
+                name="errorWarningLine"
+                className="size-14 flex-none text-tag-warning-icon"
+                aria-hidden="true"
+              />
               <span className="truncate">{row.label}</span>
             </span>
           </LogDisclosureTrigger>
@@ -250,7 +254,7 @@ function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: bo
       name={name}
       className={cn(
         'mt-[2px] size-14 flex-none',
-        terminalFailure ? 'text-tag-error-icon' : 'text-foreground-neutral-muted',
+        terminalFailure ? 'text-tag-error-icon' : 'text-foreground-contrast-secondary',
       )}
       aria-hidden="true"
     />
@@ -261,8 +265,8 @@ function MessageRoleLabel({label, terminalFailure}: {label: string; terminalFail
   return (
     <span
       className={cn(
-        'min-w-0 font-code text-foreground-neutral-muted',
-        terminalFailure && 'text-foreground-highlight-error',
+        'min-w-0 font-code text-foreground-contrast-secondary',
+        terminalFailure && 'text-foreground-contrast-primary',
       )}
     >
       <span className="truncate">{label}</span>
@@ -277,7 +281,7 @@ function RowMetadata({meta, className}: {meta: readonly SessionViewRowMeta[]; cl
   if (inlineMeta != null) {
     return (
       <span
-        className={cn('font-code text-xs text-foreground-neutral-muted', className)}
+        className={cn('font-code text-xs text-foreground-contrast-secondary', className)}
         title={`${inlineMeta.label}: ${inlineMeta.value}`}
       >
         {inlineMeta.value}
@@ -298,7 +302,7 @@ function MetadataTrigger({meta}: {meta: readonly SessionViewRowMeta[]}) {
       <TooltipTrigger asChild>
         <button
           type="button"
-          className="inline-flex size-20 flex-none items-center justify-center rounded-4 text-foreground-neutral-muted opacity-60 transition-opacity hover:bg-background-components-hover hover:text-foreground-neutral-base hover:opacity-100 focus-visible:opacity-100 focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] group-hover/log-row:opacity-100"
+          className="inline-flex size-20 flex-none items-center justify-center rounded-4 text-foreground-contrast-secondary opacity-60 transition-opacity hover:bg-background-components-hover hover:text-foreground-contrast-primary hover:opacity-100 focus-visible:opacity-100 focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] group-hover/log-row:opacity-100"
           aria-label="Show message metadata"
         >
           <Icon name="informationLine" className="size-12" aria-hidden="true" />

--- a/libs/client/logs/src/components/log-group.tsx
+++ b/libs/client/logs/src/components/log-group.tsx
@@ -42,11 +42,11 @@ function GroupStatus({node, terminated}: {node: GroupLogNode; terminated: boolea
   // closed only because an ancestor's group_end cascaded (its own end was dropped, so endTs
   // is null). Either way show "incomplete" rather than a blank slot or a forever spinner.
   if (node.closed || terminated) {
-    return <span className="text-foreground-neutral-muted">incomplete</span>;
+    return <span className="text-foreground-contrast-secondary">incomplete</span>;
   }
 
   return (
-    <span className="inline-flex items-center gap-tight text-foreground-neutral-muted">
+    <span className="inline-flex items-center gap-tight text-foreground-contrast-secondary">
       <Icon name="loader4Line" className="size-12 motion-safe:animate-spin" aria-hidden="true" />
       running
     </span>

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -157,13 +157,13 @@ function NoOutputRow({state}: {state: NonNullable<LogViewProps['emptyState']>}) 
 
   return (
     <LogRow lineNumber={null}>
-      <LogContent className="text-foreground-neutral-muted">
+      <LogContent className="text-foreground-contrast-secondary">
         <span className="inline-flex min-w-0 items-center gap-inline">
           <Icon name="info" className="size-14 flex-none" aria-hidden="true" />
           <span className="min-w-0">
             <span className="font-medium">{copy.title}</span>
             {' · '}
-            <span className="text-foreground-neutral-subtle">{copy.detail}</span>
+            <span className="text-foreground-contrast-secondary">{copy.detail}</span>
           </span>
         </span>
       </LogContent>

--- a/libs/client/logs/src/components/output-log-row.tsx
+++ b/libs/client/logs/src/components/output-log-row.tsx
@@ -27,7 +27,11 @@ export function OutputLogRow({
       data-stream={record.stream}
       className={cn(isStderr && 'shadow-[inset_2px_0_0_var(--color-border-neutral-strong)]')}
     >
-      <LogContent variant="code" ansi className={cn(isStderr && 'text-foreground-neutral-subtle')}>
+      <LogContent
+        variant="code"
+        ansi
+        className={cn(isStderr && 'text-foreground-contrast-secondary')}
+      >
         {stripTrailingNewline(record.data)}
       </LogContent>
     </LogRow>

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -11,9 +11,15 @@ import type {
 type MarkerTone = 'default' | 'warning' | 'error';
 
 const toneText: Record<MarkerTone, string> = {
-  default: 'text-foreground-neutral-muted',
-  warning: 'text-tag-warning-text',
-  error: 'text-tag-error-text',
+  default: 'text-foreground-contrast-secondary',
+  warning: 'text-foreground-contrast-primary',
+  error: 'text-foreground-contrast-primary',
+};
+
+const toneIcon: Record<MarkerTone, string> = {
+  default: 'text-foreground-contrast-secondary',
+  warning: 'text-tag-warning-icon',
+  error: 'text-tag-error-icon',
 };
 
 interface LogMarkerRowProps {
@@ -53,7 +59,11 @@ function LogMarkerRow({
     >
       <LogContent className={cn('block', toneText[tone])}>
         <span className="inline-flex w-full items-center gap-inline">
-          <Icon name={icon} className="size-14 flex-none" aria-hidden="true" />
+          <Icon
+            name={icon}
+            className={cn('size-14 flex-none', toneIcon[tone])}
+            aria-hidden="true"
+          />
           {/* Label, detail, and figures share one text cluster joined by a literal
               " · ". Flex `gap` is visual only and would copy with no separator, so the
               separators are real inline text. The dashed rule trails after the text

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -12,8 +12,8 @@ type MarkerTone = 'default' | 'warning' | 'error';
 
 const toneText: Record<MarkerTone, string> = {
   default: 'text-foreground-neutral-muted',
-  warning: 'text-orange-600 dark:text-orange-400',
-  error: 'text-red-600 dark:text-red-400',
+  warning: 'text-tag-warning-text',
+  error: 'text-tag-error-text',
 };
 
 interface LogMarkerRowProps {

--- a/libs/client/triggers/src/components/trigger-event-detail.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.tsx
@@ -431,7 +431,7 @@ function EventPayload({payload}: {payload: string}) {
             <CodeBlockItem
               value={item.filename}
               lineNumbers={false}
-              className="px-0 pb-0 [&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base [&>div]:dark:bg-background-contrast-base [&_code]:!text-foreground-neutral-on-color"
+              className="px-0 pb-0 [&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base [&_code]:!text-foreground-neutral-on-color"
             >
               <CodeBlockContent language="json" syntaxHighlighting={false}>
                 {item.code}

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -347,7 +347,7 @@ function ExpandedStep({
       role="region"
       tabIndex={0}
       aria-label={`${context.stepLabel} output, attempt ${context.attempt}`}
-      className="flex min-w-0 flex-col border-t border-border-neutral-base bg-background-neutral-base outline-none focus-visible:shadow-border-interactive-with-active dark:bg-background-contrast-subtle"
+      className="flex min-w-0 flex-col border-t border-border-neutral-base bg-background-contrast-subtle outline-none focus-visible:shadow-border-interactive-with-active"
     >
       <StepAttemptLogPanel
         stepId={context.stepId}

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -144,7 +144,7 @@ function StepLogsLoadingSurface({label, className}: {label: string; className: s
 function StepLogsWaitingSurface({startedAt, className}: {startedAt: string; className: string}) {
   return (
     <div role="status" aria-label="Waiting for logs" className={className}>
-      <Text size="xs" className="px-tight py-row text-foreground-neutral-muted">
+      <Text size="xs" className="px-tight py-row text-foreground-contrast-secondary">
         Waiting for output ·{' '}
         <span className="font-code tabular-nums" aria-hidden="true">
           <JobExecutionTimeText time={{state: 'live', fromIso: startedAt}} />

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-content.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-content.tsx
@@ -64,7 +64,7 @@ export function WorkflowSourceContent({
             className={cn(
               'min-h-full px-0 pb-0',
               '[&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base',
-              '[&_code]:!text-sm [&_code]:!text-foreground-neutral-on-inverted [&_.line]:!text-sm [&_.line]:before:!text-sm [&_.line]:before:!text-foreground-neutral-muted',
+              '[&_code]:!text-sm [&_code]:!text-foreground-contrast-primary [&_.line]:!text-sm [&_.line]:before:!text-sm [&_.line]:before:!text-foreground-contrast-secondary',
             )}
           >
             <CodeBlockContent

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-content.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-content.tsx
@@ -63,7 +63,7 @@ export function WorkflowSourceContent({
             value={item.filename}
             className={cn(
               'min-h-full px-0 pb-0',
-              '[&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base [&>div]:dark:bg-background-contrast-base',
+              '[&>div]:rounded-none [&>div]:border-0 [&>div]:bg-background-contrast-base',
               '[&_code]:!text-sm [&_code]:!text-foreground-neutral-on-inverted [&_.line]:!text-sm [&_.line]:before:!text-sm [&_.line]:before:!text-foreground-neutral-muted',
             )}
           >

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -251,6 +251,12 @@
   --background-contrast-hover: var(--color-neutral-800);
   --background-contrast-pressed: var(--color-neutral-700);
   --background-contrast-base: var(--color-neutral-900);
+  --background-contrast-highlight: color-mix(
+    in srgb,
+    var(--border-highlights-interactive) 7%,
+    var(--background-contrast-base)
+  );
+  --background-kbd-tooltip: color-mix(in srgb, var(--background-neutral-base) 20%, transparent);
   --background-backdrop-backdrop: var(--color-alpha-black-64);
   --background-modal-overlay: var(--color-alpha-black-88);
 
@@ -502,6 +508,12 @@
   --background-contrast-hover: var(--color-neutral-900);
   --background-contrast-pressed: var(--color-alpha-white-12);
   --background-contrast-base: var(--color-neutral-1000);
+  --background-contrast-highlight: color-mix(
+    in srgb,
+    var(--border-highlights-interactive) 12%,
+    var(--background-contrast-base)
+  );
+  --background-kbd-tooltip: color-mix(in srgb, var(--background-neutral-base) 10%, transparent);
   --background-backdrop-backdrop: var(--color-alpha-black-64);
   --background-modal-overlay: var(--color-alpha-black-88);
 
@@ -849,6 +861,8 @@
   --color-background-contrast-hover: var(--background-contrast-hover);
   --color-background-contrast-pressed: var(--background-contrast-pressed);
   --color-background-contrast-base: var(--background-contrast-base);
+  --color-background-contrast-highlight: var(--background-contrast-highlight);
+  --color-background-kbd-tooltip: var(--background-kbd-tooltip);
   --color-background-backdrop-backdrop: var(--background-backdrop-backdrop);
   --color-background-modal-overlay: var(--background-modal-overlay);
 

--- a/libs/shared/react/ui/src/components/avatar/avatar.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.tsx
@@ -130,7 +130,7 @@ export function Avatar({
   ...props
 }: AvatarProps) {
   const innerClassName =
-    'flex h-full w-full items-center justify-center rounded-inherit relative bg-background-neutral-base dark:bg-background-components-base text-foreground-neutral-subtle';
+    'flex h-full w-full items-center justify-center rounded-inherit relative bg-background-components-base text-foreground-neutral-subtle';
 
   const renderContent = (): ReactNode => {
     if (content === 'image') {

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -6,7 +6,7 @@ import {
   CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE,
   CODE_BLOCK_HIGHLIGHTED_LINE_STYLE,
 } from './code-content.js';
-import {CodeBlockContent} from './index.js';
+import {CodeBlockContent, CodeBlockSurface} from './index.js';
 
 vi.mock('shiki', () => ({
   codeToHtml: vi.fn(),
@@ -66,6 +66,27 @@ describe('CodeBlockContent', () => {
     });
 
     expect(codeToHtmlMock.mock.calls[0]?.[1].transformers).toBeUndefined();
+  });
+
+  test('uses the dark Shiki theme for the always-dark code surface', async () => {
+    const codeToHtmlMock = vi.mocked(codeToHtml);
+    codeToHtmlMock.mockResolvedValue(highlightedHtml);
+
+    renderCodeBlockContent({
+      code: 'steps:\n  - uses: actions/checkout@v3',
+      language: 'yaml',
+      syntaxHighlighting: true,
+    });
+
+    await waitFor(() => {
+      expect(codeToHtmlMock).toHaveBeenCalledTimes(1);
+    });
+
+    const options = codeToHtmlMock.mock.calls[0]?.[1] as {themes?: unknown} | undefined;
+    expect(options?.themes).toEqual({
+      light: 'vitesse-dark',
+      dark: 'vitesse-dark',
+    });
   });
 
   test('passes a Shiki transformer that marks explicit diff content', async () => {
@@ -140,6 +161,20 @@ describe('CodeBlockContent', () => {
     expect(CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE).toContain(
       ':!bg-background-contrast-highlight',
     );
+  });
+
+  test('uses contrast foreground tokens for the code surface', () => {
+    const {container} = render(
+      <CodeBlockSurface>
+        <pre>
+          <code>const value = true;</code>
+        </pre>
+      </CodeBlockSurface>,
+    );
+
+    const surface = container.querySelector('[data-slot="code-block-surface"]');
+    expect(surface?.className).toContain('text-foreground-contrast-primary');
+    expect(surface?.className).toContain('text-foreground-contrast-secondary');
   });
 });
 

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -136,8 +136,10 @@ describe('CodeBlockContent', () => {
   });
 
   test('keeps highlighted line backgrounds above the Shiki transparent reset', () => {
-    expect(CODE_BLOCK_HIGHLIGHTED_LINE_STYLE).toContain('!bg-[');
-    expect(CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE).toContain(':!bg-[');
+    expect(CODE_BLOCK_HIGHLIGHTED_LINE_STYLE).toContain('!bg-background-contrast-highlight');
+    expect(CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE).toContain(
+      ':!bg-background-contrast-highlight',
+    );
   });
 });
 

--- a/libs/shared/react/ui/src/components/code-block/code-block-footer.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-footer.tsx
@@ -52,7 +52,10 @@ export function CodeBlockFooter({
     return (
       <Comp
         data-slot="code-block-footer"
-        className={cn('flex w-full items-center justify-start gap-12 px-16 py-12', className)}
+        className={cn(
+          'flex w-full items-center justify-start gap-12 px-16 py-12 text-foreground-contrast-primary',
+          className,
+        )}
         {...props}
       >
         {children}
@@ -63,7 +66,10 @@ export function CodeBlockFooter({
   return (
     <Comp
       data-slot="code-block-footer"
-      className={cn('flex w-full items-center justify-start gap-12 px-16 py-12', className)}
+      className={cn(
+        'flex w-full items-center justify-start gap-12 px-16 py-12 text-foreground-contrast-primary',
+        className,
+      )}
       {...props}
     >
       <CodeBlockFooterIcon className="text-tag-success-icon">{defaultIcon}</CodeBlockFooterIcon>
@@ -179,7 +185,7 @@ export function CodeBlockFooterDescription({
     return (
       <Slot
         data-slot="code-block-footer-description"
-        className={cn('text-xs text-foreground-neutral-subtle', className)}
+        className={cn('text-xs text-foreground-contrast-secondary', className)}
         {...props}
       >
         {children}
@@ -191,7 +197,7 @@ export function CodeBlockFooterDescription({
     <Text
       data-slot="code-block-footer-description"
       size="xs"
-      className={cn('text-foreground-neutral-subtle', className)}
+      className={cn('text-foreground-contrast-secondary', className)}
       {...props}
     >
       {children}

--- a/libs/shared/react/ui/src/components/code-block/code-block.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.tsx
@@ -69,7 +69,7 @@ export function CodeBlock({
     <CodeBlockContext.Provider value={{value, onValueChange, data}}>
       <div
         className={cn(
-          'size-full overflow-hidden rounded-12 bg-background-components-pressed dark:bg-background-contrast-base shadow-button-neutral',
+          'size-full overflow-hidden rounded-12 bg-background-contrast-base shadow-button-neutral',
           className,
         )}
         {...props}
@@ -84,7 +84,7 @@ export function CodeBlockHeader({className, ...props}: CodeBlockHeaderProps) {
   return (
     <div
       className={cn(
-        'flex w-full flex-row items-center gap-12 overflow-clip bg-background-components-pressed dark:bg-background-contrast-base px-16 py-8',
+        'flex w-full flex-row items-center gap-12 overflow-clip bg-background-contrast-base px-16 py-8',
         className,
       )}
       {...props}
@@ -248,7 +248,7 @@ export function CodeBlockSurface({
     <div
       data-slot="code-block-surface"
       className={cn(
-        'flex min-h-0 min-w-0 flex-1 shrink-0 rounded-8 border border-border-contrast-bottom bg-background-neutral-base dark:bg-background-contrast-subtle font-code',
+        'flex min-h-0 min-w-0 flex-1 shrink-0 rounded-8 border border-border-contrast-bottom bg-background-contrast-subtle font-code',
         '[&_pre]:py-12 [&_pre]:font-code',
         '[&_code]:w-full [&_code]:grid [&_code]:overflow-x-auto [&_code]:bg-transparent [&_code]:font-code [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-neutral-base',
         '[&_.line]:block [&_.line]:px-12 [&_.line]:w-full [&_.line]:relative [&_.line]:font-code [&_.line]:min-h-[1.25rem]',

--- a/libs/shared/react/ui/src/components/code-block/code-block.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.tsx
@@ -122,7 +122,7 @@ export function CodeBlockFilename({className, value, children, ...props}: CodeBl
   return (
     <div
       className={cn(
-        'flex min-h-0 min-w-0 flex-1 items-center overflow-hidden text-ellipsis whitespace-nowrap text-xs leading-20 font-code text-foreground-neutral-muted',
+        'flex min-h-0 min-w-0 flex-1 items-center overflow-hidden text-ellipsis whitespace-nowrap text-xs leading-20 font-code text-foreground-contrast-secondary',
         className,
       )}
       {...props}
@@ -250,10 +250,10 @@ export function CodeBlockSurface({
       className={cn(
         'flex min-h-0 min-w-0 flex-1 shrink-0 rounded-8 border border-border-contrast-bottom bg-background-contrast-subtle font-code',
         '[&_pre]:py-12 [&_pre]:font-code',
-        '[&_code]:w-full [&_code]:grid [&_code]:overflow-x-auto [&_code]:bg-transparent [&_code]:font-code [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-neutral-base',
+        '[&_code]:w-full [&_code]:grid [&_code]:overflow-x-auto [&_code]:bg-transparent [&_code]:font-code [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-contrast-primary',
         '[&_.line]:block [&_.line]:px-12 [&_.line]:w-full [&_.line]:relative [&_.line]:font-code [&_.line]:min-h-[1.25rem]',
         lineNumbers &&
-          '[&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-neutral-subtle [&_.line]:before:font-code [&_.line]:before:select-none',
+          '[&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-contrast-secondary [&_.line]:before:font-code [&_.line]:before:select-none',
         '[&_.line.diff]:after:absolute [&_.line.diff]:after:left-0 [&_.line.diff]:after:top-0 [&_.line.diff]:after:bottom-0 [&_.line.diff]:after:w-1',
         '[&_.line.diff.add]:bg-tag-success-bg [&_.line.diff.add]:text-tag-success-text [&_.line.diff.add]:after:bg-tag-success-icon',
         '[&_.line.diff.remove]:bg-tag-error-bg [&_.line.diff.remove]:text-tag-error-text [&_.line.diff.remove]:after:bg-tag-error-icon',
@@ -305,7 +305,7 @@ export type CodeBlockContentProps = Omit<HTMLAttributes<HTMLDivElement>, 'childr
 export function CodeBlockContent({
   children,
   themes = {
-    light: 'vitesse-light',
+    light: 'vitesse-dark',
     dark: 'vitesse-dark',
   },
   language = 'typescript',

--- a/libs/shared/react/ui/src/components/code-block/code-content.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-content.tsx
@@ -8,10 +8,10 @@ import {
 import {useScrollHighlightedLineIntoView} from './use-scroll-highlighted-line.js';
 
 export const CODE_BLOCK_HIGHLIGHTED_LINE_STYLE =
-  '!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
+  '!bg-background-contrast-highlight shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
 
 export const CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE =
-  '[&_.line.highlighted-line]:!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:[&_.line.highlighted-line]:!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] [&_.line.highlighted-line]:shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
+  '[&_.line.highlighted-line]:!bg-background-contrast-highlight [&_.line.highlighted-line]:shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
 
 type CodeContentProps = HTMLAttributes<HTMLElement> & {
   code: string;

--- a/libs/shared/react/ui/src/components/code-block/code-content.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-content.tsx
@@ -52,9 +52,9 @@ export function CodeContent({
         }}
         {...props}
         className={cn(
-          'shiki-override w-full overflow-x-auto font-code [&_pre]:m-0 [&_pre]:p-0 [&_pre]:bg-transparent [&_pre]:font-code [&_code]:font-code [&_code]:bg-transparent [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-neutral-base [&_code]:grid',
+          'shiki-override w-full overflow-x-auto font-code [&_pre]:m-0 [&_pre]:p-0 [&_pre]:bg-transparent [&_pre]:font-code [&_code]:font-code [&_code]:bg-transparent [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-contrast-primary [&_code]:grid',
           lineNumbers &&
-            '[&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-neutral-subtle [&_.line]:before:font-code [&_.line]:before:select-none',
+            '[&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-contrast-secondary [&_.line]:before:font-code [&_.line]:before:select-none',
           '[&_.line]:block [&_.line]:px-12 [&_.line]:w-full [&_.line]:relative [&_.line]:font-code [&_.line]:text-xs [&_.line]:leading-20 [&_.line]:min-h-[1.25rem]',
           CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE,
           className,
@@ -77,10 +77,10 @@ export function CodeContent({
     >
       <code
         className={cn(
-          'w-full overflow-x-auto bg-transparent font-code text-xs leading-20 text-foreground-neutral-base',
+          'w-full overflow-x-auto bg-transparent font-code text-xs leading-20 text-foreground-contrast-primary',
           'grid',
           lineNumbers &&
-            '[counter-reset:line] [counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-neutral-subtle [&_.line]:before:font-code [&_.line]:before:select-none',
+            '[counter-reset:line] [counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-contrast-secondary [&_.line]:before:font-code [&_.line]:before:select-none',
         )}
       >
         {lines.map((line, index) => {

--- a/libs/shared/react/ui/src/components/code-block/code-copy-button.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-copy-button.tsx
@@ -67,7 +67,7 @@ export function CodeCopyButton({
       aria-label={isCopied ? 'Copied' : 'Copy to clipboard'}
       onClick={handleClick}
       className={cn(
-        'flex shrink-0 cursor-pointer items-center justify-center rounded-6 bg-transparent text-foreground-neutral-muted transition-colors hover:bg-background-components-hover active:bg-background-components-pressed p-4 outline-none focus-visible:shadow-button-neutral-focus',
+        'flex shrink-0 cursor-pointer items-center justify-center rounded-6 bg-transparent text-foreground-contrast-secondary transition-colors hover:bg-background-components-hover hover:text-foreground-contrast-primary active:bg-background-components-pressed p-4 outline-none focus-visible:shadow-button-neutral-focus',
         className,
       )}
     >

--- a/libs/shared/react/ui/src/components/code-block/code-tabs.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-tabs.tsx
@@ -64,11 +64,10 @@ function CodeTabsContent({
     <>
       <Tabs.List
         className={cn(
-          'relative flex w-full flex-row items-center justify-between gap-12 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden bg-background-components-pressed dark:bg-background-contrast-base px-16 py-8',
+          'relative flex w-full flex-row items-center justify-between gap-12 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden bg-background-contrast-base px-16 py-8',
           'border-b border-border-contrast-bottom',
           'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px',
-          'after:bg-border-neutral-base',
-          'dark:after:bg-border-contrast-top',
+          'after:bg-border-contrast-top',
           'after:shadow-separator-inset',
         )}
       >
@@ -99,7 +98,7 @@ function CodeTabsContent({
           <Tabs.Content key={code} value={code} className="w-full">
             <div
               className={cn(
-                'flex min-h-0 min-w-0 w-full shrink-0 rounded-8 border border-border-contrast-bottom bg-background-neutral-base dark:bg-background-contrast-subtle font-code',
+                'flex min-h-0 min-w-0 w-full shrink-0 rounded-8 border border-border-contrast-bottom bg-background-contrast-subtle font-code',
                 '[&_pre]:py-12 [&_pre]:font-code',
                 '[&_pre]:m-0 [&_pre]:px-0 [&_pre]:bg-transparent',
                 '[&_code]:w-full [&_code]:overflow-x-auto [&_code]:bg-transparent [&_code]:font-code [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-neutral-base',
@@ -164,7 +163,7 @@ export function CodeTabs({
   return (
     <Tabs.Root
       className={cn(
-        'w-full overflow-hidden rounded-12 bg-background-components-pressed dark:bg-background-contrast-base shadow-button-neutral',
+        'w-full overflow-hidden rounded-12 bg-background-contrast-base shadow-button-neutral',
         className,
       )}
       value={value}

--- a/libs/shared/react/ui/src/components/code-block/code-tabs.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-tabs.tsx
@@ -27,7 +27,7 @@ function CodeTabsContent({
   codes,
   lang = 'bash',
   themes = {
-    light: 'vitesse-light',
+    light: 'vitesse-dark',
     dark: 'vitesse-dark',
   },
   copyButton = true,
@@ -77,13 +77,13 @@ function CodeTabsContent({
               key={code}
               value={code}
               className={cn(
-                'relative px-8 py-4 text-xs leading-20 font-medium text-foreground-neutral-muted transition-colors',
+                'relative px-8 py-4 text-xs leading-20 font-medium text-foreground-contrast-secondary transition-colors',
                 'outline-none focus-visible:shadow-border-interactive-with-active focus-visible:rounded-2',
-                'data-[state=active]:text-foreground-neutral-base',
-                'hover:text-foreground-neutral-base',
+                'data-[state=active]:text-foreground-contrast-primary',
+                'hover:text-foreground-contrast-primary',
                 'data-[state=active]:z-10',
                 'data-[state=active]:after:absolute data-[state=active]:after:-bottom-9 data-[state=active]:after:left-0 data-[state=active]:after:right-0',
-                'data-[state=active]:after:h-2 data-[state=active]:after:bg-foreground-neutral-base',
+                'data-[state=active]:after:h-2 data-[state=active]:after:bg-foreground-contrast-primary',
               )}
             >
               {code}
@@ -101,9 +101,9 @@ function CodeTabsContent({
                 'flex min-h-0 min-w-0 w-full shrink-0 rounded-8 border border-border-contrast-bottom bg-background-contrast-subtle font-code',
                 '[&_pre]:py-12 [&_pre]:font-code',
                 '[&_pre]:m-0 [&_pre]:px-0 [&_pre]:bg-transparent',
-                '[&_code]:w-full [&_code]:overflow-x-auto [&_code]:bg-transparent [&_code]:font-code [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-neutral-base',
+                '[&_code]:w-full [&_code]:overflow-x-auto [&_code]:bg-transparent [&_code]:font-code [&_code]:text-xs [&_code]:leading-20 [&_code]:text-foreground-contrast-primary',
                 lineNumbers &&
-                  '[&_code]:grid [&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-neutral-subtle [&_.line]:before:font-code [&_.line]:before:select-none',
+                  '[&_code]:grid [&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-contrast-secondary [&_.line]:before:font-code [&_.line]:before:select-none',
                 '[&_.line]:block [&_.line]:px-12 [&_.line]:w-full [&_.line]:relative [&_.line]:font-code [&_.line]:min-h-[1.25rem]',
               )}
             >
@@ -126,7 +126,7 @@ export function CodeTabs({
   codes,
   lang = 'bash',
   themes = {
-    light: 'vitesse-light',
+    light: 'vitesse-dark',
     dark: 'vitesse-dark',
   },
   className,

--- a/libs/shared/react/ui/src/components/kbd/kbd.tsx
+++ b/libs/shared/react/ui/src/components/kbd/kbd.tsx
@@ -11,7 +11,7 @@ export function Kbd({className, ...props}: KbdProps) {
         'pointer-events-none inline-flex h-20 w-fit min-w-20 items-center justify-center gap-1 rounded-4 px-4 font-display text-xs font-medium select-none',
         'bg-background-components-base text-foreground-neutral-subtle border border-border-neutral-base shadow-button-neutral',
         '[&_svg:not([class*="size-"])]:size-12',
-        'in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10',
+        'in-data-[slot=tooltip-content]:bg-background-kbd-tooltip in-data-[slot=tooltip-content]:text-background',
         className,
       )}
       {...props}

--- a/libs/shared/react/ui/src/components/kbd/kbd.tsx
+++ b/libs/shared/react/ui/src/components/kbd/kbd.tsx
@@ -11,7 +11,7 @@ export function Kbd({className, ...props}: KbdProps) {
         'pointer-events-none inline-flex h-20 w-fit min-w-20 items-center justify-center gap-1 rounded-4 px-4 font-display text-xs font-medium select-none',
         'bg-background-components-base text-foreground-neutral-subtle border border-border-neutral-base shadow-button-neutral',
         '[&_svg:not([class*="size-"])]:size-12',
-        'in-data-[slot=tooltip-content]:bg-background-kbd-tooltip in-data-[slot=tooltip-content]:text-background',
+        'in-data-[slot=tooltip-content]:bg-background-kbd-tooltip in-data-[slot=tooltip-content]:text-foreground-neutral-base',
         className,
       )}
       {...props}

--- a/libs/shared/react/ui/src/components/log/log-disclosure.tsx
+++ b/libs/shared/react/ui/src/components/log/log-disclosure.tsx
@@ -97,18 +97,20 @@ export function LogDisclosureTrigger({
           {chevron === 'leading' && (
             <Icon
               name="chevronRight"
-              className="size-16 flex-none text-foreground-neutral-muted motion-safe:transition-transform group-data-[state=open]/disc:rotate-90"
+              className="size-16 flex-none text-foreground-contrast-secondary motion-safe:transition-transform group-data-[state=open]/disc:rotate-90"
             />
           )}
           {children != null && <span className="min-w-0 truncate font-medium">{children}</span>}
           {summary != null && (
-            <span className="min-w-0 truncate text-foreground-neutral-muted group-data-[state=open]/disc:hidden">
+            <span className="min-w-0 truncate text-foreground-contrast-secondary group-data-[state=open]/disc:hidden">
               {summary}
             </span>
           )}
         </CollapsibleTrigger>
         {trailing != null && (
-          <span className="flex-none tabular-nums text-foreground-neutral-muted">{trailing}</span>
+          <span className="flex-none tabular-nums text-foreground-contrast-secondary">
+            {trailing}
+          </span>
         )}
       </div>
     </LogRowFrame>

--- a/libs/shared/react/ui/src/components/log/log-header.tsx
+++ b/libs/shared/react/ui/src/components/log/log-header.tsx
@@ -18,7 +18,7 @@ export function LogHeader({className, children, end, ...props}: LogHeaderProps) 
     >
       <div className="flex min-w-0 items-center gap-6">{children}</div>
       {end != null && (
-        <div className="ml-auto flex items-center gap-8 text-foreground-neutral-muted tabular-nums">
+        <div className="ml-auto flex items-center gap-8 text-foreground-contrast-secondary tabular-nums">
           {end}
         </div>
       )}

--- a/libs/shared/react/ui/src/components/log/log-row-frame.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row-frame.tsx
@@ -55,10 +55,10 @@ export function LogRowFrame({
           'group/log-row flex items-start transition-colors',
           'hover:bg-neutral-500/[0.06]',
           // Caller styling (e.g. row tone) sits before `selected` so the cursor
-          // row always wins the background it shares with a tone tint.
+          // row always wins the selected surface and edge affordance.
           className,
           selected &&
-            'bg-background-neutral-pressed shadow-[inset_2px_0_0_var(--foreground-highlight-interactive)] hover:bg-background-neutral-pressed',
+            'bg-background-contrast-pressed shadow-[inset_2px_0_0_var(--foreground-highlight-interactive)] hover:bg-background-contrast-pressed',
         )}
         {...props}
       >
@@ -68,7 +68,7 @@ export function LogRowFrame({
             aria-hidden="true"
             className={cn(
               'w-44 flex-none select-none px-12 text-right tabular-nums',
-              selected ? 'text-foreground-neutral-base' : 'text-foreground-neutral-subtle',
+              selected ? 'text-foreground-contrast-primary' : 'text-foreground-contrast-secondary',
             )}
           >
             {lineNumber ?? ''}
@@ -85,14 +85,14 @@ export function LogRowFrame({
                 if (window.getSelection()?.isCollapsed === false) return;
                 onTimestampsClick();
               }}
-              className="w-80 flex-none cursor-pointer px-4 text-foreground-neutral-muted tabular-nums transition-colors hover:text-foreground-neutral-base"
+              className="w-80 flex-none cursor-pointer px-4 text-foreground-contrast-secondary tabular-nums transition-colors hover:text-foreground-contrast-primary"
             >
               {timeText}
             </span>
           ) : (
             <span
               data-slot="log-row-time"
-              className="w-80 flex-none px-4 text-foreground-neutral-muted tabular-nums"
+              className="w-80 flex-none px-4 text-foreground-contrast-secondary tabular-nums"
             >
               {timeText}
             </span>

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -9,6 +9,8 @@ const logRowTone = cva('', {
   variants: {
     tone: {
       default: '',
+      // Keep status on the semantic edge; full-row status fills break log rhythm
+      // and violate the Shape-Not-Just-Color Rule in DESIGN.md.
       error: 'shadow-[inset_2px_0_0_var(--tag-error-icon)]',
       warning: 'shadow-[inset_2px_0_0_var(--tag-warning-icon)]',
       success: 'shadow-[inset_2px_0_0_var(--tag-success-icon)]',

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -9,13 +9,13 @@ const logRowTone = cva('', {
   variants: {
     tone: {
       default: '',
-      error: 'bg-red-50 dark:bg-red-500/10 shadow-[inset_2px_0_0_var(--color-red-500)]',
-      warning: 'bg-orange-50 dark:bg-orange-500/10 shadow-[inset_2px_0_0_var(--color-orange-500)]',
-      success: 'bg-green-50 dark:bg-green-500/10 shadow-[inset_2px_0_0_var(--color-green-500)]',
-      info: 'bg-blue-50 dark:bg-blue-500/10 shadow-[inset_2px_0_0_var(--color-blue-500)]',
+      error: 'shadow-[inset_2px_0_0_var(--tag-error-icon)]',
+      warning: 'shadow-[inset_2px_0_0_var(--tag-warning-icon)]',
+      success: 'shadow-[inset_2px_0_0_var(--tag-success-icon)]',
+      info: 'shadow-[inset_2px_0_0_var(--tag-blue-icon)]',
       // Reserve brand orange for the `selected` affordance; the agent/highlight
       // tone reads violet, matching the agent mock and staying clear of warning.
-      accent: 'bg-purple-50 dark:bg-purple-500/10 shadow-[inset_2px_0_0_var(--color-purple-500)]',
+      accent: 'shadow-[inset_2px_0_0_var(--tag-purple-icon)]',
     },
   },
   defaultVariants: {tone: 'default'},

--- a/libs/shared/react/ui/src/components/log/log-rows.tsx
+++ b/libs/shared/react/ui/src/components/log/log-rows.tsx
@@ -44,7 +44,7 @@ export function LogRows({
         className={cn(
           'overflow-y-auto rounded-12 border border-border-contrast-bottom shadow-button-neutral',
           'bg-background-contrast-subtle',
-          'py-8 font-code text-xs leading-20 text-foreground-neutral-base',
+          'py-8 font-code text-xs leading-20 text-foreground-contrast-primary',
           'scrollbar',
           className,
         )}

--- a/libs/shared/react/ui/src/components/log/log-rows.tsx
+++ b/libs/shared/react/ui/src/components/log/log-rows.tsx
@@ -43,7 +43,7 @@ export function LogRows({
         aria-live="polite"
         className={cn(
           'overflow-y-auto rounded-12 border border-border-contrast-bottom shadow-button-neutral',
-          'bg-background-neutral-base dark:bg-background-contrast-subtle',
+          'bg-background-contrast-subtle',
           'py-8 font-code text-xs leading-20 text-foreground-neutral-base',
           'scrollbar',
           className,

--- a/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
+++ b/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
@@ -31,7 +31,7 @@ export function LogWrapToggle({
         'opacity-0 group-hover/log-row:opacity-100 focus-visible:opacity-100',
         overridden
           ? 'text-foreground-highlight-interactive opacity-100'
-          : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',
+          : 'text-foreground-contrast-secondary hover:text-foreground-contrast-primary',
         className,
       )}
       {...props}

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -94,7 +94,7 @@ export const Playground: Story = {
           </LogContent>
         </LogRow>
         <LogRow lineNumber={41} timestamp={at(10.7)}>
-          <LogContent variant="code" className="text-foreground-neutral-muted">
+          <LogContent variant="code" className="text-foreground-contrast-secondary">
             built in 412ms
           </LogContent>
         </LogRow>
@@ -119,7 +119,7 @@ export const LineNumbers: Story = {
             <LogContent variant="code">linking 318 packages</LogContent>
           </LogRow>
           <LogRow lineNumber={null}>
-            <LogContent variant="code" className="text-foreground-neutral-muted">
+            <LogContent variant="code" className="text-foreground-contrast-secondary">
               lineNumber=null: a marker row keeps the gutter blank
             </LogContent>
           </LogRow>
@@ -512,11 +512,11 @@ export const Composition: Story = {
           <LogContent variant="code">
             <Glyph className="text-blue-500 dark:text-blue-400">{'⚙ '}</Glyph>
             <span className="font-bold text-blue-600 dark:text-blue-400">read_file</span>
-            <span className="text-foreground-neutral-muted"> src/api/client.ts</span>
+            <span className="text-foreground-contrast-secondary"> src/api/client.ts</span>
           </LogContent>
         </LogRow>
         <LogRow lineNumber={44} timestamp={at(9.54)} indent={1}>
-          <LogContent variant="code" className="text-foreground-neutral-muted">
+          <LogContent variant="code" className="text-foreground-contrast-secondary">
             <Glyph className="font-bold text-green-500 dark:text-green-400">{'✓ '}</Glyph>
             read_file · 64 lines
           </LogContent>


### PR DESCRIPTION
Component source now uses semantic surface and status tokens instead of dark-mode theme branches. This unifies code and log surfaces across themes, preserves status accents on semantic edges, and adds the contrast highlight and tooltip tokens needed by code highlighting and keyboard tooltips.

Closes ENG-1573

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced theme-branching with semantic contrast surfaces and contrast foreground tokens across code, log, avatar, and kbd for consistent light/dark. Code and log surfaces are always dark; Shiki uses the dark theme in both modes. Closes ENG-1573.

- **Refactors**
  - Removed `dark:` branches; adopted `bg-background-contrast-(base|subtle|pressed)` and `text-foreground-contrast-(primary|secondary)` across CodeBlock/CodeTabs (header, surface, footer), log rows and containers (timestamps, line numbers, copy/disclosure controls), system markers, Avatar, Kbd, and workflow/trigger views.
  - Kept status accents on log-row edges and icons via `var(--tag-*-icon)`; selection uses `bg-background-contrast-pressed`.
  - Set Shiki to `vitesse-dark` in both modes; tests updated to assert theme, highlighted-line surface, and contrast tokens.

- **New Features**
  - Added `bg-background-contrast-highlight` for highlighted code lines and `bg-background-kbd-tooltip` for keyboard tooltips, with light/dark CSS variable mappings.

<sup>Written for commit 472b059cc2418c2f59fad3f2a333424ccf653f72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

