### PR TITLE
[react-ui] Add the Panel surface primitive

### DIFF
--- a/.changeset/quiet-panel-primitive.md
+++ b/.changeset/quiet-panel-primitive.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds the Panel surface primitive with header, body, row, and empty-state components.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -147,13 +147,11 @@ change.
 The one exception is the surface, frame, and panel model. It is described under
 [Layout](#layout), [Elevation and depth](#elevation-and-depth), and
 [Panels](#panels), and recorded in the `panel`, `panel-header`, and `panel-row`
-frontmatter entries. That model is committed, and `@shipfox/react-ui` is being
-brought onto it. Read those sections as the target a change should move toward,
-not as a description of what ships today.
+frontmatter entries. `@shipfox/react-ui` exposes the panel primitive, and the
+remaining page migrations are bringing callers onto the model.
 
-Two consequences while the work lands. `Panel` does not exist yet, and `Card`
-still ships in its place. One surface token still resolves to a value other than
-the ones the ladder names, and
+`Card` still ships for compatibility while its consumers migrate to `Panel`. One
+surface token still resolves to a value other than the ones the ladder names, and
 [The surface ladder](#the-surface-ladder) lists it.
 
 ## Overview
@@ -525,12 +523,12 @@ building anything: `accordion`, `alert`, `avatar`, `badge`, `button`, `calendar`
 `callout`, `card`, `code-block`, `collapsible`, `combobox`, `command`,
 `date-picker`, `date-range-picker`, `dot`, `dropdown-menu`, `empty-state`,
 `form-field`, `icon`, `input`, `kbd`, `label`, `load-error-state`, `loader`, `log`,
-`logo`, `markdown`, `modal`, `popover`, `radio-group`, `relative-time`,
+`logo`, `markdown`, `modal`, `panel`, `popover`, `radio-group`, `relative-time`,
 `scroll-area`, `search`, `select`, `sheet`, `shiny-text`, `skeleton`, `table`,
 `tabs`, `theme`, `toast`, `tooltip`, and `typography`.
 
-`Panel` is landing and replaces `Card`. Until it ships, `Card` remains the
-container in code, and [Panels](#panels) describes the target.
+`Panel` is the container for a data region. `Card` remains available for
+compatibility while its consumers migrate to `Panel`.
 
 ### Buttons
 
@@ -558,11 +556,7 @@ container in code, and [Panels](#panels) describes the target.
 
 ### Panels
 
-**This section is the target, not what ships.** `Panel` does not exist in
-`@shipfox/react-ui` yet, and `Card` is still the exported container. Do not import
-`Panel` until the package ships it.
-
-`Panel` becomes the only container for a data region, replacing `Card`. It
+`Panel` is the only container for a data region, replacing `Card`. It
 composes `PanelHeader`, `PanelTitle`, `PanelActions`, `PanelBody`, `PanelRow`,
 and `PanelEmpty`.
 

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -4,7 +4,7 @@ Shared React component library for Shipfox apps. It provides design tokens, Tail
 
 ## What it does
 
-- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Callout, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Markdown, Modal, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Switch, Table, Tabs, Textarea, ThemeProvider, Toast, Tooltip, and Typography.
+- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Callout, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Markdown, Modal, Panel, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Switch, Table, Tabs, Textarea, ThemeProvider, Toast, Tooltip, and Typography.
 - **Theme helpers**: `ThemeProvider`, `useTheme()`, and `useResolvedTheme()`.
 - **Hooks**: `useCopyToClipboard`, `useIsTextTruncated`, `useShikiHighlight`, `useShikiStyleInjection`, plus the theme hooks above.
 - **Utilities**: `cn()` for class name merging, `copyTextToClipboard`, `formatBytes`, `formatDate`/`formatTimestamp`, `formatDuration`/`humanDuration`, `formatRelative`, `debounce`, and avatar helpers (`getInitial`, `getPlaceholderImageUrl`).
@@ -78,22 +78,26 @@ export function AppRoot() {
 ## Usage
 
 ```tsx
-import {Button} from '@shipfox/react-ui/button';
-import {Card, CardContent, CardTitle} from '@shipfox/react-ui/card';
-import {Text} from '@shipfox/react-ui/typography';
+import {Panel, PanelBody, PanelHeader, PanelRow, PanelTitle} from '@shipfox/react-ui/panel';
 
-export function EmptyState() {
+export function ProjectList() {
   return (
-    <Card>
-      <CardTitle>No projects yet</CardTitle>
-      <CardContent>
-        <Text size="sm">Create a project to start running workflows.</Text>
-      </CardContent>
-      <Button iconLeft="plus">Create project</Button>
-    </Card>
+    <Panel>
+      <PanelHeader>
+        <PanelTitle>Projects</PanelTitle>
+      </PanelHeader>
+      <PanelBody>
+        <PanelRow>Shipfox</PanelRow>
+      </PanelBody>
+    </Panel>
   );
 }
 ```
+
+`Panel` is the shared container for a data region. Use `PanelRow` for rows and
+keep panels flat. Rows use a neutral hover surface, and status stays in glyphs or
+pills. Use `PanelHeader` with `variant="plain"` for a titled block on a focused
+surface.
 
 `FormField` wires up label, input, error, and description with the correct `id`, `aria-invalid`, and `aria-describedby` plumbing. Render controls through `FormFieldInput` or `FormFieldTextarea` to inherit those props automatically:
 

--- a/libs/shared/react/ui/src/components/index.ts
+++ b/libs/shared/react/ui/src/components/index.ts
@@ -26,6 +26,7 @@ export * from './log/index.js';
 export * from './logo/index.js';
 export * from './markdown/index.js';
 export * from './modal/index.js';
+export * from './panel/index.js';
 export * from './popover/index.js';
 export * from './radio-group/index.js';
 export * from './relative-time/index.js';

--- a/libs/shared/react/ui/src/components/panel/index.ts
+++ b/libs/shared/react/ui/src/components/panel/index.ts
@@ -1,0 +1,1 @@
+export * from './panel.js';

--- a/libs/shared/react/ui/src/components/panel/panel.stories.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.stories.tsx
@@ -1,0 +1,121 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {StatusBadge} from '#components/badge/index.js';
+import {Button} from '#components/button/index.js';
+import {Code, Text} from '#components/typography/index.js';
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelEmpty,
+  PanelHeader,
+  PanelRow,
+  PanelTitle,
+} from './panel.js';
+
+const headerVariants = ['strip', 'plain'] as const;
+
+const workflows = [
+  {
+    name: 'Deploy production',
+    path: '.shipfox/workflows/deploy.yml',
+    status: 'Succeeded',
+    statusVariant: 'success' as const,
+  },
+  {
+    name: 'Nightly verification',
+    path: '.shipfox/workflows/nightly.yml',
+    status: 'Syncing',
+    statusVariant: 'info' as const,
+  },
+  {
+    name: 'Release candidate',
+    path: '.shipfox/workflows/release.yml',
+    status: 'Failed',
+    statusVariant: 'error' as const,
+  },
+];
+
+const meta = {
+  title: 'Components/Panel',
+  component: Panel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Panel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: () => (
+    <Panel className="w-640">
+      <PanelHeader>
+        <PanelTitle>Workflow runs</PanelTitle>
+        <PanelActions>
+          <Button size="sm">New run</Button>
+        </PanelActions>
+      </PanelHeader>
+      <PanelBody>
+        {workflows.map((workflow) => (
+          <PanelRow key={workflow.path}>
+            <div className="min-w-0">
+              <Text size="sm" bold className="truncate">
+                {workflow.name}
+              </Text>
+              <Code variant="label" className="truncate text-foreground-neutral-subtle">
+                {workflow.path}
+              </Code>
+            </div>
+            <StatusBadge variant={workflow.statusVariant}>{workflow.status}</StatusBadge>
+          </PanelRow>
+        ))}
+      </PanelBody>
+    </Panel>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex w-640 flex-col gap-24">
+      {headerVariants.map((variant) => (
+        <Panel key={variant}>
+          <PanelHeader variant={variant}>
+            <PanelTitle>{variant === 'strip' ? 'Strip header' : 'Plain header'}</PanelTitle>
+          </PanelHeader>
+          <PanelBody>
+            <PanelRow>
+              <Text size="sm">Rows keep the panel surface and use internal hairlines.</Text>
+            </PanelRow>
+          </PanelBody>
+        </Panel>
+      ))}
+    </div>
+  ),
+};
+
+export const Compositions: Story = {
+  render: () => (
+    <div className="flex w-640 flex-col gap-24">
+      <Panel>
+        <PanelHeader variant="plain">
+          <PanelTitle>Recent deployments</PanelTitle>
+          <PanelActions>
+            <Button size="sm" variant="secondary">
+              View all
+            </Button>
+          </PanelActions>
+        </PanelHeader>
+        <PanelBody>
+          <PanelEmpty>No deployments yet</PanelEmpty>
+        </PanelBody>
+      </Panel>
+      <Panel>
+        <PanelBody>
+          <PanelEmpty compact>No filtered results</PanelEmpty>
+        </PanelBody>
+      </Panel>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -1,0 +1,74 @@
+import {render} from '@testing-library/react';
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelEmpty,
+  PanelHeader,
+  PanelRow,
+  PanelTitle,
+} from './panel.js';
+
+describe('Panel', () => {
+  test('renders the bordered panel shell and composes its regions', () => {
+    const {container} = render(
+      <Panel data-testid="panel">
+        <PanelHeader>
+          <PanelTitle>Runs</PanelTitle>
+          <PanelActions>New run</PanelActions>
+        </PanelHeader>
+        <PanelBody>
+          <PanelRow>Run one</PanelRow>
+          <PanelRow>Run two</PanelRow>
+        </PanelBody>
+      </Panel>,
+    );
+
+    const panel = container.querySelector('[data-slot="panel"]');
+    const header = container.querySelector('[data-slot="panel-header"]');
+    const rows = container.querySelectorAll('[data-slot="panel-row"]');
+
+    expect(panel?.classList.contains('rounded-8')).toBe(true);
+    expect(panel?.classList.contains('border-border-neutral-base')).toBe(true);
+    expect(header?.getAttribute('data-variant')).toBe('strip');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
+  });
+
+  test('uses a plain header without the strip divider', () => {
+    const {container} = render(
+      <Panel>
+        <PanelHeader variant="plain">Configuration</PanelHeader>
+      </Panel>,
+    );
+
+    const header = container.querySelector('[data-slot="panel-header"]');
+
+    expect(header?.getAttribute('data-variant')).toBe('plain');
+    expect(header?.classList.contains('bg-background-neutral-base')).toBe(true);
+    expect(header?.classList.contains('border-b')).toBe(false);
+  });
+
+  test('removes the divider from the final row and supports compact empty content', () => {
+    const {container} = render(
+      <>
+        <Panel>
+          <PanelBody>
+            <PanelRow>Only row</PanelRow>
+          </PanelBody>
+        </Panel>
+        <Panel>
+          <PanelBody>
+            <PanelEmpty compact>No runs</PanelEmpty>
+          </PanelBody>
+        </Panel>
+      </>,
+    );
+
+    const row = container.querySelector('[data-slot="panel-row"]');
+    const empty = container.querySelector('[data-slot="panel-empty"]');
+
+    expect(row?.classList.contains('last:border-b-0')).toBe(true);
+    expect(empty?.classList.contains('p-panel-compact')).toBe(true);
+  });
+});

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -1,0 +1,116 @@
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+import {Header} from '../typography/index.js';
+
+/** A bordered data region. A panel never contains another panel. */
+export interface PanelProps extends ComponentProps<'div'> {}
+
+export function Panel({className, ...props}: PanelProps) {
+  return (
+    <div
+      data-slot="panel"
+      className={cn(
+        'flex min-w-0 flex-col overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base text-foreground-neutral-base shadow-button-neutral',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type PanelHeaderVariant = 'strip' | 'plain';
+
+export interface PanelHeaderProps extends ComponentProps<'div'> {
+  /** Use `plain` for a titled block on a focused surface without a header strip. */
+  variant?: PanelHeaderVariant;
+}
+
+export function PanelHeader({className, variant = 'strip', ...props}: PanelHeaderProps) {
+  return (
+    <div
+      data-slot="panel-header"
+      data-variant={variant}
+      className={cn(
+        'flex min-w-0 items-center justify-between gap-group',
+        variant === 'strip'
+          ? 'min-h-48 border-b border-border-neutral-base bg-background-subtle-base px-row py-row'
+          : 'bg-background-neutral-base p-panel',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface PanelTitleProps extends ComponentProps<typeof Header> {}
+
+export function PanelTitle({className, children, variant = 'h3', ...props}: PanelTitleProps) {
+  return (
+    <Header
+      data-slot="panel-title"
+      variant={variant}
+      className={cn('min-w-0 truncate text-foreground-neutral-base', className)}
+      {...props}
+    >
+      {children}
+    </Header>
+  );
+}
+
+export interface PanelActionsProps extends ComponentProps<'div'> {}
+
+export function PanelActions({className, ...props}: PanelActionsProps) {
+  return (
+    <div
+      data-slot="panel-actions"
+      className={cn('ml-auto flex shrink-0 items-center gap-inline', className)}
+      {...props}
+    />
+  );
+}
+
+export interface PanelBodyProps extends ComponentProps<'div'> {}
+
+export function PanelBody({className, ...props}: PanelBodyProps) {
+  return (
+    <div
+      data-slot="panel-body"
+      className={cn('flex min-w-0 flex-col bg-background-neutral-base', className)}
+      {...props}
+    />
+  );
+}
+
+export interface PanelRowProps extends ComponentProps<'div'> {}
+
+export function PanelRow({className, ...props}: PanelRowProps) {
+  return (
+    <div
+      data-slot="panel-row"
+      className={cn(
+        'flex min-h-44 min-w-0 items-center justify-between gap-group border-b border-border-neutral-base bg-background-neutral-base px-row py-row text-foreground-neutral-base transition-colors last:border-b-0 hover:bg-background-neutral-hover',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface PanelEmptyProps extends ComponentProps<'div'> {
+  /** Use compact padding when the empty content is already visually dense. */
+  compact?: boolean;
+}
+
+export function PanelEmpty({className, compact = false, ...props}: PanelEmptyProps) {
+  return (
+    <div
+      data-slot="panel-empty"
+      className={cn(
+        'flex min-h-120 items-center justify-center text-center',
+        compact ? 'p-panel-compact' : 'p-panel',
+        className,
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
Adds the shared Panel surface primitive to @shipfox/react-ui for data regions. The component family follows the committed surface token, header variant, row divider, and hover rules.

Updates the package README and design guidance so Panel is documented as available while Card consumers migrate. Includes the required minor Changeset.

Local validation passes: `mise exec -- turbo check type --filter=@shipfox/react-ui...`, `mise exec -- turbo build --filter=@shipfox/react-ui...`, `mise exec -- turbo test --filter=@shipfox/react-ui...`, `mise exec -- turbo verify --filter=@shipfox/prose-policy`, and `git diff --check`. The prose policy reports 0 errors with existing warnings and suggestions.

Closes ENG-1575

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `Panel` surface primitive to `@shipfox/react-ui` to standardize data region containers and start the migration from `Card`. Fulfills ENG-1575.

- **New Features**
  - Export `Panel`, `PanelHeader` (`strip` and `plain`), `PanelTitle`, `PanelActions`, `PanelBody`, `PanelRow`, and `PanelEmpty`.
  - Update DESIGN and README to document `Panel`; keep `Card` for compatibility.
  - Add tests for header variants, row dividers/hover, and compact empty; add Storybook stories (Playground, Variants, Compositions); include a minor changeset.

- **Migration**
  - Use `Panel` for data regions and replace `Card` when ready.
  - Keep panels flat with `PanelRow`; use `PanelHeader` with `variant="plain"` for titled blocks on focused surfaces.

<sup>Written for commit 27b412776f31740dbe83398894243e426ea5b991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

