### PR TITLE
[client-workflows] Recompose workflow run list onto data frame

### DIFF
--- a/.changeset/calm-runs-panel.md
+++ b/.changeset/calm-runs-panel.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Recomposes workflow runs into a full-width data panel and shows the complete job preview.

--- a/libs/client/workflows/src/components/workflow-run-list/job-status-strip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/job-status-strip.tsx
@@ -1,12 +1,17 @@
+import {WORKFLOW_RUN_JOB_PREVIEW_LIMIT} from '@shipfox/api-workflows-dto';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
+import {memo} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import {deriveJobDisplayStatus, type JobDisplayStatus} from '#core/entities/job.js';
 import type {WorkflowRunJobSummary, WorkflowRunJobs} from '#core/workflow-run.js';
 
 const GLYPH_SIZE = 12;
+const GLYPH_GAP = 3;
+const OVERFLOW_GAP = 2;
+const OVERFLOW_LABEL_WIDTH = 40;
 const MAX_TOOLTIP_JOB_NAMES = 6;
 
 /**
@@ -22,6 +27,20 @@ const COMPACT_COUNT_FORMAT = new Intl.NumberFormat('en', {
   notation: 'compact',
   maximumFractionDigits: 1,
 });
+
+/**
+ * Reserves one full API preview and its overflow marker in a run row.
+ *
+ * Keep this derived from the API preview bound so the row reservation grows with the payload
+ * contract instead of silently drifting into the duration and timestamp columns.
+ */
+export function jobStatusStripWidthForPreview(previewLimit: number): number {
+  const previewWidth = previewLimit * GLYPH_SIZE + Math.max(previewLimit - 1, 0) * GLYPH_GAP;
+  const overflowWidth = GLYPH_GAP + GLYPH_SIZE + OVERFLOW_GAP + OVERFLOW_LABEL_WIDTH;
+  return previewWidth + overflowWidth;
+}
+
+export const JOB_STATUS_STRIP_WIDTH = jobStatusStripWidthForPreview(WORKFLOW_RUN_JOB_PREVIEW_LIMIT);
 
 // Worst-first, so the overflow glyph reports the most alarming thing it is standing in for.
 // A strip that hides a failure behind eight green discs would be worse than no strip at all.
