### PR TITLE
[client-projects] Recompose the Projects hub onto the content frame

### DIFF
--- a/.changeset/panel-grid-cell.md
+++ b/.changeset/panel-grid-cell.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Add `PanelGrid`, `PanelCell`, and `PanelCellAction` for a two-column grid of cells divided by hairlines, and add a `--shadow-focus-inset` token for controls whose parent clips the outset focus ring. `PanelCellAction` renders the trailing verb and chevron from an `action` prop, so the mark that separates a cell you open from a choice you select lives in one place. `Panel`, `PanelBody`, and `PanelRow` now accept `asChild`, so a panel can be an `aside` and a row list can keep `ul` and `li` semantics. `PanelHeader`'s strip variant returns to the canvas fill the surface ladder specifies.

--- a/.changeset/panel-grid-cell.md
+++ b/.changeset/panel-grid-cell.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": minor
 ---
 
-Add `PanelGrid`, `PanelCell`, and `PanelCellAction` for a two-column grid of cells divided by hairlines, collapsing to one column at 760px and padding an odd cell count so the last row's divider spans the panel. `PanelCellAction` renders a trailing verb and chevron from an `action` prop. Add a `--shadow-focus-inset` token for controls whose parent clips the outset focus ring. `Panel`, `PanelBody`, and `PanelRow` accept `asChild`, so a panel can render as an `aside` and a row list can keep `ul` and `li` semantics.
+Add `PanelGrid`, `PanelCell`, and `PanelCellAction` for a two-column grid of cells divided by hairlines, collapsing to one column at 760px and padding an odd cell count so the last row's dividers span the panel. `PanelGrid` takes an `as` prop for a grid whose cells are not list items. `PanelCellAction` renders a trailing verb and chevron from an `action` prop. Add a `--shadow-focus-inset` token for controls whose parent clips the outset focus ring. `Panel`, `PanelBody`, and `PanelRow` accept `asChild`, so a panel can render as an `aside` and a row list can keep `ul` and `li` semantics.

--- a/.changeset/panel-grid-cell.md
+++ b/.changeset/panel-grid-cell.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": minor
 ---
 
-Add `PanelGrid`, `PanelCell`, and `PanelCellAction` for a two-column grid of cells divided by hairlines, and add a `--shadow-focus-inset` token for controls whose parent clips the outset focus ring. `PanelCellAction` renders the trailing verb and chevron from an `action` prop, so the mark that separates a cell you open from a choice you select lives in one place. `Panel`, `PanelBody`, and `PanelRow` now accept `asChild`, so a panel can be an `aside` and a row list can keep `ul` and `li` semantics. `PanelHeader`'s strip variant returns to the canvas fill the surface ladder specifies.
+Add `PanelGrid`, `PanelCell`, and `PanelCellAction` for a two-column grid of cells divided by hairlines, collapsing to one column at 760px and padding an odd cell count so the last row's divider spans the panel. `PanelCellAction` renders a trailing verb and chevron from an `action` prop. Add a `--shadow-focus-inset` token for controls whose parent clips the outset focus ring. `Panel`, `PanelBody`, and `PanelRow` accept `asChild`, so a panel can render as an `aside` and a row list can keep `ul` and `li` semantics.

--- a/.changeset/panel-surface-consolidation.md
+++ b/.changeset/panel-surface-consolidation.md
@@ -6,4 +6,4 @@
 "@shipfox/client-triggers": patch
 ---
 
-Compose the shared `Panel` primitives instead of hand-rolling the panel class string in each package. Grids of openable things, such as the integration gallery, the available providers grid, and the harness picker, become cells inside one panel rather than standalone bordered tiles. That matches the projects hub and gives every one of these surfaces the same hover, focus, and elevation treatment.
+Panels across these surfaces share one hover, focus, and elevation treatment. Grids of openable things, including the integration gallery, the available providers grid, and the harness picker, render as cells inside a single panel divided by hairlines instead of separate bordered tiles.

--- a/.changeset/panel-surface-consolidation.md
+++ b/.changeset/panel-surface-consolidation.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/client-agent": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-secrets": patch
+"@shipfox/client-triggers": patch
+---
+
+Compose the shared `Panel` primitives instead of hand-rolling the panel class string in each package. Grids of openable things, such as the integration gallery, the available providers grid, and the harness picker, become cells inside one panel rather than standalone bordered tiles. That matches the projects hub and gives every one of these surfaces the same hover, focus, and elevation treatment.

--- a/.changeset/projects-content-panel.md
+++ b/.changeset/projects-content-panel.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-projects": patch
+---
+
+Rework the projects index into one Panel with header controls, two-column hairline cells, and preserved loading, empty, error, integration connection, and pagination states.

--- a/.changeset/radio-group-button-surface.md
+++ b/.changeset/radio-group-button-surface.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/react-ui": patch
+"@shipfox/react-ui": minor
 ---
 
-Radio choice tiles show a selected indicator dot, keep a visible focus ring when the checked item receives keyboard focus, and rest on an opaque fill that no longer changes shade with the surface behind them. Add `RadioGroupItemSkeleton`, a loading placeholder matching the tile, with a `labelClassName` prop to vary the bar width.
+Radio choice tiles show a selected indicator dot, keep a visible focus ring when the checked item receives keyboard focus, and rest on an opaque fill that no longer changes shade with the surface behind them. Add a `variant` prop: `cell` renders the group as a hairline-divided grid whose options carry no frame of their own, for a picker inside a panel. Add `RadioGroupItemSkeleton`, a loading placeholder matching either variant, with a `labelClassName` prop to vary the bar width.

--- a/.changeset/radio-group-button-surface.md
+++ b/.changeset/radio-group-button-surface.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Give radio choice tiles a selected indicator dot and keep their focus ring reachable when checked. Selection is carried by the border and the dot instead of the focus `box-shadow`, so tabbing onto the already-checked item still shows a ring. The tile fill returns to opaque surface tokens so it no longer changes shade with whatever renders behind it, and `RadioGroupItemSkeleton` ships the matching placeholder so callers stop rebuilding the box by hand.

--- a/.changeset/radio-group-button-surface.md
+++ b/.changeset/radio-group-button-surface.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": patch
 ---
 
-Give radio choice tiles a selected indicator dot and keep their focus ring reachable when checked. Selection is carried by the border and the dot instead of the focus `box-shadow`, so tabbing onto the already-checked item still shows a ring. The tile fill returns to opaque surface tokens so it no longer changes shade with whatever renders behind it, and `RadioGroupItemSkeleton` ships the matching placeholder so callers stop rebuilding the box by hand.
+Radio choice tiles show a selected indicator dot, keep a visible focus ring when the checked item receives keyboard focus, and rest on an opaque fill that no longer changes shade with the surface behind them. Add `RadioGroupItemSkeleton`, a loading placeholder matching the tile, with a `labelClassName` prop to vary the bar width.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -571,8 +571,10 @@ composes `PanelHeader`, `PanelTitle`, `PanelActions`, `PanelBody`, `PanelRow`,
   compact).
 - **Grid:** `PanelGrid` lays `PanelCell` children out in two columns divided by
   hairlines, collapsing to one column at 760px. The dividers come from
-  `nth-child` rules on the grid, so no caller passes an index. Never build a grid
-  of tiles by giving each tile its own border.
+  `nth-child` rules on the grid, so no caller passes an index. An odd cell count
+  is padded with an inert cell, so the rule above a half-full last row still
+  spans the panel; the column rule stops at the last full row rather than boxing
+  an empty slot. Never build a grid of tiles by giving each tile its own border.
 - **States:** empty, error, and loading states render inside the body. A list with
   zero rows keeps the same footprint and border as a list with rows.
 - **`asChild`:** `Panel`, `PanelBody`, `PanelRow`, and `PanelCellAction` accept

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -572,9 +572,9 @@ composes `PanelHeader`, `PanelTitle`, `PanelActions`, `PanelBody`, `PanelRow`,
 - **Grid:** `PanelGrid` lays `PanelCell` children out in two columns divided by
   hairlines, collapsing to one column at 760px. The dividers come from
   `nth-child` rules on the grid, so no caller passes an index. An odd cell count
-  is padded with an inert cell, so the rule above a half-full last row still
-  spans the panel; the column rule stops at the last full row rather than boxing
-  an empty slot. Never build a grid of tiles by giving each tile its own border.
+  is padded with an inert cell, so both rules reach the last row and a half-full
+  row reads as a grid with one empty cell rather than a single wide row. Never
+  build a grid of tiles by giving each tile its own border.
 - **States:** empty, error, and loading states render inside the body. A list with
   zero rows keeps the same footprint and border as a list with rows.
 - **`asChild`:** `Panel`, `PanelBody`, `PanelRow`, and `PanelCellAction` accept

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -597,12 +597,13 @@ by their affordance, never by their silhouette alone.
 | Navigate or open | `PanelCell` + `PanelCellAction` | trailing verb and chevron | no |
 | Row with inline actions | `PanelRow` | hover wash, actions revealed on hover | no |
 
-A picker carries its own frame only on the canvas. Inside a panel it takes
-`RadioGroup variant="cell"`, which drops the tile's radius, border, and shadow,
-because those are the panel's own four properties and repeating them is a frame
-inside a frame. A cell has no resting outline, so selection draws one only when
-checked, using `outline` rather than `box-shadow` so the focus ring stays
-readable underneath it.
+A picker carries its own frame only on the canvas. A radio tile and a panel share
+four properties: radius, border, fill, and shadow. Inside a panel the picker
+takes `RadioGroup variant="cell"`, which drops the radius, the border, and the
+shadow, since repeating the panel's own frame is a frame inside a frame. Only the
+fill stays, because a cell still has to paint over the surface behind it. A cell
+has no resting outline, so selection draws one only when checked, using `outline`
+rather than `box-shadow` so the focus ring stays readable underneath it.
 
 The leading dot and the trailing chevron are a matched pair of opposites: one
 says this becomes selected, the other says this takes you elsewhere. Dropping

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -597,6 +597,13 @@ by their affordance, never by their silhouette alone.
 | Navigate or open | `PanelCell` + `PanelCellAction` | trailing verb and chevron | no |
 | Row with inline actions | `PanelRow` | hover wash, actions revealed on hover | no |
 
+A picker carries its own frame only on the canvas. Inside a panel it takes
+`RadioGroup variant="cell"`, which drops the tile's radius, border, and shadow,
+because those are the panel's own four properties and repeating them is a frame
+inside a frame. A cell has no resting outline, so selection draws one only when
+checked, using `outline` rather than `box-shadow` so the focus ring stays
+readable underneath it.
+
 The leading dot and the trailing chevron are a matched pair of opposites: one
 says this becomes selected, the other says this takes you elsewhere. Dropping
 either one makes a choice and a link indistinguishable.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -481,6 +481,8 @@ are theme-aware inside the token, so a component never sets a raw shadow.
 - **`--shadow-button-*-focus`**: the same stack plus a 2px halo and a 4px
   `--color-primary-500` ring. This is the button focus affordance; fields and
   inputs compose their own `--shadow-border-interactive-with-active` ring.
+- **`--shadow-focus-inset`**: the inset focus ring, in `--color-primary-500` and
+  theme-invariant, for a control whose parent clips an outset ring.
 - **`--shadow-tooltip`**: the lifted stack for tooltips and popovers.
 - **`--shadow-separator-inset`**: an inset top-highlight / bottom-shadow pair for
   hairline dividers inside dark panels.
@@ -493,9 +495,10 @@ tokens carry. If you need a new elevation, add a token.
 stripped, though the exact token differs by family: buttons compose
 `--shadow-button-*-focus` (a `--color-primary-500` ring) and fields compose
 `--shadow-border-interactive-with-active`. If a container's `overflow-hidden`
-would clip the standard outset ring (as inside a log row frame), switch that one
-control to an inset ring in `--color-primary-500` (theme-invariant), never remove
-it.
+would clip the standard outset ring (as inside a log row frame or a panel cell),
+switch that one control to `--shadow-focus-inset`, never remove it. A state that
+is not focus never consumes the focus `box-shadow`: encode it in the border, a
+fill, or a glyph instead, or the focused element stops announcing itself.
 
 ## Shapes
 
@@ -555,7 +558,7 @@ building anything: `accordion`, `alert`, `avatar`, `badge`, `button`, `calendar`
 
 `Panel` is the only container for a data region, replacing `Card`. It
 composes `PanelHeader`, `PanelTitle`, `PanelActions`, `PanelBody`, `PanelRow`,
-and `PanelEmpty`.
+`PanelGrid`, `PanelCell`, `PanelCellAction`, and `PanelEmpty`.
 
 - **Shell:** `rounded-8`, panel fill, hairline border, elevation from the shadow
   tokens.
@@ -566,10 +569,51 @@ and `PanelEmpty`.
 - **Body:** rows use `px-row` and `py-row` with hairline dividers, and the last row
   drops its divider. A panel without rows uses `p-panel` (`p-panel-compact` when
   compact).
+- **Grid:** `PanelGrid` lays `PanelCell` children out in two columns divided by
+  hairlines, collapsing to one column at 760px. The dividers come from
+  `nth-child` rules on the grid, so no caller passes an index. Never build a grid
+  of tiles by giving each tile its own border.
 - **States:** empty, error, and loading states render inside the body. A list with
   zero rows keeps the same footprint and border as a list with rows.
+- **`asChild`:** `Panel`, `PanelBody`, `PanelRow`, and `PanelCellAction` accept
+  `asChild`, so a panel can be an `aside`, a row list can keep `ul` and `li`
+  semantics, and a cell action can be a router `Link`.
 
-Never tint a panel or a row background to match a status.
+Never tint a panel or a row background to match a status. Never hand-roll the
+panel class string: a bordered surface that is not a `Panel` drifts from it
+within one release.
+
+### The three interactive surface roles
+
+A rounded, bordered tile with a hover wash can mean three different things, and
+the product uses all three. They share one surface vocabulary and are told apart
+by their affordance, never by their silhouette alone.
+
+| Role | Primitive | Affordance | Persists |
+| --- | --- | --- | --- |
+| Choose one of N | `RadioGroupItem` | leading radio dot | yes |
+| Navigate or open | `PanelCell` + `PanelCellAction` | trailing verb and chevron | no |
+| Row with inline actions | `PanelRow` | hover wash, actions revealed on hover | no |
+
+The leading dot and the trailing chevron are a matched pair of opposites: one
+says this becomes selected, the other says this takes you elsewhere. Dropping
+either one makes a choice and a link indistinguishable.
+
+Each primitive owns its own affordance, so no caller draws either mark by hand:
+`RadioGroupItem` renders its dot, and `PanelCellAction` renders the verb and
+chevron from its `action` prop. A cell that navigates without an `action` is
+missing the mark that tells it apart from a choice.
+
+Selection is carried by the dot **and** the border together, never by border
+colour alone: orange is also the focus ring, so a colour-only selected state
+collides with focus and fails the use-of-colour rule. Because the dot carries
+selection, `box-shadow` on a radio item is free to mean focus and only focus,
+which is what keeps the already-checked item (the first tab stop under a roving
+tabindex) visibly focusable.
+
+Navigation never wears a standalone bordered tile. A grid of openable things is
+`PanelCell`s inside one `PanelGrid`, exactly as a list of openable things is
+`PanelRow`s inside one `PanelBody`.
 
 ### Inputs / Fields
 

