### PR TITLE
[runner-image] Emit boot I/O samples to the serial console

### DIFF
--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -5,6 +5,7 @@ Wants=network-online.target shipfox-runner.target
 
 [Service]
 Type=oneshot
+StandardOutput=journal+console
 ExecStartPre=/bin/sh -c '/usr/bin/timeout 5s /opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'
 ExecStart=/usr/bin/test -s /etc/shipfox/runner.env
 RemainAfterExit=yes

--- a/infra/images/runner/scripts/runtime/record-boot-io.sh
+++ b/infra/images/runner/scripts/runtime/record-boot-io.sh
@@ -1,6 +1,47 @@
 #!/usr/bin/env sh
 set -eu
 
+root_source=''
+root_device=''
+read_ops=''
+read_sectors=''
+uptime_seconds=''
+temporary_path=''
+boot_io_marker_emitted=0
+
+emit_boot_io_marker() {
+  if [ "$boot_io_marker_emitted" -eq 1 ]; then
+    return 0
+  fi
+
+  if [ -z "$uptime_seconds" ]; then
+    uptime_seconds="$(awk '{print $1}' /proc/uptime 2>/dev/null || printf 'unknown')"
+  fi
+
+  boot_io_marker_emitted=1
+  if [ "$1" = ok ]; then
+    printf 'shipfox-boot phase=boot-io status=ok uptime=%s root_device=%s read_ops=%s read_sectors=%s\n' \
+      "$uptime_seconds" "$root_device" "$read_ops" "$read_sectors"
+  else
+    printf 'shipfox-boot phase=boot-io status=fail uptime=%s\n' "$uptime_seconds"
+  fi
+}
+
+on_exit() {
+  if [ -n "$temporary_path" ]; then
+    rm -f "$temporary_path" || true
+  fi
+  emit_boot_io_marker fail
+}
+
+on_signal() {
+  emit_boot_io_marker fail
+  exit 124
+}
+
+trap on_exit EXIT
+trap on_signal HUP INT TERM
+
 root_source="$(findmnt -no SOURCE / || true)"
 root_device="$(lsblk -no PKNAME "$root_source" 2>/dev/null | head -n1 | tr -d '[:space:]' || true)"
 if [ -z "$root_device" ]; then
@@ -18,11 +59,11 @@ uptime_seconds="$(awk '{print $1}' /proc/uptime)"
 
 install -d -m 0755 /run/shipfox
 if [ -e /run/shipfox/boot-io ]; then
+  boot_io_marker_emitted=1
   exit 0
 fi
 
 temporary_path="$(mktemp /run/shipfox/boot-io.XXXXXX)"
-trap 'rm -f "$temporary_path"' EXIT
 cat > "$temporary_path" <<EOF
 root_device=$root_device
 read_ops=$read_ops
@@ -32,10 +73,12 @@ EOF
 chmod 0644 "$temporary_path"
 if ! ln -- "$temporary_path" /run/shipfox/boot-io 2>/dev/null; then
   if [ -e /run/shipfox/boot-io ]; then
+    boot_io_marker_emitted=1
     exit 0
   fi
   printf 'runner boot telemetry: failed to publish the boot I/O sample\n' >&2
   exit 1
 fi
 rm -f "$temporary_path"
-trap - EXIT
+temporary_path=''
+emit_boot_io_marker ok

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1038,6 +1038,7 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Service', 'ExecStartPre')).toBe(
       "/bin/sh -c '/usr/bin/timeout 5s /opt/shipfox-runner/scripts/runtime/record-boot-io.sh || true'",
     );
+    expect(systemdDirective(unit, 'Service', 'StandardOutput')).toBe('journal+console');
     expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
       '/usr/bin/test -s /etc/shipfox/runner.env',
     );
@@ -1181,6 +1182,16 @@ printf '%s %s\\n' "$root_disk_name" "$root_partition_number"
     expect(source).toContain('read -r read_ops _ read_sectors _');
     expect(source).toContain('/sys/block/$root_device/stat');
     expect(source).toContain('/run/shipfox/boot-io');
+    expect(source).toContain('trap on_exit EXIT');
+    expect(source).toContain('trap on_signal HUP INT TERM');
+    expect(source).toContain('emit_boot_io_marker ok');
+    expect(source).toContain('emit_boot_io_marker fail');
+    expect(source).toContain(
+      "printf 'shipfox-boot phase=boot-io status=ok uptime=%s root_device=%s read_ops=%s read_sectors=%s\\n'",
+    );
+    expect(source).toContain(
+      'printf \'shipfox-boot phase=boot-io status=fail uptime=%s\\n\' "$uptime_seconds"',
+    );
     expect(build).toContain(
       'record-boot-io.sh /opt/shipfox-runner/scripts/runtime/record-boot-io.sh',
     );


### PR DESCRIPTION
Boot I/O counters were measured before runner startup but disappeared into the volatile journal. This exposes the sample as a parseable `shipfox-boot` serial marker, emits a failure marker when sampling exits or times out, and routes the environment gate's stdout to the serial console. The marker preserves raw read operation and sector counters for later analysis.

Closes ENG-1612

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a parseable boot I/O sample to the serial console so it survives volatile journald loss. Previously we measured counters before runner startup but they were lost; now we emit a `shipfox-boot` marker with read stats and a failure marker on timeout or early exit. Supports ENG-1612 by exposing boot I/O for post-boot diagnostics.

- `record-boot-io.sh` emits exactly one `shipfox-boot` line: status=ok with `uptime`, `root_device`, `read_ops`, `read_sectors`, or status=fail with `uptime`; traps EXIT/HUP/INT/TERM to emit fail.
- Publishes the sample to `/run/shipfox/boot-io` via a temp file and link; exits early if the sample already exists.
- Routes `shipfox-runner-env` stdout to `journal+console` so markers reach the serial console; keeps the 5s `ExecStartPre` timeout.
- Updates tests to assert the new serial markers and unit output behavior.

<sup>Written for commit 8ae7a835fda4a19033f85b1ada0c02b20897a451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

