### PR TITLE
[client-auth] Support Markdown in signup denial messages

### DIFF
--- a/.changeset/calm-signup-markdown.md
+++ b/.changeset/calm-signup-markdown.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-auth": patch
+"@shipfox/client-auth": patch
+---
+
+Supports Markdown in configured signup denial messages.

--- a/.changeset/calm-signup-markdown.md
+++ b/.changeset/calm-signup-markdown.md
@@ -1,6 +1,7 @@
 ---
-"@shipfox/api-auth": patch
+"@shipfox/api-auth": minor
 "@shipfox/client-auth": patch
+"@shipfox/react-ui": minor
 ---
 
-Supports Markdown in configured signup denial messages.
+Supports server-declared Markdown in signup denial messages while keeping custom policy messages plain by default.

--- a/.changeset/calm-signup-markdown.md
+++ b/.changeset/calm-signup-markdown.md
@@ -5,3 +5,5 @@
 ---
 
 Supports server-declared Markdown in signup denial messages while keeping custom policy messages plain by default.
+
+Existing environment-backed messages now interpret Markdown syntax. Older clients display the Markdown source as plain text.

--- a/e2e/suites/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/suites/client/auth/tests/auth-client.e2e.ts
@@ -46,6 +46,7 @@ test('keeps an unlisted password signup on the signup form', async ({page, signu
   await expect(page).toHaveURL(SIGNUP_URL_RE);
   await expect(signup.alert()).toContainText(SIGNUP_NOT_ALLOWED_MESSAGE);
   await expect(signup.verificationHeading()).toBeHidden();
+  await stableScreenshot(page, 'auth/signup-denial');
 });
 test('starts email verification for an address in the signup allowlist', async ({signup}) => {
   await signup.goto();

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -66,7 +66,7 @@ Required environment:
 | `AUTH_SIGNUP_GATE_ENABLED` | `false` | Restricts new account creation to the configured signup email allowlist. Requires `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` or `AUTH_SIGNUP_ALLOWED_EMAILS` to be set. |
 | `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` | none | Comma-separated email domains allowed to create accounts, such as `shipfox.io,acme.com`. |
 | `AUTH_SIGNUP_ALLOWED_EMAILS` | none | Comma-separated exact email addresses allowed to create accounts. |
-| `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Description returned when the signup gate blocks an account. Defaults to "This Shipfox deployment does not accept new accounts right now." |
+| `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Markdown message returned when the signup gate blocks an account. Defaults to "This Shipfox deployment does not accept new accounts right now." |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `ADMIN_BOOTSTRAP_TOKEN` | none | Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap. |
 
@@ -89,6 +89,14 @@ Startup fails when both lists are empty. Values are trimmed and lowercased.
 The policy matches exact email addresses or exact domains. It does not match
 subdomains or wildcards. `createAuthModule` applies these settings by default;
 pass a `signupPolicy` to replace the environment-backed policy.
+
+The Shipfox client renders `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` as sanitized
+Markdown. The signup response limits the message to 500 characters. Use an
+absolute HTTP or HTTPS URL for a link:
+
+```sh
+AUTH_SIGNUP_NOT_ALLOWED_MESSAGE='New accounts require approval. [Request access](https://example.com/access).'
+```
 
 When `AUTH_PASSWORD_ENABLED=false`, the module does not register signup, login, password-reset, password-change, or email-verification routes. Refresh, logout, and current-session routes stay available. Another module must contribute a login method before the API server starts.
 

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -66,7 +66,7 @@ Required environment:
 | `AUTH_SIGNUP_GATE_ENABLED` | `false` | Restricts new account creation to the configured signup email allowlist. Requires `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` or `AUTH_SIGNUP_ALLOWED_EMAILS` to be set. |
 | `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` | none | Comma-separated email domains allowed to create accounts, such as `shipfox.io,acme.com`. |
 | `AUTH_SIGNUP_ALLOWED_EMAILS` | none | Comma-separated exact email addresses allowed to create accounts. |
-| `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Markdown message returned when the signup gate blocks an account. Defaults to "This Shipfox deployment does not accept new accounts right now." |
+| `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Markdown message returned when the signup gate blocks an account. Accepts at most 500 characters. Defaults to "This Shipfox deployment does not accept new accounts right now." |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `ADMIN_BOOTSTRAP_TOKEN` | none | Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap. |
 
@@ -91,12 +91,17 @@ subdomains or wildcards. `createAuthModule` applies these settings by default;
 pass a `signupPolicy` to replace the environment-backed policy.
 
 The Shipfox client renders `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` as sanitized
-Markdown. The signup response limits the message to 500 characters. Use an
-absolute HTTP or HTTPS URL for a link:
+Markdown. The setting accepts at most 500 characters, and startup fails when it
+is longer so the response does not cut a Markdown construct. Use an absolute
+HTTP or HTTPS URL for a link:
 
 ```sh
 AUTH_SIGNUP_NOT_ALLOWED_MESSAGE='New accounts require approval. [Request access](https://example.com/access).'
 ```
+
+The environment-backed policy declares its denial message as Markdown. A custom
+`signupPolicy` denial message stays plain text unless its result includes
+`format: 'markdown'`.
 
 When `AUTH_PASSWORD_ENABLED=false`, the module does not register signup, login, password-reset, password-change, or email-verification routes. Refresh, logout, and current-session routes stay available. Another module must contribute a login method before the API server starts.
 
@@ -329,7 +334,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `createLeaseTokenAuthMethod()`: the Fastify auth method for job lease tokens.
 - `issueRunnerSessionToken(claims)` / `verifyRunnerSessionToken(token)`: mint and verify runner session tokens.
 - `issueJobLeaseToken(claims)` / `verifyJobLeaseToken(token)`: mint and verify job lease tokens.
-- `createEnvironmentSignupPolicy()`: creates the environment-backed signup policy used by default. Pass `signupPolicy` to `createAuthModule` to replace it.
+- `createEnvironmentSignupPolicy()`: creates the environment-backed signup policy used by default. Pass `signupPolicy` to `createAuthModule` to replace it. A denied custom policy can opt into sanitized Markdown with `format: 'markdown'`; without a format, its message stays plain text.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
 - `getAuthenticatedSessionContext(request)`: reads the user ID and required refresh-session ID from verified access-token claims. It does not check whether the refresh session is still active.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.

--- a/libs/api/auth/src/config.test.ts
+++ b/libs/api/auth/src/config.test.ts
@@ -36,4 +36,16 @@ describe('signup gate configuration', () => {
     expect(config.AUTH_SIGNUP_GATE_ENABLED).toBe(true);
     expect(config.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS).toBe('shipfox.io');
   });
+
+  test('rejects a Markdown denial message that exceeds the response limit', async () => {
+    vi.stubEnv(
+      'AUTH_SIGNUP_NOT_ALLOWED_MESSAGE',
+      `${'x'.repeat(499)}[Request access](https://example.test/access)`,
+    );
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'AUTH_SIGNUP_NOT_ALLOWED_MESSAGE must contain at most 500 characters',
+    );
+  });
 });

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -46,7 +46,7 @@ export const config = createConfig({
     default: '',
   }),
   AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: str({
-    desc: 'Description returned when the signup gate blocks an account. Optional. The default is This Shipfox deployment does not accept new accounts right now.',
+    desc: 'Markdown message returned when the signup gate blocks an account. Optional. The default is This Shipfox deployment does not accept new accounts right now.',
     default: undefined,
   }),
   CLIENT_BASE_URL: str({

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -1,4 +1,5 @@
 import {bool, createConfig, num, str} from '@shipfox/config';
+import {SIGNUP_DENIAL_MESSAGE_MAX_LENGTH} from '#core/ports.js';
 
 export const config = createConfig({
   ADMIN_BOOTSTRAP_TOKEN: str({
@@ -46,7 +47,7 @@ export const config = createConfig({
     default: '',
   }),
   AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: str({
-    desc: 'Markdown message returned when the signup gate blocks an account. Optional. The default is This Shipfox deployment does not accept new accounts right now.',
+    desc: 'Markdown message returned when the signup gate blocks an account. Use at most 500 characters. Optional. The default is This Shipfox deployment does not accept new accounts right now.',
     default: undefined,
   }),
   CLIENT_BASE_URL: str({
@@ -62,6 +63,15 @@ if (
 ) {
   throw new Error(
     'AUTH_SIGNUP_GATE_ENABLED requires AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS or AUTH_SIGNUP_ALLOWED_EMAILS to be set.',
+  );
+}
+
+if (
+  config.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE !== undefined &&
+  config.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE.length > SIGNUP_DENIAL_MESSAGE_MAX_LENGTH
+) {
+  throw new Error(
+    `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE must contain at most ${SIGNUP_DENIAL_MESSAGE_MAX_LENGTH} characters.`,
   );
 }
 

--- a/libs/api/auth/src/core/auth-default-signup-policy.test.ts
+++ b/libs/api/auth/src/core/auth-default-signup-policy.test.ts
@@ -28,6 +28,7 @@ describe('low-level account creation defaults', () => {
 
     await expect(signup({email, password: 'correct horse battery staple'})).rejects.toMatchObject({
       name: 'SignupNotAllowedError',
+      format: 'markdown',
     });
   });
 
@@ -44,6 +45,7 @@ describe('low-level account creation defaults', () => {
 
     await expect(provisionUser({email})).rejects.toMatchObject({
       name: 'SignupNotAllowedError',
+      format: 'markdown',
     });
   });
 

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -202,6 +202,7 @@ describe('auth core', () => {
       expect.objectContaining({
         name: 'SignupNotAllowedError',
         message: 'This Shipfox deployment does not accept new accounts right now.',
+        format: undefined,
       }),
     );
     expect(await findUserByEmail({email})).toBeUndefined();

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -71,7 +71,10 @@ async function assertSignupAllowed(params: {
   });
 
   if (!result.allowed) {
-    throw new SignupNotAllowedError(result.message ?? DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE);
+    throw new SignupNotAllowedError(
+      result.message ?? DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
+      result.format,
+    );
   }
 }
 

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -1,3 +1,5 @@
+import type {SignupDenialMessageFormat} from './ports.js';
+
 export class WorkspaceNotFoundError extends Error {
   constructor(workspaceId: string) {
     super(`Workspace not found: ${workspaceId}`);
@@ -48,7 +50,10 @@ export class EmailTakenError extends Error {
 }
 
 export class SignupNotAllowedError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly format?: SignupDenialMessageFormat,
+  ) {
     super(message);
     this.name = 'SignupNotAllowedError';
   }

--- a/libs/api/auth/src/core/ports.ts
+++ b/libs/api/auth/src/core/ports.ts
@@ -1,7 +1,12 @@
+export const SIGNUP_DENIAL_MESSAGE_MAX_LENGTH = 500;
+export type SignupDenialMessageFormat = 'markdown';
+
 export interface SignupPolicy {
   isSignupAllowed(params: {
     email: string;
     emailVerified: boolean;
     source: string;
-  }): Promise<{allowed: true} | {allowed: false; message?: string}>;
+  }): Promise<
+    {allowed: true} | {allowed: false; message?: string; format?: SignupDenialMessageFormat}
+  >;
 }

--- a/libs/api/auth/src/core/signup-policy.test.ts
+++ b/libs/api/auth/src/core/signup-policy.test.ts
@@ -47,7 +47,11 @@ describe('createEnvironmentSignupPolicy', () => {
         emailVerified: true,
         source: 'oauth-google',
       }),
-    ).resolves.toEqual({allowed: false, message: DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE});
+    ).resolves.toEqual({
+      allowed: false,
+      message: DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
+      format: 'markdown',
+    });
   });
 
   test('returns the configured denial message for an unmatched address', async () => {
@@ -60,7 +64,11 @@ describe('createEnvironmentSignupPolicy', () => {
         emailVerified: true,
         source: 'oauth-google',
       }),
-    ).resolves.toEqual({allowed: false, message: 'Ask your administrator for access.'});
+    ).resolves.toEqual({
+      allowed: false,
+      message: 'Ask your administrator for access.',
+      format: 'markdown',
+    });
   });
 
   test('allows every address when the gate is disabled', async () => {

--- a/libs/api/auth/src/core/signup-policy.ts
+++ b/libs/api/auth/src/core/signup-policy.ts
@@ -28,6 +28,7 @@ export function createEnvironmentSignupPolicy(): SignupPolicy {
       return Promise.resolve({
         allowed: false,
         message: config.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE ?? DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
+        format: 'markdown',
       });
     },
   };

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -94,6 +94,7 @@ describe('authModule', () => {
     ).resolves.toEqual({
       allowed: false,
       message: 'This Shipfox deployment does not accept new accounts right now.',
+      format: 'markdown',
     });
   });
 

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -75,7 +75,7 @@ export {
   jobLeaseParamsFrom,
   verifyJobLeaseToken,
 } from '#core/job-lease-token.js';
-export type {SignupPolicy} from '#core/ports.js';
+export type {SignupDenialMessageFormat, SignupPolicy} from '#core/ports.js';
 export {
   issueRunnerSessionToken,
   verifyRunnerSessionToken,

--- a/libs/api/auth/src/presentation/routes/registration/signup.test.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.test.ts
@@ -53,6 +53,27 @@ describe('POST /auth/signup', () => {
     });
   });
 
