### PR TITLE
Show managed inference without workspace provider setup

### DIFF
--- a/.changeset/managed-client-surfaces.md
+++ b/.changeset/managed-client-surfaces.md
@@ -8,6 +8,6 @@
 "@shipfox/client-workflows": patch
 ---
 
-Shows managed inference providers in client surfaces without exposing workspace credential setup,
-keeps workflow examples limited to supported models, and explains managed-provider failures in
-workflow runs.
+Updates @shipfox/client-agent, @shipfox/client-onboarding, and @shipfox/client-workflows to show
+managed inference providers without exposing workspace credential setup, keep workflow examples
+limited to supported models, and explain managed-provider failures in workflow runs.

--- a/.changeset/managed-client-surfaces.md
+++ b/.changeset/managed-client-surfaces.md
@@ -1,7 +1,12 @@
 ---
+"@shipfox/api-agent": minor
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": minor
 "@shipfox/client-agent": patch
 "@shipfox/client-onboarding": patch
 "@shipfox/client-workflows": patch
 ---
 
-Shows managed inference providers in client surfaces without exposing workspace credential setup.
+Shows managed inference providers in client surfaces without exposing workspace credential setup,
+including harness-compatible models and stable managed-policy failures.

--- a/.changeset/managed-client-surfaces.md
+++ b/.changeset/managed-client-surfaces.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-agent": patch
+"@shipfox/client-onboarding": patch
+"@shipfox/client-workflows": patch
+---
+
+Shows managed inference providers in client surfaces without exposing workspace credential setup.

--- a/.changeset/managed-client-surfaces.md
+++ b/.changeset/managed-client-surfaces.md
@@ -9,4 +9,5 @@
 ---
 
 Shows managed inference providers in client surfaces without exposing workspace credential setup,
-including harness-compatible models and stable managed-policy failures.
+keeps workflow examples limited to supported models, and explains managed-provider failures in
+workflow runs.

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -76,6 +76,10 @@ export const agentInterModuleContract = defineInterModuleContract({
       errors: {
         'model-provider-not-configured': z.object({}),
         'model-provider-credentials-invalid': z.object({}),
+        'workspace-providers-disabled': z.object({
+          message: z.string().min(1).optional(),
+          managed_provider_id: modelProviderRefSchema,
+        }),
       },
     },
   },

--- a/libs/api/agent-dto/src/schemas/catalog.ts
+++ b/libs/api/agent-dto/src/schemas/catalog.ts
@@ -10,6 +10,7 @@ import {
   thinkingLevelsForHarness,
 } from '@shipfox/workflow-document';
 import {z} from 'zod';
+import {managedModelApiSchema} from './managed-provider.js';
 import {
   type ModelProviderId,
   modelProviderRefSchema,
@@ -35,6 +36,7 @@ export {
 export const agentModelOptionSchema = z.object({
   id: z.string().min(1),
   label: z.string().min(1),
+  api: managedModelApiSchema.optional(),
 });
 
 export type AgentModelOptionDto = z.infer<typeof agentModelOptionSchema>;

--- a/libs/api/agent/src/core/model-provider-catalog.test.ts
+++ b/libs/api/agent/src/core/model-provider-catalog.test.ts
@@ -24,6 +24,7 @@ describe('buildModelProviderCatalog', () => {
       expect(Object.isFrozen(managedEntry)).toBe(true);
       expect(Object.isFrozen(managedEntry.models)).toBe(true);
       expect(Object.isFrozen(managedEntry.models[0])).toBe(true);
+      expect(managedEntry.models[0]?.api).toBe('anthropic-messages');
     }
   });
 });

--- a/libs/api/agent/src/core/model-provider-catalog.ts
+++ b/libs/api/agent/src/core/model-provider-catalog.ts
@@ -57,7 +57,7 @@ function toManagedProviderCatalogEntry(
       default_model: managedProvider.defaultModel,
       credential_fields: [],
       unsupported_reason: null,
-      models: managedProvider.models.map(({id, label}) => ({id, label})),
+      models: managedProvider.models.map(({id, label, api}) => ({id, label, api})),
     }),
   );
 }

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -196,6 +196,29 @@ describe('resolveRuntimeCredentials', () => {
     await expect(result).rejects.toThrow(ModelProviderConfigNotFoundError);
   });
 
+  it('reports the managed provider when a foreign runtime provider is requested', async () => {
+    const result = resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+      },
+      {
+        workspaceProviders: 'disabled',
+        managedProvider: managedProvider(vi.fn()),
+      },
+    );
+
+    await expect(result).rejects.toMatchObject({
+      name: 'WorkspaceProvidersDisabledError',
+      managedProviderId: 'shipfox',
+    });
+  });
+
   it('returns custom provider runtime descriptors for custom rows', async () => {
     await saveProviderConfig({
       workspaceId,

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -19,7 +19,7 @@ import {
   storeValuesToRuntimeCredentials,
 } from './credential-fingerprints.js';
 import type {ModelProviderConfig} from './entities/model-provider-config.js';
-import {ModelProviderConfigNotFoundError} from './errors.js';
+import {ModelProviderConfigNotFoundError, WorkspaceProvidersDisabledError} from './errors.js';
 import {getModelProviderEntry, modelProviderCredentialKeysMatch} from './model-provider-policy.js';
 import {type AgentSecretsClient, requireAgentSecretsClient} from './secrets-client.js';
 
@@ -75,6 +75,9 @@ export async function resolveRuntimeCredentials(
       source: params.provider === runtimeConfig.AGENT_DEFAULT_PROVIDER ? 'instance' : 'workspace',
       outcome: 'unavailable',
     });
+    if (managedProvider !== undefined) {
+      throw new WorkspaceProvidersDisabledError(managedProvider.id);
+    }
     throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
   }
 

--- a/libs/api/agent/src/presentation/inter-module.test.ts
+++ b/libs/api/agent/src/presentation/inter-module.test.ts
@@ -1,0 +1,51 @@
+import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {agentTestSecretsClient} from '#test/fixtures/secrets-client.js';
+import {createAgentInterModulePresentation} from './inter-module.js';
+
+describe('agent inter-module presentation', () => {
+  test('preserves managed provider policy details for runtime credentials', async () => {
+    const managedProvider: ManagedModelProvider = {
+      id: 'shipfox',
+      label: 'Shipfox',
+      models: [{id: 'managed-model', label: 'Managed model', api: 'openai-responses'}],
+      defaultModel: 'managed-model',
+      resolveCredentials: vi.fn(),
+    };
+    const presentation = createAgentInterModulePresentation({
+      secrets: agentTestSecretsClient,
+      managedProvider,
+      workspaceProviders: 'disabled',
+    });
+    const input = {
+      workspaceId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
+      stepAttemptId: crypto.randomUUID(),
+      harness: 'pi' as const,
+      provider: 'anthropic' as const,
+      model: 'claude-opus-4-8',
+      thinking: 'high' as const,
+    };
+
+    const result = await Promise.resolve(
+      presentation.handlers.resolveRuntimeCredentials(input, {
+        signal: new AbortController().signal,
+      }),
+    ).catch((error: unknown) => error);
+
+    expect(
+      isInterModuleKnownError(agentInterModuleContract.methods.resolveRuntimeCredentials, result),
+    ).toBe(true);
+    if (
+      !isInterModuleKnownError(agentInterModuleContract.methods.resolveRuntimeCredentials, result)
+    ) {
+      throw new Error('Expected a managed provider policy error');
+    }
+    expect(result.code).toBe('workspace-providers-disabled');
+    expect(result.details).toEqual({
+      message: 'This instance only supports provider `shipfox`.',
+      managed_provider_id: 'shipfox',
+    });
+  });
+});

--- a/libs/api/agent/src/presentation/inter-module.ts
+++ b/libs/api/agent/src/presentation/inter-module.ts
@@ -84,6 +84,16 @@ function toResolveAgentConfigKnownError(error: unknown): unknown {
 }
 
 function toResolveRuntimeCredentialsKnownError(error: unknown): unknown {
+  if (error instanceof WorkspaceProvidersDisabledError) {
+    return createInterModuleKnownError(
+      agentInterModuleContract.methods.resolveRuntimeCredentials,
+      'workspace-providers-disabled',
+      {
+        message: error.message,
+        managed_provider_id: error.managedProviderId,
+      },
+    );
+  }
   if (error instanceof ModelProviderConfigNotFoundError) {
     return createInterModuleKnownError(
       agentInterModuleContract.methods.resolveRuntimeCredentials,

--- a/libs/api/agent/src/presentation/routes/model-provider-catalog.test.ts
+++ b/libs/api/agent/src/presentation/routes/model-provider-catalog.test.ts
@@ -98,7 +98,7 @@ describe('model provider catalog route', () => {
             support_status: 'supported',
             default_model: 'managed-claude',
             credential_fields: [],
-            models: [{id: 'managed-claude', label: 'Managed Claude'}],
+            models: [{id: 'managed-claude', label: 'Managed Claude', api: 'anthropic-messages'}],
           }),
         ],
       });

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -53,6 +53,21 @@ describe('stepErrorDtoSchema', () => {
     });
   });
 
+  it('accepts a stable runtime error code and managed provider identity', () => {
+    const result = stepErrorDtoSchema.parse({
+      message: 'Agent runtime config request failed with status 422: workspace-providers-disabled.',
+      code: 'workspace-providers-disabled',
+      managed_provider_id: 'shipfox',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_unsupported',
+    });
+
+    expect(result).toMatchObject({
+      code: 'workspace-providers-disabled',
+      managed_provider_id: 'shipfox',
+    });
+  });
+
   it('accepts typed output validation failures', () => {
     const result = stepErrorDtoSchema.parse({
       message: 'Output "count" must be a finite number or numeric string.',

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -59,6 +59,8 @@ export const STEP_ERROR_MESSAGE_MAX_LENGTH = 2048;
 export const stepErrorDtoSchema = z
   .object({
     message: z.string().max(STEP_ERROR_MESSAGE_MAX_LENGTH),
+    code: z.string().min(1).optional(),
+    managed_provider_id: z.string().min(1).optional(),
     exit_code: z.number().int().nullable().optional(),
     signal: z.string().optional(),
     reason: stepErrorReasonSchema.optional(),

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -38,13 +38,28 @@ export class WorkspaceNotFoundError extends Error {
   }
 }
 
+export interface AgentConfigUnresolvableErrorOptions {
+  readonly cause?: unknown;
+  readonly message?: string;
+  readonly code?: string;
+  readonly managedProviderId?: string;
+}
+
 export class AgentConfigUnresolvableError extends Error {
+  readonly code?: string | undefined;
+  readonly managedProviderId?: string | undefined;
+
   constructor(
     readonly definitionId: string,
-    options?: ErrorOptions | undefined,
+    options?: AgentConfigUnresolvableErrorOptions | undefined,
   ) {
-    super(`Agent configuration cannot be resolved for definition ${definitionId}`, options);
+    super(
+      options?.message ?? `Agent configuration cannot be resolved for definition ${definitionId}`,
+      options?.cause === undefined ? undefined : {cause: options.cause},
+    );
     this.name = 'AgentConfigUnresolvableError';
+    this.code = options?.code;
+    this.managedProviderId = options?.managedProviderId;
   }
 }
 

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -1,4 +1,8 @@
 import {
+  type AgentInterModuleClient,
+  agentInterModuleContract,
+} from '@shipfox/api-agent-dto/inter-module';
+import {
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
@@ -10,6 +14,7 @@ import {
   parseWorkflowTemplate,
   planInterpolationField,
 } from '@shipfox/expression';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {and, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {workflowsOutbox} from '#db/schema/outbox.js';
@@ -319,6 +324,55 @@ describe('nextStepForJob', () => {
         source: 'steps.build.outputs.sha',
       },
       logOutcome: 'abandoned',
+    });
+  });
+
+  test('reports managed provider policy failures as agent config errors', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const pending = steps[0];
+    if (!pending) throw new Error('Expected pending step');
+    await db()
+      .update(stepsTable)
+      .set({
+        config: {},
+        configPlan: {
+          agent: {
+            prompt: {segments: [{kind: 'literal', value: 'Review the change.'}]},
+          },
+        },
+      })
+      .where(eq(stepsTable.id, pending.id));
+
+    const agent = {
+      getValidationCatalog: vi.fn(),
+      resolveAgentConfig: vi.fn().mockRejectedValue(
+        createInterModuleKnownError(
+          agentInterModuleContract.methods.resolveAgentConfig,
+          'agent-config-invalid',
+          {
+            message: 'This instance only supports provider `shipfox`.',
+            managed_provider_id: 'shipfox',
+          },
+        ),
+      ),
+      resolveRuntimeCredentials: vi.fn(),
+    } as unknown as AgentInterModuleClient;
+
+    const next = await nextStepForJob(jobId, agent);
+
+    expect(next).toEqual({kind: 'done', status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]).toMatchObject({
+      status: 'failed',
+      error: {
+        message: 'This instance only supports provider `shipfox`.',
+        reason: 'agent_config_invalid',
+        field: 'agent',
+        source: 'agent',
+        code: 'workspace-providers-disabled',
+        managedProviderId: 'shipfox',
+        agentConfigIssue: 'provider_unsupported',
+      },
     });
   });
 

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -339,11 +339,16 @@ function dispatchConfigError(error: DispatchConfigError): Record<string, unknown
     };
   }
 
+  const isManagedProviderPolicyFailure =
+    error.code === 'workspace-providers-disabled' && error.managedProviderId !== undefined;
   return {
     message: error.message,
-    reason: 'config_unresolvable',
+    reason: isManagedProviderPolicyFailure ? 'agent_config_invalid' : 'config_unresolvable',
     field: 'agent',
     source: 'agent',
+    ...(error.code === undefined ? {} : {code: error.code}),
+    ...(error.managedProviderId === undefined ? {} : {managedProviderId: error.managedProviderId}),
+    ...(isManagedProviderPolicyFailure ? {agentConfigIssue: 'provider_unsupported'} : {}),
   };
 }
 

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -185,7 +185,14 @@ export async function completeAgentDefaults(params: {
       isInterModuleKnownError(agentInterModuleContract.methods.resolveAgentConfig, error) &&
       error.code === 'agent-config-invalid'
     ) {
-      throw new AgentConfigUnresolvableError(params.definitionId, {cause: error});
+      const managedProviderId = error.details.managed_provider_id;
+      throw new AgentConfigUnresolvableError(params.definitionId, {
+        cause: error,
+        ...(error.details.message === undefined ? {} : {message: error.details.message}),
+        ...(managedProviderId === undefined
+          ? {}
+          : {code: 'workspace-providers-disabled', managedProviderId}),
+      });
     }
     throw error;
   }

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -453,6 +453,43 @@ describe('completeStepDispatchConfig', () => {
     await expect(act()).rejects.toThrow(AgentConfigUnresolvableError);
   });
 
