### PR TITLE
[runner-image] Remove brittle image size ceilings

### DIFF
--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -57,14 +57,9 @@ of making routine package or base-image changes update a complete snapshot.
 The same gate checks `multi-user.target`, the generated GRUB command line for
 `fsck.mode=skip`, `/` and `/boot` fstab options, volatile journald storage, the
 absence of `snapd`, `cloud-init`, and `amazon-ssm-agent`, and enabled AppArmor,
-`ssh.socket`, and the EC2 Instance Connect host-key harvester. It also enforces
-the committed initramfs ceiling from `limits.env`.
+`ssh.socket`, and the EC2 Instance Connect host-key harvester.
 
-The candidate publisher describes the registered AMI and its root EBS snapshot
-before publishing candidate metadata. It compares `FullSnapshotSizeInBytes`
-with the same architecture and OS scoped `limits.env` ceiling. QEMU uses the
-same capability gate during its bake, while the AWS-only snapshot check remains
-in the existing candidate publication path. Update a requirement or limit only
+QEMU uses the same capability gate during its bake. Update a requirement only
 when intentionally changing that capability contract, and review the resulting
 diff as part of the image change.
 

--- a/infra/images/runner/composition/ubuntu24/amd64/limits.env
+++ b/infra/images/runner/composition/ubuntu24/amd64/limits.env
@@ -1,2 +1,0 @@
-initramfs_max_bytes=33554432
-full_snapshot_size_max_bytes=17179869184

--- a/infra/images/runner/composition/ubuntu24/arm64/limits.env
+++ b/infra/images/runner/composition/ubuntu24/arm64/limits.env
@@ -1,2 +1,0 @@
-initramfs_max_bytes=33554432
-full_snapshot_size_max_bytes=17179869184

--- a/infra/images/runner/scripts/build/verify-composition.sh
+++ b/infra/images/runner/scripts/build/verify-composition.sh
@@ -4,7 +4,6 @@ set -eu
 composition_dir=${SHIPFOX_RUNNER_COMPOSITION_DIR:-/tmp/shipfox-runner-image-composition}
 enabled_requirements="$composition_dir/required-enabled.txt"
 masked_requirements="$composition_dir/required-masked.txt"
-limits_file="$composition_dir/limits.env"
 image_identity="${SHIPFOX_RUNNER_IMAGE_OS:-unknown}/${SHIPFOX_RUNNER_IMAGE_ARCHITECTURE:-unknown}"
 
 fail() {
@@ -12,7 +11,7 @@ fail() {
   exit 1
 }
 
-for required_file in "$enabled_requirements" "$masked_requirements" "$limits_file"; do
+for required_file in "$enabled_requirements" "$masked_requirements"; do
   [ -r "$required_file" ] || fail "required composition file is missing: $required_file"
 done
 
@@ -133,32 +132,4 @@ for unit in ssh.socket ec2-instance-connect-harvest-hostkeys.service; do
   [ "$unit_state" != 'masked' ] || fail "required unit is masked: $unit"
 done
 
-read_limit() {
-  key=$1
-  sed -n "s/^${key}=//p" "$limits_file" | tail -n 1
-}
-
-initramfs_ceiling=$(read_limit initramfs_max_bytes)
-snapshot_ceiling=$(read_limit full_snapshot_size_max_bytes)
-case "$initramfs_ceiling" in
-  ''|*[!0-9]*) fail 'limits.env has no numeric initramfs_max_bytes' ;;
-esac
-case "$snapshot_ceiling" in
-  ''|*[!0-9]*) fail 'limits.env has no numeric full_snapshot_size_max_bytes' ;;
-esac
-
-initramfs_path=${SHIPFOX_INITRAMFS_PATH:-}
-if [ -z "$initramfs_path" ]; then
-  initramfs_path=$(find /boot -maxdepth 1 -type f -name 'initrd.img-*' -print | LC_ALL=C sort | tail -n 1)
-fi
-[ -n "$initramfs_path" ] || fail 'no initramfs was found under /boot'
-
-initramfs_size=$(stat -c '%s' "$initramfs_path")
-case "$initramfs_size" in
-  ''|*[!0-9]*) fail "could not read initramfs size for $initramfs_path" ;;
-esac
-[ "$initramfs_size" -le "$initramfs_ceiling" ] ||
-  fail "initramfs $initramfs_path is $initramfs_size bytes, exceeding ceiling $initramfs_ceiling"
-
-printf 'runner image composition verified: %s, initramfs %s bytes, snapshot ceiling %s bytes\n' \
-  "$image_identity" "$initramfs_size" "$snapshot_ceiling"
+printf 'runner image composition verified: %s\n' "$image_identity"

