### PR TITLE
[client-workflows] Join the run workspace rail to its content frame

### DIFF
--- a/.changeset/align-run-workspace.md
+++ b/.changeset/align-run-workspace.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Aligns the run workspace rail with its content frame at wide viewport sizes.

--- a/.changeset/align-run-workspace.md
+++ b/.changeset/align-run-workspace.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": patch
 ---
 
-Aligns the run workspace rail with its content frame at wide viewport sizes.
+Aligns the run workspace rail with its content frame at wide viewport sizes while keeping dedicated job content full width.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -361,6 +361,10 @@ same gutters at every width. Data surfaces run edge to edge on purpose, because 
 wide log or run table shows more per screen. The panel border supplies the edge
 the eye tracks against.
 
+The run workspace is a nested exception inside the `data` frame. At wide
+viewports, its 240px rail joins a 1120px run-level content measure. Dedicated job
+views keep their log content full width within the surrounding data surface.
+
 Marketing sits outside this model. It keeps a single content column up to about
 1280px, generous vertical rhythm, and full-bleed background panels.
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -119,7 +119,7 @@ function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="h-[720px] min-w-[1440px] w-[1440px] bg-background-subtle-base">
+      <div className="flex h-[720px] min-w-[1440px] w-[1440px] bg-background-subtle-base">
         {children}
       </div>
     </QueryClientProvider>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -3,17 +3,26 @@ import {configureApiClient} from '@shipfox/client-api';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {type ReactNode, useEffect, useState} from 'react';
-import {workflowJobDto, workflowRunDetailDto} from '#test/fixtures/workflow-run.js';
+import {
+  runAttemptsResponseDto,
+  workflowJobDto,
+  workflowRunDetailDto,
+} from '#test/fixtures/workflow-run.js';
 import {WorkflowRunView} from './workflow-run-view.js';
 
 const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
 const RUN_ID = '11111111-1111-4111-8111-111111111111';
+const RUN_STARTED_AT = '2026-06-26T11:57:00.000Z';
+const RUN_FINISHED_AT = '2026-06-26T11:59:00.000Z';
 
 const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
   id: RUN_ID,
   project_id: PROJECT_ID,
   name: 'deploy-web',
   status: 'succeeded',
+  started_at: RUN_STARTED_AT,
+  finished_at: RUN_FINISHED_AT,
+  has_started_job_execution: true,
   jobs: [
     workflowJobDto({
       key: 'build',
@@ -37,6 +46,7 @@ const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
     }),
   ],
 });
