### PR TITLE
[@shipfox/docs] Add GLM-5.3 Flash to the Cloud model reference

### DIFF
--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -59,6 +59,7 @@ reference](/reference/workflow-schema#agent-step-fields).
 | DeepSeek V4 Flash (0731) | `deepseek-v4-flash-0731` |
 | DeepSeek V4 Pro (0813) | `deepseek-v4-pro-0813` |
 | DeepSeek V4 Pro | `deepseek-v4-pro` |
+| GLM-5.3 Flash | `glm-5.3-flash` |
 | GLM-5.2 | `glm-5.2` |
 | GLM-5.1 | `glm-5.1` |
 | Kimi K3 | `kimi-k3` |


### PR DESCRIPTION
Add GLM-5.3 Flash to the managed Shipfox Cloud agent model reference so users can select the model with exact workflow ID glm-5.3-flash. Validated locally with mise exec -- turbo test --filter=@shipfox/docs... and mise exec -- turbo check type build --filter=@shipfox/docs....

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GLM-5.3 Flash to the managed Shipfox Cloud model reference so users can select the model with workflow ID `glm-5.3-flash`.

<sup>Written for commit 456276e42c98dd8c3bbc2e501cea977b27d4be06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

