### PR TITLE
[client-shell] Require explicit frames on every composed route

### DIFF
--- a/.changeset/required-route-frames.md
+++ b/.changeset/required-route-frames.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": major
+---
+
+Require composed route implementations to declare `staticData.frame` as `content`, `data`, or `focused`.

--- a/apps/client/src/shipfox-app.gen.ts
+++ b/apps/client/src/shipfox-app.gen.ts
@@ -2,7 +2,7 @@
 // biome-ignore-all format: generated code has stable, reviewable output.
 // biome-ignore-all assist/source/organizeImports: generated imports follow route order.
 import {createRoute, createRouter} from '@tanstack/react-router';
-import {assertRouteFrame, buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
+import {assertRouteImplFrame, buildAnchorSkeleton, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
 import * as route0Module from "@shipfox/client-auth/routes/index";
 import * as route1Module from "@shipfox/client-auth/routes/login";
 import * as route2Module from "@shipfox/client-auth/routes/logout";
@@ -44,10 +44,7 @@ import * as route37Module from "@shipfox/client-workspace-settings/routes/member
 import * as route38Module from "@shipfox/client-workspace-settings/routes/general";
 
 function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: string): T['options'] {
-  if (!isRouteImpl(routeImpl)) {
-    throw new TypeError(`Route implementation "${impl}" for "${path}" must export default defineRoute(...).`);
-  }
-  assertRouteFrame(routeImpl.options.staticData, impl, path);
+  assertRouteImplFrame(routeImpl, impl, path);
   return routeImpl.options;
 }
 

--- a/apps/client/src/shipfox-app.gen.ts
+++ b/apps/client/src/shipfox-app.gen.ts
@@ -2,7 +2,7 @@
 // biome-ignore-all format: generated code has stable, reviewable output.
 // biome-ignore-all assist/source/organizeImports: generated imports follow route order.
 import {createRoute, createRouter} from '@tanstack/react-router';
-import {buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
+import {assertRouteFrame, buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
 import * as route0Module from "@shipfox/client-auth/routes/index";
 import * as route1Module from "@shipfox/client-auth/routes/login";
 import * as route2Module from "@shipfox/client-auth/routes/logout";
@@ -47,6 +47,7 @@ function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: str
   if (!isRouteImpl(routeImpl)) {
     throw new TypeError(`Route implementation "${impl}" for "${path}" must export default defineRoute(...).`);
   }
+  assertRouteFrame(routeImpl.options.staticData, impl, path);
   return routeImpl.options;
 }
 

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -162,14 +162,12 @@ export default defineRoute({
   component: WorkflowsPage,
   loader: loadWorkflows,
   validateSearch: workflowsSearchSchema,
-  staticData: {frame: 'data'},
 });
 ```
 
 The route options support the TanStack behavior used by the current client: `component`, `loader`,
-`beforeLoad`, `validateSearch`, `staticData`, `pendingComponent`, and `errorComponent`. Composed route
-implementations must declare `staticData.frame` as `content`, `data`, or `focused`. The generated route
-supplies its path, parent, and router context.
+`beforeLoad`, `validateSearch`, `staticData`, `pendingComponent`, and `errorComponent`. The generated
+route supplies its path, parent, and router context.
 
 ### Paths and anchors
 
@@ -228,7 +226,7 @@ The generated file:
 - creates code-based routes below the shell anchors;
 - exports `routeTree` and `router`;
 - augments TanStack Router's `Register` with the consumer's router type; and
-- checks that each implementation is a `defineRoute()` result with a supported `staticData.frame`.
+- checks that each implementation is a `defineRoute()` result.
 
 Consumer-local generation preserves typed `Link`, `useParams`, and `useSearch` for upstream and
 external routes. The published shell must not augment `Register`, because different applications
@@ -371,7 +369,6 @@ id, key, or feature id.
 | UUID parameter after entity prefix | `Route "<path>" must place UUID parameter "<param>" after a page segment.` |
 | Route module not found | `Could not resolve route implementation "<specifier>" for "<path>".` |
 | Invalid route export | `Route implementation "<specifier>" for "<path>" must export default defineRoute(...).` |
-| Missing route frame | `Route implementation "<specifier>" for "<path>" must declare staticData.frame as "content", "data", or "focused".` |
 | Feature evaluation | `Failed to evaluate features module "<file>". Features modules must be Node-safe: <cause>` |
 | Invalid feature export | `Features module "<file>" must export a features array.` |
 

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -162,12 +162,14 @@ export default defineRoute({
   component: WorkflowsPage,
   loader: loadWorkflows,
   validateSearch: workflowsSearchSchema,
+  staticData: {frame: 'data'},
 });
 ```
 
 The route options support the TanStack behavior used by the current client: `component`, `loader`,
-`beforeLoad`, `validateSearch`, `staticData`, `pendingComponent`, and `errorComponent`. The generated
-route supplies its path, parent, and router context.
+`beforeLoad`, `validateSearch`, `staticData`, `pendingComponent`, and `errorComponent`. Composed route
+implementations must declare `staticData.frame` as `content`, `data`, or `focused`. The generated route
+supplies its path, parent, and router context.
 
 ### Paths and anchors
 
@@ -226,7 +228,7 @@ The generated file:
 - creates code-based routes below the shell anchors;
 - exports `routeTree` and `router`;
 - augments TanStack Router's `Register` with the consumer's router type; and
-- checks that each implementation is a `defineRoute()` result.
+- checks that each implementation is a `defineRoute()` result with a supported `staticData.frame`.
 
 Consumer-local generation preserves typed `Link`, `useParams`, and `useSearch` for upstream and
 external routes. The published shell must not augment `Register`, because different applications
@@ -369,6 +371,7 @@ id, key, or feature id.
 | UUID parameter after entity prefix | `Route "<path>" must place UUID parameter "<param>" after a page segment.` |
 | Route module not found | `Could not resolve route implementation "<specifier>" for "<path>".` |
 | Invalid route export | `Route implementation "<specifier>" for "<path>" must export default defineRoute(...).` |
+| Missing route frame | `Route implementation "<specifier>" for "<path>" must declare staticData.frame as "content", "data", or "focused".` |
 | Feature evaluation | `Failed to evaluate features module "<file>". Features modules must be Node-safe: <cause>` |
 | Invalid feature export | `Features module "<file>" must export a features array.` |
 

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -6,6 +6,7 @@
 - **Linear issue:** [ENG-959](https://linear.app/shipfox/issue/ENG-959/author-the-client-composition-adr)
 - **Implementation issue:** [ENG-938](https://linear.app/shipfox/issue/ENG-938/implement-and-publish-the-client-composition-seam)
 - **Amended by:** [ADR 0009: Client URLs and resource identity](0009-client-urls-resource-identity.md)
+- **Amended by:** [ADR 0012: Client route frames](0012-client-route-frames.md)
 
 ## Context
 

--- a/docs/adr/0012-client-route-frames.md
+++ b/docs/adr/0012-client-route-frames.md
@@ -1,0 +1,62 @@
+# ADR 0012: Client route frames
+
+- **Status:** Accepted.
+- **Date:** 2026-08-10.
+- **Decision owners:** E1 platform composition seams and client architecture.
+- **Linear issue:** [ENG-1582](https://linear.app/shipfox/issue/ENG-1582/declare-a-frame-on-every-route).
+- **Amends:** [ADR 0001: Public client composition contract](0001-client-composition-contract.md).
+
+## Context
+
+The client shell owns the page canvas, but route implementations previously
+left the canvas implicit or used a legacy `layout: 'full-bleed'` value. That
+allowed a composed route to silently receive the wrong surface when a page
+needed a data or focused layout.
+
+## Decision
+
+Every composed route and feature-owned layout implementation must declare
+`staticData.frame` with one of these shell-owned values:
+
+| Frame | Shell surface |
+| --- | --- |
+| `content` | Centered content up to 1120px. |
+| `data` | Full-width data surface with a bounded shell height. |
+| `focused` | Centered content up to 640px. |
+
+The generated route module and runtime composition both validate the route
+implementation and its frame. Missing or unsupported frames fail with an
+actionable diagnostic that names the implementation and composed path.
+
+The legacy `staticData.layout: 'full-bleed'` value is removed. Workflow routes
+that need an edge-to-edge surface declare `frame: 'data'` instead.
+
+When matched routes provide more than one frame, the most specific route wins.
+An exact layout route can therefore provide a default for its own surface, and
+a child route can override that default.
+
+## Consequences
+
+- The route implementation contract is breaking for published shell consumers.
+- The shell package requires a major Changeset.
+- Generated application files and the shell runtime must be updated together.
+- Page-specific canvas and scrolling changes remain owned by the route's
+  recomposition work; this decision only makes the shell surface explicit.
+
+## Rejected alternatives
+
+### Default every route to content
+
+An implicit content default hides missing design decisions and can make data
+surfaces appear inset or clip their content.
+
+### Keep legacy full-bleed metadata
+
+The legacy value encodes one layout exception instead of the shell's complete
+surface vocabulary. Replacing it with `data` keeps the route contract explicit
+and leaves room for future frame values.
+
+### Let each page own the canvas
+
+Page-owned canvases duplicate shell behavior and make composition-dependent
+navigation and sizing inconsistent across features.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ documentation model and other engineering sources, start with the
 | [0009: Client URLs and resource identity](0009-client-urls-resource-identity.md) | Accepted; amends ADR 0001 | Slug-based client URL prefixes, UUID API identities, scoped settings anchors, run-number display semantics, and composition-time route-path validation. |
 | [0010: Prose standard and enforcement](0010-prose-standard-and-enforcement.md) | Accepted | The repository prose standard, its sources, accepted divergences, and enforcement model. |
 | [0011: Semantic spacing layer](0011-semantic-spacing-layer.md) | Accepted | Semantic spacing roles, the component boundary, the sizing exclusion, and density posture. |
+| [0012: Client route frames](0012-client-route-frames.md) | Accepted; amends ADR 0001 | Shell-owned content, data, and focused frame declarations and validation for composed routes. |
 
 When a decision changes, add a new ADR that supersedes or amends the earlier
 record. Keep the original record intact so readers can understand why the

--- a/libs/client/agent/src/routes/agents-settings.tsx
+++ b/libs/client/agent/src/routes/agents-settings.tsx
@@ -2,6 +2,7 @@ import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
 import {WorkspaceHarnessesSection, WorkspaceModelProvidersSection} from '#index.js';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   component: () => {
     const workspace = useActiveWorkspace();
     return (

--- a/libs/client/agent/src/routes/model-provider.tsx
+++ b/libs/client/agent/src/routes/model-provider.tsx
@@ -4,6 +4,7 @@ import {ModelProviderOnboardingPage} from '#pages/model-provider-onboarding-page
 import {modelProviderRouteParams} from './inputs.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   component: () => {
     const {workspaceSlug} = useRouteParams(modelProviderRouteParams);
     const workspace = useActiveWorkspace();

--- a/libs/client/auth/src/routes/index.tsx
+++ b/libs/client/auth/src/routes/index.tsx
@@ -4,6 +4,7 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {redirect} from '@tanstack/react-router';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   beforeLoad: ({context}: {context: RouterContext}) => {
     const auth = context.auth;
     if (!auth || auth.isLoading) return;

--- a/libs/client/auth/src/routes/login.tsx
+++ b/libs/client/auth/src/routes/login.tsx
@@ -4,6 +4,7 @@ import {LoginPage} from '#pages/login-page.js';
 import {validateRedirectSearch} from './inputs.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: validateRedirectSearch,
   component: () => (
     <GuestGuard>

--- a/libs/client/auth/src/routes/logout.tsx
+++ b/libs/client/auth/src/routes/logout.tsx
@@ -2,4 +2,8 @@ import {defineRoute} from '@shipfox/client-shell/runtime';
 import {LogoutPage} from '#pages/logout-page.js';
 import {validateRedirectSearch} from './inputs.js';
 
-export default defineRoute({validateSearch: validateRedirectSearch, component: LogoutPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  validateSearch: validateRedirectSearch,
+  component: LogoutPage,
+});

--- a/libs/client/auth/src/routes/reset.tsx
+++ b/libs/client/auth/src/routes/reset.tsx
@@ -4,6 +4,7 @@ import {PasswordResetPage} from '#pages/password-reset-page.js';
 import {validatePasswordResetSearch} from './inputs.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: validatePasswordResetSearch,
   component: () => (
     <GuestGuard>

--- a/libs/client/auth/src/routes/signup.tsx
+++ b/libs/client/auth/src/routes/signup.tsx
@@ -4,6 +4,7 @@ import {SignupPage} from '#pages/signup-page.js';
 import {validateRedirectSearch} from './inputs.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: validateRedirectSearch,
   component: () => (
     <GuestGuard>

--- a/libs/client/auth/src/routes/workspace-onboarding.tsx
+++ b/libs/client/auth/src/routes/workspace-onboarding.tsx
@@ -4,6 +4,7 @@ import {redirect} from '@tanstack/react-router';
 import {WorkspaceOnboardingPage} from '#pages/workspace-onboarding-page.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   beforeLoad: ({context, location}: {context: RouterContext; location: {href: string}}) => {
     const auth = context.auth;
     if (!auth || auth.isLoading) return;

--- a/libs/client/integrations/src/routes/gitea.tsx
+++ b/libs/client/integrations/src/routes/gitea.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {GiteaInstallPage} from '#pages/gitea-install-page.js';
 
-export default defineRoute({component: GiteaInstallPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: GiteaInstallPage,
+});

--- a/libs/client/integrations/src/routes/github-callback.tsx
+++ b/libs/client/integrations/src/routes/github-callback.tsx
@@ -29,6 +29,7 @@ const callbackRequests = createSingleFlight<string, void>({maxTerminalResults: 3
 const toastedCallbacks = new Set<string>();
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: validateGithubCallbackSearch,
   component: GithubCallbackRoute,
 });

--- a/libs/client/integrations/src/routes/github.tsx
+++ b/libs/client/integrations/src/routes/github.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {GithubInstallPage} from '#pages/github-install-page.js';
 
-export default defineRoute({component: GithubInstallPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: GithubInstallPage,
+});

--- a/libs/client/integrations/src/routes/integrations-settings.tsx
+++ b/libs/client/integrations/src/routes/integrations-settings.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {IntegrationGallery} from '#index.js';
 
-export default defineRoute({component: IntegrationGallery});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: IntegrationGallery,
+});

--- a/libs/client/integrations/src/routes/integrations.tsx
+++ b/libs/client/integrations/src/routes/integrations.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {SourceControlOnboardingPage} from '#pages/source-control-onboarding-page.js';
 
-export default defineRoute({component: SourceControlOnboardingPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: SourceControlOnboardingPage,
+});

--- a/libs/client/integrations/src/routes/jira-callback.tsx
+++ b/libs/client/integrations/src/routes/jira-callback.tsx
@@ -3,6 +3,7 @@ import {JiraCallbackPage} from '#pages/jira-callback-page.js';
 import {parseJiraCallbackQuery} from '../jira-callback.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: parseJiraCallbackQuery,
   component: JiraCallbackPage,
 });

--- a/libs/client/integrations/src/routes/jira.tsx
+++ b/libs/client/integrations/src/routes/jira.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {JiraInstallPage} from '#pages/jira-install-page.js';
 
-export default defineRoute({component: JiraInstallPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: JiraInstallPage,
+});

--- a/libs/client/integrations/src/routes/linear-callback.tsx
+++ b/libs/client/integrations/src/routes/linear-callback.tsx
@@ -3,6 +3,7 @@ import {LinearCallbackPage} from '#pages/linear-callback-page.js';
 import {parseLinearCallbackQuery} from '../linear-callback.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: parseLinearCallbackQuery,
   component: LinearCallbackPage,
 });

--- a/libs/client/integrations/src/routes/linear.tsx
+++ b/libs/client/integrations/src/routes/linear.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {LinearInstallPage} from '#pages/linear-install-page.js';
 
-export default defineRoute({component: LinearInstallPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: LinearInstallPage,
+});

--- a/libs/client/integrations/src/routes/sentry-callback.tsx
+++ b/libs/client/integrations/src/routes/sentry-callback.tsx
@@ -3,6 +3,7 @@ import {SentryCallbackPage} from '#pages/sentry-callback-page.js';
 import {parseSentryCallbackParams} from '../sentry-callback.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: parseSentryCallbackParams,
   component: SentryCallbackPage,
 });

--- a/libs/client/integrations/src/routes/sentry.tsx
+++ b/libs/client/integrations/src/routes/sentry.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {SentryInstallPage} from '#pages/sentry-install-page.js';
 
-export default defineRoute({component: SentryInstallPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: SentryInstallPage,
+});

--- a/libs/client/integrations/src/routes/slack-callback.tsx
+++ b/libs/client/integrations/src/routes/slack-callback.tsx
@@ -3,6 +3,7 @@ import {SlackCallbackPage} from '#pages/slack-callback-page.js';
 import {parseSlackCallbackQuery} from '../slack-callback.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: parseSlackCallbackQuery,
   component: SlackCallbackPage,
 });

--- a/libs/client/integrations/src/routes/slack.tsx
+++ b/libs/client/integrations/src/routes/slack.tsx
@@ -1,3 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {SlackInstallPage} from '#pages/slack-install-page.js';
-export default defineRoute({component: SlackInstallPage});
+export default defineRoute({
+  staticData: {frame: 'focused'},
+  component: SlackInstallPage,
+});

--- a/libs/client/invitations/src/routes/accept.tsx
+++ b/libs/client/invitations/src/routes/accept.tsx
@@ -3,6 +3,7 @@ import {InvitationAcceptPage} from '#pages/invitation-accept-page.js';
 import {validateInvitationAcceptSearch} from './inputs.js';
 
 export default defineRoute({
+  staticData: {frame: 'focused'},
   validateSearch: validateInvitationAcceptSearch,
   component: InvitationAcceptPage,
 });

--- a/libs/client/projects/src/routes/create-project.tsx
+++ b/libs/client/projects/src/routes/create-project.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {CreateProjectPage} from '#pages/create-project-page.js';
 
-export default defineRoute({component: CreateProjectPage});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: CreateProjectPage,
+});