@@ -53,7 +72,7 @@ export interface JobStatusStripProps {
  * job including those the server never sent. That split is what lets the overflow glyph
  * report a failure sitting past the preview instead of quietly dropping it.
  */
-export function JobStatusStrip({jobs, className}: JobStatusStripProps) {
+export const JobStatusStrip = memo(function JobStatusStrip({jobs, className}: JobStatusStripProps) {
   if (jobs.total === 0) return null;
 
   // The data frame gives the row enough room for the whole API preview. Only jobs beyond that
@@ -109,7 +128,7 @@ export function JobStatusStrip({jobs, className}: JobStatusStripProps) {
       </TooltipContent>
     </Tooltip>
   );
-}
+});
 
 function JobStatusStripTooltip({jobs, summary}: {jobs: WorkflowRunJobs; summary: string}) {
   // Naming the jobs that need attention is the whole point of hovering; succeeded jobs are

--- a/libs/client/workflows/src/components/workflow-run-list/job-status-strip.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/job-status-strip.tsx
@@ -6,15 +6,6 @@ import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-ic
 import {deriveJobDisplayStatus, type JobDisplayStatus} from '#core/entities/job.js';
 import type {WorkflowRunJobSummary, WorkflowRunJobs} from '#core/workflow-run.js';
 
-/**
- * How many glyphs fit the strip's column before it starts costing the run name width.
- *
- * Sized so the widest case still fits the row's 160px strip column: seven 12px glyphs with
- * 3px gaps is 102px, and the overflow indicator adds a glyph plus a count of at most five
- * monospace characters, about 56px. Overshooting does not wrap, it paints over the duration
- * column. This sits under the API's preview bound, so resizing the strip is a change here.
- */
-const MAX_VISIBLE_JOBS = 7;
 const GLYPH_SIZE = 12;
 const MAX_TOOLTIP_JOB_NAMES = 6;
 
@@ -65,7 +56,10 @@ export interface JobStatusStripProps {
 export function JobStatusStrip({jobs, className}: JobStatusStripProps) {
   if (jobs.total === 0) return null;
 
-  const visible = jobs.preview.slice(0, MAX_VISIBLE_JOBS);
+  // The data frame gives the row enough room for the whole API preview. Only jobs beyond that
+  // server-side preview need an overflow marker; the old seven-glyph cap belonged to the
+  // previous 1120px page width.
+  const visible = jobs.preview;
   const hiddenCount = jobs.total - visible.length;
   const overflowStatus = worstHiddenStatus(jobs, visible);
   const summary = jobStatusSummary(jobs);

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
@@ -53,7 +53,7 @@ export function WorkflowRunFilters({
   const [sheetOpen, setSheetOpen] = useState(false);
 
   return (
-    <div className="flex flex-wrap items-center gap-inline">
+    <div className="flex w-full flex-wrap items-center gap-inline">
       <Input
         value={search.search ?? ''}
         onChange={(event) => onChange({search: event.target.value})}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -28,7 +28,7 @@ export function WorkflowRunListSkeleton() {
         >
           <Skeleton className="size-14 shrink-0 rounded-full" />
           <Skeleton className="h-12 w-[220px] max-w-[40%]" />
-          <Skeleton className="ml-auto hidden h-12 w-96 @min-[1040px]:block" />
+          <Skeleton className="ml-auto hidden h-12 w-96 @min-[1200px]:block" />
           <Skeleton className="h-12 w-48" />
           <Skeleton className="h-12 w-48" />
         </div>

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -16,7 +16,7 @@ const SKELETON_ROW_COUNT = 8;
 export function WorkflowRunListSkeleton() {
   return (
     <div
-      className="@container divide-y divide-border-neutral-base border-t border-border-neutral-base"
+      className="@container divide-y divide-border-neutral-base"
       role="status"
       aria-label="Loading runs"
     >

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -14,6 +14,7 @@ import {WorkflowRunListView} from './workflow-run-list-view.js';
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const JOB_STRIP_LABEL_RE = /jobs:/u;
 const JOB_SUMMARY_NAME_RE = /queued-build/u;
+const OVERFLOW_COUNT_RE = /^\+/u;
 const WORKSPACE_SLUG = 'acme';
 const PROJECT_SLUG = 'checkout-api';
 
@@ -33,6 +34,38 @@ describe('WorkflowRunListView', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  describe('panel composition', () => {
+    test('keeps the controls in the panel header and states in its body', async () => {
+      renderListView([run('succeeded', 'build-image')]);
+      await screen.findByText('build-image');
+
+      const panel = document.querySelector<HTMLElement>('[data-slot="panel"]');
+      const header = panel?.querySelector<HTMLElement>('[data-slot="panel-header"]');
+      const body = panel?.querySelector<HTMLElement>('[data-slot="panel-body"]');
+
+      expect(panel).not.toBeNull();
+      expect(header).not.toBeNull();
+      expect(body).not.toBeNull();
+      expect(within(header as HTMLElement).getByLabelText('Search runs')).toBeInTheDocument();
+      expect(
+        within(header as HTMLElement).getByRole('button', {name: filterTrigger('Status')}),
+      ).toBeInTheDocument();
+      expect(
+        within(header as HTMLElement).getByRole('button', {name: filterTrigger('Branch')}),
+      ).toBeInTheDocument();
+      expect(
+        within(header as HTMLElement).getByRole('button', {name: filterTrigger('Actor')}),
+      ).toBeInTheDocument();
+      expect(
+        within(header as HTMLElement).getByRole('button', {name: filterTrigger('Event')}),
+      ).toBeInTheDocument();
+      expect(
+        within(header as HTMLElement).getByLabelText('Filter runs by creation date'),
+      ).toBeInTheDocument();
+      expect(within(body as HTMLElement).getByText('build-image')).toBeInTheDocument();
+    });
   });
 
   describe('filtering', () => {
@@ -380,8 +413,17 @@ describe('WorkflowRunListView', () => {
     test('counts the jobs it had to hide beyond the strip threshold', async () => {
       renderListView([run('running', 'deploy-web', 'run-1', {...workflowRunJobsOfStatus(40)})]);
 
-      expect(await screen.findByText('+33')).toBeInTheDocument();
+      expect(await screen.findByText('+24')).toBeInTheDocument();
       expect(screen.getByRole('img', {name: '40 jobs: 40 succeeded'})).toBeInTheDocument();
+    });
+
+    test('renders every job in the API preview without a client-side cap', async () => {
+      renderListView([run('running', 'deploy-web', 'run-1', {...workflowRunJobsOfStatus(16)})]);
+
+      const strip = await screen.findByRole('img', {name: '16 jobs: 16 succeeded'});
+
+      expect(within(strip).getAllByLabelText('Succeeded')).toHaveLength(16);
+      expect(within(strip).queryByText(OVERFLOW_COUNT_RE)).not.toBeInTheDocument();
     });
 
     // The API sends a bounded preview, so a run whose only failure sits past it has no failed
@@ -398,7 +440,7 @@ describe('WorkflowRunListView', () => {
         name: '21 jobs: 1 failed, 20 succeeded',
       });
       expect(strip).toBeInTheDocument();
-      expect(screen.getByText('+14')).toBeInTheDocument();
+      expect(screen.getByText('+5')).toBeInTheDocument();
       expect(within(strip).getByLabelText('Failed')).toBeInTheDocument();
     });
 
@@ -420,8 +462,8 @@ describe('WorkflowRunListView', () => {
       ]);
 
       const strip = await screen.findByRole('img', {name: '20 jobs: 20 listening'});
-      expect(screen.getByText('+13')).toBeInTheDocument();
-      expect(within(strip).getAllByLabelText('Listening')).toHaveLength(8);
+      expect(screen.getByText('+4')).toBeInTheDocument();
+      expect(within(strip).getAllByLabelText('Listening')).toHaveLength(17);
 
       const user = userEvent.setup();
       await user.hover(strip);

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -1,4 +1,5 @@
 import type {JobStatusDto} from '@shipfox/api-workflows-dto';
+import {WORKFLOW_RUN_JOB_PREVIEW_LIMIT} from '@shipfox/api-workflows-dto';
 import {screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {WorkflowRunListItem, WorkflowRunStatus} from '#core/workflow-run.js';
@@ -8,6 +9,7 @@ import {
   workflowRunListItem,
 } from '#test/fixtures/workflow-run.js';
 import {renderWithRouter} from '#test/render.js';
+import {JOB_STATUS_STRIP_WIDTH, jobStatusStripWidthForPreview} from './job-status-strip.js';
 import type {WorkflowRunListQuery, WorkflowRunListViewProps} from './types.js';
 import {WorkflowRunListView} from './workflow-run-list-view.js';
 
@@ -424,6 +426,11 @@ describe('WorkflowRunListView', () => {
 
       expect(within(strip).getAllByLabelText('Succeeded')).toHaveLength(16);
       expect(within(strip).queryByText(OVERFLOW_COUNT_RE)).not.toBeInTheDocument();
+    });
+
+    test('reserves the full API preview and overflow marker width', () => {
+      expect(jobStatusStripWidthForPreview(WORKFLOW_RUN_JOB_PREVIEW_LIMIT)).toBe(294);
+      expect(JOB_STATUS_STRIP_WIDTH).toBe(294);
     });
 
     // The API sends a bounded preview, so a run whose only failure sits past it has no failed

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
@@ -1,3 +1,4 @@
+import {Panel, PanelBody, PanelHeader} from '@shipfox/react-ui/panel';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Header} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
@@ -58,7 +59,7 @@ export function WorkflowRunListView({
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
       <section
         aria-labelledby={headingId}
-        className={cn('flex min-h-0 min-w-0 flex-1 flex-col gap-cluster', className)}
+        className={cn('flex min-h-0 min-w-0 flex-1 flex-col', className)}
       >
         {/* The tab strip above already reads "Runs", so the page heading is for structure and
             assistive tech rather than a second visible title competing with it. */}
@@ -66,27 +67,32 @@ export function WorkflowRunListView({
           Workflow runs
         </Header>
 
-        <WorkflowRunFilters
-          search={currentSearch}
-          facets={facets}
-          onChange={handleFiltersChange}
-          onClear={handleClearFilters}
-          hasActiveFilters={hasActiveFilters}
-        />
-
-        <WorkflowRunListContent
-          query={query}
-          totalRuns={runs.length}
-          runs={filteredRuns}
-          workspaceSlug={workspaceSlug}
-          projectSlug={projectSlug}
-          hasActiveFilters={hasActiveFilters}
-          onClearFilters={handleClearFilters}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          isFetchNextPageError={isFetchNextPageError}
-          {...(onLoadMore ? {onLoadMore} : {})}
-        />
+        <Panel className="min-h-0 flex-1">
+          <PanelHeader className="flex-wrap">
+            <WorkflowRunFilters
+              search={currentSearch}
+              facets={facets}
+              onChange={handleFiltersChange}
+              onClear={handleClearFilters}
+              hasActiveFilters={hasActiveFilters}
+            />
+          </PanelHeader>
+          <PanelBody className="min-h-0 flex-1">
+            <WorkflowRunListContent
+              query={query}
+              totalRuns={runs.length}
+              runs={filteredRuns}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              hasActiveFilters={hasActiveFilters}
+              onClearFilters={handleClearFilters}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              isFetchNextPageError={isFetchNextPageError}
+              {...(onLoadMore ? {onLoadMore} : {})}
+            />
+          </PanelBody>
+        </Panel>
       </section>
     </TimeTickerProvider>
   );

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
@@ -137,27 +137,18 @@ export const NarrowLayout: Story = {
 };
 
 /**
- * Row density against the three strip sizes the threshold has to survive: comfortably under
- * it, comfortably over it, and far enough over that the overflow count carries the failure.
+ * Row density against the three strip sizes the preview bound has to survive: comfortably under
+ * it, just over it, and far enough over that the overflow count carries the failure.
  */
 export const JobStripDensity: Story = {
   args: {
     runs: [
       makeRun('succeeded', 'two-jobs', 2, {jobs: ['succeeded', 'succeeded']}),
-      makeRun('failed', 'twelve-jobs', 6, {
+      makeRun('failed', 'seventeen-jobs', 6, {
         jobs: [
-          'succeeded',
-          'succeeded',
-          'succeeded',
+          ...(Array.from({length: 12}, () => 'succeeded') as JobStatusDto[]),
           'failed',
-          'succeeded',
-          'succeeded',
-          'skipped',
-          'skipped',
-          'succeeded',
-          'succeeded',
-          'succeeded',
-          'succeeded',
+          ...(Array.from({length: 4}, () => 'skipped') as JobStatusDto[]),
         ],
       }),
       makeRun('running', 'forty-jobs', 9, {

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
@@ -229,9 +229,7 @@ function StateExample({label, children}: {label: string; children: ReactNode}) {
       <Code variant="label" className="text-foreground-neutral-subtle">
         {label}
       </Code>
-      <div className="flex h-560 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
-        {children}
-      </div>
+      <div className="flex h-560 min-w-0 bg-background-subtle-base p-16">{children}</div>
     </div>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -37,7 +37,7 @@ export function WorkflowRunRowList({
     // A container, not the viewport, drives the row's breakpoints. What a row can afford is its
     // own width; keying off the viewport would keep the job strip hidden on a wide screen or
     // crush it on a narrow one.
-    <ul className="@container divide-y divide-border-neutral-base border-t border-border-neutral-base">
+    <ul className="@container divide-y divide-border-neutral-base">
       {runs.map((run) => (
         <li key={run.id}>
           <WorkflowRunRow run={run} workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
@@ -99,10 +99,10 @@ export function WorkflowRunRow({
       </div>
 
       <span className="flex shrink-0 items-center gap-cluster">
-        {/* Fixed at the strip's worst case (see MAX_VISIBLE_JOBS) so the overflow count cannot
-            paint over the duration, and kept even when a run has no jobs planned yet, so the
-            numerics stay in line down the list instead of stepping in and out. */}
-        <span className="hidden w-160 @min-[1040px]:flex">
+        {/* Reserve the API preview's full width so the overflow count cannot paint over the
+            duration, and keep it even when a run has no jobs planned yet so the numerics stay in
+            line down the list instead of stepping in and out. */}
+        <span className="hidden w-320 @min-[1040px]:flex">
           <JobStatusStrip jobs={run.jobs} />
         </span>
         <span className="flex w-64 justify-end">
@@ -121,7 +121,7 @@ export function WorkflowRunRow({
   // Rows run edge to edge inside the list's scroll container, which would clip the standard
   // outset focus ring, so this one is inset per the design system's focus-ring rule.
   const rowClassName =
-    'flex w-full min-w-0 items-center gap-inline px-row py-row text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] focus-visible:outline-none @min-[976px]:h-44 @min-[976px]:py-0';
+    'flex w-full min-w-0 items-center gap-inline px-row py-row text-left transition-colors hover:bg-background-neutral-hover focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] focus-visible:outline-none @min-[976px]:h-44 @min-[976px]:py-0';
 
   // Optimistic manual runs (temp-<uuid>) have no detail page until the canonical row
   // replaces them on the next poll, so they render non-interactively instead of as a link

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -22,7 +22,7 @@ import {
   workflowRunCommitLabel,
 } from '#core/workflow-run.js';
 import {withoutWorkflowRunSelectionSearch} from '#core/workflow-run-url-state.js';
-import {JobStatusStrip, jobStatusSummary} from './job-status-strip.js';
+import {JOB_STATUS_STRIP_WIDTH, JobStatusStrip, jobStatusSummary} from './job-status-strip.js';
 
 export function WorkflowRunRowList({
   runs,
@@ -56,8 +56,8 @@ export function WorkflowRunRowList({
  * down the list rather than tracking each row's name length.
  *
  * The 976px threshold keeps identity and provenance on one line; below it, provenance drops
- * beneath the identity. The 1040px threshold keeps the job strip visible; below it, the strip is
- * hidden so the numeric columns remain aligned.
+ * beneath the identity. The 1200px threshold keeps the full job preview and numeric columns
+ * readable together; below it, the strip is hidden so the numeric columns remain aligned.
  */
 export function WorkflowRunRow({
   run,
@@ -101,8 +101,12 @@ export function WorkflowRunRow({
       <span className="flex shrink-0 items-center gap-cluster">
         {/* Reserve the API preview's full width so the overflow count cannot paint over the
             duration, and keep it even when a run has no jobs planned yet so the numerics stay in
-            line down the list instead of stepping in and out. */}
-        <span className="hidden w-320 @min-[1040px]:flex">
+            line down the list instead of stepping in and out. The max-content width expands if
+            the payload ever exceeds the current API preview bound. */}
+        <span
+          className="hidden w-max shrink-0 @min-[1200px]:flex"
+          style={{minWidth: JOB_STATUS_STRIP_WIDTH}}
+        >
           <JobStatusStrip jobs={run.jobs} />
         </span>
         <span className="flex w-64 justify-end">

--- a/libs/client/workflows/src/pages/workflow-run-list-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-list-page.tsx
@@ -49,17 +49,15 @@ export function WorkflowRunsPage({
   );
 
   return (
-    <div data-workflow-page-root="runs" className="flex min-h-0 flex-1 overflow-hidden">
-      <div className="mx-auto flex min-h-0 w-full flex-1 flex-col px-frame py-frame">
-        <WorkflowRunList
-          projectId={projectId}
-          workspaceSlug={workspaceSlug}
-          projectSlug={projectSlug}
-          search={search}
-          onFiltersChange={onFiltersChange}
-          onClearFilters={onClearFilters}
-        />
-      </div>
+    <div data-workflow-page-root="runs" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <WorkflowRunList
+        projectId={projectId}
+        workspaceSlug={workspaceSlug}
+        projectSlug={projectSlug}
+        search={search}
+        onFiltersChange={onFiltersChange}
+        onClearFilters={onClearFilters}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Recompose the workflow run list onto the shared data frame and Panel surface.

The route now uses the data frame's full width. Search and run filters live in the Panel header, while loading, empty, error, and list states stay in the Panel body. The job strip renders the complete API preview so the old seven-dot truncation no longer applies.

Closes ENG-1584

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recomposed the workflow run list into the full-width `data` frame on a shared `Panel`. Filters moved to the panel header, and the job strip now renders the full API preview with width tied to the server preview bound.

- **Refactors**
  - Removed the client cap on job glyphs; reserve width from `@shipfox/api-workflows-dto`’s `WORKFLOW_RUN_JOB_PREVIEW_LIMIT` via `JOB_STATUS_STRIP_WIDTH`, and only show overflow for jobs beyond the server preview. Hide the strip until the row can fit the full preview (`@min-[1200px]`) to keep numerics aligned.
  - Aligned borders and container widths with the data frame, made filters take full width, and updated stories/tests (including derived width assertions and just-over-boundary coverage). Aligns with Linear ENG-1584 (single panel, no page title, full-width layout).

<sup>Written for commit 9cfbb1d096728dc8c367146a1bce1333a1d59a49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

