### PR TITLE
[runner-image] Prevent bootstrap ordering cycles

### DIFF
--- a/infra/images/runner/assets/shipfox-bootstrap.service
+++ b/infra/images/runner/assets/shipfox-bootstrap.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Fetch and publish the Shipfox runner bootstrap environment
 After=network.target
-Before=shipfox-runner-env.path shipfox-runner-env.service
+Before=shipfox-runner-env.service
 Wants=network.target
 FailureAction=poweroff
 

--- a/infra/images/runner/assets/shipfox-runner-env.path
+++ b/infra/images/runner/assets/shipfox-runner-env.path
@@ -1,7 +1,5 @@
 [Unit]
 Description=Start the Shipfox runner lifecycle when its environment is ready
-After=network-online.target
-Wants=network-online.target
 
 [Path]
 PathExists=/etc/shipfox/runner.env

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -86,7 +86,13 @@ build {
       "sudo install -m 0755 /tmp/spot-watchdog.sh /opt/shipfox-runner/scripts/runtime/spot-watchdog.sh",
       "sudo systemctl daemon-reload",
       "sudo systemctl enable shipfox-bootstrap.service",
-      "sudo systemctl enable shipfox-spot-watchdog.service",
+      "sudo systemctl enable shipfox-spot-watchdog.service"
+    ]
+    only = ["amazon-ebs.build_image"]
+  }
+
+  provisioner "shell" {
+    inline = [
       "sudo systemd-analyze verify multi-user.target"
     ]
     only = ["amazon-ebs.build_image"]

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -86,7 +86,8 @@ build {
       "sudo install -m 0755 /tmp/spot-watchdog.sh /opt/shipfox-runner/scripts/runtime/spot-watchdog.sh",
       "sudo systemctl daemon-reload",
       "sudo systemctl enable shipfox-bootstrap.service",
-      "sudo systemctl enable shipfox-spot-watchdog.service"
+      "sudo systemctl enable shipfox-spot-watchdog.service",
+      "sudo systemd-analyze verify multi-user.target"
     ]
     only = ["amazon-ebs.build_image"]
   }

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -8,6 +8,8 @@ import {buildRunnerImageCandidate, parseRunnerImageCandidateArgs} from '#candida
 import {packerBuildArgs, readMiseNodeVersion} from '#runner-image.js';
 
 const WHITESPACE_PATTERN = /\s+/u;
+const DEDICATED_SYSTEMD_VERIFY_PROVISIONER_PATTERN =
+  /provisioner "shell" \{\s+inline = \[\s+"sudo systemd-analyze verify multi-user\.target"\s+\]\s+only = \["amazon-ebs\.build_image"\]\s+\}/u;
 const EPHEMERAL_BOOT_MASKED_UNITS = [
   'apt-daily.service',
   'apt-daily-upgrade.service',
@@ -1073,7 +1075,7 @@ describe('systemd boot activation', () => {
       'shipfox-bootstrap.service /etc/systemd/system/shipfox-bootstrap.service',
     );
     expect(build).toContain('systemctl enable shipfox-bootstrap.service');
-    expect(build).toContain('systemd-analyze verify multi-user.target');
+    expect(build).toMatch(DEDICATED_SYSTEMD_VERIFY_PROVISIONER_PATTERN);
     expect(build).toContain('rm -f /etc/hostname');
   });
 

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -955,12 +955,12 @@ describe('systemd boot activation', () => {
     expect(build).not.toContain('var-lib-shipfox-workspaces.mount');
   });
 
-  it('starts the lifecycle target when the complete environment file appears', async () => {
+  it('watches for the complete environment without blocking basic boot on network readiness', async () => {
     const pathUnit = await readUnit('shipfox-runner-env.path');
     const targetUnit = await readUnit('shipfox-runner.target');
 
-    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBe('network-online.target');
-    expect(systemdDirective(pathUnit, 'Unit', 'Wants')).toBe('network-online.target');
+    expect(systemdDirective(pathUnit, 'Unit', 'After')).toBeUndefined();
+    expect(systemdDirective(pathUnit, 'Unit', 'Wants')).toBeUndefined();
     expect(systemdDirective(pathUnit, 'Path', 'PathExists')).toBe('/etc/shipfox/runner.env');
     expect(systemdDirective(pathUnit, 'Path', 'Unit')).toBe('shipfox-runner-env.service');
     expect(systemdDirective(pathUnit, 'Install', 'WantedBy')).toBe('multi-user.target');
@@ -1051,9 +1051,7 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(bootstrapUnit, 'Unit', 'After')).toBe('network.target');
     expect(systemdDirective(bootstrapUnit, 'Unit', 'Wants')).toBe('network.target');
     expect(systemdDirective(bootstrapUnit, 'Unit', 'FailureAction')).toBe('poweroff');
-    expect(systemdDirective(bootstrapUnit, 'Unit', 'Before')).toBe(
-      'shipfox-runner-env.path shipfox-runner-env.service',
-    );
+    expect(systemdDirective(bootstrapUnit, 'Unit', 'Before')).toBe('shipfox-runner-env.service');
     expect(systemdDirective(bootstrapUnit, 'Service', 'Type')).toBe('oneshot');
     expect(systemdDirective(bootstrapUnit, 'Service', 'TimeoutStartSec')).toBe('6min');
     expect(systemdDirective(bootstrapUnit, 'Service', 'ExecStart')).toBe(
@@ -1075,6 +1073,7 @@ describe('systemd boot activation', () => {
       'shipfox-bootstrap.service /etc/systemd/system/shipfox-bootstrap.service',
     );
     expect(build).toContain('systemctl enable shipfox-bootstrap.service');
+    expect(build).toContain('systemd-analyze verify multi-user.target');
     expect(build).toContain('rm -f /etc/hostname');
   });
 


### PR DESCRIPTION
The IMDSv2 bootstrap activation introduced a systemd ordering cycle through `basic.target`, `paths.target`, `shipfox-runner-env.path`, and `shipfox-bootstrap.service`. Systemd could break that cycle by dropping either the path target or the bootstrap job, leaving instances powering off during network shutdown or reaching multi-user without publishing the runner environment.

Remove the path unit from the bootstrap ordering constraint and keep network readiness on the environment service that actually needs it. Add a Packer-time `systemd-analyze verify multi-user.target` gate so enabled-unit graph cycles fail the image build.

Validated with the 76 runner-image tests, the filtered `check`, `type`, and `verify` tasks across runner-image dependents, Packer formatting, and a fresh Ubuntu 24.04 systemd graph verification. A live AMI launch remains the final runtime smoke test.

Refs ENG-1529

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a systemd ordering cycle introduced by IMDSv2 bootstrap that could drop the path trigger or skip the bootstrap job, causing poweroff during network shutdown or reaching multi-user without publishing the runner environment. The bootstrap now orders only before the environment service, the path unit no longer depends on network-online, and the image build fails on unit-graph errors via a dedicated verification step.

- `shipfox-bootstrap.service`: `Before=shipfox-runner-env.service` only; keeps `After/Wants=network.target`.
- `shipfox-runner-env.path`: removes `After/Wants=network-online.target`; still triggers on `/etc/shipfox/runner.env`.
- Image build adds a dedicated `systemd-analyze verify multi-user.target` Packer provisioner that is independently fatal on errors.
- Action: Run a live AMI smoke test to confirm IMDSv2 bootstrap publishes the runner environment. Addresses ENG-1529.

<sup>Written for commit e59a83919c51d0b8fa630724e990b00674b0da76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

