### PR TITLE
Adopt shared panels for project setup and settings

### DIFF
--- a/.changeset/recompose-project-surfaces.md
+++ b/.changeset/recompose-project-surfaces.md
@@ -1,0 +1,6 @@
+---
+'@shipfox/client-integrations': patch
+'@shipfox/client-projects': patch
+---
+
+Recompose project settings and project creation around the shared content-frame panel surfaces.

--- a/.changeset/recompose-project-surfaces.md
+++ b/.changeset/recompose-project-surfaces.md
@@ -4,4 +4,4 @@
 '@shipfox/react-ui': patch
 ---
 
-Recompose project settings and project creation around shared content-frame panel surfaces and button-like radio choices.
+Project settings and project creation now use shared panels, with source integrations presented as button-style radio choices.

--- a/.changeset/recompose-project-surfaces.md
+++ b/.changeset/recompose-project-surfaces.md
@@ -1,6 +1,7 @@
 ---
 '@shipfox/client-integrations': patch
 '@shipfox/client-projects': patch
+'@shipfox/react-ui': patch
 ---
 
-Recompose project settings and project creation around the shared content-frame panel surfaces.
+Recompose project settings and project creation around shared content-frame panel surfaces and button-like radio choices.

--- a/libs/client/integrations/src/components/repository-picker.test.tsx
+++ b/libs/client/integrations/src/components/repository-picker.test.tsx
@@ -17,6 +17,19 @@ afterEach(() => {
 });
 
 describe('RepositoryPicker', () => {
+  test('renders the default empty message without an internal search control', () => {
+    renderPicker();
+
+    expect(screen.getByText('No repositories found.')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
+  test('renders a custom empty message', () => {
+    renderPicker({emptyMessage: 'No repositories visible to this connection.'});
+
+    expect(screen.getByText('No repositories visible to this connection.')).toBeInTheDocument();
+  });
+
   test('renders repository names without owner or default branch metadata', () => {
     renderPicker({
       repositories: [
@@ -65,12 +78,10 @@ describe('RepositoryPicker', () => {
     const {container} = renderPicker({
       repositories: [],
       isLoading: true,
-      searchValue: '',
-      onSearchChange: () => undefined,
     });
 
     expect(screen.getByRole('status')).toHaveTextContent('Loading repositories.');
-    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
 
     const loadingGrid = container.querySelector('[aria-hidden="true"]');
     if (!loadingGrid) throw new Error('Repository loading grid was not rendered');

--- a/libs/client/integrations/src/components/repository-picker.test.tsx
+++ b/libs/client/integrations/src/components/repository-picker.test.tsx
@@ -75,17 +75,17 @@ describe('RepositoryPicker', () => {
     const loadingGrid = container.querySelector('[aria-hidden="true"]');
     if (!loadingGrid) throw new Error('Repository loading grid was not rendered');
 
-    expect(loadingGrid).toHaveClass('grid', 'grid-cols-2', 'gap-inline', 'max-[760px]:grid-cols-1');
+    expect(loadingGrid).toHaveClass(
+      'grid',
+      'grid-cols-2',
+      'gap-px',
+      'bg-border-neutral-base',
+      'max-[760px]:grid-cols-1',
+    );
     expect(loadingGrid.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(4);
     for (const placeholder of loadingGrid.querySelectorAll(':scope > div')) {
-      expect(placeholder).toHaveClass(
-        'h-50',
-        'rounded-8',
-        'border',
-        'border-border-neutral-base',
-        'bg-background-neutral-base',
-        'p-[14px]',
-      );
+      expect(placeholder).toHaveClass('h-50', 'bg-background-neutral-base', 'p-[14px]');
+      expect(placeholder).not.toHaveClass('rounded-8', 'border');
     }
   });
 });

--- a/libs/client/integrations/src/components/repository-picker.tsx
+++ b/libs/client/integrations/src/components/repository-picker.tsx
@@ -1,6 +1,5 @@
 import {Button} from '@shipfox/react-ui/button';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
-import {Input} from '@shipfox/react-ui/input';
 import {Label} from '@shipfox/react-ui/label';
 import {RadioGroup, RadioGroupItem} from '@shipfox/react-ui/radio-group';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
@@ -23,9 +22,6 @@ export function RepositoryPicker({
   hasNextPage,
   onLoadMore,
   emptyMessage = 'No repositories found.',
-  searchValue,
-  onSearchChange,
-  searchDisabled,
 }: {
   repositories: Repository[];
   selectedRepositoryId: string | undefined;
@@ -35,29 +31,14 @@ export function RepositoryPicker({
   hasNextPage?: boolean;
   onLoadMore?: () => void;
   emptyMessage?: string;
-  searchValue?: string;
-  onSearchChange?: (value: string) => void;
-  searchDisabled?: boolean;
 }) {
   const labelId = useId();
-  const showSearch = onSearchChange !== undefined;
 
   return (
     <div className="flex flex-col gap-inline">
       <Label id={labelId} className="sr-only">
         Repository
       </Label>
-
-      {showSearch ? (
-        <Input
-          type="search"
-          placeholder="Search repositories…"
-          aria-label="Search repositories"
-          value={searchValue ?? ''}
-          onChange={(event) => onSearchChange?.(event.target.value)}
-          disabled={searchDisabled}
-        />
-      ) : null}
 
       {isLoading ? <RepositoryLoadingState /> : null}
 

--- a/libs/client/integrations/src/components/repository-picker.tsx
+++ b/libs/client/integrations/src/components/repository-picker.tsx
@@ -10,6 +10,8 @@ import {useId} from 'react';
 import type {Repository} from '#core/models.js';
 
 const REPOSITORY_GRID_CLASS_NAME = 'grid grid-cols-2 gap-inline max-[760px]:grid-cols-1';
+const REPOSITORY_SKELETON_GRID_CLASS_NAME =
+  'grid grid-cols-2 gap-px bg-border-neutral-base max-[760px]:grid-cols-1';
 const REPOSITORY_SKELETON_WIDTHS = ['w-64', 'w-96', 'w-80', 'w-112'] as const;
 
 export function RepositoryPicker({
@@ -59,11 +61,7 @@ export function RepositoryPicker({
 
       {isLoading ? <RepositoryLoadingState /> : null}
 
-      {!isLoading && repositories.length === 0 ? (
-        <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact">
-          <Text size="sm">{emptyMessage}</Text>
-        </div>
-      ) : null}
+      {!isLoading && repositories.length === 0 ? <Text size="sm">{emptyMessage}</Text> : null}
 
       {repositories.length > 0 ? (
         <RadioGroup
@@ -118,14 +116,11 @@ function RepositoryLoadingState() {
       <div role="status" className="sr-only">
         Loading repositories.
       </div>
-      <div aria-hidden="true" className={REPOSITORY_GRID_CLASS_NAME}>
+      <div aria-hidden="true" className={REPOSITORY_SKELETON_GRID_CLASS_NAME}>
         {/* The skeleton mirrors RadioGroupItem's own 14px padding contract so the
             placeholder and the loaded card stay the same height. */}
         {REPOSITORY_SKELETON_WIDTHS.map((width) => (
-          <div
-            key={width}
-            className="h-50 min-w-0 rounded-8 border border-border-neutral-base bg-background-neutral-base p-[14px]"
-          >
+          <div key={width} className="h-50 min-w-0 bg-background-neutral-base p-[14px]">
             <Skeleton className={`h-20 ${width}`} />
           </div>
         ))}

--- a/libs/client/integrations/src/pages/slack-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
+import {configureApiClient} from '@shipfox/client-api';
 import {screen, waitFor} from '@testing-library/react';
 import {StrictMode} from 'react';
 import {SLACK_INSTALL_WORKSPACE_KEY} from '#slack-callback.js';
@@ -27,6 +28,12 @@ vi.mock('#hooks/api/integrations.js', async (importOriginal) => {
 beforeEach(() => {
   window.sessionStorage.clear();
   completeCallbackMock.mockReset();
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: vi.fn((_input: RequestInfo | URL) =>
+      Promise.reject(new Error('Workspace list unavailable')),
+    ),
+  });
 });
 
 describe('SlackCallbackPage', () => {

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -1,6 +1,7 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {QueryClient} from '@tanstack/react-query';
-import {fireEvent, screen, waitFor} from '@testing-library/react';
+import {fireEvent, screen, waitFor, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {projectsQueryKeys} from '#hooks/api/projects.js';
 import {
   jsonResponse,
@@ -50,6 +51,17 @@ describe('CreateProjectPage', () => {
     ).not.toBeInTheDocument();
     expect(screen.getByRole('searchbox', {name: 'Search repositories'})).toBeInTheDocument();
     expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(3);
+    expect(within(panelForHeading('Project details')).getByLabelText('Project name')).toBe(
+      nameInput,
+    );
+    expect(within(panelForHeading('Project details')).getByLabelText('Project slug')).toBe(
+      slugInput,
+    );
+    expect(
+      within(panelForHeading('Repository')).getByRole('searchbox', {
+        name: 'Search repositories',
+      }),
+    ).toBeInTheDocument();
     expect(slugInput).toHaveValue('platform');
     expect(slugInput).toHaveAttribute('aria-describedby', 'project-slug-description');
     expect(screen.getByText('/w/acme/p/platform')).toBeInTheDocument();
@@ -75,6 +87,65 @@ describe('CreateProjectPage', () => {
       },
     });
   }, 10_000);
+
+  test('does not render an empty source panel when connections fail to load', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({message: 'upstream unavailable'}, {status: 500}));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}/projects/new`, <CreateProjectPage />);
+
+    expect(
+      await screen.findByText(
+        'Could not load source integrations. Refresh the integrations list to continue.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Source integration'})).not.toBeInTheDocument();
+    expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
+  });
+
+  test('passes the repository search filter to the query and renders the filtered empty state', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
+      }
+      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+        const search = new URL(request.url).searchParams.get('search');
+        return Promise.resolve(
+          jsonResponse(
+            search === 'xyz'
+              ? {repositories: [], next_cursor: null}
+              : {repositories: [repositoryDto()], next_cursor: null},
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}/projects/new`, <CreateProjectPage />);
+    expect((await screen.findAllByText('gitea-owner/platform')).length).toBeGreaterThan(0);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole('searchbox', {name: 'Search repositories'}), 'xyz');
+
+    expect(await screen.findByText('No repositories matching "xyz".')).toBeInTheDocument();
+    expect(
+      fetchImpl.mock.calls.some(([input]) => {
+        const request = input as Request;
+        return (
+          request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`) &&
+          new URL(request.url).searchParams.get('search') === 'xyz'
+        );
+      }),
+    ).toBe(true);
+  });
 
   test('auto-derives the slug from each keystroke in the name field until the slug is touched', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
@@ -502,4 +573,10 @@ function projectPostCount(fetchImpl: ReturnType<typeof vi.fn>): number {
     const request = input as Request;
     return request.url.endsWith('/projects') && request.method === 'POST';
   }).length;
+}
+
+function panelForHeading(name: string): HTMLElement {
+  const panel = screen.getByRole('heading', {name}).closest('[data-slot="panel"]');
+  if (!(panel instanceof HTMLElement)) throw new Error(`Panel not found for heading: ${name}`);
+  return panel;
 }

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -43,6 +43,13 @@ describe('CreateProjectPage', () => {
     const nameInput = await screen.findByLabelText('Project name');
     const slugInput = await screen.findByLabelText('Project slug');
     await waitFor(() => expect(nameInput).toHaveValue('Platform'));
+    expect(
+      screen.queryByText(
+        'A Shipfox project starts from a Git repository. Choose the repository Shipfox should track, then give the project a name.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('searchbox', {name: 'Search repositories'})).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(3);
     expect(slugInput).toHaveValue('platform');
     expect(slugInput).toHaveAttribute('aria-describedby', 'project-slug-description');
     expect(screen.getByText('/w/acme/p/platform')).toBeInTheDocument();

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -236,25 +236,25 @@ export function CreateProjectPage() {
         className="grid items-start gap-region lg:grid-cols-[minmax(0,1fr)_340px]"
       >
         <div className="flex min-w-0 flex-col gap-region">
-          <section aria-label="Source integration">
-            <Panel>
-              <PanelHeader>
-                <PanelTitle>Source integration</PanelTitle>
-                {connections.length === 1 ? (
-                  <PanelActions>
-                    <Button asChild variant="transparent" size="sm" className="shrink-0">
-                      <Link
-                        to="/w/$workspaceSlug/integrations"
-                        params={{workspaceSlug: workspace.slug}}
-                      >
-                        Add another integration
-                      </Link>
-                    </Button>
-                  </PanelActions>
-                ) : null}
-              </PanelHeader>
+          {connections.length > 0 ? (
+            <section aria-label="Source integration">
+              <Panel>
+                <PanelHeader>
+                  <PanelTitle>Source integration</PanelTitle>
+                  {connections.length === 1 ? (
+                    <PanelActions>
+                      <Button asChild variant="transparent" size="sm" className="shrink-0">
+                        <Link
+                          to="/w/$workspaceSlug/integrations"
+                          params={{workspaceSlug: workspace.slug}}
+                        >
+                          Add another integration
+                        </Link>
+                      </Button>
+                    </PanelActions>
+                  ) : null}
+                </PanelHeader>
 
-              {connections.length > 0 ? (
                 <PanelBody className="p-panel">
                   <ConnectionPicker
                     connections={connections}
@@ -262,9 +262,9 @@ export function CreateProjectPage() {
                     onSelect={selectConnection}
                   />
                 </PanelBody>
-              ) : null}
-            </Panel>
-          </section>
+              </Panel>
+            </section>
+          ) : null}
 
           {showRepoPicker ? (
             <section aria-label="Repository">

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -13,7 +13,9 @@ import {displayNameFieldError, SlugField} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
+import {Input} from '@shipfox/react-ui/input';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
+import {Panel, PanelActions, PanelBody, PanelHeader, PanelTitle} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
@@ -199,15 +201,9 @@ export function CreateProjectPage() {
 
   return (
     <div className="flex w-full flex-col gap-section">
-      <header className="flex flex-col gap-inline">
-        <Header id="create-project-title" variant="h1">
-          Create project
-        </Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          A Shipfox project starts from a Git repository. Choose the repository Shipfox should
-          track, then give the project a name.
-        </Text>
-      </header>
+      <Header id="create-project-title" variant="h1">
+        Create project
+      </Header>
 
       <ModelProviderReminderBanner workspaceId={workspace.id} />
 
@@ -240,161 +236,177 @@ export function CreateProjectPage() {
         className="grid items-start gap-region lg:grid-cols-[minmax(0,1fr)_340px]"
       >
         <div className="flex min-w-0 flex-col gap-region">
-          <section className="flex flex-col gap-group" aria-label="Source integration">
-            <div className="flex items-start justify-between gap-group">
-              <div className="flex flex-col gap-tight">
-                <Header variant="h3">Source integration</Header>
-                <Text size="sm" className="text-foreground-neutral-muted">
-                  Choose the integration that can access the repository.
-                </Text>
-              </div>
+          <section aria-label="Source integration">
+            <Panel>
+              <PanelHeader>
+                <PanelTitle>Source integration</PanelTitle>
+                {connections.length === 1 ? (
+                  <PanelActions>
+                    <Button asChild variant="transparent" size="sm" className="shrink-0">
+                      <Link
+                        to="/w/$workspaceSlug/integrations"
+                        params={{workspaceSlug: workspace.slug}}
+                      >
+                        Add another integration
+                      </Link>
+                    </Button>
+                  </PanelActions>
+                ) : null}
+              </PanelHeader>
 
-              {connections.length === 1 ? (
-                <Button asChild variant="transparent" size="sm" className="shrink-0">
-                  <Link
-                    to="/w/$workspaceSlug/integrations"
-                    params={{workspaceSlug: workspace.slug}}
-                  >
-                    Add another integration
-                  </Link>
-                </Button>
+              {connections.length > 0 ? (
+                <PanelBody className="p-panel">
+                  <ConnectionPicker
+                    connections={connections}
+                    selectedConnectionId={effectiveSelectedConnectionId}
+                    onSelect={selectConnection}
+                  />
+                </PanelBody>
               ) : null}
-            </div>
-
-            {connections.length > 0 ? (
-              <ConnectionPicker
-                connections={connections}
-                selectedConnectionId={effectiveSelectedConnectionId}
-                onSelect={selectConnection}
-              />
-            ) : null}
+            </Panel>
           </section>
 
           {showRepoPicker ? (
-            <section className="flex flex-col gap-group" aria-label="Repository">
-              <div className="flex flex-col gap-tight">
-                <Header variant="h3">Repository</Header>
-                <Text size="sm" className="text-foreground-neutral-muted">
-                  Select the repository this project tracks.
-                </Text>
-              </div>
-
-              <RepositoryPicker
-                repositories={repositories}
-                selectedRepositoryId={selectedRepositoryId}
-                onSelect={setSelectedRepositoryId}
-                isLoading={repositoriesQuery.isPending}
-                isFetchingNextPage={repositoriesQuery.isFetchingNextPage}
-                hasNextPage={repositoriesQuery.hasNextPage}
-                onLoadMore={() => repositoriesQuery.fetchNextPage()}
-                emptyMessage={filteredEmptyMessage}
-                searchValue={repoFilter}
-                onSearchChange={setRepoFilter}
-              />
+            <section aria-label="Repository">
+              <Panel>
+                <PanelHeader className="flex-wrap">
+                  <PanelTitle>Repository</PanelTitle>
+                  <PanelActions className="min-w-0 max-[640px]:ml-0 max-[640px]:basis-full">
+                    <Input
+                      type="search"
+                      placeholder="Search repositories…"
+                      aria-label="Search repositories"
+                      value={repoFilter}
+                      onChange={(event) => setRepoFilter(event.target.value)}
+                      className="w-full max-w-[320px]"
+                    />
+                  </PanelActions>
+                </PanelHeader>
+                <PanelBody className="p-panel">
+                  <RepositoryPicker
+                    repositories={repositories}
+                    selectedRepositoryId={selectedRepositoryId}
+                    onSelect={setSelectedRepositoryId}
+                    isLoading={repositoriesQuery.isPending}
+                    isFetchingNextPage={repositoriesQuery.isFetchingNextPage}
+                    hasNextPage={repositoriesQuery.hasNextPage}
+                    onLoadMore={() => repositoriesQuery.fetchNextPage()}
+                    emptyMessage={filteredEmptyMessage}
+                  />
+                </PanelBody>
+              </Panel>
             </section>
           ) : null}
         </div>
 
         <aside className="lg:sticky lg:top-32">
-          <div className="flex flex-col gap-group rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel">
-            <div className="flex flex-col gap-tight">
-              <Header variant="h3">Project details</Header>
-              <Text size="sm" className="text-foreground-neutral-muted">
-                Confirm the source and create the project.
-              </Text>
-            </div>
+          <Panel>
+            <PanelHeader>
+              <PanelTitle>Project details</PanelTitle>
+            </PanelHeader>
+            <PanelBody className="gap-group p-panel">
+              {formError ? (
+                <Callout role="alert" type="error">
+                  <div ref={errorRef} tabIndex={-1}>
+                    {formError}
+                  </div>
+                </Callout>
+              ) : null}
 
-            {formError ? (
-              <Callout role="alert" type="error">
-                <div ref={errorRef} tabIndex={-1}>
-                  {formError}
-                </div>
-              </Callout>
-            ) : null}
+              <ProjectSummary
+                connection={selectedConnection}
+                repositoryName={selectedRepository?.fullName}
+              />
 
-            <ProjectSummary
-              connection={selectedConnection}
-              repositoryName={selectedRepository?.fullName}
-            />
+              <form.Field
+                name="name"
+                validators={{
+                  onBlur: ({value}) =>
+                    displayNameFieldError(
+                      value,
+                      'Project name',
+                      createProjectBodySchema.shape.name,
+                    ),
+                  onSubmit: ({value}) =>
+                    displayNameFieldError(
+                      value,
+                      'Project name',
+                      createProjectBodySchema.shape.name,
+                    ),
+                }}
+              >
+                {(field) => (
+                  <FormField label="Project name" id="project-name" error={fieldError(field)}>
+                    <FormFieldInput
+                      name="name"
+                      type="text"
+                      value={field.state.value}
+                      onChange={(event) => {
+                        const nextName = event.target.value;
+                        setNameTouched(true);
+                        field.handleChange(nextName);
+                        if (!slugManuallyEdited) {
+                          setSlugCheckEnabled(true);
+                          setSlugConflict(false);
+                          form.setFieldValue('slug', slugifyName(nextName, {fallback: 'project'}));
+                        }
+                      }}
+                      onBlur={field.handleBlur}
+                      placeholder="Platform"
+                    />
+                  </FormField>
+                )}
+              </form.Field>
 
-            <form.Field
-              name="name"
-              validators={{
-                onBlur: ({value}) =>
-                  displayNameFieldError(value, 'Project name', createProjectBodySchema.shape.name),
-                onSubmit: ({value}) =>
-                  displayNameFieldError(value, 'Project name', createProjectBodySchema.shape.name),
-              }}
-            >
-              {(field) => (
-                <FormField label="Project name" id="project-name" error={fieldError(field)}>
-                  <FormFieldInput
-                    name="name"
-                    type="text"
+              <form.Field
+                name="slug"
+                validators={{
+                  onBlur: createProjectBodySchema.shape.slug,
+                  onSubmit: createProjectBodySchema.shape.slug,
+                }}
+              >
+                {(field) => (
+                  <SlugField
+                    id="project-slug"
+                    label="Project slug"
+                    name="slug"
                     value={field.state.value}
-                    onChange={(event) => {
-                      const nextName = event.target.value;
-                      setNameTouched(true);
-                      field.handleChange(nextName);
-                      if (!slugManuallyEdited) {
-                        setSlugCheckEnabled(true);
-                        setSlugConflict(false);
-                        form.setFieldValue('slug', slugifyName(nextName, {fallback: 'project'}));
-                      }
+                    onChange={(value) => {
+                      setSlugManuallyEdited(true);
+                      setSlugCheckEnabled(true);
+                      setSlugConflict(false);
+                      field.handleChange(value);
                     }}
                     onBlur={field.handleBlur}
-                    placeholder="Platform"
+                    error={
+                      slugConflict ? 'This project slug is already in use.' : fieldError(field)
+                    }
+                    description={
+                      <span className="font-code">
+                        {`/w/${workspace.slug}/p/${field.state.value}`}
+                      </span>
+                    }
+                    placeholder="platform"
+                    className="font-code"
+                    checkEnabled={slugCheckEnabled}
+                    debounceMs={0}
+                    isValid={isSlugValid}
+                    checkAvailability={checkProjectSlugAvailability}
                   />
-                </FormField>
-              )}
-            </form.Field>
+                )}
+              </form.Field>
 
-            <form.Field
-              name="slug"
-              validators={{
-                onBlur: createProjectBodySchema.shape.slug,
-                onSubmit: createProjectBodySchema.shape.slug,
-              }}
-            >
-              {(field) => (
-                <SlugField
-                  id="project-slug"
-                  label="Project slug"
-                  name="slug"
-                  value={field.state.value}
-                  onChange={(value) => {
-                    setSlugManuallyEdited(true);
-                    setSlugCheckEnabled(true);
-                    setSlugConflict(false);
-                    field.handleChange(value);
-                  }}
-                  onBlur={field.handleBlur}
-                  error={slugConflict ? 'This project slug is already in use.' : fieldError(field)}
-                  description={
-                    <span className="font-code">
-                      {`/w/${workspace.slug}/p/${field.state.value}`}
-                    </span>
-                  }
-                  placeholder="platform"
-                  className="font-code"
-                  checkEnabled={slugCheckEnabled}
-                  debounceMs={0}
-                  isValid={isSlugValid}
-                  checkAvailability={checkProjectSlugAvailability}
-                />
-              )}
-            </form.Field>
-
-            <Button
-              type="submit"
-              iconRight="chevronRight"
-              isLoading={createProject.isPending}
-              disabled={!selectedConnection || !selectedRepository}
-              className="w-full"
-            >
-              Create project
-            </Button>
-          </div>
+              <Button
+                type="submit"
+                iconRight="chevronRight"
+                isLoading={createProject.isPending}
+                disabled={!selectedConnection || !selectedRepository}
+                className="w-full"
+              >
+                Create project
+              </Button>
+            </PanelBody>
+          </Panel>
         </aside>
       </form>
     </div>

--- a/libs/client/projects/src/pages/project-settings-page.test.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.test.tsx
@@ -19,6 +19,9 @@ describe('ProjectSettingsPage', () => {
     renderProjectPage('/w/acme/p/platform/settings/general', <ProjectSettingsPage />);
     const nameInput = await screen.findByLabelText('Project name');
     expect(screen.getByRole('heading', {name: 'General'})).toBeInTheDocument();
+    const settingsForm = nameInput.closest('form');
+    expect(settingsForm).not.toBeNull();
+    expect(settingsForm).toHaveClass('max-w-[560px]');
     expect(
       screen.queryByText('Update the project name and the slug used in its URLs.'),
     ).not.toBeInTheDocument();

--- a/libs/client/projects/src/pages/project-settings-page.test.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.test.tsx
@@ -17,7 +17,13 @@ describe('ProjectSettingsPage', () => {
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
     renderProjectPage('/w/acme/p/platform/settings/general', <ProjectSettingsPage />);
-    fireEvent.change(await screen.findByLabelText('Project name'), {
+    const nameInput = await screen.findByLabelText('Project name');
+    expect(screen.getByRole('heading', {name: 'General'})).toBeInTheDocument();
+    expect(
+      screen.queryByText('Update the project name and the slug used in its URLs.'),
+    ).not.toBeInTheDocument();
+    expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
+    fireEvent.change(nameInput, {
       target: {value: 'Platform API'},
     });
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));

--- a/libs/client/projects/src/pages/project-settings-page.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.tsx
@@ -13,8 +13,9 @@ import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
+import {Panel, PanelBody} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
-import {Header, Text} from '@shipfox/react-ui/typography';
+import {Header} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import {useNavigate} from '@tanstack/react-router';
 import {useState} from 'react';
@@ -124,86 +125,97 @@ function ProjectSettingsForm({project}: {project: Project}) {
   return (
     <>
       <div className="flex min-w-0 flex-col gap-section">
-        <header className="flex flex-col gap-inline">
-          <Header variant="h1">General</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            Update the project name and the slug used in its URLs.
-          </Text>
-        </header>
+        <Header variant="h1">General</Header>
 
-        {formError ? (
-          <Callout role="alert" type="error">
-            {formError}
-          </Callout>
-        ) : null}
+        <Panel>
+          <PanelBody className="gap-group p-panel">
+            {formError ? (
+              <Callout role="alert" type="error">
+                {formError}
+              </Callout>
+            ) : null}
 
-        <form
-          className="flex max-w-[560px] flex-col gap-group"
-          noValidate
-          onSubmit={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            void form.handleSubmit();
-          }}
-        >
-          <form.Field
-            name="name"
-            validators={{
-              onBlur: ({value}) =>
-                displayNameFieldError(value, 'Project name', createProjectBodySchema.shape.name),
-              onSubmit: ({value}) =>
-                displayNameFieldError(value, 'Project name', createProjectBodySchema.shape.name),
-            }}
-          >
-            {(field) => (
-              <FormField label="Project name" id="project-settings-name" error={fieldError(field)}>
-                <FormFieldInput
-                  name="name"
-                  type="text"
-                  value={field.state.value}
-                  onChange={(event) => field.handleChange(event.target.value)}
-                  onBlur={field.handleBlur}
-                />
-              </FormField>
-            )}
-          </form.Field>
+            <form
+              className="flex w-full flex-col gap-group"
+              noValidate
+              onSubmit={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                void form.handleSubmit();
+              }}
+            >
+              <form.Field
+                name="name"
+                validators={{
+                  onBlur: ({value}) =>
+                    displayNameFieldError(
+                      value,
+                      'Project name',
+                      createProjectBodySchema.shape.name,
+                    ),
+                  onSubmit: ({value}) =>
+                    displayNameFieldError(
+                      value,
+                      'Project name',
+                      createProjectBodySchema.shape.name,
+                    ),
+                }}
+              >
+                {(field) => (
+                  <FormField
+                    label="Project name"
+                    id="project-settings-name"
+                    error={fieldError(field)}
+                  >
+                    <FormFieldInput
+                      name="name"
+                      type="text"
+                      value={field.state.value}
+                      onChange={(event) => field.handleChange(event.target.value)}
+                      onBlur={field.handleBlur}
+                    />
+                  </FormField>
+                )}
+              </form.Field>
 
-          <form.Field
-            name="slug"
-            validators={{
-              onBlur: createProjectBodySchema.shape.slug,
-              onSubmit: createProjectBodySchema.shape.slug,
-            }}
-          >
-            {(field) => (
-              <SlugField
-                id="project-settings-slug"
-                label="Project slug"
+              <form.Field
                 name="slug"
-                value={field.state.value}
-                onChange={(value) => field.handleChange(value)}
-                onBlur={field.handleBlur}
-                error={fieldError(field)}
-                description={
-                  <span className="break-all font-code">
-                    /w/{workspace.slug}/p/{field.state.value}
-                  </span>
-                }
-                placeholder="platform"
-                className="font-code"
-                currentSlug={project.slug}
-                checkEnabled
-                debounceMs={0}
-                isValid={isSlugValid}
-                checkAvailability={checkProjectSlugAvailability}
-              />
-            )}
-          </form.Field>
+                validators={{
+                  onBlur: createProjectBodySchema.shape.slug,
+                  onSubmit: createProjectBodySchema.shape.slug,
+                }}
+              >
+                {(field) => (
+                  <SlugField
+                    id="project-settings-slug"
+                    label="Project slug"
+                    name="slug"
+                    value={field.state.value}
+                    onChange={(value) => field.handleChange(value)}
+                    onBlur={field.handleBlur}
+                    error={fieldError(field)}
+                    description={
+                      <span className="break-all font-code">
+                        /w/{workspace.slug}/p/{field.state.value}
+                      </span>
+                    }
+                    placeholder="platform"
+                    className="font-code"
+                    currentSlug={project.slug}
+                    checkEnabled
+                    debounceMs={0}
+                    isValid={isSlugValid}
+                    checkAvailability={checkProjectSlugAvailability}
+                  />
+                )}
+              </form.Field>
 
-          <Button type="submit" isLoading={updateProject.isPending} className="self-start">
-            Save changes
-          </Button>
-        </form>
+              <Button type="submit" isLoading={updateProject.isPending} className="self-start">
+                Save changes
+              </Button>
+            </form>
+          </PanelBody>
+        </Panel>
       </div>
 
       <SlugChangeWarning

--- a/libs/client/projects/src/pages/project-settings-page.tsx
+++ b/libs/client/projects/src/pages/project-settings-page.tsx
@@ -136,7 +136,7 @@ function ProjectSettingsForm({project}: {project: Project}) {
             ) : null}
 
             <form
-              className="flex w-full flex-col gap-group"
+              className="flex w-full max-w-[560px] flex-col gap-group"
               noValidate
               onSubmit={(event) => {
                 event.preventDefault();

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -31,6 +31,7 @@ describe('Panel', () => {
     expect(panel?.classList.contains('rounded-8')).toBe(true);
     expect(panel?.classList.contains('border-border-neutral-base')).toBe(true);
     expect(header?.getAttribute('data-variant')).toBe('strip');
+    expect(header?.classList.contains('bg-background-neutral-base')).toBe(true);
     expect(rows).toHaveLength(2);
     expect(rows[0]?.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
   });

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -33,7 +33,7 @@ export function PanelHeader({className, variant = 'strip', ...props}: PanelHeade
       className={cn(
         'flex min-w-0 items-center justify-between gap-group',
         variant === 'strip'
-          ? 'min-h-48 border-b border-border-neutral-base bg-background-subtle-base px-row py-row'
+          ? 'min-h-48 border-b border-border-neutral-base bg-background-neutral-base px-row py-row'
           : 'bg-background-neutral-base p-panel',
         className,
       )}

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
@@ -20,7 +20,7 @@ export function RadioGroupItem({
         'hover:bg-background-button-neutral-hover active:bg-background-button-neutral-pressed',
         'data-[state=checked]:border-border-highlights-interactive data-[state=checked]:shadow-border-interactive-with-active',
         'focus-visible:shadow-border-interactive-with-active',
-        'disabled:cursor-not-allowed disabled:bg-background-neutral-disabled disabled:text-foreground-neutral-disabled disabled:shadow-none',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:border-border-neutral-base data-[disabled]:bg-background-neutral-disabled data-[disabled]:text-foreground-neutral-disabled data-[disabled]:shadow-none',
         className,
       )}
       {...props}
@@ -29,7 +29,7 @@ export function RadioGroupItem({
         aria-hidden="true"
         className="flex size-16 shrink-0 items-center justify-center rounded-full border border-border-neutral-base"
       >
-        <RadioGroupPrimitive.Indicator className="size-8 rounded-full bg-background-highlight-interactive" />
+        <RadioGroupPrimitive.Indicator className="size-8 rounded-full bg-background-highlight-interactive data-[disabled]:bg-foreground-neutral-disabled" />
       </div>
       <div className="min-w-0 flex-1">{children}</div>
     </RadioGroupPrimitive.Item>

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.tsx
@@ -16,16 +16,22 @@ export function RadioGroupItem({
   return (
     <RadioGroupPrimitive.Item
       className={cn(
-        'rounded-8 border border-border-neutral-base bg-background-neutral-base p-14 text-left transition-colors outline-none cursor-pointer',
-        'hover:bg-background-components-hover',
-        'data-[state=checked]:border-border-highlights-interactive',
-        'focus-visible:shadow-button-neutral-focus',
-        'disabled:cursor-not-allowed disabled:opacity-50',
+        'flex min-w-0 items-center gap-inline rounded-8 border border-border-neutral-base bg-background-button-neutral-default p-14 text-left text-foreground-neutral-base shadow-button-neutral transition-colors outline-none cursor-pointer',
+        'hover:bg-background-button-neutral-hover active:bg-background-button-neutral-pressed',
+        'data-[state=checked]:border-border-highlights-interactive data-[state=checked]:shadow-border-interactive-with-active',
+        'focus-visible:shadow-border-interactive-with-active',
+        'disabled:cursor-not-allowed disabled:bg-background-neutral-disabled disabled:text-foreground-neutral-disabled disabled:shadow-none',
         className,
       )}
       {...props}
     >
-      {children}
+      <div
+        aria-hidden="true"
+        className="flex size-16 shrink-0 items-center justify-center rounded-full border border-border-neutral-base"
+      >
+        <RadioGroupPrimitive.Indicator className="size-8 rounded-full bg-background-highlight-interactive" />
+      </div>
+      <div className="min-w-0 flex-1">{children}</div>
     </RadioGroupPrimitive.Item>
   );
 }

--- a/libs/shared/react/ui/src/components/table/table.test.tsx
+++ b/libs/shared/react/ui/src/components/table/table.test.tsx
@@ -32,7 +32,7 @@ describe('Table', () => {
     expect(panel?.classList.contains('border-border-neutral-base')).toBe(true);
     expect(tableContainer?.classList.contains('rounded-8')).toBe(false);
     expect(tableContainer?.classList.contains('border')).toBe(false);
-    expect(header?.classList.contains('bg-background-subtle-base')).toBe(true);
+    expect(header?.classList.contains('bg-background-neutral-base')).toBe(true);
     expect(cell?.classList.contains('bg-background-neutral-base')).toBe(false);
     expect(row?.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
     expect(row?.classList.contains('data-[selected=true]:bg-background-neutral-pressed')).toBe(


### PR DESCRIPTION
Align project settings and project creation with the Phase 4 content-frame surface contract. The pages now use shared panels with bare sub-page titles; repository controls live in the panel header and the picker no longer owns decorative surfaces. Existing form and repository-selection behavior is preserved, with focused structural coverage and a changeset for the affected packages.

Closes ENG-1591

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts shared `Panel` surfaces for project creation and settings to meet the Phase 4 surface contract (ENG-1591). Moves repository search to the Repository panel header and forwards the filter to the API; simplifies the picker and radio choices to button-style surfaces.

- Replace page layouts with shared `Panel` components; wrap "Source integration", "Repository", and "Project details"; hide the Source panel when connections are missing or fail to load and show an error instead.
- Move repository search to the Repository panel header (`Input`) and pass the filter to the repositories API; render a filtered empty state.
- `RepositoryPicker` no longer renders or accepts search controls (removed `searchValue`, `onSearchChange`, `searchDisabled`); empty state is text-only; loading skeleton uses a `gap-px` grid with `bg-border-neutral-base`.
- `RadioGroupItem` adopts button-like surfaces with an integrated indicator and disabled styles.
- `PanelHeader` “strip” background is now `bg-background-neutral-base`; affected table/panel tests updated; Slack callback test config initializes the API client for deterministic failures.
- Changeset: patch bumps for `@shipfox/client-integrations`, `@shipfox/client-projects`, and `@shipfox/react-ui`.

<sup>Written for commit eab4413fcf8662a56a0ad7b3ef2ce03c5da38a56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