--- a/libs/client/agent/src/components/add-custom-provider-card.tsx
+++ b/libs/client/agent/src/components/add-custom-provider-card.tsx
@@ -1,32 +1,18 @@
-import {Icon} from '@shipfox/react-ui/icon';
+import {PanelCell, PanelCellAction} from '@shipfox/react-ui/panel';
 import {Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
-
-const SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function AddCustomProviderCard({onConfigure}: {onConfigure: () => void}) {
   return (
-    <li>
-      <button
-        type="button"
-        className={cn(
-          'group block h-full w-full cursor-pointer p-panel-compact text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
-          SURFACE_CLASS,
-        )}
+    <PanelCell>
+      <PanelCellAction
+        action="Configure"
         aria-label="Configure custom provider"
         onClick={onConfigure}
       >
-        <div className="flex min-w-0 items-center justify-between gap-cluster">
-          <Text size="md" bold className="min-w-0 truncate">
-            Custom
-          </Text>
-          <div className="flex shrink-0 items-center gap-tight text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-            <Text size="sm">Configure</Text>
-            <Icon name="chevronRight" className="size-16" />
-          </div>
-        </div>
-      </button>
-    </li>
+        <Text as="span" size="md" bold className="min-w-0 truncate">
+          Custom
+        </Text>
+      </PanelCellAction>
+    </PanelCell>
   );
 }

--- a/libs/client/agent/src/components/available-provider-card.tsx
+++ b/libs/client/agent/src/components/available-provider-card.tsx
@@ -1,10 +1,6 @@
-import {Icon} from '@shipfox/react-ui/icon';
+import {PanelCell, PanelCellAction} from '@shipfox/react-ui/panel';
 import {Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import type {SupportedProvider} from '#core/models.js';
-
-const SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function AvailableProviderCard({
   entry,
@@ -14,26 +10,16 @@ export function AvailableProviderCard({
   onConfigure: () => void;
 }) {
   return (
-    <li>
-      <button
-        type="button"
-        className={cn(
-          'group block w-full cursor-pointer p-panel-compact text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
-          SURFACE_CLASS,
-        )}
+    <PanelCell>
+      <PanelCellAction
+        action="Configure"
         aria-label={`Configure ${entry.label}`}
         onClick={onConfigure}
       >
-        <div className="flex min-w-0 items-center justify-between gap-cluster">
-          <Text size="md" bold className="min-w-0 truncate">
-            {entry.label}
-          </Text>
-          <div className="flex shrink-0 items-center gap-tight text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-            <Text size="sm">Configure</Text>
-            <Icon name="chevronRight" className="size-16" />
-          </div>
-        </div>
-      </button>
-    </li>
+        <Text as="span" size="md" bold className="min-w-0 truncate">
+          {entry.label}
+        </Text>
+      </PanelCellAction>
+    </PanelCell>
   );
 }

--- a/libs/client/agent/src/components/available-providers-grid.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.tsx
@@ -2,13 +2,12 @@ import {Button} from '@shipfox/react-ui/button';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Input} from '@shipfox/react-ui/input';
+import {Panel, PanelBody, PanelGrid, PanelHeader} from '@shipfox/react-ui/panel';
 import type {ReactNode} from 'react';
 import {useMemo, useRef, useState} from 'react';
 import type {SupportedProvider} from '#core/models.js';
 import {providerMatchesSearch} from '#core/provider-policy.js';
 import {AvailableProviderCard} from './available-provider-card.js';
-
-export const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-cluster max-[760px]:grid-cols-1';
 
 const SEARCH_VISIBILITY_THRESHOLD = 8;
 const MAX_ECHOED_QUERY_LENGTH = 40;
@@ -45,38 +44,46 @@ export function AvailableProvidersGrid<TEntry extends SupportedProvider>({
   }
 
   return (
-    <div className="flex flex-col gap-cluster">
-      {showSearch ? (
-        <Input
-          ref={inputRef}
-          type="search"
-          aria-label="Search providers"
-          placeholder="Search providers..."
-          value={search}
-          iconLeft={<Icon name="searchLine" className="size-16 text-foreground-neutral-muted" />}
-          onChange={(event) => setSearch(event.target.value)}
-        />
-      ) : null}
-
-      {visibleCount > 0 ? (
-        <ul className={PROVIDER_GRID_CLASS} aria-label={providerListLabel}>
-          {filteredEntries.map((entry) => (
-            <AvailableProviderCard
-              key={entry.id}
-              entry={entry}
-              onConfigure={() => onSelect(entry)}
+    <>
+      <Panel>
+        {showSearch ? (
+          <PanelHeader>
+            <Input
+              ref={inputRef}
+              type="search"
+              aria-label="Search providers"
+              placeholder="Search providers..."
+              value={search}
+              iconLeft={
+                <Icon name="searchLine" className="size-16 text-foreground-neutral-muted" />
+              }
+              onChange={(event) => setSearch(event.target.value)}
             />
-          ))}
-          {trailingCardVisible ? trailingCard : null}
-        </ul>
-      ) : (
-        <NoProviderSearchResults search={trimmedSearch} onClear={clearSearch} />
-      )}
+          </PanelHeader>
+        ) : null}
+
+        <PanelBody>
+          {visibleCount > 0 ? (
+            <PanelGrid aria-label={providerListLabel}>
+              {filteredEntries.map((entry) => (
+                <AvailableProviderCard
+                  key={entry.id}
+                  entry={entry}
+                  onConfigure={() => onSelect(entry)}
+                />
+              ))}
+              {trailingCardVisible ? trailingCard : null}
+            </PanelGrid>
+          ) : (
+            <NoProviderSearchResults search={trimmedSearch} onClear={clearSearch} />
+          )}
+        </PanelBody>
+      </Panel>
 
       <p role="status" aria-live="polite" className="sr-only">
         {resultCountText}
       </p>
-    </div>
+    </>
   );
 }
 

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -8,11 +8,11 @@ import {
   DropdownMenuTrigger,
 } from '@shipfox/react-ui/dropdown-menu';
 import {Icon} from '@shipfox/react-ui/icon';
+import {Panel, PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import {useRef, useState} from 'react';
 import {DEFAULT_HARNESS, listHarnesses} from '#core/harness-policy.js';
 import type {HarnessDescriptor, HarnessId} from '#core/models.js';
@@ -22,9 +22,6 @@ import {
 } from '#hooks/api/model-providers.js';
 import {modelProviderConfigErrorToFormError} from './form-errors.js';
 import {isHarnessAvailable} from './harness-availability.js';
-
-const SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) {
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
@@ -95,29 +92,34 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
       {configsQuery.isPending ? <HarnessRowsSkeleton /> : null}
 
       {configsQuery.isError && configsQuery.data === undefined ? (
-        <div className={SURFACE_CLASS}>
+        <Panel>
           <QueryLoadError query={configsQuery} subject="harnesses" variant="panel" />
-        </div>
+        </Panel>
       ) : null}
 
       {configsQuery.data !== undefined ? (
-        <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
-          {listHarnesses().map((harness) => (
-            <HarnessRow
-              key={harness.id}
-              harness={harness}
-              isDefault={harness.id === defaultHarnessId}
-              isAvailable={isHarnessAvailable(harness, configs)}
-              isSettingDefault={pendingDefaultHarness?.workspaceId === workspaceId}
-              defaultError={
-                defaultError?.workspaceId === workspaceId && defaultError.harnessId === harness.id
-                  ? defaultError.message
-                  : undefined
-              }
-              onSetDefault={handleSetDefault}
-            />
-          ))}
-        </ul>
+        <Panel>
+          <PanelBody asChild>
+            <ul>
+              {listHarnesses().map((harness) => (
+                <HarnessRow
+                  key={harness.id}
+                  harness={harness}
+                  isDefault={harness.id === defaultHarnessId}
+                  isAvailable={isHarnessAvailable(harness, configs)}
+                  isSettingDefault={pendingDefaultHarness?.workspaceId === workspaceId}
+                  defaultError={
+                    defaultError?.workspaceId === workspaceId &&
+                    defaultError.harnessId === harness.id
+                      ? defaultError.message
+                      : undefined
+                  }
+                  onSetDefault={handleSetDefault}
+                />
+              ))}
+            </ul>
+          </PanelBody>
+        </Panel>
       ) : null}
     </section>
   );
@@ -141,78 +143,80 @@ function HarnessRow({
   const unavailableCopy = harnessUnavailableCopy(isDefault);
 
   return (
-    <li className="flex flex-col gap-inline px-row py-row transition-colors hover:bg-background-components-hover">
-      <div className="flex items-center justify-between gap-cluster">
-        <div className="flex min-w-0 items-center gap-inline">
-          {isDefault ? (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex size-16 shrink-0 items-center justify-center">
-                    <Icon
-                      name="starLine"
-                      className="size-16 text-foreground-neutral-muted"
-                      aria-hidden
-                    />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>Default harness</TooltipContent>
-              </Tooltip>
-              <span className="sr-only">Default harness</span>
-            </>
-          ) : null}
-          <Text size="md" bold className="truncate">
-            {harness.label}
-          </Text>
-          {!isAvailable ? (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex size-16 shrink-0 items-center justify-center">
-                    <Icon
-                      name="errorWarningLine"
-                      className="size-16 text-foreground-warning-base"
-                      aria-hidden
-                    />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>{unavailableCopy}</TooltipContent>
-              </Tooltip>
-              <span className="sr-only">{unavailableCopy}</span>
-            </>
+    <PanelRow asChild className="flex-col items-stretch gap-inline">
+      <li>
+        <div className="flex items-center justify-between gap-cluster">
+          <div className="flex min-w-0 items-center gap-inline">
+            {isDefault ? (
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex size-16 shrink-0 items-center justify-center">
+                      <Icon
+                        name="starLine"
+                        className="size-16 text-foreground-neutral-muted"
+                        aria-hidden
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Default harness</TooltipContent>
+                </Tooltip>
+                <span className="sr-only">Default harness</span>
+              </>
+            ) : null}
+            <Text size="md" bold className="truncate">
+              {harness.label}
+            </Text>
+            {!isAvailable ? (
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex size-16 shrink-0 items-center justify-center">
+                      <Icon
+                        name="errorWarningLine"
+                        className="size-16 text-foreground-warning-base"
+                        aria-hidden
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{unavailableCopy}</TooltipContent>
+                </Tooltip>
+                <span className="sr-only">{unavailableCopy}</span>
+              </>
+            ) : null}
+          </div>
+          {!isDefault ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton
+                  size="sm"
+                  variant="transparent"
+                  icon="more2Line"
+                  disabled={isSettingDefault}
+                  aria-label={`Open ${harness.label} harness actions`}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  icon="starLine"
+                  disabled={isSettingDefault || !isAvailable}
+                  onSelect={() => {
+                    onSetDefault(harness);
+                  }}
+                >
+                  Set as default
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           ) : null}
         </div>
-        {!isDefault ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <IconButton
-                size="sm"
-                variant="transparent"
-                icon="more2Line"
-                disabled={isSettingDefault}
-                aria-label={`Open ${harness.label} harness actions`}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                icon="starLine"
-                disabled={isSettingDefault || !isAvailable}
-                onSelect={() => {
-                  onSetDefault(harness);
-                }}
-              >
-                Set as default
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+        {defaultError ? (
+          <Callout role="alert" type="error">
+            <Text size="sm">{defaultError}</Text>
+          </Callout>
         ) : null}
-      </div>
-      {defaultError ? (
-        <Callout role="alert" type="error">
-          <Text size="sm">{defaultError}</Text>
-        </Callout>
-      ) : null}
-    </li>
+      </li>
+    </PanelRow>
   );
 }
 
@@ -224,18 +228,24 @@ function harnessUnavailableCopy(isDefault: boolean): string {
 
 function HarnessRowsSkeleton() {
   return (
-    <ul
-      role="status"
-      aria-label="Loading harnesses"
-      className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}
-    >
-      {[0, 1].map((row) => (
-        <li key={row} className="flex items-center gap-cluster px-row py-row">
-          <Skeleton className="size-16 shrink-0" />
-          <Skeleton className="h-16 w-120" />
-          <Skeleton className="ml-auto size-28 shrink-0" />
-        </li>
-      ))}
-    </ul>
+    <Panel>
+      <PanelBody asChild>
+        <ul role="status" aria-label="Loading harnesses">
+          {[0, 1].map((row) => (
+            <PanelRow
+              asChild
+              className="justify-start gap-cluster hover:bg-background-neutral-base"
+              key={row}
+            >
+              <li>
+                <Skeleton className="size-16 shrink-0" />
+                <Skeleton className="h-16 w-120" />
+                <Skeleton className="ml-auto size-28 shrink-0" />
+              </li>
+            </PanelRow>
+          ))}
+        </ul>
+      </PanelBody>
+    </Panel>
   );
 }

--- a/libs/client/agent/src/components/model-provider-grid-skeleton.tsx
+++ b/libs/client/agent/src/components/model-provider-grid-skeleton.tsx
@@ -1,24 +1,21 @@
+import {Panel, PanelBody, PanelCell, PanelGrid} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
-import {cn} from '@shipfox/react-ui/utils';
-import {PROVIDER_GRID_CLASS} from './available-providers-grid.js';
-
-const SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function ModelProviderGridSkeleton({label}: {label: string}) {
   return (
-    <div role="status" aria-busy="true" aria-label={label} className={PROVIDER_GRID_CLASS}>
-      {[0, 1, 2, 3].map((tile) => (
-        <div
-          key={tile}
-          className={cn('flex h-136 w-full flex-col justify-center p-panel-compact', SURFACE_CLASS)}
-        >
-          <div className="flex items-center justify-between gap-cluster">
-            <Skeleton className="h-16 w-100" />
-            <Skeleton className="h-16 w-64 shrink-0" />
-          </div>
-        </div>
-      ))}
-    </div>
+    <Panel>
+      <PanelBody>
+        <PanelGrid role="status" aria-busy="true" aria-label={label}>
+          {[0, 1, 2, 3].map((tile) => (
+            <PanelCell key={tile}>
+              <div className="flex items-center justify-between gap-cluster px-row py-row">
+                <Skeleton className="h-16 w-100" />
+                <Skeleton className="h-16 w-64 shrink-0" />
+              </div>
+            </PanelCell>
+          ))}
+        </PanelGrid>
+      </PanelBody>
+    </Panel>
   );
 }

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -17,11 +17,11 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@shipfox/react-ui/modal';
+import {Panel, PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import {useEffect, useMemo, useReducer, useRef, useState} from 'react';
 import {
   type ManagementModal,
@@ -58,9 +58,6 @@ import {
   usageTargetFromCustomConfig,
 } from './model-provider-usage-target.js';
 import {ModelProviderTestAndSaveForm} from './test-and-save-form.js';
-
-const SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 type UsageTarget = {
   target: ModelProviderUsageTarget;
@@ -133,75 +130,83 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
 
         {configsQuery.isError && configsQuery.data === undefined ? (
-          <div className={SURFACE_CLASS}>
+          <Panel>
             <QueryLoadError query={configsQuery} subject="model provider configs" variant="panel" />
-          </div>
+          </Panel>
         ) : null}
 
         {configsQuery.data !== undefined && configs.length === 0 ? (
-          <div className={SURFACE_CLASS}>
+          <Panel>
             <EmptyState
               icon="key2Line"
               title="No providers configured"
               description="Configure a provider below to run agent steps with workspace-managed credentials."
               variant="panel"
             />
-          </div>
+          </Panel>
         ) : null}
 
         {configs.length > 0 ? (
-          <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
-            {configs.map((config) => {
-              const catalogEntry = providerById.get(config.providerId);
-              const entry =
-                catalogEntry && isSupportedProvider(catalogEntry) ? catalogEntry : undefined;
-              const builtinConfig = isBuiltinModelProviderConfig(config) ? config : undefined;
-              const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
-              return (
-                <ConfiguredProviderRow
-                  key={config.providerId}
-                  workspaceId={workspaceId}
-                  config={config}
-                  entry={entry}
-                  isDefault={config.providerId === defaultProviderId}
-                  onEdit={() => {
-                    if (entry && builtinConfig) {
-                      dispatchModal({type: 'edit-builtin', provider: entry, config: builtinConfig});
-                    } else if (customConfig) {
-                      dispatchModal({type: 'edit-custom', config: customConfig});
-                    }
-                  }}
-                  onChangeDefaultModel={() => {
-                    if (entry && builtinConfig)
-                      dispatchModal({
-                        type: 'change-default-model',
-                        provider: entry,
-                        config: builtinConfig,
-                      });
-                  }}
-                  onShowUsage={() => {
-                    if (entry && builtinConfig) {
-                      setPendingUsageTarget(null);
-                      dispatchModal({
-                        type: 'show-usage',
-                        providerId: entry.id,
-                        initialModel: builtinConfig.defaultModel,
-                        restoreFocusToConfiguredProviders: false,
-                      });
-                    } else if (customConfig) {
-                      setPendingUsageTarget(null);
-                      dispatchModal({
-                        type: 'show-usage',
-                        providerId: customConfig.providerId,
-                        initialModel: customConfig.defaultModel,
-                        restoreFocusToConfiguredProviders: false,
-                      });
-                    }
-                  }}
-                />
-              );
-            })}
-          </ul>
+          <Panel>
+            <PanelBody asChild>
+              <ul>
+                {configs.map((config) => {
+                  const catalogEntry = providerById.get(config.providerId);
+                  const entry =
+                    catalogEntry && isSupportedProvider(catalogEntry) ? catalogEntry : undefined;
+                  const builtinConfig = isBuiltinModelProviderConfig(config) ? config : undefined;
+                  const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
+                  return (
+                    <ConfiguredProviderRow
+                      key={config.providerId}
+                      workspaceId={workspaceId}
+                      config={config}
+                      entry={entry}
+                      isDefault={config.providerId === defaultProviderId}
+                      onEdit={() => {
+                        if (entry && builtinConfig) {
+                          dispatchModal({
+                            type: 'edit-builtin',
+                            provider: entry,
+                            config: builtinConfig,
+                          });
+                        } else if (customConfig) {
+                          dispatchModal({type: 'edit-custom', config: customConfig});
+                        }
+                      }}
+                      onChangeDefaultModel={() => {
+                        if (entry && builtinConfig)
+                          dispatchModal({
+                            type: 'change-default-model',
+                            provider: entry,
+                            config: builtinConfig,
+                          });
+                      }}
+                      onShowUsage={() => {
+                        if (entry && builtinConfig) {
+                          setPendingUsageTarget(null);
+                          dispatchModal({
+                            type: 'show-usage',
+                            providerId: entry.id,
+                            initialModel: builtinConfig.defaultModel,
+                            restoreFocusToConfiguredProviders: false,
+                          });
+                        } else if (customConfig) {
+                          setPendingUsageTarget(null);
+                          dispatchModal({
+                            type: 'show-usage',
+                            providerId: customConfig.providerId,
+                            initialModel: customConfig.defaultModel,
+                            restoreFocusToConfiguredProviders: false,
+                          });
+                        }
+                      }}
+                    />
+                  );
+                })}
+              </ul>
+            </PanelBody>
+          </Panel>
         ) : null}
       </section>
 
@@ -218,9 +223,9 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
 
         {catalogQuery.isError && catalogQuery.data === undefined ? (
-          <div className={SURFACE_CLASS}>
+          <Panel>
             <QueryLoadError query={catalogQuery} subject="model provider catalog" variant="panel" />
-          </div>
+          </Panel>
         ) : null}
 
         {configsLoaded ? (
@@ -248,25 +253,35 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
 
         {unsupportedProviders.length > 0 ? (
-          <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
-            {unsupportedProviders.map((entry) => (
-              <li key={entry.id} className="flex items-start gap-cluster px-row py-row opacity-70">
-                <Icon
-                  name="forbid2Line"
-                  className="mt-[2px] size-18 shrink-0 text-foreground-neutral-muted"
-                  aria-hidden
-                />
-                <div className="flex min-w-0 flex-1 flex-col gap-tight">
-                  <Text size="md" bold className="truncate">
-                    {entry.label}
-                  </Text>
-                  <Text size="sm" className="text-foreground-neutral-muted">
-                    {entry.unsupportedReason}
-                  </Text>
-                </div>
-              </li>
-            ))}
-          </ul>
+          <Panel>
+            <PanelBody asChild>
+              <ul>
+                {unsupportedProviders.map((entry) => (
+                  <PanelRow
+                    asChild
+                    className="items-start justify-start gap-cluster opacity-70 hover:bg-background-neutral-base"
+                    key={entry.id}
+                  >
+                    <li>
+                      <Icon
+                        name="forbid2Line"
+                        className="mt-[2px] size-18 shrink-0 text-foreground-neutral-muted"
+                        aria-hidden
+                      />
+                      <div className="flex min-w-0 flex-1 flex-col gap-tight">
+                        <Text size="md" bold className="truncate">
+                          {entry.label}
+                        </Text>
+                        <Text size="sm" className="text-foreground-neutral-muted">
+                          {entry.unsupportedReason}
+                        </Text>
+                      </div>
+                    </li>
+                  </PanelRow>
+                ))}
+              </ul>
+            </PanelBody>
+          </Panel>
         ) : null}
       </section>
 
@@ -472,91 +487,93 @@ function ConfiguredProviderRow({
   }
 
   return (
-    <li className="flex flex-col gap-inline px-row py-row transition-colors hover:bg-background-components-hover">
-      <div className="flex items-center justify-between gap-cluster">
-        <div className="flex min-w-0 items-center gap-inline">
-          {isDefault ? (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex size-16 shrink-0 items-center justify-center">
-                    <Icon
-                      name="starLine"
-                      className="size-16 text-foreground-neutral-muted"
-                      aria-hidden
-                    />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>Default provider</TooltipContent>
-              </Tooltip>
-              <span className="sr-only">Default provider</span>
-            </>
-          ) : null}
-          <Text size="md" bold className="truncate">
-            {label}
-          </Text>
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <IconButton
-              size="sm"
-              variant="transparent"
-              icon="more2Line"
-              aria-label={`Open ${label} provider actions`}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {!isDefault ? (
+    <PanelRow asChild className="flex-col items-stretch gap-inline">
+      <li>
+        <div className="flex items-center justify-between gap-cluster">
+          <div className="flex min-w-0 items-center gap-inline">
+            {isDefault ? (
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex size-16 shrink-0 items-center justify-center">
+                      <Icon
+                        name="starLine"
+                        className="size-16 text-foreground-neutral-muted"
+                        aria-hidden
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Default provider</TooltipContent>
+                </Tooltip>
+                <span className="sr-only">Default provider</span>
+              </>
+            ) : null}
+            <Text size="md" bold className="truncate">
+              {label}
+            </Text>
+          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <IconButton
+                size="sm"
+                variant="transparent"
+                icon="more2Line"
+                aria-label={`Open ${label} provider actions`}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {!isDefault ? (
+                <DropdownMenuItem
+                  icon="starLine"
+                  disabled={setDefault.isPending || (!entry && !customConfig)}
+                  onSelect={() => {
+                    void handleSetDefault();
+                  }}
+                >
+                  Set as default
+                </DropdownMenuItem>
+              ) : null}
+              {isBuiltinConfig ? (
+                <DropdownMenuItem
+                  icon="settings3Line"
+                  disabled={!entry}
+                  onSelect={onChangeDefaultModel}
+                >
+                  Change default model
+                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuItem icon="bookOpenLine" disabled={!canUse} onSelect={onShowUsage}>
+                View workflow example
+              </DropdownMenuItem>
+              <DropdownMenuItem icon="editLine" disabled={!canEdit} onSelect={onEdit}>
+                {customConfig ? 'Edit' : 'Edit credentials'}
+              </DropdownMenuItem>
               <DropdownMenuItem
-                icon="starLine"
-                disabled={setDefault.isPending || (!entry && !customConfig)}
+                icon="deleteBinLine"
                 onSelect={() => {
-                  void handleSetDefault();
+                  setDeleteOpen(true);
                 }}
               >
-                Set as default
+                Delete
               </DropdownMenuItem>
-            ) : null}
-            {isBuiltinConfig ? (
-              <DropdownMenuItem
-                icon="settings3Line"
-                disabled={!entry}
-                onSelect={onChangeDefaultModel}
-              >
-                Change default model
-              </DropdownMenuItem>
-            ) : null}
-            <DropdownMenuItem icon="bookOpenLine" disabled={!canUse} onSelect={onShowUsage}>
-              View workflow example
-            </DropdownMenuItem>
-            <DropdownMenuItem icon="editLine" disabled={!canEdit} onSelect={onEdit}>
-              {customConfig ? 'Edit' : 'Edit credentials'}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              icon="deleteBinLine"
-              onSelect={() => {
-                setDeleteOpen(true);
-              }}
-            >
-              Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      {defaultError ? (
-        <Callout role="alert" type="error">
-          <Text size="sm">{defaultError}</Text>
-        </Callout>
-      ) : null}
-      <DeleteModelProviderDialog
-        open={deleteOpen}
-        onOpenChange={handleDeleteOpenChange}
-        label={label}
-        errorMessage={deleteError}
-        isLoading={deleteConfig.isPending}
-        onDelete={handleDelete}
-      />
-    </li>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        {defaultError ? (
+          <Callout role="alert" type="error">
+            <Text size="sm">{defaultError}</Text>
+          </Callout>
+        ) : null}
+        <DeleteModelProviderDialog
+          open={deleteOpen}
+          onOpenChange={handleDeleteOpenChange}
+          label={label}
+          errorMessage={deleteError}
+          isLoading={deleteConfig.isPending}
+          onDelete={handleDelete}
+        />
+      </li>
+    </PanelRow>
   );
 }
 
@@ -606,21 +623,27 @@ function DeleteModelProviderDialog({
 
 function ModelProviderRowsSkeleton({label}: {label: string}) {
   return (
-    <ul
-      role="status"
-      aria-label={label}
-      className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}
-    >
-      {[0, 1, 2].map((row) => (
-        <li key={row} className="flex items-center gap-cluster px-row py-row">
-          <Skeleton className="size-32 shrink-0" />
-          <div className="flex min-w-0 flex-1 flex-col gap-inline">
-            <Skeleton className="h-16 w-120" />
-            <Skeleton className="h-14 w-180" />
-          </div>
-          <Skeleton className="h-28 w-96 shrink-0" />
-        </li>
-      ))}
-    </ul>
+    <Panel>
+      <PanelBody asChild>
+        <ul role="status" aria-label={label}>
+          {[0, 1, 2].map((row) => (
+            <PanelRow
+              asChild
+              className="justify-start gap-cluster hover:bg-background-neutral-base"
+              key={row}
+            >
+              <li>
+                <Skeleton className="size-32 shrink-0" />
+                <div className="flex min-w-0 flex-1 flex-col gap-inline">
+                  <Skeleton className="h-16 w-120" />
+                  <Skeleton className="h-14 w-180" />
+                </div>
+                <Skeleton className="h-28 w-96 shrink-0" />
+              </li>
+            </PanelRow>
+          ))}
+        </ul>
+      </PanelBody>
+    </Panel>
   );
 }

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -2,13 +2,12 @@ import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
-import {Icon} from '@shipfox/react-ui/icon';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
+import {Panel, PanelBody, PanelCell, PanelCellAction, PanelGrid} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import {useEffect, useMemo, useReducer} from 'react';
-import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from '#components/available-providers-grid.js';
+import {AvailableProvidersGrid} from '#components/available-providers-grid.js';
 import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
 import {ModelProviderGridSkeleton} from '#components/model-provider-grid-skeleton.js';
 import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
@@ -21,9 +20,6 @@ import {
   useSetDefaultHarnessMutation,
 } from '#hooks/api/model-providers.js';
 import {dismissModelProviderOnboarding} from '#state/model-provider-onboarding.js';
-
-const SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function ModelProviderOnboardingPage({
   workspaceId,
@@ -216,42 +212,32 @@ export function ModelProviderOnboardingPage({
 
 function HarnessPicker({onSelect}: {onSelect: (harness: HarnessId) => void}) {
   return (
-    <ul className={PROVIDER_GRID_CLASS} aria-label="Agent harnesses">
-      {listHarnesses().map((harness) => (
-        <HarnessCard key={harness.id} harness={harness} onChoose={() => onSelect(harness.id)} />
-      ))}
-    </ul>
+    <Panel>
+      <PanelBody>
+        <PanelGrid aria-label="Agent harnesses">
+          {listHarnesses().map((harness) => (
+            <HarnessCard key={harness.id} harness={harness} onChoose={() => onSelect(harness.id)} />
+          ))}
+        </PanelGrid>
+      </PanelBody>
+    </Panel>
   );
 }
 
 function HarnessCard({harness, onChoose}: {harness: HarnessDescriptor; onChoose: () => void}) {
   return (
-    <li>
-      <button
-        type="button"
-        className={cn(
-          'group block w-full cursor-pointer p-panel-compact text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
-          SURFACE_CLASS,
-        )}
-        aria-label={`Choose ${harness.label}`}
-        onClick={onChoose}
-      >
-        <div className="flex min-w-0 items-center justify-between gap-cluster">
-          <div className="flex min-w-0 flex-col gap-tight">
-            <Text size="md" bold className="min-w-0 truncate">
-              {harness.label}
-            </Text>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              {harness.description}
-            </Text>
-          </div>
-          <div className="flex shrink-0 items-center gap-tight text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-            <Text size="sm">Choose</Text>
-            <Icon name="chevronRight" className="size-16" />
-          </div>
-        </div>
-      </button>
-    </li>
+    <PanelCell>
+      <PanelCellAction action="Choose" aria-label={`Choose ${harness.label}`} onClick={onChoose}>
+        <span className="flex min-w-0 flex-col gap-tight">
+          <Text as="span" size="md" bold className="min-w-0 truncate">
+            {harness.label}
+          </Text>
+          <Text as="span" size="sm" className="text-foreground-neutral-muted">
+            {harness.description}
+          </Text>
+        </span>
+      </PanelCellAction>
+    </PanelCell>
   );
 }
 

--- a/libs/client/integrations/src/components/connection-picker.tsx
+++ b/libs/client/integrations/src/components/connection-picker.tsx
@@ -19,15 +19,15 @@ export function ConnectionPicker({
   const labelId = useId();
 
   return (
-    <div className="flex flex-col gap-inline">
+    <div className="flex min-w-0 flex-col">
       <Label id={labelId} className="sr-only">
         Source integration
       </Label>
       <RadioGroup
+        variant="cell"
         aria-labelledby={labelId}
         value={selectedConnectionId ?? ''}
         onValueChange={onSelect}
-        className="grid grid-cols-2 gap-inline max-[760px]:grid-cols-1"
       >
         {connections.map((connection) => (
           <RadioGroupItem key={connection.id} value={connection.id}>

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from '@shipfox/react-ui/dropdown-menu';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {Panel, PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn, formatDate} from '@shipfox/react-ui/utils';
@@ -30,9 +31,6 @@ interface InstalledIntegrationsSectionProps {
   onDelete: (connectionId: string) => void;
   providerDisplayName: (provider: string) => string | undefined;
 }
-
-const INSTALLED_SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function InstalledIntegrationsSection({
   workspaceSlug,
@@ -59,41 +57,45 @@ export function InstalledIntegrationsSection({
       {isPending ? <InstalledSkeleton label="Loading integrations" /> : null}
 
       {error ? (
-        <div className={INSTALLED_SURFACE_CLASS}>
+        <Panel>
           <QueryLoadError
             query={{isError: true, isFetching, data: undefined, error, refetch: onRetry}}
             subject="integrations"
             variant="panel"
           />
-        </div>
+        </Panel>
       ) : null}
 
       {!isPending && !error && connections.length === 0 ? (
-        <div className={INSTALLED_SURFACE_CLASS}>
+        <Panel>
           <EmptyState
             icon="componentLine"
             title="No integrations installed yet"
             description="Install a provider below to get started."
             variant="panel"
           />
-        </div>
+        </Panel>
       ) : null}
 
       {connections.length > 0 ? (
-        <ul className={cn('divide-y divide-border-neutral-base', INSTALLED_SURFACE_CLASS)}>
-          {connections.map((connection) => (
-            <InstalledRow
-              key={connection.id}
-              connection={connection}
-              workspaceSlug={workspaceSlug}
-              isMutating={isMutating}
-              onUse={onUse}
-              onSetActive={(nextActive) => onSetActive(connection, nextActive)}
-              onDelete={onDelete}
-              providerDisplayName={providerDisplayName}
-            />
-          ))}
-        </ul>
+        <Panel>
+          <PanelBody asChild>
+            <ul>
+              {connections.map((connection) => (
+                <InstalledRow
+                  key={connection.id}
+                  connection={connection}
+                  workspaceSlug={workspaceSlug}
+                  isMutating={isMutating}
+                  onUse={onUse}
+                  onSetActive={(nextActive) => onSetActive(connection, nextActive)}
+                  onDelete={onDelete}
+                  providerDisplayName={providerDisplayName}
+                />
+              ))}
+            </ul>
+          </PanelBody>
+        </Panel>
       ) : null}
     </section>
   );
@@ -122,91 +124,99 @@ function InstalledRow({
   const providerName = providerDisplayName(connection.provider);
 
   return (
-    <li className="flex items-center gap-cluster px-row py-row transition-colors hover:bg-background-components-hover">
-      <IntegrationIcon
-        source={connection.provider}
-        aria-hidden
-        className={cn(
-          'size-24 shrink-0',
-          muted ? 'text-foreground-neutral-disabled' : 'text-foreground-neutral-base',
-        )}
-      />
-      <div className="flex min-w-0 flex-1 flex-col gap-tight">
-        <div className="flex min-w-0 items-center gap-inline">
-          <Text
-            size="md"
-            bold
-            className={cn('truncate', muted ? 'text-foreground-neutral-disabled' : undefined)}
-          >
-            {connection.displayName}
+    <PanelRow asChild className="justify-start gap-cluster">
+      <li>
+        <IntegrationIcon
+          source={connection.provider}
+          aria-hidden
+          className={cn(
+            'size-24 shrink-0',
+            muted ? 'text-foreground-neutral-disabled' : 'text-foreground-neutral-base',
+          )}
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-tight">
+          <div className="flex min-w-0 items-center gap-inline">
+            <Text
+              size="md"
+              bold
+              className={cn('truncate', muted ? 'text-foreground-neutral-disabled' : undefined)}
+            >
+              {connection.displayName}
+            </Text>
+            <ConnectionStatusBadge status={connection.lifecycleStatus} className="shrink-0" />
+          </div>
+          <Text size="sm" className="truncate text-foreground-neutral-muted">
+            Added {formatDate(connection.createdAt)}
           </Text>
-          <ConnectionStatusBadge status={connection.lifecycleStatus} className="shrink-0" />
         </div>
-        <Text size="sm" className="truncate text-foreground-neutral-muted">
-          Added {formatDate(connection.createdAt)}
-        </Text>
-      </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <IconButton
-            size="sm"
-            variant="transparent"
-            icon="more2Line"
-            aria-label={`Open ${connection.displayName} integration actions`}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {connection.externalUrl ? (
-            <DropdownMenuItem asChild>
-              <a href={connection.externalUrl} target="_blank" rel="noreferrer noopener">
-                {providerName ? `Open in ${providerName}` : 'Open provider settings'}
-              </a>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Open ${connection.displayName} integration actions`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {connection.externalUrl ? (
+              <DropdownMenuItem asChild>
+                <a href={connection.externalUrl} target="_blank" rel="noreferrer noopener">
+                  {providerName ? `Open in ${providerName}` : 'Open provider settings'}
+                </a>
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuItem onSelect={() => onUse(connection.id)}>
+              Use this integration
             </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuItem onSelect={() => onUse(connection.id)}>
-            Use this integration
-          </DropdownMenuItem>
-          {workspaceSlug ? (
-            <DropdownMenuItem asChild>
-              <Link
-                to="/w/$workspaceSlug/settings/events"
-                params={{workspaceSlug}}
-                search={{source: [connection.slug], event: [recentEventsEvent]}}
-              >
-                View recent events
-              </Link>
+            {workspaceSlug ? (
+              <DropdownMenuItem asChild>
+                <Link
+                  to="/w/$workspaceSlug/settings/events"
+                  params={{workspaceSlug}}
+                  search={{source: [connection.slug], event: [recentEventsEvent]}}
+                >
+                  View recent events
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem disabled={isMutating} onSelect={() => onSetActive(!active)}>
+              {active ? 'Disable integration' : 'Enable integration'}
             </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem disabled={isMutating} onSelect={() => onSetActive(!active)}>
-            {active ? 'Disable integration' : 'Enable integration'}
-          </DropdownMenuItem>
-          <DropdownMenuItem disabled={isMutating} onSelect={() => onDelete(connection.id)}>
-            Delete integration
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </li>
+            <DropdownMenuItem disabled={isMutating} onSelect={() => onDelete(connection.id)}>
+              Delete integration
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </li>
+    </PanelRow>
   );
 }
 
 function InstalledSkeleton({label}: {label: string}) {
   return (
-    <ul
-      role="status"
-      aria-label={label}
-      className={cn('divide-y divide-border-neutral-base', INSTALLED_SURFACE_CLASS)}
-    >
-      {[0, 1, 2].map((row) => (
-        <li key={row} className="flex items-center gap-cluster px-row py-row">
-          <Skeleton className="size-24 shrink-0" />
-          <div className="flex min-w-0 flex-1 flex-col gap-tight">
-            <Skeleton className="h-16 w-120" />
-            <Skeleton className="h-12 w-80" />
-          </div>
-          <Skeleton className="h-20 w-72 shrink-0" />
-        </li>
-      ))}
-    </ul>
+    <Panel>
+      <PanelBody asChild>
+        <ul role="status" aria-label={label}>
+          {[0, 1, 2].map((row) => (
+            <PanelRow
+              asChild
+              className="justify-start gap-cluster hover:bg-background-neutral-base"
+              key={row}
+            >
+              <li>
+                <Skeleton className="size-24 shrink-0" />
+                <div className="flex min-w-0 flex-1 flex-col gap-tight">
+                  <Skeleton className="h-16 w-120" />
+                  <Skeleton className="h-12 w-80" />
+                </div>
+                <Skeleton className="h-20 w-72 shrink-0" />
+              </li>
+            </PanelRow>
+          ))}
+        </ul>
+      </PanelBody>
+    </Panel>
   );
 }

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from '@tanstack/react-router';
 import {createStore, Provider as JotaiProvider} from 'jotai';
 import {useMemo} from 'react';
-import {expect, screen, userEvent, within} from 'storybook/test';
+import {expect, screen, userEvent, waitFor, within} from 'storybook/test';
 import {IntegrationGallery} from './integration-gallery.js';
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
@@ -162,7 +162,12 @@ export const UsageModalCloseRestoresInteraction: Story = {
     await screen.findByRole('dialog', {name: 'Use acme-corp'});
     await user.click(await screen.findByRole('button', {name: 'Done'}));
     expect(screen.queryByRole('dialog', {name: 'Use acme-corp'})).not.toBeInTheDocument();
-    expect(document.body.style.pointerEvents).not.toBe('none');
+    // The dialog unmounts before its dismissable layer releases the body, so
+    // wait for the release rather than asserting it on the same tick: clicking
+    // while `pointer-events: none` is still set is swallowed silently.
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
     await user.click(actionsButton);
     await screen.findByRole('menuitem', {name: 'Use this integration'});
   },

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -600,8 +600,9 @@ describe('IntegrationGallery: available section', () => {
 
     const link = await screen.findByRole('link', {name: 'Install GitHub'});
 
-    expect(link).toHaveClass('focus-visible:shadow-button-neutral-focus');
-    expect(link).toHaveClass('shadow-button-neutral');
+    // Cells run edge to edge inside the panel, so the ring is inset rather than
+    // the outset button ring the panel's `overflow-hidden` would crop.
+    expect(link).toHaveClass('focus-visible:shadow-focus-inset');
     expect(link.className).not.toContain('shadow-button-secondary');
     expect(within(link).getByText('Install')).toBeVisible();
     expect(within(link).queryByRole('button')).not.toBeInTheDocument();

--- a/libs/client/integrations/src/components/provider-grid.tsx
+++ b/libs/client/integrations/src/components/provider-grid.tsx
@@ -1,8 +1,7 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {IntegrationIcon} from '@shipfox/integration-icons';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
-import {Icon} from '@shipfox/react-ui/icon';
-import {Panel} from '@shipfox/react-ui/panel';
+import {Panel, PanelBody, PanelCell, PanelCellAction, PanelGrid} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
@@ -22,11 +21,6 @@ export interface ProviderGridProps {
   onOpenProvider?: ((provider: string) => void) | undefined;
 }
 
-export const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-cluster max-[760px]:grid-cols-1';
-
-export const PROVIDER_SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
-
 export function ProviderGrid({
   workspaceSlug,
   providers,
@@ -45,7 +39,7 @@ export function ProviderGrid({
 
   if (error) {
     return (
-      <div className={PROVIDER_SURFACE_CLASS}>
+      <Panel>
         <QueryLoadError
           query={{
             isError: true,
@@ -57,39 +51,42 @@ export function ProviderGrid({
           subject={errorSubject}
           variant="panel"
         />
-      </div>
+      </Panel>
     );
   }
 
   if (installableProviders.length === 0) {
     return (
-      <div className={PROVIDER_SURFACE_CLASS}>
+      <Panel>
         <EmptyState
           icon="componentLine"
           title="No integrations available"
           description={emptyMessage}
           variant="panel"
         />
-      </div>
+      </Panel>
     );
   }
 
   return (
-    <ul className={PROVIDER_GRID_CLASS}>
-      {installableProviders.map((provider) => (
-        <li key={provider.provider}>
-          <ProviderCard
-            provider={provider}
-            workspaceSlug={workspaceSlug}
-            onOpenProvider={onOpenProvider}
-          />
-        </li>
-      ))}
-    </ul>
+    <Panel>
+      <PanelBody>
+        <PanelGrid aria-label="Available integrations">
+          {installableProviders.map((provider) => (
+            <ProviderCell
+              key={provider.provider}
+              provider={provider}
+              workspaceSlug={workspaceSlug}
+              onOpenProvider={onOpenProvider}
+            />
+          ))}
+        </PanelGrid>
+      </PanelBody>
+    </Panel>
   );
 }
 
-function ProviderCard({
+function ProviderCell({
   provider,
   workspaceSlug,
   onOpenProvider,
@@ -103,74 +100,66 @@ function ProviderCard({
 
   if (catalog.kind === 'modal-connect') {
     return (
-      <button
-        type="button"
-        aria-label={`Add ${provider.displayName}`}
-        onClick={() => onOpenProvider?.(provider.provider)}
-        className="group flex h-full w-full min-w-0 items-center justify-between gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact text-left shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
-      >
-        <ProviderCardContent provider={provider} action="Add" />
-      </button>
+      <PanelCell>
+        <PanelCellAction
+          action="Add"
+          aria-label={`Add ${provider.displayName}`}
+          onClick={() => onOpenProvider?.(provider.provider)}
+        >
+          <ProviderCellContent provider={provider} />
+        </PanelCellAction>
+      </PanelCell>
     );
   }
 
   return (
-    <Link
-      to={catalog.setupPath}
-      params={{workspaceSlug}}
-      aria-label={`Install ${provider.displayName}`}
-      className="group flex h-full min-w-0 items-center justify-between gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
-    >
-      <ProviderCardContent provider={provider} action="Install" />
-    </Link>
+    <PanelCell>
+      <PanelCellAction asChild action="Install">
+        <Link
+          to={catalog.setupPath}
+          params={{workspaceSlug}}
+          aria-label={`Install ${provider.displayName}`}
+        >
+          <ProviderCellContent provider={provider} />
+        </Link>
+      </PanelCellAction>
+    </PanelCell>
   );
 }
 
-function ProviderCardContent({
-  provider,
-  action,
-}: {
-  provider: IntegrationProvider;
-  action: 'Add' | 'Install';
-}) {
+function ProviderCellContent({provider}: {provider: IntegrationProvider}) {
   return (
-    <>
-      <span className="flex min-w-0 items-center gap-cluster">
-        <IntegrationIcon
-          source={provider.provider}
-          aria-hidden
-          className="size-24 shrink-0 text-foreground-neutral-base"
-        />
-        <Text as="span" size="md" bold className="truncate">
-          {provider.displayName}
-        </Text>
-      </span>
-      <span className="flex shrink-0 items-center gap-tight text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-        <Text as="span" size="sm">
-          {action}
-        </Text>
-        <Icon name="chevronRight" className="size-16" />
-      </span>
-    </>
+    <span className="flex min-w-0 items-center gap-cluster">
+      <IntegrationIcon
+        source={provider.provider}
+        aria-hidden
+        className="size-24 shrink-0 text-foreground-neutral-base"
+      />
+      <Text as="span" size="md" bold className="truncate">
+        {provider.displayName}
+      </Text>
+    </span>
   );
 }
 
 function ProviderGridSkeleton({label}: {label: string}) {
   return (
-    <ul role="status" aria-label={label} className={PROVIDER_GRID_CLASS}>
-      {[0, 1, 2, 3].map((tile) => (
-        <li key={tile}>
-          <Panel className="h-full p-panel-compact">
-            <div className="flex items-center justify-between gap-cluster">
-              <div className="flex min-w-0 items-center gap-cluster">
-                <Skeleton className="size-24 shrink-0" />
-                <Skeleton className="h-16 w-100" />
+    <Panel>
+      <PanelBody>
+        <PanelGrid role="status" aria-label={label}>
+          {[0, 1, 2, 3].map((tile) => (
+            <PanelCell key={tile}>
+              <div className="flex items-center justify-between gap-cluster px-row py-row">
+                <div className="flex min-w-0 items-center gap-cluster">
+                  <Skeleton className="size-24 shrink-0" />
+                  <Skeleton className="h-16 w-100" />
+                </div>
+                <Skeleton className="h-16 w-64 shrink-0" />
               </div>
-              <Skeleton className="h-16 w-64 shrink-0" />
-            </div>
-          </Panel>
-        </li>
-      ))}
-    </ul>
+            </PanelCell>
+          ))}
+        </PanelGrid>
+      </PanelBody>
+    </Panel>
   );
 }

--- a/libs/client/integrations/src/components/repository-picker.test.tsx
+++ b/libs/client/integrations/src/components/repository-picker.test.tsx
@@ -86,17 +86,18 @@ describe('RepositoryPicker', () => {
     const loadingGrid = container.querySelector('[aria-hidden="true"]');
     if (!loadingGrid) throw new Error('Repository loading grid was not rendered');
 
-    expect(loadingGrid).toHaveClass(
-      'grid',
-      'grid-cols-2',
-      'gap-px',
-      'bg-border-neutral-base',
-      'max-[760px]:grid-cols-1',
-    );
+    // The placeholders sit in the same gap grid as the loaded cards, so the list
+    // does not change shape when the fetch resolves.
+    expect(loadingGrid).toHaveClass('grid', 'grid-cols-2', 'gap-inline', 'max-[760px]:grid-cols-1');
     expect(loadingGrid.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(4);
-    for (const placeholder of loadingGrid.querySelectorAll(':scope > div')) {
-      expect(placeholder).toHaveClass('h-50', 'bg-background-neutral-base', 'p-[14px]');
-      expect(placeholder).not.toHaveClass('rounded-8', 'border');
+    // The placeholder box belongs to `RadioGroupItemSkeleton`, so this only
+    // checks that each slot carries the indicator and one bar. react-ui owns
+    // keeping that surface identical to a real item.
+    const placeholders = loadingGrid.querySelectorAll(':scope > div');
+    expect(placeholders).toHaveLength(4);
+    for (const placeholder of placeholders) {
+      expect(placeholder.querySelector('[data-slot="radio-indicator"]')).not.toBeNull();
+      expect(placeholder.querySelector('[data-slot="skeleton"]')).not.toBeNull();
     }
   });
 });

--- a/libs/client/integrations/src/components/repository-picker.test.tsx
+++ b/libs/client/integrations/src/components/repository-picker.test.tsx
@@ -89,7 +89,7 @@ describe('RepositoryPicker', () => {
     // The placeholders sit in the same hairline cell grid as the loaded cards,
     // so the list does not change shape when the fetch resolves.
     expect(loadingGrid).toHaveClass('grid', 'grid-cols-2', 'max-[760px]:grid-cols-1');
-    expect(loadingGrid).toHaveClass('min-[760px]:[&>*:nth-child(even)]:border-l');
+    expect(loadingGrid).toHaveClass('min-[760px]:[&>*:nth-child(2n_of_:not(input))]:border-l');
     expect(loadingGrid).not.toHaveClass('gap-inline');
     expect(loadingGrid.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(4);
     // The placeholder box belongs to `RadioGroupItemSkeleton`, so this only

--- a/libs/client/integrations/src/components/repository-picker.test.tsx
+++ b/libs/client/integrations/src/components/repository-picker.test.tsx
@@ -86,9 +86,11 @@ describe('RepositoryPicker', () => {
     const loadingGrid = container.querySelector('[aria-hidden="true"]');
     if (!loadingGrid) throw new Error('Repository loading grid was not rendered');
 
-    // The placeholders sit in the same gap grid as the loaded cards, so the list
-    // does not change shape when the fetch resolves.
-    expect(loadingGrid).toHaveClass('grid', 'grid-cols-2', 'gap-inline', 'max-[760px]:grid-cols-1');
+    // The placeholders sit in the same hairline cell grid as the loaded cards,
+    // so the list does not change shape when the fetch resolves.
+    expect(loadingGrid).toHaveClass('grid', 'grid-cols-2', 'max-[760px]:grid-cols-1');
+    expect(loadingGrid).toHaveClass('min-[760px]:[&>*:nth-child(even)]:border-l');
+    expect(loadingGrid).not.toHaveClass('gap-inline');
     expect(loadingGrid.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(4);
     // The placeholder box belongs to `RadioGroupItemSkeleton`, so this only
     // checks that each slot carries the indicator and one bar. react-ui owns

--- a/libs/client/integrations/src/components/repository-picker.tsx
+++ b/libs/client/integrations/src/components/repository-picker.tsx
@@ -1,16 +1,13 @@
 import {Button} from '@shipfox/react-ui/button';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
 import {Label} from '@shipfox/react-ui/label';
-import {RadioGroup, RadioGroupItem} from '@shipfox/react-ui/radio-group';
-import {Skeleton} from '@shipfox/react-ui/skeleton';
+import {RadioGroup, RadioGroupItem, RadioGroupItemSkeleton} from '@shipfox/react-ui/radio-group';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Text} from '@shipfox/react-ui/typography';
 import {useId} from 'react';
 import type {Repository} from '#core/models.js';
 
 const REPOSITORY_GRID_CLASS_NAME = 'grid grid-cols-2 gap-inline max-[760px]:grid-cols-1';
-const REPOSITORY_SKELETON_GRID_CLASS_NAME =
-  'grid grid-cols-2 gap-px bg-border-neutral-base max-[760px]:grid-cols-1';
 const REPOSITORY_SKELETON_WIDTHS = ['w-64', 'w-96', 'w-80', 'w-112'] as const;
 
 export function RepositoryPicker({
@@ -78,7 +75,7 @@ function RepositoryCard({repository}: {repository: Repository}) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <RadioGroupItem value={repository.externalRepositoryId} className="min-w-0">
+        <RadioGroupItem value={repository.externalRepositoryId}>
           <span ref={nameRef} className="block min-w-0 truncate">
             <Text as="span" size="sm" bold>
               {repository.name}
@@ -97,13 +94,9 @@ function RepositoryLoadingState() {
       <div role="status" className="sr-only">
         Loading repositories.
       </div>
-      <div aria-hidden="true" className={REPOSITORY_SKELETON_GRID_CLASS_NAME}>
-        {/* The skeleton mirrors RadioGroupItem's own 14px padding contract so the
-            placeholder and the loaded card stay the same height. */}
+      <div aria-hidden="true" className={REPOSITORY_GRID_CLASS_NAME}>
         {REPOSITORY_SKELETON_WIDTHS.map((width) => (
-          <div key={width} className="h-50 min-w-0 bg-background-neutral-base p-[14px]">
-            <Skeleton className={`h-20 ${width}`} />
-          </div>
+          <RadioGroupItemSkeleton key={width} labelClassName={width} />
         ))}
       </div>
     </>

--- a/libs/client/integrations/src/components/repository-picker.tsx
+++ b/libs/client/integrations/src/components/repository-picker.tsx
@@ -1,13 +1,13 @@
 import {Button} from '@shipfox/react-ui/button';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
 import {Label} from '@shipfox/react-ui/label';
+import {PanelGrid} from '@shipfox/react-ui/panel';
 import {RadioGroup, RadioGroupItem, RadioGroupItemSkeleton} from '@shipfox/react-ui/radio-group';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Text} from '@shipfox/react-ui/typography';
 import {useId} from 'react';
 import type {Repository} from '#core/models.js';
 
-const REPOSITORY_GRID_CLASS_NAME = 'grid grid-cols-2 gap-inline max-[760px]:grid-cols-1';
 const REPOSITORY_SKELETON_WIDTHS = ['w-64', 'w-96', 'w-80', 'w-112'] as const;
 
 export function RepositoryPicker({
@@ -32,21 +32,25 @@ export function RepositoryPicker({
   const labelId = useId();
 
   return (
-    <div className="flex flex-col gap-inline">
+    <div className="flex min-w-0 flex-col">
       <Label id={labelId} className="sr-only">
         Repository
       </Label>
 
       {isLoading ? <RepositoryLoadingState /> : null}
 
-      {!isLoading && repositories.length === 0 ? <Text size="sm">{emptyMessage}</Text> : null}
+      {!isLoading && repositories.length === 0 ? (
+        <Text size="sm" className="px-row py-row">
+          {emptyMessage}
+        </Text>
+      ) : null}
 
       {repositories.length > 0 ? (
         <RadioGroup
+          variant="cell"
           aria-labelledby={labelId}
           value={selectedRepositoryId ?? ''}
           onValueChange={onSelect}
-          className={REPOSITORY_GRID_CLASS_NAME}
         >
           {repositories.map((repository) => (
             <RepositoryCard key={repository.externalRepositoryId} repository={repository} />
@@ -55,15 +59,17 @@ export function RepositoryPicker({
       ) : null}
 
       {hasNextPage && onLoadMore ? (
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          isLoading={isFetchingNextPage ?? false}
-          onClick={onLoadMore}
-        >
-          Load more
-        </Button>
+        <div className="flex justify-center border-t border-border-neutral-base p-panel-compact">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            isLoading={isFetchingNextPage ?? false}
+            onClick={onLoadMore}
+          >
+            Load more
+          </Button>
+        </div>
       ) : null}
     </div>
   );
@@ -94,11 +100,11 @@ function RepositoryLoadingState() {
       <div role="status" className="sr-only">
         Loading repositories.
       </div>
-      <div aria-hidden="true" className={REPOSITORY_GRID_CLASS_NAME}>
+      <PanelGrid as="div" aria-hidden="true">
         {REPOSITORY_SKELETON_WIDTHS.map((width) => (
-          <RadioGroupItemSkeleton key={width} labelClassName={width} />
+          <RadioGroupItemSkeleton key={width} variant="cell" labelClassName={width} />
         ))}
-      </div>
+      </PanelGrid>
     </>
   );
 }

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -313,7 +313,7 @@ function MetadataTrigger({meta}: {meta: readonly SessionViewRowMeta[]}) {
       <TooltipTrigger asChild>
         <button
           type="button"
-          className="inline-flex size-20 flex-none items-center justify-center rounded-4 text-foreground-contrast-secondary opacity-60 transition-opacity hover:bg-background-components-hover hover:text-foreground-contrast-primary hover:opacity-100 focus-visible:opacity-100 focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] group-hover/log-row:opacity-100"
+          className="inline-flex size-20 flex-none items-center justify-center rounded-4 text-foreground-contrast-secondary opacity-60 transition-opacity hover:bg-background-components-hover hover:text-foreground-contrast-primary hover:opacity-100 focus-visible:opacity-100 focus-visible:shadow-focus-inset group-hover/log-row:opacity-100"
           aria-label="Show message metadata"
         >
           <Icon name="informationLine" className="size-12" aria-hidden="true" />
@@ -347,7 +347,7 @@ function PreviewText({text}: {text: string}) {
         <button
           type="button"
           aria-expanded={expanded}
-          className="ms-inline inline-flex min-h-24 items-center rounded-4 px-tight font-display text-xs text-foreground-highlight-interactive focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)]"
+          className="ms-inline inline-flex min-h-24 items-center rounded-4 px-tight font-display text-xs text-foreground-highlight-interactive focus-visible:shadow-focus-inset"
           onClick={() => setExpanded((value) => !value)}
         >
           {expanded ? 'show less' : 'show more'}

--- a/libs/client/projects/src/components/source-strip.tsx
+++ b/libs/client/projects/src/components/source-strip.tsx
@@ -2,6 +2,7 @@ import {useActiveWorkspace} from '@shipfox/client-auth';
 import {useSourceConnectionsQuery} from '@shipfox/client-integrations';
 import {StatusBadge} from '@shipfox/react-ui/badge';
 import {Icon, type IconName} from '@shipfox/react-ui/icon';
+import {Panel} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
@@ -29,34 +30,36 @@ export function SourceStrip({
   const connection = connectionsQuery.data?.find((c) => c.id === connectionId);
 
   return (
-    <section
-      className="flex flex-col gap-inline rounded-8 border border-border-neutral-base bg-background-neutral-base px-row py-row sm:flex-row sm:items-center sm:justify-between"
-      aria-label="Project source"
+    <Panel
+      asChild
+      className="gap-inline px-row py-row sm:flex-row sm:items-center sm:justify-between"
     >
-      <div className="flex min-w-0 items-center gap-inline">
-        <Icon name={providerIconName(connection?.provider)} className="size-20 shrink-0" />
-        <div className="flex min-w-0 flex-col gap-tight sm:flex-row sm:items-center sm:gap-inline">
-          {connectionsQuery.isPending ? (
-            <Skeleton className="h-16 w-160" />
-          ) : (
-            <Text size="sm" bold className="truncate">
-              {connection?.displayName ?? 'Connected source'}
-            </Text>
-          )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Code variant="label" className="truncate text-foreground-neutral-muted">
-                {externalRepositoryId}
-              </Code>
-            </TooltipTrigger>
-            <TooltipContent>{externalRepositoryId}</TooltipContent>
-          </Tooltip>
+      <section aria-label="Project source">
+        <div className="flex min-w-0 items-center gap-inline">
+          <Icon name={providerIconName(connection?.provider)} className="size-20 shrink-0" />
+          <div className="flex min-w-0 flex-col gap-tight sm:flex-row sm:items-center sm:gap-inline">
+            {connectionsQuery.isPending ? (
+              <Skeleton className="h-16 w-160" />
+            ) : (
+              <Text size="sm" bold className="truncate">
+                {connection?.displayName ?? 'Connected source'}
+              </Text>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Code variant="label" className="truncate text-foreground-neutral-muted">
+                  {externalRepositoryId}
+                </Code>
+              </TooltipTrigger>
+              <TooltipContent>{externalRepositoryId}</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
-      </div>
-      <div className="shrink-0">
-        <SyncBadge sync={sync} isPending={isPending} />
-      </div>
-    </section>
+        <div className="shrink-0">
+          <SyncBadge sync={sync} isPending={isPending} />
+        </div>
+      </section>
+    </Panel>
   );
 }
 

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -255,7 +255,7 @@ export function CreateProjectPage() {
                   ) : null}
                 </PanelHeader>
 
-                <PanelBody className="p-panel">
+                <PanelBody>
                   <ConnectionPicker
                     connections={connections}
                     selectedConnectionId={effectiveSelectedConnectionId}
@@ -282,7 +282,7 @@ export function CreateProjectPage() {
                     />
                   </PanelActions>
                 </PanelHeader>
-                <PanelBody className="p-panel">
+                <PanelBody>
                   <RepositoryPicker
                     repositories={repositories}
                     selectedRepositoryId={selectedRepositoryId}

--- a/libs/client/projects/src/pages/home-router.test.tsx
+++ b/libs/client/projects/src/pages/home-router.test.tsx
@@ -18,7 +18,8 @@ describe('HomeRouter', () => {
 
     renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <HomeRouter />);
 
-    expect(await screen.findByRole('heading', {name: 'Projects'})).toBeInTheDocument();
+    expect(await screen.findByRole('region', {name: 'Projects'})).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', {name: 'Search projects'})).toBeInTheDocument();
     const calledUrls = fetchImpl.mock.calls.map(([input]) =>
       input instanceof Request ? input.url : String(input),
     );

--- a/libs/client/projects/src/pages/projects-hub-page.stories.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.stories.tsx
@@ -1,0 +1,203 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {type AuthState, authStateAtom} from '@shipfox/client-auth';
+import {Toaster} from '@shipfox/react-ui/toast';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {createStore, Provider as JotaiProvider} from 'jotai';
+import {useMemo} from 'react';
+import {ProjectsHubPage} from './projects-hub-page.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
+
+type Scenario = 'list' | 'empty' | 'loading' | 'error';
+
+const authState: AuthState = {
+  status: 'authenticated',
+  token: 'token',
+  user: {
+    id: '22222222-2222-4222-8222-222222222222',
+    email: 'platform@example.com',
+    name: 'Platform Engineer',
+    emailVerifiedAt: '2026-01-01T00:00:00.000Z',
+  },
+  workspaces: [{id: WORKSPACE_ID, name: 'Acme', slug: 'acme', membershipId: 'membership-1'}],
+};
+
+function ProjectsHubPageStory({scenario}: {scenario: Scenario}) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+  const store = useMemo(() => {
+    const nextStore = createStore();
+    nextStore.set(authStateAtom, authState);
+    return nextStore;
+  }, []);
+  const router = useMemo(() => createStoryRouter(), []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider store={store}>
+        <div className="min-h-screen bg-background-subtle-base px-24 py-32">
+          <div className="mx-auto w-full max-w-[1120px]">
+            <RouterProvider router={router} />
+          </div>
+        </div>
+        <Toaster />
+      </JotaiProvider>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Projects/ProjectsHubPage',
+  component: ProjectsHubPageStory,
+  parameters: {layout: 'fullscreen'},
+  args: {scenario: 'list'},
+} satisfies Meta<typeof ProjectsHubPageStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Empty: Story = {
+  args: {scenario: 'empty'},
+};
+
+export const Loading: Story = {
+  args: {scenario: 'loading'},
+};
+
+export const ErrorState: Story = {
+  args: {scenario: 'error'},
+};
+
+function createStoryRouter() {
+  const rootRoute = createRootRoute({component: Outlet});
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug',
+    component: ProjectsHubPage,
+  });
+
+  return createRouter({
+    history: createMemoryHistory({initialEntries: ['/w/acme']}),
+    routeTree: rootRoute.addChildren([workspaceRoute]),
+  });
+}
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return (input) => {
+    const url = requestUrl(input);
+
+    if (url.pathname.endsWith('/agent/model-providers')) {
+      return Promise.resolve(
+        jsonResponse({
+          configs: [
+            {
+              kind: 'builtin',
+              provider_id: 'anthropic',
+              default_model: null,
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          default_provider_id: 'anthropic',
+          default_harness_id: null,
+        }),
+      );
+    }
+
+    if (url.pathname === '/integration-connections') {
+      return Promise.resolve(
+        jsonResponse({
+          connections: [
+            {
+              id: CONNECTION_ID,
+              workspace_id: WORKSPACE_ID,
+              provider: 'github',
+              external_account_id: 'octo',
+              slug: 'github_octo',
+              display_name: 'Acme GitHub',
+              lifecycle_status: 'active',
+              capabilities: ['source_control'],
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      );
+    }
+
+    if (url.pathname === '/projects') {
+      if (scenario === 'loading') {
+        return new Promise<Response>(() => {
+          // Keep the request pending to show the initial skeleton.
+        });
+      }
+      if (scenario === 'error') {
+        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+      }
+      if (scenario === 'empty') {
+        return Promise.resolve(jsonResponse({projects: [], next_cursor: null}));
+      }
+
+      return Promise.resolve(
+        jsonResponse({
+          projects: [
+            projectForStory('Platform', '11111111-1111-4111-8111-111111111112'),
+            projectForStory('Agent', '11111111-1111-4111-8111-111111111113'),
+            projectForStory('Workflows', '11111111-1111-4111-8111-111111111114'),
+          ],
+          next_cursor: null,
+        }),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({}, {status: 404}));
+  };
+}
+
+function projectForStory(name: string, id: string) {
+  return {
+    id,
+    workspace_id: WORKSPACE_ID,
+    name,
+    slug: name.toLowerCase(),
+    source: {
+      connection_id: CONNECTION_ID,
+      external_repository_id: `github:octo/${name.toLowerCase()}`,
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) return new URL(input.url);
+  if (input instanceof URL) return input;
+  return new URL(input, 'https://api.example.test');
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {fireEvent, screen, waitFor} from '@testing-library/react';
+import {fireEvent, screen, waitFor, within} from '@testing-library/react';
 import {
   jsonResponse,
   PROJECT_TEST_WID,
@@ -17,7 +17,7 @@ describe('ProjectsHubPage', () => {
     window.sessionStorage.clear();
   });
 
-  test('renders Projects H2 + New project button + empty state with create CTA', async () => {
+  test('renders the Projects panel controls and empty state with create CTA', async () => {
     configureApiClient({
       fetchImpl: createHubFetch({
         projects: jsonResponse({projects: [], next_cursor: null}),
@@ -28,10 +28,17 @@ describe('ProjectsHubPage', () => {
     renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <ProjectsHubPage />);
 
     expect(await screen.findByText('Create your first project')).toBeInTheDocument();
-    // The page-level "Projects" title belongs in content because the top nav owns
-    // workspace identity.
-    expect(screen.getByRole('heading', {name: 'Projects'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: NEW_PROJECT_REGEX})).toHaveAttribute(
+    const projectsRegion = screen.getByRole('region', {name: 'Projects'});
+    expect(projectsRegion.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
+    const panelHeader = projectsRegion.querySelector<HTMLElement>('[data-slot="panel-header"]');
+    if (!panelHeader) throw new Error('Projects panel header was not rendered');
+    expect(panelHeader).toBeInTheDocument();
+    expect(projectsRegion.querySelector('[data-slot="panel-body"]')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Projects'})).not.toBeInTheDocument();
+    expect(
+      within(panelHeader).getByRole('searchbox', {name: 'Search projects'}),
+    ).toBeInTheDocument();
+    expect(within(panelHeader).getByRole('link', {name: NEW_PROJECT_REGEX})).toHaveAttribute(
       'href',
       WORKSPACE_PROJECTS_NEW_HREF,
     );
@@ -111,15 +118,83 @@ describe('ProjectsHubPage', () => {
 
     renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <ProjectsHubPage />);
     expect(await screen.findByText('Platform')).toBeInTheDocument();
+    const projectsList = screen.getByRole('list', {name: 'Projects list'});
+    expect(projectsList).toHaveClass('grid-cols-2', 'max-[760px]:grid-cols-1');
+    expect(projectsList).not.toHaveClass('gap-px');
+    expect(projectsList).not.toHaveClass('bg-border-neutral-base');
+    expect(projectsList.querySelectorAll(':scope > li')).toHaveLength(1);
     const projectLink = screen.getByText('Platform').closest('a');
-    // The whole card is the link, carrying the neutral focus ring (matching the
-    // integration gallery cards).
-    expect(projectLink).toHaveClass('focus-visible:shadow-button-neutral-focus');
-    expect(projectLink?.className).not.toContain('shadow-button-secondary');
+    // The whole cell is the link, carrying an inset neutral focus ring.
+    expect(projectLink).toHaveClass('focus-visible:shadow-focus-inset');
+    expect(projectLink).toHaveClass('hover:bg-background-neutral-hover');
 
     fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
 
     expect(await screen.findByText('API')).toBeInTheDocument();
+  });
+
+  test('renders an odd project count without an empty border-colored cell', async () => {
+    configureApiClient({
+      fetchImpl: createHubFetch({
+        projects: jsonResponse({
+          projects: [
+            projectDto({id: '11111111-1111-4111-8111-111111111112', name: 'Platform'}),
+            projectDto({id: '11111111-1111-4111-8111-111111111113', name: 'Agent'}),
+            projectDto({id: '11111111-1111-4111-8111-111111111114', name: 'Workflows'}),
+          ],
+          next_cursor: null,
+        }),
+      }),
+    });
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <ProjectsHubPage />);
+
+    const projectsList = await screen.findByRole('list', {name: 'Projects list'});
+    expect(projectsList.querySelectorAll(':scope > li')).toHaveLength(3);
+    expect(projectsList).not.toHaveClass('gap-px', 'bg-border-neutral-base');
+  });
+
+  test('keeps existing projects and the load-more retry after a cursor failure', async () => {
+    let cursorRequests = 0;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(requestInputUrl(input));
+      if (url.pathname.endsWith('/agent/model-providers')) {
+        return Promise.resolve(jsonResponse(modelProviderConfigsDto()));
+      }
+      if (url.pathname === '/integration-connections') {
+        return Promise.resolve(jsonResponse(connectionsDto()));
+      }
+      if (url.pathname === '/projects') {
+        if (url.searchParams.get('cursor') === 'cursor-1') {
+          cursorRequests += 1;
+          return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+        }
+        return Promise.resolve(
+          jsonResponse({
+            projects: [projectDto({id: '11111111-1111-4111-8111-111111111112', name: 'Platform'})],
+            next_cursor: 'cursor-1',
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <ProjectsHubPage />);
+    expect(await screen.findByText('Platform')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not load the next page. Existing projects are still shown.',
+    );
+    expect(screen.getByText('Platform')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Load more'})).toBeInTheDocument();
+    expect(cursorRequests).toBe(1);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
+
+    await waitFor(() => expect(cursorRequests).toBe(2));
   });
 
   test('renders an error alert with retry', async () => {

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -122,7 +122,7 @@ describe('ProjectsHubPage', () => {
     expect(projectsList).toHaveClass('grid-cols-2', 'max-[760px]:grid-cols-1');
     expect(projectsList).not.toHaveClass('gap-px');
     expect(projectsList).not.toHaveClass('bg-border-neutral-base');
-    expect(projectsList.querySelectorAll(':scope > li')).toHaveLength(1);
+    expect(projectsList.querySelectorAll('[data-slot="panel-cell"]')).toHaveLength(1);
     const projectLink = screen.getByText('Platform').closest('a');
     // The whole cell is the link, carrying an inset neutral focus ring.
     expect(projectLink).toHaveClass('focus-visible:shadow-focus-inset');
@@ -150,8 +150,13 @@ describe('ProjectsHubPage', () => {
     renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <ProjectsHubPage />);
 
     const projectsList = await screen.findByRole('list', {name: 'Projects list'});
-    expect(projectsList.querySelectorAll(':scope > li')).toHaveLength(3);
+    expect(projectsList.querySelectorAll('[data-slot="panel-cell"]')).toHaveLength(3);
     expect(projectsList).not.toHaveClass('gap-px', 'bg-border-neutral-base');
+    // The odd count is padded so the last row's divider still spans the panel,
+    // and the pad carries the panel fill rather than the border colour.
+    const filler = projectsList.querySelector('[data-slot="panel-cell-filler"]');
+    expect(filler).not.toBeNull();
+    expect(filler).toHaveClass('bg-background-neutral-base');
   });
 
   test('keeps existing projects and the load-more retry after a cursor failure', async () => {

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -11,9 +11,17 @@ import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Input} from '@shipfox/react-ui/input';
-import {Panel} from '@shipfox/react-ui/panel';
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelCell,
+  PanelCellAction,
+  PanelGrid,
+  PanelHeader,
+} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
-import {Header, Text} from '@shipfox/react-ui/typography';
+import {Text} from '@shipfox/react-ui/typography';
 import {Link, useNavigate} from '@tanstack/react-router';
 import {ModelProviderReminderBanner} from '#components/model-provider-reminder-banner.js';
 import type {Project} from '#core/project.js';
@@ -41,122 +49,118 @@ export function ProjectsHubPage({search = ''}: {search?: string}) {
 
   return (
     <div className="flex w-full flex-col gap-section">
-      <header className="flex flex-col gap-group">
-        <div className="flex items-start justify-between gap-section max-[640px]:flex-col">
-          <Header variant="h2">Projects</Header>
-        </div>
-        <div className="flex items-center gap-cluster max-[640px]:flex-col max-[640px]:items-stretch">
-          <Input
-            type="search"
-            value={search}
-            onChange={(event) => {
-              const next = event.target.value.trim();
-              navigate({search: (next ? {search: next} : {}) as never, replace: true});
-            }}
-            placeholder="Search projects…"
-            aria-label="Search projects"
-            className="flex-1"
-            iconLeft={<Icon name="searchLine" className="size-16" />}
-            iconRight={
-              isSearching ? (
-                <Icon
-                  name="spinner"
-                  size={16}
-                  className="text-foreground-neutral-muted"
-                  aria-hidden="true"
-                />
-              ) : undefined
-            }
-          />
-          <Button asChild iconLeft="addLine" className="shrink-0 max-[640px]:w-full">
-            <Link to="/w/$workspaceSlug/projects/new" params={{workspaceSlug: workspace.slug}}>
-              New project
-            </Link>
-          </Button>
-        </div>
-      </header>
-
       <ModelProviderReminderBanner workspaceId={workspace.id} />
 
-      {isInitialLoading || (search && hasNoData && query.isFetching) ? <ProjectsSkeleton /> : null}
-
-      {query.isError && hasNoData ? (
+      <section aria-label="Projects">
         <Panel>
-          <QueryLoadError query={query} subject="projects" variant="panel" />
-        </Panel>
-      ) : null}
-
-      {!isInitialLoading && !query.isError && projects.length === 0 && !search ? (
-        <Panel>
-          <EmptyProjects workspaceSlug={workspace.slug} />
-        </Panel>
-      ) : null}
-
-      {!query.isFetching && !query.isError && projects.length === 0 && search ? (
-        <Panel>
-          <NoSearchResults
-            search={search}
-            onClear={() => navigate({search: {} as never, replace: true})}
-          />
-        </Panel>
-      ) : null}
-
-      {projects.length > 0 ? (
-        <section className="flex flex-col gap-group" aria-label="Projects list">
-          <ul className="grid grid-cols-2 gap-cluster max-[760px]:grid-cols-1">
-            {projects.map((project) => (
-              <ProjectCard
-                project={project}
-                connection={connectionsById.get(project.source.connectionId)}
-                connectionsResolved={connectionsQuery.isSuccess}
-                connectionsSettled={connectionsQuery.isSuccess || connectionsQuery.isError}
-                key={project.id}
-                workspaceSlug={workspace.slug}
+          <PanelHeader className="flex-wrap max-[640px]:items-stretch">
+            <div className="min-w-0 flex-1 max-[640px]:basis-full">
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => {
+                  const next = event.target.value.trim();
+                  navigate({search: (next ? {search: next} : {}) as never, replace: true});
+                }}
+                placeholder="Search projects…"
+                aria-label="Search projects"
+                iconLeft={<Icon name="searchLine" className="size-16" />}
+                iconRight={
+                  isSearching ? (
+                    <Icon
+                      name="spinner"
+                      size={16}
+                      className="text-foreground-neutral-muted"
+                      aria-hidden="true"
+                    />
+                  ) : undefined
+                }
               />
-            ))}
-          </ul>
-          {query.error && query.data ? (
-            <Callout role="alert" type="error">
-              <Text size="sm">
-                Could not load the next page. Existing projects are still shown.
-              </Text>
-            </Callout>
-          ) : null}
-          {query.hasNextPage ? (
-            <div className="flex justify-center">
-              <Button
-                variant="secondary"
-                isLoading={query.isFetchingNextPage}
-                onClick={() => query.fetchNextPage()}
-              >
-                Load more
-              </Button>
             </div>
-          ) : null}
-        </section>
-      ) : null}
+            <PanelActions className="max-[640px]:ml-0 max-[640px]:w-full">
+              <Button asChild iconLeft="addLine" className="max-[640px]:w-full">
+                <Link to="/w/$workspaceSlug/projects/new" params={{workspaceSlug: workspace.slug}}>
+                  New project
+                </Link>
+              </Button>
+            </PanelActions>
+          </PanelHeader>
+
+          <PanelBody>
+            {isInitialLoading || (search && hasNoData && query.isFetching) ? (
+              <ProjectsSkeleton />
+            ) : null}
+
+            {query.isError && hasNoData ? (
+              <QueryLoadError query={query} subject="projects" variant="panel" />
+            ) : null}
+
+            {!isInitialLoading && !query.isError && projects.length === 0 && !search ? (
+              <EmptyProjects workspaceSlug={workspace.slug} />
+            ) : null}
+
+            {!query.isFetching && !query.isError && projects.length === 0 && search ? (
+              <NoSearchResults
+                search={search}
+                onClear={() => navigate({search: {} as never, replace: true})}
+              />
+            ) : null}
+
+            {projects.length > 0 ? (
+              <>
+                <PanelGrid aria-label="Projects list">
+                  {projects.map((project) => (
+                    <ProjectCell
+                      project={project}
+                      connection={connectionsById.get(project.source.connectionId)}
+                      connectionsResolved={connectionsQuery.isSuccess}
+                      connectionsSettled={connectionsQuery.isSuccess || connectionsQuery.isError}
+                      key={project.id}
+                      workspaceSlug={workspace.slug}
+                    />
+                  ))}
+                </PanelGrid>
+                {query.error && query.data ? (
+                  <div className="border-t border-border-neutral-base p-panel-compact">
+                    <Callout role="alert" type="error">
+                      <Text size="sm">
+                        Could not load the next page. Existing projects are still shown.
+                      </Text>
+                    </Callout>
+                  </div>
+                ) : null}
+                {query.hasNextPage ? (
+                  <div className="flex justify-center border-t border-border-neutral-base p-panel-compact">
+                    <Button
+                      variant="secondary"
+                      isLoading={query.isFetchingNextPage}
+                      onClick={() => query.fetchNextPage()}
+                    >
+                      Load more
+                    </Button>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </PanelBody>
+        </Panel>
+      </section>
     </div>
   );
 }
 
 function ProjectsSkeleton() {
   return (
-    <ul
-      role="status"
-      aria-label="Loading projects"
-      className="grid grid-cols-2 gap-cluster max-[760px]:grid-cols-1"
-    >
+    <PanelGrid role="status" aria-label="Loading projects">
       {[0, 1, 2, 3, 4, 5].map((row) => (
-        <li key={row}>
-          <Panel className="h-full p-panel-compact">
-            <div className="flex items-center gap-cluster">
-              <Skeleton className="size-24 shrink-0" />
-              <Skeleton className="h-16 w-1/2" />
-            </div>
-          </Panel>
-        </li>
+        <PanelCell key={row}>
+          <div className="flex items-center gap-cluster px-row py-row">
+            <Skeleton className="size-24 shrink-0" />
+            <Skeleton className="h-16 w-1/2" />
+          </div>
+        </PanelCell>
       ))}
-    </ul>
+    </PanelGrid>
   );
 }
 
@@ -194,7 +198,7 @@ function NoSearchResults({search, onClear}: {search: string; onClear: () => void
   );
 }
 
-function ProjectCard({
+function ProjectCell({
   project,
   connection,
   connectionsResolved,
@@ -213,34 +217,31 @@ function ProjectCard({
   const status = connectionsResolved ? (connection?.lifecycleStatus ?? 'error') : undefined;
 
   return (
-    <li>
-      <Link
-        to="/w/$workspaceSlug/p/$projectSlug"
-        params={{workspaceSlug, projectSlug: project.slug}}
-        className="block h-full rounded-8 focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
-      >
-        <Panel className="h-full p-panel-compact transition-colors hover:bg-background-components-hover">
-          <div className="flex min-w-0 items-center gap-cluster">
-            {/* Settle on success or error: a failed fetch falls back to the
-                neutral provider icon rather than spinning forever. */}
-            {connectionsSettled ? (
-              <IntegrationIcon
-                source={connection?.provider}
-                aria-hidden
-                className="size-24 shrink-0 text-foreground-neutral-base"
-              />
-            ) : (
-              <Skeleton className="size-24 shrink-0" />
-            )}
-            <div className="flex min-w-0 flex-1 items-center gap-inline">
-              <Text size="md" bold className="truncate">
-                {project.name}
-              </Text>
-              {status ? <ConnectionStatusBadge status={status} className="shrink-0" /> : null}
-            </div>
-          </div>
-        </Panel>
-      </Link>
-    </li>
+    <PanelCell>
+      <PanelCellAction asChild>
+        <Link
+          to="/w/$workspaceSlug/p/$projectSlug"
+          params={{workspaceSlug, projectSlug: project.slug}}
+        >
+          {/* Settle on success or error: a failed fetch falls back to the
+              neutral provider icon rather than spinning forever. */}
+          {connectionsSettled ? (
+            <IntegrationIcon
+              source={connection?.provider}
+              aria-hidden
+              className="size-24 shrink-0 text-foreground-neutral-base"
+            />
+          ) : (
+            <Skeleton className="size-24 shrink-0" />
+          )}
+          <span className="flex min-w-0 flex-1 items-center gap-inline">
+            <Text as="span" size="md" bold className="truncate">
+              {project.name}
+            </Text>
+            {status ? <ConnectionStatusBadge status={status} className="shrink-0" /> : null}
+          </span>
+        </Link>
+      </PanelCellAction>
+    </PanelCell>
   );
 }

--- a/libs/client/secrets/src/components/store-section-shell.tsx
+++ b/libs/client/secrets/src/components/store-section-shell.tsx
@@ -1,32 +1,27 @@
+import {Panel, PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
-import {cn} from '@shipfox/react-ui/utils';
-
-export const STORE_SURFACE_CLASS =
-  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 /** Placeholder rows shown while the store list loads. */
 export function StoreRowsSkeleton({label}: {label: string}) {
   return (
-    <div role="status" aria-label={label} className={STORE_SURFACE_CLASS}>
-      <ul className="divide-y divide-border-neutral-base">
-        {[0, 1, 2].map((row) => (
-          <li key={row} className="flex items-center gap-cluster px-row py-row">
-            <Skeleton className="h-16 w-140" />
-            <Skeleton className="h-16 w-96" />
-            <Skeleton className="ml-auto h-14 w-80 shrink-0" />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Panel>
+      <PanelBody asChild>
+        <ul role="status" aria-label={label}>
+          {[0, 1, 2].map((row) => (
+            <PanelRow
+              asChild
+              className="justify-start gap-cluster hover:bg-background-neutral-base"
+              key={row}
+            >
+              <li>
+                <Skeleton className="h-16 w-140" />
+                <Skeleton className="h-16 w-96" />
+                <Skeleton className="ml-auto h-14 w-80 shrink-0" />
+              </li>
+            </PanelRow>
+          ))}
+        </ul>
+      </PanelBody>
+    </Panel>
   );
-}
-
-export function StoreSurface({
-  className,
-  children,
-}: {
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return <div className={cn(STORE_SURFACE_CLASS, className)}>{children}</div>;
 }

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -27,7 +27,7 @@ import {copyKeyName} from './copy-key.js';
 import {DeleteEntryDialog} from './delete-entry-dialog.js';
 import {secretsErrorToFormError} from './form-errors.js';
 import {SecretForm} from './secret-form.js';
-import {StoreRowsSkeleton, StoreSurface} from './store-section-shell.js';
+import {StoreRowsSkeleton} from './store-section-shell.js';
 
 const SECRETS_DESCRIPTION =
   'Encrypted, write-only values for sensitive data like API keys, tokens, and passwords.';
@@ -71,13 +71,13 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
         {secretsQuery.isPending ? <StoreRowsSkeleton label="Loading secrets" /> : null}
 
         {secretsQuery.isError && secretsQuery.data === undefined ? (
-          <StoreSurface>
+          <Panel>
             <QueryLoadError query={secretsQuery} subject="secrets" variant="panel" />
-          </StoreSurface>
+          </Panel>
         ) : null}
 
         {secretsQuery.data !== undefined && secrets.length === 0 ? (
-          <StoreSurface>
+          <Panel>
             <EmptyState
               icon="keyLine"
               title="No secrets yet"
@@ -89,7 +89,7 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
                 </Button>
               }
             />
-          </StoreSurface>
+          </Panel>
         ) : null}
 
         {secrets.length > 0 ? (

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -26,7 +26,7 @@ import {useDeleteVariableMutation, useVariablesQuery} from '#hooks/api/variables
 import {copyKeyName} from './copy-key.js';
 import {DeleteEntryDialog} from './delete-entry-dialog.js';
 import {secretsErrorToFormError} from './form-errors.js';
-import {StoreRowsSkeleton, StoreSurface} from './store-section-shell.js';
+import {StoreRowsSkeleton} from './store-section-shell.js';
 import {VariableForm} from './variable-form.js';
 
 const VARIABLES_DESCRIPTION =
@@ -71,13 +71,13 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
         {variablesQuery.isPending ? <StoreRowsSkeleton label="Loading variables" /> : null}
 
         {variablesQuery.isError && variablesQuery.data === undefined ? (
-          <StoreSurface>
+          <Panel>
             <QueryLoadError query={variablesQuery} subject="variables" variant="panel" />
-          </StoreSurface>
+          </Panel>
         ) : null}
 
         {variablesQuery.data !== undefined && variables.length === 0 ? (
-          <StoreSurface>
+          <Panel>
             <EmptyState
               icon="bracesLine"
               title="No variables yet"
@@ -89,7 +89,7 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
                 </Button>
               }
             />
-          </StoreSurface>
+          </Panel>
         ) : null}
 
         {variables.length > 0 ? (

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -128,7 +128,7 @@ export function WorkflowRunRow({
   // Rows run edge to edge inside the list's scroll container, which would clip the standard
   // outset focus ring, so this one is inset per the design system's focus-ring rule.
   const rowClassName =
-    'flex w-full min-w-0 items-center gap-inline px-row py-row text-left transition-colors hover:bg-background-neutral-hover focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] focus-visible:outline-none @min-[976px]:h-44 @min-[976px]:py-0';
+    'flex w-full min-w-0 items-center gap-inline px-row py-row text-left transition-colors hover:bg-background-neutral-hover focus-visible:shadow-focus-inset focus-visible:outline-none @min-[976px]:h-44 @min-[976px]:py-0';
 
   // Optimistic manual runs (temp-<uuid>) have no detail page until the canonical row
   // replaces them on the next poll, so they render non-interactively instead of as a link

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -389,6 +389,8 @@
     0 2px 2px 0 var(--color-alpha-black-24);
   --shadow-border-interactive-with-active: 0 0 0 1px #ff8b16, 0 0 0 4px rgba(255, 49, 0, 0.25);
   --shadow-border-error: 0 0 0 1px #ff1f5a, 0 0 0 3px rgba(246, 0, 67, 0.25);
+  /* Theme-invariant: for controls whose parent clips the outset focus ring. */
+  --shadow-focus-inset: inset 0 0 0 2px var(--color-primary-500);
   --shadow-button-inverted:
     0 -1px 0 0 var(--color-alpha-white-12), 0 0 0 1px var(--color-alpha-white-10),
     0 0 0 1px var(--color-neutral-600), 0 0 1px 1.5px var(--color-alpha-black-24),
@@ -625,6 +627,8 @@
     0 2px 2px 0 var(--color-alpha-black-24);
   --shadow-border-interactive-with-active: 0 0 0 1px #ff8b16, 0 0 0 4px rgba(255, 49, 0, 0.25);
   --shadow-border-error: 0 0 0 1px #ff1f5a, 0 0 0 3px rgba(246, 0, 67, 0.25);
+  /* Theme-invariant: for controls whose parent clips the outset focus ring. */
+  --shadow-focus-inset: inset 0 0 0 2px var(--color-primary-500);
   --shadow-button-inverted:
     0 -1px 0 0 var(--color-alpha-white-12), 0 0 0 1px var(--color-alpha-white-10),
     0 0 0 1px var(--color-neutral-600), 0 0 1px 1.5px var(--color-alpha-black-24),
@@ -1015,6 +1019,7 @@
   --shadow-border-base: var(--shadow-border-base);
   --shadow-border-interactive-with-active: var(--shadow-border-interactive-with-active);
   --shadow-border-error: var(--shadow-border-error);
+  --shadow-focus-inset: var(--shadow-focus-inset);
   --shadow-button-inverted: var(--shadow-button-inverted);
   --shadow-button-inverted-focus: var(--shadow-button-inverted-focus);
   --shadow-button-neutral: var(--shadow-button-neutral);

--- a/libs/shared/react/ui/src/components/log/log-disclosure.tsx
+++ b/libs/shared/react/ui/src/components/log/log-disclosure.tsx
@@ -90,7 +90,7 @@ export function LogDisclosureTrigger({
             // outset focus ring top and bottom. Draw it inset (never clipped) and
             // force it: tailwind-merge can't strip the base `shadow-button-neutral-focus`
             // (it misreads the token as a shadow color), so `!` wins the cascade.
-            'focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)]!',
+            'focus-visible:shadow-focus-inset!',
             className,
           )}
         >

--- a/libs/shared/react/ui/src/components/panel/panel.stories.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.stories.tsx
@@ -1,12 +1,16 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {StatusBadge} from '#components/badge/index.js';
 import {Button} from '#components/button/index.js';
+import {Icon} from '#components/icon/index.js';
 import {Code, Text} from '#components/typography/index.js';
 import {
   Panel,
   PanelActions,
   PanelBody,
+  PanelCell,
+  PanelCellAction,
   PanelEmpty,
+  PanelGrid,
   PanelHeader,
   PanelRow,
   PanelTitle,
@@ -33,6 +37,14 @@ const workflows = [
     status: 'Failed',
     statusVariant: 'error' as const,
   },
+];
+
+const gridProjects = [
+  {name: 'Platform', path: 'platform'},
+  {name: 'Agent runtime', path: 'agent-runtime'},
+  {name: 'Workflows', path: 'workflows'},
+  {name: 'Docs site', path: 'docs-site'},
+  {name: 'Provisioner', path: 'provisioner'},
 ];
 
 const meta = {
@@ -92,6 +104,30 @@ export const Variants: Story = {
         </Panel>
       ))}
     </div>
+  ),
+};
+
+export const Grid: Story = {
+  render: () => (
+    <Panel className="w-640">
+      <PanelHeader>
+        <PanelTitle>Projects</PanelTitle>
+      </PanelHeader>
+      <PanelBody>
+        <PanelGrid aria-label="Projects">
+          {gridProjects.map((project) => (
+            <PanelCell key={project.path}>
+              <PanelCellAction>
+                <Icon name="folderLine" className="size-24 shrink-0" aria-hidden />
+                <Text as="span" size="md" bold className="truncate">
+                  {project.name}
+                </Text>
+              </PanelCellAction>
+            </PanelCell>
+          ))}
+        </PanelGrid>
+      </PanelBody>
+    </Panel>
   ),
 };
 

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -104,9 +104,57 @@ describe('PanelGrid', () => {
     // The wide and collapsed rules must share the 760px boundary, or that exact
     // viewport matches neither and the cells lose their dividers.
     expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(n+3)]:border-t')).toBe(true);
-    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(even)]:border-l')).toBe(true);
+    expect(
+      grid?.classList.contains(
+        'min-[760px]:[&>*:nth-child(even):not([data-slot=panel-cell-filler])]:border-l',
+      ),
+    ).toBe(true);
     expect(grid?.classList.contains('max-[760px]:[&>*:nth-child(n+2)]:border-t')).toBe(true);
     expect(grid?.classList.contains('[&>*]:border-border-neutral-base')).toBe(true);
+  });
+
+  test('pads a ragged last row so its divider spans the full panel', () => {
+    const {container} = render(
+      <PanelGrid>
+        <PanelCell>One</PanelCell>
+        <PanelCell>Two</PanelCell>
+        <PanelCell>Three</PanelCell>
+      </PanelGrid>,
+    );
+
+    const filler = container.querySelector('[data-slot="panel-cell-filler"]');
+
+    // Without it the rule above the third cell would stop at the middle.
+    expect(filler).not.toBeNull();
+    expect(filler?.getAttribute('aria-hidden')).toBe('true');
+    expect(filler?.textContent).toBe('');
+    // One column never leaves a row half full, so the filler must not add a row.
+    expect(filler?.classList.contains('hidden')).toBe(true);
+    expect(filler?.classList.contains('min-[760px]:block')).toBe(true);
+  });
+
+  test('adds no filler when the last row is already full', () => {
+    const {container} = render(
+      <PanelGrid>
+        <PanelCell>One</PanelCell>
+        <PanelCell>Two</PanelCell>
+      </PanelGrid>,
+    );
+
+    expect(container.querySelector('[data-slot="panel-cell-filler"]')).toBeNull();
+  });
+
+  test('ignores conditional gaps when counting cells', () => {
+    const showTrailing = false;
+    const {container} = render(
+      <PanelGrid>
+        {[<PanelCell key="a">One</PanelCell>, <PanelCell key="b">Two</PanelCell>]}
+        {showTrailing ? <PanelCell>Three</PanelCell> : null}
+      </PanelGrid>,
+    );
+
+    // A `null` slot is not a cell, so two real cells still fill the row.
+    expect(container.querySelector('[data-slot="panel-cell-filler"]')).toBeNull();
   });
 });
 

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -142,6 +142,25 @@ describe('PanelGrid', () => {
     expect(filler?.classList.contains('min-[760px]:block')).toBe(true);
   });
 
+  test('matches the filler element to the grid element when rendered as a div', () => {
+    const {container} = render(
+      <PanelGrid as="div">
+        <div>One</div>
+        <div>Two</div>
+        <div>Three</div>
+      </PanelGrid>,
+    );
+
+    const grid = container.querySelector('[data-slot="panel-grid"]');
+    const filler = container.querySelector('[data-slot="panel-cell-filler"]');
+
+    // An `li` here would be invalid markup, and the odd count still needs
+    // padding for the last row's dividers to reach across.
+    expect(grid?.tagName).toBe('DIV');
+    expect(filler?.tagName).toBe('DIV');
+    expect(grid?.children[3]).toBe(filler);
+  });
+
   test('adds no filler when the last row is already full', () => {
     const {container} = render(
       <PanelGrid>

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -167,6 +167,18 @@ describe('PanelCellAction', () => {
     expect(action.getAttribute('type')).toBe('button');
     expect(action.classList.contains('focus-visible:shadow-focus-inset')).toBe(true);
     expect(action.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
+    expect(action.classList.contains('cursor-pointer')).toBe(true);
+  });
+
+  test('treats a conditional verb that resolves to nothing as no verb', () => {
+    const showVerb = false;
+    const {container} = render(
+      <PanelCellAction action={showVerb ? 'Install' : null}>GitHub</PanelCellAction>,
+    );
+
+    // A bare chevron pushed to the far edge would claim this cell navigates.
+    expect(container.querySelector('[data-slot="panel-cell-verb"]')).toBeNull();
+    expect(screen.getByRole('button').classList.contains('justify-between')).toBe(false);
   });
 
   test('renders as its child so a link can fill the cell', () => {

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -103,9 +103,15 @@ describe('PanelGrid', () => {
     }
     // The wide and collapsed rules must share the 760px boundary, or that exact
     // viewport matches neither and the cells lose their dividers.
-    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(n+3)]:border-t')).toBe(true);
-    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(even)]:border-l')).toBe(true);
-    expect(grid?.classList.contains('max-[760px]:[&>*:nth-child(n+2)]:border-t')).toBe(true);
+    expect(
+      grid?.classList.contains('min-[760px]:[&>*:nth-child(n+3_of_:not(input))]:border-t'),
+    ).toBe(true);
+    expect(
+      grid?.classList.contains('min-[760px]:[&>*:nth-child(2n_of_:not(input))]:border-l'),
+    ).toBe(true);
+    expect(
+      grid?.classList.contains('max-[760px]:[&>*:nth-child(n+2_of_:not(input))]:border-t'),
+    ).toBe(true);
     expect(grid?.classList.contains('[&>*]:border-border-neutral-base')).toBe(true);
   });
 
@@ -128,7 +134,9 @@ describe('PanelGrid', () => {
     // The filler sits in the even slot, so the column rule reaches it and the
     // half-full row reads as a grid with an empty cell, not one wide row.
     expect(grid?.children[3]).toBe(filler);
-    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(even)]:border-l')).toBe(true);
+    expect(
+      grid?.classList.contains('min-[760px]:[&>*:nth-child(2n_of_:not(input))]:border-l'),
+    ).toBe(true);
     // One column never leaves a row half full, so the filler must not add a row.
     expect(filler?.classList.contains('hidden')).toBe(true);
     expect(filler?.classList.contains('min-[760px]:block')).toBe(true);

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -104,16 +104,12 @@ describe('PanelGrid', () => {
     // The wide and collapsed rules must share the 760px boundary, or that exact
     // viewport matches neither and the cells lose their dividers.
     expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(n+3)]:border-t')).toBe(true);
-    expect(
-      grid?.classList.contains(
-        'min-[760px]:[&>*:nth-child(even):not([data-slot=panel-cell-filler])]:border-l',
-      ),
-    ).toBe(true);
+    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(even)]:border-l')).toBe(true);
     expect(grid?.classList.contains('max-[760px]:[&>*:nth-child(n+2)]:border-t')).toBe(true);
     expect(grid?.classList.contains('[&>*]:border-border-neutral-base')).toBe(true);
   });
 
-  test('pads a ragged last row so its divider spans the full panel', () => {
+  test('pads a ragged last row so its dividers span the full panel', () => {
     const {container} = render(
       <PanelGrid>
         <PanelCell>One</PanelCell>
@@ -122,12 +118,17 @@ describe('PanelGrid', () => {
       </PanelGrid>,
     );
 
+    const grid = container.querySelector('[data-slot="panel-grid"]');
     const filler = container.querySelector('[data-slot="panel-cell-filler"]');
 
     // Without it the rule above the third cell would stop at the middle.
     expect(filler).not.toBeNull();
     expect(filler?.getAttribute('aria-hidden')).toBe('true');
     expect(filler?.textContent).toBe('');
+    // The filler sits in the even slot, so the column rule reaches it and the
+    // half-full row reads as a grid with an empty cell, not one wide row.
+    expect(grid?.children[3]).toBe(filler);
+    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(even)]:border-l')).toBe(true);
     // One column never leaves a row half full, so the filler must not add a row.
     expect(filler?.classList.contains('hidden')).toBe(true);
     expect(filler?.classList.contains('min-[760px]:block')).toBe(true);

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -1,9 +1,12 @@
-import {render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {
   Panel,
   PanelActions,
   PanelBody,
+  PanelCell,
+  PanelCellAction,
   PanelEmpty,
+  PanelGrid,
   PanelHeader,
   PanelRow,
   PanelTitle,
@@ -71,5 +74,92 @@ describe('Panel', () => {
 
     expect(row?.classList.contains('last:border-b-0')).toBe(true);
     expect(empty?.classList.contains('p-panel-compact')).toBe(true);
+  });
+});
+
+/** A cell must not carry its own divider: the grid owns every hairline. */
+const CELL_BORDER_PATTERN = /\bborder-[tl]\b/;
+
+describe('PanelGrid', () => {
+  test('draws its dividers from the cell position, so no caller counts indexes', () => {
+    const {container} = render(
+      <Panel>
+        <PanelBody>
+          <PanelGrid aria-label="Projects">
+            <PanelCell>One</PanelCell>
+            <PanelCell>Two</PanelCell>
+            <PanelCell>Three</PanelCell>
+          </PanelGrid>
+        </PanelBody>
+      </Panel>,
+    );
+
+    const grid = container.querySelector('[data-slot="panel-grid"]');
+    const cells = container.querySelectorAll('[data-slot="panel-cell"]');
+
+    expect(cells).toHaveLength(3);
+    for (const cell of cells) {
+      expect(cell.className).not.toMatch(CELL_BORDER_PATTERN);
+    }
+    // The wide and collapsed rules must share the 760px boundary, or that exact
+    // viewport matches neither and the cells lose their dividers.
+    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(n+3)]:border-t')).toBe(true);
+    expect(grid?.classList.contains('min-[760px]:[&>*:nth-child(even)]:border-l')).toBe(true);
+    expect(grid?.classList.contains('max-[760px]:[&>*:nth-child(n+2)]:border-t')).toBe(true);
+    expect(grid?.classList.contains('[&>*]:border-border-neutral-base')).toBe(true);
+  });
+});
+
+describe('PanelCellAction', () => {
+  test('defaults to a non-submitting button with an inset focus ring', () => {
+    render(<PanelCellAction>Open</PanelCellAction>);
+
+    const action = screen.getByRole('button', {name: 'Open'});
+
+    expect(action.getAttribute('type')).toBe('button');
+    expect(action.classList.contains('focus-visible:shadow-focus-inset')).toBe(true);
+    expect(action.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
+  });
+
+  test('renders as its child so a link can fill the cell', () => {
+    render(
+      <PanelCellAction asChild>
+        <a href="/projects/one">Project one</a>
+      </PanelCellAction>,
+    );
+
+    const link = screen.getByRole('link', {name: 'Project one'});
+
+    expect(link.getAttribute('type')).toBeNull();
+    expect(link.classList.contains('focus-visible:shadow-focus-inset')).toBe(true);
+  });
+
+  test('owns the trailing verb and chevron that mark a cell as navigation', () => {
+    const {container} = render(<PanelCellAction action="Install">GitHub</PanelCellAction>);
+
+    const verb = container.querySelector('[data-slot="panel-cell-verb"]');
+
+    expect(verb?.textContent).toBe('Install');
+    expect(verb?.querySelector('svg')).not.toBeNull();
+    expect(screen.getByRole('button').classList.contains('justify-between')).toBe(true);
+  });
+
+  test('keeps the verb inside the slotted child so a link wraps the whole cell', () => {
+    render(
+      <PanelCellAction asChild action="Install">
+        <a href="/install/github">GitHub</a>
+      </PanelCellAction>,
+    );
+
+    const link = screen.getByRole('link');
+
+    expect(link.querySelector('[data-slot="panel-cell-verb"]')).not.toBeNull();
+  });
+
+  test('omits the affordance when the cell is not navigation', () => {
+    const {container} = render(<PanelCellAction>Plain</PanelCellAction>);
+
+    expect(container.querySelector('[data-slot="panel-cell-verb"]')).toBeNull();
+    expect(screen.getByRole('button').classList.contains('justify-between')).toBe(false);
   });
 });

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -1,13 +1,20 @@
-import type {ComponentProps} from 'react';
+import {Slot, Slottable} from '@radix-ui/react-slot';
+import type {ComponentProps, ReactNode} from 'react';
 import {cn} from '#utils/cn.js';
-import {Header} from '../typography/index.js';
+import {Icon} from '../icon/index.js';
+import {Header, Text} from '../typography/index.js';
 
 /** A bordered data region. A panel never contains another panel. */
-export interface PanelProps extends ComponentProps<'div'> {}
+export interface PanelProps extends ComponentProps<'div'> {
+  /** Render as the child element, for a panel that is an `aside` or a `section`. */
+  asChild?: boolean;
+}
 
-export function Panel({className, ...props}: PanelProps) {
+export function Panel({className, asChild = false, ...props}: PanelProps) {
+  const Component = asChild ? Slot : 'div';
+
   return (
-    <div
+    <Component
       data-slot="panel"
       className={cn(
         'flex min-w-0 flex-col overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base text-foreground-neutral-base shadow-button-neutral',
@@ -69,11 +76,16 @@ export function PanelActions({className, ...props}: PanelActionsProps) {
   );
 }
 
-export interface PanelBodyProps extends ComponentProps<'div'> {}
+export interface PanelBodyProps extends ComponentProps<'div'> {
+  /** Render as the child element, so a row list can keep `ul` semantics. */
+  asChild?: boolean;
+}
 
-export function PanelBody({className, ...props}: PanelBodyProps) {
+export function PanelBody({className, asChild = false, ...props}: PanelBodyProps) {
+  const Component = asChild ? Slot : 'div';
+
   return (
-    <div
+    <Component
       data-slot="panel-body"
       className={cn('flex min-w-0 flex-col bg-background-neutral-base', className)}
       {...props}
@@ -81,11 +93,16 @@ export function PanelBody({className, ...props}: PanelBodyProps) {
   );
 }
 
-export interface PanelRowProps extends ComponentProps<'div'> {}
+export interface PanelRowProps extends ComponentProps<'div'> {
+  /** Render as the child element, so a row can keep `li` semantics. */
+  asChild?: boolean;
+}
 
-export function PanelRow({className, ...props}: PanelRowProps) {
+export function PanelRow({className, asChild = false, ...props}: PanelRowProps) {
+  const Component = asChild ? Slot : 'div';
+
   return (
-    <div
+    <Component
       data-slot="panel-row"
       className={cn(
         'flex min-h-44 min-w-0 items-center justify-between gap-group border-b border-border-neutral-base bg-background-neutral-base px-row py-row text-foreground-neutral-base transition-colors last:border-b-0 hover:bg-background-neutral-hover',
@@ -93,6 +110,91 @@ export function PanelRow({className, ...props}: PanelRowProps) {
       )}
       {...props}
     />
+  );
+}
+
+/**
+ * A grid of cells inside a panel body, divided by hairlines rather than gaps,
+ * because a bordered tile inside a panel would be two frames around one thing.
+ * Two columns, collapsing to one at the 760px breakpoint the product's other
+ * grids already use.
+ */
+// `max-[760px]` compiles to `width<760` and `min-[760px]` to `width>=760`, so the
+// two halves meet exactly. Pairing it with `min-[761px]` would leave 760px itself
+// matching neither rule, and the row of cells would lose its dividers.
+const PANEL_GRID_CLASS = [
+  'grid grid-cols-2 max-[760px]:grid-cols-1',
+  '[&>*]:border-border-neutral-base',
+  'min-[760px]:[&>*:nth-child(n+3)]:border-t min-[760px]:[&>*:nth-child(even)]:border-l',
+  'max-[760px]:[&>*:nth-child(n+2)]:border-t',
+].join(' ');
+
+export interface PanelGridProps extends ComponentProps<'ul'> {}
+
+export function PanelGrid({className, ...props}: PanelGridProps) {
+  return <ul data-slot="panel-grid" className={cn(PANEL_GRID_CLASS, className)} {...props} />;
+}
+
+export interface PanelCellProps extends ComponentProps<'li'> {}
+
+export function PanelCell({className, ...props}: PanelCellProps) {
+  return (
+    <li
+      data-slot="panel-cell"
+      className={cn('flex min-w-0 flex-col bg-background-neutral-base', className)}
+      {...props}
+    />
+  );
+}
+
+export interface PanelCellActionProps extends ComponentProps<'button'> {
+  /** Render as the child element, for a router `Link` that fills the cell. */
+  asChild?: boolean;
+  /**
+   * The verb for the trailing affordance, such as `Install` or `Configure`.
+   * This is what separates a cell you open from a choice you select, so pass it
+   * on anything that navigates.
+   */
+  action?: ReactNode;
+}
+
+export function PanelCellAction({
+  className,
+  asChild = false,
+  action,
+  children,
+  ...props
+}: PanelCellActionProps) {
+  const Component = asChild ? Slot : 'button';
+
+  return (
+    <Component
+      data-slot="panel-cell-action"
+      className={cn(
+        'group flex min-w-0 flex-1 items-center gap-cluster px-row py-row text-left transition-colors',
+        'hover:bg-background-neutral-hover',
+        // Cells run edge to edge inside the panel, whose `overflow-hidden` crops
+        // an outset ring, so this one is drawn inset per the focus-ring rule.
+        'focus-visible:shadow-focus-inset focus-visible:outline-none',
+        action === undefined ? undefined : 'justify-between',
+        className,
+      )}
+      {...(asChild ? {} : {type: 'button' as const})}
+      {...props}
+    >
+      <Slottable>{children}</Slottable>
+      {action === undefined ? null : (
+        <span
+          data-slot="panel-cell-verb"
+          className="flex shrink-0 items-center gap-tight text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive"
+        >
+          <Text as="span" size="sm">
+            {action}
+          </Text>
+          <Icon name="chevronRight" className="size-16" aria-hidden />
+        </span>
+      )}
+    </Component>
   );
 }
 

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -1,5 +1,12 @@
 import {Slot, Slottable} from '@radix-ui/react-slot';
-import {Children, type ComponentProps, type ReactNode} from 'react';
+import {
+  Children,
+  type ComponentProps,
+  type ElementType,
+  type HTMLAttributes,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react';
 import {cn} from '#utils/cn.js';
 import {Icon} from '../icon/index.js';
 import {Header, Text} from '../typography/index.js';
@@ -133,25 +140,33 @@ const PANEL_GRID_CLASS = [
   'max-[760px]:[&>*:nth-child(n+2)]:border-t',
 ].join(' ');
 
-export interface PanelGridProps extends ComponentProps<'ul'> {}
+export type PanelGridProps = PropsWithChildren<HTMLAttributes<HTMLElement>> & {
+  /**
+   * Render as a `div` for a grid whose cells are not list items, such as a
+   * radio group whose cells are the radio buttons themselves.
+   */
+  as?: ElementType;
+};
 
-export function PanelGrid({className, children, ...props}: PanelGridProps) {
+export function PanelGrid({className, children, as, ...props}: PanelGridProps) {
+  const Component = as ?? 'ul';
+  const Filler = Component === 'ul' ? 'li' : 'div';
   // An odd cell count leaves the last row half wide, and its dividers would stop
   // at the middle of the panel. Pad it with an inert cell that completes both
   // rules. At one column every row is already full, so the filler hides.
   const hasRaggedLastRow = Children.toArray(children).length % 2 === 1;
 
   return (
-    <ul data-slot="panel-grid" className={cn(PANEL_GRID_CLASS, className)} {...props}>
+    <Component data-slot="panel-grid" className={cn(PANEL_GRID_CLASS, className)} {...props}>
       {children}
       {hasRaggedLastRow ? (
-        <li
+        <Filler
           aria-hidden="true"
           data-slot="panel-cell-filler"
           className="hidden bg-background-neutral-base min-[760px]:block"
         />
       ) : null}
-    </ul>
+    </Component>
   );
 }
 

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -129,15 +129,20 @@ export function PanelRow({className, asChild = false, ...props}: PanelRowProps) 
 // `max-[760px]` compiles to `width<760` and `min-[760px]` to `width>=760`, so the
 // two halves meet exactly. Pairing it with `min-[761px]` would leave 760px itself
 // matching neither rule, and the row of cells would lose its dividers.
+// `of :not(input)` because a Radix radio item inside a form renders a hidden
+// bubble input beside its button. Those inputs are siblings in the grid, so a
+// plain `nth-child` counts them and the dividers land on the wrong cells.
+// These are written out in full: Tailwind scans source text, so a class built
+// by interpolation never reaches the stylesheet.
 const PANEL_GRID_CLASS = [
   'grid grid-cols-2 max-[760px]:grid-cols-1',
   '[&>*]:border-border-neutral-base',
-  'min-[760px]:[&>*:nth-child(n+3)]:border-t',
+  'min-[760px]:[&>*:nth-child(n+3_of_:not(input))]:border-t',
   // The filler takes this too, so the column rule runs the full height and a
   // half-full last row reads as a grid with an empty cell rather than one wide
   // row.
-  'min-[760px]:[&>*:nth-child(even)]:border-l',
-  'max-[760px]:[&>*:nth-child(n+2)]:border-t',
+  'min-[760px]:[&>*:nth-child(2n_of_:not(input))]:border-l',
+  'max-[760px]:[&>*:nth-child(n+2_of_:not(input))]:border-t',
 ].join(' ');
 
 export type PanelGridProps = PropsWithChildren<HTMLAttributes<HTMLElement>> & {

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -1,5 +1,5 @@
 import {Slot, Slottable} from '@radix-ui/react-slot';
-import type {ComponentProps, ReactNode} from 'react';
+import {Children, type ComponentProps, type ReactNode} from 'react';
 import {cn} from '#utils/cn.js';
 import {Icon} from '../icon/index.js';
 import {Header, Text} from '../typography/index.js';
@@ -125,14 +125,33 @@ export function PanelRow({className, asChild = false, ...props}: PanelRowProps) 
 const PANEL_GRID_CLASS = [
   'grid grid-cols-2 max-[760px]:grid-cols-1',
   '[&>*]:border-border-neutral-base',
-  'min-[760px]:[&>*:nth-child(n+3)]:border-t min-[760px]:[&>*:nth-child(even)]:border-l',
+  'min-[760px]:[&>*:nth-child(n+3)]:border-t',
+  // The filler is excluded so the column rule stops at the last full row rather
+  // than boxing an empty slot.
+  'min-[760px]:[&>*:nth-child(even):not([data-slot=panel-cell-filler])]:border-l',
   'max-[760px]:[&>*:nth-child(n+2)]:border-t',
 ].join(' ');
 
 export interface PanelGridProps extends ComponentProps<'ul'> {}
 
-export function PanelGrid({className, ...props}: PanelGridProps) {
-  return <ul data-slot="panel-grid" className={cn(PANEL_GRID_CLASS, className)} {...props} />;
+export function PanelGrid({className, children, ...props}: PanelGridProps) {
+  // An odd cell count leaves the last row half wide, and its divider would stop
+  // at the middle of the panel. Pad it with an inert cell so the rule runs the
+  // full width. At one column every row is already full, so the filler hides.
+  const hasRaggedLastRow = Children.toArray(children).length % 2 === 1;
+
+  return (
+    <ul data-slot="panel-grid" className={cn(PANEL_GRID_CLASS, className)} {...props}>
+      {children}
+      {hasRaggedLastRow ? (
+        <li
+          aria-hidden="true"
+          data-slot="panel-cell-filler"
+          className="hidden bg-background-neutral-base min-[760px]:block"
+        />
+      ) : null}
+    </ul>
+  );
 }
 
 export interface PanelCellProps extends ComponentProps<'li'> {}

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -126,18 +126,19 @@ const PANEL_GRID_CLASS = [
   'grid grid-cols-2 max-[760px]:grid-cols-1',
   '[&>*]:border-border-neutral-base',
   'min-[760px]:[&>*:nth-child(n+3)]:border-t',
-  // The filler is excluded so the column rule stops at the last full row rather
-  // than boxing an empty slot.
-  'min-[760px]:[&>*:nth-child(even):not([data-slot=panel-cell-filler])]:border-l',
+  // The filler takes this too, so the column rule runs the full height and a
+  // half-full last row reads as a grid with an empty cell rather than one wide
+  // row.
+  'min-[760px]:[&>*:nth-child(even)]:border-l',
   'max-[760px]:[&>*:nth-child(n+2)]:border-t',
 ].join(' ');
 
 export interface PanelGridProps extends ComponentProps<'ul'> {}
 
 export function PanelGrid({className, children, ...props}: PanelGridProps) {
-  // An odd cell count leaves the last row half wide, and its divider would stop
-  // at the middle of the panel. Pad it with an inert cell so the rule runs the
-  // full width. At one column every row is already full, so the filler hides.
+  // An odd cell count leaves the last row half wide, and its dividers would stop
+  // at the middle of the panel. Pad it with an inert cell that completes both
+  // rules. At one column every row is already full, so the filler hides.
   const hasRaggedLastRow = Children.toArray(children).length % 2 === 1;
 
   return (

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -185,24 +185,27 @@ export function PanelCellAction({
   ...props
 }: PanelCellActionProps) {
   const Component = asChild ? Slot : 'button';
+  // A conditional verb resolves to null or false, which must read as no verb at
+  // all rather than a bare chevron pushed to the far edge.
+  const hasAction = Boolean(action);
 
   return (
     <Component
       data-slot="panel-cell-action"
       className={cn(
-        'group flex min-w-0 flex-1 items-center gap-cluster px-row py-row text-left transition-colors',
+        'group flex min-w-0 flex-1 cursor-pointer items-center gap-cluster px-row py-row text-left transition-colors',
         'hover:bg-background-neutral-hover',
         // Cells run edge to edge inside the panel, whose `overflow-hidden` crops
         // an outset ring, so this one is drawn inset per the focus-ring rule.
         'focus-visible:shadow-focus-inset focus-visible:outline-none',
-        action === undefined ? undefined : 'justify-between',
+        hasAction && 'justify-between',
         className,
       )}
       {...(asChild ? {} : {type: 'button' as const})}
       {...props}
     >
       <Slottable>{children}</Slottable>
-      {action === undefined ? null : (
+      {hasAction ? (
         <span
           data-slot="panel-cell-verb"
           className="flex shrink-0 items-center gap-tight text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive"
@@ -212,7 +215,7 @@ export function PanelCellAction({
           </Text>
           <Icon name="chevronRight" className="size-16" aria-hidden />
         </span>
-      )}
+      ) : null}
     </Component>
   );
 }

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.stories.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 import {Label} from '#components/label/index.js';
 import {Text} from '#components/typography/index.js';
-import {RadioGroup, RadioGroupItem} from './radio-group.js';
+import {RadioGroup, RadioGroupItem, RadioGroupItemSkeleton} from './radio-group.js';
 
 const meta = {
   title: 'Components/RadioGroup',
@@ -12,7 +12,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Single-select picker built on `@radix-ui/react-radio-group`. Use for source-control connection pickers, repository pickers, and other "1-of-N" choices where each option is a card-shaped surface. Arrow keys cycle selection, Home/End jump to ends.',
+          'Single-select picker built on `@radix-ui/react-radio-group`. Use for source-control connection pickers, repository pickers, and other "1-of-N" choices where each option is a card-shaped surface. The leading dot is what separates a choice from a navigation tile, which wears a trailing chevron instead. Arrow keys cycle selection, Home/End jump to ends.',
       },
     },
   },
@@ -28,6 +28,19 @@ const SAMPLE_CONNECTIONS = [
   {id: 'conn-3', name: 'Other GitHub Source', subtitle: 'github · acme-fork'},
 ];
 
+function Option({name, subtitle}: {name: string; subtitle: string}) {
+  return (
+    <>
+      <Text as="span" size="sm" bold>
+        {name}
+      </Text>
+      <Text as="span" size="xs" className="text-foreground-neutral-muted">
+        {subtitle}
+      </Text>
+    </>
+  );
+}
+
 export const Playground: Story = {
   render: () => {
     function ControlledRadioGroup() {
@@ -42,12 +55,7 @@ export const Playground: Story = {
           >
             {SAMPLE_CONNECTIONS.map((connection) => (
               <RadioGroupItem key={connection.id} value={connection.id}>
-                <Text size="sm" bold>
-                  {connection.name}
-                </Text>
-                <Text size="xs" className="text-foreground-neutral-muted">
-                  {connection.subtitle}
-                </Text>
+                <Option name={connection.name} subtitle={connection.subtitle} />
               </RadioGroupItem>
             ))}
           </RadioGroup>
@@ -60,50 +68,38 @@ export const Playground: Story = {
 
 export const States: Story = {
   render: () => (
-    <div className="flex w-[420px] flex-col gap-10">
-      <Label>States preview</Label>
-      <RadioGroup defaultValue="conn-2">
-        <RadioGroupItem value="conn-1">
-          <Text size="sm" bold>
-            Default
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            Unselected
-          </Text>
-        </RadioGroupItem>
-        <RadioGroupItem value="conn-2">
-          <Text size="sm" bold>
-            Selected
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            data-state=&quot;checked&quot;
-          </Text>
-        </RadioGroupItem>
-        <RadioGroupItem value="conn-3" className="hover">
-          <Text size="sm" bold>
-            Hover
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            Pseudo-class preview
-          </Text>
-        </RadioGroupItem>
-        <RadioGroupItem value="conn-4" className="focus">
-          <Text size="sm" bold>
-            Focus visible
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            Keyboard focus ring
-          </Text>
-        </RadioGroupItem>
-        <RadioGroupItem value="conn-5" disabled>
-          <Text size="sm" bold>
-            Disabled
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            Not selectable
-          </Text>
-        </RadioGroupItem>
-      </RadioGroup>
+    <div className="flex w-[420px] flex-col gap-24">
+      <div className="flex flex-col gap-10">
+        <Label>States preview</Label>
+        <RadioGroup defaultValue="conn-2">
+          <RadioGroupItem value="conn-1">
+            <Option name="Default" subtitle="Unselected" />
+          </RadioGroupItem>
+          <RadioGroupItem value="conn-2">
+            <Option name="Selected" subtitle='data-state="checked"' />
+          </RadioGroupItem>
+          <RadioGroupItem value="conn-3" className="hover">
+            <Option name="Hover" subtitle="Pseudo-class preview" />
+          </RadioGroupItem>
+          <RadioGroupItem value="conn-4" disabled>
+            <Option name="Disabled" subtitle="Not selectable" />
+          </RadioGroupItem>
+        </RadioGroup>
+      </div>
+
+      {/* A roving tabindex lands keyboard focus on the checked item first, so the
+          checked + focused pair is the state most likely to regress. */}
+      <div className="flex flex-col gap-10">
+        <Label>Keyboard focus</Label>
+        <RadioGroup defaultValue="focus-2">
+          <RadioGroupItem value="focus-1" className="focus">
+            <Option name="Focus visible" subtitle="Unselected, keyboard focused" />
+          </RadioGroupItem>
+          <RadioGroupItem value="focus-2" className="focus">
+            <Option name="Focus visible" subtitle="Selected and keyboard focused" />
+          </RadioGroupItem>
+        </RadioGroup>
+      </div>
     </div>
   ),
   parameters: {
@@ -120,14 +116,25 @@ export const SingleOption: Story = {
       <Label>Source connection</Label>
       <RadioGroup defaultValue="only-one">
         <RadioGroupItem value="only-one">
-          <Text size="sm" bold>
-            Only one option
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            Pre-selected; useful when there is exactly one connection.
-          </Text>
+          <Option
+            name="Only one option"
+            subtitle="Pre-selected; useful when there is exactly one connection."
+          />
         </RadioGroupItem>
       </RadioGroup>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div className="flex w-[420px] flex-col gap-10">
+      <Label>Repository</Label>
+      <div className="flex flex-col gap-inline">
+        {['w-64', 'w-96', 'w-80', 'w-112'].map((width) => (
+          <RadioGroupItemSkeleton key={width} labelClassName={width} />
+        ))}
+      </div>
     </div>
   ),
 };

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.stories.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 import {Label} from '#components/label/index.js';
+import {Panel, PanelBody, PanelHeader, PanelTitle} from '#components/panel/index.js';
 import {Text} from '#components/typography/index.js';
 import {RadioGroup, RadioGroupItem, RadioGroupItemSkeleton} from './radio-group.js';
 
@@ -124,6 +125,31 @@ export const SingleOption: Story = {
       </RadioGroup>
     </div>
   ),
+};
+
+export const InsidePanel: Story = {
+  render: () => {
+    function CellRadioGroup() {
+      const [value, setValue] = useState<string>('conn-1');
+      return (
+        <Panel className="w-[560px]">
+          <PanelHeader>
+            <PanelTitle>Source integration</PanelTitle>
+          </PanelHeader>
+          <PanelBody>
+            <RadioGroup variant="cell" value={value} onValueChange={setValue}>
+              {SAMPLE_CONNECTIONS.map((connection) => (
+                <RadioGroupItem key={connection.id} value={connection.id}>
+                  <Option name={connection.name} subtitle={connection.subtitle} />
+                </RadioGroupItem>
+              ))}
+            </RadioGroup>
+          </PanelBody>
+        </Panel>
+      );
+    }
+    return <CellRadioGroup />;
+  },
 };
 
 export const Loading: Story = {

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
@@ -1,0 +1,104 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import {RadioGroup, RadioGroupItem, RadioGroupItemSkeleton} from './radio-group.js';
+
+function renderGroup(defaultValue: string) {
+  return render(
+    <RadioGroup defaultValue={defaultValue}>
+      <RadioGroupItem value="default">Default</RadioGroupItem>
+      <RadioGroupItem value="selected">Selected</RadioGroupItem>
+    </RadioGroup>,
+  );
+}
+
+describe('RadioGroupItem', () => {
+  test('rests on an opaque surface so the fill does not shift with the parent', () => {
+    renderGroup('selected');
+
+    const item = screen.getByRole('radio', {name: 'Default'});
+
+    expect(item.classList.contains('bg-background-neutral-base')).toBe(true);
+    expect(item.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
+    expect(item.classList.contains('shadow-button-neutral')).toBe(true);
+  });
+
+  test('keeps the focus ring reachable on the checked item', () => {
+    renderGroup('selected');
+
+    const checked = screen.getByRole('radio', {name: 'Selected'});
+
+    // Radix uses a roving tabindex, so the checked item is the first thing a
+    // keyboard user lands on. Selection must not consume `box-shadow`, or that
+    // tab stop would render no focus indicator at all.
+    expect(checked.classList.contains('focus-visible:shadow-button-neutral-focus')).toBe(true);
+    expect(
+      [...checked.classList].some((token) => token.startsWith('data-[state=checked]:shadow-')),
+    ).toBe(false);
+    expect(checked.classList.contains('shadow-button-neutral')).toBe(true);
+  });
+
+  test('marks selection with a border and an indicator dot, not colour alone', () => {
+    renderGroup('selected');
+
+    const unselected = screen.getByRole('radio', {name: 'Default'});
+    const selected = screen.getByRole('radio', {name: 'Selected'});
+
+    expect(
+      selected.classList.contains('data-[state=checked]:border-border-highlights-interactive'),
+    ).toBe(true);
+    expect(
+      selected
+        .querySelector('[data-slot="radio-indicator"]')
+        ?.classList.contains(
+          'group-data-[state=checked]/radio:border-border-highlights-interactive',
+        ),
+    ).toBe(true);
+    expect(selected.querySelector('[data-slot="radio-indicator-dot"]')).not.toBeNull();
+    expect(unselected.querySelector('[data-slot="radio-indicator-dot"]')).toBeNull();
+  });
+
+  test('moves the indicator dot when another item is chosen', () => {
+    renderGroup('default');
+
+    const target = screen.getByRole('radio', {name: 'Selected'});
+    const previous = screen.getByRole('radio', {name: 'Default'});
+
+    fireEvent.click(target);
+
+    expect(target.getAttribute('data-state')).toBe('checked');
+    expect(target.querySelector('[data-slot="radio-indicator-dot"]')).not.toBeNull();
+    expect(previous.getAttribute('data-state')).toBe('unchecked');
+    expect(previous.querySelector('[data-slot="radio-indicator-dot"]')).toBeNull();
+  });
+});
+
+// The resting box a loading placeholder has to match. Listing it here is what
+// makes a change to the item's padding or fill fail the suite instead of
+// silently desynchronising the skeleton.
+const SURFACE_TOKENS = [
+  'rounded-8',
+  'border',
+  'border-border-neutral-base',
+  'bg-background-neutral-base',
+  'px-row',
+  'py-row',
+  'shadow-button-neutral',
+  'gap-cluster',
+];
+
+describe('RadioGroupItemSkeleton', () => {
+  test('mirrors the item surface so a loading grid cannot drift from it', () => {
+    const {container} = render(<RadioGroupItemSkeleton labelClassName="w-64" />);
+    const skeleton = container.firstElementChild;
+
+    renderGroup('default');
+    const item = screen.getByRole('radio', {name: 'Default'});
+
+    for (const token of SURFACE_TOKENS) {
+      expect(item.classList.contains(token)).toBe(true);
+      expect(skeleton?.classList.contains(token)).toBe(true);
+    }
+
+    expect(skeleton?.getAttribute('aria-hidden')).toBe('true');
+    expect(skeleton?.querySelector('[data-slot="radio-indicator"]')).not.toBeNull();
+  });
+});

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
@@ -1,6 +1,27 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 import {RadioGroup, RadioGroupItem, RadioGroupItemSkeleton} from './radio-group.js';
 
+const originalResizeObserver = window.ResizeObserver;
+
+afterEach(() => {
+  window.ResizeObserver = originalResizeObserver;
+});
+
+/** Radix's bubble input measures itself, which jsdom cannot do. */
+function stubResizeObserver() {
+  window.ResizeObserver = class {
+    observe() {
+      return undefined;
+    }
+    unobserve() {
+      return undefined;
+    }
+    disconnect() {
+      return undefined;
+    }
+  } as unknown as typeof ResizeObserver;
+}
+
 function renderGroup(defaultValue: string) {
   return render(
     <RadioGroup defaultValue={defaultValue}>
@@ -96,10 +117,11 @@ describe('RadioGroup variant="cell"', () => {
 
     const item = screen.getByRole('radio', {name: 'One'});
 
-    // Panel already owns these four; repeating them is a frame inside a frame.
+    // Panel already draws the frame; repeating it is a frame inside a frame.
     expect(item.classList.contains('rounded-8')).toBe(false);
     expect(item.classList.contains('border')).toBe(false);
     expect(item.classList.contains('shadow-button-neutral')).toBe(false);
+    // The fill stays: a cell still paints over the surface behind it.
     expect(item.classList.contains('bg-background-neutral-base')).toBe(true);
   });
 
@@ -122,19 +144,7 @@ describe('RadioGroup variant="cell"', () => {
   });
 
   test('keeps its dividers when a form makes Radix add hidden bubble inputs', () => {
-    // Radix's bubble input measures itself, which jsdom cannot do.
-    const originalResizeObserver = window.ResizeObserver;
-    window.ResizeObserver = class {
-      observe() {
-        return undefined;
-      }
-      unobserve() {
-        return undefined;
-      }
-      disconnect() {
-        return undefined;
-      }
-    } as unknown as typeof ResizeObserver;
+    stubResizeObserver();
 
     const {container} = render(
       <form>
@@ -160,8 +170,6 @@ describe('RadioGroup variant="cell"', () => {
     expect(
       grid?.classList.contains('min-[760px]:[&>*:nth-child(2n_of_:not(input))]:border-l'),
     ).toBe(true);
-
-    window.ResizeObserver = originalResizeObserver;
   });
 
   test('is the grid itself, so the radio buttons are the cells', () => {

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
@@ -101,4 +101,22 @@ describe('RadioGroupItemSkeleton', () => {
     expect(skeleton?.getAttribute('aria-hidden')).toBe('true');
     expect(skeleton?.querySelector('[data-slot="radio-indicator"]')).not.toBeNull();
   });
+
+  test('lets the caller vary the bar width across a loading grid', () => {
+    const {container} = render(
+      <>
+        <RadioGroupItemSkeleton labelClassName="w-64" />
+        <RadioGroupItemSkeleton labelClassName="w-112" />
+      </>,
+    );
+
+    const bars = container.querySelectorAll('[data-slot="skeleton"]');
+
+    // A `flex-1` basis would collapse every supplied width to the same length.
+    expect(bars[0]?.classList.contains('w-64')).toBe(true);
+    expect(bars[1]?.classList.contains('w-112')).toBe(true);
+    for (const bar of bars) {
+      expect(bar.classList.contains('flex-1')).toBe(false);
+    }
+  });
 });

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
@@ -85,6 +85,61 @@ const SURFACE_TOKENS = [
   'gap-cluster',
 ];
 
+describe('RadioGroup variant="cell"', () => {
+  test('drops the tile frame so it does not repeat the panel it sits in', () => {
+    render(
+      <RadioGroup variant="cell" defaultValue="a">
+        <RadioGroupItem value="a">One</RadioGroupItem>
+        <RadioGroupItem value="b">Two</RadioGroupItem>
+      </RadioGroup>,
+    );
+
+    const item = screen.getByRole('radio', {name: 'One'});
+
+    // Panel already owns these four; repeating them is a frame inside a frame.
+    expect(item.classList.contains('rounded-8')).toBe(false);
+    expect(item.classList.contains('border')).toBe(false);
+    expect(item.classList.contains('shadow-button-neutral')).toBe(false);
+    expect(item.classList.contains('bg-background-neutral-base')).toBe(true);
+  });
+
+  test('marks selection with an outline, leaving box-shadow to mean focus', () => {
+    render(
+      <RadioGroup variant="cell" defaultValue="a">
+        <RadioGroupItem value="a">One</RadioGroupItem>
+      </RadioGroup>,
+    );
+
+    const item = screen.getByRole('radio', {name: 'One'});
+
+    expect(
+      item.classList.contains('data-[state=checked]:outline-border-highlights-interactive'),
+    ).toBe(true);
+    expect(item.classList.contains('focus-visible:shadow-focus-inset')).toBe(true);
+    expect(
+      [...item.classList].some((token) => token.startsWith('data-[state=checked]:shadow-')),
+    ).toBe(false);
+  });
+
+  test('is the grid itself, so the radio buttons are the cells', () => {
+    const {container} = render(
+      <RadioGroup variant="cell" defaultValue="a">
+        <RadioGroupItem value="a">One</RadioGroupItem>
+        <RadioGroupItem value="b">Two</RadioGroupItem>
+        <RadioGroupItem value="c">Three</RadioGroupItem>
+      </RadioGroup>,
+    );
+
+    const grid = container.querySelector('[data-slot="panel-grid"]');
+
+    // A Radix item is a button, which cannot be a child of a `ul`.
+    expect(grid?.tagName).toBe('DIV');
+    expect(grid?.getAttribute('role')).toBe('radiogroup');
+    // The odd count is padded, as in any other panel grid.
+    expect(grid?.querySelector('[data-slot="panel-cell-filler"]')?.tagName).toBe('DIV');
+  });
+});
+
 describe('RadioGroupItemSkeleton', () => {
   test('mirrors the item surface so a loading grid cannot drift from it', () => {
     const {container} = render(<RadioGroupItemSkeleton labelClassName="w-64" />);

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.test.tsx
@@ -121,6 +121,49 @@ describe('RadioGroup variant="cell"', () => {
     ).toBe(false);
   });
 
+  test('keeps its dividers when a form makes Radix add hidden bubble inputs', () => {
+    // Radix's bubble input measures itself, which jsdom cannot do.
+    const originalResizeObserver = window.ResizeObserver;
+    window.ResizeObserver = class {
+      observe() {
+        return undefined;
+      }
+      unobserve() {
+        return undefined;
+      }
+      disconnect() {
+        return undefined;
+      }
+    } as unknown as typeof ResizeObserver;
+
+    const {container} = render(
+      <form>
+        <RadioGroup variant="cell" defaultValue="a">
+          <RadioGroupItem value="a">One</RadioGroupItem>
+          <RadioGroupItem value="b">Two</RadioGroupItem>
+        </RadioGroup>
+      </form>,
+    );
+
+    const grid = container.querySelector('[data-slot="panel-grid"]');
+
+    // Inside a form each item renders a button plus a hidden input, so the DOM
+    // children are BUTTON,INPUT,BUTTON,INPUT. A plain `nth-child(2n)` would put
+    // the column divider on the invisible inputs and the second cell would show
+    // no separator at all.
+    expect([...(grid?.children ?? [])].map((child) => child.tagName)).toEqual([
+      'BUTTON',
+      'INPUT',
+      'BUTTON',
+      'INPUT',
+    ]);
+    expect(
+      grid?.classList.contains('min-[760px]:[&>*:nth-child(2n_of_:not(input))]:border-l'),
+    ).toBe(true);
+
+    window.ResizeObserver = originalResizeObserver;
+  });
+
   test('is the grid itself, so the radio buttons are the cells', () => {
     const {container} = render(
       <RadioGroup variant="cell" defaultValue="a">

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
@@ -73,7 +73,9 @@ export function RadioGroupItemSkeleton({
   return (
     <div aria-hidden="true" className={cn(ITEM_SURFACE_CLASS, className)} {...props}>
       <span data-slot="radio-indicator" className={INDICATOR_CLASS} />
-      <Skeleton className={cn('h-16 flex-1', labelClassName)} />
+      {/* `w-full`, not `flex-1`: a flex basis of 0 would beat any width passed in
+          and every placeholder would come out the same length. */}
+      <Skeleton className={cn('h-16 w-full', labelClassName)} />
     </div>
   );
 }

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
@@ -1,23 +1,54 @@
 'use client';
 
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
-import type {ComponentProps} from 'react';
+import {type ComponentProps, createContext, useContext} from 'react';
 import {cn} from '#utils/cn.js';
+import {PanelGrid} from '../panel/index.js';
 import {Skeleton} from '../skeleton/index.js';
 
 /**
- * The resting surface shared by an item and its skeleton, so a loading grid
- * never re-derives the box.
+ * `card` stands on its own surface, for a picker on the canvas. `cell` drops the
+ * frame for a picker inside a panel, where a bordered tile would repeat the
+ * panel's own border, fill, radius, and shadow.
  */
-const ITEM_SURFACE_CLASS =
-  'flex min-w-0 items-center gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base px-row py-row text-left text-foreground-neutral-base shadow-button-neutral';
+export type RadioGroupVariant = 'card' | 'cell';
+
+const RadioGroupVariantContext = createContext<RadioGroupVariant>('card');
+
+/** The resting box shared by an item and its skeleton, per variant. */
+const ITEM_SURFACE_CLASS: Record<RadioGroupVariant, string> = {
+  card: 'flex min-w-0 items-center gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base px-row py-row text-left text-foreground-neutral-base shadow-button-neutral',
+  cell: 'flex min-w-0 items-center gap-cluster bg-background-neutral-base px-row py-row text-left text-foreground-neutral-base',
+};
 
 const INDICATOR_CLASS =
   'flex size-16 shrink-0 items-center justify-center rounded-full border border-border-neutral-base';
 
-export function RadioGroup({className, ...props}: ComponentProps<typeof RadioGroupPrimitive.Root>) {
+export interface RadioGroupProps extends ComponentProps<typeof RadioGroupPrimitive.Root> {
+  variant?: RadioGroupVariant;
+}
+
+export function RadioGroup({className, variant = 'card', children, ...props}: RadioGroupProps) {
+  if (variant === 'cell') {
+    return (
+      <RadioGroupVariantContext.Provider value={variant}>
+        {/* The grid is the radio group itself: a Radix item is a button, which
+            cannot be a child of the `ul` a plain PanelGrid renders. */}
+        <RadioGroupPrimitive.Root asChild {...props}>
+          <PanelGrid as="div" className={className}>
+            {children}
+          </PanelGrid>
+        </RadioGroupPrimitive.Root>
+      </RadioGroupVariantContext.Provider>
+    );
+  }
+
   return (
-    <RadioGroupPrimitive.Root className={cn('flex flex-col gap-inline', className)} {...props} />
+    <RadioGroupVariantContext.Provider value={variant}>
+      <RadioGroupPrimitive.Root className={cn('flex flex-col gap-inline', className)} {...props}>
+        {children}
+      </RadioGroupPrimitive.Root>
+    </RadioGroupVariantContext.Provider>
   );
 }
 
@@ -26,17 +57,27 @@ export function RadioGroupItem({
   children,
   ...props
 }: ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  const variant = useContext(RadioGroupVariantContext);
+
   return (
     <RadioGroupPrimitive.Item
       className={cn(
-        ITEM_SURFACE_CLASS,
-        'group/radio cursor-pointer outline-none transition-[background-color,border-color,box-shadow]',
+        ITEM_SURFACE_CLASS[variant],
+        'group/radio cursor-pointer outline-none transition-[background-color,border-color,box-shadow,outline-color]',
         'hover:bg-background-neutral-hover',
         // Selection is carried by the border and the indicator dot, never by the
         // shadow. That leaves `box-shadow` free to mean focus and only focus, so
         // tabbing onto the already-checked item still shows a ring.
-        'data-[state=checked]:border-border-highlights-interactive',
-        'focus-visible:shadow-button-neutral-focus',
+        variant === 'card'
+          ? 'data-[state=checked]:border-border-highlights-interactive'
+          : // A cell has no resting frame, so selection draws an outline, which
+            // is layout-neutral and does not fight the grid's own hairlines.
+            'data-[state=checked]:outline data-[state=checked]:-outline-offset-1 data-[state=checked]:outline-border-highlights-interactive data-[state=checked]:focus-visible:outline data-[state=checked]:focus-visible:outline-border-highlights-interactive',
+        variant === 'card'
+          ? 'focus-visible:shadow-button-neutral-focus'
+          : // Cells run edge to edge inside the panel, whose `overflow-hidden`
+            // crops an outset ring.
+            'focus-visible:shadow-focus-inset focus-visible:outline-none',
         'data-[disabled]:cursor-not-allowed data-[disabled]:border-border-neutral-base data-[disabled]:bg-background-neutral-disabled data-[disabled]:text-foreground-neutral-disabled data-[disabled]:shadow-none',
         className,
       )}
@@ -63,15 +104,17 @@ export function RadioGroupItem({
 export interface RadioGroupItemSkeletonProps extends ComponentProps<'div'> {
   /** Vary this across a loading grid so the placeholders do not read as a stencil. */
   labelClassName?: string;
+  variant?: RadioGroupVariant;
 }
 
 export function RadioGroupItemSkeleton({
   className,
   labelClassName,
+  variant = 'card',
   ...props
 }: RadioGroupItemSkeletonProps) {
   return (
-    <div aria-hidden="true" className={cn(ITEM_SURFACE_CLASS, className)} {...props}>
+    <div aria-hidden="true" className={cn(ITEM_SURFACE_CLASS[variant], className)} {...props}>
       <span data-slot="radio-indicator" className={INDICATOR_CLASS} />
       {/* `w-full`, not `flex-1`: a flex basis of 0 would beat any width passed in
           and every placeholder would come out the same length. */}

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
@@ -3,9 +3,22 @@
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import type {ComponentProps} from 'react';
 import {cn} from '#utils/cn.js';
+import {Skeleton} from '../skeleton/index.js';
+
+/**
+ * The resting surface shared by an item and its skeleton, so a loading grid
+ * never re-derives the box.
+ */
+const ITEM_SURFACE_CLASS =
+  'flex min-w-0 items-center gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base px-row py-row text-left text-foreground-neutral-base shadow-button-neutral';
+
+const INDICATOR_CLASS =
+  'flex size-16 shrink-0 items-center justify-center rounded-full border border-border-neutral-base';
 
 export function RadioGroup({className, ...props}: ComponentProps<typeof RadioGroupPrimitive.Root>) {
-  return <RadioGroupPrimitive.Root className={cn('flex flex-col gap-8', className)} {...props} />;
+  return (
+    <RadioGroupPrimitive.Root className={cn('flex flex-col gap-inline', className)} {...props} />
+  );
 }
 
 export function RadioGroupItem({
@@ -16,22 +29,51 @@ export function RadioGroupItem({
   return (
     <RadioGroupPrimitive.Item
       className={cn(
-        'flex min-w-0 items-center gap-inline rounded-8 border border-border-neutral-base bg-background-button-neutral-default p-14 text-left text-foreground-neutral-base shadow-button-neutral transition-colors outline-none cursor-pointer',
-        'hover:bg-background-button-neutral-hover active:bg-background-button-neutral-pressed',
-        'data-[state=checked]:border-border-highlights-interactive data-[state=checked]:shadow-border-interactive-with-active',
-        'focus-visible:shadow-border-interactive-with-active',
+        ITEM_SURFACE_CLASS,
+        'group/radio cursor-pointer outline-none transition-[background-color,border-color,box-shadow]',
+        'hover:bg-background-neutral-hover',
+        // Selection is carried by the border and the indicator dot, never by the
+        // shadow. That leaves `box-shadow` free to mean focus and only focus, so
+        // tabbing onto the already-checked item still shows a ring.
+        'data-[state=checked]:border-border-highlights-interactive',
+        'focus-visible:shadow-button-neutral-focus',
         'data-[disabled]:cursor-not-allowed data-[disabled]:border-border-neutral-base data-[disabled]:bg-background-neutral-disabled data-[disabled]:text-foreground-neutral-disabled data-[disabled]:shadow-none',
         className,
       )}
       {...props}
     >
-      <div
+      <span
         aria-hidden="true"
-        className="flex size-16 shrink-0 items-center justify-center rounded-full border border-border-neutral-base"
+        data-slot="radio-indicator"
+        className={cn(
+          INDICATOR_CLASS,
+          'transition-colors group-data-[state=checked]/radio:border-border-highlights-interactive',
+        )}
       >
-        <RadioGroupPrimitive.Indicator className="size-8 rounded-full bg-background-highlight-interactive data-[disabled]:bg-foreground-neutral-disabled" />
-      </div>
-      <div className="min-w-0 flex-1">{children}</div>
+        <RadioGroupPrimitive.Indicator
+          data-slot="radio-indicator-dot"
+          className="size-8 rounded-full bg-background-highlight-interactive data-[disabled]:bg-foreground-neutral-disabled"
+        />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">{children}</span>
     </RadioGroupPrimitive.Item>
+  );
+}
+
+export interface RadioGroupItemSkeletonProps extends ComponentProps<'div'> {
+  /** Vary this across a loading grid so the placeholders do not read as a stencil. */
+  labelClassName?: string;
+}
+
+export function RadioGroupItemSkeleton({
+  className,
+  labelClassName,
+  ...props
+}: RadioGroupItemSkeletonProps) {
+  return (
+    <div aria-hidden="true" className={cn(ITEM_SURFACE_CLASS, className)} {...props}>
+      <span data-slot="radio-indicator" className={INDICATOR_CLASS} />
+      <Skeleton className={cn('h-16 flex-1', labelClassName)} />
+    </div>
   );
 }


### PR DESCRIPTION
Recompose the Projects index onto the shared content frame defined by the surface system.

The page now uses one Panel, with search and New project in its header strip. Project cells share a two-column body with internal hairlines, while loading, empty, error, connection-health, and pagination behavior remain in place. The page-level title is removed because the shell navigation already names the route.

Adds focused structural expectations and a patch Changeset for @shipfox/client-projects.

Closes ENG-1587

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recomposes the Projects hub onto the shared `Panel` frame and standardizes grids/lists on new cell primitives in `@shipfox/react-ui` for consistent layout and focus. The hub moves from a page title + standalone tiles to a single `Panel` with header controls and a two‑column `PanelGrid`, preserving loading/empty/error/connection/pagination. Also stabilizes the integration usage‑modal story by waiting for body pointer‑events to release before reopening menus. Closes ENG-1587.

- UI primitives: add `PanelGrid`, `PanelCell`, `PanelCellAction` (two-column grid; collapses at 760px; pads odd counts so hairlines span; draws full row and column dividers; counts only visible cells via `:not(input)`; `as` for non‑list grids); `Panel`, `PanelBody`, `PanelRow` accept `asChild`; add `--shadow-focus-inset`; `PanelCellAction` treats any falsy verb as absent and always uses a pointer cursor. `RadioGroup` adds `variant="cell"` and `RadioGroupItemSkeleton`; selection draws an outline so focus remains a ring.
- Adoption: Projects hub moves search and New project into `PanelHeader`/`PanelActions`, exposes a “Projects” region for navigation, keeps all states, and allows inline retry after next‑page errors. Grids/lists in `@shipfox/client-agent`, `@shipfox/client-integrations`, and `@shipfox/client-secrets` render as cells inside a single `Panel`; source/repository pickers use `variant="cell"` inside a `PanelGrid`; skeletons updated; focus rings switch to `--shadow-focus-inset`.

<sup>Written for commit 31975dc728c4cb7e493bff936aca2f19b3e9524d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

