### PR TITLE
[client-workflows] Recompose run detail onto data frame

### DIFF
--- a/.changeset/quiet-run-panels.md
+++ b/.changeset/quiet-run-panels.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Recomposes workflow run details onto the full-width data frame with panel-based regions and a neutral cancellation action.

--- a/.changeset/quiet-run-panels.md
+++ b/.changeset/quiet-run-panels.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": patch
 ---
 
-Recomposes workflow run details onto the full-width data frame with panel-based regions and a neutral cancellation action.
+Uses the standard full-width layout for workflow run details and a destructive cancellation action.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -353,9 +353,9 @@ same gutters at every width. Data surfaces run edge to edge on purpose, because 
 wide log or run table shows more per screen. The panel border supplies the edge
 the eye tracks against.
 
-The run workspace is a nested exception inside the `data` frame. At wide
-viewports, its 240px rail joins a 1120px run-level content measure. Dedicated job
-views keep their log content full width within the surrounding data surface.
+The run workspace uses the surrounding `data` frame. Its 240px rail and run-level
+panels use the frame's full width and fixed gutters. Dedicated job views keep their
+log content full width within the surrounding data surface.
 
 Marketing sits outside this model. It keeps a single content column up to about
 1280px, generous vertical rhythm, and full-bleed background panels.

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -57,7 +57,7 @@ const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({
 
 const withFrame: Decorator = (Story) => (
   <div className="min-h-screen bg-background-subtle-base">
-    <div className="mx-auto flex min-h-screen w-full max-w-[1120px] flex-col overflow-hidden border-x border-border-neutral-base bg-background-subtle-base">
+    <div className="flex min-h-screen w-full flex-col px-frame py-frame">
       <Story />
       <div className="min-h-0 flex-1 bg-background-subtle-base p-16" />
     </div>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -299,7 +299,11 @@ describe('WorkflowRunSummary', () => {
     const onCancel = vi.fn();
     renderSummary({}, {onCancel});
 
-    await user.click(await screen.findByRole('button', {name: 'Cancel workflow'}));
+    const button = await screen.findByRole('button', {name: 'Cancel workflow'});
+    expect(button).toHaveClass('bg-background-neutral-base');
+    expect(button).not.toHaveClass('bg-background-button-danger-default');
+
+    await user.click(button);
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -300,8 +300,12 @@ describe('WorkflowRunSummary', () => {
     renderSummary({}, {onCancel});
 
     const button = await screen.findByRole('button', {name: 'Cancel workflow'});
-    expect(button).toHaveClass('bg-background-neutral-base');
-    expect(button).not.toHaveClass('bg-background-button-danger-default');
+    expect(button).toHaveClass(
+      'bg-background-button-danger-default',
+      'text-foreground-neutral-on-color',
+      'shadow-button-danger',
+    );
+    expect(button).not.toHaveClass('bg-background-neutral-base');
 
     await user.click(button);
 

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -29,7 +29,7 @@ import {WorkflowRunAttemptSwitcher} from './workflow-run-attempt-switcher.js';
 const STATUS_BADGE_LABEL_WIDTH_CH = Math.max(
   ...WORKFLOW_RUN_STATUSES.map((status) => getWorkflowStatusVisual(status).label.length),
 );
-const RERUN_BUTTON_SURFACE_CLASS_NAME =
+const NEUTRAL_ACTION_SURFACE_CLASS_NAME =
   'bg-background-neutral-base hover:bg-background-neutral-hover active:bg-background-neutral-pressed';
 
 type WorkflowRunAction = 'cancel' | 'rerun-all' | 'rerun-menu' | 'none';
@@ -206,8 +206,9 @@ function WorkflowRunActionSlot({
     return (
       <Button
         type="button"
-        variant="danger"
+        variant="secondary"
         size="xs"
+        className={NEUTRAL_ACTION_SURFACE_CLASS_NAME}
         isLoading={cancelling}
         disabled={cancelling}
         onClick={onCancel}
@@ -225,7 +226,7 @@ function WorkflowRunActionSlot({
         type="button"
         variant="secondary"
         size="xs"
-        className={RERUN_BUTTON_SURFACE_CLASS_NAME}
+        className={NEUTRAL_ACTION_SURFACE_CLASS_NAME}
         isLoading={rerunPending}
         disabled={rerunPending}
         onClick={() => onRerun('all')}
@@ -244,7 +245,7 @@ function WorkflowRunActionSlot({
           type="button"
           variant="secondary"
           size="xs"
-          className={RERUN_BUTTON_SURFACE_CLASS_NAME}
+          className={NEUTRAL_ACTION_SURFACE_CLASS_NAME}
           iconRight="arrowDownSLine"
           isLoading={rerunPending}
           disabled={rerunPending}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -206,9 +206,8 @@ function WorkflowRunActionSlot({
     return (
       <Button
         type="button"
-        variant="secondary"
+        variant="danger"
         size="xs"
-        className={NEUTRAL_ACTION_SURFACE_CLASS_NAME}
         isLoading={cancelling}
         disabled={cancelling}
         onClick={onCancel}

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
@@ -92,7 +92,8 @@ describe('RunWorkspaceNav', () => {
       />,
     );
 
-    expect(await screen.findByRole('link', {name: 'Summary'})).toBeInTheDocument();
+    const summary = await screen.findByRole('link', {name: 'Summary'});
+    expect(summary).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Jobs'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Run details'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Annotations'})).toBeInTheDocument();
@@ -112,6 +113,7 @@ describe('RunWorkspaceNav', () => {
 
     const current = within(jobs).getByRole('link', {name: BUILD_LINK_PATTERN});
     expect(current).toHaveAttribute('aria-current', 'page');
+    expect(current.querySelector('[data-run-workspace-active-bar]')).not.toBeNull();
     expect(current).toHaveAttribute(
       'href',
       expect.stringContaining(`/runs/${RUN_ID}/jobs/${CURRENT_JOB_ID}`),
@@ -137,7 +139,9 @@ describe('RunWorkspaceNav', () => {
 
     expect(await screen.findByRole('heading', {name: 'Jobs'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: BUILD_LINK_PATTERN})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Summary'})).toHaveAttribute('aria-current', 'page');
+    const summary = screen.getByRole('link', {name: 'Summary'});
+    expect(summary).toHaveAttribute('aria-current', 'page');
+    expect(summary.querySelector('[data-run-workspace-active-bar]')).not.toBeNull();
   });
 
   test('scrolls the current job into view when the mobile rail opens', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.test.tsx
@@ -13,6 +13,7 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const CURRENT_JOB_ID = '88888888-8888-4888-8888-888888888888';
 const BUILD_LINK_PATTERN = /build/;
 const DEPLOY_LINK_PATTERN = /deploy/;
+const SETUP_LINK_PATTERN = /setup/;
 const NOW = Date.parse('2026-06-26T12:00:00.000Z');
 
 describe('RunWorkspaceNav', () => {
@@ -114,6 +115,12 @@ describe('RunWorkspaceNav', () => {
     const current = within(jobs).getByRole('link', {name: BUILD_LINK_PATTERN});
     expect(current).toHaveAttribute('aria-current', 'page');
     expect(current.querySelector('[data-run-workspace-active-bar]')).not.toBeNull();
+    expect(
+      within(jobs)
+        .getByRole('link', {name: SETUP_LINK_PATTERN})
+        .querySelector('[data-run-workspace-active-bar]'),
+    ).toBeNull();
+    expect(jobs.querySelectorAll('[data-run-workspace-active-bar]')).toHaveLength(1);
     expect(current).toHaveAttribute(
       'href',
       expect.stringContaining(`/runs/${RUN_ID}/jobs/${CURRENT_JOB_ID}`),
@@ -142,6 +149,33 @@ describe('RunWorkspaceNav', () => {
     const summary = screen.getByRole('link', {name: 'Summary'});
     expect(summary).toHaveAttribute('aria-current', 'page');
     expect(summary.querySelector('[data-run-workspace-active-bar]')).not.toBeNull();
+  });
+
+  test('falls back to the first job when the current job id is stale', async () => {
+    const run = workflowRunDetail({
+      id: RUN_ID,
+      jobs: [
+        workflowJobDto({id: 'job-deploy', name: 'deploy', position: 1}),
+        workflowJobDto({id: 'job-setup', name: 'setup', position: 0}),
+      ],
+    });
+
+    renderWithRouter(
+      <RunWorkspaceNav
+        workspaceSlug="acme"
+        projectSlug="project"
+        run={run}
+        activeSection="summary"
+        currentJobId="stale-job-id"
+      />,
+    );
+
+    const jobs = (await screen.findByRole('heading', {name: 'Jobs'})).closest('section');
+    if (!jobs) throw new Error('Missing jobs section');
+
+    const fallback = within(jobs).getByRole('link', {name: SETUP_LINK_PATTERN});
+    expect(fallback).toHaveAttribute('aria-current', 'page');
+    expect(jobs.querySelectorAll('[data-run-workspace-active-bar]')).toHaveLength(1);
   });
 
   test('scrolls the current job into view when the mobile rail opens', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -23,6 +23,9 @@ import {JobExecutionTimeText} from '../job-detail/job-execution-time-text.js';
 
 type RunWorkspaceSection = Exclude<WorkflowRunTab, 'jobs'>;
 
+const RUN_WORKSPACE_LINK_CLASS_NAME =
+  'relative flex min-h-32 items-center gap-inline rounded-4 px-tight outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44';
+
 export interface RunWorkspaceNavProps {
   workspaceSlug: string;
   projectSlug: string;
@@ -48,7 +51,9 @@ export function RunWorkspaceNav({
 }: RunWorkspaceNavProps) {
   const jobs = useMemo(() => [...run.jobs].sort(compareJobs), [run.jobs]);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const currentJob = jobs.find((job) => job.id === currentJobId);
+  const currentJob =
+    jobs.find((job) => job.id === currentJobId) ?? (currentJobId ? jobs[0] : undefined);
+  const resolvedCurrentJobId = currentJob?.id;
   const currentLabel = currentJob?.displayName ?? sectionLabel(activeSection);
 
   return (
@@ -96,7 +101,7 @@ export function RunWorkspaceNav({
               run={run}
               jobs={jobs}
               activeSection={activeSection}
-              currentJobId={currentJobId}
+              currentJobId={resolvedCurrentJobId}
               jobSearch={jobSearch}
               annotationSummary={annotationSummary}
               mobileOpen={mobileOpen}
@@ -141,7 +146,7 @@ function RunWorkspaceNavContent({
 
   return (
     <nav aria-label="Run workspace" className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <ul className="border-b border-border-neutral-base pb-[12px]">
+      <ul className="border-b border-border-neutral-base pb-row">
         <li>
           <RunSectionLink
             workspaceSlug={workspaceSlug}
@@ -157,7 +162,7 @@ function RunWorkspaceNavContent({
 
       <section
         aria-labelledby="run-workspace-jobs-heading"
-        className="flex min-h-0 min-w-0 flex-1 flex-col border-b border-border-neutral-base py-[12px]"
+        className="flex min-h-0 min-w-0 flex-1 flex-col border-b border-border-neutral-base py-row"
       >
         <div className="flex items-center justify-between gap-inline px-tight pb-[6px]">
           <Text
@@ -189,17 +194,12 @@ function RunWorkspaceNavContent({
                   onClick={onNavigate}
                   aria-current={current ? 'page' : undefined}
                   className={cn(
-                    'relative flex min-h-32 min-w-0 items-center gap-inline rounded-4 px-tight text-left outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
+                    RUN_WORKSPACE_LINK_CLASS_NAME,
+                    'min-w-0 text-left',
                     current && 'bg-background-neutral-hover',
                   )}
                 >
-                  {current ? (
-                    <span
-                      aria-hidden="true"
-                      data-run-workspace-active-bar
-                      className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
-                    />
-                  ) : null}
+                  {current ? <RunWorkspaceActiveBar /> : null}
                   <WorkflowStatusIcon
                     status={deriveJobDisplayStatus(job)}
                     size={12}
@@ -218,7 +218,7 @@ function RunWorkspaceNavContent({
         </ol>
       </section>
 
-      <section aria-labelledby="run-workspace-details-heading" className="pt-[12px]">
+      <section aria-labelledby="run-workspace-details-heading" className="pt-row">
         <Text
           as="h2"
           id="run-workspace-details-heading"
@@ -299,17 +299,12 @@ function RunSectionLink({
           : undefined
       }
       className={cn(
-        'relative flex min-h-32 items-center gap-inline rounded-4 px-tight text-xs font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
+        RUN_WORKSPACE_LINK_CLASS_NAME,
+        'text-xs font-medium text-foreground-neutral-base',
         current && 'bg-background-neutral-hover',
       )}
     >
-      {current ? (
-        <span
-          aria-hidden="true"
-          data-run-workspace-active-bar
-          className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
-        />
-      ) : null}
+      {current ? <RunWorkspaceActiveBar /> : null}
       {sectionLabel(section)}
       {count ? (
         <span
@@ -321,6 +316,16 @@ function RunSectionLink({
         </span>
       ) : null}
     </Link>
+  );
+}
+
+function RunWorkspaceActiveBar() {
+  return (
+    <span
+      aria-hidden="true"
+      data-run-workspace-active-bar
+      className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
+    />
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/run-workspace-nav.tsx
@@ -53,7 +53,7 @@ export function RunWorkspaceNav({
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
-      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base min-[768px]:w-240 min-[768px]:border-b-0 min-[768px]:border-r">
+      <aside className="flex min-h-0 w-full shrink-0 flex-col border-b border-border-neutral-base min-[768px]:w-240 min-[768px]:border-b-0">
         <Collapsible
           open={mobileOpen}
           onOpenChange={setMobileOpen}
@@ -140,8 +140,8 @@ function RunWorkspaceNavContent({
   }, [currentJobId, mobileOpen]);
 
   return (
-    <nav aria-label="Run workspace" className="flex min-h-0 min-w-0 flex-1 flex-col gap-group">
-      <ul>
+    <nav aria-label="Run workspace" className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <ul className="border-b border-border-neutral-base pb-[12px]">
         <li>
           <RunSectionLink
             workspaceSlug={workspaceSlug}
@@ -157,7 +157,7 @@ function RunWorkspaceNavContent({
 
       <section
         aria-labelledby="run-workspace-jobs-heading"
-        className="flex min-h-0 min-w-0 flex-1 flex-col"
+        className="flex min-h-0 min-w-0 flex-1 flex-col border-b border-border-neutral-base py-[12px]"
       >
         <div className="flex items-center justify-between gap-inline px-tight pb-[6px]">
           <Text
@@ -189,10 +189,17 @@ function RunWorkspaceNavContent({
                   onClick={onNavigate}
                   aria-current={current ? 'page' : undefined}
                   className={cn(
-                    'flex min-h-32 min-w-0 items-center gap-inline rounded-4 px-tight text-left outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
+                    'relative flex min-h-32 min-w-0 items-center gap-inline rounded-4 px-tight text-left outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
                     current && 'bg-background-neutral-hover',
                   )}
                 >
+                  {current ? (
+                    <span
+                      aria-hidden="true"
+                      data-run-workspace-active-bar
+                      className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
+                    />
+                  ) : null}
                   <WorkflowStatusIcon
                     status={deriveJobDisplayStatus(job)}
                     size={12}
@@ -211,7 +218,7 @@ function RunWorkspaceNavContent({
         </ol>
       </section>
 
-      <section aria-labelledby="run-workspace-details-heading">
+      <section aria-labelledby="run-workspace-details-heading" className="pt-[12px]">
         <Text
           as="h2"
           id="run-workspace-details-heading"
@@ -292,10 +299,17 @@ function RunSectionLink({
           : undefined
       }
       className={cn(
-        'flex min-h-32 items-center gap-inline rounded-4 px-tight text-xs font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
+        'relative flex min-h-32 items-center gap-inline rounded-4 px-tight text-xs font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active @max-[767px]:min-h-44 [@media(pointer:coarse)]:min-h-44',
         current && 'bg-background-neutral-hover',
       )}
     >
+      {current ? (
+        <span
+          aria-hidden="true"
+          data-run-workspace-active-bar
+          className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
+        />
+      ) : null}
       {sectionLabel(section)}
       {count ? (
         <span

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -133,7 +133,9 @@ function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
   return (
     <QueryClientProvider client={queryClient}>
       <div className="flex h-[720px] min-w-[1440px] w-[1440px] bg-background-subtle-base">
-        {children}
+        <div className="flex min-h-0 min-w-0 w-full flex-1 flex-col px-frame py-frame">
+          {children}
+        </div>
       </div>
     </QueryClientProvider>
   );

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -54,16 +54,15 @@ describe('WorkflowRunView', () => {
       .closest('[data-run-workspace-layout]');
     expect(workspaceLayout).toHaveClass('border-t', 'border-border-neutral-base');
     expect(workspaceLayout).not.toHaveClass('max-w-[1360px]');
-    expect(workspaceLayout?.querySelector('[data-run-workspace-frame]')).toHaveClass(
-      'mx-auto',
-      'w-full',
-      'max-w-[calc(240px_+_1120px)]',
-      'min-[768px]:flex-row',
-    );
+    const workspaceFrame = workspaceLayout?.querySelector('[data-run-workspace-frame]');
+    expect(workspaceFrame).toHaveClass('w-full', 'min-[768px]:flex-row');
+    expect(workspaceFrame).not.toHaveClass('mx-auto', 'max-w-[calc(240px_+_1120px)]');
     expect(screen.getByRole('link', {name: 'Summary'})).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('heading', {name: 'Jobs'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Run details'})).toBeInTheDocument();
-    expect(screen.getByRole('region', {name: 'All jobs summary'})).toBeInTheDocument();
+    const allJobsSummary = screen.getByRole('region', {name: 'All jobs summary'});
+    expect(allJobsSummary).toBeInTheDocument();
+    expect(allJobsSummary.querySelector('[data-slot="panel"]')).not.toBeNull();
     expect(screen.getByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
     expect(container.querySelector('[data-run-workspace-content]')).toHaveClass('flex-1');
     expect(container.querySelector('[data-run-workspace-content]')).not.toHaveClass(
@@ -82,7 +81,8 @@ describe('WorkflowRunView', () => {
     renderView({tab});
 
     const section = await screen.findByRole('region', {name: region});
-    expect(section.firstElementChild).not.toHaveClass('max-w-[1120px]');
+    expect(section.firstElementChild).not.toHaveClass('mx-auto', 'px-frame', 'max-w-[1120px]');
+    expect(section.querySelector('[data-slot="panel"]')).not.toBeNull();
   });
 
   test('keeps dedicated job content on the full-width data surface', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -63,6 +63,9 @@ describe('WorkflowRunView', () => {
     const allJobsSummary = screen.getByRole('region', {name: 'All jobs summary'});
     expect(allJobsSummary).toBeInTheDocument();
     expect(allJobsSummary.querySelector('[data-slot="panel"]')).not.toBeNull();
+    expect(allJobsSummary.querySelector('[data-slot="panel-body"]')).toHaveClass(
+      'bg-background-components-base',
+    );
     expect(screen.getByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
     expect(container.querySelector('[data-run-workspace-content]')).toHaveClass('flex-1');
     expect(container.querySelector('[data-run-workspace-content]')).not.toHaveClass(

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,6 +1,7 @@
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {Panel, PanelBody, PanelHeader} from '@shipfox/react-ui/panel';
 import {RelativeTimeProvider} from '@shipfox/react-ui/relative-time';
 import {
   Select,
@@ -11,7 +12,6 @@ import {
 } from '@shipfox/react-ui/select';
 import {toast} from '@shipfox/react-ui/toast';
 import {Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import {useNavigate} from '@tanstack/react-router';
 import {type ReactNode, useEffect, useMemo} from 'react';
 import {buildRunAnnotationList, type RunAnnotationSummary} from '#core/run-annotation.js';
@@ -54,7 +54,6 @@ import {
 } from './workflow-run-states.js';
 
 type RunWorkspaceSection = Exclude<WorkflowRunTab, 'jobs'>;
-const RUN_WORKSPACE_FRAME_CLASS_NAME = 'mx-auto w-full max-w-[calc(240px_+_1120px)]';
 
 export interface WorkflowRunViewProps {
   projectId: string;
@@ -159,7 +158,6 @@ function RunViewContent({
   const activeSection = runWorkspaceSection(tab);
   const cancelMutation = useCancelWorkflowRunMutation(runData);
   const sourceSnapshot = runData?.sourceSnapshot ?? null;
-  const hasJobContent = Boolean(jobContent);
   const resolvedSelection =
     runData && selection ? resolveWorkflowRunSelection({run: runData, selection}) : undefined;
   const highlightedLineRange = resolvedSelection?.step?.sourceLocation ?? null;
@@ -316,10 +314,7 @@ function RunViewContent({
       >
         <div
           data-run-workspace-frame
-          className={cn(
-            'flex min-h-0 min-w-0 w-full flex-1 flex-col min-[768px]:flex-row',
-            !hasJobContent && RUN_WORKSPACE_FRAME_CLASS_NAME,
-          )}
+          className="flex min-h-0 min-w-0 w-full flex-1 flex-col min-[768px]:flex-row"
         >
           {runData && workspaceSlug && projectSlug ? (
             <RunWorkspaceNav
@@ -403,16 +398,20 @@ function RunSectionContent({
         aria-label="All jobs summary"
         className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
       >
-        <div className="mx-auto flex w-full flex-col gap-group px-frame">
+        <div className="flex w-full flex-col gap-group">
           <Text as="h2" className="sr-only">
             All jobs summary
           </Text>
-          <JobGraph
-            run={run}
-            selectedJobId={selectedJobId}
-            onSelectedJobChange={onSelectGraphJob}
-            className="min-h-160 overflow-hidden"
-          />
+          <Panel className="min-h-160">
+            <PanelBody className="min-h-160 p-0">
+              <JobGraph
+                run={run}
+                selectedJobId={selectedJobId}
+                onSelectedJobChange={onSelectGraphJob}
+                className="min-h-160 overflow-hidden"
+              />
+            </PanelBody>
+          </Panel>
         </div>
       </section>
     );
@@ -439,28 +438,33 @@ function RunSectionContent({
       aria-label="Workflow source"
       className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
     >
-      <div className="mx-auto flex min-h-full w-full flex-col px-frame">
+      <div className="flex min-h-full w-full flex-col">
         <Text as="h2" className="sr-only">
           Workflow source
         </Text>
-        {sourceSnapshot ? (
-          <WorkflowSourceContent
-            source={sourceSnapshot}
-            highlightedLineRange={highlightedLineRange}
-            scrollHighlightedIntoView
-          />
-        ) : (
-          <EmptyState
-            className="min-h-160 w-full"
-            icon="fileDamageLine"
-            title="Source snapshot unavailable"
-            description={
-              run.isTemporary
-                ? 'Temporary runs do not capture workflow source.'
-                : 'This run was created before workflow source snapshots were captured.'
-            }
-          />
-        )}
+        <Panel className="min-h-160 flex-1">
+          <PanelBody className="min-h-160 flex-1 p-0">
+            {sourceSnapshot ? (
+              <WorkflowSourceContent
+                source={sourceSnapshot}
+                highlightedLineRange={highlightedLineRange}
+                scrollHighlightedIntoView
+              />
+            ) : (
+              <EmptyState
+                variant="panel"
+                className="min-h-160"
+                icon="fileDamageLine"
+                title="Source snapshot unavailable"
+                description={
+                  run.isTemporary
+                    ? 'Temporary runs do not capture workflow source.'
+                    : 'This run was created before workflow source snapshots were captured.'
+                }
+              />
+            )}
+          </PanelBody>
+        </Panel>
       </div>
     </section>
   );
@@ -534,45 +538,49 @@ function RunAnnotationsSection({
       aria-label="Run annotations"
       className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
     >
-      <div className="mx-auto flex w-full flex-col gap-group px-frame">
+      <div className="flex w-full flex-col">
         <Text as="h2" className="sr-only">
           Annotations
         </Text>
-        <div className="flex flex-wrap items-center justify-between gap-inline">
-          <RunAnnotationSummaryLine
-            summary={annotationSummary}
-            workspaceSlug={workspaceSlug}
-            projectSlug={projectSlug}
-            workflowRunId={run.id}
-            search={selection}
-          />
-          <AnnotationJobFilter
-            jobs={run.jobs}
-            selectedJobId={selectedJob?.id}
-            onSelect={onSelectAnnotationJob}
-          />
-        </div>
-        <RunAnnotationList
-          // Remounting on a filter or run-attempt change resets the render window, so the next
-          // list never inherits a "show more" position from different data.
-          key={`${run.id}:${run.runAttempt.attempt}:${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
-          query={annotations.query}
-          entries={entries}
-          derivedAnnotations={derivedAnnotations}
-          workspaceSlug={workspaceSlug}
-          projectSlug={projectSlug}
-          workflowRunId={run.id}
-          runAttempt={run.runAttempt.attempt}
-          // A run with no annotations at all offers no filter to clear, whatever the URL says.
-          filtered={Boolean(
-            (severity || selectedJob || selection?.annotation) &&
-              ((annotationSummary?.total ?? 0) > 0 || hasSynthesizedJobAnnotations),
-          )}
-          filteredJobName={selectedJob?.displayName}
-          filteredSeverity={severity}
-          onClearFilters={onClearAnnotationFilters}
-          selectedAnnotationId={selection?.annotation}
-        />
+        <Panel>
+          <PanelHeader className="flex-wrap">
+            <RunAnnotationSummaryLine
+              summary={annotationSummary}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              workflowRunId={run.id}
+              search={selection}
+            />
+            <AnnotationJobFilter
+              jobs={run.jobs}
+              selectedJobId={selectedJob?.id}
+              onSelect={onSelectAnnotationJob}
+            />
+          </PanelHeader>
+          <PanelBody className="gap-group p-panel">
+            <RunAnnotationList
+              // Remounting on a filter or run-attempt change resets the render window, so the next
+              // list never inherits a "show more" position from different data.
+              key={`${run.id}:${run.runAttempt.attempt}:${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
+              query={annotations.query}
+              entries={entries}
+              derivedAnnotations={derivedAnnotations}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              workflowRunId={run.id}
+              runAttempt={run.runAttempt.attempt}
+              // A run with no annotations at all offers no filter to clear, whatever the URL says.
+              filtered={Boolean(
+                (severity || selectedJob || selection?.annotation) &&
+                  ((annotationSummary?.total ?? 0) > 0 || hasSynthesizedJobAnnotations),
+              )}
+              filteredJobName={selectedJob?.displayName}
+              filteredSeverity={severity}
+              onClearFilters={onClearAnnotationFilters}
+              selectedAnnotationId={selection?.annotation}
+            />
+          </PanelBody>
+        </Panel>
       </div>
     </section>
   );
@@ -674,7 +682,7 @@ function RunWorkspaceNavSkeleton() {
   return (
     <aside
       aria-label="Loading run navigation"
-      className="hidden w-240 shrink-0 border-r border-border-neutral-base p-panel-compact min-[768px]:block"
+      className="hidden w-240 shrink-0 p-panel-compact min-[768px]:block"
     >
       <div className="flex flex-col gap-group">
         <div className="h-32 rounded-4 bg-background-components-subtle" />

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -403,7 +403,7 @@ function RunSectionContent({
             All jobs summary
           </Text>
           <Panel className="min-h-160">
-            <PanelBody className="min-h-160 p-0">
+            <PanelBody className="min-h-160 bg-background-components-base p-0">
               <JobGraph
                 run={run}
                 selectedJobId={selectedJobId}


### PR DESCRIPTION
The workflow run detail previously introduced its own centered run-level measure and rail treatment, so it diverged from the run list. This change makes the page consume the declared data frame, presents the graph, annotations, and source as Panel regions, and aligns the rail and cancellation treatment with the surface system. The Storybook fixture and design guidance now model the same frame.

Closes ENG-1585

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recomposes workflow run details onto the full-width data frame and renders run-level regions as `Panel`s to align with the surface system (ENG-1585). Restores graph contrast and updates the rail and cancellation treatment.

- Render the graph, Annotations, and Source inside `Panel`s from `@shipfox/react-ui/panel`; dedicated job views remain full width.
- Restore graph contrast by placing the graph in a `PanelBody` with `bg-background-components-base`; Annotations use a `PanelHeader` for controls and `PanelBody` for content, and empty state uses the panel variant.
- Rail: remove right border, add group dividers, and add a left active bar; aria-current and scroll-to-current are preserved. When the current job id is stale, highlight the first job instead of none.
- Cancel workflow button uses destructive styling instead of neutral; behavior is unchanged.
- Storybook and DESIGN.md reflect the `data` frame; tests cover panel surfaces, the active bar, and stale-id fallback; `@shipfox/client-workflows` publishes a patch with no API or routing changes.

<sup>Written for commit 61bf77fb4399442d160d1e77510751565e8b03cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

