### PR TITLE
[e2e-client-integrations] Capture settled Linear callback state

### DIFF
--- a/e2e/suites/client/integrations/tests/linear-callback.e2e.ts
+++ b/e2e/suites/client/integrations/tests/linear-callback.e2e.ts
@@ -53,6 +53,7 @@ test('Linear callback renders recovery without submitting malformed params', asy
 
 test('Linear callback redirects to the verified workspace settings on success', async ({
   auth,
+  integrationsCatalogue,
   page,
   workspaces,
 }) => {
@@ -68,6 +69,7 @@ test('Linear callback redirects to the verified workspace settings on success', 
 
   await expect(page).toHaveURL(new RegExp(`/w/${workspace.slug}/settings/integrations/?$`, 'u'));
   await expect(page.getByText('Linear installed.')).toBeVisible();
+  await expect(integrationsCatalogue.emptyInstalledState()).toBeVisible();
   await stableScreenshot(page, 'integrations/linear-callback-success');
 });
 


### PR DESCRIPTION
The Linear callback success flow can reach the settings URL and show its toast while the integrations query is still loading. That allowed the visual capture to record the loading skeleton instead of the settled empty state.

The test now waits for the existing empty installed-integrations state before the screenshot, making the capture deterministic without adding a timing delay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Linear callback success E2E by waiting for the settled empty installed-integrations state before taking the screenshot. Previously, the test could capture the loading skeleton when the toast appeared before the integrations query settled.

- Asserts `integrationsCatalogue.emptyInstalledState()` before calling `stableScreenshot`, making the capture deterministic without timing delays.
- No application behavior change; only the E2E test in `e2e/suites/client/integrations/tests/linear-callback.e2e.ts` is updated.

<sup>Written for commit 54e409ae82eddd0094b0e57a7fd0d39ab4546714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

