### PR TITLE
[docs] Document Shipfox-hosted runner labels

### DIFF
--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -18,7 +18,7 @@ workspace, you need:
 - A configured [model provider and workspace agent
   defaults](/how-to/set-up-work/configure-model-providers).
 - Runner capacity that matches the `runner:` value in the workflow below. See
-  [Runners](/operations/runners).
+  [Runner labels](/reference/runner-labels).
 
 <Callout type="info">
   No workspace yet? Getting one is a separate task. See
@@ -53,7 +53,7 @@ run (`runner`), and what to do (`jobs` and `steps`). Create
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Inspect the repository
-runner: ubuntu-latest      # label of the runner that executes the jobs
+runner: shipfox      # label of the runner that executes the jobs
 triggers:
   on_demand:
     source: manual         # fires when you click Run in the dashboard

--- a/apps/docs/content/docs/how-to/author-workflows/add-agent-steps.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/add-agent-steps.mdx
@@ -12,7 +12,7 @@ describes what it finds. It does not change any files.
 You need:
 
 - A project that can sync workflow files.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - [Configured agent
   defaults](/how-to/set-up-work/configure-model-providers).
 
@@ -24,7 +24,7 @@ workflow. It uses the workspace's default harness, provider, and model:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Summarize the repository
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/author-workflows/bound-listening-job.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/bound-listening-job.mdx
@@ -14,7 +14,7 @@ You need:
 
 - A project [connected to GitHub](/integrations/github/setup).
 - Its integration connection slug. This guide uses `github_acme` as a placeholder.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - Configured agent defaults.
 - A test branch that is ready to open as a pull request. Do not open the pull
   request until the workflow has synced.
@@ -27,7 +27,7 @@ with the slug of the GitHub integration connection. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Batch pull request feedback
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_pull_request:

--- a/apps/docs/content/docs/how-to/author-workflows/build-feedback-loop.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/build-feedback-loop.mdx
@@ -10,7 +10,7 @@ decides whether another attempt is needed.
 ## Before you begin
 
 You need a test project that can sync workflows, an online runner with the
-`ubuntu-latest` label, configured agent defaults, and an `npm test` command with
+`shipfox` label, configured agent defaults, and an `npm test` command with
 a safe failure that the agent can repair.
 
 ## Add the workflow
@@ -20,7 +20,7 @@ Create `.shipfox/workflows/fix-tests.yml`. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Fix failing tests
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/author-workflows/choose-runners.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/choose-runners.mdx
@@ -9,8 +9,9 @@ job needs.
 
 ## Before you begin
 
-You need a project that can sync workflows and access to the runner process or
-provisioner template whose labels should claim the job.
+You need a project that can sync workflows. Use the [hosted runner
+reference](/reference/runner-labels) for Shipfox Cloud. For a runner you manage,
+you also need access to its process or provisioner template.
 
 ## Match a workflow to a runner
 
@@ -19,20 +20,24 @@ provisioner template whose labels should claim the job.
 
     **Find the runner's labels**
 
