### PR TITLE
[client-workflows] Recompose workflows page onto data frame

### DIFF
--- a/.changeset/calm-workflows-panels.md
+++ b/.changeset/calm-workflows-panels.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": patch
 ---
 
-Recomposes the workflows page around separate source and definition panels.
+Removes the redundant page heading and description from the workflows page.

--- a/.changeset/calm-workflows-panels.md
+++ b/.changeset/calm-workflows-panels.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Recomposes the workflows page around separate source and definition panels.

--- a/libs/client/workflows/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.test.tsx
@@ -18,15 +18,19 @@ describe('ProjectWorkflowsPage', () => {
     renderWorkflowsPage();
 
     expect((await screen.findAllByText('Deploy production'))[0]).toBeInTheDocument();
-    expect(screen.queryByRole('heading', {name: 'Workflows'})).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Workflows'})).toHaveClass('sr-only');
     expect(
       screen.queryByText('Synced workflow definitions for this project source.'),
     ).not.toBeInTheDocument();
     expect(screen.getAllByText('.shipfox/workflows/deploy.yml')[0]).toBeInTheDocument();
-    expect(
-      screen.getByRole('region', {name: 'Project source'}).closest('[data-slot="panel"]'),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('table').closest('[data-slot="panel"]')).toBeInTheDocument();
+    const sourcePanel = screen
+      .getByRole('region', {name: 'Project source'})
+      .closest('[data-slot="panel"]');
+    const definitionsPanel = screen.getByRole('region', {name: 'Workflow definitions'});
+    expect(sourcePanel).toBeInTheDocument();
+    expect(definitionsPanel).toBeInTheDocument();
+    expect(sourcePanel).not.toBe(definitionsPanel);
+    expect(screen.getByRole('table').closest('[data-slot="panel"]')).toBe(definitionsPanel);
     // Source strip resolves connection display_name from the integrations
     // workspace cache; external_repository_id renders as a Code chip.
     expect(await screen.findByText('Acme GitHub')).toBeInTheDocument();

--- a/libs/client/workflows/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.test.tsx
@@ -12,15 +12,21 @@ const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
 
 describe('ProjectWorkflowsPage', () => {
-  test('renders workflow definitions and the source strip', async () => {
+  test('renders workflow definitions and their panel regions', async () => {
     configureApiClient({fetchImpl: createProjectDetailFetch()});
 
     renderWorkflowsPage();
 
-    expect(await screen.findByRole('heading', {name: 'Workflows'})).toBeInTheDocument();
-    expect(screen.getAllByText('Deploy production')[0]).toBeInTheDocument();
+    expect((await screen.findAllByText('Deploy production'))[0]).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Workflows'})).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Synced workflow definitions for this project source.'),
+    ).not.toBeInTheDocument();
     expect(screen.getAllByText('.shipfox/workflows/deploy.yml')[0]).toBeInTheDocument();
-    expect(screen.getByRole('region', {name: 'Project source'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('region', {name: 'Project source'}).closest('[data-slot="panel"]'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('table').closest('[data-slot="panel"]')).toBeInTheDocument();
     // Source strip resolves connection display_name from the integrations
     // workspace cache; external_repository_id renders as a Code chip.
     expect(await screen.findByText('Acme GitHub')).toBeInTheDocument();

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -32,7 +32,7 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {toast} from '@shipfox/react-ui/toast';
-import {Code, Text} from '@shipfox/react-ui/typography';
+import {Code, Header, Text} from '@shipfox/react-ui/typography';
 import {useState} from 'react';
 import {useFireManualWorkflowMutation} from '#hooks/api/workflow-runs.js';
 
@@ -68,6 +68,10 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
 
   return (
     <div className="flex w-full flex-col gap-section">
+      <Header variant="h1" className="sr-only">
+        Workflows
+      </Header>
+
       {projectQuery.isPending ? (
         <div className="flex flex-col gap-cluster">
           <Skeleton className="h-28 w-1/3" />
@@ -174,7 +178,7 @@ function WorkflowDefinitionsList({
 
   if (isError && definitions.length === 0) {
     return (
-      <Panel>
+      <Panel role="region" aria-label="Workflow definitions">
         <LoadErrorState
           title="Couldn't load workflows"
           description="Definitions could not be loaded. Source metadata remains visible."
@@ -188,7 +192,7 @@ function WorkflowDefinitionsList({
 
   if (definitions.length === 0) {
     return (
-      <Panel>
+      <Panel role="region" aria-label="Workflow definitions">
         <WorkflowEmptyState sync={sync} />
       </Panel>
     );
@@ -196,7 +200,7 @@ function WorkflowDefinitionsList({
 
   return (
     <>
-      <Panel>
+      <Panel role="region" aria-label="Workflow definitions">
         <div className="hidden md:block">
           <Table>
             <TableHeader>

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -32,7 +32,7 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {toast} from '@shipfox/react-ui/toast';
-import {Code, Header, Text} from '@shipfox/react-ui/typography';
+import {Code, Text} from '@shipfox/react-ui/typography';
 import {useState} from 'react';
 import {useFireManualWorkflowMutation} from '#hooks/api/workflow-runs.js';
 
@@ -89,13 +89,6 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
 
       {projectQuery.data ? (
         <>
-          <header className="flex flex-col gap-tight">
-            <Header variant="h2">Workflows</Header>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              Synced workflow definitions for this project source.
-            </Text>
-          </header>
-
           <SourceStrip
             connectionId={projectQuery.data.source.connectionId}
             externalRepositoryId={projectQuery.data.source.externalRepositoryId}


### PR DESCRIPTION
The workflows route now presents its source metadata and definition list as separate data regions on the declared data frame. The redundant page heading and description are removed because project navigation already identifies the page.

Regression coverage checks the title and description removal and the Panel boundary around both regions.

Closes ENG-1588

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recomposes the Workflows page onto the `data` frame to render the source strip and definitions table as separate `Panel` regions, and restores an accessible page structure. Previously the page showed a visible H2 and description; now it uses an sr-only H1, removes the H2 and description, and names the definitions region for screen readers.

- Render "Project source" and "Workflow definitions" as distinct `Panel` regions; the table lives inside the definitions panel.
- Add an sr-only H1 "Workflows"; remove the visible H2 and the description.
- Strengthen tests to assert region labels, panel boundaries, and removal of the description; no API or interaction changes.
- Patch release for `@shipfox/client-workflows`. Aligns with ENG-1588.

<sup>Written for commit 1c729ddf4a6dc3cdc6759c3a316b25f8886e97ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

