### PR TITLE
[runner-agent] Preserve default tools across providers

### DIFF
--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -315,7 +315,6 @@ describe('claudeHarnessAdapter', () => {
       prompt: expect.any(Object),
       options: expect.objectContaining({
         model: 'smollm2:135m-instruct-q2_K',
-        tools: [],
         env: expect.objectContaining({
           ANTHROPIC_API_KEY: '',
           ANTHROPIC_AUTH_TOKEN: 'ollama',
@@ -325,6 +324,7 @@ describe('claudeHarnessAdapter', () => {
         }),
       }),
     });
+    expect(lastQueryOptions()).not.toHaveProperty('tools');
     expect(lastQueryOptions().mcpServers).toBeUndefined();
   });
 
@@ -484,7 +484,6 @@ describe('claudeHarnessAdapter', () => {
     await claudeHarnessAdapter.run(invocation({credentials: {}, mcpServers: [bridge]}));
 
     expect(lastQueryOptions()).toMatchObject({
-      tools: [],
       mcpServers: {
         shipfox_integration_tools: {
           type: 'sdk',
@@ -493,6 +492,7 @@ describe('claudeHarnessAdapter', () => {
         },
       },
     });
+    expect(lastQueryOptions()).not.toHaveProperty('tools');
   });
 
   it('registers declared output tools when the Anthropic base URL override is active', async () => {
@@ -519,12 +519,12 @@ describe('claudeHarnessAdapter', () => {
     expect(queryMock).toHaveBeenCalledWith({
       prompt: expect.any(Object),
       options: expect.objectContaining({
-        tools: [],
         mcpServers: expect.objectContaining({
           shipfox_outputs: expect.objectContaining({name: 'shipfox_outputs'}),
         }),
       }),
     });
+    expect(lastQueryOptions()).not.toHaveProperty('tools');
   });
 
   it('maps Anthropic override egress denial to AgentConfigError', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -1017,15 +1017,20 @@ describe('claudeHarnessAdapter', () => {
     });
   });
 
-  it('merges integration bridges with output tools', async () => {
+  it('merges configured, integration, and managed tools', async () => {
     const bridge = mcpBridge();
     queryMock.mockReturnValue(makeQuery([successMessage, successMessage, successMessage]));
 
     const result = claudeHarnessAdapter.run(
-      invocation({mcpServers: [bridge], outputs: {summary: {type: 'string'}}}),
+      invocation({
+        tools: ['Read'],
+        mcpServers: [bridge],
+        outputs: {summary: {type: 'string'}},
+      }),
     );
 
     await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
+    expect(lastQueryOptions().tools).toEqual(['Read', 'mcp__shipfox_outputs__set_output']);
     expect(lastQueryOptions().mcpServers).toEqual(
       expect.objectContaining({
         shipfox_integration_tools: {

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -527,6 +527,24 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions()).not.toHaveProperty('tools');
   });
 
+  it('keeps the output tool enabled when Claude tools are explicitly selected', async () => {
+    queryMock.mockReturnValue(makeQuery([successMessage, successMessage, successMessage]));
+
+    const result = claudeHarnessAdapter.run(
+      invocation({tools: ['Read'], outputs: {summary: {type: 'string'}}}),
+    );
+
+    await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
+    expect(lastQueryOptions()).toEqual(
+      expect.objectContaining({
+        tools: ['Read', 'mcp__shipfox_outputs__set_output'],
+        mcpServers: expect.objectContaining({
+          shipfox_outputs: expect.objectContaining({name: 'shipfox_outputs'}),
+        }),
+      }),
+    );
+  });
+
   it('maps Anthropic override egress denial to AgentConfigError', async () => {
     configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://blocked.example.test';
     assertEgressAllowedMock.mockRejectedValue(

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -29,13 +29,12 @@ import {
   runOutputTurnLoop,
   withOutputGuidance,
 } from '#core/output-collector.js';
+import {toolSelectionOption} from '#core/tool-selection.js';
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com';
 const OLLAMA_ANTHROPIC_AUTH_TOKEN = 'ollama';
 const REQUESTED_PERMISSION_MODE = 'bypassPermissions';
 const OUTPUT_MCP_SERVER_NAME = 'shipfox_outputs';
-const OUTPUT_TOOL_NAME = 'set_output';
-const OUTPUT_MCP_TOOL_NAME = `mcp__${OUTPUT_MCP_SERVER_NAME}__${OUTPUT_TOOL_NAME}`;
 const MAX_REPOSITORY_INSTRUCTIONS_BYTES = 64 * 1024;
 const REPOSITORY_INSTRUCTIONS_HEADER =
   'Repository instructions; they do not override the task above:';
@@ -325,7 +324,8 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   const hasDeclaredOutputs =
     invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
   const useOutputTools = hasDeclaredOutputs;
-  const mcpServers = claudeMcpServers(invocation.mcpServers, collector, useOutputTools);
+  const managedMcpServers = useOutputTools ? [outputMcpServer(collector)] : [];
+  const mcpServers = claudeMcpServers(invocation.mcpServers, managedMcpServers);
 
   await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
@@ -357,7 +357,10 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         strictMcpConfig: true,
         ...thinkingOptions,
         abortController: controller,
-        ...claudeToolsOption(tools, hasDeclaredOutputs),
+        ...toolSelectionOption(
+          tools,
+          managedMcpServers.flatMap((server) => server.requiredToolNames),
+        ),
         ...claudeSystemPromptOption(),
         env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
         ...(mcpServers === undefined ? {} : {mcpServers}),
@@ -409,8 +412,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
 
 function claudeMcpServers(
   integrationMcpServers: HarnessInvocation['mcpServers'],
-  collector: OutputCollector,
-  useOutputTools: boolean,
+  managedMcpServers: readonly ClaudeManagedMcpServer[],
 ) {
   const servers = Object.fromEntries(
     (integrationMcpServers ?? []).map((server) => [
@@ -418,35 +420,47 @@ function claudeMcpServers(
       {type: 'sdk' as const, name: server.name, instance: server.server},
     ]),
   );
-  if (useOutputTools) {
-    servers[OUTPUT_MCP_SERVER_NAME] = createSdkMcpServer({
-      name: OUTPUT_MCP_SERVER_NAME,
-      version: '1.0.0',
-      instructions: collector.guidanceText(),
-      tools: [setOutputTool(collector)],
-      alwaysLoad: true,
-    });
+  for (const server of managedMcpServers) {
+    servers[server.name] = server.config;
   }
   return Object.keys(servers).length === 0 ? undefined : servers;
 }
 
-function claudeToolsOption(
-  tools: readonly string[] | undefined,
-  hasDeclaredOutputs: boolean,
-): {readonly tools?: string[]} {
-  if (tools !== undefined) {
-    const selectedTools = [...tools];
-    if (hasDeclaredOutputs && !selectedTools.includes(OUTPUT_MCP_TOOL_NAME)) {
-      selectedTools.push(OUTPUT_MCP_TOOL_NAME);
-    }
-    return {tools: selectedTools};
-  }
-  return {};
+interface ClaudeManagedMcpServer {
+  readonly name: string;
+  readonly config: ReturnType<typeof createSdkMcpServer>;
+  readonly requiredToolNames: readonly string[];
+}
+
+type ClaudeMcpTools = NonNullable<Parameters<typeof createSdkMcpServer>[0]['tools']>;
+
+function outputMcpServer(collector: OutputCollector): ClaudeManagedMcpServer {
+  return managedMcpServer({
+    name: OUTPUT_MCP_SERVER_NAME,
+    version: '1.0.0',
+    instructions: collector.guidanceText(),
+    tools: [setOutputTool(collector)],
+  });
+}
+
+function managedMcpServer<Tools extends ClaudeMcpTools>(params: {
+  name: string;
+  version: string;
+  instructions: string;
+  tools: Tools;
+}): ClaudeManagedMcpServer {
+  return {
+    name: params.name,
+    config: createSdkMcpServer({...params, alwaysLoad: true}),
+    requiredToolNames: params.tools.map(
+      (managedTool) => `mcp__${params.name}__${managedTool.name}`,
+    ),
+  };
 }
 
 function setOutputTool(collector: OutputCollector) {
   return tool(
-    OUTPUT_TOOL_NAME,
+    'set_output',
     'Set one structured output value for this workflow step.',
     {key: z.string(), value: z.string()},
     async (args) => {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -258,7 +258,6 @@ interface ClaudeAnthropicOverride {
   readonly model: string | undefined;
   readonly smallFastModel: string | undefined;
   readonly authToken: string;
-  readonly disableDefaultTools: boolean;
 }
 
 interface ClaudeAuth {
@@ -355,7 +354,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         strictMcpConfig: true,
         ...thinkingOptions,
         abortController: controller,
-        ...claudeToolsOption(tools, override),
+        ...claudeToolsOption(tools),
         ...claudeSystemPromptOption(),
         env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
         ...(mcpServers === undefined ? {} : {mcpServers}),
@@ -428,12 +427,9 @@ function claudeMcpServers(
   return Object.keys(servers).length === 0 ? undefined : servers;
 }
 
-function claudeToolsOption(
-  tools: readonly string[] | undefined,
-  override: ClaudeAnthropicOverride | undefined,
-): {readonly tools?: string[]} {
+function claudeToolsOption(tools: readonly string[] | undefined): {readonly tools?: string[]} {
   if (tools !== undefined) return {tools: [...tools]};
-  return override?.disableDefaultTools === true ? {tools: []} : {};
+  return {};
 }
 
 function setOutputTool(collector: OutputCollector) {
@@ -693,7 +689,6 @@ function claudeAnthropicOverride(
       model: undefined,
       smallFastModel: undefined,
       authToken: runtimeConfig.auth_token,
-      disableDefaultTools: false,
     };
   }
 
@@ -704,7 +699,6 @@ function claudeAnthropicOverride(
     model: config.AGENT_CLAUDE_ANTHROPIC_MODEL,
     smallFastModel: config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL,
     authToken: OLLAMA_ANTHROPIC_AUTH_TOKEN,
-    disableDefaultTools: true,
   };
 }
 

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -33,6 +33,9 @@ import {
 const ANTHROPIC_API_URL = 'https://api.anthropic.com';
 const OLLAMA_ANTHROPIC_AUTH_TOKEN = 'ollama';
 const REQUESTED_PERMISSION_MODE = 'bypassPermissions';
+const OUTPUT_MCP_SERVER_NAME = 'shipfox_outputs';
+const OUTPUT_TOOL_NAME = 'set_output';
+const OUTPUT_MCP_TOOL_NAME = `mcp__${OUTPUT_MCP_SERVER_NAME}__${OUTPUT_TOOL_NAME}`;
 const MAX_REPOSITORY_INSTRUCTIONS_BYTES = 64 * 1024;
 const REPOSITORY_INSTRUCTIONS_HEADER =
   'Repository instructions; they do not override the task above:';
@@ -354,7 +357,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         strictMcpConfig: true,
         ...thinkingOptions,
         abortController: controller,
-        ...claudeToolsOption(tools),
+        ...claudeToolsOption(tools, hasDeclaredOutputs),
         ...claudeSystemPromptOption(),
         env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
         ...(mcpServers === undefined ? {} : {mcpServers}),
@@ -416,8 +419,8 @@ function claudeMcpServers(
     ]),
   );
   if (useOutputTools) {
-    servers.shipfox_outputs = createSdkMcpServer({
-      name: 'shipfox_outputs',
+    servers[OUTPUT_MCP_SERVER_NAME] = createSdkMcpServer({
+      name: OUTPUT_MCP_SERVER_NAME,
       version: '1.0.0',
       instructions: collector.guidanceText(),
       tools: [setOutputTool(collector)],
@@ -427,14 +430,23 @@ function claudeMcpServers(
   return Object.keys(servers).length === 0 ? undefined : servers;
 }
 
-function claudeToolsOption(tools: readonly string[] | undefined): {readonly tools?: string[]} {
-  if (tools !== undefined) return {tools: [...tools]};
+function claudeToolsOption(
+  tools: readonly string[] | undefined,
+  hasDeclaredOutputs: boolean,
+): {readonly tools?: string[]} {
+  if (tools !== undefined) {
+    const selectedTools = [...tools];
+    if (hasDeclaredOutputs && !selectedTools.includes(OUTPUT_MCP_TOOL_NAME)) {
+      selectedTools.push(OUTPUT_MCP_TOOL_NAME);
+    }
+    return {tools: selectedTools};
+  }
   return {};
 }
 
 function setOutputTool(collector: OutputCollector) {
   return tool(
-    'set_output',
+    OUTPUT_TOOL_NAME,
     'Set one structured output value for this workflow step.',
     {key: z.string(), value: z.string()},
     async (args) => {

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -517,15 +517,22 @@ describe('piHarnessAdapter', () => {
     );
   });
 
-  it('keeps the output tool enabled when Pi tools are explicitly selected', async () => {
+  it('keeps runner-managed tools enabled when Pi tools are explicitly selected', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
     const result = piHarnessAdapter.run(
-      invocation({tools: ['read'], outputs: {summary: {type: 'string'}}}),
+      invocation({
+        cwd: sessionDir,
+        agentStateDir: join(sessionDir, 'runner-agent'),
+        tools: ['read'],
+        mcpServers: [mcpBridge()],
+        outputs: {summary: {type: 'string'}},
+      }),
     );
 
     await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
     expect(createAgentSessionMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
-        tools: ['read', 'set_output'],
+        tools: ['read', 'mcp', 'set_output'],
         customTools: [expect.objectContaining({name: 'set_output'})],
       }),
     );

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -517,6 +517,20 @@ describe('piHarnessAdapter', () => {
     );
   });
 
+  it('keeps the output tool enabled when Pi tools are explicitly selected', async () => {
+    const result = piHarnessAdapter.run(
+      invocation({tools: ['read'], outputs: {summary: {type: 'string'}}}),
+    );
+
+    await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
+    expect(createAgentSessionMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        tools: ['read', 'set_output'],
+        customTools: [expect.objectContaining({name: 'set_output'})],
+      }),
+    );
+  });
+
   it('passes selected Pi tool names through unchanged', async () => {
     await piHarnessAdapter.run(invocation({tools: ['read', 'web_search', 'fetch_content']}));
 

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -562,9 +562,10 @@ describe('piHarnessAdapter', () => {
 
     const options = createAgentSessionMock.mock.calls[0]?.[0];
     expect(options).not.toHaveProperty('tools');
+    expect(options).not.toHaveProperty('noTools');
   });
 
-  it('disables default Pi tools for custom providers unless tools are selected', async () => {
+  it('keeps default Pi tools for custom providers when tools are not selected', async () => {
     const model = {provider: 'local-ollama', id: 'llama'};
     findMock.mockReturnValue(model);
 
@@ -576,12 +577,13 @@ describe('piHarnessAdapter', () => {
       }),
     );
 
-    expect(createAgentSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({model, noTools: 'builtin'}),
-    );
+    const options = createAgentSessionMock.mock.calls[0]?.[0];
+    expect(options).toEqual(expect.objectContaining({model}));
+    expect(options).not.toHaveProperty('tools');
+    expect(options).not.toHaveProperty('noTools');
   });
 
-  it('preserves custom-provider builtin suppression when MCP is configured', async () => {
+  it('keeps default Pi tools for custom providers when MCP is configured', async () => {
     const model = {provider: 'local-ollama', id: 'llama'};
     findMock.mockReturnValue(model);
     sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
@@ -597,9 +599,10 @@ describe('piHarnessAdapter', () => {
       }),
     );
 
-    expect(createAgentSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({model, noTools: 'builtin'}),
-    );
+    const options = createAgentSessionMock.mock.calls[0]?.[0];
+    expect(options).toEqual(expect.objectContaining({model}));
+    expect(options).not.toHaveProperty('tools');
+    expect(options).not.toHaveProperty('noTools');
   });
 
   it('keeps output tools available for custom providers with declared outputs', async () => {
@@ -616,13 +619,15 @@ describe('piHarnessAdapter', () => {
     );
 
     await expect(result).rejects.toThrow('Agent step finished without required outputs: message');
-    expect(createAgentSessionMock).toHaveBeenCalledWith(
+    const options = createAgentSessionMock.mock.calls[0]?.[0];
+    expect(options).toEqual(
       expect.objectContaining({
         model,
-        noTools: 'builtin',
         customTools: [expect.objectContaining({name: 'set_output'})],
       }),
     );
+    expect(options).not.toHaveProperty('tools');
+    expect(options).not.toHaveProperty('noTools');
   });
 
   it('fails when Pi records an assistant error message', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -174,7 +174,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       services,
       model,
       thinkingLevel: thinking as PiThinkingLevel,
-      ...piToolsOption(tools, customProvider, mcpConfig !== undefined),
+      ...piToolsOption(tools, mcpConfig !== undefined),
       ...(hasDeclaredOutputs ? {customTools: [setOutputTool(collector)]} : {}),
       // Keep the session JSONL in the runner-owned agent-state directory so it forwards from a
       // deterministic path and is cleaned up with the job; pi's default lives under ~/.pi.
@@ -269,14 +269,13 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
 
 function piToolsOption(
   tools: readonly string[] | undefined,
-  customProvider: CustomModelProviderRuntimeConfigDto | undefined,
   hasMcpServers: boolean,
-): {tools: string[]} | {noTools: 'builtin'} | Record<string, never> {
+): {tools: string[]} | Record<string, never> {
   if (tools !== undefined) {
     const needsMcpTool = hasMcpServers && !tools.includes('mcp');
     return {tools: needsMcpTool ? [...tools, 'mcp'] : [...tools]};
   }
-  return customProvider === undefined ? {} : {noTools: 'builtin'};
+  return {};
 }
 
 interface PiMcpConfig {

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -43,10 +43,11 @@ import {
   piExtensionDirectories,
 } from '#core/pi-extensions.js';
 import {type SessionForwarder, startSessionForwarder} from '#core/session-forwarder.js';
+import {toolSelectionOption} from '#core/tool-selection.js';
 
 const KEYLESS_CUSTOM_PROVIDER_API_KEY = 'shipfox-keyless-custom-provider-placeholder';
 const SECRET_HEADER_CREDENTIAL_PREFIX = 'header:';
-const OUTPUT_TOOL_NAME = 'set_output';
+const PI_MCP_TOOL_NAME = 'mcp';
 
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions['thinkingLevel']>;
 type ModelRuntimeInstance = Awaited<ReturnType<typeof ModelRuntime.create>>;
@@ -82,6 +83,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   const collector = new OutputCollector(invocation.outputs);
   const hasDeclaredOutputs =
     invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
+  const customTools = hasDeclaredOutputs ? [setOutputTool(collector)] : [];
 
   // A listener added to an already-aborted signal never fires, so an abort that lands
   // before this point (or during the awaits below) would leave pi running and burning
@@ -175,8 +177,11 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       services,
       model,
       thinkingLevel: thinking as PiThinkingLevel,
-      ...piToolsOption(tools, mcpConfig !== undefined, hasDeclaredOutputs),
-      ...(hasDeclaredOutputs ? {customTools: [setOutputTool(collector)]} : {}),
+      ...toolSelectionOption(tools, [
+        ...(mcpConfig === undefined ? [] : [PI_MCP_TOOL_NAME]),
+        ...customTools.map((tool) => tool.name),
+      ]),
+      ...(customTools.length === 0 ? {} : {customTools}),
       // Keep the session JSONL in the runner-owned agent-state directory so it forwards from a
       // deterministic path and is cleaned up with the job; pi's default lives under ~/.pi.
       sessionManager: SessionManager.create(cwd, join(agentStateDir, 'agent-sessions')),
@@ -266,22 +271,6 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   } finally {
     await closePiSession({session, mcpConfig});
   }
-}
-
-function piToolsOption(
-  tools: readonly string[] | undefined,
-  hasMcpServers: boolean,
-  hasDeclaredOutputs: boolean,
-): {tools: string[]} | Record<string, never> {
-  if (tools !== undefined) {
-    const selectedTools = [...tools];
-    if (hasMcpServers && !selectedTools.includes('mcp')) selectedTools.push('mcp');
-    if (hasDeclaredOutputs && !selectedTools.includes(OUTPUT_TOOL_NAME)) {
-      selectedTools.push(OUTPUT_TOOL_NAME);
-    }
-    return {tools: selectedTools};
-  }
-  return {};
 }
 
 interface PiMcpConfig {
@@ -411,7 +400,7 @@ function isAssistantMessage(message: unknown): message is {
 
 function setOutputTool(collector: OutputCollector) {
   return defineTool({
-    name: OUTPUT_TOOL_NAME,
+    name: 'set_output',
     label: 'Set output',
     description: 'Set one structured output value for this workflow step.',
     promptSnippet: 'set_output records a workflow step output.',

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -46,6 +46,7 @@ import {type SessionForwarder, startSessionForwarder} from '#core/session-forwar
 
 const KEYLESS_CUSTOM_PROVIDER_API_KEY = 'shipfox-keyless-custom-provider-placeholder';
 const SECRET_HEADER_CREDENTIAL_PREFIX = 'header:';
+const OUTPUT_TOOL_NAME = 'set_output';
 
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions['thinkingLevel']>;
 type ModelRuntimeInstance = Awaited<ReturnType<typeof ModelRuntime.create>>;
@@ -174,7 +175,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       services,
       model,
       thinkingLevel: thinking as PiThinkingLevel,
-      ...piToolsOption(tools, mcpConfig !== undefined),
+      ...piToolsOption(tools, mcpConfig !== undefined, hasDeclaredOutputs),
       ...(hasDeclaredOutputs ? {customTools: [setOutputTool(collector)]} : {}),
       // Keep the session JSONL in the runner-owned agent-state directory so it forwards from a
       // deterministic path and is cleaned up with the job; pi's default lives under ~/.pi.
@@ -270,10 +271,15 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
 function piToolsOption(
   tools: readonly string[] | undefined,
   hasMcpServers: boolean,
+  hasDeclaredOutputs: boolean,
 ): {tools: string[]} | Record<string, never> {
   if (tools !== undefined) {
-    const needsMcpTool = hasMcpServers && !tools.includes('mcp');
-    return {tools: needsMcpTool ? [...tools, 'mcp'] : [...tools]};
+    const selectedTools = [...tools];
+    if (hasMcpServers && !selectedTools.includes('mcp')) selectedTools.push('mcp');
+    if (hasDeclaredOutputs && !selectedTools.includes(OUTPUT_TOOL_NAME)) {
+      selectedTools.push(OUTPUT_TOOL_NAME);
+    }
+    return {tools: selectedTools};
   }
   return {};
 }
@@ -405,7 +411,7 @@ function isAssistantMessage(message: unknown): message is {
 
 function setOutputTool(collector: OutputCollector) {
   return defineTool({
-    name: 'set_output',
+    name: OUTPUT_TOOL_NAME,
     label: 'Set output',
     description: 'Set one structured output value for this workflow step.',
     promptSnippet: 'set_output records a workflow step output.',

--- a/libs/runner/agent/src/core/tool-selection.test.ts
+++ b/libs/runner/agent/src/core/tool-selection.test.ts
@@ -1,0 +1,27 @@
+import {toolSelectionOption} from '#core/tool-selection.js';
+
+describe('toolSelectionOption', () => {
+  it('leaves harness defaults untouched when tools are not configured', () => {
+    const result = toolSelectionOption(undefined, ['set_output', 'managed_review']);
+
+    expect(result).toEqual({});
+  });
+
+  it('appends every required managed tool to an explicit selection', () => {
+    const configuredTools = ['read'];
+
+    const result = toolSelectionOption(configuredTools, ['set_output', 'managed_review']);
+
+    expect(result).toEqual({tools: ['read', 'set_output', 'managed_review']});
+    expect(configuredTools).toEqual(['read']);
+  });
+
+  it('does not duplicate required tools already selected or repeated by the caller', () => {
+    const result = toolSelectionOption(
+      ['read', 'set_output'],
+      ['set_output', 'managed_review', 'managed_review'],
+    );
+
+    expect(result).toEqual({tools: ['read', 'set_output', 'managed_review']});
+  });
+});

--- a/libs/runner/agent/src/core/tool-selection.ts
+++ b/libs/runner/agent/src/core/tool-selection.ts
@@ -1,0 +1,12 @@
+export function toolSelectionOption(
+  configuredTools: readonly string[] | undefined,
+  requiredTools: readonly string[],
+): {readonly tools?: string[]} {
+  if (configuredTools === undefined) return {};
+
+  const selectedTools = [...configuredTools];
+  for (const requiredTool of requiredTools) {
+    if (!selectedTools.includes(requiredTool)) selectedTools.push(requiredTool);
+  }
+  return {tools: selectedTools};
+}


### PR DESCRIPTION
Agent steps that omit `tools` should receive their harness's default tools. Pi custom-provider sessions instead disabled built-ins, while Claude's legacy Anthropic base URL path forced an empty tool list. This left otherwise unrestricted agents without filesystem access.

This makes tool selection independent of provider configuration. Both adapters now leave tool options unset when the workflow omits `tools`, while preserving explicit tool allowlists and Pi's MCP bridge behavior.

Steps with declared outputs also keep the runner-owned `set_output` tool available even when the workflow specifies an explicit tool list. Pi adds the custom tool name to its selection, and Claude adds the qualified output MCP tool, so restricting optional harness tools cannot break the required output protocol.

Validation:

- `pnpm --filter=@shipfox/runner-agent test -- claude-adapter.test.ts pi-adapter.test.ts`
- `turbo check type test --filter=@shipfox/runner-agent...`