--- a/infra/images/runner/src/candidate.ts
+++ b/infra/images/runner/src/candidate.ts
@@ -1,17 +1,14 @@
-import {readFile, writeFile} from 'node:fs/promises';
-import {join} from 'node:path';
+import {writeFile} from 'node:fs/promises';
 import {parseArgs} from 'node:util';
 import {
   DescribeImageAttributeCommand,
   type DescribeImageAttributeCommandOutput,
   DescribeImagesCommand,
-  DescribeSnapshotsCommand,
-  type DescribeSnapshotsCommandOutput,
   EC2Client,
   type Image,
   ModifyImageAttributeCommand,
 } from '@aws-sdk/client-ec2';
-import {getProjectRootPath, log} from '@shipfox/tool-utils';
+import {log} from '@shipfox/tool-utils';
 import {AWS_ACCOUNT_ID_PATTERN, parseBuildRunnerImageArgs} from './build-runner-image.js';
 import {buildRunnerImage, type RunnerImageBuild} from './runner-image.js';
 
@@ -19,7 +16,6 @@ const DEFAULT_CANDIDATE_TTL_DAYS = 14;
 const DEFAULT_DESCRIBE_AVAILABILITY_RETRIES = 5;
 const DEFAULT_DESCRIBE_AVAILABILITY_DELAY_MS = 2000;
 const CANDIDATE_REGION = 'eu-central-1';
-const FULL_SNAPSHOT_SIZE_LIMIT_PATTERN = /^full_snapshot_size_max_bytes=([1-9]\d*)$/mu;
 const INVALID_AMI_NOT_FOUND = 'InvalidAMIID.NotFound';
 const GIT_REVISION_PATTERN = /^[a-f0-9]{40}$/u;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
@@ -44,15 +40,9 @@ interface CandidateImageMetadata {
   owner: string;
 }
 
-interface CandidateImage {
-  image: Image;
-  metadata: CandidateImageMetadata;
-}
-
 interface Ec2ClientLike {
   send(command: DescribeImagesCommand): Promise<{Images?: Image[]}>;
   send(command: DescribeImageAttributeCommand): Promise<DescribeImageAttributeCommandOutput>;
-  send(command: DescribeSnapshotsCommand): Promise<DescribeSnapshotsCommandOutput>;
   send(command: ModifyImageAttributeCommand): Promise<unknown>;
 }
 
@@ -81,9 +71,8 @@ export async function buildRunnerImageCandidate(
     candidateId,
   );
   if (existingImage) {
-    await verifyRootSnapshotSize(client, existingImage.image, build);
-    await reshareRunnerImageCandidate(client, existingImage.metadata.amiId, build);
-    return candidateResult('reused', existingImage.metadata, build, candidateId, region);
+    await reshareRunnerImageCandidate(client, existingImage.amiId, build);
+    return candidateResult('reused', existingImage, build, candidateId, region);
   }
 
   const result = await (options.build ?? buildRunnerImage)(build);