+const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({attempts: []});
 
 const withRunApi: Decorator = (Story) => (
   <RunWorkspaceStoryProviders>
@@ -80,10 +90,21 @@ function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
       fetchImpl: (input) => {
         const url =
           input instanceof Request ? input.url : input instanceof URL ? input.href : String(input);
-        const body = url.includes('/annotations')
-          ? {annotations: [], has_more: false, next_cursor: null}
-          : RUN_RESPONSE;
+        const path = new URL(url, 'https://api.example.test').pathname;
+        const isNotFound =
+          path !== '/annotations' &&
+          path !== `/workflows/runs/${RUN_ID}/attempts` &&
+          path !== `/workflows/runs/${RUN_ID}`;
+        const body =
+          path === '/annotations'
+            ? {annotations: [], has_more: false, next_cursor: null}
+            : path === `/workflows/runs/${RUN_ID}/attempts`
+              ? RUN_ATTEMPTS_RESPONSE
+              : path === `/workflows/runs/${RUN_ID}`
+                ? RUN_RESPONSE
+                : {code: 'not-found'};
         return new Response(JSON.stringify(body), {
+          status: isNotFound ? 404 : 200,
           headers: {'content-type': 'application/json'},
         });
       },

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -61,12 +61,16 @@ const meta = {
     layout: 'fullscreen',
     viewport: {
       defaultViewport: 'wide',
-      viewports: {
+      options: {
         wide: {
           name: 'Wide',
           styles: {width: '1440px', height: '720px'},
+          type: 'desktop',
         },
       },
+    },
+    globals: {
+      viewport: {value: 'wide'},
     },
     argos: {
       modes: {dark: {theme: 'dark'}},

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -91,20 +91,19 @@ function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
         const url =
           input instanceof Request ? input.url : input instanceof URL ? input.href : String(input);
         const path = new URL(url, 'https://api.example.test').pathname;
-        const isNotFound =
-          path !== '/annotations' &&
-          path !== `/workflows/runs/${RUN_ID}/attempts` &&
-          path !== `/workflows/runs/${RUN_ID}`;
-        const body =
+        const response =
           path === '/annotations'
-            ? {annotations: [], has_more: false, next_cursor: null}
+            ? {
+                body: {annotations: [], has_more: false, next_cursor: null},
+                status: 200,
+              }
             : path === `/workflows/runs/${RUN_ID}/attempts`
-              ? RUN_ATTEMPTS_RESPONSE
+              ? {body: RUN_ATTEMPTS_RESPONSE, status: 200}
               : path === `/workflows/runs/${RUN_ID}`
-                ? RUN_RESPONSE
-                : {code: 'not-found'};
-        return new Response(JSON.stringify(body), {
-          status: isNotFound ? 404 : 200,
+                ? {body: RUN_RESPONSE, status: 200}
+                : {body: {code: 'not-found'}, status: 404};
+        return new Response(JSON.stringify(response.body), {
+          status: response.status,
           headers: {'content-type': 'application/json'},
         });
       },

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -59,9 +59,18 @@ const meta = {
   component: WorkflowRunView,
   parameters: {
     layout: 'fullscreen',
+    viewport: {
+      defaultViewport: 'wide',
+      viewports: {
+        wide: {
+          name: 'Wide',
+          styles: {width: '1440px', height: '720px'},
+        },
+      },
+    },
     argos: {
       modes: {dark: {theme: 'dark'}},
-      fitToContent: true,
+      fitToContent: false,
     },
   },
   decorators: [withRunApi],

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -1,0 +1,107 @@
+import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {type ReactNode, useEffect, useState} from 'react';
+import {workflowJobDto, workflowRunDetailDto} from '#test/fixtures/workflow-run.js';
+import {WorkflowRunView} from './workflow-run-view.js';
+
+const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+
+const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
+  id: RUN_ID,
+  project_id: PROJECT_ID,
+  name: 'deploy-web',
+  status: 'succeeded',
+  jobs: [
+    workflowJobDto({
+      key: 'build',
+      name: 'build',
+      status: 'succeeded',
+      position: 0,
+    }),
+    workflowJobDto({
+      key: 'deploy',
+      name: 'deploy',
+      status: 'succeeded',
+      position: 1,
+      dependencies: ['build'],
+    }),
+    workflowJobDto({
+      key: 'notify',
+      name: 'notify',
+      status: 'succeeded',
+      position: 2,
+      dependencies: ['deploy'],
+    }),
+  ],
+});
+
+const withRunApi: Decorator = (Story) => (
+  <RunWorkspaceStoryProviders>
+    <Story />
+  </RunWorkspaceStoryProviders>
+);
+
+const meta = {
+  title: 'Workflows/WorkflowRunView',
+  component: WorkflowRunView,
+  parameters: {
+    layout: 'fullscreen',
+    argos: {
+      modes: {dark: {theme: 'dark'}},
+      fitToContent: true,
+    },
+  },
+  decorators: [withRunApi],
+  args: {
+    projectId: PROJECT_ID,
+    workspaceSlug: 'acme',
+    projectSlug: 'platform',
+    workflowRunId: RUN_ID,
+  },
+} satisfies Meta<typeof WorkflowRunView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WideViewport: Story = {};
+
+function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
+  const [queryClient] = useState(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+  );
+  const [configured, setConfigured] = useState(false);
+
+  useEffect(() => {
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: (input) => {
+        const url =
+          input instanceof Request ? input.url : input instanceof URL ? input.href : String(input);
+        const body = url.includes('/annotations')
+          ? {annotations: [], has_more: false, next_cursor: null}
+          : RUN_RESPONSE;
+        return new Response(JSON.stringify(body), {
+          headers: {'content-type': 'application/json'},
+        });
+      },
+    });
+    setConfigured(true);
+
+    return () => {
+      configureApiClient({baseUrl: '', fetchImpl: undefined});
+    };
+  }, []);
+
+  if (!configured) return null;
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="h-[720px] min-w-[1440px] w-[1440px] bg-background-subtle-base">
+        {children}
+      </div>
+    </QueryClientProvider>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -52,10 +52,7 @@ describe('WorkflowRunView', () => {
     const workspaceLayout = screen
       .getByRole('navigation', {name: 'Run workspace'})
       .closest('[data-run-workspace-layout]');
-    expect(workspaceLayout).toHaveClass(
-      'border-t',
-      'border-border-neutral-base',
-    );
+    expect(workspaceLayout).toHaveClass('border-t', 'border-border-neutral-base');
     expect(workspaceLayout).not.toHaveClass('max-w-[1360px]');
     expect(workspaceLayout?.querySelector('[data-run-workspace-frame]')).toHaveClass(
       'mx-auto',

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -49,16 +49,18 @@ describe('WorkflowRunView', () => {
     const summary = await screen.findByRole('region', {name: 'deploy-web'});
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(screen.getByRole('navigation', {name: 'Run workspace'})).toBeInTheDocument();
-    expect(
-      screen
-        .getByRole('navigation', {name: 'Run workspace'})
-        .closest('[data-run-workspace-layout]'),
-    ).toHaveClass(
-      'mx-auto',
-      'w-full',
-      'max-w-[1360px]',
+    const workspaceLayout = screen
+      .getByRole('navigation', {name: 'Run workspace'})
+      .closest('[data-run-workspace-layout]');
+    expect(workspaceLayout).toHaveClass(
       'border-t',
       'border-border-neutral-base',
+    );
+    expect(workspaceLayout).not.toHaveClass('max-w-[1360px]');
+    expect(workspaceLayout?.querySelector('[data-run-workspace-frame]')).toHaveClass(
+      'mx-auto',
+      'w-full',
+      'max-w-[calc(240px_+_1120px)]',
       'min-[768px]:flex-row',
     );
     expect(screen.getByRole('link', {name: 'Summary'})).toHaveAttribute('aria-current', 'page');
@@ -84,6 +86,18 @@ describe('WorkflowRunView', () => {
 
     const section = await screen.findByRole('region', {name: region});
     expect(section.firstElementChild).not.toHaveClass('max-w-[1120px]');
+  });
+
+  test('keeps dedicated job content on the full-width data surface', async () => {
+    configureRunFetch();
+
+    renderView({jobContent: <div>Job logs</div>});
+
+    const jobContent = await screen.findByText('Job logs');
+    const workspaceFrame = jobContent.closest('[data-run-workspace-frame]');
+
+    expect(workspaceFrame).toHaveClass('w-full', 'min-[768px]:flex-row');
+    expect(workspaceFrame).not.toHaveClass('max-w-[calc(240px_+_1120px)]');
   });
 
   test('treats the removed Jobs tab URL as the graph Summary', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -53,7 +53,14 @@ describe('WorkflowRunView', () => {
       screen
         .getByRole('navigation', {name: 'Run workspace'})
         .closest('[data-run-workspace-layout]'),
-    ).toHaveClass('border-t', 'border-border-neutral-base', 'min-[768px]:flex-row');
+    ).toHaveClass(
+      'mx-auto',
+      'w-full',
+      'max-w-[1360px]',
+      'border-t',
+      'border-border-neutral-base',
+      'min-[768px]:flex-row',
+    );
     expect(screen.getByRole('link', {name: 'Summary'})).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('heading', {name: 'Jobs'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Run details'})).toBeInTheDocument();

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -309,7 +309,7 @@ function RunViewContent({
 
       <div
         data-run-workspace-layout
-        className="flex min-h-0 min-w-0 flex-1 flex-col border-t border-border-neutral-base min-[768px]:flex-row"
+        className="mx-auto flex min-h-0 min-w-0 w-full max-w-[1360px] flex-1 flex-col border-t border-border-neutral-base min-[768px]:flex-row"
       >
         {runData && workspaceSlug && projectSlug ? (
           <RunWorkspaceNav

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -11,6 +11,7 @@ import {
 } from '@shipfox/react-ui/select';
 import {toast} from '@shipfox/react-ui/toast';
 import {Text} from '@shipfox/react-ui/typography';
+import {cn} from '@shipfox/react-ui/utils';
 import {useNavigate} from '@tanstack/react-router';
 import {type ReactNode, useEffect, useMemo} from 'react';
 import {buildRunAnnotationList, type RunAnnotationSummary} from '#core/run-annotation.js';
@@ -53,6 +54,7 @@ import {
 } from './workflow-run-states.js';
 
 type RunWorkspaceSection = Exclude<WorkflowRunTab, 'jobs'>;
+const RUN_WORKSPACE_FRAME_CLASS_NAME = 'mx-auto w-full max-w-[calc(240px_+_1120px)]';
 
 export interface WorkflowRunViewProps {
   projectId: string;
@@ -157,6 +159,7 @@ function RunViewContent({
   const activeSection = runWorkspaceSection(tab);
   const cancelMutation = useCancelWorkflowRunMutation(runData);
   const sourceSnapshot = runData?.sourceSnapshot ?? null;
+  const hasJobContent = Boolean(jobContent);
   const resolvedSelection =
     runData && selection ? resolveWorkflowRunSelection({run: runData, selection}) : undefined;
   const highlightedLineRange = resolvedSelection?.step?.sourceLocation ?? null;
@@ -309,44 +312,55 @@ function RunViewContent({
 
       <div
         data-run-workspace-layout
-        className="mx-auto flex min-h-0 min-w-0 w-full max-w-[1360px] flex-1 flex-col border-t border-border-neutral-base min-[768px]:flex-row"
+        className="flex min-h-0 min-w-0 flex-1 flex-col border-t border-border-neutral-base"
       >
-        {runData && workspaceSlug && projectSlug ? (
-          <RunWorkspaceNav
-            workspaceSlug={workspaceSlug}
-            projectSlug={projectSlug}
-            run={runData}
-            activeSection={activeSection}
-            currentJobId={activeJobId}
-            jobSearch={jobSearch}
-            annotationSummary={annotationSummary}
-          />
-        ) : (
-          <RunWorkspaceNavSkeleton />
-        )}
-
-        <div data-run-workspace-content className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {runData && jobContent ? (
-            jobContent
-          ) : runData ? (
-            <RunSectionContent
-              section={activeSection}
-              run={runData}
-              annotations={annotations}
-              annotationSummary={annotationSummary}
+        <div
+          data-run-workspace-frame
+          className={cn(
+            'flex min-h-0 min-w-0 w-full flex-1 flex-col min-[768px]:flex-row',
+            !hasJobContent && RUN_WORKSPACE_FRAME_CLASS_NAME,
+          )}
+        >
+          {runData && workspaceSlug && projectSlug ? (
+            <RunWorkspaceNav
               workspaceSlug={workspaceSlug}
               projectSlug={projectSlug}
-              selection={selection}
-              selectedJobId={selection?.jobId}
-              onSelectGraphJob={selectGraphJob}
-              onSelectAnnotationJob={selectAnnotationJob}
-              onClearAnnotationFilters={clearAnnotationFilters}
-              sourceSnapshot={sourceSnapshot}
-              highlightedLineRange={highlightedLineRange}
+              run={runData}
+              activeSection={activeSection}
+              currentJobId={activeJobId}
+              jobSearch={jobSearch}
+              annotationSummary={annotationSummary}
             />
           ) : (
-            <div className="min-h-0 flex-1 overflow-auto p-panel">{loadingOrError}</div>
+            <RunWorkspaceNavSkeleton />
           )}
+
+          <div
+            data-run-workspace-content
+            className="flex min-h-0 min-w-0 flex-1 flex-col"
+          >
+            {runData && jobContent ? (
+              jobContent
+            ) : runData ? (
+              <RunSectionContent
+                section={activeSection}
+                run={runData}
+                annotations={annotations}
+                annotationSummary={annotationSummary}
+                workspaceSlug={workspaceSlug}
+                projectSlug={projectSlug}
+                selection={selection}
+                selectedJobId={selection?.jobId}
+                onSelectGraphJob={selectGraphJob}
+                onSelectAnnotationJob={selectAnnotationJob}
+                onClearAnnotationFilters={clearAnnotationFilters}
+                sourceSnapshot={sourceSnapshot}
+                highlightedLineRange={highlightedLineRange}
+              />
+            ) : (
+              <div className="min-h-0 flex-1 overflow-auto p-panel">{loadingOrError}</div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -335,10 +335,7 @@ function RunViewContent({
             <RunWorkspaceNavSkeleton />
           )}
 
-          <div
-            data-run-workspace-content
-            className="flex min-h-0 min-w-0 flex-1 flex-col"
-          >
+          <div data-run-workspace-content className="flex min-h-0 min-w-0 flex-1 flex-col">
             {runData && jobContent ? (
               jobContent
             ) : runData ? (


### PR DESCRIPTION
The run detail rail now shares a centered workspace frame with its 1120px content region. The frame accounts for the 240px rail and keeps the graph aligned with it at wide viewport sizes.

Closes ENG-1583

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the run workspace in `@shipfox/client-workflows`, joining the left rail to a capped run-level frame (240px rail + 1120px content) at wide viewports. Keeps the shell and job logs full width; updates DESIGN.md, adds a wide-viewport Storybook story with consolidated mocks, switches to supported viewport options, hardens frame-class tests, and ensures Argos captures the 1440×720 layout (ENG-1583).

<sup>Written for commit dd5f7e914be4c923dc7cdd4f0a895e4c1ddba54d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

