### PR TITLE
[api-runners] Make reservation accounting self-correcting

### DIFF
--- a/.changeset/runner-reservation-accounting.md
+++ b/.changeset/runner-reservation-accounting.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/api-runners": patch
+"@shipfox/api-runners-dto": patch
 ---
 
-Makes runner reservation accounting self-correcting across claimed, terminal, released, and unlaunched runner units.
+Makes runner reservation accounting self-correcting across claimed, terminal, released, and unlaunched runner units, and labels reservation-release metrics by lifecycle surface including first-claim releases.

--- a/.changeset/runner-reservation-accounting.md
+++ b/.changeset/runner-reservation-accounting.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Makes runner reservation accounting self-correcting across claimed, terminal, released, and unlaunched runner units.

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -26,7 +26,7 @@ export const demandStatSchema = z.object({
     .int()
     .min(0)
     .describe(
-      'Demand units currently masked by live unclaimed reservation runners or reserved by this poll; advisory.',
+      'Queued jobs for this label set covered by unclaimed reserved runners or reservations created in this poll; advisory scheduling estimate.',
     ),
   oldest_queued_at: z.string().datetime(),
 });

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -26,7 +26,7 @@ export const demandStatSchema = z.object({
     .int()
     .min(0)
     .describe(
-      'Active reservations for this label set; advisory, may exceed `queued` during heavy claiming.',
+      'Demand units currently masked by live unclaimed reservation runners or reserved by this poll; advisory.',
     ),
   oldest_queued_at: z.string().datetime(),
 });

--- a/libs/api/runners/src/core/maintenance.test.ts
+++ b/libs/api/runners/src/core/maintenance.test.ts
@@ -85,7 +85,7 @@ describe('reapStaleRunnerInstances', () => {
 
     expect(result).toEqual({reaped: 1, reservationsReleased: 1});
     expect(reapedSpy).toHaveBeenCalledWith(1);
-    expect(releasedSpy).toHaveBeenCalledWith(1);
+    expect(releasedSpy).toHaveBeenCalledWith(1, {surface: 'reconcile'});
   });
 });
 

--- a/libs/api/runners/src/core/maintenance.ts
+++ b/libs/api/runners/src/core/maintenance.ts
@@ -4,7 +4,7 @@ import {expireStuckJobExecutions} from '#db/job-executions.js';
 import {deleteExpiredReservations} from '#db/reservations.js';
 import {reapStaleRunnerInstances as reapStaleRunnerInstancesDb} from '#db/runner-instances.js';
 import {deleteExpiredRunnerSessions as deleteExpiredRunnerSessionsDb} from '#db/runner-sessions.js';
-import {providerRunnerReapedCount, reservationReleasedCount} from '#metrics/instance.js';
+import {providerRunnerReapedCount, recordRunnerReservationReleased} from '#metrics/instance.js';
 import {STUCK_JOB_THRESHOLD_SECONDS} from './maintenance-policy.js';
 
 export interface DetectAndExpireStuckJobsParams {
@@ -41,9 +41,7 @@ export async function reapStaleRunnerInstances(params?: {
   });
 
   if (result.reaped > 0) providerRunnerReapedCount.add(result.reaped);
-  if (result.reservationsReleased > 0) {
-    reservationReleasedCount.add(result.reservationsReleased);
-  }
+  recordRunnerReservationReleased({count: result.reservationsReleased, surface: 'reconcile'});
 
   return result;
 }

--- a/libs/api/runners/src/core/runner-instances.ts
+++ b/libs/api/runners/src/core/runner-instances.ts
@@ -18,7 +18,7 @@ import {
   providerRunnerReportCount,
   providerRunnerTerminateIntentHonoredCount,
   providerRunnerTerminateIntentIssuedCount,
-  reservationReleasedCount,
+  recordRunnerReservationReleased,
 } from '#metrics/instance.js';
 import {config} from '../config.js';
 
@@ -103,7 +103,7 @@ export async function reportRunnerInstances(
   for (const intent of result.terminateIntentsHonored) {
     providerRunnerTerminateIntentHonoredCount.add(1, {reason: intent.reason});
   }
-  if (result.reservationsReleased > 0) reservationReleasedCount.add(result.reservationsReleased);
+  recordRunnerReservationReleased({count: result.reservationsReleased, surface: 'terminal-report'});
 
   return result;
 }
@@ -116,7 +116,7 @@ export async function reconcileRunnerInstances(
     terminateGraceSeconds: config.RUNNER_RECONCILE_TERMINATE_GRACE_SECONDS,
   });
 
