### PR TITLE
[runner-image] Emit bootstrap phase markers to the serial console

### DIFF
--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -14,7 +14,7 @@ runner_mount_dropin_dir='/etc/systemd/system/shipfox-runner.service.d'
 # provider. Bound the wait by time instead, below the unit's own TimeoutStartSec.
 retry_deadline_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DEADLINE_SECONDS:-240}"
 retry_delay_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DELAY_SECONDS:-1}"
-boot_phase='imds-token'
+boot_phase='ssh-keygen'
 imds_token_succeeded=0
 
 # chrony starts alongside this unit and steps the clock on its first updates, so a wall-clock

--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -14,6 +14,8 @@ runner_mount_dropin_dir='/etc/systemd/system/shipfox-runner.service.d'
 # provider. Bound the wait by time instead, below the unit's own TimeoutStartSec.
 retry_deadline_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DEADLINE_SECONDS:-240}"
 retry_delay_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DELAY_SECONDS:-1}"
+boot_phase='imds-token'
+imds_token_succeeded=0
 
 # chrony starts alongside this unit and steps the clock on its first updates, so a wall-clock
 # bound can move under the retry loop. /proc/uptime cannot.
@@ -21,7 +23,12 @@ uptime_seconds() {
   awk '{print int($1)}' /proc/uptime
 }
 
