### PR TITLE
[runner] Route per-step Claude gateway credentials

### DIFF
--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -316,6 +316,40 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions().mcpServers).toBeUndefined();
   });
 
+  it('uses per-step Claude runtime credentials before the instance-wide override', async () => {
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
+    configMock.AGENT_CLAUDE_ANTHROPIC_MODEL = 'instance-model';
+    queryMock.mockReturnValue(makeQuery([successMessage]));
+
+    await claudeHarnessAdapter.run(
+      invocation({
+        credentials: {api_key: 'workspace-token'},
+        claude: {
+          base_url: 'https://gateway.example.test/v1',
+          auth_token: 'managed-token',
+        },
+      }),
+    );
+
+    expect(assertEgressAllowedMock).toHaveBeenCalledWith(
+      'https://gateway.example.test/v1',
+      expect.objectContaining({allowPrivateNetworks: true}),
+    );
+    expect(queryMock).toHaveBeenCalledWith({
+      prompt: expect.any(Object),
+      options: expect.objectContaining({
+        model: 'claude-opus-4-8',
+        env: expect.objectContaining({
+          ANTHROPIC_API_KEY: '',
+          ANTHROPIC_AUTH_TOKEN: 'managed-token',
+          ANTHROPIC_BASE_URL: 'https://gateway.example.test/v1',
+        }),
+      }),
+    });
+    expect(lastQueryOptions()).not.toHaveProperty('tools');
+    expect(lastQueryOptions().env).not.toHaveProperty('ANTHROPIC_MODEL');
+  });
+
   it('keeps integration bridges available with the Anthropic base URL override', async () => {
     configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
     const bridge = mcpBridge();
@@ -378,6 +412,30 @@ describe('claudeHarnessAdapter', () => {
     await expect(result).rejects.toThrow(
       new AgentConfigError(
         'Claude Anthropic base URL override blocked by egress policy: host-denied (blocked.example.test).',
+        'step_config_invalid',
+      ),
+    );
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('maps per-step endpoint egress denial to AgentConfigError', async () => {
+    assertEgressAllowedMock.mockRejectedValue(
+      new EgressDeniedErrorMock('host-denied', 'gateway.example.test'),
+    );
+
+    const result = claudeHarnessAdapter.run(
+      invocation({
+        credentials: {},
+        claude: {
+          base_url: 'https://gateway.example.test/v1',
+          auth_token: 'managed-token',
+        },
+      }),
+    );
+
+    await expect(result).rejects.toThrow(
+      new AgentConfigError(
+        'Claude Anthropic per-step endpoint blocked by egress policy: host-denied (gateway.example.test).',
         'step_config_invalid',
       ),
     );

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -37,6 +37,8 @@ interface ClaudeAnthropicOverride {
   readonly baseUrl: string;
   readonly model: string | undefined;
   readonly smallFastModel: string | undefined;
+  readonly authToken: string;
+  readonly disableDefaultTools: boolean;
 }
 
 interface ClaudeAuth {
@@ -76,11 +78,15 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     );
   }
 
-  const override = claudeAnthropicOverride();
+  const override = claudeAnthropicOverride(invocation.claude);
   const auth = claudeAuth(credentials, override);
   const targetUrl = override?.baseUrl ?? ANTHROPIC_API_URL;
   const targetLabel =
-    override === undefined ? 'Claude Anthropic API endpoint' : 'Claude Anthropic base URL override';
+    invocation.claude !== undefined
+      ? 'Claude Anthropic per-step endpoint'
+      : override === undefined
+        ? 'Claude Anthropic API endpoint'
+        : 'Claude Anthropic base URL override';
   const hasDeclaredOutputs =
     invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
   const useOutputTools = hasDeclaredOutputs;
@@ -192,7 +198,7 @@ function claudeToolsOption(
   override: ClaudeAnthropicOverride | undefined,
 ): {readonly tools?: string[]} {
   if (tools !== undefined) return {tools: [...tools]};
-  return override === undefined ? {} : {tools: []};
+  return override?.disableDefaultTools === true ? {tools: []} : {};
 }
 
 function setOutputTool(collector: OutputCollector) {
@@ -443,13 +449,27 @@ function claudeEnvironment(
   };
 }
 
-function claudeAnthropicOverride(): ClaudeAnthropicOverride | undefined {
+function claudeAnthropicOverride(
+  runtimeConfig: HarnessInvocation['claude'],
+): ClaudeAnthropicOverride | undefined {
+  if (runtimeConfig !== undefined) {
+    return {
+      baseUrl: runtimeConfig.base_url,
+      model: undefined,
+      smallFastModel: undefined,
+      authToken: runtimeConfig.auth_token,
+      disableDefaultTools: false,
+    };
+  }
+
   if (config.AGENT_CLAUDE_ANTHROPIC_BASE_URL === undefined) return undefined;
 
   return {
     baseUrl: config.AGENT_CLAUDE_ANTHROPIC_BASE_URL,
     model: config.AGENT_CLAUDE_ANTHROPIC_MODEL,
     smallFastModel: config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL,
+    authToken: OLLAMA_ANTHROPIC_AUTH_TOKEN,
+    disableDefaultTools: true,
   };
 }
 
@@ -458,7 +478,7 @@ function claudeAuth(
   override: ClaudeAnthropicOverride | undefined,
 ): ClaudeAuth {
   if (override !== undefined) {
-    return {apiKey: '', authToken: OLLAMA_ANTHROPIC_AUTH_TOKEN};
+    return {apiKey: '', authToken: override.authToken};
   }
 
   const apiKey = credentials.api_key;

--- a/libs/runner/agent/src/core/harness.ts
+++ b/libs/runner/agent/src/core/harness.ts
@@ -1,4 +1,7 @@
-import type {CustomModelProviderRuntimeConfigDto} from '@shipfox/api-agent-dto';
+import type {
+  ClaudeRuntimeConfigDto,
+  CustomModelProviderRuntimeConfigDto,
+} from '@shipfox/api-agent-dto';
 import type {OutputDeclarations} from '@shipfox/expression';
 import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 
@@ -17,6 +20,7 @@ export interface HarnessInvocation {
   readonly outputs?: OutputDeclarations | undefined;
   readonly credentials: Record<string, string>;
   readonly customProvider?: CustomModelProviderRuntimeConfigDto | undefined;
+  readonly claude?: ClaudeRuntimeConfigDto | undefined;
   readonly gitConfigGlobal?: string | undefined;
   readonly signal: AbortSignal;
   /** Forwards each verbatim session entry line as persisted, in order. Best-effort. */

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -319,6 +319,24 @@ describe('executeAgentStep', () => {
     );
   });
 
+  it('forwards Claude runtime config to the agent invocation', async () => {
+    runClaudeMock.mockResolvedValue({});
+    const claude = {
+      base_url: 'https://gateway.example.test/v1',
+      auth_token: 'managed-token',
+    };
+
+    await executeAgentStep(buildAgentStep({config: {prompt: 'p'}}), {
+      runtime: {
+        ...RUNTIME,
+        harness: 'claude',
+        claude,
+      },
+    });
+
+    expect(runClaudeMock).toHaveBeenCalledWith(expect.objectContaining({claude}));
+  });
+
   it('forwards the ambient git config path to the agent invocation', async () => {
     runAgentMock.mockResolvedValue({});
 

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -1,6 +1,7 @@
 import {
   type AgentIntegrationMcpServerConfigDto,
   agentIntegrationMcpServerSchema,
+  type ClaudeRuntimeConfigDto,
   type CustomModelProviderRuntimeConfigDto,
   type Harness,
 } from '@shipfox/api-agent-dto';
@@ -45,6 +46,7 @@ export async function executeAgentStep(
       thinking: string;
       credentials: Record<string, string>;
       custom_provider?: CustomModelProviderRuntimeConfigDto | undefined;
+      claude?: ClaudeRuntimeConfigDto | undefined;
     };
     gitConfigGlobal?: string | undefined;
     onSessionEntry?: (line: string) => void;
@@ -110,6 +112,7 @@ export async function executeAgentStep(
       provider: options.runtime.provider,
       credentials: options.runtime.credentials,
       customProvider: options.runtime.custom_provider,
+      ...(options.runtime.claude === undefined ? {} : {claude: options.runtime.claude}),
       signal: options.signal,
       gitConfigGlobal: options.gitConfigGlobal,
       onSessionEntry: options.onSessionEntry,
@@ -135,6 +138,7 @@ async function runSelectedHarness(params: {
   provider: string;
   credentials: Record<string, string>;
   customProvider: CustomModelProviderRuntimeConfigDto | undefined;
+  claude?: ClaudeRuntimeConfigDto | undefined;
   signal: AbortSignal | undefined;
   gitConfigGlobal: string | undefined;
   onSessionEntry: ((line: string) => void) | undefined;
@@ -155,6 +159,7 @@ async function runSelectedHarness(params: {
     provider,
     credentials,
     customProvider,
+    claude,
     gitConfigGlobal,
     onSessionEntry,
   } = params;
@@ -175,6 +180,7 @@ async function runSelectedHarness(params: {
         outputs,
         credentials,
         customProvider,
+        ...(claude === undefined ? {} : {claude}),
         signal,
         ...(gitConfigGlobal ? {gitConfigGlobal} : {}),
         ...(onSessionEntry ? {onSessionEntry} : {}),

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1779,6 +1779,45 @@ describe('runJobSteps', () => {
     );
   });
 
+  it('forwards Claude per-step runtime config to the agent step', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep();
+    const claude = {
+      base_url: 'https://gateway.example.test/v1',
+      auth_token: 'managed-token',
+    };
+    requestAgentRuntimeConfigMock.mockResolvedValueOnce({
+      harness: 'claude',
+      provider_id: 'shipfox',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+      credentials: {api_key: 'managed-token'},
+      claude,
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeAgentStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeAgentStepMock).toHaveBeenCalledWith(
+      agent,
+      expect.objectContaining({
+        runtime: {
+          harness: 'claude',
+          provider: 'shipfox',
+          model: 'claude-opus-4-8',
+          thinking: 'high',
+          credentials: {api_key: 'managed-token'},
+          claude,
+        },
+      }),
+    );
+  });
+
   it('opens a session stream for an agent step, forwards entries, and settles it', async () => {
     const setup = buildSetupStep();
     const agent = buildAgentStep();

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -517,6 +517,7 @@ export async function executeStep(params: {
           ...(runtimeConfig.custom_provider
             ? {custom_provider: runtimeConfig.custom_provider}
             : {}),
+          ...(runtimeConfig.claude !== undefined ? {claude: runtimeConfig.claude} : {}),
         },
         leaseToken,
         integrationToolsGatewayUrl: integrationToolsGatewayUrl(),


### PR DESCRIPTION
Managed runtime credentials already include the per-step Claude gateway URL and token, but the runner was dropping the `claude` response block before invoking the harness.

This change carries that config through orchestration and the harness invocation, sets the per-step `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` with precedence over instance-wide overrides, and applies the runner egress guard. Instance-wide Ollama override behavior and the Pi adapter remain unchanged.

Closes ENG-1604

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes per-step Claude gateway URL and token through the runner and prefers them over instance-wide overrides. This lets each step target a managed Claude gateway and enforces egress policy on that endpoint.

- Preserves the `claude` runtime block and forwards it from orchestration to `executeAgentStep` and into the Claude harness.
- Claude adapter now:
  - Uses per-step `base_url` and `auth_token` with highest priority; sets `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` and clears `ANTHROPIC_API_KEY`.
  - Applies the runner egress guard to the chosen endpoint; on denial, throws an AgentConfigError with code `step_config_invalid` and skips the query.
  - Keeps default tools enabled for per-step config; continues to disable default tools when using the instance-wide `AGENT_CLAUDE_ANTHROPIC_BASE_URL`.
- Instance-wide Ollama override behavior and the Pi adapter are unchanged. Satisfies ENG-1604.

<sup>Written for commit 8393b965cd8ee49dee6861f66500949d2fbd8bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

