### PR TITLE
[docs] List Shipfox Cloud agent models

### DIFF
--- a/apps/docs/content/docs/how-to/author-workflows/choose-runners.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/choose-runners.mdx
@@ -21,7 +21,7 @@ you also need access to its process or provisioner template.
     **Find the runner's labels**
 
     Use `shipfox` for the default Shipfox-hosted runner. To choose a different size,
-    compare the [available labels](/reference/runner-labels#available-labels).
+    compare the [available runners](/reference/runner-labels#available-runners).
 
     For a runner you manage, check `SHIPFOX_RUNNER_LABELS` in the runner process
     or its matching provisioner template. The dashboard does not list online

--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Shipfox Cloud Agent Models Reference"
 sidebarTitle: "Agent Models"
-description: "All of the agent models available on Shipfox Cloud."
+description: "All agent models available on Shipfox Cloud."
 ---
 
 Shipfox Cloud provides the following managed models for agent steps. Use the
@@ -13,16 +13,28 @@ exact `model` ID when selecting one in workflow YAML.
 
 ## Model selection
 
-```yaml
-- prompt: Review the repository and summarize the main risks.
-  provider: shipfox
-  model: gpt-5.6-sol
+```yaml title=".shipfox/workflows/review-repository.yml"
+# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
+name: Review the repository
+runner: shipfox
+
+triggers:
+  manual:
+    source: manual
+
+jobs:
+  review:
+    steps:
+      - model: gpt-5.6-luna
+        prompt: |
+          Review the repository and summarize the main risks.
+          Do not change any files.
 ```
 
 For every agent field, see the [workflow schema
 reference](/reference/workflow-schema#agent-step-fields).
 
-## Agent Models
+## Available models
 
 | Model | `model` ID |
 | --- | --- |
@@ -53,8 +65,8 @@ reference](/reference/workflow-schema#agent-step-fields).
 | Kimi K2.7 Code | `kimi-k2.7-code` |
 | Kimi K2.6 | `kimi-k2.6` |
 | Qwen3.8 2.4T A95B | `qwen3.8-2.4t-a95b` |
-| Qwen3.6 35B A3B | `qwen3.6-35b-a3b` |
-| Qwen3.5 397B A17B | `qwen3.5-397b-a17b` |
+| Qwen3.6 35 B A3B | `qwen3.6-35b-a3b` |
+| Qwen3.5 397 B A17B | `qwen3.5-397b-a17b` |
 | MiMo V2.5 Pro | `mimo-v2.5-pro` |
 | MiniMax M2.7 | `minimax-m2.7` |
 | MiniMax M2.7 Turbo | `minimax-m2.7-turbo` |

--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -1,0 +1,61 @@
+---
+title: "Shipfox Cloud Agent Models Reference"
+sidebarTitle: "Agent Models"
+description: "All of the agent models available on Shipfox Cloud."
+---
+
+Shipfox Cloud provides the following managed models for agent steps. Use the
+exact `model` ID when selecting one in workflow YAML.
+
+<Callout title="Self-hosted providers" type="info">
+    Self-hosted installations must configure [model providers](/reference/model-providers).
+</Callout>
+
+## Model selection
+
+```yaml
+- prompt: Review the repository and summarize the main risks.
+  provider: shipfox
+  model: gpt-5.6-sol
+```
+
+For every agent field, see the [workflow schema
+reference](/reference/workflow-schema#agent-step-fields).
+
+## Agent Models
+
+| Model | `model` ID |
+| --- | --- |
+| Claude Fable 5 | `claude-fable-5` |
+| Claude Opus 5 | `claude-opus-5` |
+| Claude Opus 4.8 | `claude-opus-4.8` |
+| Claude Opus 4.7 | `claude-opus-4.7` |
+| Claude Opus 4.6 | `claude-opus-4.6` |
+| Claude Sonnet 5 | `claude-sonnet-5` |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` |
+| Claude Sonnet 4.5 | `claude-sonnet-4.5` |
+| Claude Haiku 4.5 | `claude-haiku-4.5` |
+| GPT-5.6 Luna | `gpt-5.6-luna` |
+| GPT-5.6 Terra | `gpt-5.6-terra` |
+| GPT-5.6 Sol | `gpt-5.6-sol` |
+| GPT-5.5 | `gpt-5.5` |
+| GPT-5.5 pro | `gpt-5.5-pro` |
+| GPT-5.4 | `gpt-5.4` |
+| GPT-5.4 nano | `gpt-5.4-nano` |
+| GPT-5.4 mini | `gpt-5.4-mini` |
+| GPT-5.4 pro | `gpt-5.4-pro` |
+| DeepSeek V4 Flash (0731) | `deepseek-v4-flash-0731` |
+| DeepSeek V4 Pro (0813) | `deepseek-v4-pro-0813` |
+| DeepSeek V4 Pro | `deepseek-v4-pro` |
+| GLM-5.2 | `glm-5.2` |
+| GLM-5.1 | `glm-5.1` |
+| Kimi K3 | `kimi-k3` |
+| Kimi K2.7 Code | `kimi-k2.7-code` |
+| Kimi K2.6 | `kimi-k2.6` |
+| Qwen3.8 2.4T A95B | `qwen3.8-2.4t-a95b` |
+| Qwen3.6 35B A3B | `qwen3.6-35b-a3b` |
+| Qwen3.5 397B A17B | `qwen3.5-397b-a17b` |
+| MiMo V2.5 Pro | `mimo-v2.5-pro` |
+| MiniMax M2.7 | `minimax-m2.7` |
+| MiniMax M2.7 Turbo | `minimax-m2.7-turbo` |
+| MiniMax M3 | `minimax-m3` |

--- a/apps/docs/content/docs/reference/glossary.mdx
+++ b/apps/docs/content/docs/reference/glossary.mdx
@@ -65,7 +65,9 @@ This glossary defines the core terms used in Shipfox documentation and in the pr
   </Accordion>
 
   <Accordion title="Model">
-    The AI model used by an agent step (for example, `claude-opus-4-8`, `gpt-5.5-pro`). Specified with the `model` field on an agent step. When omitted, the model is resolved at runtime from the workspace provider configuration. Model catalog validation happens at runtime, not at parse time. See [Model Providers](/reference/model-providers).
+    `model` selects an agent model, such as `gpt-5.6-luna`. The [workspace
+    provider](/reference/model-providers) supplies a default. Shipfox validates
+    the model at runtime.
   </Accordion>
 
   <Accordion title="Pipeline">

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Shipfox Reference"
 sidebarTitle: "Reference"
-description: "Look up workflow fields, expressions, events, settings, limits, and runner configuration."
+description: "Look up workflow fields, expressions, models, settings, limits, and runner configuration."
 ---
 
 Use these pages when you need an exact field, value, default, or limit. They
@@ -32,7 +32,10 @@ guide](/how-to).
     Look up scopes, names, bindings, and value rules.
   </Card>
   <Card title="Model providers" href="/reference/model-providers">
-    Look up providers, models, defaults, and agent settings.
+    Look up configurable providers, defaults, and agent settings.
+  </Card>
+  <Card title="Models" href="/reference/cloud-models">
+    Look up all available models on Shipfox Cloud.
   </Card>
   <Card title="Limits" href="/reference/limits">
     Look up current size, time, count, and log limits.

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "workflow-schema",
+    "cloud-models",
     "runner-labels",
     "contexts",
     "expressions",

--- a/apps/docs/content/docs/reference/model-providers.mdx
+++ b/apps/docs/content/docs/reference/model-providers.mdx
@@ -1,15 +1,18 @@
 ---
 title: "Model Providers Reference"
 sidebarTitle: "Model Providers"
-description: "The complete Shipfox model provider catalog, including provider IDs, default models, compatible harnesses, and resolution rules."
+description: "The built-in model provider catalog, including provider IDs, support status, default models, compatible harnesses, and resolution rules."
 ---
 
 import ModelProviders from '../../generated/reference/model-providers.mdx';
 
-Agent steps run against an **AI provider**. This page is the canonical list of every
-supported provider, the `provider` ID you use in workflow YAML, its compatible
-harnesses, and the default model Shipfox uses when a step doesn't name one. For
-a setup walkthrough, see [Agent Setup](/how-to/set-up-work/configure-model-providers).
+Agent steps run against an **AI provider**. This page lists the built-in
+provider catalog shared by Shipfox installations. It includes each `provider`
+ID, support status, compatible harnesses, and default model. For a setup
+walkthrough, see [Agent Setup](/how-to/set-up-work/configure-model-providers).
+
+Shipfox Cloud also supplies the managed `shipfox` provider. See [Shipfox Cloud
+models](/reference/cloud-models) for its available models and exact IDs.
 
 ## Supported providers
 

--- a/apps/docs/content/docs/reference/runner-labels.mdx
+++ b/apps/docs/content/docs/reference/runner-labels.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Runner Labels Reference"
-sidebarTitle: "Runner Labels"
+sidebarTitle: "Runners"
 description: "All shipfox hosted runners on Shipfox cloud."
 ---
 
-## Available labels
+## Available runners
 
 | Labels | CPU | RAM | Workspace disk |
 | --- | ---: | ---: | ---: |


### PR DESCRIPTION
## Summary

Shipfox Cloud exposes a managed model catalog, but the public reference does not list its workflow-facing model IDs.

Add a dedicated agent models reference with all 33 available models, the `shipfox` provider selection, and self-hosted guidance. Add the page to Reference navigation and distinguish Cloud-managed models from configurable providers.

## Validation

- `mise exec -- turbo check type test build --filter=@shipfox/docs`
- Compared all 33 documented model IDs with Cloud's `INFERENCE_MODEL_REGISTRY` in source order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cloud agent models reference that lists every workflow-facing model ID and shows how to target the `shipfox` provider, giving users exact IDs and a copy‑pasteable example. Renames the hosted runner reference from “Runner Labels” to “Runners,” which changes the deep-link anchor.

**New Features**
- Adds a reference at /reference/cloud-models and a “Models” card in the Reference index.
- Documents 33 model IDs and includes a runnable YAML example with schema and default `shipfox` runner.
- Adds a callout for self-hosted installs to configure model providers.
- Refocuses `model-providers` on built-in providers and links to the Cloud models list.

**Migration**
- The runner section anchor is now “Available runners” (`#available-runners`); update any external links from `#available-labels`.

<sup>Written for commit dcb7e4e7827883916af0b9488fe3cf22fcccf425. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

