### PR TITLE
[client-workflows] Remove workflow page canvas overrides

### DIFF
--- a/.changeset/clear-workflow-frames.md
+++ b/.changeset/clear-workflow-frames.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": patch
 ---
 
-Removes per-page canvas and width overrides so workflow surfaces inherit their declared frame.
+Removes per-page canvas and width overrides so workflow pages render at the full width of their declared frame instead of a capped 1120px column.

--- a/.changeset/clear-workflow-frames.md
+++ b/.changeset/clear-workflow-frames.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Removes per-page canvas and width overrides so workflow surfaces inherit their declared frame.

--- a/.changeset/clear-workflow-frames.md
+++ b/.changeset/clear-workflow-frames.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": patch
 ---
 
-Removes per-page canvas and width overrides so workflow pages render at the full width of their declared frame instead of a capped 1120px column.
+Removes per-page canvas and width overrides so workflow pages render full-width surfaces instead of a locally painted, capped 1120px column.

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
@@ -75,15 +75,15 @@ const SAMPLE_RUNS: WorkflowRunListItem[] = [
 
 // One story on the full-width page. The data states (loading / empty / errors / runs) are
 // driven by args; search, the filter menus, "clear filters" and "no matches" are live in the
-// rendered toolbar since the view owns that state. The decorator gives the list the 1120px
-// content cap and a real height, so `flex-1` scrolls the way it does in the app shell.
+// rendered toolbar since the view owns that state. The decorator gives the list a full-width
+// subtle canvas and a real height, so `flex-1` scrolls the way it does in the app shell.
 const meta = {
   title: 'Workflows/WorkflowRunList',
   component: WorkflowRunListView,
   parameters: {layout: 'centered'},
   decorators: [
     (Story) => (
-      <div className="flex h-600 w-[1120px] max-w-full bg-background-neutral-base p-24">
+      <div className="flex h-600 w-full bg-background-subtle-base p-24">
         <Story />
       </div>
     ),

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -34,9 +34,9 @@ export function WorkflowRunRowList({
   projectSlug?: string | undefined;
 }) {
   return (
-    // A container, not the viewport, drives the row's breakpoints. The list is capped at
-    // 1120px inside a wider page, so what a row can afford is its own width; keying off the
-    // viewport would keep the job strip hidden on a wide screen or crush it on a narrow one.
+    // A container, not the viewport, drives the row's breakpoints. What a row can afford is its
+    // own width; keying off the viewport would keep the job strip hidden on a wide screen or
+    // crush it on a narrow one.
     <ul className="@container divide-y divide-border-neutral-base border-t border-border-neutral-base">
       {runs.map((run) => (
         <li key={run.id}>
@@ -55,9 +55,9 @@ export function WorkflowRunRowList({
  * drops beneath. The numeric columns are fixed-width so duration and time form real columns
  * down the list rather than tracking each row's name length.
  *
- * The thresholds are the container widths the spec's viewport breakpoints produce, given a
- * column capped at 1120px with 24px of page padding on each side: a 1280px viewport leaves
- * the row 1072px, and a 1024px viewport leaves it 976px.
+ * The 976px threshold keeps identity and provenance on one line; below it, provenance drops
+ * beneath the identity. The 1040px threshold keeps the job strip visible; below it, the strip is
+ * hidden so the numeric columns remain aligned.
  */
 export function WorkflowRunRow({
   run,

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -59,9 +59,9 @@ describe('WorkflowRunView', () => {
     expect(screen.getByRole('heading', {name: 'Run details'})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'All jobs summary'})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
-    expect(container.querySelector('[data-run-workspace-content]')).toHaveClass(
+    expect(container.querySelector('[data-run-workspace-content]')).toHaveClass('flex-1');
+    expect(container.querySelector('[data-run-workspace-content]')).not.toHaveClass(
       'bg-background-neutral-base',
-      'flex-1',
     );
     expect(screen.queryByRole('tab', {name: 'Jobs'})).not.toBeInTheDocument();
   });

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -66,6 +66,19 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByRole('tab', {name: 'Jobs'})).not.toBeInTheDocument();
   });
 
+  test.each([
+    {tab: undefined, region: 'All jobs summary'},
+    {tab: 'source', region: 'Workflow source'},
+    {tab: 'annotations', region: 'Run annotations'},
+  ] as const)('does not cap the $region section at 1120px', async ({tab, region}) => {
+    configureRunFetch();
+
+    renderView({tab});
+
+    const section = await screen.findByRole('region', {name: region});
+    expect(section.firstElementChild).not.toHaveClass('max-w-[1120px]');
+  });
+
   test('treats the removed Jobs tab URL as the graph Summary', async () => {
     configureRunFetch();
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -325,10 +325,7 @@ function RunViewContent({
           <RunWorkspaceNavSkeleton />
         )}
 
-        <div
-          data-run-workspace-content
-          className="flex min-h-0 min-w-0 flex-1 flex-col bg-background-neutral-base"
-        >
+        <div data-run-workspace-content className="flex min-h-0 min-w-0 flex-1 flex-col">
           {runData && jobContent ? (
             jobContent
           ) : runData ? (
@@ -395,7 +392,7 @@ function RunSectionContent({
         aria-label="All jobs summary"
         className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
       >
-        <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-group px-frame">
+        <div className="mx-auto flex w-full flex-col gap-group px-frame">
           <Text as="h2" className="sr-only">
             All jobs summary
           </Text>
@@ -431,7 +428,7 @@ function RunSectionContent({
       aria-label="Workflow source"
       className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
     >
-      <div className="mx-auto flex min-h-full w-full max-w-[1120px] flex-col px-frame">
+      <div className="mx-auto flex min-h-full w-full flex-col px-frame">
         <Text as="h2" className="sr-only">
           Workflow source
         </Text>
@@ -526,7 +523,7 @@ function RunAnnotationsSection({
       aria-label="Run annotations"
       className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
     >
-      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-group px-frame">
+      <div className="mx-auto flex w-full flex-col gap-group px-frame">
         <Text as="h2" className="sr-only">
           Annotations
         </Text>

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -48,8 +48,7 @@ describe('WorkflowJobDetailPage', () => {
 
     expect(await screen.findByRole('region', {name: 'Loading workflow run'})).toBeInTheDocument();
 
-    const layout = container.querySelector('[data-run-workspace-layout]');
-    const pageRoot = layout?.parentElement?.parentElement;
+    const pageRoot = container.querySelector('[data-workflow-page-root="job-detail"]');
 
     expect(pageRoot).not.toBeNull();
     expect(pageRoot).not.toHaveClass('bg-background-subtle-base');

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -41,6 +41,20 @@ describe('WorkflowJobDetailPage', () => {
     jobAnnotations.value = [];
   });
 
+  test('lets the job detail route inherit its shell canvas', async () => {
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    const {container} = renderJobPath();
+
+    expect(await screen.findByRole('region', {name: 'Loading workflow run'})).toBeInTheDocument();
+
+    const layout = container.querySelector('[data-run-workspace-layout]');
+    const pageRoot = layout?.parentElement?.parentElement;
+
+    expect(pageRoot).not.toBeNull();
+    expect(pageRoot).not.toHaveClass('bg-background-subtle-base');
+  });
+
   test('links the job to its annotations without rendering one', async () => {
     jobAnnotations.value = [
       {

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
@@ -56,7 +56,7 @@ export function WorkflowJobDetailPage({
     [navigate],
   );
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
+    <div data-workflow-page-root="job-detail" className="flex min-h-0 flex-1 overflow-hidden">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
@@ -56,7 +56,7 @@ export function WorkflowJobDetailPage({
     [navigate],
   );
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-subtle-base">
+    <div className="flex min-h-0 flex-1 overflow-hidden">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
@@ -17,7 +17,7 @@ export function WorkflowRunDetailPage({
   search = {},
 }: WorkflowRunDetailPageProps) {
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-subtle-base">
+    <div className="flex min-h-0 flex-1 overflow-hidden">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-detail-page.tsx
@@ -17,7 +17,7 @@ export function WorkflowRunDetailPage({
   search = {},
 }: WorkflowRunDetailPageProps) {
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
+    <div data-workflow-page-root="run-detail" className="flex min-h-0 flex-1 overflow-hidden">
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-run-list-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-list-page.tsx
@@ -49,8 +49,8 @@ export function WorkflowRunsPage({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-background-neutral-base">
-      <div className="mx-auto flex min-h-0 w-full max-w-[1120px] flex-1 flex-col px-frame py-frame">
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="mx-auto flex min-h-0 w-full flex-1 flex-col px-frame py-frame">
         <WorkflowRunList
           projectId={projectId}
           workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-run-list-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-list-page.tsx
@@ -49,7 +49,7 @@ export function WorkflowRunsPage({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
+    <div data-workflow-page-root="runs" className="flex min-h-0 flex-1 overflow-hidden">
       <div className="mx-auto flex min-h-0 w-full flex-1 flex-col px-frame py-frame">
         <WorkflowRunList
           projectId={projectId}

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -72,6 +72,21 @@ describe('WorkflowRunPages', () => {
     expect(screen.queryByLabelText('Loading workflow run')).not.toBeInTheDocument();
   });
 
+  test('lets the list route inherit its shell canvas and width', async () => {
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    renderRunsPath();
+
+    const list = await screen.findByLabelText('Workflow runs');
+    const pageContent = list.parentElement;
+    const pageRoot = pageContent?.parentElement;
+
+    expect(pageRoot).not.toBeNull();
+    expect(pageRoot).not.toHaveClass('bg-background-neutral-base');
+    expect(pageRoot).not.toHaveClass('max-w-[1120px]');
+    expect(pageContent).not.toHaveClass('max-w-[1120px]');
+  });
+
   test('keeps the list route and filters in place instead of redirecting to a run', async () => {
     configureApiClient({fetchImpl: createRunsListFetch()});
 
@@ -182,6 +197,20 @@ describe('WorkflowRunPages', () => {
     expect(screen.queryByLabelText('Workflow runs')).not.toBeInTheDocument();
     expect(screen.queryByRole('tab', {name: JOBS_TAB_NAME})).not.toBeInTheDocument();
     expect(currentSearch(router).tab).toBeUndefined();
+  });
+
+  test('lets the run detail route inherit its shell canvas', async () => {
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    const {container} = renderRunPath();
+
+    expect(await screen.findByRole('region', {name: 'Loading workflow run'})).toBeInTheDocument();
+
+    const layout = container.querySelector('[data-run-workspace-layout]');
+    const pageRoot = layout?.parentElement?.parentElement;
+
+    expect(pageRoot).not.toBeNull();
+    expect(pageRoot).not.toHaveClass('bg-background-subtle-base');
   });
 
   test('maps the removed Jobs tab URL to the graph Summary', async () => {

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -75,16 +75,14 @@ describe('WorkflowRunPages', () => {
   test('lets the list route inherit its shell canvas and width', async () => {
     configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
 
-    renderRunsPath();
+    const {container} = renderRunsPath();
 
-    const list = await screen.findByLabelText('Workflow runs');
-    const pageContent = list.parentElement;
-    const pageRoot = pageContent?.parentElement;
+    await screen.findByLabelText('Workflow runs');
+    const pageRoot = container.querySelector('[data-workflow-page-root="runs"]');
 
     expect(pageRoot).not.toBeNull();
     expect(pageRoot).not.toHaveClass('bg-background-neutral-base');
     expect(pageRoot).not.toHaveClass('max-w-[1120px]');
-    expect(pageContent).not.toHaveClass('max-w-[1120px]');
   });
 
   test('keeps the list route and filters in place instead of redirecting to a run', async () => {
@@ -206,8 +204,7 @@ describe('WorkflowRunPages', () => {
 
     expect(await screen.findByRole('region', {name: 'Loading workflow run'})).toBeInTheDocument();
 
-    const layout = container.querySelector('[data-run-workspace-layout]');
-    const pageRoot = layout?.parentElement?.parentElement;
+    const pageRoot = container.querySelector('[data-workflow-page-root="run-detail"]');
 
     expect(pageRoot).not.toBeNull();
     expect(pageRoot).not.toHaveClass('bg-background-subtle-base');


### PR DESCRIPTION
Workflow pages now inherit their canvas and width from the declared shell frame. This lets data surfaces use the full-width frame without local background paints or 1120px caps.

Closes ENG-1581

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workflow pages now inherit their canvas and width from the shell frame for a consistent layout. This enables full‑width data surfaces. Closes ENG-1581.

- **Refactors**
  - Removed local background paints from run list/detail/job pages and the run workspace content.
  - Dropped `max-w-[1120px]` caps across the run list and run view sections.
  - Added explicit `data-workflow-page-root` selectors and expanded tests to assert inherited canvas/width; updated Storybook to a full‑width subtle canvas; added a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 74034967aa7822c85b02745218012623b8330811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

