### PR TITLE
Update README.md image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://www.shipfox.io/og-image.png" alt="Shipfox" width="640" />
+  <img width="1200" height="630" alt="shipfox-og" src="https://github.com/user-attachments/assets/4a977e17-c81d-4ab5-b815-7f4439b320ef" />
 </div>
 
 <p align="center">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaces the README hero image with a GitHub-hosted asset to ensure reliable rendering on GitHub and consistent preview dimensions. Previously the README loaded https://www.shipfox.io/og-image.png at width 640; it now uses a GitHub user-attachments image with explicit width 1200 and height 630 and updated alt text.

<sup>Written for commit 3ccfc127eae659d10fd0b22cdab73d749c4ae7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

