### PR TITLE
[react-ui] Render empty, error, and loading states inside panel bodies

### DIFF
--- a/.changeset/panel-state-variants.md
+++ b/.changeset/panel-state-variants.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Add panel-body variants for empty and load-error states so data-region placeholders retain the panel footprint.

--- a/.changeset/panel-state-variants.md
+++ b/.changeset/panel-state-variants.md
@@ -1,5 +1,14 @@
 ---
 "@shipfox/react-ui": minor
+"@shipfox/client-ui": minor
+"@shipfox/client-agent": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-runners": patch
+"@shipfox/client-secrets": patch
+"@shipfox/client-triggers": patch
+"@shipfox/client-workflows": patch
+"@shipfox/client-workspace-settings": patch
 ---
 
-Add panel-body variants for empty and load-error states so data-region placeholders retain the panel footprint.
+Render empty and load-error states inside bordered panel bodies and keep loading placeholders aligned with their data regions.

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -95,8 +95,8 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
       {configsQuery.isPending ? <HarnessRowsSkeleton /> : null}
 
       {configsQuery.isError && configsQuery.data === undefined ? (
-        <div className={cn(SURFACE_CLASS, 'px-row')}>
-          <QueryLoadError query={configsQuery} subject="harnesses" />
+        <div className={SURFACE_CLASS}>
+          <QueryLoadError query={configsQuery} subject="harnesses" variant="panel" />
         </div>
       ) : null}
 

