### PR TITLE
Improve workflow run annotation readability

### DIFF
--- a/.changeset/annotations-rows-in-one-panel.md
+++ b/.changeset/annotations-rows-in-one-panel.md
@@ -1,0 +1,21 @@
+---
+'@shipfox/client-workflows': patch
+'@shipfox/client-ui': minor
+---
+
+Render run annotations as rows of the annotations panel rather than bordered cards inside it.
+
+Each annotation was a `Callout` inside the panel body: a second hairline, a second radius, a
+second shadow stack, and a fill one ramp step lighter than the panel behind it. Inline code in a
+body painted the same token as that fill, so a code chip was invisible against the card holding
+it, and the nested padding put the first character of a code fence 66px from the panel edge.
+
+Annotations are now cells of one panel, divided by the panel's own hairlines. `AnnotationCard`
+renders content and no frame, and exports the style glyph and tone maps it uses so counts and
+summaries name severity from one source. The clamp fade is a mask rather than a painted gradient,
+so it no longer assumes the color behind it.
+
+The row heading is now the block the emitting step named, falling back to the job when the server
+minted the key from a failure, so a `failure:step:<uuid>` is never the loudest text on the row.
+The provenance line is held to one line with the full value in its title, and job diagnostics with
+no execution record render in the same row as everything else and count toward the list total.

--- a/.changeset/annotations-rows-in-one-panel.md
+++ b/.changeset/annotations-rows-in-one-panel.md
@@ -3,19 +3,10 @@
 '@shipfox/client-ui': minor
 ---
 
-Render run annotations as rows of the annotations panel rather than bordered cards inside it.
+Render run annotations as rows of the annotations panel instead of bordered cards inside it.
 
-Each annotation was a `Callout` inside the panel body: a second hairline, a second radius, a
-second shadow stack, and a fill one ramp step lighter than the panel behind it. Inline code in a
-body painted the same token as that fill, so a code chip was invisible against the card holding
-it, and the nested padding put the first character of a code fence 66px from the panel edge.
+Each row is headed by the block the emitting step named, or by its job when the server minted
+the context from a failure, and its provenance line is bounded rather than sprawling. Job
+diagnostics with no execution record lead the list and count toward its total.
 
-Annotations are now cells of one panel, divided by the panel's own hairlines. `AnnotationCard`
-renders content and no frame, and exports the style glyph and tone maps it uses so counts and
-summaries name severity from one source. The clamp fade is a mask rather than a painted gradient,
-so it no longer assumes the color behind it.
-
-The row heading is now the block the emitting step named, falling back to the job when the server
-minted the key from a failure, so a `failure:step:<uuid>` is never the loudest text on the row.
-The provenance line is held to one line with the full value in its title, and job diagnostics with
-no execution record render in the same row as everything else and count toward the list total.
+`AnnotationCard` draws no frame of its own and exports the style glyph and tone maps it uses.

--- a/.changeset/remove-annotation-deep-link.md
+++ b/.changeset/remove-annotation-deep-link.md
@@ -1,0 +1,18 @@
+---
+'@shipfox/client-workflows': patch
+'@shipfox/client-ui': minor
+---
+
+Remove the annotation deep link and its selected-row state.
+
+`?annotation=<id>` was parsed, carried across navigation, and stripped in three places, but no
+surface in the product ever wrote it. No link, no redirect, no server-emitted URL. The only way
+to reach the state was to hand-write a URL containing an annotation id the product never shows
+you, so the selected row, its scroll-and-focus effect, and the render window it forced open were
+unreachable.
+
+Deleting it also removes two side effects that only fired from that unreachable state: synthetic
+job diagnostics were hidden while an annotation was selected, and the parameter counted toward
+"filters are active", which changed which empty state the reader got.
+
+`AnnotationCard` drops its `id` prop, which existed to be that deep link's scroll target.

--- a/.changeset/remove-annotation-deep-link.md
+++ b/.changeset/remove-annotation-deep-link.md
@@ -1,18 +1,10 @@
 ---
 '@shipfox/client-workflows': patch
-'@shipfox/client-ui': minor
+'@shipfox/client-ui': major
 ---
 
-Remove the annotation deep link and its selected-row state.
+Remove the `?annotation=<id>` deep link and its selected-row scroll and focus behaviour from the
+workflow run page. No surface ever produced that URL, so the state was unreachable.
 
-`?annotation=<id>` was parsed, carried across navigation, and stripped in three places, but no
-surface in the product ever wrote it. No link, no redirect, no server-emitted URL. The only way
-to reach the state was to hand-write a URL containing an annotation id the product never shows
-you, so the selected row, its scroll-and-focus effect, and the render window it forced open were
-unreachable.
-
-Deleting it also removes two side effects that only fired from that unreachable state: synthetic
-job diagnostics were hidden while an annotation was selected, and the parameter counted toward
-"filters are active", which changed which empty state the reader got.
-
-`AnnotationCard` drops its `id` prop, which existed to be that deep link's scroll target.
+`AnnotationCard` no longer accepts an `id` prop, which existed only as that deep link's scroll
+target.

--- a/.changeset/select-truncates-long-values.md
+++ b/.changeset/select-truncates-long-values.md
@@ -1,0 +1,14 @@
+---
+'@shipfox/react-ui': minor
+---
+
+Truncate a `Select` value instead of letting it wrap out of the trigger.
+
+Selected values are frequently names a user authored, such as a job or a workflow, and nothing
+bounds their length. `SelectValue` had no truncation, so a long name wrapped to a second line and
+spilled outside the trigger's fixed height. The trigger also now grows to the touch minimum where
+the pointer is coarse, matching the buttons it sits beside.
+
+Adds a `pt-panel-compact` utility, so a top padding can follow the density scale rather than
+freezing at 16px, and moves the Markdown render-guard fallback onto the code surface the rendered
+fences already use.

--- a/.changeset/select-truncates-long-values.md
+++ b/.changeset/select-truncates-long-values.md
@@ -2,13 +2,8 @@
 '@shipfox/react-ui': minor
 ---
 
-Truncate a `Select` value instead of letting it wrap out of the trigger.
+Truncate a long `Select` value instead of letting it wrap out of the trigger, and grow the
+trigger to the touch minimum where the pointer is coarse.
 
-Selected values are frequently names a user authored, such as a job or a workflow, and nothing
-bounds their length. `SelectValue` had no truncation, so a long name wrapped to a second line and
-spilled outside the trigger's fixed height. The trigger also now grows to the touch minimum where
-the pointer is coarse, matching the buttons it sits beside.
-
-Adds a `pt-panel-compact` utility, so a top padding can follow the density scale rather than
-freezing at 16px, and moves the Markdown render-guard fallback onto the code surface the rendered
-fences already use.
+Adds a `pt-panel-compact` spacing utility. A Markdown body that fails to render now falls back
+onto the same code surface a rendered fence uses.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -393,7 +393,7 @@ Compact values apply below an ancestor with `data-density="compact"`.
 | --- | --- |
 | Gaps | `gap-tight` 4 / 2, `gap-inline` 8 / 4, `gap-cluster` 12 / 8, `gap-group` 16 / 12, `gap-section` 24 / 16, `gap-region` 32 / 24 |
 | Axis gaps | `gap-x-*` and `gap-y-*` in the same six roles and the same values, for a grid whose column and row rhythm differ |
-| Padding | `p-menu-surface` 4 / 2, `p-tight` and `px-tight` 8 / 4, `px-row` 16 / 12, `py-row` 12 / 8, `p-panel-compact` 16 / 12, `p-panel` and `pb-panel` 24 / 16, `px-frame` 24 / 16, `py-frame` 32 / 24 |
+| Padding | `p-menu-surface` 4 / 2, `p-tight` and `px-tight` 8 / 4, `px-row` 16 / 12, `py-row` 12 / 8, `p-panel-compact` and `pt-panel-compact` 16 / 12, `p-panel` and `pb-panel` 24 / 16, `px-frame` 24 / 16, `py-frame` 32 / 24 |
 | Margins | `ms-inline` 8 / 4, `my-region` 32 / 24, `mt-page` 48 / 32, `-mt-inline`, `-mr-inline`, and `-mx-inline` -8 / -4 |
 
 Use a parent `gap-*` role before adding a child margin, and reach for `gap-x-*`

--- a/libs/client/ui/src/annotation-card.test.tsx
+++ b/libs/client/ui/src/annotation-card.test.tsx
@@ -6,34 +6,53 @@ import {AnnotationCard, type AnnotationCardProps} from './annotation-card.js';
 
 const styles = ['default', 'info', 'success', 'warning', 'error'] as const;
 const stylesWithDefaultGlyph = ['info', 'success', 'warning', 'error'] as const;
+const SEVERITY_LABEL = {
+  info: 'Info:',
+  success: 'Success:',
+  warning: 'Warning:',
+  error: 'Error:',
+} as const satisfies Record<(typeof stylesWithDefaultGlyph)[number], string>;
 /** Markdown link syntax that reached the DOM as text, which means the source was cut mid-link. */
 const UNPARSED_LINK_PATTERN = /^\[documentation\]/u;
 const OPEN_DOCUMENTATION_PATTERN = /Open documentation/;
 const PREFIX_PATTERN = /prefix/u;
 const DOCUMENTATION_PATTERN = /documentation/u;