-    Check `SHIPFOX_RUNNER_LABELS` in the runner process. For a provisioner, check
-    its matching template. The dashboard does not list online runner labels yet.
+    Use `shipfox` for the default Shipfox-hosted runner. To choose a different size,
+    compare the [available labels](/reference/runner-labels#available-labels).
+
+    For a runner you manage, check `SHIPFOX_RUNNER_LABELS` in the runner process
+    or its matching provisioner template. The dashboard does not list online
+    runner labels yet.
   </Step>
   <Step>
 
     **Set the workflow default**
 
-    Add labels to the top-level `runner` field. Replace the example with labels
-    from the runner. This is a complete workflow:
+    Set the top-level `runner` field. This is a complete workflow using the
+    default Shipfox-hosted runner:
 
     ```yaml
     # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
     name: Verify on Linux
-    runner: [linux, x64] # Replace with labels from your runner.
+    runner: shipfox
 
     triggers:
       manual:
@@ -51,8 +56,10 @@ provisioner template whose labels should claim the job.
     **Override one job when needed**
 
     A job-level `runner` value replaces the workflow default. For example, add
-    `runner: [linux, gpu]` to a job that needs both labels. One runner must have
-    the full set.
+    `runner: shipfox-8cpu` to a build job that needs more capacity.
+
+    For a runner you manage, the value can be a list such as `[linux, gpu]`.
+    One runner must have the full set.
   </Step>
   <Step>
 

--- a/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
@@ -17,7 +17,7 @@ You need:
 - A [custom webhook](/integrations/webhooks) integration connection and its ingest URL.
 - The integration connection slug. This guide uses `task_hook` as a placeholder.
 - A project that can sync workflow files.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 
 ## Add the workflow
 
@@ -27,7 +27,7 @@ slug of the integration connection for the custom webhook. This is a complete wo
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Require a task check
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   task_started:

--- a/apps/docs/content/docs/how-to/author-workflows/group-command-logs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/group-command-logs.mdx
@@ -9,7 +9,7 @@ Use groups when one command step produces a long stream that is hard to scan.
 ## Before you begin
 
 You need a project that can sync workflows, an online runner with the
-`ubuntu-latest` label, and a Node.js repository with a lockfile and tests.
+`shipfox` label, and a Node.js repository with a lockfile and tests.
 
 ## Add the workflow
 
@@ -18,7 +18,7 @@ Create `.shipfox/workflows/grouped-checks.yml`. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Run grouped checks
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/author-workflows/pass-outputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/pass-outputs.mdx
@@ -10,7 +10,7 @@ needs. The workflow derives a version from Git and prints it in a later job.
 ## Before you begin
 
 You need a project that can sync workflows and an online runner with the
-`ubuntu-latest` label. The repository must contain at least one Git commit.
+`shipfox` label. The repository must contain at least one Git commit.
 
 ## Add the workflow
 
@@ -19,7 +19,7 @@ Create `.shipfox/workflows/release-version.yml`. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Preview a release version
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/author-workflows/pass-trigger-inputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/pass-trigger-inputs.mdx
@@ -13,7 +13,7 @@ trigger to the full test suite.
 You need:
 
 - A project that can sync workflow files.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A Node.js repository with `test:smoke` and `test` scripts.
 
 ## Add the workflow
@@ -23,7 +23,7 @@ Create `.shipfox/workflows/test-suites.yml`. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Run the right test suite
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual_smoke:

--- a/apps/docs/content/docs/how-to/author-workflows/post-pull-request-review.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/post-pull-request-review.mdx
@@ -15,7 +15,7 @@ You need:
 - A project connected to GitHub.
 - Its integration connection slug. This guide uses `github_acme` as a placeholder.
 - A GitHub integration connection that can read and write pull-request reviews.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - Configured agent defaults.
 - A test branch that is ready to open as a pull request. Do not open it until
   the workflow has synced.
@@ -28,7 +28,7 @@ Create `.shipfox/workflows/post-pull-request-review.yml`. Replace
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Post a pull request review
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_pull_request:

--- a/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
@@ -13,7 +13,7 @@ any integration tool.
 You need:
 
 - A GitHub-backed project whose source integration connection can write repository contents.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - Configured agent defaults.
 - A repository with `README.md`.
 - A repository where a temporary `shipfox/docs-*` branch is safe.
@@ -26,7 +26,7 @@ workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Push a README update
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/author-workflows/run-manually.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/run-manually.mdx
@@ -10,7 +10,7 @@ testing a new workflow, or repeating a task without waiting for an outside event
 ## Before you begin
 
 You need a project that can sync workflows and an online runner with the
-`ubuntu-latest` label.
+`shipfox` label.
 
 ## Add and use a manual trigger
 
@@ -25,7 +25,7 @@ You need a project that can sync workflows and an online runner with the
     ```yaml
     # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
     name: On-demand checks
-    runner: ubuntu-latest
+    runner: shipfox
 
     triggers:
       manual:

--- a/apps/docs/content/docs/how-to/author-workflows/run-shell-commands.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/run-shell-commands.mdx
@@ -12,7 +12,7 @@ job. The workflow uses fixed shell commands, not an agent.
 You need:
 
 - A project that can sync workflows.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A Node.js repository with a lockfile and an `npm test` command.
 
 ## Add the workflow
@@ -22,7 +22,7 @@ Create `.shipfox/workflows/project-checks.yml`. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Run project checks
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/author-workflows/schedule-workflows.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/schedule-workflows.mdx
@@ -10,7 +10,7 @@ need an integration connection.
 ## Before you begin
 
 You need a project that can sync workflows, an online runner with the
-`ubuntu-latest` label, and a command or script for the scheduled task.
+`shipfox` label, and a command or script for the scheduled task.
 
 ## Add a scheduled trigger
 
@@ -25,7 +25,7 @@ You need a project that can sync workflows, an online runner with the
     ```yaml
     # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
     name: Nightly maintenance
-    runner: ubuntu-latest
+    runner: shipfox
 
     triggers:
       nightly:

--- a/apps/docs/content/docs/how-to/author-workflows/trigger-ready-pull-requests.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/trigger-ready-pull-requests.mdx
@@ -14,7 +14,7 @@ You need:
 
 - A project connected to GitHub.
 - The slug of its GitHub integration connection. This guide uses `github_acme` as a placeholder.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A Node.js repository with a lockfile and an `npm test` command.
 
 Replace `main` below if the repository uses another default branch.
@@ -27,7 +27,7 @@ Create `.shipfox/workflows/ready-pull-request-checks.yml`. Replace
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Check ready pull requests
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   opened_ready:

--- a/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
@@ -14,7 +14,7 @@ You need:
 - A project [connected to GitHub](/integrations/github/setup).
 - Its integration connection slug. This guide uses `github_acme` as a placeholder.
 - A GitHub integration connection that supports agent tools.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - Configured agent defaults.
 - A test branch that is ready to open as a pull request. Do not open it until
   the workflow has synced.
@@ -27,7 +27,7 @@ the slug of your GitHub integration connection. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Read a new pull request
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_pull_request:

--- a/apps/docs/content/docs/how-to/author-workflows/use-structured-agent-outputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/use-structured-agent-outputs.mdx
@@ -11,7 +11,7 @@ the agent's final response.
 ## Before you begin
 
 You need a project that can sync workflows, an online runner with the
-`ubuntu-latest` label, and configured agent defaults.
+`shipfox` label, and configured agent defaults.
 
 ## Add the workflow
 
@@ -21,7 +21,7 @@ workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Classify release risk
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/recipes/checks-on-push.mdx
+++ b/apps/docs/content/docs/how-to/recipes/checks-on-push.mdx
@@ -13,7 +13,7 @@ You need:
 
 - A Shipfox project [connected to GitHub](/integrations/github/setup).
 - The slug of the GitHub integration connection. This recipe uses `github_acme` as a placeholder.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A configured model provider and workspace agent defaults.
 - A Node.js repository with a lockfile and an `npm test` command.
 
@@ -25,7 +25,7 @@ the slug of your GitHub integration connection. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Checks on push
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_push:

--- a/apps/docs/content/docs/how-to/recipes/event-to-verified-pull-request.mdx
+++ b/apps/docs/content/docs/how-to/recipes/event-to-verified-pull-request.mdx
@@ -18,7 +18,7 @@ You need:
   placeholder.
 - A GitHub integration connection used as the project source. It must be able
   to push repository contents and use the `create_pull_request` agent tool.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A configured model provider and workspace agent defaults.
 - A Node.js repository with a lockfile and an `npm test` command.
 - A safe Sentry project and repository where an automated test branch is
@@ -32,7 +32,7 @@ with the slug of your Sentry integration connection. This is a complete workflow
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Turn a Sentry issue into a verified pull request
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_issue:

--- a/apps/docs/content/docs/how-to/recipes/parallel-ci-agent-review.mdx
+++ b/apps/docs/content/docs/how-to/recipes/parallel-ci-agent-review.mdx
@@ -12,7 +12,7 @@ should start only after both checks pass.
 You need:
 
 - A project [connected to GitHub](/integrations/github/setup). Find its integration connection slug in **Settings → Integrations**.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A configured model provider and workspace agent defaults.
 - A Node.js repository with `lint` and `test` scripts.
 
@@ -24,7 +24,7 @@ the slug of your GitHub integration connection. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Parallel CI and agent review
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_push:

--- a/apps/docs/content/docs/how-to/recipes/triage-sentry-issues.mdx
+++ b/apps/docs/content/docs/how-to/recipes/triage-sentry-issues.mdx
@@ -15,7 +15,7 @@ You need:
 - A Shipfox project whose repository contains the affected code.
 - A Sentry integration connection in the workspace.
 - The slug of the Sentry integration connection. This recipe uses `sentry_acme` as a placeholder.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A configured model provider and workspace agent defaults.
 
 ## Add the workflow
@@ -26,7 +26,7 @@ the slug of your Sentry integration connection. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Triage new Sentry issues
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_issue:

--- a/apps/docs/content/docs/how-to/set-up-work/add-custom-model-provider.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/add-custom-model-provider.mdx
@@ -70,7 +70,7 @@ example values with the values saved in the form. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Review with a custom provider
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/set-up-work/configure-model-providers.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/configure-model-providers.mdx
@@ -14,7 +14,7 @@ You need:
 
 - The provider's API key. The form asks for any other provider values.
 - A project that can sync workflow files.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 
 ## Configure the agent runtime
 
@@ -78,7 +78,7 @@ the workspace settings you checked above.
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Check agent defaults
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/how-to/set-up-work/create-project.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/create-project.mdx
@@ -57,7 +57,7 @@ a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Project integration connection check
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:
@@ -76,5 +76,5 @@ Commit the file to the default branch. Push it, then open the project's
 A successful sync lists the workflow. If the sync badge reports a failure, use
 [Troubleshoot workflow sync](/how-to/run-and-troubleshoot/workflow-sync).
 
-You only need an online `ubuntu-latest` runner to start the workflow. Shipfox
+You only need an online `shipfox` runner to start the workflow. Shipfox
 can find the workflow without a runner.

--- a/apps/docs/content/docs/how-to/set-up-work/secrets-and-variables.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/secrets-and-variables.mdx
@@ -30,7 +30,7 @@ Add this complete workflow to the project:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Verify workspace values
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -16,7 +16,7 @@ workflow into your repository, push it, then start it from the dashboard:
 ```yaml title=".shipfox/workflows/hello.yaml"
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Hello world
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_demand:

--- a/apps/docs/content/docs/installation/local.mdx
+++ b/apps/docs/content/docs/installation/local.mdx
@@ -134,7 +134,7 @@ without a cloud account. For a production deployment, see
     ```bash
     SHIPFOX_API_URL=http://localhost:16101 \
     SHIPFOX_RUNNER_REGISTRATION_TOKEN=<YOUR_REGISTRATION_TOKEN> \
-    SHIPFOX_RUNNER_LABELS=ubuntu-latest,node-22 \
+    SHIPFOX_RUNNER_LABELS=shipfox,node-22 \
     pnpm --filter=@shipfox/runner dev
     ```
 
@@ -158,7 +158,7 @@ without a cloud account. For a production deployment, see
     ```yaml
     # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
     name: First run
-    runner: ubuntu-latest
+    runner: shipfox
     triggers:
       on_demand:
         source: manual

--- a/apps/docs/content/docs/integrations/github/setup.mdx
+++ b/apps/docs/content/docs/integrations/github/setup.mdx
@@ -13,7 +13,7 @@ integration connection can give selected GitHub tools to an agent. See the
 You need access to workspace integration settings. You must also be able to
 install a GitHub App on the target account or organization.
 
-To verify a run, you also need an online runner with the `ubuntu-latest` label.
+To verify a run, you also need an online runner with the `shipfox` label.
 
 ## Install the GitHub App
 
@@ -57,7 +57,7 @@ workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Check the GitHub integration connection
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_push:

--- a/apps/docs/content/docs/integrations/sentry/setup.mdx
+++ b/apps/docs/content/docs/integrations/sentry/setup.mdx
@@ -13,7 +13,7 @@ You need access to workspace integration settings. You must also be able to
 install an App in the target Sentry organization.
 
 To verify a run, you also need a project that can sync workflows and an online
-runner with the `ubuntu-latest` label.
+runner with the `shipfox` label.
 
 ## Install the Sentry App
 
@@ -49,7 +49,7 @@ with the integration connection slug. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Check the Sentry integration connection
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_issue:

--- a/apps/docs/content/docs/integrations/webhooks/setup.mdx
+++ b/apps/docs/content/docs/integrations/webhooks/setup.mdx
@@ -14,7 +14,7 @@ You need access to workspace integration settings. You also need a terminal or
 system that can send an HTTP `POST` request.
 
 To verify a run, you need a project that can sync workflows and an online runner
-with the `ubuntu-latest` label.
+with the `shipfox` label.
 
 ## Create the integration connection
 
@@ -62,7 +62,7 @@ the integration connection slug. This is a complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Check the custom webhook
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_deploy_event:

--- a/apps/docs/content/docs/operations/runners.mdx
+++ b/apps/docs/content/docs/operations/runners.mdx
@@ -36,7 +36,7 @@ each placeholder with a value from your deployment:
 ```bash
 SHIPFOX_API_URL='<YOUR_SHIPFOX_API_URL>' \
 SHIPFOX_RUNNER_REGISTRATION_TOKEN='<YOUR_REGISTRATION_TOKEN>' \
-SHIPFOX_RUNNER_LABELS='ubuntu-latest' \
+SHIPFOX_RUNNER_LABELS='shipfox' \
 SHIPFOX_POLL_MAX_DURATION_MS=0 \
 mise exec -- pnpm --filter=@shipfox/runner dev
 ```

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -14,6 +14,9 @@ guide](/how-to).
   <Card title="Workflow schema" href="/reference/workflow-schema">
     Look up trigger, job, step, agent, gate, and listening fields.
   </Card>
+  <Card title="Runner labels" href="/reference/runner-labels">
+    Compare CPU, memory, and workspace storage for Shipfox-hosted runners.
+  </Card>
   <Card title="Contexts" href="/reference/contexts">
     Look up every context, its properties, and the fields that can read it.
   </Card>
@@ -42,7 +45,7 @@ guide](/how-to).
   </Card>
 </Cards>
 
-## Runners
+## Runner operations
 
 <Cards>
   <Card title="Runner configuration" href="/reference/runner">

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "workflow-schema",
+    "runner-labels",
     "contexts",
     "expressions",
     "trigger-sources",

--- a/apps/docs/content/docs/reference/runner-labels.mdx
+++ b/apps/docs/content/docs/reference/runner-labels.mdx
@@ -1,0 +1,20 @@
+---
+title: "Runner Labels Reference"
+sidebarTitle: "Runner Labels"
+description: "All shipfox hosted runners on Shipfox cloud."
+---
+
+## Available labels
+
+| Labels | CPU | RAM | Workspace disk |
+| --- | ---: | ---: | ---: |
+| `shipfox-1cpu` | 1 vCPU | 4 GiB | 25 GiB |
+| `shipfox`<br />`shipfox-2cpu` | 2 vCPUs | 8 GiB | 50 GiB |
+| `shipfox-4cpu` | 4 vCPUs | 16 GiB | 100 GiB |
+| `shipfox-8cpu` | 8 vCPUs | 32 GiB | 200 GiB |
+| `shipfox-16cpu` | 16 vCPUs | 64 GiB | 400 GiB |
+
+All Shipfox-hosted runners use Ubuntu 24.04 on the x64 architecture. The
+workspace disk holds the job checkout and other files created during the job.
+Each runner also has a separate 30 GiB system disk for the operating system and
+installed tools.

--- a/apps/docs/content/docs/reference/runner.mdx
+++ b/apps/docs/content/docs/reference/runner.mdx
@@ -30,6 +30,9 @@ heartbeat remains healthy.
 
 A job is dispatched to a runner only when the runner's labels include **all** labels the job's `runner:` field requires. A runner may carry several labels; one machine may run several runner processes with different label sets.
 
+For the Shipfox-hosted labels available in Shipfox Cloud, see [Runner
+labels](/reference/runner-labels).
+
 ## Token types
 
 | Prefix | Name | Created by | Lifetime |
@@ -74,6 +77,9 @@ Model provider credentials are **workspace configuration**, delivered to the run
 ## Related pages
 
 <Cards>
+  <Card title="Runner labels" href="/reference/runner-labels">
+    Compare Shipfox-hosted runner CPU, memory, and workspace storage.
+  </Card>
   <Card title="Runners and execution" href="/understand/runners-and-execution-environments">
     Understand placement, labels, capacity, and checkout isolation.
   </Card>

--- a/apps/docs/content/docs/tutorials/respond-to-pull-request-feedback.mdx
+++ b/apps/docs/content/docs/tutorials/respond-to-pull-request-feedback.mdx
@@ -27,7 +27,7 @@ Use a test repository, not production work. The repository must have:
 - A GitHub integration connection that can read pull requests and post review-comment
   replies.
 - The integration connection slug. This lesson uses `github_acme` as a placeholder.
-- An online runner with the `ubuntu-latest` label.
+- An online runner with the `shipfox` label.
 - A configured model provider and workspace agent defaults.
 - Permission to open and close a pull request and add a review comment.
 
@@ -43,7 +43,7 @@ complete workflow:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Respond to pull request feedback
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   on_pull_request:

--- a/apps/docs/content/docs/understand/data-and-templating.mdx
+++ b/apps/docs/content/docs/understand/data-and-templating.mdx
@@ -56,7 +56,7 @@ This complete workflow moves a version between two isolated jobs:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Pass a version between jobs
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/understand/feedback-loops.mdx
+++ b/apps/docs/content/docs/understand/feedback-loops.mdx
@@ -37,13 +37,15 @@ that decides whether the next action is safe. A unit test can guard behavior
 before a commit. A policy check can guard a deploy. A read-back can confirm an
 external write.
 
-In a project with `npm test`, an online `ubuntu-latest` runner, and configured
-agent defaults, this complete workflow shows the loop:
+Every Shipfox Cloud workspace can run this example on the hosted
+[`shipfox` runner](/reference/runner-labels). The project also needs an
+`npm test` command and configured agent defaults. This complete workflow shows
+the loop:
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Fix failing tests
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:

--- a/apps/docs/content/docs/understand/index.mdx
+++ b/apps/docs/content/docs/understand/index.mdx
@@ -8,8 +8,9 @@ Shipfox stores engineering work as **workflows** beside the code they act on.
 An event starts a run. Jobs divide the work. Runners provide the compute, and
 steps perform fixed commands or work that needs an agent's judgment.
 
-Shipfox plans and records the work. Runners do it in an environment that the
-team controls.
+Shipfox plans and records the work. Runners execute it in an isolated
+environment. Every Shipfox Cloud workspace can use Shipfox-hosted runners.
+Teams can also connect self-managed runners for environments they control.
 
 The same model appears in the workflow file and in the run view.
 
@@ -52,7 +53,7 @@ Read these pages in order when the model is new.
    boundary and what that boundary isolates.
 5. [Runners and execution
    environments](/understand/runners-and-execution-environments) explains how
-   labels and capacity place each job.
+   hosted and self-managed capacity place each job.
 6. [Context and templating](/understand/data-and-templating) explains when data
    becomes available and how results move forward.
 7. [Integrations, integration connections, and

--- a/apps/docs/content/docs/understand/jobs-and-steps.mdx
+++ b/apps/docs/content/docs/understand/jobs-and-steps.mdx
@@ -51,7 +51,7 @@ This complete workflow shows the boundary:
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
 name: Check and review a change
-runner: ubuntu-latest
+runner: shipfox
 
 triggers:
   manual:
@@ -76,6 +76,10 @@ jobs:
 `lint` and `test` can run in parallel. Each installs its own dependencies.
 `review` waits for both, but receives neither job's files nor logs. It reviews
 its own fresh checkout.
+
+The `shipfox` label selects the default Shipfox-hosted runner, which is
+available to every Shipfox Cloud workspace. The [Runner labels
+reference](/reference/runner-labels) lists the other hosted sizes.
 
 The [parallel CI
 recipe](/how-to/recipes/parallel-ci-agent-review) applies this shape to a GitHub

--- a/apps/docs/content/docs/understand/runners-and-execution-environments.mdx
+++ b/apps/docs/content/docs/understand/runners-and-execution-environments.mdx
@@ -1,33 +1,31 @@
 ---
 title: "Runners and execution environments"
 sidebarTitle: "Runners & Execution"
-description: "Understand how labels, capacity, isolation, and network access place jobs on your compute."
+description: "Understand how Shipfox-hosted and self-managed runners use labels, capacity, isolation, and network access."
 ---
 
-A **runner** is the process that claims and executes Shipfox jobs on compute the
-team controls. Shipfox plans the job, tracks its state, and stores its result.
-The runner owns the environment where commands and agents actually work.
+A **runner** is the process that claims and executes Shipfox jobs. Shipfox plans
+the job, tracks its state, and stores its result. The runner owns the environment
+where commands and agents actually work.
 
-Shipfox decides which work is ready. A runner decides which ready job it can
-claim.
+Every Shipfox Cloud workspace can use Shipfox-hosted runners with no installation or registration. Workflows select them using a [Shipfox-hosted runner label](/reference/runner-labels).
 
-A label is a promise about the host. Capacity says how much work it can take.
-Both must fit before a job starts.
+Teams can also connect self-managed runners for private networks, specialized hardware, or local tools. Both use the same job and label model.
 
-The workflow asks for needs, not a machine name. This keeps placement easy to
-review.
-It also keeps jobs portable.
+With self-managed runners, teams control capacity and access. Shipfox-hosted runners handle that operational work for jobs that fit the hosted environment.
 
-This boundary lets work reach private code and internal networks. It can also
-use special hardware and local tools. Shipfox does not own that infrastructure.
-The team owns its capacity and access.
 
 ## Labels express placement needs
 
 A job requests labels. A runner can claim it only when the runner has every
 requested label and free capacity.
 
-Useful labels describe capabilities or policy.
+Shipfox-hosted labels select a documented execution environment and size. The
+[Runner labels reference](/reference/runner-labels) lists their CPU, memory,
+storage, operating system, and architecture. Self-managed labels describe the
+capabilities or policies that the team provides.
+
+Useful self-managed labels describe capabilities or policy.
 
 - Operating system or architecture.
 - Hardware such as a GPU or large-memory machine.
@@ -45,6 +43,9 @@ with more access than it needs.
 
 A job can be ready even when it cannot start. No online runner may match its
 labels, or every matching runner may already be at capacity.
+
+Hosted runners are available to every Shipfox Cloud workspace, but a job can
+still wait while matching hosted capacity is busy.
 
 In that state the job remains pending. The workflow has not failed, and starting
 another run does not create the missing capacity. The scheduler waits for a
@@ -66,6 +67,8 @@ Each job execution receives a fresh repository checkout. Steps in that
 execution share the files. Separate jobs and later listening executions do not
 share files, installed packages, process environment, or logs.
 
+On Shipfox Cloud, a hosted runner serves one job and stops after that job ends.
+
 Isolation makes placement flexible. A retry or parallel job does not depend on
 files from another runner. Isolation also adds setup work. Each job must install
 its own tools or restore them from an external cache.
@@ -84,20 +87,26 @@ Network access belongs in placement design. A runner on a private network can
 reach internal systems. Work placed there also gets that reach. Use labels and
 workspace boundaries to send only the intended jobs there.
 
-## Long-lived and provisioned runners trade speed for isolation
+## Hosted and self-managed runner models
 
-The two models make different tradeoffs.
+Shipfox-hosted runners are provisioned for one job. Self-managed runners can
+stay online or be provisioned for each job. These models make different
+tradeoffs.
 
 | Model | Fits | Tradeoff |
 | --- | --- | --- |
-| Long-lived runner | Steady work and environments that are slow to create. | Starts quickly, but the host and capacity must be maintained over time. |
-| Provisioned runner | Bursty work or a strong single-job cleanup boundary. | Starts from a cleaner environment, but adds startup time and infrastructure. |
+| Shipfox-hosted runner | Every Shipfox Cloud workspace and jobs that fit a documented hosted environment. | Requires no runner infrastructure from the team, but its capabilities follow the hosted runner catalog. |
+| Self-managed long-lived runner | Steady work and environments that are slow to create. | Starts quickly, but the host and capacity must be maintained over time. |
+| Self-managed provisioned runner | Bursty work or a strong single-job cleanup boundary. | Starts from a cleaner environment, but adds startup time and infrastructure. |
 
-Both models use the same job and label rules. Checkout and permission rules also
-stay the same. A workspace can use both. The workflow asks for labels. It does
-not choose how long a runner lives.
+All models use the same job and label rules. Checkout and permission rules also
+stay the same. A Shipfox Cloud workspace can combine hosted and self-managed
+runners. The workflow asks for labels. It does not choose how long a runner
+lives.
 
-Use [Start and register a runner](/operations/runners) for the operational
-task. The [Runner reference](/reference/runner) lists exact configuration and
-token facts. [Jobs and steps](/understand/jobs-and-steps) explains when work
-should share one execution environment.
+Use the [Runner labels reference](/reference/runner-labels) to choose hosted
+capacity. Use [Start and register a runner](/operations/runners) to add
+self-managed capacity. The [Runner configuration
+reference](/reference/runner) lists exact configuration and token facts. [Jobs
+and steps](/understand/jobs-and-steps) explains when work should share one
+execution environment.


### PR DESCRIPTION
## Summary

Give Shipfox Cloud users a clear reference for the hosted runner capacity available to every workspace, including the `shipfox` and `shipfox-2cpu` alias relationship.

Use the real `shipfox` default throughout workflow examples and clarify when teams would choose Shipfox-hosted or self-managed runners.

## Validation

Passed `mise exec -- turbo check test --filter=@shipfox/docs`.

Passed `mise exec -- turbo build --filter=@shipfox/docs...`.

Confirmed the final diff is clean and `apps/docs` contains no `ubuntu-latest` or `shipfox-default` runner labels.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents Shipfox-hosted runner labels and switches all docs and examples from the old `ubuntu-latest`/`shipfox-default` labels to the hosted default `shipfox` (an alias of `shipfox-2cpu`). This aligns guidance with the capacity available to every Shipfox Cloud workspace.

- Adds a new reference page at /reference/runner-labels listing hosted sizes and the `shipfox` ↔ `shipfox-2cpu` alias.
- Updates how-to, tutorials, integration setup, and conceptual pages to use `shipfox` by default and link to the new reference; shows job-level overrides like `shipfox-8cpu`.
- Clarifies hosted vs self-managed runner positioning and keeps self-managed label examples (e.g., `[linux, gpu]`) where relevant.
- Replaces prior links to Runners with Runner labels where capacity choice is the goal.

**Review notes**
- Verify the new Runner labels reference for accuracy of CPU, RAM, and disk values and alias behavior.
- Spot-check that all workflow snippets now use `runner: shipfox` and that no `ubuntu-latest` or `shipfox-default` labels remain.
- Confirm cross-links: reference index/cards, runner config page, and “Runners & Execution” all point to Runner labels appropriately.

**Adoption**
- If you previously copied examples using `ubuntu-latest`, update them to `shipfox` (or another hosted size like `shipfox-8cpu`). Self-managed runner usage is unchanged.

<sup>Written for commit b9b882261a6595e9011365cf6437b8ba97fc5cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

