### PR TITLE
[client-workflows] Remove duplicate job log divider

### DIFF
--- a/libs/client/workflows/src/components/job-detail/job-detail-header.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.test.tsx
@@ -3,21 +3,6 @@ import {workflowJob, workflowJobExecutionDto} from '#test/fixtures/workflow-run.
 import {JobDetailHeader} from './job-detail-header.js';
 
 describe('JobDetailHeader', () => {
-  test('does not draw a divider below the header', () => {
-    render(
-      <JobDetailHeader
-        job={workflowJob()}
-        selectedJobExecution={undefined}
-        onSelectedJobExecutionChange={vi.fn()}
-        workspaceSlug="acme"
-        projectSlug="project"
-        workflowRunId="run-1"
-      />,
-    );
-
-    expect(screen.getByRole('banner')).not.toHaveClass('border-b');
-  });
-
   test('labels a live run duration as running', () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-26T12:00:00.000Z'));
     const job = workflowJob({

--- a/libs/client/workflows/src/components/job-detail/job-detail-header.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.test.tsx
@@ -3,6 +3,21 @@ import {workflowJob, workflowJobExecutionDto} from '#test/fixtures/workflow-run.
 import {JobDetailHeader} from './job-detail-header.js';
 
 describe('JobDetailHeader', () => {
+  test('does not draw a divider below the header', () => {
+    render(
+      <JobDetailHeader
+        job={workflowJob()}
+        selectedJobExecution={undefined}
+        onSelectedJobExecutionChange={vi.fn()}
+        workspaceSlug="acme"
+        projectSlug="project"
+        workflowRunId="run-1"
+      />,
+    );
+
+    expect(screen.getByRole('banner')).not.toHaveClass('border-b');
+  });
+
   test('labels a live run duration as running', () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-26T12:00:00.000Z'));
     const job = workflowJob({

--- a/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
@@ -45,7 +45,7 @@ export function JobDetailHeader({
   const jobStatus = getWorkflowStatusVisual(selectedStatus);
 
   return (
-    <header className="border-b border-border-neutral-base px-row py-row">
+    <header className="px-row py-row">
       <div className="flex min-w-0 items-start justify-between gap-cluster">
         <div className="flex min-w-0 flex-col gap-inline">
           <div className="flex min-w-0 items-center gap-inline">


### PR DESCRIPTION
Removes the redundant divider below the job detail header so it no longer sits directly against the logs panel border. The panel remains the single boundary, keeping the job view compact while reducing visual weight.

Validation:
- `mise exec -- turbo test --filter=@shipfox/client-workflows` (635 tests)
- `mise exec -- turbo check type build depcruise --filter=@shipfox/client-workflows...`
- Impeccable layout scan