+  test('declares Markdown denial messages in the client error details', () => {
+    const errorHandler = createSignupRoute({} as WorkspacesInterModuleClient).errorHandler as (
+      error: unknown,
+    ) => never;
+    const message = 'Read the [access policy](https://example.test/access).';
+    let mapped: unknown;
+
+    try {
+      errorHandler(new SignupNotAllowedError(message, 'markdown'));
+    } catch (error) {
+      mapped = error;
+    }
+
+    expect(mapped).toMatchObject({
+      message,
+      status: 403,
+      code: 'signup-not-allowed',
+      details: {message, format: 'markdown'},
+    });
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/libs/api/auth/src/presentation/routes/registration/signup.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.ts
@@ -11,11 +11,9 @@ import {
   TokenExpiredError,
   TokenInvalidError,
 } from '#core/errors.js';
-import type {SignupPolicy} from '#core/ports.js';
+import {SIGNUP_DENIAL_MESSAGE_MAX_LENGTH, type SignupPolicy} from '#core/ports.js';
 import {setRefreshTokenCookie} from '#presentation/auth/refresh-cookie.js';
 import {toUserDto} from '#presentation/dto/user.js';
-
-const SIGNUP_NOT_ALLOWED_MESSAGE_MAX_LENGTH = 500;
 
 export function createSignupRoute(
   workspaces: WorkspacesInterModuleClient,
@@ -43,10 +41,10 @@ export function createSignupRoute(
         throw new ClientError('Email already registered', 'email-taken', {status: 409});
       }
       if (error instanceof SignupNotAllowedError) {
-        const message = error.message.slice(0, SIGNUP_NOT_ALLOWED_MESSAGE_MAX_LENGTH);
+        const message = error.message.slice(0, SIGNUP_DENIAL_MESSAGE_MAX_LENGTH);
         throw new ClientError(message, 'signup-not-allowed', {
           status: 403,
-          details: {message},
+          details: {message, ...(error.format ? {format: error.format} : {})},
         });
       }
       if (error instanceof TokenInvalidError) {

--- a/libs/client/auth/src/pages/form-errors.test.ts
+++ b/libs/client/auth/src/pages/form-errors.test.ts
@@ -78,6 +78,20 @@ describe('signupErrorToFormError', () => {
       message: 'We could not reach the API. Check your connection and try again.',
     });
   });
+
+  test('marks configured signup denial messages as Markdown', () => {
+    const message = 'Read the [access policy](https://example.test/access).';
+    const error = new ApiError({
+      code: 'signup-not-allowed',
+      message: 'Forbidden',
+      status: 403,
+      details: {code: 'signup-not-allowed', details: {message}},
+    });
+
+    const result = signupErrorToFormError(error);
+
+    expect(result).toEqual({kind: 'form', message, format: 'markdown'});
+  });
 });
 
 describe('passwordResetRequestErrorToFormError', () => {

--- a/libs/client/auth/src/pages/form-errors.test.ts
+++ b/libs/client/auth/src/pages/form-errors.test.ts
@@ -85,12 +85,26 @@ describe('signupErrorToFormError', () => {
       code: 'signup-not-allowed',
       message: 'Forbidden',
       status: 403,
-      details: {code: 'signup-not-allowed', details: {message}},
+      details: {code: 'signup-not-allowed', details: {message, format: 'markdown'}},
     });
 
     const result = signupErrorToFormError(error);
 
     expect(result).toEqual({kind: 'form', message, format: 'markdown'});
+  });
+
+  test('keeps unformatted signup policy messages as plain text', () => {
+    const message = 'Email <admin>@example.test for access.';
+    const error = new ApiError({
+      code: 'signup-not-allowed',
+      message: 'Forbidden',
+      status: 403,
+      details: {code: 'signup-not-allowed', details: {message}},
+    });
+
+    const result = signupErrorToFormError(error);
+
+    expect(result).toEqual({kind: 'form', message});
   });
 });
 

