### PR TITLE
[@shipfox/docs] Expand landing-page workflow examples

### DIFF
--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -73,6 +73,10 @@ Teams use Shipfox for work such as:
   makes the check pass again.
 - **Review pull requests.** Each new pull request gets an agent review based on
   the team's guidelines, with follow-up on later changes.
+- **Keep documentation in sync.** An agent runs daily to identify gaps in your
+  documentation and opens pull requests to keep it up to date.
+- **Answer product questions.** An agent tagged in a Slack or Teams conversation
+  reads your code and gives precise answers to product questions.
 
 ## Where to go next
 


### PR DESCRIPTION
Expand the landing page examples to cover daily documentation maintenance and precise product answers from Slack or Teams. This clarifies additional practical ways teams can use Shipfox agents.

Validated with: mise exec -- turbo check test --filter=@shipfox/docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands `@shipfox/docs` landing page examples to show daily docs maintenance and chat-based product Q&A, clarifying practical Shipfox agent workflows.

- Adds “Keep documentation in sync”: a daily agent identifies gaps and opens PRs.
- Adds “Answer product questions”: an agent tagged in Slack or Teams reads code and replies with precise answers.
- Docs-only change; no product or API behavior changes.

<sup>Written for commit 2e859528f44cece96a0eb6422e46c09b27a7c77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

