### PR TITLE
[runner-image] Add 4 GiB swap to runner images

### DIFF
--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -19,6 +19,8 @@ Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host ope
 
 The image is checked during the bake and starts with `multi-user.target` as the systemd default. It skips boot-time filesystem checks and applies `noatime` to `/` and `/boot`.
 
+The image includes a 4 GiB `/swapfile`; the bake initializes it and persists it in `/etc/fstab` for runner startup.
+
 The fstab entries for `/boot` and `/boot/efi` use `noauto` and pass 0. The partitions remain in the image for the bootloader, but systemd does not mount them during runner startup. `configure-ephemeral-boot.sh` masks the image's package, bootloader, and firmware update units so they cannot write to the detached mount-point directories.
 
 `fsck.mode=skip` also suppresses checks for other filesystems with a non-zero pass number. Do not add a durable filesystem with a non-zero pass number without revisiting this image contract.

--- a/infra/images/runner/scripts/build/setup-runner.sh
+++ b/infra/images/runner/scripts/build/setup-runner.sh
@@ -7,6 +7,15 @@ apt-get update
 apt-get install --yes --no-install-recommends \
   ca-certificates curl wget git openssh-client tar gzip xz-utils bzip2 zip unzip jq \
   build-essential cloud-guest-utils python3 pkg-config ripgrep fd-find sudo amazon-ec2-utils
+
+# Keep a disk-backed memory reserve available while jobs run.
+swapfile="$root_dir/swapfile"
+fallocate -l 4G "$swapfile"
+chmod 600 "$swapfile"
+mkswap "$swapfile"
+swapon "$swapfile"
+printf '%s\n' '/swapfile none swap sw 0 0' >> "$root_dir/etc/fstab"
+
 # The final image reads its one user-data payload directly from IMDSv2. Keep cloud-init
 # only long enough for Packer's initial NoCloud SSH bootstrap, then remove its package and state.
 apt-get purge --yes cloud-init

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1308,6 +1308,7 @@ describe('runner image composition', () => {
       expect(chmodIndex).toBeGreaterThan(fallocateIndex);
       expect(mkswapIndex).toBeGreaterThan(chmodIndex);
       expect(swaponIndex).toBeGreaterThan(mkswapIndex);
+      expect((await stat(join(fixture.root, 'swapfile'))).mode & 0o777).toBe(0o600);
       expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toContain(
         '/swapfile none swap sw 0 0\n',
       );

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1291,6 +1291,31 @@ UUID=efi /boot/efi vfat defaults,noauto 0 0
 });
 
 describe('runner image composition', () => {
+  it('creates and enables a 4 GiB swap file', async () => {
+    const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
+    const fixture = await createRunnerImageSetupFixture();
+
+    try {
+      execFileSync('/bin/sh', [script.pathname], {env: fixture.environment, stdio: 'pipe'});
+
+      const events = (await readFile(fixture.commandLog, 'utf8')).trim().split('\n');
+      const fallocateIndex = events.indexOf(`fallocate -l 4G ${join(fixture.root, 'swapfile')}`);
+      const chmodIndex = events.indexOf(`chmod 600 ${join(fixture.root, 'swapfile')}`);
+      const mkswapIndex = events.indexOf(`mkswap ${join(fixture.root, 'swapfile')}`);
+      const swaponIndex = events.indexOf(`swapon ${join(fixture.root, 'swapfile')}`);
+
+      expect(fallocateIndex).toBeGreaterThanOrEqual(0);
+      expect(chmodIndex).toBeGreaterThan(fallocateIndex);
+      expect(mkswapIndex).toBeGreaterThan(chmodIndex);
+      expect(swaponIndex).toBeGreaterThan(mkswapIndex);
+      expect(await readFile(join(fixture.root, 'etc/fstab'), 'utf8')).toContain(
+        '/swapfile none swap sw 0 0\n',
+      );
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
   it('unmounts seeded snaps, purges snapd, and removes its image state', async () => {
     const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
     const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
@@ -1493,6 +1518,7 @@ async function createRunnerImageSetupFixture() {
   await mkdir(join(root, 'etc/default'), {recursive: true});
   await mkdir(join(root, 'etc/sudoers.d'), {recursive: true});
   await mkdir(commandDirectory, {recursive: true});
+  await writeFile(join(root, 'etc/fstab'), '# fstab\n');
 
   await writeExecutable(
     join(commandDirectory, 'apt-get'),
@@ -1502,6 +1528,18 @@ printf 'apt-get %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
 if [ "$1" = purge ] && [ "\${3:-}" = snapd ] && [ -n "\${RUNNER_IMAGE_FAIL_PURGE:-}" ]; then
   exit 1
 fi
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'fallocate'),
+    `#!/bin/sh
+set -eu
+printf 'fallocate %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+last=''
+for argument; do
+  last="$argument"
+done
+: > "$last"
 `,
   );
   await writeExecutable(
@@ -1542,7 +1580,28 @@ done
 `,
   );
   await writeExecutable(join(commandDirectory, 'ln'), '#!/bin/sh\nexec /bin/ln "$@"\n');
-  await writeExecutable(join(commandDirectory, 'chmod'), '#!/bin/sh\nexec /bin/chmod "$@"\n');
+  await writeExecutable(
+    join(commandDirectory, 'chmod'),
+    `#!/bin/sh
+set -eu
+printf 'chmod %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+exec /bin/chmod "$@"
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'mkswap'),
+    `#!/bin/sh
+set -eu
+printf 'mkswap %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+`,
+  );
+  await writeExecutable(
+    join(commandDirectory, 'swapon'),
+    `#!/bin/sh
+set -eu
+printf 'swapon %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+`,
+  );
   await writeExecutable(join(commandDirectory, 'groupadd'), '#!/bin/sh\nexit 0\n');
   await writeExecutable(join(commandDirectory, 'id'), '#!/bin/sh\nexit 1\n');
   await writeExecutable(join(commandDirectory, 'useradd'), '#!/bin/sh\nexit 0\n');


### PR DESCRIPTION
Runner images now include a 4 GiB disk-backed swap file to provide a memory reserve during job execution. The shared AWS and QEMU bake setup creates the file with mode 0600, initializes and enables it, and persists it in `/etc/fstab` for startup.

The runner-image composition fixture covers the swap command sequence and persisted fstab entry, and the package README documents the image contract.

Validation: `mise exec -- turbo test check type --filter=@shipfox/runner-image...`, `mise exec -- pnpm --filter=@shipfox/runner-image verify`, shell syntax, and `git diff --check` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 4 GiB disk-backed swap file to runner images to provide a memory reserve during jobs. Previously the runner image had no swap; now the bake creates `/swapfile`, enables it, persists it in `/etc/fstab` so swap activates on startup, and enforces mode 0600. Expect possible slowdowns under memory pressure as workloads may swap.

**Review notes**
- `setup-runner.sh` creates `/swapfile` with mode 0600 via `fallocate -l 4G`, `chmod 600`, `mkswap`, `swapon`, and appends `/swapfile none swap sw 0 0` to `fstab`.
- `runner-image.test.ts` validates command order, asserts the swapfile is mode 0600, and checks the persisted `fstab` entry; the fixture stubs `fallocate`, `chmod`, `mkswap`, and `swapon`, and seeds `fstab`.
- README documents the swapfile in the image contract.

<sup>Written for commit 1c583625097b13ee45618cdce84398558d974446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

