### PR TITLE
Replace cloud-init with an IMDSv2 runner bootstrap

### DIFF
--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -15,19 +15,20 @@ Copy [`templates.example.yaml`](templates.example.yaml). Set
 `SHIPFOX_PROVISIONER_TEMPLATES_FILE` to that copy. Set `target_concurrency` above
 zero to keep ready runners without demand.
 
-The AMI must include the Shipfox runner and its shutdown watchdog. Cloud-init writes
-`/etc/shipfox/runner.env` with the API URL, one-use token, labels, workspace root, poll time,
-and maximum lifetime. It formats and mounts the separate workspace volume at
-`/var/lib/shipfox/workspaces` before the runner starts. The AMI reads that file and shuts
-down when its watchdog exits.
+The AMI must include the Shipfox runner and its shutdown watchdog. `shipfox-bootstrap.service`
+reads IMDSv2 user data and writes `/etc/shipfox/runner.env`. It formats and mounts the separate
+workspace volume at `/var/lib/shipfox/workspaces` before the runner starts. The AMI reads that
+file and shuts down when its watchdog exits.
 
 ### AMI migration
 
 The split-volume launch contract requires AMIs to be rebuilt before using the 30 GB boot
 volume in the example defaults. An older AMI can contain more root data than the smaller
-volume accepts, which makes the launch fail. Deploy the provider change before publishing
-the replacement AMI. During the transition, keep `root_volume_gb` at or above the old AMI's
-root snapshot size until every template uses a rebuilt AMI.
+volume accepts, which makes the launch fail. Publish and repoint the replacement AMI before
+deploying the provider change. The old AMI expects cloud-init YAML; the new image expects a
+raw environment file. A rollback requires a provider and AMI from the same contract. During
+the transition, keep `root_volume_gb` at or above the old AMI's root snapshot size until every
+template uses a rebuilt AMI.
 
 ## Template families
 

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -11,7 +11,7 @@ BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS=1234567890
 BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_RUNNER_VERSION=0.1.0 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image.js ubuntu24 qemu
 ```
 
-The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `eu-central-1`. The QEMU build defaults to a pinned Canonical Ubuntu 24.04 release image and configures its temporary Packer SSH access through a NoCloud seed; that seed is consumed during the build and is not part of the final runtime contract. To use a different QEMU source, set both `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
+The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `eu-central-1`. The QEMU build uses a pinned Canonical Ubuntu 24.04 release image. Packer accesses QEMU through a temporary NoCloud seed. The seed is consumed during the build and is not part of the runtime contract. To use a different QEMU source, set `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
 
 Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host operating system before running a QEMU build.
 
@@ -73,8 +73,8 @@ an older image.
 The provider owns the values and must never bake them into the image. On EC2,
 `shipfox-bootstrap.service` reads the raw user data from IMDSv2, validates it, and stages
 the complete file at `/etc/shipfox/runner.env.tmp` with mode `0600` and root ownership.
-It grows the root filesystem when the launch volume is larger than the AMI snapshot,
-prepares the disposable workspace volume, and then atomically renames the file into
+The bootstrap grows the root filesystem when the launch volume exceeds the AMI snapshot.
+It prepares the disposable workspace volume. It atomically renames the file into
 `/etc/shipfox/runner.env` on the same filesystem. The image watches the final path and
 starts the lifecycle target when it appears. Invalid or unavailable user data therefore
 never reaches the runner environment gate.

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -11,7 +11,7 @@ BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS=1234567890
 BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_RUNNER_VERSION=0.1.0 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image.js ubuntu24 qemu
 ```
 
-The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `eu-central-1`. The QEMU build defaults to a pinned Canonical Ubuntu 24.04 release image and configures its temporary Packer SSH access through a NoCloud seed; the final image locks that bootstrap account. To use a different QEMU source, set both `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
+The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `eu-central-1`. The QEMU build defaults to a pinned Canonical Ubuntu 24.04 release image and configures its temporary Packer SSH access through a NoCloud seed; that seed is consumed during the build and is not part of the final runtime contract. To use a different QEMU source, set both `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
 
 Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host operating system before running a QEMU build.
 
@@ -23,7 +23,7 @@ The fstab entries for `/boot` and `/boot/efi` use `noauto` and pass 0. The parti
 
 `fsck.mode=skip` also suppresses checks for other filesystems with a non-zero pass number. Do not add a durable filesystem with a non-zero pass number without revisiting this image contract.
 
-The IPv6 duplicate-address detection setting is a drop-in for the netplan-generated primary interface configuration. Netplan remains responsible for DHCP, addresses, routes, and online requirements.
+The image ships `/etc/netplan/01-shipfox.yaml`, which matches the primary Ethernet interface and enables DHCP. The IPv6 duplicate-address detection setting is a systemd-networkd drop-in for that generated interface configuration.
 
 The image is built for one job and one instance lifetime. The bake applies
 filesystem and network boot policy in `configure-boot.sh`, and disposable
@@ -70,14 +70,14 @@ an older image.
 
 ## Environment contract
 
-The provider owns the values and must never bake them into the image. It must publish
-`/etc/shipfox/runner.env` atomically: stage the complete file at
-`/etc/shipfox/runner.env.tmp`, then rename it into place on the same filesystem. The
-image watches the final path and starts the lifecycle target when it appears, so this
-contract does not depend on cloud-init's systemd units or stage ordering. The path unit
-pulls the environment gate, which in turn pulls the lifecycle target after its check
-passes. Cloud-init uses `write_files` for the temporary file and a final-stage `runcmd`
-rename; an off-cloud provisioner must provide the same temp-plus-rename behavior.
+The provider owns the values and must never bake them into the image. On EC2,
+`shipfox-bootstrap.service` reads the raw user data from IMDSv2, validates it, and stages
+the complete file at `/etc/shipfox/runner.env.tmp` with mode `0600` and root ownership.
+It grows the root filesystem when the launch volume is larger than the AMI snapshot,
+prepares the disposable workspace volume, and then atomically renames the file into
+`/etc/shipfox/runner.env` on the same filesystem. The image watches the final path and
+starts the lifecycle target when it appears. Invalid or unavailable user data therefore
+never reaches the runner environment gate.
 
 The provider-rendered environment contains:
 

--- a/infra/images/runner/assets/01-shipfox.yaml
+++ b/infra/images/runner/assets/01-shipfox.yaml
@@ -1,0 +1,10 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    primary:
+      match:
+        name: "e*"
+      dhcp4: true
+      dhcp6: false
+      optional: false

--- a/infra/images/runner/assets/shipfox-bootstrap.service
+++ b/infra/images/runner/assets/shipfox-bootstrap.service
@@ -3,7 +3,7 @@ Description=Fetch and publish the Shipfox runner bootstrap environment
 After=network.target
 Before=shipfox-runner-env.path shipfox-runner-env.service
 Wants=network.target
-FailureAction=poweroff-immediate
+FailureAction=poweroff
 
 [Service]
 Type=oneshot

--- a/infra/images/runner/assets/shipfox-bootstrap.service
+++ b/infra/images/runner/assets/shipfox-bootstrap.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fetch and publish the Shipfox runner bootstrap environment
+After=network.target
+Before=shipfox-runner-env.path shipfox-runner-env.service
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-bootstrap.service
+++ b/infra/images/runner/assets/shipfox-bootstrap.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Fetch and publish the Shipfox runner bootstrap environment
-After=network.target
+After=network-online.target
 Before=shipfox-runner-env.path shipfox-runner-env.service
