### PR TITLE
[docs] Add Jira integration documentation

### DIFF
--- a/apps/docs/content/docs/integrations/jira/events.mdx
+++ b/apps/docs/content/docs/integrations/jira/events.mdx
@@ -1,0 +1,52 @@
+---
+title: "Jira events"
+sidebarTitle: "Events"
+description: "Look up the Jira event names Shipfox delivers and the payload fields exposed to workflows."
+---
+
+import JiraEvents from '../../../generated/integrations/jira/events.mdx';
+
+This reference lists Jira issue and comment events that Shipfox delivers to a
+Jira integration connection. See the [Jira overview](/integrations/jira) for
+availability and setup.
+
+## Payload
+
+The `event` value contains the validated Jira webhook envelope plus `cloudId`,
+which identifies the connected Jira site. Jira-specific fields remain provider
+owned.
+
+| Field | Description |
+| --- | --- |
+| `webhookEvent` | The Jira webhook event name. |
+| `timestamp` | The event timestamp supplied by Jira. |
+| `issue` | The Jira issue object, including its ID, key, and fields. |
+| `user` | The Jira user associated with the event. |
+| `matchedWebhookIds` | Optional IDs of the Jira webhooks that matched the event. |
+| `cloudId` | The connected Jira site's cloud ID, added by Shipfox. |
+
+Issue events also include `issue_event_type_name` and may include `changelog`.
+Comment events include a `comment` object. See the
+[Jira webhook documentation](https://developer.atlassian.com/cloud/jira/platform/webhooks/)
+for provider-specific field details.
+
+Shipfox discards `jira:issue_updated`, `comment_created`, and
+`comment_updated` events authored by the account that authorized the integration
+connection.
+
+## Trigger fragment
+
+Replace `jira_acme` with the slug of your Jira integration connection:
+
+```yaml
+triggers:
+  on_jira:
+    source: jira_acme
+    event: jira:issue_updated
+```
+
+For trigger field rules, see the [workflow schema reference](/reference/workflow-schema#trigger-fields).
+
+## Event catalog
+
+<JiraEvents />

--- a/apps/docs/content/docs/integrations/jira/index.mdx
+++ b/apps/docs/content/docs/integrations/jira/index.mdx
@@ -1,0 +1,57 @@
+---
+title: "Jira integration"
+sidebarTitle: "Jira"
+description: "Look up Jira OAuth access, integration connection identity, issue events, and agent tools."
+catalog:
+  summary: "Connect a Jira site, receive issue events, and give agents scoped Jira tools."
+  availability: "available"
+  capabilities: ["events", "agent_tools"]
+  categories: ["issue-tracking"]
+  aliases: ["issues", "tickets"]
+  icon: "jira"
+---
+
+Jira connects a Jira Cloud site to Shipfox. It sends issue and comment events
+and provides scoped tools for agent steps.
+
+## Categories and related terms
+
+**Category:** Issue tracking.
+
+**Related terms:** Issues, tickets.
+
+**Availability:** Available.
+
+## Authentication
+
+Shipfox uses Jira OAuth authorization. The flow requests
+`read:jira-work`, `write:jira-work`, `read:jira-user`, `manage:jira-webhook`, and
+`offline_access`.
+
+## Integration connection identity
+
+The slug of a Jira integration connection defaults to `jira_<site>`, where
+`<site>` is the normalized Jira site name. For example, `jira_acme`. If the site
+name is unavailable, Shipfox uses the Jira cloud ID. Shipfox makes the slug
+unique within the workspace.
+
+Use the slug as `source` for Jira events:
+
+```yaml
+triggers:
+  on_jira:
+    source: jira_acme
+    event: jira:issue_updated
+```
+
+For trigger field rules, see the [workflow schema reference](/reference/workflow-schema#trigger-fields).
+
+## Capabilities
+
+| Capability | Availability |
+| --- | --- |
+| Source control | **Not available.** |
+| Events | Available. [View Jira events](/integrations/jira/events). |
+| Agent tools | Available. [View Jira agent tools](/integrations/jira/tools). |
+
+[Connect Jira](/integrations/jira/setup) to create an integration connection.

--- a/apps/docs/content/docs/integrations/jira/meta.json
+++ b/apps/docs/content/docs/integrations/jira/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Jira",
+  "pages": ["index", "setup", "events", "tools"]
+}

--- a/apps/docs/content/docs/integrations/jira/setup.mdx
+++ b/apps/docs/content/docs/integrations/jira/setup.mdx
@@ -1,0 +1,52 @@
+---
+title: "Connect Jira to a Shipfox workspace"
+sidebarTitle: "Setup"
+description: "Authorize a Jira site, copy the integration connection slug, and verify event and agent-tool access."
+---
+
+Connect Jira when a workflow needs Jira events or an agent step needs Jira
+tools. See the [Jira overview](/integrations/jira) for its capabilities.
+
+## Before you begin
+
+You need access to workspace integration settings. You also need permission to
+authorize Shipfox in the target Jira Cloud site.
+
+If your Atlassian account can access multiple Jira sites, identify the site that
+the workspace should use.
+
+## Authorize Jira
+
+<Steps>
+  <Step>
+
+    **Start the integration connection**
+
+    Open **Settings → Integrations** in the workspace. Select **Jira**, then
+    start the integration connection.
+  </Step>
+  <Step>
+
+    **Authorize the Jira site**
+
+    Sign in to Atlassian and authorize Shipfox. If Jira lists multiple sites,
+    select the site to connect to this Shipfox workspace.
+  </Step>
+  <Step>
+
+    **Record the integration connection slug**
+
+    Open the new integration connection's menu. Select **Use this integration**.
+    Copy the slug from the event or tool-selection example. Workflows use the
+    slug as `source`, and agent steps use it as `connection`.
+  </Step>
+</Steps>
+
+## Verify the integration connection
+
+Open **Settings → Integrations** and check that the Jira integration connection
+is active and advertises Events and Agent tools.
+
+To test `jira:issue_updated`, `comment_created`, or `comment_updated`, use a
+Jira account other than the account that authorized the integration. Shipfox
+discards those self-authored events.

--- a/apps/docs/content/docs/integrations/jira/tools.mdx
+++ b/apps/docs/content/docs/integrations/jira/tools.mdx
@@ -1,0 +1,23 @@
+---
+title: "Jira agent tools"
+sidebarTitle: "Tools"
+description: "Look up the Jira tools, selectors, permissions, inputs, and outputs available to agent steps."
+---
+
+import JiraTools from '../../../generated/integrations/jira/tools.mdx';
+
+This reference lists the shipped Jira agent-tool catalog. See the [Jira
+overview](/integrations/jira) for availability and setup.
+
+## Selectors
+
+Use a standalone tool selector in an agent step's `integrations:` block. For the
+agent integration contract, see the [workflow schema reference](/reference/workflow-schema#agent-integration-fields).
+
+## Tool catalog
+
+Jira read tools require the `read:jira-work` OAuth scope. Jira write tools
+require `write:jira-work`, and the workflow step's `integrations` entry must set
+`allow_write: true` or Shipfox rejects the step at validation.
+
+<JiraTools />

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -40,6 +40,8 @@
     "@shipfox/expression": "workspace:*",
     "@shipfox/api-integration-github": "workspace:*",
     "@shipfox/api-integration-github-dto": "workspace:*",
+    "@shipfox/api-integration-jira": "workspace:*",
+    "@shipfox/api-integration-jira-dto": "workspace:*",
     "@shipfox/api-integration-linear": "workspace:*",
     "@shipfox/api-integration-sentry-dto": "workspace:*",
     "@shipfox/api-integration-slack": "workspace:*",

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -9,6 +9,10 @@ import {
 } from '@shipfox/api-integration-github/agent-tools';
 import {githubEventCatalog} from '@shipfox/api-integration-github-dto';
 import {
+  jiraAgentToolCatalog,
+  jiraAgentToolSelectionCatalog,
+} from '@shipfox/api-integration-jira/agent-tools';
+import {
   linearAgentToolCatalog,
   linearAgentToolSelectionCatalog,
 } from '@shipfox/api-integration-linear/agent-tools';
@@ -31,6 +35,7 @@ import {
   contextRootShape,
   WORKFLOW_FIELD_YAML_KEYS,
 } from './lib/context-reference.mjs';
+import {jiraEventCatalog} from './lib/jira-event-catalog.mjs';
 import {slugForHeading} from './lib/slug.mjs';
 
 const docsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -40,6 +45,11 @@ const dtoCatalogBySlug = {
     eventCatalog: githubEventCatalog,
     toolCatalog: githubAgentToolCatalog,
     toolSelectionCatalog: githubAgentToolSelectionCatalog,
+  },
+  jira: {
+    eventCatalog: jiraEventCatalog,
+    toolCatalog: jiraAgentToolCatalog,
+    toolSelectionCatalog: jiraAgentToolSelectionCatalog,
   },
   linear: {
     toolCatalog: linearAgentToolCatalog,
@@ -273,12 +283,15 @@ function renderFields(schema) {
       : conditional.has(name)
         ? 'Conditional'
         : 'Optional';
+    const propertyType = Array.isArray(property.type)
+      ? property.type.join(' | ')
+      : (property.type ?? 'value');
     const type =
       strings(property.enum).length > 0
-        ? `${property.type}: ${strings(property.enum)
+        ? `${propertyType}: ${strings(property.enum)
             .map((item) => `\`${item}\``)
             .join(', ')}`
-        : (property.type ?? 'value');
+        : propertyType;
     return `| \`${name}\` | ${escapeTableCell(type)} | ${requirement} | ${escapeTableCell(property.description ?? '')} |`;
   });
   if (rows.length === 0) return ['This schema accepts an object with provider-defined fields.'];

--- a/apps/docs/scripts/lib/jira-event-catalog.mjs
+++ b/apps/docs/scripts/lib/jira-event-catalog.mjs
@@ -1,0 +1,37 @@
+import {jiraWebhookEventNames} from '@shipfox/api-integration-jira-dto';
+
+const eventDetails = {
+  'jira:issue_created': {
+    summary: 'A Jira issue is created.',
+    emittedWhen: 'Jira sends an issue-created webhook.',
+  },
+  'jira:issue_updated': {
+    summary: 'A Jira issue changes.',
+    emittedWhen: 'Jira sends an issue-updated webhook.',
+  },
+  'jira:issue_deleted': {
+    summary: 'A Jira issue is deleted.',
+    emittedWhen: 'Jira sends an issue-deleted webhook.',
+  },
+  comment_created: {
+    summary: 'A comment is added to a Jira issue.',
+    emittedWhen: 'Jira sends a comment-created webhook.',
+  },
+  comment_updated: {
+    summary: 'A comment on a Jira issue changes.',
+    emittedWhen: 'Jira sends a comment-updated webhook.',
+  },
+  comment_deleted: {
+    summary: 'A comment is deleted from a Jira issue.',
+    emittedWhen: 'Jira sends a comment-deleted webhook.',
+  },
+};
+
+export const jiraEventCatalog = {
+  provider: 'Jira',
+  events: jiraWebhookEventNames.map((name) => ({
+    name,
+    ...eventDetails[name],
+    payloadKind: 'shipfox-normalized',
+  })),
+};

--- a/apps/docs/src/app/components/integration-catalog.tsx
+++ b/apps/docs/src/app/components/integration-catalog.tsx
@@ -3,7 +3,7 @@
 import {Search, Webhook, X} from 'lucide-react';
 import Link from 'next/link';
 import {useEffect, useMemo, useRef, useState} from 'react';
-import {siGithub, siLinear, siSentry, siSlack} from 'simple-icons';
+import {siGithub, siJira, siLinear, siSentry, siSlack} from 'simple-icons';
 import {captureDocsEvent} from '@/lib/docs-analytics';
 import {nextCatalogSearchState, normalizeCatalogQuery} from '@/lib/docs-analytics-core';
 import {
@@ -452,6 +452,7 @@ function ProviderIcon({icon}: {icon: CatalogIcon}) {
 
   const brandIcon = {
     github: siGithub,
+    jira: siJira,
     sentry: siSentry,
     linear: siLinear,
     slack: siSlack,

--- a/apps/docs/src/lib/integration-catalog.ts
+++ b/apps/docs/src/lib/integration-catalog.ts
@@ -17,6 +17,7 @@ export const INTEGRATION_CATALOG_ICONS = [
   'webhooks',
   'linear',
   'slack',
+  'jira',
 ] as const;
 
 export type CatalogAvailability = (typeof INTEGRATION_CATALOG_AVAILABILITIES)[number];

--- a/apps/docs/src/lib/integration-docs-completeness.test.ts
+++ b/apps/docs/src/lib/integration-docs-completeness.test.ts
@@ -31,6 +31,12 @@ const validInput: IntegrationDocsCompletenessInput = {
     webhooks: {availability: 'available', capabilities: ['events'], eventCount: 1, toolCount: 0},
     linear: {availability: 'available', capabilities: ['agent_tools'], eventCount: 0, toolCount: 1},
     slack: {availability: 'available', capabilities: ['agent_tools'], eventCount: 0, toolCount: 1},
+    jira: {
+      availability: 'available',
+      capabilities: ['events', 'agent_tools'],
+      eventCount: 6,
+      toolCount: 11,
+    },
   },
   integrationDirectories: {
     github: directory(
@@ -68,6 +74,17 @@ const validInput: IntegrationDocsCompletenessInput = {
       categories: ['messaging'],
       aliases: ['chat'],
     }),
+    jira: directory(
+      'jira',
+      ['index', 'setup', 'events', 'tools'],
+      ['index', 'setup', 'events', 'tools'],
+      {
+        availability: 'available',
+        capabilities: ['events', 'agent_tools'],
+        categories: ['issue-tracking'],
+        aliases: ['issues', 'tickets'],
+      },
+    ),
   },
   categoryLabels: catalogCategoryLabels,
   triggerSources: '## Sources at a glance\n| Cron | `cron` | `tick` |\n\n## cron',

--- a/apps/docs/src/lib/registered-integration-providers.ts
+++ b/apps/docs/src/lib/registered-integration-providers.ts
@@ -42,6 +42,12 @@ export const registeredIntegrationProviders: readonly RegisteredIntegrationProvi
   {slug: 'linear', kind: 'catalog', availability: 'available', capabilities: ['agent_tools']},
   {slug: 'slack', kind: 'catalog', availability: 'available', capabilities: ['agent_tools']},
   {
+    slug: 'jira',
+    kind: 'catalog',
+    availability: 'available',
+    capabilities: ['events', 'agent_tools'],
+  },
+  {
     slug: 'cron',
     kind: 'built-in-source',
     availability: 'available',

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -4,10 +4,11 @@ import {loader} from 'fumadocs-core/source';
 import {statusBadgesPlugin} from 'fumadocs-core/source/status-badges';
 import {icons} from 'lucide-react';
 import {createElement} from 'react';
-import {siGithub, siLinear, siSentry, siSlack} from 'simple-icons';
+import {siGithub, siJira, siLinear, siSentry, siSlack} from 'simple-icons';
 
 const simpleIcons = {
   github: siGithub,
+  jira: siJira,
   sentry: siSentry,
   linear: siLinear,
   slack: siSlack,
@@ -53,8 +54,8 @@ export const source = loader({
   icon(icon) {
     if (!icon) return;
     if (icon in icons) return createElement(icons[icon as keyof typeof icons]);
-    if (icon.startsWith('si:')) {
-      const key = icon.slice(3) as keyof typeof simpleIcons;
+    if (icon.startsWith('si:') || icon in simpleIcons) {
+      const key = (icon.startsWith('si:') ? icon.slice(3) : icon) as keyof typeof simpleIcons;
       const si = simpleIcons[key];
       if (si)
         return createElement(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,6 +719,12 @@ importers:
       '@shipfox/api-integration-github-dto':
         specifier: workspace:*
         version: link:../../libs/api/integration/github-dto
+      '@shipfox/api-integration-jira':
+        specifier: workspace:*
+        version: link:../../libs/api/integration/jira
+      '@shipfox/api-integration-jira-dto':
+        specifier: workspace:*
+        version: link:../../libs/api/integration/jira-dto
       '@shipfox/api-integration-linear':
         specifier: workspace:*
         version: link:../../libs/api/integration/linear


### PR DESCRIPTION
This documents the validated Jira integration so workspace users can connect Jira Cloud sites, configure event triggers, and use scoped Jira agent tools.

The docs catalog now includes Jira setup, event, and tool references, with generated event and tool tables sourced from the provider contracts.

Validated locally with `mise exec -- pnpm --dir apps/docs test`, `mise exec -- turbo check --filter=@shipfox/docs...`, `mise exec -- turbo type --filter=@shipfox/docs...`, and `mise exec -- turbo build --filter=@shipfox/docs...`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Jira integration docs (setup, events, tools) and generator support so the docs catalog lists Jira and shows provider-validated event and tool references. This lets users connect a Jira Cloud site, configure event triggers, and use Jira agent tools.

- Review docs content under `apps/docs/content/docs/integrations/jira/*` (notes include discarding self-authored `issue_updated`/`comment_*` events).
- Generator: adds Jira event/tool catalogs (`@shipfox/api-integration-jira`, `@shipfox/api-integration-jira-dto`) and improves field rendering for union types/enums; check for cross-provider table impacts.
- UI/catalog: registers Jira provider and icon; icon loader now accepts either `si:jira` or `jira`.
- Tests/completeness: updates expected Jira availability, capabilities, and counts.
- Build: adds Jira packages to `apps/docs/package.json`; updates lockfile.
- No migrations or runtime behavior changes.

<sup>Written for commit 23c1715c22bc4f4faec7562b2d55954fbc4a253c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

