### PR TITLE
[react-ui] Make tables inherit panel surfaces

### DIFF
--- a/.changeset/bright-tables-in-panels.md
+++ b/.changeset/bright-tables-in-panels.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Make tables inherit their wrapping panel surface and keep container borders and radii on `Panel`.

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {StatusBadge} from '#components/badge/index.js';
 import {Button} from '#components/button/index.js';
 import {Code} from '#components/typography/index.js';
+import {Panel} from '../panel/panel.js';
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from './table.js';
 
 const meta = {
@@ -40,7 +41,7 @@ const workflows = [
 
 export const Playground: Story = {
   render: () => (
-    <div className="w-760 rounded-8 border border-border-neutral-base bg-background-neutral-base">
+    <Panel className="w-760">
       <Table>
         <TableHeader>
           <TableRow>
@@ -71,6 +72,6 @@ export const Playground: Story = {
           ))}
         </TableBody>
       </Table>
-    </div>
+    </Panel>
   ),
 };

--- a/libs/shared/react/ui/src/components/table/table.test.tsx
+++ b/libs/shared/react/ui/src/components/table/table.test.tsx
@@ -1,0 +1,42 @@
+import {render} from '@testing-library/react';
+import {Panel} from '../panel/panel.js';
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from './table.js';
+
+describe('Table', () => {
+  test('inherits its panel surface and leaves the container chrome to Panel', () => {
+    const {container} = render(
+      <Panel>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Workflow</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow data-selected="true">
+              <TableCell>Deploy production</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </Panel>,
+    );
+
+    const panel = container.querySelector('[data-slot="panel"]');
+    const table = container.querySelector('[data-slot="table"]');
+    const tableContainer = table?.parentElement;
+    const header = container.querySelector('[data-slot="table-head"]');
+    const cell = container.querySelector('[data-slot="table-cell"]');
+    const row = container.querySelector('[data-slot="table-row"][data-selected="true"]');
+
+    expect(panel?.classList.contains('rounded-8')).toBe(true);
+    expect(panel?.classList.contains('border-border-neutral-base')).toBe(true);
+    expect(tableContainer?.classList.contains('rounded-8')).toBe(false);
+    expect(tableContainer?.classList.contains('border')).toBe(false);
+    expect(header?.classList.contains('bg-background-subtle-base')).toBe(true);
+    expect(cell?.classList.contains('bg-background-neutral-base')).toBe(false);
+    expect(row?.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
+    expect(row?.classList.contains('data-[selected=true]:bg-background-neutral-pressed')).toBe(
+      true,
+    );
+  });
+});

--- a/libs/shared/react/ui/src/components/table/table.tsx
+++ b/libs/shared/react/ui/src/components/table/table.tsx
@@ -3,7 +3,7 @@ import {cn} from '#utils/cn.js';
 
 function Table({className, ...props}: ComponentProps<'table'>) {
   return (
-    <div className="relative w-full overflow-auto rounded-8 scrollbar">
+    <div className="relative w-full overflow-auto scrollbar">
       <table
         data-slot="table"
         className={cn('w-full caption-bottom text-sm', className)}
@@ -68,7 +68,7 @@ function TableCell({className, ...props}: ComponentProps<'td'>) {
     <td
       data-slot="table-cell"
       className={cn(
-        'truncate bg-background-neutral-base px-12 py-10 align-middle text-sm leading-20 text-foreground-neutral-base',
+        'truncate px-12 py-10 align-middle text-sm leading-20 text-foreground-neutral-base',
         'group-hover/row:bg-background-neutral-hover',
         'group-data-[selected=true]/row:bg-background-neutral-pressed!',
         '[&:has([role=checkbox])]:pr-0 [&:has([role=checkbox])]:pt-14',


### PR DESCRIPTION
Tables currently paint the panel surface in every cell and carry their own radius, so wrapping them in the shared Panel can double-paint the data region. This makes Table inherit the Panel fill and leaves the outer border and radius to Panel while preserving the canvas header strip and row states.

The Storybook example and a rendered contract test now keep the intended Panel composition explicit. Existing page consumers will be migrated by the linked Phase 4 page-recomposition issues; this PR is the Phase 2 primitive step.

Part of ENG-1576

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tables now inherit their wrapping `Panel` surface to avoid double-painting and keep borders/radius on `Panel`. Preserves the header strip and row hover/selected states; progresses ENG-1576 (Phase 2 of page recomposition).

- **Refactors**
  - Removed container rounding and cell background from `Table` so it inherits `Panel` surface.
  - Updated Storybook to wrap `Table` with `Panel`.
  - Added a render test to assert surface inheritance, border/radius ownership, and row/header states.

<sup>Written for commit 3f3f638c580cfcc28ba546dabcd7e5947a18ea3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

