### PR TITLE
[e2e-client-auth] Stabilize signup denial screenshot

### DIFF
--- a/e2e/suites/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/suites/client/auth/tests/auth-client.e2e.ts
@@ -39,7 +39,7 @@ test('logs in through the UI with an E2E-created verified user', async ({
 test('keeps an unlisted password signup on the signup form', async ({page, signup}) => {
   await signup.goto();
   await signup.submit({
-    email: `blocked-${randomUUID()}@example.test`,
+    email: 'blocked@example.test',
     name: 'Blocked Signup',
     password: 'correct horse battery staple',
   });


### PR DESCRIPTION
The auth signup-denial E2E snapshot used a UUID-derived email, so the visible input changed on every run and Argos reported false visual drift. The test now uses the fixed blocked@example.test address; the E2E allowlist rejects that domain before account creation, so uniqueness is unnecessary.

Verified with `mise run e2e -- --filter=@shipfox/e2e-client-auth` (11 passed), the package Biome and dependency-cruise checks, and `git diff --check`. Argos may show a one-time expected baseline update for the old random address.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the signup-denial E2E snapshot by replacing the UUID-based email with blocked@example.test. This removes run-to-run input changes and stops Argos false visual diffs; the allowlist rejects this domain before account creation, so behavior is unchanged.

- Affects only the signup denial test; no production code changes.
- Argos may require a one-time baseline update; no other actions.

<sup>Written for commit 5a07485e0e187076016603531eec6513737ea575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

