### PR TITLE
[expression] Add first and last list methods

### DIFF
--- a/.changeset/quiet-list-tail.md
+++ b/.changeset/quiet-list-tail.md
@@ -3,5 +3,3 @@
 ---
 
 Adds `list.first()` and `list.last()` to return the first or final element of a non-empty workflow expression list.
-
-Deploy this version to every workflow expression evaluator before authors use these methods. Older evaluators reject expressions that call them.

--- a/.changeset/quiet-list-tail.md
+++ b/.changeset/quiet-list-tail.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds `list.first()` and `list.last()` to return the first or final element of a non-empty workflow expression list.

--- a/.changeset/quiet-list-tail.md
+++ b/.changeset/quiet-list-tail.md
@@ -3,3 +3,5 @@
 ---
 
 Adds `list.first()` and `list.last()` to return the first or final element of a non-empty workflow expression list.
+
+Deploy this version to every workflow expression evaluator before authors use these methods. Older evaluators reject expressions that call them.

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -83,6 +83,8 @@ passes.
 | Call | Example | Result |
 | --- | --- | --- |
 | `list.size()`, `string.size()` | `executions.size() > 1` | Number of elements or characters |
+| `list.first()` | `execution.events.first().data` | The first element of a list |
+| `list.last()` | `execution.events.last().data` | The final element of a list |
 | `list.all(item, predicate)` | `executions.all(e, e.status == "succeeded")` | True when every element matches |
 | `list.exists(item, predicate)` | `execution.events.exists(e, e.event == "push")` | True when at least one element matches |
 | `list.exists_one(item, predicate)` | `needs.exists_one(j, j.status == "failed")` | True when exactly one element matches |
@@ -99,6 +101,10 @@ passes.
 | `range(start, stop, step)` | `range(1, 3, 1)` | An inclusive list of integers |
 | `toJson(value)` | `toJson(event.pull_request.labels)` | The value serialized as compact JSON text |
 | `fromJson(string)` | `fromJson(event.payload)` | The JSON text parsed into a CEL value |
+
+`list.first()` and `list.last()` keep the element's type. Calling either method
+on an empty list causes an evaluation error, so a predicate using that value
+does not pass.
 
 `range()` accepts a positive step and can materialize at most 1,000 values and
 1,000,000 context-byte fan-out units in one evaluation. `toJson()` can produce

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -103,8 +103,8 @@ passes.
 | `fromJson(string)` | `fromJson(event.payload)` | The JSON text parsed into a CEL value |
 
 `list.first()` and `list.last()` keep the element's type. Calling either method
-on an empty list causes an evaluation error, so a predicate using that value
-does not pass.
+on an empty list causes an evaluation error. Workflow job and step conditions
+record that outcome as errored rather than rejected.
 
 `range()` accepts a positive step and can materialize at most 1,000 values and
 1,000,000 context-byte fan-out units in one evaluation. `toJson()` can produce

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -10,7 +10,8 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
 - **`ExpressionTypeEnvironment`**: Lists names and field types for typed checks.
 - **`evaluateWorkflowExpression`**: Runs a checked value against caller data.
 - **`createWorkflowEnvironment`**: Creates an isolated evaluator with the shared
-  `range()`, `toJson()`, and `fromJson()` functions.
+  `list.first()`, `list.last()`, `range()`, `toJson()`, and `fromJson()`
+  functions.
 - **`evaluateWorkflowExpressionWithEnvironment`**: Runs a checked value against
   a caller-owned CEL environment for explicitly scoped custom functions.
 - **`WorkflowExpressionEnvironment`**: The evaluate-only environment shape
