### PR TITLE
[react-ui] Add Panel and Table Storybook coverage

### DIFF
--- a/.changeset/visual-panel-stories.md
+++ b/.changeset/visual-panel-stories.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Adds Panel and Table Storybook coverage for empty, error, loading, and interaction states.

--- a/.changeset/visual-panel-stories.md
+++ b/.changeset/visual-panel-stories.md
@@ -1,5 +1,0 @@
----
-"@shipfox/react-ui": patch
----
-
-Adds Panel and Table Storybook coverage for empty, error, loading, and interaction states.

--- a/libs/shared/react/ui/src/components/panel/panel.stories.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.stories.tsx
@@ -125,13 +125,16 @@ export const RowStates: Story = {
       </PanelHeader>
       <PanelBody>
         <PanelRow className="panel-row-hover">
-          <div className="min-w-0">
-            <Text size="sm" bold>
-              Hovered row
-            </Text>
-            <Text size="xs" className="text-foreground-neutral-base">
-              The row hover surface stays one step from the panel.
-            </Text>
+          <div className="flex min-w-0 items-center gap-inline">
+            <input type="checkbox" readOnly aria-label="Select hovered row" />
+            <div className="min-w-0">
+              <Text size="sm" bold>
+                Hovered row
+              </Text>
+              <Text size="xs" className="text-foreground-neutral-base">
+                The row hover surface stays one step from the panel.
+              </Text>
+            </div>
           </div>
           <StatusBadge variant="info">Running</StatusBadge>
         </PanelRow>
@@ -139,18 +142,24 @@ export const RowStates: Story = {
           data-selected="true"
           className="data-[selected=true]:bg-background-neutral-pressed data-[selected=true]:hover:bg-background-neutral-pressed"
         >
-          <div className="min-w-0">
-            <Text size="sm" bold>
-              Selected row
-            </Text>
-            <Text size="xs" className="text-foreground-neutral-base">
-              Selection uses the pressed neutral surface.
-            </Text>
+          <div className="flex min-w-0 items-center gap-inline">
+            <input type="checkbox" checked readOnly aria-label="Select selected row" />
+            <div className="min-w-0">
+              <Text size="sm" bold>
+                Selected row
+              </Text>
+              <Text size="xs" className="text-foreground-neutral-base">
+                Selection uses the pressed neutral surface.
+              </Text>
+            </div>
           </div>
           <StatusBadge variant="success">Succeeded</StatusBadge>
         </PanelRow>
         <PanelRow>
-          <Text size="sm">Default row</Text>
+          <div className="flex min-w-0 items-center gap-inline">
+            <input type="checkbox" readOnly aria-label="Select default row" />
+            <Text size="sm">Default row</Text>
+          </div>
         </PanelRow>
       </PanelBody>
     </Panel>

--- a/libs/shared/react/ui/src/components/panel/panel.stories.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.stories.tsx
@@ -1,7 +1,10 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {StatusBadge} from '#components/badge/index.js';
 import {Button} from '#components/button/index.js';
+import {EmptyState} from '#components/empty-state/index.js';
 import {Icon} from '#components/icon/index.js';
+import {LoadErrorState} from '#components/load-error-state/index.js';
+import {Skeleton} from '#components/skeleton/index.js';
 import {Code, Text} from '#components/typography/index.js';
 import {
   Panel,
@@ -9,7 +12,6 @@ import {
   PanelBody,
   PanelCell,
   PanelCellAction,
-  PanelEmpty,
   PanelGrid,
   PanelHeader,
   PanelRow,
@@ -103,6 +105,120 @@ export const Variants: Story = {
           </PanelBody>
         </Panel>
       ))}
+      <Panel>
+        <PanelBody>
+          <PanelRow>
+            <Text size="sm">This panel has no header and starts directly with its body.</Text>
+          </PanelRow>
+        </PanelBody>
+      </Panel>
+    </div>
+  ),
+};
+
+export const RowStates: Story = {
+  render: () => (
+    <Panel className="w-640">
+      <PanelHeader>
+        <PanelTitle>Workflow runs</PanelTitle>
+      </PanelHeader>
+      <PanelBody>
+        <PanelRow className="panel-row-hover">
+          <div className="min-w-0">
+            <Text size="sm" bold>
+              Hovered row
+            </Text>
+            <Text size="xs" className="text-foreground-neutral-muted">
+              The row hover surface stays one step from the panel.
+            </Text>
+          </div>
+          <StatusBadge variant="info">Running</StatusBadge>
+        </PanelRow>
+        <PanelRow
+          data-selected="true"
+          className="data-[selected=true]:bg-background-neutral-pressed data-[selected=true]:hover:bg-background-neutral-pressed"
+        >
+          <div className="min-w-0">
+            <Text size="sm" bold>
+              Selected row
+            </Text>
+            <Text size="xs" className="text-foreground-neutral-muted">
+              Selection uses the pressed neutral surface.
+            </Text>
+          </div>
+          <StatusBadge variant="success">Succeeded</StatusBadge>
+        </PanelRow>
+        <PanelRow>
+          <Text size="sm">Default row</Text>
+        </PanelRow>
+      </PanelBody>
+    </Panel>
+  ),
+  parameters: {
+    pseudo: {
+      hover: '.panel-row-hover',
+    },
+  },
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex w-640 flex-col gap-24">
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>Empty body</PanelTitle>
+        </PanelHeader>
+        <PanelBody>
+          <EmptyState
+            variant="panel"
+            icon="inboxLine"
+            title="No workflow runs yet"
+            description="Runs from this project will appear here once one is launched."
+          />
+        </PanelBody>
+      </Panel>
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>Error body</PanelTitle>
+        </PanelHeader>
+        <PanelBody>
+          <LoadErrorState
+            variant="panel"
+            title="Couldn't load workflow runs"
+            description="Something went wrong. Check your connection and try again."
+            onRetry={() => undefined}
+            retryLabel="Retry loading workflow runs"
+          />
+        </PanelBody>
+      </Panel>
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>Loading body</PanelTitle>
+        </PanelHeader>
+        <PanelBody>
+          <PanelRow className="justify-start gap-group">
+            <div className="flex min-w-0 flex-1 flex-col gap-8">
+              <Skeleton className="h-16 w-240" />
+              <Skeleton className="h-12 w-160" />
+            </div>
+            <Skeleton className="h-20 w-80 shrink-0" />
+          </PanelRow>
+          <PanelRow className="justify-start gap-group">
+            <div className="flex min-w-0 flex-1 flex-col gap-8">
+              <Skeleton className="h-16 w-200" />
+              <Skeleton className="h-12 w-120" />
+            </div>
+            <Skeleton className="h-20 w-80 shrink-0" />
+          </PanelRow>
+          <PanelRow className="justify-start gap-group">
+            <div className="flex min-w-0 flex-1 flex-col gap-8">
+              <Skeleton className="h-16 w-280" />
+              <Skeleton className="h-12 w-144" />
+            </div>
+            <Skeleton className="h-20 w-80 shrink-0" />
+          </PanelRow>
+        </PanelBody>
+      </Panel>
     </div>
   ),
 };
