### PR TITLE
[docs] Reframe docs entry points around the agent platform

### DIFF
--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -10,7 +10,7 @@ based on the repository's files.
 
 ## Before you begin
 
-This lesson starts from a workspace you can already sign in to. In that
+This lesson starts from a Shipfox workspace you already have access to. In that
 workspace, you need:
 
 - A [source integration connection](/integrations) that can read the test

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -10,11 +10,19 @@ based on the repository's files.
 
 ## Before you begin
 
+This lesson starts from a workspace you can already sign in to. In that
+workspace, you need:
+
+- A [source integration connection](/integrations) that can read the test
+  repository.
+- A configured [model provider and workspace agent
+  defaults](/how-to/set-up-work/configure-model-providers).
+- Runner capacity that matches the `runner:` value in the workflow below. See
+  [Runners](/operations/runners).
+
 <Callout type="info">
-  This lesson requires a workspace login, a source integration connection that
-  can read the test repository, an online `ubuntu-latest` runner, and configured
-  agent [defaults](/how-to/set-up-work/configure-model-providers). See
-  [Installation](/installation) if Shipfox is not running yet.
+  No workspace yet? Getting one is a separate task. See
+  [Installation](/installation).
 </Callout>
 
 ## Connect your project
@@ -82,7 +90,7 @@ hello world
 *A run detail page: status, the job graph, and every step with its duration.*
 
 <Callout type="info">
-  A run stuck in `pending` means no online runner matches the `runner:` label in your workflow. Check that a runner with the label `ubuntu-latest` is online. See [Resolve pending jobs](/how-to/run-and-troubleshoot/pending-jobs).
+  A run stuck in `pending` means no online runner matches the `runner:` value in your workflow. See [Resolve pending jobs](/how-to/run-and-troubleshoot/pending-jobs).
 </Callout>
 
 ## Verify the result

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ description: "The agent platform for engineering teams. Define agents in git, tr
 
 ## Agent platform for engineering teams
 
-Shipfox lets you automate real engineering work with agents that you can trust in production.
+Shipfox lets you automate real engineering work with agents you trust in production.
 
 You describe what the agent does. Shipfox handles everything around it: orchestration, secure access to your tools, execution next to your code, monitoring, and central control.
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,96 +1,89 @@
 ---
-title: "Shipfox: Your AI software factory"
+title: "Shipfox · Your AI Software Factory"
 sidebarTitle: "Home"
-description: "Shipfox is your AI software factory. Build workflows that run shell and AI agent steps, start them from the tools you already use, and run them on compute you control."
+description: "The agent platform for engineering teams. Define agents in git, trigger them on any event from your stack, and give them secure access to your tools and teammates."
 ---
 
-**Your AI software factory.**
+## Agent platform for engineering teams
 
-Shipfox turns your engineering work into workflows that AI agents can run. You write each workflow as YAML in your repository. A matching event can start a run, such as a code push or an alert. An agent can read context, use selected tools, and act within the workflow's permissions. Every step streams to the dashboard as it runs.
+Shipfox lets you automate real engineering work with agents that you can trust in production.
 
-<DocsVideo
-  lightSrc="/img/job-run-light.mp4"
-  lightPoster="/img/job-run-light-poster.jpg"
-  darkSrc="/img/job-run-dark.mp4"
-  darkPoster="/img/job-run-dark-poster.jpg"
-  width={1920}
-  height={1080}
-  label="A Shipfox run: the fix, verify_fix, and deploy_fix workflow with the claude-opus-4-8 agent step streaming its thinking and tool calls live in the dashboard."
-/>
+You describe what the agent does. Shipfox handles everything around it: orchestration, secure access to your tools, execution next to your code, monitoring, and central control.
 
-<Cards>
-  <Card title="Get started" href="/getting-started">
-    Connect a repository and run your first workflow in a few minutes.
-  </Card>
-  <Card title="Browse integrations" href="/integrations">
-    Find a provider in the catalog and connect it.
-  </Card>
-  <Card title="See how it works" href="/understand">
-    The run model in one page: triggers, jobs, steps, agents, and runners.
-  </Card>
-</Cards>
-
-## Anatomy of a workflow
-
-A workflow starts with a trigger, then runs one or more jobs. Each job is an ordered list of steps, and a step is a shell command or an AI agent. Larger workflows chain many jobs and run them in parallel.
-
-This fragment adds a Sentry trigger and a job below the top-level `name` and
-`runner` fields of an existing workflow:
+Agents live in your repository as [YAML](/reference/workflow-schema). This workflow runs your tests on every push, then puts an agent on the result:
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
+name: Review on push
+runner: ubuntu-latest
+
 triggers:
-  on_alert:                        # Define any trigger from your integrations
-    source: sentry_prod              # Replace with the slug of your Sentry integration connection.
-    event: issue.created
+  on_push:
+    source: github_acme # the slug of your GitHub integration connection
+    event: push
+
 jobs:
-  fix:
+  review:
     steps:
