### PR TITLE
Enforce surface-system architecture boundaries

### DIFF
--- a/.changeset/surface-route-contract.md
+++ b/.changeset/surface-route-contract.md
@@ -2,4 +2,4 @@
 "@shipfox/client-shell": major
 ---
 
-Requires composed route implementations to declare a supported frame for surface-system layout ownership.
+Requires composed route implementations to declare `staticData.frame` as `content`, `data`, or `focused`.

--- a/.changeset/surface-route-contract.md
+++ b/.changeset/surface-route-contract.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": major
+---
+
+Requires composed route implementations to declare a supported frame for surface-system layout ownership.

--- a/biome.json
+++ b/biome.json
@@ -242,6 +242,107 @@
       ]
     },
     {
+      "path": "./tools/biome/plugins/client-architecture/no-page-canvas-tokens.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/libs/client/shell/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-dark-variants.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-nested-panel.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-table-outside-panel.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-arbitrary-page-width.grit",
+      "includes": [
+        "**/libs/client/**",
+        "!**/libs/client/shell/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
       "path": "./tools/biome/plugins/database-boundaries/no-direct-table-declaration.grit",
       "includes": [
         "**/libs/api/**/src/db/**",

--- a/biome.json
+++ b/biome.json
@@ -247,6 +247,7 @@
         "**/libs/client/**",
         "**/libs/shared/react/ui/**",
         "!**/libs/client/shell/**",
+        "!**/libs/client/config/src/config-error-screen.tsx",
         "!**/dist/**",
         "!**/node_modules/**",
         "!**/*.test.ts",

--- a/biome.json
+++ b/biome.json
@@ -325,7 +325,10 @@
     {
       "path": "./tools/biome/plugins/client-architecture/no-arbitrary-page-width.grit",
       "includes": [
-        "**/libs/client/**",
+        "**/libs/client/**/src/pages/**",
+        "**/libs/client/integrations/src/components/callback-status-shell.tsx",
+        "**/libs/client/integrations/src/components/redirect-install-page.tsx",
+        "**/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx",
         "!**/libs/client/shell/**",
         "!**/dist/**",
         "!**/node_modules/**",

--- a/biome.json
+++ b/biome.json
@@ -326,9 +326,6 @@
       "path": "./tools/biome/plugins/client-architecture/no-arbitrary-page-width.grit",
       "includes": [
         "**/libs/client/**/src/pages/**",
-        "**/libs/client/integrations/src/components/callback-status-shell.tsx",
-        "**/libs/client/integrations/src/components/redirect-install-page.tsx",
-        "**/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx",
         "!**/libs/client/shell/**",
         "!**/dist/**",
         "!**/node_modules/**",

--- a/libs/client/.storybook/main.ts
+++ b/libs/client/.storybook/main.ts
@@ -1,5 +1,5 @@
-import type {StorybookConfig} from '@storybook/react-vite';
 import {createRequire} from 'node:module';
+import type {StorybookConfig} from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   framework: '@storybook/react-vite',

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -104,7 +104,7 @@ export function ModelProviderOnboardingPage({
       : 'model-provider-provider-step';
 
   return (
-    <div className="mx-auto flex w-full max-w-[640px] flex-col gap-section">
+    <div className="mx-auto flex w-full flex-col gap-section">
       <header className="flex flex-col gap-cluster">
         <div className="flex items-start justify-between gap-group max-[520px]:flex-col max-[520px]:gap-inline">
           <Header id={headingId} variant="h1" tabIndex={-1} className="outline-none">

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -78,8 +78,8 @@ export function WorkspaceOnboardingPage() {
   });
 
   return (
-    <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
-      <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full max-w-[1120px] flex-col gap-section">
+    <main className="min-h-screen px-frame py-frame max-[520px]:px-row">
+      <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full flex-col gap-section">
         <header className="flex items-center justify-between">
           <div className="flex items-center gap-inline">
             <div className="flex size-36 items-center justify-center rounded-8 border border-border-neutral-base bg-background-neutral-base shadow-button-neutral">

--- a/libs/client/integrations/src/components/callback-status-shell.tsx
+++ b/libs/client/integrations/src/components/callback-status-shell.tsx
@@ -43,8 +43,8 @@ export function CallbackStatusShell({
     : undefined;
 
   return (
-    <main className="flex min-h-screen bg-background-subtle-base px-row py-frame">
-      <div className="mx-auto flex w-full max-w-[480px] flex-col justify-center gap-section">
+    <main className="flex min-h-screen px-row py-frame">
+      <div className="mx-auto flex w-full flex-col justify-center gap-section">
         <h2 ref={headingRef} tabIndex={-1} className="text-24 font-semibold outline-none">
           {title}
         </h2>

--- a/libs/client/integrations/src/components/repository-picker.tsx
+++ b/libs/client/integrations/src/components/repository-picker.tsx
@@ -60,7 +60,7 @@ export function RepositoryPicker({
       {isLoading ? <RepositoryLoadingState /> : null}
 
       {!isLoading && repositories.length === 0 ? (
-        <div className="rounded-8 border border-border-neutral-base bg-background-subtle-base p-panel-compact">
+        <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact">
           <Text size="sm">{emptyMessage}</Text>
         </div>
       ) : null}

--- a/libs/client/integrations/src/pages/gitea-install-page.tsx
+++ b/libs/client/integrations/src/pages/gitea-install-page.tsx
@@ -40,7 +40,7 @@ export function GiteaInstallPage() {
   });
 
   return (
-    <div className="mx-auto flex w-full max-w-[480px] flex-col gap-section">
+    <div className="mx-auto flex w-full flex-col gap-section">
       <header className="flex flex-col gap-inline">
         <Header variant="h1">Install Gitea</Header>
         <Text size="md" className="text-foreground-neutral-muted">

--- a/libs/client/integrations/src/pages/jira-callback-page.tsx
+++ b/libs/client/integrations/src/pages/jira-callback-page.tsx
@@ -300,8 +300,8 @@ function JiraSiteSelectionPage({
   onSelect: (site: JiraSite) => void;
 }) {
   return (
-    <main className="flex min-h-screen bg-background-subtle-base px-row py-frame">
-      <div className="mx-auto flex w-full max-w-[480px] flex-col justify-center gap-section">
+    <main className="flex min-h-screen px-row py-frame">
+      <div className="mx-auto flex w-full flex-col justify-center gap-section">
         <header className="flex flex-col gap-inline">
           <Header variant="h2">Choose a Jira site</Header>
           <Text size="sm" className="text-foreground-neutral-muted">

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -246,10 +246,8 @@ export function SentryCallbackPage() {
 
 function CallbackColumn({children}: {children: React.ReactNode}) {
   return (
-    <main className="flex min-h-screen bg-background-subtle-base px-row py-frame">
-      <div className="mx-auto flex w-full max-w-[480px] flex-col justify-center gap-section">
-        {children}
-      </div>
+    <main className="flex min-h-screen px-row py-frame">
+      <div className="mx-auto flex w-full flex-col justify-center gap-section">{children}</div>
     </main>
   );
 }

--- a/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
+++ b/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
@@ -8,7 +8,7 @@ export function SourceControlOnboardingPage() {
   const providersQuery = useIntegrationProvidersQuery({capability: 'source_control'});
 
   return (
-    <div className="mx-auto flex w-full max-w-[640px] flex-col gap-section">
+    <div className="mx-auto flex w-full flex-col gap-section">
       <header className="flex flex-col gap-inline">
         <Header variant="h1">Install source control</Header>
         <Text size="md" className="text-foreground-neutral-muted">

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -1,5 +1,6 @@
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {Card} from '@shipfox/react-ui/card';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -45,7 +46,7 @@ export function ManualRegistrationTokenList({
 }) {
   return (
     <>
-      <div className="max-[760px]:hidden">
+      <Card className="max-[760px]:hidden overflow-hidden p-0">
         <Table className="table-fixed">
           <TableHeader>
             <TableRow>
@@ -80,7 +81,7 @@ export function ManualRegistrationTokenList({
             ))}
           </TableBody>
         </Table>
-      </div>
+      </Card>
       <ul
         className="hidden flex-col gap-inline max-[760px]:flex"
         aria-label="Manual registration tokens"

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -1,5 +1,6 @@
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {Card} from '@shipfox/react-ui/card';
 import {Dot} from '@shipfox/react-ui/dot';
 import {
   DropdownMenu,
@@ -53,7 +54,7 @@ export function ProvisionerTokenList({
 }) {
   return (
     <>
-      <div className="max-[760px]:hidden">
+      <Card className="max-[760px]:hidden overflow-hidden p-0">
         <Table className="table-fixed">
           <TableHeader>
             <TableRow>
@@ -92,7 +93,7 @@ export function ProvisionerTokenList({
             ))}
           </TableBody>
         </Table>
-      </div>
+      </Card>
       <ul className="hidden flex-col gap-inline max-[760px]:flex" aria-label="Provisioner tokens">
         {tokens.map((token) => (
           <li

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -1,5 +1,6 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Card} from '@shipfox/react-ui/card';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -91,7 +92,7 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
         ) : null}
 
         {secrets.length > 0 ? (
-          <StoreSurface>
+          <Card className="overflow-hidden p-0">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -114,7 +115,7 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
                 ))}
               </TableBody>
             </Table>
-          </StoreSurface>
+          </Card>
         ) : null}
       </section>
 

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -1,5 +1,6 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Card} from '@shipfox/react-ui/card';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -91,7 +92,7 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
         ) : null}
 
         {variables.length > 0 ? (
-          <StoreSurface>
+          <Card className="overflow-hidden p-0">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -114,7 +115,7 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
                 ))}
               </TableBody>
             </Table>
-          </StoreSurface>
+          </Card>
         ) : null}
       </section>
 

--- a/libs/client/shell/test/search-route-impl.tsx
+++ b/libs/client/shell/test/search-route-impl.tsx
@@ -5,4 +5,5 @@ export default defineRoute({
   component: () => <div>Search route</div>,
   validateSearch: (search: Record<string, unknown>) =>
     ({tab: search.tab === 'activity' ? 'activity' : 'overview'}) as const,
+  staticData: {frame: 'content'},
 });

--- a/libs/client/shell/test/search-route-impl.tsx
+++ b/libs/client/shell/test/search-route-impl.tsx
@@ -1,7 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 
 export default defineRoute({
-  staticData: {frame: 'content'},
   component: () => <div>Search route</div>,
   validateSearch: (search: Record<string, unknown>) =>
     ({tab: search.tab === 'activity' ? 'activity' : 'overview'}) as const,

--- a/libs/client/triggers/src/components/events-list.tsx
+++ b/libs/client/triggers/src/components/events-list.tsx
@@ -1,5 +1,6 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
+import {Card} from '@shipfox/react-ui/card';
 import {Table, TableBody, TableHead, TableHeader, TableRow} from '@shipfox/react-ui/table';
 import {hasTriggerEventFilters} from '#core/trigger-event.js';
 import {EventsFilterBar} from './events-filter-bar.js';
@@ -40,7 +41,7 @@ export function EventsList({
   }
 
   return (
-    <div className="flex min-h-0 flex-col overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+    <Card className="min-h-0 overflow-hidden p-0">
       <EventsFilterBar
         filters={filters}
         onFiltersChange={onFiltersChange}
@@ -92,6 +93,6 @@ export function EventsList({
           ) : null}
         </>
       ) : null}
-    </div>
+    </Card>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -38,7 +38,8 @@ describe('WorkflowRunSummary', () => {
 
     const summary = await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(summary).toHaveClass('bg-background-subtle-base', 'px-row', 'py-row');
+    expect(summary).toHaveClass('px-row', 'py-row');
+    expect(summary).not.toHaveClass('bg-background-subtle-base');
     expect(summary.firstElementChild).not.toHaveClass('max-w-[1120px]');
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(within(summary).getAllByText('Running')).not.toHaveLength(0);

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -70,7 +70,7 @@ export function WorkflowRunSummary({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <section aria-labelledby={headingId} className="bg-background-subtle-base px-row py-row">
+      <section aria-labelledby={headingId} className="px-row py-row">
         <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-cluster gap-y-inline overflow-hidden max-[480px]:grid-cols-1">
           <div className="col-start-1 row-start-1 min-w-0 max-[480px]:col-start-auto max-[480px]:row-start-auto">
             <div className="flex min-w-0 items-center gap-inline">

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -53,7 +53,7 @@ export function RunWorkspaceNav({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base bg-background-subtle-base min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
+      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
         <Collapsible
           open={mobileOpen}
           onOpenChange={setMobileOpen}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
@@ -7,7 +7,7 @@ import {Text} from '@shipfox/react-ui/typography';
 
 export function WorkflowRunSkeleton() {
   return (
-    <section aria-label="Loading workflow run" className="bg-background-subtle-base px-row py-row">
+    <section aria-label="Loading workflow run" className="px-row py-row">
       <div className="flex min-w-0 flex-wrap items-center gap-x-cluster gap-y-inline">
         <div className="flex min-w-0 items-center gap-inline">
           <Skeleton className="size-8 rounded-full" />

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -663,7 +663,7 @@ function RunWorkspaceNavSkeleton() {
   return (
     <aside
       aria-label="Loading run navigation"
-      className="hidden w-240 shrink-0 border-r border-border-neutral-base bg-background-subtle-base p-panel-compact min-[768px]:block"
+      className="hidden w-240 shrink-0 border-r border-border-neutral-base p-panel-compact min-[768px]:block"
     >
       <div className="flex flex-col gap-group">
         <div className="h-32 rounded-4 bg-background-components-subtle" />

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -9,6 +9,7 @@ import {
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {Card} from '@shipfox/react-ui/card';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {LoadErrorState} from '@shipfox/react-ui/load-error-state';
@@ -195,7 +196,7 @@ function WorkflowDefinitionsList({
 
   return (
     <>
-      <div className="hidden rounded-8 border border-border-neutral-base md:block">
+      <Card className="hidden overflow-hidden p-0 md:block">
         <Table>
           <TableHeader>
             <TableRow>
@@ -265,7 +266,7 @@ function WorkflowDefinitionsList({
             })}
           </TableBody>
         </Table>
-      </div>
+      </Card>
 
       <div className="flex flex-col rounded-8 border border-border-neutral-base md:hidden">
         {definitions.map((definition) => {

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -4,6 +4,7 @@ import {QueryLoadError} from '@shipfox/client-ui';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {Card} from '@shipfox/react-ui/card';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {Icon} from '@shipfox/react-ui/icon';
@@ -88,28 +89,30 @@ function MembersSection({
       ) : null}
 
       {members.length > 0 ? (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Email</TableHead>
-              <TableHead>Joined</TableHead>
-              <TableHead className="w-80 text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {members.map((member) => (
-              <MemberRow
-                key={member.id}
-                member={member}
-                members={members}
-                currentUserId={auth.user?.id}
-                workspaceId={workspaceId}
-                workspaceName={workspaceName}
-              />
-            ))}
-          </TableBody>
-        </Table>
+        <Card className="overflow-hidden p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Joined</TableHead>
+                <TableHead className="w-80 text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((member) => (
+                <MemberRow
+                  key={member.id}
+                  member={member}
+                  members={members}
+                  currentUserId={auth.user?.id}
+                  workspaceId={workspaceId}
+                  workspaceName={workspaceName}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
       ) : null}
     </section>
   );
@@ -233,25 +236,27 @@ function PendingInvitationsSection({
       {query.data !== undefined && invitations.length === 0 ? <EmptyInvitations /> : null}
 
       {invitations.length > 0 ? (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Email</TableHead>
-              <TableHead>Invited by</TableHead>
-              <TableHead>Expires</TableHead>
-              <TableHead className="w-80 text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {invitations.map((invitation) => (
-              <InvitationRow
-                key={invitation.id}
-                invitation={invitation}
-                workspaceId={workspaceId}
-              />
-            ))}
-          </TableBody>
-        </Table>
+        <Card className="overflow-hidden p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Invited by</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead className="w-80 text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {invitations.map((invitation) => (
+                <InvitationRow
+                  key={invitation.id}
+                  invitation={invitation}
+                  workspaceId={workspaceId}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
       ) : null}
     </section>
   );

--- a/libs/shared/react/ui/src/components/loader/full-page-loader.tsx
+++ b/libs/shared/react/ui/src/components/loader/full-page-loader.tsx
@@ -9,7 +9,7 @@ export function FullPageLoader({className, ...props}: ComponentProps<'div'>) {
       role="status"
       aria-label="Loading"
       aria-busy="true"
-      className={cn('flex h-dvh items-center justify-center bg-background-subtle-base', className)}
+      className={cn('flex h-dvh items-center justify-center', className)}
       {...props}
     >
       <ShipfoxLoader size={64} animation="circular" color="orange" background="dark" />

--- a/libs/shared/react/ui/src/components/table/table.tsx
+++ b/libs/shared/react/ui/src/components/table/table.tsx
@@ -54,7 +54,7 @@ function TableHead({className, ...props}: ComponentProps<'th'>) {
     <th
       data-slot="table-head"
       className={cn(
-        'h-40 border-b border-border-neutral-base bg-background-subtle-base px-12 text-left align-middle text-xs font-medium leading-20 text-foreground-neutral-subtle',
+        'h-40 border-b border-border-neutral-base bg-background-neutral-base px-12 text-left align-middle text-xs font-medium leading-20 text-foreground-neutral-subtle',
         '[&:has([role=checkbox])]:w-0 [&:has([role=checkbox])]:px-12 [&:has([role=checkbox])]:pr-0 [&:has([role=checkbox])]:pt-6',
         className,
       )}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/biome.fixture.json
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/biome.fixture.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "vcs": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "bracketSpacing": false,
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "plugins": [
+    {
+      "path": "../../no-page-canvas-tokens.grit",
+      "includes": ["**/no-page-canvas-tokens/**"]
+    },
+    {
+      "path": "../../no-dark-variants.grit",
+      "includes": ["**/no-dark-variants/**"]
+    },
+    {
+      "path": "../../no-nested-panel.grit",
+      "includes": ["**/no-nested-panel/**"]
+    },
+    {
+      "path": "../../no-table-outside-panel.grit",
+      "includes": ["**/no-table-outside-panel/**"]
+    },
+    {
+      "path": "../../no-arbitrary-page-width.grit",
+      "includes": ["**/no-arbitrary-page-width/**"]
+    }
+  ],
+  "files": {
+    "includes": ["**/*.tsx"]
+  }
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-arbitrary-page-width/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-arbitrary-page-width/allowed.tsx
@@ -1,0 +1,3 @@
+export function AllowedFrameWidth() {
+  return <div className="mx-auto w-full max-w-content">Content</div>;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-arbitrary-page-width/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-arbitrary-page-width/rejected.tsx
@@ -1,0 +1,3 @@
+export function RejectedFrameWidth() {
+  return <div className="mx-auto w-full max-w-[1120px]">Content</div>;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/allowed.tsx
@@ -1,3 +1,5 @@
+export const documentation = 'dark: variants are disabled';
+
 export function AllowedTheme() {
   return <div className="bg-background-neutral-base text-foreground-neutral-base">Content</div>;
 }

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/allowed.tsx
@@ -1,0 +1,3 @@
+export function AllowedTheme() {
+  return <div className="bg-background-neutral-base text-foreground-neutral-base">Content</div>;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/rejected.tsx
@@ -1,0 +1,5 @@
+const darkClass = 'dark:text-white';
+
+export function RejectedTheme() {
+  return <div className="bg-background-neutral-base dark:bg-background-contrast-subtle">Content</div>;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/rejected.tsx
@@ -1,4 +1,6 @@
 export const darkClass = 'dark:text-white';
+export const splitPrefix = 'dark:';
+export const splitTemplateClass = `dark:${'bg-black'}`;
 const templateClass = `dark:bg-black ${'text-white'}`;
 
 export function RejectedTheme() {

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-dark-variants/rejected.tsx
@@ -1,5 +1,6 @@
-const darkClass = 'dark:text-white';
+export const darkClass = 'dark:text-white';
+const templateClass = `dark:bg-black ${'text-white'}`;
 
 export function RejectedTheme() {
-  return <div className="bg-background-neutral-base dark:bg-background-contrast-subtle">Content</div>;
+  return <div className={`bg-background-neutral-base ${templateClass}`}>Content</div>;
 }

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-nested-panel/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-nested-panel/allowed.tsx
@@ -1,0 +1,9 @@
+import {Panel} from '@shipfox/react-ui/panel';
+
+export function AllowedPanel() {
+  return (
+    <Panel>
+      <div>Rows stay inside one panel.</div>
+    </Panel>
+  );
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-nested-panel/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-nested-panel/rejected.tsx
@@ -1,0 +1,9 @@
+import {Panel} from '@shipfox/react-ui/panel';
+
+export function RejectedPanel() {
+  return (
+    <Panel>
+      <Panel />
+    </Panel>
+  );
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-page-canvas-tokens/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-page-canvas-tokens/allowed.tsx
@@ -1,0 +1,3 @@
+export function AllowedCanvas() {
+  return <div className="bg-background-neutral-base">Content</div>;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-page-canvas-tokens/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-page-canvas-tokens/rejected.tsx
@@ -1,0 +1,3 @@
+export function RejectedCanvas() {
+  return <div className="min-h-screen bg-background-subtle-base">Content</div>;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-table-outside-panel/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-table-outside-panel/allowed.tsx
@@ -1,3 +1,4 @@
+import {Card} from '@shipfox/react-ui/card';
 import {Panel} from '@shipfox/react-ui/panel';
 import {Table} from '@shipfox/react-ui/table';
 
@@ -8,5 +9,13 @@ export function AllowedTable() {
         <Table />
       </div>
     </Panel>
+  );
+}
+
+export function AllowedTableInCurrentPanelImplementation() {
+  return (
+    <Card>
+      <Table />
+    </Card>
   );
 }

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-table-outside-panel/allowed.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-table-outside-panel/allowed.tsx
@@ -1,0 +1,12 @@
+import {Panel} from '@shipfox/react-ui/panel';
+import {Table} from '@shipfox/react-ui/table';
+
+export function AllowedTable() {
+  return (
+    <Panel>
+      <div>
+        <Table />
+      </div>
+    </Panel>
+  );
+}

--- a/tools/biome/plugins/client-architecture/fixtures/surface-system/no-table-outside-panel/rejected.tsx
+++ b/tools/biome/plugins/client-architecture/fixtures/surface-system/no-table-outside-panel/rejected.tsx
@@ -1,0 +1,5 @@
+import {Table} from '@shipfox/react-ui/table';
+
+export function RejectedTable() {
+  return <Table />;
+}

--- a/tools/biome/plugins/client-architecture/no-arbitrary-page-width.grit
+++ b/tools/biome/plugins/client-architecture/no-arbitrary-page-width.grit
@@ -1,0 +1,21 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsxOpeningElement(name = $element_name) as $element where {
+    $element_name <: or {"div", "form", "main", "section"},
+    $element <: r".*(?:[a-z-]+:)?max-w-\[[^\]]+\].*",
+    register_diagnostic(
+      span=$element,
+      message="client-architecture/no-arbitrary-page-width: declare the route frame; the shell owns page width instead of an arbitrary max-w-[...] utility."
+    )
+  },
+  JsxSelfClosingElement(name = $element_name) as $element where {
+    $element_name <: or {"div", "form", "main", "section"},
+    $element <: r".*(?:[a-z-]+:)?max-w-\[[^\]]+\].*",
+    register_diagnostic(
+      span=$element,
+      message="client-architecture/no-arbitrary-page-width: declare the route frame; the shell owns page width instead of an arbitrary max-w-[...] utility."
+    )
+  }
+}

--- a/tools/biome/plugins/client-architecture/no-dark-variants.grit
+++ b/tools/biome/plugins/client-architecture/no-dark-variants.grit
@@ -3,28 +3,28 @@ language js(typescript, jsx)
 
 or {
   JsStringLiteralExpression() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${\x22\x27\x60]+|\$\{|[\x22\x27\x60]).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsxString() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${\x22\x27\x60]+|\$\{|[\x22\x27\x60]).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsTemplateExpression() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${\x22\x27\x60]+|\$\{|[\x22\x27\x60]).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsTemplateElement() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${\x22\x27\x60]+|\$\{|[\x22\x27\x60]).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."

--- a/tools/biome/plugins/client-architecture/no-dark-variants.grit
+++ b/tools/biome/plugins/client-architecture/no-dark-variants.grit
@@ -3,14 +3,28 @@ language js(typescript, jsx)
 
 or {
   JsStringLiteralExpression() as $class where {
-    $class <: r".*dark:.*",
+    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsxString() as $class where {
-    $class <: r".*dark:.*",
+    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
+    register_diagnostic(
+      span=$class,
+      message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
+    )
+  },
+  JsTemplateExpression() as $class where {
+    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
+    register_diagnostic(
+      span=$class,
+      message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
+    )
+  },
+  JsTemplateElement() as $class where {
+    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."

--- a/tools/biome/plugins/client-architecture/no-dark-variants.grit
+++ b/tools/biome/plugins/client-architecture/no-dark-variants.grit
@@ -1,0 +1,19 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsStringLiteralExpression() as $class where {
+    $class <: r".*dark:.*",
+    register_diagnostic(
+      span=$class,
+      message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
+    )
+  },
+  JsxString() as $class where {
+    $class <: r".*dark:.*",
+    register_diagnostic(
+      span=$class,
+      message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
+    )
+  }
+}

--- a/tools/biome/plugins/client-architecture/no-dark-variants.grit
+++ b/tools/biome/plugins/client-architecture/no-dark-variants.grit
@@ -3,28 +3,28 @@ language js(typescript, jsx)
 
 or {
   JsStringLiteralExpression() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsxString() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsTemplateExpression() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."
     )
   },
   JsTemplateElement() as $class where {
-    $class <: r".*(?:^|\s)[^\s]*dark:[^\s]+(?:\s|$).*",
+    $class <: r".*(?:^|\s)[^\s]*dark:(?:[^\s${]+|\$\{).*",
     register_diagnostic(
       span=$class,
       message="client-architecture/no-dark-variants: use semantic surface and foreground tokens so the theme resolves through the token ladder."

--- a/tools/biome/plugins/client-architecture/no-nested-panel.grit
+++ b/tools/biome/plugins/client-architecture/no-nested-panel.grit
@@ -1,0 +1,17 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+JsxElement(
+  opening_element = JsxOpeningElement(name = $outer_name),
+  children = $children,
+) as $outer where {
+  $outer_name <: "Panel",
+  $children <: contains or {
+    JsxElement(opening_element = JsxOpeningElement(name = "Panel")),
+    JsxSelfClosingElement(name = "Panel"),
+  },
+  register_diagnostic(
+    span=$outer,
+    message="client-architecture/no-nested-panel: keep one Panel and use its internal rows or cells instead of placing a Panel inside another Panel."
+  )
+}

--- a/tools/biome/plugins/client-architecture/no-page-canvas-tokens.grit
+++ b/tools/biome/plugins/client-architecture/no-page-canvas-tokens.grit
@@ -1,0 +1,19 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsStringLiteralExpression() as $token where {
+    $token <: r".*\bbg-background-(?:subtle-base|neutral-background)\b.*",
+    register_diagnostic(
+      span=$token,
+      message="client-architecture/no-page-canvas-tokens: let the shell-owned frame provide the canvas; use a Panel or a semantic surface role for page content."
+    )
+  },
+  JsxString() as $token where {
+    $token <: r".*\bbg-background-(?:subtle-base|neutral-background)\b.*",
+    register_diagnostic(
+      span=$token,
+      message="client-architecture/no-page-canvas-tokens: let the shell-owned frame provide the canvas; use a Panel or a semantic surface role for page content."
+    )
+  }
+}

--- a/tools/biome/plugins/client-architecture/no-table-outside-panel.grit
+++ b/tools/biome/plugins/client-architecture/no-table-outside-panel.grit
@@ -3,17 +3,21 @@ language js(typescript, jsx)
 
 or {
   JsxElement(opening_element = JsxOpeningElement(name = "Table")) as $table where {
-    $table <: not within JsxElement(opening_element = JsxOpeningElement(name = "Panel")),
+    $table <: not within JsxElement(
+      opening_element = JsxOpeningElement(name = or {"Panel", "Card"}),
+    ),
     register_diagnostic(
       span=$table,
-      message="client-architecture/no-table-outside-panel: wrap the Table in a Panel; the Panel owns the border, radius, and surface."
+      message="client-architecture/no-table-outside-panel: wrap the Table in a Panel (Card is the current implementation); the Panel owns the border, radius, and surface."
     )
   },
   JsxSelfClosingElement(name = "Table") as $table where {
-    $table <: not within JsxElement(opening_element = JsxOpeningElement(name = "Panel")),
+    $table <: not within JsxElement(
+      opening_element = JsxOpeningElement(name = or {"Panel", "Card"}),
+    ),
     register_diagnostic(
       span=$table,
-      message="client-architecture/no-table-outside-panel: wrap the Table in a Panel; the Panel owns the border, radius, and surface."
+      message="client-architecture/no-table-outside-panel: wrap the Table in a Panel (Card is the current implementation); the Panel owns the border, radius, and surface."
     )
   }
 }

--- a/tools/biome/plugins/client-architecture/no-table-outside-panel.grit
+++ b/tools/biome/plugins/client-architecture/no-table-outside-panel.grit
@@ -1,0 +1,19 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsxElement(opening_element = JsxOpeningElement(name = "Table")) as $table where {
+    $table <: not within JsxElement(opening_element = JsxOpeningElement(name = "Panel")),
+    register_diagnostic(
+      span=$table,
+      message="client-architecture/no-table-outside-panel: wrap the Table in a Panel; the Panel owns the border, radius, and surface."
+    )
+  },
+  JsxSelfClosingElement(name = "Table") as $table where {
+    $table <: not within JsxElement(opening_element = JsxOpeningElement(name = "Panel")),
+    register_diagnostic(
+      span=$table,
+      message="client-architecture/no-table-outside-panel: wrap the Table in a Panel; the Panel owns the border, radius, and surface."
+    )
+  }
+}

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -112,6 +112,10 @@ describe('client-architecture Biome plugins', () => {
           const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
           assert.match(output, new RegExp(`client-architecture/${ruleName}`, 'u'));
           assert.match(output, /rejected\.tsx:/u);
+          if (ruleName === 'no-dark-variants') {
+            assert.match(output, /rejected\.tsx:2:/u);
+            assert.match(output, /rejected\.tsx:3:/u);
+          }
           return true;
         },
       );

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -27,6 +27,14 @@ const rawSpacingFixtureRoot = resolve(
   workspaceRoot,
   'tools/biome/plugins/client-architecture/fixtures/no-raw-spacing',
 );
+const surfaceSystemFixtureConfig = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/client-architecture/fixtures/surface-system/biome.fixture.json',
+);
+const surfaceSystemFixtureRoot = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/client-architecture/fixtures/surface-system',
+);
 const rejectedLocationPattern = /rejected\.ts:3/u;
 const testFixturePattern = /ignored\.test\.ts/u;
 const storyFixturePattern = /ignored\.stories\.ts/u;
@@ -44,6 +52,14 @@ const fixtureRuleNames = [
   'no-response-dto-in-presentation',
   'no-raw-api-request',
   'no-query-cache-ownership',
+] as const;
+
+const surfaceSystemRuleNames = [
+  'no-page-canvas-tokens',
+  'no-dark-variants',
+  'no-nested-panel',
+  'no-table-outside-panel',
+  'no-arbitrary-page-width',
 ] as const;
 
 describe('client-architecture Biome plugins', () => {
@@ -72,6 +88,39 @@ describe('client-architecture Biome plugins', () => {
       const {stdout, stderr} = await execFileAsync(
         process.execPath,
         [biomeCheck, '--config-path', fixtureConfig, resolve(ruleRoot, 'allowed.ts')],
+        {cwd: workspaceRoot},
+      );
+
+      assert.doesNotMatch(`${stdout}${stderr}`, new RegExp(`client-architecture/${ruleName}`, 'u'));
+    });
+  }
+
+  for (const ruleName of surfaceSystemRuleNames) {
+    const ruleRoot = resolve(surfaceSystemFixtureRoot, ruleName);
+
+    test(`${ruleName} fails its rejected fixture`, async () => {
+      await assert.rejects(
+        execFileAsync(
+          process.execPath,
+          [biomeCheck, '--config-path', surfaceSystemFixtureConfig, ruleRoot],
+          {
+            cwd: workspaceRoot,
+          },
+        ),
+        (error: unknown) => {
+          const commandError = error as {stdout?: string; stderr?: string};
+          const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+          assert.match(output, new RegExp(`client-architecture/${ruleName}`, 'u'));
+          assert.match(output, /rejected\.tsx:/u);
+          return true;
+        },
+      );
+    });
+
+    test(`${ruleName} passes its allowed fixture`, async () => {
+      const {stdout, stderr} = await execFileAsync(
+        process.execPath,
+        [biomeCheck, '--config-path', surfaceSystemFixtureConfig, resolve(ruleRoot, 'allowed.tsx')],
         {cwd: workspaceRoot},
       );
 
@@ -215,6 +264,77 @@ describe('client-architecture Biome plugins', () => {
         '!**/*.gen.tsx',
       ],
     });
+  });
+
+  test('registers surface-system plugins for their owned source boundaries', async () => {
+    const rootConfig = JSON.parse(await readFile(resolve(workspaceRoot, 'biome.json'), 'utf8')) as {
+      plugins: {includes: string[]; path: string}[];
+    };
+
+    for (const ruleName of surfaceSystemRuleNames) {
+      const plugin = rootConfig.plugins.find(({path}) =>
+        path.endsWith(`/client-architecture/${ruleName}.grit`),
+      );
+      assert.ok(plugin, `Expected root Biome config to register ${ruleName}.`);
+      assert.ok(plugin.includes.includes('!**/*.test.tsx'));
+      assert.ok(plugin.includes.includes('!**/*.stories.tsx'));
+      assert.ok(plugin.includes.includes('!**/generated/**'));
+    }
+
+    const canvasPlugin = rootConfig.plugins.find(({path}) =>
+      path.endsWith('/client-architecture/no-page-canvas-tokens.grit'),
+    );
+    assert.ok(canvasPlugin?.includes.includes('**/libs/client/**'));
+    assert.ok(canvasPlugin?.includes.includes('**/libs/shared/react/ui/**'));
+    assert.ok(canvasPlugin?.includes.includes('!**/libs/client/shell/**'));
+
+    const pageWidthPlugin = rootConfig.plugins.find(({path}) =>
+      path.endsWith('/client-architecture/no-arbitrary-page-width.grit'),
+    );
+    assert.ok(pageWidthPlugin?.includes.includes('**/libs/client/**'));
+    assert.ok(pageWidthPlugin?.includes.includes('!**/libs/client/shell/**'));
+  });
+
+  test('enforces all surface-system plugins through the real root config', async () => {
+    const probePath = resolve(
+      workspaceRoot,
+      'libs/client/workflows/src/pages/zz-surface-system-glob-regression.tsx',
+    );
+    await writeFile(
+      probePath,
+      [
+        "import {Panel} from '@shipfox/react-ui/panel';",
+        "import {Table} from '@shipfox/react-ui/table';",
+        'export function SurfaceSystemProbe() {',
+        '  return (',
+        '    <div className="bg-background-subtle-base dark:bg-black max-w-[1120px]">',
+        '      <Table />',
+        '      <Panel>',
+        '        <Panel />',
+        '      </Panel>',
+        '    </div>',
+        '  );',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    try {
+      await assert.rejects(
+        execFileAsync(process.execPath, [biomeCheck, '--config-path', rootConfig, probePath], {
+          cwd: workspaceRoot,
+        }),
+        (error: unknown) => {
+          const commandError = error as {stdout?: string; stderr?: string};
+          const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+          for (const ruleName of surfaceSystemRuleNames) {
+            assert.match(output, new RegExp(`client-architecture/${ruleName}`, 'u'));
+          }
+          return true;
+        },
+      );
+    } finally {
+      await rm(probePath);
+    }
   });
 
   // The fixture config scopes each rule to its fixture directory. These tests run

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -291,7 +291,23 @@ describe('client-architecture Biome plugins', () => {
     const pageWidthPlugin = rootConfig.plugins.find(({path}) =>
       path.endsWith('/client-architecture/no-arbitrary-page-width.grit'),
     );
-    assert.ok(pageWidthPlugin?.includes.includes('**/libs/client/**'));
+    assert.ok(pageWidthPlugin?.includes.includes('**/libs/client/**/src/pages/**'));
+    assert.ok(
+      pageWidthPlugin?.includes.includes(
+        '**/libs/client/integrations/src/components/callback-status-shell.tsx',
+      ),
+    );
+    assert.ok(
+      pageWidthPlugin?.includes.includes(
+        '**/libs/client/integrations/src/components/redirect-install-page.tsx',
+      ),
+    );
+    assert.ok(
+      pageWidthPlugin?.includes.includes(
+        '**/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx',
+      ),
+    );
+    assert.ok(!pageWidthPlugin?.includes.includes('**/libs/client/**'));
     assert.ok(pageWidthPlugin?.includes.includes('!**/libs/client/shell/**'));
   });
 

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -292,21 +292,6 @@ describe('client-architecture Biome plugins', () => {
       path.endsWith('/client-architecture/no-arbitrary-page-width.grit'),
     );
     assert.ok(pageWidthPlugin?.includes.includes('**/libs/client/**/src/pages/**'));
-    assert.ok(
-      pageWidthPlugin?.includes.includes(
-        '**/libs/client/integrations/src/components/callback-status-shell.tsx',
-      ),
-    );
-    assert.ok(
-      pageWidthPlugin?.includes.includes(
-        '**/libs/client/integrations/src/components/redirect-install-page.tsx',
-      ),
-    );
-    assert.ok(
-      pageWidthPlugin?.includes.includes(
-        '**/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx',
-      ),
-    );
     assert.ok(!pageWidthPlugin?.includes.includes('**/libs/client/**'));
     assert.ok(pageWidthPlugin?.includes.includes('!**/libs/client/shell/**'));
   });


### PR DESCRIPTION
Adds repository checks for the Surface and layout system contract.

The change registers five local Biome rules with accepted and rejected fixtures, covering canvas tokens, dark variants, nested Panels, Tables outside Panels, and arbitrary page widths. It also requires every composed route implementation to declare a supported `content`, `data`, or `focused` frame before shell assembly or generated route loading.

The published `@shipfox/client-shell` route contract is breaking for consumers that do not declare `staticData.frame`, so the PR includes a major Changeset. The new surface rules remain repository-local and are not added to the published `@shipfox/biome` file set.

Focused validation passes: Biome tests (44), shell tests (118), shell typecheck, shell check, and `git diff --check`.

The dependent check still reports pre-existing surface migration findings in `@shipfox/react-ui` and `@shipfox/client-config`; those migrations are tracked separately and are intentionally not included here.

Closes ENG-1594

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces surface-system boundaries and a strict route-frame contract to prevent layout drift. Implements ENG-1594 with repo-local Biome checks; routes without frames now fail at startup and legacy full-bleed patterns were removed. Updates workflow run summary and loader to leave canvas ownership to the shell.

- New Features
  - Adds local Biome rules: no page-canvas tokens outside shell, no `dark:` variants (strings/JSX text/templates, incl. split prefixes), no nested `Panel`, no `Table` outside `Panel`, and no arbitrary `max-w-[...]` on page containers.
  - Registers plugins in root `biome.json` with targeted includes (page-width rule scoped to `src/pages/**`), adds a dedicated fixture config, and tests that verify plugin registration and root-config enforcement.
  - Requires a `RouteFrame` ('content' | 'data' | 'focused'); `assertRouteFrame` guards the generator and shell assembly. Production routes now declare frames. UI migrations convert tables to `Card`, remove page-level canvas tokens and arbitrary widths, keep the full-page loader on the shell canvas, and use the panel surface for table headers and workflow summary.

- Migration
  - Breaking in `@shipfox/client-shell`: every route must set `staticData.frame` to "content", "data", or "focused".
  - Route generation/loading now throws if missing.

<sup>Written for commit 7f521e7377877575f78e7c5dc77c9fb8a7185702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

