### PR TITLE
[client-workflows] Show live timers in whole seconds

### DIFF
--- a/.changeset/calm-timers-tick.md
+++ b/.changeset/calm-timers-tick.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Displays live job duration timers in whole seconds.

--- a/libs/client/workflows/src/components/job-detail/job-execution-time-text.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-execution-time-text.test.ts
@@ -1,19 +1,46 @@
 import {formatJobExecutionTime} from './job-execution-time-text.js';
 
+const FROM_ISO = '2026-08-15T08:51:00.000Z';
+const FROM_MS = Date.parse(FROM_ISO);
+
 describe('formatJobExecutionTime', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  test('formats live timers as whole seconds', () => {
+  test.each([
+    [999, '0s'],
+    [37_999, '37s'],
+    [60_000, '1m 00s'],
+    [124_999, '2m 04s'],
+    [3_780_999, '1h 03m'],
+  ])('formats a live %i ms timer as %s', (elapsedMs, expected) => {
     vi.useFakeTimers();
-    vi.setSystemTime('2026-08-15T08:51:37.300Z');
+    vi.setSystemTime(FROM_MS + elapsedMs);
 
     const result = formatJobExecutionTime({
       state: 'live',
-      fromIso: '2026-08-15T08:51:00.000Z',
+      fromIso: FROM_ISO,
     });
 
-    expect(result).toBe('37s');
+    expect(result).toBe(expected);
+  });
+
+  test('falls back to zero seconds for an invalid live timestamp', () => {
+    const result = formatJobExecutionTime({state: 'live', fromIso: 'not-a-date'});
+
+    expect(result).toBe('0s');
+  });
+
+  test.each([
+    [{seconds: 37}, '37s'],
+    [{minutes: 1}, '1m 00s'],
+    [{minutes: 2, seconds: 4}, '2m 04s'],
+    [{hours: 1}, '1h 00m'],
+    [{hours: 1, minutes: 3}, '1h 03m'],
+  ])('formats a fixed timer consistently as %s', (elapsed, expected) => {
+    const result = formatJobExecutionTime({state: 'fixed', elapsed});
+
+    expect(result).toBe(expected);
   });
 });

--- a/libs/client/workflows/src/components/job-detail/job-execution-time-text.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-execution-time-text.test.ts
@@ -1,0 +1,19 @@
+import {formatJobExecutionTime} from './job-execution-time-text.js';
+
+describe('formatJobExecutionTime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('formats live timers as whole seconds', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-08-15T08:51:37.300Z');
+
+    const result = formatJobExecutionTime({
+      state: 'live',
+      fromIso: '2026-08-15T08:51:00.000Z',
+    });
+
+    expect(result).toBe('37s');
+  });
+});

--- a/libs/client/workflows/src/components/job-detail/job-execution-time-text.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-execution-time-text.tsx
@@ -1,6 +1,6 @@
 import {useTimeTick} from '@shipfox/react-ui/time-ticker';
-import {humanDuration} from '@shipfox/react-ui/utils';
 import type {JobExecutionTime} from '#core/workflow-run.js';
+import {formatJobExecutionTimeLabel} from '../job-graph/job-duration-format.js';
 
 export function JobExecutionTimeText({time}: {time: JobExecutionTime}) {
   useTimeTick();
@@ -9,26 +9,5 @@ export function JobExecutionTimeText({time}: {time: JobExecutionTime}) {
 }
 
 export function formatJobExecutionTime(time: JobExecutionTime): string {
-  if (time.state === 'live') {
-    return humanDuration(time.fromIso);
-  }
-
-  return formatElapsedDuration(time.elapsed);
-}
-
-function formatElapsedDuration(duration: {
-  days?: number | undefined;
-  hours?: number | undefined;
-  minutes?: number | undefined;
-  seconds?: number | undefined;
-}): string {
-  const days = duration.days ?? 0;
-  const hours = duration.hours ?? 0;
-  const minutes = duration.minutes ?? 0;
-  const seconds = duration.seconds ?? 0;
-
-  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
-  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  if (minutes > 0) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
-  return `${seconds}s`;
+  return formatJobExecutionTimeLabel(time);
 }

--- a/libs/client/workflows/src/components/job-detail/job-execution-time-text.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-execution-time-text.tsx
@@ -1,5 +1,5 @@
 import {useTimeTick} from '@shipfox/react-ui/time-ticker';
-import {formatDuration} from '@shipfox/react-ui/utils';
+import {humanDuration} from '@shipfox/react-ui/utils';
 import type {JobExecutionTime} from '#core/workflow-run.js';
 
 export function JobExecutionTimeText({time}: {time: JobExecutionTime}) {
@@ -10,7 +10,7 @@ export function JobExecutionTimeText({time}: {time: JobExecutionTime}) {
 
 export function formatJobExecutionTime(time: JobExecutionTime): string {
   if (time.state === 'live') {
-    return formatDuration(Date.now() - Date.parse(time.fromIso));
+    return humanDuration(time.fromIso);
   }
 
   return formatElapsedDuration(time.elapsed);

--- a/libs/client/workflows/src/components/job-graph/job-duration-format.ts
+++ b/libs/client/workflows/src/components/job-graph/job-duration-format.ts
@@ -8,7 +8,7 @@ import type {
 export function formatJobExecutionTimeLabel(time: JobExecutionTime): string {
   switch (time.state) {
     case 'live':
-      return humanDuration(time.fromIso);
+      return humanDuration(time.fromIso) || '0s';
     case 'fixed':
       return formatFixedDurationLabel(time.elapsed);
     default: {


### PR DESCRIPTION
Live duration timers used the precision formatter, so queued jobs, running jobs, and timed waiting states could display tenths of a second while neighboring run timers displayed whole seconds.

Use the existing wall-clock formatter for these live timers and keep live and completed job durations on one display convention. Invalid live timestamps now fall back to `0s`. Completed step and log measurements continue to use their precise formatter.

Focused regression coverage checks truncation, sub-second display, minute and hour boundaries, invalid timestamps, and live/fixed parity.