### PR TITLE
Retire the legacy page background token

### DIFF
--- a/.changeset/retire-neutral-background.md
+++ b/.changeset/retire-neutral-background.md
@@ -1,5 +1,6 @@
 ---
 '@shipfox/react-ui': major
+'@shipfox/client-workflows': patch
 ---
 
-Retire the `background-neutral-background` CSS token; use `background-subtle-base` for page canvas surfaces.
+Retire the `background-neutral-background` CSS token and migrate workflow page canvases to `background-subtle-base`.

--- a/.changeset/retire-neutral-background.md
+++ b/.changeset/retire-neutral-background.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/react-ui': major
+---
+
+Retire the `background-neutral-background` CSS token; use `background-subtle-base` for page canvas surfaces.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -436,8 +436,7 @@ this table as the contract the package is moving to.
 | `--background-contrast-base` (dark) | `--color-neutral-800` | `--color-neutral-1000` |
 
 `--background-contrast-subtle` and `--background-contrast-hover` are translucent
-in dark today and become opaque in the same change. `--background-neutral-background`
-still paints about 30 surfaces and retires onto the canvas role.
+in dark today and become opaque in the same change.
 
 **Overlays sit outside this ladder.** A popover uses
 `--background-neutral-overlay`, a tooltip uses its own variant tokens, and a modal

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -216,8 +216,8 @@ automatically, so component code never branches on theme. The families:
   `-field-base` / `-field-hover` (inputs), `-neutral-overlay` (popovers),
   `-highlight-{base,hover,interactive}` (brand-tied selection), `-modal-overlay` /
   `-backdrop-backdrop` (scrims), and `-accent-{neutral,blue,purple,success,warning,error}-{soft,base,strong}`.
-  `-neutral-background` is still defined and still paints about 30 surfaces. It
-  carries no role in the ladder and retires onto the canvas.
+  The former neutral background role is retired; use the canvas token for page
+  surfaces.
 - Foregrounds: `text-foreground-neutral-{base,subtle,muted,disabled}`,
   `-on-color` (on a saturated fill), `-on-inverted` (on a contrast surface),
   `-highlight-interactive` (link/CTA orange), `-highlight-error`.