+/** Any frame the card might draw around itself: a border, a radius, or the inline chip fill. */
+const CARD_FRAME_PATTERN = /\b(?:border|rounded-|bg-background-components)/u;
 
 describe('AnnotationCard', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test.each(styles)('renders %s annotations as callouts', (style) => {
+  test.each(styles)('carries %s severity in a glyph', (style) => {
     const {container} = renderAnnotationCard({style, body: `**${style}** body`});
 
-    expect(container.querySelector('[data-slot="callout"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="annotation-style-icon"]')).not.toBeNull();
   });
 
-  test.each(stylesWithDefaultGlyph)('renders the default %s glyph', (style) => {
-    const {container} = renderAnnotationCard({style, body: 'Body'});
+  test.each(stylesWithDefaultGlyph)('announces %s severity to a screen reader', (style) => {
+    // The glyph is the only thing carrying severity, and it is hidden from assistive tech.
+    renderAnnotationCard({style, body: 'Body'});
 
-    expect(container.querySelector('[data-slot="callout-icon"]')).not.toBeNull();
+    expect(screen.getByText(SEVERITY_LABEL[style], {selector: '.sr-only'})).toBeInTheDocument();
   });
 
-  test('renders default style with the side-line treatment', () => {
+  test('leaves the default style unannounced', () => {
     const {container} = renderAnnotationCard({style: 'default', body: 'Body'});
 
-    expect(container.querySelector('[data-slot="callout-icon"]')).toBeNull();
-    expect(container.querySelector('[data-slot="callout-line"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="annotation-style-icon"]')).not.toBeNull();
+    expect(container.querySelector('.sr-only')).toBeNull();
+  });
+
+  test('renders no frame of its own', () => {
+    // The list it belongs to owns the row padding and the hairline between rows. A bordered box
+    // here would be a second frame inside the annotations panel.
+    const {container} = renderAnnotationCard({style: 'error', body: 'Body', title: 'deploy'});
+    const root = container.firstElementChild;
+
+    expect(container.querySelector('[data-slot="callout"]')).toBeNull();
+    expect(root?.className).not.toMatch(CARD_FRAME_PATTERN);
   });
 
   test('renders sanitized Markdown', () => {

--- a/libs/client/ui/src/annotation-card.tsx
+++ b/libs/client/ui/src/annotation-card.tsx
@@ -1,6 +1,6 @@
 import type {AnnotationStyleDto} from '@shipfox/annotations-dto';
 import {Button} from '@shipfox/react-ui/button';
-import {Callout, CalloutContent} from '@shipfox/react-ui/callout';
+import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {Markdown} from '@shipfox/react-ui/markdown';
 import {cn} from '@shipfox/react-ui/utils';
 import {type ReactNode, useEffect, useId, useRef, useState} from 'react';
@@ -26,6 +26,42 @@ const OVERFLOW_TOLERANCE = 8;
 const MAX_COLLAPSED_BODY_CHARS = 4_000;
 
 /**
+ * The glyph vocabulary for annotation style.
+ *
+ * One map, so the mark beside `1 error` in a summary line is the mark on the error row below it.
+ */
+const ANNOTATION_STYLE_ICON = {
+  default: 'fileTextLine',
+  info: 'info',
+  success: 'checkboxCircleFill',
+  warning: 'errorWarningFill',
+  error: 'closeCircleFill',
+} as const satisfies Record<AnnotationStyleDto, IconName>;
+
+/**
+ * Style tone lives in the glyph, never in the surface behind it.
+ *
+ * A row tinted to match its severity turns a list of warnings into one warning band, and leaves
+ * the reader no calm ground to scan.
+ */
+const ANNOTATION_STYLE_TONE = {
+  default: 'text-tag-neutral-icon',
+  info: 'text-tag-blue-icon',
+  success: 'text-tag-success-icon',
+  warning: 'text-tag-warning-icon',
+  error: 'text-tag-error-icon',
+} as const satisfies Record<AnnotationStyleDto, string>;
+
+/** Severity is carried by a colored glyph, which a screen reader cannot see. */
+const ANNOTATION_STYLE_LABEL = {
+  default: null,
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+} as const satisfies Record<AnnotationStyleDto, string | null>;
+
+/**
  * Cuts Markdown source at a line boundary.
  *
  * Only the line boundary needs handling: a mid-line cut can split a link or inline code and
@@ -46,10 +82,19 @@ function collapsedPreview(body: string): string {
 const BODY_MEASURE =
   '[&>p]:max-w-[75ch] [&>ul]:max-w-[75ch] [&>ol]:max-w-[75ch] [&>blockquote]:max-w-[75ch] [&>h1]:max-w-[75ch] [&>h2]:max-w-[75ch] [&>h3]:max-w-[75ch] [&>h4]:max-w-[75ch]';
 
+/**
+ * Fades the clipped body into whatever is behind it.
+ *
+ * A mask rather than a gradient overlay because the card draws no surface of its own: the row
+ * behind it belongs to the caller, so there is no color here to fade a painted overlay to.
+ */
+const BODY_CLAMP_FADE =
+  '[mask-image:linear-gradient(to_bottom,#000_calc(100%_-_48px),transparent)]';
+
 type AnnotationCardProps = {
   style: AnnotationStyleDto;
   body: string;
-  /** The annotation's `context`, shown as its title. */
+  /** The row's heading, which is the job the annotation came from. */
   title?: string | undefined;
   /** Heading element for the title. Callers own the document outline. */
   titleAs?: 'h2' | 'h3' | 'h4' | undefined;
@@ -58,10 +103,15 @@ type AnnotationCardProps = {
   /** A single action, such as a link back to the emitting step. */
   action?: ReactNode | undefined;
   maxBodyHeight?: number | undefined;
-  id?: string | undefined;
 };
 
 /**
+ * One annotation's content: severity glyph, heading, provenance, and body.
+ *
+ * It renders no frame of its own. The list it belongs to owns the row padding and the hairline
+ * that separates one annotation from the next, because a bordered tile inside the annotations
+ * panel would be two frames around one thing.
+ *
  * Deliberately not memoized: `provenance` and `action` are elements the caller builds fresh on
  * every render, so a shallow compare could never hit. The parse cost that actually matters is
  * held by `Markdown`, which memoizes on its primitive props.
@@ -74,7 +124,6 @@ function AnnotationCard({
   provenance,
   action,
   maxBodyHeight = DEFAULT_MAX_BODY_HEIGHT,
-  id,
 }: AnnotationCardProps) {
   const bodyId = useId();
   const contentRef = useRef<HTMLDivElement>(null);
@@ -124,15 +173,26 @@ function AnnotationCard({
   // over the budget is never clipped without a disclosure to open it.
   const collapsed = hasBody && !expanded && (!measured || disclosable);
   const rendered = collapsed && truncated ? collapsedPreview(body) : body;
+  const styleLabel = ANNOTATION_STYLE_LABEL[style];
 
   return (
-    <Callout id={id} type={style}>
-      <CalloutContent className="flex flex-col gap-6">
+    <div className="flex min-w-0 flex-1 gap-cluster">
+      {styleLabel ? <span className="sr-only">{styleLabel}: </span> : null}
+      <Icon
+        data-slot="annotation-style-icon"
+        name={ANNOTATION_STYLE_ICON[style]}
+        size={16}
+        aria-hidden="true"
+        // Optically centered on the 20px line box of the title beside it, not on the column.
+        className={cn('mt-2 shrink-0', ANNOTATION_STYLE_TONE[style])}
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col gap-inline">
         {hasHeader ? (
-          <div className="flex min-w-0 items-start justify-between gap-8">
-            <div className="flex min-w-0 flex-col gap-2">
+          <div className="flex min-w-0 items-start justify-between gap-cluster">
+            <div className="flex min-w-0 flex-col gap-tight">
               {title ? (
-                <TitleTag className="min-w-0 break-words font-code text-sm font-medium leading-20 text-foreground-neutral-base">
+                <TitleTag className="min-w-0 break-words text-sm font-medium leading-20 text-foreground-neutral-base">
                   {title}
                 </TitleTag>
               ) : null}
@@ -143,10 +203,14 @@ function AnnotationCard({
         ) : null}
 
         {hasBody ? (
-          <div className="flex min-w-0 flex-col gap-4">
+          <div className="flex min-w-0 flex-col gap-tight">
             <div
               id={bodyId}
-              className={cn('relative min-w-0', collapsed && 'overflow-hidden')}
+              className={cn(
+                'relative min-w-0',
+                collapsed && 'overflow-hidden',
+                collapsed && disclosable && BODY_CLAMP_FADE,
+              )}
               style={collapsed ? {maxHeight: maxBodyHeight} : undefined}
               // Tabbing to a link inside a clipped body cannot scroll it into view, so reveal the
               // body rather than move focus somewhere invisible.
@@ -157,12 +221,6 @@ function AnnotationCard({
                   {rendered}
                 </Markdown>
               </div>
-              {collapsed && disclosable ? (
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-x-0 bottom-0 h-48 bg-linear-to-t from-background-components-base to-transparent"
-                />
-              ) : null}
             </div>
             {disclosable ? (
               // The fade above it carries the "there is more" signal, so the control itself
@@ -181,9 +239,15 @@ function AnnotationCard({
             ) : null}
           </div>
         ) : null}
-      </CalloutContent>
-    </Callout>
+      </div>
+    </div>
   );
 }
 
-export {AnnotationCard, type AnnotationCardProps, DEFAULT_MAX_BODY_HEIGHT};
+export {
+  ANNOTATION_STYLE_ICON,
+  ANNOTATION_STYLE_TONE,
+  AnnotationCard,
+  type AnnotationCardProps,
+  DEFAULT_MAX_BODY_HEIGHT,
+};

--- a/libs/client/workflows/src/components/workflow-run-tabs/index.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/index.ts
@@ -1,5 +1,5 @@
 export {RunAnnotationCountChip} from './run-annotation-count-chip.js';
-export {annotationElementId, RunAnnotationItem} from './run-annotation-item.js';
+export {RunAnnotationItem} from './run-annotation-item.js';
 export {
   type DerivedRunAnnotation,
   RunAnnotationList,

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -1,12 +1,28 @@
 import {AnnotationCard} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
+import {PanelRow} from '@shipfox/react-ui/panel';
 import {Text} from '@shipfox/react-ui/typography';
-import {cn} from '@shipfox/react-ui/utils';
 import {Link} from '@tanstack/react-router';
-import {useEffect, useRef} from 'react';
-import type {RunAnnotationEntry} from '#core/run-annotation.js';
+import type {ReactNode} from 'react';
+import type {RunAnnotationEntry, RunAnnotationStyle} from '#core/run-annotation.js';
 import {workflowJobSearchParams} from '#routes/inputs.js';
+
+/**
+ * Annotations are cells inside the run's annotations panel, separated by the panel's own
+ * hairlines. `items-start` because a row holds a block of Markdown rather than a single line,
+ * and the row hover fill is cancelled because the row is not itself a target: the only thing to
+ * open is the button inside it.
+ */
+const ANNOTATION_ROW_CLASS =
+  'items-start justify-start gap-cluster hover:bg-background-neutral-base';
+
+/**
+ * The server mints `failure:step:<uuid>` and `failure:job:<uuid>` for annotations it derives
+ * from a failure. Those are routing keys, not something a reader named, and the row already
+ * links to the step they point at.
+ */
+const GENERATED_CONTEXT = /^failure:(?:job|step):/;
 
 export interface RunAnnotationItemProps {
   entry: RunAnnotationEntry;
@@ -14,15 +30,14 @@ export interface RunAnnotationItemProps {
   projectSlug?: string | undefined;
   workflowRunId: string;
   runAttempt?: number | undefined;
-  /** Deep-link target from `?annotation=`, which takes focus rather than only being scrolled to. */
-  selected?: boolean | undefined;
 }
 
 /**
  * One annotation, and the only place in the product that renders an annotation body.
  *
- * The title is the annotation's `context`, which is what the emitting step named the block.
- * Everything below it exists so a reader can get from a diagnostic back to its cause.
+ * The heading answers "what is this", which is the block the emitting step named when it chose
+ * one, and the job that produced it otherwise. Everything below it exists so a reader can get
+ * from a diagnostic back to its cause.
  */
 export function RunAnnotationItem({
   entry,
@@ -30,43 +45,19 @@ export function RunAnnotationItem({
   projectSlug,
   workflowRunId,
   runAttempt,
-  selected = false,
 }: RunAnnotationItemProps) {
   const {annotation, origin} = entry;
   const canLink = Boolean(origin && workspaceSlug && projectSlug);
-  const itemRef = useRef<HTMLLIElement>(null);
-  const focusedRef = useRef(false);
-
-  useEffect(() => {
-    if (!selected) {
-      focusedRef.current = false;
-      return;
-    }
-    if (focusedRef.current) return;
-
-    // A deep link that only scrolls leaves a keyboard or screen-reader user at the document
-    // start while the page moves under them.
-    focusedRef.current = true;
-    itemRef.current?.focus({preventScroll: true});
-    itemRef.current?.scrollIntoView({block: 'nearest'});
-  }, [selected]);
+  const namedContext = GENERATED_CONTEXT.test(annotation.context) ? null : annotation.context;
+  const title = namedContext ?? entry.jobName ?? annotation.context;
 
   return (
-    <li
-      ref={itemRef}
-      tabIndex={-1}
-      aria-current={selected ? 'true' : undefined}
-      className={cn(
-        'rounded-8 outline-none focus-visible:shadow-border-interactive-with-active',
-        selected && 'shadow-border-interactive-with-active',
-      )}
-    >
+    <AnnotationRow>
       <AnnotationCard
-        id={annotationElementId(annotation.id)}
         style={annotation.style}
-        title={annotation.context}
+        title={title}
         titleAs="h3"
-        provenance={<RunAnnotationProvenance entry={entry} />}
+        provenance={<RunAnnotationProvenance entry={entry} showJobName={Boolean(namedContext)} />}
         body={annotation.body}
         action={
           canLink && origin ? (
@@ -100,24 +91,88 @@ export function RunAnnotationItem({
           ) : null
         }
       />
-    </li>
+    </AnnotationRow>
   );
 }
 
-/** `job · execution #2 · run tests · attempt 1`, dropping any part the run no longer resolves. */
-function RunAnnotationProvenance({entry}: {entry: RunAnnotationEntry}) {
-  const parts = [entry.jobName, entry.executionLabel, entry.stepLabel, entry.attemptLabel].filter(
-    (part): part is string => Boolean(part),
+export interface RunDerivedAnnotationItemProps {
+  style: RunAnnotationStyle;
+  jobName: string;
+  body: string;
+}
+
+/**
+ * A terminal job that never created an execution record.
+ *
+ * It has no step to link to and no context of its own, so it is titled by its job and says
+ * plainly that no execution exists. It renders in the same row as every other annotation, since
+ * a job that failed before it started is a diagnostic like any other, and often the first one
+ * worth reading.
+ */
+export function RunDerivedAnnotationItem({style, jobName, body}: RunDerivedAnnotationItemProps) {
+  return (
+    <AnnotationRow>
+      <AnnotationCard
+        style={style}
+        title={jobName}
+        titleAs="h3"
+        provenance={
+          <Text
+            as="p"
+            size="xs"
+            className="min-w-0 truncate font-code text-foreground-neutral-subtle"
+          >
+            no execution recorded
+          </Text>
+        }
+        body={body}
+      />
+    </AnnotationRow>
   );
+}
+
+function AnnotationRow({children}: {children: ReactNode}) {
+  return (
+    <PanelRow asChild className={ANNOTATION_ROW_CLASS}>
+      <li>{children}</li>
+    </PanelRow>
+  );
+}
+
+/**
+ * `execution #2 · run tests · attempt 1`, dropping any part the run no longer resolves.
+ *
+ * Held to one line. A step with no `name` is labelled by its prompt, which arrives already cut
+ * by the server, and letting that sprawl over three wrapped lines presents a severed sentence as
+ * if it were a complete label. Truncating says the value was cut; the title attribute returns
+ * the rest.
+ */
+function RunAnnotationProvenance({
+  entry,
+  showJobName,
+}: {
+  entry: RunAnnotationEntry;
+  showJobName: boolean;
+}) {
+  const parts = [
+    showJobName ? entry.jobName : null,
+    entry.executionLabel,
+    entry.stepLabel,
+    entry.attemptLabel,
+  ].filter((part): part is string => Boolean(part));
+
+  if (parts.length === 0) return null;
+
+  const label = parts.join(' · ');
 
   return (
-    <Text as="p" size="xs" className="min-w-0 break-words font-code text-foreground-neutral-subtle">
-      {parts.join(' · ')}
+    <Text
+      as="p"
+      size="xs"
+      title={label}
+      className="min-w-0 truncate font-code text-foreground-neutral-subtle"
+    >
+      {label}
     </Text>
   );
-}
-
-/** Stable element id so `?annotation=<id>` can scroll to and highlight one annotation. */
-export function annotationElementId(annotationId: string): string {
-  return `run-annotation-${annotationId}`;
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -18,11 +18,24 @@ const ANNOTATION_ROW_CLASS =
   'items-start justify-start gap-cluster hover:bg-background-neutral-base';
 
 /**
- * The server mints `failure:step:<uuid>` and `failure:job:<uuid>` for annotations it derives
- * from a failure. Those are routing keys, not something a reader named, and the row already
- * links to the step they point at.
+ * Contexts the server mints itself, each with the heading to use when the job that would
+ * normally name the row cannot be resolved.
+ *
+ * These are routing keys rather than something a reader chose, so they never become the
+ * heading. The convention is re-derived here from the server's producers
+ * (`on-failure-annotations.ts`, `agent-tool-capability-warning.ts`), which means a step is free
+ * to pick a context that collides with one of these prefixes and get retitled. Carrying the
+ * distinction on the annotation record instead would remove the guesswork.
  */
-const GENERATED_CONTEXT = /^failure:(?:job|step):/;
+const MINTED_CONTEXTS = [
+  {prefix: 'failure:step:', fallbackTitle: 'Step failure'},
+  {prefix: 'failure:job:', fallbackTitle: 'Job failure'},
+  {prefix: 'agent-tool-capability:', fallbackTitle: 'Agent tool capability'},
+] as const;
+
+function mintedContext(context: string) {
+  return MINTED_CONTEXTS.find(({prefix}) => context.startsWith(prefix));
+}
 
 export interface RunAnnotationItemProps {
   entry: RunAnnotationEntry;
@@ -48,8 +61,11 @@ export function RunAnnotationItem({
 }: RunAnnotationItemProps) {
   const {annotation, origin} = entry;
   const canLink = Boolean(origin && workspaceSlug && projectSlug);
-  const namedContext = GENERATED_CONTEXT.test(annotation.context) ? null : annotation.context;
-  const title = namedContext ?? entry.jobName ?? annotation.context;
+  // A minted context is never the heading, not even as a last resort: a run that no longer
+  // contains the emitting job resolves no name, and printing the routing key would put a bare
+  // uuid where the row's subject belongs.
+  const minted = mintedContext(annotation.context);
+  const title = minted ? (entry.jobName ?? minted.fallbackTitle) : annotation.context;
 
   return (
     <AnnotationRow>
@@ -57,7 +73,7 @@ export function RunAnnotationItem({
         style={annotation.style}
         title={title}
         titleAs="h3"
-        provenance={<RunAnnotationProvenance entry={entry} showJobName={Boolean(namedContext)} />}
+        provenance={<RunAnnotationProvenance entry={entry} showJobName={!minted} />}
         body={annotation.body}
         action={
           canLink && origin ? (
@@ -142,10 +158,11 @@ function AnnotationRow({children}: {children: ReactNode}) {
 /**
  * `execution #2 · run tests · attempt 1`, dropping any part the run no longer resolves.
  *
- * Held to one line. A step with no `name` is labelled by its prompt, which arrives already cut
- * by the server, and letting that sprawl over three wrapped lines presents a severed sentence as
- * if it were a complete label. Truncating says the value was cut; the title attribute returns
- * the rest.
+ * Bounded to two lines. A step with no `name` is labelled by its prompt, which arrives already
+ * cut by the server, and letting that sprawl unbounded presents a severed sentence as if it were
+ * a complete label. Two lines rather than one because the title attribute is the only other way
+ * to read the rest and a touch device never surfaces it, so the clamp has to carry most labels
+ * on its own; the ellipsis still says the value was cut.
  */
 function RunAnnotationProvenance({
   entry,
@@ -170,7 +187,7 @@ function RunAnnotationProvenance({
       as="p"
       size="xs"
       title={label}
-      className="min-w-0 truncate font-code text-foreground-neutral-subtle"
+      className="min-w-0 line-clamp-2 font-code text-foreground-neutral-subtle"
     >
       {label}
     </Text>

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -5,7 +5,11 @@ import {PanelRow} from '@shipfox/react-ui/panel';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
 import type {ReactNode} from 'react';
-import type {RunAnnotationEntry, RunAnnotationStyle} from '#core/run-annotation.js';
+import type {
+  RunAnnotationEntry,
+  RunAnnotationRecord,
+  RunAnnotationStyle,
+} from '#core/run-annotation.js';
 import {workflowJobSearchParams} from '#routes/inputs.js';
 
 /**
@@ -18,23 +22,35 @@ const ANNOTATION_ROW_CLASS =
   'items-start justify-start gap-cluster hover:bg-background-neutral-base';
 
 /**
- * Contexts the server mints itself, each with the heading to use when the job that would
- * normally name the row cannot be resolved.
+ * The contexts the server mints itself, each rebuilt exactly as its producer builds it, with the
+ * heading to use when the job that would normally name the row cannot be resolved.
  *
- * These are routing keys rather than something a reader chose, so they never become the
- * heading. The convention is re-derived here from the server's producers
- * (`on-failure-annotations.ts`, `agent-tool-capability-warning.ts`), which means a step is free
- * to pick a context that collides with one of these prefixes and get retitled. Carrying the
- * distinction on the annotation record instead would remove the guesswork.
+ * These are routing keys rather than something a reader chose, so they never become the heading.
+ * Rebuilt whole rather than matched by prefix: `context` is caller-chosen with no reserved
+ * namespace, so a prefix would claim any annotation a step happened to name `failure:...`. Every
+ * producer keys off an id the annotation already carries, so reconstructing the entire key means
+ * a step has to choose a context identical to one built from its own step or job id before it is
+ * mistaken for a diagnostic.
  */
 const MINTED_CONTEXTS = [
-  {prefix: 'failure:step:', fallbackTitle: 'Step failure'},
-  {prefix: 'failure:job:', fallbackTitle: 'Job failure'},
-  {prefix: 'agent-tool-capability:', fallbackTitle: 'Agent tool capability'},
+  {
+    key: ({originStepId}: MintedContextSource) => `failure:step:${originStepId}`,
+    fallbackTitle: 'Step failure',
+  },
+  {
+    key: ({jobId}: MintedContextSource) => `failure:job:${jobId}`,
+    fallbackTitle: 'Job failure',
+  },
+  {
+    key: ({originStepId}: MintedContextSource) => `agent-tool-capability:${originStepId}`,
+    fallbackTitle: 'Agent tool capability',
+  },
 ] as const;
 
-function mintedContext(context: string) {
-  return MINTED_CONTEXTS.find(({prefix}) => context.startsWith(prefix));
+type MintedContextSource = Pick<RunAnnotationRecord, 'context' | 'jobId' | 'originStepId'>;
+
+function mintedContext(annotation: MintedContextSource) {
+  return MINTED_CONTEXTS.find(({key}) => key(annotation) === annotation.context);
 }
 
 export interface RunAnnotationItemProps {
@@ -64,7 +80,7 @@ export function RunAnnotationItem({
   // A minted context is never the heading, not even as a last resort: a run that no longer
   // contains the emitting job resolves no name, and printing the routing key would put a bare
   // uuid where the row's subject belongs.
-  const minted = mintedContext(annotation.context);
+  const minted = mintedContext(annotation);
   const title = minted ? (entry.jobName ?? minted.fallbackTitle) : annotation.context;
 
   return (

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
@@ -1,0 +1,213 @@
+import {screen, within} from '@testing-library/react';
+import {
+  buildRunAnnotationList,
+  type RunAnnotationRecord,
+  type RunAnnotationStyle,
+} from '#core/run-annotation.js';
+import type {Job} from '#core/workflow-run.js';
+import {
+  workflowJob,
+  workflowJobExecutionDto,
+  workflowStepAttemptDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
+import {renderWithRouter} from '#test/render.js';
+import {
+  type DerivedRunAnnotation,
+  RunAnnotationList,
+  type RunAnnotationListQuery,
+} from './run-annotation-list.js';
+
+const BUILD_JOB_ID = '44444444-4444-4444-8444-00000000000b';
+const BUILD_EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
+const BUILD_STEP_ID = '55555555-5555-4555-8555-00000000000b';
+const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
+const MISSING_JOB_ID = '44444444-4444-4444-8444-00000000000f';
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+
+const SHOW_MORE_PATTERN = /Show \d+ more of \d+/;
+const OPEN_STEP_PATTERN = /Open step/;
+
+describe('RunAnnotationList', () => {
+  test('heads a row with the block the emitting step named', async () => {
+    renderList([annotation({id: 'a1', context: 'smoke check'})]);
+
+    expect(await screen.findByRole('heading', {level: 3, name: 'smoke check'})).toBeInTheDocument();
+  });
+
+  test('heads a server-minted context with its job instead of the routing key', async () => {
+    // The server keys failure annotations by step id. That is a routing key, not a name a reader
+    // chose, so the job answers "what is this" and the key never reaches the heading.
+    renderList([annotation({id: 'a1', context: `failure:step:${BUILD_STEP_ID}`})]);
+
+    expect(await screen.findByRole('heading', {level: 3, name: 'build'})).toBeInTheDocument();
+    expect(screen.queryByText(`failure:step:${BUILD_STEP_ID}`)).not.toBeInTheDocument();
+  });
+
+  test('heads the other minted context family the same way', async () => {
+    renderList([annotation({id: 'a1', context: `agent-tool-capability:${BUILD_STEP_ID}`})]);
+
+    expect(await screen.findByRole('heading', {level: 3, name: 'build'})).toBeInTheDocument();
+  });
+
+  test('names a minted context whose job the run no longer resolves', async () => {
+    // A job missing from the run snapshot resolves no name and no step link, so the routing key
+    // would otherwise be the only text on the row.
+    renderList([
+      annotation({id: 'a1', context: `failure:step:${BUILD_STEP_ID}`, jobId: MISSING_JOB_ID}),
+    ]);
+
+    expect(
+      await screen.findByRole('heading', {level: 3, name: 'Step failure'}),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(`failure:step:${BUILD_STEP_ID}`)).not.toBeInTheDocument();
+  });
+
+  test('drops the job from provenance when the job is already the heading', async () => {
+    renderList([annotation({id: 'a1', context: `failure:step:${BUILD_STEP_ID}`})]);
+
+    expect(await screen.findByText('run smoke checks · attempt 1')).toBeInTheDocument();
+  });
+
+  test('keeps the job in provenance when the step named the block', async () => {
+    renderList([annotation({id: 'a1', context: 'smoke check'})]);
+
+    expect(await screen.findByText('build · run smoke checks · attempt 1')).toBeInTheDocument();
+  });
+
+  test('leads with a job that never created an execution', async () => {
+    // It is the most upstream thing in the run and has no step to link to, so it must not trail
+    // behind a render window that could bury it.
+    renderList([annotation({id: 'a1', context: 'smoke check'})], {
+      derivedAnnotations: [derived({id: 'd1', jobName: 'deploy production'})],
+    });
+
+    await screen.findByText('no execution recorded');
+    const headings = screen.getAllByRole('heading', {level: 3});
+
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      'deploy production',
+      'smoke check',
+    ]);
+  });
+
+  test('counts a derived row in the total the render window reports', async () => {
+    const entries = Array.from({length: 26}, (_unused, index) =>
+      annotation({
+        id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(index).padStart(12, '0')}`,
+        context: `context-${index}`,
+        sequence: index + 1,
+      }),
+    );
+
+    renderList(entries, {derivedAnnotations: [derived({id: 'd1', jobName: 'deploy production'})]});
+
+    expect(await screen.findByRole('button', {name: SHOW_MORE_PATTERN})).toHaveTextContent(
+      'Show 1 more of 27',
+    );
+  });
+
+  test('links a row back to the step that emitted it', async () => {
+    renderList([annotation({id: 'a1', context: 'smoke check'})]);
+
+    const row = (await screen.findByRole('heading', {level: 3, name: 'smoke check'})).closest('li');
+
+    expect(within(row as HTMLElement).getByRole('link', {name: OPEN_STEP_PATTERN})).toHaveAttribute(
+      'href',
+      expect.stringContaining(`/runs/${RUN_ID}/jobs/${BUILD_JOB_ID}`),
+    );
+  });
+
+  test('offers no step link when the run no longer contains the emitting step', async () => {
+    renderList([annotation({id: 'a1', context: 'smoke check', jobId: MISSING_JOB_ID})]);
+
+    await screen.findByRole('heading', {level: 3, name: 'smoke check'});
+    expect(screen.queryByRole('link', {name: OPEN_STEP_PATTERN})).not.toBeInTheDocument();
+  });
+});
+
+function renderList(
+  annotations: RunAnnotationRecord[],
+  {
+    derivedAnnotations,
+    query = listQuery(),
+  }: {
+    derivedAnnotations?: readonly DerivedRunAnnotation[];
+    query?: RunAnnotationListQuery;
+  } = {},
+) {
+  return renderWithRouter(
+    <RunAnnotationList
+      query={query}
+      entries={buildRunAnnotationList({annotations, jobs})}
+      derivedAnnotations={derivedAnnotations}
+      workspaceSlug="acme"
+      projectSlug="platform"
+      workflowRunId={RUN_ID}
+      runAttempt={1}
+      filtered={false}
+    />,
+  );
+}
+
+function listQuery(overrides: Partial<RunAnnotationListQuery> = {}): RunAnnotationListQuery {
+  return {
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    data: {pages: []},
+    error: null,
+    refetch: () => undefined,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: () => undefined,
+    ...overrides,
+  };
+}
+
+function annotation(overrides: Partial<RunAnnotationRecord> & {id: string}): RunAnnotationRecord {
+  return {
+    jobId: BUILD_JOB_ID,
+    jobExecutionId: BUILD_EXECUTION_ID,
+    originStepId: BUILD_STEP_ID,
+    originStepAttempt: 1,
+    context: 'default',
+    style: 'error' as RunAnnotationStyle,
+    sequence: 1,
+    body: 'Body',
+    ...overrides,
+  };
+}
+
+function derived(overrides: Partial<DerivedRunAnnotation> & {id: string}): DerivedRunAnnotation {
+  return {
+    style: 'warning',
+    jobName: 'deploy production',
+    body: 'Skipped before an execution was created.',
+    ...overrides,
+  };
+}
+
+const jobs: Job[] = [
+  workflowJob({
+    id: BUILD_JOB_ID,
+    key: 'build',
+    name: 'build',
+    position: 0,
+    job_executions: [
+      workflowJobExecutionDto({
+        id: BUILD_EXECUTION_ID,
+        job_id: BUILD_JOB_ID,
+        steps: [
+          workflowStepDto({
+            id: BUILD_STEP_ID,
+            name: 'run smoke checks',
+            attempts: [
+              workflowStepAttemptDto({id: BUILD_ATTEMPT_ID, step_id: BUILD_STEP_ID, attempt: 1}),
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+];

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
@@ -50,6 +50,16 @@ describe('RunAnnotationList', () => {
     expect(await screen.findByRole('heading', {level: 3, name: 'build'})).toBeInTheDocument();
   });
 
+  test('leaves a step-chosen context that only looks minted as the heading', async () => {
+    // `context` is caller-chosen with no reserved namespace, so matching the server's keys by
+    // prefix would silently retitle a step's own annotation and hide the name it picked.
+    renderList([annotation({id: 'a1', context: 'failure:step: see the runbook'})]);
+
+    expect(
+      await screen.findByRole('heading', {level: 3, name: 'failure:step: see the runbook'}),
+    ).toBeInTheDocument();
+  });
+
   test('names a minted context whose job the run no longer resolves', async () => {
     // A job missing from the run snapshot resolves no name and no step link, so the routing key
     // would otherwise be the only text on the row.

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -79,9 +79,7 @@ export function RunAnnotationList({
 
   if (query.isError && entries === undefined) {
     return (
-      <PanelBody className="p-panel">
-        <QueryLoadError query={query} subject="annotations" icon="fileDamageLine" />
-      </PanelBody>
+      <QueryLoadError query={query} subject="annotations" icon="fileDamageLine" variant="panel" />
     );
   }
 

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -1,12 +1,13 @@
-import {AnnotationCard, QueryLoadError, type QueryLoadErrorQuery} from '@shipfox/client-ui';
+import {QueryLoadError, type QueryLoadErrorQuery} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
-import {Callout} from '@shipfox/react-ui/callout';
+import {Callout, CalloutContent} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
-import {useState} from 'react';
+import {type ReactNode, useState} from 'react';
 import type {RunAnnotationEntry, RunAnnotationStyle} from '#core/run-annotation.js';
-import {RunAnnotationItem} from './run-annotation-item.js';
+import {RunAnnotationItem, RunDerivedAnnotationItem} from './run-annotation-item.js';
 import {RunAnnotationsEmpty} from './run-annotations-empty.js';
 
 export interface RunAnnotationListQuery extends QueryLoadErrorQuery {
@@ -31,13 +32,12 @@ export interface RunAnnotationListProps {
   filteredSeverity?: string | undefined;
   filtered: boolean;
   onClearFilters?: (() => void) | undefined;
-  /** Annotation id from `?annotation=`, which the matching card scrolls to and focuses. */
-  selectedAnnotationId?: string | undefined;
 }
 
 export interface DerivedRunAnnotation {
   id: string;
   style: RunAnnotationStyle;
+  jobName: string;
   body: string;
 }
 
@@ -51,7 +51,11 @@ export interface DerivedRunAnnotation {
 const RENDER_WINDOW = 25;
 
 /**
- * The annotations list.
+ * The annotations list, and the whole body of the panel it sits in.
+ *
+ * It owns the panel body rather than being dropped into a padded one, because each of its
+ * states wants a different treatment: rows are flush cells divided by hairlines, an empty state
+ * fills the body, and the banners above and below the rows are bands with their own padding.
  *
  * Loading, empty, error, and stale are four distinct renderings on purpose: coalescing a failed
  * fetch into an empty result tells a reader their run is clean when the truth is unknown.
@@ -68,31 +72,28 @@ export function RunAnnotationList({
   filteredSeverity,
   filtered,
   onClearFilters,
-  selectedAnnotationId,
 }: RunAnnotationListProps) {
   const [visibleCount, setVisibleCount] = useState(RENDER_WINDOW);
-
-  // A deep-linked annotation past the window would otherwise be unreachable: it is in the data,
-  // absent from the DOM, and nothing on screen says so.
-  const selectedIndex = selectedAnnotationId
-    ? (entries?.findIndex((entry) => entry.annotation.id === selectedAnnotationId) ?? -1)
-    : -1;
-  const renderCount = Math.max(visibleCount, selectedIndex + 1);
 
   if (query.isPending) return <RunAnnotationListSkeleton />;
 
   if (query.isError && entries === undefined) {
-    return <QueryLoadError query={query} subject="annotations" icon="fileDamageLine" />;
+    return (
+      <PanelBody className="p-panel">
+        <QueryLoadError query={query} subject="annotations" icon="fileDamageLine" />
+      </PanelBody>
+    );
   }
 
   if (entries === undefined) return <RunAnnotationListSkeleton />;
 
-  const visible = entries.slice(0, renderCount);
+  const visible = entries.slice(0, visibleCount);
   const hiddenCount = entries.length - visible.length;
-  const hasContent = entries.length > 0 || derivedAnnotations.length > 0;
+  const totalCount = entries.length + derivedAnnotations.length;
+  const hasContent = totalCount > 0;
 
   return (
-    <div className="flex min-w-0 flex-col gap-cluster">
+    <>
       {query.isError ? <RunAnnotationStaleError query={query} /> : null}
 
       {!hasContent ? (
@@ -107,50 +108,70 @@ export function RunAnnotationList({
           <RunAnnotationsEmpty />
         )
       ) : (
-        <ol className="flex min-w-0 flex-col gap-cluster">
-          {visible.map((entry) => (
-            <RunAnnotationItem
-              key={entry.annotation.id}
-              entry={entry}
-              workspaceSlug={workspaceSlug}
-              projectSlug={projectSlug}
-              workflowRunId={workflowRunId}
-              runAttempt={runAttempt}
-              selected={entry.annotation.id === selectedAnnotationId}
-            />
-          ))}
-          {derivedAnnotations.map((annotation) => (
-            <li key={annotation.id}>
-              <AnnotationCard style={annotation.style} body={annotation.body} />
-            </li>
-          ))}
-        </ol>
+        <PanelBody asChild>
+          <ol>
+            {/* A job that failed before it ever created an execution is the most upstream thing
+                in the run, and it has no step to link to. It leads rather than trailing behind a
+                render window that could bury it. */}
+            {derivedAnnotations.map((annotation) => (
+              <RunDerivedAnnotationItem
+                key={annotation.id}
+                style={annotation.style}
+                jobName={annotation.jobName}
+                body={annotation.body}
+              />
+            ))}
+            {visible.map((entry) => (
+              <RunAnnotationItem
+                key={entry.annotation.id}
+                entry={entry}
+                workspaceSlug={workspaceSlug}
+                projectSlug={projectSlug}
+                workflowRunId={workflowRunId}
+                runAttempt={runAttempt}
+              />
+            ))}
+          </ol>
+        </PanelBody>
       )}
 
       {hiddenCount > 0 ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          className="self-start [@media(pointer:coarse)]:min-h-44"
-          onClick={() => setVisibleCount((current) => current + RENDER_WINDOW)}
-        >
-          Show {Math.min(hiddenCount, RENDER_WINDOW)} more of {entries.length}
-        </Button>
+        <RunAnnotationListFooter>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="[@media(pointer:coarse)]:min-h-44"
+            onClick={() => setVisibleCount((current) => current + RENDER_WINDOW)}
+          >
+            Show {Math.min(hiddenCount, RENDER_WINDOW)} more of {totalCount}
+          </Button>
+        </RunAnnotationListFooter>
       ) : query.hasNextPage ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          className="self-start [@media(pointer:coarse)]:min-h-44"
-          isLoading={query.isFetchingNextPage}
-          onClick={() => {
-            void query.fetchNextPage();
-          }}
-        >
-          Load more annotations
-        </Button>
+        <RunAnnotationListFooter>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="[@media(pointer:coarse)]:min-h-44"
+            isLoading={query.isFetchingNextPage}
+            onClick={() => {
+              void query.fetchNextPage();
+            }}
+          >
+            Load more annotations
+          </Button>
+        </RunAnnotationListFooter>
       ) : null}
+    </>
+  );
+}
+
+/** A band below the rows, separated by the same hairline that divides them. */
+function RunAnnotationListFooter({children}: {children: ReactNode}) {
+  return (
+    <div className="flex border-t border-border-neutral-base bg-background-neutral-base px-row py-row">
+      {children}
     </div>
   );
 }
@@ -202,24 +223,25 @@ function RunAnnotationsFilteredEmpty({
   onClearFilters: (() => void) | undefined;
 }) {
   return (
-    <div className="flex flex-col items-center gap-cluster">
-      <EmptyState
-        icon="fileDamageLine"
-        title={incomplete ? 'No matches in loaded annotations' : 'No matching annotations'}
-        description={filteredEmptyDescription({jobName, severity, incomplete})}
-      />
-      {onClearFilters ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          className="[@media(pointer:coarse)]:min-h-44"
-          onClick={onClearFilters}
-        >
-          Clear filters
-        </Button>
-      ) : null}
-    </div>
+    <EmptyState
+      variant="panel"
+      icon="fileDamageLine"
+      title={incomplete ? 'No matches in loaded annotations' : 'No matching annotations'}
+      description={filteredEmptyDescription({jobName, severity, incomplete})}
+      action={
+        onClearFilters ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="[@media(pointer:coarse)]:min-h-44"
+            onClick={onClearFilters}
+          >
+            Clear filters
+          </Button>
+        ) : null
+      }
+    />
   );
 }
 
@@ -227,26 +249,31 @@ function RunAnnotationsFilteredEmpty({
  * A failed poll keeps the annotations already on screen and marks them stale rather than
  * clearing. Polite rather than assertive: the poll runs every 4s and a flapping API would
  * otherwise interrupt a screen reader on every cycle.
+ *
+ * A band inside the panel rather than a bordered notice, because the hairline below it already
+ * separates it from the rows and a second frame would be a box inside a box.
  */
 function RunAnnotationStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
-    <Callout role="status" aria-live="polite" type="error">
-      <div className="flex w-full items-center justify-between gap-inline">
-        <Text size="xs">Could not refresh annotations.</Text>
-        <Button
-          type="button"
-          size="2xs"
-          variant="secondary"
-          className="[@media(pointer:coarse)]:min-h-44"
-          isLoading={query.isFetching}
-          onClick={() => {
-            void query.refetch();
-          }}
-        >
-          Retry
-        </Button>
-      </div>
-    </Callout>
+    <div className="border-b border-border-neutral-base bg-background-neutral-base px-row py-row">
+      <Callout role="status" aria-live="polite" type="error" variant="secondary">
+        <CalloutContent className="flex items-center justify-between gap-inline">
+          <Text size="xs">Could not refresh annotations.</Text>
+          <Button
+            type="button"
+            size="2xs"
+            variant="secondary"
+            className="[@media(pointer:coarse)]:min-h-44"
+            isLoading={query.isFetching}
+            onClick={() => {
+              void query.refetch();
+            }}
+          >
+            Retry
+          </Button>
+        </CalloutContent>
+      </Callout>
+    </div>
   );
 }
 
@@ -254,20 +281,25 @@ const ANNOTATION_SKELETON_ROWS = ['first', 'second', 'third'];
 
 function RunAnnotationListSkeleton() {
   return (
-    <section aria-label="Loading annotations" className="flex flex-col gap-cluster">
-      {ANNOTATION_SKELETON_ROWS.map((row) => (
-        <div
-          key={row}
-          className="flex gap-cluster rounded-8 border border-border-neutral-base bg-background-components-base px-[12px] py-[8px]"
-        >
-          <Skeleton className="h-40 w-4 rounded-full" />
-          <div className="flex min-w-0 flex-1 flex-col gap-inline">
-            <Skeleton className="h-20 w-160 rounded-4" />
-            <Skeleton className="h-16 w-240 rounded-4" />
-            <Skeleton className="h-40 w-full rounded-4" />
-          </div>
-        </div>
-      ))}
-    </section>
+    <PanelBody asChild>
+      <ul aria-label="Loading annotations" role="status">
+        {ANNOTATION_SKELETON_ROWS.map((row) => (
+          <PanelRow
+            asChild
+            key={row}
+            className="items-start justify-start gap-cluster hover:bg-background-neutral-base"
+          >
+            <li>
+              <Skeleton className="size-16 shrink-0 rounded-full" />
+              <div className="flex min-w-0 flex-1 flex-col gap-inline">
+                <Skeleton className="h-20 w-160 rounded-4" />
+                <Skeleton className="h-16 w-240 rounded-4" />
+                <Skeleton className="h-40 w-full rounded-4" />
+              </div>
+            </li>
+          </PanelRow>
+        ))}
+      </ul>
+    </PanelBody>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.test.tsx
@@ -94,15 +94,6 @@ describe('RunAnnotationSummaryLine', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  test('clears a stale annotation when linking to a severity', async () => {
-    await renderSummaryLine({annotation: 'annotation-old'});
-
-    expect(screen.getByRole('link', {name: '2 errors'})).toHaveAttribute(
-      'href',
-      '/w/acme/p/project/runs/run-1?tab=annotations&severity=error',
-    );
-  });
-
   test('marks a truncated read as a lower bound', async () => {
     await renderSummaryLine({}, {...ANNOTATION_SUMMARY, truncated: true});
 

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-summary-line.tsx
@@ -130,18 +130,11 @@ function SeverityLink({
     return <span className="inline-flex items-center gap-tight">{content}</span>;
   }
 
-  const searchWithoutAnnotation = withoutAnnotation(search);
-
   return (
     <Link
       to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
       params={{workspaceSlug, projectSlug, workflowRunId}}
-      search={
-        workflowRunSearchParams(
-          {...searchWithoutAnnotation, tab: 'annotations', severity},
-          search,
-        ) as never
-      }
+      search={workflowRunSearchParams({...search, tab: 'annotations', severity}, search) as never}
       className="inline-flex items-center gap-tight rounded-4 outline-none hover:underline focus-visible:shadow-border-interactive-with-active"
     >
       {content}
@@ -149,15 +142,8 @@ function SeverityLink({
   );
 }
 
-/** A selected annotation is stale the moment the list it was chosen from is refiltered. */
-function withoutAnnotation(search: WorkflowRunsSearch): WorkflowRunsSearch {
-  const next = {...search};
-  delete next.annotation;
-  return next;
-}
-
 function withoutSeverity(search: WorkflowRunsSearch): WorkflowRunsSearch {
-  const next = withoutAnnotation(search);
+  const next = {...search};
   delete next.severity;
   return next;
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations-empty.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations-empty.tsx
@@ -3,6 +3,7 @@ import {EmptyState} from '@shipfox/react-ui/empty-state';
 export function RunAnnotationsEmpty({jobName}: {jobName?: string | undefined} = {}) {
   return (
     <EmptyState
+      variant="panel"
       icon="fileDamageLine"
       title="No annotations"
       description={

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
@@ -1,3 +1,4 @@
+import {Panel, PanelHeader} from '@shipfox/react-ui/panel';
 import type {Meta, StoryObj} from '@storybook/react';
 import type {ReactNode} from 'react';
 import {
@@ -14,7 +15,11 @@ import {
   workflowStepDto,
 } from '#test/fixtures/workflow-run.js';
 import {RunAnnotationCountChip} from './run-annotation-count-chip.js';
-import {RunAnnotationList, type RunAnnotationListQuery} from './run-annotation-list.js';
+import {
+  type DerivedRunAnnotation,
+  RunAnnotationList,
+  type RunAnnotationListQuery,
+} from './run-annotation-list.js';
 import {RunAnnotationSummaryLine} from './run-annotation-summary-line.js';
 
 const WORKSPACE_SLUG = 'acme';
@@ -37,6 +42,12 @@ const LONG_BODY = [
     (_unused, index) => `- \`packages/web/src/route-${index}.test.ts\` expected 200, received 503`,
   ),
 ].join('\n');
+
+/**
+ * An agent step with no `name` is labelled by its prompt, which the server has already cut.
+ * The row must hold that to one line rather than letting a severed sentence sprawl.
+ */
+const UNNAMED_AGENT_STEP = 'claude-fable-5 · Reply to this prompt with exactly "Hello world". Then';
 
 const meta = {
   title: 'Workflows/RunAnnotations',
@@ -68,6 +79,15 @@ export const Playground: Story = {
         originStepId: TEST_STEP_ID,
         body: '2 specs retried before passing.\n\n| Spec | Retries |\n| --- | --- |\n| `checkout.spec.ts` | 1 |\n| `billing.spec.ts` | 2 |',
       }),
+      // No context of its own: the server minted the key from the failing step, so the row falls
+      // back to naming its job.
+      annotation({
+        id: 'a5',
+        context: `failure:step:${BUILD_STEP_ID}`,
+        style: 'error',
+        sequence: 5,
+        body: '**Step failed**\n\nReason: `agent_config_invalid`\nExit code: `none`\n\nHarness "claude" only supports provider "anthropic"; received "shipfox".',
+      }),
       annotation({
         id: 'a3',
         context: 'deploy',
@@ -84,17 +104,23 @@ export const Playground: Story = {
       }),
     ];
 
-    return <AnnotationsFrame annotations={annotations} />;
+    return (
+      <AnnotationsFrame
+        annotations={annotations}
+        derivedAnnotations={[
+          {
+            id: 'derived-deploy',
+            style: 'warning',
+            jobName: 'deploy production',
+            body: 'Skipped before an execution was created.\n\nReview its dependencies or condition before re-running.\nReason: `dependency_failed`',
+          },
+        ]}
+      />
+    );
   },
 };
 
 export const BoundedBody: Story = {
-  // The only story in this package that earns a second Argos mode. The clamp's fade is the one
-  // gradient in the client, and it blends a surface token that flips with the theme, so a
-  // dark-only capture would never catch it breaking on a light card.
-  parameters: {
-    argos: {modes: {dark: {theme: 'dark'}, light: {theme: 'light'}}},
-  },
   render: () => (
     <AnnotationsFrame
       annotations={[
@@ -130,12 +156,50 @@ export const DataStates: Story = {
         <StateExample label="Filtered miss">
           <AnnotationsList annotations={[]} filtered filteredJobName="build" />
         </StateExample>
-        <StateExample label="Truncated counts">
-          <RunAnnotationSummaryLine
-            summary={{...summarizeRunAnnotations(loaded), total: 500, error: 12, truncated: true}}
-            workspaceSlug={WORKSPACE_SLUG}
-            projectSlug={PROJECT_SLUG}
-            workflowRunId={RUN_ID}
+        {/* A filtered miss while a page is still unread says so, and offers the fetch that could
+            still find a match. The two states share a panel and must not read as the same one. */}
+        <StateExample label="Filtered miss, page unread">
+          <AnnotationsList
+            annotations={[]}
+            filtered
+            filteredSeverity="error"
+            query={storyQuery({hasNextPage: true})}
+          />
+        </StateExample>
+        {/* The footer band against the last row: `border-t` meeting `last:border-b-0` is one
+            hairline or two, and only a capture with rows above it shows which.
+            The sibling "Show N more of M" band is the same chrome with a different label, and its
+            counting is pinned by a unit test, so it is not captured here at 25 rows. */}
+        <StateExample label="Another page to load">
+          <AnnotationsList
+            annotations={[
+              annotation({id: 'p1', context: 'deploy', style: 'success'}),
+              annotation({id: 'p2', context: 'coverage', style: 'info', sequence: 2}),
+            ]}
+            query={storyQuery({hasNextPage: true})}
+          />
+        </StateExample>
+        {/* `default` carries no severity, so it is the one style with a neutral glyph and nothing
+            announced to a screen reader. */}
+        <StateExample label="No severity">
+          <AnnotationsList
+            annotations={[annotation({id: 'plain', context: 'release notes', style: 'default'})]}
+          />
+        </StateExample>
+        <StateExample label="Unnamed agent step">
+          <AnnotationsList
+            annotations={[
+              annotation({
+                id: 'unnamed',
+                context: `failure:step:${TEST_STEP_ID}`,
+                style: 'error',
+                jobId: TEST_JOB_ID,
+                jobExecutionId: TEST_EXECUTION_ID,
+                originStepId: TEST_STEP_ID,
+                body: 'Reason: `agent_config_invalid`',
+              }),
+            ]}
+            jobs={jobsWithUnnamedAgentStep}
           />
         </StateExample>
       </div>
@@ -166,45 +230,82 @@ export const CountChips: Story = {
   ),
 };
 
-function AnnotationsFrame({annotations}: {annotations: RunAnnotationRecord[]}) {
+function AnnotationsFrame({
+  annotations,
+  derivedAnnotations,
+}: {
+  annotations: RunAnnotationRecord[];
+  derivedAnnotations?: readonly DerivedRunAnnotation[];
+}) {
   return (
-    <div className="min-h-screen bg-background-neutral-base py-16">
-      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-16 px-24">
-        <RunAnnotationSummaryLine
+    <div className="min-h-screen bg-background-subtle-base py-16">
+      <div className="mx-auto flex w-full max-w-[1120px] flex-col px-24">
+        <AnnotationsList
+          annotations={annotations}
+          derivedAnnotations={derivedAnnotations}
           summary={summarizeRunAnnotations(annotations)}
-          workspaceSlug={WORKSPACE_SLUG}
-          projectSlug={PROJECT_SLUG}
-          workflowRunId={RUN_ID}
         />
-        <AnnotationsList annotations={annotations} />
       </div>
     </div>
   );
 }
 
+/**
+ * The list is the body of a panel, so every story renders it inside one. Capturing it loose on
+ * the canvas would hide the thing most likely to break: whether its rows read as cells of the
+ * panel or as tiles floating inside it.
+ */
 function AnnotationsList({
   annotations,
+  derivedAnnotations,
+  jobs: jobsOverride,
   query = storyQuery(),
   filtered = false,
   filteredJobName,
+  filteredSeverity,
+  summary,
 }: {
   annotations: RunAnnotationRecord[];
+  derivedAnnotations?: readonly DerivedRunAnnotation[];
+  jobs?: Job[];
   query?: RunAnnotationListQuery;
   filtered?: boolean;
   filteredJobName?: string;
+  filteredSeverity?: string;
+  summary?: ReturnType<typeof summarizeRunAnnotations>;
 }) {
+  const resolvedJobs = jobsOverride ?? jobs;
+
   return (
-    <RunAnnotationList
-      query={query}
-      entries={query.data === undefined ? undefined : buildRunAnnotationList({annotations, jobs})}
-      workspaceSlug={WORKSPACE_SLUG}
-      projectSlug={PROJECT_SLUG}
-      workflowRunId={RUN_ID}
-      runAttempt={1}
-      filtered={filtered}
-      filteredJobName={filteredJobName}
-      onClearFilters={() => undefined}
-    />
+    <Panel>
+      {summary ? (
+        <PanelHeader className="flex-wrap">
+          <RunAnnotationSummaryLine
+            summary={summary}
+            workspaceSlug={WORKSPACE_SLUG}
+            projectSlug={PROJECT_SLUG}
+            workflowRunId={RUN_ID}
+          />
+        </PanelHeader>
+      ) : null}
+      <RunAnnotationList
+        query={query}
+        entries={
+          query.data === undefined
+            ? undefined
+            : buildRunAnnotationList({annotations, jobs: resolvedJobs})
+        }
+        derivedAnnotations={derivedAnnotations}
+        workspaceSlug={WORKSPACE_SLUG}
+        projectSlug={PROJECT_SLUG}
+        workflowRunId={RUN_ID}
+        runAttempt={1}
+        filtered={filtered}
+        filteredJobName={filteredJobName}
+        filteredSeverity={filteredSeverity}
+        onClearFilters={() => undefined}
+      />
+    </Panel>
   );
 }
 
@@ -282,6 +383,31 @@ const jobs: Job[] = [
           workflowStepDto({
             id: TEST_STEP_ID,
             name: 'vitest',
+            attempts: [
+              workflowStepAttemptDto({id: TEST_ATTEMPT_ID, step_id: TEST_STEP_ID, attempt: 1}),
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+];
+
+const jobsWithUnnamedAgentStep: Job[] = [
+  jobs[0] as Job,
+  workflowJob({
+    id: TEST_JOB_ID,
+    key: 'test',
+    name: 'Hello world on Anthropic models with Claude',
+    position: 1,
+    job_executions: [
+      workflowJobExecutionDto({
+        id: TEST_EXECUTION_ID,
+        job_id: TEST_JOB_ID,
+        steps: [
+          workflowStepDto({
+            id: TEST_STEP_ID,
+            name: UNNAMED_AGENT_STEP,
             attempts: [
               workflowStepAttemptDto({id: TEST_ATTEMPT_ID, step_id: TEST_STEP_ID, attempt: 1}),
             ],

--- a/libs/client/workflows/src/components/workflow-run-tabs/severity-visuals.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/severity-visuals.ts
@@ -1,18 +1,15 @@
+import {ANNOTATION_STYLE_ICON, ANNOTATION_STYLE_TONE} from '@shipfox/client-ui';
 import type {IconName} from '@shipfox/react-ui/icon';
 import type {RunAnnotationSeverity} from '#core/run-annotation.js';
 
 /**
  * The glyph vocabulary for annotation severity, shared by every count surface.
  *
- * Deliberately the same marks the `Callout` uses on the cards themselves, so the glyph beside
- * `1 error` in the summary is the glyph on the error card below it.
+ * Re-exported rather than restated: these are the same marks the annotation rows render, so the
+ * glyph beside `1 error` in the summary is the glyph on the error row below it, by construction
+ * rather than by two lists agreeing.
  */
-export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> = {
-  error: 'closeCircleFill',
-  warning: 'errorWarningFill',
-  info: 'info',
-  success: 'checkboxCircleFill',
-};
+export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> = ANNOTATION_STYLE_ICON;
 
 /**
  * Severity tone lives in the glyph, never in the label.
@@ -21,12 +18,7 @@ export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> = {
  * reserves for links, focus, and "you are here". Shape plus tone in a 12px mark distinguishes
  * an error from a warning without either of them shouting.
  */
-export const SEVERITY_ICON_TONE: Record<RunAnnotationSeverity, string> = {
-  error: 'text-tag-error-icon',
-  warning: 'text-tag-warning-icon',
-  info: 'text-tag-blue-icon',
-  success: 'text-tag-success-icon',
-};
+export const SEVERITY_ICON_TONE: Record<RunAnnotationSeverity, string> = ANNOTATION_STYLE_TONE;
 
 /** Hairline tone for a bordered count chip, matching the glyph it sits beside. */
 export const SEVERITY_CHIP_TONE: Record<RunAnnotationSeverity, string> = {

--- a/libs/client/workflows/src/components/workflow-run-tabs/severity-visuals.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/severity-visuals.ts
@@ -1,15 +1,27 @@
 import {ANNOTATION_STYLE_ICON, ANNOTATION_STYLE_TONE} from '@shipfox/client-ui';
 import type {IconName} from '@shipfox/react-ui/icon';
-import type {RunAnnotationSeverity} from '#core/run-annotation.js';
+import {RUN_ANNOTATION_SEVERITIES, type RunAnnotationSeverity} from '#core/run-annotation.js';
+
+/**
+ * Narrows an annotation-style map to the severities the run surfaces rank and filter by.
+ *
+ * Built by picking keys rather than by annotating the wider map, so the `default` style cannot
+ * ride along invisibly behind the type and reappear the first time a caller iterates these.
+ */
+function bySeverity<Value>(styleMap: Record<RunAnnotationSeverity, Value>) {
+  return Object.fromEntries(
+    RUN_ANNOTATION_SEVERITIES.map((severity) => [severity, styleMap[severity]]),
+  ) as Record<RunAnnotationSeverity, Value>;
+}
 
 /**
  * The glyph vocabulary for annotation severity, shared by every count surface.
  *
- * Re-exported rather than restated: these are the same marks the annotation rows render, so the
- * glyph beside `1 error` in the summary is the glyph on the error row below it, by construction
- * rather than by two lists agreeing.
+ * Derived from the marks the annotation rows render rather than restated, so the glyph beside
+ * `1 error` in the summary is the glyph on the error row below it by construction.
  */
-export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> = ANNOTATION_STYLE_ICON;
+export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> =
+  bySeverity(ANNOTATION_STYLE_ICON);
 
 /**
  * Severity tone lives in the glyph, never in the label.
@@ -18,7 +30,8 @@ export const SEVERITY_ICON: Record<RunAnnotationSeverity, IconName> = ANNOTATION
  * reserves for links, focus, and "you are here". Shape plus tone in a 12px mark distinguishes
  * an error from a warning without either of them shouting.
  */
-export const SEVERITY_ICON_TONE: Record<RunAnnotationSeverity, string> = ANNOTATION_STYLE_TONE;
+export const SEVERITY_ICON_TONE: Record<RunAnnotationSeverity, string> =
+  bySeverity(ANNOTATION_STYLE_TONE);
 
 /** Hairline tone for a bordered count chip, matching the glyph it sits beside. */
 export const SEVERITY_CHIP_TONE: Record<RunAnnotationSeverity, string> = {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -79,6 +79,9 @@ const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
 });
 const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({attempts: []});
 
+/** Stable identity: a fresh `[]` per render would retrigger the API-client effect every render. */
+const NO_ANNOTATIONS: AnnotationDto[] = [];
+
 const RUN_ANNOTATIONS: AnnotationDto[] = [
   annotationDto({
     id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001',
@@ -105,7 +108,7 @@ const RUN_ANNOTATIONS: AnnotationDto[] = [
 
 const withRunApi: Decorator = (Story, context) => (
   <RunWorkspaceStoryProviders
-    annotations={(context.parameters.annotations ?? []) as AnnotationDto[]}
+    annotations={(context.parameters.annotations ?? NO_ANNOTATIONS) as AnnotationDto[]}
   >
     <Story />
   </RunWorkspaceStoryProviders>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -1,3 +1,4 @@
+import type {AnnotationDto} from '@shipfox/annotations-dto';
 import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
@@ -6,7 +7,10 @@ import {type ReactNode, useEffect, useState} from 'react';
 import {
   runAttemptsResponseDto,
   workflowJobDto,
+  workflowJobExecutionDto,
   workflowRunDetailDto,
+  workflowStepAttemptDto,
+  workflowStepDto,
 } from '#test/fixtures/workflow-run.js';
 import {WorkflowRunView} from './workflow-run-view.js';
 
@@ -14,6 +18,10 @@ const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
 const RUN_ID = '11111111-1111-4111-8111-111111111111';
 const RUN_STARTED_AT = '2026-06-26T11:57:00.000Z';
 const RUN_FINISHED_AT = '2026-06-26T11:59:00.000Z';
+const BUILD_JOB_ID = '44444444-4444-4444-8444-00000000000b';
+const BUILD_EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
+const BUILD_STEP_ID = '55555555-5555-4555-8555-00000000000b';
+const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
 
 const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
   id: RUN_ID,
@@ -25,10 +33,33 @@ const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
   has_started_job_execution: true,
   jobs: [
     workflowJobDto({
+      id: BUILD_JOB_ID,
       key: 'build',
       name: 'build',
       status: 'succeeded',
       position: 0,
+      job_executions: [
+        workflowJobExecutionDto({
+          id: BUILD_EXECUTION_ID,
+          job_id: BUILD_JOB_ID,
+          status: 'succeeded',
+          steps: [
+            workflowStepDto({
+              id: BUILD_STEP_ID,
+              name: 'run smoke checks',
+              status: 'succeeded',
+              attempts: [
+                workflowStepAttemptDto({
+                  id: BUILD_ATTEMPT_ID,
+                  step_id: BUILD_STEP_ID,
+                  attempt: 1,
+                  status: 'succeeded',
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
     }),
     workflowJobDto({
       key: 'deploy',
@@ -48,8 +79,34 @@ const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
 });
 const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({attempts: []});
 
-const withRunApi: Decorator = (Story) => (
-  <RunWorkspaceStoryProviders>
+const RUN_ANNOTATIONS: AnnotationDto[] = [
+  annotationDto({
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001',
+    context: 'smoke check',
+    style: 'error',
+    sequence: 3,
+    body: 'Task nine failed the smoke check against `https://preview.example.com`.\n\n```sh\ncurl -sSf https://preview.example.com/healthz\n```',
+  }),
+  annotationDto({
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002',
+    context: 'flaky tests',
+    style: 'warning',
+    sequence: 2,
+    body: '2 specs retried before passing.',
+  }),
+  annotationDto({
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000003',
+    context: 'deploy',
+    style: 'success',
+    sequence: 1,
+    body: 'Deployed **v42** to staging.',
+  }),
+];
+
+const withRunApi: Decorator = (Story, context) => (
+  <RunWorkspaceStoryProviders
+    annotations={(context.parameters.annotations ?? []) as AnnotationDto[]}
+  >
     <Story />
   </RunWorkspaceStoryProviders>
 );
@@ -91,7 +148,39 @@ type Story = StoryObj<typeof meta>;
 
 export const WideViewport: Story = {};
 
-function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
+/**
+ * The annotations section in the page frame it actually ships in.
+ *
+ * The standalone `Workflows/RunAnnotations` stories capture the panel on its own, which cannot
+ * show the two things that only exist here: the rail marking the section, and how the panel and
+ * its rows sit against the run header and the frame gutters.
+ */
+export const Annotations: Story = {
+  parameters: {annotations: RUN_ANNOTATIONS},
+  args: {tab: 'annotations'},
+};
+
+function annotationDto(overrides: Partial<AnnotationDto> & {id: string}): AnnotationDto {
+  return {
+    job_id: BUILD_JOB_ID,
+    job_execution_id: BUILD_EXECUTION_ID,
+    origin_step_id: BUILD_STEP_ID,
+    origin_step_attempt: 1,
+    context: 'default',
+    style: 'default',
+    sequence: 1,
+    body: 'Body',
+    ...overrides,
+  };
+}
+
+function RunWorkspaceStoryProviders({
+  annotations,
+  children,
+}: {
+  annotations: AnnotationDto[];
+  children: ReactNode;
+}) {
   const [queryClient] = useState(
     () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
   );
@@ -107,7 +196,7 @@ function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
         const response =
           path === '/annotations'
             ? {
-                body: {annotations: [], has_more: false, next_cursor: null},
+                body: {annotations, has_more: false, next_cursor: null},
                 status: 200,
               }
             : path === `/workflows/runs/${RUN_ID}/attempts`
@@ -126,7 +215,7 @@ function RunWorkspaceStoryProviders({children}: {children: ReactNode}) {
     return () => {
       configureApiClient({baseUrl: '', fetchImpl: undefined});
     };
-  }, []);
+  }, [annotations]);
 
   if (!configured) return null;
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -223,30 +223,6 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByRole('button', {name: SHOW_MORE_PATTERN})).not.toBeInTheDocument();
   });
 
-  test('focuses a deep-linked annotation beyond the render window', async () => {
-    const deepLinkedId = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000029';
-    configureRunFetch(
-      Array.from({length: 30}, (_unused, index) =>
-        annotationDto({
-          id:
-            index === 29
-              ? deepLinkedId
-              : `aaaaaaaa-aaaa-4aaa-8aaa-${String(index).padStart(12, '0')}`,
-          context: `context-${index}`,
-          sequence: index + 1,
-        }),
-      ),
-    );
-
-    renderView({tab: 'annotations', selection: {annotation: deepLinkedId}});
-
-    const target = await screen.findByRole('heading', {level: 3, name: 'context-29'});
-    const selected = target.closest('li');
-    await waitFor(() => expect(selected).toHaveFocus());
-    expect(selected).toHaveAttribute('aria-current', 'true');
-    expect(selected).toHaveClass('shadow-border-interactive-with-active');
-  });
-
   test('separates a filtered miss from a run with no annotations', async () => {
     configureRunFetch([annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info'})]);
 
@@ -290,7 +266,6 @@ describe('WorkflowRunView', () => {
         stepId: BUILD_STEP_ID,
         stepAttemptId: BUILD_ATTEMPT_ID,
         severity: 'error',
-        annotation: ANNOTATION_ID_ONE,
       },
     });
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -650,6 +650,7 @@ function AnnotationJobFilter({
   const sortedJobs = [...jobs].sort(
     (left, right) => left.position - right.position || left.id.localeCompare(right.id),
   );
+  const selectedJobName = jobs.find((job) => job.id === selectedJobId)?.displayName;
 
   return (
     <Select
@@ -659,6 +660,9 @@ function AnnotationJobFilter({
       <SelectTrigger
         size="small"
         aria-label="Filter annotations by job"
+        // Job names are user-authored and the trigger truncates them. Radix renders the value
+        // itself, so only a caller that knows the selected job can offer the full name back.
+        title={selectedJobName ?? 'All jobs'}
         className="w-full min-[480px]:w-240"
       >
         <SelectValue />

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -263,7 +263,6 @@ function RunViewContent({
     delete nextSearch.stepId;
     delete nextSearch.stepAttemptId;
     delete nextSearch.severity;
-    delete nextSearch.annotation;
 
     void navigate({
       to: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId',
@@ -396,7 +395,7 @@ function RunSectionContent({
     return (
       <section
         aria-label="All jobs summary"
-        className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
+        className="min-h-0 flex-1 overflow-auto pb-panel pt-panel-compact"
       >
         <div className="flex w-full flex-col gap-group">
           <Text as="h2" className="sr-only">
@@ -436,7 +435,7 @@ function RunSectionContent({
   return (
     <section
       aria-label="Workflow source"
-      className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
+      className="min-h-0 flex-1 overflow-auto pb-panel pt-panel-compact"
     >
       <div className="flex min-h-full w-full flex-col">
         <Text as="h2" className="sr-only">
@@ -525,6 +524,7 @@ function RunAnnotationsSection({
       .map((job) => ({
         id: `derived-${job.id}`,
         style: job.status === 'failed' ? 'error' : 'warning',
+        jobName: job.displayName,
         body: derivedJobAnnotation(job),
       }));
   }, [records, run.jobs, selectedJob, selection]);
@@ -536,7 +536,7 @@ function RunAnnotationsSection({
   return (
     <section
       aria-label="Run annotations"
-      className="min-h-0 flex-1 overflow-auto pb-panel pt-[16px]"
+      className="min-h-0 flex-1 overflow-auto pb-panel pt-panel-compact"
     >
       <div className="flex w-full flex-col">
         <Text as="h2" className="sr-only">
@@ -557,29 +557,28 @@ function RunAnnotationsSection({
               onSelect={onSelectAnnotationJob}
             />
           </PanelHeader>
-          <PanelBody className="gap-group p-panel">
-            <RunAnnotationList
-              // Remounting on a filter or run-attempt change resets the render window, so the next
-              // list never inherits a "show more" position from different data.
-              key={`${run.id}:${run.runAttempt.attempt}:${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
-              query={annotations.query}
-              entries={entries}
-              derivedAnnotations={derivedAnnotations}
-              workspaceSlug={workspaceSlug}
-              projectSlug={projectSlug}
-              workflowRunId={run.id}
-              runAttempt={run.runAttempt.attempt}
-              // A run with no annotations at all offers no filter to clear, whatever the URL says.
-              filtered={Boolean(
-                (severity || selectedJob || selection?.annotation) &&
-                  ((annotationSummary?.total ?? 0) > 0 || hasSynthesizedJobAnnotations),
-              )}
-              filteredJobName={selectedJob?.displayName}
-              filteredSeverity={severity}
-              onClearFilters={onClearAnnotationFilters}
-              selectedAnnotationId={selection?.annotation}
-            />
-          </PanelBody>
+          {/* The list owns the panel body: its rows are flush cells divided by the panel's own
+              hairlines, and each of its other states wants its own padding. */}
+          <RunAnnotationList
+            // Remounting on a filter or run-attempt change resets the render window, so the next
+            // list never inherits a "show more" position from different data.
+            key={`${run.id}:${run.runAttempt.attempt}:${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
+            query={annotations.query}
+            entries={entries}
+            derivedAnnotations={derivedAnnotations}
+            workspaceSlug={workspaceSlug}
+            projectSlug={projectSlug}
+            workflowRunId={run.id}
+            runAttempt={run.runAttempt.attempt}
+            // A run with no annotations at all offers no filter to clear, whatever the URL says.
+            filtered={Boolean(
+              (severity || selectedJob) &&
+                ((annotationSummary?.total ?? 0) > 0 || hasSynthesizedJobAnnotations),
+            )}
+            filteredJobName={selectedJob?.displayName}
+            filteredSeverity={severity}
+            onClearFilters={onClearAnnotationFilters}
+          />
         </Panel>
       </div>
     </section>
@@ -590,12 +589,10 @@ function matchesDerivedAnnotationFilters(
   style: 'warning' | 'error',
   selection: WorkflowRunsSearch | undefined,
 ): boolean {
-  if (selection?.severity && style !== selection.severity) return false;
-  // A selected annotation is a deep-link to a real annotation record. Synthetic diagnostics
-  // have no id or context, so they must not remain visible behind that selection.
-  return !selection?.annotation;
+  return !selection?.severity || style === selection.severity;
 }
 
+/** The row is titled by its job, so the body opens with what happened rather than repeating it. */
 function derivedJobAnnotation(job: Job): string {
   const reason = job.statusReason ? `Reason: \`${job.statusReason}\`` : null;
   const traceSummary = formatConditionEvaluation(job.evaluationTrace);
@@ -603,7 +600,7 @@ function derivedJobAnnotation(job: Job): string {
 
   if (job.status === 'skipped') {
     return [
-      `**${job.displayName}** was skipped before an execution was created.`,
+      'Skipped before an execution was created.',
       '',
       'Review its dependencies or condition before re-running.',
       details,
@@ -612,7 +609,7 @@ function derivedJobAnnotation(job: Job): string {
       .join('\n');
   }
   return [
-    `**${job.displayName}** failed before an execution was created.`,
+    'Failed before an execution was created.',
     '',
     'Check runner availability and workflow configuration before re-running.',
     details,

--- a/libs/client/workflows/src/routes/inputs.test.ts
+++ b/libs/client/workflows/src/routes/inputs.test.ts
@@ -121,9 +121,10 @@ describe('the job detail URL contract', () => {
   });
 
   test('accepts known tabs and annotation severities while dropping unknown values', () => {
-    expect(
-      validateWorkflowRunsSearch({tab: 'annotations', annotation: 'run-1', severity: 'error'}),
-    ).toEqual({tab: 'annotations', annotation: 'run-1', severity: 'error'});
+    expect(validateWorkflowRunsSearch({tab: 'annotations', severity: 'error'})).toEqual({
+      tab: 'annotations',
+      severity: 'error',
+    });
     expect(validateWorkflowRunsSearch({tab: 'unknown', severity: 'critical'})).toEqual({});
     expect(workflowRunTab({})).toBe('summary');
     expect(workflowRunTab({tab: 'source'})).toBe('source');
@@ -168,7 +169,6 @@ describe('the run list URL contract', () => {
       after: '2026-05-01',
       before: '2026-05-31',
       tab: 'annotations',
-      annotation: 'annotation-1',
       severity: 'warning',
     };
 
@@ -216,7 +216,6 @@ describe('the run list URL contract', () => {
         search: 'deploy',
         status: ['running'],
         tab: 'jobs',
-        annotation: 'annotation-1',
         severity: 'error',
         jobId: 'job-1',
       }),

--- a/libs/client/workflows/src/routes/inputs.ts
+++ b/libs/client/workflows/src/routes/inputs.ts
@@ -42,7 +42,6 @@ export interface WorkflowRunsSearch extends WorkflowRunSelectionInput {
   /** Inclusive upper bound on the run's local calendar date, `YYYY-MM-DD`. */
   before?: string;
   tab?: WorkflowRunTab;
-  annotation?: string;
   severity?: WorkflowRunAnnotationSeverity;
 }
 
@@ -76,7 +75,6 @@ export function validateWorkflowRunsSearch(input: Record<string, unknown>): Work
   const before = calendarDate(input.before);
   const tabValue = string(input.tab);
   const tab = tabValue && TAB_VALUES.has(tabValue) ? (tabValue as WorkflowRunTab) : undefined;
-  const annotation = string(input.annotation);
   const severityValue = string(input.severity);
   const severity =
     severityValue && ANNOTATION_SEVERITY_VALUES.has(severityValue)
@@ -93,7 +91,6 @@ export function validateWorkflowRunsSearch(input: Record<string, unknown>): Work
     ...(after ? {after} : {}),
     ...(before ? {before} : {}),
     ...(tab ? {tab} : {}),
-    ...(annotation ? {annotation} : {}),
     ...(severity ? {severity} : {}),
     ...workflowSelectionFromSearch(input, true),
   };
@@ -125,7 +122,6 @@ export function workflowRunSearchParams(
     ...(search.after ? {after: search.after} : {}),
     ...(search.before ? {before: search.before} : {}),
     ...(search.tab && search.tab !== 'summary' ? {tab: search.tab} : {}),
-    ...(search.annotation ? {annotation: search.annotation} : {}),
     ...(search.severity ? {severity: search.severity} : {}),
     ...workflowSelectionSearchParams(selection, true),
   };
@@ -145,7 +141,7 @@ export function workflowRunTab(
 
 /** Serializes only list filters when leaving a run detail page for the run list. */
 export function workflowRunListSearchParams(search: WorkflowRunsSearch) {
-  const {tab: _tab, annotation: _annotation, severity: _severity, ...listSearch} = search;
+  const {tab: _tab, severity: _severity, ...listSearch} = search;
   return workflowRunSearchParams(listSearch, {});
 }
 

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -1211,6 +1211,10 @@
   padding-bottom: var(--pad-panel);
 }
 
+@utility pt-panel-compact {
+  padding-top: var(--pad-panel-compact);
+}
+
 @utility px-tight {
   padding-inline: var(--pad-tight);
 }

--- a/libs/shared/react/ui/src/components/markdown/markdown.tsx
+++ b/libs/shared/react/ui/src/components/markdown/markdown.tsx
@@ -248,7 +248,9 @@ class MarkdownRenderGuard extends Component<MarkdownRenderGuardProps, MarkdownRe
     if (this.state.hasError) {
       return (
         <pre
-          className="min-w-0 whitespace-pre-wrap rounded-8 bg-background-components-base p-12 font-code text-xs leading-20 text-foreground-neutral-base [overflow-wrap:anywhere]"
+          // The same code surface a rendered fence lands on, so a body that fails to parse still
+          // reads as code rather than as a chip the size of a paragraph.
+          className="min-w-0 whitespace-pre-wrap rounded-8 bg-background-contrast-base p-12 font-code text-xs leading-20 text-foreground-contrast-primary [overflow-wrap:anywhere]"
           dir="auto"
         >
           {this.props.body}

--- a/libs/shared/react/ui/src/components/select/select.tsx
+++ b/libs/shared/react/ui/src/components/select/select.tsx
@@ -14,14 +14,26 @@ function SelectGroup({...props}: ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({...props}: ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+function SelectValue({className, ...props}: ComponentProps<typeof SelectPrimitive.Value>) {
+  return (
+    // Selected values are frequently names a user authored, such as a job or a workflow, and
+    // nothing bounds their length. Without this the value wraps and spills out of the trigger's
+    // fixed height instead of ending in an ellipsis.
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn('min-w-0 truncate text-left', className)}
+      {...props}
+    />
+  );
 }
 
 const selectTriggerVariants = cva(
   [
     'flex items-center justify-between gap-8',
-    'w-full rounded-6 px-8 text-sm leading-20',
+    'w-full min-w-0 rounded-6 px-8 text-sm leading-20',
+    // The trigger keeps its compact height so it sits level with the metadata beside it, and
+    // grows to the touch minimum only where the pointer is coarse.
+    '[@media(pointer:coarse)]:min-h-44',
     'bg-background-field-base text-foreground-neutral-subtle',
     'shadow-button-neutral transition-[color,box-shadow] outline-none',
     'hover:bg-background-field-hover',


### PR DESCRIPTION
Workflow-run annotations now read as one coherent panel: rows own their spacing and dividers, severity is carried by shared icons with accessible labels, and job-level diagnostics use useful headings. The unreachable `?annotation=` state and its selected-row focus/render-window behavior are removed.

The related shared UI changes keep long Select values inside their triggers, use the compact panel spacing token, and keep Markdown fallback content on the same code surface as rendered fences.

Validation: `mise exec -- turbo check type test --filter=@shipfox/client-workflows...` (228 tasks succeeded; 634 `@shipfox/client-workflows` tests passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run annotations now render as flush rows in one panel, with severity shown via shared glyphs and accessible labels. The unreachable `?annotation=` deep link and its focus/scroll behavior are removed.

- Refactors
  - The list owns the panel body; rows provide their own spacing/dividers, with header/foot bands for stale/errors and actions.
  - `AnnotationCard` drops its frame, clamps long bodies with a mask fade, and exports shared `ANNOTATION_STYLE_ICON`/`ANNOTATION_STYLE_TONE`.
  - Headings use the step-named block; server-minted contexts (`failure:*`, `agent-tool-capability:*`) are matched by full key and titled by the job, with fallback headings when the job is missing.
  - The provenance line is bounded to two lines and carries the full value in the title; derived diagnostics lead the list and count toward totals.
  - Severity tone lives only in the glyph; count visuals reuse the same maps and exclude the `default` style.
  - Load-error and empty states use panel variants; `Select` triggers truncate long values and grow to touch minimum on coarse pointers; the job filter exposes the full job name via the trigger’s title.
  - Adds `pt-panel-compact`; Markdown fallback uses the same code surface as rendered fences.

- Migration
  - Remove the `?annotation=` search param from run routes and helpers; do not read or write it via `workflowRunSearchParams` or `validateWorkflowRunsSearch`.
  - Remove selected-row focus/scroll and render-window exceptions tied to that param; “filters active” no longer considers an annotation id.
  - `AnnotationCard` removes its `id` prop, and `annotationElementId` is no longer exported from `@shipfox/client-workflows`.
  - Consumers of `@shipfox/client-workflows`, `@shipfox/client-ui`, and `@shipfox/react-ui` should update imports to use the shared severity exports and panel utilities.

<sup>Written for commit dfd756889a0d61044cdcd99ebc0996756fe030e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

