### PR TITLE
[runner-image] Surface runner startup I/O and readahead

### DIFF
--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -18,6 +18,6 @@ Restart=no
 KillSignal=SIGTERM
 KillMode=control-group
 TimeoutStopSec=90s
-StandardOutput=journal
+StandardOutput=journal+console
 StandardError=journal
 SyslogIdentifier=shipfox-runner

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -13,7 +13,7 @@ EnvironmentFile=/etc/shipfox/runner.env
 Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
 ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh
 WorkingDirectory=/opt/runner
-ExecStart=/usr/local/bin/node dist/index.js
+ExecStart=/opt/shipfox-runner/scripts/runtime/run-runner.sh /usr/local/bin/node dist/index.js
 Restart=no
 KillSignal=SIGTERM
 KillMode=control-group

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -93,6 +93,7 @@ build {
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/record-boot-io.sh /opt/shipfox-runner/scripts/runtime/record-boot-io.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/shipfox-bootstrap.sh /opt/shipfox-runner/scripts/runtime/shipfox-bootstrap.sh",
+      "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/run-runner.sh /opt/shipfox-runner/scripts/runtime/run-runner.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/verify-workspace-mount.sh /opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh",
       "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",
       "sudo install -m 0644 /tmp/shipfox-runner-image-scripts/runtime/helpers/resolve-root-partition.sh /opt/shipfox-runner/scripts/runtime/helpers/resolve-root-partition.sh",

--- a/infra/images/runner/scripts/runtime/run-runner.sh
+++ b/infra/images/runner/scripts/runtime/run-runner.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# The runner service keeps its stdout attached to the EC2 console so the boot timeline can be
+# collected with GetConsoleOutput. Keep the rest of the runner's output in journald: this filter
+# forwards only the explicitly marked boot-timeline record to the inherited console descriptor.
+exec 3>&1
+
+if [ "$#" -eq 0 ]; then
+  set -- /usr/local/bin/node dist/index.js
+fi
+
+set +e
+"$@" 2>&1 |
+  awk -v console_path=/dev/fd/3 '
+    index($0, "\"console_marker\":\"runner_boot_timeline\"") {
+      print $0 > console_path
+      fflush(console_path)
+      next
+    }
+    {
+      print $0 > "/dev/stderr"
+      fflush("/dev/stderr")
+    }
+  '
+
+pipeline_status=("${PIPESTATUS[@]}")
+set -e
+runner_status=${pipeline_status[0]}
+filter_status=${pipeline_status[1]}
+if [ "$runner_status" -ne 0 ]; then
+  exit "$runner_status"
+fi
+exit "$filter_status"

--- a/infra/images/runner/scripts/runtime/run-runner.sh
+++ b/infra/images/runner/scripts/runtime/run-runner.sh
@@ -1,34 +1,14 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 # The runner service keeps its stdout attached to the EC2 console so the boot timeline can be
-# collected with GetConsoleOutput. Keep the rest of the runner's output in journald: this filter
-# forwards only the explicitly marked boot-timeline record to the inherited console descriptor.
+# collected with GetConsoleOutput. Keep the rest of the runner's output in journald by redirecting
+# the child process to stderr while preserving the console descriptor as an extra file descriptor.
 exec 3>&1
 
 if [ "$#" -eq 0 ]; then
   set -- /usr/local/bin/node dist/index.js
 fi
 
-set +e
-"$@" 2>&1 |
-  awk -v console_path=/dev/fd/3 '
-    index($0, "\"console_marker\":\"runner_boot_timeline\"") {
-      print $0 > console_path
-      fflush(console_path)
-      next
-    }
-    {
-      print $0 > "/dev/stderr"
-      fflush("/dev/stderr")
-    }
-  '
-
-pipeline_status=("${PIPESTATUS[@]}")
-set -e
-runner_status=${pipeline_status[0]}
-filter_status=${pipeline_status[1]}
-if [ "$runner_status" -ne 0 ]; then
-  exit "$runner_status"
-fi
-exit "$filter_status"
+export SHIPFOX_BOOT_CONSOLE_FD=3
+exec "$@" 1>&2

--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -57,6 +57,13 @@ configure_root_readahead() {
     return 0
   fi
 
+  if [ "$root_readahead_after" != "$root_readahead_sectors" ]; then
+    printf 'shipfox-boot phase=readahead status=fail uptime=%s root_source=%s before_sectors=%s target_sectors=%s after_sectors=%s reason=clamped\n' \
+      "$(uptime_seconds)" "$root_source" "$root_readahead_before" "$root_readahead_sectors" \
+      "$root_readahead_after"
+    return 0
+  fi
+
   printf 'shipfox-boot phase=readahead status=ok uptime=%s root_source=%s before_sectors=%s target_sectors=%s after_sectors=%s\n' \
     "$(uptime_seconds)" "$root_source" "$root_readahead_before" "$root_readahead_sectors" \
     "$root_readahead_after"

--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -16,7 +16,8 @@ runner_mount_dropin_dir='/etc/systemd/system/shipfox-runner.service.d'
 # provider. Bound the wait by time instead, below the unit's own TimeoutStartSec.
 retry_deadline_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DEADLINE_SECONDS:-240}"
 retry_delay_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DELAY_SECONDS:-1}"
