### PR TITLE
[react-ui] Make dark-mode code surfaces near-black and opaque

### DIFF
--- a/.changeset/dark-code-surfaces.md
+++ b/.changeset/dark-code-surfaces.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/react-ui': patch
+---
+
+Make dark-mode code surfaces near-black and opaque.

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -478,10 +478,10 @@
   --background-neutral-disabled: var(--color-neutral-800);
   --background-field-hover: var(--color-alpha-white-8);
   --background-switch-off: var(--color-neutral-700);
-  --background-contrast-subtle: var(--color-alpha-white-2);
-  --background-contrast-hover: var(--color-alpha-white-8);
+  --background-contrast-subtle: var(--color-neutral-950);
+  --background-contrast-hover: var(--color-neutral-900);
   --background-contrast-pressed: var(--color-alpha-white-12);
-  --background-contrast-base: var(--color-neutral-800);
+  --background-contrast-base: var(--color-neutral-1000);
   --background-neutral-background: var(--color-neutral-1000);
   --background-backdrop-backdrop: var(--color-alpha-black-64);
   --background-modal-overlay: var(--color-alpha-black-88);


### PR DESCRIPTION
Make dark-mode code and log surfaces use the opaque near-black contrast ladder. This prevents translucent dark values from compositing over route-specific page canvases, so the same log surface keeps one color across its host pages.

Closes ENG-1571

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch dark‑mode code and log surfaces in `@shipfox/react-ui` to opaque near‑black neutrals, replacing translucent contrast tokens. Prevents compositing over route canvases so surfaces stay the same color across pages. Closes ENG-1571.

<sup>Written for commit 46596350146808426200a4a3a9a98d25f6d1db13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

