### PR TITLE
[api-agent] Honor workspace default harness in validation

### DIFF
--- a/.changeset/bright-harness-defaults.md
+++ b/.changeset/bright-harness-defaults.md
@@ -4,4 +4,4 @@
 "@shipfox/api-definitions": minor
 ---
 
-Adds workspace-aware validation that applies the configured default agent harness to harness-specific workflow fields.
+Applies each workspace's configured default harness when checking harness-specific tools, thinking, models, and shared sessions. Managed-inference workspaces using Pi can use Pi tool names without declaring the harness.

--- a/.changeset/bright-harness-defaults.md
+++ b/.changeset/bright-harness-defaults.md
@@ -1,7 +1,7 @@
 ---
 "@shipfox/api-agent": minor
 "@shipfox/api-agent-dto": minor
-"@shipfox/api-definitions": patch
+"@shipfox/api-definitions": minor
 ---
 
-Uses each workspace's default agent harness when validating harness-specific workflow fields, including tools, for managed inference and workspace provider configurations.
+Adds workspace-aware validation that applies the configured default agent harness to harness-specific workflow fields.

--- a/.changeset/bright-harness-defaults.md
+++ b/.changeset/bright-harness-defaults.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-agent": minor
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-definitions": patch
+---
+
+Uses each workspace's default agent harness when validating harness-specific workflow fields, including tools, for managed inference and workspace provider configurations.