--- a/libs/client/auth/src/pages/form-errors.ts
+++ b/libs/client/auth/src/pages/form-errors.ts
@@ -3,7 +3,7 @@ import {authErrorMessage} from './form-utils.js';
 
 export type FormErrorMapping<TField extends string> =
   | {kind: 'field'; field: TField; message: string}
-  | {kind: 'form'; message: string};
+  | {kind: 'form'; message: string; format?: 'markdown'};
 
 type LoginField = 'email' | 'password';
 type SignupField = 'email' | 'password' | 'name';
@@ -24,6 +24,9 @@ export function loginErrorToFormError(error: unknown): FormErrorMapping<LoginFie
 export function signupErrorToFormError(error: unknown): FormErrorMapping<SignupField> {
   if (apiCode(error) === 'email-taken') {
     return {kind: 'field', field: 'email', message: authErrorMessage(error)};
+  }
+  if (apiCode(error) === 'signup-not-allowed') {
+    return {kind: 'form', message: authErrorMessage(error), format: 'markdown'};
   }
   return {kind: 'form', message: authErrorMessage(error)};
 }

--- a/libs/client/auth/src/pages/form-errors.ts
+++ b/libs/client/auth/src/pages/form-errors.ts
@@ -1,5 +1,5 @@
 import {ApiError} from '@shipfox/client-api';