@@ -128,30 +244,5 @@ export const Grid: Story = {
         </PanelGrid>
       </PanelBody>
     </Panel>
-  ),
-};
-
-export const Compositions: Story = {
-  render: () => (
-    <div className="flex w-640 flex-col gap-24">
-      <Panel>
-        <PanelHeader variant="plain">
-          <PanelTitle>Recent deployments</PanelTitle>
-          <PanelActions>
-            <Button size="sm" variant="secondary">
-              View all
-            </Button>
-          </PanelActions>
-        </PanelHeader>
-        <PanelBody>
-          <PanelEmpty>No deployments yet</PanelEmpty>
-        </PanelBody>
-      </Panel>
-      <Panel>
-        <PanelBody>
-          <PanelEmpty compact>No filtered results</PanelEmpty>
-        </PanelBody>
-      </Panel>
-    </div>
   ),
 };

--- a/libs/shared/react/ui/src/components/panel/panel.stories.tsx
+++ b/libs/shared/react/ui/src/components/panel/panel.stories.tsx
@@ -12,6 +12,7 @@ import {
   PanelBody,
   PanelCell,
   PanelCellAction,
+  PanelEmpty,
   PanelGrid,
   PanelHeader,
   PanelRow,
@@ -128,7 +129,7 @@ export const RowStates: Story = {
             <Text size="sm" bold>
               Hovered row
             </Text>
-            <Text size="xs" className="text-foreground-neutral-muted">
+            <Text size="xs" className="text-foreground-neutral-base">
               The row hover surface stays one step from the panel.
             </Text>
           </div>
@@ -142,7 +143,7 @@ export const RowStates: Story = {
             <Text size="sm" bold>
               Selected row
             </Text>
-            <Text size="xs" className="text-foreground-neutral-muted">
+            <Text size="xs" className="text-foreground-neutral-base">
               Selection uses the pressed neutral surface.
             </Text>
           </div>
@@ -193,9 +194,24 @@ export const States: Story = {
       </Panel>
       <Panel>
         <PanelHeader>
-          <PanelTitle>Loading body</PanelTitle>
+          <PanelTitle>Compact empty body</PanelTitle>
         </PanelHeader>
         <PanelBody>
+          <PanelEmpty compact>
+            <Text size="sm" className="text-foreground-neutral-subtle">
+              No filtered results
+            </Text>
+          </PanelEmpty>
+        </PanelBody>
+      </Panel>
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>Loading body</PanelTitle>
+        </PanelHeader>
+        <PanelBody aria-busy="true">
+          <span className="sr-only" role="status" aria-live="polite">
+            Loading workflow runs
+          </span>
           <PanelRow className="justify-start gap-group">
             <div className="flex min-w-0 flex-1 flex-col gap-8">
               <Skeleton className="h-16 w-240" />

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -63,13 +63,7 @@ export const Playground: Story = {
             <TableRow
               key={workflow.path}
               data-selected={workflow.path === selectedWorkflowPath ? 'true' : undefined}
-              className={
-                workflow.path === selectedWorkflowPath
-                  ? 'table-row-selected'
-                  : workflow.path === hoveredWorkflowPath
-                    ? 'table-row-hover'
-                    : undefined
-              }
+              className={workflow.path === hoveredWorkflowPath ? 'table-row-hover' : undefined}
             >
               <TableCell className="w-40">
                 <input

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -40,6 +40,7 @@ const workflows = [
 ];
 
 const selectedWorkflowPath = '.shipfox/workflows/nightly.yml';
+const hoveredWorkflowPath = '.shipfox/workflows/deploy.yml';
 
 export const Playground: Story = {
   render: () => (
@@ -62,7 +63,13 @@ export const Playground: Story = {
             <TableRow
               key={workflow.path}
               data-selected={workflow.path === selectedWorkflowPath ? 'true' : undefined}
-              className={workflow.path === selectedWorkflowPath ? 'table-row-selected' : undefined}
+              className={
+                workflow.path === selectedWorkflowPath
+                  ? 'table-row-selected'
+                  : workflow.path === hoveredWorkflowPath
+                    ? 'table-row-hover'
+                    : undefined
+              }
             >
               <TableCell className="w-40">
                 <input
@@ -93,7 +100,7 @@ export const Playground: Story = {
   ),
   parameters: {
     pseudo: {
-      hover: '.table-row-selected',
+      hover: '.table-row-hover',
     },
   },
 };

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -47,6 +47,9 @@ export const Playground: Story = {
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead>
+              <span className="sr-only">Select workflow</span>
+            </TableHead>
             <TableHead>Workflow</TableHead>
             <TableHead>Path</TableHead>
             <TableHead>Status</TableHead>
@@ -61,6 +64,14 @@ export const Playground: Story = {
               data-selected={workflow.path === selectedWorkflowPath ? 'true' : undefined}
               className={workflow.path === selectedWorkflowPath ? 'table-row-selected' : undefined}
             >
+              <TableCell className="w-40">
+                <input
+                  type="checkbox"
+                  checked={workflow.path === selectedWorkflowPath}
+                  readOnly
+                  aria-label={`Select ${workflow.name}`}
+                />
+              </TableCell>
               <TableCell className="font-medium">{workflow.name}</TableCell>
               <TableCell>
                 <Code>{workflow.path}</Code>

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -54,7 +54,10 @@ export const Playground: Story = {
         </TableHeader>
         <TableBody>
           {workflows.map((workflow) => (
-            <TableRow key={workflow.path}>
+            <TableRow
+              key={workflow.path}
+              data-selected={workflow.name === 'Nightly verification' ? 'true' : undefined}
+            >
               <TableCell className="font-medium">{workflow.name}</TableCell>
               <TableCell>
                 <Code>{workflow.path}</Code>

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -39,6 +39,8 @@ const workflows = [
   },
 ];
 
+const selectedWorkflowPath = '.shipfox/workflows/nightly.yml';
+
 export const Playground: Story = {
   render: () => (
     <Panel className="w-760">
@@ -56,7 +58,8 @@ export const Playground: Story = {
           {workflows.map((workflow) => (
             <TableRow
               key={workflow.path}
-              data-selected={workflow.name === 'Nightly verification' ? 'true' : undefined}
+              data-selected={workflow.path === selectedWorkflowPath ? 'true' : undefined}
+              className={workflow.path === selectedWorkflowPath ? 'table-row-selected' : undefined}
             >
               <TableCell className="font-medium">{workflow.name}</TableCell>
               <TableCell>
@@ -77,4 +80,9 @@ export const Playground: Story = {
       </Table>
     </Panel>
   ),
+  parameters: {
+    pseudo: {
+      hover: '.table-row-selected',
+    },
+  },
 };


### PR DESCRIPTION
Adds the Storybook coverage needed to review the surface primitives in both themes.

The Panel stories cover both header variants, headerless panels, row hover and selection, empty, error, and loading bodies, plus a tile grid with internal hairlines. The Table story keeps the table inside a Panel and includes a selected row.

The existing react-ui Storybook Argos configuration captures light and dark modes.

Closes ENG-1579

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Storybook coverage for Panel and Table primitives in both themes to lock visual regressions and prevent light/dark drift. Makes hover, selection, empty, error, and loading states accessible and Argos-testable.

- Panel stories: both header variants and a headerless panel; row hover via .panel-row-hover with Storybook pseudo hover; selection via data-selected with checkboxes and aria-labels; `EmptyState`, `LoadErrorState`, and `Skeleton` use variant="panel"; loading body sets aria-busy and includes an sr-only live status; includes a tile grid with internal hairlines.
- Table playground: table inside a Panel; selection column with a checkbox and an sr-only header label; selection uses data-selected only (removed the inert .table-row-selected marker); distinct hover row via .table-row-hover with Storybook pseudo hover.
- Argos captures light and dark; ships as a `@shipfox/react-ui` patch. Aligns with ENG-1579.

<sup>Written for commit ce0ce44799508029ccbf8333df2b763fe1429e46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

