### PR TITLE
Recompose workspace settings and sections

### DIFF
--- a/.changeset/bright-settings-rail.md
+++ b/.changeset/bright-settings-rail.md
@@ -1,0 +1,11 @@
+---
+"@shipfox/client-agent": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-runners": patch
+"@shipfox/client-secrets": patch
+"@shipfox/client-shell": patch
+"@shipfox/client-triggers": patch
+"@shipfox/client-workspace-settings": patch
+---
+
+Recomposes workspace settings with a content-frame layout, panel-backed sections, and a compact settings rail.

--- a/.changeset/bright-settings-rail.md
+++ b/.changeset/bright-settings-rail.md
@@ -8,4 +8,4 @@
 "@shipfox/client-workspace-settings": patch
 ---
 
-Recomposes workspace settings with a content-frame layout, panel-backed sections, and a compact settings rail.
+Reorganizes workspace settings into a compact sidebar rail with section panels and moves Events settings into the shared content frame.

--- a/.changeset/bright-settings-rail.md
+++ b/.changeset/bright-settings-rail.md
@@ -8,4 +8,4 @@
 "@shipfox/client-workspace-settings": patch
 ---
 
-Reorganizes workspace settings into a compact sidebar rail with section panels and moves Events settings into the shared content frame.
+Reorganizes workspace settings into a compact sidebar rail with section panels and relocates Events settings into the new workspace layout.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -373,8 +373,9 @@ Two things follow:
 - **Object identity is not a page title.** A run header keeps its status pill,
   name, trigger, and duration, because those name the object rather than the page.
 
-Settings sub-pages are the exception and keep a bare title. The settings nav does
-not name the active section anywhere else.
+Settings sub-pages are the exception and keep a bare title. The settings nav
+provides the navigation context and active state, but it is not a content
+heading, so the title stays in the page content.
 
 ### Spacing
 