-Wants=network.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot
+TimeoutStartSec=6min
 ExecStart=/opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh
 RemainAfterExit=yes
 

--- a/infra/images/runner/assets/shipfox-bootstrap.service
+++ b/infra/images/runner/assets/shipfox-bootstrap.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Fetch and publish the Shipfox runner bootstrap environment
-After=network-online.target
+After=network.target
 Before=shipfox-runner-env.path shipfox-runner-env.service
-Wants=network-online.target
+Wants=network.target
+FailureAction=poweroff-immediate
 
 [Service]
 Type=oneshot

--- a/infra/images/runner/assets/shipfox-runner-env.path
+++ b/infra/images/runner/assets/shipfox-runner-env.path
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start the Shipfox runner lifecycle when its environment is ready
-After=network-online.target
+After=network-online.target shipfox-bootstrap.service
 Wants=network-online.target
 
 [Path]

--- a/infra/images/runner/assets/shipfox-runner-env.path
+++ b/infra/images/runner/assets/shipfox-runner-env.path
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start the Shipfox runner lifecycle when its environment is ready
-After=network-online.target shipfox-bootstrap.service
+After=network-online.target
 Wants=network-online.target
 
 [Path]

--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Validate Shipfox runner environment file
-After=network-online.target
+After=network-online.target shipfox-bootstrap.service
 Wants=network-online.target shipfox-runner.target
 
 [Service]

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -31,20 +31,17 @@ build {
 
   provisioner "shell" {
     inline = [
-      "sudo install -d -m 0755 /etc/systemd/network/10-netplan-ens5.network.d",
-      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-ens5.network.d/99-shipfox-runner.conf"
+      "sudo install -d -m 0755 /etc/netplan",
+      "sudo rm -f /etc/netplan/50-cloud-init.yaml",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/01-shipfox.yaml /etc/netplan/01-shipfox.yaml"
     ]
-    only = ["amazon-ebs.build_image"]
   }
 
   provisioner "shell" {
     inline = [
-      "sudo install -d -m 0755 /etc/systemd/network/10-netplan-ens3.network.d /etc/systemd/network/10-netplan-enp1s0.network.d /etc/systemd/network/10-netplan-eth0.network.d",
-      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-ens3.network.d/99-shipfox-runner.conf",
-      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-enp1s0.network.d/99-shipfox-runner.conf",
-      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-eth0.network.d/99-shipfox-runner.conf"
+      "sudo install -d -m 0755 /etc/systemd/network/10-netplan-primary.network.d",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.networkd.conf /etc/systemd/network/10-netplan-primary.network.d/99-shipfox-runner.conf"
     ]
-    only = ["qemu.build_image"]
   }
 
   provisioner "shell" {
@@ -60,8 +57,10 @@ build {
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-boot-complete.service /etc/systemd/system/shipfox-runner-boot-complete.service",
       "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-bootstrap.service /etc/systemd/system/shipfox-bootstrap.service",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/record-boot-io.sh /opt/shipfox-runner/scripts/runtime/record-boot-io.sh",
+      "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/shipfox-bootstrap.sh /opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/verify-workspace-mount.sh /opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",
       "sudo systemctl daemon-reload",
@@ -86,6 +85,7 @@ build {
       "sudo install -m 0644 /tmp/shipfox-spot-watchdog.service /etc/systemd/system/shipfox-spot-watchdog.service",
       "sudo install -m 0755 /tmp/spot-watchdog.sh /opt/shipfox-runner/scripts/runtime/spot-watchdog.sh",
       "sudo systemctl daemon-reload",
+      "sudo systemctl enable shipfox-bootstrap.service",
       "sudo systemctl enable shipfox-spot-watchdog.service"
     ]
     only = ["amazon-ebs.build_image"]
@@ -96,7 +96,11 @@ build {
     inline = [
       "sudo passwd --lock ubuntu",
       "sudo rm -f /home/ubuntu/.ssh/authorized_keys",
-      "sudo test ! -e /home/ubuntu/.ssh/authorized_keys"
+      "sudo test ! -e /home/ubuntu/.ssh/authorized_keys",
+      "sudo rm -f /etc/hostname",
+      "sudo test ! -e /etc/hostname",
+      "sudo rm -f /etc/ssh/ssh_host_*",
+      "sudo test -z \"$(find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*' -print -quit)\""
     ]
   }
 

--- a/infra/images/runner/scripts/build/setup-runner.sh
+++ b/infra/images/runner/scripts/build/setup-runner.sh
@@ -6,7 +6,11 @@ root_dir=${RUNNER_IMAGE_ROOT:-/}
 apt-get update
 apt-get install --yes --no-install-recommends \
   ca-certificates curl wget git openssh-client tar gzip xz-utils bzip2 zip unzip jq \
-  build-essential python3 pkg-config ripgrep fd-find sudo amazon-ec2-utils
+  build-essential cloud-guest-utils python3 pkg-config ripgrep fd-find sudo amazon-ec2-utils
+# The final image reads its one user-data payload directly from IMDSv2. Keep cloud-init
+# only long enough for Packer's initial NoCloud SSH bootstrap, then remove its package and state.
+apt-get purge --yes cloud-init
+rm -rf "$root_dir/etc/cloud"
 # Runner instances have no host-management credentials. Remove snapd and its seeded
 # snaps instead of carrying a failed host-management path into every boot.
 # Stop snapd before unmounting its seeded loop-backed squashfs filesystems. The base

--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -21,11 +21,6 @@ abort_boot() {
   exit 1
 }
 
-fail_boot() {
-  printf 'shipfox bootstrap: %s\n' "$1" >&2
-  exit 1
-}
-
 validate_runner_env() {
   awk '
   BEGIN {
@@ -244,14 +239,14 @@ if ! /usr/bin/ssh-keygen -A; then
 fi
 
 if ! fetch_user_data; then
-  fail_boot 'Unable to read runner user data from IMDSv2 after retries.'
+  abort_boot 'Unable to read runner user data from IMDSv2 after retries.'
 fi
 if ! install -m 0600 -o root -g root "$user_data_fetch_path" "$runner_env_temp_path"; then
-  fail_boot 'Unable to stage runner user data.'
+  abort_boot 'Unable to stage runner user data.'
 fi
 if ! validate_runner_env "$runner_env_temp_path"; then
   rm -f "$runner_env_temp_path"
-  fail_boot 'Runner user data is not a valid environment file.'
+  abort_boot 'Runner user data is not a valid environment file.'
 fi
 
 grow_root_filesystem

--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env sh
+set -eu
+
+umask 077
+
+imds_base_url='http://169.254.169.254'
+runner_env_dir='/etc/shipfox'
+runner_env_path="$runner_env_dir/runner.env"
+runner_env_temp_path="$runner_env_dir/runner.env.tmp"
+workspace_root='/var/lib/shipfox/workspaces'
+workspace_mount_unit='var-lib-shipfox-workspaces.mount'
+runner_mount_dropin_dir='/etc/systemd/system/shipfox-runner.service.d'
+retry_count="${SHIPFOX_BOOTSTRAP_RETRY_COUNT:-30}"
+retry_delay_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DELAY_SECONDS:-1}"
+
+abort_boot() {
+  printf 'shipfox bootstrap: %s\n' "$1" >&2
+  if ! systemctl poweroff --no-wall; then
+    /sbin/poweroff -f || true
+  fi
+  exit 1
+}
+
+fail_boot() {
+  printf 'shipfox bootstrap: %s\n' "$1" >&2
+  exit 1
+}
+
+validate_runner_env() {
+  awk '
+  BEGIN {
+    required_count = split("SHIPFOX_API_URL SHIPFOX_RUNNER_BOOTSTRAP_TOKEN SHIPFOX_RUNNER_PROVIDER_KIND SHIPFOX_RUNNER_PROTOCOL_VERSION SHIPFOX_RUNNER_LABELS SHIPFOX_RUNNER_WORKSPACE_ROOT SHIPFOX_POLL_MAX_DURATION_MS SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS", required, " ")
+    for (i = 1; i <= required_count; i++) allowed[required[i]] = 1
+  }
+
+  {
+    separator = index($0, "=")
+    if (separator < 2 || $0 ~ /\r/) {
+      invalid = 1
+      next
+    }
+
+    key = substr($0, 1, separator - 1)
+    value = substr($0, separator + 1)
+    if (!(key in allowed) || seen[key] || value == "" || value == "\"\"") invalid = 1
+    seen[key] = 1
+  }
+
+  END {
+    for (i = 1; i <= required_count; i++) {
+      if (!seen[required[i]]) invalid = 1
+    }
+    exit invalid
+  }
+  ' "$1"
+}
+
+fetch_user_data() {
+  token=''
+  attempt=1
+  while [ "$attempt" -le "$retry_count" ]; do
+    token="$(curl --fail --silent --show-error --noproxy '*' --connect-timeout 2 --max-time 5 \
+      --request PUT \
+      --header 'X-aws-ec2-metadata-token-ttl-seconds: 21600' \
+      "$imds_base_url/latest/api/token" 2>/dev/null || true)"
+    if [ -n "$token" ] && curl --fail --silent --show-error --noproxy '*' --connect-timeout 2 --max-time 5 \
+      --header "X-aws-ec2-metadata-token: $token" \
+      --output "$user_data_fetch_path" \
+      "$imds_base_url/latest/user-data"; then
+      return 0
+    fi
+
+    rm -f "$user_data_fetch_path"
+    if [ "$attempt" -lt "$retry_count" ]; then
+      sleep "$retry_delay_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+grow_root_filesystem() {
+  root_source="$(findmnt -n -o SOURCE / 2>/dev/null || true)"
+  root_source="$(readlink -f "$root_source" 2>/dev/null || true)"
+  if [ -z "$root_source" ] || [ ! -b "$root_source" ]; then
+    abort_boot 'Unable to identify the root filesystem.'
+  fi
+
+  root_type="$(lsblk -ndo TYPE "$root_source" 2>/dev/null || true)"
+  if [ "$root_type" = 'disk' ]; then
+    root_disk="$root_source"
+    root_disk_size="$(blockdev --getsize64 "$root_disk" 2>/dev/null || true)"
+    root_filesystem_size="$(df -B1 --output=size / | tail -n 1 | tr -d '[:space:]')"
+    if [ -z "$root_disk_size" ] || [ -z "$root_filesystem_size" ]; then
+      abort_boot 'Unable to measure the root filesystem.'
+    fi
+    if [ "$root_disk_size" -gt "$root_filesystem_size" ]; then
+      if ! resize2fs "$root_source"; then
+        abort_boot 'Unable to grow the root filesystem.'
+      fi
+    fi
+    return
+  fi
+
+  root_disk_name="$(lsblk -ndo PKNAME "$root_source" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+  root_partition_number="$(lsblk -ndo PARTNUM "$root_source" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+  if [ -z "$root_disk_name" ] || [ -z "$root_partition_number" ]; then
+    abort_boot 'Unable to identify the root partition.'
+  fi
+  root_disk="/dev/$root_disk_name"
+  root_disk_size="$(blockdev --getsize64 "$root_disk" 2>/dev/null || true)"
+  root_partition_size="$(blockdev --getsize64 "$root_source" 2>/dev/null || true)"
+  if [ -z "$root_disk_size" ] || [ -z "$root_partition_size" ]; then
+    abort_boot 'Unable to measure the root partition.'
+  fi
+  if [ "$root_disk_size" -le "$root_partition_size" ]; then
+    return
+  fi
+
+  if ! command -v growpart >/dev/null 2>&1; then
+    abort_boot 'growpart is not installed.'
+  fi
+  if ! growpart "$root_disk" "$root_partition_number"; then
+    abort_boot 'Unable to grow the root partition.'
+  fi
+  if ! resize2fs "$root_source"; then
+    abort_boot 'Unable to grow the root filesystem.'
+  fi
+}
+
+resolve_workspace_device() {
+  workspace_candidate_count=0
+  workspace_device=''
+  for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
+    if [ "$candidate" = "$root_disk" ]; then
+      continue
+    fi
+
+    model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
+    case "$model" in
+      *'Amazon EC2 NVMe Instance Storage'*)
+        continue
+        ;;
+      *'Amazon Elastic Block Store'*)
+        ;;
+      '')
+        case "$candidate" in
+          /dev/sd*|/dev/xvd*)
+            ;;
+          *)
+            continue
+            ;;
+        esac
+        ;;
+      *)
+        continue
+        ;;
+    esac
+
+    workspace_candidate_count=$((workspace_candidate_count + 1))
+    workspace_device="$candidate"
+  done
+
+  if [ "$workspace_candidate_count" -ne 1 ]; then
+    abort_boot "Unable to uniquely resolve the EC2 workspace disk; found $workspace_candidate_count non-root EBS disks."
+  fi
+
+  workspace_disk_name="$(lsblk -ndo PKNAME "$workspace_device" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+  if [ -z "$workspace_disk_name" ]; then
+    workspace_disk_name="$(lsblk -ndo NAME "$workspace_device" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+  fi
+  if [ -z "$workspace_disk_name" ] || [ "/dev/$workspace_disk_name" = "$root_disk" ]; then
+    abort_boot 'The EC2 workspace disk resolves to the root disk.'
+  fi
+}
+
+configure_workspace_mount() {
+  if ! install -d -o shipfox -g shipfox "$workspace_root"; then
+    abort_boot "Unable to create the EC2 workspace directory at $workspace_root."
+  fi
+
+  resolve_workspace_device
+  if ! blkid "$workspace_device" >/dev/null 2>&1; then
+    if ! mkfs.ext4 -F -E lazy_itable_init=1,lazy_journal_init=1 -L shipfox-workspc "$workspace_device"; then
+      abort_boot "Unable to format the EC2 workspace device $workspace_device."
+    fi
+  fi
+
+  workspace_uuid="$(blkid -s UUID -o value "$workspace_device" 2>/dev/null || true)"
+  if [ -z "$workspace_uuid" ]; then
+    abort_boot 'The EC2 workspace disk has no filesystem UUID.'
+  fi
+
+  workspace_mount_unit_path="/etc/systemd/system/$workspace_mount_unit"
+  if ! printf '%s\n' \
+    '[Unit]' \
+    'Description=Mount the Shipfox job workspace volume' \
+    '' \
+    '[Mount]' \
+    "What=UUID=$workspace_uuid" \
+    "Where=$workspace_root" \
+    'Type=ext4' \
+    'Options=defaults,nofail' \
+    '' \
+    '[Install]' \
+    'WantedBy=multi-user.target' > "$workspace_mount_unit_path"; then
+    abort_boot "Unable to write the EC2 workspace mount unit at $workspace_mount_unit_path."
+  fi
+
+  runner_mount_dropin_path="$runner_mount_dropin_dir/10-shipfox-workspace.conf"
+  if ! mkdir -p "$runner_mount_dropin_dir"; then
+    abort_boot "Unable to create the runner mount dependency directory at $runner_mount_dropin_dir."
+  fi
+  if ! printf '%s\n' '[Unit]' "Requires=$workspace_mount_unit" "After=$workspace_mount_unit" > "$runner_mount_dropin_path"; then
+    abort_boot "Unable to write the runner mount dependency at $runner_mount_dropin_path."
+  fi
+
+  if ! systemctl daemon-reload; then
+    abort_boot 'Unable to reload systemd after configuring the EC2 workspace mount.'
+  fi
+  if ! systemctl enable "$workspace_mount_unit"; then
+    abort_boot "Unable to enable the EC2 workspace mount unit $workspace_mount_unit."
+  fi
+  if ! systemctl start "$workspace_mount_unit"; then
+    abort_boot "Unable to start the EC2 workspace mount unit $workspace_mount_unit."
+  fi
+  if ! mountpoint -q "$workspace_root"; then
+    abort_boot "The EC2 workspace volume did not mount at $workspace_root."
+  fi
+  if ! chown shipfox:shipfox "$workspace_root"; then
+    abort_boot "Unable to assign ownership of the EC2 workspace directory at $workspace_root."
+  fi
+}
+
+install -d -m 0755 "$runner_env_dir"
+rm -f "$runner_env_path" "$runner_env_temp_path"
+user_data_fetch_path="$(mktemp "$runner_env_dir/runner.env.fetch.XXXXXX")"
+trap 'rm -f "$user_data_fetch_path" "$runner_env_temp_path"' EXIT
+
+# Cloud-init used to create these keys on each boot. Remove them from the AMI during
+# the bake and recreate them here so EC2 Instance Connect never sees shared keys.
+if ! /usr/bin/ssh-keygen -A; then
+  abort_boot 'Unable to generate SSH host keys.'
+fi
+
+if ! fetch_user_data; then
+  fail_boot 'Unable to read runner user data from IMDSv2 after retries.'
+fi
+if ! install -m 0600 -o root -g root "$user_data_fetch_path" "$runner_env_temp_path"; then
+  fail_boot 'Unable to stage runner user data.'
+fi
+if ! validate_runner_env "$runner_env_temp_path"; then
+  rm -f "$runner_env_temp_path"
+  fail_boot 'Runner user data is not a valid environment file.'
+fi
+
+grow_root_filesystem
+configure_workspace_mount
+
+if ! mv -- "$runner_env_temp_path" "$runner_env_path"; then
+  abort_boot 'Unable to publish the runner environment after boot setup.'
+fi

