### PR TITLE
Recompose job detail and log pane onto the data frame

### DIFF
--- a/.changeset/framed-job-logs.md
+++ b/.changeset/framed-job-logs.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-logs": minor
+"@shipfox/client-workflows": patch
+---
+
+Composes job detail logs into the Panel surface with searchable output and display controls.

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -10,7 +10,7 @@ import {
 } from '@shipfox/react-ui/log';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {cn} from '@shipfox/react-ui/utils';
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import type {SessionViewRow, SessionViewRowMeta} from '#core/log-model.js';
 
 const PREVIEW_CHAR_LIMIT = 1200;
@@ -23,6 +23,7 @@ export interface AgentSessionRowsProps {
   resolvedToolCallIds: ReadonlySet<string>;
   toolCallNames: ReadonlyMap<string, string>;
   indent: number;
+  forceOpen?: boolean;
 }
 
 export function AgentSessionRows({
@@ -30,6 +31,7 @@ export function AgentSessionRows({
   resolvedToolCallIds,
   toolCallNames,
   indent,
+  forceOpen = false,
 }: AgentSessionRowsProps) {
   return rows.map((row, index) => (
     <AgentSessionRowView
@@ -39,6 +41,7 @@ export function AgentSessionRows({
       resolvedToolCallIds={resolvedToolCallIds}
       toolCallNames={toolCallNames}
       indent={indent}
+      forceOpen={forceOpen}
     />
   ));
 }
@@ -48,12 +51,20 @@ function AgentSessionRowView({
   resolvedToolCallIds,
   toolCallNames,
   indent,
+  forceOpen,
 }: {
   row: SessionViewRow;
   resolvedToolCallIds: ReadonlySet<string>;
   toolCallNames: ReadonlyMap<string, string>;
   indent: number;
+  forceOpen: boolean;
 }) {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (forceOpen) setOpen(true);
+  }, [forceOpen]);
+  const disclosureProps = {open: forceOpen || open, onOpenChange: setOpen};
+
   switch (row.kind) {
     case 'message':
       return (
@@ -82,7 +93,7 @@ function AgentSessionRowView({
       );
     case 'thinking':
       return (
-        <LogDisclosure indent={indent}>
+        <LogDisclosure indent={indent} {...disclosureProps}>
           <LogDisclosureTrigger
             summary={wordSummary(row.text)}
             timestamp={new Date(row.timestamp)}
@@ -100,7 +111,7 @@ function AgentSessionRowView({
     case 'tool-call': {
       const awaitingResult = row.id != null && !resolvedToolCallIds.has(row.id);
       return (
-        <LogDisclosure indent={indent}>
+        <LogDisclosure indent={indent} {...disclosureProps}>
           <LogDisclosureTrigger
             timestamp={new Date(row.timestamp)}
             summary={compactPreview(row.summary ?? row.input)}
@@ -148,7 +159,7 @@ function AgentSessionRowView({
             '(unmatched)')
           : row.toolName;
       return (
-        <LogDisclosure indent={indent}>
+        <LogDisclosure indent={indent} {...disclosureProps}>
           <LogDisclosureTrigger
             timestamp={new Date(row.timestamp)}
             summary={compactPreview(row.output)}
@@ -213,7 +224,7 @@ function AgentSessionRowView({
       );
     case 'raw':
       return (
-        <LogDisclosure indent={indent}>
+        <LogDisclosure indent={indent} {...disclosureProps}>
           <LogDisclosureTrigger
             timestamp={new Date(row.timestamp)}
             summary={compactPreview(row.raw)}

--- a/libs/client/logs/src/components/log-group.tsx
+++ b/libs/client/logs/src/components/log-group.tsx
@@ -3,7 +3,7 @@
 import {Icon} from '@shipfox/react-ui/icon';
 import {LogDisclosure, LogDisclosureContent, LogDisclosureTrigger} from '@shipfox/react-ui/log';
 import {cn, formatDuration} from '@shipfox/react-ui/utils';
-import type {ReactNode} from 'react';
+import {type ReactNode, useEffect, useState} from 'react';
 import type {GroupLogNode} from '#core/log-tree.js';
 
 export interface LogGroupProps {
@@ -12,13 +12,26 @@ export interface LogGroupProps {
   terminated: boolean;
   children: ReactNode;
   defaultOpen?: boolean;
+  forceOpen?: boolean;
 }
 
-export function LogGroup({node, depth, terminated, children, defaultOpen = false}: LogGroupProps) {
+export function LogGroup({
+  node,
+  depth,
+  terminated,
+  children,
+  defaultOpen = false,
+  forceOpen = false,
+}: LogGroupProps) {
   const lineLabel = `${node.lineCount} ${node.lineCount === 1 ? 'line' : 'lines'}`;
+  const [open, setOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    if (forceOpen) setOpen(true);
+  }, [forceOpen]);
 
   return (
-    <LogDisclosure indent={depth} defaultOpen={defaultOpen}>
+    <LogDisclosure indent={depth} open={forceOpen || open} onOpenChange={setOpen}>
       <LogDisclosureTrigger
         summary={lineLabel}
         trailing={<GroupStatus node={node} terminated={terminated} />}

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -144,6 +144,39 @@ describe('LogView', () => {
     expect(screen.getByText('1 line')).toBeInTheDocument();
   });
 
+  test('normalizes search text and restores all rows when search is cleared', async () => {
+    const records = [output('Failure: validation failed\n'), output('success: recovered\n')];
+    const {rerender} = render(<LogView search="  FAILURE  " records={records} />);
+
+    await waitFor(() => expect(screen.getByText('Failure: validation failed')).toBeInTheDocument());
+    expect(screen.queryByText('success: recovered')).not.toBeInTheDocument();
+
+    rerender(<LogView search="" records={records} />);
+
+    await waitFor(() => expect(screen.getByText('success: recovered')).toBeInTheDocument());
+  });
+
+  test('searches marker labels and drops groups without matching descendants', () => {
+    render(
+      <LogView
+        search="missing"
+        records={[
+          groupStart('build', 'Build'),
+          output('build succeeded\n'),
+          groupEnd('build'),
+          groupStart('deploy', 'Deploy'),
+          output('deploy started\n'),
+          groupEnd('deploy'),
+          {v: 1, ts, type: 'gap', droppedBytes: 64},
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Output missing')).toBeInTheDocument();
+    expect(screen.queryByText('Build')).not.toBeInTheDocument();
+    expect(screen.queryByText('Deploy')).not.toBeInTheDocument();
+  });
+
   test('shows a message when the log search has no matches', () => {
     render(<LogView search="missing" records={[output('hello\n')]} />);
 
@@ -328,7 +361,7 @@ describe('LogView', () => {
     );
   });
 
-  test('anchors terminal failures when requested', async () => {
+  test('anchors terminal failures once while search changes', async () => {
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);
       return 1;
@@ -349,26 +382,26 @@ describe('LogView', () => {
       .spyOn(HTMLElement.prototype, 'scrollIntoView')
       .mockImplementation(() => undefined);
 
-    render(
-      <LogView
-        anchorToFailure
-        records={[
-          output('setup\n'),
-          agentSession({
-            kind: 'message',
-            timestamp: ts,
-            role: 'assistant',
-            label: 'assistant',
-            meta: [],
-            text: 'I cannot continue.',
-            terminalFailure: true,
-          }),
-        ]}
-        search="cannot"
-      />,
-    );
+    const records = [
+      output('setup\n'),
+      agentSession({
+        kind: 'message',
+        timestamp: ts,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [],
+        text: 'I cannot continue.',
+        terminalFailure: true,
+      }),
+    ];
+    const {rerender} = render(<LogView anchorToFailure records={records} search="cannot" />);
 
     await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({block: 'center'}));
+    scrollIntoView.mockClear();
+
+    rerender(<LogView anchorToFailure records={records} search="missing" />);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });
 

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -256,6 +256,34 @@ describe('LogView', () => {
     expect(screen.getByText('awaiting result')).toBeDefined();
   });
 
+  test('keeps tool relationships when search matches only one side', () => {
+    const records = [
+      agentSession({
+        kind: 'tool-call',
+        timestamp: ts,
+        id: 'call-1',
+        name: 'edit_file',
+        input: '{}',
+      }),
+      agentSession({
+        kind: 'tool-result',
+        timestamp: ts + 1,
+        toolCallId: 'call-1',
+        toolName: 'edit_file',
+        output: 'patched',
+        isError: false,
+      }),
+    ];
+
+    const {unmount} = render(<LogView search="{}" records={records} />);
+    expect(screen.queryByText('awaiting result')).not.toBeInTheDocument();
+
+    unmount();
+    render(<LogView search="patched" records={records} />);
+    expect(screen.getByText('result edit_file')).toBeInTheDocument();
+    expect(screen.queryByText('result (unmatched)')).not.toBeInTheDocument();
+  });
+
   test('renders unknown session entries without crashing', () => {
     render(
       <LogView

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -85,6 +85,38 @@ describe('LogView', () => {
     expect(screen.queryByText('No output yet')).toBeNull();
   });
 
+  test('filters output and session rows by the log search term', () => {
+    render(
+      <LogView
+        search="failure"
+        records={[
+          output('setup complete\n'),
+          output('failure: test failed\n'),
+          agentSession({
+            kind: 'message',
+            timestamp: ts,
+            role: 'assistant',
+            label: 'assistant',
+            meta: [],
+            text: 'The failure is in the validation step.',
+            terminalFailure: false,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('failure: test failed')).toBeDefined();
+    expect(screen.getByText('The failure is in the validation step.')).toBeDefined();
+    expect(screen.queryByText('setup complete')).toBeNull();
+  });
+
+  test('shows a message when the log search has no matches', () => {
+    render(<LogView search="missing" records={[output('hello\n')]} />);
+
+    expect(screen.getByText('No log lines match “missing”.')).toBeDefined();
+    expect(screen.queryByText('hello')).toBeNull();
+  });
+
   test('allows terminal logs to opt out of live announcements', () => {
     render(<LogView records={[output('hello\n')]} ariaLive="off" />);
 

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -12,6 +12,20 @@ const output = (data: string): LogRecord => ({
   stream: 'stdout',
   data,
 });
+const groupStart = (groupId: string, name: string): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'group_start',
+  groupId,
+  parentGroupId: null,
+  name,
+});
+const groupEnd = (groupId: string): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'group_end',
+  groupId,
+});
 type AgentSessionRow = Extract<LogRecord, {type: 'agent_session'}>['row'];
 
 const agentSession = (row: AgentSessionRow, offsetMs = 0): LogRecord => ({
@@ -108,12 +122,32 @@ describe('LogView', () => {
     expect(screen.getByText('failure: test failed')).toBeDefined();
     expect(screen.getByText('The failure is in the validation step.')).toBeDefined();
     expect(screen.queryByText('setup complete')).toBeNull();
+    expect(screen.getByRole('log')).toHaveAttribute('aria-live', 'off');
+    expect(screen.getByRole('status')).toHaveTextContent('Log search updated for “failure”.');
+  });
+
+  test('opens matching groups and filters their children', () => {
+    render(
+      <LogView
+        search="success"
+        records={[
+          groupStart('build', 'Build'),
+          output('setup complete\n'),
+          output('Success: compiled\n'),
+          groupEnd('build'),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Success: compiled')).toBeInTheDocument();
+    expect(screen.queryByText('setup complete')).not.toBeInTheDocument();
+    expect(screen.getByText('1 line')).toBeInTheDocument();
   });
 
   test('shows a message when the log search has no matches', () => {
     render(<LogView search="missing" records={[output('hello\n')]} />);
 
-    expect(screen.getByText('No log lines match “missing”.')).toBeDefined();
+    expect(screen.getByRole('status')).toHaveTextContent('No log lines match “missing”.');
     expect(screen.queryByText('hello')).toBeNull();
   });
 
@@ -302,6 +336,7 @@ describe('LogView', () => {
             terminalFailure: true,
           }),
         ]}
+        search="cannot"
       />,
     );
 

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -3,9 +3,16 @@
 import {Icon} from '@shipfox/react-ui/icon';
 import {LogContent, LogRow, LogRows, type LogTimestampMode} from '@shipfox/react-ui/log';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
-import {cn} from '@shipfox/react-ui/utils';
-import {type ReactNode, type UIEventHandler, useEffect, useMemo, useRef} from 'react';
+import {
+  type ReactNode,
+  type UIEventHandler,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import type {LogRecord} from '#core/log-model.js';
+import {buildLogSearchIndex, filterLogNodes} from '#core/log-search.js';
 import {
   assertNever,
   buildLogTree,
@@ -52,14 +59,22 @@ export function LogView({
 }: LogViewProps) {
   const rowsRef = useRef<HTMLDivElement>(null);
   const tree = useMemo(() => buildLogTree(records), [records]);
-  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const deferredSearch = useDeferredValue(search);
+  const normalizedSearch = deferredSearch.trim().toLocaleLowerCase();
+  const searchIndex = useMemo(() => buildLogSearchIndex(tree.nodes), [tree.nodes]);
   const visibleNodes = useMemo(
-    () => (normalizedSearch ? filterLogNodes(tree.nodes, normalizedSearch) : tree.nodes),
-    [normalizedSearch, tree.nodes],
+    () =>
+      normalizedSearch ? filterLogNodes(tree.nodes, normalizedSearch, searchIndex) : tree.nodes,
+    [normalizedSearch, searchIndex, tree.nodes],
   );
-  const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(tree.nodes), [tree.nodes]);
+  const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(visibleNodes), [visibleNodes]);
   const noOutputState = normalizedSearch ? null : getNoOutputState(tree, emptyState);
   const anchorRecordCount = records.length;
+  const searchStatus = normalizedSearch
+    ? visibleNodes.length === 0
+      ? `No log lines match “${deferredSearch.trim()}”.`
+      : `Log search updated for “${deferredSearch.trim()}”.`
+    : null;
 
   useEffect(() => {
     if (!anchorToFailure) return;
@@ -82,22 +97,36 @@ export function LogView({
   }, [anchorToFailure, anchorRecordCount]);
 
   return (
-    <LogRows
-      ref={rowsRef}
-      timestamps={timestamps}
-      wrap={wrap}
-      showLineNumbers={showLineNumbers}
-      aria-live={ariaLive}
-      className={cn('bg-background-contrast-base', className)}
-      onScroll={onScroll}
-      {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
-    >
-      {noOutputState ? <NoOutputRow state={noOutputState} /> : null}
-      {normalizedSearch && visibleNodes.length === 0 ? (
-        <NoSearchMatchesRow query={search.trim()} />
+    <>
+      {searchStatus ? (
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {searchStatus}
+        </div>
       ) : null}
-      {renderNodes(visibleNodes, 0, tree, defaultGroupsOpen, resolvedToolCalls)}
-    </LogRows>
+      <LogRows
+        ref={rowsRef}
+        timestamps={timestamps}
+        wrap={wrap}
+        showLineNumbers={showLineNumbers}
+        aria-live={normalizedSearch ? 'off' : ariaLive}
+        className={className}
+        onScroll={onScroll}
+        {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
+      >
+        {noOutputState ? <NoOutputRow state={noOutputState} /> : null}
+        {normalizedSearch && visibleNodes.length === 0 ? (
+          <NoSearchMatchesRow query={deferredSearch.trim()} />
+        ) : null}
+        {renderNodes(
+          visibleNodes,
+          0,
+          tree,
+          defaultGroupsOpen,
+          Boolean(normalizedSearch),
+          resolvedToolCalls,
+        )}
+      </LogRows>
+    </>
   );
 }
 
@@ -116,7 +145,7 @@ export function LogViewSkeleton({
       timestamps={timestamps}
       wrap={wrap}
       showLineNumbers={showLineNumbers}
-      className={cn('bg-background-contrast-base', className)}
+      className={className}
       role="presentation"
       aria-live="off"
       aria-hidden="true"
@@ -195,36 +224,12 @@ function NoSearchMatchesRow({query}: {query: string}) {
   );
 }
 
-function filterLogNodes(nodes: readonly LogNode[], query: string): LogNode[] {
-  return nodes.flatMap((node): LogNode[] => {
-    const matches = searchableNodeText(node).toLocaleLowerCase().includes(query);
-    if (node.kind !== 'group') return matches ? [node] : [];
-
-    const children = matches ? node.children : filterLogNodes(node.children, query);
-    return matches || children.length > 0 ? [{...node, children}] : [];
-  });
-}
-
-function searchableNodeText(node: LogNode): string {
-  switch (node.kind) {
-    case 'output':
-      return node.record.data;
-    case 'group':
-      return node.record.name;
-    case 'marker':
-      return JSON.stringify(node.record) ?? '';
-    case 'session':
-      return JSON.stringify(node.record.row) ?? '';
-    default:
-      return assertNever(node);
-  }
-}
-
 function renderNodes(
   nodes: readonly LogNode[],
   depth: number,
   tree: LogTree,
   defaultGroupsOpen: boolean,
+  forceOpen: boolean,
   resolvedToolCalls: ResolvedToolCalls,
 ): ReactNode[] {
   // `node.seq` is the stable, unique render key (see `LogNodeBase`): a concatenated
@@ -249,8 +254,16 @@ function renderNodes(
             depth={depth}
             terminated={tree.terminated}
             defaultOpen={defaultGroupsOpen}
+            forceOpen={forceOpen}
           >
-            {renderNodes(node.children, depth + 1, tree, defaultGroupsOpen, resolvedToolCalls)}
+            {renderNodes(
+              node.children,
+              depth + 1,
+              tree,
+              defaultGroupsOpen,
+              forceOpen,
+              resolvedToolCalls,
+            )}
           </LogGroup>
         );
       case 'marker':
@@ -263,6 +276,7 @@ function renderNodes(
             resolvedToolCallIds={resolvedToolCalls.ids}
             toolCallNames={resolvedToolCalls.names}
             indent={depth}
+            forceOpen={forceOpen}
           />
         );
       default:

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -3,6 +3,7 @@
 import {Icon} from '@shipfox/react-ui/icon';
 import {LogContent, LogRow, LogRows, type LogTimestampMode} from '@shipfox/react-ui/log';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
+import {cn} from '@shipfox/react-ui/utils';
 import {type ReactNode, type UIEventHandler, useEffect, useMemo, useRef} from 'react';
 import type {LogRecord} from '#core/log-model.js';
 import {
@@ -25,6 +26,7 @@ export interface LogViewProps {
   emptyState?: 'complete' | 'pending';
   defaultGroupsOpen?: boolean;
   anchorToFailure?: boolean;
+  search?: string;
   ariaLive?: 'off' | 'polite' | 'assertive';
   className?: string | undefined;
   onScroll?: UIEventHandler<HTMLDivElement> | undefined;
@@ -43,14 +45,20 @@ export function LogView({
   emptyState = 'complete',
   defaultGroupsOpen = false,
   anchorToFailure = false,
+  search = '',
   ariaLive = 'polite',
   className,
   onScroll,
 }: LogViewProps) {
   const rowsRef = useRef<HTMLDivElement>(null);
   const tree = useMemo(() => buildLogTree(records), [records]);
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const visibleNodes = useMemo(
+    () => (normalizedSearch ? filterLogNodes(tree.nodes, normalizedSearch) : tree.nodes),
+    [normalizedSearch, tree.nodes],
+  );
   const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(tree.nodes), [tree.nodes]);
-  const noOutputState = getNoOutputState(tree, emptyState);
+  const noOutputState = normalizedSearch ? null : getNoOutputState(tree, emptyState);
   const anchorRecordCount = records.length;
 
   useEffect(() => {
@@ -80,12 +88,15 @@ export function LogView({
       wrap={wrap}
       showLineNumbers={showLineNumbers}
       aria-live={ariaLive}
-      className={className}
+      className={cn('bg-background-contrast-base', className)}
       onScroll={onScroll}
       {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
     >
       {noOutputState ? <NoOutputRow state={noOutputState} /> : null}
-      {renderNodes(tree.nodes, 0, tree, defaultGroupsOpen, resolvedToolCalls)}
+      {normalizedSearch && visibleNodes.length === 0 ? (
+        <NoSearchMatchesRow query={search.trim()} />
+      ) : null}
+      {renderNodes(visibleNodes, 0, tree, defaultGroupsOpen, resolvedToolCalls)}
     </LogRows>
   );
 }
@@ -105,7 +116,7 @@ export function LogViewSkeleton({
       timestamps={timestamps}
       wrap={wrap}
       showLineNumbers={showLineNumbers}
-      className={className}
+      className={cn('bg-background-contrast-base', className)}
       role="presentation"
       aria-live="off"
       aria-hidden="true"
@@ -169,6 +180,44 @@ function NoOutputRow({state}: {state: NonNullable<LogViewProps['emptyState']>}) 
       </LogContent>
     </LogRow>
   );
+}
+
+function NoSearchMatchesRow({query}: {query: string}) {
+  return (
+    <LogRow lineNumber={null}>
+      <LogContent className="text-foreground-contrast-secondary">
+        <span className="inline-flex min-w-0 items-center gap-inline">
+          <Icon name="searchLine" className="size-14 flex-none" aria-hidden="true" />
+          <span>No log lines match “{query}”.</span>
+        </span>
+      </LogContent>
+    </LogRow>
+  );
+}
+
+function filterLogNodes(nodes: readonly LogNode[], query: string): LogNode[] {
+  return nodes.flatMap((node): LogNode[] => {
+    const matches = searchableNodeText(node).toLocaleLowerCase().includes(query);
+    if (node.kind !== 'group') return matches ? [node] : [];
+
+    const children = matches ? node.children : filterLogNodes(node.children, query);
+    return matches || children.length > 0 ? [{...node, children}] : [];
+  });
+}
+
+function searchableNodeText(node: LogNode): string {
+  switch (node.kind) {
+    case 'output':
+      return node.record.data;
+    case 'group':
+      return node.record.name;
+    case 'marker':
+      return JSON.stringify(node.record) ?? '';
+    case 'session':
+      return JSON.stringify(node.record.row) ?? '';
+    default:
+      return assertNever(node);
+  }
 }
 
 function renderNodes(

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -60,14 +60,14 @@ export function LogView({
   const rowsRef = useRef<HTMLDivElement>(null);
   const tree = useMemo(() => buildLogTree(records), [records]);
   const deferredSearch = useDeferredValue(search);
-  const normalizedSearch = deferredSearch.trim().toLocaleLowerCase();
+  const normalizedSearch = deferredSearch.trim().toLowerCase();
   const searchIndex = useMemo(() => buildLogSearchIndex(tree.nodes), [tree.nodes]);
   const visibleNodes = useMemo(
     () =>
       normalizedSearch ? filterLogNodes(tree.nodes, normalizedSearch, searchIndex) : tree.nodes,
     [normalizedSearch, searchIndex, tree.nodes],
   );
-  const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(visibleNodes), [visibleNodes]);
+  const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(tree.nodes), [tree.nodes]);
   const noOutputState = normalizedSearch ? null : getNoOutputState(tree, emptyState);
   const anchorRecordCount = records.length;
   const searchStatus = normalizedSearch

--- a/libs/client/logs/src/core/log-search.test.ts
+++ b/libs/client/logs/src/core/log-search.test.ts
@@ -1,0 +1,96 @@
+import type {LogRecord} from './log-model.js';
+import {buildLogSearchIndex, filterLogNodes} from './log-search.js';
+import {buildLogTree, type GroupLogNode, type LogNode} from './log-tree.js';
+
+const output = (data: string): LogRecord => ({
+  v: 1,
+  ts: 0,
+  type: 'output',
+  stream: 'stdout',
+  data,
+});
+
+const groupStart = (
+  groupId: string,
+  name: string,
+  parentGroupId: string | null = null,
+): LogRecord => ({
+  v: 1,
+  ts: 0,
+  type: 'group_start',
+  groupId,
+  parentGroupId,
+  name,
+});
+
+const groupEnd = (groupId: string): LogRecord => ({
+  v: 1,
+  ts: 0,
+  type: 'group_end',
+  groupId,
+});
+
+const asGroup = (node: LogNode | undefined): GroupLogNode => {
+  if (node?.kind !== 'group') throw new Error(`expected group, got ${node?.kind}`);
+  return node;
+};
+
+describe('filterLogNodes', () => {
+  test('keeps matching group ancestors and counts only visible output lines', () => {
+    const tree = buildLogTree([
+      groupStart('build', 'Build'),
+      output('not this line'),
+      output('\u001b[32mSuccess\u001b[0m: compiled'),
+      groupEnd('build'),
+    ]);
+
+    const filtered = filterLogNodes(tree.nodes, 'success', buildLogSearchIndex(tree.nodes));
+    const group = asGroup(filtered[0]);
+
+    expect(group.children).toHaveLength(1);
+    expect(group.children[0]?.kind).toBe('output');
+    expect(group.lineCount).toBe(1);
+  });
+
+  test('keeps every child when the group name matches', () => {
+    const tree = buildLogTree([
+      groupStart('build', 'Build'),
+      output('first'),
+      output('second'),
+      groupEnd('build'),
+    ]);
+
+    const filtered = filterLogNodes(tree.nodes, 'build', buildLogSearchIndex(tree.nodes));
+    const group = asGroup(filtered[0]);
+
+    expect(group.children).toHaveLength(2);
+    expect(group.lineCount).toBe(2);
+  });
+
+  test('searches rendered labels and strips ANSI without matching structural fields', () => {
+    const records: LogRecord[] = [
+      output('\u001b[32mSuccess\u001b[0m: compiled'),
+      {v: 1, ts: 0, type: 'gap', droppedBytes: 64},
+      {
+        v: 1,
+        ts: 0,
+        type: 'agent_session',
+        row: {
+          kind: 'message',
+          timestamp: 0,
+          role: 'assistant',
+          label: 'assistant',
+          meta: [],
+          text: 'Validation passed.',
+          terminalFailure: false,
+        },
+      },
+    ];
+    const tree = buildLogTree(records);
+    const index = buildLogSearchIndex(tree.nodes);
+
+    expect(filterLogNodes(tree.nodes, '  SUCCESS  ', index)).toHaveLength(1);
+    expect(filterLogNodes(tree.nodes, 'output missing', index)).toHaveLength(1);
+    expect(filterLogNodes(tree.nodes, 'error', index)).toHaveLength(0);
+  });
+});

--- a/libs/client/logs/src/core/log-search.ts
+++ b/libs/client/logs/src/core/log-search.ts
@@ -18,7 +18,7 @@ export function filterLogNodes(
   query: string,
   index: LogSearchIndex,
 ): LogNode[] {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const normalizedQuery = query.trim().toLowerCase();
   return filterLogNodesInternal(nodes, normalizedQuery, index);
 }
 
@@ -46,7 +46,7 @@ function filterLogNodesInternal(
 
 function indexNodes(nodes: readonly LogNode[], textBySeq: Map<number, string>): void {
   for (const node of nodes) {
-    textBySeq.set(node.seq, searchableNodeText(node).toLocaleLowerCase());
+    textBySeq.set(node.seq, searchableNodeText(node).toLowerCase());
     if (node.kind === 'group') indexNodes(node.children, textBySeq);
   }
 }

--- a/libs/client/logs/src/core/log-search.ts
+++ b/libs/client/logs/src/core/log-search.ts
@@ -1,0 +1,121 @@
+import type {SessionViewRow} from './log-model.js';
+import {assertNever, type LogNode, stripTrailingNewline} from './log-tree.js';
+
+const ANSI_SGR_SEQUENCE = new RegExp(`${String.fromCodePoint(0x1b)}\\[[0-9;]*m`, 'g');
+
+export interface LogSearchIndex {
+  textBySeq: ReadonlyMap<number, string>;
+}
+
+export function buildLogSearchIndex(nodes: readonly LogNode[]): LogSearchIndex {
+  const textBySeq = new Map<number, string>();
+  indexNodes(nodes, textBySeq);
+  return {textBySeq};
+}
+
+export function filterLogNodes(
+  nodes: readonly LogNode[],
+  query: string,
+  index: LogSearchIndex,
+): LogNode[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  return filterLogNodesInternal(nodes, normalizedQuery, index);
+}
+
+function filterLogNodesInternal(
+  nodes: readonly LogNode[],
+  query: string,
+  index: LogSearchIndex,
+): LogNode[] {
+  return nodes.flatMap((node): LogNode[] => {
+    const matches = index.textBySeq.get(node.seq)?.includes(query) ?? false;
+    if (node.kind !== 'group') return matches ? [node] : [];
+
+    const children = matches ? node.children : filterLogNodesInternal(node.children, query, index);
+    if (!matches && children.length === 0) return [];
+
+    return [
+      {
+        ...node,
+        children,
+        lineCount: matches ? node.lineCount : countOutputLines(children),
+      },
+    ];
+  });
+}
+
+function indexNodes(nodes: readonly LogNode[], textBySeq: Map<number, string>): void {
+  for (const node of nodes) {
+    textBySeq.set(node.seq, searchableNodeText(node).toLocaleLowerCase());
+    if (node.kind === 'group') indexNodes(node.children, textBySeq);
+  }
+}
+
+function searchableNodeText(node: LogNode): string {
+  switch (node.kind) {
+    case 'output':
+      return stripAnsi(stripTrailingNewline(node.record.data));
+    case 'group':
+      return node.record.name;
+    case 'marker':
+      return markerText(node.record.type);
+    case 'session':
+      return sessionRowText(node.record.row);
+    default:
+      return assertNever(node);
+  }
+}
+
+function markerText(type: 'end' | 'gap' | 'capped' | 'runner_lost'): string {
+  switch (type) {
+    case 'end':
+      return 'End of log';
+    case 'gap':
+      return 'Output missing';
+    case 'capped':
+      return 'Log size limit reached';
+    case 'runner_lost':
+      return 'Runner disconnected';
+    default:
+      return assertNever(type);
+  }
+}
+
+function sessionRowText(row: SessionViewRow): string {
+  switch (row.kind) {
+    case 'message':
+      return stripAnsi(
+        [row.label, row.text, ...row.meta.flatMap((meta) => [meta.label, meta.value])].join(' '),
+      );
+    case 'thinking':
+      return stripAnsi(['thinking', row.text].join(' '));
+    case 'tool-call':
+      return stripAnsi(['tool', row.name, row.summary, row.input].filter(Boolean).join(' '));
+    case 'tool-result':
+      return stripAnsi(
+        ['result', row.toolName, row.output, row.isError ? 'error' : 'ok'].join(' '),
+      );
+    case 'lifecycle':
+      return stripAnsi(
+        [row.label, row.detail, ...row.meta.flatMap((meta) => [meta.label, meta.value])]
+          .filter(Boolean)
+          .join(' '),
+      );
+    case 'raw':
+      return stripAnsi([row.label, row.raw].join(' '));
+    default:
+      return assertNever(row);
+  }
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_SGR_SEQUENCE, '');
+}
+
+function countOutputLines(nodes: readonly LogNode[]): number {
+  return nodes.reduce((count, node) => {
+    if (node.kind === 'output') return count + 1;
+    if (node.kind === 'group') return count + node.lineCount;
+    return count;
+  }, 0);
+}

--- a/libs/client/logs/src/hooks/api/step-logs-query.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs-query.test.tsx
@@ -235,6 +235,31 @@ describe('useStepAttemptLogsQuery', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  test('does not mark a reused initial request as a manual refresh', async () => {
+    let resolveInitialRequest!: (response: Response) => void;
+    const initialRequest = new Promise<Response>((resolve) => {
+      resolveInitialRequest = resolve;
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockReturnValueOnce(initialRequest)
+      .mockResolvedValue(jsonResponse({code: 'not-found'}, {status: 404}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook(
+      {stepId: STEP_ID, attempt: 1},
+      {retryMissingStream: true, missingStreamRetryCount: 1, missingStreamRetryDelayMs: 10},
+    );
+    await waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+
+    const refresh = result.current.refetchLogs();
+    resolveInitialRequest(jsonResponse({code: 'not-found'}, {status: 404}));
+    await refresh;
+
+    await waitFor(() => expect(result.current.data?.complete).toBe(true));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   test('starts a fresh bounded window after unbounded missing-stream polling', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({code: 'not-found'}, {status: 404}));
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});

--- a/libs/client/logs/src/hooks/api/step-logs-query.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs-query.test.tsx
@@ -218,6 +218,23 @@ describe('useStepAttemptLogsQuery', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
+  test('does not spend the bounded missing-stream budget on manual refreshes', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({code: 'not-found'}, {status: 404}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook(
+      {stepId: STEP_ID, attempt: 1},
+      {retryMissingStream: true, missingStreamRetryCount: 1, missingStreamRetryDelayMs: 60_000},
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const refresh = await result.current.refetchLogs();
+
+    expect(refresh.error).toBeTruthy();
+    expect(refresh.data).toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   test('starts a fresh bounded window after unbounded missing-stream polling', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({code: 'not-found'}, {status: 404}));
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -1,7 +1,7 @@
 import {readLogsResponseSchema} from '@shipfox/api-logs-dto';
 import {ApiError, checkedApiRequest} from '@shipfox/client-api';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {useRef} from 'react';
+import {useCallback, useRef} from 'react';
 import {
   mergeLogRead,
   STEP_LOG_LIVE_REFETCH_MS,
@@ -80,6 +80,7 @@ export function useStepAttemptLogsQuery(
   const queryClient = useQueryClient();
   const missingStreamFailureCountRef = useRef(0);
   const missingStreamScopeRef = useRef<string | null>(null);
+  const manualRefetchRef = useRef(false);
   const enabled = Boolean(stepId && attempt && Number.isInteger(attempt) && attempt > 0);
   const queryKey =
     enabled && stepId && attempt
@@ -97,11 +98,13 @@ export function useStepAttemptLogsQuery(
   const initialErrorRetryDelayMs = options.initialErrorRetryDelayMs ?? STEP_LOG_LIVE_REFETCH_MS;
   const missingStreamRetryDelayMs = options.missingStreamRetryDelayMs ?? STEP_LOG_LIVE_REFETCH_MS;
 
-  return useQuery({
+  const query = useQuery({
     queryKey,
     enabled,
     queryFn: async ({signal}) => {
       const previous = queryClient.getQueryData<StepLogSnapshot>(queryKey);
+      const manualRefetch = manualRefetchRef.current;
+      manualRefetchRef.current = false;
       let response: Awaited<ReturnType<typeof readStepAttemptLogsPage>>;
       try {
         response = await readStepAttemptLogsPage({
@@ -114,7 +117,8 @@ export function useStepAttemptLogsQuery(
         if (
           options.retryMissingStream &&
           previous === undefined &&
-          isMissingStepLogStreamError(error)
+          isMissingStepLogStreamError(error) &&
+          !manualRefetch
         ) {
           const retryCount = options.missingStreamRetryCount;
           if (retryCount === undefined) throw error;
@@ -166,6 +170,13 @@ export function useStepAttemptLogsQuery(
     refetchOnWindowFocus: (query) => !query.state.data?.complete,
     refetchOnReconnect: (query) => !query.state.data?.complete,
   });
+
+  const refetchLogs = useCallback(() => {
+    if (!query.isFetching) manualRefetchRef.current = true;
+    return query.refetch({cancelRefetch: false});
+  }, [query.isFetching, query.refetch]);
+
+  return {...query, refetchLogs};
 }
 
 function emptyCompleteLogSnapshot(): StepLogSnapshot {

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -172,9 +172,9 @@ export function useStepAttemptLogsQuery(
   });
 
   const refetchLogs = useCallback(() => {
-    if (!query.isFetching) manualRefetchRef.current = true;
-    return query.refetch({cancelRefetch: false});
-  }, [query.isFetching, query.refetch]);
+    manualRefetchRef.current = true;
+    return query.refetch();
+  }, [query.refetch]);
 
   return {...query, refetchLogs};
 }

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -172,9 +172,14 @@ export function useStepAttemptLogsQuery(
   });
 
   const refetchLogs = useCallback(() => {
-    manualRefetchRef.current = true;
+    // React Query reuses an in-flight request when it has no cached data. Only
+    // mark a refetch as manual when this call can start a new request; otherwise
+    // the marker would be consumed by the next automatic poll.
+    if (!query.isFetching || query.data !== undefined) {
+      manualRefetchRef.current = true;
+    }
     return query.refetch();
-  }, [query.refetch]);
+  }, [query.data, query.isFetching, query.refetch]);
 
   return {...query, refetchLogs};
 }

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -23,7 +23,7 @@ import {Link} from '@tanstack/react-router';
 import {type RefObject, useCallback, useEffect, useRef, useState} from 'react';
 import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {summarizeJobAnnotations} from '#core/run-annotation.js';
-import {isWorkflowRunTerminal, type Job, type JobExecution, type Step} from '#core/workflow-run.js';
+import {isWorkflowRunTerminal, type Job, type JobExecution} from '#core/workflow-run.js';
 import {useWorkflowRunAnnotationSummaryQuery} from '#hooks/api/annotations.js';
 import {useRunAnnotationsQuery} from '#hooks/api/run-annotations.js';
 import type {useWorkflowRunAttemptQuery} from '#hooks/api/workflow-runs.js';
@@ -33,7 +33,11 @@ import {
   workflowRunSearchParams,
 } from '#routes/inputs.js';
 import {type StepExpandedContext, StepList} from '../step-list/index.js';
-import {getStepStatusVisual, stepLabel} from '../step-list/step-list-model.js';
+import {
+  buildStepListModel,
+  getStepStatusVisual,
+  type StepListModel,
+} from '../step-list/step-list-model.js';
 import {
   WorkflowRunNotFound,
   WorkflowRunStaleError,
@@ -56,7 +60,6 @@ import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 import {StepInspectorSheet} from './step-troubleshooting.js';
 
 type InspectorState = {key: string; attemptId: string | null};
-type LogRefreshRequest = {attemptId: string; token: number};
 
 export interface JobDetailViewProps {
   workspaceSlug: string;
@@ -88,7 +91,7 @@ export function JobDetailView({
   const [wrapLogs, setWrapLogs] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(true);
   const [expandedLogAttemptIds, setExpandedLogAttemptIds] = useState<readonly string[]>([]);
-  const [logRefreshRequest, setLogRefreshRequest] = useState<LogRefreshRequest | null>(null);
+  const [logRefreshTokens, setLogRefreshTokens] = useState<Record<string, number>>({});
   const [logFetchingByAttemptId, setLogFetchingByAttemptId] = useState<Record<string, boolean>>({});
   const hasLoadedData = query.data !== undefined;
   // Reuse the run workspace's bounded annotation read for the job header chip. The separate
@@ -131,16 +134,6 @@ export function JobDetailView({
     heading?.focus({preventScroll: true});
   }, [hasLoadedData, jobId]);
 
-  useEffect(() => {
-    if (!jobId) return;
-    setLogSearch('');
-    setWrapLogs(false);
-    setShowLineNumbers(true);
-    setExpandedLogAttemptIds([]);
-    setLogRefreshRequest(null);
-    setLogFetchingByAttemptId({});
-  }, [jobId]);
-
   const handleLogFetchingChange = useCallback((attemptId: string, isFetching: boolean) => {
     setLogFetchingByAttemptId((current) => {
       if (current[attemptId] === isFetching) return current;
@@ -175,6 +168,7 @@ export function JobDetailView({
   const resolvedSelection = resolveWorkflowJobSelection({job, selection: search});
   const selectedJobExecution = resolvedSelection.jobExecution;
   const hasExplicitStep = Boolean(search.stepId && resolvedSelection.step);
+  const stepListModel = buildStepListModel({job, jobExecution: selectedJobExecution});
   const currentLandingSelection = workflowJobLandingSelection(selectedJobExecution);
   if (selectedJobExecution) {
     const frozenLanding = landingSelectionRef.current;
@@ -201,7 +195,7 @@ export function JobDetailView({
   }
   const landingSelection = landingSelectionRef.current?.selection;
   const selectedAttemptId = hasExplicitStep ? resolvedSelection.selectedAttemptId : undefined;
-  const runningSelection = runningStepSelection(selectedJobExecution);
+  const runningSelection = runningStepSelection(selectedJobExecution, stepListModel);
   const selectedStepId = resolvedSelection.step?.id ?? landingSelection?.stepId;
   const selectedAttemptForNotice = hasExplicitStep
     ? resolvedSelection.selectedAttemptId
@@ -209,6 +203,7 @@ export function JobDetailView({
   const expandedLogSelection = findExpandedLogSelection(
     selectedJobExecution,
     expandedLogAttemptIds,
+    stepListModel,
   );
   const selectedLogStep = expandedLogSelection?.step;
   const selectedLogAttempt = expandedLogSelection?.attempt;
@@ -272,9 +267,9 @@ export function JobDetailView({
 
   function refreshLogs() {
     if (!selectedLogAttempt) return;
-    setLogRefreshRequest((current) => ({
-      attemptId: selectedLogAttempt.id,
-      token: (current?.token ?? 0) + 1,
+    setLogRefreshTokens((current) => ({
+      ...current,
+      [selectedLogAttempt.id]: (current[selectedLogAttempt.id] ?? 0) + 1,
     }));
   }
 
@@ -311,7 +306,7 @@ export function JobDetailView({
               />
               <Panel data-job-log-panel className="min-w-0">
                 <JobLogPanelHeader
-                  step={selectedLogStep}
+                  stepLabel={expandedLogSelection?.stepLabel}
                   attempt={selectedLogAttempt?.attempt}
                   status={selectedLogStatus}
                   search={logSearch}
@@ -352,11 +347,7 @@ export function JobDetailView({
                             wrap={wrapLogs}
                             showLineNumbers={showLineNumbers}
                             attemptId={context.attemptId}
-                            refreshToken={
-                              logRefreshRequest?.attemptId === context.attemptId
-                                ? logRefreshRequest.token
-                                : 0
-                            }
+                            refreshToken={logRefreshTokens[context.attemptId] ?? 0}
                             onFetchingChange={handleLogFetchingChange}
                           />
                         )}
@@ -465,7 +456,7 @@ function ExpandedStep({
 }
 
 function JobLogPanelHeader({
-  step,
+  stepLabel,
   attempt,
   status,
   search,
@@ -478,7 +469,7 @@ function JobLogPanelHeader({
   onWrapChange,
   disabled,
 }: {
-  step: Step | undefined;
+  stepLabel: string | undefined;
   attempt: number | undefined;
   status: string | undefined;
   search: string;
@@ -497,7 +488,7 @@ function JobLogPanelHeader({
     <PanelHeader className="flex flex-wrap items-center gap-group">
       <div className="min-w-0 flex-1">
         <Text size="sm" bold className="truncate text-foreground-neutral-base">
-          {step ? stepLabel(step, step.position) : 'Logs'}
+          {stepLabel ?? 'Logs'}
         </Text>
         {statusVisual ? (
           <div className="flex min-w-0 items-center gap-inline text-foreground-neutral-muted">
@@ -531,7 +522,7 @@ function JobLogPanelHeader({
           icon="refreshLine"
           aria-label="Refresh logs"
           onClick={onRefresh}
-          disabled={disabled}
+          disabled={disabled || refreshing}
           isLoading={refreshing}
         />
         <DropdownMenu>
@@ -644,7 +635,7 @@ function NewerAttemptNotice({
   );
 }
 
-function runningStepSelection(jobExecution: JobExecution | undefined) {
+function runningStepSelection(jobExecution: JobExecution | undefined, model: StepListModel) {
   if (!jobExecution) return undefined;
   const steps = [...jobExecution.steps].sort(
     (left, right) => left.position - right.position || left.id.localeCompare(right.id),
@@ -660,7 +651,7 @@ function runningStepSelection(jobExecution: JobExecution | undefined) {
       return {
         stepId: step.id,
         attemptId: attempt.id,
-        stepLabel: stepLabel(step, step.position),
+        stepLabel: model.entries.find((entry) => entry.id === attempt.id)?.step.label ?? 'Step',
       };
   }
   return undefined;
@@ -677,6 +668,7 @@ function findAttempt(jobExecution: JobExecution, attemptId: string) {
 function findExpandedLogSelection(
   jobExecution: JobExecution | undefined,
   attemptIds: readonly string[],
+  model: StepListModel,
 ) {
   if (!jobExecution) return undefined;
 
@@ -685,7 +677,8 @@ function findExpandedLogSelection(
     if (!attemptId) continue;
     const match = findAttempt(jobExecution, attemptId);
     const attempt = match?.step.attempts.find((candidate) => candidate.id === attemptId);
-    if (match && attempt) return {step: match.step, attempt};
+    const entry = model.entries.find((candidate) => candidate.id === attemptId);
+    if (match && attempt && entry) return {step: match.step, attempt, stepLabel: entry.step.label};
   }
 
   return undefined;

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -20,7 +20,7 @@ import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
-import {type RefObject, useEffect, useRef, useState} from 'react';
+import {type RefObject, useCallback, useEffect, useRef, useState} from 'react';
 import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {summarizeJobAnnotations} from '#core/run-annotation.js';
 import {isWorkflowRunTerminal, type Job, type JobExecution, type Step} from '#core/workflow-run.js';
@@ -33,7 +33,7 @@ import {
   workflowRunSearchParams,
 } from '#routes/inputs.js';
 import {type StepExpandedContext, StepList} from '../step-list/index.js';
-import {getStepStatusVisual} from '../step-list/step-list-model.js';
+import {getStepStatusVisual, stepLabel} from '../step-list/step-list-model.js';
 import {
   WorkflowRunNotFound,
   WorkflowRunStaleError,
@@ -56,6 +56,7 @@ import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 import {StepInspectorSheet} from './step-troubleshooting.js';
 
 type InspectorState = {key: string; attemptId: string | null};
+type LogRefreshRequest = {attemptId: string; token: number};
 
 export interface JobDetailViewProps {
   workspaceSlug: string;
@@ -86,7 +87,9 @@ export function JobDetailView({
   const [logSearch, setLogSearch] = useState('');
   const [wrapLogs, setWrapLogs] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(true);
-  const [logRefreshToken, setLogRefreshToken] = useState(0);
+  const [expandedLogAttemptIds, setExpandedLogAttemptIds] = useState<readonly string[]>([]);
+  const [logRefreshRequest, setLogRefreshRequest] = useState<LogRefreshRequest | null>(null);
+  const [logFetchingByAttemptId, setLogFetchingByAttemptId] = useState<Record<string, boolean>>({});
   const hasLoadedData = query.data !== undefined;
   // Reuse the run workspace's bounded annotation read for the job header chip. The separate
   // summary query below stays counts-only and is scoped to the inspector's selected execution.
@@ -127,6 +130,23 @@ export function JobDetailView({
     // after rail navigation without putting focus on a decorative status element.
     heading?.focus({preventScroll: true});
   }, [hasLoadedData, jobId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    setLogSearch('');
+    setWrapLogs(false);
+    setShowLineNumbers(true);
+    setExpandedLogAttemptIds([]);
+    setLogRefreshRequest(null);
+    setLogFetchingByAttemptId({});
+  }, [jobId]);
+
+  const handleLogFetchingChange = useCallback((attemptId: string, isFetching: boolean) => {
+    setLogFetchingByAttemptId((current) => {
+      if (current[attemptId] === isFetching) return current;
+      return {...current, [attemptId]: isFetching};
+    });
+  }, []);
 
   if (query.isPending) return <JobDetailSkeleton />;
 
@@ -186,11 +206,16 @@ export function JobDetailView({
   const selectedAttemptForNotice = hasExplicitStep
     ? resolvedSelection.selectedAttemptId
     : landingSelection?.attemptId;
-  const selectedLogStep = selectedJobExecution?.steps.find((step) => step.id === selectedStepId);
-  const selectedLogAttempt = selectedLogStep?.attempts.find(
-    (attempt) => attempt.id === (selectedAttemptForNotice ?? undefined),
+  const expandedLogSelection = findExpandedLogSelection(
+    selectedJobExecution,
+    expandedLogAttemptIds,
   );
+  const selectedLogStep = expandedLogSelection?.step;
+  const selectedLogAttempt = expandedLogSelection?.attempt;
   const selectedLogStatus = selectedLogAttempt?.status ?? selectedLogStep?.status;
+  const logIsFetching = Boolean(
+    selectedLogAttempt && logFetchingByAttemptId[selectedLogAttempt.id],
+  );
   const showRetargetNotice =
     runningSelection !== undefined &&
     (selectedStepId !== runningSelection.stepId ||
@@ -246,11 +271,11 @@ export function JobDetailView({
   }
 
   function refreshLogs() {
-    if (selectedLogStep && selectedLogAttempt) {
-      setLogRefreshToken((token) => token + 1);
-      return;
-    }
-    void query.refetch();
+    if (!selectedLogAttempt) return;
+    setLogRefreshRequest((current) => ({
+      attemptId: selectedLogAttempt.id,
+      token: (current?.token ?? 0) + 1,
+    }));
   }
 
   return (
@@ -292,11 +317,12 @@ export function JobDetailView({
                   search={logSearch}
                   onSearchChange={setLogSearch}
                   onRefresh={refreshLogs}
+                  refreshing={logIsFetching}
                   showLineNumbers={showLineNumbers}
                   onShowLineNumbersChange={setShowLineNumbers}
                   wrap={wrapLogs}
                   onWrapChange={setWrapLogs}
-                  disabled={!selectedLogStep}
+                  disabled={!selectedLogAttempt}
                 />
                 <PanelBody className="min-w-0 p-0">
                   <Text as="h2" className="sr-only">
@@ -311,6 +337,7 @@ export function JobDetailView({
                         selectedAttemptId={selectedAttemptId}
                         defaultSelectedAttemptId={landingSelection?.attemptId}
                         onSelectedAttemptChange={selectAttempt}
+                        onExpandedAttemptIdsChange={setExpandedLogAttemptIds}
                         inspectorOpenAttemptId={inspectorOpenAttemptId}
                         onInspectorOpenChange={onInspectorOpenChange}
                         autoSelectActiveAttempt
@@ -324,7 +351,13 @@ export function JobDetailView({
                             search={logSearch}
                             wrap={wrapLogs}
                             showLineNumbers={showLineNumbers}
-                            refreshToken={logRefreshToken}
+                            attemptId={context.attemptId}
+                            refreshToken={
+                              logRefreshRequest?.attemptId === context.attemptId
+                                ? logRefreshRequest.token
+                                : 0
+                            }
+                            onFetchingChange={handleLogFetchingChange}
                           />
                         )}
                         renderInspector={(entry) => (
@@ -392,14 +425,18 @@ function ExpandedStep({
   search,
   wrap,
   showLineNumbers,
+  attemptId,
   refreshToken,
+  onFetchingChange,
 }: {
   context: StepExpandedContext;
   pageScrollRef: RefObject<HTMLDivElement | null>;
   search: string;
   wrap: boolean;
   showLineNumbers: boolean;
+  attemptId: string;
   refreshToken: number;
+  onFetchingChange: (attemptId: string, isFetching: boolean) => void;
 }) {
   if (context.carriedOver) return <CarriedOverStepPanel />;
 
@@ -419,7 +456,9 @@ function ExpandedStep({
         search={search}
         wrap={wrap}
         showLineNumbers={showLineNumbers}
+        attemptId={attemptId}
         refreshToken={refreshToken}
+        onFetchingChange={onFetchingChange}
       />
     </section>
   );
@@ -432,6 +471,7 @@ function JobLogPanelHeader({
   search,
   onSearchChange,
   onRefresh,
+  refreshing,
   showLineNumbers,
   onShowLineNumbersChange,
   wrap,
@@ -444,6 +484,7 @@ function JobLogPanelHeader({
   search: string;
   onSearchChange: (value: string) => void;
   onRefresh: () => void;
+  refreshing: boolean;
   showLineNumbers: boolean;
   onShowLineNumbersChange: (value: boolean) => void;
   wrap: boolean;
@@ -456,7 +497,7 @@ function JobLogPanelHeader({
     <PanelHeader className="flex flex-wrap items-center gap-group">
       <div className="min-w-0 flex-1">
         <Text size="sm" bold className="truncate text-foreground-neutral-base">
-          {step ? stepLabel(step) : 'Logs'}
+          {step ? stepLabel(step, step.position) : 'Logs'}
         </Text>
         {statusVisual ? (
           <div className="flex min-w-0 items-center gap-inline text-foreground-neutral-muted">
@@ -490,6 +531,8 @@ function JobLogPanelHeader({
           icon="refreshLine"
           aria-label="Refresh logs"
           onClick={onRefresh}
+          disabled={disabled}
+          isLoading={refreshing}
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -499,6 +542,7 @@ function JobLogPanelHeader({
               size="sm"
               icon="settings3Line"
               aria-label="Log settings"
+              disabled={disabled}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" size="sm">
@@ -517,14 +561,6 @@ function JobLogPanelHeader({
       </PanelActions>
     </PanelHeader>
   );
-}
-
-function stepLabel(step: Pick<Step, 'name' | 'key'>): string {
-  const name = step.name.trim();
-  if (name) return name;
-
-  const key = step.key?.trim();
-  return key || 'Step';
 }
 
 function EmptyStateForMissingExecution({job}: {job: Job}) {
@@ -621,7 +657,11 @@ function runningStepSelection(jobExecution: JobExecution | undefined) {
       .reverse()
       .find((candidate) => candidate.status === 'running');
     if (attempt)
-      return {stepId: step.id, attemptId: attempt.id, stepLabel: step.name || step.key || step.id};
+      return {
+        stepId: step.id,
+        attemptId: attempt.id,
+        stepLabel: stepLabel(step, step.position),
+      };
   }
   return undefined;
 }
@@ -631,6 +671,23 @@ function findAttempt(jobExecution: JobExecution, attemptId: string) {
     const attempt = step.attempts.find((candidate) => candidate.id === attemptId);
     if (attempt) return {step, attemptId: attempt.id};
   }
+  return undefined;
+}
+
+function findExpandedLogSelection(
+  jobExecution: JobExecution | undefined,
+  attemptIds: readonly string[],
+) {
+  if (!jobExecution) return undefined;
+
+  for (let index = attemptIds.length - 1; index >= 0; index -= 1) {
+    const attemptId = attemptIds[index];
+    if (!attemptId) continue;
+    const match = findAttempt(jobExecution, attemptId);
+    const attempt = match?.step.attempts.find((candidate) => candidate.id === attemptId);
+    if (match && attempt) return {step: match.step, attempt};
+  }
+
   return undefined;
 }
 

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -3,8 +3,19 @@
 
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
+import {Badge} from '@shipfox/react-ui/badge';
+import {IconButton} from '@shipfox/react-ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@shipfox/react-ui/dropdown-menu';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
+import {Panel, PanelActions, PanelBody, PanelHeader} from '@shipfox/react-ui/panel';
+import {SearchInline} from '@shipfox/react-ui/search';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Text} from '@shipfox/react-ui/typography';
@@ -12,7 +23,7 @@ import {Link} from '@tanstack/react-router';
 import {type RefObject, useEffect, useRef, useState} from 'react';
 import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {summarizeJobAnnotations} from '#core/run-annotation.js';
-import {isWorkflowRunTerminal, type Job, type JobExecution} from '#core/workflow-run.js';
+import {isWorkflowRunTerminal, type Job, type JobExecution, type Step} from '#core/workflow-run.js';
 import {useWorkflowRunAnnotationSummaryQuery} from '#hooks/api/annotations.js';
 import {useRunAnnotationsQuery} from '#hooks/api/run-annotations.js';
 import type {useWorkflowRunAttemptQuery} from '#hooks/api/workflow-runs.js';
@@ -22,6 +33,7 @@ import {
   workflowRunSearchParams,
 } from '#routes/inputs.js';
 import {type StepExpandedContext, StepList} from '../step-list/index.js';
+import {getStepStatusVisual} from '../step-list/step-list-model.js';
 import {
   WorkflowRunNotFound,
   WorkflowRunStaleError,
@@ -71,6 +83,10 @@ export function JobDetailView({
   const rootRef = useRef<HTMLDivElement>(null);
   const pageScrollRef = useRef<HTMLDivElement>(null);
   const landingSelectionRef = useRef<FrozenLandingSelection | undefined>(undefined);
+  const [logSearch, setLogSearch] = useState('');
+  const [wrapLogs, setWrapLogs] = useState(false);
+  const [showLineNumbers, setShowLineNumbers] = useState(true);
+  const [logRefreshToken, setLogRefreshToken] = useState(0);
   const hasLoadedData = query.data !== undefined;
   // Reuse the run workspace's bounded annotation read for the job header chip. The separate
   // summary query below stays counts-only and is scoped to the inspector's selected execution.
@@ -170,6 +186,11 @@ export function JobDetailView({
   const selectedAttemptForNotice = hasExplicitStep
     ? resolvedSelection.selectedAttemptId
     : landingSelection?.attemptId;
+  const selectedLogStep = selectedJobExecution?.steps.find((step) => step.id === selectedStepId);
+  const selectedLogAttempt = selectedLogStep?.attempts.find(
+    (attempt) => attempt.id === (selectedAttemptForNotice ?? undefined),
+  );
+  const selectedLogStatus = selectedLogAttempt?.status ?? selectedLogStep?.status;
   const showRetargetNotice =
     runningSelection !== undefined &&
     (selectedStepId !== runningSelection.stepId ||
@@ -224,6 +245,14 @@ export function JobDetailView({
     });
   }
 
+  function refreshLogs() {
+    if (selectedLogStep && selectedLogAttempt) {
+      setLogRefreshToken((token) => token + 1);
+      return;
+    }
+    void query.refetch();
+  }
+
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
       <div ref={rootRef} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -255,49 +284,73 @@ export function JobDetailView({
                   ) : undefined
                 }
               />
-              <Text as="h2" className="sr-only">
-                Logs
-              </Text>
-              {selectedJobExecution ? (
-                <>
-                  <MaterializedOutputFailureNotice jobExecution={selectedJobExecution} />
-                  <StepList
-                    job={job}
-                    jobExecution={selectedJobExecution}
-                    selectedAttemptId={selectedAttemptId}
-                    defaultSelectedAttemptId={landingSelection?.attemptId}
-                    onSelectedAttemptChange={selectAttempt}
-                    inspectorOpenAttemptId={inspectorOpenAttemptId}
-                    onInspectorOpenChange={onInspectorOpenChange}
-                    autoSelectActiveAttempt
-                    emptyState={emptyStateForJob(job, selectedJobExecution)}
-                    showHeader={false}
-                    className="rounded-none border-0 bg-transparent"
-                    renderExpandedStep={(context) => (
-                      <ExpandedStep context={context} pageScrollRef={pageScrollRef} />
-                    )}
-                    renderInspector={(entry) => (
-                      <StepInspectorSheet
-                        entry={entry}
-                        open
-                        onOpenChange={(open) => onInspectorOpenChange(open ? entry.id : null)}
-                        workspaceSlug={workspaceSlug}
-                        projectSlug={projectSlug}
-                        workflowRunId={run.id}
-                        runAttempt={run.runAttempt.attempt}
-                        jobId={job.id}
-                        annotationCount={annotationCountForStep(
-                          annotationSummaryQuery.data,
-                          entry.step.id,
-                          entry.attempt,
+              <Panel data-job-log-panel className="min-w-0">
+                <JobLogPanelHeader
+                  step={selectedLogStep}
+                  attempt={selectedLogAttempt?.attempt}
+                  status={selectedLogStatus}
+                  search={logSearch}
+                  onSearchChange={setLogSearch}
+                  onRefresh={refreshLogs}
+                  showLineNumbers={showLineNumbers}
+                  onShowLineNumbersChange={setShowLineNumbers}
+                  wrap={wrapLogs}
+                  onWrapChange={setWrapLogs}
+                  disabled={!selectedLogStep}
+                />
+                <PanelBody className="min-w-0 p-0">
+                  <Text as="h2" className="sr-only">
+                    Logs
+                  </Text>
+                  {selectedJobExecution ? (
+                    <>
+                      <MaterializedOutputFailureNotice jobExecution={selectedJobExecution} />
+                      <StepList
+                        job={job}
+                        jobExecution={selectedJobExecution}
+                        selectedAttemptId={selectedAttemptId}
+                        defaultSelectedAttemptId={landingSelection?.attemptId}
+                        onSelectedAttemptChange={selectAttempt}
+                        inspectorOpenAttemptId={inspectorOpenAttemptId}
+                        onInspectorOpenChange={onInspectorOpenChange}
+                        autoSelectActiveAttempt
+                        emptyState={emptyStateForJob(job, selectedJobExecution)}
+                        showHeader={false}
+                        className="rounded-none border-0 bg-transparent shadow-none"
+                        renderExpandedStep={(context) => (
+                          <ExpandedStep
+                            context={context}
+                            pageScrollRef={pageScrollRef}
+                            search={logSearch}
+                            wrap={wrapLogs}
+                            showLineNumbers={showLineNumbers}
+                            refreshToken={logRefreshToken}
+                          />
+                        )}
+                        renderInspector={(entry) => (
+                          <StepInspectorSheet
+                            entry={entry}
+                            open
+                            onOpenChange={(open) => onInspectorOpenChange(open ? entry.id : null)}
+                            workspaceSlug={workspaceSlug}
+                            projectSlug={projectSlug}
+                            workflowRunId={run.id}
+                            runAttempt={run.runAttempt.attempt}
+                            jobId={job.id}
+                            annotationCount={annotationCountForStep(
+                              annotationSummaryQuery.data,
+                              entry.step.id,
+                              entry.attempt,
+                            )}
+                          />
                         )}
                       />
-                    )}
-                  />
-                </>
-              ) : (
-                <EmptyStateForMissingExecution job={job} />
-              )}
+                    </>
+                  ) : (
+                    <EmptyStateForMissingExecution job={job} />
+                  )}
+                </PanelBody>
+              </Panel>
             </section>
             {showRetargetNotice && runningSelection ? (
               <div
@@ -336,9 +389,17 @@ export function JobDetailView({
 function ExpandedStep({
   context,
   pageScrollRef,
+  search,
+  wrap,
+  showLineNumbers,
+  refreshToken,
 }: {
   context: StepExpandedContext;
   pageScrollRef: RefObject<HTMLDivElement | null>;
+  search: string;
+  wrap: boolean;
+  showLineNumbers: boolean;
+  refreshToken: number;
 }) {
   if (context.carriedOver) return <CarriedOverStepPanel />;
 
@@ -347,7 +408,7 @@ function ExpandedStep({
       role="region"
       tabIndex={0}
       aria-label={`${context.stepLabel} output, attempt ${context.attempt}`}
-      className="flex min-w-0 flex-col border-t border-border-neutral-base bg-background-contrast-subtle outline-none focus-visible:shadow-border-interactive-with-active"
+      className="flex min-w-0 flex-col border-t border-border-neutral-base bg-background-contrast-base outline-none focus-visible:shadow-border-interactive-with-active"
     >
       <StepAttemptLogPanel
         stepId={context.stepId}
@@ -355,10 +416,115 @@ function ExpandedStep({
         attemptStatus={context.attemptStatus}
         attemptStartedAt={context.attemptStartedAt}
         pageScrollRef={pageScrollRef}
-        surfaceClassName="rounded-none border-0 bg-transparent shadow-none"
+        search={search}
+        wrap={wrap}
+        showLineNumbers={showLineNumbers}
+        refreshToken={refreshToken}
       />
     </section>
   );
+}
+
+function JobLogPanelHeader({
+  step,
+  attempt,
+  status,
+  search,
+  onSearchChange,
+  onRefresh,
+  showLineNumbers,
+  onShowLineNumbersChange,
+  wrap,
+  onWrapChange,
+  disabled,
+}: {
+  step: Step | undefined;
+  attempt: number | undefined;
+  status: string | undefined;
+  search: string;
+  onSearchChange: (value: string) => void;
+  onRefresh: () => void;
+  showLineNumbers: boolean;
+  onShowLineNumbersChange: (value: boolean) => void;
+  wrap: boolean;
+  onWrapChange: (value: boolean) => void;
+  disabled: boolean;
+}) {
+  const statusVisual = status ? getStepStatusVisual(status) : undefined;
+
+  return (
+    <PanelHeader className="flex flex-wrap items-center gap-group">
+      <div className="min-w-0 flex-1">
+        <Text size="sm" bold className="truncate text-foreground-neutral-base">
+          {step ? stepLabel(step) : 'Logs'}
+        </Text>
+        {statusVisual ? (
+          <div className="flex min-w-0 items-center gap-inline text-foreground-neutral-muted">
+            <Badge variant={statusVisual.badge} size="2xs" radius="rounded">
+              {statusVisual.label}
+            </Badge>
+            {attempt ? (
+              <span className="font-code text-xs leading-20 tabular-nums">attempt {attempt}</span>
+            ) : null}
+          </div>
+        ) : (
+          <Text size="xs" className="text-foreground-neutral-muted">
+            Select a step to view its logs.
+          </Text>
+        )}
+      </div>
+      <PanelActions className="min-w-0 flex-wrap justify-end">
+        <SearchInline
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+          aria-label="Search logs"
+          placeholder="Search logs"
+          size="small"
+          className="w-180 max-w-full"
+          disabled={disabled}
+        />
+        <IconButton
+          type="button"
+          variant="transparent"
+          size="sm"
+          icon="refreshLine"
+          aria-label="Refresh logs"
+          onClick={onRefresh}
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              type="button"
+              variant="transparent"
+              size="sm"
+              icon="settings3Line"
+              aria-label="Log settings"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" size="sm">
+            <DropdownMenuLabel>Log display</DropdownMenuLabel>
+            <DropdownMenuCheckboxItem
+              checked={showLineNumbers}
+              onCheckedChange={onShowLineNumbersChange}
+            >
+              Line numbers
+            </DropdownMenuCheckboxItem>
+            <DropdownMenuCheckboxItem checked={wrap} onCheckedChange={onWrapChange}>
+              Wrap long lines
+            </DropdownMenuCheckboxItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </PanelActions>
+    </PanelHeader>
+  );
+}
+
+function stepLabel(step: Pick<Step, 'name' | 'key'>): string {
+  const name = step.name.trim();
+  if (name) return name;
+
+  const key = step.key?.trim();
+  return key || 'Step';
 }
 
 function EmptyStateForMissingExecution({job}: {job: Job}) {

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.test.tsx
@@ -2,7 +2,7 @@ import {configureApiClient} from '@shipfox/client-api';
 import {type StepLogSnapshot, stepLogsQueryKeys} from '@shipfox/client-logs';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {act, cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
-import {createRef, type ReactNode} from 'react';
+import {createRef} from 'react';
 import {inlineLogBody, outputLine} from '#test/fixtures/logs.js';
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 
@@ -49,25 +49,28 @@ function renderPanel(
     new QueryClient({
       defaultOptions: {queries: {retry: false}},
     });
-  const wrapper = ({children}: {children: ReactNode}) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
   const pageScrollRef = createRef<HTMLDivElement>();
-
-  return {
-    queryClient,
-    ...render(
+  const renderPanelUi = (panelProps: Partial<Parameters<typeof StepAttemptLogPanel>[0]>) => (
+    <QueryClientProvider client={queryClient}>
       <div ref={pageScrollRef}>
         <StepAttemptLogPanel
           stepId={STEP_ID}
           attempt={1}
           attemptStatus="running"
           pageScrollRef={pageScrollRef}
-          {...props}
+          {...panelProps}
         />
-      </div>,
-      {wrapper},
-    ),
+      </div>
+    </QueryClientProvider>
+  );
+  const rendered = render(renderPanelUi(props));
+
+  return {
+    queryClient,
+    ...rendered,
+    rerenderPanel: (nextProps: Partial<Parameters<typeof StepAttemptLogPanel>[0]> = {}) => {
+      rendered.rerender(renderPanelUi({...props, ...nextProps}));
+    },
   };
 }
 
@@ -246,20 +249,10 @@ describe('StepAttemptLogPanel', () => {
       .mockResolvedValueOnce(jsonResponse(inlineLogBody(outputLine('first\n'), 1)))
       .mockResolvedValueOnce(jsonResponse(inlineLogBody(outputLine('second\n'), 2)));
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
-    const {rerender} = renderPanel({attemptStatus: 'succeeded', refreshToken: 0});
+    const {rerenderPanel} = renderPanel({attemptStatus: 'succeeded', refreshToken: 0});
 
     expect(await screen.findByText('first')).toBeInTheDocument();
-    rerender(
-      <div>
-        <StepAttemptLogPanel
-          stepId={STEP_ID}
-          attempt={1}
-          attemptStatus="succeeded"
-          pageScrollRef={createRef<HTMLDivElement>()}
-          refreshToken={1}
-        />
-      </div>,
-    );
+    rerenderPanel({refreshToken: 1});
 
     expect(await screen.findByText('second')).toBeInTheDocument();
     expect(fetchImpl).toHaveBeenCalledTimes(2);

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.test.tsx
@@ -240,6 +240,31 @@ describe('StepAttemptLogPanel', () => {
     expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
   });
 
+  test('refetches the expanded attempt when its refresh token changes', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(inlineLogBody(outputLine('first\n'), 1)))
+      .mockResolvedValueOnce(jsonResponse(inlineLogBody(outputLine('second\n'), 2)));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    const {rerender} = renderPanel({attemptStatus: 'succeeded', refreshToken: 0});
+
+    expect(await screen.findByText('first')).toBeInTheDocument();
+    rerender(
+      <div>
+        <StepAttemptLogPanel
+          stepId={STEP_ID}
+          attempt={1}
+          attemptStatus="succeeded"
+          pageScrollRef={createRef<HTMLDivElement>()}
+          refreshToken={1}
+        />
+      </div>,
+    );
+
+    expect(await screen.findByText('second')).toBeInTheDocument();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   test('does not follow new log output after the user scrolls away from the tail', async () => {
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -27,7 +27,9 @@ export interface StepAttemptLogPanelProps {
   search?: string | undefined;
   wrap?: boolean | undefined;
   showLineNumbers?: boolean | undefined;
+  attemptId?: string | undefined;
   refreshToken?: number | undefined;
+  onFetchingChange?: ((attemptId: string, isFetching: boolean) => void) | undefined;
   initialErrorRetryCount?: number | undefined;
   initialErrorRetryDelayMs?: number | undefined;
 }
@@ -42,7 +44,9 @@ export function StepAttemptLogPanel({
   search = '',
   wrap = false,
   showLineNumbers = true,
+  attemptId,
   refreshToken = 0,
+  onFetchingChange,
   initialErrorRetryCount = INITIAL_LOG_ERROR_RETRY_COUNT,
   initialErrorRetryDelayMs = INITIAL_LOG_ERROR_RETRY_DELAY_MS,
 }: StepAttemptLogPanelProps) {
@@ -68,8 +72,13 @@ export function StepAttemptLogPanel({
   useEffect(() => {
     if (refreshToken === lastRefreshTokenRef.current) return;
     lastRefreshTokenRef.current = refreshToken;
-    void query.refetch();
-  }, [query.refetch, refreshToken]);
+    void query.refetchLogs();
+  }, [query.refetchLogs, refreshToken]);
+
+  useEffect(() => {
+    if (!attemptId) return;
+    onFetchingChange?.(attemptId, query.isFetching);
+  }, [attemptId, onFetchingChange, query.isFetching]);
 
   useEffect(() => {
     const scrollElement = pageScrollRef.current;
@@ -125,7 +134,7 @@ export function StepAttemptLogPanel({
   }
 
   if (initialError) {
-    return <StepLogsError retrying={query.isFetching} onRetry={() => void query.refetch()} />;
+    return <StepLogsError retrying={query.isFetching} onRetry={() => void query.refetchLogs()} />;
   }
 
   return (
@@ -144,7 +153,7 @@ export function StepAttemptLogPanel({
               size="2xs"
               variant="secondary"
               isLoading={query.isFetching}
-              onClick={() => void query.refetch()}
+              onClick={() => void query.refetchLogs()}
             >
               Retry
             </Button>
@@ -158,7 +167,7 @@ export function StepAttemptLogPanel({
         showLineNumbers={showLineNumbers}
         emptyState={query.data?.complete ? 'complete' : 'pending'}
         anchorToFailure={anchorToFailure}
-        ariaLive={attemptStatus === 'running' ? 'polite' : 'off'}
+        ariaLive={search.trim() ? 'off' : attemptStatus === 'running' ? 'polite' : 'off'}
         className={surfaceClassName}
       />
     </div>

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -239,7 +239,14 @@ function StepLogsError({retrying, onRetry}: {retrying: boolean; onRetry: () => v
     >
       <div className="flex min-w-0 flex-1 items-center justify-between gap-inline">
         <Text size="xs">Could not load logs.</Text>
-        <Button type="button" size="2xs" variant="secondary" isLoading={retrying} onClick={onRetry}>
+        <Button
+          type="button"
+          size="2xs"
+          variant="secondary"
+          isLoading={retrying}
+          disabled={retrying}
+          onClick={onRetry}
+        >
           Retry
         </Button>
       </div>

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -13,7 +13,7 @@ import {JobExecutionTimeText} from './job-execution-time-text.js';
 const TAIL_FOLLOW_THRESHOLD_PX = 24;
 const INITIAL_LOG_ERROR_RETRY_COUNT = 5;
 const INITIAL_LOG_ERROR_RETRY_DELAY_MS = 1_500;
-const defaultLogSurfaceClasses = 'rounded-8';
+const defaultLogSurfaceClasses = 'rounded-none border-0 bg-background-contrast-base shadow-none';
 
 export interface StepAttemptLogPanelProps {
   stepId: string;
@@ -24,6 +24,10 @@ export interface StepAttemptLogPanelProps {
   /** The page scroll column used by the uncapped job-detail log surface. */
   pageScrollRef: RefObject<HTMLElement | null>;
   surfaceClassName?: string | undefined;
+  search?: string | undefined;
+  wrap?: boolean | undefined;
+  showLineNumbers?: boolean | undefined;
+  refreshToken?: number | undefined;
   initialErrorRetryCount?: number | undefined;
   initialErrorRetryDelayMs?: number | undefined;
 }
@@ -35,6 +39,10 @@ export function StepAttemptLogPanel({
   attemptStartedAt,
   pageScrollRef,
   surfaceClassName = defaultLogSurfaceClasses,
+  search = '',
+  wrap = false,
+  showLineNumbers = true,
+  refreshToken = 0,
   initialErrorRetryCount = INITIAL_LOG_ERROR_RETRY_COUNT,
   initialErrorRetryDelayMs = INITIAL_LOG_ERROR_RETRY_DELAY_MS,
 }: StepAttemptLogPanelProps) {
@@ -55,6 +63,13 @@ export function StepAttemptLogPanel({
     retryMissingStream && query.data === undefined && isMissingStepLogStreamError(query.error);
   const initialError = query.isError && query.data === undefined && !missingActiveStream;
   const staleError = query.isError && query.data !== undefined;
+  const lastRefreshTokenRef = useRef(refreshToken);
+
+  useEffect(() => {
+    if (refreshToken === lastRefreshTokenRef.current) return;
+    lastRefreshTokenRef.current = refreshToken;
+    void query.refetch();
+  }, [query.refetch, refreshToken]);
 
   useEffect(() => {
     const scrollElement = pageScrollRef.current;
@@ -85,14 +100,28 @@ export function StepAttemptLogPanel({
   }, [anchorToFailure, pageScrollRef, recordCount]);
 
   if (query.isPending) {
-    return <StepLogsLoadingSurface label="Loading logs" className={surfaceClassName} />;
+    return (
+      <StepLogsLoadingSurface
+        label="Loading logs"
+        className={surfaceClassName}
+        wrap={wrap}
+        showLineNumbers={showLineNumbers}
+      />
+    );
   }
 
   if (missingActiveStream) {
     if (attemptStatus === 'running' && attemptStartedAt) {
       return <StepLogsWaitingSurface startedAt={attemptStartedAt} className={surfaceClassName} />;
     }
-    return <StepLogsLoadingSurface label="Waiting for logs" className={surfaceClassName} />;
+    return (
+      <StepLogsLoadingSurface
+        label="Waiting for logs"
+        className={surfaceClassName}
+        wrap={wrap}
+        showLineNumbers={showLineNumbers}
+      />
+    );
   }
 
   if (initialError) {
@@ -124,6 +153,9 @@ export function StepAttemptLogPanel({
       ) : null}
       <LogView
         records={records}
+        search={search}
+        wrap={wrap}
+        showLineNumbers={showLineNumbers}
         emptyState={query.data?.complete ? 'complete' : 'pending'}
         anchorToFailure={anchorToFailure}
         ariaLive={attemptStatus === 'running' ? 'polite' : 'off'}
@@ -133,10 +165,20 @@ export function StepAttemptLogPanel({
   );
 }
 
-function StepLogsLoadingSurface({label, className}: {label: string; className: string}) {
+function StepLogsLoadingSurface({
+  label,
+  className,
+  wrap,
+  showLineNumbers,
+}: {
+  label: string;
+  className: string;
+  wrap: boolean;
+  showLineNumbers: boolean;
+}) {
   return (
     <div role="status" aria-label={label}>
-      <LogViewSkeleton className={className} />
+      <LogViewSkeleton className={className} wrap={wrap} showLineNumbers={showLineNumbers} />
     </div>
   );
 }

--- a/libs/client/workflows/src/components/step-list/step-list-model.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.ts
@@ -132,7 +132,7 @@ function toStepModel(step: Step, index: number): StepModel {
   };
 }
 
-function stepLabel(step: Step, index: number): string {
+export function stepLabel(step: Step, index: number): string {
   const name = step.name.trim();
   if (name) return name;
 

--- a/libs/client/workflows/src/components/step-list/step-list.test.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.test.tsx
@@ -210,7 +210,7 @@ describe('StepList', () => {
     await user.click(deployRow);
 
     expect(buildRow.parentElement?.parentElement).not.toHaveClass('bg-background-components-hover');
-    expect(deployRow.parentElement?.parentElement).toHaveClass('bg-background-components-hover');
+    expect(deployRow.parentElement?.parentElement).toHaveClass('bg-background-neutral-hover');
   });
 
   test('opens a default selected attempt', () => {

--- a/libs/client/workflows/src/components/step-list/step-list.test.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.test.tsx
@@ -145,6 +145,34 @@ describe('StepList', () => {
     expect(screen.getByText(`logs for ${deployAttempt.id}`)).toBeInTheDocument();
   });
 
+  test('reports the expanded attempt ids as rows change', async () => {
+    const user = userEvent.setup();
+    const onExpandedAttemptIdsChange = vi.fn();
+    const buildAttempt = makeAttempt({status: 'succeeded'});
+    const deployAttempt = makeAttempt({status: 'running'});
+    const build = makeStep({name: 'build', attempts: [buildAttempt]});
+    const deploy = makeStep({name: 'deploy', position: 1, attempts: [deployAttempt]});
+    render(
+      <StepList
+        job={makeJob({steps: [build, deploy]})}
+        onExpandedAttemptIdsChange={onExpandedAttemptIdsChange}
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'build, Succeeded, attempt 1'}));
+    expect(onExpandedAttemptIdsChange).toHaveBeenLastCalledWith([buildAttempt.id]);
+
+    await user.click(screen.getByRole('button', {name: 'deploy, Running, attempt 1'}));
+    expect(onExpandedAttemptIdsChange).toHaveBeenLastCalledWith([
+      buildAttempt.id,
+      deployAttempt.id,
+    ]);
+
+    await user.click(screen.getByRole('button', {name: 'build, Succeeded, attempt 1'}));
+    expect(onExpandedAttemptIdsChange).toHaveBeenLastCalledWith([deployAttempt.id]);
+  });
+
   test('keeps multiple expanded rows open when external attempt selection is singular', async () => {
     const user = userEvent.setup();
     const buildAttempt = makeAttempt({status: 'succeeded'});

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -223,7 +223,7 @@ function StepListContent({
       <section
         aria-labelledby={showHeader ? titleId : undefined}
         className={cn(
-          'flex min-h-0 flex-col rounded-8 border border-border-neutral-base bg-background-components-base',
+          'flex min-h-0 flex-col rounded-8 border border-border-neutral-base bg-background-neutral-base',
           className,
         )}
       >
@@ -425,8 +425,8 @@ function StepRow({
     <>
       <div
         className={cn(
-          'group flex min-w-0 items-center gap-inline pr-[8px] transition-colors hover:bg-background-components-hover active:bg-background-components-pressed',
-          selected && 'bg-background-components-hover',
+          'group flex min-w-0 items-center gap-inline bg-background-neutral-base pr-[8px] transition-colors hover:bg-background-neutral-hover active:bg-background-neutral-pressed',
+          selected && 'bg-background-neutral-hover',
           !hasExpandedContent && ['border-b border-border-neutral-base', isLast && 'border-b-0'],
         )}
       >

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -58,6 +58,7 @@ export interface StepListProps {
   selectedAttemptId?: string | null | undefined;
   defaultSelectedAttemptId?: string | undefined;
   onSelectedAttemptChange?: ((attemptId: string | undefined) => void) | undefined;
+  onExpandedAttemptIdsChange?: ((attemptIds: readonly string[]) => void) | undefined;
   inspectorOpenAttemptId?: string | null | undefined;
   onInspectorOpenChange?: ((attemptId: string | null) => void) | undefined;
   autoSelectActiveAttempt?: boolean | undefined;
@@ -74,6 +75,7 @@ export function StepList({
   selectedAttemptId,
   defaultSelectedAttemptId,
   onSelectedAttemptChange,
+  onExpandedAttemptIdsChange,
   inspectorOpenAttemptId = null,
   onInspectorOpenChange,
   autoSelectActiveAttempt = false,
@@ -96,6 +98,7 @@ export function StepList({
       selectedAttemptId={selectedAttemptId}
       defaultSelectedAttemptId={defaultSelectedAttemptId}
       onSelectedAttemptChange={onSelectedAttemptChange}
+      onExpandedAttemptIdsChange={onExpandedAttemptIdsChange}
       inspectorOpenAttemptId={inspectorOpenAttemptId}
       onInspectorOpenChange={onInspectorOpenChange}
       autoSelectActiveAttempt={autoSelectActiveAttempt}
@@ -113,6 +116,7 @@ function StepListContent({
   selectedAttemptId,
   defaultSelectedAttemptId,
   onSelectedAttemptChange,
+  onExpandedAttemptIdsChange,
   inspectorOpenAttemptId = null,
   onInspectorOpenChange,
   autoSelectActiveAttempt,
@@ -134,19 +138,34 @@ function StepListContent({
   const lastNotifiedSelectedAttemptId = useRef<string | null>(null);
   const autoSelectedAttemptIdRef = useRef<string | undefined>(undefined);
   const previousSelectedAttemptIdRef = useRef<string | null | undefined>(selectedAttemptId);
+  const lastReportedExpandedAttemptIdsKeyRef = useRef<string | null>(null);
   const shouldUseControlledCollapsedState =
     selectedAttemptId === null && lastNotifiedSelectedAttemptId.current === null;
   const autoSelectedAttemptId =
     selectedAttemptId === undefined && autoSelectActiveAttempt && !userSelectedAttempt
       ? (autoSelectedAttemptIdRef.current ?? model.activeEntryId)
       : undefined;
-  const autoSelectedAttemptIds = autoSelectedAttemptId ? [autoSelectedAttemptId] : [];
-  const selectedAttemptIds = shouldUseControlledCollapsedState
-    ? []
-    : localSelectedAttemptIds.length > 0
-      ? localSelectedAttemptIds
-      : autoSelectedAttemptIds;
+  const autoSelectedAttemptIds = useMemo(
+    () => (autoSelectedAttemptId ? [autoSelectedAttemptId] : []),
+    [autoSelectedAttemptId],
+  );
+  const selectedAttemptIds = useMemo(
+    () =>
+      shouldUseControlledCollapsedState
+        ? []
+        : localSelectedAttemptIds.length > 0
+          ? localSelectedAttemptIds
+          : autoSelectedAttemptIds,
+    [autoSelectedAttemptIds, localSelectedAttemptIds, shouldUseControlledCollapsedState],
+  );
   const hasExpandedContent = renderExpandedStep !== undefined;
+
+  useEffect(() => {
+    const key = selectedAttemptIds.join('|');
+    if (lastReportedExpandedAttemptIdsKeyRef.current === key) return;
+    lastReportedExpandedAttemptIdsKeyRef.current = key;
+    onExpandedAttemptIdsChange?.(selectedAttemptIds);
+  }, [onExpandedAttemptIdsChange, selectedAttemptIds]);
 
   useEffect(() => {
     if (selectedAttemptId !== undefined) {

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -117,6 +117,9 @@ describe('WorkflowJobDetailPage', () => {
       await screen.findByRole('region', {name: 'tests output, attempt 2'}),
     ).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'release logs'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Search logs'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Refresh logs'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Log settings'})).toBeInTheDocument();
     expect(screen.queryByRole('tab')).not.toBeInTheDocument();
     expect(screen.getByRole('img', {name: 'Job status: Succeeded'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -101,6 +101,7 @@ describe('WorkflowJobDetailPage', () => {
   });
 
   test('resolves an exact job execution and step attempt from a deep link', async () => {
+    const user = userEvent.setup();
     configureApiClient({fetchImpl: vi.fn(jobDetailFetch)});
 
     renderJobPath(
@@ -120,6 +121,21 @@ describe('WorkflowJobDetailPage', () => {
     expect(screen.getByRole('textbox', {name: 'Search logs'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Refresh logs'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Log settings'})).toBeInTheDocument();
+    const testsAttempt = screen.getByRole('button', {name: 'tests, Succeeded, attempt 2'});
+    await user.click(testsAttempt);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('region', {name: 'tests output, attempt 2'}),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole('textbox', {name: 'Search logs'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Refresh logs'})).toBeDisabled();
+
+    await user.click(testsAttempt);
+    expect(
+      await screen.findByRole('region', {name: 'tests output, attempt 2'}),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Search logs'})).not.toBeDisabled();
     expect(screen.queryByRole('tab')).not.toBeInTheDocument();
     expect(screen.getByRole('img', {name: 'Job status: Succeeded'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
@@ -56,7 +56,10 @@ export function WorkflowJobDetailPage({
     [navigate],
   );
   return (
-    <div data-workflow-page-root="job-detail" className="flex min-h-0 flex-1 overflow-hidden">
+    <div
+      data-workflow-page-root="job-detail"
+      className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+    >
       <WorkflowRunView
         projectId={projectId}
         workspaceSlug={workspaceSlug}

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.tsx
@@ -70,6 +70,7 @@ export function WorkflowJobDetailPage({
         jobSearch={search}
         jobContent={
           <JobDetailView
+            key={jobId}
             workspaceSlug={workspaceSlug}
             projectSlug={projectSlug}
             workflowRunId={workflowRunId}


### PR DESCRIPTION
Recompose the workflow job detail surface around the data frame and Panel primitive from the Surface and layout system.

The job detail keeps the rail on the canvas and renders the log area as one full-width Panel. The header carries selected step context, search, refresh, and display settings. Log rendering supports filtering and opaque near-black code surfaces, while step rows use neutral panel tokens.

Closes ENG-1586

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recomposed the job detail logs onto a full-width `Panel` with a unified header for search, refresh, line numbers, and wrapping. Expanded log search to cover output, markers, and agent sessions with clear status messages and safer refresh behavior (ENG-1586).

- **New Features**
  - Full-width log pane using `@shipfox/react-ui/panel` with step/attempt/status in the header.
  - Log search filters output, markers, and session rows; opens matching groups; keeps tool-call/result pairs; shows “No matches”; pauses live announcements.
  - Refresh is scoped to the expanded attempt; header controls disable when no attempt is open; line numbers and wrap settings apply across views.

- **Refactors**
  - Added a log-search index with normalized, ANSI-stripped matching and correct group line counts; expanded focused tests for search and filtering.
  - `StepList` reports expanded attempt IDs; job view targets per-attempt refresh and fetch state; `useStepAttemptLogsQuery` exposes `refetchLogs`, treats manual refreshes safely, and preserves the missing-stream retry lifecycle/budget.
  - Migrated visuals to neutral tokens with min-w-0 fixes; extended `LogView` with contrast background and a11y status messages; preserved modeled step labels and job-detail state; changesets for `@shipfox/client-logs` (minor) and `@shipfox/client-workflows` (patch).

<sup>Written for commit 8628a3207de65c1f33d7001e825615d79ef1f3ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

