### PR TITLE
[react-ui] Restore workflow navigation spacing

### DIFF
--- a/.changeset/even-nav-spacing.md
+++ b/.changeset/even-nav-spacing.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Restores density-aware top and bottom row padding utilities.

--- a/libs/shared/react/ui/index.css
+++ b/libs/shared/react/ui/index.css
@@ -1227,6 +1227,14 @@
   padding-block: var(--pad-row-y);
 }
 
+@utility pt-row {
+  padding-top: var(--pad-row-y);
+}
+
+@utility pb-row {
+  padding-bottom: var(--pad-row-y);
+}
+
 @utility px-frame {
   padding-inline: var(--pad-frame-x);
 }


### PR DESCRIPTION
## Summary

The workflow run rail used directional row-padding classes without matching semantic utilities. Summary and Run details therefore collapsed against their dividers while Jobs kept the intended inset.

This adds density-aware directional row padding to the shared spacing scale. Navigation sections now keep the same rhythm in comfortable and compact density modes.

## Validation

Package and dependency check, type, build, and test graphs pass. This includes 469 React UI tests and 645 client workflows tests. The full client production build, Changesets status, Vale, diff check, and Impeccable layout detector also pass.