+  it('preserves managed provider policy details in unresolvable agent config errors', async () => {
+    const pending = step({
+      type: 'agent',
+      config: {},
+      configPlan: {
+        agent: {
+          prompt: plannedField('Review the change.'),
+        },
+      },
+    });
+    const failingResolver: AgentDefaultsResolver = () => {
+      throw createInterModuleKnownError(
+        agentInterModuleContract.methods.resolveAgentConfig,
+        'agent-config-invalid',
+        {
+          message: 'This instance only supports provider `shipfox`.',
+          managed_provider_id: 'shipfox',
+        },
+      );
+    };
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults: failingResolver,
+        definitionId: 'def-1',
+      });
+
+    await expect(act()).rejects.toMatchObject({
+      name: 'AgentConfigUnresolvableError',
+      message: 'This instance only supports provider `shipfox`.',
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
+    });
+  });
+
   it('throws when a server-side segment still survives dispatch', async () => {
     const pending = step({
       config: {},

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -43,12 +43,16 @@ describe('fromStepErrorDto', () => {
   it('persists the machine-readable agent config issue in camelCase', () => {
     const persisted = fromStepErrorDto({
       message: 'Missing credentials',
+      code: 'workspace-providers-disabled',
+      managed_provider_id: 'shipfox',
       reason: 'agent_config_invalid',
       agent_config_issue: 'provider_not_configured',
     });
 
     expect(persisted).toEqual({
       message: 'Missing credentials',
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
       reason: 'agent_config_invalid',
       agentConfigIssue: 'provider_not_configured',
     });
@@ -180,6 +184,8 @@ describe('toStepDto error category', () => {
         type: 'agent',
         error: {
           message: 'Unknown provider "foo" for agent step.',
+          code: 'workspace-providers-disabled',
+          managedProviderId: 'shipfox',
           reason: 'agent_config_invalid',
           agentConfigIssue: 'provider_unsupported',
         },
@@ -188,6 +194,8 @@ describe('toStepDto error category', () => {
 
     expect(dto.error).toEqual({
       message: 'Unknown provider "foo" for agent step.',
+      code: 'workspace-providers-disabled',
+      managed_provider_id: 'shipfox',
       reason: 'agent_config_invalid',
       agent_config_issue: 'provider_unsupported',
       category: 'user',

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -22,6 +22,9 @@ function toStepErrorDto(
 ): StepErrorDto {
   if (error === null) return null;
   const message = typeof error.message === 'string' ? error.message : '';
+  const code = typeof error.code === 'string' ? error.code : undefined;
+  const managedProviderId =
+    typeof error.managedProviderId === 'string' ? error.managedProviderId : undefined;
   const exitCode = error.exitCode;
   const signal = typeof error.signal === 'string' ? error.signal : undefined;
   const field = typeof error.field === 'string' ? error.field : undefined;
@@ -30,6 +33,8 @@ function toStepErrorDto(
   const agentConfigIssue = agentConfigIssueSchema.safeParse(error.agentConfigIssue);
   return {
     message,
+    ...(code === undefined ? {} : {code}),
+    ...(managedProviderId === undefined ? {} : {managed_provider_id: managedProviderId}),
     ...(exitCode === null || typeof exitCode === 'number' ? {exit_code: exitCode} : {}),
     ...(signal === undefined ? {} : {signal}),
     ...(reason.success ? {reason: reason.data} : {}),
@@ -48,6 +53,10 @@ export function fromStepErrorDto(error: StepErrorDto | undefined): Record<string
   if (!error) return null;
   return {
     message: error.message,
+    ...(error.code === undefined ? {} : {code: error.code}),
+    ...(error.managed_provider_id === undefined
+      ? {}
+      : {managedProviderId: error.managed_provider_id}),
     ...(error.exit_code === null || typeof error.exit_code === 'number'
       ? {exitCode: error.exit_code}
       : {}),

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -300,6 +300,36 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     expect(res.json().code).toBe('model-provider-not-configured');
   });
 
+  test('returns managed provider policy details when workspace providers are disabled', async () => {
+    const {job, step} = await createRunningAgentStep();
+    resolveRuntimeCredentials.mockRejectedValueOnce(
+      createInterModuleKnownError(
+        agentInterModuleContract.methods.resolveRuntimeCredentials,
+        'workspace-providers-disabled',
+        {
+          message: 'This instance only supports provider `shipfox`.',
+          managed_provider_id: 'shipfox',
+        },
+      ),
+    );
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: runtimeConfigUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({
+      code: 'workspace-providers-disabled',
+      details: {
+        message: 'This instance only supports provider `shipfox`.',
+        managed_provider_id: 'shipfox',
+      },
+    });
+  });
+
   test('returns 409 and reports when workspace credentials cannot be decrypted', async () => {
     const {job, step} = await createRunningAgentStep();
     resolveRuntimeCredentials.mockRejectedValueOnce(

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -330,6 +330,33 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     });
   });
 
+  test('includes a fallback message when managed provider details omit one', async () => {
+    const {job, step} = await createRunningAgentStep();
+    resolveRuntimeCredentials.mockRejectedValueOnce(
+      createInterModuleKnownError(
+        agentInterModuleContract.methods.resolveRuntimeCredentials,
+        'workspace-providers-disabled',
+        {managed_provider_id: 'shipfox'},
+      ),
+    );
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: runtimeConfigUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({
+      code: 'workspace-providers-disabled',
+      details: {
+        message: 'Workspace provider configuration is disabled',
+        managed_provider_id: 'shipfox',
+      },
+    });
+  });
+
   test('returns 409 and reports when workspace credentials cannot be decrypted', async () => {
     const {job, step} = await createRunningAgentStep();
     resolveRuntimeCredentials.mockRejectedValueOnce(

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -64,6 +64,25 @@ export function createAgentRuntimeConfigRoute(params: {
           },
         );
       }
+      if (
+        isInterModuleKnownError(
+          agentInterModuleContract.methods.resolveRuntimeCredentials,
+          error,
+        ) &&
+        error.code === 'workspace-providers-disabled'
+      ) {
+        throw new ClientError(
+          error.details.message ?? 'Workspace provider configuration is disabled',
+          'workspace-providers-disabled',
+          {
+            status: 422,
+            details: {
+              managed_provider_id: error.details.managed_provider_id,
+              ...(error.details.message === undefined ? {} : {message: error.details.message}),
+            },
+          },
+        );
+      }
       throw error;
     },
     handler: async (request, reply) => {

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -71,17 +71,14 @@ export function createAgentRuntimeConfigRoute(params: {
         ) &&
         error.code === 'workspace-providers-disabled'
       ) {
-        throw new ClientError(
-          error.details.message ?? 'Workspace provider configuration is disabled',
-          'workspace-providers-disabled',
-          {
-            status: 422,
-            details: {
-              managed_provider_id: error.details.managed_provider_id,
-              ...(error.details.message === undefined ? {} : {message: error.details.message}),
-            },
+        const message = error.details.message ?? 'Workspace provider configuration is disabled';
+        throw new ClientError(message, 'workspace-providers-disabled', {
+          status: 422,
+          details: {
+            managed_provider_id: error.details.managed_provider_id,
+            message,
           },
-        );
+        });
       }
       throw error;
     },

--- a/libs/client/agent/src/components/form-errors.test.ts
+++ b/libs/client/agent/src/components/form-errors.test.ts
@@ -81,6 +81,15 @@ describe('modelProviderConfigErrorToFormError', () => {
       'Configure this provider before setting it as the default.',
     ],
     [
+      new ApiError({
+        code: 'workspace-providers-disabled',
+        message: 'Provider policy rejected the request.',
+        status: 422,
+        details: {message: 'This instance only supports provider `shipfox`.'},
+      }),
+      'This instance only supports provider `shipfox`.',
+    ],
+    [
       new ApiError({code: 'not-found', message: 'Provider config not found', status: 404}),
       'This custom provider no longer exists. Refresh and try again.',
     ],

--- a/libs/client/agent/src/components/form-errors.ts
+++ b/libs/client/agent/src/components/form-errors.ts
@@ -76,6 +76,9 @@ function apiErrorMessage(error: ApiError): string {
   if (error.code === 'provider-not-configured') {
     return 'Configure this provider before setting it as the default.';
   }
+  if (error.code === 'workspace-providers-disabled') {
+    return typeof details.message === 'string' ? details.message : error.message;
+  }
   return error.message;
 }
 

--- a/libs/client/agent/src/components/harness-availability.test.ts
+++ b/libs/client/agent/src/components/harness-availability.test.ts
@@ -51,6 +51,23 @@ describe('harness availability', () => {
     expect(isHarnessAvailable(getHarness('claude'), [], catalog)).toBe(true);
   });
 
+  test('does not mark Claude available when managed models do not support Anthropic messages', () => {
+    const catalog = toProviderCatalog(
+      modelProviderCatalogResponse(
+        [
+          managedModelProviderEntry({
+            default_model: 'gpt-5.5-pro',
+            models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'}],
+          }),
+        ],
+        'disabled',
+      ),
+    );
+
+    expect(isHarnessAvailable(getHarness('pi'), [], catalog)).toBe(true);
+    expect(isHarnessAvailable(getHarness('claude'), [], catalog)).toBe(false);
+  });
+
   test('returns compatible harnesses for builtin and custom providers', () => {
     expect(compatibleHarnessIds({isCustom: false, providerId: 'anthropic'})).toEqual([
       'pi',
@@ -58,8 +75,21 @@ describe('harness availability', () => {
     ]);
     expect(compatibleHarnessIds({isCustom: false, providerId: 'openai'})).toEqual(['pi']);
     expect(compatibleHarnessIds({isCustom: true, providerId: 'custom-provider'})).toEqual(['pi']);
-    expect(compatibleHarnessIds({isCustom: false, isManaged: true, providerId: 'shipfox'})).toEqual(
-      ['pi', 'claude'],
-    );
+    expect(
+      compatibleHarnessIds({
+        isCustom: false,
+        isManaged: true,
+        models: [{api: 'openai-responses'}, {api: 'anthropic-messages'}],
+        providerId: 'shipfox',
+      }),
+    ).toEqual(['pi', 'claude']);
+    expect(
+      compatibleHarnessIds({
+        isCustom: false,
+        isManaged: true,
+        models: [{api: 'openai-responses'}],
+        providerId: 'shipfox',
+      }),
+    ).toEqual(['pi']);
   });
 });

--- a/libs/client/agent/src/components/harness-availability.test.ts
+++ b/libs/client/agent/src/components/harness-availability.test.ts
@@ -1,6 +1,11 @@
 import {getHarness} from '#core/harness-policy.js';
-import {toProviderConfig} from '#hooks/api/model-provider-mapper.js';
-import {customModelProviderConfig, modelProviderConfig} from '#test/fixtures/model-providers.js';
+import {toProviderCatalog, toProviderConfig} from '#hooks/api/model-provider-mapper.js';
+import {
+  customModelProviderConfig,
+  managedModelProviderEntry,
+  modelProviderCatalogResponse,
+  modelProviderConfig,
+} from '#test/fixtures/model-providers.js';
 import {compatibleHarnessIds, isHarnessAvailable} from './harness-availability.js';
 
 describe('harness availability', () => {
@@ -37,6 +42,15 @@ describe('harness availability', () => {
     expect(isHarnessAvailable(getHarness('claude'), [])).toBe(false);
   });
 
+  test('marks harnesses available from a managed-only catalog without workspace configs', () => {
+    const catalog = toProviderCatalog(
+      modelProviderCatalogResponse([managedModelProviderEntry()], 'disabled'),
+    );
+
+    expect(isHarnessAvailable(getHarness('pi'), [], catalog)).toBe(true);
+    expect(isHarnessAvailable(getHarness('claude'), [], catalog)).toBe(true);
+  });
+
   test('returns compatible harnesses for builtin and custom providers', () => {
     expect(compatibleHarnessIds({isCustom: false, providerId: 'anthropic'})).toEqual([
       'pi',
@@ -44,5 +58,8 @@ describe('harness availability', () => {
     ]);
     expect(compatibleHarnessIds({isCustom: false, providerId: 'openai'})).toEqual(['pi']);
     expect(compatibleHarnessIds({isCustom: true, providerId: 'custom-provider'})).toEqual(['pi']);
+    expect(compatibleHarnessIds({isCustom: false, isManaged: true, providerId: 'shipfox'})).toEqual(
+      ['pi', 'claude'],
+    );
   });
 });

--- a/libs/client/agent/src/components/harness-availability.ts
+++ b/libs/client/agent/src/components/harness-availability.ts
@@ -1,11 +1,16 @@
 import {compatibleHarnessIds, configSupportsHarness} from '#core/harness-policy.js';
-import type {HarnessDescriptor, ProviderConfig} from '#core/models.js';
+import type {HarnessDescriptor, ProviderCatalog, ProviderConfig} from '#core/models.js';
+import {isManagedOnlyCatalog, isSupportedProvider} from '#core/provider-policy.js';
 
 export function isHarnessAvailable(
   descriptor: HarnessDescriptor,
   configs: readonly ProviderConfig[],
+  catalog?: ProviderCatalog,
 ): boolean {
-  return configs.some((config) => configSupportsHarness(config, descriptor));
+  return (
+    configs.some((config) => configSupportsHarness(config, descriptor)) ||
+    (isManagedOnlyCatalog(catalog) && (catalog?.providers.some(isSupportedProvider) ?? false))
+  );
 }
 
 export {compatibleHarnessIds};

--- a/libs/client/agent/src/components/harness-availability.ts
+++ b/libs/client/agent/src/components/harness-availability.ts
@@ -1,4 +1,8 @@
-import {compatibleHarnessIds, configSupportsHarness} from '#core/harness-policy.js';
+import {
+  compatibleHarnessIds,
+  configSupportsHarness,
+  managedModelSupportsHarness,
+} from '#core/harness-policy.js';
 import type {HarnessDescriptor, ProviderCatalog, ProviderConfig} from '#core/models.js';
 import {isManagedOnlyCatalog, isSupportedProvider} from '#core/provider-policy.js';
 
@@ -9,7 +13,13 @@ export function isHarnessAvailable(
 ): boolean {
   return (
     configs.some((config) => configSupportsHarness(config, descriptor)) ||
-    (isManagedOnlyCatalog(catalog) && (catalog?.providers.some(isSupportedProvider) ?? false))
+    (isManagedOnlyCatalog(catalog) &&
+      (catalog?.providers.some(
+        (provider) =>
+          isSupportedProvider(provider) &&
+          provider.models.some((model) => managedModelSupportsHarness(descriptor.id, model)),
+      ) ??
+        false))
   );
 }
 

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import type {ReactElement} from 'react';
 import {
   AGENT_TEST_WORKSPACE_ID,
+  modelProviderCatalogResponse,
   modelProviderConfig,
   modelProviderConfigsResponse,
 } from '#test/fixtures/model-providers.js';
@@ -17,6 +18,13 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
     headers: {'content-type': 'application/json'},
     ...init,
   });
+}
+
+function harnessRequestResponse(input: RequestInfo | URL, body: unknown) {
+  const url = new URL(input instanceof Request ? input.url : input.toString());
+  return url.pathname.endsWith('/agent/model-provider-catalog')
+    ? jsonResponse(modelProviderCatalogResponse())
+    : jsonResponse(body);
 }
 
 function renderHarnesses(element: ReactElement) {
@@ -48,7 +56,11 @@ describe('WorkspaceHarnessesSection', () => {
     const user = userEvent.setup();
     configureApiClient({
       baseUrl: 'https://api.example.test',
-      fetchImpl: vi.fn().mockResolvedValue(jsonResponse(modelProviderConfigsResponse())),
+      fetchImpl: vi
+        .fn()
+        .mockImplementation((input: RequestInfo | URL) =>
+          Promise.resolve(harnessRequestResponse(input, modelProviderConfigsResponse())),
+        ),
     });
 
     renderHarnesses(<WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
@@ -69,11 +81,14 @@ describe('WorkspaceHarnessesSection', () => {
     const user = userEvent.setup();
     configureApiClient({
       baseUrl: 'https://api.example.test',
-      fetchImpl: vi.fn().mockResolvedValue(
-        jsonResponse(
-          modelProviderConfigsResponse({
-            configs: [modelProviderConfig({provider_id: 'openai'})],
-          }),
+      fetchImpl: vi.fn().mockImplementation((input: RequestInfo | URL) =>
+        Promise.resolve(
+          harnessRequestResponse(
+            input,
+            modelProviderConfigsResponse({
+              configs: [modelProviderConfig({provider_id: 'openai'})],
+            }),
+          ),
         ),
       ),
     });
@@ -101,7 +116,7 @@ describe('WorkspaceHarnessesSection', () => {
         requestBody = await request.clone().json();
         return await updateResponse.promise;
       }
-      return jsonResponse(modelProviderConfigsResponse());
+      return harnessRequestResponse(input, modelProviderConfigsResponse());
     });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
@@ -128,7 +143,7 @@ describe('WorkspaceHarnessesSection', () => {
       if (request.method === 'PUT') {
         return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
       }
-      return Promise.resolve(jsonResponse(modelProviderConfigsResponse()));
+      return Promise.resolve(harnessRequestResponse(input, modelProviderConfigsResponse()));
     });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
@@ -154,7 +169,7 @@ describe('WorkspaceHarnessesSection', () => {
       if (request.method === 'PUT') {
         return updateResponse.promise;
       }
-      return Promise.resolve(jsonResponse(modelProviderConfigsResponse()));
+      return Promise.resolve(harnessRequestResponse(input, modelProviderConfigsResponse()));
     });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
     const nextWorkspaceId = '22222222-2222-4222-8222-222222222222';

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -106,6 +106,33 @@ describe('WorkspaceHarnessesSection', () => {
     expect(screen.getByRole('menuitem', {name: 'Set as default'})).toHaveAttribute('data-disabled');
   });
 
+  test('keeps harnesses unavailable when the catalog fails and no providers are configured', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn().mockImplementation((input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input.toString());
+        if (url.pathname.endsWith('/agent/model-provider-catalog')) {
+          return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+        }
+        return Promise.resolve(
+          harnessRequestResponse(input, modelProviderConfigsResponse({configs: []})),
+        );
+      }),
+    });
+
+    renderHarnesses(<WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    const claudeRow = (await screen.findByText('Claude')).closest('li');
+    if (claudeRow === null) throw new Error('Expected Claude row');
+    expect(
+      within(claudeRow).getByText('Configure a compatible model provider to use this harness.'),
+    ).toHaveClass('sr-only');
+
+    await openHarnessActions(user, 'Claude');
+    expect(screen.getByRole('menuitem', {name: 'Set as default'})).toHaveAttribute('data-disabled');
+  });
+
   test('sets the default harness and shows a success toast', async () => {
     const user = userEvent.setup();
     let requestBody: unknown;

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -106,7 +106,9 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
                   key={harness.id}
                   harness={harness}
                   isDefault={harness.id === defaultHarnessId}
-                  isAvailable={isHarnessAvailable(harness, configs, catalog)}
+                  isAvailable={
+                    catalog === undefined || isHarnessAvailable(harness, configs, catalog)
+                  }
                   isSettingDefault={pendingDefaultHarness?.workspaceId === workspaceId}
                   defaultError={
                     defaultError?.workspaceId === workspaceId &&

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -17,6 +17,7 @@ import {useRef, useState} from 'react';
 import {DEFAULT_HARNESS, listHarnesses} from '#core/harness-policy.js';
 import type {HarnessDescriptor, HarnessId} from '#core/models.js';
 import {
+  useModelProviderCatalogQuery,
   useModelProviderConfigsQuery,
   useSetDefaultHarnessMutation,
 } from '#hooks/api/model-providers.js';
@@ -24,6 +25,7 @@ import {modelProviderConfigErrorToFormError} from './form-errors.js';
 import {isHarnessAvailable} from './harness-availability.js';
 
 export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) {
+  const catalogQuery = useModelProviderCatalogQuery();
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
   const setDefaultHarness = useSetDefaultHarnessMutation();
   const activeWorkspaceIdRef = useRef(workspaceId);
@@ -37,6 +39,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
     {workspaceId: string; harnessId: HarnessId; message: string} | undefined
   >();
   const configs = configsQuery.data?.configs ?? [];
+  const catalog = catalogQuery.data;
   const defaultHarnessId = configsQuery.data?.defaultHarnessId ?? DEFAULT_HARNESS;
   activeWorkspaceIdRef.current = workspaceId;
 
@@ -103,7 +106,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
                   key={harness.id}
                   harness={harness}
                   isDefault={harness.id === defaultHarnessId}
-                  isAvailable={isHarnessAvailable(harness, configs)}
+                  isAvailable={isHarnessAvailable(harness, configs, catalog)}
                   isSettingDefault={pendingDefaultHarness?.workspaceId === workspaceId}
                   defaultError={
                     defaultError?.workspaceId === workspaceId &&

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -106,9 +106,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
                   key={harness.id}
                   harness={harness}
                   isDefault={harness.id === defaultHarnessId}
-                  isAvailable={
-                    catalog === undefined || isHarnessAvailable(harness, configs, catalog)
-                  }
+                  isAvailable={isHarnessAvailable(harness, configs, catalog)}
                   isSettingDefault={pendingDefaultHarness?.workspaceId === workspaceId}
                   defaultError={
                     defaultError?.workspaceId === workspaceId &&

--- a/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
@@ -77,6 +77,29 @@ describe('ModelProviderUsageModal', () => {
     );
   });
 
+  test('does not offer Claude when managed models do not support Anthropic messages', async () => {
+    const onOpenChange = vi.fn();
+    const entry = supportedProvider({
+      id: 'shipfox',
+      label: 'Shipfox Managed',
+      defaultModel: 'gpt-5.5-pro',
+      models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'}],
+    });
+
+    render(
+      <ModelProviderUsageModal
+        target={usageTargetFromCatalogEntry(entry, {isManaged: true})}
+        initialModel="gpt-5.5-pro"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const dialog = await screen.findByRole('dialog', {name: 'Use Shipfox Managed in a workflow'});
+    expect(dialog).toHaveTextContent('harness: pi');
+    expect(screen.queryByRole('button', {name: 'Harness'})).not.toBeInTheDocument();
+  });
+
   test('uses the workspace default harness when it is compatible', async () => {
     const onOpenChange = vi.fn();
     const entry = supportedProvider();

--- a/libs/client/agent/src/components/model-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.tsx
@@ -59,6 +59,7 @@ export function ModelProviderUsageModal({
     if (!target) return;
     const nextCompatibleHarnessIds = compatibleHarnessIds({
       isCustom: target.isCustom,
+      isManaged: target.isManaged,
       providerId: target.id,
     });
     setSelectedHarness(selectInitialHarness(nextCompatibleHarnessIds, workspaceDefaultHarnessId));
@@ -67,7 +68,11 @@ export function ModelProviderUsageModal({
   const compatibleIds = useMemo(
     () =>
       target
-        ? compatibleHarnessIds({isCustom: target.isCustom, providerId: target.id})
+        ? compatibleHarnessIds({
+            isCustom: target.isCustom,
+            isManaged: target.isManaged,
+            providerId: target.id,
+          })
         : ([] as HarnessId[]),
     [target],
   );

--- a/libs/client/agent/src/components/model-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.tsx
@@ -22,7 +22,12 @@ import {
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {useEffect, useMemo, useRef, useState} from 'react';
-import {DEFAULT_HARNESS, getHarness, listHarnesses} from '#core/harness-policy.js';
+import {
+  DEFAULT_HARNESS,
+  getHarness,
+  listHarnesses,
+  managedModelSupportsHarness,
+} from '#core/harness-policy.js';
 import type {HarnessId} from '#core/models.js';
 import {buildAgentWorkflowExample} from './agent-workflow-example.js';
 import {compatibleHarnessIds} from './harness-availability.js';
@@ -60,6 +65,7 @@ export function ModelProviderUsageModal({
     const nextCompatibleHarnessIds = compatibleHarnessIds({
       isCustom: target.isCustom,
       isManaged: target.isManaged,
+      models: target.models,
       providerId: target.id,
     });
     setSelectedHarness(selectInitialHarness(nextCompatibleHarnessIds, workspaceDefaultHarnessId));
@@ -71,6 +77,7 @@ export function ModelProviderUsageModal({
         ? compatibleHarnessIds({
             isCustom: target.isCustom,
             isManaged: target.isManaged,
+            models: target.models,
             providerId: target.id,
           })
         : ([] as HarnessId[]),
@@ -84,10 +91,24 @@ export function ModelProviderUsageModal({
       })),
     [compatibleIds],
   );
+  const compatibleModels = useMemo(() => {
+    if (!target) return [];
+    return target.isManaged
+      ? target.models.filter((model) => managedModelSupportsHarness(selectedHarness, model))
+      : target.models;
+  }, [selectedHarness, target]);
   const modelOptions = useMemo(
-    () => target?.models.map((model) => ({value: model.id, label: model.label})) ?? [],
-    [target],
+    () => compatibleModels.map((model) => ({value: model.id, label: model.label})),
+    [compatibleModels],
   );
+  useEffect(() => {
+    if (!target || compatibleModels.length === 0) return;
+    setSelectedModel((current) =>
+      compatibleModels.some((model) => model.id === current)
+        ? current
+        : (compatibleModels[0]?.id ?? ''),
+    );
+  }, [compatibleModels, target]);
   const example = target
     ? buildAgentWorkflowExample({
         harness: selectedHarness,
@@ -217,10 +238,10 @@ export function ModelProviderUsageModal({
 
                 <div className="flex flex-col gap-inline">
                   <Text size="sm" bold>
-                    Available models ({target.models.length})
+                    Available models ({compatibleModels.length})
                   </Text>
                   <ul className="rounded-8 border border-border-neutral-base">
-                    {target.models.map((model) => (
+                    {compatibleModels.map((model) => (
                       <ModelProviderModelRow key={model.id} label={model.label} id={model.id} />
                     ))}
                   </ul>

--- a/libs/client/agent/src/components/model-provider-usage-target.ts
+++ b/libs/client/agent/src/components/model-provider-usage-target.ts
@@ -4,16 +4,21 @@ export interface ModelProviderUsageTarget {
   id: string;
   label: string;
   isCustom: boolean;
+  isManaged: boolean;
   models: ReadonlyArray<{id: string; label: string}>;
   defaultModel: string | null;
 }
 
-export function usageTargetFromCatalogEntry(entry: SupportedProvider): ModelProviderUsageTarget {
+export function usageTargetFromCatalogEntry(
+  entry: SupportedProvider,
+  options: {isManaged?: boolean} = {},
+): ModelProviderUsageTarget {
   const provider = entry;
   return {
     id: provider.id,
     label: provider.label,
     isCustom: false,
+    isManaged: options.isManaged ?? false,
     models: provider.models,
     defaultModel: provider.defaultModel,
   };
@@ -27,6 +32,7 @@ export function usageTargetFromCustomConfig(
     id: provider.providerId,
     label: provider.displayName,
     isCustom: true,
+    isManaged: false,
     models: provider.models,
     defaultModel: provider.defaultModel,
   };

--- a/libs/client/agent/src/components/model-provider-usage-target.ts
+++ b/libs/client/agent/src/components/model-provider-usage-target.ts
@@ -1,11 +1,11 @@
-import type {CustomProviderConfig, SupportedProvider} from '#core/models.js';
+import type {AgentModel, CustomProviderConfig, SupportedProvider} from '#core/models.js';
 
 export interface ModelProviderUsageTarget {
   id: string;
   label: string;
   isCustom: boolean;
   isManaged: boolean;
-  models: ReadonlyArray<{id: string; label: string}>;
+  models: ReadonlyArray<AgentModel>;
   defaultModel: string | null;
 }
 

--- a/libs/client/agent/src/components/model-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/model-providers-section.stories.tsx
@@ -22,6 +22,7 @@ type Scenario =
   | 'loading'
   | 'configs-error'
   | 'catalog-error'
+  | 'managed-only'
   | 'long-names';
 
 interface ModelProvidersStoryProps {
@@ -138,6 +139,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
 
+export const ManagedOnly: Story = {
+  args: {scenario: 'managed-only'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Managed by this instance. No workspace credentials are required.');
+    await canvas.findByRole('button', {name: 'Use in a workflow'});
+  },
+};
+
 export const EmptyConfigured: Story = {
   args: {scenario: 'empty-configured'},
 };
@@ -226,7 +236,12 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     if (scenario === 'loading') return new Promise<Response>(() => undefined);
     if (url.pathname.endsWith('/agent/model-provider-catalog')) {
       if (scenario === 'catalog-error') return Promise.resolve(errorResponse());
-      return Promise.resolve(jsonResponse({providers: catalogForScenario(scenario)}));
+      return Promise.resolve(
+        jsonResponse({
+          providers: catalogForScenario(scenario),
+          ...(scenario === 'managed-only' ? {workspace_providers: 'disabled'} : {}),
+        }),
+      );
     }
     if (url.pathname.endsWith('/agent/model-providers')) {
       if (scenario === 'configs-error') return Promise.resolve(errorResponse());
@@ -237,6 +252,20 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
 }
 
 function catalogForScenario(scenario: Scenario): ModelProviderCatalogEntryDto[] {
+  if (scenario === 'managed-only') {
+    return [
+      providerEntry({
+        id: 'shipfox',
+        label: 'Shipfox Managed',
+        default_model: 'claude-opus-4-8',
+        credential_fields: [],
+        models: [
+          {id: 'claude-opus-4-8', label: 'Claude Opus 4.8', api: 'anthropic-messages'},
+          {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'},
+        ],
+      }),
+    ];
+  }
   if (scenario !== 'long-names') return CATALOG;
   return [
     providerEntry({
@@ -254,6 +283,9 @@ function catalogForScenario(scenario: Scenario): ModelProviderCatalogEntryDto[] 
 }
 
 function configsForScenario(scenario: Scenario) {
+  if (scenario === 'managed-only') {
+    return {configs: [], default_provider_id: null, default_harness_id: null};
+  }
   if (scenario === 'empty-configured' || scenario === 'configs-error') {
     return {configs: [], default_provider_id: null, default_harness_id: null};
   }

--- a/libs/client/agent/src/components/model-providers-section.test.tsx
+++ b/libs/client/agent/src/components/model-providers-section.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import type {ReactElement} from 'react';
 import {
   AGENT_TEST_WORKSPACE_ID,
+  managedModelProviderEntry,
   modelProviderCatalogResponse,
   modelProviderConfig,
   modelProviderConfigsResponse,
@@ -60,6 +61,46 @@ function customProviderConfig(): CustomModelProviderConfigDto {
 }
 
 describe('WorkspaceModelProvidersSection', () => {
+  test('renders managed provider models without exposing workspace provider setup', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/model-provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(modelProviderCatalogResponse([managedModelProviderEntry()], 'disabled')),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(modelProviderConfigsResponse({configs: [], default_provider_id: null})),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderModelProviders(<WorkspaceModelProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    expect(await screen.findByText('Managed provider')).toBeVisible();
+    expect(screen.getByText('Shipfox Managed')).toBeVisible();
+    expect(screen.getByRole('list', {name: 'Shipfox Managed models'})).toHaveTextContent(
+      'Claude Opus 4.8',
+    );
+    expect(screen.getByRole('list', {name: 'Shipfox Managed models'})).toHaveTextContent(
+      'GPT-5.5 Pro',
+    );
+    expect(screen.queryByText('Available providers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unsupported providers')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Configure custom provider'}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('API key')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Use in a workflow'}));
+
+    const usageDialog = await screen.findByRole('dialog', {
+      name: 'Use Shipfox Managed in a workflow',
+    });
+    expect(usageDialog).toHaveTextContent('provider: shipfox');
+    expect(usageDialog).toHaveTextContent('model: claude-opus-4-8');
+  });
+
   test('renders configured, available, and unsupported providers', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       if (requestPath(input).endsWith('/agent/model-provider-catalog')) {

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -84,51 +84,47 @@ function ManagedProviderSection({
 
       {provider ? (
         <Panel>
-          <PanelBody asChild>
-            <PanelRow asChild className="flex-col items-stretch gap-group">
-              <li>
-                <div className="flex min-w-0 flex-col gap-tight">
-                  <Text size="md" bold>
-                    {provider.label}
-                  </Text>
-                  <Text size="sm" className="text-foreground-neutral-muted">
-                    Managed by this instance. No workspace credentials are required.
-                  </Text>
-                </div>
+          <PanelBody className="gap-group p-panel">
+            <div className="flex min-w-0 flex-col gap-tight">
+              <Text size="md" bold>
+                {provider.label}
+              </Text>
+              <Text size="sm" className="text-foreground-neutral-muted">
+                Managed by this instance. No workspace credentials are required.
+              </Text>
+            </div>
 
-                <div className="flex flex-col gap-inline">
-                  <Text size="sm" bold>
-                    Available models ({provider.models.length})
-                  </Text>
-                  <ul
-                    aria-label={`${provider.label} models`}
-                    className="rounded-8 border border-border-neutral-base"
+            <div className="flex flex-col gap-inline">
+              <Text size="sm" bold>
+                Available models ({provider.models.length})
+              </Text>
+              <ul
+                aria-label={`${provider.label} models`}
+                className="rounded-8 border border-border-neutral-base"
+              >
+                {provider.models.map((model) => (
+                  <li
+                    key={model.id}
+                    className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
                   >
-                    {provider.models.map((model) => (
-                      <li
-                        key={model.id}
-                        className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
-                      >
-                        <Text as="span" size="sm" bold className="min-w-0 truncate">
-                          {model.label}
-                        </Text>
-                        <Code
-                          as="span"
-                          variant="label"
-                          className="min-w-0 truncate text-foreground-neutral-muted"
-                        >
-                          {model.id}
-                        </Code>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+                    <Text as="span" size="sm" bold className="min-w-0 truncate">
+                      {model.label}
+                    </Text>
+                    <Code
+                      as="span"
+                      variant="label"
+                      className="min-w-0 truncate text-foreground-neutral-muted"
+                    >
+                      {model.id}
+                    </Code>
+                  </li>
+                ))}
+              </ul>
+            </div>
 
-                <Button type="button" size="sm" variant="secondary" onClick={onShowUsage}>
-                  Use in a workflow
-                </Button>
-              </li>
-            </PanelRow>
+            <Button type="button" size="sm" variant="secondary" onClick={onShowUsage}>
+              Use in a workflow
+            </Button>
           </PanelBody>
         </Panel>
       ) : (

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -21,7 +21,7 @@ import {Panel, PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
-import {Header, Text} from '@shipfox/react-ui/typography';
+import {Code, Header, Text} from '@shipfox/react-ui/typography';
 import {useEffect, useMemo, useReducer, useRef, useState} from 'react';
 import {
   type ManagementModal,
@@ -36,7 +36,9 @@ import type {
 } from '#core/models.js';
 import {
   customProviderCardMatchesSearch,
+  isManagedOnlyCatalog,
   isSupportedProvider,
+  managedProviderFromCatalog,
   availableProviders as selectAvailableProviders,
 } from '#core/provider-policy.js';
 import {
@@ -67,6 +69,82 @@ type UsageTarget = {
 
 const USAGE_MODAL_OPEN_DELAY_MS = 250;
 
+function ManagedProviderSection({
+  provider,
+  onShowUsage,
+}: {
+  provider: SupportedProvider | undefined;
+  onShowUsage: () => void;
+}) {
+  return (
+    <section className="flex flex-col gap-group" aria-label="Managed provider">
+      <div className="flex flex-col gap-tight">
+        <Header variant="h3">Managed provider</Header>
+      </div>
+
+      {provider ? (
+        <Panel>
+          <PanelBody asChild>
+            <PanelRow asChild className="flex-col items-stretch gap-group">
+              <li>
+                <div className="flex min-w-0 flex-col gap-tight">
+                  <Text size="md" bold>
+                    {provider.label}
+                  </Text>
+                  <Text size="sm" className="text-foreground-neutral-muted">
+                    Managed by this instance. No workspace credentials are required.
+                  </Text>
+                </div>
+
+                <div className="flex flex-col gap-inline">
+                  <Text size="sm" bold>
+                    Available models ({provider.models.length})
+                  </Text>
+                  <ul
+                    aria-label={`${provider.label} models`}
+                    className="rounded-8 border border-border-neutral-base"
+                  >
+                    {provider.models.map((model) => (
+                      <li
+                        key={model.id}
+                        className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
+                      >
+                        <Text as="span" size="sm" bold className="min-w-0 truncate">
+                          {model.label}
+                        </Text>
+                        <Code
+                          as="span"
+                          variant="label"
+                          className="min-w-0 truncate text-foreground-neutral-muted"
+                        >
+                          {model.id}
+                        </Code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <Button type="button" size="sm" variant="secondary" onClick={onShowUsage}>
+                  Use in a workflow
+                </Button>
+              </li>
+            </PanelRow>
+          </PanelBody>
+        </Panel>
+      ) : (
+        <Panel>
+          <EmptyState
+            icon="errorWarningLine"
+            title="Managed provider unavailable"
+            description="This instance is configured without workspace providers, but no managed provider was returned."
+            variant="panel"
+          />
+        </Panel>
+      )}
+    </section>
+  );
+}
+
 export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: string}) {
   const catalogQuery = useModelProviderCatalogQuery();
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
@@ -78,6 +156,8 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
   const configs = configsQuery.data?.configs ?? [];
   const configsLoaded = configsQuery.data !== undefined;
   const defaultProviderId = configsQuery.data?.defaultProviderId ?? null;
+  const managedOnly = isManagedOnlyCatalog(catalogQuery.data);
+  const managedProvider = managedProviderFromCatalog(catalogQuery.data);
   const providerById = useMemo(
     () =>
       new Map<string, ProviderCatalogEntry>(providers.map((provider) => [provider.id, provider])),
@@ -107,174 +187,207 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
     const config = configs.find((item) => item.providerId === modal.providerId);
     if (config?.kind === 'custom') return usageTargetFromCustomConfig(config);
     const entry = providerById.get(modal.providerId);
-    return entry && isSupportedProvider(entry) ? usageTargetFromCatalogEntry(entry) : null;
-  }, [configs, modal, providerById]);
+    return entry && isSupportedProvider(entry)
+      ? usageTargetFromCatalogEntry(entry, {isManaged: managedOnly})
+      : null;
+  }, [configs, managedOnly, modal, providerById]);
 
   return (
     <div className="flex min-w-0 flex-col gap-region">
-      <section
-        ref={configuredProvidersRegionRef}
-        className="flex flex-col gap-group outline-none"
-        aria-label="Configured providers"
-        tabIndex={-1}
-      >
-        <div className="flex flex-col gap-tight">
-          <Header variant="h3">Configured providers</Header>
-        </div>
+      {managedOnly ? (
+        <ManagedProviderSection
+          provider={managedProvider}
+          onShowUsage={() => {
+            if (!managedProvider) return;
+            dispatchModal({
+              type: 'show-usage',
+              providerId: managedProvider.id,
+              initialModel: managedProvider.defaultModel,
+              restoreFocusToConfiguredProviders: false,
+            });
+          }}
+        />
+      ) : (
+        <>
+          <section
+            ref={configuredProvidersRegionRef}
+            className="flex flex-col gap-group outline-none"
+            aria-label="Configured providers"
+            tabIndex={-1}
+          >
+            <div className="flex flex-col gap-tight">
+              <Header variant="h3">Configured providers</Header>
+            </div>
 
-        {configsQuery.isPending ? (
-          <ModelProviderRowsSkeleton label="Loading configured providers" />
-        ) : null}
+            {configsQuery.isPending ? (
+              <ModelProviderRowsSkeleton label="Loading configured providers" />
+            ) : null}
 
-        {configsQuery.isError && configsQuery.data === undefined ? (
-          <Panel>
-            <QueryLoadError query={configsQuery} subject="model provider configs" variant="panel" />
-          </Panel>
-        ) : null}
+            {configsQuery.isError && configsQuery.data === undefined ? (
+              <Panel>
+                <QueryLoadError
+                  query={configsQuery}
+                  subject="model provider configs"
+                  variant="panel"
+                />
+              </Panel>
+            ) : null}
 
-        {configsQuery.data !== undefined && configs.length === 0 ? (
-          <Panel>
-            <EmptyState
-              icon="key2Line"
-              title="No providers configured"
-              description="Configure a provider below to run agent steps with workspace-managed credentials."
-              variant="panel"
-            />
-          </Panel>
-        ) : null}
+            {configsQuery.data !== undefined && configs.length === 0 ? (
+              <Panel>
+                <EmptyState
+                  icon="key2Line"
+                  title="No providers configured"
+                  description="Configure a provider below to run agent steps with workspace-managed credentials."
+                  variant="panel"
+                />
+              </Panel>
+            ) : null}
 
-        {configs.length > 0 ? (
-          <Panel>
-            <PanelBody asChild>
-              <ul>
-                {configs.map((config) => {
-                  const catalogEntry = providerById.get(config.providerId);
-                  const entry =
-                    catalogEntry && isSupportedProvider(catalogEntry) ? catalogEntry : undefined;
-                  const builtinConfig = isBuiltinModelProviderConfig(config) ? config : undefined;
-                  const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
-                  return (
-                    <ConfiguredProviderRow
-                      key={config.providerId}
-                      workspaceId={workspaceId}
-                      config={config}
-                      entry={entry}
-                      isDefault={config.providerId === defaultProviderId}
-                      onEdit={() => {
-                        if (entry && builtinConfig) {
-                          dispatchModal({
-                            type: 'edit-builtin',
-                            provider: entry,
-                            config: builtinConfig,
-                          });
-                        } else if (customConfig) {
-                          dispatchModal({type: 'edit-custom', config: customConfig});
-                        }
-                      }}
-                      onChangeDefaultModel={() => {
-                        if (entry && builtinConfig)
-                          dispatchModal({
-                            type: 'change-default-model',
-                            provider: entry,
-                            config: builtinConfig,
-                          });
-                      }}
-                      onShowUsage={() => {
-                        if (entry && builtinConfig) {
-                          setPendingUsageTarget(null);
-                          dispatchModal({
-                            type: 'show-usage',
-                            providerId: entry.id,
-                            initialModel: builtinConfig.defaultModel,
-                            restoreFocusToConfiguredProviders: false,
-                          });
-                        } else if (customConfig) {
-                          setPendingUsageTarget(null);
-                          dispatchModal({
-                            type: 'show-usage',
-                            providerId: customConfig.providerId,
-                            initialModel: customConfig.defaultModel,
-                            restoreFocusToConfiguredProviders: false,
-                          });
-                        }
-                      }}
-                    />
-                  );
-                })}
-              </ul>
-            </PanelBody>
-          </Panel>
-        ) : null}
-      </section>
+            {configs.length > 0 ? (
+              <Panel>
+                <PanelBody asChild>
+                  <ul>
+                    {configs.map((config) => {
+                      const catalogEntry = providerById.get(config.providerId);
+                      const entry =
+                        catalogEntry && isSupportedProvider(catalogEntry)
+                          ? catalogEntry
+                          : undefined;
+                      const builtinConfig = isBuiltinModelProviderConfig(config)
+                        ? config
+                        : undefined;
+                      const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
+                      return (
+                        <ConfiguredProviderRow
+                          key={config.providerId}
+                          workspaceId={workspaceId}
+                          config={config}
+                          entry={entry}
+                          isDefault={config.providerId === defaultProviderId}
+                          onEdit={() => {
+                            if (entry && builtinConfig) {
+                              dispatchModal({
+                                type: 'edit-builtin',
+                                provider: entry,
+                                config: builtinConfig,
+                              });
+                            } else if (customConfig) {
+                              dispatchModal({type: 'edit-custom', config: customConfig});
+                            }
+                          }}
+                          onChangeDefaultModel={() => {
+                            if (entry && builtinConfig)
+                              dispatchModal({
+                                type: 'change-default-model',
+                                provider: entry,
+                                config: builtinConfig,
+                              });
+                          }}
+                          onShowUsage={() => {
+                            if (entry && builtinConfig) {
+                              setPendingUsageTarget(null);
+                              dispatchModal({
+                                type: 'show-usage',
+                                providerId: entry.id,
+                                initialModel: builtinConfig.defaultModel,
+                                restoreFocusToConfiguredProviders: false,
+                              });
+                            } else if (customConfig) {
+                              setPendingUsageTarget(null);
+                              dispatchModal({
+                                type: 'show-usage',
+                                providerId: customConfig.providerId,
+                                initialModel: customConfig.defaultModel,
+                                restoreFocusToConfiguredProviders: false,
+                              });
+                            }
+                          }}
+                        />
+                      );
+                    })}
+                  </ul>
+                </PanelBody>
+              </Panel>
+            ) : null}
+          </section>
 
-      <section className="flex flex-col gap-group" aria-label="Available providers">
-        <div className="flex flex-col gap-tight">
-          <Header variant="h3">Available providers</Header>
-        </div>
+          <section className="flex flex-col gap-group" aria-label="Available providers">
+            <div className="flex flex-col gap-tight">
+              <Header variant="h3">Available providers</Header>
+            </div>
 
-        {catalogQuery.isPending || configsQuery.isPending ? (
-          <ModelProviderGridSkeleton label="Loading available providers" />
-        ) : null}
+            {catalogQuery.isPending || configsQuery.isPending ? (
+              <ModelProviderGridSkeleton label="Loading available providers" />
+            ) : null}
 
-        {catalogQuery.isError && catalogQuery.data === undefined ? (
-          <Panel>
-            <QueryLoadError query={catalogQuery} subject="model provider catalog" variant="panel" />
-          </Panel>
-        ) : null}
+            {catalogQuery.isError && catalogQuery.data === undefined ? (
+              <Panel>
+                <QueryLoadError
+                  query={catalogQuery}
+                  subject="model provider catalog"
+                  variant="panel"
+                />
+              </Panel>
+            ) : null}
 
-        {configsLoaded ? (
-          <AvailableProvidersGrid
-            entries={availableProviders}
-            onSelect={(entry) => dispatchModal({type: 'configure-builtin', provider: entry})}
-            trailingCard={
-              <AddCustomProviderCard onConfigure={() => dispatchModal({type: 'create-custom'})} />
-            }
-            trailingCardMatchesSearch={customProviderCardMatchesSearch}
-          />
-        ) : null}
-      </section>
+            {configsLoaded ? (
+              <AvailableProvidersGrid
+                entries={availableProviders}
+                onSelect={(entry) => dispatchModal({type: 'configure-builtin', provider: entry})}
+                trailingCard={
+                  <AddCustomProviderCard
+                    onConfigure={() => dispatchModal({type: 'create-custom'})}
+                  />
+                }
+                trailingCardMatchesSearch={customProviderCardMatchesSearch}
+              />
+            ) : null}
+          </section>
 
-      <section className="flex flex-col gap-group" aria-label="Unsupported providers">
-        <div className="flex flex-col gap-tight">
-          <Header variant="h3">Unsupported providers</Header>
-        </div>
+          <section className="flex flex-col gap-group" aria-label="Unsupported providers">
+            <div className="flex flex-col gap-tight">
+              <Header variant="h3">Unsupported providers</Header>
+            </div>
 
-        {catalogQuery.isPending ? (
-          <ModelProviderRowsSkeleton label="Loading unsupported providers" />
-        ) : null}
+            {catalogQuery.isPending ? (
+              <ModelProviderRowsSkeleton label="Loading unsupported providers" />
+            ) : null}
 
-        {unsupportedProviders.length > 0 ? (
-          <Panel>
-            <PanelBody asChild>
-              <ul>
-                {unsupportedProviders.map((entry) => (
-                  <PanelRow
-                    asChild
-                    className="items-start justify-start gap-cluster opacity-70 hover:bg-background-neutral-base"
-                    key={entry.id}
-                  >
-                    <li>
-                      <Icon
-                        name="forbid2Line"
-                        className="mt-[2px] size-18 shrink-0 text-foreground-neutral-muted"
-                        aria-hidden
-                      />
-                      <div className="flex min-w-0 flex-1 flex-col gap-tight">
-                        <Text size="md" bold className="truncate">
-                          {entry.label}
-                        </Text>
-                        <Text size="sm" className="text-foreground-neutral-muted">
-                          {entry.unsupportedReason}
-                        </Text>
-                      </div>
-                    </li>
-                  </PanelRow>
-                ))}
-              </ul>
-            </PanelBody>
-          </Panel>
-        ) : null}
-      </section>
+            {unsupportedProviders.length > 0 ? (
+              <Panel>
+                <PanelBody asChild>
+                  <ul>
+                    {unsupportedProviders.map((entry) => (
+                      <PanelRow
+                        asChild
+                        className="items-start justify-start gap-cluster opacity-70 hover:bg-background-neutral-base"
+                        key={entry.id}
+                      >
+                        <li>
+                          <Icon
+                            name="forbid2Line"
+                            className="mt-[2px] size-18 shrink-0 text-foreground-neutral-muted"
+                            aria-hidden
+                          />
+                          <div className="flex min-w-0 flex-1 flex-col gap-tight">
+                            <Text size="md" bold className="truncate">
+                              {entry.label}
+                            </Text>
+                            <Text size="sm" className="text-foreground-neutral-muted">
+                              {entry.unsupportedReason}
+                            </Text>
+                          </div>
+                        </li>
+                      </PanelRow>
+                    ))}
+                  </ul>
+                </PanelBody>
+              </Panel>
+            ) : null}
+          </section>
+        </>
+      )}
 
       <Modal
         open={modal.kind === 'configure-builtin' || modal.kind === 'edit-builtin'}

--- a/libs/client/agent/src/core/harness-policy.ts
+++ b/libs/client/agent/src/core/harness-policy.ts
@@ -73,12 +73,15 @@ export function configSupportsHarness(config: ProviderConfig, harness: HarnessDe
 
 export function compatibleHarnessIds({
   isCustom,
+  isManaged = false,
   providerId,
 }: {
   isCustom: boolean;
+  isManaged?: boolean;
   providerId: string;
 }): HarnessId[] {
   if (isCustom) return [DEFAULT_HARNESS];
+  if (isManaged) return harnesses.map((harness) => harness.id);
   return harnesses
     .filter((harness) => harness.supportedProviderIds.includes(providerId))
     .map((harness) => harness.id);

--- a/libs/client/agent/src/core/harness-policy.ts
+++ b/libs/client/agent/src/core/harness-policy.ts
@@ -1,4 +1,4 @@
-import type {HarnessDescriptor, HarnessId, ProviderConfig} from './models.js';
+import type {AgentModel, HarnessDescriptor, HarnessId, ProviderConfig} from './models.js';
 
 export const DEFAULT_HARNESS: HarnessId = 'pi';
 
@@ -71,17 +71,34 @@ export function configSupportsHarness(config: ProviderConfig, harness: HarnessDe
     : harness.supportedProviderIds.includes(config.providerId);
 }
 
+export function managedModelSupportsHarness(
+  harnessId: HarnessId,
+  model: Pick<AgentModel, 'api'>,
+): boolean {
+  return harnessId === 'pi' || model.api === undefined || model.api === 'anthropic-messages';
+}
+
 export function compatibleHarnessIds({
   isCustom,
   isManaged = false,
+  models,
   providerId,
 }: {
   isCustom: boolean;
   isManaged?: boolean;
+  models?: readonly Pick<AgentModel, 'api'>[];
   providerId: string;
 }): HarnessId[] {
   if (isCustom) return [DEFAULT_HARNESS];
-  if (isManaged) return harnesses.map((harness) => harness.id);
+  if (isManaged) {
+    return harnesses
+      .filter(
+        (harness) =>
+          models === undefined ||
+          models.some((model) => managedModelSupportsHarness(harness.id, model)),
+      )
+      .map((harness) => harness.id);
+  }
   return harnesses
     .filter((harness) => harness.supportedProviderIds.includes(providerId))
     .map((harness) => harness.id);

--- a/libs/client/agent/src/core/models.ts
+++ b/libs/client/agent/src/core/models.ts
@@ -16,6 +16,7 @@ export interface HarnessDescriptor {
 export interface AgentModel {
   readonly id: string;
   readonly label: string;
+  readonly api?: ProviderApi | undefined;
   readonly contextWindow?: number | undefined;
   readonly maxOutputTokens?: number | undefined;
   readonly inputImage?: boolean | undefined;

--- a/libs/client/agent/src/core/models.ts
+++ b/libs/client/agent/src/core/models.ts
@@ -1,4 +1,5 @@
 export type HarnessId = 'pi' | 'claude';
+export type WorkspaceProvidersPolicy = 'enabled' | 'disabled';
 export type ProviderApi =
   | 'openai-completions'
   | 'openai-responses'
@@ -76,6 +77,7 @@ export type ProviderConfig = BuiltinProviderConfig | CustomProviderConfig;
 
 export interface ProviderCatalog {
   readonly providers: readonly ProviderCatalogEntry[];
+  readonly workspaceProviders: WorkspaceProvidersPolicy;
 }
 
 export interface ProviderConfiguration {

--- a/libs/client/agent/src/core/provider-policy.ts
+++ b/libs/client/agent/src/core/provider-policy.ts
@@ -1,5 +1,6 @@
 import type {
   HarnessDescriptor,
+  ProviderCatalog,
   ProviderCatalogEntry,
   ProviderConfig,
   SupportedProvider,
@@ -11,6 +12,17 @@ export function isSupportedProvider(entry: ProviderCatalogEntry): entry is Suppo
 
 export function supportsProvider(harness: HarnessDescriptor, providerId: string): boolean {
   return harness.supportedProviderIds.includes(providerId);
+}
+
+export function isManagedOnlyCatalog(catalog: ProviderCatalog | undefined): boolean {
+  return catalog?.workspaceProviders === 'disabled';
+}
+
+export function managedProviderFromCatalog(
+  catalog: ProviderCatalog | undefined,
+): SupportedProvider | undefined {
+  if (!isManagedOnlyCatalog(catalog)) return undefined;
+  return catalog?.providers.find(isSupportedProvider);
 }
 
 export function availableProviders(

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
@@ -1,4 +1,5 @@
 import {
+  managedModelProviderEntry,
   modelProviderCatalogResponse,
   modelProviderConfigsResponse,
   modelProviderEntry,
@@ -15,6 +16,23 @@ test('maps provider catalog entries before they reach the client domain', () => 
       credentialFields: [{key: 'api_key', label: 'API key', secret: true}],
     }),
   ]);
+});
+
+test('maps the managed-only workspace policy and managed provider models', () => {
+  const catalog = toProviderCatalog(
+    modelProviderCatalogResponse([managedModelProviderEntry()], 'disabled'),
+  );
+
+  expect(catalog.workspaceProviders).toBe('disabled');
+  expect(catalog.providers[0]).toEqual(
+    expect.objectContaining({
+      id: 'shipfox',
+      models: [
+        {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+        {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'},
+      ],
+    }),
+  );
 });
 
 test('maps configuration response defaults and provider config fields', () => {

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
@@ -28,8 +28,8 @@ test('maps the managed-only workspace policy and managed provider models', () =>
     expect.objectContaining({
       id: 'shipfox',
       models: [
-        {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
-        {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'},
+        {id: 'claude-opus-4-8', label: 'Claude Opus 4.8', api: 'anthropic-messages'},
+        {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'},
       ],
     }),
   );

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.ts
@@ -21,7 +21,10 @@ import type {
 } from '#core/models.js';
 
 export function toProviderCatalog(response: ModelProviderCatalogResponseDto): ProviderCatalog {
-  return {providers: response.providers.map(toProviderCatalogEntry)};
+  return {
+    providers: response.providers.map(toProviderCatalogEntry),
+    workspaceProviders: response.workspace_providers ?? 'enabled',
+  };
 }
 
 export function toProviderCatalogEntry(entry: ModelProviderCatalogEntryDto): ProviderCatalogEntry {

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.ts
@@ -107,6 +107,7 @@ export function toCustomProviderConfig(config: CustomModelProviderConfigDto): Cu
 function toAgentModel(model: {
   id: string;
   label: string;
+  api?: AgentModel['api'];
   context_window?: number | undefined;
   max_output_tokens?: number | undefined;
   input_image?: boolean | undefined;
@@ -115,6 +116,7 @@ function toAgentModel(model: {
   return {
     id: model.id,
     label: model.label,
+    ...(model.api === undefined ? {} : {api: model.api}),
     ...(model.context_window === undefined ? {} : {contextWindow: model.context_window}),
     ...(model.max_output_tokens === undefined ? {} : {maxOutputTokens: model.max_output_tokens}),
     ...(model.input_image === undefined ? {} : {inputImage: model.input_image}),

--- a/libs/client/agent/src/hooks/api/model-providers.test.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.test.ts
@@ -40,6 +40,17 @@ describe('model provider transport', () => {
     expect(request.method).toBe('GET');
   });
 
+  test('preserves the managed-only workspace policy from the catalog', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(modelProviderCatalogResponse(undefined, 'disabled')));
+    configureApiClient({fetchImpl});
+
+    const result = await getModelProviderCatalog();
+
+    expect(result.workspaceProviders).toBe('disabled');
+  });
+
   test('fetches workspace model provider configs', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(modelProviderConfigsResponse()));
     configureApiClient({fetchImpl});

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
@@ -9,7 +9,13 @@ import {ModelProviderOnboardingPage} from './model-provider-onboarding-page.js';
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 
-type Scenario = 'available' | 'loading' | 'catalog-error' | 'no-providers' | 'long-names';
+type Scenario =
+  | 'available'
+  | 'loading'
+  | 'catalog-error'
+  | 'managed-only'
+  | 'no-providers'
+  | 'long-names';
 
 interface ModelProviderOnboardingStoryProps {
   scenario: Scenario;
@@ -129,6 +135,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
 
+export const ManagedOnly: Story = {
+  args: {scenario: 'managed-only'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', {name: 'Managed inference is ready'});
+    await canvas.findByRole('button', {name: 'Continue to project setup'});
+  },
+};
+
 export const Loading: Story = {
   args: {scenario: 'loading'},
   play: async ({canvasElement}) => {
@@ -204,7 +219,12 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     if (scenario === 'loading') return new Promise<Response>(() => undefined);
     if (url.pathname.endsWith('/agent/model-provider-catalog')) {
       if (scenario === 'catalog-error') return Promise.resolve(errorResponse());
-      return Promise.resolve(jsonResponse({providers: catalogForScenario(scenario)}));
+      return Promise.resolve(
+        jsonResponse({
+          providers: catalogForScenario(scenario),
+          ...(scenario === 'managed-only' ? {workspace_providers: 'disabled'} : {}),
+        }),
+      );
     }
     if (request?.method === 'PUT' && url.pathname.includes('/agent/model-providers/')) {
       return Promise.resolve(
@@ -220,6 +240,20 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
 }
 
 function catalogForScenario(scenario: Scenario): ModelProviderCatalogEntryDto[] {
+  if (scenario === 'managed-only') {
+    return [
+      providerEntry({
+        id: 'shipfox',
+        label: 'Shipfox Managed',
+        default_model: 'claude-opus-4-8',
+        credential_fields: [],
+        models: [
+          {id: 'claude-opus-4-8', label: 'Claude Opus 4.8', api: 'anthropic-messages'},
+          {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'},
+        ],
+      }),
+    ];
+  }
   if (scenario === 'no-providers') return [];
   if (scenario !== 'long-names') return CATALOG;
   return [

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
@@ -9,13 +9,7 @@ import {ModelProviderOnboardingPage} from './model-provider-onboarding-page.js';
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 
-type Scenario =
-  | 'available'
-  | 'loading'
-  | 'catalog-error'
-  | 'managed-only'
-  | 'no-providers'
-  | 'long-names';
+type Scenario = 'available' | 'loading' | 'catalog-error' | 'no-providers' | 'long-names';
 
 interface ModelProviderOnboardingStoryProps {
   scenario: Scenario;
@@ -135,15 +129,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
 
-export const ManagedOnly: Story = {
-  args: {scenario: 'managed-only'},
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await canvas.findByRole('heading', {name: 'Managed inference is ready'});
-    await canvas.findByRole('button', {name: 'Continue to project setup'});
-  },
-};
-
 export const Loading: Story = {
   args: {scenario: 'loading'},
   play: async ({canvasElement}) => {
@@ -222,7 +207,6 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
       return Promise.resolve(
         jsonResponse({
           providers: catalogForScenario(scenario),
-          ...(scenario === 'managed-only' ? {workspace_providers: 'disabled'} : {}),
         }),
       );
     }
@@ -240,20 +224,6 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
 }
 
 function catalogForScenario(scenario: Scenario): ModelProviderCatalogEntryDto[] {
-  if (scenario === 'managed-only') {
-    return [
-      providerEntry({
-        id: 'shipfox',
-        label: 'Shipfox Managed',
-        default_model: 'claude-opus-4-8',
-        credential_fields: [],
-        models: [
-          {id: 'claude-opus-4-8', label: 'Claude Opus 4.8', api: 'anthropic-messages'},
-          {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'},
-        ],
-      }),
-    ];
-  }
   if (scenario === 'no-providers') return [];
   if (scenario !== 'long-names') return CATALOG;
   return [

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -60,7 +60,9 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    expect(await screen.findByRole('heading', {name: 'Managed inference is ready'})).toBeVisible();
+    const heading = await screen.findByRole('heading', {name: 'Managed inference is ready'});
+    expect(heading).toBeVisible();
+    await waitFor(() => expect(heading).toHaveFocus());
     expect(screen.getByText('Shipfox Managed')).toBeVisible();
     expect(screen.getByRole('list', {name: 'Shipfox Managed models'})).toHaveTextContent(
       'GPT-5.5 Pro',

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -7,6 +7,7 @@ import type {ReactElement} from 'react';
 import {isModelProviderOnboardingDismissed} from '#state/model-provider-onboarding.js';
 import {
   AGENT_TEST_WORKSPACE_ID,
+  managedModelProviderEntry,
   modelProviderCatalogResponse,
   modelProviderConfig,
   modelProviderEntry,
@@ -40,6 +41,36 @@ function renderOnboarding(element: ReactElement) {
 describe('ModelProviderOnboardingPage', () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  test('shows managed provider models without asking for workspace credentials', async () => {
+    const onConfigured = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(modelProviderCatalogResponse([managedModelProviderEntry()], 'disabled')),
+      );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={onConfigured}
+      />,
+    );
+
+    expect(await screen.findByRole('heading', {name: 'Managed inference is ready'})).toBeVisible();
+    expect(screen.getByText('Shipfox Managed')).toBeVisible();
+    expect(screen.getByRole('list', {name: 'Shipfox Managed models'})).toHaveTextContent(
+      'GPT-5.5 Pro',
+    );
+    expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('API key')).not.toBeInTheDocument();
+
+    await userEvent.setup().click(screen.getByRole('button', {name: 'Continue to project setup'}));
+
+    expect(onConfigured).toHaveBeenCalledTimes(1);
   });
 
   test('skips setup, records the dismissed flag, and does not save a provider or harness', async () => {

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -43,7 +43,7 @@ describe('ModelProviderOnboardingPage', () => {
     window.localStorage.clear();
   });
 
-  test('shows managed provider models without asking for workspace credentials', async () => {
+  test('continues directly when workspace providers are managed by the instance', async () => {
     const onConfigured = vi.fn();
     const fetchImpl = vi
       .fn()
@@ -60,19 +60,12 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    const heading = await screen.findByRole('heading', {name: 'Managed inference is ready'});
-    expect(heading).toBeVisible();
-    await waitFor(() => expect(heading).toHaveFocus());
-    expect(screen.getByText('Shipfox Managed')).toBeVisible();
-    expect(screen.getByRole('list', {name: 'Shipfox Managed models'})).toHaveTextContent(
-      'GPT-5.5 Pro',
-    );
+    await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByRole('heading', {name: 'Managed inference is ready'}),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
     expect(screen.queryByLabelText('API key')).not.toBeInTheDocument();
-
-    await userEvent.setup().click(screen.getByRole('button', {name: 'Continue to project setup'}));
-
-    expect(onConfigured).toHaveBeenCalledTimes(1);
   });
 
   test('skips setup, records the dismissed flag, and does not save a provider or harness', async () => {

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -50,12 +50,14 @@ export function ModelProviderOnboardingPage({
   useEffect(() => {
     document
       .getElementById(
-        onboarding.step === 'choose-harness'
-          ? 'model-provider-harness-step'
-          : 'model-provider-provider-step',
+        managedOnly
+          ? 'managed-provider-ready'
+          : onboarding.step === 'choose-harness'
+            ? 'model-provider-harness-step'
+            : 'model-provider-provider-step',
       )
       ?.focus();
-  }, [onboarding.step]);
+  }, [managedOnly, onboarding.step]);
 
   if (managedOnly) {
     return <ManagedOnlyOnboarding provider={managedProvider} onContinue={onConfigured} />;

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -248,47 +248,45 @@ function ManagedOnlyOnboarding({
 
       {provider ? (
         <Panel>
-          <PanelBody asChild>
-            <div className="flex flex-col gap-group">
-              <div className="flex min-w-0 flex-col gap-tight">
-                <Text size="md" bold>
-                  {provider.label}
-                </Text>
-                <Text size="sm" className="text-foreground-neutral-muted">
-                  Available for agent steps in this workspace.
-                </Text>
-              </div>
-              <div className="flex flex-col gap-inline">
-                <Text size="sm" bold>
-                  Available models ({provider.models.length})
-                </Text>
-                <ul
-                  aria-label={`${provider.label} models`}
-                  className="rounded-8 border border-border-neutral-base"
-                >
-                  {provider.models.map((model) => (
-                    <li
-                      key={model.id}
-                      className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
-                    >
-                      <Text as="span" size="sm" bold className="min-w-0 truncate">
-                        {model.label}
-                      </Text>
-                      <Code
-                        as="span"
-                        variant="label"
-                        className="min-w-0 truncate text-foreground-neutral-muted"
-                      >
-                        {model.id}
-                      </Code>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <Button type="button" onClick={onContinue}>
-                Continue to project setup
-              </Button>
+          <PanelBody className="gap-group p-panel">
+            <div className="flex min-w-0 flex-col gap-tight">
+              <Text size="md" bold>
+                {provider.label}
+              </Text>
+              <Text size="sm" className="text-foreground-neutral-muted">
+                Available for agent steps in this workspace.
+              </Text>
             </div>
+            <div className="flex flex-col gap-inline">
+              <Text size="sm" bold>
+                Available models ({provider.models.length})
+              </Text>
+              <ul
+                aria-label={`${provider.label} models`}
+                className="rounded-8 border border-border-neutral-base"
+              >
+                {provider.models.map((model) => (
+                  <li
+                    key={model.id}
+                    className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
+                  >
+                    <Text as="span" size="sm" bold className="min-w-0 truncate">
+                      {model.label}
+                    </Text>
+                    <Code
+                      as="span"
+                      variant="label"
+                      className="min-w-0 truncate text-foreground-neutral-muted"
+                    >
+                      {model.id}
+                    </Code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <Button type="button" onClick={onContinue}>
+              Continue to project setup
+            </Button>
           </PanelBody>
         </Panel>
       ) : (

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -5,8 +5,8 @@ import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
 import {Panel, PanelBody, PanelCell, PanelCellAction, PanelGrid} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
-import {Code, Header, Text} from '@shipfox/react-ui/typography';
-import {useEffect, useMemo, useReducer} from 'react';
+import {Header, Text} from '@shipfox/react-ui/typography';
+import {useEffect, useMemo, useReducer, useRef} from 'react';
 import {AvailableProvidersGrid} from '#components/available-providers-grid.js';
 import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
 import {ModelProviderGridSkeleton} from '#components/model-provider-grid-skeleton.js';
@@ -14,11 +14,7 @@ import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
 import {DEFAULT_HARNESS, harnessSupportsProvider, listHarnesses} from '#core/harness-policy.js';
 import type {HarnessDescriptor, HarnessId, SupportedProvider} from '#core/models.js';
 import {initialOnboardingState, onboardingReducer} from '#core/onboarding-reducer.js';
-import {
-  isManagedOnlyCatalog,
-  isSupportedProvider,
-  managedProviderFromCatalog,
-} from '#core/provider-policy.js';
+import {isManagedOnlyCatalog, isSupportedProvider} from '#core/provider-policy.js';
 import {
   useModelProviderCatalogQuery,
   useSetDefaultHarnessMutation,
@@ -39,7 +35,7 @@ export function ModelProviderOnboardingPage({
   const [onboarding, dispatch] = useReducer(onboardingReducer, initialOnboardingState);
   const supportedProviders = catalogQuery.data?.providers.filter(isSupportedProvider) ?? [];
   const managedOnly = isManagedOnlyCatalog(catalogQuery.data);
-  const managedProvider = managedProviderFromCatalog(catalogQuery.data);
+  const managedOnlyForwarded = useRef(false);
   const filteredProviders = useMemo(() => {
     if (onboarding.step === 'choose-harness') return [];
     return supportedProviders.filter((provider) =>
@@ -48,20 +44,23 @@ export function ModelProviderOnboardingPage({
   }, [onboarding, supportedProviders]);
 
   useEffect(() => {
+    if (!managedOnly || managedOnlyForwarded.current) return;
+    managedOnlyForwarded.current = true;
+    onConfigured();
+  }, [managedOnly, onConfigured]);
+
+  useEffect(() => {
+    if (managedOnly) return;
     document
       .getElementById(
-        managedOnly
-          ? 'managed-provider-ready'
-          : onboarding.step === 'choose-harness'
-            ? 'model-provider-harness-step'
-            : 'model-provider-provider-step',
+        onboarding.step === 'choose-harness'
+          ? 'model-provider-harness-step'
+          : 'model-provider-provider-step',
       )
       ?.focus();
   }, [managedOnly, onboarding.step]);
 
-  if (managedOnly) {
-    return <ManagedOnlyOnboarding provider={managedProvider} onContinue={onConfigured} />;
-  }
+  if (managedOnly) return null;
 
   function handleSkip() {
     try {
@@ -218,89 +217,6 @@ export function ModelProviderOnboardingPage({
           ) : null}
         </ModalContent>
       </Modal>
-    </div>
-  );
-}
-
-function ManagedOnlyOnboarding({
-  provider,
-  onContinue,
-}: {
-  provider: SupportedProvider | undefined;
-  onContinue: () => void;
-}) {
-  return (
-    <div className="flex w-full flex-col gap-section">
-      <header className="flex flex-col gap-cluster">
-        <div className="flex items-start justify-between gap-group max-[520px]:flex-col max-[520px]:gap-inline">
-          <Header id="managed-provider-ready" variant="h1" tabIndex={-1} className="outline-none">
-            Managed inference is ready
-          </Header>
-          <Button type="button" variant="secondary" onClick={onContinue} className="shrink-0">
-            Continue
-          </Button>
-        </div>
-        <Text size="md" className="text-foreground-neutral-muted">
-          This instance manages model access for your workspace. No provider credentials or setup
-          are required.
-        </Text>
-      </header>
-
-      {provider ? (
-        <Panel>
-          <PanelBody className="gap-group p-panel">
-            <div className="flex min-w-0 flex-col gap-tight">
-              <Text size="md" bold>
-                {provider.label}
-              </Text>
-              <Text size="sm" className="text-foreground-neutral-muted">
-                Available for agent steps in this workspace.
-              </Text>
-            </div>
-            <div className="flex flex-col gap-inline">
-              <Text size="sm" bold>
-                Available models ({provider.models.length})
-              </Text>
-              <ul
-                aria-label={`${provider.label} models`}
-                className="rounded-8 border border-border-neutral-base"
-              >
-                {provider.models.map((model) => (
-                  <li
-                    key={model.id}
-                    className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
-                  >
-                    <Text as="span" size="sm" bold className="min-w-0 truncate">
-                      {model.label}
-                    </Text>
-                    <Code
-                      as="span"
-                      variant="label"
-                      className="min-w-0 truncate text-foreground-neutral-muted"
-                    >
-                      {model.id}
-                    </Code>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <Button type="button" onClick={onContinue}>
-              Continue to project setup
-            </Button>
-          </PanelBody>
-        </Panel>
-      ) : (
-        <EmptyState
-          icon="errorWarningLine"
-          title="Managed provider unavailable"
-          description="This instance is configured without workspace providers, but no managed provider was returned."
-          action={
-            <Button type="button" onClick={onContinue}>
-              Continue to project setup
-            </Button>
-          }
-        />
-      )}
     </div>
   );
 }

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -5,7 +5,7 @@ import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
 import {Panel, PanelBody, PanelCell, PanelCellAction, PanelGrid} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
-import {Header, Text} from '@shipfox/react-ui/typography';
+import {Code, Header, Text} from '@shipfox/react-ui/typography';
 import {useEffect, useMemo, useReducer} from 'react';
 import {AvailableProvidersGrid} from '#components/available-providers-grid.js';
 import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
@@ -14,7 +14,11 @@ import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
 import {DEFAULT_HARNESS, harnessSupportsProvider, listHarnesses} from '#core/harness-policy.js';
 import type {HarnessDescriptor, HarnessId, SupportedProvider} from '#core/models.js';
 import {initialOnboardingState, onboardingReducer} from '#core/onboarding-reducer.js';
-import {isSupportedProvider} from '#core/provider-policy.js';
+import {
+  isManagedOnlyCatalog,
+  isSupportedProvider,
+  managedProviderFromCatalog,
+} from '#core/provider-policy.js';
 import {
   useModelProviderCatalogQuery,
   useSetDefaultHarnessMutation,
@@ -34,6 +38,8 @@ export function ModelProviderOnboardingPage({
   const setDefaultHarness = useSetDefaultHarnessMutation();
   const [onboarding, dispatch] = useReducer(onboardingReducer, initialOnboardingState);
   const supportedProviders = catalogQuery.data?.providers.filter(isSupportedProvider) ?? [];
+  const managedOnly = isManagedOnlyCatalog(catalogQuery.data);
+  const managedProvider = managedProviderFromCatalog(catalogQuery.data);
   const filteredProviders = useMemo(() => {
     if (onboarding.step === 'choose-harness') return [];
     return supportedProviders.filter((provider) =>
@@ -50,6 +56,10 @@ export function ModelProviderOnboardingPage({
       )
       ?.focus();
   }, [onboarding.step]);
+
+  if (managedOnly) {
+    return <ManagedOnlyOnboarding provider={managedProvider} onContinue={onConfigured} />;
+  }
 
   function handleSkip() {
     try {
@@ -206,6 +216,91 @@ export function ModelProviderOnboardingPage({
           ) : null}
         </ModalContent>
       </Modal>
+    </div>
+  );
+}
+
+function ManagedOnlyOnboarding({
+  provider,
+  onContinue,
+}: {
+  provider: SupportedProvider | undefined;
+  onContinue: () => void;
+}) {
+  return (
+    <div className="flex w-full flex-col gap-section">
+      <header className="flex flex-col gap-cluster">
+        <div className="flex items-start justify-between gap-group max-[520px]:flex-col max-[520px]:gap-inline">
+          <Header id="managed-provider-ready" variant="h1" tabIndex={-1} className="outline-none">
+            Managed inference is ready
+          </Header>
+          <Button type="button" variant="secondary" onClick={onContinue} className="shrink-0">
+            Continue
+          </Button>
+        </div>
+        <Text size="md" className="text-foreground-neutral-muted">
+          This instance manages model access for your workspace. No provider credentials or setup
+          are required.
+        </Text>
+      </header>
+
+      {provider ? (
+        <Panel>
+          <PanelBody asChild>
+            <div className="flex flex-col gap-group">
+              <div className="flex min-w-0 flex-col gap-tight">
+                <Text size="md" bold>
+                  {provider.label}
+                </Text>
+                <Text size="sm" className="text-foreground-neutral-muted">
+                  Available for agent steps in this workspace.
+                </Text>
+              </div>
+              <div className="flex flex-col gap-inline">
+                <Text size="sm" bold>
+                  Available models ({provider.models.length})
+                </Text>
+                <ul
+                  aria-label={`${provider.label} models`}
+                  className="rounded-8 border border-border-neutral-base"
+                >
+                  {provider.models.map((model) => (
+                    <li
+                      key={model.id}
+                      className="flex min-w-0 items-center justify-between gap-inline border-b border-border-neutral-base px-row py-row last:border-b-0"
+                    >
+                      <Text as="span" size="sm" bold className="min-w-0 truncate">
+                        {model.label}
+                      </Text>
+                      <Code
+                        as="span"
+                        variant="label"
+                        className="min-w-0 truncate text-foreground-neutral-muted"
+                      >
+                        {model.id}
+                      </Code>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <Button type="button" onClick={onContinue}>
+                Continue to project setup
+              </Button>
+            </div>
+          </PanelBody>
+        </Panel>
+      ) : (
+        <EmptyState
+          icon="errorWarningLine"
+          title="Managed provider unavailable"
+          description="This instance is configured without workspace providers, but no managed provider was returned."
+          action={
+            <Button type="button" onClick={onContinue}>
+              Continue to project setup
+            </Button>
+          }
+        />
+      )}
     </div>
   );
 }

--- a/libs/client/agent/test/fixtures/model-providers.ts
+++ b/libs/client/agent/test/fixtures/model-providers.ts
@@ -4,6 +4,7 @@ import type {
   ModelProviderCatalogEntryDto,
   ModelProviderCatalogResponseDto,
   ModelProviderConfigDto,
+  WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
 
 export const AGENT_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
@@ -33,6 +34,22 @@ export function modelProviderEntry(
     models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
     ...overrides,
   };
+}
+
+export function managedModelProviderEntry(
+  overrides: Partial<ModelProviderCatalogEntryDto> = {},
+): ModelProviderCatalogEntryDto {
+  return modelProviderEntry({
+    id: 'shipfox',
+    label: 'Shipfox Managed',
+    default_model: 'claude-opus-4-8',
+    credential_fields: [],
+    models: [
+      {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+      {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'},
+    ],
+    ...overrides,
+  });
 }
 
 export function unsupportedModelProviderEntry(
@@ -95,8 +112,12 @@ export function customModelProviderConfig(
 
 export function modelProviderCatalogResponse(
   modelProviders: ModelProviderCatalogEntryDto[] = [modelProviderEntry()],
+  workspaceProviders?: WorkspaceProvidersPolicy,
 ): ModelProviderCatalogResponseDto {
-  return {providers: modelProviders};
+  return {
+    providers: modelProviders,
+    ...(workspaceProviders === undefined ? {} : {workspace_providers: workspaceProviders}),
+  };
 }
 
 export function modelProviderConfigsResponse(

--- a/libs/client/agent/test/fixtures/model-providers.ts
+++ b/libs/client/agent/test/fixtures/model-providers.ts
@@ -45,8 +45,8 @@ export function managedModelProviderEntry(
     default_model: 'claude-opus-4-8',
     credential_fields: [],
     models: [
-      {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
-      {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'},
+      {id: 'claude-opus-4-8', label: 'Claude Opus 4.8', api: 'anthropic-messages'},
+      {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro', api: 'openai-responses'},
     ],
     ...overrides,
   });

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -82,6 +82,7 @@ interface SetupFetchOptions {
   projectsFail?: boolean;
   connectionsFail?: boolean;
   providerConfigsFail?: boolean;
+  workspaceProviders?: 'enabled' | 'disabled';
   projectsPending?: boolean;
   workspaceStatus?: 'active' | 'suspended' | 'deleted';
 }
@@ -95,6 +96,7 @@ function setupFetch(options: SetupFetchOptions = {}) {
     projectsFail = false,
     connectionsFail = false,
     providerConfigsFail = false,
+    workspaceProviders,
     projectsPending = false,
     workspaceStatus = 'active',
   } = options;
@@ -137,6 +139,14 @@ function setupFetch(options: SetupFetchOptions = {}) {
           configs: providerConfigs,
           default_provider_id: defaultProviderId,
           default_harness_id: null,
+        }),
+      );
+    }
+    if (url.endsWith('/agent/model-provider-catalog')) {
+      return Promise.resolve(
+        jsonResponse({
+          providers: [],
+          ...(workspaceProviders === undefined ? {} : {workspace_providers: workspaceProviders}),
         }),
       );
     }
@@ -351,6 +361,20 @@ describe('workspace setup route hook', () => {
 
     expect(await screen.findByText('Model provider onboarding')).toBeInTheDocument();
     expect(screen.getByTestId('project-navigation')).toHaveTextContent('hidden');
+  });
+
+  test('skips provider onboarding when workspace providers are managed by the instance', async () => {
+    const fetchImpl = setupFetch({
+      connections: [sourceConnection()],
+      providerConfigs: [],
+      defaultProviderId: null,
+      workspaceProviders: 'disabled',
+    });
+
+    renderSetupRoute(`/w/${WORKSPACE_SLUG}/integrations`, fetchImpl);
+
+    expect(await screen.findByText('Create project')).toBeInTheDocument();
+    expect(calledUrls(fetchImpl).some((url) => url.endsWith('/agent/model-providers'))).toBe(false);
   });
 
   test('keeps the provider onboarding route available while provider setup is pending', async () => {

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -374,7 +374,7 @@ describe('workspace setup route hook', () => {
     renderSetupRoute(`/w/${WORKSPACE_SLUG}/integrations`, fetchImpl);
 
     expect(await screen.findByText('Create project')).toBeInTheDocument();
-    expect(calledUrls(fetchImpl).some((url) => url.endsWith('/agent/model-providers'))).toBe(false);
+    expect(calledUrls(fetchImpl).some((url) => url.endsWith('/agent/model-providers'))).toBe(true);
   });
 
   test('keeps the provider onboarding route available while provider setup is pending', async () => {

--- a/libs/client/onboarding/src/workspace-setup-route.ts
+++ b/libs/client/onboarding/src/workspace-setup-route.ts
@@ -1,5 +1,6 @@
 import {
   isModelProviderOnboardingDismissed,
+  modelProviderCatalogQueryOptions,
   modelProviderConfigsQueryOptions,
 } from '@shipfox/client-agent';
 import {
@@ -139,6 +140,14 @@ async function hasHandledModelProviderOnboarding(
   workspaceId: string,
 ): Promise<boolean> {
   if (isModelProviderOnboardingDismissed(workspaceId)) return true;
+
+  try {
+    const catalog = await queryClient.fetchQuery(modelProviderCatalogQueryOptions());
+    if (catalog.workspaceProviders === 'disabled') return true;
+  } catch {
+    // Keep the existing provider-config fallback when older or unavailable APIs
+    // do not expose the workspace provider policy yet.
+  }
 
   const options = modelProviderConfigsQueryOptions(workspaceId);
   try {

--- a/libs/client/onboarding/src/workspace-setup-route.ts
+++ b/libs/client/onboarding/src/workspace-setup-route.ts
@@ -141,22 +141,27 @@ async function hasHandledModelProviderOnboarding(
 ): Promise<boolean> {
   if (isModelProviderOnboardingDismissed(workspaceId)) return true;
 
-  try {
-    const catalog = await queryClient.fetchQuery(modelProviderCatalogQueryOptions());
-    if (catalog.workspaceProviders === 'disabled') return true;
-  } catch {
-    // Keep the existing provider-config fallback when older or unavailable APIs
-    // do not expose the workspace provider policy yet.
+  const catalogOptions = modelProviderCatalogQueryOptions();
+  const configOptions = modelProviderConfigsQueryOptions(workspaceId);
+  const [catalogResult, configsResult] = await Promise.allSettled([
+    queryClient.fetchQuery(catalogOptions),
+    queryClient.fetchQuery(configOptions),
+  ]);
+
+  if (
+    catalogResult.status === 'fulfilled' &&
+    catalogResult.value.workspaceProviders === 'disabled'
+  ) {
+    return true;
   }
 
-  const options = modelProviderConfigsQueryOptions(workspaceId);
-  try {
-    const configs = await queryClient.fetchQuery(options);
+  if (configsResult.status === 'fulfilled') {
+    const configs = configsResult.value;
     return configs.configs.length > 0;
-  } catch {
-    const cached = queryClient.getQueryData<{configs: unknown[]}>(options.queryKey);
-    return cached?.configs.length !== 0;
   }
+
+  const cached = queryClient.getQueryData<{configs: unknown[]}>(configOptions.queryKey);
+  return cached?.configs.length !== 0;
 }
 
 function normalizePath(pathname: string) {

--- a/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.stories.tsx
@@ -83,6 +83,17 @@ const errorCases: Array<{
       category: 'user',
     },
   },
+  {
+    label: 'Managed-only policy',
+    error: {
+      message: 'This instance only supports provider `shipfox`.',
+      exitCode: null,
+      signal: undefined,
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_unsupported',
+      category: 'user',
+    },
+  },
 ];
 
 export const Playground: Story = {};
@@ -111,6 +122,20 @@ export const TestProviderUnsupported: Story = {
     error: makeError('provider_unsupported'),
   },
   play: assertCallout('Choose a supported model provider', false),
+};
+
+export const TestManagedOnlyPolicy: Story = {
+  args: {
+    error: {
+      message: 'This instance only supports provider `shipfox`.',
+      exitCode: null,
+      signal: undefined,
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_unsupported',
+      category: 'user',
+    },
+  },
+  play: assertCallout('Use shipfox for this instance', false),
 };
 
 function makeError(agentConfigIssue: AgentConfigIssueValue): StepError {

--- a/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.stories.tsx
@@ -87,6 +87,8 @@ const errorCases: Array<{
     label: 'Managed-only policy',
     error: {
       message: 'This instance only supports provider `shipfox`.',
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
       exitCode: null,
       signal: undefined,
       reason: 'agent_config_invalid',
@@ -128,6 +130,8 @@ export const TestManagedOnlyPolicy: Story = {
   args: {
     error: {
       message: 'This instance only supports provider `shipfox`.',
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
       exitCode: null,
       signal: undefined,
       reason: 'agent_config_invalid',

--- a/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.tsx
@@ -9,6 +9,8 @@ import {Button} from '@shipfox/react-ui/button';
 import {Link} from '@tanstack/react-router';
 import type {AgentStepConfig, StepError} from '#core/workflow-run.js';
 
+const MANAGED_ONLY_PROVIDER_MESSAGE = /This instance only supports provider `([^`]+)`/u;
+
 export function AgentConfigFailureCallout({
   workspaceSlug,
   config,
@@ -47,6 +49,15 @@ function agentConfigFailureCopy(
   config: AgentStepConfig | null,
   error: StepError | null,
 ): {title: string; description: string; showProviderCta: boolean} {
+  const managedOnlyProvider = managedOnlyProviderFromMessage(error?.message);
+  if (managedOnlyProvider) {
+    return {
+      title: `Use ${managedOnlyProvider} for this instance`,
+      description: `This instance only supports provider \`${managedOnlyProvider}\`. Update this step to use \`${managedOnlyProvider}\`, or remove its provider field to use the managed default.`,
+      showProviderCta: false,
+    };
+  }
+
   const provider = configValue(config?.provider, 'the selected provider');
   const model = configValue(config?.model, 'the selected model');
 
@@ -90,6 +101,11 @@ function agentConfigFailureCopy(
         showProviderCta: true,
       };
   }
+}
+
+function managedOnlyProviderFromMessage(message: string | undefined): string | undefined {
+  if (!message) return undefined;
+  return message.match(MANAGED_ONLY_PROVIDER_MESSAGE)?.[1];
 }
 
 function configValue(value: string | null | undefined, fallback: string): string {

--- a/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/job-detail/agent-config-failure-callout.tsx
@@ -9,7 +9,7 @@ import {Button} from '@shipfox/react-ui/button';
 import {Link} from '@tanstack/react-router';
 import type {AgentStepConfig, StepError} from '#core/workflow-run.js';
 
-const MANAGED_ONLY_PROVIDER_MESSAGE = /This instance only supports provider `([^`]+)`/u;
+const MANAGED_ONLY_PROVIDER_CODE = 'workspace-providers-disabled';
 
 export function AgentConfigFailureCallout({
   workspaceSlug,
@@ -49,7 +49,7 @@ function agentConfigFailureCopy(
   config: AgentStepConfig | null,
   error: StepError | null,
 ): {title: string; description: string; showProviderCta: boolean} {
-  const managedOnlyProvider = managedOnlyProviderFromMessage(error?.message);
+  const managedOnlyProvider = managedOnlyProviderFromError(error);
   if (managedOnlyProvider) {
     return {
       title: `Use ${managedOnlyProvider} for this instance`,
@@ -103,9 +103,11 @@ function agentConfigFailureCopy(
   }
 }
 
-function managedOnlyProviderFromMessage(message: string | undefined): string | undefined {
-  if (!message) return undefined;
-  return message.match(MANAGED_ONLY_PROVIDER_MESSAGE)?.[1];
+function managedOnlyProviderFromError(error: StepError | null): string | undefined {
+  if (error?.code !== MANAGED_ONLY_PROVIDER_CODE && error?.managedProviderId === undefined) {
+    return undefined;
+  }
+  return error.managedProviderId ?? 'the managed provider';
 }
 
 function configValue(value: string | null | undefined, fallback: string): string {

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
@@ -1,3 +1,4 @@
+import type {Step} from '#core/workflow-run.js';
 import {
   workflowJob,
   workflowJobExecutionDto,
@@ -9,6 +10,7 @@ import {
   jobSucceededSummary,
   outputFailureDescriptionForExecution,
   skippedJobDescription,
+  toSelectedAttemptError,
 } from './job-empty-states.js';
 
 describe('jobSucceededSummary', () => {
@@ -29,6 +31,25 @@ describe('jobSucceededSummary', () => {
     if (!execution) throw new Error('Expected a job execution');
 
     expect(jobSucceededSummary(job, execution)).toBe('1 step succeeded');
+  });
+});
+
+describe('toSelectedAttemptError', () => {
+  test('preserves managed-provider metadata from a historical attempt', () => {
+    const error = toSelectedAttemptError({type: 'agent'} as Step, {
+      message: 'This instance only supports provider `shipfox`.',
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_unsupported',
+    });
+
+    expect(error).toMatchObject({
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_unsupported',
+    });
   });
 });
 

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -292,8 +292,18 @@ export function toSelectedAttemptError(
 
   if (resolvedReason === undefined) return null;
 
+  const code = typeof error.code === 'string' ? error.code : undefined;
+  const managedProviderId =
+    typeof error.managedProviderId === 'string'
+      ? error.managedProviderId
+      : typeof error.managed_provider_id === 'string'
+        ? error.managed_provider_id
+        : undefined;
+
   return {
     message: typeof error.message === 'string' ? error.message : '',
+    ...(code === undefined ? {} : {code}),
+    ...(managedProviderId === undefined ? {} : {managedProviderId}),
     exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
     signal: typeof error.signal === 'string' ? error.signal : undefined,
     reason: resolvedReason,

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -51,6 +51,8 @@ export interface StepSourceLocation {
 
 export interface StepError {
   message: string;
+  code?: string | undefined;
+  managedProviderId?: string | undefined;
   exitCode: number | null;
   signal: string | undefined;
   reason: StepErrorReason | undefined;

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -217,6 +217,10 @@ export function toStep(dto: WorkflowRunStepDetailDto): Step {
     error: dto.error
       ? {
           message: dto.error.message,
+          ...(dto.error.code === undefined ? {} : {code: dto.error.code}),
+          ...(dto.error.managed_provider_id === undefined
+            ? {}
+            : {managedProviderId: dto.error.managed_provider_id}),
           exitCode: dto.error.exit_code ?? null,
           signal: dto.error.signal,
           reason: dto.error.reason,

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -10,6 +10,7 @@ const {AgentRuntimeConfigRequestError, StepSecretsRequestError, resolveWorkingDi
         public readonly status: number,
         public readonly code: string | undefined,
         public readonly agentConfigIssue: AgentConfigIssueDto | undefined = undefined,
+        public readonly managedProviderId: string | undefined = undefined,
       ) {
         super(
           code === undefined
@@ -2018,6 +2019,37 @@ describe('runJobSteps', () => {
         error: expect.objectContaining({
           reason: 'agent_config_invalid',
           agent_config_issue: 'provider_not_configured',
+        }),
+      }),
+    );
+  });
+
+  it('reports managed-only runtime policy errors with their stable code and provider', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'failed'});
+    requestAgentRuntimeConfigMock.mockRejectedValueOnce(
+      new AgentRuntimeConfigRequestError(
+        422,
+        'workspace-providers-disabled',
+        'provider_unsupported',
+        'shipfox',
+      ),
+    );
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: agent.id,
+        error: expect.objectContaining({
+          code: 'workspace-providers-disabled',
+          managed_provider_id: 'shipfox',
         }),
       }),
     );

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -788,6 +788,10 @@ function agentRuntimeConfigFailure(error: unknown): StepResult {
         message: error.message,
         reason: agentConfigIssue ? 'agent_config_invalid' : 'agent_invocation_failed',
         ...(agentConfigIssue ? {agent_config_issue: agentConfigIssue} : {}),
+        ...(error.code === undefined ? {} : {code: error.code}),
+        ...(error.managedProviderId === undefined
+          ? {}
+          : {managed_provider_id: error.managedProviderId}),
       },
       exit_code: null,
     };

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -448,6 +448,33 @@ describe('api-client auth contexts', () => {
     );
   });
 
+  it('preserves the managed provider identity from a policy error response', async () => {
+    stubFetch(() =>
+      jsonResponse(
+        {
+          code: 'workspace-providers-disabled',
+          details: {managed_provider_id: 'shipfox'},
+        },
+        422,
+      ),
+    );
+    const leaseClient = createLeaseClient('lease-runtime');
+
+    const request = requestAgentRuntimeConfig(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+    });
+
+    await expect(request).rejects.toMatchObject(
+      new AgentRuntimeConfigRequestError(
+        422,
+        'workspace-providers-disabled',
+        'provider_unsupported',
+        'shipfox',
+      ),
+    );
+  });
+
   it('requestAgentRuntimeConfig retries transient 429 and 5xx responses', async () => {
     const responses = [
       new Response(null, {status: 429}),

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -125,6 +125,7 @@ export class AgentRuntimeConfigRequestError extends Error {
     public readonly agentConfigIssue: AgentConfigIssueDto | undefined = agentConfigIssueForCode(
       code,
     ),
+    public readonly managedProviderId: string | undefined = undefined,
   ) {
     super(
       code === undefined
@@ -434,7 +435,13 @@ export async function requestAgentRuntimeConfig(
     });
   } catch (error) {
     if (error instanceof HTTPError) {
-      throw new AgentRuntimeConfigRequestError(error.response.status, codeFromBody(error.data));
+      const info = errorInfoFromBody(error.data);
+      throw new AgentRuntimeConfigRequestError(
+        error.response.status,
+        info.code,
+        agentConfigIssueForCode(info.code),
+        info.managedProviderId,
+      );
     }
     throw error;
   }
@@ -454,7 +461,13 @@ export async function requestAgentRuntimeConfig(
     return parsed.data;
   }
 
-  throw new AgentRuntimeConfigRequestError(response.status, await errorCode(response));
+  const info = await runtimeConfigErrorInfo(response);
+  throw new AgentRuntimeConfigRequestError(
+    response.status,
+    info.code,
+    agentConfigIssueForCode(info.code),
+    info.managedProviderId,
+  );
 }
 
 export async function requestStepSecrets(
@@ -626,9 +639,41 @@ async function errorCode(response: Response): Promise<string | undefined> {
   }
 }
 
+async function runtimeConfigErrorInfo(
+  response: Response,
+): Promise<{code: string | undefined; managedProviderId: string | undefined}> {
+  try {
+    return errorInfoFromBody((await response.json()) as unknown);
+  } catch {
+    return {code: undefined, managedProviderId: undefined};
+  }
+}
+
+function errorInfoFromBody(body: unknown): {
+  code: string | undefined;
+  managedProviderId: string | undefined;
+} {
+  if (typeof body !== 'object' || body === null) {
+    return {code: undefined, managedProviderId: undefined};
+  }
+
+  const code = 'code' in body && typeof body.code === 'string' ? body.code : undefined;
+  const details =
+    'details' in body && typeof body.details === 'object' && body.details !== null
+      ? body.details
+      : undefined;
+  const managedProviderId =
+    details !== undefined &&
+    'managed_provider_id' in details &&
+    typeof details.managed_provider_id === 'string'
+      ? details.managed_provider_id
+      : undefined;
+
+  return {code, managedProviderId};
+}
+
 function codeFromBody(body: unknown): string | undefined {
-  if (typeof body !== 'object' || body === null || !('code' in body)) return undefined;
-  return typeof body.code === 'string' ? body.code : undefined;
+  return errorInfoFromBody(body).code;
 }
 
 function agentConfigIssueForCode(code: string | undefined): AgentConfigIssueDto | undefined {
@@ -637,6 +682,8 @@ function agentConfigIssueForCode(code: string | undefined): AgentConfigIssueDto 
     case 'agent-step-config-invalid':
     case 'agent-runtime-config-invalid':
       return 'step_config_invalid';
+    case 'workspace-providers-disabled':
+      return 'provider_unsupported';
     case 'model-provider-not-configured':
       return 'provider_not_configured';
     case 'model-provider-unsupported':


### PR DESCRIPTION
The hosted inference instance policy can disable workspace provider configuration. This change makes that policy visible and actionable in client surfaces.

- Maps the catalog policy into the client domain and renders the managed provider and models in agent settings and onboarding.
- Keeps harnesses and workflow usage surfaces available without workspace credentials.
- Skips provider onboarding when the instance manages providers and shows clear policy errors for foreign provider references.

The API catalog and policy contract are already available on `main`; this pull request consumes that contract in the client packages.

Closes ENG-1605

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows managed inference providers across client UIs when workspace provider setup is disabled, and returns a stable managed-only policy error. Previously harnesses could look available without configs; now we enable them only when the managed catalog confirms compatibility and always include a usable error message for policy rejections.

- Maps the `workspace_providers` policy into the client domain (defaulting to `enabled`), adds model API fields to catalog models in `@shipfox/api-agent` and `@shipfox/api-agent-dto`, and derives harness availability from managed models; keeps harness actions disabled if the catalog cannot be read.
- Renders a Managed provider section in `@shipfox/client-agent` settings; hides Available/Unsupported providers and credential inputs under managed-only; updates the usage modal to filter harnesses/models by managed APIs; adds Storybook scenarios for managed-only settings and onboarding.
- Skips provider onboarding when the instance manages providers: `@shipfox/client-agent` onboarding screen is bypassed and `@shipfox/client-onboarding` advances directly to project setup.
- Propagates managed-only policy failures end to end: inter-module adds `workspace-providers-disabled` with `managed_provider_id`; `@shipfox/api-workflows(-dto)` carries `code` and `managed_provider_id` and maps to `agent_config_invalid` with `provider_unsupported`; the runtime-config route returns 422 with code, managed provider id, and a fallback message; `@shipfox/runner` and its protocol preserve code and managed provider id; `@shipfox/client-workflows` renders a callout guiding users to use the managed provider; `@shipfox/client-agent` surfaces the policy message in form errors.
- No migration required; older backends without the policy keep existing behavior. Aligns with ENG-1605.

<sup>Written for commit 4b7f877527dfe4334e5d304625ede1c127d3e9ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

