### PR TITLE
Restore page interaction after closing modal surfaces

### DIFF
--- a/.changeset/modal-body-release.md
+++ b/.changeset/modal-body-release.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Stops closing Modal, Sheet, and DropdownMenu surfaces from catching clicks while they animate out, and releases the body pointer-events lock once they close, so a stalled or missed dismissal no longer leaves the page unclickable until a reload.

--- a/.changeset/modal-body-release.md
+++ b/.changeset/modal-body-release.md
@@ -2,4 +2,4 @@
 "@shipfox/react-ui": patch
 ---
 
-Stops closing Modal, Sheet, and DropdownMenu surfaces from catching clicks while they animate out, and releases the body pointer-events lock once they close, so a stalled or missed dismissal no longer leaves the page unclickable until a reload.
+Stops closing Modal, Sheet, and popper surfaces from catching clicks while they animate out. Modal and Sheet also release a body pointer-events lock left behind by a missed dismissal.

--- a/.changeset/usage-modal-standard-close.md
+++ b/.changeset/usage-modal-standard-close.md
@@ -2,4 +2,4 @@
 "@shipfox/client-integrations": patch
 ---
 
-Closes the integration usage modal through the shared Modal lifecycle instead of unmounting it directly, restoring its exit animation.
+Closes the integration usage modal through the shared Modal lifecycle instead of unmounting it directly. Requires the matching `@shipfox/react-ui` patch for the closed-state pointer-events guard.

--- a/.changeset/usage-modal-standard-close.md
+++ b/.changeset/usage-modal-standard-close.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-integrations": patch
+---
+
+Closes the integration usage modal through the shared Modal lifecycle instead of unmounting it directly, restoring its exit animation.

--- a/.changeset/usage-modal-standard-close.md
+++ b/.changeset/usage-modal-standard-close.md
@@ -2,4 +2,4 @@
 "@shipfox/client-integrations": patch
 ---
 