-      - run: npm install           # a shell step
-      - prompt: |                  # an agent step uses workspace defaults
-          Investigate the alert in the repository and report the likely cause.
-          Do not change files.
+      - run: npm test
+      - prompt: |
+          Review the changes in this push and report the highest-risk findings.
 ```
 
-## What to build
+Your first agent runs in minutes with Shipfox cloud.
 
 <Cards>
-  <Card title="Respond to alerts" href="/how-to/recipes/triage-sentry-issues">
-    A Sentry issue starts a run, and an agent reports the likely cause.
+  <Card title="Get started" href="/getting-started">
+    Connect a repository and run your first workflow in minutes.
   </Card>
-  <Card title="Check every push" href="/how-to/recipes/checks-on-push">
-    Run tests, lint, and an AI review on every commit, in one workflow.
-  </Card>
-  <Card title="Run parallel CI" href="/how-to/recipes/parallel-ci-agent-review">
-    Run checks in parallel and fan in to an agent review.
-  </Card>
-  <Card title="Let agents fix code" href="/how-to/author-workflows/build-feedback-loop">
-    Pair an agent with a gate so it retries until the check passes.
+  <Card title="Browse integrations" href="/integrations">
+    Connect source control, monitoring, tickets, chat, and other tools.
   </Card>
 </Cards>
 
-## Why Shipfox
+## Agents that stay under control
 
-- **Agents automate your process.** Any step can be an AI agent that reads your repository, runs tools, and acts on the result.
-- **Watch every run.** Runs, jobs, and steps stream live to the dashboard. Agent steps show their messages, thinking, tool calls, tokens, and cost. See [Workflows and runs](/understand/workflows-and-runs).
-- **Works with your daily tools.** Start runs from GitHub, Sentry, or any custom webhook. See [Integrations](/integrations).
-- **Your harness, your models.** Pick your agent harness and any of the supported [model providers](/reference/model-providers).
-- **Run on your compute.** Jobs run on isolated [runners](/understand/runners-and-execution-environments) you control. Use long-lived capacity or provision a runner for each job.
-- **Open source, MIT.** Self-host the whole platform. [Shipfox on GitHub](https://github.com/ShipfoxHQ/shipfox).
+You decide how much freedom each agent gets. Workflows combine [agent steps](/understand/agents), where a model decides what to do, with [shell steps](/how-to/author-workflows/run-shell-commands) that run your exact commands. You set the structure. The model works inside it.
+
+## Loops that run until the result is correct
+
+A [feedback loop](/understand/feedback-loops) repeats an agent until your condition is met. The agent keeps working until the output is right, without a person in the loop.
+
+## Secure by design
+
+Agents run next to your code in [ephemeral runners](/understand/runners-and-execution-environments). Each runner starts in isolation and stops at the end of the job. No data stays between two runs. Each agent reaches only the [tools that you allow](/understand/integrations-connections-and-tools).
+
+## Open source and self-hostable
+
+The whole platform is open source under the MIT license. Read it on [GitHub](https://github.com/ShipfoxHQ/shipfox), or [run Shipfox on your own infrastructure](/installation) so that your code and your credentials never leave it.
+
+## One place to control everything
+
+You monitor and manage every agent from one place. Every [run](/understand/workflows-and-runs) streams its jobs, steps, agent messages, tool calls, tokens, and cost while it happens.
+
+## What teams build with Shipfox
+
+Teams use Shipfox for work such as:
+
+- **Triage monitoring errors.** A new error starts an agent that produces a fix
+  and opens a pull request.
+- **Turn tickets into code.** An assigned ticket starts an agent that opens a
+  pull request and responds to review comments.
+- **Fix failing CI.** A failing check starts an agent that produces a fix and
+  makes the check pass again.
+- **Review pull requests.** Each new pull request gets an agent review based on
+  the team's guidelines, with follow-up on later changes.
 
 ## Where to go next
 
 <Cards>
   <Card title="Get started" href="/getting-started">
-    Connect a repository, add a workflow, and fire your first run.
+    Connect a repository and run your first workflow in minutes.
   </Card>
   <Card title="Understand Shipfox" href="/understand">
-    Events, jobs, agents, feedback loops, and asynchronous interaction.
+    Learn how events, jobs, agents, runners, and feedback loops work together.
   </Card>
-  <Card title="Integrations" href="/integrations">
-    Connect your monitoring, ticketing, and chat tools, and webhooks.
-  </Card>
-  <Card title="Installation" href="/installation">
-    Self-host Shipfox for your team.
+  <Card title="Browse integrations" href="/integrations">
+    See which tools can start workflows and which operations agents can use.
   </Card>
 </Cards>

--- a/apps/docs/content/docs/installation/index.mdx
+++ b/apps/docs/content/docs/installation/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: "Installing Shipfox"
 sidebarTitle: "Overview"
-description: "How to run Shipfox: evaluate locally or self-host on your own infrastructure. An overview of the components and the setup paths."
+description: "How to get a Shipfox workspace: use Shipfox Cloud, evaluate locally, or self-host on your own infrastructure. An overview of the components and the setup paths."
 ---
 
-Shipfox has two parts to stand up: a **control plane** and one or more **runners**.
-The control plane contains the API and dashboard, backed by PostgreSQL, Temporal,
-and S3-compatible object storage. Runners execute jobs on compute you own. This section is for whoever operates that
-infrastructure, typically a platform, DevEx, or SRE team.
+Shipfox runs as a **control plane** and one or more **runners**. On [Shipfox
+Cloud](https://app.shipfox.io) both are provided and there is nothing to install:
+create a workspace and go straight to [Quick Start](/getting-started).
+
+To run Shipfox yourself, you stand up both parts. The control plane contains the
+API and dashboard, backed by PostgreSQL, Temporal, and S3-compatible object
+storage. Runners execute jobs on compute you own. The rest of this section is for
+whoever operates that infrastructure, typically a platform, DevEx, or SRE team.
 
 <Callout type="info">
   Configuring projects and authoring workflows needs none of this. If Shipfox is
@@ -27,6 +31,9 @@ infrastructure, typically a platform, DevEx, or SRE team.
 ## Choose a path
 
 <Cards>
+  <Card title="Shipfox Cloud" href="https://app.shipfox.io">
+    Create a workspace on managed infrastructure. Runner capacity is provided.
+  </Card>
   <Card title="Local evaluation" href="/installation/local">
     Run the whole stack on your machine with Docker Compose to try Shipfox out.
   </Card>

--- a/apps/docs/src/app/(home)/layout.tsx
+++ b/apps/docs/src/app/(home)/layout.tsx
@@ -1,6 +1,6 @@
 import {DocsLayout} from 'fumadocs-ui/layouts/docs';
 import type {ReactNode} from 'react';
-import {baseOptions} from '@/app/layout.config';
+import {baseOptions, ShipfoxDashboardButton} from '@/app/layout.config';
 import {source} from '@/lib/source';
 
 // Per-page metadata (title, description, and OG/Twitter images) is generated in
@@ -8,7 +8,11 @@ import {source} from '@/lib/source';
 
 export default function Layout({children}: {children: ReactNode}) {
   return (
-    <DocsLayout tree={source.pageTree} {...baseOptions}>
+    <DocsLayout
+      tree={source.pageTree}
+      {...baseOptions}
+      sidebar={{footer: <ShipfoxDashboardButton />}}
+    >
       {/* @ts-ignore: fuma-docs and monorepo react versions seem to be incompatible */}
       {children}
     </DocsLayout>

--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -1,5 +1,22 @@
+import {buttonVariants} from 'fumadocs-ui/components/ui/button';
 import type {BaseLayoutProps} from 'fumadocs-ui/layouts/shared';
 import {basePath} from '@/url';
+
+export function ShipfoxDashboardButton() {
+  return (
+    <a
+      href="https://app.shipfox.io"
+      target="_blank"
+      rel="noreferrer"
+      className={buttonVariants({
+        color: 'primary',
+        className: 'w-full md:order-first md:mb-2',
+      })}
+    >
+      Go to dashboard
+    </a>
+  );
+}
 
 /**
  * Shared layout configurations


### PR DESCRIPTION
This updates the docs entry points to match Shipfox's current product story: an agent platform for engineering teams.

The docs home now leads with a runnable push-triggered workflow and explains controlled agent execution, feedback loops, secure ephemeral runners, self-hosting, and common team use cases. Installation distinguishes Shipfox Cloud from local evaluation and self-hosting, while Getting Started states the required workspace, integration, provider, and runner setup. The shared docs layout adds a direct dashboard CTA.

Validated locally with `mise exec -- turbo check --filter=@shipfox/docs...`, `mise exec -- turbo type --filter=@shipfox/docs...`, `mise exec -- turbo test --filter=@shipfox/docs...`, and `mise exec -- turbo build --filter=@shipfox/docs...`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframes docs entry points around Shipfox as an agent platform for engineering teams and adds a persistent “Go to dashboard” CTA in the docs sidebar to steer new users to Cloud-first onboarding.

- Home: leads with a push-triggered workflow example using `on_push`, a GitHub integration slug, and `$schema` at https://www.shipfox.io/docs/workflow.schema.json; confirm schema and links resolve.
- Getting Started: prerequisites are explicit (source integration, model provider/workspace defaults, runner capacity matching the `runner:` value); “pending” guidance now references the `runner:` value.
- Installation: clarifies that Shipfox Cloud provides control plane and runner capacity and adds a Cloud card CTA; self-hosting and local evaluation paths remain.
- Layout: adds `ShipfoxDashboardButton` (styled with `fumadocs-ui` `buttonVariants`) as `sidebar.footer` on the docs home layout; verify spacing in mobile/dark mode and that it opens https://app.shipfox.io in a new tab.
- Copy: removes filler flagged by the prose policy across updated pages.

<sup>Written for commit e41efcfa929090421e436421dc6e34cd81bed36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

