### PR TITLE
[api-agent] Route providerless workflows through managed inference

### DIFF
--- a/.changeset/calm-models-route.md
+++ b/.changeset/calm-models-route.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/api-agent": patch
+"@shipfox/api-agent": minor
 ---
 
 Ignores stored workspace provider defaults when an instance managed provider is available.

--- a/.changeset/calm-models-route.md
+++ b/.changeset/calm-models-route.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-agent": patch
+---
+
+Makes the instance managed provider the default when workflows omit the provider.

--- a/.changeset/calm-models-route.md
+++ b/.changeset/calm-models-route.md
@@ -2,4 +2,5 @@
 "@shipfox/api-agent": patch
 ---
 
-Makes the instance managed provider the default when workflows omit the provider.
+Ignores stored workspace provider defaults when an instance managed provider is available.
+Providerless steps still honor instance defaults and otherwise use the managed provider.

--- a/.changeset/native-claude-models.md
+++ b/.changeset/native-claude-models.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-agent": minor
+---
+
+Allows managed catalog models to declare an optional `claudeModelId` for the Claude harness.
+Runtime resolution keeps the catalog model ID when the field is absent.

--- a/libs/api/agent-dto/src/schemas/managed-provider.test.ts
+++ b/libs/api/agent-dto/src/schemas/managed-provider.test.ts
@@ -17,6 +17,7 @@ describe('managed provider model metadata', () => {
     const dto = toCustomAgentModelDto({
       id: 'gpt-5.6-sol',
       label: 'GPT 5.6 Sol',
+      claudeModelId: 'claude-opus-5',
       thinkingLevelMap,
       compat,
     });
@@ -60,10 +61,12 @@ describe('managed provider model metadata', () => {
     expect(managedModelCompatSchema.safeParse({thinkingFormat: 'unsupported'}).success).toBe(false);
     expect(
       managedModelMetadataSchema.safeParse({
+        claudeModelId: 'claude-haiku-4-5',
         thinkingLevelMap: {minimal: null},
         compat: {supportsStore: false, thinkingFormat: 'deepseek'},
       }).success,
     ).toBe(true);
+    expect(managedModelMetadataSchema.safeParse({claudeModelId: ''}).success).toBe(false);
     expect(
       managedModelMetadataSchema.safeParse({
         thinkingLevelMap: {minimal: null},

--- a/libs/api/agent-dto/src/schemas/managed-provider.ts
+++ b/libs/api/agent-dto/src/schemas/managed-provider.ts
@@ -28,6 +28,7 @@ export const managedModelMetadataSchema = customAgentModelSchema
     compat: true,
   })
   .extend({
+    claudeModelId: z.string().min(1).max(128).optional(),
     thinkingLevelMap: managedModelThinkingLevelMapSchema.optional(),
     thinking_level_map: managedModelThinkingLevelMapSchema.optional(),
     compat: managedModelCompatSchema.optional(),
@@ -57,8 +58,12 @@ export interface ManagedModelEntry extends Readonly<ManagedModelMetadata> {
 export function toCustomAgentModelDto(
   model: Pick<ManagedModelEntry, 'id' | 'label'> & ManagedModelMetadata,
 ): CustomAgentModelDto {
-  const {thinkingLevelMap, thinking_level_map, ...metadata} =
-    managedModelMetadataSchema.parse(model);
+  const {
+    claudeModelId: _claudeModelId,
+    thinkingLevelMap,
+    thinking_level_map,
+    ...metadata
+  } = managedModelMetadataSchema.parse(model);
   const normalizedThinkingLevelMap = thinkingLevelMap ?? thinking_level_map;
 
   return {

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -182,6 +182,56 @@ describe('resolveAgentConfig', () => {
     expect(resolved.model).toBe('responses-model');
   });
 
+  test('keeps the instance default provider when a managed provider exists', () => {
+    const resolved = resolveAgentConfig(
+      {},
+      {
+        workspaceDefaultProviderId: 'anthropic',
+        instanceDefaultProvider: 'openai',
+        instanceDefaultModel: 'gpt-5.5-pro',
+        managedProvider: managedProvider(),
+      },
+    );
+
+    expect(resolved.provider).toBe('openai');
+    expect(resolved.model).toBe('gpt-5.5-pro');
+  });
+
+  test('falls back by harness without restoring the workspace default provider', () => {
+    const resolved = resolveAgentConfig(
+      {harness: 'claude'},
+      {
+        workspaceDefaultProviderId: 'openai',
+        managedProvider: {
+          ...managedProvider(),
+          models: [
+            {
+              id: 'responses-model',
+              label: 'Responses model',
+              api: 'openai-responses' as const,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(resolved.provider).toBe('anthropic');
+    expect(resolved.model).toBe('claude-opus-5');
+  });
+
+  test('does not infer a workspace provider from an explicit workspace-only model', () => {
+    const resolve = () =>
+      resolveAgentConfig(
+        {model: 'gpt-5.5-pro'},
+        {
+          workspaceDefaultProviderId: 'openai',
+          managedProvider: managedProvider(),
+        },
+      );
+
+    expect(resolve).toThrow(InvalidAgentModelError);
+  });
+
   test('keeps an explicit workspace provider when a managed provider exists', () => {
     const resolved = resolveAgentConfig(
       {provider: 'openai', model: 'gpt-5.5-pro'},

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -136,6 +136,65 @@ describe('resolveAgentConfig', () => {
     expect(incompatible).toThrow(InvalidAgentModelError);
   });
 
+  test.each([
+    'gpt-5.6-luna',
+    'deepseek-v4-flash-0731',
+  ])('resolves explicit managed model %s without an explicit provider', (model) => {
+    const resolved = resolveAgentConfig(
+      {harness: 'pi', model, thinking: 'max'},
+      {
+        workspaceDefaultProviderId: 'anthropic',
+        managedProvider: managedProvider(),
+      },
+    );
+
+    expect(resolved).toEqual({
+      harness: 'pi',
+      provider: 'shipfox',
+      model,
+      thinking: 'max',
+    });
+  });
+
+  test('prefers the managed provider when the workspace default serves the same model id', () => {
+    const resolved = resolveAgentConfig(
+      {harness: 'pi', model: 'claude-opus-5'},
+      {
+        workspaceDefaultProviderId: 'anthropic',
+        managedProvider: managedProvider(),
+      },
+    );
+
+    expect(resolved.provider).toBe('shipfox');
+    expect(resolved.model).toBe('claude-opus-5');
+  });
+
+  test('ignores the workspace default provider when a managed provider exists', () => {
+    const resolved = resolveAgentConfig(
+      {},
+      {
+        workspaceDefaultProviderId: 'openai',
+        managedProvider: managedProvider(),
+      },
+    );
+
+    expect(resolved.provider).toBe('shipfox');
+    expect(resolved.model).toBe('responses-model');
+  });
+
+  test('keeps an explicit workspace provider when a managed provider exists', () => {
+    const resolved = resolveAgentConfig(
+      {provider: 'openai', model: 'gpt-5.5-pro'},
+      {
+        workspaceDefaultProviderId: 'anthropic',
+        managedProvider: managedProvider(),
+      },
+    );
+
+    expect(resolved.provider).toBe('openai');
+    expect(resolved.model).toBe('gpt-5.5-pro');
+  });
+
   test('instance model and thinking overrides win over managed provider defaults', () => {
     const resolved = resolveAgentConfig(
       {provider: 'shipfox'},
@@ -521,6 +580,13 @@ function managedProvider() {
       {id: 'claude-model', label: 'Claude model', api: 'anthropic-messages' as const},
       {id: 'responses-model', label: 'Responses model', api: 'openai-responses' as const},
       {id: 'completion-model', label: 'Completions model', api: 'openai-completions' as const},
+      {id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', api: 'openai-responses' as const},
+      {
+        id: 'deepseek-v4-flash-0731',
+        label: 'DeepSeek V4 Flash (0731)',
+        api: 'openai-responses' as const,
+      },
+      {id: 'claude-opus-5', label: 'Claude Opus 5', api: 'anthropic-messages' as const},
     ],
     defaultModel: 'responses-model',
     defaultThinking: 'low' as const,

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -128,21 +128,10 @@ function resolveProvider(
     return provider;
   }
 
-  if (ctx.managedProvider !== undefined) {
-    const provider = ctx.managedProvider.id;
-    if (!isHarnessCompatible(harness, provider, getProviderConfig(provider, ctx))) {
-      throw new UnsupportedHarnessProviderError(
-        harness,
-        provider,
-        supportedProviderIds(harness, descriptor, ctx),
-      );
-    }
-    return provider;
-  }
-
   const candidates = [
-    ctx.workspaceDefaultProviderId,
+    ctx.managedProvider === undefined ? ctx.workspaceDefaultProviderId : undefined,
     ctx.instanceDefaultProvider,
+    ctx.managedProvider?.id,
     descriptor.defaultProviderId,
   ];
   for (const candidate of candidates) {

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -128,6 +128,18 @@ function resolveProvider(
     return provider;
   }
 
+  if (ctx.managedProvider !== undefined) {
+    const provider = ctx.managedProvider.id;
+    if (!isHarnessCompatible(harness, provider, getProviderConfig(provider, ctx))) {
+      throw new UnsupportedHarnessProviderError(
+        harness,
+        provider,
+        supportedProviderIds(harness, descriptor, ctx),
+      );
+    }
+    return provider;
+  }
+
   const candidates = [
     ctx.workspaceDefaultProviderId,
     ctx.instanceDefaultProvider,

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -232,6 +232,48 @@ describe('resolveRuntimeCredentials', () => {
   });
 
   it('resolves managed provider credentials into the Claude per-step contract', async () => {
+    const runId = crypto.randomUUID();
+    const stepAttemptId = crypto.randomUUID();
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    resolveCredentials.mockResolvedValue({
+      api: 'anthropic-messages',
+      baseUrl: 'https://gateway.example.test/inference/v1/',
+      credentials: {api_key: 'managed-token'},
+    });
+
+    const result = await resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId,
+        stepAttemptId,
+        harness: 'claude',
+        provider: 'shipfox',
+        model: 'claude-model',
+        thinking: 'high',
+      },
+      {managedProvider: managedProvider(resolveCredentials)},
+    );
+
+    expect(resolveCredentials).toHaveBeenCalledWith({
+      workspaceId,
+      runId,
+      stepAttemptId,
+      model: 'claude-model',
+    });
+    expect(result).toEqual({
+      harness: 'claude',
+      provider_id: 'shipfox',
+      model: 'claude-haiku-4-5',
+      thinking: 'high',
+      credentials: {api_key: 'managed-token'},
+      claude: {
+        base_url: 'https://gateway.example.test/inference',
+        auth_token: 'managed-token',
+      },
+    });
+  });
+
+  it('keeps the catalog model ID when a managed model has no Claude model ID', async () => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     resolveCredentials.mockResolvedValue({
       api: 'anthropic-messages',
@@ -246,23 +288,13 @@ describe('resolveRuntimeCredentials', () => {
         stepAttemptId: crypto.randomUUID(),
         harness: 'claude',
         provider: 'shipfox',
-        model: 'claude-model',
+        model: 'unmapped-claude-model',
         thinking: 'high',
       },
       {managedProvider: managedProvider(resolveCredentials)},
     );
 
-    expect(result).toEqual({
-      harness: 'claude',
-      provider_id: 'shipfox',
-      model: 'claude-model',
-      thinking: 'high',
-      credentials: {api_key: 'managed-token'},
-      claude: {
-        base_url: 'https://gateway.example.test/inference',
-        auth_token: 'managed-token',
-      },
-    });
+    expect(result.model).toBe('unmapped-claude-model');
   });
 
   it.each([
@@ -297,6 +329,7 @@ describe('resolveRuntimeCredentials', () => {
         {managedProvider: managedProvider(resolveCredentials)},
       );
 
+      expect(runtime.model).toBe(model);
       const apiKey = runtime.credentials.api_key;
       if (apiKey === undefined) {
         throw new Error('Expected managed Pi API key');
@@ -769,7 +802,17 @@ function managedProvider(
     id: 'shipfox',
     label: 'Shipfox',
     models: [
-      {id: 'claude-model', label: 'Claude model', api: 'anthropic-messages'},
+      {
+        id: 'claude-model',
+        label: 'Claude model',
+        api: 'anthropic-messages',
+        claudeModelId: 'claude-haiku-4-5',
+      },
+      {
+        id: 'unmapped-claude-model',
+        label: 'Unmapped Claude model',
+        api: 'anthropic-messages',
+      },
       {
         id: 'responses-model',
         label: 'Responses model',

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -176,10 +176,13 @@ function toResponse(
       }
     | undefined,
 ): AgentRuntimeCredentialsResponseDto {
+  const managedModel = managed?.provider.models.find((candidate) => candidate.id === params.model);
+  const runtimeModel =
+    params.harness === 'claude' ? (managedModel?.claudeModelId ?? params.model) : params.model;
   const response: AgentRuntimeCredentialsResponseDto = {
     harness: params.harness,
     provider_id: params.provider,
-    model: params.model,
+    model: runtimeModel,
     thinking: params.thinking,
     credentials,
   };
@@ -199,8 +202,9 @@ function toResponse(
   }
 
   if (managed !== undefined) {
-    const model = managed.provider.models.find((candidate) => candidate.id === params.model);
-    const modelDescriptor = toCustomAgentModelDto(model ?? {id: params.model, label: params.model});
+    const modelDescriptor = toCustomAgentModelDto(
+      managedModel ?? {id: params.model, label: params.model},
+    );
     const clientApi =
       params.harness === 'claude' ? 'anthropic-messages' : managed.runtimeConfig.api;
 

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -633,22 +633,22 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions()).not.toHaveProperty('effort');
   });
 
-  it('resolves dotted managed-catalog model IDs to their family capabilities', async () => {
+  it('passes managed model IDs through without punctuation-based rewriting', async () => {
     queryMock.mockReturnValue(makeQuery([successMessage]));
 
-    await claudeHarnessAdapter.run(invocation({model: 'claude-opus-4.8', thinking: 'high'}));
+    await claudeHarnessAdapter.run(
+      invocation({
+        provider: 'shipfox',
+        model: 'catalog.model-id',
+        claude: {
+          base_url: 'https://inference.shipfox.dev/v1',
+          auth_token: 'managed-token',
+        },
+      }),
+    );
 
-    expect(lastQueryOptions()).toMatchObject({
-      thinking: {type: 'adaptive'},
-      effort: 'high',
-    });
-    queryMock.mockClear();
-
-    await claudeHarnessAdapter.run(invocation({model: 'claude-haiku-4.5', thinking: 'medium'}));
-
-    expect(lastQueryOptions()).toMatchObject({
-      thinking: {type: 'enabled', budgetTokens: 8_192},
-    });
+    expect(lastQueryOptions().model).toBe('catalog.model-id');
+    expect(lastQueryOptions()).not.toHaveProperty('thinking');
     expect(lastQueryOptions()).not.toHaveProperty('effort');
   });
 
@@ -784,13 +784,13 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions()).not.toHaveProperty('effort');
   });
 
-  it('normalizes a managed Haiku 4.5 model for Claude Code and sends no effort', async () => {
+  it('sends no effort for a managed Haiku 4.5 step with medium thinking', async () => {
     queryMock.mockReturnValue(makeQuery([successMessage]));
 
     const result = await claudeHarnessAdapter.run(
       invocation({
         provider: 'shipfox',
-        model: 'claude-haiku-4.5',
+        model: 'claude-haiku-4-5',
         thinking: 'medium',
         credentials: {api_key: 'managed-token'},
         claude: {

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -784,13 +784,13 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions()).not.toHaveProperty('effort');
   });
 
-  it('sends no effort for a managed Haiku 4.5 step with medium thinking', async () => {
+  it('normalizes a managed Haiku 4.5 model for Claude Code and sends no effort', async () => {
     queryMock.mockReturnValue(makeQuery([successMessage]));
 
     const result = await claudeHarnessAdapter.run(
       invocation({
         provider: 'shipfox',
-        model: 'claude-haiku-4-5',
+        model: 'claude-haiku-4.5',
         thinking: 'medium',
         credentials: {api_key: 'managed-token'},
         claude: {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -162,6 +162,12 @@ function claudeModelCapabilities(model: string): ClaudeModelCapabilities | undef
   return CLAUDE_MODEL_CAPABILITIES[familyId];
 }
 
+function claudeCodeModel(model: string, usesManagedEndpoint: boolean): string {
+  // Claude Code treats dotted managed catalog IDs as unknown models and then
+  // replaces legacy thinking with adaptive thinking plus its default effort.
+  return usesManagedEndpoint ? model.replaceAll('.', '-') : model;
+}
+
 /**
  * Builds the Claude SDK thinking and effort options for the selected model.
  * Shipfox's cross-harness thinking level is not an Anthropic `effort` level:
@@ -327,7 +333,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
 
   await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
-  const effectiveModel = override?.model ?? model;
+  const effectiveModel = override?.model ?? claudeCodeModel(model, invocation.claude !== undefined);
   const thinkingOptions = claudeThinkingOptions(effectiveModel, thinking);
 
   let configDir: string | undefined;

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -152,20 +152,12 @@ interface ClaudeThinkingOptions {
   readonly effort?: EffortLevel;
 }
 
-// Dated snapshot IDs (claude-haiku-4-5-20251001) resolve to their family row,
-// and dotted managed-catalog IDs (claude-haiku-4.5, claude-opus-4.8) resolve
-// to their dashed family row (claude-haiku-4-5, claude-opus-4-8).
+// Dated snapshot IDs (claude-haiku-4-5-20251001) resolve to their family row.
 const MODEL_SNAPSHOT_DATE_SUFFIX = /-\d{8}$/;
 
 function claudeModelCapabilities(model: string): ClaudeModelCapabilities | undefined {
-  const familyId = model.replace(MODEL_SNAPSHOT_DATE_SUFFIX, '').replaceAll('.', '-');
+  const familyId = model.replace(MODEL_SNAPSHOT_DATE_SUFFIX, '');
   return CLAUDE_MODEL_CAPABILITIES[familyId];
-}
-
-function claudeCodeModel(model: string, usesManagedEndpoint: boolean): string {
-  // Claude Code treats dotted managed catalog IDs as unknown models and then
-  // replaces legacy thinking with adaptive thinking plus its default effort.
-  return usesManagedEndpoint ? model.replaceAll('.', '-') : model;
 }
 
 /**
@@ -333,7 +325,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
 
   await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
-  const effectiveModel = override?.model ?? claudeCodeModel(model, invocation.claude !== undefined);
+  const effectiveModel = override?.model ?? model;
   const thinkingOptions = claudeThinkingOptions(effectiveModel, thinking);
 
   let configDir: string | undefined;


### PR DESCRIPTION
## Summary

Providerless workflow agent steps now ignore stored workspace defaults when an instance managed provider is configured. They still honor an instance-wide default and otherwise select the managed provider, while incompatible managed catalogs fall back by harness.

Explicit provider fields continue to select workspace providers. Regression coverage includes both reported managed model IDs, overlapping catalog IDs, instance-default precedence, non-pi harness fallback, and workspace-only model rejection.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/api-agent...`
- `mise exec -- turbo verify --filter=@shipfox/prose-policy`
- `mise exec -- git diff --check origin/main...HEAD`