+emit_boot_phase() {
+  printf 'shipfox-boot phase=%s status=%s uptime=%s\n' "$1" "$2" "$(uptime_seconds)"
+}
+
 abort_boot() {
+  emit_boot_phase "$boot_phase" fail
   printf 'shipfox bootstrap: %s\n' "$1" >&2
   printf '%s\n' 'shipfox bootstrap: link and route state at abort:' >&2
   ip -brief address >&2 || true
@@ -63,6 +70,7 @@ validate_runner_env() {
 
 fetch_user_data() {
   token=''
+  boot_phase='imds-token'
   # Each attempt can block in curl for longer than the delay, so the bound reads a clock rather
   # than counting iterations. Testing it before the attempt keeps a sleep that crosses the
   # deadline from buying one more full attempt.
@@ -72,14 +80,25 @@ fetch_user_data() {
       --request PUT \
       --header 'X-aws-ec2-metadata-token-ttl-seconds: 21600' \
       "$imds_base_url/latest/api/token" 2>/dev/null || true)"
-    if [ -n "$token" ] && curl --fail --silent --show-error --noproxy '*' --connect-timeout 2 --max-time 5 \
-      --header "X-aws-ec2-metadata-token: $token" \
-      --output "$user_data_fetch_path" \
-      "$imds_base_url/latest/user-data"; then
-      return 0
+    if [ -n "$token" ]; then
+      if [ "$imds_token_succeeded" -eq 0 ]; then
+        emit_boot_phase 'imds-token' ok
+        imds_token_succeeded=1
+      fi
+      boot_phase='imds-userdata'
+      if curl --fail --silent --show-error --noproxy '*' --connect-timeout 2 --max-time 5 \
+        --header "X-aws-ec2-metadata-token: $token" \
+        --output "$user_data_fetch_path" \
+        "$imds_base_url/latest/user-data"; then
+        emit_boot_phase 'imds-userdata' ok
+        return 0
+      fi
     fi
 
     rm -f "$user_data_fetch_path"
+    if [ "$imds_token_succeeded" -eq 0 ]; then
+      boot_phase='imds-token'
+    fi
     sleep "$retry_delay_seconds"
   done
   return 1
@@ -252,6 +271,7 @@ fi
 if ! fetch_user_data; then
   abort_boot 'Unable to read runner user data from IMDSv2 after retries.'
 fi
+boot_phase='validate-env'
 if ! install -m 0600 -o root -g root "$user_data_fetch_path" "$runner_env_temp_path"; then
   abort_boot 'Unable to stage runner user data.'
 fi
@@ -259,10 +279,17 @@ if ! validate_runner_env "$runner_env_temp_path"; then
   rm -f "$runner_env_temp_path"
   abort_boot 'Runner user data is not a valid environment file.'
 fi
+emit_boot_phase 'validate-env' ok
 
+boot_phase='root-grow'
 grow_root_filesystem
+emit_boot_phase 'root-grow' ok
+boot_phase='workspace-mount'
 configure_workspace_mount
+emit_boot_phase 'workspace-mount' ok
 
+boot_phase='env-published'
 if ! mv -- "$runner_env_temp_path" "$runner_env_path"; then
   abort_boot 'Unable to publish the runner environment after boot setup.'
 fi
+emit_boot_phase 'env-published' ok

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1066,6 +1066,20 @@ describe('systemd boot activation', () => {
     expect(source).toContain("awk '{print int($1)}' /proc/uptime");
     expect(source).toContain('while [ "$(uptime_seconds)" -lt "$deadline" ]');
     expect(source).not.toContain('date +%s');
+    for (const phase of [
+      'imds-token',
+      'imds-userdata',
+      'validate-env',
+      'root-grow',
+      'workspace-mount',
+      'env-published',
+    ]) {
+      expect(source).toContain(phase);
+    }
+    expect(source).toContain(
+      'printf \'shipfox-boot phase=%s status=%s uptime=%s\\n\' "$1" "$2" "$(uptime_seconds)"',
+    );
+    expect(source).toContain('emit_boot_phase "$boot_phase" fail');
     expect(source).toContain('growpart "$root_disk" "$root_partition_number"');
     expect(source).toContain('resize2fs "$root_source"');
     expect(source).toContain('mkfs.ext4 -F -E lazy_itable_init=1,lazy_journal_init=1');

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1076,6 +1076,21 @@ describe('systemd boot activation', () => {
     ]) {
       expect(source).toContain(phase);
     }
+    expect(source).toContain("boot_phase='ssh-keygen'");
+    let previousSuccessMarkerIndex = -1;
+    for (const marker of [
+      "emit_boot_phase 'imds-token' ok",
+      "emit_boot_phase 'imds-userdata' ok",
+      "emit_boot_phase 'validate-env' ok",
+      "emit_boot_phase 'root-grow' ok",
+      "emit_boot_phase 'workspace-mount' ok",
+      "emit_boot_phase 'env-published' ok",
+    ]) {
+      const successMarkerIndex = source.indexOf(marker);
+
+      expect(successMarkerIndex).toBeGreaterThan(previousSuccessMarkerIndex);
+      previousSuccessMarkerIndex = successMarkerIndex;
+    }
     expect(source).toContain(
       'printf \'shipfox-boot phase=%s status=%s uptime=%s\\n\' "$1" "$2" "$(uptime_seconds)"',
     );


### PR DESCRIPTION
Runner instances can power off before enrollment, leaving the serial console as the only diagnostic channel. This adds parseable bootstrap phase markers using the existing monotonic `/proc/uptime` helper.

Failures emit one marker for the active phase before the existing abort diagnostics, while successful boots emit all six markers in order. The runner-image tests pin the phase names and marker format.

Closes ENG-1597

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits parseable bootstrap phase markers to the serial console to diagnose pre-enrollment runner failures. Previously there were no structured markers; now the bootstrap prints monotonic-uptime markers and, on failure, emits a single fail marker for the active phase (including early SSH key generation) before existing diagnostics. Successful boots emit all six phases in order. Closes ENG-1597.

- Marker format: "shipfox-boot phase=<phase> status=<ok|fail> uptime=<seconds>" using `/proc/uptime`.
- Phases, in order: imds-token, imds-userdata, validate-env, root-grow, workspace-mount, env-published; early aborts report as ssh-keygen.
- Tests pin the marker format, phase names, and the ordered success markers.

<sup>Written for commit a0578961cfcaf61a4d7a980c4a34906e83b6cc6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

