### PR TITLE
[api-agent] Enforce managed-only workspace provider policy

### DIFF
--- a/.changeset/quiet-workspace-providers.md
+++ b/.changeset/quiet-workspace-providers.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-agent": minor
+"@shipfox/api-agent-dto": minor
+---
+
+Adds an instance policy that can restrict workspace model-provider configuration to an injected managed provider.

--- a/libs/api/agent-dto/src/index.ts
+++ b/libs/api/agent-dto/src/index.ts
@@ -126,4 +126,6 @@ export {
   updateCustomModelProviderHeaderRequestSchema,
   updateModelProviderConfigBodySchema,
   updateModelProviderDefaultModelBodySchema,
+  type WorkspaceProvidersPolicy,
+  workspaceProvidersPolicySchema,
 } from '#schemas/index.js';

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -55,7 +55,12 @@ export const agentInterModuleContract = defineInterModuleContract({
     resolveAgentConfig: {
       input: z.object({workspaceId: z.string().uuid().nullable(), config: agentConfigInputSchema}),
       output: resolvedAgentConfigSchema,
-      errors: {'agent-config-invalid': z.object({})},
+      errors: {
+        'agent-config-invalid': z.object({
+          message: z.string().min(1).optional(),
+          managed_provider_id: modelProviderRefSchema.optional(),
+        }),
+      },
     },
     resolveRuntimeCredentials: {
       input: z.object({

--- a/libs/api/agent-dto/src/schemas/catalog.test.ts
+++ b/libs/api/agent-dto/src/schemas/catalog.test.ts
@@ -5,14 +5,24 @@ import {
   listSupportedModelProviders,
   MODEL_PROVIDER_CATALOG_SEED,
   modelProviderCatalogEntrySchema,
+  modelProviderCatalogResponseSchema,
   modelProviderCatalogSeedSchema,
-  workspaceProvidersPolicySchema,
 } from './catalog.js';
 import {
   MODEL_PROVIDER_IDS,
   SUPPORTED_MODEL_PROVIDER_IDS,
   UNSUPPORTED_MODEL_PROVIDER_IDS,
 } from './model-provider-id.js';
+
+const managedProviderCatalogEntry = {
+  id: 'shipfox-managed',
+  label: 'Shipfox Managed',
+  support_status: 'supported',
+  default_model: 'managed-claude',
+  credential_fields: [],
+  unsupported_reason: null,
+  models: [{id: 'managed-claude', label: 'Managed Claude'}],
+};
 
 describe('model provider catalog', () => {
   it('parses the catalog seed', () => {
@@ -153,19 +163,31 @@ describe('model provider catalog', () => {
     expect(parsed).toHaveLength(37);
   });
 
-  it('parses a managed provider response entry and workspace provider policy', () => {
-    const parsed = modelProviderCatalogEntrySchema.parse({
-      id: 'shipfox-managed',
-      label: 'Shipfox Managed',
-      support_status: 'supported',
-      default_model: 'managed-claude',
-      credential_fields: [],
-      unsupported_reason: null,
-      models: [{id: 'managed-claude', label: 'Managed Claude'}],
-    });
+  it('parses a managed provider response entry', () => {
+    const parsed = modelProviderCatalogEntrySchema.parse(managedProviderCatalogEntry);
 
     expect(parsed.id).toBe('shipfox-managed');
-    expect(workspaceProvidersPolicySchema.parse('disabled')).toBe('disabled');
+  });
+
+  it('parses enabled and disabled policies through the full catalog response', () => {
+    for (const workspaceProviders of ['enabled', 'disabled'] as const) {
+      const parsed = modelProviderCatalogResponseSchema.parse({
+        providers: [managedProviderCatalogEntry],
+        workspace_providers: workspaceProviders,
+      });
+
+      expect(parsed.workspace_providers).toBe(workspaceProviders);
+    }
+  });
+
+  it('rejects an invalid workspace provider policy in the full catalog response', () => {
+    const parse = () =>
+      modelProviderCatalogResponseSchema.parse({
+        providers: [managedProviderCatalogEntry],
+        workspace_providers: 'invalid',
+      });
+
+    expect(parse).toThrow();
   });
 
   it('rejects a supported response entry without models', () => {

--- a/libs/api/agent-dto/src/schemas/catalog.test.ts
+++ b/libs/api/agent-dto/src/schemas/catalog.test.ts
@@ -6,6 +6,7 @@ import {
   MODEL_PROVIDER_CATALOG_SEED,
   modelProviderCatalogEntrySchema,
   modelProviderCatalogSeedSchema,
+  workspaceProvidersPolicySchema,
 } from './catalog.js';
 import {
   MODEL_PROVIDER_IDS,
@@ -150,6 +151,21 @@ describe('model provider catalog', () => {
     const parsed = modelProviderCatalogEntrySchema.array().parse(responseEntries);
 
     expect(parsed).toHaveLength(37);
+  });
+
+  it('parses a managed provider response entry and workspace provider policy', () => {
+    const parsed = modelProviderCatalogEntrySchema.parse({
+      id: 'shipfox-managed',
+      label: 'Shipfox Managed',
+      support_status: 'supported',
+      default_model: 'managed-claude',
+      credential_fields: [],
+      unsupported_reason: null,
+      models: [{id: 'managed-claude', label: 'Managed Claude'}],
+    });
+
+    expect(parsed.id).toBe('shipfox-managed');
+    expect(workspaceProvidersPolicySchema.parse('disabled')).toBe('disabled');
   });
 
   it('rejects a supported response entry without models', () => {

--- a/libs/api/agent-dto/src/schemas/catalog.ts
+++ b/libs/api/agent-dto/src/schemas/catalog.ts
@@ -12,6 +12,7 @@ import {
 import {z} from 'zod';
 import {
   type ModelProviderId,
+  modelProviderRefSchema,
   providerIdSchema,
   SUPPORTED_MODEL_PROVIDER_IDS,
   type SupportedModelProviderId,
@@ -50,6 +51,10 @@ export const modelProviderSupportStatusSchema = z.enum(['supported', 'unsupporte
 
 export type ModelProviderSupportStatus = z.infer<typeof modelProviderSupportStatusSchema>;
 
+export const workspaceProvidersPolicySchema = z.enum(['enabled', 'disabled']);
+
+export type WorkspaceProvidersPolicy = z.infer<typeof workspaceProvidersPolicySchema>;
+
 const supportedModelProviderIds = new Set<string>(SUPPORTED_MODEL_PROVIDER_IDS);
 const unsupportedModelProviderIds = new Set<string>(UNSUPPORTED_MODEL_PROVIDER_IDS);
 
@@ -67,12 +72,24 @@ export const modelProviderCatalogSeedSchema =
 
 export type ModelProviderCatalogSeedDto = z.infer<typeof modelProviderCatalogSeedSchema>;
 
-export const modelProviderCatalogEntrySchema = modelProviderCatalogSeedBaseSchema
+const modelProviderCatalogEntryBaseSchema = z.object({
+  id: modelProviderRefSchema,
+  label: z.string().min(1),
+  support_status: modelProviderSupportStatusSchema,
+  default_model: z.string().min(1).nullable(),
+  credential_fields: z.array(modelProviderCredentialFieldSchema),
+  unsupported_reason: z.string().min(1).nullable(),
+});
+
+export const modelProviderCatalogEntrySchema = modelProviderCatalogEntryBaseSchema
   .extend({
     models: z.array(agentModelOptionSchema),
   })
   .superRefine((entry, ctx) => {
-    validateCatalogSeedEntry(entry, ctx);
+    const seedId = providerIdSchema.safeParse(entry.id);
+    if (seedId.success) {
+      validateCatalogSeedEntry({...entry, id: seedId.data}, ctx);
+    }
 
     if (entry.support_status === 'supported') {
       if (entry.models.length === 0) {
@@ -105,6 +122,7 @@ export type ModelProviderCatalogEntryDto = z.infer<typeof modelProviderCatalogEn
 
 export const modelProviderCatalogResponseSchema = z.object({
   providers: z.array(modelProviderCatalogEntrySchema),
+  workspace_providers: workspaceProvidersPolicySchema.optional(),
 });
 
 export type ModelProviderCatalogResponseDto = z.infer<typeof modelProviderCatalogResponseSchema>;

--- a/libs/api/agent-dto/src/schemas/index.ts
+++ b/libs/api/agent-dto/src/schemas/index.ts
@@ -25,6 +25,8 @@ export {
   modelProviderSupportStatusSchema,
   piAgentThinkingSchema,
   thinkingLevelsForHarness,
+  type WorkspaceProvidersPolicy,
+  workspaceProvidersPolicySchema,
 } from './catalog.js';
 export {
   type CreateCustomModelProviderBodyDto,

--- a/libs/api/agent/src/config.test.ts
+++ b/libs/api/agent/src/config.test.ts
@@ -16,6 +16,48 @@ describe('agent config', () => {
     expect(module.config.AGENT_DEFAULT_PROVIDER_API_KEY).toBe('sk-instance-secret');
   });
 
+  it('defaults workspace provider configuration to enabled', async () => {
+    vi.resetModules();
+
+    const module = await import('./config.js');
+
+    expect(module.config.AGENT_WORKSPACE_PROVIDERS).toBe('enabled');
+    expect(module.workspaceProvidersPolicy).toBe('enabled');
+  });
+
+  it('accepts disabled workspace provider configuration with a managed provider', async () => {
+    vi.resetModules();
+    vi.stubEnv('AGENT_WORKSPACE_PROVIDERS', 'disabled');
+
+    const module = await import('./config.js');
+
+    expect(module.workspaceProvidersPolicy).toBe('disabled');
+    expect(() => module.assertAgentConfig(managedProvider())).not.toThrow();
+  });
+
+  it('requires a managed provider when workspace provider configuration is disabled', async () => {
+    vi.resetModules();
+    vi.stubEnv('AGENT_WORKSPACE_PROVIDERS', 'disabled');
+
+    const module = await import('./config.js');
+
+    expect(() => module.assertAgentConfig()).toThrow(
+      'AGENT_WORKSPACE_PROVIDERS=disabled requires an injected managed model provider',
+    );
+  });
+
+  it('rejects a foreign instance default when workspace provider configuration is disabled', async () => {
+    vi.resetModules();
+    vi.stubEnv('AGENT_WORKSPACE_PROVIDERS', 'disabled');
+    vi.stubEnv('AGENT_DEFAULT_PROVIDER', 'openai');
+
+    const module = await import('./config.js');
+
+    expect(() => module.assertAgentConfig(managedProvider())).toThrow(
+      'This instance only supports provider `shipfox`',
+    );
+  });
+
   it('throws when an instance key is set for a multi-field provider', async () => {
     vi.resetModules();
     vi.stubEnv('AGENT_DEFAULT_PROVIDER', 'azure-openai-responses');

--- a/libs/api/agent/src/config.ts
+++ b/libs/api/agent/src/config.ts
@@ -6,14 +6,21 @@ import {
   managedModelApiSchema,
   modelProviderRefSchema,
   SUPPORTED_MODEL_PROVIDER_IDS,
+  type WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
 import {bool, createConfig, num, str} from '@shipfox/config';
+import {WorkspaceProvidersDisabledError} from '#core/errors.js';
 import {getModelProviderEntry} from '#core/model-provider-policy.js';
 
 const AGENT_THINKING_CHOICES = agentThinkingSchema.options;
 const SUPPORTED_PROVIDER_IDS_DESCRIPTION = SUPPORTED_MODEL_PROVIDER_IDS.join(', ');
 
 export const config = createConfig({
+  AGENT_WORKSPACE_PROVIDERS: str({
+    desc: 'Controls whether workspaces can configure model providers. Use enabled to preserve the default workspace provider behavior, or disabled when the injected managed provider is the only provider for this instance.',
+    choices: ['enabled', 'disabled'],
+    default: 'enabled',
+  }),
   AGENT_DEFAULT_PROVIDER: str({
     desc: `Instance-wide default model provider ID used when a workflow and workspace do not choose one. Optional. Use one of the supported model catalog IDs (${SUPPORTED_PROVIDER_IDS_DESCRIPTION}) or the injected managed provider.`,
     default: undefined,
@@ -53,6 +60,9 @@ export const config = createConfig({
   }),
 });
 
+export const workspaceProvidersPolicy =
+  config.AGENT_WORKSPACE_PROVIDERS as WorkspaceProvidersPolicy;
+
 export const harnessToolDeploymentConfig = buildHarnessToolDeploymentConfig({
   piEnabledToolPackages: config.AGENT_PI_ENABLED_TOOL_PACKAGES,
   piWebSearchEnabled: config.AGENT_PI_WEB_SEARCH_ENABLED,
@@ -60,6 +70,20 @@ export const harnessToolDeploymentConfig = buildHarnessToolDeploymentConfig({
 
 export function assertAgentConfig(managedProvider?: ManagedModelProvider): void {
   if (managedProvider !== undefined) assertManagedProvider(managedProvider);
+
+  if (workspaceProvidersPolicy === 'disabled') {
+    if (managedProvider === undefined) {
+      throw new Error(
+        'AGENT_WORKSPACE_PROVIDERS=disabled requires an injected managed model provider.',
+      );
+    }
+    if (
+      config.AGENT_DEFAULT_PROVIDER !== undefined &&
+      config.AGENT_DEFAULT_PROVIDER !== managedProvider.id
+    ) {
+      throw new WorkspaceProvidersDisabledError(managedProvider.id);
+    }
+  }
 
   const defaultProvider = config.AGENT_DEFAULT_PROVIDER;
   if (defaultProvider !== undefined && !isRegisteredProvider(defaultProvider, managedProvider)) {

--- a/libs/api/agent/src/core/errors.ts
+++ b/libs/api/agent/src/core/errors.ts
@@ -32,6 +32,13 @@ export class UnsupportedModelProviderError extends Error {
   }
 }
 
+export class WorkspaceProvidersDisabledError extends Error {
+  constructor(public readonly managedProviderId: string) {
+    super(`This instance only supports provider \`${managedProviderId}\`.`);
+    this.name = 'WorkspaceProvidersDisabledError';
+  }
+}
+
 export class UnsupportedHarnessProviderError extends Error {
   constructor(
     public readonly harness: Harness,

--- a/libs/api/agent/src/core/index.ts
+++ b/libs/api/agent/src/core/index.ts
@@ -19,6 +19,7 @@ export {
   UnsupportedHarnessProviderError,
   UnsupportedHarnessThinkingError,
   UnsupportedModelProviderError,
+  WorkspaceProvidersDisabledError,
 } from './errors.js';
 export {
   getHarnessDescriptor,
@@ -61,3 +62,7 @@ export {
   resolveRuntimeCredentials,
 } from './resolve-runtime-credentials.js';
 export {createWorkspaceAgentDefaultsResolver} from './workspace-agent-defaults-resolver.js';
+export {
+  assertWorkspaceProviderConfigurationEnabled,
+  type WorkspaceProviderPolicyOptions,
+} from './workspace-provider-policy.js';

--- a/libs/api/agent/src/core/model-provider-catalog.test.ts
+++ b/libs/api/agent/src/core/model-provider-catalog.test.ts
@@ -1,0 +1,29 @@
+import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
+import {buildModelProviderCatalog} from './model-provider-catalog.js';
+
+describe('buildModelProviderCatalog', () => {
+  it('deep-freezes managed provider entries in both policy modes', () => {
+    const managedProvider = {
+      id: 'shipfox-managed',
+      label: 'Shipfox Managed',
+      models: [{id: 'managed-claude', label: 'Managed Claude', api: 'anthropic-messages' as const}],
+      defaultModel: 'managed-claude',
+      resolveCredentials: async () => ({
+        api: 'anthropic-messages' as const,
+        baseUrl: 'https://gateway.example.com',
+        credentials: {api_key: 'token'},
+      }),
+    } satisfies ManagedModelProvider;
+
+    for (const workspaceProviders of ['enabled', 'disabled'] as const) {
+      const catalog = buildModelProviderCatalog({managedProvider, workspaceProviders});
+      const managedEntry = catalog.find((entry) => entry.id === managedProvider.id);
+
+      if (managedEntry === undefined) throw new Error('Missing managed provider catalog entry');
+
+      expect(Object.isFrozen(managedEntry)).toBe(true);
+      expect(Object.isFrozen(managedEntry.models)).toBe(true);
+      expect(Object.isFrozen(managedEntry.models[0])).toBe(true);
+    }
+  });
+});

--- a/libs/api/agent/src/core/model-provider-catalog.ts
+++ b/libs/api/agent/src/core/model-provider-catalog.ts
@@ -49,15 +49,17 @@ function getCatalog(): readonly ModelProviderCatalogEntryDto[] {
 function toManagedProviderCatalogEntry(
   managedProvider: ManagedModelProvider,
 ): ModelProviderCatalogEntryDto {
-  return modelProviderCatalogEntrySchema.parse({
-    id: managedProvider.id,
-    label: managedProvider.label,
-    support_status: 'supported',
-    default_model: managedProvider.defaultModel,
-    credential_fields: [],
-    unsupported_reason: null,
-    models: managedProvider.models.map(({id, label}) => ({id, label})),
-  });
+  return deepFreeze(
+    modelProviderCatalogEntrySchema.parse({
+      id: managedProvider.id,
+      label: managedProvider.label,
+      support_status: 'supported',
+      default_model: managedProvider.defaultModel,
+      credential_fields: [],
+      unsupported_reason: null,
+      models: managedProvider.models.map(({id, label}) => ({id, label})),
+    }),
+  );
 }
 
 function deepFreeze<T>(value: T): T {

--- a/libs/api/agent/src/core/model-provider-catalog.ts
+++ b/libs/api/agent/src/core/model-provider-catalog.ts
@@ -1,13 +1,37 @@
 import {
+  type ManagedModelProvider,
   MODEL_PROVIDER_CATALOG_SEED,
   type ModelProviderCatalogEntryDto,
   modelProviderCatalogEntrySchema,
+  type WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
 import {listPiProviderModels} from './harness/pi.js';
 
 let cachedCatalog: readonly ModelProviderCatalogEntryDto[] | undefined;
 
-export function buildModelProviderCatalog(): readonly ModelProviderCatalogEntryDto[] {
+export function buildModelProviderCatalog(
+  options: {
+    managedProvider?: ManagedModelProvider | undefined;
+    workspaceProviders?: WorkspaceProvidersPolicy | undefined;
+  } = {},
+): readonly ModelProviderCatalogEntryDto[] {
+  const workspaceProviders = options.workspaceProviders ?? 'enabled';
+  if (workspaceProviders === 'disabled') {
+    if (options.managedProvider === undefined) {
+      throw new Error(
+        'workspace provider configuration is disabled but no managed provider is registered',
+      );
+    }
+    return Object.freeze([toManagedProviderCatalogEntry(options.managedProvider)]);
+  }
+
+  const catalog = getCatalog();
+  if (options.managedProvider === undefined) return catalog;
+
+  return Object.freeze([...catalog, toManagedProviderCatalogEntry(options.managedProvider)]);
+}
+
+function getCatalog(): readonly ModelProviderCatalogEntryDto[] {
   if (cachedCatalog) return cachedCatalog;
 
   const catalog = modelProviderCatalogEntrySchema.array().parse(
@@ -20,6 +44,20 @@ export function buildModelProviderCatalog(): readonly ModelProviderCatalogEntryD
 
   cachedCatalog = deepFreeze(catalog);
   return cachedCatalog;
+}
+
+function toManagedProviderCatalogEntry(
+  managedProvider: ManagedModelProvider,
+): ModelProviderCatalogEntryDto {
+  return modelProviderCatalogEntrySchema.parse({
+    id: managedProvider.id,
+    label: managedProvider.label,
+    support_status: 'supported',
+    default_model: managedProvider.defaultModel,
+    credential_fields: [],
+    unsupported_reason: null,
+    models: managedProvider.models.map(({id, label}) => ({id, label})),
+  });
 }
 
 function deepFreeze<T>(value: T): T {

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -12,6 +12,7 @@ import {
   UnsupportedHarnessProviderError,
   UnsupportedHarnessThinkingError,
   UnsupportedModelProviderError,
+  WorkspaceProvidersDisabledError,
 } from './errors.js';
 import * as harnessCatalog from './harness/index.js';
 import {catalogDefaultAgentResolver, resolveAgentConfig} from './resolve-agent-config.js';
@@ -152,6 +153,32 @@ describe('resolveAgentConfig', () => {
       model: 'claude-model',
       thinking: 'high',
     });
+  });
+
+  test('defaults to the managed provider when workspace providers are disabled', () => {
+    const resolved = resolveAgentConfig(
+      {},
+      {
+        workspaceProviders: 'disabled',
+        workspaceDefaultProviderId: 'openai',
+        instanceDefaultProvider: 'openai',
+        managedProvider: managedProvider(),
+      },
+    );
+
+    expect(resolved.provider).toBe('shipfox');
+    expect(resolved.model).toBe('responses-model');
+  });
+
+  test('rejects foreign provider references when workspace providers are disabled', () => {
+    const resolve = () =>
+      resolveAgentConfig(
+        {provider: 'openai'},
+        {workspaceProviders: 'disabled', managedProvider: managedProvider()},
+      );
+
+    expect(resolve).toThrow(WorkspaceProvidersDisabledError);
+    expect(resolve).toThrow('This instance only supports provider `shipfox`');
   });
 
   test('uses instance model and thinking only for the resolved instance model provider', () => {

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -8,12 +8,14 @@ import {
   type ManagedModelEntry,
   type ManagedModelProvider,
   type ModelProviderRef,
+  type WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
 import {
   InvalidAgentModelError,
   UnsupportedHarnessProviderError,
   UnsupportedHarnessThinkingError,
   UnsupportedModelProviderError,
+  WorkspaceProvidersDisabledError,
 } from './errors.js';
 import {listHarnessProviderModels} from './harness/index.js';
 import {getModelProviderEntry} from './model-provider-policy.js';
@@ -43,6 +45,7 @@ export interface AgentConfigResolutionContext {
   readonly instanceDefaultModel?: string | undefined;
   readonly instanceDefaultThinking?: AgentThinking | undefined;
   readonly managedProvider?: ManagedModelProvider | undefined;
+  readonly workspaceProviders?: WorkspaceProvidersPolicy | undefined;
 }
 
 interface WorkspaceProviderDefaults {
@@ -91,6 +94,28 @@ function resolveProvider(
   harness: Harness,
 ): ModelProviderRef {
   const descriptor = getHarnessDescriptor(harness);
+  if (ctx.workspaceProviders === 'disabled') {
+    const managedProvider = ctx.managedProvider;
+    if (managedProvider === undefined) {
+      throw new Error(
+        'workspace provider configuration is disabled but no managed provider is registered',
+      );
+    }
+    if (step.provider !== undefined && step.provider !== managedProvider.id) {
+      throw new WorkspaceProvidersDisabledError(managedProvider.id);
+    }
+
+    const providerConfig = getProviderConfig(managedProvider.id, ctx);
+    if (!isHarnessCompatible(harness, managedProvider.id, providerConfig)) {
+      throw new UnsupportedHarnessProviderError(
+        harness,
+        managedProvider.id,
+        supportedProviderIds(harness, descriptor, ctx),
+      );
+    }
+    return managedProvider.id;
+  }
+
   if (step.provider !== undefined) {
     const provider = resolveSupportedProvider(step.provider, ctx);
     if (!isHarnessCompatible(harness, provider, getProviderConfig(provider, ctx))) {

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -170,6 +170,32 @@ describe('resolveRuntimeCredentials', () => {
     await expect(mismatched).rejects.toMatchObject({name: 'ModelProviderConfigNotFoundError'});
   });
 
+  it('refuses workspace credentials and instance fallback when workspace providers are disabled', async () => {
+    await saveProviderConfig({
+      workspaceId,
+      providerId: 'anthropic',
+      credentials: {api_key: 'sk-workspace-secret'},
+    });
+
+    const result = resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+      },
+      {
+        workspaceProviders: 'disabled',
+        runtimeConfig: instanceConfig(),
+      },
+    );
+
+    await expect(result).rejects.toThrow(ModelProviderConfigNotFoundError);
+  });
+
   it('returns custom provider runtime descriptors for custom rows', async () => {
     await saveProviderConfig({
       workspaceId,

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -6,10 +6,11 @@ import type {
   ManagedProviderRuntimeConfig,
   ModelProviderRef,
   SupportedModelProviderId,
+  WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
 import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
-import {config} from '#config.js';
+import {config, workspaceProvidersPolicy} from '#config.js';
 import {getModelProviderConfig} from '#db/index.js';
 import {agentRuntimeConfigResolvedCount} from '#metrics/index.js';
 import {
@@ -39,6 +40,7 @@ interface RuntimeCredentialsConfig {
 
 interface ResolveRuntimeCredentialsOptions {
   runtimeConfig?: RuntimeCredentialsConfig | undefined;
+  workspaceProviders?: WorkspaceProvidersPolicy | undefined;
   secrets?: AgentSecretsClient | undefined;
   managedProvider?: ManagedModelProvider | undefined;
   getCredentialBag?:
@@ -51,6 +53,7 @@ export async function resolveRuntimeCredentials(
   options?: ResolveRuntimeCredentialsOptions,
 ): Promise<AgentRuntimeCredentialsResponseDto> {
   const runtimeConfig = options?.runtimeConfig ?? config;
+  const configuredWorkspaceProviders = options?.workspaceProviders ?? workspaceProvidersPolicy;
   const secrets = options?.secrets;
   const managedProvider = options?.managedProvider;
   if (managedProvider?.id === params.provider) {
@@ -65,6 +68,14 @@ export async function resolveRuntimeCredentials(
       provider: managedProvider,
       runtimeConfig: managedRuntimeConfig,
     });
+  }
+
+  if (configuredWorkspaceProviders === 'disabled') {
+    agentRuntimeConfigResolvedCount.add(1, {
+      source: params.provider === runtimeConfig.AGENT_DEFAULT_PROVIDER ? 'instance' : 'workspace',
+      outcome: 'unavailable',
+    });
+    throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
   }
 
   const providerConfig = await getModelProviderConfig({

--- a/libs/api/agent/src/core/validation-catalog.test.ts
+++ b/libs/api/agent/src/core/validation-catalog.test.ts
@@ -44,4 +44,27 @@ describe('getAgentValidationCatalog', () => {
     expect(claude?.supported_provider_ids).toContain(managedProvider.id);
     expect(claude?.model_ids_by_provider?.[managedProvider.id]).toEqual(['managed-claude']);
   });
+
+  it('exposes only the managed provider when workspace providers are disabled', () => {
+    const managedProvider = {
+      id: 'shipfox-managed',
+      label: 'Shipfox Managed',
+      models: [{id: 'managed-claude', label: 'Managed Claude', api: 'anthropic-messages' as const}],
+      defaultModel: 'managed-claude',
+      resolveCredentials: async () => ({
+        api: 'anthropic-messages' as const,
+        baseUrl: 'https://gateway.example.com',
+        credentials: {api_key: 'token'},
+      }),
+    } satisfies ManagedModelProvider;
+
+    const catalog = getAgentValidationCatalog(managedProvider, 'disabled');
+
+    expect(catalog.providers).toEqual([{id: managedProvider.id, support_status: 'supported'}]);
+    expect(
+      catalog.harnesses.every((harness) =>
+        harness.supported_provider_ids.every((providerId) => providerId === managedProvider.id),
+      ),
+    ).toBe(true);
+  });
 });

--- a/libs/api/agent/src/core/validation-catalog.ts
+++ b/libs/api/agent/src/core/validation-catalog.ts
@@ -1,4 +1,4 @@
-import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
+import type {ManagedModelProvider, WorkspaceProvidersPolicy} from '@shipfox/api-agent-dto';
 import {
   listEnabledHarnessTools,
   listHarnessDescriptors,
@@ -12,12 +12,16 @@ import {getModelProviderEntry} from './model-provider-policy.js';
 /** Produces the versioned, JSON-safe policy snapshot consumed by Definitions. */
 export function getAgentValidationCatalog(
   managedProvider?: ManagedModelProvider | undefined,
+  workspaceProviders: WorkspaceProvidersPolicy = 'enabled',
 ): AgentValidationCatalog {
+  const managedOnly = workspaceProviders === 'disabled';
   const providers = [
-    ...MODEL_PROVIDER_IDS.map((id) => ({
-      id,
-      support_status: getModelProviderEntry(id)?.support_status ?? 'unsupported',
-    })),
+    ...(managedOnly
+      ? []
+      : MODEL_PROVIDER_IDS.map((id) => ({
+          id,
+          support_status: getModelProviderEntry(id)?.support_status ?? 'unsupported',
+        }))),
     ...(managedProvider === undefined
       ? []
       : [{id: managedProvider.id, support_status: 'supported' as const}]),
@@ -28,18 +32,25 @@ export function getAgentValidationCatalog(
     providers,
     harnesses: listHarnessDescriptors().map((harness) => ({
       id: harness.id,
-      supported_provider_ids: [
-        ...harness.supportedProviderIds,
-        ...(managedProvider !== undefined &&
-        managedModelsForHarness(harness.id, managedProvider).length > 0
+      supported_provider_ids: managedOnly
+        ? managedProvider !== undefined &&
+          managedModelsForHarness(harness.id, managedProvider).length > 0
           ? [managedProvider.id]
-          : []),
-      ],
+          : []
+        : [
+            ...harness.supportedProviderIds,
+            ...(managedProvider !== undefined &&
+            managedModelsForHarness(harness.id, managedProvider).length > 0
+              ? [managedProvider.id]
+              : []),
+          ],
       model_ids_by_provider: Object.fromEntries([
-        ...harness.supportedProviderIds.map((providerId) => [
-          providerId,
-          listHarnessProviderModels(harness.id, providerId).map((model) => model.id),
-        ]),
+        ...(managedOnly
+          ? []
+          : harness.supportedProviderIds.map((providerId) => [
+              providerId,
+              listHarnessProviderModels(harness.id, providerId).map((model) => model.id),
+            ])),
         ...(managedProvider === undefined
           ? []
           : [

--- a/libs/api/agent/src/core/validation-catalog.ts
+++ b/libs/api/agent/src/core/validation-catalog.ts
@@ -1,4 +1,8 @@
-import type {ManagedModelProvider, WorkspaceProvidersPolicy} from '@shipfox/api-agent-dto';
+import type {
+  HarnessDescriptor,
+  ManagedModelProvider,
+  WorkspaceProvidersPolicy,
+} from '@shipfox/api-agent-dto';
 import {
   listEnabledHarnessTools,
   listHarnessDescriptors,
@@ -9,63 +13,121 @@ import {harnessToolDeploymentConfig} from '#config.js';
 import {listHarnessProviderModels} from './harness/index.js';
 import {getModelProviderEntry} from './model-provider-policy.js';
 
+type HarnessValidationCatalog = AgentValidationCatalog['harnesses'][number];
+
 /** Produces the versioned, JSON-safe policy snapshot consumed by Definitions. */
 export function getAgentValidationCatalog(
   managedProvider?: ManagedModelProvider | undefined,
   workspaceProviders: WorkspaceProvidersPolicy = 'enabled',
 ): AgentValidationCatalog {
   const managedOnly = workspaceProviders === 'disabled';
-  const providers = [
-    ...(managedOnly
-      ? []
-      : MODEL_PROVIDER_IDS.map((id) => ({
-          id,
-          support_status: getModelProviderEntry(id)?.support_status ?? 'unsupported',
-        }))),
-    ...(managedProvider === undefined
-      ? []
-      : [{id: managedProvider.id, support_status: 'supported' as const}]),
-  ];
 
   return {
     version: 1,
-    providers,
-    harnesses: listHarnessDescriptors().map((harness) => ({
-      id: harness.id,
-      supported_provider_ids: managedOnly
-        ? managedProvider !== undefined &&
-          managedModelsForHarness(harness.id, managedProvider).length > 0
-          ? [managedProvider.id]
-          : []
-        : [
-            ...harness.supportedProviderIds,
-            ...(managedProvider !== undefined &&
-            managedModelsForHarness(harness.id, managedProvider).length > 0
-              ? [managedProvider.id]
-              : []),
-          ],
-      model_ids_by_provider: Object.fromEntries([
-        ...(managedOnly
-          ? []
-          : harness.supportedProviderIds.map((providerId) => [
-              providerId,
-              listHarnessProviderModels(harness.id, providerId).map((model) => model.id),
-            ])),
-        ...(managedProvider === undefined
-          ? []
-          : [
-              [
-                managedProvider.id,
-                managedModelsForHarness(harness.id, managedProvider).map((model) => model.id),
-              ],
-            ]),
-      ]),
-      thinking_levels: [...harness.thinkingLevels],
-      effective_tools: listEnabledHarnessTools(harness.id, harnessToolDeploymentConfig).map(
-        (tool) => tool.name,
-      ),
-    })),
+    providers: buildValidationProviders(managedProvider, managedOnly),
+    harnesses: listHarnessDescriptors().map((harness) =>
+      buildHarnessValidationCatalog(harness, managedProvider, managedOnly),
+    ),
   };
+}
+
+function buildValidationProviders(
+  managedProvider: ManagedModelProvider | undefined,
+  managedOnly: boolean,
+): AgentValidationCatalog['providers'] {
+  const providers: AgentValidationCatalog['providers'] = [];
+
+  if (!managedOnly) {
+    providers.push(
+      ...MODEL_PROVIDER_IDS.map((id) => ({
+        id,
+        support_status: getModelProviderEntry(id)?.support_status ?? 'unsupported',
+      })),
+    );
+  }
+
+  if (managedProvider !== undefined) {
+    providers.push({id: managedProvider.id, support_status: 'supported'});
+  }
+
+  return providers;
+}
+
+function buildHarnessValidationCatalog(
+  harness: HarnessDescriptor,
+  managedProvider: ManagedModelProvider | undefined,
+  managedOnly: boolean,
+): HarnessValidationCatalog {
+  const managedModels = getManagedModelsForHarness(harness, managedProvider);
+
+  return {
+    id: harness.id,
+    supported_provider_ids: buildSupportedProviderIds(
+      harness,
+      managedProvider,
+      managedModels,
+      managedOnly,
+    ),
+    model_ids_by_provider: buildModelIdsByProvider(
+      harness,
+      managedProvider,
+      managedModels,
+      managedOnly,
+    ),
+    thinking_levels: [...harness.thinkingLevels],
+    effective_tools: listEnabledHarnessTools(harness.id, harnessToolDeploymentConfig).map(
+      (tool) => tool.name,
+    ),
+  };
+}
+
+function buildSupportedProviderIds(
+  harness: HarnessDescriptor,
+  managedProvider: ManagedModelProvider | undefined,
+  managedModels: ManagedModelProvider['models'],
+  managedOnly: boolean,
+): string[] {
+  if (managedOnly) {
+    if (managedProvider === undefined || managedModels.length === 0) return [];
+    return [managedProvider.id];
+  }
+
+  const providerIds = [...harness.supportedProviderIds];
+  if (managedProvider !== undefined && managedModels.length > 0) {
+    providerIds.push(managedProvider.id);
+  }
+  return providerIds;
+}
+
+function buildModelIdsByProvider(
+  harness: HarnessDescriptor,
+  managedProvider: ManagedModelProvider | undefined,
+  managedModels: ManagedModelProvider['models'],
+  managedOnly: boolean,
+): Record<string, string[]> {
+  const modelIdsByProvider: Record<string, string[]> = {};
+
+  if (!managedOnly) {
+    for (const providerId of harness.supportedProviderIds) {
+      modelIdsByProvider[providerId] = listHarnessProviderModels(harness.id, providerId).map(
+        (model) => model.id,
+      );
+    }
+  }
+
+  if (managedProvider !== undefined) {
+    modelIdsByProvider[managedProvider.id] = managedModels.map((model) => model.id);
+  }
+
+  return modelIdsByProvider;
+}
+
+function getManagedModelsForHarness(
+  harness: HarnessDescriptor,
+  managedProvider: ManagedModelProvider | undefined,
+): ManagedModelProvider['models'] {
+  if (managedProvider === undefined) return [];
+  return managedModelsForHarness(harness.id, managedProvider);
 }
 
 function managedModelsForHarness(

--- a/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
+++ b/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
@@ -1,4 +1,9 @@
-import type {AgentThinking, ManagedModelProvider, ModelProviderRef} from '@shipfox/api-agent-dto';
+import type {
+  AgentThinking,
+  ManagedModelProvider,
+  ModelProviderRef,
+  WorkspaceProvidersPolicy,
+} from '@shipfox/api-agent-dto';
 import {config} from '#config.js';
 import {getAgentWorkspaceDefaultsSnapshot} from '#db/index.js';
 import type {AgentConfigResolutionContext, AgentDefaultsResolver} from './resolve-agent-config.js';
@@ -7,6 +12,7 @@ import {resolveAgentConfig} from './resolve-agent-config.js';
 export async function createWorkspaceAgentDefaultsResolver(
   workspaceId: string,
   managedProvider?: ManagedModelProvider | undefined,
+  workspaceProviders?: WorkspaceProvidersPolicy | undefined,
 ): Promise<AgentDefaultsResolver> {
   const snapshot = await getAgentWorkspaceDefaultsSnapshot(workspaceId);
   const workspaceProviderConfigs = new Map<
@@ -34,6 +40,7 @@ export async function createWorkspaceAgentDefaultsResolver(
     instanceDefaultModel: config.AGENT_DEFAULT_PROVIDER_MODEL,
     instanceDefaultThinking: config.AGENT_DEFAULT_PROVIDER_THINKING as AgentThinking | undefined,
     managedProvider,
+    workspaceProviders,
   };
 
   return (step) => resolveAgentConfig(step, ctx);

--- a/libs/api/agent/src/core/workspace-provider-policy.ts
+++ b/libs/api/agent/src/core/workspace-provider-policy.ts
@@ -1,0 +1,19 @@
+import type {WorkspaceProvidersPolicy} from '@shipfox/api-agent-dto';
+import {WorkspaceProvidersDisabledError} from './errors.js';
+
+export interface WorkspaceProviderPolicyOptions {
+  readonly workspaceProviders: WorkspaceProvidersPolicy;
+  readonly managedProviderId?: string | undefined;
+}
+
+export function assertWorkspaceProviderConfigurationEnabled(
+  options: WorkspaceProviderPolicyOptions,
+): void {
+  if (options.workspaceProviders !== 'disabled') return;
+  if (options.managedProviderId === undefined) {
+    throw new Error(
+      'workspace provider configuration is disabled but no managed provider is registered',
+    );
+  }
+  throw new WorkspaceProvidersDisabledError(options.managedProviderId);
+}

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -1,6 +1,6 @@
 import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
-import {assertAgentConfig} from '#config.js';
+import {assertAgentConfig, workspaceProvidersPolicy} from '#config.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
 import {db, migrationsPath} from '#db/index.js';
 import {createAgentE2eRoutes} from '#presentation/e2eRoutes/index.js';
@@ -35,6 +35,7 @@ export {
   testAndSaveModelProviderConfig,
   UnsupportedModelProviderError,
   updateCustomModelProviderConfig,
+  WorkspaceProvidersDisabledError,
 } from '#core/index.js';
 export {
   getAgentWorkspaceSettings,
@@ -53,8 +54,21 @@ export function createAgentModule(params: {
   return {
     name: 'agent',
     database: {db, migrationsPath, databaseNamespace: 'agent'},
-    routes: createAgentRoutes(params.secrets),
-    e2eRoutes: [createAgentE2eRoutes(params.secrets)],
-    interModulePresentations: [createAgentInterModulePresentation(params)],
+    routes: createAgentRoutes(params.secrets, {
+      managedProvider: params.managedProvider,
+      workspaceProviders: workspaceProvidersPolicy,
+    }),
+    e2eRoutes: [
+      createAgentE2eRoutes(params.secrets, {
+        managedProviderId: params.managedProvider?.id,
+        workspaceProviders: workspaceProvidersPolicy,
+      }),
+    ],
+    interModulePresentations: [
+      createAgentInterModulePresentation({
+        ...params,
+        workspaceProviders: workspaceProvidersPolicy,
+      }),
+    ],
   };
 }

--- a/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.ts
+++ b/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.ts
@@ -3,9 +3,14 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {agentSystemNamespace} from '#core/credential-fingerprints.js';
 import {listHarnessProviderModels} from '#core/harness/registry.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  type WorkspaceProviderPolicyOptions,
+} from '#core/index.js';
 import {getModelProviderEntry} from '#core/model-provider-policy.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
 import {upsertModelProviderConfig} from '#db/index.js';
+import {translateModelProviderRouteError} from '#presentation/routes/errors.js';
 
 const createE2eModelProviderBodySchema = z.object({
   workspace_id: z.string().uuid(),
@@ -19,7 +24,10 @@ const createE2eModelProviderResponseSchema = z.object({
   provider_id: z.literal('anthropic'),
 });
 
-export function createE2eModelProviderRoute(secrets: AgentSecretsClient) {
+export function createE2eModelProviderRoute(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
   return defineRoute({
     method: 'POST',
     path: '/model-provider',
@@ -28,7 +36,9 @@ export function createE2eModelProviderRoute(secrets: AgentSecretsClient) {
       body: createE2eModelProviderBodySchema,
       response: {201: createE2eModelProviderResponseSchema},
     },
+    errorHandler: translateModelProviderRouteError,
     handler: async (request, reply) => {
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
       const entry = getModelProviderEntry(request.body.provider_id);
       if (entry === undefined || entry.default_model === null) {
         throw new ClientError('Unsupported E2E model provider', 'unsupported-model-provider', {

--- a/libs/api/agent/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/agent/src/presentation/e2eRoutes/index.ts
@@ -1,9 +1,16 @@
 import type {RouteGroup} from '@shipfox/node-fastify';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {createE2eModelProviderRoute} from './create-model-provider.js';
 
-export function createAgentE2eRoutes(secrets: AgentSecretsClient): RouteGroup {
-  return {prefix: '/agent', routes: [createE2eModelProviderRoute(secrets)]};
+export function createAgentE2eRoutes(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+): RouteGroup {
+  return {
+    prefix: '/agent',
+    routes: [createE2eModelProviderRoute(secrets, workspaceProviderPolicy)],
+  };
 }
 
 export const agentE2eRoutes = createAgentE2eRoutes(undefined as unknown as AgentSecretsClient);

--- a/libs/api/agent/src/presentation/inter-module.ts
+++ b/libs/api/agent/src/presentation/inter-module.ts
@@ -1,4 +1,4 @@
-import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
+import type {ManagedModelProvider, WorkspaceProvidersPolicy} from '@shipfox/api-agent-dto';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module';
 import {
@@ -13,6 +13,7 @@ import {
   UnsupportedHarnessProviderError,
   UnsupportedHarnessThinkingError,
   UnsupportedModelProviderError,
+  WorkspaceProvidersDisabledError,
 } from '#core/errors.js';
 import {resolveAgentConfig} from '#core/resolve-agent-config.js';
 import {resolveRuntimeCredentials} from '#core/resolve-runtime-credentials.js';
@@ -23,16 +24,25 @@ import {createWorkspaceAgentDefaultsResolver} from '#core/workspace-agent-defaul
 export function createAgentInterModulePresentation(params: {
   secrets: AgentSecretsClient;
   managedProvider?: ManagedModelProvider | undefined;
+  workspaceProviders?: WorkspaceProvidersPolicy | undefined;
 }): InterModulePresentation<typeof agentInterModuleContract> {
   return defineInterModulePresentation(agentInterModuleContract, {
-    getValidationCatalog: () => getAgentValidationCatalog(params.managedProvider),
+    getValidationCatalog: () =>
+      getAgentValidationCatalog(params.managedProvider, params.workspaceProviders),
     resolveAgentConfig: async ({workspaceId, config}) => {
       try {
         const resolve =
           workspaceId === null
             ? (step: Parameters<typeof resolveAgentConfig>[0]) =>
-                resolveAgentConfig(step, {managedProvider: params.managedProvider})
-            : await createWorkspaceAgentDefaultsResolver(workspaceId, params.managedProvider);
+                resolveAgentConfig(step, {
+                  managedProvider: params.managedProvider,
+                  workspaceProviders: params.workspaceProviders,
+                })
+            : await createWorkspaceAgentDefaultsResolver(
+                workspaceId,
+                params.managedProvider,
+                params.workspaceProviders,
+              );
         return await resolve(config);
       } catch (error) {
         throw toResolveAgentConfigKnownError(error);
@@ -43,6 +53,7 @@ export function createAgentInterModulePresentation(params: {
         return await resolveRuntimeCredentials(input, {
           managedProvider: params.managedProvider,
           secrets: params.secrets,
+          workspaceProviders: params.workspaceProviders,
         });
       } catch (error) {
         throw toResolveRuntimeCredentialsKnownError(error);
@@ -56,12 +67,17 @@ function toResolveAgentConfigKnownError(error: unknown): unknown {
     error instanceof InvalidAgentModelError ||
     error instanceof UnsupportedHarnessProviderError ||
     error instanceof UnsupportedHarnessThinkingError ||
-    error instanceof UnsupportedModelProviderError
+    error instanceof UnsupportedModelProviderError ||
+    error instanceof WorkspaceProvidersDisabledError
   ) {
     return createInterModuleKnownError(
       agentInterModuleContract.methods.resolveAgentConfig,
       'agent-config-invalid',
-      {},
+      {
+        ...(error instanceof WorkspaceProvidersDisabledError
+          ? {message: error.message, managed_provider_id: error.managedProviderId}
+          : {}),
+      },
     );
   }
   return error;

--- a/libs/api/agent/src/presentation/routes/create-custom-model-provider.ts
+++ b/libs/api/agent/src/presentation/routes/create-custom-model-provider.ts
@@ -5,12 +5,19 @@ import {
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {createCustomModelProviderConfig} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  createCustomModelProviderConfig,
+} from '#core/index.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {toCustomModelProviderConfigDto} from '#presentation/dto/index.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export function createCustomModelProviderRoute(secrets: AgentSecretsClient) {
+export function createCustomModelProviderRoute(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
   return defineRoute({
     method: 'POST',
     path: '/custom-model-providers',
@@ -35,6 +42,7 @@ export function createCustomModelProviderRoute(secrets: AgentSecretsClient) {
       });
 
       requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
       const config = await createCustomModelProviderConfig(
         {

--- a/libs/api/agent/src/presentation/routes/delete-model-provider-config.ts
+++ b/libs/api/agent/src/presentation/routes/delete-model-provider-config.ts
@@ -2,10 +2,18 @@ import {modelProviderRefSchema} from '@shipfox/api-agent-dto';
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {deleteModelProviderConfig} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  deleteModelProviderConfig,
+} from '#core/index.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
+import {translateModelProviderRouteError} from './errors.js';
 
-export function createDeleteModelProviderConfigRoute(secrets: AgentSecretsClient) {
+export function createDeleteModelProviderConfigRoute(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
   return defineRoute({
     method: 'DELETE',
     path: '/model-providers/:providerId',
@@ -19,9 +27,11 @@ export function createDeleteModelProviderConfigRoute(secrets: AgentSecretsClient
         204: z.void(),
       },
     },
+    errorHandler: translateModelProviderRouteError,
     handler: async (request, reply) => {
       const {workspaceId, providerId} = request.params;
       requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
       const deleted = await deleteModelProviderConfig({workspaceId, providerId}, {secrets});
       if (!deleted) {

--- a/libs/api/agent/src/presentation/routes/discover-custom-model-provider-models-by-slug.ts
+++ b/libs/api/agent/src/presentation/routes/discover-custom-model-provider-models-by-slug.ts
@@ -7,13 +7,18 @@ import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {
+  assertWorkspaceProviderConfigurationEnabled,
   discoverCustomModelProviderModels,
   resolveCustomModelProviderDiscoveryParams,
 } from '#core/index.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export function createDiscoverCustomModelProviderModelsBySlugRoute(secrets: AgentSecretsClient) {
+export function createDiscoverCustomModelProviderModelsBySlugRoute(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
   return defineRoute({
     method: 'POST',
     path: '/custom-model-providers/:slug/discover-models',
@@ -32,6 +37,7 @@ export function createDiscoverCustomModelProviderModelsBySlugRoute(secrets: Agen
     handler: async (request) => {
       const {workspaceId, slug} = request.params;
       requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
       const discoveryParams = await resolveCustomModelProviderDiscoveryParams(
         {

--- a/libs/api/agent/src/presentation/routes/discover-custom-model-provider-models.ts
+++ b/libs/api/agent/src/presentation/routes/discover-custom-model-provider-models.ts
@@ -5,25 +5,37 @@ import {
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {discoverCustomModelProviderModels} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  discoverCustomModelProviderModels,
+} from '#core/index.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export const discoverCustomModelProviderModelsRoute = defineRoute({
-  method: 'POST',
-  path: '/custom-model-providers/discover-models',
-  description: 'Discover models exposed by a custom model provider endpoint',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid()}),
-    body: discoverCustomModelProviderModelsBodySchema,
-    response: {
-      200: discoverCustomModelProviderModelsResponseSchema,
+export function createDiscoverCustomModelProviderModelsRoute(
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
+  return defineRoute({
+    method: 'POST',
+    path: '/custom-model-providers/discover-models',
+    description: 'Discover models exposed by a custom model provider endpoint',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid()}),
+      body: discoverCustomModelProviderModelsBodySchema,
+      response: {
+        200: discoverCustomModelProviderModelsResponseSchema,
+      },
     },
-  },
-  errorHandler: translateModelProviderRouteError,
-  handler: async (request) => {
-    const {workspaceId} = request.params;
-    requireWorkspaceAccess({request, workspaceId});
+    errorHandler: translateModelProviderRouteError,
+    handler: async (request) => {
+      const {workspaceId} = request.params;
+      requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
-    return await discoverCustomModelProviderModels(request.body);
-  },
-});
+      return await discoverCustomModelProviderModels(request.body);
+    },
+  });
+}
+
+export const discoverCustomModelProviderModelsRoute =
+  createDiscoverCustomModelProviderModelsRoute();

--- a/libs/api/agent/src/presentation/routes/errors.ts
+++ b/libs/api/agent/src/presentation/routes/errors.ts
@@ -12,6 +12,7 @@ import {
   ModelProviderConfigNotFoundError,
   ModelProviderValidationError,
   UnsupportedModelProviderError,
+  WorkspaceProvidersDisabledError,
 } from '#core/index.js';
 import {getModelProviderCredentialKeys} from '#core/model-provider-policy.js';
 
@@ -93,6 +94,16 @@ export function translateModelProviderRouteError(error: unknown): never {
     throw new ClientError('Provider is not supported', 'provider-unsupported', {
       status: 422,
       details: {provider_id: error.providerId},
+    });
+  }
+
+  if (error instanceof WorkspaceProvidersDisabledError) {
+    throw new ClientError(error.message, 'workspace-providers-disabled', {
+      status: 422,
+      details: {
+        managed_provider_id: error.managedProviderId,
+        message: error.message,
+      },
     });
   }
 

--- a/libs/api/agent/src/presentation/routes/index.ts
+++ b/libs/api/agent/src/presentation/routes/index.ts
@@ -1,40 +1,58 @@
+import type {ManagedModelProvider, WorkspaceProvidersPolicy} from '@shipfox/api-agent-dto';
 import {AUTH_USER} from '@shipfox/api-auth-context';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {createCustomModelProviderRoute} from './create-custom-model-provider.js';
 import {createDeleteModelProviderConfigRoute} from './delete-model-provider-config.js';
-import {discoverCustomModelProviderModelsRoute} from './discover-custom-model-provider-models.js';
+import {createDiscoverCustomModelProviderModelsRoute} from './discover-custom-model-provider-models.js';
 import {createDiscoverCustomModelProviderModelsBySlugRoute} from './discover-custom-model-provider-models-by-slug.js';
-import {listModelProviderCatalogRoute} from './list-model-provider-catalog.js';
+import {createListModelProviderCatalogRoute} from './list-model-provider-catalog.js';
 import {listModelProviderConfigsRoute} from './list-model-provider-configs.js';
 import {setDefaultHarnessRoute} from './set-default-harness.js';
-import {setDefaultModelProviderRoute} from './set-default-model-provider.js';
+import {createSetDefaultModelProviderRoute} from './set-default-model-provider.js';
 import {createUpdateCustomModelProviderRoute} from './update-custom-model-provider.js';
-import {updateModelProviderDefaultModelRoute} from './update-model-provider-default-model.js';
+import {createUpdateModelProviderDefaultModelRoute} from './update-model-provider-default-model.js';
 import {createUpsertModelProviderConfigRoute} from './upsert-model-provider-config.js';
 
-export function createAgentRoutes(secrets: AgentSecretsClient): RouteGroup[] {
+export function createAgentRoutes(
+  secrets: AgentSecretsClient,
+  options: {
+    managedProvider?: ManagedModelProvider | undefined;
+    workspaceProviders?: WorkspaceProvidersPolicy | undefined;
+  } = {},
+): RouteGroup[] {
+  const workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {
+    workspaceProviders: options.workspaceProviders ?? 'enabled',
+    managedProviderId: options.managedProvider?.id,
+  };
+
   return [
     {
       prefix: '/workspaces/:workspaceId/agent',
       auth: AUTH_USER,
       routes: [
         listModelProviderConfigsRoute,
-        createCustomModelProviderRoute(secrets),
-        discoverCustomModelProviderModelsRoute,
-        createDiscoverCustomModelProviderModelsBySlugRoute(secrets),
-        createUpdateCustomModelProviderRoute(secrets),
-        createUpsertModelProviderConfigRoute(secrets),
-        updateModelProviderDefaultModelRoute,
-        createDeleteModelProviderConfigRoute(secrets),
+        createCustomModelProviderRoute(secrets, workspaceProviderPolicy),
+        createDiscoverCustomModelProviderModelsRoute(workspaceProviderPolicy),
+        createDiscoverCustomModelProviderModelsBySlugRoute(secrets, workspaceProviderPolicy),
+        createUpdateCustomModelProviderRoute(secrets, workspaceProviderPolicy),
+        createUpsertModelProviderConfigRoute(secrets, workspaceProviderPolicy),
+        createUpdateModelProviderDefaultModelRoute(workspaceProviderPolicy),
+        createDeleteModelProviderConfigRoute(secrets, workspaceProviderPolicy),
         setDefaultHarnessRoute,
-        setDefaultModelProviderRoute,
+        createSetDefaultModelProviderRoute(workspaceProviderPolicy),
       ],
     },
     {
       prefix: '/agent',
       auth: AUTH_USER,
-      routes: [listModelProviderCatalogRoute],
+      routes: [
+        createListModelProviderCatalogRoute({
+          managedProvider: options.managedProvider,
+          workspaceProviders: options.workspaceProviders,
+        }),
+      ],
     },
   ];
 }

--- a/libs/api/agent/src/presentation/routes/list-model-provider-catalog.ts
+++ b/libs/api/agent/src/presentation/routes/list-model-provider-catalog.ts
@@ -1,15 +1,36 @@
-import {modelProviderCatalogResponseSchema} from '@shipfox/api-agent-dto';
+import {
+  type ManagedModelProvider,
+  modelProviderCatalogResponseSchema,
+  type WorkspaceProvidersPolicy,
+} from '@shipfox/api-agent-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {buildModelProviderCatalog} from '#core/index.js';
 
-export const listModelProviderCatalogRoute = defineRoute({
-  method: 'GET',
-  path: '/model-provider-catalog',
-  description: 'List available model providers and models',
-  schema: {
-    response: {
-      200: modelProviderCatalogResponseSchema,
+export function createListModelProviderCatalogRoute(
+  options: {
+    managedProvider?: ManagedModelProvider | undefined;
+    workspaceProviders?: WorkspaceProvidersPolicy | undefined;
+  } = {},
+) {
+  const workspaceProviders = options.workspaceProviders ?? 'enabled';
+
+  return defineRoute({
+    method: 'GET',
+    path: '/model-provider-catalog',
+    description: 'List available model providers and models',
+    schema: {
+      response: {
+        200: modelProviderCatalogResponseSchema,
+      },
     },
-  },
-  handler: () => ({providers: buildModelProviderCatalog()}),
-});
+    handler: () => ({
+      providers: buildModelProviderCatalog({
+        managedProvider: options.managedProvider,
+        workspaceProviders,
+      }),
+      workspace_providers: workspaceProviders,
+    }),
+  });
+}
+
+export const listModelProviderCatalogRoute = createListModelProviderCatalogRoute();

--- a/libs/api/agent/src/presentation/routes/model-provider-catalog.test.ts
+++ b/libs/api/agent/src/presentation/routes/model-provider-catalog.test.ts
@@ -1,7 +1,8 @@
+import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
 import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
 import type {AuthMethod, FastifyRequest} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
-import {agentRoutes} from './index.js';
+import {agentRoutes, createAgentRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -69,5 +70,52 @@ describe('model provider catalog route', () => {
         }
       }
     });
+
+    it('returns only the managed provider and the disabled policy when configured', async () => {
+      await closeApp();
+      app = await createApp({
+        auth: [fakeUserAuth],
+        routes: createAgentRoutes(undefined as never, {
+          managedProvider: managedProvider(),
+          workspaceProviders: 'disabled',
+        }),
+        swagger: false,
+      });
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/agent/model-provider-catalog',
+        headers: {authorization: 'Bearer user'},
+      });
+
+      expect(res.statusCode, res.body).toBe(200);
+      expect(res.json()).toMatchObject({
+        workspace_providers: 'disabled',
+        providers: [
+          expect.objectContaining({
+            id: 'shipfox',
+            support_status: 'supported',
+            default_model: 'managed-claude',
+            credential_fields: [],
+            models: [{id: 'managed-claude', label: 'Managed Claude'}],
+          }),
+        ],
+      });
+    });
   });
 });
+
+function managedProvider(): ManagedModelProvider {
+  return {
+    id: 'shipfox',
+    label: 'Shipfox',
+    models: [{id: 'managed-claude', label: 'Managed Claude', api: 'anthropic-messages'}],
+    defaultModel: 'managed-claude',
+    resolveCredentials: async () => ({
+      api: 'anthropic-messages',
+      baseUrl: 'https://gateway.example.com',
+      credentials: {api_key: 'token'},
+    }),
+  };
+}

--- a/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
@@ -20,7 +20,7 @@ import {
 } from '#db/index.js';
 import {modelProviderConfigs} from '#db/schema/model-provider-configs.js';
 import {getSecretsByNamespace, setSecrets} from '#test/fixtures/secrets-client.js';
-import {agentRoutes} from './index.js';
+import {agentRoutes, createAgentRoutes} from './index.js';
 
 vi.mock('@earendil-works/pi-ai/compat', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@earendil-works/pi-ai/compat')>();
@@ -390,6 +390,53 @@ describe('model provider config routes', () => {
       });
 
       expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects catalog and custom provider writes when workspace providers are disabled', async () => {
+      await closeApp();
+      app = await createApp({
+        auth: [fakeUserAuth],
+        routes: createAgentRoutes(undefined as never, {
+          managedProvider: managedProvider(),
+          workspaceProviders: 'disabled',
+        }),
+        swagger: false,
+      });
+      await app.ready();
+
+      const catalogWrite = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/model-providers/anthropic`,
+        headers: {authorization: 'Bearer user'},
+        payload: {credentials: {api_key: 'sk-secret'}},
+      });
+      const customWrite = await app.inject({
+        method: 'POST',
+        url: `/workspaces/${workspaceId}/agent/custom-model-providers`,
+        headers: {authorization: 'Bearer user'},
+        payload: {
+          slug: 'local-vllm',
+          display_name: 'Local vLLM',
+          api: 'openai-responses',
+          base_url: 'http://127.0.0.1:11434/v1',
+          models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+        },
+      });
+
+      expect(catalogWrite.statusCode).toBe(422);
+      expect(customWrite.statusCode).toBe(422);
+      expect(catalogWrite.json()).toMatchObject({
+        code: 'workspace-providers-disabled',
+        details: {
+          message: 'This instance only supports provider `shipfox`.',
+        },
+      });
+      expect(customWrite.json()).toMatchObject({
+        code: 'workspace-providers-disabled',
+        details: {
+          message: 'This instance only supports provider `shipfox`.',
+        },
+      });
     });
   });
 
@@ -803,5 +850,19 @@ describe('model provider config routes', () => {
       values: {API_KEY: 'seeded-secret'},
     });
     expect(rows).toHaveLength(1);
+  }
+
+  function managedProvider() {
+    return {
+      id: 'shipfox',
+      label: 'Shipfox',
+      models: [{id: 'managed-claude', label: 'Managed Claude', api: 'anthropic-messages' as const}],
+      defaultModel: 'managed-claude',
+      resolveCredentials: async () => ({
+        api: 'anthropic-messages' as const,
+        baseUrl: 'https://gateway.example.com',
+        credentials: {api_key: 'token'},
+      }),
+    };
   }
 });

--- a/libs/api/agent/src/presentation/routes/set-default-model-provider.ts
+++ b/libs/api/agent/src/presentation/routes/set-default-model-provider.ts
@@ -5,43 +5,54 @@ import {
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {UnsupportedModelProviderError} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  UnsupportedModelProviderError,
+} from '#core/index.js';
 import {getModelProviderEntry} from '#core/model-provider-policy.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {getModelProviderConfig, setDefaultModelProvider} from '#db/index.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export const setDefaultModelProviderRoute = defineRoute({
-  method: 'PUT',
-  path: '/default-model-provider',
-  description: 'Set the default model provider for a workspace',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid()}),
-    body: setDefaultModelProviderBodySchema,
-    response: {
-      200: setDefaultModelProviderResponseSchema,
+export function createSetDefaultModelProviderRoute(
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
+  return defineRoute({
+    method: 'PUT',
+    path: '/default-model-provider',
+    description: 'Set the default model provider for a workspace',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid()}),
+      body: setDefaultModelProviderBodySchema,
+      response: {
+        200: setDefaultModelProviderResponseSchema,
+      },
     },
-  },
-  errorHandler: translateModelProviderRouteError,
-  handler: async (request) => {
-    const {workspaceId} = request.params;
-    requireWorkspaceAccess({request, workspaceId});
+    errorHandler: translateModelProviderRouteError,
+    handler: async (request) => {
+      const {workspaceId} = request.params;
+      requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
-    const existingConfig = await getModelProviderConfig({
-      workspaceId,
-      providerId: request.body.provider_id,
-    });
-    if (existingConfig?.kind !== 'custom') {
-      const entry = getModelProviderEntry(request.body.provider_id);
-      if (entry === undefined || entry.support_status !== 'supported') {
-        throw new UnsupportedModelProviderError(request.body.provider_id);
+      const existingConfig = await getModelProviderConfig({
+        workspaceId,
+        providerId: request.body.provider_id,
+      });
+      if (existingConfig?.kind !== 'custom') {
+        const entry = getModelProviderEntry(request.body.provider_id);
+        if (entry === undefined || entry.support_status !== 'supported') {
+          throw new UnsupportedModelProviderError(request.body.provider_id);
+        }
       }
-    }
 
-    const settings = await setDefaultModelProvider({
-      workspaceId,
-      providerId: request.body.provider_id,
-    });
+      const settings = await setDefaultModelProvider({
+        workspaceId,
+        providerId: request.body.provider_id,
+      });
 
-    return {default_provider_id: settings.defaultProviderId};
-  },
-});
+      return {default_provider_id: settings.defaultProviderId};
+    },
+  });
+}
+
+export const setDefaultModelProviderRoute = createSetDefaultModelProviderRoute();

--- a/libs/api/agent/src/presentation/routes/update-custom-model-provider.ts
+++ b/libs/api/agent/src/presentation/routes/update-custom-model-provider.ts
@@ -6,12 +6,19 @@ import {
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {updateCustomModelProviderConfig} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  updateCustomModelProviderConfig,
+} from '#core/index.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {toCustomModelProviderConfigDto} from '#presentation/dto/index.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export function createUpdateCustomModelProviderRoute(secrets: AgentSecretsClient) {
+export function createUpdateCustomModelProviderRoute(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
   return defineRoute({
     method: 'PUT',
     path: '/custom-model-providers/:slug',
@@ -39,6 +46,7 @@ export function createUpdateCustomModelProviderRoute(secrets: AgentSecretsClient
       });
 
       requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
       const config = await updateCustomModelProviderConfig(
         {

--- a/libs/api/agent/src/presentation/routes/update-model-provider-default-model.ts
+++ b/libs/api/agent/src/presentation/routes/update-model-provider-default-model.ts
@@ -6,35 +6,46 @@ import {
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {updateModelProviderConfigDefaultModel} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  updateModelProviderConfigDefaultModel,
+} from '#core/index.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {toModelProviderConfigResponseDto} from '#presentation/dto/index.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export const updateModelProviderDefaultModelRoute = defineRoute({
-  method: 'PUT',
-  path: '/model-providers/:providerId/default-model',
-  description: 'Update the default model for an existing model provider configuration',
-  schema: {
-    params: z.object({
-      workspaceId: z.string().uuid(),
-      providerId: modelProviderRefSchema,
-    }),
-    body: updateModelProviderDefaultModelBodySchema,
-    response: {
-      200: modelProviderConfigResponseSchema,
+export function createUpdateModelProviderDefaultModelRoute(
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
+  return defineRoute({
+    method: 'PUT',
+    path: '/model-providers/:providerId/default-model',
+    description: 'Update the default model for an existing model provider configuration',
+    schema: {
+      params: z.object({
+        workspaceId: z.string().uuid(),
+        providerId: modelProviderRefSchema,
+      }),
+      body: updateModelProviderDefaultModelBodySchema,
+      response: {
+        200: modelProviderConfigResponseSchema,
+      },
     },
-  },
-  errorHandler: translateModelProviderRouteError,
-  handler: async (request) => {
-    const {workspaceId, providerId} = request.params;
-    requireWorkspaceAccess({request, workspaceId});
+    errorHandler: translateModelProviderRouteError,
+    handler: async (request) => {
+      const {workspaceId, providerId} = request.params;
+      requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
-    const config = await updateModelProviderConfigDefaultModel({
-      workspaceId,
-      providerId,
-      defaultModel: request.body.default_model,
-    });
+      const config = await updateModelProviderConfigDefaultModel({
+        workspaceId,
+        providerId,
+        defaultModel: request.body.default_model,
+      });
 
-    return toModelProviderConfigResponseDto(config);
-  },
-});
+      return toModelProviderConfigResponseDto(config);
+    },
+  });
+}
+
+export const updateModelProviderDefaultModelRoute = createUpdateModelProviderDefaultModelRoute();

--- a/libs/api/agent/src/presentation/routes/upsert-model-provider-config.ts
+++ b/libs/api/agent/src/presentation/routes/upsert-model-provider-config.ts
@@ -6,12 +6,19 @@ import {
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {testAndSaveModelProviderConfig} from '#core/index.js';
+import {
+  assertWorkspaceProviderConfigurationEnabled,
+  testAndSaveModelProviderConfig,
+} from '#core/index.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import type {WorkspaceProviderPolicyOptions} from '#core/workspace-provider-policy.js';
 import {toModelProviderConfigDto} from '#presentation/dto/index.js';
 import {translateModelProviderRouteError} from './errors.js';
 
-export function createUpsertModelProviderConfigRoute(secrets: AgentSecretsClient) {
+export function createUpsertModelProviderConfigRoute(
+  secrets: AgentSecretsClient,
+  workspaceProviderPolicy: WorkspaceProviderPolicyOptions = {workspaceProviders: 'enabled'},
+) {
   return defineRoute({
     method: 'PUT',
     path: '/model-providers/:providerId',
@@ -39,6 +46,7 @@ export function createUpsertModelProviderConfigRoute(secrets: AgentSecretsClient
       });
 
       const membership = requireWorkspaceAccess({request, workspaceId});
+      assertWorkspaceProviderConfigurationEnabled(workspaceProviderPolicy);
 
       const config = await testAndSaveModelProviderConfig(
         {


### PR DESCRIPTION
Adds the instance-level workspace-provider policy required for managed hosted inference.

When `AGENT_WORKSPACE_PROVIDERS=disabled`, the agent requires an injected managed provider, resolves it as the only provider, exposes only it in validation and catalog responses, rejects workspace provider configuration writes, and fails closed before workspace or instance-fallback credentials are read. The default `enabled` path preserves existing behavior. DTO/inter-module contracts and a Changeset are included.

Validation passed with the agent dependency-closure typecheck, check, and dependency-cruise tasks; agent tests (203), DTO tests (121), and client-agent dependency-closure typecheck. `git diff --check` also passed.

Closes ENG-1600

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces an instance-level workspace-provider policy for managed-only hosted inference. Previously workspaces could configure any provider; with AGENT_WORKSPACE_PROVIDERS=disabled the agent exposes only the injected managed provider, defaults resolution to it, and blocks provider writes and non‑managed usage; the default enabled path preserves current behavior.

- Config & policy: adds AGENT_WORKSPACE_PROVIDERS (default enabled); when disabled, requires an injected managed provider and rejects a foreign instance default with WorkspaceProvidersDisabledError; exports `workspaceProvidersPolicy`.
- DTO/contract: adds `WorkspaceProvidersPolicy`; catalog response includes optional `workspace_providers`; catalog entry IDs accept `modelProviderRef` (enables managed IDs); `resolveAgentConfig` known error now includes optional `message` and `managed_provider_id`.
- Catalog/validation: `buildModelProviderCatalog` accepts `{managedProvider, workspaceProviders}`, deep‑freezes injected entries, and returns managed‑only when disabled; validation catalog accepts the policy and restricts providers/models to managed‑only when disabled.
- Resolution/credentials: `resolveAgentConfig` defaults to managed provider and rejects foreign provider refs when disabled; `resolveRuntimeCredentials` refuses workspace credentials and instance fallback in disabled mode.
- Presentation: all provider‑management and discovery routes gate on the policy and return 422 `workspace-providers-disabled` with `managed_provider_id`; `list-model-provider-catalog` includes `workspace_providers` and honors managed‑only; inter‑module and E2E presentations pass the policy through.
- Rollout: set AGENT_WORKSPACE_PROVIDERS=disabled only if a managed provider is injected; DTO changes are additive and require no client migration. Bumps `@shipfox/api-agent` and `@shipfox/api-agent-dto` minor. Addresses ENG-1600.

<sup>Written for commit 1260682447fb403b4333ef314e567b8c3a9d24d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

