### PR TITLE
[react-ui] Improve tooltip hover timing

### DIFF
--- a/.changeset/quiet-tooltips-warm.md
+++ b/.changeset/quiet-tooltips-warm.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/react-ui': patch
+---
+
+Delay initial tooltip hovers and open adjacent tooltips immediately while the interface is warm.

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
@@ -147,7 +147,9 @@ describe('WorkspaceManualRegistrationTokensSettingsSection', () => {
     await user.unhover(expiresDateTrigger);
     await user.hover(createdDateTrigger);
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
+    });
   });
 
   test('truncates long token names and shows the full name in a tooltip', async () => {

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -172,7 +172,9 @@ describe('WorkspaceProvisionerTokensSettingsSection', () => {
     await user.unhover(expiresDateTrigger);
     await user.hover(createdDateTrigger);
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
+    });
   });
 
   test('truncates long token names and shows the full name in a tooltip', async () => {

--- a/libs/shared/react/ui/src/components/avatar/avatar-group.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar-group.tsx
@@ -142,7 +142,7 @@ export function AvatarGroup({
   }, [childrenArray, maxVisible]);
 
   return (
-    <TooltipProvider delayDuration={0}>
+    <TooltipProvider>
       <div
         className={cn(avatarGroupVariants({size: normalizedSize}), className)}
         data-slot="avatar-group"

--- a/libs/shared/react/ui/src/components/tooltip/tooltip.stories.tsx
+++ b/libs/shared/react/ui/src/components/tooltip/tooltip.stories.tsx
@@ -41,7 +41,7 @@ const meta = {
   },
   args: {
     defaultOpen: false,
-    delayDuration: 0,
+    delayDuration: 200,
     variant: 'default',
     size: 'md',
     side: 'top',

--- a/libs/shared/react/ui/src/components/tooltip/tooltip.test.tsx
+++ b/libs/shared/react/ui/src/components/tooltip/tooltip.test.tsx
@@ -1,0 +1,133 @@
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from './tooltip.js';
+
+function TooltipPair() {
+  return (
+    <TooltipProvider disableHoverableContent>
+      <Tooltip>
+        <TooltipTrigger>First trigger</TooltipTrigger>
+        <TooltipContent>First tooltip</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger>Second trigger</TooltipTrigger>
+        <TooltipContent>Second tooltip</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function movePointerOver(element: HTMLElement) {
+  fireEvent.pointerMove(element, {pointerType: 'mouse'});
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Tooltip timing', () => {
+  test('waits before opening a standalone tooltip', () => {
+    render(
+      <Tooltip>
+        <TooltipTrigger>Trigger</TooltipTrigger>
+        <TooltipContent>Tooltip content</TooltipContent>
+      </Tooltip>,
+    );
+
+    movePointerOver(screen.getByRole('button', {name: 'Trigger'}));
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole('tooltip').textContent).toBe('Tooltip content');
+    expect(
+      document.querySelector('[data-slot="tooltip-content"]')?.getAttribute('data-state'),
+    ).toBe('delayed-open');
+  });
+
+  test('cancels a pending tooltip when the pointer only crosses its trigger', () => {
+    render(
+      <Tooltip>
+        <TooltipTrigger>Trigger</TooltipTrigger>
+        <TooltipContent>Tooltip content</TooltipContent>
+      </Tooltip>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+
+    movePointerOver(trigger);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    fireEvent.pointerLeave(trigger);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  test('opens adjacent tooltips immediately during the shared warm window', () => {
+    render(<TooltipPair />);
+    const firstTrigger = screen.getByRole('button', {name: 'First trigger'});
+    const secondTrigger = screen.getByRole('button', {name: 'Second trigger'});
+
+    movePointerOver(firstTrigger);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.getByRole('tooltip').textContent).toBe('First tooltip');
+
+    fireEvent.pointerLeave(firstTrigger);
+    movePointerOver(secondTrigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('Second tooltip');
+  });
+
+  test('restores the opening delay after the warm window expires', () => {
+    render(<TooltipPair />);
+    const firstTrigger = screen.getByRole('button', {name: 'First trigger'});
+    const secondTrigger = screen.getByRole('button', {name: 'Second trigger'});
+
+    movePointerOver(firstTrigger);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    fireEvent.pointerLeave(firstTrigger);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    movePointerOver(secondTrigger);
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole('tooltip').textContent).toBe('Second tooltip');
+  });
+
+  test('opens immediately for keyboard focus', () => {
+    render(
+      <Tooltip>
+        <TooltipTrigger>Trigger</TooltipTrigger>
+        <TooltipContent>Tooltip content</TooltipContent>
+      </Tooltip>,
+    );
+
+    fireEvent.focus(screen.getByRole('button', {name: 'Trigger'}));
+
+    expect(screen.getByRole('tooltip').textContent).toBe('Tooltip content');
+    expect(
+      document.querySelector('[data-slot="tooltip-content"]')?.getAttribute('data-state'),
+    ).toBe('instant-open');
+  });
+});

--- a/libs/shared/react/ui/src/components/tooltip/tooltip.tsx
+++ b/libs/shared/react/ui/src/components/tooltip/tooltip.tsx
@@ -2,9 +2,13 @@
 
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import {cva, type VariantProps} from 'class-variance-authority';
-import {motion, type Transition} from 'framer-motion';
-import type {ComponentProps} from 'react';
+import {type HTMLMotionProps, motion, type Transition, useReducedMotion} from 'framer-motion';
+import {type ComponentProps, createContext, forwardRef, useContext} from 'react';
 import {cn} from '#utils/cn.js';
+
+const defaultDelayDuration = 200;
+const defaultSkipDelayDuration = 300;
+const TooltipProviderContext = createContext(false);
 
 const tooltipContentVariants = cva(
   'rounded-8 px-8 py-4 text-xs font-medium leading-20 z-50 w-fit text-balance shadow-tooltip',
@@ -28,25 +32,30 @@ const tooltipContentVariants = cva(
   },
 );
 
+/** Shares the standard cold-open delay and warm window across descendant tooltips. */
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = defaultDelayDuration,
+  skipDelayDuration = defaultSkipDelayDuration,
   ...props
 }: ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={delayDuration}
-      {...props}
-    />
+    <TooltipProviderContext.Provider value={true}>
+      <TooltipPrimitive.Provider
+        data-slot="tooltip-provider"
+        delayDuration={delayDuration}
+        skipDelayDuration={skipDelayDuration}
+        {...props}
+      />
+    </TooltipProviderContext.Provider>
   );
 }
 
+/** Uses the nearest provider, or supplies the standard timing when rendered alone. */
 function Tooltip({...props}: ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  const hasProvider = useContext(TooltipProviderContext);
+  const root = <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+
+  return hasProvider ? root : <TooltipProvider>{root}</TooltipProvider>;
 }
 
 function TooltipTrigger({...props}: ComponentProps<typeof TooltipPrimitive.Trigger>) {
@@ -64,6 +73,30 @@ type TooltipContentProps = ComponentProps<typeof TooltipPrimitive.Content> &
     animated?: boolean;
     transition?: Transition;
   };
+
+type AnimatedTooltipContentProps = Omit<HTMLMotionProps<'div'>, 'transition'> & {
+  'data-state'?: 'closed' | 'delayed-open' | 'instant-open';
+  transition: Transition;
+};
+
+const AnimatedTooltipContent = forwardRef<HTMLDivElement, AnimatedTooltipContentProps>(
+  function AnimatedTooltipContent({'data-state': state, transition, ...props}, ref) {
+    const reducedMotion = useReducedMotion();
+    const shouldAnimate = !reducedMotion && state !== 'instant-open';
+
+    return (
+      <motion.div
+        ref={ref}
+        data-state={state}
+        {...props}
+        initial={shouldAnimate ? {opacity: 0, scale: 0.95} : false}
+        animate={{opacity: 1, scale: 1}}
+        {...(shouldAnimate ? {exit: {opacity: 0, scale: 0.95}} : {})}
+        transition={shouldAnimate ? transition : {duration: 0}}
+      />
+    );
+  },
+);
 
 function TooltipContent({
   className,
@@ -84,15 +117,12 @@ function TooltipContent({
           asChild
           {...props}
         >
-          <motion.div
+          <AnimatedTooltipContent
             className={cn(tooltipContentVariants({variant, size, className}))}
-            initial={{opacity: 0, scale: 0.95}}
-            animate={{opacity: 1, scale: 1}}
-            exit={{opacity: 0, scale: 0.95}}
             transition={transition}
           >
             {children}
-          </motion.div>
+          </AnimatedTooltipContent>
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     );


### PR DESCRIPTION
Tooltips currently open immediately when the pointer crosses dense product surfaces, creating avoidable visual noise. This change adds a 200ms cold-hover delay while keeping adjacent tooltips instant during a 300ms warm window.

The shared tooltip now reuses the app-level provider while retaining standalone package behavior. Instant and reduced-motion openings render without the entrance animation, and avatar groups use the same timing.

Validation: `mise exec -- turbo check type test --filter=@shipfox/react-ui...` (75 test files, 469 tests) and dependent type validation across 26 packages.