### PR TITLE
[client-shell] Add docs link to client navigation

### DIFF
--- a/.changeset/tidy-foxes-read.md
+++ b/.changeset/tidy-foxes-read.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/client-shell': patch
+---
+
+Add a persistent documentation link to the client navigation.

--- a/libs/client/shell/src/components/nav-bar.test.tsx
+++ b/libs/client/shell/src/components/nav-bar.test.tsx
@@ -51,7 +51,7 @@ describe('NavBar', () => {
   test('links to the documentation before the user menu', async () => {
     await renderWorkspacePage({path: '/w/workspace/workspace'});
 
-    const docsLink = await screen.findByRole('link', {name: 'Docs'});
+    const docsLink = await screen.findByRole('link', {name: 'Docs (opens in new tab)'});
     const userMenu = screen.getByRole('button', {name: 'User menu'});
 
     expect(docsLink).toHaveAttribute('href', 'https://shipfox.io/docs');
@@ -102,6 +102,13 @@ describe('NavBar', () => {
     });
 
     expect(await screen.findByRole('heading', {name: 'Page'})).toBeVisible();
+    const docsLink = screen.getByRole('link', {name: 'Docs (opens in new tab)'});
+    const userMenu = screen.getByRole('button', {name: 'User menu'});
+
+    expect(docsLink).toBeVisible();
+    expect(docsLink.compareDocumentPosition(userMenu) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
     expect(screen.queryByRole('button', {name: 'Get started'})).not.toBeInTheDocument();
   });
 });

--- a/libs/client/shell/src/components/nav-bar.test.tsx
+++ b/libs/client/shell/src/components/nav-bar.test.tsx
@@ -47,7 +47,21 @@ async function renderWorkspacePage(options: {
   });
 }
 
-describe('NavBar workspace-setup indicator', () => {
+describe('NavBar', () => {
+  test('links to the documentation before the user menu', async () => {
+    await renderWorkspacePage({path: '/w/workspace/workspace'});
+
+    const docsLink = await screen.findByRole('link', {name: 'Docs'});
+    const userMenu = screen.getByRole('button', {name: 'User menu'});
+
+    expect(docsLink).toHaveAttribute('href', 'https://shipfox.io/docs');
+    expect(docsLink).toHaveAttribute('target', '_blank');
+    expect(docsLink).toHaveAttribute('rel', 'noreferrer noopener');
+    expect(docsLink.compareDocumentPosition(userMenu) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   test('renders no indicator when the slot is absent', async () => {
     await renderWorkspacePage({path: '/w/workspace/workspace'});
 

--- a/libs/client/shell/src/components/nav-bar.tsx
+++ b/libs/client/shell/src/components/nav-bar.tsx
@@ -1,3 +1,4 @@
+import {Button} from '@shipfox/react-ui/button';
 import {Logo} from '@shipfox/react-ui/logo';
 import {Link} from '@tanstack/react-router';
 import {useActiveWorkspace} from '#runtime/active-workspace.js';
@@ -36,6 +37,11 @@ export function NavBar({hideProjectNavigation = false}: {hideProjectNavigation?:
         </>
       )}
       <div className="flex-1" />
+      <Button asChild variant="transparentMuted" size="sm" iconRight="externalLink">
+        <a href="https://shipfox.io/docs" target="_blank" rel="noreferrer noopener">
+          Docs
+        </a>
+      </Button>
       <UserMenu />
     </header>
   );

--- a/libs/client/shell/src/components/nav-bar.tsx
+++ b/libs/client/shell/src/components/nav-bar.tsx
@@ -37,8 +37,13 @@ export function NavBar({hideProjectNavigation = false}: {hideProjectNavigation?:
         </>
       )}
       <div className="flex-1" />
-      <Button asChild variant="transparentMuted" size="sm" iconRight="externalLink">
-        <a href="https://shipfox.io/docs" target="_blank" rel="noreferrer noopener">
+      <Button asChild variant="transparent" size="sm" iconRight="externalLink">
+        <a
+          href="https://shipfox.io/docs"
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label="Docs (opens in new tab)"
+        >
           Docs
         </a>
       </Button>

--- a/libs/client/shell/src/components/nav-bar.tsx
+++ b/libs/client/shell/src/components/nav-bar.tsx
@@ -37,7 +37,7 @@ export function NavBar({hideProjectNavigation = false}: {hideProjectNavigation?:
         </>
       )}
       <div className="flex-1" />
-      <Button asChild variant="transparent" size="sm" iconRight="externalLink">
+      <Button asChild variant="transparent" size="sm" className="text-foreground-neutral-subtle">
         <a
           href="https://shipfox.io/docs"
           target="_blank"


### PR DESCRIPTION
Add a persistent Docs link to the authenticated client navigation so users can reach troubleshooting and learning material without searching for the docs site.

The muted utility control sits before the user menu, opens https://shipfox.io/docs in a new tab, and includes an external-link affordance. A focused DOM test covers its destination, new-tab safety attributes, and placement. A patch Changeset records the published package change.

Validated locally with `mise exec -- turbo check type test build --filter=@shipfox/client-shell...` (107 tasks passed, including 183 client-shell tests and rendered Storybook coverage). Interactive screenshot review was unavailable locally because no browser connection was available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent Docs link to the authenticated client navigation so users can reach troubleshooting and learning material without searching for the docs site.

The transparent button sits before the user menu, opens https://shipfox.io/docs in a new tab with `noreferrer noopener`, and carries an accessible label indicating it opens in a new tab. Tests cover the destination, safety attributes, visibility, and placement. A patch changeset records the published `@shipfox/client-shell` change.

<sup>Written for commit 84bbb9dc1c6cbdf89473c56dbc954dfe793bbb34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

