### PR TITLE
[GitHub integration] Add workflow lifecycle events

### DIFF
--- a/.changeset/bright-workflows-finish.md
+++ b/.changeset/bright-workflows-finish.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github-dto": minor
+---
+
+Adds the documented GitHub Actions workflow job and workflow run events to the integration catalogue.

--- a/libs/api/integration/github-dto/src/event-catalog.ts
+++ b/libs/api/integration/github-dto/src/event-catalog.ts
@@ -68,6 +68,19 @@ const releaseActions = [
   ['released', 'A release is published from a pre-release.'],
 ] as const satisfies readonly GithubWebhookActionDetail[];
 
+const workflowJobActions = [
+  ['completed', 'A job in a workflow run finishes.'],
+  ['in_progress', 'A job in a workflow run started processing on a runner.'],
+  ['queued', 'A job in a workflow run was created.'],
+  ['waiting', 'A job in a workflow run was created and is waiting for approvals.'],
+] as const satisfies readonly GithubWebhookActionDetail[];
+
+const workflowRunActions = [
+  ['completed', 'A workflow run finishes.'],
+  ['in_progress', 'A workflow run started processing on a runner.'],
+  ['requested', 'A workflow run was triggered.'],
+] as const satisfies readonly GithubWebhookActionDetail[];
+
 function githubActionEvents(
   family: string,
   actions: readonly GithubWebhookActionDetail[],
@@ -97,5 +110,7 @@ export const githubEventCatalog = {
     ...githubActionEvents('pull_request_review_comment', pullRequestReviewCommentActions),
     ...githubActionEvents('issues', issueActions),
     ...githubActionEvents('release', releaseActions),
+    ...githubActionEvents('workflow_job', workflowJobActions),
+    ...githubActionEvents('workflow_run', workflowRunActions),
   ],
 } as const satisfies IntegrationEventCatalog;


### PR DESCRIPTION
Adds the GitHub Actions workflow job and workflow run events to the GitHub source event catalogue.

This makes action-qualified workflow lifecycle events available to downstream trigger discovery and generated integration docs, covering the activity types documented by GitHub.

Validated with the focused DTO check, type check, build, and the docs generation/test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GitHub Actions workflow job and workflow run events to the GitHub event catalogue. These lifecycle events were previously absent, so downstream trigger discovery and generated integration docs now cover them.

- Release the new events as a minor version bump for `@shipfox/api-integration-github-dto`.

<sup>Written for commit 10adaa1d114b8d3ee632f9eee02be58ca16a952f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