@@ -158,7 +147,7 @@ async function findRunnerImageCandidate(
   revision: string,
   architecture: 'amd64' | 'arm64',
   candidateId: string,
-): Promise<CandidateImage | null> {
+): Promise<CandidateImageMetadata | null> {
   const output = await client.send(
     new DescribeImagesCommand({
       Owners: ['self'],
@@ -180,7 +169,7 @@ async function findRunnerImageCandidate(
     );
   }
   const image = images[0];
-  return image ? {image, metadata: candidateImageMetadata(image)} : null;
+  return image ? candidateImageMetadata(image) : null;
 }
 
 async function describeBuiltCandidate(
@@ -209,50 +198,7 @@ async function describeBuiltCandidate(
   ) {
     throw new Error(`Candidate AMI ${amiId} does not carry the expected build identity tags.`);
   }
-  await verifyRootSnapshotSize(client, image, build);
   return metadata;
-}
-
-async function verifyRootSnapshotSize(
-  client: Ec2ClientLike,
-  image: Image,
-  build: RunnerImageBuild,
-): Promise<void> {
-  const amiId = required(image.ImageId, 'Candidate AMI ID');
-  const rootSnapshotId = image.BlockDeviceMappings?.find(
-    (mapping) => mapping.DeviceName === image.RootDeviceName,
-  )?.Ebs?.SnapshotId;
-  if (!rootSnapshotId) {
-    throw new Error(`Candidate AMI ${amiId} has no root EBS snapshot to verify.`);
-  }
-
-  const output = await client.send(new DescribeSnapshotsCommand({SnapshotIds: [rootSnapshotId]}));
-  const snapshot = output.Snapshots?.find((candidate) => candidate.SnapshotId === rootSnapshotId);
-  const fullSnapshotSize = snapshot?.FullSnapshotSizeInBytes;
-  if (fullSnapshotSize === undefined || !Number.isSafeInteger(fullSnapshotSize)) {
-    throw new Error(
-      `Candidate AMI ${amiId} root snapshot ${rootSnapshotId} has no valid full size.`,
-    );
-  }
-
-  const ceiling = await readFullSnapshotSizeCeiling(build);
-  if (fullSnapshotSize > ceiling) {
-    throw new Error(
-      `Candidate AMI ${amiId} root snapshot ${rootSnapshotId} is ${fullSnapshotSize} bytes, exceeding committed ceiling ${ceiling} bytes.`,
-    );
-  }
-}
-
-async function readFullSnapshotSizeCeiling(build: RunnerImageBuild): Promise<number> {
-  const rootDir = getProjectRootPath(import.meta.url);
-  const limitsPath = join(rootDir, 'composition', build.os, build.architecture, 'limits.env');
-  const contents = await readFile(limitsPath, 'utf8');
-  const value = contents.match(FULL_SNAPSHOT_SIZE_LIMIT_PATTERN)?.[1];
-  const ceiling = value ? Number(value) : Number.NaN;
-  if (!Number.isSafeInteger(ceiling) || ceiling <= 0) {
-    throw new Error(`Runner image composition limit is invalid: ${limitsPath}`);
-  }
-  return ceiling;
 }
 
 // DescribeImages can briefly lag behind a Packer build that just registered the

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -462,23 +462,17 @@ describe('parseBuildRunnerImageArgs', () => {
 
 describe('runner image candidates', () => {
   const revision = '0123456789abcdef0123456789abcdef01234567';
-  const rootSnapshotId = 'snap-0123456789abcdef0';
   const availableImage = (amiId: string, architecture: 'amd64' | 'arm64') => ({
     ImageId: amiId,
     State: 'available' as const,
     OwnerId: '123456789012',
     CreationDate: '2026-07-19T10:15:00Z',
-    RootDeviceName: '/dev/sda1',
-    BlockDeviceMappings: [{DeviceName: '/dev/sda1', Ebs: {SnapshotId: rootSnapshotId}}],
     Tags: [
       {Key: 'shipfox.candidate_id', Value: `main-${revision}`},
       {Key: 'shipfox.revision', Value: revision},
       {Key: 'shipfox.architecture', Value: architecture},
       {Key: 'shipfox.expires_at', Value: '2026-08-03T10:00:00Z'},
     ],
-  });
-  const snapshotResponse = (fullSnapshotSizeInBytes = 8 * 1024 * 1024 * 1024) => ({
-    Snapshots: [{SnapshotId: rootSnapshotId, FullSnapshotSizeInBytes: fullSnapshotSizeInBytes}],
   });
 
   it('builds a candidate when no matching AMI exists', async () => {
@@ -502,8 +496,7 @@ describe('runner image candidates', () => {
       .mockResolvedValueOnce({Images: []})
       .mockResolvedValueOnce({
         Images: [availableImage('ami-0123abc456def7890', 'amd64')],
-      })
-      .mockResolvedValueOnce(snapshotResponse());
+      });
     const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
 
     const candidate = await buildRunnerImageCandidate(build, {
@@ -545,7 +538,6 @@ describe('runner image candidates', () => {
     const send = vi
       .fn()
       .mockResolvedValueOnce({Images: [availableImage('ami-0fedcba9876543210', 'arm64')]})
-      .mockResolvedValueOnce(snapshotResponse())
       .mockResolvedValueOnce({
         LaunchPermissions: [
           {UserId: '123456789012'},
@@ -625,38 +617,6 @@ describe('runner image candidates', () => {
     await expect(candidate).rejects.toThrow('Expected at most one amd64 candidate AMI');
   });
 
-  it('rejects a reused AMI whose root snapshot exceeds its committed ceiling', async () => {
-    const build = parseBuildRunnerImageArgs(
-      ['ubuntu24', 'aws'],
-      {
-        BUILD_ARCH: 'arm64',
-        BUILD_ATTEMPT: '1',
-        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
-        BUILD_CANDIDATE_ID: `main-${revision}`,
-        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
-        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
-        BUILD_IMAGE_LIFECYCLE: 'candidate',
-        BUILD_NUMBER: '42',
-        BUILD_REVISION: revision,
-      },
-      '24.17.0',
-    );
-    const send = vi
-      .fn()
-      .mockResolvedValueOnce({Images: [availableImage('ami-0fedcba9876543210', 'arm64')]})
-      .mockResolvedValueOnce(snapshotResponse(17 * 1024 * 1024 * 1024));
-    const buildImage = vi.fn();
-
-    const candidate = buildRunnerImageCandidate(build, {
-      build: buildImage,
-      client: {send},
-    });
-
-    await expect(candidate).rejects.toThrow('exceeding committed ceiling');
-    expect(buildImage).not.toHaveBeenCalled();
-    expect(send).toHaveBeenCalledTimes(2);
-  });
-
   it('rejects a built AMI that is not available yet', async () => {
     const build = parseBuildRunnerImageArgs(
       ['ubuntu24', 'aws'],
@@ -714,8 +674,7 @@ describe('runner image candidates', () => {
       })
       .mockResolvedValueOnce({
         Images: [availableImage('ami-0123abc456def7890', 'amd64')],
-      })
-      .mockResolvedValueOnce(snapshotResponse());
+      });
     const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
 
     const candidate = await buildRunnerImageCandidate(build, {
@@ -727,39 +686,6 @@ describe('runner image candidates', () => {
 
     expect(candidate.status).toBe('built');
     expect(candidate.amiId).toBe('ami-0123abc456def7890');
-  });
-
-  it('rejects a built AMI whose root snapshot exceeds its committed ceiling', async () => {
-    const build = parseBuildRunnerImageArgs(
-      ['ubuntu24', 'aws'],
-      {
-        BUILD_ARCH: 'amd64',
-        BUILD_ATTEMPT: '1',
-        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
-        BUILD_CANDIDATE_ID: `main-${revision}`,
-        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
-        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
-        BUILD_IMAGE_LIFECYCLE: 'candidate',
-        BUILD_NUMBER: '42',
-        BUILD_REVISION: revision,
-      },
-      '24.17.0',
-    );
-    const send = vi
-      .fn()
-      .mockResolvedValueOnce({Images: []})
-      .mockResolvedValueOnce({
-        Images: [availableImage('ami-0123abc456def7890', 'amd64')],
-      })
-      .mockResolvedValueOnce(snapshotResponse(17 * 1024 * 1024 * 1024));
-    const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
-
-    const candidate = buildRunnerImageCandidate(build, {
-      build: buildImage,
-      client: {send},
-    });
-
-    await expect(candidate).rejects.toThrow('exceeding committed ceiling');
   });
 
   it('retries a transient AMI-not-found response during availability checks', async () => {
@@ -787,8 +713,7 @@ describe('runner image candidates', () => {
       .mockRejectedValueOnce(notFound)
       .mockResolvedValueOnce({
         Images: [availableImage('ami-0123abc456def7890', 'amd64')],
-      })
-      .mockResolvedValueOnce(snapshotResponse());
+      });
     const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
 
     const candidate = await buildRunnerImageCandidate(build, {
@@ -799,7 +724,7 @@ describe('runner image candidates', () => {
     });
 
     expect(candidate.status).toBe('built');
-    expect(send).toHaveBeenCalledTimes(4);
+    expect(send).toHaveBeenCalledTimes(3);
   });
 
   it('rejects a built AMI whose tags do not match the requested build', async () => {
@@ -1630,22 +1555,6 @@ describe('runner image composition', () => {
     }
   });
 
-  it('fails the image bake when the initramfs exceeds its committed ceiling', async () => {
-    const script = new URL('../scripts/build/verify-composition.sh', import.meta.url);
-    const fixture = await createCompositionFixture();
-
-    try {
-      expect(() =>
-        execFileSync('/bin/sh', [script.pathname], {
-          env: {...fixture.environment, RUNNER_IMAGE_INITRAMFS_SIZE: '33554433'},
-          stdio: 'pipe',
-        }),
-      ).toThrow('exceeding ceiling');
-    } finally {
-      await rm(fixture.root, {force: true, recursive: true});
-    }
-  });
-
   it('creates and enables a 4 GiB swap file', async () => {
     const script = new URL('../scripts/build/setup-runner.sh', import.meta.url);
     const fixture = await createRunnerImageSetupFixture();
@@ -2042,8 +1951,6 @@ async function createCompositionFixture() {
 
   await mkdir(commandDirectory, {recursive: true});
   await mkdir(compositionDirectory, {recursive: true});
-  await mkdir(join(root, 'boot'), {recursive: true});
-  await writeFile(join(root, 'boot/initrd.img-test'), 'initramfs');
   await writeFile(join(root, 'grub.cfg'), 'linux /vmlinuz fsck.mode=skip\n');
   await writeFile(
     join(root, 'fstab'),
@@ -2054,10 +1961,6 @@ UUID=efi /boot/efi vfat defaults,noauto 0 0
   );
   await writeFile(join(compositionDirectory, 'required-enabled.txt'), `${enabledRequirements}\n`);
   await writeFile(join(compositionDirectory, 'required-masked.txt'), `${maskedRequirements}\n`);
-  await writeFile(
-    join(compositionDirectory, 'limits.env'),
-    'initramfs_max_bytes=33554432\nfull_snapshot_size_max_bytes=17179869184\n',
-  );
 
   await writeExecutable(
     join(commandDirectory, 'systemctl'),
@@ -2108,15 +2011,6 @@ UUID=efi /boot/efi vfat defaults,noauto 0 0
     ].join('\n'),
   );
   await writeExecutable(join(commandDirectory, 'growpart'), '#!/bin/sh\nexit 0\n');
-  await writeExecutable(
-    join(commandDirectory, 'stat'),
-    [
-      '#!/bin/sh',
-      'set -eu',
-      '[ "$1" = -c ]',
-      `printf "%s\\n" "\${RUNNER_IMAGE_INITRAMFS_SIZE:-1024}"`,
-    ].join('\n'),
-  );
 
   return {
     enabledInventory,
@@ -2128,7 +2022,6 @@ UUID=efi /boot/efi vfat defaults,noauto 0 0
       RUNNER_IMAGE_MASKED_INVENTORY: maskedInventory,
       SHIPFOX_FSTAB: join(root, 'fstab'),
       SHIPFOX_GRUB_CONFIG: join(root, 'grub.cfg'),
-      SHIPFOX_INITRAMFS_PATH: join(root, 'boot/initrd.img-test'),
       SHIPFOX_RUNNER_COMPOSITION_DIR: compositionDirectory,
       SHIPFOX_RUNNER_IMAGE_ARCHITECTURE: 'amd64',
       SHIPFOX_RUNNER_IMAGE_OS: 'ubuntu24',


### PR DESCRIPTION
Runner-image builds currently enforce architecture-specific initramfs and EBS full-snapshot byte ceilings. The AMD build crossed its initramfs limit after normal kernel and base-image drift even though the AMI build itself succeeded, making the fixed thresholds prone to false failures.

This removes the size limits and their architecture-specific files and test fixtures. Composition verification continues to enforce the required systemd, filesystem, package, boot, and networking capabilities, while candidate publication continues to validate AMI identity and sharing.

The tradeoff is that initramfs and full-snapshot growth will no longer fail builds solely because of byte size.

Validation: `mise exec -- turbo check type test verify --filter=@shipfox/runner-image...` (151 tasks successful, 84 runner-image tests passed, and Packer configuration valid).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes architecture-specific initramfs and EBS full-snapshot size ceilings from runner-image builds to avoid false failures from normal kernel/base-image drift. Previously builds failed when sizes exceeded `limits.env`; now size alone no longer fails a build, while composition checks and AMI identity/sharing remain enforced.

- Delete `composition/.../limits.env` and remove ceiling parsing from `verify-composition.sh`; the script now only enforces required system capabilities.
- Remove snapshot size verification from candidate publication (`candidate.ts` stops describing snapshots and comparing `FullSnapshotSizeInBytes`); AMI availability, tags, sharing, and KMS settings are still validated.
- Update tests and docs to drop ceiling fixtures and expectations; QEMU bake still uses the same capability gate.
- No migration needed; do not rely on `limits.env` or byte ceilings going forward.

<sup>Written for commit 7a54efd1be0a1a80e2cc8411798b03bdd9a64a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

