### PR TITLE
[node-object-storage] Support consumer-specific buckets

### DIFF
--- a/.changeset/consumer-specific-object-storage-buckets.md
+++ b/.changeset/consumer-specific-object-storage-buckets.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-object-storage": patch
+---
+
+Allow deployments to leave the shared object-storage bucket unset when each consumer provides its own bucket override.

--- a/libs/shared/node/object-storage/README.md
+++ b/libs/shared/node/object-storage/README.md
@@ -4,7 +4,7 @@ Shared Node infrastructure for scoped S3-compatible object storage.
 
 ## What it does
 
-- **Shared S3 profile**: Loads one endpoint, region, bucket, credential pair, and addressing mode.
+- **Shared S3 profile**: Loads common endpoint, region, credentials, and addressing mode, with an optional default bucket.
 - **`S3ObjectStore`**: Restricts object operations to one non-empty key prefix.
 - **Object operations**: Uploads and reads bytes, streams multipart uploads, signs reads, lists keys, and deletes objects.
 - **Client policies**: Uses enforced short timeouts for control operations and lets each consumer bound data-transfer requests when needed.
@@ -15,7 +15,7 @@ Shared Node infrastructure for scoped S3-compatible object storage.
 pnpm add @shipfox/node-object-storage
 ```
 
-Set the `OBJECT_STORAGE_S3_*` variables for the deployment. Leave both credential variables unset to use the AWS SDK credential provider chain.
+Set the shared `OBJECT_STORAGE_S3_*` connection variables for the deployment. Set `OBJECT_STORAGE_S3_BUCKET` when consumers share a default bucket, or leave it unset when every consumer selects its own bucket. Leave both credential variables unset to use the AWS SDK credential provider chain.
 
 ## Usage
 
@@ -23,10 +23,15 @@ Set the `OBJECT_STORAGE_S3_*` variables for the deployment. Leave both credentia
 import {
   createS3ObjectStore,
   objectStorageS3Profile,
+  resolveObjectStorageS3Profile,
 } from '@shipfox/node-object-storage';
 
 const sessions = createS3ObjectStore({
-  profile: objectStorageS3Profile,
+  profile: resolveObjectStorageS3Profile(
+    objectStorageS3Profile,
+    {bucket: 'shipfox-sessions'},
+    'SESSION_STORAGE_S3',
+  ),
   prefix: 'agent-sessions',
   transferRequestTimeoutMs: 300_000,
 });
@@ -42,7 +47,7 @@ sessions.close();
 
 ## Environment
 
-The schema in `src/config.ts` owns the shared S3 variables and their defaults. Consumers can resolve package-specific overrides with `resolveObjectStorageS3Profile`.
+The schema in `src/config.ts` owns the shared S3 variables and their defaults. Consumers resolve package-specific overrides with `resolveObjectStorageS3Profile`. Resolution fails when neither the consumer nor the shared profile selects a bucket.
 
 ## Behavior notes
 

--- a/libs/shared/node/object-storage/src/config.test.ts
+++ b/libs/shared/node/object-storage/src/config.test.ts
@@ -1,6 +1,12 @@
 import {loadObjectStorageS3Profile, resolveObjectStorageS3Profile} from './config.js';
 
 describe('loadObjectStorageS3Profile', () => {
+  it('leaves the shared bucket unset for consumer-owned bucket selection', () => {
+    const profile = loadObjectStorageS3Profile({OBJECT_STORAGE_S3_BUCKET: undefined});
+
+    expect(profile.bucket).toBeUndefined();
+  });
+
   it('loads one explicit credential pair', () => {
     const profile = loadObjectStorageS3Profile({
       OBJECT_STORAGE_S3_ACCESS_KEY_ID: 'access-key',
@@ -43,6 +49,31 @@ describe('resolveObjectStorageS3Profile', () => {
     );
 
     expect(resolved).toEqual({...base, bucket: 'sessions', forcePathStyle: true});
+  });
+
+  it('uses a consumer bucket when the shared bucket is unset', () => {
+    const withoutBucket = loadObjectStorageS3Profile({
+      OBJECT_STORAGE_S3_ENDPOINT: 'https://objects.example.test',
+      OBJECT_STORAGE_S3_REGION: 'base-region',
+      OBJECT_STORAGE_S3_BUCKET: undefined,
+      OBJECT_STORAGE_S3_FORCE_PATH_STYLE: 'false',
+    });
+
+    const resolved = resolveObjectStorageS3Profile(
+      withoutBucket,
+      {bucket: 'consumer-bucket'},
+      'LOG_STORAGE_S3',
+    );
+
+    expect(resolved.bucket).toBe('consumer-bucket');
+  });
+
+  it('rejects a consumer without a shared or consumer bucket', () => {
+    const withoutBucket = loadObjectStorageS3Profile({OBJECT_STORAGE_S3_BUCKET: undefined});
+
+    expect(() => resolveObjectStorageS3Profile(withoutBucket, {}, 'LOG_STORAGE_S3')).toThrow(
+      'LOG_STORAGE_S3_BUCKET or OBJECT_STORAGE_S3_BUCKET must be set.',
+    );
   });
 
   it('treats consumer credentials as one pair', () => {

--- a/libs/shared/node/object-storage/src/config.ts
+++ b/libs/shared/node/object-storage/src/config.ts
@@ -13,6 +13,14 @@ export interface ObjectStorageS3Profile {
   readonly forcePathStyle: boolean;
 }
 
+export interface ObjectStorageS3BaseProfile {
+  readonly endpoint: string;
+  readonly region: string;
+  readonly bucket?: string | undefined;
+  readonly credentials?: ObjectStorageS3Credentials | undefined;
+  readonly forcePathStyle: boolean;
+}
+
 export interface ObjectStorageS3ProfileOverrides {
   readonly endpoint?: string | undefined;
   readonly region?: string | undefined;
@@ -32,8 +40,8 @@ export const objectStorageConfigSchema = {
     default: 'garage',
   }),
   OBJECT_STORAGE_S3_BUCKET: str({
-    desc: 'Bucket used by Shipfox object-storage consumers. Each consumer uses a separate key prefix. Defaults to shipfox, which dev/garage/bootstrap.sh creates.',
-    default: 'shipfox',
+    desc: 'Optional default bucket used by Shipfox object-storage consumers. Leave it unset when every consumer selects its own bucket. Local development sets it to the shipfox bucket that dev/garage/bootstrap.sh creates.',
+    default: undefined,
   }),
   OBJECT_STORAGE_S3_ACCESS_KEY_ID: str({
     desc: 'Optional access key ID used to authenticate to the shared object store. Set it with OBJECT_STORAGE_S3_SECRET_ACCESS_KEY, or leave both unset to use the standard AWS SDK credential provider chain.',
@@ -51,7 +59,7 @@ export const objectStorageConfigSchema = {
 
 export function loadObjectStorageS3Profile(
   update?: Partial<NodeJS.ProcessEnv>,
-): ObjectStorageS3Profile {
+): ObjectStorageS3BaseProfile {
   const loaded = createConfig(objectStorageConfigSchema, update);
   const credentials = credentialPair(
     loaded.OBJECT_STORAGE_S3_ACCESS_KEY_ID,
@@ -69,7 +77,7 @@ export function loadObjectStorageS3Profile(
 }
 
 export function resolveObjectStorageS3Profile(
-  base: ObjectStorageS3Profile,
+  base: ObjectStorageS3BaseProfile,
   overrides: ObjectStorageS3ProfileOverrides,
   overrideName: string,
 ): ObjectStorageS3Profile {
@@ -79,11 +87,15 @@ export function resolveObjectStorageS3Profile(
   const credentials = hasCredentialOverride
     ? credentialPair(accessKeyId, secretAccessKey, overrideName)
     : base.credentials;
+  const bucket = emptyStringAsUndefined(overrides.bucket) ?? base.bucket;
+  if (!bucket) {
+    throw new Error(`${overrideName}_BUCKET or OBJECT_STORAGE_S3_BUCKET must be set.`);
+  }
 
   return {
     endpoint: overrides.endpoint ?? base.endpoint,
     region: overrides.region ?? base.region,
-    bucket: overrides.bucket ?? base.bucket,
+    bucket,
     credentials,
     forcePathStyle: overrides.forcePathStyle ?? base.forcePathStyle,
   };

--- a/libs/shared/node/object-storage/src/index.ts
+++ b/libs/shared/node/object-storage/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ObjectStorageS3BaseProfile,
   ObjectStorageS3Credentials,
   ObjectStorageS3Profile,
   ObjectStorageS3ProfileOverrides,


### PR DESCRIPTION
Allow Cloud deployments to leave the shared object-storage bucket unset when logs and agent sessions each select their own bucket.

The shared loader previously required OBJECT_STORAGE_S3_BUCKET during module initialization, which prevented consumer-specific bucket overrides from being the complete configuration. This makes the base bucket optional, validates that a bucket exists only after applying consumer overrides, and exports the base-profile type for callers that intentionally defer bucket selection.

A single shared bucket remains supported. The separate-bucket model is needed by the coordinated Cloud infrastructure rollout so each data class can have independent IAM and lifecycle policy.

Cloud rollout counterpart: ShipfoxHQ/cloud#299.