### PR TITLE
Document and verify the shared workspace setup contract

### DIFF
--- a/docs/guides/local-development-and-release-workflow.md
+++ b/docs/guides/local-development-and-release-workflow.md
@@ -45,8 +45,10 @@ checks.
 
 ## Prepare an agent workspace
 
-Agent workspaces use two stable repository entrypoints after `mise` is
-available:
+Agent workspaces use two stable repository entrypoints after the host installs
+`mise`. [mise.toml](../../mise.toml) and
+[dev/workspace-setup.sh](../../dev/workspace-setup.sh) own their executable
+behavior.
 
 | Need | Command | Result |
 | --- | --- | --- |
@@ -54,9 +56,21 @@ available:
 | Run a read-only job, such as PR review. | `mise run --yes workspace:setup:context` | Installs pinned tools, frozen dependencies, and repository context. It starts no service or shared Ollama. |
 
 The full command depends on the context command. Both commands are
-non-interactive and safe to rerun after a partial failure.
+non-interactive. A rerun normally reconciles the prepared state. The
+[Shared Ollama](#shared-ollama) section documents the manual recovery exception.
 
-The environment selects the setup profile without changing either command:
+Profile selection uses the first matching signal:
+
+1. `SHIPFOX_SETUP_PROFILE` explicitly selects `conductor-local`,
+   `conductor-cloud`, `workflow`, or `developer`.
+2. `CONDUCTOR_IS_LOCAL=1` selects `conductor-local`.
+   `CONDUCTOR_IS_LOCAL=0` selects `conductor-cloud`.
+3. `SHIPFOX_WORKSPACE` selects `workflow`.
+4. No matching signal selects `developer`.
+
+Conductor supplies `CONDUCTOR_IS_LOCAL`. Workflow hosts supply
+`SHIPFOX_WORKSPACE`. Use the explicit override only to emulate a supported
+profile.
 
 | Environment | Full setup behavior |
 | --- | --- |
@@ -65,16 +79,28 @@ The environment selects the setup profile without changing either command:
 | Ephemeral workflow | Starts worktree services without starting shared Ollama. |
 | Direct developer invocation | Starts worktree services and the shared Shipfox Ollama service. |
 
-The host must provide `mise`. Service-starting workflow hosts must also provide
-Docker and Docker Compose. Workflow host provisioning stays outside these
+The host must provide `mise` 2026.5.18 or newer, matching the minimum in
+`mise.toml`. Service-starting profiles also require Docker, Docker Compose, and
+a running Docker daemon. Workflow host provisioning stays outside these
 repository commands.
+
+These commands execute branch-controlled mise tasks, setup scripts, and
+dependency lifecycle scripts. Treat a checked-out review branch as executable
+code. Run read-only PR jobs in an isolated sandbox without mounted credentials,
+copied secrets, or access to trusted host state.
 
 Setup does not copy secrets, certificates, or static ignored files. Use
 Conductor Files to Copy, `.worktreeinclude`, or the existing environment
-provisioning mechanism for those files.
+provisioning mechanism only for trusted, non-review workspaces.
 
-Service cleanup also stays outside setup. Conductor archive hooks continue to
-run `mise exec -- pnpm dev:services:destroy` for local workspaces.
+Local profiles share one Ollama state directory under the repository root.
+Avoid concurrent cold starts or stop operations until one setup reports the
+shared service as healthy.
+
+Service cleanup also stays outside setup. Conductor archive hooks run
+`mise exec -- pnpm dev:services:destroy` for local workspaces. A workflow must
+use a disposable host or run the same destroy command at the end of its job.
+Persistent hosts can use the status and stop commands below before cleanup.
 
 ## Docker services and Conductor worktrees
 

--- a/docs/guides/local-development-and-release-workflow.md
+++ b/docs/guides/local-development-and-release-workflow.md
@@ -43,6 +43,39 @@ If you add, update, or exempt a dependency, read the
 catalog rules, exceptions, package families, and the required dependency
 checks.
 
+## Prepare an agent workspace
+
+Agent workspaces use two stable repository entrypoints after `mise` is
+available:
+
+| Need | Command | Result |
+| --- | --- | --- |
+| Build, run, or test the code. | `mise run --yes workspace:setup` | Installs pinned tools, frozen dependencies, repository context, the test browser, and profile-required services. |
+| Run a read-only job, such as PR review. | `mise run --yes workspace:setup:context` | Installs pinned tools, frozen dependencies, and repository context. It starts no service or shared Ollama. |
+
+The full command depends on the context command. Both commands are
+non-interactive and safe to rerun after a partial failure.
+
+The environment selects the setup profile without changing either command:
+
+| Environment | Full setup behavior |
+| --- | --- |
+| Local Conductor workspace | Starts worktree services and the shared Shipfox Ollama service. |
+| Conductor cloud workspace | Prepares dependencies and context without starting services. |
+| Ephemeral workflow | Starts worktree services without starting shared Ollama. |
+| Direct developer invocation | Starts worktree services and the shared Shipfox Ollama service. |
+
+The host must provide `mise`. Service-starting workflow hosts must also provide
+Docker and Docker Compose. Workflow host provisioning stays outside these
+repository commands.
+
+Setup does not copy secrets, certificates, or static ignored files. Use
+Conductor Files to Copy, `.worktreeinclude`, or the existing environment
+provisioning mechanism for those files.
+
+Service cleanup also stays outside setup. Conductor archive hooks continue to
+run `mise exec -- pnpm dev:services:destroy` for local workspaces.
+
 ## Docker services and Conductor worktrees
 
 A normal checkout uses the repository Docker Compose stack:


### PR DESCRIPTION
Document the two stable workspace setup entrypoints and their profile, host-provisioning, service, cleanup, and ignored-file boundaries in the local development guide.

The cross-repository verification used isolated fresh Shipfox and Cloud checkouts. Both context and full commands passed fresh runs and reruns. Local profiles reached healthy worktree services, Cloud generated its pinned guidance, workflow profiles started no shared Ollama, and cloud profiles created no service state. Consumer checks also confirmed that Conductor and implementation jobs use the same full command while read-only review jobs use the context-only command.

Detailed dated evidence, timings, revisions, prerequisite failures, and the Conductor cloud profile-simulation boundary are recorded in the shared Linear setup plan.

Closes ENG-1547

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and verifies the shared workspace setup contract across Shipfox and Cloud (ENG-1547). Defines two stable entrypoints, profile-selection signals, host prerequisites (`mise` min and Docker for service profiles), and safety bounds for secrets/ignored files, shared Ollama, and workflow cleanup.

- **Migration**
  - Read-only jobs: `mise run --yes workspace:setup:context`
  - Build/run/test jobs: `mise run --yes workspace:setup`

<sup>Written for commit f8ecc8433eb82c18387be10a7c1a7601564c8f33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