-  if (result.reservationsReleased > 0) reservationReleasedCount.add(result.reservationsReleased);
+  recordRunnerReservationReleased({count: result.reservationsReleased, surface: 'reconcile'});
   providerRunnerReconcileCallCount.add(1);
   if (result.absentIds.length > 0) providerRunnerAbsentTerminatedCount.add(result.absentIds.length);
 

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -483,6 +483,7 @@ describe('claimPendingJobExecution', () => {
   });
 
   it('releases a provisioned runner reservation on its first claim only', async () => {
+    const reservationReleaseMetric = vi.spyOn(runnerMetrics.reservationReleasedCount, 'add');
     const provisionerId = crypto.randomUUID();
     const providerRunnerId = `provisioned-runner-${crypto.randomUUID()}`;
     const [reservation] = await db()
@@ -550,6 +551,11 @@ describe('claimPendingJobExecution', () => {
     expect(firstClaim?.jobExecutionId).toBe(firstPending.jobExecutionId);
     expect(afterFirstClaim?.count).toBe(1);
     expect(firstReleaseAt).toBeInstanceOf(Date);
+    expect(
+      reservationReleaseMetric.mock.calls.filter(
+        ([value, attributes]) => value === 1 && attributes?.surface === 'first-claim',
+      ),
+    ).toHaveLength(1);
     expect(secondClaim?.jobExecutionId).toBe(secondPending.jobExecutionId);
     expect(afterSecondClaim?.count).toBe(1);
     expect(runnerAfterSecondClaim?.reservationReleasedAt).toEqual(firstReleaseAt);

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -484,81 +484,85 @@ describe('claimPendingJobExecution', () => {
 
   it('releases a provisioned runner reservation on its first claim only', async () => {
     const reservationReleaseMetric = vi.spyOn(runnerMetrics.reservationReleasedCount, 'add');
-    const provisionerId = crypto.randomUUID();
-    const providerRunnerId = `provisioned-runner-${crypto.randomUUID()}`;
-    const [reservation] = await db()
-      .insert(reservations)
-      .values({
+    try {
+      const provisionerId = crypto.randomUUID();
+      const providerRunnerId = `provisioned-runner-${crypto.randomUUID()}`;
+      const [reservation] = await db()
+        .insert(reservations)
+        .values({
+          workspaceId,
+          provisionerId,
+          requiredLabels: sessionLabels,
+          count: 2,
+          expiresAt: new Date(Date.now() + 60_000),
+        })
+        .returning({id: reservations.id});
+      if (!reservation) throw new Error('Expected reservation');
+
+      const runner = await providerRunnerFactory.create({
         workspaceId,
         provisionerId,
-        requiredLabels: sessionLabels,
-        count: 2,
-        expiresAt: new Date(Date.now() + 60_000),
-      })
-      .returning({id: reservations.id});
-    if (!reservation) throw new Error('Expected reservation');
-
-    const runner = await providerRunnerFactory.create({
-      workspaceId,
-      provisionerId,
-      providerRunnerId,
-      reservationId: reservation.id,
-      runnerSessionId,
-      state: 'running',
-      labels: sessionLabels,
-    });
-    await db()
-      .update(runnerSessions)
-      .set({
-        registrationTokenKind: 'ephemeral',
-        maxClaims: 2,
-        provisionerId,
         providerRunnerId,
-      })
-      .where(eq(runnerSessions.id, runnerSessionId));
+        reservationId: reservation.id,
+        runnerSessionId,
+        state: 'running',
+        labels: sessionLabels,
+      });
+      await db()
+        .update(runnerSessions)
+        .set({
+          registrationTokenKind: 'ephemeral',
+          maxClaims: 2,
+          provisionerId,
+          providerRunnerId,
+        })
+        .where(eq(runnerSessions.id, runnerSessionId));
 
-    const firstPending = await pendingJobFactory.create({workspaceId});
-    const firstClaim = await claimPendingJobExecution({
-      workspaceId,
-      runnerSessionId,
-      maxClaims: 2,
-    });
-    const [afterFirstClaim] = await db()
-      .select({count: reservations.count})
-      .from(reservations)
-      .where(eq(reservations.id, reservation.id));
-    const [runnerAfterFirstClaim] = await db()
-      .select({reservationReleasedAt: providerRunners.reservationReleasedAt})
-      .from(providerRunners)
-      .where(eq(providerRunners.id, runner.id));
-    const firstReleaseAt = runnerAfterFirstClaim?.reservationReleasedAt;
+      const firstPending = await pendingJobFactory.create({workspaceId});
+      const firstClaim = await claimPendingJobExecution({
+        workspaceId,
+        runnerSessionId,
+        maxClaims: 2,
+      });
+      const [afterFirstClaim] = await db()
+        .select({count: reservations.count})
+        .from(reservations)
+        .where(eq(reservations.id, reservation.id));
+      const [runnerAfterFirstClaim] = await db()
+        .select({reservationReleasedAt: providerRunners.reservationReleasedAt})
+        .from(providerRunners)
+        .where(eq(providerRunners.id, runner.id));
+      const firstReleaseAt = runnerAfterFirstClaim?.reservationReleasedAt;
 
-    const secondPending = await pendingJobFactory.create({workspaceId});
-    const secondClaim = await claimPendingJobExecution({
-      workspaceId,
-      runnerSessionId,
-      maxClaims: 2,
-    });
-    const [afterSecondClaim] = await db()
-      .select({count: reservations.count})
-      .from(reservations)
-      .where(eq(reservations.id, reservation.id));
-    const [runnerAfterSecondClaim] = await db()
-      .select({reservationReleasedAt: providerRunners.reservationReleasedAt})
-      .from(providerRunners)
-      .where(eq(providerRunners.id, runner.id));
+      const secondPending = await pendingJobFactory.create({workspaceId});
+      const secondClaim = await claimPendingJobExecution({
+        workspaceId,
+        runnerSessionId,
+        maxClaims: 2,
+      });
+      const [afterSecondClaim] = await db()
+        .select({count: reservations.count})
+        .from(reservations)
+        .where(eq(reservations.id, reservation.id));
+      const [runnerAfterSecondClaim] = await db()
+        .select({reservationReleasedAt: providerRunners.reservationReleasedAt})
+        .from(providerRunners)
+        .where(eq(providerRunners.id, runner.id));
 
-    expect(firstClaim?.jobExecutionId).toBe(firstPending.jobExecutionId);
-    expect(afterFirstClaim?.count).toBe(1);
-    expect(firstReleaseAt).toBeInstanceOf(Date);
-    expect(
-      reservationReleaseMetric.mock.calls.filter(
-        ([value, attributes]) => value === 1 && attributes?.surface === 'first-claim',
-      ),
-    ).toHaveLength(1);
-    expect(secondClaim?.jobExecutionId).toBe(secondPending.jobExecutionId);
-    expect(afterSecondClaim?.count).toBe(1);
-    expect(runnerAfterSecondClaim?.reservationReleasedAt).toEqual(firstReleaseAt);
+      expect(firstClaim?.jobExecutionId).toBe(firstPending.jobExecutionId);
+      expect(afterFirstClaim?.count).toBe(1);
+      expect(firstReleaseAt).toBeInstanceOf(Date);
+      expect(
+        reservationReleaseMetric.mock.calls.filter(
+          ([value, attributes]) => value === 1 && attributes?.surface === 'first-claim',
+        ),
+      ).toHaveLength(1);
+      expect(secondClaim?.jobExecutionId).toBe(secondPending.jobExecutionId);
+      expect(afterSecondClaim?.count).toBe(1);
+      expect(runnerAfterSecondClaim?.reservationReleasedAt).toEqual(firstReleaseAt);
+    } finally {
+      reservationReleaseMetric.mockRestore();
+    }
   });
 
   it('allows a manual session to claim repeatedly', async () => {

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -35,6 +35,7 @@ import {
   type ProviderRunnerLifecycleObservation,
   recordJobExecutionQueueTime,
   recordProviderRunnerActivationToFirstClaim,
+  recordRunnerReservationReleased,
 } from '#metrics/instance.js';
 import type {Tx} from './db.js';
 import {db} from './db.js';
@@ -231,6 +232,7 @@ export async function claimPendingJobExecution(params: {
 
   let activationToFirstClaimObservation: ProviderRunnerLifecycleObservation | null = null;
   let queueTimeObservation: JobExecutionQueueTimeObservation | null = null;
+  let firstClaimReservationReleaseCount = 0;
   const result = await db().transaction(async (tx) => {
     let provisionerId: string | null = null;
     let providerRunnerId: string | null = null;
@@ -419,7 +421,7 @@ export async function claimPendingJobExecution(params: {
             )
             .limit(1);
           if (reservation)
-            await releaseReservationUnits(tx, {
+            firstClaimReservationReleaseCount += await releaseReservationUnits(tx, {
               workspaceId: reservation.workspaceId,
               provisionerId: releasedRunner.provisionerId,
               releases: [{reservationId, count: 1}],
@@ -469,6 +471,10 @@ export async function claimPendingJobExecution(params: {
       jobExecutionId: row.jobExecutionId,
       projectId: row.projectId,
     };
+  });
+  recordRunnerReservationReleased({
+    count: firstClaimReservationReleaseCount,
+    surface: 'first-claim',
   });
   if (queueTimeObservation) recordJobExecutionQueueTime(queueTimeObservation);
   if (activationToFirstClaimObservation)

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -150,6 +150,76 @@ describe('pollDemandAndReserve', () => {
     }
   }, 10_000);
 
+  it('counts leaked units across live reservation lifecycle states', async () => {
+    const leakedUnitsBefore = await countLiveReservationLeakUnits();
+    await createIntendedReservation({
+      workspaceId,
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const partialReservation = await createIntendedReservation({
+      workspaceId,
+      count: 2,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: partialReservation.id,
+      firstClaimedAt: null,
+    });
+
+    const claimedReservation = await createIntendedReservation({
+      workspaceId,
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: claimedReservation.id,
+      firstClaimedAt: new Date(),
+    });
+
+    const terminalReservation = await createIntendedReservation({
+      workspaceId,
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: terminalReservation.id,
+      state: 'terminated',
+    });
+
+    const releasedReservation = await createIntendedReservation({
+      workspaceId,
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: releasedReservation.id,
+      reservationReleasedAt: new Date(),
+    });
+
+    const coveredReservation = await createIntendedReservation({
+      workspaceId,
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: coveredReservation.id,
+      firstClaimedAt: null,
+    });
+    await createIntendedReservation({
+      workspaceId,
+      count: 1,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    expect(await countLiveReservationLeakUnits()).toBe(leakedUnitsBefore + 5);
+  });
+
   it('does not create a bound reservation when no idle runner can be rebound', async () => {
     await createPendingJobs(1, ['linux']);
 
@@ -2085,6 +2155,7 @@ describe('pollDemandAndReserve', () => {
 
   async function createIntendedReservation(params: {
     workspaceId: string;
+    count?: number;
     expiresAt: Date;
   }): Promise<{id: string}> {
     const [reservation] = await db()
@@ -2093,7 +2164,7 @@ describe('pollDemandAndReserve', () => {
         workspaceId: params.workspaceId,
         provisionerId,
         requiredLabels: ['linux'],
-        count: 1,
+        count: params.count ?? 1,
         expiresAt: params.expiresAt,
       })
       .returning({id: reservations.id});

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -4,6 +4,7 @@ import {and, eq, inArray, or, sql, sum} from 'drizzle-orm';
 import type {RunnerInstanceState} from '#core/entities/runner-instance.js';
 import {db} from '#db/db.js';
 import {
+  countLiveReservationLeakUnits,
   deleteExpiredReservations,
   deleteReservationsByIds,
   pollDemandAndReserve,
@@ -111,6 +112,50 @@ describe('pollDemandAndReserve', () => {
     expect(result.reservations).toEqual([expect.objectContaining({labels: ['linux'], count: 1})]);
     expect(result.stats[0]).toMatchObject({queued: 1, reserved: 1});
   });
+
+  it('does not block on reservation locks while observing leaked units', async () => {
+    const leakedUnitsBefore = await countLiveReservationLeakUnits();
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning({id: reservations.id});
+    if (!reservation) throw new Error('Expected reservation');
+    const lockClient = await pgClient().connect();
+    let transactionOpen = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await lockClient.query('BEGIN');
+      transactionOpen = true;
+      await lockClient.query('SELECT id FROM runners_reservations WHERE id = $1 FOR UPDATE', [
+        reservation.id,
+      ]);
+      await lockClient.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        `runners_assignment:${provisionerId}:${reservation.id}`,
+      ]);
+
+      const leakedUnits = await Promise.race([
+        countLiveReservationLeakUnits(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error('Leak gauge waited on reservation mutation locks')),
+            1_000,
+          );
+        }),
+      ]);
+
+      expect(leakedUnits).toBe(leakedUnitsBefore + 1);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      if (transactionOpen) await lockClient.query('ROLLBACK');
+      lockClient.release();
+    }
+  }, 10_000);
 
   it('does not create a bound reservation when no idle runner can be rebound', async () => {
     await createPendingJobs(1, ['linux']);

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -115,17 +115,10 @@ describe('pollDemandAndReserve', () => {
 
   it('does not block on reservation locks while observing leaked units', async () => {
     const leakedUnitsBefore = await countLiveReservationLeakUnits();
-    const [reservation] = await db()
-      .insert(reservations)
-      .values({
-        workspaceId,
-        provisionerId,
-        requiredLabels: ['linux'],
-        count: 1,
-        expiresAt: new Date(Date.now() + 60_000),
-      })
-      .returning({id: reservations.id});
-    if (!reservation) throw new Error('Expected reservation');
+    const reservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
     const lockClient = await pgClient().connect();
     let transactionOpen = false;
     let timeout: ReturnType<typeof setTimeout> | undefined;

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -43,6 +43,75 @@ describe('pollDemandAndReserve', () => {
     expect(result.stats[0]).toMatchObject({labels: ['linux'], queued: 50, reserved: 20});
   });
 
+  it('does not mask demand with a claimed reservation unit', async () => {
+    const reservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      workspaceId,
+      reservationId: reservation.id,
+      firstClaimedAt: new Date(),
+      controlSessionExpiresAt: new Date(Date.now() - 1_000),
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    expect(result.reservations).toEqual([expect.objectContaining({labels: ['linux'], count: 1})]);
+    expect(result.stats[0]).toMatchObject({queued: 1, reserved: 1});
+  });
+
+  it('masks exactly one unit for a booting unclaimed runner', async () => {
+    const reservation = await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createIdleRunner({
+      labels: ['linux'],
+      reservationId: reservation.id,
+      firstClaimedAt: null,
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    expect(result.reservations).toEqual([]);
+    expect(result.stats[0]).toMatchObject({queued: 1, reserved: 1});
+  });
+
+  it('does not mask demand when a granted unit has no live unclaimed runner', async () => {
+    await createIntendedReservation({
+      workspaceId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    expect(result.reservations).toEqual([expect.objectContaining({labels: ['linux'], count: 1})]);
+    expect(result.stats[0]).toMatchObject({queued: 1, reserved: 1});
+  });
+
   it('does not create a bound reservation when no idle runner can be rebound', async () => {
     await createPendingJobs(1, ['linux']);
 
@@ -368,7 +437,7 @@ describe('pollDemandAndReserve', () => {
     ).toHaveLength(1);
   });
 
-  it('does not charge adopted runners against later overlapping demand', async () => {
+  it('keeps a booting adopted runner in later overlapping demand accounting', async () => {
     const adoptedRunner = await createIdleRunner({labels: ['linux', 'gpu']});
     await createPendingJobs(1, ['linux', 'gpu']);
 
@@ -394,26 +463,17 @@ describe('pollDemandAndReserve', () => {
     const boundReservation = storedReservations.find(
       (reservation) => reservation.requiredLabels.includes('gpu') && reservation.kind === 'bound',
     );
-    const launchReservation = storedReservations.find(
-      (reservation) => !reservation.requiredLabels.includes('gpu') && reservation.kind === 'launch',
-    );
     const [storedRunner] = await db()
       .select()
       .from(providerRunners)
       .where(eq(providerRunners.id, adoptedRunner.id));
 
-    expect(result.reservations).toEqual([
-      expect.objectContaining({
-        reservationId: launchReservation?.id,
-        labels: ['linux'],
-        count: 1,
-      }),
-    ]);
+    expect(result.reservations).toEqual([]);
     expect(boundReservation).toMatchObject({kind: 'bound', count: 1});
     expect(storedRunner?.reservationId).toBe(boundReservation?.id);
   });
 
-  it('deducts only pending launch units from a partially adopted reservation', async () => {
+  it('deducts all booting units from a partially adopted reservation', async () => {
     await createIdleRunner({labels: ['linux', 'gpu']});
     await createIdleRunner({labels: ['linux', 'gpu']});
     await createPendingJobs(3, ['linux', 'gpu']);
@@ -436,12 +496,10 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux-gpu', ['linux', 'gpu'], 2)],
     });
 
-    expect(secondPoll.reservations).toEqual([
-      expect.objectContaining({labels: ['linux'], count: 1}),
-    ]);
+    expect(secondPoll.reservations).toEqual([]);
   });
 
-  it('deducts a launch reservation with no adopted units in full', async () => {
+  it('does not let a launch reservation with no live runner mask demand', async () => {
     await createPendingJobs(1, ['linux', 'gpu']);
 
     const firstPoll = await pollDemandAndReserve({
@@ -462,10 +520,12 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
     });
 
-    expect(secondPoll.reservations).toEqual([]);
+    expect(secondPoll.reservations).toEqual([
+      expect.objectContaining({labels: ['gpu', 'linux'], count: 1}),
+    ]);
   });
 
-  it('counts an intended runner while its reservation assignment is in flight', async () => {
+  it('keeps an intended runner while its reservation assignment is in flight in accounting', async () => {
     const intendedReservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
@@ -484,12 +544,10 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
     });
 
-    expect(result.reservations).toEqual([
-      expect.objectContaining({labels: ['gpu', 'linux'], count: 1}),
-    ]);
+    expect(result.reservations).toEqual([]);
   });
 
-  it('deducts a released runner reservation unit as pending', async () => {
+  it('does not deduct a released runner reservation unit from capacity', async () => {
     const reservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
@@ -509,10 +567,12 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
     });
 
-    expect(result.reservations).toEqual([]);
+    expect(result.reservations).toEqual([
+      expect.objectContaining({labels: ['gpu', 'linux'], count: 1}),
+    ]);
   });
 
-  it('deducts a terminal intended runner reservation unit as pending', async () => {
+  it('does not deduct a terminal intended runner reservation unit from capacity', async () => {
     const reservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
@@ -532,10 +592,12 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
     });
 
-    expect(result.reservations).toEqual([]);
+    expect(result.reservations).toEqual([
+      expect.objectContaining({labels: ['gpu', 'linux'], count: 1}),
+    ]);
   });
 
-  it('deducts a terminal assigned runner reservation unit as pending', async () => {
+  it('does not deduct a terminal assigned runner reservation unit from capacity', async () => {
     const reservation = await createIntendedReservation({
       workspaceId,
       expiresAt: new Date(Date.now() + 60_000),
@@ -555,7 +617,9 @@ describe('pollDemandAndReserve', () => {
       templates: [template('linux-gpu', ['linux', 'gpu'], 1)],
     });
 
-    expect(result.reservations).toEqual([]);
+    expect(result.reservations).toEqual([
+      expect.objectContaining({labels: ['gpu', 'linux'], count: 1}),
+    ]);
   });
 
   it('counts only active assigned runners when deducting provisioner reservations', async () => {
@@ -1190,7 +1254,26 @@ describe('pollDemandAndReserve', () => {
     ]);
   });
 
-  it('serializes multiple provisioners so total active reservations do not exceed queued demand', async () => {
+  it('applies existing booting reservations across multiple provisioners', async () => {
+    const reservedProvisionerId = crypto.randomUUID();
+    const [reservedReservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId: reservedProvisionerId,
+        requiredLabels: ['linux'],
+        count: 5,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning({id: reservations.id});
+    if (!reservedReservation) throw new Error('Expected reservation');
+    for (let index = 0; index < 5; index++) {
+      await createIdleRunner({
+        provisionerId: reservedProvisionerId,
+        labels: ['linux'],
+        reservationId: reservedReservation.id,
+      });
+    }
     await createPendingJobs(5, ['linux']);
 
     await Promise.all([
@@ -1211,7 +1294,7 @@ describe('pollDemandAndReserve', () => {
     ]);
 
     const reserved = await activeReservedCount();
-    expect(reserved).toBeLessThanOrEqual(5);
+    expect(reserved).toBe(5);
   });
 
   it('allocates eligible workspace heads in oldest-demand order without overselling templates', async () => {
@@ -1332,7 +1415,7 @@ describe('pollDemandAndReserve', () => {
     expect(result.stats[0]).toMatchObject({queued: 1, reserved: 1});
   });
 
-  it('deducts this provisioner active reservations from advertised capacity', async () => {
+  it('does not mask demand with spent reservations from this provisioner', async () => {
     await createPendingJobs(10, ['linux']);
     await reservationFactory.create({
       workspaceId,
@@ -1351,9 +1434,9 @@ describe('pollDemandAndReserve', () => {
     });
 
     const reserved = await activeReservedCount();
-    expect(result.reservations).toEqual([]);
+    expect(result.reservations).toEqual([expect.objectContaining({labels: ['linux'], count: 5})]);
     expect(result.stats[0]).toMatchObject({queued: 10, reserved: 5});
-    expect(reserved).toBe(5);
+    expect(reserved).toBe(10);
   });
 
   it('returns multiple reservation groups in one response', async () => {
@@ -1982,6 +2065,7 @@ describe('pollDemandAndReserve', () => {
 
   async function createIdleRunner(params: {
     id?: string;
+    provisionerId?: string;
     labels: string[];
     createdAt?: Date;
     controlSessionExpiresAt?: Date;
@@ -1990,20 +2074,23 @@ describe('pollDemandAndReserve', () => {
     reservationId?: string | null;
     intendedReservationId?: string | null;
     reservationReleasedAt?: Date | null;
+    firstClaimedAt?: Date | null;
     state?: RunnerInstanceState;
   }) {
     const createdAt = params.createdAt ?? new Date();
+    const runnerProvisionerId = params.provisionerId ?? provisionerId;
     const [runner] = await db()
       .insert(providerRunners)
       .values({
         ...(params.id ? {id: params.id} : {}),
-        provisionerId,
+        provisionerId: runnerProvisionerId,
         workspaceId: params.workspaceId,
         reservationId: params.reservationId,
         providerRunnerId: crypto.randomUUID(),
         launchKind: params.launchKind ?? 'manual',
         intendedReservationId: params.intendedReservationId,
         reservationReleasedAt: params.reservationReleasedAt,
+        firstClaimedAt: params.firstClaimedAt,
         labels: params.labels,
         state: params.state ?? 'running',
         reportedAt: createdAt,
@@ -2017,7 +2104,7 @@ describe('pollDemandAndReserve', () => {
       .insert(runnerControlSessions)
       .values({
         runnerInstanceId: runner.id,
-        provisionerId,
+        provisionerId: runnerProvisionerId,
         hashedToken: crypto.randomUUID(),
         prefix: 'test',
         expiresAt: params.controlSessionExpiresAt ?? new Date(Date.now() + 60_000),

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -117,6 +117,15 @@ interface NewReservationUnits {
   count: number;
 }
 
+interface ActiveProvisionerReservationRow {
+  provisionerId: string;
+  requiredLabels: string[];
+  /** Units still represented by a live runner that has not claimed a job. */
+  reserved: number;
+  /** Live units that have no unclaimed runner behind them. */
+  leaked: number;
+}
+
 interface PollDemandAndReserveResult {
   stats: DemandStat[];
   /** Only launch reservations are exposed to the provisioner. */
@@ -248,31 +257,26 @@ async function pollDemandAndReserveLockedTx(
     );
   }
 
-  const activeReservationRows = await tx
-    .select({
-      requiredLabels: reservations.requiredLabels,
-      reserved: sql<number>`coalesce(sum(${reservations.count}), 0)::int`,
-    })
-    .from(reservations)
-    .where(
-      and(eq(reservations.workspaceId, params.workspaceId), gt(reservations.expiresAt, sql`now()`)),
-    )
-    .groupBy(reservations.requiredLabels);
-
-  const reservedByLabels = new Map(
-    activeReservationRows.map((row) => [labelKey(row.requiredLabels), row.reserved]),
-  );
   const activeProvisionerReservationRows = await listActiveProvisionerReservationRowsTx(tx, {
     workspaceId: params.workspaceId,
-    provisionerId: params.provisionerId,
   });
+  const reservedByLabels = new Map<string, number>();
+  for (const row of activeProvisionerReservationRows) {
+    const key = labelKey(row.requiredLabels);
+    reservedByLabels.set(key, (reservedByLabels.get(key) ?? 0) + row.reserved);
+  }
 
   const templates = params.templates.map((template) => ({
     templateKey: template.templateKey,
     labels: [...canonicalizeLabels(template.labels)],
     remainingSlots: template.availableSlots,
   }));
-  deductProvisionerReservations(templates, activeProvisionerReservationRows);
+  deductProvisionerReservations(
+    templates,
+    activeProvisionerReservationRows.filter(
+      (reservation) => reservation.provisionerId === params.provisionerId,
+    ),
+  );
   const stats: DemandStat[] = [];
   const grants: ReservationGrant[] = [];
   const newlyReservedUnits: NewReservationUnits[] = [];
@@ -382,15 +386,15 @@ async function pollDemandAndReserveLockedTx(
 
 async function listActiveProvisionerReservationRowsTx(
   tx: Tx,
-  params: {workspaceId: string; provisionerId: string},
-): Promise<Array<{requiredLabels: string[]; reserved: number}>> {
+  params: {workspaceId?: string; provisionerId?: string},
+): Promise<ActiveProvisionerReservationRow[]> {
   const candidateRows = await tx
-    .select({id: reservations.id})
+    .select({id: reservations.id, provisionerId: reservations.provisionerId})
     .from(reservations)
     .where(
       and(
-        eq(reservations.workspaceId, params.workspaceId),
-        eq(reservations.provisionerId, params.provisionerId),
+        params.workspaceId ? eq(reservations.workspaceId, params.workspaceId) : undefined,
+        params.provisionerId ? eq(reservations.provisionerId, params.provisionerId) : undefined,
         gt(reservations.expiresAt, sql`now()`),
       ),
     );
@@ -399,68 +403,89 @@ async function listActiveProvisionerReservationRowsTx(
 
   // Assignment and provider-report transactions use this key before changing runner
   // links. Lock it before counting so an in-flight assignment cannot expose its unit twice.
-  await lockRunnerReservationAdvisoryKeysTx(tx, {
-    provisionerId: params.provisionerId,
-    reservationIds: candidateIds,
-  });
+  const candidateIdsByProvisioner = new Map<string, string[]>();
+  for (const row of candidateRows) {
+    const reservationIds = candidateIdsByProvisioner.get(row.provisionerId) ?? [];
+    reservationIds.push(row.id);
+    candidateIdsByProvisioner.set(row.provisionerId, reservationIds);
+  }
+  for (const provisionerId of [...candidateIdsByProvisioner.keys()].sort()) {
+    await lockRunnerReservationAdvisoryKeysTx(tx, {
+      provisionerId,
+      reservationIds: candidateIdsByProvisioner.get(provisionerId) ?? [],
+    });
+  }
 
   const activeRows = await tx
     .select({
       id: reservations.id,
+      provisionerId: reservations.provisionerId,
       requiredLabels: reservations.requiredLabels,
       count: reservations.count,
     })
     .from(reservations)
     .where(
       and(
-        eq(reservations.workspaceId, params.workspaceId),
-        eq(reservations.provisionerId, params.provisionerId),
+        params.workspaceId ? eq(reservations.workspaceId, params.workspaceId) : undefined,
+        params.provisionerId ? eq(reservations.provisionerId, params.provisionerId) : undefined,
         gt(reservations.expiresAt, sql`now()`),
       ),
     )
-    .orderBy(asc(reservations.id))
+    .orderBy(asc(reservations.provisionerId), asc(reservations.id))
     .for('update');
   if (activeRows.length === 0) return [];
 
   const activeIds = activeRows.map((row) => row.id);
   const activeIdSet = new Set(activeIds);
-  const usedRunnerRows = await tx
+  const provisionerIds = [...new Set(activeRows.map((row) => row.provisionerId))];
+  const linkedRunnerRows = await tx
     .select({
       id: providerRunners.id,
+      firstClaimedAt: providerRunners.firstClaimedAt,
       reservationId: providerRunners.reservationId,
       intendedReservationId: providerRunners.intendedReservationId,
+      reservationReleasedAt: providerRunners.reservationReleasedAt,
+      state: providerRunners.state,
     })
     .from(providerRunners)
     .where(
       and(
-        eq(providerRunners.provisionerId, params.provisionerId),
-        isNull(providerRunners.reservationReleasedAt),
+        inArray(providerRunners.provisionerId, provisionerIds),
         or(
-          and(
-            inArray(providerRunners.reservationId, activeIds),
-            notInArray(providerRunners.state, [...terminalStates]),
-          ),
-          and(
-            inArray(providerRunners.intendedReservationId, activeIds),
-            notInArray(providerRunners.state, [...terminalStates]),
-          ),
+          inArray(providerRunners.reservationId, activeIds),
+          inArray(providerRunners.intendedReservationId, activeIds),
         ),
       ),
     );
-  const usedByReservation = new Map<string, Set<string>>();
-  for (const runner of usedRunnerRows) {
+  const unclaimedByReservation = new Map<string, Set<string>>();
+  for (const runner of linkedRunnerRows) {
+    const isTerminal = terminalStates.some((state) => state === runner.state);
+    const isUnclaimed =
+      runner.firstClaimedAt === null && runner.reservationReleasedAt === null && !isTerminal;
+    if (!isUnclaimed) continue;
     if (runner.reservationId && activeIdSet.has(runner.reservationId)) {
-      addUsedRunner(usedByReservation, runner.reservationId, runner.id);
+      addUsedRunner(unclaimedByReservation, runner.reservationId, runner.id);
     }
     if (runner.intendedReservationId && activeIdSet.has(runner.intendedReservationId)) {
-      addUsedRunner(usedByReservation, runner.intendedReservationId, runner.id);
+      addUsedRunner(unclaimedByReservation, runner.intendedReservationId, runner.id);
     }
   }
 
-  return activeRows.flatMap((reservation) => {
-    const used = usedByReservation.get(reservation.id)?.size ?? 0;
-    const pending = Math.max(0, reservation.count - used);
-    return pending > 0 ? [{requiredLabels: reservation.requiredLabels, reserved: pending}] : [];
+  return activeRows.map((reservation) => {
+    const unclaimed = unclaimedByReservation.get(reservation.id)?.size ?? 0;
+    return {
+      provisionerId: reservation.provisionerId,
+      requiredLabels: reservation.requiredLabels,
+      reserved: Math.min(reservation.count, unclaimed),
+      leaked: Math.max(0, reservation.count - unclaimed),
+    };
+  });
+}
+
+export async function countLiveReservationLeakUnits(): Promise<number> {
+  return await db().transaction(async (tx) => {
+    const rows = await listActiveProvisionerReservationRowsTx(tx, {});
+    return rows.reduce((total, row) => total + row.leaked, 0);
   });
 }
 

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -487,10 +487,13 @@ async function listActiveProvisionerReservationRowsTx(
 }
 
 export async function countLiveReservationLeakUnits(): Promise<number> {
-  return await db().transaction(async (tx) => {
-    const rows = await listActiveProvisionerReservationRowsTx(tx, {lockForMutation: false});
-    return rows.reduce((total, row) => total + row.leaked, 0);
-  });
+  return await db().transaction(
+    async (tx) => {
+      const rows = await listActiveProvisionerReservationRowsTx(tx, {lockForMutation: false});
+      return rows.reduce((total, row) => total + row.leaked, 0);
+    },
+    {isolationLevel: 'repeatable read', accessMode: 'read only'},
+  );
 }
 
 function addUsedRunner(

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -386,8 +386,9 @@ async function pollDemandAndReserveLockedTx(
 
 async function listActiveProvisionerReservationRowsTx(
   tx: Tx,
-  params: {workspaceId?: string; provisionerId?: string},
+  params: {workspaceId?: string; provisionerId?: string; lockForMutation?: boolean},
 ): Promise<ActiveProvisionerReservationRow[]> {
+  const lockForMutation = params.lockForMutation ?? true;
   const candidateRows = await tx
     .select({id: reservations.id, provisionerId: reservations.provisionerId})
     .from(reservations)
@@ -401,22 +402,24 @@ async function listActiveProvisionerReservationRowsTx(
   const candidateIds = candidateRows.map((row) => row.id);
   if (candidateIds.length === 0) return [];
 
-  // Assignment and provider-report transactions use this key before changing runner
-  // links. Lock it before counting so an in-flight assignment cannot expose its unit twice.
-  const candidateIdsByProvisioner = new Map<string, string[]>();
-  for (const row of candidateRows) {
-    const reservationIds = candidateIdsByProvisioner.get(row.provisionerId) ?? [];
-    reservationIds.push(row.id);
-    candidateIdsByProvisioner.set(row.provisionerId, reservationIds);
-  }
-  for (const provisionerId of [...candidateIdsByProvisioner.keys()].sort()) {
-    await lockRunnerReservationAdvisoryKeysTx(tx, {
-      provisionerId,
-      reservationIds: candidateIdsByProvisioner.get(provisionerId) ?? [],
-    });
+  if (lockForMutation) {
+    // Assignment and provider-report transactions use this key before changing runner
+    // links. Lock it before counting so an in-flight assignment cannot expose its unit twice.
+    const candidateIdsByProvisioner = new Map<string, string[]>();
+    for (const row of candidateRows) {
+      const reservationIds = candidateIdsByProvisioner.get(row.provisionerId) ?? [];
+      reservationIds.push(row.id);
+      candidateIdsByProvisioner.set(row.provisionerId, reservationIds);
+    }
+    for (const provisionerId of [...candidateIdsByProvisioner.keys()].sort()) {
+      await lockRunnerReservationAdvisoryKeysTx(tx, {
+        provisionerId,
+        reservationIds: candidateIdsByProvisioner.get(provisionerId) ?? [],
+      });
+    }
   }
 
-  const activeRows = await tx
+  const activeRowsQuery = tx
     .select({
       id: reservations.id,
       provisionerId: reservations.provisionerId,
@@ -431,8 +434,9 @@ async function listActiveProvisionerReservationRowsTx(
         gt(reservations.expiresAt, sql`now()`),
       ),
     )
-    .orderBy(asc(reservations.provisionerId), asc(reservations.id))
-    .for('update');
+    .orderBy(asc(reservations.provisionerId), asc(reservations.id));
+  // Metrics use a point-in-time read and must not contend with scheduling mutations.
+  const activeRows = await (lockForMutation ? activeRowsQuery.for('update') : activeRowsQuery);
   if (activeRows.length === 0) return [];
 
   const activeIds = activeRows.map((row) => row.id);
@@ -484,7 +488,7 @@ async function listActiveProvisionerReservationRowsTx(
 
 export async function countLiveReservationLeakUnits(): Promise<number> {
   return await db().transaction(async (tx) => {
-    const rows = await listActiveProvisionerReservationRowsTx(tx, {});
+    const rows = await listActiveProvisionerReservationRowsTx(tx, {lockForMutation: false});
     return rows.reduce((total, row) => total + row.leaked, 0);
   });
 }

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -208,10 +208,21 @@ export const providerRunnerActivationOutcomeCount = meter.createCounter<{
   description: 'Demand-backed runner activation outcomes by recovery action',
 });
 
-export const reservationReleasedCount = meter.createCounter<Record<string, never>>(
-  'runners_reservation_released',
-  {description: 'Reservation units released from terminal provisioned runner reports'},
-);
+export type RunnerReservationReleaseSurface = 'first-claim' | 'terminal-report' | 'reconcile';
+
+export const reservationReleasedCount = meter.createCounter<{
+  surface: RunnerReservationReleaseSurface;
+}>('runners_reservation_released', {
+  description: 'Reservation units released by lifecycle surface',
+});
+
+export function recordRunnerReservationReleased(params: {
+  count: number;
+  surface: RunnerReservationReleaseSurface;
+}): void {
+  if (params.count <= 0) return;
+  recordMetric(() => reservationReleasedCount.add(params.count, {surface: params.surface}));
+}
 
 export type RunnerReservationPromotionFailureReason =
   | 'reservation-expired'

--- a/libs/api/runners/src/metrics/service.test.ts
+++ b/libs/api/runners/src/metrics/service.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => {
     pendingJobExecutions: {},
     providerRunnersByPhase: {},
     providerRunnersByPhaseOldestAge: {},
+    reservationLeakUnits: {},
     runningJobExecutions: {},
   };
   const gaugeByName = {
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => {
     runners_pending_job_executions: gauges.pendingJobExecutions,
     runners_provider_runner_by_phase: gauges.providerRunnersByPhase,
     runners_provider_runner_by_phase_oldest_age: gauges.providerRunnersByPhaseOldestAge,
+    runners_reservation_leaked_units: gauges.reservationLeakUnits,
     runners_running_job_executions: gauges.runningJobExecutions,
   };
   return {
@@ -20,6 +22,7 @@ const mocks = vi.hoisted(() => {
     gauges,
     getMeter: vi.fn(),
     getJobExecutionQueueDepth: vi.fn(),
+    countLiveReservationLeakUnits: vi.fn(),
     listProviderRunnerByPhaseMetrics: vi.fn(),
     getServiceMetricsProvider: vi.fn(),
   };
@@ -33,6 +36,9 @@ vi.mock('#config.js', () => ({
 }));
 vi.mock('#db/job-executions.js', () => ({
   getJobExecutionQueueDepth: mocks.getJobExecutionQueueDepth,
+}));
+vi.mock('#db/reservations.js', () => ({
+  countLiveReservationLeakUnits: mocks.countLiveReservationLeakUnits,
 }));
 vi.mock('#db/runner-instances.js', () => ({
   countStaleEnrolledRunnerInstances: mocks.countStaleEnrolledRunnerInstances,
@@ -54,6 +60,7 @@ describe('registerRunnersServiceMetrics', () => {
     mocks.countStaleEnrolledRunnerInstances.mockReset();
     mocks.createObservableGauge.mockClear();
     mocks.getJobExecutionQueueDepth.mockReset();
+    mocks.countLiveReservationLeakUnits.mockReset();
     mocks.listProviderRunnerByPhaseMetrics.mockReset();
     mocks.getMeter.mockReset();
     mocks.getServiceMetricsProvider.mockReset();
@@ -61,6 +68,7 @@ describe('registerRunnersServiceMetrics', () => {
       pendingJobExecutions: 0,
       runningJobExecutions: 0,
     });
+    mocks.countLiveReservationLeakUnits.mockResolvedValue(0);
     mocks.listProviderRunnerByPhaseMetrics.mockResolvedValue([]);
     mocks.getMeter.mockReturnValue({
       createObservableGauge: mocks.createObservableGauge,
@@ -93,6 +101,22 @@ describe('registerRunnersServiceMetrics', () => {
     );
   });
 
+  it('observes live reservation units without an unclaimed runner', async () => {
+    mocks.countLiveReservationLeakUnits.mockResolvedValue(3);
+
+    registerRunnersServiceMetrics();
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    if (typeof callback !== 'function') throw new Error('Expected metrics callback');
+    const observer = {observe: vi.fn()};
+
+    await callback(observer);
+
+    expect(mocks.createObservableGauge).toHaveBeenCalledWith('runners_reservation_leaked_units', {
+      description: 'Live reservation units without an unclaimed runner behind them',
+    });
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.reservationLeakUnits, 3);
+  });
+
   it('keeps queue gauges observable when the enrolled-runner query fails', async () => {
     mocks.getJobExecutionQueueDepth.mockResolvedValue({
       pendingJobExecutions: 3,
@@ -109,7 +133,7 @@ describe('registerRunnersServiceMetrics', () => {
 
     expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.pendingJobExecutions, 3);
     expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.runningJobExecutions, 4);
-    expect(observer.observe).toHaveBeenCalledTimes(2);
+    expect(observer.observe).toHaveBeenCalledTimes(3);
   });
 
   it('observes provider runners by lifecycle phase', async () => {

--- a/libs/api/runners/src/metrics/service.ts
+++ b/libs/api/runners/src/metrics/service.ts
@@ -1,6 +1,7 @@
 import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {getJobExecutionQueueDepth} from '#db/job-executions.js';
+import {countLiveReservationLeakUnits} from '#db/reservations.js';
 import {
   countStaleEnrolledRunnerInstances,
   listProviderRunnerByPhaseMetrics,
@@ -43,17 +44,25 @@ export function registerRunnersServiceMetrics(): void {
       unit: 'ms',
     },
   );
+  const reservationLeakUnits = meter.createObservableGauge('runners_reservation_leaked_units', {
+    description: 'Live reservation units without an unclaimed runner behind them',
+  });
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const [depthResult, staleEnrolledRunnerCountResult, providerRunnersByPhaseResult] =
-        await Promise.allSettled([
-          getJobExecutionQueueDepth(),
-          countStaleEnrolledRunnerInstances({
-            graceSeconds: config.RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS,
-          }),
-          listProviderRunnerByPhaseMetrics(),
-        ]);
+      const [
+        depthResult,
+        staleEnrolledRunnerCountResult,
+        providerRunnersByPhaseResult,
+        reservationLeakUnitsResult,
+      ] = await Promise.allSettled([
+        getJobExecutionQueueDepth(),
+        countStaleEnrolledRunnerInstances({
+          graceSeconds: config.RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS,
+        }),
+        listProviderRunnerByPhaseMetrics(),
+        countLiveReservationLeakUnits(),
+      ]);
 
       if (depthResult.status === 'fulfilled') {
         observer.observe(pendingJobExecutions, depthResult.value.pendingJobExecutions);
@@ -77,6 +86,9 @@ export function registerRunnersServiceMetrics(): void {
           );
         }
       }
+      if (reservationLeakUnitsResult.status === 'fulfilled') {
+        observer.observe(reservationLeakUnits, reservationLeakUnitsResult.value);
+      }
     },
     [
       pendingJobExecutions,
@@ -84,6 +96,7 @@ export function registerRunnersServiceMetrics(): void {
       enrolledRunnersWithoutRecentReport,
       providerRunnersByPhase,
       providerRunnersByPhaseOldestAge,
+      reservationLeakUnits,
     ],
   );
 }

--- a/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
@@ -323,7 +323,7 @@ describe('POST /provisioners/runner-instances/reconcile', () => {
     expect(
       addSpy.mock.calls
         .slice(addCallsBefore)
-        .filter(([value, attributes]) => value === 2 && attributes === undefined),
+        .filter(([value, attributes]) => value === 2 && attributes?.surface === 'reconcile'),
     ).toHaveLength(1);
   });
 

--- a/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
@@ -17,9 +17,13 @@ import {vi} from '@shipfox/vitest/vi';
 import {and, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
+import {reservations} from '#db/schema/reservations.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
-import {providerRunnerTerminateIntentHonoredCount} from '#metrics/instance.js';
+import {
+  providerRunnerTerminateIntentHonoredCount,
+  reservationReleasedCount,
+} from '#metrics/instance.js';
 import {providerRunnerFactory, runnerSessionFactory, runnersTestAuthClient} from '#test/index.js';
 import {createRunnerRoutes} from './index.js';
 
@@ -238,6 +242,97 @@ describe('POST /provisioners/runner-instances/report', () => {
           value === 1 && JSON.stringify(attributes) === JSON.stringify({reason: 'job-cancelled'}),
       );
     expect(honoredCalls).toHaveLength(1);
+  });
+
+  it('records the terminal-report reservation release surface for a released unit', async () => {
+    const releasedSpy = vi.spyOn(reservationReleasedCount, 'add');
+    try {
+      const [reservation] = await db()
+        .insert(reservations)
+        .values({
+          workspaceId,
+          provisionerId: provisionerTokenId,
+          requiredLabels: ['linux'],
+          count: 1,
+          expiresAt: new Date(Date.now() + 60_000),
+        })
+        .returning({id: reservations.id});
+      if (!reservation) throw new Error('Expected reservation');
+
+      await providerRunnerFactory.create({
+        workspaceId,
+        provisionerId: provisionerTokenId,
+        providerRunnerId: 'reservation-linked-runner',
+        reservationId: reservation.id,
+        state: 'running',
+      });
+      const callsBefore = releasedSpy.mock.calls.length;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/provisioners/runner-instances/report',
+        headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+        payload: {
+          events: [
+            {
+              provider_runner_id: 'reservation-linked-runner',
+              labels: ['linux'],
+              state: 'terminated',
+              reported_at: new Date().toISOString(),
+            },
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({accepted: 1, reservations_released: 1});
+      expect(
+        releasedSpy.mock.calls
+          .slice(callsBefore)
+          .filter(([, attributes]) => attributes?.surface === 'terminal-report'),
+      ).toEqual([[1, {surface: 'terminal-report'}]]);
+    } finally {
+      releasedSpy.mockRestore();
+    }
+  });
+
+  it('does not emit the terminal-report reservation release metric for zero releases', async () => {
+    const releasedSpy = vi.spyOn(reservationReleasedCount, 'add');
+    try {
+      await providerRunnerFactory.create({
+        workspaceId,
+        provisionerId: provisionerTokenId,
+        providerRunnerId: 'unlinked-runner',
+        state: 'running',
+      });
+      const callsBefore = releasedSpy.mock.calls.length;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/provisioners/runner-instances/report',
+        headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+        payload: {
+          events: [
+            {
+              provider_runner_id: 'unlinked-runner',
+              labels: ['linux'],
+              state: 'terminated',
+              reported_at: new Date().toISOString(),
+            },
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({accepted: 1, reservations_released: 0});
+      expect(
+        releasedSpy.mock.calls
+          .slice(callsBefore)
+          .filter(([, attributes]) => attributes?.surface === 'terminal-report'),
+      ).toEqual([]);
+    } finally {
+      releasedSpy.mockRestore();
+    }
   });
 
   it('returns 400 for provider-sensitive extra fields', async () => {


### PR DESCRIPTION
Runner demand was using raw active reservation counts, so claimed, terminal, released, or never-launched units could continue masking demand after they were no longer backed by a live unclaimed runner.

This change makes reservation accounting self-correcting across provisioners, adds a gauge for live reservation units without an unclaimed runner, and labels release metrics by lifecycle surface. It also adds real-Postgres regressions for claimed, booting, and unlaunched reservation units.

Validation completed locally with affected-package Turbo test, type, check, and dependency-cruise gates, database-boundary verification, and changeset validation.

Closes ENG-1713

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes runner reservation accounting self-correcting so leaked units no longer mask demand across provisioners. Old: we deducted raw active reservation counts. New: we count only units backed by a live unclaimed runner; leaked units no longer reduce capacity and surface via a gauge. Closes ENG-1713.

- DB: per‑provisioner reservation rows compute reserved=min(count, unclaimed runners) and leaked=count−unclaimed; includes assigned and intended, excludes terminal and released; groups advisory locks by provisioner to serialize mutations; adds `countLiveReservationLeakUnits` using a repeatable‑read, read‑only snapshot that does not block mutation locks.
- Polling: aggregates reserved capacity across all provisioners for demand stats; deducts only this provisioner’s active reservations when granting; keeps intended/booting units in accounting; expands regressions for claimed, booting, terminal, released, unlaunched, partial adoption, and cross‑provisioner cases.
- Metrics: adds gauge `runners_reservation_leaked_units`; introduces `recordRunnerReservationReleased` and labels `runners_reservation_released` by surface (`first-claim`, `terminal-report`, `reconcile`); wires surfaces into claim, report, and reconcile paths and skips emission on zero releases.
- API/DTO: clarifies `poll-demand` `reserved` as “Queued jobs for this label set covered by unclaimed reserved runners or reservations created in this poll; advisory scheduling estimate.”
- Release: publishes patches to `@shipfox/api-runners` and `@shipfox/api-runners-dto`.

<sup>Written for commit 8b4329ec28a3fad6c9b2d30cec54b15ed55b2fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

