### PR TITLE
[@shipfox/client-agent] Gate onboarding on catalog readiness

### DIFF
--- a/.changeset/quiet-onboarding-catalog.md
+++ b/.changeset/quiet-onboarding-catalog.md
@@ -2,4 +2,4 @@
 "@shipfox/client-agent": patch
 ---
 
-Keep agent provider onboarding behind the model provider catalog loading and error states.
+Agent provider onboarding now waits for the model provider catalog before showing provider and harness selection, with a loading state and a retryable error state when the catalog cannot be loaded.

--- a/.changeset/quiet-onboarding-catalog.md
+++ b/.changeset/quiet-onboarding-catalog.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-agent": patch
+---
+
+Keep agent provider onboarding behind the model provider catalog loading and error states.

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
@@ -131,25 +131,17 @@ export const Playground: Story = {};
 
 export const Loading: Story = {
   args: {scenario: 'loading'},
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
-  },
 };
 
 export const CatalogError: Story = {
   args: {scenario: 'catalog-error'},
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
-  },
 };
 
 export const NoProvidersAvailable: Story = {
   args: {scenario: 'no-providers'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+    await userEvent.click(await canvas.findByRole('button', {name: 'Choose pi'}));
   },
 };
 
@@ -157,7 +149,7 @@ export const LongNames: Story = {
   args: {scenario: 'long-names'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+    await userEvent.click(await canvas.findByRole('button', {name: 'Choose pi'}));
   },
 };
 
