### PR TITLE
Allow shell steps to reuse persisted checkout credentials

### DIFF
--- a/.changeset/persisted-checkout-shell-steps.md
+++ b/.changeset/persisted-checkout-shell-steps.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/runner-execution": patch
+"@shipfox/runner-orchestration": patch
+---
+
+Forward the ambient Git config a persisted checkout writes to shell run steps, so a later `run` step commits and pushes with the checkout author identity and repository-scoped credential.

--- a/.changeset/persisted-checkout-shell-steps.md
+++ b/.changeset/persisted-checkout-shell-steps.md
@@ -3,4 +3,4 @@
 "@shipfox/runner-orchestration": patch
 ---
 
-Forward the ambient Git config a persisted checkout writes to shell run steps, so a later `run` step commits and pushes with the checkout author identity and repository-scoped credential.
+Forward the ambient Git config a persisted checkout writes to shell run steps. A later `run` step then commits and pushes with the checkout author identity and repository-scoped credential.

--- a/libs/runner/execution/src/core/checkout-execution.ts
+++ b/libs/runner/execution/src/core/checkout-execution.ts
@@ -2,6 +2,7 @@ import type {CheckoutTokenResponseDto, StepErrorReasonDto} from '@shipfox/api-wo
 import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError, requestCheckoutToken} from '@shipfox/runner-protocol';
 import {
+  ambientGitCredentialSecrets,
   type CheckoutCommandStartMetadata,
   CheckoutError,
   type CheckoutFailureKind,
@@ -72,6 +73,7 @@ export async function checkoutRepositoryAt(params: {
 }): Promise<
   CheckoutPhaseResult<{
     ambientGitConfigPath?: string | undefined;
+    ambientGitConfigSecrets?: string[] | undefined;
     checkout: NonNullable<StepResult['checkout']>;
   }>
 > {
@@ -97,7 +99,7 @@ export async function checkoutRepositoryAt(params: {
       onOutput: checkoutOutput(log),
     });
     log?.writeGroup({name: 'Checkout complete', lines: [`Checked out commit: ${commit}`]});
-    const ambientGitConfigPath = await persistAmbientGitCredential({
+    const ambientGitConfig = await persistAmbientGitCredential({
       gitConfigPath,
       checkout,
       log,
@@ -112,7 +114,12 @@ export async function checkoutRepositoryAt(params: {
           commit,
           path: destination,
         },
-        ...(ambientGitConfigPath ? {ambientGitConfigPath} : {}),
+        ...(ambientGitConfig
+          ? {
+              ambientGitConfigPath: ambientGitConfig.path,
+              ambientGitConfigSecrets: ambientGitConfig.secrets,
+            }
+          : {}),
       },
     };
   } catch (error) {
@@ -142,24 +149,25 @@ async function persistAmbientGitCredential(params: {
   checkout: CheckoutTokenResponseDto;
   log?: CheckoutLogSink | undefined;
   scope: CheckoutFailureScope;
-}): Promise<string | undefined> {
+}): Promise<{path: string; secrets: string[]} | undefined> {
   const {gitConfigPath, checkout, log, scope} = params;
-  if (!checkout.auth?.persist || checkout.auth.carry !== 'header') return undefined;
+  const auth = checkout.auth;
+  if (!auth?.persist || auth.carry !== 'header') return undefined;
 
   try {
     await writeAmbientGitCredential({
       configPath: gitConfigPath,
       repositoryUrl: checkout.repository_url,
-      auth: checkout.auth,
+      auth,
       ...(checkout.git_author ? {gitAuthor: checkout.git_author} : {}),
     });
-    return gitConfigPath;
+    return {path: gitConfigPath, secrets: ambientGitCredentialSecrets(auth)};
   } catch (error) {
     writeWarning(
       log,
       'Repository access was not persisted',
       [
-        `The checkout succeeded, but agent steps will run without ambient git authentication. Details: ${messageOf(error)}`,
+        `The checkout succeeded, but agent and run steps will run without ambient git authentication. Details: ${messageOf(error)}`,
         'Git commands in later steps may need their own credentials.',
       ],
       scope,

--- a/libs/runner/execution/src/core/checkout-step.ts
+++ b/libs/runner/execution/src/core/checkout-step.ts
@@ -33,6 +33,7 @@ export type CheckoutDestinations = Map<string, CheckoutDestination>;
 export interface CheckoutStepExecution {
   result: StepResult;
   ambientGitConfigPath?: string | undefined;
+  ambientGitConfigSecrets?: string[] | undefined;
 }
 
 /**
@@ -135,6 +136,9 @@ export async function executeCheckoutStep(params: {
       result: {success: true, error: null, exit_code: 0, checkout: result},
       ...(checkout.value.ambientGitConfigPath
         ? {ambientGitConfigPath: checkout.value.ambientGitConfigPath}
+        : {}),
+      ...(checkout.value.ambientGitConfigSecrets
+        ? {ambientGitConfigSecrets: checkout.value.ambientGitConfigSecrets}
         : {}),
     };
   } catch (error) {

--- a/libs/runner/execution/src/core/run-step.realgit.test.ts
+++ b/libs/runner/execution/src/core/run-step.realgit.test.ts
@@ -1,5 +1,6 @@
 import {execFile} from 'node:child_process';
 import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {createServer, type Server} from 'node:http';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {promisify} from 'node:util';
@@ -27,6 +28,7 @@ const AUTH: CheckoutTokenAuthDto = {
   persist: true,
 };
 const EXPECTED_HEADER = `Authorization: Basic ${Buffer.from(`${AUTH.username}:${AUTH.token}`).toString('base64')}`;
+const EXPECTED_AUTHORIZATION = EXPECTED_HEADER.slice('Authorization: '.length);
 
 let workdir: string;
 let repository: string;
@@ -39,6 +41,30 @@ async function git(args: string[], dir: string): Promise<void> {
 
 function readCapture(): Promise<string> {
   return readFile(capturePath, 'utf8');
+}
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Test server did not expose a TCP address');
+  }
+  return address.port;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function uploadPackAdvertisement(): string {
+  const payload = `${'0'.repeat(40)} HEAD\0symref=HEAD:refs/heads/main\n`;
+  const packet = `${(Buffer.byteLength(payload) + 4).toString(16).padStart(4, '0')}${payload}`;
+  return `001e# service=git-upload-pack\n0000${packet}0000`;
 }
 
 beforeEach(async () => {
@@ -104,6 +130,46 @@ describe('executeRunStep with a persisted checkout config (real git)', () => {
     const repositoryConfig = await readFile(join(repository, '.git', 'config'), 'utf8');
     expect(repositoryConfig).not.toContain(AUTH.token);
     expect(repositoryConfig).not.toContain('extraHeader');
+  });
+
+  it('does not let a run step mutate the shared ambient config', async () => {
+    const before = await readFile(gitConfigPath, 'utf8');
+    const step = buildRunStep('git config --global user.email "mutated@example.com"');
+
+    const result = await executeRunStep(step, {cwd: repository, gitConfigGlobal: gitConfigPath});
+
+    expect(result.success).toBe(true);
+    expect(await readFile(gitConfigPath, 'utf8')).toBe(before);
+  });
+
+  it('sends the persisted credential through a real git HTTP request', async () => {
+    let authorization: string | undefined;
+    const server = createServer((request, response) => {
+      authorization = request.headers.authorization;
+      response.writeHead(200, {'content-type': 'application/x-git-upload-pack-advertisement'});
+      response.end(uploadPackAdvertisement());
+    });
+    const port = await listen(server);
+    const repositoryUrl = `http://127.0.0.1:${port}/repo.git`;
+
+    try {
+      await writeAmbientGitCredential({
+        configPath: gitConfigPath,
+        repositoryUrl,
+        auth: AUTH,
+        gitAuthor: GIT_AUTHOR,
+      });
+      const step = buildRunStep(`git ls-remote "${repositoryUrl}"`);
+      const result = await executeRunStep(step, {
+        cwd: repository,
+        gitConfigGlobal: gitConfigPath,
+      });
+
+      expect(result.success).toBe(true);
+      expect(authorization).toBe(EXPECTED_AUTHORIZATION);
+    } finally {
+      await close(server);
+    }
   });
 
   it('leaves git without the checkout identity when credentials were not persisted', async () => {

--- a/libs/runner/execution/src/core/run-step.realgit.test.ts
+++ b/libs/runner/execution/src/core/run-step.realgit.test.ts
@@ -45,8 +45,12 @@ function readCapture(): Promise<string> {
 
 async function listen(server: Server): Promise<number> {
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => resolve());
+    const onError = (error: Error): void => reject(error);
+    server.once('error', onError);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', onError);
+      resolve();
+    });
   });
   const address = server.address();
   if (address === null || typeof address === 'string') {

--- a/libs/runner/execution/src/core/run-step.realgit.test.ts
+++ b/libs/runner/execution/src/core/run-step.realgit.test.ts
@@ -1,0 +1,139 @@
+import {execFile} from 'node:child_process';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {promisify} from 'node:util';
+import type {CheckoutTokenAuthDto, StepDto} from '@shipfox/api-workflows-dto';
+import {writeAmbientGitCredential} from '@shipfox/runner-workspace';
+import {executeRunStep} from '#core/run-step.js';
+
+// Exercises the persisted-checkout contract for shell steps against real git: the ambient
+// config a persisted checkout writes must reach `git` in the step, so a workflow can commit
+// and push without authoring its own identity or credential. A mocked spawn would accept an
+// environment entry git never reads.
+const execFileAsync = promisify(execFile);
+const REPOSITORY_URL = 'https://github.com/acme/repo.git';
+const GIT_AUTHOR = {
+  name: 'shipfox-ai[bot]',
+  email: '12345+shipfox-ai[bot]@users.noreply.github.com',
+};
+const AUTH: CheckoutTokenAuthDto = {
+  kind: 'basic',
+  username: 'x-access-token',
+  token: 'ghs-persisted-token',
+  expires_at: '2026-01-01T00:00:00.000Z',
+  carry: 'header',
+  host: 'github.com',
+  persist: true,
+};
+const EXPECTED_HEADER = `Authorization: Basic ${Buffer.from(`${AUTH.username}:${AUTH.token}`).toString('base64')}`;
+
+let workdir: string;
+let repository: string;
+let gitConfigPath: string;
+let capturePath: string;
+
+async function git(args: string[], dir: string): Promise<void> {
+  await execFileAsync('git', args, {cwd: dir});
+}
+
+function readCapture(): Promise<string> {
+  return readFile(capturePath, 'utf8');
+}
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), 'shipfox-run-step-git-'));
+  repository = join(workdir, 'repo');
+  gitConfigPath = join(workdir, 'cred', 'git-cred.config');
+  capturePath = join(workdir, 'capture.txt');
+  await mkdir(repository, {recursive: true});
+  await git(['init', '-b', 'main'], repository);
+  // The ambient config includes the host's global config, so a host commit.gpgsign=true
+  // would fail the commit for a signing key this throwaway repository does not have.
+  await git(['config', 'commit.gpgsign', 'false'], repository);
+  await writeFile(join(repository, 'README.md'), '# hello\n');
+
+  await writeAmbientGitCredential({
+    configPath: gitConfigPath,
+    repositoryUrl: REPOSITORY_URL,
+    auth: AUTH,
+    gitAuthor: GIT_AUTHOR,
+  });
+});
+
+afterEach(async () => {
+  await rm(workdir, {recursive: true, force: true});
+});
+
+describe('executeRunStep with a persisted checkout config (real git)', () => {
+  it('commits with the checkout author identity without workflow-authored git config', async () => {
+    const step = buildRunStep(
+      [
+        'git add README.md',
+        'git commit -m "Reproduce checkout configuration"',
+        `git log -1 --pretty="%an <%ae>" > "${capturePath}"`,
+      ].join('\n'),
+    );
+
+    const result = await executeRunStep(step, {cwd: repository, gitConfigGlobal: gitConfigPath});
+
+    expect(result.error).toBeNull();
+    expect(result.success).toBe(true);
+    expect((await readCapture()).trim()).toBe(`${GIT_AUTHOR.name} <${GIT_AUTHOR.email}>`);
+  });
+
+  it('exposes the repository-scoped authentication header to git in the step', async () => {
+    const step = buildRunStep(
+      `git config --get-urlmatch http.extraHeader ${REPOSITORY_URL} > "${capturePath}"`,
+    );
+
+    const result = await executeRunStep(step, {cwd: repository, gitConfigGlobal: gitConfigPath});
+
+    expect(result.success).toBe(true);
+    expect((await readCapture()).trim()).toBe(EXPECTED_HEADER);
+  });
+
+  it('keeps the credential out of the repository config', async () => {
+    const step = buildRunStep(
+      ['git add README.md', 'git commit -m "Commit with ambient credentials"'].join('\n'),
+    );
+
+    const result = await executeRunStep(step, {cwd: repository, gitConfigGlobal: gitConfigPath});
+
+    expect(result.success).toBe(true);
+    const repositoryConfig = await readFile(join(repository, '.git', 'config'), 'utf8');
+    expect(repositoryConfig).not.toContain(AUTH.token);
+    expect(repositoryConfig).not.toContain('extraHeader');
+  });
+
+  it('leaves git without the checkout identity when credentials were not persisted', async () => {
+    const step = buildRunStep(
+      `git config --get user.email > "${capturePath}" || echo "unset" > "${capturePath}"`,
+    );
+
+    const result = await executeRunStep(step, {cwd: repository});
+
+    expect(result.success).toBe(true);
+    expect((await readCapture()).trim()).not.toBe(GIT_AUTHOR.email);
+  });
+});
+
+function buildRunStep(run: string): StepDto {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    job_execution_id: '00000000-0000-0000-0000-000000000003',
+    key: 'test-step',
+    name: 'test-step',
+    source_location: null,
+    status: 'running',
+    status_reason: null,
+    type: 'run',
+    config: {run},
+    error: null,
+    evaluation_trace: null,
+    position: 0,
+    current_attempt: 1,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -578,6 +578,23 @@ describe('executeRunStep', () => {
     expect(stderr).not.toContain(hex);
   });
 
+  it('redacts persisted Git credential forms from a config dump', async () => {
+    const token = 'ghs-persisted-token-for-redaction';
+    const credential = Buffer.from(`x-access-token:${token}`).toString('base64');
+    const header = `Authorization: Basic ${credential}`;
+    const step = buildStep({config: {run: `printf '%s\\n' ${JSON.stringify(header)}`}});
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as never);
+
+    const result = await executeRunStep(step, {secretValues: [token, credential]});
+
+    const stdout = stdoutWrite.mock.calls.map((call) => String(call[0])).join('');
+    expect(result.success).toBe(true);
+    expect(stdout).toContain('Authorization: Basic ***');
+    expect(stdout).not.toContain(header);
+    expect(stdout).not.toContain(token);
+    expect(stdout).not.toContain(credential);
+  });
+
   it('redacts env and command secret output from the runner stdout tee', async () => {
     const secret = 'runtime-secret-e2e';
     const step = buildStep({

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -202,6 +202,42 @@ describe('executeRunStep', () => {
     expect(JSON.parse(output.text())).toEqual({SHIPFOX_WORKSPACE: '/runner/workspace'});
   });
 
+  it('exposes the ambient git config as GIT_CONFIG_GLOBAL and overrides user env', async () => {
+    const step = buildStep({
+      config: {
+        run: nodeEnvDumpCommand(['GIT_CONFIG_GLOBAL']),
+        env: {GIT_CONFIG_GLOBAL: '/tmp/user.gitconfig'},
+      },
+    });
+
+    const output = collectOutput();
+    const result = await executeRunStep(step, {
+      gitConfigGlobal: '/runner-cred/job-1/git-cred.config',
+      onOutput: output.sink,
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(output.text())).toEqual({
+      GIT_CONFIG_GLOBAL: '/runner-cred/job-1/git-cred.config',
+    });
+  });
+
+  it('leaves GIT_CONFIG_GLOBAL unset when the checkout persisted no credentials', async () => {
+    const previous = process.env.GIT_CONFIG_GLOBAL;
+    delete process.env.GIT_CONFIG_GLOBAL;
+    try {
+      const step = buildStep({config: {run: nodeEnvDumpCommand(['GIT_CONFIG_GLOBAL'])}});
+      const output = collectOutput();
+
+      const result = await executeRunStep(step, {onOutput: output.sink});
+
+      expect(result.success).toBe(true);
+      expect(JSON.parse(output.text())).toEqual({GIT_CONFIG_GLOBAL: null});
+    } finally {
+      if (previous !== undefined) process.env.GIT_CONFIG_GLOBAL = previous;
+    }
+  });
+
   it('collects SHIPFOX_STEP_SUMMARY as a default annotation', async () => {
     const step = buildStep({
       config: {run: 'echo "### Summary" >> "$SHIPFOX_STEP_SUMMARY"'},

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -49,6 +49,12 @@ interface RunStepOptions {
   signal?: AbortSignal;
   cwd?: string;
   workspace?: string;
+  /**
+   * Path to the ambient Git config a persisted checkout wrote. Exported as
+   * `GIT_CONFIG_GLOBAL` so `git` in the step sees the checkout author identity and the
+   * repository-scoped credential, matching what agent steps already get.
+   */
+  gitConfigGlobal?: string;
   secretEnv?: Readonly<Record<string, string>>;
   secretValues?: readonly string[];
   onOutput?: OutputSink;
@@ -139,6 +145,7 @@ function spawnAndCapture(
         ...((options.workspace ?? options.cwd)
           ? {SHIPFOX_WORKSPACE: options.workspace ?? options.cwd}
           : {}),
+        ...(options.gitConfigGlobal ? {GIT_CONFIG_GLOBAL: options.gitConfigGlobal} : {}),
         SHIPFOX_OUTPUT: outputPath,
         ...(annotationSpool?.env ?? {}),
       },

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -1,7 +1,7 @@
 import {spawn} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
 import {accessSync, constants, statSync} from 'node:fs';
-import {open, unlink, writeFile} from 'node:fs/promises';
+import {chmod, copyFile, open, unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
 import {TextDecoder} from 'node:util';
@@ -92,6 +92,7 @@ async function runShellCommand(
   const metadata = commandStartMetadata({command, scriptPath, cwd: options.cwd});
   notifyCommandStart(options.onCommandStart, cloneCommandStartMetadata(metadata));
   let annotationSpool: AnnotationSpool | undefined;
+  let isolatedGitConfigGlobal: string | undefined;
 
   try {
     await writeFile(scriptPath, command, {mode: 0o700});
@@ -105,7 +106,16 @@ async function runShellCommand(
       );
     }
 
-    const result = await spawnAndCapture(metadata, stepEnv, outputPath, annotationSpool, options);
+    isolatedGitConfigGlobal = await isolateGitConfigGlobal(options.gitConfigGlobal);
+    const result = await spawnAndCapture(
+      metadata,
+      stepEnv,
+      outputPath,
+      annotationSpool,
+      isolatedGitConfigGlobal === undefined
+        ? options
+        : {...options, gitConfigGlobal: isolatedGitConfigGlobal},
+    );
     const outputResult = await finalizeStepOutput(result, outputPath);
     if (!annotationSpool) return outputResult;
 
@@ -113,10 +123,33 @@ async function runShellCommand(
     if (annotations.length === 0) return outputResult;
     return {...outputResult, annotations};
   } finally {
+    if (isolatedGitConfigGlobal !== undefined) {
+      await unlink(isolatedGitConfigGlobal).catch(() => undefined);
+    }
     if (annotationSpool) await disposeAnnotationSpool(annotationSpool);
     await unlink(scriptPath).catch(() => undefined);
     await unlink(outputPath).catch(() => undefined);
   }
+}
+
+async function isolateGitConfigGlobal(configPath: string | undefined): Promise<string | undefined> {
+  if (configPath === undefined) return undefined;
+  const isolatedPath = join(tmpdir(), `shipfox-gitconfig-${randomUUID()}`);
+  try {
+    await copyFile(configPath, isolatedPath);
+    await chmod(isolatedPath, 0o600);
+    return isolatedPath;
+  } catch (error) {
+    await unlink(isolatedPath).catch(() => undefined);
+    if (isFileSystemError(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+}
+
+function isFileSystemError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
 }
 
 function spawnAndCapture(

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -233,6 +233,7 @@ describe('executeSetupStep', () => {
         },
       },
       ambientGitConfigPath: GIT_CONFIG_PATH,
+      ambientGitConfigSecrets: ['t'],
     });
   });
 
@@ -298,7 +299,7 @@ describe('executeSetupStep', () => {
     expect(log.writeGroup).toHaveBeenCalledWith({
       name: 'Repository access was not persisted',
       lines: [
-        'The checkout succeeded, but agent steps will run without ambient git authentication. Details: disk denied',
+        'The checkout succeeded, but agent and run steps will run without ambient git authentication. Details: disk denied',
         'Git commands in later steps may need their own credentials.',
       ],
       source: 'stderr',
@@ -338,7 +339,7 @@ describe('executeSetupStep', () => {
       {
         name: 'Repository access was not persisted',
         lines: [
-          'The checkout succeeded, but agent steps will run without ambient git authentication. Details: disk denied',
+          'The checkout succeeded, but agent and run steps will run without ambient git authentication. Details: disk denied',
           'Git commands in later steps may need their own credentials.',
         ],
       },

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -27,6 +27,7 @@ export interface SetupJobContext {
 export interface SetupStepExecution {
   result: StepResult;
   ambientGitConfigPath?: string | undefined;
+  ambientGitConfigSecrets?: string[] | undefined;
 }
 
 // The synthetic "Set up job" step body. It owns per-job workspace preparation and the
@@ -78,6 +79,9 @@ export async function executeSetupStep(params: {
     result: {success: true, error: null, exit_code: 0, checkout: checkout.value.checkout},
     ...(checkout.value.ambientGitConfigPath
       ? {ambientGitConfigPath: checkout.value.ambientGitConfigPath}
+      : {}),
+    ...(checkout.value.ambientGitConfigSecrets
+      ? {ambientGitConfigSecrets: checkout.value.ambientGitConfigSecrets}
       : {}),
   };
 }
@@ -133,6 +137,7 @@ async function runCheckoutSetup(params: {
 }): Promise<
   CheckoutPhaseResult<{
     ambientGitConfigPath?: string | undefined;
+    ambientGitConfigSecrets?: string[] | undefined;
     checkout: NonNullable<StepResult['checkout']>;
   }>
 > {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1591,6 +1591,70 @@ describe('runJobSteps', () => {
     );
   });
 
+  it('passes the setup ambient git config path to run steps', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    executeSetupStepMock.mockResolvedValueOnce({
+      result: {success: true, error: null, exit_code: 0},
+      ambientGitConfigPath: GIT_CONFIG_PATH,
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.objectContaining({gitConfigGlobal: GIT_CONFIG_PATH}),
+    );
+  });
+
+  it('passes a checkout step ambient git config path to later run steps', async () => {
+    const setup = buildSetupStep();
+    const checkout = buildCheckoutStep({config: {checkout: {path: 'repo'}}});
+    const run = buildRunStep();
+    executeCheckoutStepMock.mockResolvedValueOnce({
+      result: {success: true, error: null, exit_code: 0},
+      ambientGitConfigPath: GIT_CONFIG_PATH,
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(checkout, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.objectContaining({gitConfigGlobal: GIT_CONFIG_PATH}),
+    );
+  });
+
+  it('omits the git config path from run steps when the checkout did not persist credentials', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.not.objectContaining({gitConfigGlobal: expect.anything()}),
+    );
+  });
+
   it('uses provider, model, and thinking from runtime config instead of stale step config', async () => {
     const setup = buildSetupStep();
     const agent = buildAgentStep({

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1613,6 +1613,31 @@ describe('runJobSteps', () => {
     );
   });
 
+  it('passes persisted checkout secrets to run steps for output redaction', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    executeSetupStepMock.mockResolvedValueOnce({
+      result: {success: true, error: null, exit_code: 0},
+      ambientGitConfigPath: GIT_CONFIG_PATH,
+      ambientGitConfigSecrets: ['checkout-token', 'basic-credential'],
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.objectContaining({
+        secretValues: expect.arrayContaining(['checkout-token', 'basic-credential']),
+      }),
+    );
+  });
+
   it('passes a checkout step ambient git config path to later run steps', async () => {
     const setup = buildSetupStep();
     const checkout = buildCheckoutStep({config: {checkout: {path: 'repo'}}});
@@ -1637,7 +1662,7 @@ describe('runJobSteps', () => {
     );
   });
 
-  it('omits the git config path from run steps when the checkout did not persist credentials', async () => {
+  it('omits the git config path from run steps when no prior step produced an ambient git config', async () => {
     const setup = buildSetupStep();
     const run = buildRunStep();
     requestNextStepMock

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1636,6 +1636,11 @@ describe('runJobSteps', () => {
         secretValues: expect.arrayContaining(['checkout-token', 'basic-credential']),
       }),
     );
+    expect(createStepLogStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secrets: expect.arrayContaining(['checkout-token', 'basic-credential']),
+      }),
+    );
   });
 
   it('passes a checkout step ambient git config path to later run steps', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -555,6 +555,7 @@ export async function executeStep(params: {
       signal,
       cwd: stepCwd,
       workspace: cwd,
+      ...(ambientGitConfigPath ? {gitConfigGlobal: ambientGitConfigPath} : {}),
       ...(runSecretMaterial?.secretEnv ? {secretEnv: runSecretMaterial.secretEnv} : {}),
       ...(runSecretMaterial?.secretValues ? {secretValues: runSecretMaterial.secretValues} : {}),
       onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -95,6 +95,7 @@ export async function runJobSteps(params: {
   let workspacePrepared = false;
   let logsPrepared = false;
   let ambientGitConfigPath: string | undefined;
+  let ambientGitConfigSecrets: string[] = [];
   const checkoutDestinations: CheckoutDestinations = new Map();
 
   // The most recent step's stream, kept until the next
@@ -140,6 +141,7 @@ export async function runJobSteps(params: {
         workspacePrepared,
         checkoutDestinations,
         ambientGitConfigPath,
+        ambientGitConfigSecrets,
         jobId,
         stepLabel,
         logsDir,
@@ -150,6 +152,11 @@ export async function runJobSteps(params: {
       activeStream = execution.stream;
       if (execution.preparedWorkspace) workspacePrepared = true;
       if (execution.ambientGitConfigPath) ambientGitConfigPath = execution.ambientGitConfigPath;
+      if (execution.ambientGitConfigSecrets) {
+        ambientGitConfigSecrets = [
+          ...new Set([...ambientGitConfigSecrets, ...execution.ambientGitConfigSecrets]),
+        ];
+      }
       if (execution.result.success && execution.result.checkout) {
         rememberCheckoutDestination(checkoutDestinations, execution.result.checkout);
       }
@@ -248,6 +255,7 @@ export interface StepExecution {
   /** True when a setup step succeeded, unlocking the run steps that follow it. */
   preparedWorkspace: boolean;
   ambientGitConfigPath?: string | undefined;
+  ambientGitConfigSecrets?: string[] | undefined;
 }
 
 // Runs one step and always yields a StepResult, never throws: a crash before a result
@@ -268,6 +276,7 @@ export async function executeStep(params: {
   workspacePrepared: boolean;
   checkoutDestinations?: CheckoutDestinations | undefined;
   ambientGitConfigPath?: string | undefined;
+  ambientGitConfigSecrets?: string[] | undefined;
   gitConfigPath: string;
   jobId: string;
   stepLabel: string;
@@ -287,6 +296,7 @@ export async function executeStep(params: {
     workspacePrepared,
     checkoutDestinations = new Map(),
     ambientGitConfigPath,
+    ambientGitConfigSecrets = [],
     gitConfigPath,
     jobId,
     stepLabel,
@@ -374,6 +384,9 @@ export async function executeStep(params: {
         logOutcome: setupStream ? undefined : 'abandoned',
         preparedWorkspace: setup.result.success,
         ...(setup.ambientGitConfigPath ? {ambientGitConfigPath: setup.ambientGitConfigPath} : {}),
+        ...(setup.ambientGitConfigSecrets
+          ? {ambientGitConfigSecrets: setup.ambientGitConfigSecrets}
+          : {}),
       };
     }
 
@@ -428,6 +441,9 @@ export async function executeStep(params: {
         preparedWorkspace: false,
         ...(checkout.ambientGitConfigPath
           ? {ambientGitConfigPath: checkout.ambientGitConfigPath}
+          : {}),
+        ...(checkout.ambientGitConfigSecrets
+          ? {ambientGitConfigSecrets: checkout.ambientGitConfigSecrets}
           : {}),
       };
     }
@@ -530,7 +546,15 @@ export async function executeStep(params: {
     // Log capture is best-effort: if the spool cannot be opened (e.g. a broken logs dir),
     // abandon capture and run the step without a stream rather than failing the step itself.
     let stepStream: StepLogStream | undefined;
-    const runSecrets = [...secrets, ...(runSecretMaterial?.secretValues ?? [])];
+    const runSecrets = [
+      ...secrets,
+      ...ambientGitConfigSecrets,
+      ...(runSecretMaterial?.secretValues ?? []),
+    ];
+    const runSecretValues = [
+      ...ambientGitConfigSecrets,
+      ...(runSecretMaterial?.secretValues ?? []),
+    ];
     const runSecretVariants = buildSecretVariants(runSecrets);
     crashSecretVariants = runSecretVariants;
     try {
@@ -557,7 +581,7 @@ export async function executeStep(params: {
       workspace: cwd,
       ...(ambientGitConfigPath ? {gitConfigGlobal: ambientGitConfigPath} : {}),
       ...(runSecretMaterial?.secretEnv ? {secretEnv: runSecretMaterial.secretEnv} : {}),
-      ...(runSecretMaterial?.secretValues ? {secretValues: runSecretMaterial.secretValues} : {}),
+      ...(runSecretValues.length > 0 ? {secretValues: runSecretValues} : {}),
       onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
       onOutput: (chunk, source) => stepStream?.write(chunk, source),
     });

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -441,7 +441,7 @@ describe('writeAmbientGitCredential', () => {
     expect(mode).toBe(0o600);
     expect(content).toContain('[http "https://github.com/acme/repo.git"]');
     expect(content).toContain('extraHeader = "Authorization: Bearer tok-123"');
-    expect(content).toContain('[http]\n\tfollowRedirects = false');
+    expect(content).not.toContain('[http]\n\tfollowRedirects = false');
   });
 
   it('accumulates credentials for multiple repositories in one config', async () => {

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -231,8 +231,6 @@ export function writeAmbientGitCredential(params: {
           ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
           ...userLines,
           ...repositoryLines,
-          '[http]',
-          '\tfollowRedirects = false',
           '',
         ];
         await writeFile(temporaryConfigPath, lines.join('\n'), {flag: 'wx', mode: 0o600});
@@ -258,6 +256,12 @@ export function writeAmbientGitCredential(params: {
     }
     await chmod(configPath, 0o600);
   });
+}
+
+/** Returns every persisted credential form that can appear in the ambient Git config. */
+export function ambientGitCredentialSecrets(auth: CheckoutTokenAuthDto): string[] {
+  if (auth.kind === 'bearer') return [auth.token];
+  return [auth.token, basicCredential(auth)];
 }
 
 async function withAmbientGitConfigLock<T>(
@@ -313,9 +317,7 @@ function isGitConfigKeyMissing(error: unknown): boolean {
 // not a substring of the base64 the header carries, so redacting only the token would
 // leak the base64; include it explicitly.
 function secretsOf(auth: CheckoutTokenAuthDto | undefined): string[] {
-  if (!auth) return [];
-  if (auth.kind === 'bearer') return [auth.token];
-  return [auth.token, basicCredential(auth)];
+  return auth === undefined ? [] : ambientGitCredentialSecrets(auth);
 }
 
 function classifyCheckoutError(

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  ambientGitCredentialSecrets,
   assertGitAvailable,
   type CheckoutCommandStartMetadata,
   CheckoutError,


### PR DESCRIPTION
Shell run steps now receive the ambient Git config path produced by setup or checkout. This preserves the checkout author identity and repository-scoped credential for later workflow commands, allowing them to commit and push without reconfiguring Git or writing credentials into .git/config.

The execution and orchestration paths are covered by focused unit tests and real-git integration coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run steps now reuse the checkout’s ambient Git config and secrets. Previously they ran without the checkout identity or repo-scoped credential; now they inherit both, enabling commit/push without touching .git/config, with no change when credentials weren’t persisted.

- Export the ambient config to run steps as GIT_CONFIG_GLOBAL only when checkout persistence succeeded; otherwise leave it unset.
- Override any user-provided GIT_CONFIG_GLOBAL for the step.
- Run each step with an isolated 0600 copy of the config and delete it after the step to prevent shared-state mutation.
- Forward the config path and persisted credential forms from setup/checkout through orchestration to run steps, and include them in run-step and log redaction (token and Basic credential).
- Keep credentials out of the repository config and drop the checkout-only redirect policy from the persistent config.
- Real-git coverage verifies author identity, extraHeader propagation, HTTP transport, and redaction.

<sup>Written for commit 3ec7c59ab059d9e5f2e535522ad70a1dfce817e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