-root_readahead_sectors=2048
+# Leave this unset for baseline boots. Set it to 1024 or 2048 only for a controlled experiment.
+root_readahead_sectors="${SHIPFOX_ROOT_READAHEAD_SECTORS:-}"
 boot_phase='ssh-keygen'
 imds_token_succeeded=0
 
@@ -31,6 +32,20 @@ emit_boot_phase() {
 }
 
 configure_root_readahead() {
+  if [ -z "$root_readahead_sectors" ]; then
+    printf 'shipfox-boot phase=readahead status=skipped uptime=%s reason=not-configured\n' \
+      "$(uptime_seconds)"
+    return 0
+  fi
+
+  case "$root_readahead_sectors" in
+    *[!0-9]*)
+      printf 'shipfox-boot phase=readahead status=fail uptime=%s target_sectors=%s reason=invalid-target\n' \
+        "$(uptime_seconds)" "$root_readahead_sectors"
+      return 0
+      ;;
+  esac
+
   if ! resolve_root_source; then
     printf 'shipfox-boot phase=readahead status=fail uptime=%s reason=root-source-unavailable\n' \
       "$(uptime_seconds)"

--- a/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
+++ b/infra/images/runner/scripts/runtime/shipfox-bootstrap.sh
@@ -16,6 +16,7 @@ runner_mount_dropin_dir='/etc/systemd/system/shipfox-runner.service.d'
 # provider. Bound the wait by time instead, below the unit's own TimeoutStartSec.
 retry_deadline_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DEADLINE_SECONDS:-240}"
 retry_delay_seconds="${SHIPFOX_BOOTSTRAP_RETRY_DELAY_SECONDS:-1}"
+root_readahead_sectors=2048
 boot_phase='ssh-keygen'
 imds_token_succeeded=0
 
