### PR TITLE
[client-shell] Replace full-bleed layout with declared page frames

### DIFF
--- a/.changeset/declared-page-frames.md
+++ b/.changeset/declared-page-frames.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": patch
+---
+
+Replaces the full-bleed layout flag with declared content, data, and focused page frames.

--- a/.changeset/declared-page-frames.md
+++ b/.changeset/declared-page-frames.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/client-shell": patch
+"@shipfox/client-shell": minor
 ---
 
-Replaces the full-bleed layout flag with declared content, data, and focused page frames.
+Adds declared content, data, and focused page frames while preserving legacy full-bleed route metadata during migration.

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -7,10 +7,13 @@ import {NavBar} from './nav-bar.js';
 import {NavTabs} from './nav-tabs.js';
 
 type PageFrame = 'content' | 'data' | 'focused';
+type ResolvedPageFrame = PageFrame | 'legacy-full-bleed';
 
 declare module '@tanstack/react-router' {
   interface StaticDataRouteOption {
     frame?: PageFrame;
+    /** @deprecated Use `frame: 'data'`. */
+    layout?: 'full-bleed';
   }
 }
 
@@ -31,14 +34,16 @@ export function MainLayout({
   const {projectSlug} = useRouteParams(parseWorkspaceProjectParams);
   const matches = useMatches();
   if (!workspace) return <FullPageLoader />;
-  const frame = matches.reduce<PageFrame>(
-    (current, match) => match.staticData.frame ?? current,
+  const frame = matches.reduce<ResolvedPageFrame>(
+    (current, match) =>
+      match.staticData.frame ??
+      (match.staticData.layout === 'full-bleed' ? 'legacy-full-bleed' : current),
     'content',
   );
   const appContentHeight = hideProjectNavigation
     ? '[--app-content-h:calc(100dvh_-_56px)]'
     : '[--app-content-h:calc(100dvh_-_96px)]';
-  const isDataFrame = frame === 'data';
+  const isFullBleedFrame = frame === 'data' || frame === 'legacy-full-bleed';
   return (
     <div className="h-screen w-full flex flex-col bg-background-subtle-base">
       <NavBar hideProjectNavigation={hideProjectNavigation} />
@@ -46,11 +51,15 @@ export function MainLayout({
         <NavTabs entries={navigation} scope={projectSlug ? 'project' : 'workspace'} />
       )}
       <main
-        className={`${isDataFrame ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'flex-1 overflow-auto'} ${appContentHeight}`}
+        className={`${isFullBleedFrame ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'flex-1 overflow-auto'} ${appContentHeight}`}
       >
-        <div className={frameClassNames[frame]}>
+        {frame === 'legacy-full-bleed' ? (
           <Outlet />
-        </div>
+        ) : (
+          <div className={frameClassNames[frame]}>
+            <Outlet />
+          </div>
+        )}
       </main>
     </div>
   );

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -6,11 +6,19 @@ import {parseWorkspaceProjectParams, useRouteParams} from '#runtime/route-inputs
 import {NavBar} from './nav-bar.js';
 import {NavTabs} from './nav-tabs.js';
 
+type PageFrame = 'content' | 'data' | 'focused';
+
 declare module '@tanstack/react-router' {
   interface StaticDataRouteOption {
-    layout?: 'full-bleed';
+    frame?: PageFrame;
   }
 }
+
+const frameClassNames: Record<PageFrame, string> = {
+  content: 'mx-auto w-full max-w-[1120px] px-frame py-frame',
+  data: 'flex min-h-0 w-full flex-1 flex-col px-frame py-frame',
+  focused: 'mx-auto w-full max-w-[640px] px-frame py-frame',
+};
 
 export function MainLayout({
   navigation,
@@ -23,27 +31,27 @@ export function MainLayout({
   const {projectSlug} = useRouteParams(parseWorkspaceProjectParams);
   const matches = useMatches();
   if (!workspace) return <FullPageLoader />;
-  const fullBleed = matches.some((match) => match.staticData.layout === 'full-bleed');
+  const frame = matches.reduce<PageFrame>(
+    (current, match) => match.staticData.frame ?? current,
+    'content',
+  );
   const appContentHeight = hideProjectNavigation
     ? '[--app-content-h:calc(100dvh_-_56px)]'
     : '[--app-content-h:calc(100dvh_-_96px)]';
+  const isDataFrame = frame === 'data';
   return (
     <div className="h-screen w-full flex flex-col bg-background-subtle-base">
       <NavBar hideProjectNavigation={hideProjectNavigation} />
       {hideProjectNavigation ? undefined : (
         <NavTabs entries={navigation} scope={projectSlug ? 'project' : 'workspace'} />
       )}
-      {fullBleed ? (
-        <main className="flex-1 min-h-0 flex flex-col overflow-hidden">
+      <main
+        className={`${isDataFrame ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'flex-1 overflow-auto'} ${appContentHeight}`}
+      >
+        <div className={frameClassNames[frame]}>
           <Outlet />
-        </main>
-      ) : (
-        <main className={`flex-1 overflow-auto ${appContentHeight}`}>
-          <div className="max-w-[1120px] mx-auto px-frame py-frame">
-            <Outlet />
-          </div>
-        </main>
-      )}
+        </div>
+      </main>
     </div>
   );
 }

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -29,10 +29,12 @@ export function buildAnchorSkeleton({
   const rootRoute = createRootRouteWithContext<RouterContext>()({
     component: Outlet,
     notFoundComponent: NotFoundPage,
+    staticData: {frame: 'focused'},
   });
   const workspaceLayout = createRoute({
     getParentRoute: () => rootRoute,
     path: anchorPaths.workspaceLayout,
+    staticData: {frame: 'content'},
     beforeLoad: async ({context, params, location}) => {
       const auth = context.auth;
       if (!auth || auth.isLoading || !context.queryClient) return;
@@ -83,6 +85,7 @@ export function buildAnchorSkeleton({
   const projectLayout = createRoute({
     getParentRoute: () => workspaceLayout,
     path: '/p/$projectSlug',
+    staticData: {frame: 'content'},
     beforeLoad: async ({context, params}) => {
       const auth = context.auth;
       if (!auth || auth.isLoading || !context.queryClient) return;

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -29,7 +29,6 @@ export function buildAnchorSkeleton({
   const rootRoute = createRootRouteWithContext<RouterContext>()({
     component: Outlet,
     notFoundComponent: NotFoundPage,
-    staticData: {frame: 'focused'},
   });
   const workspaceLayout = createRoute({
     getParentRoute: () => rootRoute,

--- a/libs/client/shell/src/runtime/routes.test.tsx
+++ b/libs/client/shell/src/runtime/routes.test.tsx
@@ -114,4 +114,47 @@ describe('composed routes', () => {
     ]);
     expect(await screen.findByRole('heading', {name: 'users'})).toBeVisible();
   });
+
+  test.each([
+    {
+      frame: 'content' as const,
+      mainClass: 'overflow-auto',
+      frameClass: 'max-w-[1120px]',
+    },
+    {
+      frame: 'data' as const,
+      mainClass: 'overflow-hidden',
+      frameClass: 'flex-1',
+    },
+    {
+      frame: 'focused' as const,
+      mainClass: 'overflow-auto',
+      frameClass: 'max-w-[640px]',
+    },
+  ])('renders the $frame page frame from route static data', async ({
+    frame,
+    mainClass,
+    frameClass,
+  }) => {
+    const feature = defineClientFeature({
+      id: 'acme.frames',
+      routes: [{path: '/w/$workspaceSlug/frames', parent: 'workspaceLayout', impl: 'frames'}],
+    });
+
+    await renderComposedShell({
+      features: [feature],
+      initialPath: '/w/workspace/frames',
+      resolveImpl: () =>
+        defineRoute({
+          staticData: {frame},
+          component: () => <h1>Frames</h1>,
+        }),
+    });
+
+    expect(await screen.findByRole('heading', {name: 'Frames'})).toBeVisible();
+    const main = screen.getByRole('main');
+    const frameContainer = main.firstElementChild;
+    expect(main).toHaveClass(mainClass);
+    expect(frameContainer).toHaveClass(frameClass);
+  });
 });

--- a/libs/client/shell/src/runtime/routes.test.tsx
+++ b/libs/client/shell/src/runtime/routes.test.tsx
@@ -157,4 +157,47 @@ describe('composed routes', () => {
     expect(main).toHaveClass(mainClass);
     expect(frameContainer).toHaveClass(frameClass);
   });
+
+  test('defaults routes without a declared frame to the content frame', async () => {
+    const feature = defineClientFeature({
+      id: 'acme.default-frame',
+      routes: [
+        {path: '/w/$workspaceSlug/default-frame', parent: 'workspaceLayout', impl: 'default'},
+      ],
+    });
+
+    await renderComposedShell({
+      features: [feature],
+      initialPath: '/w/workspace/default-frame',
+      resolveImpl: () => defineRoute({component: () => <h1>Default frame</h1>}),
+    });
+
+    expect(await screen.findByRole('heading', {name: 'Default frame'})).toBeVisible();
+    const main = screen.getByRole('main');
+    expect(main).toHaveClass('overflow-auto');
+    expect(main.firstElementChild).toHaveClass('max-w-[1120px]');
+  });
+
+  test('keeps legacy full-bleed routes on the compatibility frame', async () => {
+    const feature = defineClientFeature({
+      id: 'acme.legacy-frame',
+      routes: [{path: '/w/$workspaceSlug/legacy-frame', parent: 'workspaceLayout', impl: 'legacy'}],
+    });
+
+    await renderComposedShell({
+      features: [feature],
+      initialPath: '/w/workspace/legacy-frame',
+      resolveImpl: () =>
+        defineRoute({
+          staticData: {layout: 'full-bleed'},
+          component: () => <h1>Legacy frame</h1>,
+        }),
+    });
+
+    expect(await screen.findByRole('heading', {name: 'Legacy frame'})).toBeVisible();
+    const main = screen.getByRole('main');
+    expect(main).toHaveClass('overflow-hidden');
+    expect(main.firstElementChild).toBe(screen.getByRole('heading', {name: 'Legacy frame'}));
+    expect(main.firstElementChild).not.toHaveClass('max-w-[1120px]');
+  });
 });


### PR DESCRIPTION
The shell now derives page sizing and overflow from declared route frames. New route metadata uses `frame: 'content'`, `frame: 'data'`, or `frame: 'focused'`.

The legacy `layout: 'full-bleed'` metadata remains supported as a deprecated compatibility path, preserving existing full-height data surfaces while feature consumers migrate. Workspace and project anchors default to the content frame; root-level routes use their own shells.

Closes ENG-1580