### PR TITLE
Ignore Cubic reviews for release PRs

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -5,3 +5,5 @@ reviews:
   ignore:
     files:
       - '**/drizzle/meta/**'
+    head_branches:
+      - changeset-release/main


### PR DESCRIPTION
Configure Cubic to skip AI reviews for pull requests created from the generated `changeset-release/main` release branch. Preserve the existing ignore rule for generated Drizzle metadata.

Validation: parsed `cubic.yaml` with Ruby's YAML loader and passed `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips Cubic reviews for PRs with head branch `changeset-release/main`, preserving the existing ignore for `**/drizzle/meta/**`. Previously these automated release PRs were reviewed; now they are ignored to reduce noise and save CI minutes, with no impact on other PRs.

<sup>Written for commit 4f21e596cda9c0ef9081741cb3a672e04f2a0f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

