### PR TITLE
[client-workflows] Stabilize workflow source panel visual snapshots

### DIFF
--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
@@ -53,15 +53,16 @@ async function captureHighlightedSourcePanel(
   screenshotName: string,
 ) {
   await screen.findByRole('dialog', {name: 'Workflow source'});
-  await waitFor(
+  const codeContent = await waitFor(
     () => {
-      if (!document.querySelector('.shiki-override')) {
+      const content = document.querySelector('.shiki-override')?.textContent?.trim();
+      if (!content) {
         throw new Error('Shiki highlighting has not rendered yet');
       }
+      return content;
     },
     {timeout: 10_000},
   );
-  const codeContent = document.querySelector('.shiki-override')?.textContent ?? '';
   const loadedCodeFonts = await document.fonts.load('400 14px "Commit Mono"', codeContent);
   if (!loadedCodeFonts.some((font) => font.status === 'loaded')) {
     throw new Error('Commit Mono has not loaded yet');

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
@@ -61,10 +61,12 @@ async function captureHighlightedSourcePanel(
     },
     {timeout: 10_000},
   );
-  const loadedCodeFonts = await document.fonts.load('400 14px "Commit Mono"');
+  const codeContent = document.querySelector('.shiki-override')?.textContent ?? '';
+  const loadedCodeFonts = await document.fonts.load('400 14px "Commit Mono"', codeContent);
   if (!loadedCodeFonts.some((font) => font.status === 'loaded')) {
     throw new Error('Commit Mono has not loaded yet');
   }
+  await document.fonts.ready;
   await argosScreenshot(ctx, screenshotName);
 }
 


### PR DESCRIPTION
Storybook's highlighted workflow source panel screenshot could capture before the rendered code font had completed its layout pass. The Argos capture now requests Commit Mono for the actual Shiki content and waits for the document font set to settle before taking the screenshot. This keeps the stabilization scoped to the visual fixture and leaves runtime code unchanged.

Validation: the affected-package Turbo check, type, and test tasks passed, including both Storybook runs for the workflow source panel.