### PR TITLE
[docs] Make the hello-world workflow copy-pasteable

### DIFF
--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -10,25 +10,29 @@ Shipfox lets you automate real engineering work with agents you trust in product
 
 You describe what the agent does. Shipfox handles everything around it: orchestration, secure access to your tools, execution next to your code, monitoring, and central control.
 
-Agents live in your repository as [YAML](/reference/workflow-schema). This workflow runs your tests on every push, then puts an agent on the result:
+Agents live in your repository as [YAML](/reference/workflow-schema). Copy this
+workflow into your repository, push it, then start it from the dashboard:
 
-```yaml
+```yaml title=".shipfox/workflows/hello.yaml"
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-name: Review on push
+name: Hello world
 runner: ubuntu-latest
 
 triggers:
-  on_push:
-    source: github_acme # the slug of your GitHub integration connection
-    event: push
+  on_demand:
+    source: manual # fires when you select Run in the dashboard
+    event: fire
 
 jobs:
-  review:
+  hello:
     steps:
-      - run: npm test
-      - prompt: |
-          Review the changes in this push and report the highest-risk findings.
+      - run: echo "Hello from Shipfox"
+      - prompt: Reply with a one-sentence hello.
 ```
+
+Shipfox picks up every file in `.shipfox/workflows/`. Swap the manual trigger
+for a push, a new ticket, or an alert when you want the agent to start on its
+own.
 
 Your first agent runs in minutes with Shipfox cloud.
 

--- a/apps/docs/scripts/check-workflow-schema.mjs
+++ b/apps/docs/scripts/check-workflow-schema.mjs
@@ -31,7 +31,11 @@ for (const anchor of requiredAnchors) {
 for (const file of await filesUnder(contentRoot)) {
   if (!file.endsWith('.mdx')) continue;
   const content = await readFile(file, 'utf8');
-  for (const match of content.matchAll(/^([ \t]*)```yaml[ \t]*\n([\s\S]*?)^\1```[ \t]*$/gm)) {
+  // The optional trailer keeps blocks with code-block meta, such as
+  // `title="..."`, inside the check instead of silently skipping them.
+  for (const match of content.matchAll(
+    /^([ \t]*)```yaml(?:[ \t][^\n]*)?\n([\s\S]*?)^\1```[ \t]*$/gm,
+  )) {
     const body = dedent(match[2] ?? '', match[1] ?? '');
     if (!/^(?:name|jobs):/m.test(body)) continue;
     if (!body.startsWith(`${schemaHeader}\n`)) {


### PR DESCRIPTION
Update the docs home page's first workflow example to a runnable manual Hello world workflow that readers can copy into `.shipfox/workflows/hello.yaml` and start from the dashboard.

Add concise guidance on workflow discovery and adapting the trigger. Extend the workflow schema check to cover YAML fences with code-block metadata, keeping the new titled example validated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the docs home page example a runnable manual “Hello world” workflow that readers can copy into `.shipfox/workflows/hello.yaml` and start from the dashboard. Previously it showed a push-triggered test+review example; now it uses an on-demand manual trigger to ensure copy‑paste works out of the box.

**Review and rollout notes**
- Replaces the push/test/review example with a minimal `on_demand` workflow (`source: manual`, `event: fire`) and brief guidance on workflow discovery and changing the trigger later.
- Extends the docs schema check to validate YAML code blocks with metadata (e.g., `title="..."`) so these examples are no longer skipped.
- Required for docs contributors: If a YAML block defines `name` or `jobs`, include the schema header line (`# yaml-language-server: $schema=...`) even when the code fence has metadata, or CI will fail.

<sup>Written for commit e32a7dcbfa550925571364f913aec3efa2e3c87a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

