### PR TITLE
[provisioner-ec2] Log EC2 state reason on runner termination

### DIFF
--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -932,6 +932,50 @@ describe('createEc2Lifecycle', () => {
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
+  it('logs EC2 termination state details when the instance carries them', async () => {
+    const launchTime = new Date('2026-01-01T00:00:00.000Z');
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'running',
+          launchTime,
+          ami: 'ami-actual',
+          availabilityZone: 'eu-west-3a',
+          stateTransitionReason: 'User initiated (2026-01-01 00:05:00 GMT)',
+          stateReasonCode: 'Client.UserInitiatedShutdown',
+          stateReasonMessage: 'Instance shutdown from the guest.',
+        }),
+      ],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      {
+        provisioned_runner_id: 'runner-1',
+        runner_instance_id: RUNNER_INSTANCE_ID,
+        instance_id: 'i-123',
+        aws_instance_id: 'i-123',
+        template_key: 'spot-small',
+        ami: 'ami-actual',
+        launch_time: launchTime.toISOString(),
+        reason: 'backend-terminate',
+        state_transition_reason: 'User initiated (2026-01-01 00:05:00 GMT)',
+        state_reason_code: 'Client.UserInitiatedShutdown',
+        state_reason_message: 'Instance shutdown from the guest.',
+        availability_zone: 'eu-west-3a',
+      },
+      'Terminated EC2 runner instance',
+    );
+  });
+
   it('keeps successful termination actions when a later instance fails', async () => {
     const engine = fakeEngine({
       instances: [
@@ -1236,6 +1280,8 @@ function instance(args: {
   architecture?: Ec2InstanceView['architecture'];
   availabilityZone?: string;
   stateTransitionReason?: string;
+  stateReasonCode?: string;
+  stateReasonMessage?: string;
   launchTime?: Date;
   ami?: string;
   instanceId?: string;
@@ -1261,6 +1307,8 @@ function instance(args: {
       'shipfox.labels': args.labels ?? 'ubuntu22',
     },
     ...(args.stateTransitionReason ? {stateTransitionReason: args.stateTransitionReason} : {}),
+    ...(args.stateReasonCode ? {stateReasonCode: args.stateReasonCode} : {}),
+    ...(args.stateReasonMessage ? {stateReasonMessage: args.stateReasonMessage} : {}),
     ...(args.launchTime ? {launchTime: args.launchTime} : {}),
   };
 }

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -718,6 +718,18 @@ function terminationLogFields(
     ami: instance.ami ?? fallbackAmi ?? template?.spec.ami ?? 'unknown',
     launch_time: instance.launchTime?.toISOString() ?? null,
     reason,
+    ...(instance.stateTransitionReason !== undefined
+      ? {state_transition_reason: instance.stateTransitionReason}
+      : {}),
+    ...(instance.stateReasonCode !== undefined
+      ? {state_reason_code: instance.stateReasonCode}
+      : {}),
+    ...(instance.stateReasonMessage !== undefined
+      ? {state_reason_message: instance.stateReasonMessage}
+      : {}),
+    ...(instance.availabilityZone !== undefined
+      ? {availability_zone: instance.availabilityZone}
+      : {}),
   };
 }
 


### PR DESCRIPTION
Record EC2's state transition reason, reason code, reason message, and availability zone alongside the provisioner termination reason when those values are available. This distinguishes guest-initiated shutdowns and EC2 reclamations from provisioner reaps without adding API calls or metric labels.

The lifecycle coverage verifies both populated and missing EC2 state fields.

Closes ENG-1596


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log EC2 termination state details for runner instances to distinguish guest-initiated shutdowns and EC2 reclamations from provisioner reaps. Previously we logged only the provisioner termination reason; now we include EC2 state details when present without extra API calls or metric labels.

- Adds conditional fields to termination logs: state_transition_reason, state_reason_code, state_reason_message, availability_zone.
- Extends lifecycle tests to cover instances with and without these fields.
- No behavior change to termination flow; improves observability only. Addresses ENG-1596.

<sup>Written for commit 0cea63b7d1224da570badb8e532545affb2c03ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