-Closes the integration usage modal through the shared Modal lifecycle instead of unmounting it directly. Requires the matching `@shipfox/react-ui` patch for the closed-state pointer-events guard.
+Closes the integration usage modal through the shared Modal lifecycle instead of unmounting it directly, so it completes its exit animation.

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -163,7 +163,12 @@ export const UsageModalCloseRestoresInteraction: Story = {
     await user.click(await screen.findByRole('button', {name: 'Done'}));
     // The dialog stays mounted while it animates out, which is what keeps the
     // close from being an abrupt unmount.
-    expect(document.querySelector('[role="dialog"][data-state="closed"]')).not.toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Use acme-corp'})).toHaveAttribute(
+        'data-state',
+        'closed',
+      );
+    });
     // Both the removal and the body pointer-events release therefore land after
     // the click rather than on the same tick.
     await waitFor(() => {

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -161,8 +161,11 @@ export const UsageModalCloseRestoresInteraction: Story = {
     await user.click(await screen.findByRole('menuitem', {name: 'Use this integration'}));
     await screen.findByRole('dialog', {name: 'Use acme-corp'});
     await user.click(await screen.findByRole('button', {name: 'Done'}));
-    // The dialog plays an exit animation, so both the removal and the body
-    // pointer-events release land after the click rather than on the same tick.
+    // The dialog stays mounted while it animates out, which is what keeps the
+    // close from being an abrupt unmount.
+    expect(document.querySelector('[role="dialog"][data-state="closed"]')).not.toBeNull();
+    // Both the removal and the body pointer-events release therefore land after
+    // the click rather than on the same tick.
     await waitFor(() => {
       expect(screen.queryByRole('dialog', {name: 'Use acme-corp'})).not.toBeInTheDocument();
       expect(document.body.style.pointerEvents).not.toBe('none');

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -161,12 +161,16 @@ export const UsageModalCloseRestoresInteraction: Story = {
     await user.click(await screen.findByRole('menuitem', {name: 'Use this integration'}));
     await screen.findByRole('dialog', {name: 'Use acme-corp'});
     await user.click(await screen.findByRole('button', {name: 'Done'}));
-    expect(screen.queryByRole('dialog', {name: 'Use acme-corp'})).not.toBeInTheDocument();
-    // The dialog unmounts before its dismissable layer releases the body, so
-    // wait for the release rather than asserting it on the same tick: clicking
-    // while `pointer-events: none` is still set is swallowed silently.
+    // The dialog plays an exit animation, so both the removal and the body
+    // pointer-events release land after the click rather than on the same tick.
     await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Use acme-corp'})).not.toBeInTheDocument();
       expect(document.body.style.pointerEvents).not.toBe('none');
+    });
+    // Radix dismisses on the first outside pointerdown while the previous menu is
+    // still mounted, so let it finish leaving before reopening.
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="menu"]')).toHaveLength(0);
     });
     await user.click(actionsButton);
     await screen.findByRole('menuitem', {name: 'Use this integration'});

--- a/libs/client/integrations/src/components/integration-usage-modal.tsx
+++ b/libs/client/integrations/src/components/integration-usage-modal.tsx
@@ -71,10 +71,8 @@ export function IntegrationUsageModal({
   );
   const title = connection ? `Use ${connection.displayName}` : 'Use integration';
 
-  if (!open || connection === null) return null;
-
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal open={open && connection !== null} onOpenChange={onOpenChange}>
       <ModalContent aria-describedby={undefined} className="max-h-[calc(100vh-32px)] max-w-[640px]">
         <ModalTitle className="sr-only">{title}</ModalTitle>
         <ModalHeader>

--- a/libs/client/integrations/src/components/integration-usage-modal.tsx
+++ b/libs/client/integrations/src/components/integration-usage-modal.tsx
@@ -26,7 +26,7 @@ import {
 } from '@shipfox/react-ui/select';
 import {Text} from '@shipfox/react-ui/typography';
 import type {ReactNode} from 'react';
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {ConnectionStatusBadge} from '#connection-status-badge.js';
 import type {IntegrationConnection} from '#core/models.js';
 
@@ -62,14 +62,20 @@ export function IntegrationUsageModal({
     );
   }, [eventValuesKey]);
 
-  const workflowExample = connection
-    ? buildWorkflowExample({source: connection.slug, event: selectedEvent})
+  // The caller clears the connection in the same render that closes the modal,
+  // so keep the last one to render against while the surface animates out.
+  const lastConnection = useRef(connection);
+  if (connection !== null) lastConnection.current = connection;
+  const shownConnection = connection ?? lastConnection.current;
+
+  const workflowExample = shownConnection
+    ? buildWorkflowExample({source: shownConnection.slug, event: selectedEvent})
     : '';
   const data = useMemo(
     () => [{language: 'yaml', filename: WORKFLOW_FILENAME, code: workflowExample}],
     [workflowExample],
   );
-  const title = connection ? `Use ${connection.displayName}` : 'Use integration';
+  const title = shownConnection ? `Use ${shownConnection.displayName}` : 'Use integration';
 
   return (
     <Modal open={open && connection !== null} onOpenChange={onOpenChange}>
@@ -81,8 +87,11 @@ export function IntegrationUsageModal({
               <Text size="lg" aria-hidden="true" className="truncate">
                 {title}
               </Text>
-              {connection ? (
-                <ConnectionStatusBadge status={connection.lifecycleStatus} className="shrink-0" />
+              {shownConnection ? (
+                <ConnectionStatusBadge
+                  status={shownConnection.lifecycleStatus}
+                  className="shrink-0"
+                />
               ) : null}
             </div>
             <Text size="sm" className="text-foreground-neutral-muted">
@@ -90,7 +99,7 @@ export function IntegrationUsageModal({
             </Text>
           </div>
         </ModalHeader>
-        {connection ? (
+        {shownConnection ? (
           <>
             <ModalBody className="min-h-0 flex-1 gap-section overflow-y-auto overflow-x-clip scrollbar">
               <section className="flex w-full flex-col gap-cluster">

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -1235,6 +1235,13 @@
   * {
     @apply border-border-neutral-base font-display;
   }
+  /* Radix positions every popper surface (dropdown menu, submenu, select,
+     popover) inside this wrapper and keeps it mounted for the exit animation.
+     The wrapper, not the content, is what a click hits, so it has to go inert
+     as soon as its surface starts closing. */
+  [data-radix-popper-content-wrapper]:has([data-state="closed"]) {
+    pointer-events: none;
+  }
   html {
     @apply bg-background-neutral-base text-foreground-neutral-base;
     font-feature-settings:

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -1239,7 +1239,7 @@
      popover) inside this wrapper and keeps it mounted for the exit animation.
      The wrapper, not the content, is what a click hits, so it has to go inert
      as soon as its surface starts closing. */
-  [data-radix-popper-content-wrapper]:has([data-state="closed"]) {
+  [data-radix-popper-content-wrapper]:has(> [data-state="closed"]) {
     pointer-events: none;
   }
   html {

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -439,13 +439,15 @@ export const TestClosingMenuStopsCatchingClicks: Story = {
     await userEvent.click(await screen.findByRole('button', {name: 'Open Menu'}));
     await userEvent.click(await screen.findByRole('menuitem', {name: 'Edit'}));
 
-    const menu = document.querySelector('[role="menu"][data-state="closed"]');
-    expect(menu).not.toBeNull();
-    expect(window.getComputedStyle(menu as Element).pointerEvents).toBe('none');
+    await waitFor(() => {
+      const menu = document.querySelector('[role="menu"][data-state="closed"]');
+      expect(menu).not.toBeNull();
+      expect(window.getComputedStyle(menu as Element).pointerEvents).toBe('none');
 
-    const wrapper = (menu as Element).closest('[data-radix-popper-content-wrapper]');
-    expect(wrapper).not.toBeNull();
-    expect(window.getComputedStyle(wrapper as Element).pointerEvents).toBe('none');
+      const wrapper = (menu as Element).closest('[data-radix-popper-content-wrapper]');
+      expect(wrapper).not.toBeNull();
+      expect(window.getComputedStyle(wrapper as Element).pointerEvents).toBe('none');
+    });
 
     await waitFor(() => {
       expect(document.querySelector('[role="menu"]')).toBeNull();

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -1,7 +1,9 @@
 import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
-import {screen} from '@testing-library/react';
+import {screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
+import {expect} from 'storybook/test';
 import {Avatar} from '../avatar/index.js';
 import {Button} from '../button/index.js';
 import {
@@ -423,5 +425,30 @@ export const CompleteExample: Story = {
         )}
       </div>
     );
+  },
+};
+
+/**
+ * Radix keeps the menu mounted inside its popper wrapper for the exit animation,
+ * and the wrapper is what a click hits. Both have to go inert as soon as the
+ * menu starts closing, or the first click after a dismissal is swallowed.
+ */
+export const TestClosingMenuStopsCatchingClicks: Story = {
+  ...Playground,
+  play: async () => {
+    await userEvent.click(await screen.findByRole('button', {name: 'Open Menu'}));
+    await userEvent.click(await screen.findByRole('menuitem', {name: 'Edit'}));
+
+    const menu = document.querySelector('[role="menu"][data-state="closed"]');
+    expect(menu).not.toBeNull();
+    expect(window.getComputedStyle(menu as Element).pointerEvents).toBe('none');
+
+    const wrapper = (menu as Element).closest('[data-radix-popper-content-wrapper]');
+    expect(wrapper).not.toBeNull();
+    expect(window.getComputedStyle(wrapper as Element).pointerEvents).toBe('none');
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
   },
 };

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -35,6 +35,9 @@ const dropdownMenuContentVariants = cva(
     'data-[state=open]:animate-in data-[state=closed]:animate-out',
     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+    // The menu outlives its own close by the length of the exit animation; stop
+    // it catching clicks meant for whatever is underneath.
+    'data-[state=closed]:pointer-events-none!',
     'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
     'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
   ],

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -35,9 +35,6 @@ const dropdownMenuContentVariants = cva(
     'data-[state=open]:animate-in data-[state=closed]:animate-out',
     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-    // The menu outlives its own close by the length of the exit animation; stop
-    // it catching clicks meant for whatever is underneath.
-    'data-[state=closed]:pointer-events-none!',
     'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
     'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
   ],

--- a/libs/shared/react/ui/src/components/modal/modal.stories.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.stories.tsx
@@ -216,11 +216,13 @@ export const TestClosingSurfaceStopsCatchingClicks: Story = {
 
     await userEvent.click(await screen.findByRole('button', {name: CANCEL_REGEX}));
 
-    const closing = document.querySelectorAll(CLOSING_SURFACE_SELECTOR);
-    expect(closing.length).toBeGreaterThan(0);
-    for (const node of closing) {
-      expect(window.getComputedStyle(node).pointerEvents).toBe('none');
-    }
+    await waitFor(() => {
+      const closing = document.querySelectorAll(CLOSING_SURFACE_SELECTOR);
+      expect(closing.length).toBeGreaterThan(0);
+      for (const node of closing) {
+        expect(window.getComputedStyle(node).pointerEvents).toBe('none');
+      }
+    });
 
     await waitFor(() => {
       expect(document.body.style.pointerEvents).not.toBe('none');

--- a/libs/shared/react/ui/src/components/modal/modal.stories.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.stories.tsx
@@ -1,8 +1,9 @@
 import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
-import {screen, within} from '@testing-library/react';
+import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
+import {expect} from 'storybook/test';
 import {Button} from '../button/index.js';
 import {Input} from '../input/index.js';
 import {Label} from '../label/index.js';
@@ -63,28 +64,6 @@ export const Playground: Story = {
         </Modal>
       </div>
     );
-  },
-};
-
-/**
- * The overlay outlives the modal by the length of its exit animation. While it
- * is still on screen it must not catch clicks meant for the page behind it,
- * otherwise a stalled exit leaves the page silently inert.
- */
-export const ClosingOverlayStopsCatchingClicks: Story = {
-  ...Playground,
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(await canvas.findByRole('button', {name: OPEN_MODAL_REGEX}));
-    await screen.findByRole('dialog');
-
-    await userEvent.click(await screen.findByRole('button', {name: CANCEL_REGEX}));
-
-    const overlay = document.querySelector('[data-state="closed"].fixed.inset-0');
-    if (overlay === null) throw new Error('overlay left the DOM before it could be checked');
-    if (window.getComputedStyle(overlay).pointerEvents !== 'none') {
-      throw new Error('closing overlay still catches pointer events');
-    }
   },
 };
 
@@ -216,5 +195,35 @@ export const SettingsForm: Story = {
         </Modal>
       </div>
     );
+  },
+};
+
+const CLOSING_SURFACE_SELECTOR =
+  '[data-state="closed"][role="dialog"], [data-state="closed"].fixed.inset-0';
+
+/**
+ * Overlay and content both outlive the modal by the length of the exit
+ * animation. While they are on screen they must not catch clicks meant for the
+ * page behind them, otherwise a stalled exit leaves the page silently inert.
+ * The body pointer-events lock has to come off in the same window.
+ */
+export const TestClosingSurfaceStopsCatchingClicks: Story = {
+  ...Playground,
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', {name: OPEN_MODAL_REGEX}));
+    await screen.findByRole('dialog');
+
+    await userEvent.click(await screen.findByRole('button', {name: CANCEL_REGEX}));
+
+    const closing = document.querySelectorAll(CLOSING_SURFACE_SELECTOR);
+    expect(closing.length).toBeGreaterThan(0);
+    for (const node of closing) {
+      expect(window.getComputedStyle(node).pointerEvents).toBe('none');
+    }
+
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
   },
 };

--- a/libs/shared/react/ui/src/components/modal/modal.stories.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.stories.tsx
@@ -19,6 +19,7 @@ import {
 
 const OPEN_MODAL_REGEX = /open modal/i;
 const ACCOUNT_SETTINGS_REGEX = /account settings/i;
+const CANCEL_REGEX = /cancel/i;
 
 const meta = {
   title: 'Components/Modal',
@@ -62,6 +63,28 @@ export const Playground: Story = {
         </Modal>
       </div>
     );
+  },
+};
+
+/**
+ * The overlay outlives the modal by the length of its exit animation. While it
+ * is still on screen it must not catch clicks meant for the page behind it,
+ * otherwise a stalled exit leaves the page silently inert.
+ */
+export const ClosingOverlayStopsCatchingClicks: Story = {
+  ...Playground,
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', {name: OPEN_MODAL_REGEX}));
+    await screen.findByRole('dialog');
+
+    await userEvent.click(await screen.findByRole('button', {name: CANCEL_REGEX}));
+
+    const overlay = document.querySelector('[data-state="closed"].fixed.inset-0');
+    if (overlay === null) throw new Error('overlay left the DOM before it could be checked');
+    if (window.getComputedStyle(overlay).pointerEvents !== 'none') {
+      throw new Error('closing overlay still catches pointer events');
+    }
   },
 };
 

--- a/libs/shared/react/ui/src/components/modal/modal.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.tsx
@@ -2,7 +2,7 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {cva} from 'class-variance-authority';
-import {type ComponentProps, createContext, type ReactNode, useContext, useState} from 'react';
+import {type ComponentProps, createContext, type ReactNode, useContext} from 'react';
 import {Drawer as VaulDrawer} from 'vaul';
 import {useBodyPointerEventsRelease} from '#hooks/useBodyPointerEventsRelease.js';
 import {useMediaQuery} from '#hooks/useMediaQuery.js';
@@ -28,9 +28,9 @@ function useModalContext() {
 }
 
 // A closing surface outlives its dialog: the overlay keeps covering the page for
-// the length of its exit animation, and Radix gives it `pointer-events: auto`.
-// Dropping pointer events on `data-state=closed` keeps a fading — or stuck —
-// overlay from eating clicks meant for the page behind it.
+// the length of its exit animation, and Radix gives it `pointer-events: auto`
+// inline. Dropping pointer events on `data-state=closed` keeps a fading (or
+// stuck) overlay from eating clicks meant for the page behind it.
 const modalOverlayVariants = cva(
   'fixed inset-0 z-40 bg-background-backdrop-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:pointer-events-none!',
 );
@@ -46,10 +46,7 @@ function Modal({
   ...props
 }: ComponentProps<typeof DialogPrimitive.Root> & {breakpoint?: string}) {
   const isDesktop = useMediaQuery(breakpoint);
-  // Mirrors the open state so uncontrolled callers are covered too.
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(props.defaultOpen ?? false);
-
-  useBodyPointerEventsRelease(props.open ?? uncontrolledOpen);
+  const trackOpenChange = useBodyPointerEventsRelease(props.open);
 
   const contextValue: ModalContextValue = {
     breakpoint,
@@ -59,7 +56,7 @@ function Modal({
   const Root = isDesktop ? DialogPrimitive.Root : VaulDrawer.Root;
 
   function handleOpenChange(nextOpen: boolean) {
-    setUncontrolledOpen(nextOpen);
+    trackOpenChange(nextOpen);
     onOpenChange?.(nextOpen);
   }
 

--- a/libs/shared/react/ui/src/components/modal/modal.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.tsx
@@ -46,7 +46,7 @@ function Modal({
   ...props
 }: ComponentProps<typeof DialogPrimitive.Root> & {breakpoint?: string}) {
   const isDesktop = useMediaQuery(breakpoint);
-  const trackOpenChange = useBodyPointerEventsRelease(props.open);
+  const trackOpenChange = useBodyPointerEventsRelease(props.open ?? props.defaultOpen);
 
   const contextValue: ModalContextValue = {
     breakpoint,

--- a/libs/shared/react/ui/src/components/modal/modal.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.tsx
@@ -2,8 +2,9 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {cva} from 'class-variance-authority';
-import {type ComponentProps, createContext, type ReactNode, useContext} from 'react';
+import {type ComponentProps, createContext, type ReactNode, useContext, useState} from 'react';
 import {Drawer as VaulDrawer} from 'vaul';
+import {useBodyPointerEventsRelease} from '#hooks/useBodyPointerEventsRelease.js';
 import {useMediaQuery} from '#hooks/useMediaQuery.js';
 import {cn} from '#utils/cn.js';
 import {Button} from '../button/index.js';
@@ -26,20 +27,29 @@ function useModalContext() {
   return context;
 }
 
+// A closing surface outlives its dialog: the overlay keeps covering the page for
+// the length of its exit animation, and Radix gives it `pointer-events: auto`.
+// Dropping pointer events on `data-state=closed` keeps a fading — or stuck —
+// overlay from eating clicks meant for the page behind it.
 const modalOverlayVariants = cva(
-  'fixed inset-0 z-40 bg-background-backdrop-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+  'fixed inset-0 z-40 bg-background-backdrop-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:pointer-events-none!',
 );
 
 const modalContentVariants = cva(
-  'fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100vh-32px)] flex-col overflow-clip bg-background-neutral-base rounded-16 w-full max-w-[576px] -translate-x-1/2 -translate-y-1/2 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 shadow-tooltip',
+  'fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100vh-32px)] flex-col overflow-clip bg-background-neutral-base rounded-16 w-full max-w-[576px] -translate-x-1/2 -translate-y-1/2 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:pointer-events-none! shadow-tooltip',
 );
 
 function Modal({
   breakpoint = '(min-width: 768px)',
   children,
+  onOpenChange,
   ...props
 }: ComponentProps<typeof DialogPrimitive.Root> & {breakpoint?: string}) {
   const isDesktop = useMediaQuery(breakpoint);
+  // Mirrors the open state so uncontrolled callers are covered too.
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(props.defaultOpen ?? false);
+
+  useBodyPointerEventsRelease(props.open ?? uncontrolledOpen);
 
   const contextValue: ModalContextValue = {
     breakpoint,
@@ -48,9 +58,16 @@ function Modal({
 
   const Root = isDesktop ? DialogPrimitive.Root : VaulDrawer.Root;
 
+  function handleOpenChange(nextOpen: boolean) {
+    setUncontrolledOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  }
+
   return (
     <ModalContext.Provider value={contextValue}>
-      <Root {...props}>{children}</Root>
+      <Root {...props} onOpenChange={handleOpenChange}>
+        {children}
+      </Root>
     </ModalContext.Provider>
   );
 }
@@ -110,7 +127,7 @@ function ModalContent({className, children, overlayClassName, ...props}: ModalCo
         <ModalOverlay className={overlayClassName} />
         <VaulDrawer.Content
           className={cn(
-            'fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-background-neutral-base rounded-t-16 max-h-[85vh] shadow-tooltip',
+            'fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-background-neutral-base rounded-t-16 max-h-[85vh] shadow-tooltip data-[state=closed]:pointer-events-none!',
             className,
           )}
           {...props}

--- a/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
@@ -331,11 +331,13 @@ export const TestClosingSurfaceStopsCatchingClicks: Story = {
     const dialog = await screen.findByRole('dialog');
     await userEvent.click(within(dialog).getAllByRole('button')[0] as HTMLElement);
 
-    const closing = document.querySelectorAll(CLOSING_SURFACE_SELECTOR);
-    expect(closing.length).toBeGreaterThan(0);
-    for (const node of closing) {
-      expect(window.getComputedStyle(node).pointerEvents).toBe('none');
-    }
+    await waitFor(() => {
+      const closing = document.querySelectorAll(CLOSING_SURFACE_SELECTOR);
+      expect(closing.length).toBeGreaterThan(0);
+      for (const node of closing) {
+        expect(window.getComputedStyle(node).pointerEvents).toBe('none');
+      }
+    });
 
     await waitFor(() => {
       expect(document.body.style.pointerEvents).not.toBe('none');

--- a/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
@@ -1,7 +1,9 @@
 import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
-import {screen} from '@testing-library/react';
+import {screen, waitFor, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
+import {expect} from 'storybook/test';
 import {Button} from '../button/index.js';
 import {Input} from '../input/index.js';
 import {Label} from '../label/index.js';
@@ -300,5 +302,43 @@ export const LongContent: Story = {
         </Sheet>
       </div>
     );
+  },
+};
+
+const CLOSING_SURFACE_SELECTOR =
+  '[data-state="closed"][role="dialog"], [data-state="closed"].fixed.inset-0';
+
+/**
+ * Closing an uncontrolled sheet must leave the page usable straight away: the
+ * overlay and content stop catching clicks while they slide out, and the body
+ * pointer-events lock comes off. Uncontrolled is the case with no other
+ * coverage, since every visual story above drives `open` itself.
+ */
+export const TestClosingSurfaceStopsCatchingClicks: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+        </SheetHeader>
+        <SheetBody>
+          <Text size="sm">Body</Text>
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  ),
+  play: async () => {
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.click(within(dialog).getAllByRole('button')[0] as HTMLElement);
+
+    const closing = document.querySelectorAll(CLOSING_SURFACE_SELECTOR);
+    expect(closing.length).toBeGreaterThan(0);
+    for (const node of closing) {
+      expect(window.getComputedStyle(node).pointerEvents).toBe('none');
+    }
+
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
   },
 };

--- a/libs/shared/react/ui/src/components/sheet/sheet.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {cva, type VariantProps} from 'class-variance-authority';
-import {type ComponentProps, useState} from 'react';
+import type {ComponentProps} from 'react';
 import {useBodyPointerEventsRelease} from '#hooks/useBodyPointerEventsRelease.js';
 import {useMediaQuery} from '#hooks/useMediaQuery.js';
 import {cn} from '#utils/cn.js';
@@ -52,13 +52,10 @@ const sheetContentVariants = cva(
 );
 
 function Sheet({onOpenChange, ...props}: ComponentProps<typeof DialogPrimitive.Root>) {
-  // Mirrors the open state so uncontrolled callers are covered too.
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(props.defaultOpen ?? false);
-
-  useBodyPointerEventsRelease(props.open ?? uncontrolledOpen);
+  const trackOpenChange = useBodyPointerEventsRelease(props.open);
 
   function handleOpenChange(nextOpen: boolean) {
-    setUncontrolledOpen(nextOpen);
+    trackOpenChange(nextOpen);
     onOpenChange?.(nextOpen);
   }
 

--- a/libs/shared/react/ui/src/components/sheet/sheet.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.tsx
@@ -2,21 +2,25 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {cva, type VariantProps} from 'class-variance-authority';
-import type {ComponentProps} from 'react';
+import {type ComponentProps, useState} from 'react';
+import {useBodyPointerEventsRelease} from '#hooks/useBodyPointerEventsRelease.js';
 import {useMediaQuery} from '#hooks/useMediaQuery.js';
 import {cn} from '#utils/cn.js';
 import {Button} from '../button/index.js';
 import {Icon} from '../icon/index.js';
 import {Kbd} from '../kbd/index.js';
 
+// See modal.tsx: a closing overlay keeps covering the page for the length of its
+// exit animation, so it must stop catching clicks as soon as it starts closing.
 const sheetOverlayVariants = cva(
-  'fixed inset-0 z-40 bg-background-backdrop-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+  'fixed inset-0 z-40 bg-background-backdrop-backdrop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:pointer-events-none!',
 );
 
 const sheetContentVariants = cva(
   [
     'fixed z-50 gap-4 bg-background-neutral-base shadow-tooltip transition ease-in-out',
     'data-[state=open]:animate-in data-[state=closed]:animate-out',
+    'data-[state=closed]:pointer-events-none!',
     'data-[state=closed]:duration-300 data-[state=open]:duration-500',
     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
   ],
@@ -47,8 +51,18 @@ const sheetContentVariants = cva(
   },
 );
 
-function Sheet({...props}: ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="sheet" {...props} />;
+function Sheet({onOpenChange, ...props}: ComponentProps<typeof DialogPrimitive.Root>) {
+  // Mirrors the open state so uncontrolled callers are covered too.
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(props.defaultOpen ?? false);
+
+  useBodyPointerEventsRelease(props.open ?? uncontrolledOpen);
+
+  function handleOpenChange(nextOpen: boolean) {
+    setUncontrolledOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  }
+
+  return <DialogPrimitive.Root data-slot="sheet" {...props} onOpenChange={handleOpenChange} />;
 }
 
 function SheetTrigger({className, ...props}: ComponentProps<typeof DialogPrimitive.Trigger>) {

--- a/libs/shared/react/ui/src/components/sheet/sheet.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.tsx
@@ -52,7 +52,7 @@ const sheetContentVariants = cva(
 );
 
 function Sheet({onOpenChange, ...props}: ComponentProps<typeof DialogPrimitive.Root>) {
-  const trackOpenChange = useBodyPointerEventsRelease(props.open);
+  const trackOpenChange = useBodyPointerEventsRelease(props.open ?? props.defaultOpen);
 
   function handleOpenChange(nextOpen: boolean) {
     trackOpenChange(nextOpen);

--- a/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
+++ b/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
@@ -1,4 +1,5 @@
 import {act, render} from '@testing-library/react';
+import {useEffect} from 'react';
 import {useBodyPointerEventsRelease} from './useBodyPointerEventsRelease.js';
 
 function Probe({open}: {open: boolean}) {
@@ -8,7 +9,12 @@ function Probe({open}: {open: boolean}) {
 
 /** Mirrors an uncontrolled surface, which reports its state through the callback. */
 function CallbackProbe({onReady}: {onReady: (track: (next: boolean) => void) => void}) {
-  onReady(useBodyPointerEventsRelease());
+  const track = useBodyPointerEventsRelease();
+
+  useEffect(() => {
+    onReady(track);
+  }, [onReady, track]);
+
   return null;
 }
 

--- a/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
+++ b/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
@@ -1,4 +1,4 @@
-import {render, waitFor} from '@testing-library/react';
+import {act, render} from '@testing-library/react';
 import {useBodyPointerEventsRelease} from './useBodyPointerEventsRelease.js';
 
 function Probe({open}: {open: boolean}) {
@@ -11,64 +11,100 @@ function lockBody() {
   document.body.style.pointerEvents = 'none';
 }
 
+/** Runs past every checkpoint the hook schedules. */
+function settleCheckpoints() {
+  act(() => {
+    vi.advanceTimersByTime(2000);
+  });
+}
+
+function addLayer(state: 'open' | 'closed') {
+  const layer = document.createElement('div');
+  layer.setAttribute('role', 'menu');
+  layer.setAttribute('data-state', state);
+  document.body.append(layer);
+  return layer;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   document.body.style.removeProperty('pointer-events');
   document.body.replaceChildren();
 });
 
 describe('useBodyPointerEventsRelease', () => {
-  test('releases a lock left behind after the surface closes', async () => {
+  test('releases a lock left behind after the surface closes', () => {
     const {rerender} = render(<Probe open />);
     lockBody();
 
     rerender(<Probe open={false} />);
+    settleCheckpoints();
 
-    await waitFor(() => {
-      expect(document.body.style.pointerEvents).toBe('');
-    });
+    expect(document.body.style.pointerEvents).toBe('');
   });
 
-  test('releases a lock left behind when the surface unmounts while open', async () => {
+  test('releases a lock left behind when the surface unmounts while open', () => {
     const {unmount} = render(<Probe open />);
     lockBody();
 
     unmount();
+    settleCheckpoints();
 
-    await waitFor(() => {
-      expect(document.body.style.pointerEvents).toBe('');
-    });
+    expect(document.body.style.pointerEvents).toBe('');
   });
 
-  test('leaves the lock alone while another layer still owns it', async () => {
-    const menu = document.createElement('div');
-    menu.setAttribute('role', 'menu');
-    document.body.append(menu);
-
+  test('releases the lock even when a closed layer lingers in the document', () => {
     const {rerender} = render(<Probe open />);
     lockBody();
+    addLayer('closed');
 
     rerender(<Probe open={false} />);
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    settleCheckpoints();
+
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+
+  test('leaves the lock alone while an open layer still owns it', () => {
+    const {rerender} = render(<Probe open />);
+    lockBody();
+    addLayer('open');
+
+    rerender(<Probe open={false} />);
+    settleCheckpoints();
 
     expect(document.body.style.pointerEvents).toBe('none');
   });
 
-  test('does not touch the body when no lock is present', async () => {
+  test('leaves a lock the page already held before the surface opened', () => {
+    lockBody();
+    const {rerender} = render(<Probe open />);
+
+    rerender(<Probe open={false} />);
+    settleCheckpoints();
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  test('does not touch the body when no lock is present', () => {
     document.body.style.pointerEvents = 'auto';
     const {rerender} = render(<Probe open />);
 
     rerender(<Probe open={false} />);
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    settleCheckpoints();
 
     expect(document.body.style.pointerEvents).toBe('auto');
   });
 
-  test('does nothing when the surface was never opened', async () => {
+  test('does nothing when the surface was never opened', () => {
     lockBody();
     const {rerender} = render(<Probe open={false} />);
 
     rerender(<Probe open={false} />);
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    settleCheckpoints();
 
     expect(document.body.style.pointerEvents).toBe('none');
   });

--- a/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
+++ b/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
@@ -6,6 +6,12 @@ function Probe({open}: {open: boolean}) {
   return null;
 }
 
+/** Mirrors an uncontrolled surface, which reports its state through the callback. */
+function CallbackProbe({onReady}: {onReady: (track: (next: boolean) => void) => void}) {
+  onReady(useBodyPointerEventsRelease());
+  return null;
+}
+
 /** Stands in for the lock Radix's dismissable layer puts on the body. */
 function lockBody() {
   document.body.style.pointerEvents = 'none';
@@ -107,5 +113,23 @@ describe('useBodyPointerEventsRelease', () => {
     settleCheckpoints();
 
     expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  test('releases the lock for a surface that reports through the callback', () => {
+    let track: (next: boolean) => void = () => undefined;
+    render(
+      <CallbackProbe
+        onReady={(next) => {
+          track = next;
+        }}
+      />,
+    );
+
+    track(true);
+    lockBody();
+    track(false);
+    settleCheckpoints();
+
+    expect(document.body.style.pointerEvents).toBe('');
   });
 });

--- a/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
+++ b/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.test.tsx
@@ -1,0 +1,75 @@
+import {render, waitFor} from '@testing-library/react';
+import {useBodyPointerEventsRelease} from './useBodyPointerEventsRelease.js';
+
+function Probe({open}: {open: boolean}) {
+  useBodyPointerEventsRelease(open);
+  return null;
+}
+
+/** Stands in for the lock Radix's dismissable layer puts on the body. */
+function lockBody() {
+  document.body.style.pointerEvents = 'none';
+}
+
+afterEach(() => {
+  document.body.style.removeProperty('pointer-events');
+  document.body.replaceChildren();
+});
+
+describe('useBodyPointerEventsRelease', () => {
+  test('releases a lock left behind after the surface closes', async () => {
+    const {rerender} = render(<Probe open />);
+    lockBody();
+
+    rerender(<Probe open={false} />);
+
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).toBe('');
+    });
+  });
+
+  test('releases a lock left behind when the surface unmounts while open', async () => {
+    const {unmount} = render(<Probe open />);
+    lockBody();
+
+    unmount();
+
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).toBe('');
+    });
+  });
+
+  test('leaves the lock alone while another layer still owns it', async () => {
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    document.body.append(menu);
+
+    const {rerender} = render(<Probe open />);
+    lockBody();
+
+    rerender(<Probe open={false} />);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  test('does not touch the body when no lock is present', async () => {
+    document.body.style.pointerEvents = 'auto';
+    const {rerender} = render(<Probe open />);
+
+    rerender(<Probe open={false} />);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(document.body.style.pointerEvents).toBe('auto');
+  });
+
+  test('does nothing when the surface was never opened', async () => {
+    lockBody();
+    const {rerender} = render(<Probe open={false} />);
+
+    rerender(<Probe open={false} />);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+});

--- a/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.ts
+++ b/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.ts
@@ -1,64 +1,79 @@
 'use client';
 
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 
 // Radix's dismissable layer locks `body { pointer-events: none }` while a modal
-// layer is mounted and restores the previous value when that layer unregisters.
-// The restore runs in a passive effect, so a layer torn down in the same commit
+// layer is open and restores the previous value when the last layer unregisters.
+// That restore runs in a passive effect, so a layer torn down in the same commit
 // that closed it leaves no slack: a click landing in that window is swallowed,
-// and a restore that never runs leaves the whole page inert until a reload.
-// Releasing the lock here bounds that failure to a few hundred milliseconds.
+// and a restore that never runs leaves the page inert until a reload.
 
-// Anything Radix renders that may still hold the lock legitimately. While one of
-// these is in the document the lock is somebody else's to release.
-const ACTIVE_LAYER_SELECTOR = [
-  '[role="dialog"]',
-  '[role="alertdialog"]',
-  '[role="menu"]',
-  '[role="listbox"]',
-  '[data-radix-popper-content-wrapper]',
+// Only an open layer can hold the lock. Radix hands it back the moment a surface
+// closes, so a closed node still playing its exit animation owns nothing.
+const OPEN_LAYER_SELECTOR = [
+  '[data-state="open"][role="dialog"]',
+  '[data-state="open"][role="alertdialog"]',
+  '[data-state="open"][role="menu"]',
+  '[data-state="open"][role="listbox"]',
 ].join(',');
 
-// Re-checked across the window in which Radix and its exit animations settle.
-const CHECKPOINTS_MS = [0, 120, 400];
+// Spread across the window in which Radix and its exit animations settle.
+const CHECKPOINTS_MS = [0, 120, 400, 1000];
 
-function releaseBodyPointerEvents(): void {
+function releaseBodyPointerEvents(inheritedPointerEvents: string): void {
   if (typeof document === 'undefined') return;
+  // The page was already locked before this surface opened, so the lock belongs
+  // to someone else and stays untouched.
+  if (inheritedPointerEvents === 'none') return;
   if (document.body.style.pointerEvents !== 'none') return;
-  if (document.querySelector(ACTIVE_LAYER_SELECTOR) !== null) return;
+  if (document.querySelector(OPEN_LAYER_SELECTOR) !== null) return;
 
   document.body.style.removeProperty('pointer-events');
 }
 
-function scheduleRelease(): void {
+function scheduleRelease(inheritedPointerEvents: string): void {
   if (typeof window === 'undefined') return;
 
   for (const delay of CHECKPOINTS_MS) {
-    window.setTimeout(releaseBodyPointerEvents, delay);
+    window.setTimeout(() => releaseBodyPointerEvents(inheritedPointerEvents), delay);
   }
 }
 
 /**
  * Guarantees the body pointer-events lock is released once a modal surface has
  * closed, including when it unmounts while still open.
+ *
+ * Pass `open` for controlled surfaces. The returned callback covers uncontrolled
+ * ones and should be called from the surface's `onOpenChange`.
  */
-export function useBodyPointerEventsRelease(open: boolean): void {
+export function useBodyPointerEventsRelease(open?: boolean): (nextOpen: boolean) => void {
+  const inheritedPointerEvents = useRef('');
   const wasOpen = useRef(false);
 
-  useEffect(() => {
-    if (open) {
+  const trackOpenChange = useCallback((nextOpen: boolean) => {
+    if (nextOpen) {
+      if (!wasOpen.current && typeof document !== 'undefined') {
+        inheritedPointerEvents.current = document.body.style.pointerEvents;
+      }
       wasOpen.current = true;
       return;
     }
     if (!wasOpen.current) return;
 
     wasOpen.current = false;
-    scheduleRelease();
-  }, [open]);
+    scheduleRelease(inheritedPointerEvents.current);
+  }, []);
+
+  useEffect(() => {
+    if (open === undefined) return;
+    trackOpenChange(open);
+  }, [open, trackOpenChange]);
 
   useEffect(() => {
     return () => {
-      if (wasOpen.current) scheduleRelease();
+      if (wasOpen.current) scheduleRelease(inheritedPointerEvents.current);
     };
   }, []);
+
+  return trackOpenChange;
 }

--- a/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.ts
+++ b/libs/shared/react/ui/src/hooks/useBodyPointerEventsRelease.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import {useEffect, useRef} from 'react';
+
+// Radix's dismissable layer locks `body { pointer-events: none }` while a modal
+// layer is mounted and restores the previous value when that layer unregisters.
+// The restore runs in a passive effect, so a layer torn down in the same commit
+// that closed it leaves no slack: a click landing in that window is swallowed,
+// and a restore that never runs leaves the whole page inert until a reload.
+// Releasing the lock here bounds that failure to a few hundred milliseconds.
+
+// Anything Radix renders that may still hold the lock legitimately. While one of
+// these is in the document the lock is somebody else's to release.
+const ACTIVE_LAYER_SELECTOR = [
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+  '[data-radix-popper-content-wrapper]',
+].join(',');
+
+// Re-checked across the window in which Radix and its exit animations settle.
+const CHECKPOINTS_MS = [0, 120, 400];
+
+function releaseBodyPointerEvents(): void {
+  if (typeof document === 'undefined') return;
+  if (document.body.style.pointerEvents !== 'none') return;
+  if (document.querySelector(ACTIVE_LAYER_SELECTOR) !== null) return;
+
+  document.body.style.removeProperty('pointer-events');
+}
+
+function scheduleRelease(): void {
+  if (typeof window === 'undefined') return;
+
+  for (const delay of CHECKPOINTS_MS) {
+    window.setTimeout(releaseBodyPointerEvents, delay);
+  }
+}
+
+/**
+ * Guarantees the body pointer-events lock is released once a modal surface has
+ * closed, including when it unmounts while still open.
+ */
+export function useBodyPointerEventsRelease(open: boolean): void {
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      wasOpen.current = true;
+      return;
+    }
+    if (!wasOpen.current) return;
+
+    wasOpen.current = false;
+    scheduleRelease();
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (wasOpen.current) scheduleRelease();
+    };
+  }, []);
+}


### PR DESCRIPTION
Closing modal, sheet, and dropdown surfaces could leave an exiting layer intercepting the next click or leave Radix's body pointer-events lock in place. This change makes closing surfaces non-interactive during their exit animation, releases stale body locks after other active layers settle, and keeps the integration usage modal mounted through the shared lifecycle so its close animation completes.

It adds focused regression coverage for the shared release hook, modal overlay behavior, and integration usage flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores page interaction after closing Modal, Sheet, and popper surfaces. Previously, closing could swallow the next click and leave a body pointer-events lock; now closing layers go inert during exit, and a shared hook releases stale body locks while respecting open layers and pre-existing locks.

- Adds `useBodyPointerEventsRelease` in `@shipfox/react-ui` and wires it via a tracking callback in Modal and Sheet `onOpenChange`. Works for controlled, uncontrolled, and `defaultOpen` cases; schedules checkpointed release after close/unmount and skips if another open layer owns the lock or the page set it earlier.
- Makes overlays and content non-interactive while `data-state="closed"`. For popper UIs, applies the guard to the Radix wrapper `[data-radix-popper-content-wrapper]:has(> [data-state="closed"])` so only a closing direct child goes inert (submenus no longer disable an open parent).
- Updates `@shipfox/client-integrations`: the integration usage modal closes through the shared Modal lifecycle and keeps the last connection during exit so the close animation completes.
- Adds tests for the release hook (lingering-layer and pre-existing-lock cases) and close-path stories for Modal, Sheet, and DropdownMenu that wait for the closed state and body lock release.

- Migration
  - If tests interact immediately after closing a surface, wait for the surface to reach `data-state="closed"` or unmount, and for the body lock to clear, before asserting/interacting.
  - Remove any workarounds that manually clear `document.body.style.pointerEvents`.

<sup>Written for commit 01f58ebb83162ca06d6a345d99be7becb15612a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

