### PR TITLE
Consolidate focused surfaces onto one frame

### DIFF
--- a/.changeset/focused-surface-frame.md
+++ b/.changeset/focused-surface-frame.md
@@ -1,0 +1,9 @@
+---
+'@shipfox/client-agent': patch
+'@shipfox/client-auth': patch
+'@shipfox/client-integrations': patch
+'@shipfox/client-invitations': patch
+'@shipfox/client-shell': minor
+---
+
+Consolidate authentication, onboarding, integration-install, and callback surfaces onto the shared focused frame.

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -104,7 +104,7 @@ export function ModelProviderOnboardingPage({
       : 'model-provider-provider-step';
 
   return (
-    <div className="mx-auto flex w-full flex-col gap-section">
+    <div className="flex w-full flex-col gap-section">
       <header className="flex flex-col gap-cluster">
         <div className="flex items-start justify-between gap-group max-[520px]:flex-col max-[520px]:gap-inline">
           <Header id={headingId} variant="h1" tabIndex={-1} className="outline-none">

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -1,5 +1,6 @@
 import {slugifyName, slugSchema} from '@shipfox/api-common-dto';
 import {createWorkspaceBodySchema} from '@shipfox/api-workspaces-dto';
+import {FocusedFrame} from '@shipfox/client-shell/runtime';
 import {displayNameFieldError, SlugField} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -16,23 +17,6 @@ import {checkWorkspaceSlugAvailability, useCreateWorkspaceAuth} from '#hooks/api
 import {useAuthState} from '#hooks/use-auth-state.js';
 import {lastWorkspaceIdAtom, rememberLastWorkspaceId} from '#state/last-workspace.js';
 import {workspaceOnboardingErrorToFormError} from './form-errors.js';
-
-const previewMetrics = [
-  {label: 'Runs', value: '--'},
-  {label: 'Passed', value: '--'},
-  {label: 'Failed', value: '--'},
-  {label: 'Duration', value: '--'},
-];
-const previewBars = [
-  {id: 'runs-start', height: 32},
-  {id: 'runs-mid-low', height: 48},
-  {id: 'runs-dip', height: 28},
-  {id: 'runs-mid-high', height: 66},
-  {id: 'runs-mid', height: 54},
-  {id: 'runs-peak', height: 82},
-  {id: 'runs-late-low', height: 44},
-  {id: 'runs-late-high', height: 74},
-];
 
 function isSlugValid(value: string): boolean {
   return slugSchema.safeParse(value).success;
@@ -79,7 +63,7 @@ export function WorkspaceOnboardingPage() {
 
   return (
     <main className="min-h-screen px-frame py-frame max-[520px]:px-row">
-      <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full flex-col gap-section">
+      <FocusedFrame className="flex min-h-[calc(100vh-64px)] flex-col gap-section">
         <header className="flex items-center justify-between">
           <div className="flex items-center gap-inline">
             <div className="flex size-36 items-center justify-center rounded-8 border border-border-neutral-base bg-background-neutral-base shadow-button-neutral">
@@ -91,9 +75,9 @@ export function WorkspaceOnboardingPage() {
           </div>
         </header>
 
-        <section className="grid flex-1 items-center gap-region lg:grid-cols-[minmax(0,440px)_minmax(0,1fr)]">
+        <section className="flex flex-1 items-center">
           <form
-            className="relative z-10 w-full"
+            className="w-full"
             noValidate
             aria-labelledby="workspace-onboarding-title"
             onSubmit={(event) => {
@@ -208,70 +192,8 @@ export function WorkspaceOnboardingPage() {
               </PanelBody>
             </Panel>
           </form>
-
-          <div className="hidden flex-col gap-group lg:flex" aria-hidden="true">
-            <div className="grid grid-cols-4 gap-cluster">
-              {previewMetrics.map((metric) => (
-                <div
-                  className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral"
-                  key={metric.label}
-                >
-                  <Text size="xs" className="text-foreground-neutral-muted">
-                    {metric.label}
-                  </Text>
-                  <Text size="xl" bold>
-                    {metric.value}
-                  </Text>
-                </div>
-              ))}
-            </div>
-            <div className="grid grid-cols-2 gap-group">
-              <PreviewPanel title="Performance over time" />
-              <PreviewPanel title="Duration distribution" bars />
-            </div>
-            <div className="flex flex-col gap-cluster rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral">
-              <Text size="sm" bold>
-                Jobs breakdown
-              </Text>
-              <div className="flex flex-col gap-inline">
-                {[0, 1, 2, 3].map((row) => (
-                  <div
-                    className="grid grid-cols-[1fr_80px_80px] gap-cluster border-t border-border-neutral-base pt-[10px]"
-                    key={row}
-                  >
-                    <div className="h-12 rounded-full bg-background-neutral-disabled" />
-                    <div className="h-12 rounded-full bg-background-neutral-disabled" />
-                    <div className="h-12 rounded-full bg-background-neutral-disabled" />
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
         </section>
-      </div>
+      </FocusedFrame>
     </main>
-  );
-}
-
-function PreviewPanel({title, bars = false}: {title: string; bars?: boolean}) {
-  return (
-    <div className="flex flex-col gap-group rounded-8 border border-border-neutral-base bg-background-neutral-base p-panel-compact shadow-button-neutral">
-      <Text size="sm" bold>
-        {title}
-      </Text>
-      <div className="flex h-[220px] items-end gap-inline border-b border-l border-border-neutral-base px-row pb-[10px]">
-        {previewBars.map((bar) => (
-          <div
-            className={
-              bars
-                ? 'w-full rounded-t-4 bg-background-neutral-disabled'
-                : 'w-full rounded-full bg-background-neutral-disabled'
-            }
-            key={`${title}-${bar.id}`}
-            style={{height: `${bar.height}%`}}
-          />
-        ))}
-      </div>
-    </div>
   );
 }

--- a/libs/client/integrations/src/components/callback-status-shell.tsx
+++ b/libs/client/integrations/src/components/callback-status-shell.tsx
@@ -1,3 +1,4 @@
+import {FocusedFrame} from '@shipfox/client-shell/runtime';
 import {ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {Text} from '@shipfox/react-ui/typography';
@@ -43,8 +44,8 @@ export function CallbackStatusShell({
     : undefined;
 
   return (
-    <main className="flex min-h-screen px-row py-frame">
-      <div className="mx-auto flex w-full flex-col justify-center gap-section">
+    <main className="flex min-h-screen px-frame py-frame">
+      <FocusedFrame className="flex flex-col justify-center gap-section">
         <h2 ref={headingRef} tabIndex={-1} className="text-24 font-semibold outline-none">
           {title}
         </h2>
@@ -71,7 +72,7 @@ export function CallbackStatusShell({
           ) : null}
           {settings}
         </div>
-      </div>
+      </FocusedFrame>
     </main>
   );
 }

--- a/libs/client/integrations/src/components/redirect-install-page.test.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.test.tsx
@@ -62,6 +62,11 @@ describe('RedirectInstallPage', () => {
 
     // Alert mounts via framer-motion (opacity 0 in jsdom), so assert presence.
     expect(await screen.findByText('Sentry app not configured')).toBeInTheDocument();
+    expect(screen.getByRole('alert').parentElement).toHaveClass(
+      'mx-auto',
+      'w-full',
+      'max-w-[640px]',
+    );
     expect(screen.getByRole('link', {name: 'Back to integrations'})).toBeVisible();
   });
 

--- a/libs/client/integrations/src/components/redirect-install-page.test.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import {ApiError} from '@shipfox/client-api';
+import {FOCUSED_FRAME_CONTENT_CLASS_NAME} from '@shipfox/client-shell/runtime';
 import {screen, waitFor} from '@testing-library/react';
 import {StrictMode} from 'react';
 import {INTEGRATIONS_TEST_WID, renderIntegrationsPage} from '#test/render.js';
 import {RedirectInstallPage} from './redirect-install-page.js';
+
+const FOCUSED_FRAME_CONTENT_CLASSES = FOCUSED_FRAME_CONTENT_CLASS_NAME.split(' ');
 
 function renderInstallPage(
   props: Parameters<typeof RedirectInstallPage>[0],
@@ -62,11 +65,7 @@ describe('RedirectInstallPage', () => {
 
     // Alert mounts via framer-motion (opacity 0 in jsdom), so assert presence.
     expect(await screen.findByText('Sentry app not configured')).toBeInTheDocument();
-    expect(screen.getByRole('alert').parentElement).toHaveClass(
-      'mx-auto',
-      'w-full',
-      'max-w-[640px]',
-    );
+    expect(screen.getByRole('alert').parentElement).toHaveClass(...FOCUSED_FRAME_CONTENT_CLASSES);
     expect(screen.getByRole('link', {name: 'Back to integrations'})).toBeVisible();
   });
 

--- a/libs/client/integrations/src/components/redirect-install-page.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.tsx
@@ -54,7 +54,7 @@ export function RedirectInstallPage({
 
   if (errorMessage) {
     return (
-      <div className="mx-auto flex w-full max-w-[480px] flex-col gap-group">
+      <div className="flex w-full flex-col gap-group">
         <Callout role="alert" type="error">
           <Text size="sm">{errorMessage}</Text>
         </Callout>

--- a/libs/client/integrations/src/components/redirect-install-page.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.tsx
@@ -1,5 +1,6 @@
 import {ApiError} from '@shipfox/client-api';
 import {useActiveWorkspace} from '@shipfox/client-auth';
+import {FocusedFrame} from '@shipfox/client-shell/runtime';
 import {ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
@@ -54,7 +55,7 @@ export function RedirectInstallPage({
 
   if (errorMessage) {
     return (
-      <div className="flex w-full flex-col gap-group">
+      <FocusedFrame className="flex flex-col gap-group">
         <Callout role="alert" type="error">
           <Text size="sm">{errorMessage}</Text>
         </Callout>
@@ -63,7 +64,7 @@ export function RedirectInstallPage({
             Back to integrations
           </Link>
         </ButtonLink>
-      </div>
+      </FocusedFrame>
     );
   }
 

--- a/libs/client/integrations/src/pages/gitea-install-page.tsx
+++ b/libs/client/integrations/src/pages/gitea-install-page.tsx
@@ -40,7 +40,7 @@ export function GiteaInstallPage() {
   });
 
   return (
-    <div className="mx-auto flex w-full flex-col gap-section">
+    <div className="flex w-full flex-col gap-section">
       <header className="flex flex-col gap-inline">
         <Header variant="h1">Install Gitea</Header>
         <Text size="md" className="text-foreground-neutral-muted">

--- a/libs/client/integrations/src/pages/jira-callback-page.tsx
+++ b/libs/client/integrations/src/pages/jira-callback-page.tsx
@@ -1,5 +1,5 @@
 import {useAuthState, useRefreshAuth} from '@shipfox/client-auth';
-import {useRouteSearch} from '@shipfox/client-shell/runtime';
+import {FocusedFrame, useRouteSearch} from '@shipfox/client-shell/runtime';
 import {sessionStorageOrUndefined} from '@shipfox/client-ui';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -300,8 +300,8 @@ function JiraSiteSelectionPage({
   onSelect: (site: JiraSite) => void;
 }) {
   return (
-    <main className="flex min-h-screen px-row py-frame">
-      <div className="mx-auto flex w-full flex-col justify-center gap-section">
+    <main className="flex min-h-screen px-frame py-frame">
+      <FocusedFrame className="flex flex-col justify-center gap-section">
         <header className="flex flex-col gap-inline">
           <Header variant="h2">Choose a Jira site</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
@@ -360,7 +360,7 @@ function JiraSiteSelectionPage({
             </ButtonLink>
           )}
         </div>
-      </div>
+      </FocusedFrame>
     </main>
   );
 }

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -1,5 +1,5 @@
 import {useAuthState, useRefreshAuth} from '@shipfox/client-auth';
-import {useRouteSearch} from '@shipfox/client-shell/runtime';
+import {FocusedFrame, useRouteSearch} from '@shipfox/client-shell/runtime';
 import {createSingleFlight, sessionStorageOrUndefined} from '@shipfox/client-ui';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -246,8 +246,8 @@ export function SentryCallbackPage() {
 
 function CallbackColumn({children}: {children: React.ReactNode}) {
   return (
-    <main className="flex min-h-screen px-row py-frame">
-      <div className="mx-auto flex w-full flex-col justify-center gap-section">{children}</div>
+    <main className="flex min-h-screen px-frame py-frame">
+      <FocusedFrame className="flex flex-col justify-center gap-section">{children}</FocusedFrame>
     </main>
   );
 }

--- a/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
+++ b/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
@@ -8,7 +8,7 @@ export function SourceControlOnboardingPage() {
   const providersQuery = useIntegrationProvidersQuery({capability: 'source_control'});
 
   return (
-    <div className="mx-auto flex w-full flex-col gap-section">
+    <div className="flex w-full flex-col gap-section">
       <header className="flex flex-col gap-inline">
         <Header variant="h1">Install source control</Header>
         <Text size="md" className="text-foreground-neutral-muted">

--- a/libs/client/shell/src/components/auth-shell.tsx
+++ b/libs/client/shell/src/components/auth-shell.tsx
@@ -1,6 +1,7 @@
 import {Icon} from '@shipfox/react-ui/icon';
 import {Header, type HeaderProps, Text} from '@shipfox/react-ui/typography';
 import type {PropsWithChildren, ReactNode, Ref} from 'react';
+import {FocusedFrame} from './focused-frame.js';
 
 export interface AuthShellProps {
   title: string;
@@ -33,33 +34,33 @@ export function AuthShell({
       >
         <div className="h-full w-full bg-[radial-gradient(circle,rgba(230,62,0,0.48)_1.6px,transparent_1.8px)] bg-[length:44px_44px]" />
       </div>
-      <section
-        className={
-          className ?? 'relative flex w-full max-w-[384px] flex-col items-stretch gap-region'
-        }
-        aria-labelledby="auth-title"
-      >
-        <div className="flex flex-col items-center gap-group">
-          <div className="flex size-64 items-center justify-center rounded-12 border border-border-neutral-base bg-background-neutral-base p-tight shadow-button-neutral">
-            <Icon name="shipfox" className="size-42 text-background-highlight-interactive" />
+      <FocusedFrame className="relative">
+        <section
+          className={className ?? 'relative flex w-full flex-col items-stretch gap-region'}
+          aria-labelledby="auth-title"
+        >
+          <div className="flex flex-col items-center gap-group">
+            <div className="flex size-64 items-center justify-center rounded-12 border border-border-neutral-base bg-background-neutral-base p-tight shadow-button-neutral">
+              <Icon name="shipfox" className="size-42 text-background-highlight-interactive" />
+            </div>
+            <div className="flex min-w-[128px] flex-col items-center gap-tight text-center">
+              <Header
+                id="auth-title"
+                variant="h1"
+                tabIndex={-1}
+                {...headingProps}
+                {...(headingRef ? ({ref: headingRef} as HeaderProps) : {})}
+              >
+                {title}
+              </Header>
+              <Text size="sm" className="text-foreground-neutral-subtle">
+                {description}
+              </Text>
+            </div>
           </div>
-          <div className="flex min-w-[128px] flex-col items-center gap-tight text-center">
-            <Header
-              id="auth-title"
-              variant="h1"
-              tabIndex={-1}
-              {...headingProps}
-              {...(headingRef ? ({ref: headingRef} as HeaderProps) : {})}
-            >
-              {title}
-            </Header>
-            <Text size="sm" className="text-foreground-neutral-subtle">
-              {description}
-            </Text>
-          </div>
-        </div>
-        {children}
-      </section>
+          {children}
+        </section>
+      </FocusedFrame>
     </main>
   );
 }

--- a/libs/client/shell/src/components/focused-frame.test.tsx
+++ b/libs/client/shell/src/components/focused-frame.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import {render, screen} from '@testing-library/react';
+import {FocusedFrame} from './focused-frame.js';
+
+describe('FocusedFrame', () => {
+  test('provides the shared focused width and centering contract', () => {
+    render(
+      <FocusedFrame>
+        <span>Focused content</span>
+      </FocusedFrame>,
+    );
+
+    expect(screen.getByText('Focused content').parentElement).toHaveClass(
+      'mx-auto',
+      'w-full',
+      'max-w-[640px]',
+    );
+  });
+});

--- a/libs/client/shell/src/components/focused-frame.tsx
+++ b/libs/client/shell/src/components/focused-frame.tsx
@@ -1,0 +1,11 @@
+import {cn} from '@shipfox/react-ui/utils';
+import type {PropsWithChildren} from 'react';
+
+export const FOCUSED_FRAME_CONTENT_CLASS_NAME = 'mx-auto w-full max-w-[640px]';
+
+export function FocusedFrame({
+  children,
+  className,
+}: PropsWithChildren<{className?: string | undefined}>) {
+  return <div className={cn(FOCUSED_FRAME_CONTENT_CLASS_NAME, className)}>{children}</div>;
+}

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -4,6 +4,7 @@ import type {NavTabEntry} from '#contract.js';
 import {useMaybeActiveWorkspace} from '#runtime/active-workspace.js';
 import type {RouteFrame} from '#runtime/route-frame.js';
 import {parseWorkspaceProjectParams, useRouteParams} from '#runtime/route-inputs.js';
+import {FOCUSED_FRAME_CONTENT_CLASS_NAME} from './focused-frame.js';
 import {NavBar} from './nav-bar.js';
 import {NavTabs} from './nav-tabs.js';
 
@@ -16,7 +17,7 @@ declare module '@tanstack/react-router' {
 const frameClassNames: Record<RouteFrame, string> = {
   content: 'mx-auto w-full max-w-[1120px] px-frame py-frame',
   data: 'flex min-h-0 w-full flex-1 flex-col px-frame py-frame',
-  focused: 'mx-auto w-full max-w-[640px] px-frame py-frame',
+  focused: `${FOCUSED_FRAME_CONTENT_CLASS_NAME} px-frame py-frame`,
 };
 
 export function MainLayout({

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -1,5 +1,8 @@
 export {AuthActions, AuthShell, type AuthShellProps} from '#components/auth-shell.js';
-export {FocusedFrame} from '#components/focused-frame.js';
+export {
+  FOCUSED_FRAME_CONTENT_CLASS_NAME,
+  FocusedFrame,
+} from '#components/focused-frame.js';
 export {WorkspaceCrumb, type WorkspaceCrumbProps} from '#components/workspace-crumb.js';
 export {WorkspaceSwitcher} from '#components/workspace-switcher.js';
 export type {

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -1,4 +1,5 @@
 export {AuthActions, AuthShell, type AuthShellProps} from '#components/auth-shell.js';
+export {FocusedFrame} from '#components/focused-frame.js';
 export {WorkspaceCrumb, type WorkspaceCrumbProps} from '#components/workspace-crumb.js';
 export {WorkspaceSwitcher} from '#components/workspace-switcher.js';
 export type {

--- a/libs/client/shell/src/runtime/workspace-setup.tsx
+++ b/libs/client/shell/src/runtime/workspace-setup.tsx
@@ -5,6 +5,7 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import type {QueryClient} from '@tanstack/react-query';
 import {type ErrorComponentProps, useRouter} from '@tanstack/react-router';
+import {FocusedFrame} from '#components/focused-frame.js';
 
 export interface WorkspaceSetupState {
   hideProjectNavigation: boolean;
@@ -33,7 +34,7 @@ export function WorkspaceSetupPending() {
 export function WorkspaceUnavailablePage({workspaceName}: {workspaceName?: string | undefined}) {
   return (
     <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
-      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-cluster">
+      <FocusedFrame className="flex flex-col gap-cluster">
         <Header variant="h1">Workspace unavailable</Header>
         <Text size="md" className="text-foreground-neutral-muted">
           {workspaceName
@@ -41,7 +42,7 @@ export function WorkspaceUnavailablePage({workspaceName}: {workspaceName?: strin
             : 'This workspace is currently unavailable.'}{' '}
           Please contact your configured support contact if you need help.
         </Text>
-      </div>
+      </FocusedFrame>
     </main>
   );
 }
@@ -60,7 +61,7 @@ export function WorkspaceLayoutErrorRoute({error, reset}: ErrorComponentProps) {
         : 'Try again in a moment.';
   return (
     <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
-      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-section">
+      <FocusedFrame className="flex flex-col gap-section">
         <Header variant="h1">{setupError ? 'Workspace setup' : 'Workspace'}</Header>
         <Callout role="alert" type="error">
           <div className="flex flex-col gap-inline">
@@ -73,7 +74,7 @@ export function WorkspaceLayoutErrorRoute({error, reset}: ErrorComponentProps) {
             </Button>
           </div>
         </Callout>
-      </div>
+      </FocusedFrame>
     </main>
   );
 }


### PR DESCRIPTION
Consolidate the standalone focused experiences around one shell-owned frame so route pages no longer reimplement centering and max-width behavior.

- Add the reusable 640px `FocusedFrame` and use it for auth, onboarding, integration-install, and callback surfaces.
- Remove bespoke width wrappers and the wide workspace-onboarding preview.
- Keep route-level frame ownership in `MainLayout` while preserving the existing auth editorial background and Panel structure.

Closes ENG-1592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes focused routes on a single shell-owned 640px frame for consistent layout. Previously pages self-centered; now `FocusedFrame` or `MainLayout`’s `focused` frame enforce width. Removes the wide workspace-onboarding preview.

- Adds `FocusedFrame` and `FOCUSED_FRAME_CONTENT_CLASS_NAME` exported from `@shipfox/client-shell/runtime`; `MainLayout`’s `focused` frame consumes the constant for a single source of truth.
- Migrates auth, workspace onboarding, integration callback/status (Jira/Sentry), redirect-install error, and workspace unavailable/setup error to the shared frame; removes local `mx-auto`/`max-w` wrappers.
- Tests: adds a `FocusedFrame` contract test; updates redirect-install coverage to import `FOCUSED_FRAME_CONTENT_CLASS_NAME` and assert width on the error container to prevent drift.

**Migration**
- For any focused route, remove local centering wrappers and wrap content in `FocusedFrame` or use the route’s `focused` frame in `MainLayout`.
- Update tests/snapshots to import `FOCUSED_FRAME_CONTENT_CLASS_NAME` instead of asserting hard-coded classes.

<sup>Written for commit 293dd217e427d5c86e0ab164073c8fa21119a550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