--- a/e2e/kit/src/ui/page-objects.test.ts
+++ b/e2e/kit/src/ui/page-objects.test.ts
@@ -128,7 +128,7 @@ describe('ui page objects', () => {
     const pageObject = page();
     const nav = locator('nav');
     const link = locator('link');
-    pageObject.getByRole.mockReturnValueOnce(locator('heading')).mockReturnValueOnce(nav);
+    pageObject.getByRole.mockReturnValue(nav);
     nav.getByRole.mockReturnValue(link);
     const {SettingsShell} = await import('./page-objects.js');
     const shell = new SettingsShell(pageObject as never);

--- a/e2e/kit/src/ui/page-objects.ts
+++ b/e2e/kit/src/ui/page-objects.ts
@@ -142,12 +142,7 @@ export class SettingsShell {
   async goto(workspaceSlug: string, tab: SettingsTab): Promise<void> {
     await this.page.goto(settingsPath(workspaceSlug, tab));
     await expect(this.page).toHaveURL(new RegExp(`${settingsPath(workspaceSlug, tab)}/?$`, 'u'));
-    await expect(this.heading()).toBeVisible();
     await expect(this.activeNavLink(tab)).toHaveAttribute('aria-current', 'page');
-  }
-
-  heading(): AppLocator {
-    return this.page.getByRole('heading', {name: 'Workspace settings'});
   }
 
   nav(): AppLocator {

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -84,9 +84,6 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
     <section className="flex flex-col gap-group" aria-label="Harnesses">
       <div className="flex flex-col gap-tight">
         <Header variant="h3">Harnesses</Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          Harnesses available to run agent steps in this workspace.
-        </Text>
       </div>
 
       {configsQuery.isPending ? <HarnessRowsSkeleton /> : null}

--- a/libs/client/agent/src/components/model-providers-section.test.tsx
+++ b/libs/client/agent/src/components/model-providers-section.test.tsx
@@ -89,8 +89,8 @@ describe('WorkspaceModelProvidersSection', () => {
     expect(screen.getByText('Default provider')).toHaveClass('sr-only');
     expect(screen.getByText('Available providers')).toBeVisible();
     expect(
-      screen.getByText('Providers that can be configured for agent steps in this workspace.'),
-    ).toBeVisible();
+      screen.queryByText('Providers that can be configured for agent steps in this workspace.'),
+    ).not.toBeInTheDocument();
     expect(screen.getByText('OpenAI')).toBeVisible();
     const customProviderButton = screen.getByRole('button', {name: 'Configure custom provider'});
     expect(within(customProviderButton).getByText('Custom')).toBeVisible();

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -120,9 +120,6 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
       >
         <div className="flex flex-col gap-tight">
           <Header variant="h3">Configured providers</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            Workspace credentials available to agent steps.
-          </Text>
         </div>
 
         {configsQuery.isPending ? (
@@ -213,9 +210,6 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
       <section className="flex flex-col gap-group" aria-label="Available providers">
         <div className="flex flex-col gap-tight">
           <Header variant="h3">Available providers</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            Providers that can be configured for agent steps in this workspace.
-          </Text>
         </div>
 
         {catalogQuery.isPending || configsQuery.isPending ? (
@@ -243,9 +237,6 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
       <section className="flex flex-col gap-group" aria-label="Unsupported providers">
         <div className="flex flex-col gap-tight">
           <Header variant="h3">Unsupported providers</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            Providers that cannot be configured in this workspace yet.
-          </Text>
         </div>
 
         {catalogQuery.isPending ? (

--- a/libs/client/agent/src/routes/agents-settings.tsx
+++ b/libs/client/agent/src/routes/agents-settings.tsx
@@ -1,4 +1,5 @@
 import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {Header} from '@shipfox/react-ui/typography';
 import {WorkspaceHarnessesSection, WorkspaceModelProvidersSection} from '#index.js';
 
 export default defineRoute({
@@ -6,9 +7,12 @@ export default defineRoute({
   component: () => {
     const workspace = useActiveWorkspace();
     return (
-      <div className="flex flex-col gap-region">
-        <WorkspaceHarnessesSection workspaceId={workspace.id} />
-        <WorkspaceModelProvidersSection workspaceId={workspace.id} />
+      <div className="flex min-w-0 flex-col gap-section">
+        <Header variant="h1">Agents</Header>
+        <div className="flex flex-col gap-region">
+          <WorkspaceHarnessesSection workspaceId={workspace.id} />
+          <WorkspaceModelProvidersSection workspaceId={workspace.id} />
+        </div>
       </div>
     );
   },

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -49,9 +49,6 @@ export function InstalledIntegrationsSection({
     <section className="flex flex-col gap-group" aria-label="Installed integrations">
       <div className="flex flex-col gap-tight">
         <Header variant="h3">Installed integrations</Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          Provider accounts installed in this workspace.
-        </Text>
       </div>
 
       {isPending ? <InstalledSkeleton label="Loading integrations" /> : null}

--- a/libs/client/integrations/src/components/integration-gallery-for-workspace.tsx
+++ b/libs/client/integrations/src/components/integration-gallery-for-workspace.tsx
@@ -148,9 +148,6 @@ export function IntegrationGalleryForWorkspace({
       <section className="flex flex-col gap-group" aria-label="Available integrations">
         <div className="flex flex-col gap-tight">
           <Header variant="h3">Available integrations</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            Providers available to install in this workspace.
-          </Text>
         </div>
 
         {workspaceSlug ? (

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -244,7 +244,9 @@ describe('IntegrationGallery — installed section', () => {
 
     expect(await screen.findByText('acme-one')).toBeVisible();
     expect(screen.getByText('acme-two')).toBeVisible();
-    expect(screen.getByText('Provider accounts installed in this workspace.')).toBeVisible();
+    expect(
+      screen.queryByText('Provider accounts installed in this workspace.'),
+    ).not.toBeInTheDocument();
   });
 
   test('sorts stably by provider name then created_at regardless of input order', async () => {
@@ -592,7 +594,9 @@ describe('IntegrationGallery: available section', () => {
     expect(await screen.findByRole('link', {name: 'Install GitHub'})).toBeVisible();
     expect(screen.getByRole('link', {name: 'Install Sentry'})).toBeVisible();
     expect(screen.getByRole('button', {name: 'Add Webhook'})).toBeVisible();
-    expect(screen.getByText('Providers available to install in this workspace.')).toBeVisible();
+    expect(
+      screen.queryByText('Providers available to install in this workspace.'),
+    ).not.toBeInTheDocument();
   });
 
   test('exposes each available tile as a single link with no nested button', async () => {

--- a/libs/client/integrations/src/routes/integrations-settings.tsx
+++ b/libs/client/integrations/src/routes/integrations-settings.tsx
@@ -1,7 +1,13 @@
 import {defineRoute} from '@shipfox/client-shell/runtime';
+import {Header} from '@shipfox/react-ui/typography';
 import {IntegrationGallery} from '#index.js';
 
 export default defineRoute({
   staticData: {frame: 'content'},
-  component: IntegrationGallery,
+  component: () => (
+    <div className="flex min-w-0 flex-col gap-section">
+      <Header variant="h1">Integrations</Header>
+      <IntegrationGallery />
+    </div>
+  ),
 });

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -48,7 +48,7 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
           <div className="flex flex-col gap-tight">
             <Header variant="h3">Runner registration tokens</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
-              Tokens are reusable until revoked.
+              Tokens are reusable until they expire or are revoked.
             </Text>
           </div>
           <div className="flex items-center gap-cluster">

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -47,6 +47,9 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
         <div className="flex items-center justify-between gap-group max-[640px]:items-start">
           <div className="flex flex-col gap-tight">
             <Header variant="h3">Runner registration tokens</Header>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Tokens are reusable until revoked.
+            </Text>
           </div>
           <div className="flex items-center gap-cluster">
             {tokensQuery.isFetching && !tokensQuery.isPending ? (

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -47,10 +47,6 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
         <div className="flex items-center justify-between gap-group max-[640px]:items-start">
           <div className="flex flex-col gap-tight">
             <Header variant="h3">Runner registration tokens</Header>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              Register individual runner agents that run jobs directly in this workspace. Tokens are
-              reusable until revoked.
-            </Text>
           </div>
           <div className="flex items-center gap-cluster">
             {tokensQuery.isFetching && !tokensQuery.isPending ? (

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
@@ -52,10 +52,6 @@ export function WorkspaceProvisionerTokensSettingsSection({workspaceId}: {worksp
         <div className="flex items-center justify-between gap-group max-[640px]:items-start">
           <div className="flex flex-col gap-tight">
             <Header variant="h3">Runner provisioner registration tokens</Header>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              Register runner provisioners that connect to this workspace and create runners
-              dynamically based on demand.
-            </Text>
           </div>
           <div className="flex items-center gap-cluster">
             {(tokensQuery.isFetching && !tokensQuery.isPending) ||

--- a/libs/client/runners/src/routes/provisioners-settings.tsx
+++ b/libs/client/runners/src/routes/provisioners-settings.tsx
@@ -1,9 +1,16 @@
 import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {Header} from '@shipfox/react-ui/typography';
 import {WorkspaceProvisionerTokensSettingsSection} from '#index.js';
 
 export default defineRoute({
   staticData: {frame: 'content'},
-  component: () => (
-    <WorkspaceProvisionerTokensSettingsSection workspaceId={useActiveWorkspace().id} />
-  ),
+  component: () => {
+    const workspace = useActiveWorkspace();
+    return (
+      <div className="flex min-w-0 flex-col gap-section">
+        <Header variant="h1">Runner provisioners</Header>
+        <WorkspaceProvisionerTokensSettingsSection workspaceId={workspace.id} />
+      </div>
+    );
+  },
 });

--- a/libs/client/runners/src/routes/runners-settings.tsx
+++ b/libs/client/runners/src/routes/runners-settings.tsx
@@ -1,9 +1,16 @@
 import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {Header} from '@shipfox/react-ui/typography';
 import {WorkspaceManualRegistrationTokensSettingsSection} from '#index.js';
 
 export default defineRoute({
   staticData: {frame: 'content'},
-  component: () => (
-    <WorkspaceManualRegistrationTokensSettingsSection workspaceId={useActiveWorkspace().id} />
-  ),
+  component: () => {
+    const workspace = useActiveWorkspace();
+    return (
+      <div className="flex min-w-0 flex-col gap-section">
+        <Header variant="h1">Runners</Header>
+        <WorkspaceManualRegistrationTokensSettingsSection workspaceId={workspace.id} />
+      </div>
+    );
+  },
 });

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -19,7 +19,7 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {toast} from '@shipfox/react-ui/toast';
-import {Code, Header} from '@shipfox/react-ui/typography';
+import {Code, Header, Text} from '@shipfox/react-ui/typography';
 import {useMemo, useState} from 'react';
 import {type SecretMetadata, workspaceStoreScope} from '#core/store.js';
 import {useDeleteSecretMutation, useSecretsQuery} from '#hooks/api/secrets.js';
@@ -31,6 +31,7 @@ import {StoreRowsSkeleton} from './store-section-shell.js';
 
 const EMPTY_SECRETS_DESCRIPTION =
   'Create a secret to store sensitive values like API keys, tokens, and passwords.';
+const SECRETS_SECURITY_NOTE = 'Encrypted, write-only values for sensitive data.';
 
 type FormState = {mode: 'create'} | {mode: 'edit'; key: string} | null;
 
@@ -56,7 +57,10 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
       <section className="flex flex-col gap-group" aria-label="Secrets">
         <div className="flex items-start justify-between gap-group">
           <div className="flex flex-col gap-tight">
-            <Header variant="h3">Secrets</Header>
+            <Header variant="h1">Secrets</Header>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              {SECRETS_SECURITY_NOTE}
+            </Text>
           </div>
           <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
             Create secret

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -19,7 +19,7 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {toast} from '@shipfox/react-ui/toast';
-import {Code, Header, Text} from '@shipfox/react-ui/typography';
+import {Code, Header} from '@shipfox/react-ui/typography';
 import {useMemo, useState} from 'react';
 import {type SecretMetadata, workspaceStoreScope} from '#core/store.js';
 import {useDeleteSecretMutation, useSecretsQuery} from '#hooks/api/secrets.js';
@@ -29,8 +29,6 @@ import {secretsErrorToFormError} from './form-errors.js';
 import {SecretForm} from './secret-form.js';
 import {StoreRowsSkeleton} from './store-section-shell.js';
 
-const SECRETS_DESCRIPTION =
-  'Encrypted, write-only values for sensitive data like API keys, tokens, and passwords.';
 const EMPTY_SECRETS_DESCRIPTION =
   'Create a secret to store sensitive values like API keys, tokens, and passwords.';
 
@@ -59,9 +57,6 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
         <div className="flex items-start justify-between gap-group">
           <div className="flex flex-col gap-tight">
             <Header variant="h3">Secrets</Header>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              {SECRETS_DESCRIPTION}
-            </Text>
           </div>
           <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
             Create secret

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -19,7 +19,7 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {toast} from '@shipfox/react-ui/toast';
-import {Code, Header, Text} from '@shipfox/react-ui/typography';
+import {Code, Header} from '@shipfox/react-ui/typography';
 import {useMemo, useState} from 'react';
 import {type VariablePreview, workspaceStoreScope} from '#core/store.js';
 import {useDeleteVariableMutation, useVariablesQuery} from '#hooks/api/variables.js';
@@ -29,8 +29,6 @@ import {secretsErrorToFormError} from './form-errors.js';
 import {StoreRowsSkeleton} from './store-section-shell.js';
 import {VariableForm} from './variable-form.js';
 
-const VARIABLES_DESCRIPTION =
-  'Plaintext configuration values for non-sensitive data like regions, flags, and log levels.';
 const EMPTY_VARIABLES_DESCRIPTION =
   'Create a variable to store non-sensitive configuration like regions, flags, and log levels.';
 
@@ -59,9 +57,6 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
         <div className="flex items-start justify-between gap-group">
           <div className="flex flex-col gap-tight">
             <Header variant="h3">Variables</Header>
-            <Text size="sm" className="text-foreground-neutral-muted">
-              {VARIABLES_DESCRIPTION}
-            </Text>
           </div>
           <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
             Create variable

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -56,7 +56,7 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
       <section className="flex flex-col gap-group" aria-label="Variables">
         <div className="flex items-start justify-between gap-group">
           <div className="flex flex-col gap-tight">
-            <Header variant="h3">Variables</Header>
+            <Header variant="h1">Variables</Header>
           </div>
           <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
             Create variable

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -1,9 +1,11 @@
 import {FullPageLoader} from '@shipfox/react-ui/loader';
-import {Outlet, useMatches} from '@tanstack/react-router';
+import {Navigate, Outlet, useMatches} from '@tanstack/react-router';
 import type {NavTabEntry} from '#contract.js';
 import {useMaybeActiveWorkspace} from '#runtime/active-workspace.js';
+import {useAuthState} from '#runtime/auth.js';
 import type {RouteFrame} from '#runtime/route-frame.js';
 import {parseWorkspaceProjectParams, useRouteParams} from '#runtime/route-inputs.js';
+import {WorkspaceUnavailablePage} from '#runtime/workspace-setup.js';
 import {FOCUSED_FRAME_CONTENT_CLASS_NAME} from './focused-frame.js';
 import {NavBar} from './nav-bar.js';
 import {NavTabs} from './nav-tabs.js';
@@ -27,10 +29,13 @@ export function MainLayout({
   navigation: readonly NavTabEntry[];
   hideProjectNavigation?: boolean;
 }) {
+  const auth = useAuthState();
   const workspace = useMaybeActiveWorkspace();
   const {projectSlug} = useRouteParams(parseWorkspaceProjectParams);
   const matches = useMatches();
-  if (!workspace) return <FullPageLoader />;
+  if (auth.isLoading) return <FullPageLoader />;
+  if (!auth.isAuthenticated) return <Navigate to={'/auth/login' as never} replace />;
+  if (!workspace) return <WorkspaceUnavailablePage />;
   const frame = matches.reduce<RouteFrame>(
     (current, match) => match.staticData.frame ?? current,
     'content',

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -1,5 +1,5 @@
 import {FullPageLoader} from '@shipfox/react-ui/loader';
-import {Navigate, Outlet, useMatches} from '@tanstack/react-router';
+import {Navigate, Outlet, useLocation, useMatches} from '@tanstack/react-router';
 import type {NavTabEntry} from '#contract.js';
 import {useMaybeActiveWorkspace} from '#runtime/active-workspace.js';
 import {useAuthState} from '#runtime/auth.js';
@@ -31,10 +31,15 @@ export function MainLayout({
 }) {
   const auth = useAuthState();
   const workspace = useMaybeActiveWorkspace();
+  const location = useLocation();
   const {projectSlug} = useRouteParams(parseWorkspaceProjectParams);
   const matches = useMatches();
   if (auth.isLoading) return <FullPageLoader />;
-  if (!auth.isAuthenticated) return <Navigate to={'/auth/login' as never} replace />;
+  if (!auth.isAuthenticated) {
+    return (
+      <Navigate to={'/auth/login' as never} search={{redirect: location.href} as never} replace />
+    );
+  }
   if (!workspace) return <WorkspaceUnavailablePage />;
   const frame = matches.reduce<RouteFrame>(
     (current, match) => match.staticData.frame ?? current,

--- a/libs/client/shell/src/components/settings-nav.tsx
+++ b/libs/client/shell/src/components/settings-nav.tsx
@@ -1,5 +1,5 @@
-import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
+import {cn} from '@shipfox/react-ui/utils';
 import {Link, useMatchRoute} from '@tanstack/react-router';
 import type {SettingsSectionEntry} from '#contract.js';
 import {
@@ -33,29 +33,36 @@ export function SettingsNav({
   return (
     <nav
       aria-label={`${scope === 'workspace' ? 'Workspace' : 'Project'} settings`}
-      className="flex flex-col gap-tight"
+      className="flex min-w-0 flex-col"
     >
-      {scopedEntries.map((entry) => {
-        const to = `${settingsPath}/${entry.pathSegment}`;
-        const active = Boolean(matchRoute({to: to as never, params: paramsForLink as never}));
-        return (
-          <Button
-            key={entry.id}
-            asChild
-            variant={active ? 'secondary' : 'transparent'}
-            className="w-full justify-start"
-          >
-            <Link
-              to={to as never}
-              params={paramsForLink as never}
-              aria-current={active ? 'page' : undefined}
-            >
-              <Icon name={entry.icon} className="size-16" />
-              {entry.label}
-            </Link>
-          </Button>
-        );
-      })}
+      <ul className="divide-y divide-border-neutral-base">
+        {scopedEntries.map((entry) => {
+          const to = `${settingsPath}/${entry.pathSegment}`;
+          const active = Boolean(matchRoute({to: to as never, params: paramsForLink as never}));
+          return (
+            <li key={entry.id} className="py-tight first:pt-0 last:pb-0">
+              <Link
+                to={to as never}
+                params={paramsForLink as never}
+                aria-current={active ? 'page' : undefined}
+                className={cn(
+                  'relative flex min-h-32 w-full items-center justify-start gap-inline rounded-4 px-tight text-left text-sm font-medium text-foreground-neutral-base outline-none transition-colors hover:bg-background-neutral-hover focus-visible:shadow-border-interactive-with-active',
+                  active && 'bg-background-neutral-hover',
+                )}
+              >
+                {active ? (
+                  <span
+                    aria-hidden="true"
+                    className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
+                  />
+                ) : null}
+                <Icon name={entry.icon} className="size-16" aria-hidden="true" />
+                {entry.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
     </nav>
   );
 }

--- a/libs/client/shell/src/components/settings-nav.tsx
+++ b/libs/client/shell/src/components/settings-nav.tsx
@@ -53,6 +53,7 @@ export function SettingsNav({
                 {active ? (
                   <span
                     aria-hidden="true"
+                    data-settings-active-bar
                     className="absolute inset-y-0 left-0 w-2 rounded-l-4 bg-border-highlights-interactive"
                   />
                 ) : null}

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -157,12 +157,14 @@ function SettingsAnchorLayout({
 
   return (
     <div className={title ? 'flex w-full flex-col gap-section' : 'w-full'}>
-      {title && description ? (
+      {title ? (
         <header className="flex flex-col gap-inline">
           <Header variant="h2">{title}</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            {description}
-          </Text>
+          {description ? (
+            <Text size="sm" className="text-foreground-neutral-muted">
+              {description}
+            </Text>
+          ) : null}
         </header>
       ) : null}
 

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -5,7 +5,7 @@ import {MainLayout} from '#components/main-layout.js';
 import {NotFoundPage} from '#components/not-found-page.js';
 import {SettingsNav} from '#components/settings-nav.js';
 import type {NavTabEntry, SettingsSectionEntry} from '#contract.js';
-import {useActiveWorkspace, useMaybeActiveWorkspace} from './active-workspace.js';
+import {useMaybeActiveWorkspace} from './active-workspace.js';
 import {anchorPaths} from './anchor-paths.js';
 import {rememberLastWorkspaceId} from './last-workspace.js';
 import {parseWorkspaceParams, parseWorkspaceProjectParams, useRouteParams} from './route-inputs.js';
@@ -126,15 +126,7 @@ export function buildAnchorSkeleton({
     getParentRoute: () => workspaceLayout,
     path: '/settings',
     component: () => {
-      const workspace = useActiveWorkspace();
-      return (
-        <SettingsAnchorLayout
-          scope="workspace"
-          title="Workspace settings"
-          description={`Configure ${workspace.name}.`}
-          settingsSections={settingsSections}
-        />
-      );
+      return <SettingsAnchorLayout scope="workspace" settingsSections={settingsSections} />;
     },
   });
   return {
@@ -154,8 +146,8 @@ function SettingsAnchorLayout({
   settingsSections,
 }: {
   scope: 'workspace' | 'project';
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   settingsSections: readonly SettingsSectionEntry[];
 }) {
   const params = useRouteParams((input): {workspaceSlug?: string; projectSlug?: string} =>
@@ -164,13 +156,15 @@ function SettingsAnchorLayout({
   if (!params.workspaceSlug || (scope === 'project' && !params.projectSlug)) return null;
 
   return (
-    <div className="flex w-full flex-col gap-section">
-      <header className="flex flex-col gap-inline">
-        <Header variant="h2">{title}</Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          {description}
-        </Text>
-      </header>
+    <div className={title ? 'flex w-full flex-col gap-section' : 'w-full'}>
+      {title && description ? (
+        <header className="flex flex-col gap-inline">
+          <Header variant="h2">{title}</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            {description}
+          </Text>
+        </header>
+      ) : null}
 
       <div className="grid grid-cols-[180px_minmax(0,1fr)] gap-region max-[760px]:grid-cols-1">
         <SettingsNav entries={settingsSections} scope={scope} />

--- a/libs/client/shell/src/runtime/registries.test.tsx
+++ b/libs/client/shell/src/runtime/registries.test.tsx
@@ -75,7 +75,8 @@ describe('composition registries', () => {
         defineRoute({staticData: {frame: 'content'}, component: () => <h1>Settings page</h1>}),
     });
 
-    expect(await screen.findByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+    expect(await screen.findByRole('heading', {name: 'Settings page'})).toBeVisible();
+    expect(screen.queryByRole('heading', {name: 'Workspace settings'})).not.toBeInTheDocument();
     expect((await screen.findAllByRole('tab')).map((tab) => tab.textContent)).toEqual([
       'First A',
       'First B',
@@ -93,6 +94,11 @@ describe('composition registries', () => {
       'Second setting',
     ]);
     expect(firstSettingsLink).toHaveClass('w-full', 'justify-start');
+    expect(firstSettingsLink).toHaveAttribute('aria-current', 'page');
+    expect(firstSettingsLink).toHaveClass('bg-background-neutral-hover');
+    expect(firstSettingsLink.querySelector('[aria-hidden="true"]')).toHaveClass(
+      'bg-border-highlights-interactive',
+    );
     expect(firstSettingsLink.querySelector('svg')).toHaveClass('size-16');
   });
 });

--- a/libs/client/shell/src/runtime/registries.test.tsx
+++ b/libs/client/shell/src/runtime/registries.test.tsx
@@ -86,8 +86,10 @@ describe('composition registries', () => {
     const settingsNavigation = screen.getByRole('navigation', {name: 'Workspace settings'});
     expect(settingsNavigation.parentElement).toHaveClass('grid', 'grid-cols-[180px_minmax(0,1fr)]');
     const settingsLinks = within(settingsNavigation).getAllByRole('link');
-    const [firstSettingsLink] = settingsLinks;
-    if (!firstSettingsLink) throw new Error('Expected at least one settings link.');
+    const [firstSettingsLink, secondSettingsLink] = settingsLinks;
+    if (!firstSettingsLink || !secondSettingsLink) {
+      throw new Error('Expected at least two settings links.');
+    }
 
     expect(settingsLinks.map((link) => link.textContent)).toEqual([
       'First setting',
@@ -100,5 +102,44 @@ describe('composition registries', () => {
       'bg-border-highlights-interactive',
     );
     expect(firstSettingsLink.querySelector('svg')).toHaveClass('size-16');
+    expect(secondSettingsLink).not.toHaveAttribute('aria-current');
+    expect(secondSettingsLink).not.toHaveClass('bg-background-neutral-hover');
+    expect(secondSettingsLink.querySelector('[data-settings-active-bar]')).not.toBeInTheDocument();
+  });
+
+  test('keeps the project settings heading and project-scoped navigation', async () => {
+    const feature = defineClientFeature({
+      id: 'acme.project-settings',
+      settingsSections: [
+        {
+          id: 'project.general',
+          pathSegment: 'general',
+          label: 'General',
+          icon: 'settings3Line',
+          scope: 'project',
+        },
+      ],
+      routes: [
+        {
+          path: '/w/$workspaceSlug/p/$projectSlug/settings/general',
+          parent: 'projectSettings',
+          impl: 'project-general',
+        },
+      ],
+    });
+
+    await renderComposedShell({
+      features: [feature],
+      initialPath: '/w/workspace/p/project/settings/general',
+      resolveImpl: () =>
+        defineRoute({staticData: {frame: 'content'}, component: () => <h1>General</h1>}),
+    });
+
+    expect(await screen.findByRole('heading', {name: 'Project settings'})).toBeVisible();
+    expect(screen.getByText('Configure this project.')).toBeVisible();
+    const projectNavigation = screen.getByRole('navigation', {name: 'Project settings'});
+    const projectLink = within(projectNavigation).getByRole('link', {name: 'General'});
+    expect(projectLink).toHaveAttribute('href', '/w/workspace/p/project/settings/general');
+    expect(projectLink).toHaveAttribute('aria-current', 'page');
   });
 });

--- a/libs/client/triggers/src/routes/events-settings.test.ts
+++ b/libs/client/triggers/src/routes/events-settings.test.ts
@@ -1,0 +1,7 @@
+import eventsSettingsRoute from './events-settings.js';
+
+describe('events settings route', () => {
+  test('uses the content frame', () => {
+    expect(eventsSettingsRoute.options.staticData.frame).toBe('content');
+  });
+});

--- a/libs/client/triggers/src/routes/events-settings.tsx
+++ b/libs/client/triggers/src/routes/events-settings.tsx
@@ -1,4 +1,5 @@
 import {defineRoute, useActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {Header} from '@shipfox/react-ui/typography';
 import {getRouteApi} from '@tanstack/react-router';
 import type {TriggerEventFilters} from '#core/trigger-event.js';
 import {EventsPage} from '#pages/events-page.js';
@@ -25,12 +26,15 @@ export default defineRoute({
       void navigate({search: {...search, ...patch}, replace: true});
     };
     return (
-      <EventsPage
-        workspaceId={workspace.id}
-        workspaceSlug={workspace.slug}
-        filters={search}
-        onFiltersChange={onFiltersChange}
-      />
+      <div className="flex min-w-0 flex-col gap-section">
+        <Header variant="h1">Events</Header>
+        <EventsPage
+          workspaceId={workspace.id}
+          workspaceSlug={workspace.slug}
+          filters={search}
+          onFiltersChange={onFiltersChange}
+        />
+      </div>
     );
   },
 });

--- a/libs/client/triggers/src/routes/events-settings.tsx
+++ b/libs/client/triggers/src/routes/events-settings.tsx
@@ -15,7 +15,7 @@ function validateSearch(search: Record<string, unknown>): TriggerEventsSearch {
 }
 
 export default defineRoute({
-  staticData: {frame: 'data'},
+  staticData: {frame: 'content'},
   validateSearch,
   component: () => {
     const workspace = useActiveWorkspace();

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -34,7 +34,6 @@ import {useState} from 'react';
 import {
   getInvitationExpiry,
   getMemberRemovalRestriction,
-  memberCount,
   type PendingInvitation,
   type WorkspaceMember,
 } from '#core/membership.js';
@@ -75,11 +74,6 @@ function MembersSection({
     <section className="flex flex-col gap-group">
       <div className="flex flex-col gap-tight">
         <Header variant="h3">Members</Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          {query.isPending
-            ? 'Loading members…'
-            : `${memberCount(members)} ${memberCount(members) === 1 ? 'member' : 'members'}`}
-        </Text>
       </div>
 
       {query.isPending ? <TableSkeleton rows={3} cols={3} label="Loading members" /> : null}
@@ -215,11 +209,6 @@ function PendingInvitationsSection({
       <div className="flex items-center justify-between gap-group">
         <div className="flex flex-col gap-tight">
           <Header variant="h3">Pending invitations</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            {query.isPending
-              ? 'Loading invitations…'
-              : `${invitations.length} ${invitations.length === 1 ? 'invitation' : 'invitations'}`}
-          </Text>
         </div>
         <InviteMemberModal
           open={inviteOpen}

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -73,7 +73,7 @@ function MembersSection({
   return (
     <section className="flex flex-col gap-group">
       <div className="flex flex-col gap-tight">
-        <Header variant="h3">Members</Header>
+        <Header variant="h1">Members</Header>
       </div>
 
       {query.isPending ? <TableSkeleton rows={3} cols={3} label="Loading members" /> : null}

--- a/libs/client/workspace-settings/src/components/workspace-settings-shell.tsx
+++ b/libs/client/workspace-settings/src/components/workspace-settings-shell.tsx
@@ -1,5 +1,10 @@
-import {useMaybeActiveWorkspace} from '@shipfox/client-shell/runtime';
+import {
+  useAuthState,
+  useMaybeActiveWorkspace,
+  WorkspaceUnavailablePage,
+} from '@shipfox/client-shell/runtime';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
+import {Navigate} from '@tanstack/react-router';
 import type {ReactNode} from 'react';
 
 interface WorkspaceSettingsShellProps {
@@ -7,8 +12,11 @@ interface WorkspaceSettingsShellProps {
 }
 
 export function WorkspaceSettingsShell({children}: WorkspaceSettingsShellProps) {
+  const auth = useAuthState();
   const workspace = useMaybeActiveWorkspace();
-  if (!workspace) return <FullPageLoader />;
+  if (auth.isLoading) return <FullPageLoader />;
+  if (!auth.isAuthenticated) return <Navigate to={'/auth/login' as never} replace />;
+  if (!workspace) return <WorkspaceUnavailablePage />;
 
   return children(workspace);
 }

--- a/libs/client/workspace-settings/src/pages/general-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/general-settings-page.tsx
@@ -8,8 +8,9 @@ import {displayNameFieldError, SlugChangeWarning, SlugField} from '@shipfox/clie
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
+import {Panel, PanelBody} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
-import {Header, Text} from '@shipfox/react-ui/typography';
+import {Header} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import {useNavigate} from '@tanstack/react-router';
 import {useState} from 'react';
@@ -95,93 +96,94 @@ function WorkspaceGeneralForm({workspace}: {workspace: ReturnType<typeof useActi
   return (
     <>
       <div className="flex min-w-0 flex-col gap-section">
-        <header className="flex flex-col gap-inline">
-          <Header variant="h1">General</Header>
-          <Text size="sm" className="text-foreground-neutral-muted">
-            Update the workspace name and the slug used in its URLs.
-          </Text>
-        </header>
+        <Header variant="h1">General</Header>
 
-        {formError ? (
-          <Callout role="alert" type="error">
-            {formError}
-          </Callout>
-        ) : null}
+        <Panel>
+          <PanelBody className="gap-group p-panel">
+            {formError ? (
+              <Callout role="alert" type="error">
+                {formError}
+              </Callout>
+            ) : null}
 
-        <form
-          className="flex max-w-[560px] flex-col gap-group"
-          noValidate
-          onSubmit={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            void form.handleSubmit();
-          }}
-        >
-          <form.Field
-            name="name"
-            validators={{
-              onBlur: ({value}) =>
-                displayNameFieldError(
-                  value,
-                  'Workspace name',
-                  createWorkspaceBodySchema.shape.name,
-                ),
-              onSubmit: ({value}) =>
-                displayNameFieldError(
-                  value,
-                  'Workspace name',
-                  createWorkspaceBodySchema.shape.name,
-                ),
-            }}
-          >
-            {(field) => (
-              <FormField
-                label="Workspace name"
-                id="workspace-settings-name"
-                error={fieldError(field)}
+            <form
+              className="flex w-full max-w-[560px] flex-col gap-group"
+              noValidate
+              onSubmit={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                void form.handleSubmit();
+              }}
+            >
+              <form.Field
+                name="name"
+                validators={{
+                  onBlur: ({value}) =>
+                    displayNameFieldError(
+                      value,
+                      'Workspace name',
+                      createWorkspaceBodySchema.shape.name,
+                    ),
+                  onSubmit: ({value}) =>
+                    displayNameFieldError(
+                      value,
+                      'Workspace name',
+                      createWorkspaceBodySchema.shape.name,
+                    ),
+                }}
               >
-                <FormFieldInput
-                  name="name"
-                  type="text"
-                  value={field.state.value}
-                  onChange={(event) => field.handleChange(event.target.value)}
-                  onBlur={field.handleBlur}
-                />
-              </FormField>
-            )}
-          </form.Field>
+                {(field) => (
+                  <FormField
+                    label="Workspace name"
+                    id="workspace-settings-name"
+                    error={fieldError(field)}
+                  >
+                    <FormFieldInput
+                      name="name"
+                      type="text"
+                      value={field.state.value}
+                      onChange={(event) => field.handleChange(event.target.value)}
+                      onBlur={field.handleBlur}
+                    />
+                  </FormField>
+                )}
+              </form.Field>
 
-          <form.Field
-            name="slug"
-            validators={{
-              onBlur: createWorkspaceBodySchema.shape.slug,
-              onSubmit: createWorkspaceBodySchema.shape.slug,
-            }}
-          >
-            {(field) => (
-              <SlugField
-                id="workspace-settings-slug"
-                label="Workspace slug"
+              <form.Field
                 name="slug"
-                value={field.state.value}
-                onChange={(value) => field.handleChange(value)}
-                onBlur={field.handleBlur}
-                error={fieldError(field)}
-                description={<span className="break-all font-code">/w/{field.state.value}</span>}
-                placeholder="acme"
-                className="font-code"
-                currentSlug={workspace.slug}
-                checkEnabled
-                isValid={isSlugValid}
-                checkAvailability={checkWorkspaceSlugAvailability}
-              />
-            )}
-          </form.Field>
+                validators={{
+                  onBlur: createWorkspaceBodySchema.shape.slug,
+                  onSubmit: createWorkspaceBodySchema.shape.slug,
+                }}
+              >
+                {(field) => (
+                  <SlugField
+                    id="workspace-settings-slug"
+                    label="Workspace slug"
+                    name="slug"
+                    value={field.state.value}
+                    onChange={(value) => field.handleChange(value)}
+                    onBlur={field.handleBlur}
+                    error={fieldError(field)}
+                    description={
+                      <span className="break-all font-code">/w/{field.state.value}</span>
+                    }
+                    placeholder="acme"
+                    className="font-code"
+                    currentSlug={workspace.slug}
+                    checkEnabled
+                    isValid={isSlugValid}
+                    checkAvailability={checkWorkspaceSlugAvailability}
+                  />
+                )}
+              </form.Field>
 
-          <Button type="submit" isLoading={updateWorkspace.isPending} className="self-start">
-            Save changes
-          </Button>
-        </form>
+              <Button type="submit" isLoading={updateWorkspace.isPending} className="self-start">
+                Save changes
+              </Button>
+            </form>
+          </PanelBody>
+        </Panel>
       </div>
 
       <SlugChangeWarning


### PR DESCRIPTION
Recomposes workspace settings around the content-frame surface system. The workspace hub now uses a bare settings rail with the active treatment shared by the run rail. Forms and section data stay inside panels, redundant subpage descriptions are removed, and Events settings uses the content frame.

A patch Changeset covers the seven affected published client packages. Local focused checks, types, tests, the client architecture audit, and prose policy all pass.

Closes ENG-1590

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recomposes workspace settings into the content frame with a compact link-based rail and page-owned H1 titles. Previously the hub forced a “Workspace settings” heading and button nav; now each settings page owns its title, the rail uses links with aria-current and an active bar, Events renders in the content frame, and login redirects preserve deep links. Refs ENG-1590.

- Converts `SettingsNav` to list-based `Link` items with active styling; tests assert aria-current and active bar.
- Restores H1 titles for Agents, Integrations, Runners, Runner provisioners, Secrets (with a concise security note), Variables, Members, and Events; removes redundant section descriptions.
- Wraps General settings in a `Panel` and moves the error callout into the panel body.
- Switches Events to `frame: 'content'` and adds a route test.
- Guards auth and workspace presence in the main layout and settings shell: unauthenticated users redirect to login with the current URL preserved; missing workspaces show `WorkspaceUnavailablePage`.
- Clarifies copy: runner registration tokens are reusable until they expire or are revoked.
- Updates docs to clarify the heading model; project settings retain their header and optional description; updates E2E and registry tests accordingly.
- Publishes patch updates to `@shipfox/client-agent`, `@shipfox/client-integrations`, `@shipfox/client-runners`, `@shipfox/client-secrets`, `@shipfox/client-shell`, `@shipfox/client-triggers`, `@shipfox/client-workspace-settings`.

- Settings routes must set `staticData.frame: 'content'`.
- Remove tests asserting a forced “Workspace settings” heading; assert link-based nav with `aria-current` instead.

<sup>Written for commit df2baccd6bd5cfa96f514a7663f18fb566f6b84c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

