### PR TITLE
[provisioner-core] Isolate config tests from runner environment

### DIFF
--- a/libs/provisioner/core/src/config.test.ts
+++ b/libs/provisioner/core/src/config.test.ts
@@ -1,5 +1,18 @@
 // Import #config.js inside each test so env validation reruns after vi.stubEnv.
 
+const defaultedEnvNames = [
+  'SHIPFOX_API_URL',
+  'SHIPFOX_RUNNER_API_URL',
+  'SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS',
+  'SHIPFOX_PROVISIONER_POLL_INTERVAL_MS',
+  'SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS',
+  'SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS',
+  'SHIPFOX_PROVISIONER_MAX_RESERVATIONS',
+  'SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE',
+  'SHIPFOX_RUNNER_POLL_MAX_DURATION_MS',
+  'SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS',
+] as const;
+
 describe('provisioner core config validation', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -89,7 +102,7 @@ describe('provisioner core config validation', () => {
   });
 
   it('accepts the documented defaults', async () => {
-    vi.stubEnv('SHIPFOX_API_URL', undefined);
+    for (const name of defaultedEnvNames) vi.stubEnv(name, undefined);
     vi.resetModules();
 
     const {config} = await import('#config.js');

--- a/libs/provisioner/core/src/provisioner-env.test.ts
+++ b/libs/provisioner/core/src/provisioner-env.test.ts
@@ -1,15 +1,24 @@
-import {buildRunnerEnv} from '#provisioner.js';
-
 describe('buildRunnerEnv', () => {
-  it('includes the runner maximum lifetime in the shared image contract', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('includes the runner lifecycle limits in the shared image contract', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS', '7200');
+    vi.stubEnv('SHIPFOX_RUNNER_POLL_MAX_DURATION_MS', '600000');
+    vi.resetModules();
+
+    const {buildRunnerEnv} = await import('#provisioner.js');
+
     const runnerEnv = buildRunnerEnv({
       template: {key: 'small', labels: ['ubuntu24'], maxConcurrency: 1, cost: 1, spec: null},
       bootstrapToken: 'sf_rbt_test',
     });
 
     expect(runnerEnv).toMatchObject({
-      SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: '3600',
-      SHIPFOX_POLL_MAX_DURATION_MS: '300000',
+      SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: '7200',
+      SHIPFOX_POLL_MAX_DURATION_MS: '600000',
     });
   });
 });


### PR DESCRIPTION
Provisioner config is evaluated from the process environment at module import time. Runners that set lifecycle overrides caused tests of documented defaults and runner image environment propagation to use host values instead.

This keeps the defaults test independent by clearing every variable with a documented default, and loads the runner environment contract only after stubbing independent lifecycle values. Runtime configuration behavior is unchanged.

Validation: `mise exec -- env SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS=172800 turbo test check type --filter=@shipfox/provisioner-core --force` (48 tasks passed).

No Changeset is required because `@shipfox/provisioner-core` is private.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates provisioner config tests from the runner environment so documented defaults and image environment propagation are verified against known values instead of host overrides.

- The defaults test now clears every variable with a documented default before loading config.
- The runner image contract test stubs independent lifecycle values before importing the module.
- Runtime configuration behavior is unchanged; no changeset is required since `@shipfox/provisioner-core` is private.

<sup>Written for commit 07050c97a9b2f9dec46014f918260b12520ad69b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

