### PR TITLE
Make managed provider runtime URLs dialect-safe

### DIFF
--- a/.changeset/managed-provider-dialect-safe-urls.md
+++ b/.changeset/managed-provider-dialect-safe-urls.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-agent": patch
+"@shipfox/api-agent-dto": patch
+---
+
+Normalizes managed-provider runtime gateway roots for the client URL semantics of each API dialect.

--- a/.changeset/managed-provider-dialect-safe-urls.md
+++ b/.changeset/managed-provider-dialect-safe-urls.md
@@ -1,6 +1,9 @@
 ---
-"@shipfox/api-agent": patch
-"@shipfox/api-agent-dto": patch
+"@shipfox/api-agent": major
+"@shipfox/api-agent-dto": major
 ---
 
-Normalizes managed-provider runtime gateway roots for the client URL semantics of each API dialect.
+Defines managed-provider `baseUrl` as a gateway mount root and normalizes it
+for the client URL semantics of each API dialect. Providers that previously
+returned client-ready bases must migrate to return the gateway root before
+upgrading.

--- a/.changeset/managed-provider-dialect-safe-urls.md
+++ b/.changeset/managed-provider-dialect-safe-urls.md
@@ -4,6 +4,5 @@
 ---
 
 Defines managed-provider `baseUrl` as a gateway mount root and normalizes it
-for the client URL semantics of each API dialect. Providers that previously
-returned client-ready bases must migrate to return the gateway root before
-upgrading.
+for client requests. Providers that previously returned client-ready bases must
+migrate to return the gateway root before upgrading.

--- a/libs/api/agent-dto/src/schemas/managed-provider.ts
+++ b/libs/api/agent-dto/src/schemas/managed-provider.ts
@@ -71,8 +71,16 @@ export function toCustomAgentModelDto(
   };
 }
 
+/**
+ * Lease-scoped credentials and endpoint returned by a managed provider.
+ *
+ * `baseUrl` is the provider's gateway mount root, including any deployment
+ * path prefix but not a client-specific API path. The agent runtime normalizes
+ * this root for the declared API family before handing it to a harness client.
+ */
 export interface ManagedProviderRuntimeConfig {
   readonly api: ManagedModelApi;
+  /** Gateway mount root, including deployment path prefixes but no client API path. */
   readonly baseUrl: string;
   readonly credentials: Record<string, string>;
 }

--- a/libs/api/agent-dto/src/schemas/managed-provider.ts
+++ b/libs/api/agent-dto/src/schemas/managed-provider.ts
@@ -75,12 +75,13 @@ export function toCustomAgentModelDto(
  * Lease-scoped credentials and endpoint returned by a managed provider.
  *
  * `baseUrl` is the provider's gateway mount root, including any deployment
- * path prefix but not a client-specific API path. The agent runtime normalizes
- * this root for the declared API family before handing it to a harness client.
+ * path prefix but not a client-specific API path, query, or fragment. The
+ * agent runtime normalizes this root for the client API family before handing
+ * it to a harness client.
  */
 export interface ManagedProviderRuntimeConfig {
   readonly api: ManagedModelApi;
-  /** Gateway mount root, including deployment path prefixes but no client API path. */
+  /** Gateway mount root, including path prefixes but no client API path, query, or fragment. */
   readonly baseUrl: string;
   readonly credentials: Record<string, string>;
 }

--- a/libs/api/agent/src/core/managed-provider-url.test.ts
+++ b/libs/api/agent/src/core/managed-provider-url.test.ts
@@ -22,14 +22,33 @@ describe.each([
     );
   });
 