--- a/libs/api/agent-dto/src/inter-module.test.ts
+++ b/libs/api/agent-dto/src/inter-module.test.ts
@@ -3,6 +3,21 @@ import {agentInterModuleContract, agentSessionDescriptorSchema} from './inter-mo
 const UUID = '00000000-0000-4000-8000-000000000001';
 
 describe('agentInterModuleContract', () => {
+  test('carries workspace context and the effective default harness for validation', () => {
+    const input = agentInterModuleContract.methods.getValidationCatalog.input.parse({
+      workspaceId: UUID,
+    });
+    const output = agentInterModuleContract.methods.getValidationCatalog.output.parse({
+      version: 1,
+      default_harness_id: 'pi',
+      providers: [],
+      harnesses: [],
+    });
+
+    expect(input).toEqual({workspaceId: UUID});
+    expect(output.default_harness_id).toBe('pi');
+  });
+
   test('accepts valid claimSession payloads in both modes', () => {
     const input = {
       workspaceId: UUID,

--- a/libs/api/agent-dto/src/inter-module.test.ts
+++ b/libs/api/agent-dto/src/inter-module.test.ts
@@ -3,12 +3,24 @@ import {agentInterModuleContract, agentSessionDescriptorSchema} from './inter-mo
 const UUID = '00000000-0000-4000-8000-000000000001';
 
 describe('agentInterModuleContract', () => {
-  test('carries workspace context and the effective default harness for validation', () => {
-    const input = agentInterModuleContract.methods.getValidationCatalog.input.parse({
-      workspaceId: UUID,
-    });
+  test('preserves the original validation catalog contract', () => {
+    const input = agentInterModuleContract.methods.getValidationCatalog.input.parse({});
     const output = agentInterModuleContract.methods.getValidationCatalog.output.parse({
       version: 1,
+      providers: [],
+      harnesses: [],
+    });
+
+    expect(input).toEqual({});
+    expect(output).toEqual({version: 1, providers: [], harnesses: []});
+  });
+
+  test('carries workspace context and the effective default harness in the V2 catalog', () => {
+    const input = agentInterModuleContract.methods.getValidationCatalogV2.input.parse({
+      workspaceId: UUID,
+    });
+    const output = agentInterModuleContract.methods.getValidationCatalogV2.output.parse({
+      version: 2,
       default_harness_id: 'pi',
       providers: [],
       harnesses: [],

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -10,6 +10,7 @@ import {
 
 const agentValidationCatalogSchema = z.object({
   version: z.literal(1),
+  default_harness_id: harnessSchema,
   providers: z.array(
     z.object({
       id: z.string().min(1),
@@ -51,7 +52,7 @@ export const agentInterModuleContract = defineInterModuleContract({
   module: 'agent',
   methods: {
     getValidationCatalog: {
-      input: z.object({}),
+      input: z.object({workspaceId: z.string().uuid().nullable()}),
       output: agentValidationCatalogSchema,
       errors: {},
     },

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -8,9 +8,7 @@ import {
   modelProviderRefSchema,
 } from '#schemas/index.js';
 
-const agentValidationCatalogSchema = z.object({
-  version: z.literal(1),
-  default_harness_id: harnessSchema,
+const agentValidationCatalogFieldsSchema = z.object({
   providers: z.array(
     z.object({
       id: z.string().min(1),
@@ -28,7 +26,17 @@ const agentValidationCatalogSchema = z.object({
   ),
 });
 
+const agentValidationCatalogSchema = agentValidationCatalogFieldsSchema.extend({
+  version: z.literal(1),
+});
+
+const agentValidationCatalogV2Schema = agentValidationCatalogFieldsSchema.extend({
+  version: z.literal(2),
+  default_harness_id: harnessSchema,
+});
+
 export type AgentValidationCatalog = z.infer<typeof agentValidationCatalogSchema>;
+export type AgentValidationCatalogV2 = z.infer<typeof agentValidationCatalogV2Schema>;
 
 const agentConfigInputSchema = z.object({
   harness: harnessSchema.optional(),
@@ -52,8 +60,13 @@ export const agentInterModuleContract = defineInterModuleContract({
   module: 'agent',
   methods: {
     getValidationCatalog: {
-      input: z.object({workspaceId: z.string().uuid().nullable()}),
+      input: z.object({}),
       output: agentValidationCatalogSchema,
+      errors: {},
+    },
+    getValidationCatalogV2: {
+      input: z.object({workspaceId: z.string().uuid().nullable()}),
+      output: agentValidationCatalogV2Schema,
       errors: {},
     },
     resolveAgentConfig: {

--- a/libs/api/agent/src/core/validation-catalog.test.ts
+++ b/libs/api/agent/src/core/validation-catalog.test.ts
@@ -7,6 +7,7 @@ describe('getAgentValidationCatalog', () => {
     const pi = catalog.harnesses.find((harness) => harness.id === 'pi');
     const claude = catalog.harnesses.find((harness) => harness.id === 'claude');
 
+    expect(catalog.default_harness_id).toBe('pi');
     expect(Object.keys(pi?.model_ids_by_provider ?? {})).toEqual(
       expect.arrayContaining(pi?.supported_provider_ids ?? []),
     );
@@ -16,6 +17,12 @@ describe('getAgentValidationCatalog', () => {
     expect(pi?.model_ids_by_provider?.['qwen-token-plan-individual']).toContain('qwen3.8-max');
     expect(pi?.thinking_levels).toContain('max');
     expect(claude?.model_ids_by_provider?.anthropic).toContain('claude-opus-4-8');
+  });
+
+  it('includes the configured default harness', () => {
+    const catalog = getAgentValidationCatalog(undefined, 'enabled', 'claude');
+
+    expect(catalog.default_harness_id).toBe('claude');
   });
 
   it('includes injected managed providers with harness-compatible models', () => {

--- a/libs/api/agent/src/core/validation-catalog.test.ts
+++ b/libs/api/agent/src/core/validation-catalog.test.ts
@@ -1,5 +1,5 @@
 import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
-import {getAgentValidationCatalog} from './validation-catalog.js';
+import {getAgentValidationCatalog, getAgentValidationCatalogV2} from './validation-catalog.js';
 
 describe('getAgentValidationCatalog', () => {
   it('includes the model allowlist for each harness/provider pair', () => {
@@ -7,7 +7,6 @@ describe('getAgentValidationCatalog', () => {
     const pi = catalog.harnesses.find((harness) => harness.id === 'pi');
     const claude = catalog.harnesses.find((harness) => harness.id === 'claude');
 
-    expect(catalog.default_harness_id).toBe('pi');
     expect(Object.keys(pi?.model_ids_by_provider ?? {})).toEqual(
       expect.arrayContaining(pi?.supported_provider_ids ?? []),
     );
@@ -19,8 +18,14 @@ describe('getAgentValidationCatalog', () => {
     expect(claude?.model_ids_by_provider?.anthropic).toContain('claude-opus-4-8');
   });
 
-  it('includes the configured default harness', () => {
-    const catalog = getAgentValidationCatalog(undefined, 'enabled', 'claude');
+  it('includes the built-in default harness in the V2 catalog', () => {
+    const catalog = getAgentValidationCatalogV2();
+
+    expect(catalog.default_harness_id).toBe('pi');
+  });
+
+  it('includes the configured default harness in the V2 catalog', () => {
+    const catalog = getAgentValidationCatalogV2(undefined, 'enabled', 'claude');
 
     expect(catalog.default_harness_id).toBe('claude');
   });

--- a/libs/api/agent/src/core/validation-catalog.ts
+++ b/libs/api/agent/src/core/validation-catalog.ts
@@ -1,9 +1,11 @@
 import type {
+  Harness,
   HarnessDescriptor,
   ManagedModelProvider,
   WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
 import {
+  DEFAULT_HARNESS,
   listEnabledHarnessTools,
   listHarnessDescriptors,
   MODEL_PROVIDER_IDS,
@@ -19,11 +21,13 @@ type HarnessValidationCatalog = AgentValidationCatalog['harnesses'][number];
 export function getAgentValidationCatalog(
   managedProvider?: ManagedModelProvider | undefined,
   workspaceProviders: WorkspaceProvidersPolicy = 'enabled',
+  defaultHarnessId: Harness = DEFAULT_HARNESS,
 ): AgentValidationCatalog {
   const managedOnly = workspaceProviders === 'disabled';
 
   return {
     version: 1,
+    default_harness_id: defaultHarnessId,
     providers: buildValidationProviders(managedProvider, managedOnly),
     harnesses: listHarnessDescriptors().map((harness) =>
       buildHarnessValidationCatalog(harness, managedProvider, managedOnly),

--- a/libs/api/agent/src/core/validation-catalog.ts
+++ b/libs/api/agent/src/core/validation-catalog.ts
@@ -10,7 +10,10 @@ import {
   listHarnessDescriptors,
   MODEL_PROVIDER_IDS,
 } from '@shipfox/api-agent-dto';
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {
+  AgentValidationCatalog,
+  AgentValidationCatalogV2,
+} from '@shipfox/api-agent-dto/inter-module';
 import {harnessToolDeploymentConfig} from '#config.js';
 import {listHarnessProviderModels} from './harness/index.js';
 import {getModelProviderEntry} from './model-provider-policy.js';
@@ -21,17 +24,27 @@ type HarnessValidationCatalog = AgentValidationCatalog['harnesses'][number];
 export function getAgentValidationCatalog(
   managedProvider?: ManagedModelProvider | undefined,
   workspaceProviders: WorkspaceProvidersPolicy = 'enabled',
-  defaultHarnessId: Harness = DEFAULT_HARNESS,
 ): AgentValidationCatalog {
   const managedOnly = workspaceProviders === 'disabled';
 
   return {
     version: 1,
-    default_harness_id: defaultHarnessId,
     providers: buildValidationProviders(managedProvider, managedOnly),
     harnesses: listHarnessDescriptors().map((harness) =>
       buildHarnessValidationCatalog(harness, managedProvider, managedOnly),
     ),
+  };
+}
+
+export function getAgentValidationCatalogV2(
+  managedProvider?: ManagedModelProvider | undefined,
+  workspaceProviders: WorkspaceProvidersPolicy = 'enabled',
+  defaultHarnessId: Harness = DEFAULT_HARNESS,
+): AgentValidationCatalogV2 {
+  return {
+    ...getAgentValidationCatalog(managedProvider, workspaceProviders),
+    version: 2,
+    default_harness_id: defaultHarnessId,
   };
 }
 

--- a/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
+++ b/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
@@ -5,23 +5,23 @@ import {
   type ModelProviderRef,
   type WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import {config} from '#config.js';
-import {getAgentWorkspaceDefaultsSnapshot} from '#db/index.js';
+import {getAgentWorkspaceDefaultsSnapshot, getAgentWorkspaceSettings} from '#db/index.js';
 import type {AgentConfigResolutionContext, AgentDefaultsResolver} from './resolve-agent-config.js';
 import {resolveAgentConfig} from './resolve-agent-config.js';
-import {getAgentValidationCatalog} from './validation-catalog.js';
+import {getAgentValidationCatalogV2} from './validation-catalog.js';
 
 export async function getWorkspaceAgentValidationCatalog(
   workspaceId: string,
   managedProvider?: ManagedModelProvider | undefined,
   workspaceProviders?: WorkspaceProvidersPolicy | undefined,
-): Promise<AgentValidationCatalog> {
-  const snapshot = await getAgentWorkspaceDefaultsSnapshot(workspaceId);
-  return getAgentValidationCatalog(
+): Promise<AgentValidationCatalogV2> {
+  const settings = await getAgentWorkspaceSettings(workspaceId);
+  return getAgentValidationCatalogV2(
     managedProvider,
     workspaceProviders,
-    snapshot.defaultHarnessId ?? DEFAULT_HARNESS,
+    settings?.defaultHarnessId ?? DEFAULT_HARNESS,
   );
 }
 

--- a/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
+++ b/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
@@ -1,13 +1,29 @@
-import type {
-  AgentThinking,
-  ManagedModelProvider,
-  ModelProviderRef,
-  WorkspaceProvidersPolicy,
+import {
+  type AgentThinking,
+  DEFAULT_HARNESS,
+  type ManagedModelProvider,
+  type ModelProviderRef,
+  type WorkspaceProvidersPolicy,
 } from '@shipfox/api-agent-dto';
+import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 import {config} from '#config.js';
 import {getAgentWorkspaceDefaultsSnapshot} from '#db/index.js';
 import type {AgentConfigResolutionContext, AgentDefaultsResolver} from './resolve-agent-config.js';
 import {resolveAgentConfig} from './resolve-agent-config.js';
+import {getAgentValidationCatalog} from './validation-catalog.js';
+
+export async function getWorkspaceAgentValidationCatalog(
+  workspaceId: string,
+  managedProvider?: ManagedModelProvider | undefined,
+  workspaceProviders?: WorkspaceProvidersPolicy | undefined,
+): Promise<AgentValidationCatalog> {
+  const snapshot = await getAgentWorkspaceDefaultsSnapshot(workspaceId);
+  return getAgentValidationCatalog(
+    managedProvider,
+    workspaceProviders,
+    snapshot.defaultHarnessId ?? DEFAULT_HARNESS,
+  );
+}
 
 export async function createWorkspaceAgentDefaultsResolver(
   workspaceId: string,

--- a/libs/api/agent/src/presentation/inter-module.test.ts
+++ b/libs/api/agent/src/presentation/inter-module.test.ts
@@ -5,7 +5,71 @@ import {setDefaultHarness} from '#db/index.js';
 import {agentTestSecretsClient} from '#test/fixtures/secrets-client.js';
 import {createAgentInterModulePresentation} from './inter-module.js';
 
+const workspaceDefaultsResolverMocks = vi.hoisted(() => ({
+  getWorkspaceAgentValidationCatalog: vi.fn(),
+}));
+
+vi.mock('#core/workspace-agent-defaults-resolver.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('#core/workspace-agent-defaults-resolver.js')>();
+  workspaceDefaultsResolverMocks.getWorkspaceAgentValidationCatalog.mockImplementation(
+    actual.getWorkspaceAgentValidationCatalog,
+  );
+  return {
+    ...actual,
+    getWorkspaceAgentValidationCatalog:
+      workspaceDefaultsResolverMocks.getWorkspaceAgentValidationCatalog,
+  };
+});
+
 describe('agent inter-module presentation', () => {
+  beforeEach(() => {
+    workspaceDefaultsResolverMocks.getWorkspaceAgentValidationCatalog.mockClear();
+  });
+
+  test('preserves the original validation catalog response', async () => {
+    const presentation = createAgentInterModulePresentation({secrets: agentTestSecretsClient});
+
+    const catalog = await presentation.handlers.getValidationCatalog(
+      {},
+      {signal: new AbortController().signal},
+    );
+
+    expect(catalog.version).toBe(1);
+    expect(catalog).not.toHaveProperty('default_harness_id');
+  });
+
+  test('uses the built-in default harness without workspace context', async () => {
+    const presentation = createAgentInterModulePresentation({secrets: agentTestSecretsClient});
+
+    const catalog = await presentation.handlers.getValidationCatalogV2(
+      {workspaceId: null},
+      {signal: new AbortController().signal},
+    );
+
+    expect(catalog.default_harness_id).toBe('pi');
+    expect(
+      workspaceDefaultsResolverMocks.getWorkspaceAgentValidationCatalog,
+    ).not.toHaveBeenCalled();
+  });
+
+  test('uses the built-in default harness for a workspace without settings', async () => {
+    const workspaceId = crypto.randomUUID();
+    const presentation = createAgentInterModulePresentation({secrets: agentTestSecretsClient});
+
+    const catalog = await presentation.handlers.getValidationCatalogV2(
+      {workspaceId},
+      {signal: new AbortController().signal},
+    );
+
+    expect(catalog.default_harness_id).toBe('pi');
+    expect(workspaceDefaultsResolverMocks.getWorkspaceAgentValidationCatalog).toHaveBeenCalledWith(
+      workspaceId,
+      undefined,
+      undefined,
+    );
+  });
+
   test('loads the workspace default harness for managed inference validation', async () => {
     const workspaceId = crypto.randomUUID();
     await setDefaultHarness({workspaceId, harnessId: 'claude'});
@@ -21,7 +85,7 @@ describe('agent inter-module presentation', () => {
       workspaceProviders: 'disabled',
     });
 
-    const catalog = await presentation.handlers.getValidationCatalog(
+    const catalog = await presentation.handlers.getValidationCatalogV2(
       {workspaceId},
       {signal: new AbortController().signal},
     );

--- a/libs/api/agent/src/presentation/inter-module.test.ts
+++ b/libs/api/agent/src/presentation/inter-module.test.ts
@@ -1,10 +1,34 @@
 import type {ManagedModelProvider} from '@shipfox/api-agent-dto';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {setDefaultHarness} from '#db/index.js';
 import {agentTestSecretsClient} from '#test/fixtures/secrets-client.js';
 import {createAgentInterModulePresentation} from './inter-module.js';
 
 describe('agent inter-module presentation', () => {
+  test('loads the workspace default harness for managed inference validation', async () => {
+    const workspaceId = crypto.randomUUID();
+    await setDefaultHarness({workspaceId, harnessId: 'claude'});
+    const presentation = createAgentInterModulePresentation({
+      secrets: agentTestSecretsClient,
+      managedProvider: {
+        id: 'shipfox',
+        label: 'Shipfox',
+        models: [{id: 'managed-model', label: 'Managed model', api: 'anthropic-messages'}],
+        defaultModel: 'managed-model',
+        resolveCredentials: vi.fn(),
+      },
+      workspaceProviders: 'disabled',
+    });
+
+    const catalog = await presentation.handlers.getValidationCatalog(
+      {workspaceId},
+      {signal: new AbortController().signal},
+    );
+
+    expect(catalog.default_harness_id).toBe('claude');
+  });
+
   test('preserves managed provider policy details for runtime credentials', async () => {
     const managedProvider: ManagedModelProvider = {
       id: 'shipfox',

--- a/libs/api/agent/src/presentation/inter-module.ts
+++ b/libs/api/agent/src/presentation/inter-module.ts
@@ -24,7 +24,7 @@ import {
 import {resolveAgentConfig} from '#core/resolve-agent-config.js';
 import {resolveRuntimeCredentials} from '#core/resolve-runtime-credentials.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
-import {getAgentValidationCatalog} from '#core/validation-catalog.js';
+import {getAgentValidationCatalog, getAgentValidationCatalogV2} from '#core/validation-catalog.js';
 import {
   createWorkspaceAgentDefaultsResolver,
   getWorkspaceAgentValidationCatalog,
@@ -37,9 +37,11 @@ export function createAgentInterModulePresentation(params: {
   workspaceProviders?: WorkspaceProvidersPolicy | undefined;
 }): InterModulePresentation<typeof agentInterModuleContract> {
   return defineInterModulePresentation(agentInterModuleContract, {
-    getValidationCatalog: async ({workspaceId}) =>
+    getValidationCatalog: () =>
+      getAgentValidationCatalog(params.managedProvider, params.workspaceProviders),
+    getValidationCatalogV2: async ({workspaceId}) =>
       workspaceId === null
-        ? getAgentValidationCatalog(params.managedProvider, params.workspaceProviders)
+        ? getAgentValidationCatalogV2(params.managedProvider, params.workspaceProviders)
         : await getWorkspaceAgentValidationCatalog(
             workspaceId,
             params.managedProvider,

--- a/libs/api/agent/src/presentation/inter-module.ts
+++ b/libs/api/agent/src/presentation/inter-module.ts
@@ -25,7 +25,10 @@ import {resolveAgentConfig} from '#core/resolve-agent-config.js';
 import {resolveRuntimeCredentials} from '#core/resolve-runtime-credentials.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
 import {getAgentValidationCatalog} from '#core/validation-catalog.js';
-import {createWorkspaceAgentDefaultsResolver} from '#core/workspace-agent-defaults-resolver.js';
+import {
+  createWorkspaceAgentDefaultsResolver,
+  getWorkspaceAgentValidationCatalog,
+} from '#core/workspace-agent-defaults-resolver.js';
 import {carryOverSessions} from '#db/index.js';
 
 export function createAgentInterModulePresentation(params: {
@@ -34,8 +37,14 @@ export function createAgentInterModulePresentation(params: {
   workspaceProviders?: WorkspaceProvidersPolicy | undefined;
 }): InterModulePresentation<typeof agentInterModuleContract> {
   return defineInterModulePresentation(agentInterModuleContract, {
-    getValidationCatalog: () =>
-      getAgentValidationCatalog(params.managedProvider, params.workspaceProviders),
+    getValidationCatalog: async ({workspaceId}) =>
+      workspaceId === null
+        ? getAgentValidationCatalog(params.managedProvider, params.workspaceProviders)
+        : await getWorkspaceAgentValidationCatalog(
+            workspaceId,
+            params.managedProvider,
+            params.workspaceProviders,
+          ),
     resolveAgentConfig: async ({workspaceId, config}) => {
       try {
         const resolve =

--- a/libs/api/definitions/src/core/resolve-definition-at-ref.test.ts
+++ b/libs/api/definitions/src/core/resolve-definition-at-ref.test.ts
@@ -115,10 +115,10 @@ interface Clients {
   agent: AgentInterModuleClient;
 }
 
-function makeClients(projectId = crypto.randomUUID()): Clients {
+function makeClients(projectId = crypto.randomUUID(), workspaceId = crypto.randomUUID()): Clients {
   const project = {
     id: projectId,
-    workspaceId: crypto.randomUUID(),
+    workspaceId,
     sourceConnectionId: crypto.randomUUID(),
     sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
     name: 'Platform',
@@ -187,7 +187,8 @@ beforeEach(() => {
 describe('resolveDefinitionAtRef', () => {
   test('resolves a valid definition at the pinned commit and creates only the lineage', async () => {
     const projectId = crypto.randomUUID();
-    const clients = makeClients(projectId);
+    const workspaceId = crypto.randomUUID();
+    const clients = makeClients(projectId, workspaceId);
 
     const result = await resolveDefinitionAtRef({
       projectId,
@@ -216,6 +217,7 @@ describe('resolveDefinitionAtRef', () => {
       expect.objectContaining({ref: COMMIT, path: CONFIG_PATH}),
     );
     expect(clients.integrations.getAgentToolsContext).toHaveBeenCalled();
+    expect(clients.agent.getValidationCatalog).toHaveBeenCalledWith({workspaceId});
 
     // Only the lineage row exists: no definition row and no outbox event.
     const lineages = await countLineageRows(projectId);

--- a/libs/api/definitions/src/core/resolve-definition-at-ref.test.ts
+++ b/libs/api/definitions/src/core/resolve-definition-at-ref.test.ts
@@ -137,7 +137,7 @@ function makeClients(projectId = crypto.randomUUID(), workspaceId = crypto.rando
       getAgentToolsContext: vi.fn(async () => agentToolsContext),
     } as unknown as IntegrationsModuleClient,
     agent: {
-      getValidationCatalog: vi.fn(async () => agentValidationCatalog),
+      getValidationCatalogV2: vi.fn(async () => agentValidationCatalog),
     } as unknown as AgentInterModuleClient,
   };
 }
@@ -217,7 +217,7 @@ describe('resolveDefinitionAtRef', () => {
       expect.objectContaining({ref: COMMIT, path: CONFIG_PATH}),
     );
     expect(clients.integrations.getAgentToolsContext).toHaveBeenCalled();
-    expect(clients.agent.getValidationCatalog).toHaveBeenCalledWith({workspaceId});
+    expect(clients.agent.getValidationCatalogV2).toHaveBeenCalledWith({workspaceId});
 
     // Only the lineage row exists: no definition row and no outbox event.
     const lineages = await countLineageRows(projectId);

--- a/libs/api/definitions/src/core/resolve-definition-at-ref.ts
+++ b/libs/api/definitions/src/core/resolve-definition-at-ref.ts
@@ -242,7 +242,7 @@ async function listDefinitionsAtRefUnsafe(
   );
   throwIfAborted(params.signal);
   const agentValidationCatalog = await callWithSignal(
-    params.agent.getValidationCatalog,
+    params.agent.getValidationCatalogV2,
     {workspaceId: source.workspaceId},
     params.signal,
   );
@@ -430,7 +430,7 @@ async function parseDefinitionAtRef(params: {
   signal: AbortSignal | undefined;
 }): Promise<ParsedDefinition> {
   const agentValidationCatalog = await callWithSignal(
-    params.agent.getValidationCatalog,
+    params.agent.getValidationCatalogV2,
     {workspaceId: params.source.workspaceId},
     params.signal,
   );

--- a/libs/api/definitions/src/core/resolve-definition-at-ref.ts
+++ b/libs/api/definitions/src/core/resolve-definition-at-ref.ts
@@ -243,7 +243,7 @@ async function listDefinitionsAtRefUnsafe(
   throwIfAborted(params.signal);
   const agentValidationCatalog = await callWithSignal(
     params.agent.getValidationCatalog,
-    {},
+    {workspaceId: source.workspaceId},
     params.signal,
   );
   throwIfAborted(params.signal);
@@ -431,7 +431,7 @@ async function parseDefinitionAtRef(params: {
 }): Promise<ParsedDefinition> {
   const agentValidationCatalog = await callWithSignal(
     params.agent.getValidationCatalog,
-    {},
+    {workspaceId: params.source.workspaceId},
     params.signal,
   );
   throwIfAborted(params.signal);

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -1,5 +1,5 @@
 import {createHash} from 'node:crypto';
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {boundedMap} from '@shipfox/node-module';
@@ -87,7 +87,7 @@ export interface FetchAndParseWorkflowsParams extends SyncSourceContext {
   ref: string;
   paths: string[];
   onProgress?: ((path: string) => void) | undefined;
-  agentValidationCatalog: AgentValidationCatalog;
+  agentValidationCatalog: AgentValidationCatalogV2;
   loadIntegrationValidationContext?: (() => Promise<IntegrationValidationContext>) | undefined;
 }
 
@@ -149,7 +149,7 @@ function parseWorkflowSnapshot(params: {
   path: string;
   content: string;
   integrationValidationContext?: IntegrationValidationContext | undefined;
-  agentValidationCatalog: AgentValidationCatalog;
+  agentValidationCatalog: AgentValidationCatalogV2;
 }): ParsedWorkflow {
   try {
     const definition =

--- a/libs/api/definitions/src/core/validate-definition.ts
+++ b/libs/api/definitions/src/core/validate-definition.ts
@@ -1,4 +1,4 @@
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import {InvalidWorkflowDocumentError} from '@shipfox/workflow-document';
 import {definitionDefaultRunnerLabels} from '../config.js';
 import type {IntegrationValidationContext} from './entities/integration-context.js';
@@ -16,7 +16,7 @@ export type {ValidationDiagnostic} from './entities/validation-diagnostic.js';
 
 export interface DefinitionValidationOptions {
   defaultRunnerLabels?: readonly string[];
-  agentValidationCatalog: AgentValidationCatalog;
+  agentValidationCatalog: AgentValidationCatalogV2;
   integrationValidationContext?: IntegrationValidationContext;
 }
 

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -39,7 +39,6 @@ export type WorkflowModelValidationIssueCode =
   | 'listening-job-missing-resolution-source'
   | 'listening-job-no-active-matcher'
   | 'listening-timeout-exceeds-run-timeout'
-  | 'missing-harness-for-tools'
   | 'missing-connection-for-integration'
   | 'missing-connection-for-tool'
   | 'missing-job-needs-edge'

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -131,7 +131,7 @@ export function normalizeJobs(
     issues.push(...(issuesBySourceName.get(sourceName) ?? []));
   }
 
-  validateAgentSessionSharing(document, issues);
+  validateAgentSessionSharing(document, issues, context.agentValidationCatalog.default_harness_id);
 
   return entries.flatMap(([sourceName]) => {
     const model = modelsBySourceName.get(sourceName);
@@ -1093,7 +1093,7 @@ interface SessionSharingStep {
   readonly stepKey: string | undefined;
   readonly keySource: string;
   readonly mode: 'resume' | 'fork';
-  readonly harness: string | undefined;
+  readonly harness: string;
 }
 
 // Bounds the cross-job sharing pass so a hostile or degenerate document cannot
@@ -1105,7 +1105,7 @@ const MAX_SESSION_SHARING_PAIR_EVALUATIONS = 100_000;
 // at most one issue is reported per code per key, so the earliest conflict in
 // the examined window is the one that matters. The window always retains the
 // first resume-mode step of each distinct job and one step per distinct
-// declared harness before it fills with the earliest remaining steps (see
+// effective harness before it fills with the earliest remaining steps (see
 // selectSessionSharingWindow), so a job holding many serial steps -- or a job
 // whose first sharing step forks the session -- cannot push another job's
 // resume step -- or a divergent harness -- out of the window.
@@ -1129,7 +1129,7 @@ const RUN_GLOBAL_SESSION_KEY_CONTEXT_ROOTS = new Set<string>([
 // Cross-job authoring checks for shared agent sessions: two resume-mode steps
 // with statically identical session key templates from jobs without a
 // transitive needs ancestry would claim the same session in parallel, and
-// steps sharing a static key must agree on the literal harness because a
+// steps sharing a static key must agree on the effective harness because a
 // session is pinned to the harness that created it. Templates are compared
 // literally only; distinct templates that collide at runtime stay the
 // dispatch-time claim's job, and templates that reference per-job context are
@@ -1142,12 +1142,13 @@ const RUN_GLOBAL_SESSION_KEY_CONTEXT_ROOTS = new Set<string>([
 // budget; the run-global-only classification is memoized per keySource. At
 // most one issue is reported per session key per code, each group is examined
 // up to a fixed step window that always retains the first resume-mode step of
-// each distinct job and one step per distinct declared harness, and the whole
+// each distinct job and one step per distinct effective harness, and the whole
 // pass stops after a fixed pair budget, so large documents stay bounded and
 // long serial runs cannot hide sharing conflicts.
 function validateAgentSessionSharing(
   document: WorkflowDocument,
   issues: WorkflowModelValidationIssue[],
+  defaultHarnessId: string,
 ): void {
   const steps: SessionSharingStep[] = [];
   for (const [jobName, job] of Object.entries(document.jobs)) {
@@ -1159,7 +1160,7 @@ function validateAgentSessionSharing(
         stepKey: step.key,
         keySource: typeof step.session === 'string' ? step.session : step.session.key,
         mode: typeof step.session === 'string' ? 'resume' : (step.session.mode ?? 'resume'),
-        harness: step.harness,
+        harness: step.harness ?? defaultHarnessId,
       });
     });
   }
@@ -1193,7 +1194,7 @@ function validateAgentSessionSharing(
   // be exhausted by unrelated (different-key) pairs before later identical
   // keys are examined. Each group is then cut to a fixed window (see
   // selectSessionSharingWindow) that always keeps the first resume-mode step
-  // of each distinct job and one step per distinct declared harness, so a
+  // of each distinct job and one step per distinct effective harness, so a
   // single degenerate group cannot starve every later key and a long serial
   // job -- or a fork step hiding its job's resume step -- cannot hide another
   // job's sharing step behind the window. Keys that reference per-job context
@@ -1269,22 +1270,12 @@ function validateAgentSessionSharing(
           }
         }
 
-        // A step that omits `harness` resolves at dispatch to the workspace
-        // default harness (or `pi` when none is configured), which this
-        // authoring layer cannot know. Omission is therefore exempt from the
-        // literal agreement check; a mismatch against the resolved default
-        // surfaces at claim time.
-        if (
-          prior.harness !== undefined &&
-          later.harness !== undefined &&
-          prior.harness !== later.harness &&
-          !harnessMismatchReportedKeys.has(keySource)
-        ) {
+        if (prior.harness !== later.harness && !harnessMismatchReportedKeys.has(keySource)) {
           harnessMismatchReportedKeys.add(keySource);
           issues.push(
             issue({
               code: 'agent-session-harness-mismatch',
-              message: `Agent steps ${sessionSharingStepLabel(prior)} (job "${prior.jobName}") and ${sessionSharingStepLabel(later)} (job "${later.jobName}") share session key "${keySource}" but declare different harnesses: "${prior.harness}" and "${later.harness}". A session is pinned to the harness that created it. Declare the same harness on every step that shares the session key.`,
+              message: `Agent steps ${sessionSharingStepLabel(prior)} (job "${prior.jobName}") and ${sessionSharingStepLabel(later)} (job "${later.jobName}") share session key "${keySource}" but resolve to different harnesses: "${prior.harness}" and "${later.harness}". A session is pinned to the harness that created it. Ensure every step that shares the session key resolves to the same harness.`,
               path: ['jobs', later.jobName, 'steps', later.stepIndex, 'session'],
               details: {
                 key: keySource,
@@ -1306,7 +1297,7 @@ function sessionStepPathKey(step: SessionSharingStep): string {
 
 // Cuts a session-key group to the fixed step window while always retaining
 // the first resume-mode step of each distinct job and one step per distinct
-// declared harness, then fills the remainder with the earliest steps in
+// effective harness, then fills the remainder with the earliest steps in
 // document order. Without the resume retention, one job holding more than
 // MAX_SESSION_SHARING_STEPS_PER_KEY serial steps -- or a job whose first
 // sharing step forks the session -- would fill the window and silently drop
@@ -1327,18 +1318,17 @@ function selectSessionSharingWindow(steps: readonly SessionSharingStep[]): Sessi
     if (window.length >= MAX_SESSION_SHARING_STEPS_PER_KEY || inWindow.has(step)) return;
     inWindow.add(step);
     window.push(step);
-    if (step.harness !== undefined) harnessesInWindow.add(step.harness);
+    harnessesInWindow.add(step.harness);
   };
 
   // Reservation pass: a step is added when it is the first resume-mode step
-  // of its job or the first step with its declared harness. A fork step
+  // of its job or the first step with its effective harness. A fork step
   // therefore never consumes the slot that protects its job's resume step,
   // and the two roles share the window budget so neither can starve the
   // other before the fill pass runs.
   for (const step of steps) {
     const isFirstResumeOfJob = step.mode === 'resume' && !resumeStepsByJob.has(step.jobName);
-    const isHarnessRepresentative =
-      step.harness !== undefined && !harnessesInWindow.has(step.harness);
+    const isHarnessRepresentative = !harnessesInWindow.has(step.harness);
     if (!isFirstResumeOfJob && !isHarnessRepresentative) continue;
     if (isFirstResumeOfJob) resumeStepsByJob.add(step.jobName);
     add(step);
@@ -1409,7 +1399,7 @@ function validateAgentStep(params: {
   validateHarnessThinking(params);
   validateHarnessTools(params);
   const providerId = params.step.provider;
-  const harness = params.step.harness;
+  const harness = params.step.harness ?? params.agentValidationCatalog.default_harness_id;
   const provider =
     providerId === undefined
       ? undefined
@@ -1441,8 +1431,6 @@ function validateAgentStep(params: {
       return;
     }
 
-    if (harness === undefined) return;
-
     const descriptor = params.agentValidationCatalog.harnesses.find(
       (entry) => entry.id === harness,
     );
@@ -1463,7 +1451,7 @@ function validateAgentStep(params: {
     }
   }
 
-  if (!params.validateLiteralModel || providerId === undefined || harness === undefined) return;
+  if (!params.validateLiteralModel || providerId === undefined) return;
   if (provider === undefined || provider.support_status !== 'supported') return;
 
   const model = params.step.model;
@@ -1490,21 +1478,9 @@ function validateHarnessTools(params: {
   issues: WorkflowModelValidationIssue[];
   agentValidationCatalog: AgentValidationCatalog;
 }): void {
-  const {harness, tools} = params.step;
+  const {tools} = params.step;
   if (tools === undefined) return;
-
-  if (harness === undefined) {
-    params.issues.push(
-      issue({
-        code: 'missing-harness-for-tools',
-        message:
-          'Agent step tools require an explicit harness because tool names are harness-specific.',
-        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'tools'],
-        details: {tools},
-      }),
-    );
-    return;
-  }
+  const harness = params.step.harness ?? params.agentValidationCatalog.default_harness_id;
 
   const supportedTools =
     params.agentValidationCatalog.harnesses.find((entry) => entry.id === harness)
@@ -1532,8 +1508,9 @@ function validateHarnessThinking(params: {
   issues: WorkflowModelValidationIssue[];
   agentValidationCatalog: AgentValidationCatalog;
 }): void {
-  const {harness, thinking} = params.step;
-  if (harness === undefined || thinking === undefined) return;
+  const {thinking} = params.step;
+  if (thinking === undefined) return;
+  const harness = params.step.harness ?? params.agentValidationCatalog.default_harness_id;
   // An interpolated level is only known when the step dispatches, so the agent
   // module checks it against the resolved harness there.
   if (hasInterpolationSyntax(thinking)) return;

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -1,4 +1,4 @@
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import {
   type AvailabilitySite,
   buildTypedRootsEnvironment,
@@ -64,7 +64,7 @@ import {issue} from './validation-issue.js';
 
 export interface NormalizeContext {
   readonly defaultRunnerLabels: readonly string[];
-  readonly agentValidationCatalog: AgentValidationCatalog;
+  readonly agentValidationCatalog: AgentValidationCatalogV2;
   readonly integrationValidationContext?: IntegrationValidationContext | undefined;
 }
 
@@ -1394,7 +1394,7 @@ function validateAgentStep(params: {
   issues: WorkflowModelValidationIssue[];
   validateLiteralModel: boolean;
   validateLiteralProvider: boolean;
-  agentValidationCatalog: AgentValidationCatalog;
+  agentValidationCatalog: AgentValidationCatalogV2;
 }): void {
   validateHarnessThinking(params);
   validateHarnessTools(params);
@@ -1476,7 +1476,7 @@ function validateHarnessTools(params: {
   sourceName: string;
   stepIndex: number;
   issues: WorkflowModelValidationIssue[];
-  agentValidationCatalog: AgentValidationCatalog;
+  agentValidationCatalog: AgentValidationCatalogV2;
 }): void {
   const {tools} = params.step;
   if (tools === undefined) return;
@@ -1506,7 +1506,7 @@ function validateHarnessThinking(params: {
   sourceName: string;
   stepIndex: number;
   issues: WorkflowModelValidationIssue[];
-  agentValidationCatalog: AgentValidationCatalog;
+  agentValidationCatalog: AgentValidationCatalogV2;
 }): void {
   const {thinking} = params.step;
   if (thinking === undefined) return;

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1,4 +1,4 @@
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import type {WorkflowDocument} from '@shipfox/workflow-document';
 import {agentValidationCatalog} from '#test/agent-validation-catalog.js';
 import type {IntegrationValidationContext} from '../entities/integration-context.js';
@@ -6895,7 +6895,7 @@ describe('normalizeWorkflowDocument', () => {
 
     it('accepts a managed provider on Claude when the catalog exposes an Anthropic model', () => {
       const providerId = 'shipfox-managed';
-      const managedCatalog: AgentValidationCatalog = {
+      const managedCatalog: AgentValidationCatalogV2 = {
         ...agentValidationCatalog,
         providers: [
           ...agentValidationCatalog.providers,

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -983,7 +983,7 @@ describe('normalizeWorkflowDocument', () => {
         {
           code: 'agent-session-harness-mismatch',
           message:
-            'Agent steps "plan" (job "plan") and "implement" (job "implement") share session key "main" but declare different harnesses: "pi" and "claude". A session is pinned to the harness that created it. Declare the same harness on every step that shares the session key.',
+            'Agent steps "plan" (job "plan") and "implement" (job "implement") share session key "main" but resolve to different harnesses: "pi" and "claude". A session is pinned to the harness that created it. Ensure every step that shares the session key resolves to the same harness.',
           path: ['jobs', 'implement', 'steps', 0, 'session'],
           details: {
             key: 'main',
@@ -1014,7 +1014,7 @@ describe('normalizeWorkflowDocument', () => {
       expect(model.jobs).toHaveLength(2);
     });
 
-    it('does not report harness disagreement when one step omits the harness', () => {
+    it('uses the default harness when one session-sharing step omits it', () => {
       const model = normalizeWorkflowDocument({
         name: 'session sharing',
         jobs: {
@@ -1029,6 +1029,36 @@ describe('normalizeWorkflowDocument', () => {
       });
 
       expect(model.jobs).toHaveLength(2);
+    });
+
+    it('reports harness disagreement against the configured default harness', () => {
+      const error = expectInvalid(
+        {
+          name: 'session sharing',
+          jobs: {
+            plan: {
+              steps: [{key: 'plan', prompt: 'Plan.', session: 'main', harness: 'pi'}],
+            },
+            implement: {
+              needs: 'plan',
+              steps: [{key: 'implement', prompt: 'Implement.', session: 'main'}],
+            },
+          },
+        },
+        {
+          agentValidationCatalog: {
+            ...agentValidationCatalog,
+            default_harness_id: 'claude',
+          },
+        },
+      );
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'agent-session-harness-mismatch',
+          details: expect.objectContaining({harnesses: ['pi', 'claude']}),
+        }),
+      ]);
     });
 
     it('reports both parallel resume and harness disagreement for a conflicting pair', () => {
@@ -1142,7 +1172,7 @@ describe('normalizeWorkflowDocument', () => {
         {
           code: 'agent-session-harness-mismatch',
           message:
-            'Agent steps "plan" (job "implement") and "implement" (job "implement") share session key "main" but declare different harnesses: "pi" and "claude". A session is pinned to the harness that created it. Declare the same harness on every step that shares the session key.',
+            'Agent steps "plan" (job "implement") and "implement" (job "implement") share session key "main" but resolve to different harnesses: "pi" and "claude". A session is pinned to the harness that created it. Ensure every step that shares the session key resolves to the same harness.',
           path: ['jobs', 'implement', 'steps', 1, 'session'],
           details: {
             key: 'main',
@@ -1853,7 +1883,7 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
-  it('defers harness-specific validation when harness is omitted', () => {
+  it('uses the configured default for harness-specific validation', () => {
     const document: WorkflowDocument = {
       name: 'workspace-default harness',
       jobs: {
@@ -1861,7 +1891,7 @@ describe('normalizeWorkflowDocument', () => {
           steps: [
             {
               provider: 'anthropic',
-              model: 'claude-sonnet-4-6',
+              model: 'claude-opus-4-8',
               prompt: 'Fix it.',
             },
           ],
@@ -1869,12 +1899,14 @@ describe('normalizeWorkflowDocument', () => {
       },
     };
 
-    const model = normalizeWorkflowDocument(document);
+    const model = normalizeWorkflowDocument(document, {
+      agentValidationCatalog: {...agentValidationCatalog, default_harness_id: 'claude'},
+    });
 
     expect(model.jobs[0]?.steps[0]).toMatchObject({
       kind: 'agent',
       provider: 'anthropic',
-      model: 'claude-sonnet-4-6',
+      model: 'claude-opus-4-8',
     });
   });
 
@@ -1962,28 +1994,60 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
-  it('rejects tools without an explicit harness', () => {
+  it('accepts tools supported by the default harness', () => {
     const document: WorkflowDocument = {
       name: 'agent build',
       jobs: {
         fix: {
-          steps: [{prompt: 'Search it.', tools: ['Read']}],
+          steps: [{prompt: 'Search it.', tools: ['read', 'web_search']}],
         },
       },
     };
 
-    const error = expectInvalid(document);
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      tools: ['read', 'web_search'],
+    });
+  });
+
+  it('accepts tools supported by a configured Claude default harness', () => {
+    const document: WorkflowDocument = {
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [{prompt: 'Search it.', tools: ['Read', 'WebSearch']}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document, {
+      agentValidationCatalog: {...agentValidationCatalog, default_harness_id: 'claude'},
+    });
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      tools: ['Read', 'WebSearch'],
+    });
+  });
+
+  it('rejects tools unsupported by the default harness', () => {
+    const error = expectInvalid({
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [{prompt: 'Search it.', tools: ['WebSearch']}],
+        },
+      },
+    });
 
     expect(error.issues).toEqual([
-      {
-        code: 'missing-harness-for-tools',
-        message:
-          'Agent step tools require an explicit harness because tool names are harness-specific.',
-        path: ['jobs', 'fix', 'steps', 0, 'tools'],
-        details: {tools: ['Read']},
-        severity: 'error',
-        scope: 'definition',
-      },
+      expect.objectContaining({
+        code: 'harness-tool-incompatible',
+        path: ['jobs', 'fix', 'steps', 0, 'tools', 0],
+        details: expect.objectContaining({harness: 'pi', tool: 'WebSearch'}),
+      }),
     ]);
   });
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -1,4 +1,4 @@
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import {canonicalizeLabels} from '@shipfox/runner-labels';
 import type {WorkflowDocument} from '@shipfox/workflow-document';
 import type {IntegrationValidationContext} from '../entities/integration-context.js';
@@ -19,7 +19,7 @@ export function normalizeWorkflowDocument(
   document: WorkflowDocument,
   options: {
     defaultRunnerLabels?: readonly string[] | undefined;
-    agentValidationCatalog: AgentValidationCatalog;
+    agentValidationCatalog: AgentValidationCatalogV2;
     integrationValidationContext?: IntegrationValidationContext | undefined;
     stepSourceLocations?: WorkflowStepSourceLocationMap | undefined;
     /** Provide a fresh array for each call to collect non-fatal validation issues. */

--- a/libs/api/definitions/src/presentation/routes/at-ref.test.ts
+++ b/libs/api/definitions/src/presentation/routes/at-ref.test.ts
@@ -70,7 +70,7 @@ const integrationsMocks = {
 const integrations = integrationsMocks as unknown as IntegrationsModuleClient;
 
 const agentMocks = {
-  getValidationCatalog: vi.fn(),
+  getValidationCatalogV2: vi.fn(),
 };
 const agent = agentMocks as unknown as AgentInterModuleClient;
 
@@ -120,7 +120,7 @@ describe('GET /api/definitions/at-ref', () => {
       ref: COMMIT,
       content: validYaml,
     });
-    agentMocks.getValidationCatalog.mockResolvedValue(agentValidationCatalog);
+    agentMocks.getValidationCatalogV2.mockResolvedValue(agentValidationCatalog);
     projectsMocks.getProjectById.mockImplementation(({projectId}) =>
       Promise.resolve({
         project: {
@@ -160,7 +160,10 @@ describe('GET /api/definitions/at-ref', () => {
       {signal: expect.any(AbortSignal)},
     );
     expect(projectsMocks.getProjectById).toHaveBeenCalledOnce();
-    expect(agentMocks.getValidationCatalog).toHaveBeenCalledWith({workspaceId}, expect.anything());
+    expect(agentMocks.getValidationCatalogV2).toHaveBeenCalledWith(
+      {workspaceId},
+      expect.anything(),
+    );
   });
 
   test('returns 200 listing an invalid file with its errors instead of failing', async () => {

--- a/libs/api/definitions/src/presentation/routes/at-ref.test.ts
+++ b/libs/api/definitions/src/presentation/routes/at-ref.test.ts
@@ -160,6 +160,7 @@ describe('GET /api/definitions/at-ref', () => {
       {signal: expect.any(AbortSignal)},
     );
     expect(projectsMocks.getProjectById).toHaveBeenCalledOnce();
+    expect(agentMocks.getValidationCatalog).toHaveBeenCalledWith({workspaceId}, expect.anything());
   });
 
   test('returns 200 listing an invalid file with its errors instead of failing', async () => {

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -13,7 +13,7 @@ import {buildCreateDefinitionRoute} from './create-definition.js';
 
 const getProjectById = vi.fn();
 const projects = {getProjectById} as Pick<ProjectsModuleClient, 'getProjectById'>;
-const agent = {getValidationCatalog: vi.fn(() => agentValidationCatalog)};
+const agent = {getValidationCatalogV2: vi.fn(() => agentValidationCatalog)};
 
 describe('POST /api/definitions', () => {
   let app: FastifyInstance;
@@ -89,7 +89,7 @@ jobs:
     expect(body.sha).toBeNull();
     expect(body.ref).toBeNull();
     expect(body.fetched_at).toBeDefined();
-    expect(agent.getValidationCatalog).toHaveBeenLastCalledWith({workspaceId});
+    expect(agent.getValidationCatalogV2).toHaveBeenLastCalledWith({workspaceId});
   });
 
   test('skips connection snapshot loading when YAML has no integrations', async () => {

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -89,6 +89,7 @@ jobs:
     expect(body.sha).toBeNull();
     expect(body.ref).toBeNull();
     expect(body.fetched_at).toBeDefined();
+    expect(agent.getValidationCatalog).toHaveBeenLastCalledWith({workspaceId});
   });
 
   test('skips connection snapshot loading when YAML has no integrations', async () => {

--- a/libs/api/definitions/src/presentation/routes/create-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.ts
@@ -57,7 +57,9 @@ export function buildCreateDefinitionRoute(options: CreateDefinitionRouteOptions
       const {project_id: projectId, config_path, source, yaml: yamlString, sha, ref} = request.body;
       const project = await requireProjectAccess(request, projectId, options.projects);
 
-      const agentValidationCatalog = await options.agent.getValidationCatalog({});
+      const agentValidationCatalog = await options.agent.getValidationCatalog({
+        workspaceId: project.workspaceId,
+      });
       const structurallyParsed = parseDefinitionForCreate(yamlString, {agentValidationCatalog});
       const {integrations} = options;
       const parsed =

--- a/libs/api/definitions/src/presentation/routes/create-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.ts
@@ -57,7 +57,7 @@ export function buildCreateDefinitionRoute(options: CreateDefinitionRouteOptions
       const {project_id: projectId, config_path, source, yaml: yamlString, sha, ref} = request.body;
       const project = await requireProjectAccess(request, projectId, options.projects);
 
-      const agentValidationCatalog = await options.agent.getValidationCatalog({
+      const agentValidationCatalog = await options.agent.getValidationCatalogV2({
         workspaceId: project.workspaceId,
       });
       const structurallyParsed = parseDefinitionForCreate(yamlString, {agentValidationCatalog});

--- a/libs/api/definitions/src/presentation/routes/index.test.ts
+++ b/libs/api/definitions/src/presentation/routes/index.test.ts
@@ -11,7 +11,7 @@ const projects = {
 } as unknown as ProjectsModuleClient;
 const definitionRoutes = createDefinitionRoutes({
   projects,
-  agent: {getValidationCatalog: vi.fn(() => agentValidationCatalog)} as never,
+  agent: {getValidationCatalogV2: vi.fn(() => agentValidationCatalog)} as never,
   integrations: {} as never,
 });
 

--- a/libs/api/definitions/src/presentation/routes/index.ts
+++ b/libs/api/definitions/src/presentation/routes/index.ts
@@ -23,7 +23,7 @@ export function createDefinitionRoutes(options: DefinitionRouteOptions): RouteGr
         buildCreateDefinitionRoute(options),
         buildListDefinitionsRoute(options.projects),
         buildGetDefinitionRoute(options.projects),
-        buildValidateDefinitionRoute(options.agent),
+        buildValidateDefinitionRoute(options),
         buildAtRefRoute(options),
       ],
     },

--- a/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
@@ -6,6 +6,7 @@ import {buildValidateDefinitionRoute} from './validate-definition.js';
 
 describe('POST /definitions/validate', () => {
   let app: FastifyInstance;
+  const getValidationCatalog = vi.fn(() => agentValidationCatalog);
 
   beforeAll(async () => {
     app = Fastify();
@@ -14,7 +15,7 @@ describe('POST /definitions/validate', () => {
     app.post(
       '/definitions/validate',
       buildValidateDefinitionRoute({
-        getValidationCatalog: vi.fn(() => agentValidationCatalog),
+        getValidationCatalog,
       } as never),
     );
     await app.ready();
@@ -42,6 +43,7 @@ jobs:
     expect(body.diagnostics).toEqual([]);
     expect(body.workflow_document.name).toBe('Test');
     expect(body.workflow_model.kind).toBe('workflow');
+    expect(getValidationCatalog).toHaveBeenCalledWith({workspaceId: null});
   });
 
   test('invalid YAML returns 200 with { valid: false, errors }', async () => {

--- a/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
@@ -1,3 +1,5 @@
+import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
@@ -6,19 +8,40 @@ import {buildValidateDefinitionRoute} from './validate-definition.js';
 
 describe('POST /definitions/validate', () => {
   let app: FastifyInstance;
-  const getValidationCatalog = vi.fn(() => agentValidationCatalog);
+  let projectId = crypto.randomUUID();
+  let workspaceId = crypto.randomUUID();
+  const getProjectById = vi.fn();
+  const getValidationCatalogV2 = vi.fn(() => agentValidationCatalog);
 
   beforeAll(async () => {
     app = Fastify();
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
+    app.addHook('onRequest', (request, _reply, done) => {
+      setUserContext(
+        request,
+        buildUserContext({
+          userId: crypto.randomUUID(),
+          email: 'user@example.com',
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
+        }),
+      );
+      done();
+    });
     app.post(
       '/definitions/validate',
       buildValidateDefinitionRoute({
-        getValidationCatalog,
-      } as never),
+        agent: {getValidationCatalogV2} as never,
+        projects: {getProjectById} as Pick<ProjectsModuleClient, 'getProjectById'> as never,
+      }),
     );
     await app.ready();
+  });
+
+  beforeEach(() => {
+    projectId = crypto.randomUUID();
+    workspaceId = crypto.randomUUID();
+    getProjectById.mockResolvedValue({project: {id: projectId, workspaceId}});
   });
 
   test('valid YAML returns 200 with { valid: true }', async () => {
@@ -43,7 +66,29 @@ jobs:
     expect(body.diagnostics).toEqual([]);
     expect(body.workflow_document.name).toBe('Test');
     expect(body.workflow_model.kind).toBe('workflow');
-    expect(getValidationCatalog).toHaveBeenCalledWith({workspaceId: null});
+    expect(getValidationCatalogV2).toHaveBeenCalledWith({workspaceId: null});
+  });
+
+  test('uses the project workspace default when project context is provided', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/definitions/validate',
+      payload: {
+        project_id: projectId,
+        yaml: `
+name: Test
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - run: echo hello
+`,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(getProjectById).toHaveBeenCalledWith({projectId});
+    expect(getValidationCatalogV2).toHaveBeenCalledWith({workspaceId});
   });
 
   test('invalid YAML returns 200 with { valid: false, errors }', async () => {

--- a/libs/api/definitions/src/presentation/routes/validate-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.ts
@@ -39,7 +39,7 @@ export function buildValidateDefinitionRoute(agent: AgentInterModuleClient) {
     handler: async (request) => {
       const {yaml} = request.body;
       const result = validateDefinition(yaml, {
-        agentValidationCatalog: await agent.getValidationCatalog({}),
+        agentValidationCatalog: await agent.getValidationCatalog({workspaceId: null}),
       });
 
       if (result.valid) {

--- a/libs/api/definitions/src/presentation/routes/validate-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.ts
@@ -4,12 +4,15 @@ import {
   definitionValidationDiagnosticSchema,
   definitionValidationErrorSchema,
 } from '@shipfox/api-definitions-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {validateDefinition} from '#core/validate-definition.js';
+import {requireProjectAccess} from './project-access.js';
 
 const validateBodySchema = z.object({
   yaml: z.string().min(1).max(1_000_000),
+  project_id: z.string().uuid().optional(),
 });
 
 const validationResultSchema = z.union([
@@ -25,7 +28,10 @@ const validationResultSchema = z.union([
   }),
 ]);
 
-export function buildValidateDefinitionRoute(agent: AgentInterModuleClient) {
+export function buildValidateDefinitionRoute(options: {
+  agent: AgentInterModuleClient;
+  projects: ProjectsModuleClient;
+}) {
   return defineRoute({
     method: 'POST',
     path: '/validate',
@@ -37,9 +43,13 @@ export function buildValidateDefinitionRoute(agent: AgentInterModuleClient) {
       },
     },
     handler: async (request) => {
-      const {yaml} = request.body;
+      const {yaml, project_id: projectId} = request.body;
+      const workspaceId =
+        projectId === undefined
+          ? null
+          : (await requireProjectAccess(request, projectId, options.projects)).workspaceId;
       const result = validateDefinition(yaml, {
-        agentValidationCatalog: await agent.getValidationCatalog({workspaceId: null}),
+        agentValidationCatalog: await options.agent.getValidationCatalogV2({workspaceId}),
       });
 
       if (result.valid) {

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -9,7 +9,8 @@ import {workflowDefinitions} from '#db/schema/definitions.js';
 import {agentValidationCatalog} from '#test/agent-validation-catalog.js';
 import {createDefinitionSyncActivities} from './sync-activities.js';
 
-const agent = {getValidationCatalog: vi.fn(() => agentValidationCatalog)} as never;
+const getValidationCatalog = vi.fn(() => agentValidationCatalog);
+const agent = {getValidationCatalog} as never;
 
 vi.mock('@temporalio/activity', () => ({
   Context: {
@@ -224,10 +225,11 @@ describe('definition sync activities', () => {
   describe('fetchAndApplyDefinitionWorkflows', () => {
     it('upserts workflow definitions and soft-deletes orphans', async () => {
       const activities = createDefinitionSyncActivities(sourceControl(), agent);
+      const workspaceId = crypto.randomUUID();
 
       const result = await activities.fetchAndApplyDefinitionWorkflows({
         projectId,
-        workspaceId: crypto.randomUUID(),
+        workspaceId,
         sourceConnectionId,
         sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
         sourceRef: 'main',
@@ -237,6 +239,7 @@ describe('definition sync activities', () => {
       expect(result.appliedCount).toBe(1);
       expect(result.deletedCount).toBe(0);
       expect(result.diagnostics).toEqual([]);
+      expect(getValidationCatalog).toHaveBeenLastCalledWith({workspaceId});
     });
 
     it('adds the workflow file path to persisted diagnostics', async () => {

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -9,8 +9,8 @@ import {workflowDefinitions} from '#db/schema/definitions.js';
 import {agentValidationCatalog} from '#test/agent-validation-catalog.js';
 import {createDefinitionSyncActivities} from './sync-activities.js';
 
-const getValidationCatalog = vi.fn(() => agentValidationCatalog);
-const agent = {getValidationCatalog} as never;
+const getValidationCatalogV2 = vi.fn(() => agentValidationCatalog);
+const agent = {getValidationCatalogV2} as never;
 
 vi.mock('@temporalio/activity', () => ({
   Context: {
@@ -239,7 +239,7 @@ describe('definition sync activities', () => {
       expect(result.appliedCount).toBe(1);
       expect(result.deletedCount).toBe(0);
       expect(result.diagnostics).toEqual([]);
-      expect(getValidationCatalog).toHaveBeenLastCalledWith({workspaceId});
+      expect(getValidationCatalogV2).toHaveBeenLastCalledWith({workspaceId});
     });
 
     it('adds the workflow file path to persisted diagnostics', async () => {

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -139,7 +139,7 @@ function createFetchAndApplyActivity(
         ...input,
         ref: input.sourceCommitSha ?? input.sourceRef,
         sourceControl,
-        agentValidationCatalog: await agent.getValidationCatalog({
+        agentValidationCatalog: await agent.getValidationCatalogV2({
           workspaceId: input.workspaceId,
         }),
         onProgress: (path) => Context.current().heartbeat({path}),

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -139,7 +139,9 @@ function createFetchAndApplyActivity(
         ...input,
         ref: input.sourceCommitSha ?? input.sourceRef,
         sourceControl,
-        agentValidationCatalog: await agent.getValidationCatalog({}),
+        agentValidationCatalog: await agent.getValidationCatalog({
+          workspaceId: input.workspaceId,
+        }),
         onProgress: (path) => Context.current().heartbeat({path}),
         loadIntegrationValidationContext:
           integrations === undefined

--- a/libs/api/definitions/test/agent-validation-catalog.ts
+++ b/libs/api/definitions/test/agent-validation-catalog.ts
@@ -24,6 +24,7 @@ const piModelIdsByProvider = Object.fromEntries(
 
 export const agentValidationCatalog: AgentValidationCatalog = {
   version: 1,
+  default_harness_id: 'pi',
   providers: MODEL_PROVIDER_IDS.map((id) => ({
     id,
     support_status:

--- a/libs/api/definitions/test/agent-validation-catalog.ts
+++ b/libs/api/definitions/test/agent-validation-catalog.ts
@@ -5,7 +5,7 @@ import {
   MODEL_PROVIDER_CATALOG_SEED,
   MODEL_PROVIDER_IDS,
 } from '@shipfox/api-agent-dto';
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 
 const piModelIdsByProvider = Object.fromEntries(
   MODEL_PROVIDER_CATALOG_SEED.filter((entry) => entry.support_status === 'supported').map(
@@ -22,8 +22,8 @@ const piModelIdsByProvider = Object.fromEntries(
   ),
 );
 
-export const agentValidationCatalog: AgentValidationCatalog = {
-  version: 1,
+export const agentValidationCatalog: AgentValidationCatalogV2 = {
+  version: 2,
   default_harness_id: 'pi',
   providers: MODEL_PROVIDER_IDS.map((id) => ({
     id,

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -205,6 +205,7 @@ describe('defaultModules', () => {
           contract: agentInterModuleContract,
           handlers: {
             getValidationCatalog: vi.fn(),
+            getValidationCatalogV2: vi.fn(),
             resolveAgentConfig: vi.fn(),
             resolveRuntimeCredentials: vi.fn(),
             claimSession: vi.fn(),

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -345,6 +345,7 @@ describe('nextStepForJob', () => {
 
     const agent = {
       getValidationCatalog: vi.fn(),
+      getValidationCatalogV2: vi.fn(),
       resolveAgentConfig: vi.fn().mockRejectedValue(
         createInterModuleKnownError(
           agentInterModuleContract.methods.resolveAgentConfig,

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -1,7 +1,10 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {createWorkflowModelSnapshot, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
-import {agentValidationCatalog} from '#test/fixtures/agent-inter-module.js';
+import {
+  agentValidationCatalog,
+  agentValidationCatalogV2,
+} from '#test/fixtures/agent-inter-module.js';
 import {workflowModel} from '#test/index.js';
 import type {TriggerPayload, WorkflowRunDevSource} from './entities/workflow-run.js';
 import {DefinitionNotFoundError, ProjectMismatchError} from './errors.js';
@@ -60,6 +63,7 @@ describe('runWorkflow', () => {
   let projectId: string;
   const agent: AgentInterModuleClient = {
     getValidationCatalog: vi.fn().mockResolvedValue(agentValidationCatalog),
+    getValidationCatalogV2: vi.fn().mockResolvedValue(agentValidationCatalogV2),
     resolveAgentConfig: mockResolveAgentConfig,
     resolveRuntimeCredentials: vi.fn(),
     claimSession: vi.fn(),
@@ -256,6 +260,7 @@ describe('runDevWorkflow', () => {
   let projectId: string;
   const agent: AgentInterModuleClient = {
     getValidationCatalog: vi.fn().mockResolvedValue(agentValidationCatalog),
+    getValidationCatalogV2: vi.fn().mockResolvedValue(agentValidationCatalogV2),
     resolveAgentConfig: mockResolveAgentConfig,
     resolveRuntimeCredentials: vi.fn(),
     claimSession: vi.fn(),

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -52,6 +52,7 @@ const resolveRuntimeCredentials = vi.fn<AgentInterModuleClient['resolveRuntimeCr
 );
 const agentTestClient: AgentInterModuleClient = {
   getValidationCatalog: vi.fn(),
+  getValidationCatalogV2: vi.fn(),
   resolveAgentConfig: vi.fn(),
   resolveRuntimeCredentials,
   claimSession: vi.fn(),

--- a/libs/api/workflows/test/fixtures/agent-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/agent-inter-module.ts
@@ -8,13 +8,13 @@ import {
 import type {
   AgentInterModuleClient,
   AgentValidationCatalog,
+  AgentValidationCatalogV2,
 } from '@shipfox/api-agent-dto/inter-module';
 import {agentThinkingSchema} from '@shipfox/workflow-document';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 
 export const agentValidationCatalog: AgentValidationCatalog = {
   version: 1,
-  default_harness_id: 'pi',
   providers: MODEL_PROVIDER_IDS.map((id) => ({
     id,
     support_status:
@@ -31,9 +31,18 @@ export const agentValidationCatalog: AgentValidationCatalog = {
   })),
 };
 
+export const agentValidationCatalogV2: AgentValidationCatalogV2 = {
+  ...agentValidationCatalog,
+  version: 2,
+  default_harness_id: 'pi',
+};
+
 export const agentTestClient: AgentInterModuleClient = {
   getValidationCatalog() {
     return Promise.resolve(agentValidationCatalog);
+  },
+  getValidationCatalogV2() {
+    return Promise.resolve(agentValidationCatalogV2);
   },
   resolveAgentConfig({config}) {
     return Promise.resolve(resolveTestAgentDefaults(config));

--- a/libs/api/workflows/test/fixtures/agent-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/agent-inter-module.ts
@@ -14,6 +14,7 @@ import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 
 export const agentValidationCatalog: AgentValidationCatalog = {
   version: 1,
+  default_harness_id: 'pi',
   providers: MODEL_PROVIDER_IDS.map((id) => ({
     id,
     support_status:


### PR DESCRIPTION
Workflow validation rejected harness-specific tools whenever a workflow step omitted `harness`, even though dispatch resolves the workspace default harness. This prevented managed-inference workspaces configured with Pi from using Pi tool names without redundantly declaring the harness.

The validation catalog now carries the effective workspace default, and project-aware definition paths request it with workspace context. Harness-specific tool, thinking, model, and shared-session checks use that effective default; the standalone validation endpoint falls back to Pi when no workspace exists.

The published Agent and Definitions packages include a Changeset. Validation passed with `turbo check type test --filter=@shipfox/api-agent-dto --filter=@shipfox/api-agent --filter=@shipfox/api-definitions --filter=@shipfox/api-workflows` (121 tasks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow validation to honor each workspace's configured default harness when a step omits `harness`, so managed-inference workspaces using Pi can use Pi tool names without declaring the harness. Harness-specific tool, model, and thinking checks now resolve to the workspace default, falling back to Pi when no workspace exists.

- Adds a V2 validation catalog that carries the effective default so the existing V1 endpoint stays unchanged.
- The validate-definition route accepts an optional `project_id` to resolve the project's workspace default; without it, validation falls back to Pi.
- Session-sharing checks now compare effective harnesses, so a step that declares the default and one that omits it no longer falsely conflict.
- Removes the `missing-harness-for-tools` error; unsupported tools now report as incompatible with the resolved harness.
- Adds a Changeset to `@shipfox/api-agent`, `@shipfox/api-agent-dto`, and `@shipfox/api-definitions`.

<sup>Written for commit 57601c41e58e1f1c24f1e4a08a0c677a5ceeb332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