@@ -27,6 +28,38 @@ uptime_seconds() {
 
 emit_boot_phase() {
   printf 'shipfox-boot phase=%s status=%s uptime=%s\n' "$1" "$2" "$(uptime_seconds)"
+}
+
+configure_root_readahead() {
+  if ! resolve_root_source; then
+    printf 'shipfox-boot phase=readahead status=fail uptime=%s reason=root-source-unavailable\n' \
+      "$(uptime_seconds)"
+    return 0
+  fi
+
+  root_readahead_before="$(blockdev --getra "$root_source" 2>/dev/null || true)"
+  if [ -z "$root_readahead_before" ]; then
+    printf 'shipfox-boot phase=readahead status=fail uptime=%s root_source=%s reason=read-failed\n' \
+      "$(uptime_seconds)" "$root_source"
+    return 0
+  fi
+
+  if ! blockdev --setra "$root_readahead_sectors" "$root_source"; then
+    printf 'shipfox-boot phase=readahead status=fail uptime=%s root_source=%s before_sectors=%s target_sectors=%s reason=set-failed\n' \
+      "$(uptime_seconds)" "$root_source" "$root_readahead_before" "$root_readahead_sectors"
+    return 0
+  fi
+
+  root_readahead_after="$(blockdev --getra "$root_source" 2>/dev/null || true)"
+  if [ -z "$root_readahead_after" ]; then
+    printf 'shipfox-boot phase=readahead status=fail uptime=%s root_source=%s before_sectors=%s target_sectors=%s reason=verify-failed\n' \
+      "$(uptime_seconds)" "$root_source" "$root_readahead_before" "$root_readahead_sectors"
+    return 0
+  fi
+
+  printf 'shipfox-boot phase=readahead status=ok uptime=%s root_source=%s before_sectors=%s target_sectors=%s after_sectors=%s\n' \
+    "$(uptime_seconds)" "$root_source" "$root_readahead_before" "$root_readahead_sectors" \
+    "$root_readahead_after"
 }
 
 abort_boot() {
@@ -315,6 +348,8 @@ main() {
   rm -f "$runner_env_path" "$runner_env_temp_path"
   user_data_fetch_path="$(mktemp "$runner_env_dir/runner.env.fetch.XXXXXX")"
   trap 'rm -f "$user_data_fetch_path" "$runner_env_temp_path"' EXIT
+
+  configure_root_readahead
 
   # Cloud-init used to create these keys on each boot. Remove them from the AMI during
   # the bake and recreate them here so EC2 Instance Connect never sees shared keys.

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,4 +1,4 @@
-import {execFileSync} from 'node:child_process';
+import {execFileSync, spawnSync} from 'node:child_process';
 import {chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
@@ -921,10 +921,44 @@ describe('systemd boot activation', () => {
     );
     expect(unit).not.toContain('RequiresMountsFor=');
     expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
-      '/usr/local/bin/node dist/index.js',
+      '/opt/shipfox-runner/scripts/runtime/run-runner.sh /usr/local/bin/node dist/index.js',
     );
     expect(systemdDirective(unit, 'Service', 'StandardOutput')).toBe('journal+console');
     expect(unit).not.toContain('--enable-source-maps');
+  });
+
+  it('forwards only the marked boot timeline to the EC2 console', async () => {
+    const unit = await readUnit('shipfox-runner.service');
+    const script = new URL('../scripts/runtime/run-runner.sh', import.meta.url);
+    const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
+    const source = await readFile(script, 'utf8');
+
+    execFileSync('/bin/bash', ['-n', script.pathname], {stdio: 'pipe'});
+
+    const result = spawnSync(
+      '/bin/bash',
+      [
+        script.pathname,
+        process.execPath,
+        '-e',
+        [
+          "process.stdout.write('ordinary stdout\\n');",
+          "process.stderr.write('ordinary stderr\\n');",
+          'process.stdout.write(\'{"console_marker":"runner_boot_timeline"}\\n\');',
+          'process.exitCode = 7;',
+        ].join(''),
+      ],
+      {encoding: 'utf8'},
+    );
+
+    expect(result.status).toBe(7);
+    expect(result.stdout).toBe('{"console_marker":"runner_boot_timeline"}\n');
+    expect(result.stderr).toContain('ordinary stdout');
+    expect(result.stderr).toContain('ordinary stderr');
+    expect(source).toContain('console_marker');
+    expect(source).toContain('PIPESTATUS');
+    expect(build).toContain('run-runner.sh /opt/shipfox-runner/scripts/runtime/run-runner.sh');
+    expect(unit).toContain('StandardError=journal');
   });
 
   it('ships the provider-gated workspace preflight separately from the runner app', async () => {
@@ -1083,6 +1117,8 @@ describe('systemd boot activation', () => {
     expect(source).toContain('configure_root_readahead() {');
     expect(source).toContain('blockdev --getra "$root_source"');
     expect(source).toContain('blockdev --setra "$root_readahead_sectors" "$root_source"');
+    expect(source).toContain('root_readahead_after" != "$root_readahead_sectors"');
+    expect(source).toContain('reason=clamped');
     expect(source).toContain('phase=readahead status=ok');
     expect(source).toContain('phase=readahead status=fail');
     expect(source).toContain('configure_root_readahead');

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -923,6 +923,7 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Service', 'ExecStart')).toBe(
       '/usr/local/bin/node dist/index.js',
     );
+    expect(systemdDirective(unit, 'Service', 'StandardOutput')).toBe('journal+console');
     expect(unit).not.toContain('--enable-source-maps');
   });
 
@@ -1078,6 +1079,13 @@ describe('systemd boot activation', () => {
     expect(source).toContain("awk '{print int($1)}' /proc/uptime");
     expect(source).toContain('while [ "$(uptime_seconds)" -lt "$deadline" ]');
     expect(source).not.toContain('date +%s');
+    expect(source).toContain('root_readahead_sectors=2048');
+    expect(source).toContain('configure_root_readahead() {');
+    expect(source).toContain('blockdev --getra "$root_source"');
+    expect(source).toContain('blockdev --setra "$root_readahead_sectors" "$root_source"');
+    expect(source).toContain('phase=readahead status=ok');
+    expect(source).toContain('phase=readahead status=fail');
+    expect(source).toContain('configure_root_readahead');
     for (const phase of [
       'imds-token',
       'imds-userdata',

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -933,7 +933,7 @@ describe('systemd boot activation', () => {
     const build = await readFile(new URL('../build.pkr.hcl', import.meta.url), 'utf8');
     const source = await readFile(script, 'utf8');
 
-    execFileSync('/bin/bash', ['-n', script.pathname], {stdio: 'pipe'});
+    execFileSync('/bin/sh', ['-n', script.pathname], {stdio: 'pipe'});
 
     const result = spawnSync(
       '/bin/bash',
@@ -944,7 +944,7 @@ describe('systemd boot activation', () => {
         [
           "process.stdout.write('ordinary stdout\\n');",
           "process.stderr.write('ordinary stderr\\n');",
-          'process.stdout.write(\'{"console_marker":"runner_boot_timeline"}\\n\');',
+          'require(\'node:fs\').writeSync(Number(process.env.SHIPFOX_BOOT_CONSOLE_FD), \'{"console_marker":"runner_boot_timeline"}\\n\');',
           'process.exitCode = 7;',
         ].join(''),
       ],
@@ -955,8 +955,8 @@ describe('systemd boot activation', () => {
     expect(result.stdout).toBe('{"console_marker":"runner_boot_timeline"}\n');
     expect(result.stderr).toContain('ordinary stdout');
     expect(result.stderr).toContain('ordinary stderr');
-    expect(source).toContain('console_marker');
-    expect(source).toContain('PIPESTATUS');
+    expect(source).toContain('SHIPFOX_BOOT_CONSOLE_FD=3');
+    expect(source).toContain('exec "$@" 1>&2');
     expect(build).toContain('run-runner.sh /opt/shipfox-runner/scripts/runtime/run-runner.sh');
     expect(unit).toContain('StandardError=journal');
   });
@@ -1113,15 +1113,24 @@ describe('systemd boot activation', () => {
     expect(source).toContain("awk '{print int($1)}' /proc/uptime");
     expect(source).toContain('while [ "$(uptime_seconds)" -lt "$deadline" ]');
     expect(source).not.toContain('date +%s');
-    expect(source).toContain('root_readahead_sectors=2048');
+    expect(source).toContain('root_readahead_sectors="$' + '{SHIPFOX_ROOT_READAHEAD_SECTORS:-}"');
     expect(source).toContain('configure_root_readahead() {');
     expect(source).toContain('blockdev --getra "$root_source"');
     expect(source).toContain('blockdev --setra "$root_readahead_sectors" "$root_source"');
+    expect(source).toContain('phase=readahead status=skipped');
+    expect(source).toContain('reason=invalid-target');
     expect(source).toContain('root_readahead_after" != "$root_readahead_sectors"');
     expect(source).toContain('reason=clamped');
-    expect(source).toContain('phase=readahead status=ok');
-    expect(source).toContain('phase=readahead status=fail');
-    expect(source).toContain('configure_root_readahead');
+    expect(source).toContain(
+      "printf 'shipfox-boot phase=readahead status=ok uptime=%s root_source=%s before_sectors=%s target_sectors=%s after_sectors=%s\\n' \\",
+    );
+    expect(source).toContain(
+      "printf 'shipfox-boot phase=readahead status=fail uptime=%s root_source=%s before_sectors=%s target_sectors=%s after_sectors=%s reason=clamped\\n' \\",
+    );
+    const readaheadCallIndex = source.indexOf('\n  configure_root_readahead\n');
+    const sshKeygenIndex = source.indexOf('\n  if ! /usr/bin/ssh-keygen -A;');
+    expect(readaheadCallIndex).toBeGreaterThanOrEqual(0);
+    expect(readaheadCallIndex).toBeLessThan(sshKeygenIndex);
     for (const phase of [
       'imds-token',
       'imds-userdata',
@@ -1186,6 +1195,91 @@ describe('systemd boot activation', () => {
     expect(build).toContain('systemctl enable shipfox-bootstrap.service');
     expect(build).toMatch(DEDICATED_SYSTEMD_VERIFY_PROVISIONER_PATTERN);
     expect(build).toContain('rm -f /etc/hostname');
+  });
+
+  it('classifies every readahead outcome without aborting bootstrap', async () => {
+    const script = new URL('../scripts/runtime/shipfox-bootstrap.sh', import.meta.url);
+    const source = await readFile(script, 'utf8');
+    const functionStart = source.indexOf('configure_root_readahead() {');
+    const functionEnd = source.indexOf('\nabort_boot() {', functionStart);
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(functionEnd).toBeGreaterThan(functionStart);
+
+    const harness = `set -eu
+${source.slice(functionStart, functionEnd)}
+uptime_seconds() {
+  printf '%s\\n' 12
+}
+resolve_root_source() {
+  if [ "$RUNNER_IMAGE_READAHEAD_SCENARIO" = root-source-unavailable ]; then
+    return 1
+  fi
+  root_source='/dev/nvme0n1'
+}
+blockdev() {
+  case "$1" in
+    --getra)
+      if [ "$RUNNER_IMAGE_READAHEAD_SCENARIO" = read-failed ]; then
+          return 1
+      fi
+      if [ "$getra_after" = verify-failed ]; then
+        return 1
+      fi
+      if [ -n "$getra_after" ]; then
+        printf '%s\\n' "$getra_after"
+      else
+        printf '%s\\n' 256
+      fi
+      ;;
+    --setra)
+      [ "$2" = 2048 ]
+      [ "$3" = /dev/nvme0n1 ]
+      if [ "$RUNNER_IMAGE_READAHEAD_SCENARIO" = set-failed ]; then
+        return 1
+      fi
+      case "$RUNNER_IMAGE_READAHEAD_SCENARIO" in
+        verify-failed) getra_after=verify-failed ;;
+        clamped) getra_after=1024 ;;
+        applied) getra_after=2048 ;;
+        *) return 2 ;;
+      esac
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+run_scenario() {
+  RUNNER_IMAGE_READAHEAD_SCENARIO="$1"
+  root_readahead_sectors="$2"
+  getra_after=''
+  configure_root_readahead
+}
+run_scenario not-configured ''
+run_scenario invalid-target '1MiB'
+run_scenario root-source-unavailable 2048
+run_scenario read-failed 2048
+run_scenario set-failed 2048
+run_scenario verify-failed 2048
+run_scenario clamped 2048
+run_scenario applied 2048
+`;
+
+    const output = execFileSync('/bin/sh', ['-c', harness], {encoding: 'utf8'});
+
+    expect(output).toBe(
+      [
+        'shipfox-boot phase=readahead status=skipped uptime=12 reason=not-configured',
+        'shipfox-boot phase=readahead status=fail uptime=12 target_sectors=1MiB reason=invalid-target',
+        'shipfox-boot phase=readahead status=fail uptime=12 reason=root-source-unavailable',
+        'shipfox-boot phase=readahead status=fail uptime=12 root_source=/dev/nvme0n1 reason=read-failed',
+        'shipfox-boot phase=readahead status=fail uptime=12 root_source=/dev/nvme0n1 before_sectors=256 target_sectors=2048 reason=set-failed',
+        'shipfox-boot phase=readahead status=fail uptime=12 root_source=/dev/nvme0n1 before_sectors=256 target_sectors=2048 reason=verify-failed',
+        'shipfox-boot phase=readahead status=fail uptime=12 root_source=/dev/nvme0n1 before_sectors=256 target_sectors=2048 after_sectors=1024 reason=clamped',
+        'shipfox-boot phase=readahead status=ok uptime=12 root_source=/dev/nvme0n1 before_sectors=256 target_sectors=2048 after_sectors=2048',
+        '',
+      ].join('\n'),
+    );
   });
 
   it('resolves a partitioned NVMe root from the kernel partition attribute', () => {

--- a/libs/runner/orchestration/src/config.test.ts
+++ b/libs/runner/orchestration/src/config.test.ts
@@ -40,5 +40,6 @@ describe('poll config validation', () => {
     expect(config.SHIPFOX_POLL_INTERVAL_MS).toBe(1000);
     expect(config.SHIPFOX_POLL_MAX_INTERVAL_MS).toBe(5000);
     expect(config.SHIPFOX_POLL_MAX_DURATION_MS).toBe(300_000);
+    expect(config.SHIPFOX_BOOT_CONSOLE_FD).toBeUndefined();
   });
 });

--- a/libs/runner/orchestration/src/config.ts
+++ b/libs/runner/orchestration/src/config.ts
@@ -5,6 +5,10 @@ export const config = createConfig({
     desc: 'Optional image revision reported by runners that do not have baked image metadata. Leave it empty when no revision is available.',
     default: '',
   }),
+  SHIPFOX_BOOT_CONSOLE_FD: num({
+    desc: 'Internal file descriptor used by the runner image to write the sanitized boot timeline to the EC2 console. Leave it unset outside the image service wrapper.',
+    default: undefined,
+  }),
   SHIPFOX_POLL_INTERVAL_MS: num({
     desc: 'How often the runner asks the API for new jobs, in milliseconds. The runner backs off toward SHIPFOX_POLL_MAX_INTERVAL_MS while idle or after errors.',
     default: 1000,

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -522,6 +522,7 @@ describe('startRunner', () => {
     expect(bootTimelineCalls).toHaveLength(1);
     expect(bootTimelineCalls[0]?.[0]).toEqual(
       expect.objectContaining({
+        console_marker: 'runner_boot_timeline',
         boot_timeline_version: 2,
         telemetry_state: expect.any(String),
         process_entry_uptime_seconds: expect.any(Number),

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -1,3 +1,4 @@
+import {writeSync} from 'node:fs';
 import {join} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
@@ -52,6 +53,21 @@ let bootPhaseTimeline: RunnerBootPhaseTimeline | undefined;
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
 type RunnerSession = Awaited<ReturnType<typeof registerRunnerSession>>;
+
+function emitBootTimelineToConsole(fields: Record<string, number | string>): void {
+  const consoleFd = config.SHIPFOX_BOOT_CONSOLE_FD;
+  if (consoleFd === undefined) return;
+
+  try {
+    writeSync(
+      consoleFd,
+      `${JSON.stringify({level: 30, time: Date.now(), ...fields, msg: 'runner.boot_timeline'})}\n`,
+    );
+  } catch {
+    // The journal event below remains the fallback when the console descriptor is unavailable.
+  }
+}
+
 const shutdownController = createGracefulShutdownController({
   onFirstSignal: (signal) => {
     running = false;
@@ -318,15 +334,14 @@ async function initializeManagedRunnerSession(
     providerKind: enrollmentConfig.providerKind,
     protocolVersion: enrollmentConfig.protocolVersion,
   });
-  logger().info(
-    {
-      console_marker: 'runner_boot_timeline',
-      ...bootTimeline.createEvent(bootTimeline.captureEnrollment()),
-      ...runnerBootPhaseTimeline.snapshot(),
-      provider_kind: enrollmentConfig.providerKind,
-    },
-    'runner.boot_timeline',
-  );
+  const bootTimelineFields = {
+    console_marker: 'runner_boot_timeline',
+    ...bootTimeline.createEvent(bootTimeline.captureEnrollment()),
+    ...runnerBootPhaseTimeline.snapshot(),
+    provider_kind: enrollmentConfig.providerKind,
+  };
+  emitBootTimelineToConsole(bootTimelineFields);
+  logger().info(bootTimelineFields, 'runner.boot_timeline');
   const activationToken =
     enrollmentActivationToken ?? (await waitForRunnerActivation(controlSessionToken));
   if (!activationToken) return undefined;

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -320,6 +320,7 @@ async function initializeManagedRunnerSession(
   });
   logger().info(
     {
+      console_marker: 'runner_boot_timeline',
       ...bootTimeline.createEvent(bootTimeline.captureEnrollment()),
       ...runnerBootPhaseTimeline.snapshot(),
       provider_kind: enrollmentConfig.providerKind,


### PR DESCRIPTION
Expose runner startup read counters through a bounded EC2 console path and keep the readahead experiment observable without changing the baseline by default.

`runner.boot_timeline` already computes process-start to enrollment read deltas. The image wrapper redirects normal runner/job output to journald while preserving a dedicated console fd; the runner writes only the sanitized boot-timeline JSON record to that fd.

Bootstrap records the readahead baseline and applies a target only when `SHIPFOX_ROOT_READAHEAD_SECTORS` is explicitly configured. It verifies the resulting value and marks unavailable, invalid, failed, or clamped attempts instead of labelling them successful.

The real AMI experiment remains outstanding: collect several baseline, 512 KiB, and 1 MiB boots, then record runner_read_ops/runner_read_bytes and keep or revert based on evidence. This PR intentionally does not claim those runtime measurements.

Refs ENG-1615