### PR TITLE
[client-workflows] Remove nested panels from workflow run list

### DIFF
--- a/.changeset/flat-workflow-run-panel.md
+++ b/.changeset/flat-workflow-run-panel.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/client-workflows': patch
+---
+
+Remove nested panel borders from workflow run list content and states.

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
@@ -1,5 +1,4 @@
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Panel} from '@shipfox/react-ui/panel';
 import type {WorkflowRunListItem} from '#core/workflow-run.js';
 import type {WorkflowRunListQuery} from './types.js';
 import {
@@ -53,18 +52,14 @@ export function WorkflowRunListContent({
   const showNoMatches = hasLoaded && runs.length === 0 && !showEmptyState;
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
+    <>
       {isPending ? <WorkflowRunListSkeleton /> : null}
       {!isPending ? (
-        <Panel>
-          <QueryLoadError query={query} subject="workflow runs" icon="pulseLine" variant="panel" />
-        </Panel>
+        <QueryLoadError query={query} subject="workflow runs" icon="pulseLine" variant="panel" />
       ) : null}
       {!isPending && refreshFailed ? <WorkflowRunListStaleError query={query} /> : null}
       {showEmptyState ? (
-        <Panel>
-          <WorkflowRunListEmpty workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
-        </Panel>
+        <WorkflowRunListEmpty workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
       ) : null}
       {showNoMatches ? (
         <WorkflowRunListNoMatches
@@ -86,6 +81,6 @@ export function WorkflowRunListContent({
           />
         </>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -2,7 +2,6 @@ import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
-import {Panel} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
@@ -16,7 +15,7 @@ const SKELETON_ROW_COUNT = 8;
  */
 export function WorkflowRunListSkeleton() {
   return (
-    <Panel role="status" aria-label="Loading runs" className="@container divide-y">
+    <div role="status" aria-label="Loading runs" className="@container divide-y">
       {Array.from({length: SKELETON_ROW_COUNT}).map((_, index) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton row, stable position
@@ -30,7 +29,7 @@ export function WorkflowRunListSkeleton() {
           <Skeleton className="h-12 w-48" />
         </div>
       ))}
-    </Panel>
+    </div>
   );
 }
 
@@ -114,43 +113,41 @@ export function WorkflowRunListNoMatches({
   onLoadMore?: () => void;
 }) {
   return (
-    <Panel>
-      <div className="flex flex-col gap-inline">
-        {isFetchNextPageError ? (
-          <Callout role="alert" type="error">
-            Could not load more workflow runs. Try again to continue searching older runs.
-          </Callout>
-        ) : null}
-        <EmptyState
-          icon="filterOffLine"
-          title={hasNextPage ? 'No matches in loaded history' : 'No matching runs'}
-          description={
-            hasNextPage
-              ? 'No loaded run matches these filters. Load more to search further back.'
-              : 'No run matches these filters.'
-          }
-          action={
-            <div className="flex flex-wrap justify-center gap-inline">
-              {hasNextPage && onLoadMore ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="primary"
-                  isLoading={isFetchingNextPage}
-                  onClick={onLoadMore}
-                >
-                  Load more runs
-                </Button>
-              ) : null}
-              <Button type="button" size="sm" variant="secondary" onClick={onClear}>
-                Show all runs
+    <div className="flex flex-col gap-inline">
+      {isFetchNextPageError ? (
+        <Callout role="alert" type="error">
+          Could not load more workflow runs. Try again to continue searching older runs.
+        </Callout>
+      ) : null}
+      <EmptyState
+        icon="filterOffLine"
+        title={hasNextPage ? 'No matches in loaded history' : 'No matching runs'}
+        description={
+          hasNextPage
+            ? 'No loaded run matches these filters. Load more to search further back.'
+            : 'No run matches these filters.'
+        }
+        action={
+          <div className="flex flex-wrap justify-center gap-inline">
+            {hasNextPage && onLoadMore ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="primary"
+                isLoading={isFetchingNextPage}
+                onClick={onLoadMore}
+              >
+                Load more runs
               </Button>
-            </div>
-          }
-          variant="panel"
-        />
-      </div>
-    </Panel>
+            ) : null}
+            <Button type="button" size="sm" variant="secondary" onClick={onClear}>
+              Show all runs
+            </Button>
+          </div>
+        }
+        variant="panel"
+      />
+    </div>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -48,6 +48,7 @@ describe('WorkflowRunListView', () => {
       const body = panel?.querySelector<HTMLElement>('[data-slot="panel-body"]');
 
       expect(panel).not.toBeNull();
+      expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
       expect(header).not.toBeNull();
       expect(body).not.toBeNull();
       expect(within(header as HTMLElement).getByLabelText('Search runs')).toBeInTheDocument();
@@ -204,6 +205,7 @@ describe('WorkflowRunListView', () => {
       renderListView([], {query: loadedQuery({isPending: true, data: undefined})});
 
       expect(await screen.findByLabelText('Loading runs')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
       expect(screen.queryByText('No runs yet')).not.toBeInTheDocument();
     });
 
@@ -217,6 +219,7 @@ describe('WorkflowRunListView', () => {
       renderListView([]);
 
       expect(await screen.findByText('No runs yet')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
       expect(screen.getByRole('link', {name: 'View workflows'})).toBeInTheDocument();
       expect(screen.queryByRole('button', {name: 'Show all runs'})).not.toBeInTheDocument();
     });
@@ -228,6 +231,7 @@ describe('WorkflowRunListView', () => {
       await user.type(await screen.findByLabelText('Search runs'), 'no-such-run');
 
       expect(screen.getByText('No matching runs')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
       expect(screen.queryByText('No runs yet')).not.toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Show all runs'})).toBeInTheDocument();
     });
@@ -248,6 +252,7 @@ describe('WorkflowRunListView', () => {
       });
 
       expect(await screen.findByLabelText('Search runs')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-slot="panel"]')).toHaveLength(1);
       expect(screen.queryByText('No runs yet')).not.toBeInTheDocument();
       expect(screen.queryByText('No matching runs')).not.toBeInTheDocument();
     });

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
@@ -77,7 +77,7 @@ export function WorkflowRunListView({
               hasActiveFilters={hasActiveFilters}
             />
           </PanelHeader>
-          <PanelBody className="min-h-0 flex-1">
+          <PanelBody className="min-h-0 flex-1 overflow-y-auto">
             <WorkflowRunListContent
               query={query}
               totalRuns={runs.length}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -1,6 +1,5 @@
 import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {Icon, type IconName} from '@shipfox/react-ui/icon';
-import {Panel} from '@shipfox/react-ui/panel';
 import {RelativeTime} from '@shipfox/react-ui/relative-time';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
@@ -38,15 +37,13 @@ export function WorkflowRunRowList({
     // A container, not the viewport, drives the row's breakpoints. What a row can afford is its
     // own width; keying off the viewport would keep the job strip hidden on a wide screen or
     // crush it on a narrow one.
-    <Panel className="@container">
-      <ul className="divide-y divide-border-neutral-base">
-        {runs.map((run) => (
-          <li key={run.id}>
-            <WorkflowRunRow run={run} workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
-          </li>
-        ))}
-      </ul>
-    </Panel>
+    <ul className="@container divide-y divide-border-neutral-base">
+      {runs.map((run) => (
+        <li key={run.id}>
+          <WorkflowRunRow run={run} workspaceSlug={workspaceSlug} projectSlug={projectSlug} />
+        </li>
+      ))}
+    </ul>
   );
 }
 


### PR DESCRIPTION
The workflow run list rendered its filters inside an outer panel while its loaded, loading, empty, and error content created additional panels. That produced the inset borders and radii visible around the list content.

Keep the filters as the single panel header and render every list state directly inside its scrollable body. Regression assertions cover loaded, loading, empty, filtered-empty, and initial-error states, and the published package includes a patch Changeset.

## Validation

- `mise exec -- turbo check --filter=@shipfox/client-workflows...`
- `mise exec -- turbo test type build --filter=@shipfox/client-workflows...`
- 43 focused workflow run list tests
- Impeccable layout detector and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened the workflow run list to remove nested panels that created unwanted inset borders. Previously, states like loading/empty/error wrapped content in their own `Panel`s; now the list renders all states directly inside the outer panel’s scrollable body.

- Replaced inner `Panel` wrappers in content, state, and row list components with plain containers; preserved styling by keeping `variant="panel"` where needed.
- Added `overflow-y-auto` to `PanelBody`; removed the extra scroll container in content.
- Updated tests to assert a single `[data-slot="panel"]` across loaded, loading, empty, filtered-empty, and initial-error states.
- Published a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 3f9f79707eac47eb7244db05d44d5ecf37cadad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