--- a/libs/client/projects/src/routes/home.tsx
+++ b/libs/client/projects/src/routes/home.tsx
@@ -3,6 +3,7 @@ import {HomeRouter} from '#pages/home-router.js';
 import {validateProjectsSearch} from './search.js';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   validateSearch: validateProjectsSearch,
   component: () => <HomeRouter search={useRouteSearch(validateProjectsSearch)} />,
 });

--- a/libs/client/projects/src/routes/project-index.tsx
+++ b/libs/client/projects/src/routes/project-index.tsx
@@ -2,6 +2,7 @@ import {defineRoute} from '@shipfox/client-shell/runtime';
 import {redirect} from '@tanstack/react-router';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   beforeLoad: ({params}: {params: {workspaceSlug: string; projectSlug: string}}) => {
     throw redirect({
       to: '/w/$workspaceSlug/p/$projectSlug/runs',

--- a/libs/client/projects/src/routes/project-settings-index.tsx
+++ b/libs/client/projects/src/routes/project-settings-index.tsx
@@ -2,6 +2,7 @@ import {defineRoute} from '@shipfox/client-shell/runtime';
 import {redirect} from '@tanstack/react-router';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   beforeLoad: ({params}: {params: {workspaceSlug: string; projectSlug: string}}) => {
     throw redirect({
       to: '/w/$workspaceSlug/p/$projectSlug/settings/general',

--- a/libs/client/projects/src/routes/project-settings.tsx
+++ b/libs/client/projects/src/routes/project-settings.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {ProjectSettingsPage} from '#pages/project-settings-page.js';
 
-export default defineRoute({component: ProjectSettingsPage});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: ProjectSettingsPage,
+});

--- a/libs/client/runners/src/routes/provisioners-settings.tsx
+++ b/libs/client/runners/src/routes/provisioners-settings.tsx
@@ -2,6 +2,7 @@ import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
 import {WorkspaceProvisionerTokensSettingsSection} from '#index.js';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   component: () => (
     <WorkspaceProvisionerTokensSettingsSection workspaceId={useActiveWorkspace().id} />
   ),

--- a/libs/client/runners/src/routes/runners-settings.tsx
+++ b/libs/client/runners/src/routes/runners-settings.tsx
@@ -2,6 +2,7 @@ import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
 import {WorkspaceManualRegistrationTokensSettingsSection} from '#index.js';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   component: () => (
     <WorkspaceManualRegistrationTokensSettingsSection workspaceId={useActiveWorkspace().id} />
   ),

--- a/libs/client/secrets/src/routes/secrets-settings.tsx
+++ b/libs/client/secrets/src/routes/secrets-settings.tsx
@@ -2,5 +2,6 @@ import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
 import {WorkspaceSecretsSection} from '#index.js';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   component: () => <WorkspaceSecretsSection workspaceId={useActiveWorkspace().id} />,
 });

--- a/libs/client/secrets/src/routes/variables-settings.tsx
+++ b/libs/client/secrets/src/routes/variables-settings.tsx
@@ -2,5 +2,6 @@ import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
 import {WorkspaceVariablesSection} from '#index.js';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   component: () => <WorkspaceVariablesSection workspaceId={useActiveWorkspace().id} />,
 });

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -2,22 +2,18 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {Outlet, useMatches} from '@tanstack/react-router';
 import type {NavTabEntry} from '#contract.js';
 import {useMaybeActiveWorkspace} from '#runtime/active-workspace.js';
