### PR TITLE
Fix Gitea seed workflow trigger sources

### DIFF
--- a/dev/gitea/seed/api/.shipfox/workflows/ci.yml
+++ b/dev/gitea/seed/api/.shipfox/workflows/ci.yml
@@ -4,7 +4,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
 jobs:
   test:

--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-claude.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-claude.yml
@@ -5,7 +5,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:

--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-pi.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-pi.yml
@@ -5,7 +5,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:

--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
@@ -7,7 +7,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:

--- a/dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml
@@ -5,7 +5,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:

--- a/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
@@ -5,7 +5,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:

--- a/dev/gitea/seed/demo/.shipfox/workflows/hello-world.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/hello-world.yml
@@ -7,7 +7,7 @@ triggers:
     source: manual
     event: fire
   on_push:
-    source: gitea
+    source: gitea_shipfox
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:


### PR DESCRIPTION
Update the seeded Gitea push-trigger workflows to listen on the connection-specific `gitea_shipfox` source.

This keeps repositories bootstrapped by the local Gitea setup aligned with the Shipfox Gitea connection while preserving manual triggers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches seeded Gitea workflows to listen for push events from `gitea_shipfox` instead of the generic `gitea`, so bootstrapped repos only react to the Shipfox Gitea connection. Manual triggers are unchanged; no job logic was touched.

**Migration**
- Ensure your Shipfox Gitea connection emits source `gitea_shipfox`, or update the workflows to match your connection’s source name.

<sup>Written for commit 94b8a2b40ac2731e32335ad4542ea5e84188bb27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