-import {authErrorMessage} from './form-utils.js';
+import {authErrorMessage, authErrorMessageFormat} from './form-utils.js';
 
 export type FormErrorMapping<TField extends string> =
   | {kind: 'field'; field: TField; message: string}
@@ -26,7 +26,12 @@ export function signupErrorToFormError(error: unknown): FormErrorMapping<SignupF
     return {kind: 'field', field: 'email', message: authErrorMessage(error)};
   }
   if (apiCode(error) === 'signup-not-allowed') {
-    return {kind: 'form', message: authErrorMessage(error), format: 'markdown'};
+    const format = authErrorMessageFormat(error);
+    return {
+      kind: 'form',
+      message: authErrorMessage(error),
+      ...(format ? {format} : {}),
+    };
   }
   return {kind: 'form', message: authErrorMessage(error)};
 }

--- a/libs/client/auth/src/pages/form-utils.test.ts
+++ b/libs/client/auth/src/pages/form-utils.test.ts
@@ -1,5 +1,5 @@
 import {ApiError} from '@shipfox/client-api';
-import {authErrorMessage} from './form-utils.js';
+import {authErrorMessage, authErrorMessageFormat} from './form-utils.js';
 
 describe('authErrorMessage', () => {
   test.each([
@@ -40,5 +40,46 @@ describe('authErrorMessage', () => {
     const result = authErrorMessage(new Error('boom'));
 
     expect(result).toBe('Something went wrong. Try again.');
+  });
+});
+
+describe('authErrorMessageFormat', () => {
+  test('returns Markdown for signup denial errors that declare it', () => {
+    const error = new ApiError({
+      code: 'signup-not-allowed',
+      message: 'Forbidden',
+      status: 403,
+      details: {details: {format: 'markdown'}},
+    });
+
+    const result = authErrorMessageFormat(error);
+
+    expect(result).toBe('markdown');
+  });
+
+  test.each([
+    [
+      'a different error code',
+      new ApiError({
+        code: 'unknown-api-code',
+        message: 'Try later',
+        status: 400,
+        details: {details: {format: 'markdown'}},
+      }),
+    ],
+    [
+      'an unsupported signup denial format',
+      new ApiError({
+        code: 'signup-not-allowed',
+        message: 'Forbidden',
+        status: 403,
+        details: {details: {format: 'html'}},
+      }),
+    ],
+    ['a non-API error', new Error('boom')],
+  ])('returns undefined for %s', (_case, error) => {
+    const result = authErrorMessageFormat(error);
+
+    expect(result).toBeUndefined();
   });
 });

--- a/libs/client/auth/src/pages/form-utils.ts
+++ b/libs/client/auth/src/pages/form-utils.ts
@@ -4,12 +4,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function signupNotAllowedMessage(error: ApiError): string | undefined {
+function signupNotAllowedDetails(error: ApiError): Record<string, unknown> | undefined {
   if (error.code !== 'signup-not-allowed') return undefined;
   if (!isRecord(error.details)) return undefined;
   const details = error.details.details;
-  if (!isRecord(details)) return undefined;
-  return typeof details.message === 'string' ? details.message : undefined;
+  return isRecord(details) ? details : undefined;
+}
+
+function signupNotAllowedMessage(error: ApiError): string | undefined {
+  const details = signupNotAllowedDetails(error);
+  return typeof details?.message === 'string' ? details.message : undefined;
+}
+
+export function authErrorMessageFormat(error: unknown): 'markdown' | undefined {
+  if (!(error instanceof ApiError)) return undefined;
+  return signupNotAllowedDetails(error)?.format === 'markdown' ? 'markdown' : undefined;
 }
 
 export function authErrorMessage(error: unknown): string {

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {act, fireEvent, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, screen, waitFor, within} from '@testing-library/react';
 import {pageUserFactory} from '#test/factories/user.js';
 import {renderAuthPage} from '#test/pages.js';
 import {jsonResponse, requestUrl} from '#test/utils.js';
@@ -7,6 +7,7 @@ import {SignupPage} from './signup-page.js';
 
 const SUBMITTED_EMAIL_RE = /new@example.com/;
 const RESEND_COUNTDOWN_RE = /^Resend in \d+s$/;
+const ACCESS_POLICY_RE = /access policy/i;
 function emailChallenge() {
   return {
     id: '019f814f-3cfd-779a-82f2-6588eefd572c',
@@ -257,6 +258,42 @@ describe('SignupPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Email already exists');
+  });
+
+  test('renders configured signup denial messages as Markdown', async () => {
+    const message = [
+      '## Signups require approval',
+      '',
+      '- Review the [access policy](https://example.test/access).',
+    ].join('\n');
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {code: 'signup-not-allowed', message: 'Forbidden', details: {message}},
+          {status: 403},
+        ),
+      );
+    configureApiClient({fetchImpl});
+
+    renderAuthPage('/auth/signup', <SignupPage />);
+    fireEvent.change(await screen.findByLabelText('Name'), {target: {value: 'New User'}});
+    fireEvent.change(screen.getByLabelText('Email'), {target: {value: 'new@example.com'}});
+    fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'long secure password'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
+
+    const alert = await screen.findByRole('alert');
+    expect(
+      within(alert).getByRole('heading', {level: 2, name: 'Signups require approval'}),
+    ).toBeInTheDocument();
+    expect(within(alert).getByRole('listitem')).toBeInTheDocument();
+    expect(within(alert).getByRole('link', {name: ACCESS_POLICY_RE})).toHaveAttribute(
+      'href',
+      'https://example.test/access',
+    );
   });
 
   test('validates the name locally', async () => {

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -237,7 +237,7 @@ describe('SignupPage', () => {
     expect(await screen.findByRole('heading', {name: 'Authenticated home'})).toBeInTheDocument();
   });
 
-  test('surfaces duplicate-email errors', async () => {
+  test('renders ordinary form errors as plain text', async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
@@ -245,7 +245,7 @@ describe('SignupPage', () => {
       )
       .mockResolvedValueOnce(
         jsonResponse(
-          {code: 'email-already-exists', message: 'Email already exists'},
+          {code: 'email-already-exists', message: 'Email *already* exists'},
           {status: 409},
         ),
       );
@@ -257,12 +257,14 @@ describe('SignupPage', () => {
     fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'long secure password'}});
     fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('Email already exists');
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Email *already* exists');
+    expect(within(alert).queryByText('already', {selector: 'em'})).not.toBeInTheDocument();
   });
 
   test('renders configured signup denial messages as Markdown', async () => {
     const message = [
-      '## Signups require approval',
+      '# Signups require approval',
       '',
       '- Review the [access policy](https://example.test/access).',
     ].join('\n');
@@ -273,7 +275,11 @@ describe('SignupPage', () => {
       )
       .mockResolvedValueOnce(
         jsonResponse(
-          {code: 'signup-not-allowed', message: 'Forbidden', details: {message}},
+          {
+            code: 'signup-not-allowed',
+            message: 'Forbidden',
+            details: {message, format: 'markdown'},
+          },
           {status: 403},
         ),
       );

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -7,9 +7,10 @@ import {
 } from '@shipfox/client-shell/runtime';
 import {displayNameFieldError} from '@shipfox/client-ui';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
-import {Callout} from '@shipfox/react-ui/callout';
+import {Callout, CalloutContent} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {Icon} from '@shipfox/react-ui/icon';
+import {Markdown} from '@shipfox/react-ui/markdown';
 import {toast} from '@shipfox/react-ui/toast';
 import {Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
@@ -45,7 +46,7 @@ export function SignupPage() {
   const [authFormDraft, setAuthFormDraft] = useAtom(authFormDraftAtom);
   const [emailChallenge, setEmailChallenge] = useState<{email: string; id: string} | undefined>();
   const [nextResendAvailableAt, setNextResendAvailableAt] = useState<string | undefined>();
-  const [formError, setFormError] = useState<string | undefined>();
+  const [formError, setFormError] = useState<{message: string; format?: 'markdown'} | undefined>();
   const [resendError, setResendError] = useState<string | undefined>();
   const [invitationRefreshFailure, setInvitationRefreshFailure] = useState<{
     workspaceId: string;
@@ -138,7 +139,7 @@ export function SignupPage() {
             errorMap: {...prev.errorMap, onServer: mapped.message},
           }));
         } else {
-          setFormError(mapped.message);
+          setFormError(mapped);
         }
       }
     },
@@ -295,7 +296,13 @@ export function SignupPage() {
       >
         {formError ? (
           <Callout role="alert" type="error">
-            {formError}
+            <CalloutContent>
+              {formError.format === 'markdown' ? (
+                <Markdown className="[&>*:last-child]:mb-0">{formError.message}</Markdown>
+              ) : (
+                formError.message
+              )}
+            </CalloutContent>
           </Callout>
         ) : null}
         <form.Field

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -298,7 +298,9 @@ export function SignupPage() {
           <Callout role="alert" type="error">
             <CalloutContent>
               {formError.format === 'markdown' ? (
-                <Markdown className="[&>*:last-child]:mb-0">{formError.message}</Markdown>
+                <Markdown className="[&>*:last-child]:mb-0" headingLevelOffset={1}>
+                  {formError.message}
+                </Markdown>
               ) : (
                 formError.message
               )}

--- a/libs/shared/react/ui/src/components/markdown/markdown.test.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.test.tsx
@@ -127,6 +127,13 @@ describe('Markdown', () => {
     expect(container.querySelector('[dir="auto"]')).not.toBeNull();
   });
 
+  test('offsets headings when Markdown is nested below a page title', () => {
+    const {getByRole} = renderMarkdown('# Primary\n\n## Secondary', 1);
+
+    expect(getByRole('heading', {level: 2, name: 'Primary'})).not.toBeNull();
+    expect(getByRole('heading', {level: 3, name: 'Secondary'})).not.toBeNull();
+  });
+
   test('falls back to escaped plain text when rendering throws', () => {
     const body = '<script>alert(1)</script>';
 
@@ -141,10 +148,10 @@ describe('Markdown', () => {
   });
 });
 
-function renderMarkdown(body: string) {
+function renderMarkdown(body: string, headingLevelOffset: 0 | 1 = 0) {
   return render(
     <MarkdownTestHost>
-      <Markdown>{body}</Markdown>
+      <Markdown headingLevelOffset={headingLevelOffset}>{body}</Markdown>
     </MarkdownTestHost>,
   );
 }

--- a/libs/shared/react/ui/src/components/markdown/markdown.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.tsx
@@ -24,31 +24,44 @@ const sanitizeSchema = {
   },
 };
 
+type MarkdownHeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+type MarkdownHeadingComponent = NonNullable<Components['h1']>;
+
+const headingClassNames = {
+  1: 'mb-8 text-lg font-medium text-foreground-neutral-base',
+  2: 'mb-8 text-md font-medium text-foreground-neutral-base',
+  3: 'mb-8 text-sm font-medium text-foreground-neutral-base',
+  4: 'mb-8 text-sm font-medium text-foreground-neutral-base',
+} as const;
+
+function createMarkdownHeading(
+  tag: MarkdownHeadingTag,
+  baseClassName: string,
+): MarkdownHeadingComponent {
+  const Heading = tag;
+  return ({className, node: _node, ...props}) => (
+    <Heading className={cn(baseClassName, className)} {...props} />
+  );
+}
+
+const markdownHeadingComponents = {
+  h1: createMarkdownHeading('h1', headingClassNames[1]),
+  h2: createMarkdownHeading('h2', headingClassNames[2]),
+  h3: createMarkdownHeading('h3', headingClassNames[3]),
+  h4: createMarkdownHeading('h4', headingClassNames[4]),
+} satisfies Components;
+
+const nestedMarkdownHeadingComponents = {
+  h1: createMarkdownHeading('h2', headingClassNames[1]),
+  h2: createMarkdownHeading('h3', headingClassNames[2]),
+  h3: createMarkdownHeading('h4', headingClassNames[3]),
+  h4: createMarkdownHeading('h5', headingClassNames[4]),
+  h5: createMarkdownHeading('h6', headingClassNames[4]),
+  h6: createMarkdownHeading('h6', headingClassNames[4]),
+} satisfies Components;
+
 const markdownComponents = {
-  h1: ({className, node: _node, ...props}) => (
-    <h1
-      className={cn('mb-8 text-lg font-medium text-foreground-neutral-base', className)}
-      {...props}
-    />
-  ),
-  h2: ({className, node: _node, ...props}) => (
-    <h2
-      className={cn('mb-8 text-md font-medium text-foreground-neutral-base', className)}
-      {...props}
-    />
-  ),
-  h3: ({className, node: _node, ...props}) => (
-    <h3
-      className={cn('mb-8 text-sm font-medium text-foreground-neutral-base', className)}
-      {...props}
-    />
-  ),
-  h4: ({className, node: _node, ...props}) => (
-    <h4
-      className={cn('mb-8 text-sm font-medium text-foreground-neutral-base', className)}
-      {...props}
-    />
-  ),
+  ...markdownHeadingComponents,
   p: ({className, node: _node, ...props}) => (
     <p
       className={cn('mb-8 text-sm leading-20 text-foreground-neutral-base', className)}
@@ -180,12 +193,18 @@ const markdownComponents = {
   },
 } satisfies Components;
 
+const nestedMarkdownComponents = {
+  ...markdownComponents,
+  ...nestedMarkdownHeadingComponents,
+} satisfies Components;
+
 type MarkdownProps = {
   children: string;
   className?: string | undefined;
+  headingLevelOffset?: 0 | 1 | undefined;
 };
 
-function MarkdownImpl({children, className}: MarkdownProps) {
+function MarkdownImpl({children, className, headingLevelOffset = 0}: MarkdownProps) {
   if (!children.trim()) return null;
 
   return (
@@ -194,7 +213,7 @@ function MarkdownImpl({children, className}: MarkdownProps) {
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
-          components={markdownComponents}
+          components={headingLevelOffset === 1 ? nestedMarkdownComponents : markdownComponents}
         >
           {children}
         </ReactMarkdown>


### PR DESCRIPTION
Self-hosters can now use Markdown in `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` to provide actionable signup guidance, including links. The signup form renders only `signup-not-allowed` responses through the sanitized design-system Markdown surface; other form errors remain plain text.

The Auth configuration docs now describe the Markdown format and existing 500-character response limit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders server-declared signup denial messages as sanitized Markdown and enforces a 500-character limit to avoid mid-Markdown truncation. Previously all denial messages were plain text; now only `signup-not-allowed` responses render Markdown when the server sets `details.format: 'markdown'`.

- `@shipfox/api-auth`: environment-backed signup policy now returns denial messages with `format: 'markdown'`; `SignupNotAllowedError` carries an optional `format`; signup route returns `{details: {message, format}}` and trims to `SIGNUP_DENIAL_MESSAGE_MAX_LENGTH` (500); config rejects `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` over the limit; exports `SignupDenialMessageFormat` and `SIGNUP_DENIAL_MESSAGE_MAX_LENGTH`; README documents Markdown support, the limit, and link guidance.
- `@shipfox/client-auth`: adds `authErrorMessageFormat` and gates Markdown strictly to `signup-not-allowed` with `format: 'markdown'`; all other errors render as plain text; signup page renders Markdown inside callouts with a nested heading offset.
- `@shipfox/react-ui`: `Markdown` adds `headingLevelOffset` and normalized heading styles; sanitization remains in place.
- Rollout: no migration. Ensure `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` ≤ 500. Custom `signupPolicy` can opt into Markdown by returning `format: 'markdown'`. Older clients display Markdown source as plain text.

<sup>Written for commit 00748a27d889c1421e60a156142df2875705c9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