-  it('preserves a deployment path prefix and URL components', () => {
-    expect(
-      managedProviderAdapterBaseUrl(
-        api,
-        'https://gateway.example.test/control-plane/inference/v1/?tenant=staging#runtime',
-      ),
-    ).toBe(
-      `https://gateway.example.test/control-plane${expectedPath === '/inference/v1' ? '/inference/v1' : '/inference'}?tenant=staging#runtime`,
+  it.each([
+    {
+      baseUrl: 'https://gateway.example.test/v1-team/inference',
+      expectedOpenAi: 'https://gateway.example.test/v1-team/inference/v1',
+      expectedAnthropic: 'https://gateway.example.test/v1-team/inference',
+    },
+    {
+      baseUrl: 'https://gateway.example.test/control-plane/inference/v1/v1',
+      expectedOpenAi: 'https://gateway.example.test/control-plane/inference/v1',
+      expectedAnthropic: 'https://gateway.example.test/control-plane/inference',
+    },
+    {
+      baseUrl: 'https://gateway.example.test/control-plane/inference/v1/?tenant=staging#runtime',
+      expectedOpenAi: 'https://gateway.example.test/control-plane/inference/v1',
+      expectedAnthropic: 'https://gateway.example.test/control-plane/inference',
+    },
+  ])('preserves path prefixes and produces a client-safe URL for %s', ({
+    baseUrl,
+    expectedOpenAi,
+    expectedAnthropic,
+  }) => {
+    expect(managedProviderAdapterBaseUrl(api, baseUrl)).toBe(
+      api === 'anthropic-messages' ? expectedAnthropic : expectedOpenAi,
     );
   });
+});
+
+it('passes malformed values through for runtime DTO validation', () => {
+  expect(managedProviderAdapterBaseUrl('openai-responses', 'not a url')).toBe('not a url');
 });

--- a/libs/api/agent/src/core/managed-provider-url.test.ts
+++ b/libs/api/agent/src/core/managed-provider-url.test.ts
@@ -49,6 +49,9 @@ describe.each([
   });
 });
 