@@ -92,9 +93,12 @@ const passed = evaluateWorkflowPredicate(expression, {
 - Context values can include external data. Interpolatable fields rely on their
   structural sink guarantees, while host and availability checks remain enforced.
 - Evaluation is deterministic and has no side effects.
-- Workflow evaluation includes the shared `range()`, `toJson()`, and `fromJson()`
-  functions. Use a caller-owned environment when a custom function is intentionally
-  needed outside that registry.
+- Workflow evaluation includes the shared `list.first()`, `list.last()`,
+  `range()`, `toJson()`, and `fromJson()` functions. Use a caller-owned
+  environment when a custom function is intentionally needed outside that
+  registry.
+- `list.first()` and `list.last()` return the first or final element and
+  preserve its type. An empty list causes an evaluation error.
 - `range()` accepts CEL integers and safe integer values from JavaScript
   contexts. An environment is built once and reused, and each evaluation gets
   its own materialization budget, shared by nested range calls and restored when

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -124,9 +124,43 @@ describe('evaluateWorkflowExpression', () => {
   });
 
   it.each([
-    'first',
-    'last',
-  ] as const)('reports %s on an empty list as an evaluation failure', (method) => {
+    ['first', 'first'],
+    ['last', 'last'],
+  ] as const)('evaluates chained access after dynamic list %s', (method, expected) => {
+    const expression = createWorkflowExpression({
+      source: `event.values.${method}().label`,
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {values: [{label: 'first'}, {label: 'last'}]},
+    });
+
+    expect(result).toBe(expected);
+  });
+
+  it.each([
+    ['first', 'first'],
+    ['last', 'last'],
+  ] as const)('evaluates %s for a Set list value', (method, expected) => {
+    const expression = createWorkflowExpression({
+      source: `event.values.${method}()`,
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {values: new Set(['first', 'last'])},
+    });
+
+    expect(result).toBe(expected);
+  });
+
+  it.each([
+    ['first', 'array', []],
+    ['first', 'Set', new Set()],
+    ['last', 'array', []],
+    ['last', 'Set', new Set()],
+  ] as const)('reports %s on an empty %s as an evaluation failure', (method, _kind, values) => {
     const expression = createWorkflowExpression({
       source: `event.values.${method}()`,
       check: {
@@ -140,9 +174,11 @@ describe('evaluateWorkflowExpression', () => {
       },
     });
 
-    const evaluateEmpty = () => evaluateWorkflowExpression(expression, {event: {values: []}});
+    const evaluateEmpty = () => evaluateWorkflowExpression(expression, {event: {values}});
+    const failClosed = evaluateWorkflowPredicateFailClosed(expression, {event: {values}});
 
     expect(evaluateEmpty).toThrow(WorkflowExpressionEvaluationError);
+    expect(failClosed).toEqual({value: false, evaluationFailed: true});
   });
 
   it('gives each default-environment evaluation a full range budget', () => {

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -99,6 +99,52 @@ describe('evaluateWorkflowExpression', () => {
     expect(result).toEqual([2n, 4n, 6n]);
   });
 
+  it.each([
+    ['first', 'first'],
+    ['last', 'last'],
+  ] as const)('evaluates %s through the default workflow environment', (method, expected) => {
+    const expression = createWorkflowExpression({
+      source: `event.values.${method}()`,
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {
+            kind: 'object',
+            fields: {values: {kind: 'list', element: 'string'}},
+          },
+        },
+      },
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {values: ['first', 'last']},
+    });
+
+    expect(result).toBe(expected);
+  });
+
+  it.each([
+    'first',
+    'last',
+  ] as const)('reports %s on an empty list as an evaluation failure', (method) => {
+    const expression = createWorkflowExpression({
+      source: `event.values.${method}()`,
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {
+            kind: 'object',
+            fields: {values: {kind: 'list', element: 'string'}},
+          },
+        },
+      },
+    });
+
+    const evaluateEmpty = () => evaluateWorkflowExpression(expression, {event: {values: []}});
+
+    expect(evaluateEmpty).toThrow(WorkflowExpressionEvaluationError);
+  });
+
   it('gives each default-environment evaluation a full range budget', () => {
     const expression = createWorkflowExpression({
       source: 'range(1, 1000, 1).size()',

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -142,6 +142,22 @@ describe('evaluateWorkflowExpression', () => {
   it.each([
     ['first', 'first'],
     ['last', 'last'],
+  ] as const)('evaluates a nested call after dynamic list %s', (method, expected) => {
+    const expression = createWorkflowExpression({
+      source: `event.values.${method}().${method}()`,
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {values: [['first'], ['last']]},
+    });
+
+    expect(result).toBe(expected);
+  });
+
+  it.each([
+    ['first', 'first'],
+    ['last', 'last'],
   ] as const)('evaluates %s for a Set list value', (method, expected) => {
     const expression = createWorkflowExpression({
       source: `event.values.${method}()`,

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -80,12 +80,75 @@ describe('createWorkflowExpression', () => {
       source: 'range(1, 3, 1).size() == 3',
       check: {mode: 'typed'},
     });
+    const firstExpression = createWorkflowExpression({
+      source: 'event.values.first()',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {
+            kind: 'object',
+            fields: {values: {kind: 'list', element: 'string'}},
+          },
+        },
+      },
+    });
+    const lastExpression = createWorkflowExpression({
+      source: 'event.values.last()',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {
+            kind: 'object',
+            fields: {values: {kind: 'list', element: 'string'}},
+          },
+        },
+      },
+    });
 
     expect(jsonExpression.resultType).toBe('string');
     expect(parsedExpression.check).toBe('typed');
     expect(parsedPredicateExpression.check).toBe('typed');
     expect(dynamicJsonExpression.resultType).toBeUndefined();
     expect(rangeExpression.resultType).toBe('bool');
+    expect(firstExpression.resultType).toBe('string');
+    expect(lastExpression.resultType).toBe('string');
+  });
+
+  it.each(['first', 'last'] as const)('preserves typed object fields through list %s', (method) => {
+    const expression = createWorkflowExpression({
+      source: `event.values.${method}().label`,
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {
+            kind: 'object',
+            fields: {
+              values: {
+                kind: 'list',
+                element: {kind: 'object', fields: {label: 'string'}},
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(expression.resultType).toBe('string');
+  });
+
+  it.each(['first', 'last'] as const)('rejects %s on a non-list receiver', (method) => {
+    const act = () =>
+      createWorkflowExpression({
+        source: `event.value.${method}()`,
+        check: {
+          mode: 'typed',
+          typeEnvironment: {
+            event: {kind: 'object', fields: {value: 'string'}},
+          },
+        },
+      });
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
   });
 
   it('does not treat fromJson text in a dynamic expression as a function call', () => {

--- a/libs/shared/expression/src/workflow-function-registry.ts
+++ b/libs/shared/expression/src/workflow-function-registry.ts
@@ -15,6 +15,8 @@ const utf8Encoder = new TextEncoder();
 const RANGE_FUNCTION_SIGNATURE = 'range(dyn, dyn, dyn): list<int>';
 const TO_JSON_FUNCTION_SIGNATURE = 'toJson(dyn): string';
 const FROM_JSON_FUNCTION_SIGNATURE = 'fromJson(string): dyn';
+const FIRST_FUNCTION_SIGNATURE = 'list<T>.first(): T';
+const LAST_FUNCTION_SIGNATURE = 'list<T>.last(): T';
 
 interface WorkflowFunctionBudget {
   remainingRangeElements: number;
@@ -54,6 +56,20 @@ const workflowFunctionRegistry = [
     createHandler: (): RegisteredFunctionHandler => (value: unknown) => {
       if (typeof value !== 'string') throw new TypeError('fromJson() expects a JSON string');
       return JSON.parse(value, reviveJsonNumber) as unknown;
+    },
+  },
+  {
+    signature: FIRST_FUNCTION_SIGNATURE,
+    createHandler: (): RegisteredFunctionHandler => (value: readonly unknown[]) => {
+      if (value.length === 0) throw new RangeError('first() requires a non-empty list');
+      return value[0];
+    },
+  },
+  {
+    signature: LAST_FUNCTION_SIGNATURE,
+    createHandler: (): RegisteredFunctionHandler => (value: readonly unknown[]) => {
+      if (value.length === 0) throw new RangeError('last() requires a non-empty list');
+      return value[value.length - 1];
     },
   },
 ] satisfies readonly WorkflowFunctionDefinition[];

--- a/libs/shared/expression/src/workflow-function-registry.ts
+++ b/libs/shared/expression/src/workflow-function-registry.ts
@@ -16,7 +16,9 @@ const RANGE_FUNCTION_SIGNATURE = 'range(dyn, dyn, dyn): list<int>';
 const TO_JSON_FUNCTION_SIGNATURE = 'toJson(dyn): string';
 const FROM_JSON_FUNCTION_SIGNATURE = 'fromJson(string): dyn';
 const FIRST_FUNCTION_SIGNATURE = 'list<T>.first(): T';
+const DYNAMIC_FIRST_FUNCTION_SIGNATURE = 'list<dyn>.first(): dyn';
 const LAST_FUNCTION_SIGNATURE = 'list<T>.last(): T';
+const DYNAMIC_LAST_FUNCTION_SIGNATURE = 'list<dyn>.last(): dyn';
 
 interface WorkflowFunctionBudget {
   remainingRangeElements: number;
@@ -60,19 +62,48 @@ const workflowFunctionRegistry = [
   },
   {
     signature: FIRST_FUNCTION_SIGNATURE,
-    createHandler: (): RegisteredFunctionHandler => (value: readonly unknown[]) => {
-      if (value.length === 0) throw new RangeError('first() requires a non-empty list');
-      return value[0];
-    },
+    createHandler: (): RegisteredFunctionHandler => firstListElement,
+  },
+  {
+    signature: DYNAMIC_FIRST_FUNCTION_SIGNATURE,
+    createHandler: (): RegisteredFunctionHandler => firstListElement,
   },
   {
     signature: LAST_FUNCTION_SIGNATURE,
-    createHandler: (): RegisteredFunctionHandler => (value: readonly unknown[]) => {
-      if (value.length === 0) throw new RangeError('last() requires a non-empty list');
-      return value[value.length - 1];
-    },
+    createHandler: (): RegisteredFunctionHandler => lastListElement,
+  },
+  {
+    signature: DYNAMIC_LAST_FUNCTION_SIGNATURE,
+    createHandler: (): RegisteredFunctionHandler => lastListElement,
   },
 ] satisfies readonly WorkflowFunctionDefinition[];
+
+function firstListElement(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    if (value.length === 0) throw new RangeError('first() requires a non-empty list');
+    return value[0];
+  }
+  if (value instanceof Set) {
+    const first = value.values().next();
+    if (first.done) throw new RangeError('first() requires a non-empty list');
+    return first.value;
+  }
+  throw new TypeError('first() expects a list');
+}
+
+function lastListElement(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    if (value.length === 0) throw new RangeError('last() requires a non-empty list');
+    return value[value.length - 1];
+  }
+  if (value instanceof Set) {
+    if (value.size === 0) throw new RangeError('last() requires a non-empty list');
+    let last: unknown;
+    for (const element of value) last = element;
+    return last;
+  }
+  throw new TypeError('last() expects a list');
+}
 
 /**
  * Register the shared functions and return the budgets their handlers close over.


### PR DESCRIPTION
Add `list.first()` and `list.last()` receiver methods to workflow expressions so authors can access edge elements without calculating indices.

Both methods preserve the list element type. They fail expression evaluation for an empty list instead of returning a nullable sentinel. The expression reference and package README document the contract, and the minor Changeset packages both methods as one feature.

## Rollout

Deploy this `@shipfox/expression` version to every workflow expression evaluator before authors use these methods. Older or rolled-back evaluators reject persisted expressions that call them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `list.first()` and `list.last()` to workflow expressions so authors can read edge elements without index math. Both preserve the element type and error on empty lists; job and step conditions record these as errored.

- Registers these methods in the default workflow environment in `@shipfox/expression`, with typed and dynamic overloads so chained and nested access on untyped lists works; supports `Set`-backed CEL lists.
- The type checker requires a list receiver and propagates the element type; it rejects non-list receivers.
- Required: deploy this `@shipfox/expression` version to all evaluators before authors use these methods; older evaluators reject expressions that call them.

<sup>Written for commit 577b46ed5ccf0f2407cbdedb821912df28fe07a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