--- a/libs/client/agent/src/components/model-provider-grid-skeleton.tsx
+++ b/libs/client/agent/src/components/model-provider-grid-skeleton.tsx
@@ -1,0 +1,24 @@
+import {Skeleton} from '@shipfox/react-ui/skeleton';
+import {cn} from '@shipfox/react-ui/utils';
+import {PROVIDER_GRID_CLASS} from './available-providers-grid.js';
+
+const SURFACE_CLASS =
+  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
+
+export function ModelProviderGridSkeleton({label}: {label: string}) {
+  return (
+    <div role="status" aria-busy="true" aria-label={label} className={PROVIDER_GRID_CLASS}>
+      {[0, 1, 2, 3].map((tile) => (
+        <div
+          key={tile}
+          className={cn('flex h-136 w-full flex-col justify-center p-panel-compact', SURFACE_CLASS)}
+        >
+          <div className="flex items-center justify-between gap-cluster">
+            <Skeleton className="h-16 w-100" />
+            <Skeleton className="h-16 w-64 shrink-0" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -1,7 +1,6 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
-import {Card} from '@shipfox/react-ui/card';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -47,10 +46,11 @@ import {
   useSetDefaultModelProviderMutation,
 } from '#hooks/api/model-providers.js';
 import {AddCustomProviderCard} from './add-custom-provider-card.js';
-import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from './available-providers-grid.js';
+import {AvailableProvidersGrid} from './available-providers-grid.js';
 import {ChangeDefaultModelForm} from './change-default-model-form.js';
 import {CustomModelProviderForm} from './custom-model-provider-form.js';
 import {modelProviderConfigErrorToFormError} from './form-errors.js';
+import {ModelProviderGridSkeleton} from './model-provider-grid-skeleton.js';
 import {ModelProviderUsageModal} from './model-provider-usage-modal.js';
 import {
   type ModelProviderUsageTarget,
@@ -213,7 +213,9 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
           </Text>
         </div>
 
-        {catalogQuery.isPending || configsQuery.isPending ? <ModelProviderGridSkeleton /> : null}
+        {catalogQuery.isPending || configsQuery.isPending ? (
+          <ModelProviderGridSkeleton label="Loading available providers" />
+        ) : null}
 
         {catalogQuery.isError && catalogQuery.data === undefined ? (
           <div className={SURFACE_CLASS}>
@@ -620,20 +622,5 @@ function ModelProviderRowsSkeleton({label}: {label: string}) {
         </li>
       ))}
     </ul>
-  );
-}
-
-function ModelProviderGridSkeleton() {
-  return (
-    <div role="status" aria-label="Loading available providers" className={PROVIDER_GRID_CLASS}>
-      {[0, 1, 2, 3].map((card) => (
-        <Card key={card} className="h-136 w-full justify-center p-panel-compact">
-          <div className="flex items-center justify-between gap-cluster">
-            <Skeleton className="h-16 w-100" />
-            <Skeleton className="h-16 w-64 shrink-0" />
-          </div>
-        </Card>
-      ))}
-    </div>
   );
 }

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -1,6 +1,7 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {Card} from '@shipfox/react-ui/card';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -132,17 +133,18 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
 
         {configsQuery.isError && configsQuery.data === undefined ? (
-          <div className={cn(SURFACE_CLASS, 'px-row')}>
-            <QueryLoadError query={configsQuery} subject="model provider configs" />
+          <div className={SURFACE_CLASS}>
+            <QueryLoadError query={configsQuery} subject="model provider configs" variant="panel" />
           </div>
         ) : null}
 
         {configsQuery.data !== undefined && configs.length === 0 ? (
-          <div className={cn(SURFACE_CLASS, 'px-row')}>
+          <div className={SURFACE_CLASS}>
             <EmptyState
               icon="key2Line"
               title="No providers configured"
               description="Configure a provider below to run agent steps with workspace-managed credentials."
+              variant="panel"
             />
           </div>
         ) : null}
@@ -214,8 +216,8 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         {catalogQuery.isPending || configsQuery.isPending ? <ModelProviderGridSkeleton /> : null}
 
         {catalogQuery.isError && catalogQuery.data === undefined ? (
-          <div className={cn(SURFACE_CLASS, 'px-row')}>
-            <QueryLoadError query={catalogQuery} subject="model provider catalog" />
+          <div className={SURFACE_CLASS}>
+            <QueryLoadError query={catalogQuery} subject="model provider catalog" variant="panel" />
           </div>
         ) : null}
 
@@ -625,7 +627,12 @@ function ModelProviderGridSkeleton() {
   return (
     <div role="status" aria-label="Loading available providers" className={PROVIDER_GRID_CLASS}>
       {[0, 1, 2, 3].map((card) => (
-        <Skeleton key={card} className="h-136 w-full" />
+        <Card key={card} className="h-136 w-full justify-center p-panel-compact">
+          <div className="flex items-center justify-between gap-cluster">
+            <Skeleton className="h-16 w-100" />
+            <Skeleton className="h-16 w-64 shrink-0" />
+          </div>
+        </Card>
       ))}
     </div>
   );

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -1,17 +1,16 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
-import {Card} from '@shipfox/react-ui/card';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
-import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
 import {useEffect, useMemo, useReducer} from 'react';
 import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from '#components/available-providers-grid.js';
 import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
+import {ModelProviderGridSkeleton} from '#components/model-provider-grid-skeleton.js';
 import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
 import {DEFAULT_HARNESS, harnessSupportsProvider, listHarnesses} from '#core/harness-policy.js';
 import type {HarnessDescriptor, HarnessId, SupportedProvider} from '#core/models.js';
@@ -266,11 +265,7 @@ function ModelProviderPicker({
   onSelect: (entry: SupportedProvider) => void;
 }) {
   if (catalogQuery.isPending) {
-    return (
-      <div role="status" aria-busy="true" aria-label="Loading model providers">
-        <ModelProviderGridSkeleton />
-      </div>
-    );
+    return <ModelProviderGridSkeleton label="Loading model providers" />;
   }
 
   if (catalogQuery.isError && catalogQuery.data === undefined) {
@@ -288,19 +283,4 @@ function ModelProviderPicker({
   }
 
   return <AvailableProvidersGrid entries={supportedProviders} onSelect={onSelect} />;
-}
-
-function ModelProviderGridSkeleton() {
-  return (
-    <div className={PROVIDER_GRID_CLASS}>
-      {[0, 1, 2, 3].map((card) => (
-        <Card key={card} className="h-136 w-full justify-center p-panel-compact">
-          <div className="flex items-center justify-between gap-cluster">
-            <Skeleton className="h-16 w-100" />
-            <Skeleton className="h-16 w-64 shrink-0" />
-          </div>
-        </Card>
-      ))}
-    </div>
-  );
 }

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -1,6 +1,7 @@
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
+import {Card} from '@shipfox/react-ui/card';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
@@ -293,7 +294,12 @@ function ModelProviderGridSkeleton() {
   return (
     <div className={PROVIDER_GRID_CLASS}>
       {[0, 1, 2, 3].map((card) => (
-        <Skeleton key={card} className="h-136 w-full" />
+        <Card key={card} className="h-136 w-full justify-center p-panel-compact">
+          <div className="flex items-center justify-between gap-cluster">
+            <Skeleton className="h-16 w-100" />
+            <Skeleton className="h-16 w-64 shrink-0" />
+          </div>
+        </Card>
       ))}
     </div>
   );

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -59,20 +59,22 @@ export function InstalledIntegrationsSection({
       {isPending ? <InstalledSkeleton label="Loading integrations" /> : null}
 
       {error ? (
-        <div className={cn(INSTALLED_SURFACE_CLASS, 'px-row')}>
+        <div className={INSTALLED_SURFACE_CLASS}>
           <QueryLoadError
             query={{isError: true, isFetching, data: undefined, error, refetch: onRetry}}
             subject="integrations"
+            variant="panel"
           />
         </div>
       ) : null}
 
       {!isPending && !error && connections.length === 0 ? (
-        <div className={cn(INSTALLED_SURFACE_CLASS, 'px-row')}>
+        <div className={INSTALLED_SURFACE_CLASS}>
           <EmptyState
             icon="componentLine"
             title="No integrations installed yet"
             description="Install a provider below to get started."
+            variant="panel"
           />
         </div>
       ) : null}

--- a/libs/client/integrations/src/components/provider-grid.tsx
+++ b/libs/client/integrations/src/components/provider-grid.tsx
@@ -5,7 +5,6 @@ import {Icon} from '@shipfox/react-ui/icon';
 import {Panel} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import {Link} from '@tanstack/react-router';
 import type {IntegrationProvider} from '#core/models.js';
 import {PROVIDER_CATALOG} from '#provider-catalog.js';
@@ -46,7 +45,7 @@ export function ProviderGrid({
 
   if (error) {
     return (
-      <div className={cn(PROVIDER_SURFACE_CLASS, 'px-row')}>
+      <div className={PROVIDER_SURFACE_CLASS}>
         <QueryLoadError
           query={{
             isError: true,
@@ -56,6 +55,7 @@ export function ProviderGrid({
             refetch: onRetry ?? (() => undefined),
           }}
           subject={errorSubject}
+          variant="panel"
         />
       </div>
     );
@@ -63,11 +63,12 @@ export function ProviderGrid({
 
   if (installableProviders.length === 0) {
     return (
-      <div className={cn(PROVIDER_SURFACE_CLASS, 'px-row')}>
+      <div className={PROVIDER_SURFACE_CLASS}>
         <EmptyState
           icon="componentLine"
           title="No integrations available"
           description={emptyMessage}
+          variant="panel"
         />
       </div>
     );

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -81,18 +81,24 @@ export function ProjectsHubPage({search = ''}: {search?: string}) {
       {isInitialLoading || (search && hasNoData && query.isFetching) ? <ProjectsSkeleton /> : null}
 
       {query.isError && hasNoData ? (
-        <QueryLoadError query={query} subject="projects" variant="panel" />
+        <Panel>
+          <QueryLoadError query={query} subject="projects" variant="panel" />
+        </Panel>
       ) : null}
 
       {!isInitialLoading && !query.isError && projects.length === 0 && !search ? (
-        <EmptyProjects workspaceSlug={workspace.slug} />
+        <Panel>
+          <EmptyProjects workspaceSlug={workspace.slug} />
+        </Panel>
       ) : null}
 
       {!query.isFetching && !query.isError && projects.length === 0 && search ? (
-        <NoSearchResults
-          search={search}
-          onClear={() => navigate({search: {} as never, replace: true})}
-        />
+        <Panel>
+          <NoSearchResults
+            search={search}
+            onClear={() => navigate({search: {} as never, replace: true})}
+          />
+        </Panel>
       ) : null}
 
       {projects.length > 0 ? (

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -80,7 +80,9 @@ export function ProjectsHubPage({search = ''}: {search?: string}) {
 
       {isInitialLoading || (search && hasNoData && query.isFetching) ? <ProjectsSkeleton /> : null}
 
-      {query.isError && hasNoData ? <QueryLoadError query={query} subject="projects" /> : null}
+      {query.isError && hasNoData ? (
+        <QueryLoadError query={query} subject="projects" variant="panel" />
+      ) : null}
 
       {!isInitialLoading && !query.isError && projects.length === 0 && !search ? (
         <EmptyProjects workspaceSlug={workspace.slug} />
@@ -158,6 +160,7 @@ function EmptyProjects({workspaceSlug}: {workspaceSlug: string}) {
       icon="folderLine"
       title="Create your first project"
       description="Connect a repository-backed project to start building workflows."
+      variant="panel"
       action={
         <Button asChild iconRight="chevronRight">
           <Link to="/w/$workspaceSlug/projects/new" params={{workspaceSlug}}>
@@ -175,6 +178,7 @@ function NoSearchResults({search, onClear}: {search: string; onClear: () => void
       icon="searchLine"
       title={`No projects match “${search}”`}
       description="Try a different search, or clear it to see all projects."
+      variant="panel"
       action={
         <Button size="sm" variant="secondary" onClick={onClear}>
           Clear search

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -219,6 +219,7 @@ export function EmptyManualRegistrationTokens() {
       icon="key2Line"
       title="No usable manual registration tokens"
       description="Create a token to connect a runner to this workspace."
+      variant="panel"
     />
   );
 }
@@ -228,10 +229,10 @@ export function ManualRegistrationTokenTableSkeleton() {
     <div
       role="status"
       aria-label="Loading manual registration tokens"
-      className="flex flex-col gap-inline"
+      className="flex flex-col divide-y divide-border-neutral-base overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base"
     >
       {[0, 1, 2].map((row) => (
-        <Skeleton key={row} className="h-44 w-full" />
+        <Skeleton key={row} className="h-44 w-full rounded-none" />
       ))}
     </div>
   );

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -45,8 +45,8 @@ export function ManualRegistrationTokenList({
   tokens: ManualRegistrationToken[];
 }) {
   return (
-    <>
-      <Panel className="max-[760px]:hidden">
+    <Panel>
+      <div className="max-[760px]:hidden">
         <Table className="table-fixed">
           <TableHeader>
             <TableRow>
@@ -81,16 +81,13 @@ export function ManualRegistrationTokenList({
             ))}
           </TableBody>
         </Table>
-      </Panel>
+      </div>
       <ul
-        className="hidden flex-col gap-inline max-[760px]:flex"
+        className="hidden flex-col divide-y divide-border-neutral-base max-[760px]:flex"
         aria-label="Manual registration tokens"
       >
         {tokens.map((token) => (
-          <li
-            key={token.id}
-            className="flex flex-col gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact"
-          >
+          <li key={token.id} className="flex flex-col gap-cluster p-panel-compact">
             <div className="flex items-start justify-between gap-cluster">
               <div className="min-w-0 flex-1">
                 <TokenName name={tokenDisplayName(token)} />
@@ -117,7 +114,7 @@ export function ManualRegistrationTokenList({
           </li>
         ))}
       </ul>
-    </>
+    </Panel>
   );
 }
 
@@ -226,14 +223,10 @@ export function EmptyManualRegistrationTokens() {
 
 export function ManualRegistrationTokenTableSkeleton() {
   return (
-    <div
-      role="status"
-      aria-label="Loading manual registration tokens"
-      className="flex flex-col divide-y divide-border-neutral-base overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base"
-    >
+    <Panel role="status" aria-label="Loading manual registration tokens" className="divide-y">
       {[0, 1, 2].map((row) => (
         <Skeleton key={row} className="h-44 w-full rounded-none" />
       ))}
-    </div>
+    </Panel>
   );
 }

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -92,7 +92,11 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
         {tokensQuery.isPending ? <ManualRegistrationTokenTableSkeleton /> : null}
 
         {tokensQuery.isError && tokensQuery.data === undefined ? (
-          <QueryLoadError query={tokensQuery} subject="manual registration tokens" />
+          <QueryLoadError
+            query={tokensQuery}
+            subject="manual registration tokens"
+            variant="panel"
+          />
         ) : null}
 
         {tokensQuery.data !== undefined && tokens.length === 0 ? (

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -9,6 +9,7 @@ import {
   ModalTitle,
   ModalTrigger,
 } from '@shipfox/react-ui/modal';
+import {Panel} from '@shipfox/react-ui/panel';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useState} from 'react';
 import type {CreatedManualRegistrationToken} from '#core/token.js';
@@ -92,15 +93,19 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
         {tokensQuery.isPending ? <ManualRegistrationTokenTableSkeleton /> : null}
 
         {tokensQuery.isError && tokensQuery.data === undefined ? (
-          <QueryLoadError
-            query={tokensQuery}
-            subject="manual registration tokens"
-            variant="panel"
-          />
+          <Panel>
+            <QueryLoadError
+              query={tokensQuery}
+              subject="manual registration tokens"
+              variant="panel"
+            />
+          </Panel>
         ) : null}
 
         {tokensQuery.data !== undefined && tokens.length === 0 ? (
-          <EmptyManualRegistrationTokens />
+          <Panel>
+            <EmptyManualRegistrationTokens />
+          </Panel>
         ) : null}
 
         {tokens.length > 0 ? (

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -257,15 +257,20 @@ export function EmptyProvisionerTokens() {
       icon="key2Line"
       title="No usable provisioner registration tokens"
       description="Create a token to connect a provisioner that provisions runners on demand."
+      variant="panel"
     />
   );
 }
 
 export function ProvisionerTokenTableSkeleton() {
   return (
-    <div role="status" aria-label="Loading provisioner tokens" className="flex flex-col gap-inline">
+    <div
+      role="status"
+      aria-label="Loading provisioner tokens"
+      className="flex flex-col divide-y divide-border-neutral-base overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base"
+    >
       {[0, 1, 2].map((row) => (
-        <Skeleton key={row} className="h-44 w-full" />
+        <Skeleton key={row} className="h-44 w-full rounded-none" />
       ))}
     </div>
   );

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -53,8 +53,8 @@ export function ProvisionerTokenList({
   activeIds: ReadonlySet<string>;
 }) {
   return (
-    <>
-      <Panel className="max-[760px]:hidden">
+    <Panel>
+      <div className="max-[760px]:hidden">
         <Table className="table-fixed">
           <TableHeader>
             <TableRow>
@@ -93,13 +93,13 @@ export function ProvisionerTokenList({
             ))}
           </TableBody>
         </Table>
-      </Panel>
-      <ul className="hidden flex-col gap-inline max-[760px]:flex" aria-label="Provisioner tokens">
+      </div>
+      <ul
+        className="hidden flex-col divide-y divide-border-neutral-base max-[760px]:flex"
+        aria-label="Provisioner tokens"
+      >
         {tokens.map((token) => (
-          <li
-            key={token.id}
-            className="flex flex-col gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact"
-          >
+          <li key={token.id} className="flex flex-col gap-cluster p-panel-compact">
             <div className="flex items-start justify-between gap-cluster">
               <div className="min-w-0 flex-1">
                 <TokenName name={provisionerTokenDisplayName(token)} />
@@ -132,7 +132,7 @@ export function ProvisionerTokenList({
           </li>
         ))}
       </ul>
-    </>
+    </Panel>
   );
 }
 
@@ -264,14 +264,10 @@ export function EmptyProvisionerTokens() {
 
 export function ProvisionerTokenTableSkeleton() {
   return (
-    <div
-      role="status"
-      aria-label="Loading provisioner tokens"
-      className="flex flex-col divide-y divide-border-neutral-base overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base"
-    >
+    <Panel role="status" aria-label="Loading provisioner tokens" className="divide-y">
       {[0, 1, 2].map((row) => (
         <Skeleton key={row} className="h-44 w-full rounded-none" />
       ))}
-    </div>
+    </Panel>
   );
 }

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
@@ -9,6 +9,7 @@ import {
   ModalTitle,
   ModalTrigger,
 } from '@shipfox/react-ui/modal';
+import {Panel} from '@shipfox/react-ui/panel';
 import {RelativeTimeProvider} from '@shipfox/react-ui/relative-time';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useMemo, useState} from 'react';
@@ -98,14 +99,20 @@ export function WorkspaceProvisionerTokensSettingsSection({workspaceId}: {worksp
         {tokensQuery.isPending ? <ProvisionerTokenTableSkeleton /> : null}
 
         {tokensQuery.isError && tokensQuery.data === undefined ? (
-          <QueryLoadError
-            query={tokensQuery}
-            subject="provisioner registration tokens"
-            variant="panel"
-          />
+          <Panel>
+            <QueryLoadError
+              query={tokensQuery}
+              subject="provisioner registration tokens"
+              variant="panel"
+            />
+          </Panel>
         ) : null}
 
-        {tokensQuery.data !== undefined && tokens.length === 0 ? <EmptyProvisionerTokens /> : null}
+        {tokensQuery.data !== undefined && tokens.length === 0 ? (
+          <Panel>
+            <EmptyProvisionerTokens />
+          </Panel>
+        ) : null}
 
         {tokens.length > 0 ? (
           <RelativeTimeProvider>

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
@@ -98,7 +98,11 @@ export function WorkspaceProvisionerTokensSettingsSection({workspaceId}: {worksp
         {tokensQuery.isPending ? <ProvisionerTokenTableSkeleton /> : null}
 
         {tokensQuery.isError && tokensQuery.data === undefined ? (
-          <QueryLoadError query={tokensQuery} subject="provisioner registration tokens" />
+          <QueryLoadError
+            query={tokensQuery}
+            subject="provisioner registration tokens"
+            variant="panel"
+          />
         ) : null}
 
         {tokensQuery.data !== undefined && tokens.length === 0 ? <EmptyProvisionerTokens /> : null}

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -71,17 +71,18 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
         {secretsQuery.isPending ? <StoreRowsSkeleton label="Loading secrets" /> : null}
 
         {secretsQuery.isError && secretsQuery.data === undefined ? (
-          <StoreSurface className="px-row">
-            <QueryLoadError query={secretsQuery} subject="secrets" />
+          <StoreSurface>
+            <QueryLoadError query={secretsQuery} subject="secrets" variant="panel" />
           </StoreSurface>
         ) : null}
 
         {secretsQuery.data !== undefined && secrets.length === 0 ? (
-          <StoreSurface className="px-row">
+          <StoreSurface>
             <EmptyState
               icon="keyLine"
               title="No secrets yet"
               description={EMPTY_SECRETS_DESCRIPTION}
+              variant="panel"
               action={
                 <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
                   Create secret

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -71,17 +71,18 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
         {variablesQuery.isPending ? <StoreRowsSkeleton label="Loading variables" /> : null}
 
         {variablesQuery.isError && variablesQuery.data === undefined ? (
-          <StoreSurface className="px-row">
-            <QueryLoadError query={variablesQuery} subject="variables" />
+          <StoreSurface>
+            <QueryLoadError query={variablesQuery} subject="variables" variant="panel" />
           </StoreSurface>
         ) : null}
 
         {variablesQuery.data !== undefined && variables.length === 0 ? (
-          <StoreSurface className="px-row">
+          <StoreSurface>
             <EmptyState
               icon="bracesLine"
               title="No variables yet"
               description={EMPTY_VARIABLES_DESCRIPTION}
+              variant="panel"
               action={
                 <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
                   Create variable

--- a/libs/client/triggers/src/components/events-list-states.tsx
+++ b/libs/client/triggers/src/components/events-list-states.tsx
@@ -8,12 +8,16 @@ import {Link} from '@tanstack/react-router';
 
 export function EventsListSkeleton() {
   return (
-    <div className="flex flex-col gap-inline p-tight" role="status" aria-label="Loading events">
+    <div
+      className="flex flex-col divide-y divide-border-neutral-base"
+      role="status"
+      aria-label="Loading events"
+    >
       {Array.from({length: 8}).map((_, index) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton row, stable position
           key={index}
-          className="flex h-20 items-center gap-cluster"
+          className="flex min-h-44 items-center gap-cluster px-row py-row"
         >
           <Skeleton className="size-6 shrink-0 rounded-full" />
           <Skeleton className="h-12 w-1/4" />
@@ -27,39 +31,37 @@ export function EventsListSkeleton() {
 
 export function EventsListEmpty({workspaceSlug}: {workspaceSlug?: string | undefined}) {
   return (
-    <div className="p-panel-compact">
-      <EmptyState
-        icon="pulseLine"
-        title="No events yet"
-        description="Events appear here once a connected integration delivers one or you fire a trigger."
-        action={
-          workspaceSlug ? (
-            <Button asChild size="sm" variant="secondary">
-              <Link to="/w/$workspaceSlug/settings/integrations" params={{workspaceSlug}}>
-                Configure integrations
-              </Link>
-            </Button>
-          ) : undefined
-        }
-      />
-    </div>
+    <EmptyState
+      icon="pulseLine"
+      title="No events yet"
+      description="Events appear here once a connected integration delivers one or you fire a trigger."
+      action={
+        workspaceSlug ? (
+          <Button asChild size="sm" variant="secondary">
+            <Link to="/w/$workspaceSlug/settings/integrations" params={{workspaceSlug}}>
+              Configure integrations
+            </Link>
+          </Button>
+        ) : undefined
+      }
+      variant="panel"
+    />
   );
 }
 
 export function EventsListNoMatches({onClear}: {onClear: () => void}) {
   return (
-    <div className="p-panel-compact">
-      <EmptyState
-        icon="filterOffLine"
-        title="No matching events"
-        description="No events match your current filters."
-        action={
-          <Button type="button" size="sm" variant="secondary" onClick={onClear}>
-            Clear filters
-          </Button>
-        }
-      />
-    </div>
+    <EmptyState
+      icon="filterOffLine"
+      title="No matching events"
+      description="No events match your current filters."
+      action={
+        <Button type="button" size="sm" variant="secondary" onClick={onClear}>
+          Clear filters
+        </Button>
+      }
+      variant="panel"
+    />
   );
 }
 

--- a/libs/client/triggers/src/components/events-list.tsx
+++ b/libs/client/triggers/src/components/events-list.tsx
@@ -52,7 +52,9 @@ export function EventsList({
       />
 
       {query.isPending ? <EventsListSkeleton /> : null}
-      {!query.isPending ? <QueryLoadError query={query} subject="events" icon="pulseLine" /> : null}
+      {!query.isPending ? (
+        <QueryLoadError query={query} subject="events" icon="pulseLine" variant="panel" />
+      ) : null}
       {!query.isPending && refreshFailed ? <EventsListStaleError query={query} /> : null}
       {showEmptyState && !activeFilters ? <EventsListEmpty workspaceSlug={workspaceSlug} /> : null}
       {showEmptyState && activeFilters ? <EventsListNoMatches onClear={clearFilters} /> : null}

--- a/libs/client/ui/src/query-load-error.test.tsx
+++ b/libs/client/ui/src/query-load-error.test.tsx
@@ -24,6 +24,19 @@ describe('QueryLoadError', () => {
     expect(screen.getByRole('button', {name: 'Retry loading integrations'})).toBeInTheDocument();
   });
 
+  it('passes the panel variant through to the placeholder', () => {
+    const query = buildQuery();
+
+    const {container} = render(
+      <QueryLoadError query={query} subject="integrations" variant="panel" />,
+    );
+
+    expect(container.querySelector('[data-slot="empty-state"]')).toHaveAttribute(
+      'data-variant',
+      'panel',
+    );
+  });
+
   it('renders nothing when stale data is present (a refetch failed after a prior success)', () => {
     const query = buildQuery({data: {connections: []}});
 

--- a/libs/client/ui/src/query-load-error.tsx
+++ b/libs/client/ui/src/query-load-error.tsx
@@ -1,3 +1,4 @@
+import type {EmptyStateVariant} from '@shipfox/react-ui/empty-state';
 import type {IconName} from '@shipfox/react-ui/icon';
 import {LoadErrorState} from '@shipfox/react-ui/load-error-state';
 import {loadErrorCopy} from './load-error-copy.js';
@@ -21,6 +22,8 @@ export interface QueryLoadErrorProps {
   /** Lowercase noun for the resource, e.g. "integrations". Drives copy + aria. */
   subject: string;
   icon?: IconName;
+  /** Layout variant for the state when it is rendered inside a data-region panel. */
+  variant?: EmptyStateVariant;
 }
 
 /**
@@ -29,7 +32,7 @@ export interface QueryLoadErrorProps {
  * success) it renders nothing, so the caller keeps showing that data instead of
  * wiping it. Returns null otherwise.
  */
-export function QueryLoadError({query, subject, icon}: QueryLoadErrorProps) {
+export function QueryLoadError({query, subject, icon, variant}: QueryLoadErrorProps) {
   if (!query.isError || query.data !== undefined) return null;
 
   const copy = loadErrorCopy(query.error, {subject});
@@ -44,6 +47,7 @@ export function QueryLoadError({query, subject, icon}: QueryLoadErrorProps) {
       }}
       retrying={query.isFetching}
       retryLabel={`Retry loading ${subject}`}
+      {...(variant ? {variant} : {})}
     />
   );
 }

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -558,11 +558,10 @@ function EmptyStateForMissingExecution({job}: {job: Job}) {
   const emptyState = emptyStateForMissingExecution(job);
   return (
     <EmptyState
-      className="min-h-120 p-panel"
       icon="componentLine"
       title={emptyState.title}
       description={emptyState.description}
-      variant="compact"
+      variant="panel"
     />
   );
 }

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -256,11 +256,11 @@ function humanizeFailureReason(reason: string): string {
 export function CarriedOverStepPanel() {
   return (
     <EmptyState
-      className="min-h-120 rounded-8 border border-border-neutral-base bg-background-components-base p-panel"
+      className="rounded-8 border border-border-neutral-base bg-background-components-base"
       icon="componentLine"
       title="Carried over from a previous attempt"
       description="Not executed in this run."
-      variant="compact"
+      variant="panel"
     />
   );
 }

--- a/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-content.tsx
@@ -37,11 +37,11 @@ export function JobGraphContent({
   if (model.nodes.length === 0) {
     return (
       <EmptyState
-        className="min-h-160 p-panel"
+        className="min-h-160"
         icon="componentLine"
         title="No jobs yet"
         description="This run has not materialized jobs."
-        variant="compact"
+        variant="panel"
       />
     );
   }

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -326,11 +326,10 @@ function StepListEmptyStateView({
   if (!emptyState.status) {
     return (
       <EmptyState
-        className="min-h-120 p-panel"
         icon="componentLine"
         title={emptyState.title}
         description={emptyState.description}
-        variant="compact"
+        variant="panel"
       />
     );
   }

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
@@ -1,4 +1,5 @@
 import {QueryLoadError} from '@shipfox/client-ui';
+import {Panel} from '@shipfox/react-ui/panel';
 import type {WorkflowRunListItem} from '#core/workflow-run.js';
 import type {WorkflowRunListQuery} from './types.js';
 import {
@@ -55,11 +56,15 @@ export function WorkflowRunListContent({
     <div className="min-h-0 flex-1 overflow-y-auto">
       {isPending ? <WorkflowRunListSkeleton /> : null}
       {!isPending ? (
-        <QueryLoadError query={query} subject="workflow runs" icon="pulseLine" variant="panel" />
+        <Panel>
+          <QueryLoadError query={query} subject="workflow runs" icon="pulseLine" variant="panel" />
+        </Panel>
       ) : null}
       {!isPending && refreshFailed ? <WorkflowRunListStaleError query={query} /> : null}
       {showEmptyState ? (
-        <WorkflowRunListEmpty workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
+        <Panel>
+          <WorkflowRunListEmpty workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
+        </Panel>
       ) : null}
       {showNoMatches ? (
         <WorkflowRunListNoMatches

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
@@ -55,7 +55,7 @@ export function WorkflowRunListContent({
     <div className="min-h-0 flex-1 overflow-y-auto">
       {isPending ? <WorkflowRunListSkeleton /> : null}
       {!isPending ? (
-        <QueryLoadError query={query} subject="workflow runs" icon="pulseLine" />
+        <QueryLoadError query={query} subject="workflow runs" icon="pulseLine" variant="panel" />
       ) : null}
       {!isPending && refreshFailed ? <WorkflowRunListStaleError query={query} /> : null}
       {showEmptyState ? (

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -24,7 +24,7 @@ export function WorkflowRunListSkeleton() {
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton row, stable position
           key={index}
-          className="flex items-center gap-inline px-row py-row @min-[976px]:h-44 @min-[976px]:py-0"
+          className="flex min-h-44 items-center gap-inline px-row py-row @min-[976px]:h-44 @min-[976px]:py-0"
         >
           <Skeleton className="size-14 shrink-0 rounded-full" />
           <Skeleton className="h-12 w-[220px] max-w-[40%]" />
@@ -89,6 +89,7 @@ export function WorkflowRunListEmpty({
           </Button>
         ) : null
       }
+      variant="panel"
     />
   );
 }
@@ -148,6 +149,7 @@ export function WorkflowRunListNoMatches({
             </Button>
           </div>
         }
+        variant="panel"
       />
     </div>
   );

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -2,6 +2,7 @@ import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {Panel} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
@@ -15,11 +16,7 @@ const SKELETON_ROW_COUNT = 8;
  */
 export function WorkflowRunListSkeleton() {
   return (
-    <div
-      className="@container divide-y divide-border-neutral-base"
-      role="status"
-      aria-label="Loading runs"
-    >
+    <Panel role="status" aria-label="Loading runs" className="@container divide-y">
       {Array.from({length: SKELETON_ROW_COUNT}).map((_, index) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton row, stable position
@@ -33,7 +30,7 @@ export function WorkflowRunListSkeleton() {
           <Skeleton className="h-12 w-48" />
         </div>
       ))}
-    </div>
+    </Panel>
   );
 }
 
@@ -117,41 +114,43 @@ export function WorkflowRunListNoMatches({
   onLoadMore?: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-inline">
-      {isFetchNextPageError ? (
-        <Callout role="alert" type="error">
-          Could not load more workflow runs. Try again to continue searching older runs.
-        </Callout>
-      ) : null}
-      <EmptyState
-        icon="filterOffLine"
-        title={hasNextPage ? 'No matches in loaded history' : 'No matching runs'}
-        description={
-          hasNextPage
-            ? 'No loaded run matches these filters. Load more to search further back.'
-            : 'No run matches these filters.'
-        }
-        action={
-          <div className="flex flex-wrap justify-center gap-inline">
-            {hasNextPage && onLoadMore ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="primary"
-                isLoading={isFetchingNextPage}
-                onClick={onLoadMore}
-              >
-                Load more runs
+    <Panel>
+      <div className="flex flex-col gap-inline">
+        {isFetchNextPageError ? (
+          <Callout role="alert" type="error">
+            Could not load more workflow runs. Try again to continue searching older runs.
+          </Callout>
+        ) : null}
+        <EmptyState
+          icon="filterOffLine"
+          title={hasNextPage ? 'No matches in loaded history' : 'No matching runs'}
+          description={
+            hasNextPage
+              ? 'No loaded run matches these filters. Load more to search further back.'
+              : 'No run matches these filters.'
+          }
+          action={
+            <div className="flex flex-wrap justify-center gap-inline">
+              {hasNextPage && onLoadMore ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="primary"
+                  isLoading={isFetchingNextPage}
+                  onClick={onLoadMore}
+                >
+                  Load more runs
+                </Button>
+              ) : null}
+              <Button type="button" size="sm" variant="secondary" onClick={onClear}>
+                Show all runs
               </Button>
-            ) : null}
-            <Button type="button" size="sm" variant="secondary" onClick={onClear}>
-              Show all runs
-            </Button>
-          </div>
-        }
-        variant="panel"
-      />
-    </div>
+            </div>
+          }
+          variant="panel"
+        />
+      </div>
+    </Panel>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -1,5 +1,6 @@
 import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {Icon, type IconName} from '@shipfox/react-ui/icon';
+import {Panel} from '@shipfox/react-ui/panel';
 import {RelativeTime} from '@shipfox/react-ui/relative-time';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
@@ -37,13 +38,15 @@ export function WorkflowRunRowList({
     // A container, not the viewport, drives the row's breakpoints. What a row can afford is its
     // own width; keying off the viewport would keep the job strip hidden on a wide screen or
     // crush it on a narrow one.
-    <ul className="@container divide-y divide-border-neutral-base">
-      {runs.map((run) => (
-        <li key={run.id}>
-          <WorkflowRunRow run={run} workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
-        </li>
-      ))}
-    </ul>
+    <Panel className="@container">
+      <ul className="divide-y divide-border-neutral-base">
+        {runs.map((run) => (
+          <li key={run.id}>
+            <WorkflowRunRow run={run} workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
+          </li>
+        ))}
+      </ul>
+    </Panel>
   );
 }
 

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -171,153 +171,161 @@ function WorkflowDefinitionsList({
 }) {
   if (isPending) {
     return (
-      <div className="flex flex-col divide-y divide-border-neutral-base overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+      <Panel role="status" aria-label="Loading workflows" className="divide-y">
         <Skeleton className="h-44 w-full rounded-none" />
         <Skeleton className="h-44 w-full rounded-none" />
         <Skeleton className="h-44 w-full rounded-none" />
-      </div>
+      </Panel>
     );
   }
 
   if (isError && definitions.length === 0) {
     return (
-      <LoadErrorState
-        title="Couldn't load workflows"
-        description="Definitions could not be loaded. Source metadata remains visible."
-        onRetry={onRetry}
-        retryLabel="Retry loading workflows"
-        variant="panel"
-      />
+      <Panel>
+        <LoadErrorState
+          title="Couldn't load workflows"
+          description="Definitions could not be loaded. Source metadata remains visible."
+          onRetry={onRetry}
+          retryLabel="Retry loading workflows"
+          variant="panel"
+        />
+      </Panel>
     );
   }
 
   if (definitions.length === 0) {
-    return <WorkflowEmptyState sync={sync} />;
+    return (
+      <Panel>
+        <WorkflowEmptyState sync={sync} />
+      </Panel>
+    );
   }
 
   return (
     <>
-      <Panel className="hidden md:flex">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-40"></TableHead>
-              <TableHead>Workflow</TableHead>
-              <TableHead className="w-180">Updated</TableHead>
-              <TableHead className="w-80 text-right"></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {definitions.map((definition) => {
-              const runErrorMessage =
-                runError?.definitionId === definition.id ? runError.message : null;
-              const isRunning = runningDefinitionId === definition.id;
+      <Panel>
+        <div className="hidden md:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-40"></TableHead>
+                <TableHead>Workflow</TableHead>
+                <TableHead className="w-180">Updated</TableHead>
+                <TableHead className="w-80 text-right"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {definitions.map((definition) => {
+                const runErrorMessage =
+                  runError?.definitionId === definition.id ? runError.message : null;
+                const isRunning = runningDefinitionId === definition.id;
 
-              return (
-                // The workflow-name cell holds a `<button>` so the row is
-                // keyboard-reachable (Tab focuses, Enter/Space activates
-                // via native button semantics). The TableRow itself is no
-                // longer clickable: a row-level onClick would be invisible
-                // to keyboard users and require custom keydown handling.
-                // The `group` class on the row still drives the Run button
-                // reveal on hover or focus-within.
-                <TableRow key={definition.id} className="group">
-                  <TableCell>
-                    <Icon
-                      name={sourceIcon(definition.source)}
-                      className="size-16 text-foreground-neutral-muted"
-                      aria-hidden="true"
-                    />
-                  </TableCell>
-                  <TableCell className="max-w-260">
-                    <div className="flex min-w-0 flex-col gap-tight">
-                      <button
-                        type="button"
-                        onClick={() => onOpenDefinition(definition)}
-                        className="flex min-w-0 flex-col gap-tight text-left outline-none focus-visible:shadow-border-interactive-with-active rounded-4"
-                      >
-                        <Text size="sm" bold className="truncate">
-                          {definition.name}
-                        </Text>
-                        <Code className="truncate text-foreground-neutral-muted">
-                          {definition.configPath ?? 'Manual definition'}
-                        </Code>
-                      </button>
-                      {runErrorMessage ? (
-                        <Text size="xs" className="text-tag-error-text">
-                          {runErrorMessage}
-                        </Text>
-                      ) : null}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-foreground-neutral-muted">
-                    <RelativeTime value={definition.updatedAt} />
-                  </TableCell>
-                  <TableCell>
-                    {definition.manualTrigger ? (
-                      <div className="flex justify-end opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-                        <Button size="xs" isLoading={isRunning} onClick={() => onRun(definition)}>
-                          Run
-                        </Button>
+                return (
+                  // The workflow-name cell holds a `<button>` so the row is
+                  // keyboard-reachable (Tab focuses, Enter/Space activates
+                  // via native button semantics). The TableRow itself is no
+                  // longer clickable: a row-level onClick would be invisible
+                  // to keyboard users and require custom keydown handling.
+                  // The `group` class on the row still drives the Run button
+                  // reveal on hover or focus-within.
+                  <TableRow key={definition.id} className="group">
+                    <TableCell>
+                      <Icon
+                        name={sourceIcon(definition.source)}
+                        className="size-16 text-foreground-neutral-muted"
+                        aria-hidden="true"
+                      />
+                    </TableCell>
+                    <TableCell className="max-w-260">
+                      <div className="flex min-w-0 flex-col gap-tight">
+                        <button
+                          type="button"
+                          onClick={() => onOpenDefinition(definition)}
+                          className="flex min-w-0 flex-col gap-tight rounded-4 text-left outline-none focus-visible:shadow-border-interactive-with-active"
+                        >
+                          <Text size="sm" bold className="truncate">
+                            {definition.name}
+                          </Text>
+                          <Code className="truncate text-foreground-neutral-muted">
+                            {definition.configPath ?? 'Manual definition'}
+                          </Code>
+                        </button>
+                        {runErrorMessage ? (
+                          <Text size="xs" className="text-tag-error-text">
+                            {runErrorMessage}
+                          </Text>
+                        ) : null}
                       </div>
-                    ) : null}
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </Panel>
+                    </TableCell>
+                    <TableCell className="text-foreground-neutral-muted">
+                      <RelativeTime value={definition.updatedAt} />
+                    </TableCell>
+                    <TableCell>
+                      {definition.manualTrigger ? (
+                        <div className="flex justify-end opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                          <Button size="xs" isLoading={isRunning} onClick={() => onRun(definition)}>
+                            Run
+                          </Button>
+                        </div>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
 
-      <div className="flex flex-col rounded-8 border border-border-neutral-base md:hidden">
-        {definitions.map((definition) => {
-          const runErrorMessage =
-            runError?.definitionId === definition.id ? runError.message : null;
-          const isRunning = runningDefinitionId === definition.id;
+        <div className="flex flex-col md:hidden">
+          {definitions.map((definition) => {
+            const runErrorMessage =
+              runError?.definitionId === definition.id ? runError.message : null;
+            const isRunning = runningDefinitionId === definition.id;
 
-          return (
-            <div
-              key={definition.id}
-              className="flex flex-col gap-inline border-b border-border-neutral-base p-panel-compact last:border-b-0"
-            >
-              <button
-                type="button"
-                className="flex min-w-0 items-start gap-inline text-left"
-                onClick={() => onOpenDefinition(definition)}
+            return (
+              <div
+                key={definition.id}
+                className="flex flex-col gap-inline border-b border-border-neutral-base p-panel-compact last:border-b-0"
               >
-                <Icon
-                  name={sourceIcon(definition.source)}
-                  className="size-16 shrink-0 text-foreground-neutral-muted"
-                  aria-hidden="true"
-                />
-                <div className="flex min-w-0 flex-col gap-tight">
-                  <Text size="sm" bold className="break-words">
-                    {definition.name}
+                <button
+                  type="button"
+                  className="flex min-w-0 items-start gap-inline text-left"
+                  onClick={() => onOpenDefinition(definition)}
+                >
+                  <Icon
+                    name={sourceIcon(definition.source)}
+                    className="size-16 shrink-0 text-foreground-neutral-muted"
+                    aria-hidden="true"
+                  />
+                  <div className="flex min-w-0 flex-col gap-tight">
+                    <Text size="sm" bold className="break-words">
+                      {definition.name}
+                    </Text>
+                    <Code className="break-words text-foreground-neutral-muted">
+                      {definition.configPath ?? 'Manual definition'}
+                    </Code>
+                  </div>
+                </button>
+                <div className="flex items-center justify-between gap-inline">
+                  <Text size="xs" className="text-foreground-neutral-muted">
+                    Updated <RelativeTime value={definition.updatedAt} />
                   </Text>
-                  <Code className="break-words text-foreground-neutral-muted">
-                    {definition.configPath ?? 'Manual definition'}
-                  </Code>
+                  {definition.manualTrigger ? (
+                    <Button size="sm" isLoading={isRunning} onClick={() => onRun(definition)}>
+                      Run
+                    </Button>
+                  ) : null}
                 </div>
-              </button>
-              <div className="flex items-center justify-between gap-inline">
-                <Text size="xs" className="text-foreground-neutral-muted">
-                  Updated <RelativeTime value={definition.updatedAt} />
-                </Text>
-                {definition.manualTrigger ? (
-                  <Button size="sm" isLoading={isRunning} onClick={() => onRun(definition)}>
-                    Run
-                  </Button>
+                {runErrorMessage ? (
+                  <Text size="xs" className="text-tag-error-text">
+                    {runErrorMessage}
+                  </Text>
                 ) : null}
               </div>
-              {runErrorMessage ? (
-                <Text size="xs" className="text-tag-error-text">
-                  {runErrorMessage}
-                </Text>
-              ) : null}
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      </Panel>
 
       {isFetchNextPageError ? (
         <Callout role="alert" type="error">

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -171,10 +171,10 @@ function WorkflowDefinitionsList({
 }) {
   if (isPending) {
     return (
-      <div className="flex flex-col gap-inline">
-        <Skeleton className="h-40 w-full" />
-        <Skeleton className="h-40 w-full" />
-        <Skeleton className="h-40 w-full" />
+      <div className="flex flex-col divide-y divide-border-neutral-base overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+        <Skeleton className="h-44 w-full rounded-none" />
+        <Skeleton className="h-44 w-full rounded-none" />
+        <Skeleton className="h-44 w-full rounded-none" />
       </div>
     );
   }
@@ -186,6 +186,7 @@ function WorkflowDefinitionsList({
         description="Definitions could not be loaded. Source metadata remains visible."
         onRetry={onRetry}
         retryLabel="Retry loading workflows"
+        variant="panel"
       />
     );
   }
@@ -356,7 +357,7 @@ function WorkflowEmptyState({sync}: {sync: DefinitionSyncSummary | null}) {
             ? 'No workflow definitions found.'
             : 'Workflow sync has not reported yet.';
 
-  return <EmptyState icon="flowChart" title="No workflows" description={message} />;
+  return <EmptyState icon="flowChart" title="No workflows" description={message} variant="panel" />;
 }
 
 function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummary | null | undefined}) {

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -85,7 +85,7 @@ function MembersSection({
       {query.isPending ? <TableSkeleton rows={3} cols={3} /> : null}
 
       {query.isError && query.data === undefined ? (
-        <QueryLoadError query={query} subject="members" />
+        <QueryLoadError query={query} subject="members" variant="panel" />
       ) : null}
 
       {members.length > 0 ? (
@@ -230,7 +230,7 @@ function PendingInvitationsSection({
       {query.isPending ? <TableSkeleton rows={2} cols={3} /> : null}
 
       {query.isError && query.data === undefined ? (
-        <QueryLoadError query={query} subject="invitations" />
+        <QueryLoadError query={query} subject="invitations" variant="panel" />
       ) : null}
 
       {query.data !== undefined && invitations.length === 0 ? <EmptyInvitations /> : null}
@@ -458,16 +458,20 @@ function EmptyInvitations() {
       icon="mailLine"
       title="No pending invitations."
       description="Invite someone above to grow your workspace."
+      variant="panel"
     />
   );
 }
 
 function TableSkeleton({rows, cols}: {rows: number; cols: number}) {
   return (
-    <div className="flex flex-col gap-cluster">
+    <div className="flex flex-col overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
       {Array.from({length: rows}).map((_, rowIdx) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder rows
-        <div key={rowIdx} className="grid grid-cols-3 gap-group">
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder rows
+          key={rowIdx}
+          className="grid min-h-44 grid-cols-3 gap-group border-b border-border-neutral-base px-row py-row last:border-b-0"
+        >
           {Array.from({length: cols}).map((__, colIdx) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder cells
             <Skeleton key={colIdx} className="h-20" />

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -82,10 +82,12 @@ function MembersSection({
         </Text>
       </div>
 
-      {query.isPending ? <TableSkeleton rows={3} cols={3} /> : null}
+      {query.isPending ? <TableSkeleton rows={3} cols={3} label="Loading members" /> : null}
 
       {query.isError && query.data === undefined ? (
-        <QueryLoadError query={query} subject="members" variant="panel" />
+        <Panel>
+          <QueryLoadError query={query} subject="members" variant="panel" />
+        </Panel>
       ) : null}
 
       {members.length > 0 ? (
@@ -227,13 +229,19 @@ function PendingInvitationsSection({
         />
       </div>
 
-      {query.isPending ? <TableSkeleton rows={2} cols={3} /> : null}
+      {query.isPending ? <TableSkeleton rows={2} cols={3} label="Loading invitations" /> : null}
 
       {query.isError && query.data === undefined ? (
-        <QueryLoadError query={query} subject="invitations" variant="panel" />
+        <Panel>
+          <QueryLoadError query={query} subject="invitations" variant="panel" />
+        </Panel>
       ) : null}
 
-      {query.data !== undefined && invitations.length === 0 ? <EmptyInvitations /> : null}
+      {query.data !== undefined && invitations.length === 0 ? (
+        <Panel>
+          <EmptyInvitations />
+        </Panel>
+      ) : null}
 
       {invitations.length > 0 ? (
         <Panel>
@@ -463,14 +471,14 @@ function EmptyInvitations() {
   );
 }
 
-function TableSkeleton({rows, cols}: {rows: number; cols: number}) {
+function TableSkeleton({rows, cols, label}: {rows: number; cols: number; label: string}) {
   return (
-    <div className="flex flex-col overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+    <Panel role="status" aria-label={label} className="divide-y">
       {Array.from({length: rows}).map((_, rowIdx) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder rows
           key={rowIdx}
-          className="grid min-h-44 grid-cols-3 gap-group border-b border-border-neutral-base px-row py-row last:border-b-0"
+          className="grid min-h-44 grid-cols-3 gap-group px-row py-row"
         >
           {Array.from({length: cols}).map((__, colIdx) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder cells
@@ -478,6 +486,6 @@ function TableSkeleton({rows, cols}: {rows: number; cols: number}) {
           ))}
         </div>
       ))}
-    </div>
+    </Panel>
   );
 }

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.stories.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.stories.tsx
@@ -74,3 +74,17 @@ export const Compact: Story = {
     variant: 'compact',
   },
 };
+
+export const Panel: Story = {
+  render: (args) => (
+    <div className="w-640 rounded-8 border border-border-neutral-base bg-background-neutral-base">
+      <EmptyState {...args} />
+    </div>
+  ),
+  args: {
+    icon: 'inboxLine',
+    title: 'No runs yet',
+    description: 'Runs from this project will appear here once one is launched.',
+    variant: 'panel',
+  },
+};

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.test.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.test.tsx
@@ -10,8 +10,28 @@ describe('EmptyState', () => {
     const state = container.querySelector('[data-testid="empty-state"]');
 
     expect(state?.getAttribute('data-variant')).toBe('panel');
-    expect(state?.classList.contains('min-h-120')).toBe(true);
-    expect(state?.classList.contains('w-full')).toBe(true);
-    expect(state?.classList.contains('p-panel')).toBe(true);
+    for (const className of [
+      'min-h-120',
+      'w-full',
+      'flex-1',
+      'flex-col',
+      'items-center',
+      'justify-center',
+      'gap-12',
+      'p-panel',
+    ]) {
+      expect(state?.classList.contains(className)).toBe(true);
+    }
+    expect(state?.querySelector('.space-y-4')).not.toBeNull();
+  });
+
+  test('keeps the default layout when no variant is provided', () => {
+    const {container} = render(<EmptyState title="No runs yet" data-testid="empty-state" />);
+
+    const state = container.querySelector('[data-testid="empty-state"]');
+
+    expect(state?.getAttribute('data-variant')).toBe('default');
+    expect(state?.classList.contains('min-h-120')).toBe(false);
+    expect(state?.classList.contains('p-panel')).toBe(false);
   });
 });

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.test.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.test.tsx
@@ -1,0 +1,17 @@
+import {render} from '@testing-library/react';
+import {EmptyState} from './empty-state.js';
+
+describe('EmptyState', () => {
+  test('fills a panel body when using the panel variant', () => {
+    const {container} = render(
+      <EmptyState variant="panel" title="No runs yet" data-testid="empty-state" />,
+    );
+
+    const state = container.querySelector('[data-testid="empty-state"]');
+
+    expect(state?.getAttribute('data-variant')).toBe('panel');
+    expect(state?.classList.contains('min-h-120')).toBe(true);
+    expect(state?.classList.contains('w-full')).toBe(true);
+    expect(state?.classList.contains('p-panel')).toBe(true);
+  });
+});

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.tsx
@@ -1,6 +1,7 @@
 import type {ComponentProps, ReactNode} from 'react';
 import {cn} from '#utils/cn.js';
 import {Icon, type IconName} from '../icon/index.js';
+import {PanelEmpty} from '../panel/index.js';
 import {Text} from '../typography/index.js';
 
 export type EmptyStateVariant = 'default' | 'compact' | 'panel';
@@ -31,7 +32,7 @@ export function EmptyState({
     variant === 'compact'
       ? 'flex flex-col items-center justify-center gap-10'
       : variant === 'panel'
-        ? 'flex min-h-120 w-full flex-1 flex-col items-center justify-center gap-12 p-panel'
+        ? 'w-full flex-1 flex-col gap-12'
         : 'flex flex-col items-center justify-center gap-12 py-48';
 
   const iconContainerClasses =
@@ -39,8 +40,10 @@ export function EmptyState({
       ? 'flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8'
       : 'flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong';
 
+  const EmptyStateContainer = variant === 'panel' ? PanelEmpty : 'div';
+
   return (
-    <div
+    <EmptyStateContainer
       data-slot="empty-state"
       data-variant={variant}
       className={cn(containerClasses, className)}
@@ -57,7 +60,7 @@ export function EmptyState({
           )}
         />
       </div>
-      <div className={cn('text-center', variant === 'default' && 'space-y-4')}>
+      <div className={cn('text-center', variant !== 'compact' && 'space-y-4')}>
         {title ? (
           <Text
             size="sm"
@@ -77,6 +80,6 @@ export function EmptyState({
         ) : null}
       </div>
       {action ? <div>{action}</div> : null}
-    </div>
+    </EmptyStateContainer>
   );
 }

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.tsx
@@ -3,6 +3,8 @@ import {cn} from '#utils/cn.js';
 import {Icon, type IconName} from '../icon/index.js';
 import {Text} from '../typography/index.js';
 
+export type EmptyStateVariant = 'default' | 'compact' | 'panel';
+
 export interface EmptyStateProps extends ComponentProps<'div'> {
   icon?: IconName;
   /** Tints the icon only: neutral for "no content", error for a failed load. */
@@ -11,7 +13,8 @@ export interface EmptyStateProps extends ComponentProps<'div'> {
   description?: ReactNode;
   /** Single primary action (a Button/Link) rendered below the text. */
   action?: ReactNode;
-  variant?: 'default' | 'compact';
+  /** Fills the body of a bordered data-region panel. */
+  variant?: EmptyStateVariant;
 }
 
 export function EmptyState({
@@ -27,7 +30,9 @@ export function EmptyState({
   const containerClasses =
     variant === 'compact'
       ? 'flex flex-col items-center justify-center gap-10'
-      : 'flex flex-col items-center justify-center gap-12 py-48';
+      : variant === 'panel'
+        ? 'flex min-h-120 w-full flex-1 flex-col items-center justify-center gap-12 p-panel'
+        : 'flex flex-col items-center justify-center gap-12 py-48';
 
   const iconContainerClasses =
     variant === 'compact'
@@ -35,7 +40,12 @@ export function EmptyState({
       : 'flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong';
 
   return (
-    <div className={cn(containerClasses, className)} {...props}>
+    <div
+      data-slot="empty-state"
+      data-variant={variant}
+      className={cn(containerClasses, className)}
+      {...props}
+    >
       <div className={iconContainerClasses}>
         <Icon
           name={icon}

--- a/libs/shared/react/ui/src/components/load-error-state/load-error-state.stories.tsx
+++ b/libs/shared/react/ui/src/components/load-error-state/load-error-state.stories.tsx
@@ -38,3 +38,17 @@ export const Retrying: Story = {
     retryLabel: 'Retry loading members',
   },
 };
+
+export const Panel: Story = {
+  render: (args) => (
+    <div className="w-640 rounded-8 border border-border-neutral-base bg-background-neutral-base">
+      <LoadErrorState {...args} />
+    </div>
+  ),
+  args: {
+    title: "Couldn't load runs",
+    description: 'Something went wrong. Check your connection and try again.',
+    retryLabel: 'Retry loading runs',
+    variant: 'panel',
+  },
+};

--- a/libs/shared/react/ui/src/components/load-error-state/load-error-state.test.tsx
+++ b/libs/shared/react/ui/src/components/load-error-state/load-error-state.test.tsx
@@ -1,0 +1,15 @@
+import {render} from '@testing-library/react';
+import {LoadErrorState} from './load-error-state.js';
+
+describe('LoadErrorState', () => {
+  test('passes the panel variant to its empty-state body', () => {
+    const {container} = render(
+      <LoadErrorState variant="panel" title="Could not load runs" onRetry={() => undefined} />,
+    );
+
+    const state = container.querySelector('[data-slot="empty-state"]');
+
+    expect(state?.getAttribute('data-variant')).toBe('panel');
+    expect(state?.classList.contains('min-h-120')).toBe(true);
+  });
+});

--- a/libs/shared/react/ui/src/components/load-error-state/load-error-state.tsx
+++ b/libs/shared/react/ui/src/components/load-error-state/load-error-state.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 import {Button} from '../button/index.js';
-import {EmptyState} from '../empty-state/index.js';
+import {EmptyState, type EmptyStateVariant} from '../empty-state/index.js';
 import type {IconName} from '../icon/index.js';
 
 export interface LoadErrorStateProps {
@@ -13,7 +13,7 @@ export interface LoadErrorStateProps {
   retrying?: boolean;
   /** Accessible label for the Retry button, e.g. "Retry loading integrations". */
   retryLabel?: string;
-  variant?: 'default' | 'compact';
+  variant?: EmptyStateVariant;
 }
 
 /**

--- a/libs/shared/react/ui/src/components/panel/panel.test.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.test.tsx
@@ -31,6 +31,7 @@ describe('Panel', () => {
     expect(panel?.classList.contains('rounded-8')).toBe(true);
     expect(panel?.classList.contains('border-border-neutral-base')).toBe(true);
     expect(header?.getAttribute('data-variant')).toBe('strip');
+    expect(header?.classList.contains('bg-background-neutral-base')).toBe(true);
     expect(rows).toHaveLength(2);
     expect(rows[0]?.classList.contains('hover:bg-background-neutral-hover')).toBe(true);
   });

--- a/libs/shared/react/ui/src/components/panel/panel.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.tsx
@@ -33,7 +33,7 @@ export function PanelHeader({className, variant = 'strip', ...props}: PanelHeade
       className={cn(
         'flex min-w-0 items-center justify-between gap-group',
         variant === 'strip'
-          ? 'min-h-48 border-b border-border-neutral-base bg-background-subtle-base px-row py-row'
+          ? 'min-h-48 border-b border-border-neutral-base bg-background-neutral-base px-row py-row'
           : 'bg-background-neutral-base p-panel',
         className,
       )}


### PR DESCRIPTION
Add a panel layout variant to the shared EmptyState and LoadErrorState primitives, then migrate panel-backed client regions to render their empty, error, and loading states within the panel body. This keeps the data-region footprint stable between zero rows, loading, errors, and populated content.

Closes ENG-1578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render empty, error, and loading states inside panel bodies so data regions keep a stable footprint across states and populated content. Previously these states floated on the page; now they render within each Panel with aligned skeleton rows, and the Panel header strip background passes surface validation (ENG-1578).

- Adds `variant="panel"` to `EmptyState` and `LoadErrorState` in `@shipfox/react-ui`; introduces `PanelEmpty`; updates stories/tests.
- `QueryLoadError` in `@shipfox/client-ui` now accepts and forwards `variant`; adds test.
- Centralizes the provider-grid skeleton and reuses it in agent provider pages and onboarding.
- Migrates data regions to panel-backed states and skeletons: workflows (definitions, runs list, graph/steps empties), triggers events, projects hub, workspace members/invitations, runners tokens, integrations (installed and catalog), and secrets/variables.
- Fixes `PanelHeader` strip background to satisfy surface validation; updates panel/table tests.
- Migration: when rendering states inside a panel, pass `variant="panel"` to `EmptyState`, `LoadErrorState`, or `QueryLoadError`; wrap standalone empties/errors/no-matches in a `Panel` and remove extra padding wrappers.

<sup>Written for commit b7c27e41660d2c23a865c8bc08f932c171c7339d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

