### PR TITLE
[runner-image] Fix bootstrap on maximal root partitions

### DIFF
--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -168,20 +168,38 @@ grow_root_filesystem() {
     abort_boot 'Unable to identify the root partition.'
   fi
   root_disk="/dev/$root_disk_name"
-  root_disk_size="$(blockdev --getsize64 "$root_disk" 2>/dev/null || true)"
-  root_partition_size="$(blockdev --getsize64 "$root_source" 2>/dev/null || true)"
-  if [ -z "$root_disk_size" ] || [ -z "$root_partition_size" ]; then
+  root_disk_size="$(cat "/sys/block/$root_disk_name/size" 2>/dev/null || true)"
+  root_partition_start="$(cat "/sys/block/$root_disk_name/$root_partition_name/start" 2>/dev/null || true)"
+  root_partition_size="$(cat "/sys/block/$root_disk_name/$root_partition_name/size" 2>/dev/null || true)"
+  if [ -z "$root_disk_size" ] || [ -z "$root_partition_start" ] || [ -z "$root_partition_size" ]; then
     abort_boot 'Unable to measure the root partition.'
   fi
-  if [ "$root_disk_size" -le "$root_partition_size" ]; then
+  root_partition_end=$((root_partition_start + root_partition_size))
+  if [ $((root_disk_size - root_partition_end)) -lt 2048 ]; then
     return
   fi
 
   if ! command -v growpart >/dev/null 2>&1; then
     abort_boot 'growpart is not installed.'
   fi
-  if ! growpart "$root_disk" "$root_partition_number"; then
-    abort_boot 'Unable to grow the root partition.'
+  growpart_output=''
+  growpart_status=0
+  if growpart_output="$(growpart "$root_disk" "$root_partition_number" 2>&1)"; then
+    growpart_status=0
+  else
+    growpart_status=$?
+  fi
+  if [ -n "$growpart_output" ]; then
+    printf '%s\n' "$growpart_output"
+  fi
+  if [ "$growpart_status" -ne 0 ]; then
+    case "$growpart_output" in
+      *NOCHANGE*)
+        ;;
+      *)
+        abort_boot 'Unable to grow the root partition.'
+        ;;
+    esac
   fi
   if ! resize2fs "$root_source"; then
     abort_boot 'Unable to grow the root filesystem.'

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1113,7 +1113,18 @@ describe('systemd boot activation', () => {
     expect(source).toContain('--verify-root-partition');
     expect(source).toContain('shipfox bootstrap whole-disk root verified: %s');
     expect(source).not.toContain('SHIPFOX_BOOTSTRAP_LIBRARY');
+    expect(source).toContain('root_disk_size="$(cat "/sys/block/$root_disk_name/size"');
+    expect(source).toContain(
+      'root_partition_start="$(cat "/sys/block/$root_disk_name/$root_partition_name/start"',
+    );
+    expect(source).toContain(
+      'root_partition_size="$(cat "/sys/block/$root_disk_name/$root_partition_name/size"',
+    );
+    expect(source).toContain('root_partition_end=$((root_partition_start + root_partition_size))');
+    expect(source).toContain('if [ $((root_disk_size - root_partition_end)) -lt 2048 ]; then');
     expect(source).toContain('growpart "$root_disk" "$root_partition_number"');
+    expect(source).toContain('2>&1)"; then');
+    expect(source).toContain('*NOCHANGE*)');
     expect(source).toContain('resize2fs "$root_source"');
     expect(source).toContain('mkfs.ext4 -F -E lazy_itable_init=1,lazy_journal_init=1');
     expect(source).toContain('install -m 0600 -o root -g root');
@@ -1165,6 +1176,112 @@ printf '%s %s\\n' "$root_disk_name" "$root_partition_number"
     );
 
     expect(result).toBe('nvme0n1 4\n');
+  });
+
+  it('skips a maximal root partition and tolerates growpart NOCHANGE', async () => {
+    const script = new URL('../scripts/runtime/shipfox-bootstrap.sh', import.meta.url);
+    const source = await readFile(script, 'utf8');
+    const functionStart = source.indexOf('grow_root_filesystem() {');
+    const functionEnd = source.indexOf('\nresolve_workspace_device() {', functionStart);
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(functionEnd).toBeGreaterThan(functionStart);
+
+    const root = await mkdtemp(join(tmpdir(), 'shipfox-root-growth-'));
+    const commandDirectory = join(root, 'commands');
+    const commandLog = join(root, 'command.log');
+    await mkdir(commandDirectory, {recursive: true});
+    await writeExecutable(
+      join(commandDirectory, 'growpart'),
+      `#!/bin/sh
+set -eu
+printf 'growpart %s\\n' "$RUNNER_IMAGE_GROW_SCENARIO" >> "$RUNNER_IMAGE_GROW_LOG"
+case "$RUNNER_IMAGE_GROW_SCENARIO" in
+  nochange)
+    printf '%s\\n' 'NOCHANGE: partition 1 is already at maximum size' >&2
+    exit 1
+    ;;
+  grow)
+    printf '%s\\n' 'CHANGED: partition 1 grown'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`,
+    );
+    await writeExecutable(
+      join(commandDirectory, 'resize2fs'),
+      `#!/bin/sh
+set -eu
+printf 'resize2fs %s %s\\n' "$RUNNER_IMAGE_GROW_SCENARIO" "$1" >> "$RUNNER_IMAGE_GROW_LOG"
+`,
+    );
+
+    const harness = `set -eu
+${source.slice(functionStart, functionEnd)}
+resolve_root_source() {
+  root_source='/dev/nvme0n1p1'
+}
+resolve_root_partition() {
+  root_disk_name='nvme0n1'
+  root_partition_name='nvme0n1p1'
+  root_partition_number='1'
+}
+abort_boot() {
+  printf 'abort %s\\n' "$1" >> "$RUNNER_IMAGE_GROW_LOG"
+  exit 1
+}
+lsblk() {
+  [ "$1" = '-ndo' ]
+  [ "$2" = 'TYPE' ]
+  printf '%s\\n' part
+}
+cat() {
+  case "$1" in
+    /sys/block/nvme0n1/size)
+      printf '%s\\n' 100000
+      ;;
+    /sys/block/nvme0n1/nvme0n1p1/start)
+      printf '%s\\n' 2048
+      ;;
+    /sys/block/nvme0n1/nvme0n1p1/size)
+      case "$RUNNER_IMAGE_GROW_SCENARIO" in
+        equal) printf '%s\\n' 97919 ;;
+        nochange|grow) printf '%s\\n' 90000 ;;
+        *) exit 2 ;;
+      esac
+      ;;
+    *)
+      exit 2
+      ;;
+  esac
+}
+run_scenario() {
+  export RUNNER_IMAGE_GROW_SCENARIO="$1"
+  grow_root_filesystem
+}
+run_scenario equal
+run_scenario nochange
+run_scenario grow
+`;
+
+    try {
+      const output = execFileSync('/bin/sh', ['-c', harness], {
+        env: {
+          ...process.env,
+          PATH: `${commandDirectory}:${process.env.PATH ?? ''}`,
+          RUNNER_IMAGE_GROW_LOG: commandLog,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(output).toContain('NOCHANGE: partition 1 is already at maximum size');
+      expect(await readFile(commandLog, 'utf8')).toBe(
+        'growpart nochange\nresize2fs nochange /dev/nvme0n1p1\ngrowpart grow\nresize2fs grow /dev/nvme0n1p1\n',
+      );
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
   });
 
   it('resolves the root device and publishes a boot I/O sample', async () => {


### PR DESCRIPTION
Partitioned Ubuntu roots compare the whole disk with the partition size, so the bootstrap always attempts growth even when the partition already reaches the disk end. growpart then reports NOCHANGE and the bootstrap powers the runner off.

Use the kernel's sector geometry and alignment slack to skip already-maximal partitions, while preserving partition and filesystem growth for larger volumes. Capture growpart output so NOCHANGE is safe but genuine errors remain fatal. Add executable regression coverage for maximal, NOCHANGE, and growth paths.

Validation: mise exec -- turbo test --filter=@shipfox/runner-image... (64 tasks, 85 runner-image tests), the runner-image Biome check, shell syntax validation, and git diff --check. The runner-image type task remains blocked by the pre-existing missing @shipfox/vitest declaration in vitest.config.ts.

Closes ENG-1613

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runner bootstrap aborts on equal-sized volumes by correctly detecting maximal root partitions. Previously we compared disk and partition sizes and always invoked `growpart`; `growpart` returned NOCHANGE and the bootstrap powered off. Now we use kernel sector geometry to skip growth when the partition already reaches the disk end and treat NOCHANGE as non-fatal.

- Compares `/sys/block/<disk>/size`, `<partition>/start`, and `<partition>/size` in sectors; skips both partition and filesystem growth when slack < 2048 sectors.
- Captures and prints `growpart` output; aborts only on non-NOCHANGE failures; continues with `resize2fs` even when `growpart` reports NOCHANGE.
- Adds executable tests covering maximal, NOCHANGE, and growth paths; aligns with ENG-1613.

<sup>Written for commit c3b2a3a81240539228306df80323f5a9b012cd71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