--- a/infra/images/runner/scripts/runtime/start-max-lifetime.sh
+++ b/infra/images/runner/scripts/runtime/start-max-lifetime.sh
@@ -11,6 +11,12 @@ lifetime_seconds="$default_lifetime_seconds"
 if [ -r /etc/shipfox/runner.env ]; then
   configured_lifetime="$(sed -n 's/^SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS=//p' /etc/shipfox/runner.env | tail -n 1)"
   case "$configured_lifetime" in
+    \"*\")
+      configured_lifetime="${configured_lifetime#\"}"
+      configured_lifetime="${configured_lifetime%\"}"
+      ;;
+  esac
+  case "$configured_lifetime" in
     ''|*[!0-9]*) ;;
     *)
       if [ "$configured_lifetime" -gt 0 ]; then

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1048,7 +1048,9 @@ describe('systemd boot activation', () => {
 
     execFileSync('sh', ['-n', script.pathname], {stdio: 'pipe'});
 
-    expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network-online.target');
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network.target');
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'Wants')).toBe('network.target');
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'FailureAction')).toBe('poweroff-immediate');
     expect(systemdDirective(bootstrapUnit, 'Unit', 'Before')).toBe(
       'shipfox-runner-env.path shipfox-runner-env.service',
     );

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -959,7 +959,9 @@ describe('systemd boot activation', () => {
     const pathUnit = await readUnit('shipfox-runner-env.path');
     const targetUnit = await readUnit('shipfox-runner.target');
 
-    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe('network-online.target');
+    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe(
+      'network-online.target shipfox-bootstrap.service',
+    );
     expect(systemdDirective(pathUnit, 'Unit', 'Wants')).toBe('network-online.target');
     expect(systemdDirective(pathUnit, 'Path', 'PathExists')).toBe('/etc/shipfox/runner.env');
     expect(systemdDirective(pathUnit, 'Path', 'Unit')).toBe('shipfox-runner-env.service');
@@ -1021,7 +1023,9 @@ describe('systemd boot activation', () => {
   it('keeps the environment gate as a persistent non-empty-file check', async () => {
     const unit = await readUnit('shipfox-runner-env.service');
 
-    expect(systemdDirective(unit, 'Unit', 'After')).toBe('network-online.target');
+    expect(systemdDirective(unit, 'Unit', 'After')).toBe(
+      'network-online.target shipfox-bootstrap.service',
+    );
     expect(systemdDirective(unit, 'Unit', 'Wants')).toBe(
       'network-online.target shipfox-runner.target',
     );
@@ -1036,6 +1040,41 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Install', 'WantedBy')).toBeUndefined();
     expect(unit).not.toContain('cloud-config.service');
     expect(unit).not.toContain('cloud-final.service');
+  });
+
+  it('fetches and publishes EC2 user data before the environment gate', async () => {
+    const bootstrapUnit = await readUnit('shipfox-bootstrap.service');
+    const script = new URL('../scripts/runtime/shipfox-bootstrap.sh', import.meta.url);
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+    const source = await readFile(script, 'utf8');
+
+    execFileSync('sh', ['-n', script.pathname], {stdio: 'pipe'});
+
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network.target');
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'Before')).toBe(
+      'shipfox-runner-env.path shipfox-runner-env.service',
+    );
+    expect(systemdDirective(bootstrapUnit, 'Service', 'Type')).toBe('oneshot');
+    expect(systemdDirective(bootstrapUnit, 'Service', 'ExecStart')).toBe(
+      '/opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh',
+    );
+    expect(systemdDirective(bootstrapUnit, 'Install', 'WantedBy')).toBe('multi-user.target');
+    expect(source).toContain('X-aws-ec2-metadata-token-ttl-seconds: 21600');
+    expect(source).toContain('--request PUT');
+    expect(source).toContain('/latest/user-data');
+    expect(source).toContain('growpart "$root_disk" "$root_partition_number"');
+    expect(source).toContain('resize2fs "$root_source"');
+    expect(source).toContain('mkfs.ext4 -F -E lazy_itable_init=1,lazy_journal_init=1');
+    expect(source).toContain('install -m 0600 -o root -g root');
+    expect(source).toContain('mv -- "$runner_env_temp_path" "$runner_env_path"');
+    expect(build).toContain(
+      'shipfox-bootstrap.sh /opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh',
+    );
+    expect(build).toContain(
+      'shipfox-bootstrap.service /etc/systemd/system/shipfox-bootstrap.service',
+    );
+    expect(build).toContain('systemctl enable shipfox-bootstrap.service');
+    expect(build).toContain('rm -f /etc/hostname');
   });
 
   it('resolves the root device and publishes a boot I/O sample', async () => {
@@ -1234,13 +1273,16 @@ UUID=efi /boot/efi vfat defaults,noauto 0 0
       new URL('../assets/shipfox-runner.networkd.conf', import.meta.url),
       'utf8',
     );
+    const netplan = await readFile(new URL('../assets/01-shipfox.yaml', import.meta.url), 'utf8');
     const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
 
     expect(network).toBe('[Network]\nIPv6DuplicateAddressDetection=0\n');
-    expect(build).toContain('10-netplan-ens5.network.d/99-shipfox-runner.conf');
-    expect(build).toContain('10-netplan-ens3.network.d/99-shipfox-runner.conf');
-    expect(build).toContain('10-netplan-enp1s0.network.d/99-shipfox-runner.conf');
-    expect(build).toContain('10-netplan-eth0.network.d/99-shipfox-runner.conf');
+    expect(netplan).toContain('name: "e*"');
+    expect(netplan).toContain('dhcp4: true');
+    expect(netplan).toContain('optional: false');
+    expect(build).toContain('10-netplan-primary.network.d/99-shipfox-runner.conf');
+    expect(build).toContain('01-shipfox.yaml /etc/netplan/01-shipfox.yaml');
+    expect(build).toContain('rm -f /etc/netplan/50-cloud-init.yaml');
     expect(build).not.toContain('DHCP=yes');
     expect(build).not.toContain('RequiredForOnline=yes');
     expect(build).not.toContain('05-shipfox-runner.network');
@@ -1272,12 +1314,14 @@ describe('runner image composition', () => {
       expect(build).toContain('scripts/build/setup-runner.sh');
       expect(stopIndex).toBeGreaterThanOrEqual(0);
       expect(purgeIndex).toBeGreaterThan(stopIndex);
+      expect(events).toContain('apt-get purge --yes cloud-init');
       expect(unmountEvents).toHaveLength(5);
       expect(unmountEvents).toContain(`umount -l ${join(fixture.root, 'snap/amazon-ssm-agent')}`);
       expect(unmountEvents.every((event) => events.indexOf(event) < purgeIndex)).toBe(true);
       expect(await pathExists(join(fixture.root, 'snap'))).toBe(false);
       expect(await pathExists(join(fixture.root, 'snap/amazon-ssm-agent'))).toBe(false);
       expect(await pathExists(join(fixture.root, 'var/lib/snapd'))).toBe(false);
+      expect(await pathExists(join(fixture.root, 'etc/cloud'))).toBe(false);
     } finally {
       await rm(fixture.root, {force: true, recursive: true});
     }
@@ -1296,7 +1340,9 @@ describe('runner image composition', () => {
       ).toThrow();
 
       expect(await pathExists(join(fixture.root, 'snap'))).toBe(true);
-      expect(await readFile(fixture.commandLog, 'utf8')).not.toContain('rm -rf');
+      expect(await readFile(fixture.commandLog, 'utf8')).not.toContain(
+        `rm -rf ${join(fixture.root, 'snap')}`,
+      );
     } finally {
       await rm(fixture.root, {force: true, recursive: true});
     }
@@ -1440,6 +1486,7 @@ async function createRunnerImageSetupFixture() {
   await mkdir(join(root, 'snap/snapd'), {recursive: true});
   await mkdir(join(root, 'var/lib/snapd'), {recursive: true});
   await mkdir(join(root, 'var/lib/apt/lists'), {recursive: true});
+  await mkdir(join(root, 'etc/cloud'), {recursive: true});
   await mkdir(join(root, 'usr/bin'), {recursive: true});
   await mkdir(join(root, 'usr/local/bin'), {recursive: true});
   await mkdir(join(root, 'etc/default'), {recursive: true});
@@ -1451,7 +1498,7 @@ async function createRunnerImageSetupFixture() {
     `#!/bin/sh
 set -eu
 printf 'apt-get %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
-if [ "$1" = purge ] && [ -n "\${RUNNER_IMAGE_FAIL_PURGE:-}" ]; then
+if [ "$1" = purge ] && [ "\${3:-}" = snapd ] && [ -n "\${RUNNER_IMAGE_FAIL_PURGE:-}" ]; then
   exit 1
 fi
 `,

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -959,9 +959,7 @@ describe('systemd boot activation', () => {
     const pathUnit = await readUnit('shipfox-runner-env.path');
     const targetUnit = await readUnit('shipfox-runner.target');
 
-    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe(
-      'network-online.target shipfox-bootstrap.service',
-    );
+    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe('network-online.target');
     expect(systemdDirective(pathUnit, 'Unit', 'Wants')).toBe('network-online.target');
     expect(systemdDirective(pathUnit, 'Path', 'PathExists')).toBe('/etc/shipfox/runner.env');
     expect(systemdDirective(pathUnit, 'Path', 'Unit')).toBe('shipfox-runner-env.service');
@@ -1050,11 +1048,12 @@ describe('systemd boot activation', () => {
 
     execFileSync('sh', ['-n', script.pathname], {stdio: 'pipe'});
 
-    expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network.target');
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network-online.target');
     expect(systemdDirective(bootstrapUnit, 'Unit', 'Before')).toBe(
       'shipfox-runner-env.path shipfox-runner-env.service',
     );
     expect(systemdDirective(bootstrapUnit, 'Service', 'Type')).toBe('oneshot');
+    expect(systemdDirective(bootstrapUnit, 'Service', 'TimeoutStartSec')).toBe('6min');
     expect(systemdDirective(bootstrapUnit, 'Service', 'ExecStart')).toBe(
       '/opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh',
     );

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1050,7 +1050,7 @@ describe('systemd boot activation', () => {
 
     expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network.target');
     expect(systemdDirective(bootstrapUnit, 'Unit', 'Wants')).toBe('network.target');
-    expect(systemdDirective(bootstrapUnit, 'Unit', 'FailureAction')).toBe('poweroff-immediate');
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'FailureAction')).toBe('poweroff');
     expect(systemdDirective(bootstrapUnit, 'Unit', 'Before')).toBe(
       'shipfox-runner-env.path shipfox-runner-env.service',
     );

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -9,13 +9,14 @@ control loop.
 - `loadEc2Templates(filePath)` reads, parses, and validates EC2 template YAML.
 - `Ec2TemplateSpec` describes the EC2 launch details for a template.
 - `Ec2TemplateConfigError` identifies a missing, malformed, or invalid template file.
-- `renderRunnerBootstrapUserData(options)` renders cloud-init for the prebaked managed-runner image.
+- `renderRunnerBootstrapUserData(options)` renders the raw IMDS user-data environment for the prebaked managed-runner image.
 - `redactRunnerBootstrapUserData(options)` returns launch metadata that is safe to log.
 
 The user-data renderer writes the API URL, one-use bootstrap token, runner-declared labels,
 managed-runner protocol metadata, the managed workspace root, poll deadline, and watchdog
-lifetime. It formats and mounts the non-root EBS volume before the runner starts. It never
-renders a workspace ID, workspace registration token, or activation token.
+lifetime. The image's EC2 bootstrap service formats and mounts the non-root EBS volume before
+the runner starts. It never renders a workspace ID, workspace registration token, or
+activation token.
 
 ## Template config
 
@@ -104,9 +105,9 @@ equivalent so the planner prefers Spot before spilling to on-demand capacity.
 `root_volume_gb` is the boot volume size. `workspace_volume_gb` is a separate, encrypted gp3
 volume created for per-job checkouts, logs, and credentials. The provider deletes both
 volumes with the instance. `workspace_device_name` is the EC2 block-device mapping name;
-cloud-init resolves the attached EBS disk to its runtime device before formatting and
-mounting it at `/var/lib/shipfox/workspaces`. It fails closed when the mapping is absent and
-the non-root EBS disk is not unique.
+the EC2 bootstrap service resolves the attached EBS disk to its runtime device before
+formatting and mounting it at `/var/lib/shipfox/workspaces`. It fails closed when the
+non-root EBS disk is absent or not unique.
 
 The example defaults change general runner capacity from one 100 GB EBS volume to a 30 GB
 boot volume plus a 100 GB workspace volume (130 GB total). The GPU example uses 30 GB plus

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -1,7 +1,4 @@
 import {execFileSync} from 'node:child_process';
-import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
-import {tmpdir} from 'node:os';
-import {join} from 'node:path';
 
 import {
   type RunnerBootstrapUserDataOptions,
@@ -19,42 +16,24 @@ const options: RunnerBootstrapUserDataOptions = {
 };
 
 describe('renderRunnerBootstrapUserData', () => {
-  it('publishes the runner environment only after boot-owned workspace setup', () => {
+  it('renders only the validated runner environment file', () => {
     const userData = renderRunnerBootstrapUserData(options);
 
-    expect(userData).toContain(`write_files:
-  - path: /etc/shipfox/runner.env.tmp
-    owner: root:root
-    permissions: '0600'
-    content: |`);
-    for (const line of [
-      'SHIPFOX_API_URL="https://api.shipfox.test"',
-      'SHIPFOX_RUNNER_BOOTSTRAP_TOKEN="sf_rbt_sensitive-bootstrap-token"',
-      'SHIPFOX_RUNNER_PROVIDER_KIND="ec2"',
-      'SHIPFOX_RUNNER_PROTOCOL_VERSION="1"',
-      'SHIPFOX_RUNNER_LABELS="linux,x64,self-hosted"',
-      'SHIPFOX_RUNNER_WORKSPACE_ROOT="/var/lib/shipfox/workspaces"',
-      'SHIPFOX_POLL_MAX_DURATION_MS="300000"',
-      'SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS="3600"',
-    ]) {
-      expect(userData).toContain(`      ${line}`);
-    }
-    expect(userData).toContain("workspace_mount_unit='var-lib-shipfox-workspaces.mount'");
-    expect(userData).toContain('abort_boot()');
-    expect(userData).toContain('systemctl poweroff --no-wall');
-    expect(userData).toContain(
-      "printf '[Unit]\\nDescription=Mount the Shipfox job workspace volume",
+    expect(userData).toBe(
+      `${[
+        'SHIPFOX_API_URL="https://api.shipfox.test"',
+        'SHIPFOX_RUNNER_BOOTSTRAP_TOKEN="sf_rbt_sensitive-bootstrap-token"',
+        'SHIPFOX_RUNNER_PROVIDER_KIND="ec2"',
+        'SHIPFOX_RUNNER_PROTOCOL_VERSION="1"',
+        'SHIPFOX_RUNNER_LABELS="linux,x64,self-hosted"',
+        'SHIPFOX_RUNNER_WORKSPACE_ROOT="/var/lib/shipfox/workspaces"',
+        'SHIPFOX_POLL_MAX_DURATION_MS="300000"',
+        'SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS="3600"',
+      ].join('\n')}\n`,
     );
-    expect(userData).toContain(
-      `printf '[Unit]\\nRequires=%s\\nAfter=%s\\n' "$workspace_mount_unit"`,
-    );
-    expect(userData).not.toContain('/etc/fstab');
-    expect(userData).not.toContain('SHIPFOX_RUNNER_WORKSPACE_MOUNT_REQUIRED');
-    expect(userData).not.toContain('mount "$workspace_device"');
-    expect(userData.indexOf('systemctl start "$workspace_mount_unit"')).toBeLessThan(
-      userData.indexOf('/usr/bin/mv --'),
-    );
-    expect(userData).toContain("if ! /usr/bin/mv -- '/etc/shipfox/runner.env.tmp'");
+    expect(userData).not.toContain('#cloud-config');
+    expect(userData).not.toContain('write_files');
+    expect(userData).not.toContain('runcmd');
   });
 
   it('does not render workspace-scoped registration material', () => {
@@ -64,42 +43,12 @@ describe('renderRunnerBootstrapUserData', () => {
     expect(userData).not.toContain('WORKSPACE_ID');
   });
 
-  it('renders a workspace mount script accepted by POSIX sh', () => {
-    const script = extractWorkspaceMountScript(renderRunnerBootstrapUserData(options));
-
-    expect(() => execFileSync('sh', ['-n', '-c', script])).not.toThrow();
-  });
-
-  it('powers off before publishing the environment when workspace setup fails', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'shipfox-ec2-user-data-'));
-    const commandDirectory = join(root, 'commands');
-    const poweroffLog = join(root, 'poweroff.log');
-    const script = extractWorkspaceMountScript(renderRunnerBootstrapUserData(options));
-
-    await mkdir(commandDirectory, {recursive: true});
-    await writeFile(join(commandDirectory, 'install'), '#!/bin/sh\nexit 1\n');
-    await writeFile(
-      join(commandDirectory, 'systemctl'),
-      '#!/bin/sh\nprintf "%s\\n" "$*" >> "$BOOT_TEST_POWEROFF_LOG"\n',
-    );
-    await chmod(join(commandDirectory, 'install'), 0o755);
-    await chmod(join(commandDirectory, 'systemctl'), 0o755);
-
-    try {
-      expect(() =>
-        execFileSync('sh', ['-c', script], {
-          env: {
-            ...process.env,
-            BOOT_TEST_POWEROFF_LOG: poweroffLog,
-            PATH: `${commandDirectory}:${process.env.PATH ?? ''}`,
-          },
-          stdio: 'pipe',
-        }),
-      ).toThrow();
-      expect(await readFile(poweroffLog, 'utf8')).toBe('poweroff --no-wall\n');
-    } finally {
-      await rm(root, {force: true, recursive: true});
-    }
+  it('keeps the rendered environment shell-compatible', () => {
+    expect(() =>
+      execFileSync('sh', ['-c', 'set -a; . /dev/stdin'], {
+        input: renderRunnerBootstrapUserData(options),
+      }),
+    ).not.toThrow();
   });
 
   it('rejects unsafe environment values', () => {
@@ -128,15 +77,3 @@ describe('redactRunnerBootstrapUserData', () => {
     expect(JSON.stringify(redacted)).not.toContain(options.apiUrl);
   });
 });
-
-function extractWorkspaceMountScript(userData: string): string {
-  const marker = 'runcmd:\n  - |\n';
-  const markerOffset = userData.indexOf(marker);
-
-  expect(markerOffset).toBeGreaterThanOrEqual(0);
-  return userData
-    .slice(markerOffset + marker.length)
-    .split('\n')
-    .map((line) => (line.startsWith('      ') ? line.slice(6) : line))
-    .join('\n');
-}

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -1,4 +1,7 @@
 import {execFileSync} from 'node:child_process';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 
 import {
   type RunnerBootstrapUserDataOptions,
@@ -43,12 +46,16 @@ describe('renderRunnerBootstrapUserData', () => {
     expect(userData).not.toContain('WORKSPACE_ID');
   });
 
-  it('keeps the rendered environment shell-compatible', () => {
-    expect(() =>
-      execFileSync('sh', ['-c', 'set -a; . /dev/stdin'], {
-        input: renderRunnerBootstrapUserData(options),
-      }),
-    ).not.toThrow();
+  it('keeps the rendered environment shell-compatible', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'shipfox-user-data-'));
+    const envPath = join(directory, 'runner.env');
+
+    try {
+      await writeFile(envPath, renderRunnerBootstrapUserData(options));
+      expect(() => execFileSync('sh', ['-c', 'set -a; . "$1"', 'sh', envPath])).not.toThrow();
+    } finally {
+      await rm(directory, {force: true, recursive: true});
+    }
   });
 
   it('rejects unsafe environment values', () => {

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -1,163 +1,6 @@
-const CLOUD_INIT_HEADER = '#cloud-config';
 const RUNNER_ENV_PATH = '/etc/shipfox/runner.env';
-const RUNNER_ENV_TEMP_PATH = '/etc/shipfox/runner.env.tmp';
 const RUNNER_WORKSPACE_ROOT = '/var/lib/shipfox/workspaces';
-const WORKSPACE_MOUNT_UNIT = 'var-lib-shipfox-workspaces.mount';
-const RUNNER_MOUNT_DROPIN_DIR = '/etc/systemd/system/shipfox-runner.service.d';
-const WORKSPACE_FS_LABEL = 'shipfox-workspc';
 const EC2_DEVICE_NAME_PATTERN = /^\/dev\/[A-Za-z0-9]+$/;
-
-function workspaceMountScript(workspaceDeviceName: string): string {
-  return String.raw`set -u
-abort_boot() {
-  printf '%s\n' "$1" >&2
-  if ! systemctl poweroff --no-wall; then
-    /sbin/poweroff -f || true
-  fi
-  exit 1
-}
-
-workspace_root='${RUNNER_WORKSPACE_ROOT}'
-workspace_device_name='${workspaceDeviceName}'
-workspace_mount_unit='${WORKSPACE_MOUNT_UNIT}'
-workspace_mount_unit_path="/etc/systemd/system/$workspace_mount_unit"
-runner_mount_dropin_dir='${RUNNER_MOUNT_DROPIN_DIR}'
-runner_mount_dropin_path="$runner_mount_dropin_dir/10-shipfox-workspace.conf"
-if ! install -d -o shipfox -g shipfox "$workspace_root"; then
-  abort_boot "Unable to create the EC2 workspace directory at $workspace_root."
-fi
-
-# Xen exposes the configured mapping name directly. Nitro may expose the same
-# EBS volume as an NVMe device, so resolve it by its EBS model when the mapping
-# name is not present. Never guess when more than one non-root EBS disk exists.
-workspace_device=''
-if [ -b "$workspace_device_name" ]; then
-  workspace_device_type="$(lsblk -ndo TYPE "$workspace_device_name" || true)"
-  if [ "$workspace_device_type" != 'disk' ]; then
-    abort_boot "Configured workspace device $workspace_device_name is not a disk."
-  fi
-  workspace_real_device="$(readlink -f "$workspace_device_name" 2>/dev/null || true)"
-  if [ -z "$workspace_real_device" ]; then
-    abort_boot "Unable to resolve configured workspace device $workspace_device_name."
-  fi
-  workspace_model="$(cat "/sys/class/block/$(basename "$workspace_real_device")/device/model" 2>/dev/null || true)"
-  case "$workspace_model" in
-    *'Amazon EC2 NVMe Instance Storage'*)
-      abort_boot "Configured workspace device $workspace_device_name is instance storage."
-      ;;
-    *)
-      workspace_device="$workspace_device_name"
-      ;;
-  esac
-fi
-
-root_source="$(findmnt -n -o SOURCE / 2>/dev/null || true)"
-if [ -z "$root_source" ]; then
-  abort_boot 'Unable to identify the root filesystem.'
-fi
-root_disk="$(lsblk -ndo PKNAME "$root_source" || true)"
-if [ -z "$root_disk" ]; then
-  root_disk="$(lsblk -ndo NAME "$root_source" || true)"
-fi
-if [ -z "$root_disk" ]; then
-  abort_boot 'Unable to identify the root disk.'
-fi
-if [ -n "$workspace_device" ]; then
-  workspace_disk="$(lsblk -ndo PKNAME "$workspace_device" || true)"
-  if [ -z "$workspace_disk" ]; then
-    workspace_disk="$(lsblk -ndo NAME "$workspace_device" || true)"
-  fi
-  if [ -z "$workspace_disk" ]; then
-    abort_boot "Unable to identify the disk backing $workspace_device_name."
-  fi
-  if [ "$workspace_disk" = "$root_disk" ]; then
-    abort_boot "Configured workspace device $workspace_device_name resolves to the root disk."
-  fi
-fi
-
-workspace_mapping_tool_available=false
-if command -v ebsnvme-id >/dev/null 2>&1; then
-  workspace_mapping_tool_available=true
-fi
-
-if [ -z "$workspace_device" ]; then
-  configured_device_name="$(printf '%s\n' "$workspace_device_name" | sed 's#^/dev/##')"
-  workspace_candidate_count=0
-  workspace_candidate=''
-  for candidate in $(lsblk -dnro NAME,TYPE | awk '$2 == "disk" {print "/dev/" $1}'); do
-    if [ "$candidate" = "/dev/$root_disk" ]; then
-      continue
-    fi
-    model="$(cat "/sys/class/block/$(basename "$candidate")/device/model" 2>/dev/null || true)"
-    if [ "$model" != 'Amazon Elastic Block Store' ]; then
-      continue
-    fi
-    if [ "$workspace_mapping_tool_available" = true ]; then
-      mapped_device_name="$(ebsnvme-id -b "$candidate" 2>/dev/null || true)"
-      mapped_device_name="$(printf '%s\n' "$mapped_device_name" | sed 's#^/dev/##')"
-      if [ "$mapped_device_name" != "$configured_device_name" ]; then
-        continue
-      fi
-    fi
-    workspace_candidate_count=$((workspace_candidate_count + 1))
-    workspace_candidate="$candidate"
-  done
-  if [ "$workspace_candidate_count" -ne 1 ]; then
-    abort_boot "Unable to uniquely resolve EC2 workspace device $workspace_device_name; found $workspace_candidate_count non-root EBS disks."
-  fi
-  workspace_device="$workspace_candidate"
-fi
-
-if [ -z "$workspace_device" ]; then
-  abort_boot 'Unable to find the EC2 workspace disk.'
-fi
-
-if ! blkid "$workspace_device" >/dev/null 2>&1; then
-  if ! mkfs.ext4 -F -E lazy_itable_init=1,lazy_journal_init=1 -L '${WORKSPACE_FS_LABEL}' "$workspace_device"; then
-    abort_boot "Unable to format the EC2 workspace device $workspace_device."
-  fi
-fi
-workspace_uuid="$(blkid -s UUID -o value "$workspace_device" 2>/dev/null || true)"
-if [ -z "$workspace_uuid" ]; then
-  abort_boot 'The EC2 workspace disk has no filesystem UUID.'
-fi
-
-# systemd owns the mount after boot. Write the unit only after the filesystem UUID
-# exists so the unit and the EC2 device selection have one source of truth.
-if ! printf '[Unit]\nDescription=Mount the Shipfox job workspace volume\n\n[Mount]\nWhat=UUID=%s\nWhere=%s\nType=ext4\nOptions=defaults,nofail\n\n[Install]\nWantedBy=multi-user.target\n' \
-  "$workspace_uuid" "$workspace_root" > "$workspace_mount_unit_path"; then
-  abort_boot "Unable to write the EC2 workspace mount unit at $workspace_mount_unit_path."
-fi
-
-# Keep the shared runner image provider-neutral. EC2 adds this boot-time dependency
-# after writing the unit; QEMU never runs this EC2 bootstrap and receives no drop-in.
-if ! mkdir -p "$runner_mount_dropin_dir"; then
-  abort_boot "Unable to create the runner mount dependency directory at $runner_mount_dropin_dir."
-fi
-if ! printf '[Unit]\nRequires=%s\nAfter=%s\n' "$workspace_mount_unit" "$workspace_mount_unit" > "$runner_mount_dropin_path"; then
-  abort_boot "Unable to write the runner mount dependency at $runner_mount_dropin_path."
-fi
-
-if ! systemctl daemon-reload; then
-  abort_boot 'Unable to reload systemd after configuring the EC2 workspace mount.'
-fi
-if ! systemctl enable "$workspace_mount_unit"; then
-  abort_boot "Unable to enable the EC2 workspace mount unit $workspace_mount_unit."
-fi
-if ! systemctl start "$workspace_mount_unit"; then
-  abort_boot "Unable to start the EC2 workspace mount unit $workspace_mount_unit."
-fi
-if ! mountpoint -q "$workspace_root"; then
-  abort_boot "The EC2 workspace volume did not mount at $workspace_root."
-fi
-if ! chown shipfox:shipfox "$workspace_root"; then
-  abort_boot "Unable to assign ownership of the EC2 workspace directory at $workspace_root."
-fi
-if ! /usr/bin/mv -- '${RUNNER_ENV_TEMP_PATH}' '${RUNNER_ENV_PATH}'; then
-  abort_boot 'Unable to publish the runner environment after the EC2 workspace mounted.'
-fi
-`;
-}
 
 /** Values written into the runner image environment file at EC2 boot. */
 export interface RunnerBootstrapUserDataOptions {
@@ -194,30 +37,16 @@ interface RunnerBootstrapEnvironment {
 }
 
 /**
- * Renders the cloud-init configuration consumed by the prebaked Shipfox runner image.
- * Cloud-init stages the file under a temporary path and atomically renames it into place;
- * the image's path unit starts the lifecycle target when the final path appears. No
- * workspace-scoped credential is included. The environment is published only after the
- * EC2 workspace volume has been formatted and mounted, so the runner only ever receives a
- * usable workspace directory and remains independent of storage implementation details.
+ * Renders the environment file consumed by the prebaked Shipfox runner image.
+ * The EC2 image's IMDSv2 bootstrap unit stages this payload, prepares the root and workspace
+ * filesystems, then atomically publishes it at the path watched by the runner lifecycle.
+ * No workspace-scoped credential is included.
  */
 export function renderRunnerBootstrapUserData(options: RunnerBootstrapUserDataOptions): string {
   const environment = runnerBootstrapEnvironment(options);
-  const envFile = Object.entries(environment)
+  return `${Object.entries(environment)
     .map(([key, value]) => `${key}=${escapeEnvironmentValue(value)}`)
-    .join('\n');
-
-  return `${CLOUD_INIT_HEADER}
-write_files:
-  - path: ${RUNNER_ENV_TEMP_PATH}
-    owner: root:root
-    permissions: '0600'
-    content: |
-${indent(envFile, 6)}
-runcmd:
-  - |
-${indent(workspaceMountScript(options.workspaceDeviceName), 6)}
-`;
+    .join('\n')}\n`;
 }
 
 /** Returns only non-sensitive metadata suitable for structured launch logs. */
@@ -269,12 +98,4 @@ function runnerBootstrapEnvironment(
 
 function escapeEnvironmentValue(value: string): string {
   return JSON.stringify(value);
-}
-
-function indent(value: string, spaces: number): string {
-  const padding = ' '.repeat(spaces);
-  return value
-    .split('\n')
-    .map((line) => (line.length === 0 ? line : `${padding}${line}`))
-    .join('\n');
 }


### PR DESCRIPTION
## Summary

Replace the runner image's cloud-init user-data delivery with a minimal IMDSv2 bootstrap unit. The unit retries metadata access, validates and atomically publishes the environment, performs launch-volume and workspace preparation, and preserves the EC2 boot security behavior.

The image now uses static primary-interface Netplan, purges cloud-init after the build-time QEMU NoCloud seed, and removes build-time hostname and host-key state. The provider continues to emit the same validated environment contract.

Local validation is green; live AWS/QEMU boot validation was not available in this workspace.

Closes ENG-1529

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace cloud-init with an IMDSv2 bootstrap for the EC2 runner image to cut ~12s from boot while keeping the same environment contract. Old: cloud-init wrote `/etc/shipfox/runner.env` from `#cloud-config`. New: `shipfox-bootstrap.service` fetches IMDSv2 user data, validates and atomically publishes the env, grows the root FS, prepares the workspace EBS volume, regenerates SSH host keys, and powers off gracefully on invalid or unavailable user data. Addresses ENG-1529.

- Boot flow and ordering: `shipfox-bootstrap.service` `Type=oneshot`, `After=network.target`, `Wants=network.target`, `Before=shipfox-runner-env.{path,service}`, `FailureAction=poweroff`; `shipfox-runner-env.service` `After=network-online.target shipfox-bootstrap.service`.
- IMDSv2 token flow with bounded retries; fail closed if user data cannot be fetched, staged, or validated; stage `0600` root-owned then atomic rename to `/etc/shipfox/runner.env`.
- Boot prep: grow root filesystem when the launch volume exceeds the snapshot; resolve/format/mount workspace EBS via a systemd Mount unit required by the runner.
- Networking and image: ship `/etc/netplan/01-shipfox.yaml` (match `e*`, `dhcp4: true`, `dhcp6: false`); purge `cloud-init` and `/etc/cloud`; remove `/etc/netplan/50-cloud-init.yaml`; remove `/etc/hostname` and `ssh_host_*` from the AMI and regenerate keys at boot; enable `shipfox-bootstrap.service`.
- Provider: `renderRunnerBootstrapUserData` now returns a plain env file; watchdog parsing accepts quoted values.

- Rollout
  - Callers of `renderRunnerBootstrapUserData` must send the raw env payload, not a `#cloud-config` document.
  - Publish and repoint AMIs before deploying the provider change; rollbacks require matching provider and AMI.
  - Ensure IMDSv2 is available; instances shut down early on invalid or missing user data.
  - Templates may set `root_volume_gb` larger than the snapshot; the bootstrap grows the filesystem and mounts the workspace volume before the runner starts.

<sup>Written for commit f0f55ad72e95ee49516299b6ac31b81df82c355b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