+import type {RouteFrame} from '#runtime/route-frame.js';
 import {parseWorkspaceProjectParams, useRouteParams} from '#runtime/route-inputs.js';
 import {NavBar} from './nav-bar.js';
 import {NavTabs} from './nav-tabs.js';
 
-type PageFrame = 'content' | 'data' | 'focused';
-type ResolvedPageFrame = PageFrame | 'legacy-full-bleed';
-
 declare module '@tanstack/react-router' {
   interface StaticDataRouteOption {
-    frame?: PageFrame;
-    /** @deprecated Use `frame: 'data'`. */
-    layout?: 'full-bleed';
+    frame?: RouteFrame;
   }
 }
 
-const frameClassNames: Record<PageFrame, string> = {
+const frameClassNames: Record<RouteFrame, string> = {
   content: 'mx-auto w-full max-w-[1120px] px-frame py-frame',
   data: 'flex min-h-0 w-full flex-1 flex-col px-frame py-frame',
   focused: 'mx-auto w-full max-w-[640px] px-frame py-frame',
@@ -34,16 +30,14 @@ export function MainLayout({
   const {projectSlug} = useRouteParams(parseWorkspaceProjectParams);
   const matches = useMatches();
   if (!workspace) return <FullPageLoader />;
-  const frame = matches.reduce<ResolvedPageFrame>(
-    (current, match) =>
-      match.staticData.frame ??
-      (match.staticData.layout === 'full-bleed' ? 'legacy-full-bleed' : current),
+  const frame = matches.reduce<RouteFrame>(
+    (current, match) => match.staticData.frame ?? current,
     'content',
   );
   const appContentHeight = hideProjectNavigation
     ? '[--app-content-h:calc(100dvh_-_56px)]'
     : '[--app-content-h:calc(100dvh_-_96px)]';
-  const isFullBleedFrame = frame === 'data' || frame === 'legacy-full-bleed';
+  const isFullBleedFrame = frame === 'data';
   return (
     <div className="h-screen w-full flex flex-col bg-background-subtle-base">
       <NavBar hideProjectNavigation={hideProjectNavigation} />
@@ -53,13 +47,9 @@ export function MainLayout({
       <main
         className={`${isFullBleedFrame ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'flex-1 overflow-auto'} ${appContentHeight}`}
       >
-        {frame === 'legacy-full-bleed' ? (
+        <div className={frameClassNames[frame]}>
           <Outlet />
-        ) : (
-          <div className={frameClassNames[frame]}>
-            <Outlet />
-          </div>
-        )}
+        </div>
       </main>
     </div>
   );

--- a/libs/client/shell/src/components/user-menu.test.tsx
+++ b/libs/client/shell/src/components/user-menu.test.tsx
@@ -25,7 +25,8 @@ async function openAccountMenu(chrome: Partial<ChromeSlots> = {}) {
   await renderComposedShell({
     features: [accountMenuFeature()],
     initialPath: '/w/workspace/account-menu',
-    resolveImpl: () => defineRoute({component: () => <h1>Account menu</h1>}),
+    resolveImpl: () =>
+      defineRoute({staticData: {frame: 'content'}, component: () => <h1>Account menu</h1>}),
     chrome,
   });
   fireEvent.pointerDown(await screen.findByRole('button', {name: 'User menu'}));

--- a/libs/client/shell/src/runtime/assemble-route-tree.ts
+++ b/libs/client/shell/src/runtime/assemble-route-tree.ts
@@ -4,6 +4,7 @@ import type {RouteParentId} from '#contract.js';
 import {routePathForParent} from '#runtime/anchor-paths.js';
 import {buildAnchorSkeleton} from '#runtime/anchors.js';
 import type {RouteImpl} from '#runtime/define-route.js';
+import {assertRouteFrame} from '#runtime/route-frame.js';
 
 export type ResolveRouteImpl = (specifier: string) => RouteImpl | Promise<RouteImpl>;
 
@@ -61,6 +62,7 @@ export async function assembleRouteTree(
 
   for (const layout of layouts) {
     const impl = await options.resolveImpl(layout.impl);
+    assertRouteFrame(impl.options.staticData, layout.impl, layout.path);
     const parentRoute = isShellAnchor(layout.parent)
       ? skeleton.anchors[layout.parent]
       : layoutRoutes.get(layout.parent);
@@ -78,6 +80,7 @@ export async function assembleRouteTree(
   const routeEntries: Array<{parent: RouteParentId; route: AnyRoute}> = await Promise.all(
     routes.map(async (route) => {
       const impl = await options.resolveImpl(route.impl);
+      assertRouteFrame(impl.options.staticData, route.impl, route.path);
       const parentRoute = isShellAnchor(route.parent)
         ? skeleton.anchors[route.parent]
         : layoutRoutes.get(route.parent);

--- a/libs/client/shell/src/runtime/assemble-route-tree.ts
+++ b/libs/client/shell/src/runtime/assemble-route-tree.ts
@@ -4,7 +4,7 @@ import type {RouteParentId} from '#contract.js';
 import {routePathForParent} from '#runtime/anchor-paths.js';
 import {buildAnchorSkeleton} from '#runtime/anchors.js';
 import type {RouteImpl} from '#runtime/define-route.js';
-import {assertRouteFrame} from '#runtime/route-frame.js';
+import {assertRouteImplFrame} from '#runtime/route-frame.js';
 
 export type ResolveRouteImpl = (specifier: string) => RouteImpl | Promise<RouteImpl>;
 
@@ -62,7 +62,7 @@ export async function assembleRouteTree(
 
   for (const layout of layouts) {
     const impl = await options.resolveImpl(layout.impl);
-    assertRouteFrame(impl.options.staticData, layout.impl, layout.path);
+    assertRouteImplFrame(impl, layout.impl, layout.path);
     const parentRoute = isShellAnchor(layout.parent)
       ? skeleton.anchors[layout.parent]
       : layoutRoutes.get(layout.parent);
@@ -80,7 +80,7 @@ export async function assembleRouteTree(
   const routeEntries: Array<{parent: RouteParentId; route: AnyRoute}> = await Promise.all(
     routes.map(async (route) => {
       const impl = await options.resolveImpl(route.impl);
-      assertRouteFrame(impl.options.staticData, route.impl, route.path);
+      assertRouteImplFrame(impl, route.impl, route.path);
       const parentRoute = isShellAnchor(route.parent)
         ? skeleton.anchors[route.parent]
         : layoutRoutes.get(route.parent);

--- a/libs/client/shell/src/runtime/define-route.test.ts
+++ b/libs/client/shell/src/runtime/define-route.test.ts
@@ -2,7 +2,7 @@ import {defineRoute, isRouteImpl} from './define-route.js';
 
 describe('isRouteImpl', () => {
   test('accepts implementations created by defineRoute', () => {
-    const route = defineRoute({component: () => null});
+    const route = defineRoute({staticData: {frame: 'content'}, component: () => null});
 
     expect(isRouteImpl(route)).toBe(true);
   });
@@ -11,5 +11,10 @@ describe('isRouteImpl', () => {
     const component = () => null;
 
     expect(isRouteImpl(component)).toBe(false);
+  });
+
+  test('requires a shell-owned frame in route options', () => {
+    // @ts-expect-error Route implementations must declare their shell-owned frame.
+    defineRoute({component: () => null});
   });
 });

--- a/libs/client/shell/src/runtime/define-route.ts
+++ b/libs/client/shell/src/runtime/define-route.ts
@@ -1,11 +1,16 @@
 import type {ComponentType} from 'react';
+import type {RouteFrame} from './route-frame.js';
+
+export interface RouteStaticData extends Record<string, unknown> {
+  frame: RouteFrame;
+}
 
 export interface RouteImplOptions {
   component?: ComponentType;
   loader?: unknown;
   validateSearch?: unknown;
   beforeLoad?: unknown;
-  staticData?: unknown;
+  staticData: RouteStaticData;
   pendingComponent?: ComponentType;
   errorComponent?: ComponentType;
 }

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -25,6 +25,7 @@ export * from './define-route.js';
 export * from './last-workspace.js';
 export * from './layout-navigation.js';
 export * from './nav-order.js';
+export * from './route-frame.js';
 export * from './route-inputs.js';
 export * from './router-context.js';
 export * from './search-serialization.js';

--- a/libs/client/shell/src/runtime/registries.test.tsx
+++ b/libs/client/shell/src/runtime/registries.test.tsx
@@ -71,7 +71,8 @@ describe('composition registries', () => {
     await renderComposedShell({
       features,
       initialPath: '/w/workspace/settings/first',
-      resolveImpl: () => defineRoute({component: () => <h1>Settings page</h1>}),
+      resolveImpl: () =>
+        defineRoute({staticData: {frame: 'content'}, component: () => <h1>Settings page</h1>}),
     });
 
     expect(await screen.findByRole('heading', {name: 'Workspace settings'})).toBeVisible();

--- a/libs/client/shell/src/runtime/route-frame.test.ts
+++ b/libs/client/shell/src/runtime/route-frame.test.ts
@@ -1,4 +1,4 @@
-import {assertRouteFrame, isRouteFrame, routeFrames} from './route-frame.js';
+import {assertRouteFrame, assertRouteImplFrame, isRouteFrame, routeFrames} from './route-frame.js';
 
 describe('route frames', () => {
   test('defines the supported shell-owned frames', () => {
@@ -13,11 +13,18 @@ describe('route frames', () => {
   test.each([
     undefined,
     {},
+    {layout: 'full-bleed'},
     {frame: 'full-bleed'},
     {frame: 'content-wide'},
   ])('rejects a route without a supported frame: %j', (staticData) => {
     expect(() => assertRouteFrame(staticData, './route.tsx', '/example')).toThrow(
       'must declare staticData.frame as "content", "data", or "focused".',
+    );
+  });
+
+  test('rejects a module that does not export a defined route', () => {
+    expect(() => assertRouteImplFrame({}, './route.tsx', '/example')).toThrow(
+      'must export default defineRoute(...).',
     );
   });
 });

--- a/libs/client/shell/src/runtime/route-frame.test.ts
+++ b/libs/client/shell/src/runtime/route-frame.test.ts
@@ -1,0 +1,23 @@
+import {assertRouteFrame, isRouteFrame, routeFrames} from './route-frame.js';
+
+describe('route frames', () => {
+  test('defines the supported shell-owned frames', () => {
+    expect(routeFrames).toEqual(['content', 'data', 'focused']);
+    expect(routeFrames.every(isRouteFrame)).toBe(true);
+  });
+
+  test.each(routeFrames)('accepts the %s frame', (frame) => {
+    expect(() => assertRouteFrame({frame}, './route.tsx', '/example')).not.toThrow();
+  });
+
+  test.each([
+    undefined,
+    {},
+    {frame: 'full-bleed'},
+    {frame: 'content-wide'},
+  ])('rejects a route without a supported frame: %j', (staticData) => {
+    expect(() => assertRouteFrame(staticData, './route.tsx', '/example')).toThrow(
+      'must declare staticData.frame as "content", "data", or "focused".',
+    );
+  });
+});

--- a/libs/client/shell/src/runtime/route-frame.ts
+++ b/libs/client/shell/src/runtime/route-frame.ts
@@ -1,3 +1,5 @@
+import {isRouteImpl, type RouteImpl} from './define-route.js';
+
 export const routeFrames = ['content', 'data', 'focused'] as const;
 
 export type RouteFrame = (typeof routeFrames)[number];
@@ -20,4 +22,17 @@ export function assertRouteFrame(
   throw new Error(
     `Route implementation "${impl}" for "${path}" must declare staticData.frame as "content", "data", or "focused".`,
   );
+}
+
+export function assertRouteImplFrame(
+  routeImpl: unknown,
+  impl: string,
+  path: string,
+): asserts routeImpl is RouteImpl {
+  if (!isRouteImpl(routeImpl)) {
+    throw new TypeError(
+      `Route implementation "${impl}" for "${path}" must export default defineRoute(...).`,
+    );
+  }
+  assertRouteFrame(routeImpl.options.staticData, impl, path);
 }

--- a/libs/client/shell/src/runtime/route-frame.ts
+++ b/libs/client/shell/src/runtime/route-frame.ts
@@ -1,0 +1,23 @@
+export const routeFrames = ['content', 'data', 'focused'] as const;
+
+export type RouteFrame = (typeof routeFrames)[number];
+
+export function isRouteFrame(value: unknown): value is RouteFrame {
+  return typeof value === 'string' && (routeFrames as readonly string[]).includes(value);
+}
+
+export function assertRouteFrame(
+  staticData: unknown,
+  impl: string,
+  path: string,
+): asserts staticData is {frame: RouteFrame} {
+  const frame =
+    typeof staticData === 'object' && staticData !== null && 'frame' in staticData
+      ? staticData.frame
+      : undefined;
+  if (isRouteFrame(frame)) return;
+
+  throw new Error(
+    `Route implementation "${impl}" for "${path}" must declare staticData.frame as "content", "data", or "focused".`,
+  );
+}

--- a/libs/client/shell/src/runtime/routes.test.tsx
+++ b/libs/client/shell/src/runtime/routes.test.tsx
@@ -15,7 +15,8 @@ describe('composed routes', () => {
     await renderComposedShell({
       features: [feature],
       initialPath: '/insights',
-      resolveImpl: () => defineRoute({component: () => <h1>Insights</h1>}),
+      resolveImpl: () =>
+        defineRoute({staticData: {frame: 'focused'}, component: () => <h1>Insights</h1>}),
     });
 
     expect(await screen.findByRole('heading', {name: 'Insights'})).toBeVisible();
@@ -38,6 +39,7 @@ describe('composed routes', () => {
       initialPath: '/projects',
       resolveImpl: (specifier) =>
         defineRoute({
+          staticData: {frame: 'focused'},
           component: () => (
             <h1>{specifier === 'override' ? 'Commercial projects' : 'Upstream projects'}</h1>
           ),
@@ -90,6 +92,7 @@ describe('composed routes', () => {
       resolveImpl: (specifier) => {
         if (specifier === 'layout') {
           return defineRoute({
+            staticData: {frame: 'content'},
             component: () => (
               <>
                 <nav aria-label="Administration sections">
@@ -104,7 +107,10 @@ describe('composed routes', () => {
             ),
           });
         }
-        return defineRoute({component: () => <h1>{specifier}</h1>});
+        return defineRoute({
+          staticData: {frame: 'content'},
+          component: () => <h1>{specifier}</h1>,
+        });
       },
     });
 
@@ -158,7 +164,7 @@ describe('composed routes', () => {
     expect(frameContainer).toHaveClass(frameClass);
   });
 
-  test('defaults routes without a declared frame to the content frame', async () => {
+  test('rejects routes without a declared frame', async () => {
     const feature = defineClientFeature({
       id: 'acme.default-frame',
       routes: [
@@ -166,38 +172,14 @@ describe('composed routes', () => {
       ],
     });
 
-    await renderComposedShell({
-      features: [feature],
-      initialPath: '/w/workspace/default-frame',
-      resolveImpl: () => defineRoute({component: () => <h1>Default frame</h1>}),
-    });
-
-    expect(await screen.findByRole('heading', {name: 'Default frame'})).toBeVisible();
-    const main = screen.getByRole('main');
-    expect(main).toHaveClass('overflow-auto');
-    expect(main.firstElementChild).toHaveClass('max-w-[1120px]');
-  });
-
-  test('keeps legacy full-bleed routes on the compatibility frame', async () => {
-    const feature = defineClientFeature({
-      id: 'acme.legacy-frame',
-      routes: [{path: '/w/$workspaceSlug/legacy-frame', parent: 'workspaceLayout', impl: 'legacy'}],
-    });
-
-    await renderComposedShell({
-      features: [feature],
-      initialPath: '/w/workspace/legacy-frame',
-      resolveImpl: () =>
-        defineRoute({
-          staticData: {layout: 'full-bleed'},
-          component: () => <h1>Legacy frame</h1>,
-        }),
-    });
-
-    expect(await screen.findByRole('heading', {name: 'Legacy frame'})).toBeVisible();
-    const main = screen.getByRole('main');
-    expect(main).toHaveClass('overflow-hidden');
-    expect(main.firstElementChild).toBe(screen.getByRole('heading', {name: 'Legacy frame'}));
-    expect(main.firstElementChild).not.toHaveClass('max-w-[1120px]');
+    await expect(
+      renderComposedShell({
+        features: [feature],
+        initialPath: '/w/workspace/default-frame',
+        resolveImpl: () => defineRoute({component: () => <h1>Missing frame</h1>}),
+      }),
+    ).rejects.toThrow(
+      'Route implementation "default" for "/w/$workspaceSlug/default-frame" must declare staticData.frame',
+    );
   });
 });

--- a/libs/client/shell/src/runtime/routes.test.tsx
+++ b/libs/client/shell/src/runtime/routes.test.tsx
@@ -1,5 +1,5 @@
 import {Link, Outlet} from '@tanstack/react-router';
-import {screen} from '@testing-library/react';
+import {screen, within} from '@testing-library/react';
 import {defineClientFeature} from '#contract.js';
 import {renderComposedShell} from '#test/render.js';
 import {defineRoute} from './define-route.js';
@@ -54,32 +54,51 @@ describe('composed routes', () => {
     const features = [
       defineClientFeature({
         id: 'acme.admin',
-        layouts: [{id: 'acme.admin.layout', path: '/admin', parent: 'root', impl: 'layout'}],
+        layouts: [
+          {
+            id: 'acme.admin.layout',
+            path: '/w/$workspaceSlug/admin',
+            parent: 'workspaceLayout',
+            impl: 'layout',
+          },
+        ],
       }),
       defineClientFeature({
         id: 'acme.users',
-        routes: [{path: '/admin/users', parent: 'acme.admin.layout', impl: 'users'}],
+        routes: [
+          {
+            path: '/w/$workspaceSlug/admin/users',
+            parent: 'acme.admin.layout',
+            impl: 'users',
+          },
+        ],
         navigation: [
           {
             id: 'admin.users',
             scope: 'layout',
             layout: 'acme.admin.layout',
             label: 'Users',
-            to: '/admin/users',
+            to: '/w/$workspaceSlug/admin/users',
             order: 200,
           },
         ],
       }),
       defineClientFeature({
         id: 'acme.overview',
-        routes: [{path: '/admin/overview', parent: 'acme.admin.layout', impl: 'overview'}],
+        routes: [
+          {
+            path: '/w/$workspaceSlug/admin/overview',
+            parent: 'acme.admin.layout',
+            impl: 'overview',
+          },
+        ],
         navigation: [
           {
             id: 'admin.overview',
             scope: 'layout',
             layout: 'acme.admin.layout',
             label: 'Overview',
-            to: '/admin/overview',
+            to: '/w/$workspaceSlug/admin/overview',
             order: 100,
           },
         ],
@@ -88,11 +107,11 @@ describe('composed routes', () => {
 
     await renderComposedShell({
       features,
-      initialPath: '/admin/users',
+      initialPath: '/w/workspace/admin/users',
       resolveImpl: (specifier) => {
         if (specifier === 'layout') {
           return defineRoute({
-            staticData: {frame: 'content'},
+            staticData: {frame: 'data'},
             component: () => (
               <>
                 <nav aria-label="Administration sections">
@@ -114,11 +133,14 @@ describe('composed routes', () => {
       },
     });
 
-    expect((await screen.findAllByRole('link')).map((link) => link.textContent)).toEqual([
-      'Overview',
-      'Users',
-    ]);
+    const sectionLinks = within(
+      await screen.findByRole('navigation', {name: 'Administration sections'}),
+    ).getAllByRole('link');
+    expect(sectionLinks.map((link) => link.textContent)).toEqual(['Overview', 'Users']);
     expect(await screen.findByRole('heading', {name: 'users'})).toBeVisible();
+    const main = await screen.findByRole('main');
+    expect(main).toHaveClass('overflow-auto');
+    expect(main.firstElementChild).toHaveClass('max-w-[1120px]');
   });
 
   test.each([
@@ -176,7 +198,7 @@ describe('composed routes', () => {
       renderComposedShell({
         features: [feature],
         initialPath: '/w/workspace/default-frame',
-        resolveImpl: () => defineRoute({component: () => <h1>Missing frame</h1>}),
+        resolveImpl: () => defineRoute({component: () => <h1>Missing frame</h1>} as never),
       }),
     ).rejects.toThrow(
       'Route implementation "default" for "/w/$workspaceSlug/default-frame" must declare staticData.frame',

--- a/libs/client/shell/src/vite/generate.ts
+++ b/libs/client/shell/src/vite/generate.ts
@@ -164,13 +164,14 @@ export function generateAppModule({
 // biome-ignore-all format: generated code has stable, reviewable output.
 // biome-ignore-all assist/source/organizeImports: generated imports follow route order.
 import {createRoute, createRouter} from '@tanstack/react-router';
-import {buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
+import {assertRouteFrame, buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
 ${imports}
 
 function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: string): T['options'] {
   if (!isRouteImpl(routeImpl)) {
     throw new TypeError(\`Route implementation "\${impl}" for "\${path}" must export default defineRoute(...).\`);
   }
+  assertRouteFrame(routeImpl.options.staticData, impl, path);
   return routeImpl.options;
 }
 

--- a/libs/client/shell/src/vite/generate.ts
+++ b/libs/client/shell/src/vite/generate.ts
@@ -164,14 +164,11 @@ export function generateAppModule({
 // biome-ignore-all format: generated code has stable, reviewable output.
 // biome-ignore-all assist/source/organizeImports: generated imports follow route order.
 import {createRoute, createRouter} from '@tanstack/react-router';
-import {assertRouteFrame, buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
+import {assertRouteImplFrame, buildAnchorSkeleton, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
 ${imports}
 
 function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: string): T['options'] {
-  if (!isRouteImpl(routeImpl)) {
-    throw new TypeError(\`Route implementation "\${impl}" for "\${path}" must export default defineRoute(...).\`);
-  }
-  assertRouteFrame(routeImpl.options.staticData, impl, path);
+  assertRouteImplFrame(routeImpl, impl, path);
   return routeImpl.options;
 }
 

--- a/libs/client/shell/test/default-route-impl.tsx
+++ b/libs/client/shell/test/default-route-impl.tsx
@@ -1,3 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 
-export default defineRoute({component: () => <div>Default route</div>});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: () => <div>Default route</div>,
+});

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-layout.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-layout.tsx
@@ -18,4 +18,7 @@ function ExternalAdminLayout() {
   );
 }
 
-export default defineRoute({component: ExternalAdminLayout});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: ExternalAdminLayout,
+});

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-overview.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-overview.tsx
@@ -1,3 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 
-export default defineRoute({component: () => <h1>External administration overview</h1>});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: () => <h1>External administration overview</h1>,
+});

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-users.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-users.tsx
@@ -1,3 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 
-export default defineRoute({component: () => <h1>External administration users</h1>});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: () => <h1>External administration users</h1>,
+});

--- a/libs/client/shell/test/external/fixture/src/features/external-settings.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-settings.tsx
@@ -14,6 +14,6 @@ function ExternalSettings() {
   );
 }
 
-const route = defineRoute({component: ExternalSettings});
+const route = defineRoute({staticData: {frame: 'content'}, component: ExternalSettings});
 
 export default route;

--- a/libs/client/shell/test/external/fixture/src/features/login-override.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/login-override.tsx
@@ -4,6 +4,6 @@ function ExternalLogin() {
   return <h1>External login</h1>;
 }
 
-const route = defineRoute({component: ExternalLogin});
+const route = defineRoute({staticData: {frame: 'focused'}, component: ExternalLogin});
 
 export default route;

--- a/libs/client/shell/test/named-route-impl.tsx
+++ b/libs/client/shell/test/named-route-impl.tsx
@@ -1,3 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 
-export default defineRoute({component: () => <div>Named route</div>});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: () => <div>Named route</div>,
+});

--- a/libs/client/shell/test/search-route-impl.tsx
+++ b/libs/client/shell/test/search-route-impl.tsx
@@ -1,6 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   component: () => <div>Search route</div>,
   validateSearch: (search: Record<string, unknown>) =>
     ({tab: search.tab === 'activity' ? 'activity' : 'overview'}) as const,

--- a/libs/client/shell/test/typecheck/shipfox-app.gen.ts
+++ b/libs/client/shell/test/typecheck/shipfox-app.gen.ts
@@ -2,16 +2,13 @@
 // biome-ignore-all format: generated code has stable, reviewable output.
 // biome-ignore-all assist/source/organizeImports: generated imports follow route order.
 import {createRoute, createRouter} from '@tanstack/react-router';
-import {assertRouteFrame, buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
+import {assertRouteImplFrame, buildAnchorSkeleton, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
 import * as route0Module from "#test/search-route-impl.js";
 import * as route1Module from "#test/default-route-impl.js";
 import * as route2Module from "#test/named-route-impl.js";
 
 function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: string): T['options'] {
-  if (!isRouteImpl(routeImpl)) {
-    throw new TypeError(`Route implementation "${impl}" for "${path}" must export default defineRoute(...).`);
-  }
-  assertRouteFrame(routeImpl.options.staticData, impl, path);
+  assertRouteImplFrame(routeImpl, impl, path);
   return routeImpl.options;
 }
 

--- a/libs/client/shell/test/typecheck/shipfox-app.gen.ts
+++ b/libs/client/shell/test/typecheck/shipfox-app.gen.ts
@@ -2,7 +2,7 @@
 // biome-ignore-all format: generated code has stable, reviewable output.
 // biome-ignore-all assist/source/organizeImports: generated imports follow route order.
 import {createRoute, createRouter} from '@tanstack/react-router';
-import {buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
+import {assertRouteFrame, buildAnchorSkeleton, isRouteImpl, parseAppSearch, stringifyAppSearch, type RouteImpl, type RouterContext} from '@shipfox/client-shell/runtime';
 import * as route0Module from "#test/search-route-impl.js";
 import * as route1Module from "#test/default-route-impl.js";
 import * as route2Module from "#test/named-route-impl.js";
@@ -11,6 +11,7 @@ function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: str
   if (!isRouteImpl(routeImpl)) {
     throw new TypeError(`Route implementation "${impl}" for "${path}" must export default defineRoute(...).`);
   }
+  assertRouteFrame(routeImpl.options.staticData, impl, path);
   return routeImpl.options;
 }
 

--- a/libs/client/triggers/src/routes/events-settings.tsx
+++ b/libs/client/triggers/src/routes/events-settings.tsx
@@ -15,6 +15,7 @@ function validateSearch(search: Record<string, unknown>): TriggerEventsSearch {
 }
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   validateSearch,
   component: () => {
     const workspace = useActiveWorkspace();

--- a/libs/client/workflows/src/routes/job-detail.tsx
+++ b/libs/client/workflows/src/routes/job-detail.tsx
@@ -4,7 +4,7 @@ import {validateWorkflowJobSearch, workflowJobRouteParams} from './inputs.js';
 import {ProjectRoute} from './project-route.js';
 
 export default defineRoute({
-  staticData: {layout: 'full-bleed'},
+  staticData: {frame: 'data'},
   validateSearch: validateWorkflowJobSearch,
   component: () => {
     const {workspaceSlug, projectSlug, workflowRunId, jobId} =

--- a/libs/client/workflows/src/routes/run-detail.tsx
+++ b/libs/client/workflows/src/routes/run-detail.tsx
@@ -4,7 +4,7 @@ import {validateWorkflowRunsSearch, workflowRouteParams} from './inputs.js';
 import {ProjectRoute} from './project-route.js';
 
 export default defineRoute({
-  staticData: {layout: 'full-bleed'},
+  staticData: {frame: 'data'},
   validateSearch: validateWorkflowRunsSearch,
   component: () => {
     const {workspaceSlug, projectSlug, workflowRunId} = useRouteParams(workflowRouteParams);

--- a/libs/client/workflows/src/routes/runs.tsx
+++ b/libs/client/workflows/src/routes/runs.tsx
@@ -4,7 +4,7 @@ import {validateWorkflowRunsSearch, workflowRouteParams} from './inputs.js';
 import {ProjectRoute} from './project-route.js';
 
 export default defineRoute({
-  staticData: {layout: 'full-bleed'},
+  staticData: {frame: 'data'},
   validateSearch: validateWorkflowRunsSearch,
   component: () => {
     const {workspaceSlug, projectSlug} = useRouteParams(workflowRouteParams);

--- a/libs/client/workflows/src/routes/workflows.tsx
+++ b/libs/client/workflows/src/routes/workflows.tsx
@@ -3,6 +3,7 @@ import {ProjectWorkflowsPage} from '#pages/project-workflows-page.js';
 import {ProjectRoute} from './project-route.js';
 
 export default defineRoute({
+  staticData: {frame: 'data'},
   component: () => {
     return (
       <ProjectRoute>{(project) => <ProjectWorkflowsPage projectId={project.id} />}</ProjectRoute>

--- a/libs/client/workspace-settings/src/routes/general.tsx
+++ b/libs/client/workspace-settings/src/routes/general.tsx
@@ -1,4 +1,7 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {GeneralSettingsPage} from '#pages/general-settings-page.js';
 
-export default defineRoute({component: GeneralSettingsPage});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: GeneralSettingsPage,
+});

--- a/libs/client/workspace-settings/src/routes/index.tsx
+++ b/libs/client/workspace-settings/src/routes/index.tsx
@@ -2,6 +2,7 @@ import {defineRoute} from '@shipfox/client-shell/runtime';
 import {redirect} from '@tanstack/react-router';
 
 export default defineRoute({
+  staticData: {frame: 'content'},
   beforeLoad: ({params}: {params: {workspaceSlug: string}}) => {
     throw redirect({
       to: '/w/$workspaceSlug/settings/members',

--- a/libs/client/workspace-settings/src/routes/members.tsx
+++ b/libs/client/workspace-settings/src/routes/members.tsx
@@ -1,3 +1,6 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {MembersSettingsPage} from '#pages/members-settings-page.js';
-export default defineRoute({component: MembersSettingsPage});
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: MembersSettingsPage,
+});


### PR DESCRIPTION
Make page frames an explicit contract for every composed client route.

The shell now validates `staticData.frame` during generated route loading and runtime composition, so missing or unsupported frames fail with an actionable error instead of silently falling back to content. All 39 production route implementations declare the intended `content`, `data`, or `focused` frame, and the legacy full-bleed workflow metadata is migrated to `data`.

The public `@shipfox/client-shell` contract is documented in ADR 0001 and covered by a major Changeset. The route-frame validation shape follows the adjacent ENG-1594 architecture work so the two changes remain compatible.

Closes ENG-1582

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit `staticData.frame` on every composed route in `@shipfox/client-shell` and validate it during codegen and runtime to standardize layout and fail fast. Legacy `layout: 'full-bleed'` is removed; use `frame: 'data'`. Closes ENG-1582 and aligns with ENG-1594.

- **New Features**
  - Added `RouteFrame`, `routeFrames`, `assertRouteFrame`, and `assertRouteImplFrame`; generator and runtime now verify frames for routes and layouts.
  - `defineRoute` now requires `staticData.frame` (typed); tests cover accepted/rejected frames.
  - `MainLayout` supports only `content`, `data`, `focused`.
  - Added ADR 0012; updated ADR index and added amendment link in ADR 0001; generated `shipfox-app.gen.ts` uses `assertRouteImplFrame`.

- **Migration**
  - Add `staticData.frame` to every route: `content`, `data`, or `focused`.
  - Replace `staticData.layout: 'full-bleed'` with `staticData.frame: 'data'`.
  - Missing/invalid frames throw with an error naming the impl and path.
  - Major changeset published for `@shipfox/client-shell`.

<sup>Written for commit dc0c60d496ff489cf5693190d9df58094ba216b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