@@ -165,7 +157,7 @@ export const FilteredProviders: Story = {
   args: {scenario: 'available'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+    await userEvent.click(await canvas.findByRole('button', {name: 'Choose pi'}));
     await userEvent.type(
       await canvas.findByRole('searchbox', {name: 'Search providers'}),
       'openrouter',
@@ -178,7 +170,7 @@ export const NoMatchingProviders: Story = {
   args: {scenario: 'available'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+    await userEvent.click(await canvas.findByRole('button', {name: 'Choose pi'}));
     await userEvent.type(
       await canvas.findByRole('searchbox', {name: 'Search providers'}),
       'not-a-provider',
@@ -191,7 +183,7 @@ export const ConfigureModalOpen: Story = {
   args: {scenario: 'available'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+    await userEvent.click(await canvas.findByRole('button', {name: 'Choose pi'}));
     await userEvent.click(await canvas.findByRole('button', {name: 'Configure Anthropic'}));
     await screen.findByLabelText('API key');
   },

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -1,9 +1,10 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui/toast';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {render, screen, waitFor, within} from '@testing-library/react';
+import {act, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {ReactElement} from 'react';
+import {modelProviderQueryKeys} from '#hooks/api/model-providers.js';
 import {isModelProviderOnboardingDismissed} from '#state/model-provider-onboarding.js';
 import {
   AGENT_TEST_WORKSPACE_ID,
@@ -30,12 +31,15 @@ function requestPath(input: RequestInfo | URL): string {
 function renderOnboarding(element: ReactElement) {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      {element}
-      <Toaster />
-    </QueryClientProvider>,
-  );
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        {element}
+        <Toaster />
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 describe('ModelProviderOnboardingPage', () => {
@@ -63,6 +67,7 @@ describe('ModelProviderOnboardingPage', () => {
 
     expect(screen.getByRole('status', {name: 'Loading model providers'})).toBeVisible();
     expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Skip for now'})).toBeVisible();
 
     resolveCatalog(jsonResponse(modelProviderCatalogResponse()));
 
@@ -398,11 +403,35 @@ describe('ModelProviderOnboardingPage', () => {
     await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
   });
 
-  test('renders the catalog load error instead of harness selection', async () => {
+  test('renders the catalog load error and keeps skip available', async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl: vi.fn().mockResolvedValue(jsonResponse({code: 'server-error'}, {status: 500})),
     });
+
+    renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={onSkip}
+        onConfigured={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("Couldn't load model provider catalog")).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: 'Skip for now'}));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  test('recovers from a catalog load error after retry', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}))
+      .mockResolvedValueOnce(jsonResponse(modelProviderCatalogResponse()));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
     renderOnboarding(
       <ModelProviderOnboardingPage
@@ -413,7 +442,36 @@ describe('ModelProviderOnboardingPage', () => {
     );
 
     expect(await screen.findByText("Couldn't load model provider catalog")).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Skip for now'})).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: 'Retry loading model provider catalog'}));
+
+    expect(await screen.findByRole('button', {name: 'Choose pi'})).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole('heading', {name: 'Choose agent harness'})).toHaveFocus(),
+    );
+  });
+
+  test('keeps the loaded harness choices when a catalog refetch fails', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(modelProviderCatalogResponse()))
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {queryClient} = renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole('button', {name: 'Choose pi'})).toBeVisible();
+
+    await act(async () => {
+      await queryClient.refetchQueries({queryKey: modelProviderQueryKeys.catalog()});
+    });
+
+    expect(screen.getByRole('button', {name: 'Choose pi'})).toBeVisible();
+    expect(screen.queryByText("Couldn't load model provider catalog")).not.toBeInTheDocument();
   });
 });

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -43,6 +43,35 @@ describe('ModelProviderOnboardingPage', () => {
     window.localStorage.clear();
   });
 
+  test('waits for the catalog policy before rendering harness selection', async () => {
+    let resolveCatalog!: (response: Response) => void;
+    const catalogResponse = new Promise<Response>((resolve) => {
+      resolveCatalog = resolve;
+    });
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn().mockReturnValue(catalogResponse),
+    });
+
+    renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('status', {name: 'Loading model providers'})).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
+
+    resolveCatalog(jsonResponse(modelProviderCatalogResponse()));
+
+    expect(await screen.findByRole('button', {name: 'Choose pi'})).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole('heading', {name: 'Choose agent harness'})).toHaveFocus(),
+    );
+  });
+
   test('continues directly when workspace providers are managed by the instance', async () => {
     const onConfigured = vi.fn();
     const fetchImpl = vi
@@ -83,7 +112,7 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Skip for now'}));
+    await user.click(await screen.findByRole('button', {name: 'Skip for now'}));
 
     expect(onSkip).toHaveBeenCalledTimes(1);
     expect(onConfigured).not.toHaveBeenCalled();
@@ -91,7 +120,7 @@ describe('ModelProviderOnboardingPage', () => {
     expect(fetchImpl.mock.calls.some(([input]) => (input as Request).method === 'PUT')).toBe(false);
   });
 
-  test('places skip before the harness choices', () => {
+  test('places skip before the harness choices', async () => {
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl: vi.fn().mockResolvedValue(jsonResponse(modelProviderCatalogResponse())),
@@ -105,8 +134,8 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    const skip = screen.getByRole('button', {name: 'Skip for now'});
-    const harness = screen.getByRole('button', {name: 'Choose pi'});
+    const skip = await screen.findByRole('button', {name: 'Skip for now'});
+    const harness = await screen.findByRole('button', {name: 'Choose pi'});
 
     expect(skip.compareDocumentPosition(harness)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
@@ -138,19 +167,19 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    expect(screen.getByRole('heading', {name: 'Choose agent harness'})).toBeVisible();
-    expect(screen.getByRole('button', {name: 'Choose pi'})).toBeVisible();
+    expect(await screen.findByRole('heading', {name: 'Choose agent harness'})).toBeVisible();
+    expect(await screen.findByRole('button', {name: 'Choose pi'})).toBeVisible();
     expect(screen.getByText('Works with 30+ model providers')).toBeVisible();
-    expect(screen.getByRole('button', {name: 'Choose Claude'})).toBeVisible();
+    expect(await screen.findByRole('button', {name: 'Choose Claude'})).toBeVisible();
     expect(screen.getByText('Runs on your Anthropic API key')).toBeVisible();
 
-    await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
+    await user.click(await screen.findByRole('button', {name: 'Choose Claude'}));
 
     expect(await screen.findByRole('button', {name: 'Configure Anthropic'})).toBeVisible();
     expect(screen.queryByRole('button', {name: 'Configure OpenAI'})).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', {name: 'Back'}));
-    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
+    await user.click(await screen.findByRole('button', {name: 'Choose pi'}));
 
     expect(await screen.findByRole('button', {name: 'Configure Anthropic'})).toBeVisible();
     expect(screen.getByRole('button', {name: 'Configure OpenAI'})).toBeVisible();
@@ -172,7 +201,7 @@ describe('ModelProviderOnboardingPage', () => {
         onConfigured={vi.fn()}
       />,
     );
-    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
+    await user.click(await screen.findByRole('button', {name: 'Choose pi'}));
     const search = await screen.findByRole('searchbox', {name: 'Search providers'});
 
     await user.type(search, 'provider 6');
@@ -208,7 +237,7 @@ describe('ModelProviderOnboardingPage', () => {
         />,
       );
 
-      await user.click(screen.getByRole('button', {name: 'Skip for now'}));
+      await user.click(await screen.findByRole('button', {name: 'Skip for now'}));
 
       expect(onSkip).toHaveBeenCalledTimes(1);
     } finally {
@@ -250,7 +279,7 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
+    await user.click(await screen.findByRole('button', {name: 'Choose pi'}));
     await user.click(await screen.findByRole('button', {name: 'Configure OpenAI'}));
     await user.type(await screen.findByLabelText('API key'), 'sk-proj-secret');
     await user.click(screen.getByRole('button', {name: 'Test & save'}));
@@ -300,7 +329,7 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
+    await user.click(await screen.findByRole('button', {name: 'Choose Claude'}));
     await user.click(await screen.findByRole('button', {name: 'Configure Anthropic'}));
     await user.type(await screen.findByLabelText('API key'), 'sk-ant-secret');
     await user.click(screen.getByRole('button', {name: 'Test & save'}));
@@ -354,7 +383,7 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
+    await user.click(await screen.findByRole('button', {name: 'Choose Claude'}));
     await user.click(await screen.findByRole('button', {name: 'Configure Anthropic'}));
     await user.type(await screen.findByLabelText('API key'), 'sk-ant-secret');
     await user.click(screen.getByRole('button', {name: 'Test & save'}));
@@ -369,9 +398,7 @@ describe('ModelProviderOnboardingPage', () => {
     await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
   });
 
-  test('keeps skip available when the catalog fails to load after selecting a harness', async () => {
-    const user = userEvent.setup();
-    const onSkip = vi.fn();
+  test('renders the catalog load error instead of harness selection', async () => {
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl: vi.fn().mockResolvedValue(jsonResponse({code: 'server-error'}, {status: 500})),
@@ -380,15 +407,13 @@ describe('ModelProviderOnboardingPage', () => {
     renderOnboarding(
       <ModelProviderOnboardingPage
         workspaceId={AGENT_TEST_WORKSPACE_ID}
-        onSkip={onSkip}
+        onSkip={vi.fn()}
         onConfigured={vi.fn()}
       />,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
     expect(await screen.findByText("Couldn't load model provider catalog")).toBeInTheDocument();
-    await user.click(screen.getByRole('button', {name: 'Skip for now'}));
-
-    expect(onSkip).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', {name: 'Choose pi'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Skip for now'})).not.toBeInTheDocument();
   });
 });

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -34,6 +34,7 @@ export function ModelProviderOnboardingPage({
   const setDefaultHarness = useSetDefaultHarnessMutation();
   const [onboarding, dispatch] = useReducer(onboardingReducer, initialOnboardingState);
   const supportedProviders = catalogQuery.data?.providers.filter(isSupportedProvider) ?? [];
+  const catalogLoaded = catalogQuery.data !== undefined;
   const managedOnly = isManagedOnlyCatalog(catalogQuery.data);
   const managedOnlyForwarded = useRef(false);
   const filteredProviders = useMemo(() => {
@@ -50,7 +51,7 @@ export function ModelProviderOnboardingPage({
   }, [managedOnly, onConfigured]);
 
   useEffect(() => {
-    if (managedOnly) return;
+    if (managedOnly || !catalogLoaded) return;
     document
       .getElementById(
         onboarding.step === 'choose-harness'
@@ -58,7 +59,15 @@ export function ModelProviderOnboardingPage({
           : 'model-provider-provider-step',
       )
       ?.focus();
-  }, [managedOnly, onboarding.step]);
+  }, [catalogLoaded, managedOnly, onboarding.step]);
+
+  if (catalogQuery.isPending) {
+    return <ModelProviderGridSkeleton label="Loading model providers" />;
+  }
+
+  if (catalogQuery.isError && catalogQuery.data === undefined) {
+    return <QueryLoadError query={catalogQuery} subject="model provider catalog" />;
+  }
 
   if (managedOnly) return null;
 

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -35,6 +35,8 @@ export function ModelProviderOnboardingPage({
   const [onboarding, dispatch] = useReducer(onboardingReducer, initialOnboardingState);
   const supportedProviders = catalogQuery.data?.providers.filter(isSupportedProvider) ?? [];
   const catalogLoaded = catalogQuery.data !== undefined;
+  const catalogLoading = catalogQuery.isPending;
+  const catalogLoadError = catalogQuery.isError && catalogQuery.data === undefined;
   const managedOnly = isManagedOnlyCatalog(catalogQuery.data);
   const managedOnlyForwarded = useRef(false);
   const filteredProviders = useMemo(() => {
@@ -60,14 +62,6 @@ export function ModelProviderOnboardingPage({
       )
       ?.focus();
   }, [catalogLoaded, managedOnly, onboarding.step]);
-
-  if (catalogQuery.isPending) {
-    return <ModelProviderGridSkeleton label="Loading model providers" />;
-  }
-
-  if (catalogQuery.isError && catalogQuery.data === undefined) {
-    return <QueryLoadError query={catalogQuery} subject="model provider catalog" />;
-  }
 
   if (managedOnly) return null;
 
@@ -140,27 +134,36 @@ export function ModelProviderOnboardingPage({
       </header>
 
       <section aria-labelledby={headingId} className="flex flex-col gap-group">
-        {onboarding.step === 'choose-harness' ? (
-          <HarnessPicker
-            onSelect={(harnessId) => dispatch({type: 'harness-selected', harnessId})}
-          />
-        ) : (
-          <>
-            <div>
-              <Button type="button" variant="transparent" onClick={() => dispatch({type: 'back'})}>
-                Back
-              </Button>
-            </div>
-            <ModelProviderPicker
-              key={onboarding.harnessId}
-              catalogQuery={catalogQuery}
-              supportedProviders={filteredProviders}
-              onSelect={(entry) => {
-                dispatch({type: 'provider-selected', provider: entry});
-              }}
+        {catalogLoading ? <ModelProviderGridSkeleton label="Loading model providers" /> : null}
+        {catalogLoadError ? (
+          <QueryLoadError query={catalogQuery} subject="model provider catalog" />
+        ) : null}
+        {!catalogLoading && !catalogLoadError ? (
+          onboarding.step === 'choose-harness' ? (
+            <HarnessPicker
+              onSelect={(harnessId) => dispatch({type: 'harness-selected', harnessId})}
             />
-          </>
-        )}
+          ) : (
+            <>
+              <div>
+                <Button
+                  type="button"
+                  variant="transparent"
+                  onClick={() => dispatch({type: 'back'})}
+                >
+                  Back
+                </Button>
+              </div>
+              <ModelProviderPicker
+                key={onboarding.harnessId}
+                supportedProviders={filteredProviders}
+                onSelect={(entry) => {
+                  dispatch({type: 'provider-selected', provider: entry});
+                }}
+              />
+            </>
+          )
+        ) : null}
       </section>
 
       <Modal
@@ -262,23 +265,13 @@ function HarnessCard({harness, onChoose}: {harness: HarnessDescriptor; onChoose:
 }
 
 function ModelProviderPicker({
-  catalogQuery,
   supportedProviders,
   onSelect,
 }: {
-  catalogQuery: ReturnType<typeof useModelProviderCatalogQuery>;
   supportedProviders: SupportedProvider[];
   onSelect: (entry: SupportedProvider) => void;
 }) {
-  if (catalogQuery.isPending) {
-    return <ModelProviderGridSkeleton label="Loading model providers" />;
-  }
-
-  if (catalogQuery.isError && catalogQuery.data === undefined) {
-    return <QueryLoadError query={catalogQuery} subject="model provider catalog" />;
-  }
-
-  if (catalogQuery.data !== undefined && supportedProviders.length === 0) {
+  if (supportedProviders.length === 0) {
     return (
       <EmptyState
         icon="componentLine"


### PR DESCRIPTION
Model provider onboarding now waits for the catalog policy before rendering harness selection. Pending requests show the loading skeleton, initial catalog failures show the retryable query-load error, and enabled catalogs preserve the existing harness flow. Focus is restored when the catalog becomes ready.

Closes ENG-1617

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate model provider onboarding in `@shipfox/client-agent` on catalog readiness to prevent inconsistent harness choices and fix focus issues (ENG-1617). Previously the harness chooser rendered immediately; now onboarding shows a loading state, a retryable error on initial failure, and restores focus after the catalog loads.

- Show a labeled loading skeleton while the catalog request is pending; keep “Skip for now” visible and functional; hide harness/provider UI until ready.
- On initial load failure (no cached data), render a retryable catalog error; keep “Skip for now”; do not render harness/provider UI.
- Restore focus to the current step when the catalog becomes ready; keep the enabled-catalog harness flow unchanged.
- Keep loaded harness choices if a later catalog refetch fails; do not regress to an error state.
- Preserve the instance-managed path: managed-only catalogs still bypass onboarding.
- Move query gating to the page: `ModelProviderPicker` no longer handles loading/error and assumes a ready provider list.
- Update stories/tests to await async UI with findByRole; remove unnecessary interactions in loading/error scenarios.

<sup>Written for commit f953f3c289e1f2d13f20f57bab1f7584f5f6f6d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

