### PR TITLE
Prevent main CI checks from racing npm publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,8 @@ jobs:
     env:
       SHIPFOX_TURBO_CONCURRENCY: "4"
       CLOUDFLARE_PAGES_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      SHIPFOX_PUBLICATION_REGISTRY_BASE: ${{ needs.release-mode.outputs.previous_revision || github.event.pull_request.base.sha || github.event.before }}
-      SHIPFOX_PUBLICATION_REGISTRY_REQUIRED: ${{ needs.release-mode.outputs.mode != 'normal' }}
+      SHIPFOX_PUBLICATION_REGISTRY_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+      SHIPFOX_PUBLICATION_REGISTRY_REQUIRED: ${{ github.event_name == 'pull_request' && needs.release-mode.outputs.mode != 'normal' }}
 
     steps:
       - name: Check out repository

--- a/tools/package-release/test/publish-workflows.test.ts
+++ b/tools/package-release/test/publish-workflows.test.ts
@@ -31,6 +31,7 @@ describe('package release workflows', () => {
     assert.ok(workflow.includes('cancel-in-progress: false'));
     assert.ok(workflow.includes('ref: $' + '{{ needs.authorize-release.outputs.revision }}'));
     assert.ok(workflow.includes('verify-generated-release'));
+    assert.ok(workflow.includes('SHIPFOX_PUBLICATION_REGISTRY_BASE:'));
     assert.ok(workflow.includes('NPM_CONFIG_PROVENANCE: "true"'));
     assert.ok(workflow.includes('package-release-workflow.mjs authorize'));
     assert.ok(workflow.includes('steps.release-app-token.outputs.app-slug'));

--- a/tools/package-release/test/release-ci-workflow.test.ts
+++ b/tools/package-release/test/release-ci-workflow.test.ts
@@ -7,6 +7,10 @@ import {parse} from 'yaml';
 const packageDirectory = dirname(fileURLToPath(import.meta.url));
 const workflowPath = resolve(packageDirectory, '../../../.github/workflows/ci.yml');
 const mainRefConditionPattern = /github\.ref == 'refs\/heads\/main'/;
+const pullRequestBaseExpression =
+  '${{' + " github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}";
+const pullRequestRequiredExpression =
+  '${{' + " github.event_name == 'pull_request' && needs.release-mode.outputs.mode != 'normal' }}";
 
 function readWorkflow() {
   return readFile(workflowPath, 'utf8');
@@ -79,6 +83,21 @@ describe('generated release CI path', () => {
     assert.ok(workflow.includes('oras tag "$APPLICATION_IMAGE_REPOSITORY@$digest"'));
     assert.ok(workflow.includes('--reuse-from-revision "$PREVIOUS_REVISION"'));
     assert.ok(workflow.includes('application image rebuilds, and Packer runner candidates'));
+  });
+
+  test('keeps version-only static verification independent from publication timing', async () => {
+    const workflow = await readWorkflow();
+    const parsedWorkflow = parse(workflow);
+    const staticVerification = parsedWorkflow.jobs['static-verification'];
+
+    assert.equal(
+      staticVerification.env.SHIPFOX_PUBLICATION_REGISTRY_BASE,
+      pullRequestBaseExpression,
+    );
+    assert.equal(
+      staticVerification.env.SHIPFOX_PUBLICATION_REGISTRY_REQUIRED,
+      pullRequestRequiredExpression,
+    );
   });
 
   test('keeps required checks successful when the image matrix is intentionally skipped', async () => {


### PR DESCRIPTION
Main CI can be queued behind the serialized npm publisher. When it later runs against a version-only merge, its registry preflight can compare already-published package versions with the merge base and fail even though publication succeeded.

This keeps registry collision checks for pull requests and the publication workflow, while making main-push static verification run closure validation independently of publication timing. Workflow tests assert both paths retain their intended guards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents main CI static verification from racing the serialized npm publisher. Previously main runs could inherit registry preflight and fail on version-only merges after publication; now registry collision checks run only for pull requests and during the publication workflow, so main verification is independent of publication timing.

- Gate `SHIPFOX_PUBLICATION_REGISTRY_BASE` and `SHIPFOX_PUBLICATION_REGISTRY_REQUIRED` to pull_request events in `ci.yml`.
- Add workflow tests to assert PR-only gating and that publication and PR paths keep their registry guards.

<sup>Written for commit 4e750f962d3d41c8e7701b4369b5968979cce7e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