-it('passes malformed values through for runtime DTO validation', () => {
-  expect(managedProviderAdapterBaseUrl('openai-responses', 'not a url')).toBe('not a url');
+it.each([
+  'not a url',
+  'localhost:8000/inference',
+])('passes malformed values through for runtime DTO validation: %s', (baseUrl) => {
+  expect(managedProviderAdapterBaseUrl('openai-responses', baseUrl)).toBe(baseUrl);
 });

--- a/libs/api/agent/src/core/managed-provider-url.test.ts
+++ b/libs/api/agent/src/core/managed-provider-url.test.ts
@@ -1,0 +1,35 @@
+import type {ManagedModelApi} from '@shipfox/api-agent-dto';
+import {managedProviderAdapterBaseUrl} from './managed-provider-url.js';
+
+const baseUrlVariants = [
+  'https://gateway.example.test/inference',
+  'https://gateway.example.test/inference/',
+  'https://gateway.example.test/inference/v1',
+  'https://gateway.example.test/inference/v1/',
+] as const;
+
+describe.each([
+  {api: 'openai-responses', expectedPath: '/inference/v1'},
+  {api: 'openai-completions', expectedPath: '/inference/v1'},
+  {api: 'anthropic-messages', expectedPath: '/inference'},
+] satisfies readonly {api: ManagedModelApi; expectedPath: string}[])('$api', ({
+  api,
+  expectedPath,
+}) => {
+  it.each(baseUrlVariants)('normalizes %s without duplicating the dialect version', (baseUrl) => {
+    expect(managedProviderAdapterBaseUrl(api, baseUrl)).toBe(
+      `https://gateway.example.test${expectedPath}`,
+    );
+  });
+
+  it('preserves a deployment path prefix and URL components', () => {
+    expect(
+      managedProviderAdapterBaseUrl(
+        api,
+        'https://gateway.example.test/control-plane/inference/v1/?tenant=staging#runtime',
+      ),
+    ).toBe(
+      `https://gateway.example.test/control-plane${expectedPath === '/inference/v1' ? '/inference/v1' : '/inference'}?tenant=staging#runtime`,
+    );
+  });
+});

--- a/libs/api/agent/src/core/managed-provider-url.ts
+++ b/libs/api/agent/src/core/managed-provider-url.ts
@@ -24,6 +24,7 @@ export function managedProviderAdapterBaseUrl(
     // Preserve the existing downstream DTO validation for malformed provider data.
     return gatewayBaseUrl;
   }
+  if (url.origin === 'null') return gatewayBaseUrl;
 
   url.search = '';
   url.hash = '';

--- a/libs/api/agent/src/core/managed-provider-url.ts
+++ b/libs/api/agent/src/core/managed-provider-url.ts
@@ -26,8 +26,6 @@ export function managedProviderAdapterBaseUrl(
   }
   if (url.origin === 'null') return gatewayBaseUrl;
 
-  url.search = '';
-  url.hash = '';
   const gatewayPath = url.pathname
     .replace(TRAILING_SLASHES_PATTERN, '')
     .replace(TRAILING_API_VERSION_PATTERN, '');

--- a/libs/api/agent/src/core/managed-provider-url.ts
+++ b/libs/api/agent/src/core/managed-provider-url.ts
@@ -10,16 +10,27 @@ const TRAILING_API_VERSION_PATTERN = /(?:\/v1)+$/u;
  * OpenAI clients append their operation path to a `/v1` base, while Anthropic
  * clients append `/v1/messages` themselves. Deployment path prefixes remain
  * untouched, and a version suffix is normalized before the dialect is applied.
+ * Query and fragment components are omitted because clients append operations
+ * to the base URL as path components.
  */
 export function managedProviderAdapterBaseUrl(
   api: ManagedModelApi,
   gatewayBaseUrl: string,
 ): string {
-  const url = new URL(gatewayBaseUrl);
+  let url: URL;
+  try {
+    url = new URL(gatewayBaseUrl);
+  } catch {
+    // Preserve the existing downstream DTO validation for malformed provider data.
+    return gatewayBaseUrl;
+  }
+
+  url.search = '';
+  url.hash = '';
   const gatewayPath = url.pathname
     .replace(TRAILING_SLASHES_PATTERN, '')
     .replace(TRAILING_API_VERSION_PATTERN, '');
   const adapterPath = api === 'anthropic-messages' ? gatewayPath : `${gatewayPath}/v1`;
 
-  return `${url.origin}${adapterPath}${url.search}${url.hash}`;
+  return `${url.origin}${adapterPath}`;
 }

--- a/libs/api/agent/src/core/managed-provider-url.ts
+++ b/libs/api/agent/src/core/managed-provider-url.ts
@@ -1,0 +1,25 @@
+import type {ManagedModelApi} from '@shipfox/api-agent-dto';
+
+const TRAILING_SLASHES_PATTERN = /\/+$/u;
+const TRAILING_API_VERSION_PATTERN = /(?:\/v1)+$/u;
+
+/**
+ * Converts the managed provider's declared gateway root into the base URL
+ * expected by the client for its API dialect.
+ *
+ * OpenAI clients append their operation path to a `/v1` base, while Anthropic
+ * clients append `/v1/messages` themselves. Deployment path prefixes remain
+ * untouched, and a version suffix is normalized before the dialect is applied.
+ */
+export function managedProviderAdapterBaseUrl(
+  api: ManagedModelApi,
+  gatewayBaseUrl: string,
+): string {
+  const url = new URL(gatewayBaseUrl);
+  const gatewayPath = url.pathname
+    .replace(TRAILING_SLASHES_PATTERN, '')
+    .replace(TRAILING_API_VERSION_PATTERN, '');
+  const adapterPath = api === 'anthropic-messages' ? gatewayPath : `${gatewayPath}/v1`;
+
+  return `${url.origin}${adapterPath}${url.search}${url.hash}`;
+}

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -1,9 +1,18 @@
-import type {ManagedModelProvider, ModelProviderRef} from '@shipfox/api-agent-dto';
+import {type Context, complete, type Model} from '@earendil-works/pi-ai/compat';
+import type {
+  AgentRuntimeCredentialsResponseDto,
+  ManagedModelApi,
+  ManagedModelProvider,
+  ModelProviderRef,
+} from '@shipfox/api-agent-dto';
 import {deleteModelProviderConfig, upsertModelProviderConfig} from '#db/index.js';
 import {setSecrets} from '#test/fixtures/secrets-client.js';
 import {agentSystemNamespace, customCredentialsToStoreValues} from './credential-fingerprints.js';
 import {ModelProviderConfigNotFoundError} from './errors.js';
 import {resolveRuntimeCredentials} from './resolve-runtime-credentials.js';
+
+const TRAILING_SLASHES_PATTERN = /\/+$/u;
+const TRAILING_API_VERSION_PATTERN = /(?:\/v1)+$/u;
 
 describe('resolveRuntimeCredentials', () => {
   let workspaceId: string;
@@ -44,7 +53,7 @@ describe('resolveRuntimeCredentials', () => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     resolveCredentials.mockResolvedValue({
       api: 'openai-responses',
-      baseUrl: 'https://gateway.example.test',
+      baseUrl: 'https://gateway.example.test/inference/',
       credentials: {api_key: 'managed-token'},
     });
 
@@ -75,7 +84,7 @@ describe('resolveRuntimeCredentials', () => {
       credentials: {api_key: 'managed-token'},
       custom_provider: {
         api: 'openai-responses',
-        base_url: 'https://gateway.example.test',
+        base_url: 'https://gateway.example.test/inference/v1',
         headers: [],
         secret_header_names: [],
         models: [
@@ -103,7 +112,7 @@ describe('resolveRuntimeCredentials', () => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     resolveCredentials.mockResolvedValue({
       api: 'openai-completions',
-      baseUrl: 'https://gateway.example.test',
+      baseUrl: 'https://gateway.example.test/inference/v1/',
       credentials: {api_key: 'managed-token'},
     });
 
@@ -128,7 +137,7 @@ describe('resolveRuntimeCredentials', () => {
       credentials: {api_key: 'managed-token'},
       custom_provider: {
         api: 'openai-completions',
-        base_url: 'https://gateway.example.test',
+        base_url: 'https://gateway.example.test/inference/v1',
         headers: [],
         secret_header_names: [],
         models: [{id: 'plain-model', label: 'Plain model'}],
@@ -197,7 +206,7 @@ describe('resolveRuntimeCredentials', () => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     resolveCredentials.mockResolvedValue({
       api: 'anthropic-messages',
-      baseUrl: 'https://gateway.example.test',
+      baseUrl: 'https://gateway.example.test/inference/v1/',
       credentials: {api_key: 'managed-token'},
     });
 
@@ -221,10 +230,72 @@ describe('resolveRuntimeCredentials', () => {
       thinking: 'high',
       credentials: {api_key: 'managed-token'},
       claude: {
-        base_url: 'https://gateway.example.test',
+        base_url: 'https://gateway.example.test/inference',
         auth_token: 'managed-token',
       },
     });
+  });
+
+  it.each([
+    {api: 'openai-responses', model: 'responses-model', path: '/responses'},
+    {api: 'openai-completions', model: 'plain-model', path: '/chat/completions'},
+    {api: 'anthropic-messages', model: 'claude-model', path: '/v1/messages'},
+  ] satisfies readonly {
+    api: ManagedModelApi;
+    model: string;
+    path: string;
+  }[])('composes the $api runtime response with the real Pi client URL construction', async ({
+    api,
+    model,
+    path,
+  }) => {
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('capture request'));
+    const baseUrls = [
+      'https://gateway.example.test/inference',
+      'https://gateway.example.test/inference/',
+      'https://gateway.example.test/inference/v1',
+      'https://gateway.example.test/inference/v1/',
+    ];
+
+    for (const baseUrl of baseUrls) {
+      resolveCredentials.mockResolvedValueOnce({
+        api,
+        baseUrl,
+        credentials: {api_key: 'opaque-test-credential'},
+      });
+      const runtime = await resolveRuntimeCredentials(
+        {
+          workspaceId,
+          runId: crypto.randomUUID(),
+          stepAttemptId: crypto.randomUUID(),
+          harness: 'pi',
+          provider: 'shipfox',
+          model,
+          thinking: 'high',
+        },
+        {managedProvider: managedProvider(resolveCredentials)},
+      );
+
+      const apiKey = runtime.credentials.api_key;
+      if (apiKey === undefined) {
+        throw new Error('Expected managed Pi API key');
+      }
+      await complete(toPiModel(runtime), piContext(), {
+        apiKey,
+        maxRetries: 0,
+      });
+    }
+
+    expect(fetchSpy.mock.calls.map(([input]) => String(input))).toEqual(
+      baseUrls.map((baseUrl) => {
+        const gatewayRoot = baseUrl
+          .replace(TRAILING_SLASHES_PATTERN, '')
+          .replace(TRAILING_API_VERSION_PATTERN, '');
+        const adapterBaseUrl = api === 'anthropic-messages' ? gatewayRoot : `${gatewayRoot}/v1`;
+        return `${adapterBaseUrl}${path}`;
+      }),
+    );
   });
 
   it('prefers workspace credentials over the instance fallback', async () => {
@@ -534,6 +605,39 @@ describe('resolveRuntimeCredentials', () => {
     }
   });
 });
+
+function piContext(): Context {
+  return {
+    messages: [{role: 'user', content: 'Reply with OK.', timestamp: 0}],
+  };
+}
+
+function toPiModel(response: AgentRuntimeCredentialsResponseDto): Model<ManagedModelApi> {
+  const customProvider = response.custom_provider;
+  if (customProvider === undefined) {
+    throw new Error('Expected managed Pi custom provider');
+  }
+  const model = customProvider.models[0];
+  if (model === undefined) {
+    throw new Error('Expected managed Pi model');
+  }
+  if (customProvider.api === 'google-generative-ai') {
+    throw new Error('Expected a managed Pi API dialect');
+  }
+
+  return {
+    id: response.model,
+    name: model.label,
+    api: customProvider.api,
+    provider: response.provider_id,
+    baseUrl: customProvider.base_url,
+    reasoning: model.reasoning ?? false,
+    input: model.input_image === true ? ['text', 'image'] : ['text'],
+    cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0},
+    contextWindow: model.context_window ?? 1_000_000,
+    maxTokens: model.max_output_tokens ?? 65_536,
+  };
+}
 
 async function saveProviderConfig(params: {
   workspaceId: string;

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -11,8 +11,37 @@ import {agentSystemNamespace, customCredentialsToStoreValues} from './credential
 import {ModelProviderConfigNotFoundError} from './errors.js';
 import {resolveRuntimeCredentials} from './resolve-runtime-credentials.js';
 
-const TRAILING_SLASHES_PATTERN = /\/+$/u;
-const TRAILING_API_VERSION_PATTERN = /(?:\/v1)+$/u;
+const managedGatewayBaseUrlVariants = [
+  'https://gateway.example.test/inference',
+  'https://gateway.example.test/inference/',
+  'https://gateway.example.test/inference/v1',
+  'https://gateway.example.test/inference/v1/',
+  'https://gateway.example.test/inference/v1/?tenant=staging#runtime',
+] as const;
+
+const expectedPiRequestUrls = {
+  'openai-responses': [
+    'https://gateway.example.test/inference/v1/responses',
+    'https://gateway.example.test/inference/v1/responses',
+    'https://gateway.example.test/inference/v1/responses',
+    'https://gateway.example.test/inference/v1/responses',
+    'https://gateway.example.test/inference/v1/responses',
+  ],
+  'openai-completions': [
+    'https://gateway.example.test/inference/v1/chat/completions',
+    'https://gateway.example.test/inference/v1/chat/completions',
+    'https://gateway.example.test/inference/v1/chat/completions',
+    'https://gateway.example.test/inference/v1/chat/completions',
+    'https://gateway.example.test/inference/v1/chat/completions',
+  ],
+  'anthropic-messages': [
+    'https://gateway.example.test/inference/v1/messages',
+    'https://gateway.example.test/inference/v1/messages',
+    'https://gateway.example.test/inference/v1/messages',
+    'https://gateway.example.test/inference/v1/messages',
+    'https://gateway.example.test/inference/v1/messages',
+  ],
+} satisfies Record<ManagedModelApi, readonly string[]>;
 
 describe('resolveRuntimeCredentials', () => {
   let workspaceId: string;
@@ -237,28 +266,19 @@ describe('resolveRuntimeCredentials', () => {
   });
 
   it.each([
-    {api: 'openai-responses', model: 'responses-model', path: '/responses'},
-    {api: 'openai-completions', model: 'plain-model', path: '/chat/completions'},
-    {api: 'anthropic-messages', model: 'claude-model', path: '/v1/messages'},
+    {api: 'openai-responses', model: 'responses-model'},
+    {api: 'openai-completions', model: 'plain-model'},
+    {api: 'anthropic-messages', model: 'claude-model'},
   ] satisfies readonly {
     api: ManagedModelApi;
     model: string;
-    path: string;
   }[])('composes the $api runtime response with the real Pi client URL construction', async ({
     api,
     model,
-    path,
   }) => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('capture request'));
-    const baseUrls = [
-      'https://gateway.example.test/inference',
-      'https://gateway.example.test/inference/',
-      'https://gateway.example.test/inference/v1',
-      'https://gateway.example.test/inference/v1/',
-    ];
-
-    for (const baseUrl of baseUrls) {
+    for (const baseUrl of managedGatewayBaseUrlVariants) {
       resolveCredentials.mockResolvedValueOnce({
         api,
         baseUrl,
@@ -287,15 +307,76 @@ describe('resolveRuntimeCredentials', () => {
       });
     }
 
-    expect(fetchSpy.mock.calls.map(([input]) => String(input))).toEqual(
-      baseUrls.map((baseUrl) => {
-        const gatewayRoot = baseUrl
-          .replace(TRAILING_SLASHES_PATTERN, '')
-          .replace(TRAILING_API_VERSION_PATTERN, '');
-        const adapterBaseUrl = api === 'anthropic-messages' ? gatewayRoot : `${gatewayRoot}/v1`;
-        return `${adapterBaseUrl}${path}`;
-      }),
+    expect(fetchSpy.mock.calls.map(([input]) => String(input))).toEqual(expectedPiRequestUrls[api]);
+  });
+
+  it.each([
+    {
+      baseUrl: managedGatewayBaseUrlVariants[0],
+      expected: 'https://gateway.example.test/inference',
+    },
+    {
+      baseUrl: managedGatewayBaseUrlVariants[1],
+      expected: 'https://gateway.example.test/inference',
+    },
+    {
+      baseUrl: managedGatewayBaseUrlVariants[2],
+      expected: 'https://gateway.example.test/inference',
+    },
+    {
+      baseUrl: managedGatewayBaseUrlVariants[3],
+      expected: 'https://gateway.example.test/inference',
+    },
+    {
+      baseUrl: managedGatewayBaseUrlVariants[4],
+      expected: 'https://gateway.example.test/inference',
+    },
+  ])('normalizes the Claude client base URL for %s', async ({baseUrl, expected}) => {
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    resolveCredentials.mockResolvedValue({
+      api: 'anthropic-messages',
+      baseUrl,
+      credentials: {api_key: 'opaque-test-credential'},
+    });
+
+    const result = await resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'claude',
+        provider: 'shipfox',
+        model: 'claude-model',
+        thinking: 'high',
+      },
+      {managedProvider: managedProvider(resolveCredentials)},
     );
+
+    expect(result.claude?.base_url).toBe(expected);
+  });
+
+  it('uses Claude client URL semantics when a managed lease reports another API dialect', async () => {
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    resolveCredentials.mockResolvedValue({
+      api: 'openai-responses',
+      baseUrl: 'https://gateway.example.test/inference',
+      credentials: {api_key: 'opaque-test-credential'},
+    });
+
+    const result = await resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'claude',
+        provider: 'shipfox',
+        model: 'claude-model',
+        thinking: 'high',
+      },
+      {managedProvider: managedProvider(resolveCredentials)},
+    );
+
+    expect(result.claude?.base_url).toBe('https://gateway.example.test/inference');
   });
 
   it('prefers workspace credentials over the instance fallback', async () => {

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -21,6 +21,7 @@ import {
 } from './credential-fingerprints.js';
 import type {ModelProviderConfig} from './entities/model-provider-config.js';
 import {ModelProviderConfigNotFoundError, WorkspaceProvidersDisabledError} from './errors.js';
+import {managedProviderAdapterBaseUrl} from './managed-provider-url.js';
 import {getModelProviderEntry, modelProviderCredentialKeysMatch} from './model-provider-policy.js';
 import {type AgentSecretsClient, requireAgentSecretsClient} from './secrets-client.js';
 
@@ -204,7 +205,10 @@ function toResponse(
     if (params.harness === 'pi') {
       response.custom_provider = {
         api: managed.runtimeConfig.api,
-        base_url: managed.runtimeConfig.baseUrl,
+        base_url: managedProviderAdapterBaseUrl(
+          managed.runtimeConfig.api,
+          managed.runtimeConfig.baseUrl,
+        ),
         headers: [],
         secret_header_names: [],
         models: [modelDescriptor],
@@ -216,7 +220,10 @@ function toResponse(
         throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
       }
       response.claude = {
-        base_url: managed.runtimeConfig.baseUrl,
+        base_url: managedProviderAdapterBaseUrl(
+          managed.runtimeConfig.api,
+          managed.runtimeConfig.baseUrl,
+        ),
         auth_token: authToken,
       };
     }

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -201,14 +201,13 @@ function toResponse(
   if (managed !== undefined) {
     const model = managed.provider.models.find((candidate) => candidate.id === params.model);
     const modelDescriptor = toCustomAgentModelDto(model ?? {id: params.model, label: params.model});
+    const clientApi =
+      params.harness === 'claude' ? 'anthropic-messages' : managed.runtimeConfig.api;
 
     if (params.harness === 'pi') {
       response.custom_provider = {
         api: managed.runtimeConfig.api,
-        base_url: managedProviderAdapterBaseUrl(
-          managed.runtimeConfig.api,
-          managed.runtimeConfig.baseUrl,
-        ),
+        base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
         headers: [],
         secret_header_names: [],
         models: [modelDescriptor],
@@ -220,10 +219,7 @@ function toResponse(
         throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
       }
       response.claude = {
-        base_url: managedProviderAdapterBaseUrl(
-          managed.runtimeConfig.api,
-          managed.runtimeConfig.baseUrl,
-        ),
+        base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
         auth_token: authToken,
       };
     }


### PR DESCRIPTION
Managed runtime configs carry the gateway mount root, but Pi/OpenAI and Claude/Anthropic clients append different paths. This change documents that contract and normalizes the root at the upstream agent seam: OpenAI receives a `/v1` client base, while Anthropic receives the gateway root so its client adds `/v1/messages`.

The normalizer preserves deployment path prefixes, strips query and fragment components that would interfere with client path joining, and passes malformed values through for the existing runtime DTO validation. Claude normalization follows Claude client semantics even if lease metadata reports another dialect. Custom-provider URL semantics remain unchanged.

This is a coordinated breaking contract change: providers that previously returned client-ready bases must migrate to return the gateway root before consuming the major `@shipfox/api-agent` and `@shipfox/api-agent-dto` releases. The Cloud package release/consumption and authenticated staging smoke remain the downstream follow-up described by ENG-1715.

Validation: `mise exec -- turbo check type test --filter=@shipfox/api-agent...` (132 tasks); `mise exec -- git diff --check`.

Part of ENG-1715

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make managed-provider runtime URLs dialect-safe so clients build correct API paths. Previously we passed the gateway root through; now we normalize per dialect: OpenAI gets a /v1 base, while Anthropic gets the gateway root and appends /v1/messages itself.

- Normalize client base URLs in `resolveRuntimeCredentials` for both `custom_provider.base_url` and `claude.base_url` via `managedProviderAdapterBaseUrl`:
  - Deduplicate trailing `/v1` and slashes, preserve deployment path prefixes, and omit query/fragment by reconstructing origin + pathname.
  - Leave malformed values unchanged to keep existing DTO validation.
  - Use Claude URL semantics when the harness is Claude, even if the lease reports another API dialect.
- Add docs on `ManagedProviderRuntimeConfig.baseUrl` (gateway mount root) and tests covering path normalization and real Pi client request URLs across OpenAI and Anthropic.
- Breaking change: providers must return the gateway mount root (not a client-ready base) before upgrading `@shipfox/api-agent` and `@shipfox/api-agent-dto`.

<sup>Written for commit c6b7ab058687374505ef768a960c5090636f73f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

