### PR TITLE
[runner-orchestration] Isolate config tests from runner environment

### DIFF
--- a/libs/runner/orchestration/src/config.test.ts
+++ b/libs/runner/orchestration/src/config.test.ts
@@ -33,6 +33,10 @@ describe('poll config validation', () => {
   });
 
   it('accepts the documented poll defaults', async () => {
+    vi.stubEnv('SHIPFOX_POLL_INTERVAL_MS', undefined);
+    vi.stubEnv('SHIPFOX_POLL_MAX_INTERVAL_MS', undefined);
+    vi.stubEnv('SHIPFOX_POLL_MAX_DURATION_MS', undefined);
+    vi.stubEnv('SHIPFOX_BOOT_CONSOLE_FD', undefined);
     vi.resetModules();
 
     const {config} = await import('#config.js');
@@ -41,5 +45,14 @@ describe('poll config validation', () => {
     expect(config.SHIPFOX_POLL_MAX_INTERVAL_MS).toBe(5000);
     expect(config.SHIPFOX_POLL_MAX_DURATION_MS).toBe(300_000);
     expect(config.SHIPFOX_BOOT_CONSOLE_FD).toBeUndefined();
+  });
+
+  it('accepts the runner image boot console descriptor', async () => {
+    vi.stubEnv('SHIPFOX_BOOT_CONSOLE_FD', '3');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.SHIPFOX_BOOT_CONSOLE_FD).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Runner workflows export `SHIPFOX_BOOT_CONSOLE_FD=3` so sanitized boot timeline events can reach the EC2 console. The config-default test assumed that variable was absent, causing validation to fail and restart when it ran inside the runner image.

Make the default assertions control their environment explicitly and cover descriptor `3` as valid configuration. Runtime behavior and Cloud deployment configuration remain unchanged.

## Validation

- `mise exec -- env SHIPFOX_BOOT_CONSOLE_FD=3 pnpm --filter @shipfox/runner-orchestration test` (115 tests passed)
- `mise exec -- env -u SHIPFOX_BOOT_CONSOLE_FD pnpm --filter @shipfox/runner-orchestration test` (115 tests passed)
- `mise exec -- turbo check type test --filter=@shipfox/runner-orchestration...` (141 tasks passed)
- `mise exec -- env SHIPFOX_BOOT_CONSOLE_FD=3 pnpm turbo check type test --concurrency=4` (708 tasks passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the config-default tests so they pass inside the runner image, which exports `SHIPFOX_BOOT_CONSOLE_FD=3` and caused validation to restart during tests.

**Bug Fixes**
- Stubs the poll interval and boot console environment variables before asserting defaults.
- Adds a test accepting descriptor `3` as valid boot console configuration.
- Runtime behavior and Cloud deployment configuration are unchanged.

<sup>Written for commit b5e1757ea687c1fbcc148028f4b8020eed1b01b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