--- a/apps/storybook/src/introduction.tsx
+++ b/apps/storybook/src/introduction.tsx
@@ -64,7 +64,7 @@ export function IntroductionPage() {
   }, []);
 
   return (
-    <main className="min-h-dvh bg-background-neutral-background px-24 py-48">
+    <main className="min-h-dvh bg-background-subtle-base px-24 py-48">
       <div className="mx-auto flex max-w-[960px] flex-col gap-32">
         <header className="max-w-[720px]">
           <Code variant="label" bold className="text-foreground-neutral-muted">

--- a/libs/client/agent/src/components/custom-model-provider-form.stories.tsx
+++ b/libs/client/agent/src/components/custom-model-provider-form.stories.tsx
@@ -23,7 +23,7 @@ function CustomModelProviderFormStory({mode}: CustomModelProviderFormStoryProps)
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="min-h-screen bg-background-neutral-background p-24">
+      <div className="min-h-screen bg-background-subtle-base p-24">
         <Modal open={open} onOpenChange={setOpen}>
           <ModalContent
             className="max-h-[min(760px,calc(100vh-32px))]"

--- a/libs/client/agent/src/components/harnesses-section.stories.tsx
+++ b/libs/client/agent/src/components/harnesses-section.stories.tsx
@@ -33,7 +33,7 @@ function HarnessesStory({scenario}: HarnessesStoryProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
+      <div className="mx-auto w-full max-w-[760px] bg-background-subtle-base p-24">
         <WorkspaceHarnessesSection workspaceId={WORKSPACE_ID} />
       </div>
       <Toaster />

--- a/libs/client/agent/src/components/model-provider-usage-modal.stories.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.stories.tsx
@@ -20,7 +20,7 @@ function ModelProviderUsageModalStory({variant}: ModelProviderUsageModalStoryPro
       : usageTargetFromCatalogEntry(entry);
 
   return (
-    <div className="min-h-screen bg-background-neutral-background p-24">
+    <div className="min-h-screen bg-background-subtle-base p-24">
       <ModelProviderUsageModal
         target={target}
         initialModel={target.defaultModel}

--- a/libs/client/agent/src/components/model-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/model-providers-section.stories.tsx
@@ -118,7 +118,7 @@ function ModelProvidersStory({scenario}: ModelProvidersStoryProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
+      <div className="mx-auto w-full max-w-[760px] bg-background-subtle-base p-24">
         <WorkspaceModelProvidersSection workspaceId={WORKSPACE_ID} />
       </div>
       <Toaster />

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
@@ -105,7 +105,7 @@ function ModelProviderOnboardingStory({scenario}: ModelProviderOnboardingStoryPr
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="bg-background-neutral-background px-24 py-32">
+      <div className="bg-background-subtle-base px-24 py-32">
         <ModelProviderOnboardingPage
           workspaceId={WORKSPACE_ID}
           onSkip={() => undefined}

--- a/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
@@ -111,13 +111,17 @@ describe('WorkspaceOnboardingPage', () => {
     const slug = screen.getByLabelText('Workspace slug');
     expect(screen.getByText(`${window.location.origin}/w/acme`)).toBeInTheDocument();
     fireEvent.change(name, {target: {value: 'Acme Labs'}});
-    expect(slug).toHaveValue('acme-labs');
-    expect(screen.getByText(`${window.location.origin}/w/acme-labs`)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(slug).toHaveValue('acme-labs');
+      expect(screen.getByText(`${window.location.origin}/w/acme-labs`)).toBeInTheDocument();
+    });
 
     fireEvent.change(slug, {target: {value: 'custom-workspace'}});
     fireEvent.change(name, {target: {value: 'Renamed Labs'}});
-    expect(slug).toHaveValue('custom-workspace');
-    expect(screen.getByText(`${window.location.origin}/w/custom-workspace`)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(slug).toHaveValue('custom-workspace');
+      expect(screen.getByText(`${window.location.origin}/w/custom-workspace`)).toBeInTheDocument();
+    });
   });
 
   test('checks a manually edited workspace slug for availability', async () => {

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -82,7 +82,7 @@ function IntegrationGalleryStory({scenario}: IntegrationGalleryStoryProps) {
       getParentRoute: () => workspaceRoute,
       path: 'settings/integrations',
       component: () => (
-        <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
+        <div className="mx-auto w-full max-w-[760px] bg-background-subtle-base p-24">
           <IntegrationGallery workspaceId={WORKSPACE_ID} />
         </div>
       ),

--- a/libs/client/integrations/src/components/webhook/webhook-modals.stories.tsx
+++ b/libs/client/integrations/src/components/webhook/webhook-modals.stories.tsx
@@ -126,7 +126,7 @@ export const CopyableValueState: Story = {
 
 function StorySurface({scenario}: {scenario: Scenario}) {
   return (
-    <div className="min-h-screen bg-background-neutral-background p-24">
+    <div className="min-h-screen bg-background-subtle-base p-24">
       {scenario === 'create-form' ? (
         <WebhookCreateModal
           workspaceId={WORKSPACE_ID}

--- a/libs/client/projects/src/pages/create-project-page.stories.tsx
+++ b/libs/client/projects/src/pages/create-project-page.stories.tsx
@@ -64,7 +64,7 @@ function CreateProjectPageStory({scenario}: CreateProjectPageStoryProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <JotaiProvider store={store}>
-        <div className="min-h-screen bg-background-neutral-background px-24 py-32">
+        <div className="min-h-screen bg-background-subtle-base px-24 py-32">
           <div className="mx-auto w-full max-w-[1120px]">
             <RouterProvider router={router} />
           </div>

--- a/libs/client/projects/src/pages/project-settings-page.stories.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.stories.tsx
@@ -71,7 +71,7 @@ function ProjectSettingsPageStory({scenario}: ProjectSettingsPageStoryProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <JotaiProvider store={store}>
-        <div className="min-h-screen bg-background-neutral-background px-24 py-32">
+        <div className="min-h-screen bg-background-subtle-base px-24 py-32">
           <div className="mx-auto w-full max-w-[1120px]">
             <RouterProvider router={router} />
           </div>

--- a/libs/client/runners/src/components/token-settings-sections.stories.tsx
+++ b/libs/client/runners/src/components/token-settings-sections.stories.tsx
@@ -225,7 +225,7 @@ export const CreatedTokenPanels: Story = {
 
 function StorySurface({children}: {children: ReactNode}) {
   return (
-    <div className="min-h-screen bg-background-neutral-background p-24">
+    <div className="min-h-screen bg-background-subtle-base p-24">
       <div className="mx-auto flex w-full max-w-[920px] flex-col gap-32">{children}</div>
     </div>
   );

--- a/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {layout: 'centered'},
   decorators: [
     (Story) => (
-      <div className="h-520 w-900 overflow-auto bg-background-neutral-background p-16">
+      <div className="h-520 w-900 overflow-auto bg-background-subtle-base p-16">
         <Story />
       </div>
     ),

--- a/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   parameters: {layout: 'centered'},
   decorators: [
     (Story) => (
-      <div className="bg-background-neutral-background p-16">
+      <div className="bg-background-subtle-base p-16">
         <Story />
       </div>
     ),

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -56,10 +56,10 @@ const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({
 });
 
 const withFrame: Decorator = (Story) => (
-  <div className="min-h-screen bg-background-neutral-background">
+  <div className="min-h-screen bg-background-subtle-base">
     <div className="mx-auto flex min-h-screen w-full max-w-[1120px] flex-col overflow-hidden border-x border-border-neutral-base bg-background-subtle-base">
       <Story />
-      <div className="min-h-0 flex-1 bg-background-neutral-background p-16" />
+      <div className="min-h-0 flex-1 bg-background-subtle-base p-16" />
     </div>
   </div>
 );

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -38,7 +38,7 @@ describe('WorkflowRunSummary', () => {
 
     const summary = await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(summary).toHaveClass('bg-background-neutral-background', 'px-row', 'py-row');
+    expect(summary).toHaveClass('bg-background-subtle-base', 'px-row', 'py-row');
     expect(summary.firstElementChild).not.toHaveClass('max-w-[1120px]');
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(within(summary).getAllByText('Running')).not.toHaveLength(0);

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -70,10 +70,7 @@ export function WorkflowRunSummary({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <section
-        aria-labelledby={headingId}
-        className="bg-background-neutral-background px-row py-row"
-      >
+      <section aria-labelledby={headingId} className="bg-background-subtle-base px-row py-row">
         <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-cluster gap-y-inline overflow-hidden max-[480px]:grid-cols-1">
           <div className="col-start-1 row-start-1 min-w-0 max-[480px]:col-start-auto max-[480px]:row-start-auto">
             <div className="flex min-w-0 items-center gap-inline">

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -53,7 +53,7 @@ export function RunWorkspaceNav({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base bg-background-neutral-background min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
+      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base bg-background-subtle-base min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
         <Collapsible
           open={mobileOpen}
           onOpenChange={setMobileOpen}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
@@ -7,10 +7,7 @@ import {Text} from '@shipfox/react-ui/typography';
 
 export function WorkflowRunSkeleton() {
   return (
-    <section
-      aria-label="Loading workflow run"
-      className="bg-background-neutral-background px-row py-row"
-    >
+    <section aria-label="Loading workflow run" className="bg-background-subtle-base px-row py-row">
       <div className="flex min-w-0 flex-wrap items-center gap-x-cluster gap-y-inline">
         <div className="flex min-w-0 items-center gap-inline">
           <Skeleton className="size-8 rounded-full" />

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -666,7 +666,7 @@ function RunWorkspaceNavSkeleton() {
   return (
     <aside
       aria-label="Loading run navigation"
-      className="hidden w-240 shrink-0 border-r border-border-neutral-base bg-background-neutral-background p-panel-compact min-[768px]:block"
+      className="hidden w-240 shrink-0 border-r border-border-neutral-base bg-background-subtle-base p-panel-compact min-[768px]:block"
     >
       <div className="flex flex-col gap-group">
         <div className="h-32 rounded-4 bg-background-components-subtle" />

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
@@ -56,7 +56,7 @@ export function WorkflowJobDetailPage({
     [navigate],
   );
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-neutral-background">
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-subtle-base">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
@@ -17,7 +17,7 @@ export function WorkflowRunDetailPage({
   search = {},
 }: WorkflowRunDetailPageProps) {
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-neutral-background">
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-subtle-base">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -230,7 +230,6 @@
   --background-contrast-hover: var(--color-neutral-800);
   --background-contrast-pressed: var(--color-neutral-700);
   --background-contrast-base: var(--color-neutral-900);
-  --background-neutral-background: var(--color-neutral-50);
   --background-backdrop-backdrop: var(--color-alpha-black-64);
   --background-modal-overlay: var(--color-alpha-black-88);
 
@@ -482,7 +481,6 @@
   --background-contrast-hover: var(--color-neutral-900);
   --background-contrast-pressed: var(--color-alpha-white-12);
   --background-contrast-base: var(--color-neutral-1000);
-  --background-neutral-background: var(--color-neutral-1000);
   --background-backdrop-backdrop: var(--color-alpha-black-64);
   --background-modal-overlay: var(--color-alpha-black-88);
 
@@ -830,7 +828,6 @@
   --color-background-contrast-hover: var(--background-contrast-hover);
   --color-background-contrast-pressed: var(--background-contrast-pressed);
   --color-background-contrast-base: var(--background-contrast-base);
-  --color-background-neutral-background: var(--background-neutral-background);
   --color-background-backdrop-backdrop: var(--background-backdrop-backdrop);
   --color-background-modal-overlay: var(--background-modal-overlay);
 

--- a/libs/shared/react/ui/src/components/tabs/tabs.stories.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.stories.tsx
@@ -24,7 +24,7 @@ export const Playground: Story = {
     await argosScreenshot(ctx, 'Tabs Default');
   },
   render: () => (
-    <div className="bg-background-neutral-background p-24 w-[80vw]">
+    <div className="bg-background-subtle-base p-24 w-[80vw]">
       <Tabs defaultValue="analytics">
         <TabsList className="gap-12 border-b border-neutral-strong">
           <TabsTrigger value="analytics">Analytics</TabsTrigger>
@@ -44,7 +44,7 @@ export const Controlled: Story = {
   render: () => {
     const [value, setValue] = useState('analytics');
     return (
-      <div className="bg-background-neutral-background p-24 w-[80vw]">
+      <div className="bg-background-subtle-base p-24 w-[80vw]">
         <Tabs value={value} onValueChange={setValue}>
           <TabsList className="gap-12 border-b border-neutral-strong">
             <TabsTrigger value="analytics">Analytics</TabsTrigger>
@@ -79,7 +79,7 @@ export const MultipleTabs: Story = {
     await argosScreenshot(ctx, 'Tabs Multiple');
   },
   render: () => (
-    <div className="bg-background-neutral-background p-24 w-[80vw]">
+    <div className="bg-background-subtle-base p-24 w-[80vw]">
       <Tabs defaultValue="tab1">
         <TabsList className="gap-12 border-b border-neutral-strong">
           <TabsTrigger value="tab1">Tab 1</TabsTrigger>

--- a/libs/shared/react/ui/src/design-tokens.test.ts
+++ b/libs/shared/react/ui/src/design-tokens.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+
+import {readFileSync} from 'node:fs';
+
+const css = readFileSync(new URL('../index.css', import.meta.url), 'utf8');
+
+describe('surface token contract', () => {
+  test('keeps the canvas opaque and removes the retired background token', () => {
+    expect(css).toContain('--background-subtle-base: var(--color-neutral-50);');
+    expect(css).toContain('--background-subtle-base: var(--color-neutral-950);');
+    expect(css).not.toContain('--background-subtle-base: var(--color-alpha-');
+    expect(css).not.toContain('background-neutral-background');
+  });
+});

--- a/libs/shared/react/ui/src/design-tokens.test.ts
+++ b/libs/shared/react/ui/src/design-tokens.test.ts
@@ -1,5 +1,4 @@
-/// <reference types="node" />
-
+// @ts-expect-error Node built-ins are available in the Vitest Node environment but not part of the UI package's browser type surface.
 import {readFileSync} from 'node:fs';
 
 const css = readFileSync(new URL('../index.css', import.meta.url), 'utf8');

--- a/libs/shared/react/ui/src/spacing/spacing.stories.tsx
+++ b/libs/shared/react/ui/src/spacing/spacing.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 function SpacingPreview() {
   return (
-    <div className="min-h-screen bg-background-neutral-background text-foreground-neutral-base">
+    <div className="min-h-screen bg-background-subtle-base text-foreground-neutral-base">
       <div className="mx-auto flex max-w-[1120px] flex-col gap-region px-frame py-frame">
         <header className="flex items-center justify-between gap-cluster border-b border-border-neutral-base p-panel">
           <div className="flex items-center gap-inline">


### PR DESCRIPTION
Unify page canvas surfaces on `background-subtle-base` and remove the retired `background-neutral-background` token.

This moves workflow chrome and Storybook page backdrops onto the shared canvas token, removes the obsolete public CSS declarations and Tailwind alias, and includes the required major Changeset for `@shipfox/react-ui`.

Closes ENG-1572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies page canvases on `background-subtle-base`, retires the `background-neutral-background` token, and makes the light canvas opaque. Updates workflow and Storybook surfaces, updates design docs, adds a token contract test, stabilizes the workspace slug prefill test, and publishes a major for `@shipfox/react-ui` plus a patch for `@shipfox/client-workflows` (ENG-1572).

- **Migration**
  - Replace Tailwind `bg-background-neutral-background` with `bg-background-subtle-base`.
  - Replace CSS vars `--background-neutral-background` and `--color-background-neutral-background` with `--background-subtle-base` and `--color-background-subtle-base`.

<sup>Written for commit c989984c790ab903a2603018d7668510bb82351c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

