### PR TITLE
Enforce control-flow readability limits

### DIFF
--- a/.changeset/calm-flows-read.md
+++ b/.changeset/calm-flows-read.md
@@ -50,4 +50,4 @@
 "@shipfox/worktree-services": patch
 ---
 
-Simplifies internal control flow with no change to public APIs or behavior.
+Simplifies internal control flow and preserves cached empty project states after failed refreshes.

--- a/.changeset/calm-flows-read.md
+++ b/.changeset/calm-flows-read.md
@@ -50,4 +50,4 @@
 "@shipfox/worktree-services": patch
 ---
 
-Simplifies complex control flow to meet shared readability limits.
+Simplifies internal control flow with no change to public APIs or behavior.

--- a/.changeset/calm-flows-read.md
+++ b/.changeset/calm-flows-read.md
@@ -1,0 +1,53 @@
+---
+"@shipfox/annotations": patch
+"@shipfox/api-agent": patch
+"@shipfox/api-agent-dto": patch
+"@shipfox/api-auth": patch
+"@shipfox/api-auth-context": patch
+"@shipfox/api-definitions": patch
+"@shipfox/api-email-challenges": patch
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-core-dto": patch
+"@shipfox/api-integration-gitea": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-jira": patch
+"@shipfox/api-integration-linear": patch
+"@shipfox/api-integration-sentry": patch
+"@shipfox/api-integration-slack": patch
+"@shipfox/api-logs": patch
+"@shipfox/api-projects": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-server": patch
+"@shipfox/api-triggers": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-workspaces": patch
+"@shipfox/architecture-policy": patch
+"@shipfox/client-agent": patch
+"@shipfox/client-auth": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-invitations": patch
+"@shipfox/client-logs": patch
+"@shipfox/client-onboarding": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-runners": patch
+"@shipfox/client-shell": patch
+"@shipfox/client-triggers": patch
+"@shipfox/client-ui": patch
+"@shipfox/client-workflows": patch
+"@shipfox/cloudflare-pages": patch
+"@shipfox/docker": patch
+"@shipfox/engineering-guidance": patch
+"@shipfox/expression": patch
+"@shipfox/node-egress-guard": patch
+"@shipfox/node-envelope-encryption": patch
+"@shipfox/node-module": patch
+"@shipfox/node-outbox": patch
+"@shipfox/react-ui": patch
+"@shipfox/redact": patch
+"@shipfox/runner-labels": patch
+"@shipfox/vite": patch
+"@shipfox/workflow-document": patch
+"@shipfox/worktree-services": patch
+---
+
+Simplifies complex control flow to meet shared readability limits.

--- a/.changeset/calm-flows-read.md
+++ b/.changeset/calm-flows-read.md
@@ -50,4 +50,4 @@
 "@shipfox/worktree-services": patch
 ---
 
-Simplifies internal control flow and preserves cached empty project states after failed refreshes.
+Preserves existing package behavior while simplifying internal control flow.

--- a/.changeset/steady-projects-refresh.md
+++ b/.changeset/steady-projects-refresh.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-projects": patch
+---
+
+Preserves cached empty project states after failed refreshes.

--- a/.github/scripts/package-release-workflow.mjs
+++ b/.github/scripts/package-release-workflow.mjs
@@ -83,48 +83,34 @@ function releaseFromPullRequest(pullRequest, revision) {
   };
 }
 
-async function authorize() {
-  const eventName = argument('event-name');
-  const repository = argument('repository');
-  const expectedAppId = argument('release-app-id');
-  const revision = argument('revision');
-  let release = {
-    authorId: argument('author-id') ?? '',
-    baseRevision: argument('base') ?? '',
-    headRef: argument('head-ref') ?? '',
-    headRepository: argument('head-repository') ?? '',
-    revision: revision ?? '',
-  };
-
-  if (eventName === 'pull_request' && argument('merged') !== 'true') {
-    await writeOutput({authorized: 'false'});
-    return;
-  }
-  if (eventName === 'workflow_dispatch' && revision) {
-    const result = await run('gh', ['api', `repos/${repository}/commits/${revision}/pulls`]);
-    const pullRequest =
-      result.code === 0
-        ? JSON.parse(result.stdout).find(
-            (candidate) => candidate.merged_at !== null && candidate.merge_commit_sha === revision,
-          )
-        : undefined;
-    if (pullRequest) release = releaseFromPullRequest(pullRequest, revision);
-  }
-
-  const reason =
+function authorizationReason(release, repository, expectedAppId) {
+  if (
     !release.revision ||
     !release.baseRevision ||
     !release.headRepository ||
     !release.headRef ||
     !release.authorId
-      ? 'missing-release-metadata'
-      : release.headRepository !== repository
-        ? 'head-repository-mismatch'
-        : release.headRef !== 'changeset-release/main'
-          ? 'release-branch-mismatch'
-          : release.authorId !== expectedAppId
-            ? 'release-app-mismatch'
-            : 'authorized';
+  ) {
+    return 'missing-release-metadata';
+  }
+  if (release.headRepository !== repository) return 'head-repository-mismatch';
+  if (release.headRef !== 'changeset-release/main') return 'release-branch-mismatch';
+  if (release.authorId !== expectedAppId) return 'release-app-mismatch';
+  return 'authorized';
+}
+
+async function resolveWorkflowDispatchRelease(eventName, repository, revision, fallback) {
+  if (eventName !== 'workflow_dispatch' || !revision) return fallback;
+
+  const result = await run('gh', ['api', `repos/${repository}/commits/${revision}/pulls`]);
+  if (result.code !== 0) return fallback;
+  const pullRequest = JSON.parse(result.stdout).find(
+    (candidate) => candidate.merged_at !== null && candidate.merge_commit_sha === revision,
+  );
+  return pullRequest ? releaseFromPullRequest(pullRequest, revision) : fallback;
+}
+
+async function writeAuthorizationResult(release, reason) {
   const authorized = reason === 'authorized';
   await writeOutput({
     authorized: String(authorized),
@@ -140,6 +126,34 @@ async function authorize() {
   process.stdout.write(`${JSON.stringify({authorized, reason})}\n`);
 }
 
+async function authorize() {
+  const eventName = argument('event-name');
+  const repository = argument('repository');
+  const expectedAppId = argument('release-app-id');
+  const revision = argument('revision');
+  const suppliedRelease = {
+    authorId: argument('author-id') ?? '',
+    baseRevision: argument('base') ?? '',
+    headRef: argument('head-ref') ?? '',
+    headRepository: argument('head-repository') ?? '',
+    revision: revision ?? '',
+  };
+
+  if (eventName === 'pull_request' && argument('merged') !== 'true') {
+    await writeOutput({authorized: 'false'});
+    return;
+  }
+  const release = await resolveWorkflowDispatchRelease(
+    eventName,
+    repository,
+    revision,
+    suppliedRelease,
+  );
+
+  const reason = authorizationReason(release, repository, expectedAppId);
+  await writeAuthorizationResult(release, reason);
+}
+
 function classificationResult(values, reason, message) {
   return {
     versionOnlyMain: values.versionOnlyMain ?? false,
@@ -149,6 +163,13 @@ function classificationResult(values, reason, message) {
     reason,
     message,
   };
+}
+
+function releaseMetadataResult({authorId, expectedAppId, headRef, headRepository, repository}) {
+  if (headRepository !== repository) return 'head-repository-mismatch';
+  if (headRef !== 'changeset-release/main') return 'release-branch-mismatch';
+  if (authorId !== expectedAppId) return 'release-app-mismatch';
+  return undefined;
 }
 
 async function writeMainClassification(result) {
@@ -177,75 +198,58 @@ async function writeMainClassification(result) {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
-async function classifyMain() {
-  const revision = argument('revision');
-  const repository = argument('repository');
-  const expectedAppId = argument('release-app-id');
-  const invalidMetadata = !revision || !repository || !expectedAppId;
-
-  if (invalidMetadata) {
-    await writeMainClassification(
-      classificationResult(
-        {},
-        'missing-main-classification-metadata',
-        'The main commit classifier did not receive the required metadata.',
-      ),
-    );
-    return;
-  }
-
+async function resolvePreviousRevision(revision) {
   const parentResult = await run('git', ['rev-parse', `${revision}^1`]);
   if (parentResult.code !== 0) {
-    await writeMainClassification(
-      classificationResult(
+    return {
+      error: classificationResult(
         {},
         'parent-revision-unavailable',
         'The parent revision could not be resolved; normal main CI remains required.',
       ),
-    );
-    return;
+    };
   }
   const previousRevision = parentResult.stdout.trim();
   if (!REVISION_PATTERN.test(previousRevision)) {
-    await writeMainClassification(
-      classificationResult(
+    return {
+      error: classificationResult(
         {},
         'parent-revision-invalid',
         'The resolved parent is not a full Git revision; normal main CI remains required.',
       ),
-    );
-    return;
+    };
   }
+  return {previousRevision};
+}
 
-  const pullRequestsResult = await run('gh', [
+async function resolveReleasePullRequest(repository, revision) {
+  const result = await run('gh', [
     'api',
     `repos/${repository}/commits/${revision}/pulls`,
     '--header',
     'Accept: application/vnd.github+json',
   ]);
-  if (pullRequestsResult.code !== 0) {
-    await writeMainClassification(
-      classificationResult(
+  if (result.code !== 0) {
+    return {
+      error: classificationResult(
         {},
         'merged-release-pr-unavailable',
         'The merged pull request could not be resolved; normal main CI remains required.',
       ),
-    );
-    return;
+    };
   }
 
   let pullRequests;
   try {
-    pullRequests = JSON.parse(pullRequestsResult.stdout);
+    pullRequests = JSON.parse(result.stdout);
   } catch {
-    await writeMainClassification(
-      classificationResult(
+    return {
+      error: classificationResult(
         {},
         'merged-release-pr-invalid',
         'GitHub returned invalid pull request metadata; normal main CI remains required.',
       ),
-    );
-    return;
+    };
   }
 
   const releasePullRequest = Array.isArray(pullRequests)
@@ -256,43 +260,27 @@ async function classifyMain() {
           pullRequest.base?.ref === 'main',
       )
     : undefined;
-  const releasePrUrl = releasePullRequest?.html_url ?? '';
-  const releasePrNumber = releasePullRequest?.number ? String(releasePullRequest.number) : '';
-
   if (!releasePullRequest) {
-    await writeMainClassification(
-      classificationResult(
-        {releasePrUrl, releasePrNumber},
+    return {
+      error: classificationResult(
+        {},
         'merged-release-pr-not-found',
         'The commit is not the merged result of a pull request targeting main.',
       ),
-    );
-    return;
+    };
   }
+  return {releasePullRequest};
+}
 
-  const headRepository = releasePullRequest.head?.repo?.full_name ?? '';
-  const headRef = releasePullRequest.head?.ref ?? '';
-  const authorId = String(releasePullRequest.user?.id ?? '');
-  const metadataResult =
-    headRepository !== repository
-      ? 'head-repository-mismatch'
-      : headRef !== 'changeset-release/main'
-        ? 'release-branch-mismatch'
-        : authorId !== expectedAppId
-          ? 'release-app-mismatch'
-          : undefined;
-
-  if (metadataResult) {
-    await writeMainClassification(
-      classificationResult(
-        {releasePrUrl, releasePrNumber},
-        metadataResult,
-        'The merged pull request metadata is not an approved generated release.',
-      ),
-    );
-    return;
-  }
-
+async function verifyGeneratedRelease({
+  authorId,
+  expectedAppId,
+  headRef,
+  headRepository,
+  previousRevision,
+  repository,
+  revision,
+}) {
   const verifierResult = await run('pnpm', [
     '--silent',
     '--filter=@shipfox/package-release',
@@ -325,9 +313,74 @@ async function classifyMain() {
   } catch {
     verifier = undefined;
   }
+  return {verifier, verified: verifierResult.code === 0};
+}
 
-  const versionOnlyMain =
-    verifierResult.code === 0 && verifier?.classification === 'generated-release';
+async function classifyMain() {
+  const revision = argument('revision');
+  const repository = argument('repository');
+  const expectedAppId = argument('release-app-id');
+  const invalidMetadata = !revision || !repository || !expectedAppId;
+
+  if (invalidMetadata) {
+    await writeMainClassification(
+      classificationResult(
+        {},
+        'missing-main-classification-metadata',
+        'The main commit classifier did not receive the required metadata.',
+      ),
+    );
+    return;
+  }
+
+  const previousRevisionResult = await resolvePreviousRevision(revision);
+  if (previousRevisionResult.error) {
+    await writeMainClassification(previousRevisionResult.error);
+    return;
+  }
+  const previousRevision = previousRevisionResult.previousRevision;
+
+  const releasePullRequestResult = await resolveReleasePullRequest(repository, revision);
+  if (releasePullRequestResult.error) {
+    await writeMainClassification(releasePullRequestResult.error);
+    return;
+  }
+  const releasePullRequest = releasePullRequestResult.releasePullRequest;
+  const releasePrUrl = releasePullRequest?.html_url ?? '';
+  const releasePrNumber = releasePullRequest?.number ? String(releasePullRequest.number) : '';
+
+  const headRepository = releasePullRequest.head?.repo?.full_name ?? '';
+  const headRef = releasePullRequest.head?.ref ?? '';
+  const authorId = String(releasePullRequest.user?.id ?? '');
+  const metadataResult = releaseMetadataResult({
+    authorId,
+    expectedAppId,
+    headRef,
+    headRepository,
+    repository,
+  });
+
+  if (metadataResult) {
+    await writeMainClassification(
+      classificationResult(
+        {releasePrUrl, releasePrNumber},
+        metadataResult,
+        'The merged pull request metadata is not an approved generated release.',
+      ),
+    );
+    return;
+  }
+
+  const {verifier, verified} = await verifyGeneratedRelease({
+    authorId,
+    expectedAppId,
+    headRef,
+    headRepository,
+    previousRevision,
+    repository,
+    revision,
+  });
+  const versionOnlyMain = verified && verifier?.classification === 'generated-release';
   await writeMainClassification(
     classificationResult(
       versionOnlyMain
@@ -404,8 +457,9 @@ async function summarizeUpdate() {
   const after = JSON.parse(await readFile(argument('after'), 'utf8'));
   const beforeHead = before[0]?.headRefOid;
   const afterHead = after[0]?.headRefOid;
-  const result =
-    !beforeHead && afterHead ? 'created' : beforeHead !== afterHead ? 'updated' : 'unchanged';
+  let result = 'unchanged';
+  if (!beforeHead && afterHead) result = 'created';
+  else if (beforeHead !== afterHead) result = 'updated';
   const number = after[0]?.number;
   await writeSummary(
     [

--- a/.github/scripts/package-release-workflow.mjs
+++ b/.github/scripts/package-release-workflow.mjs
@@ -93,10 +93,14 @@ function authorizationReason(release, repository, expectedAppId) {
   ) {
     return 'missing-release-metadata';
   }
+  return releaseMetadataReason(release, repository, expectedAppId) ?? 'authorized';
+}
+
+function releaseMetadataReason(release, repository, expectedAppId) {
   if (release.headRepository !== repository) return 'head-repository-mismatch';
   if (release.headRef !== 'changeset-release/main') return 'release-branch-mismatch';
   if (release.authorId !== expectedAppId) return 'release-app-mismatch';
-  return 'authorized';
+  return undefined;
 }
 
 async function resolveWorkflowDispatchRelease(eventName, repository, revision, fallback) {
@@ -163,13 +167,6 @@ function classificationResult(values, reason, message) {
     reason,
     message,
   };
-}
-
-function releaseMetadataResult({authorId, expectedAppId, headRef, headRepository, repository}) {
-  if (headRepository !== repository) return 'head-repository-mismatch';
-  if (headRef !== 'changeset-release/main') return 'release-branch-mismatch';
-  if (authorId !== expectedAppId) return 'release-app-mismatch';
-  return undefined;
 }
 
 async function writeMainClassification(result) {
@@ -352,13 +349,11 @@ async function classifyMain() {
   const headRepository = releasePullRequest.head?.repo?.full_name ?? '';
   const headRef = releasePullRequest.head?.ref ?? '';
   const authorId = String(releasePullRequest.user?.id ?? '');
-  const metadataResult = releaseMetadataResult({
-    authorId,
-    expectedAppId,
-    headRef,
-    headRepository,
+  const metadataResult = releaseMetadataReason(
+    {authorId, headRef, headRepository},
     repository,
-  });
+    expectedAppId,
+  );
 
   if (metadataResult) {
     await writeMainClassification(

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -214,6 +214,47 @@ function renderEventCatalog(catalog) {
 
 const UNCATEGORIZED_TOOL_CATEGORY = 'tools';
 
+function renderToolMethod(tool, method) {
+  return [
+    '',
+    `##### \`${tool.id}.${method.id}\``,
+    '',
+    method.description,
+    '',
+    `**Sensitivity:** ${method.sensitivity}.`,
+    '',
+    `**Sensitive:** ${method.sensitive ? 'Yes.' : 'No.'}`,
+    '',
+    `**Required permissions:** ${formatScope(method.requiredScope)}`,
+    '',
+    methodRequirements(tool.inputSchema, method.id),
+  ];
+}
+
+function renderTool(tool, selectionCatalog) {
+  const lines = [
+    `#### \`${tool.id}\``,
+    '',
+    tool.description,
+    '',
+    `**Sensitivity:** ${tool.sensitivity}.`,
+    '',
+    `**Sensitive:** ${tool.sensitive ? 'Yes.' : 'No.'}`,
+    '',
+    `**Required permissions:** ${formatScope(tool.requiredScope)}`,
+    '',
+    `**Selector tokens:** ${formatSelectors(tool.id, selectionCatalog)}`,
+    '',
+    '##### Input',
+    '',
+    ...renderFields(tool.inputSchema),
+  ];
+  for (const method of tool.methods ?? []) lines.push(...renderToolMethod(tool, method));
+  if (tool.outputSchema) lines.push('', '##### Output', '', ...renderFields(tool.outputSchema));
+  lines.push('');
+  return lines;
+}
+
 function renderToolCatalog(catalog, selectionCatalog) {
   const lines = [];
   const categoryOf = (tool) => tool.category ?? UNCATEGORIZED_TOOL_CATEGORY;
@@ -221,41 +262,7 @@ function renderToolCatalog(catalog, selectionCatalog) {
   for (const category of categories) {
     lines.push(`### ${category.replaceAll('_', ' ')}`, '');
     for (const tool of catalog.filter((candidate) => categoryOf(candidate) === category)) {
-      lines.push(
-        `#### \`${tool.id}\``,
-        '',
-        tool.description,
-        '',
-        `**Sensitivity:** ${tool.sensitivity}.`,
-        '',
-        `**Sensitive:** ${tool.sensitive ? 'Yes.' : 'No.'}`,
-        '',
-        `**Required permissions:** ${formatScope(tool.requiredScope)}`,
-        '',
-        `**Selector tokens:** ${formatSelectors(tool.id, selectionCatalog)}`,
-        '',
-        '##### Input',
-        '',
-        ...renderFields(tool.inputSchema),
-      );
-      for (const method of tool.methods ?? []) {
-        lines.push(
-          '',
-          `##### \`${tool.id}.${method.id}\``,
-          '',
-          method.description,
-          '',
-          `**Sensitivity:** ${method.sensitivity}.`,
-          '',
-          `**Sensitive:** ${method.sensitive ? 'Yes.' : 'No.'}`,
-          '',
-          `**Required permissions:** ${formatScope(method.requiredScope)}`,
-          '',
-          methodRequirements(tool.inputSchema, method.id),
-        );
-      }
-      if (tool.outputSchema) lines.push('', '##### Output', '', ...renderFields(tool.outputSchema));
-      lines.push('');
+      lines.push(...renderTool(tool, selectionCatalog));
     }
   }
   return lines.join('\n').trimEnd();
@@ -283,11 +290,9 @@ function renderFields(schema) {
   );
   const rows = Object.entries(properties).map(([name, value]) => {
     const property = unwrapNullableProperty(object(value));
-    const requirement = required.has(name)
-      ? 'Required'
-      : conditional.has(name)
-        ? 'Conditional'
-        : 'Optional';
+    let requirement = 'Optional';
+    if (required.has(name)) requirement = 'Required';
+    else if (conditional.has(name)) requirement = 'Conditional';
     const propertyType = Array.isArray(property.type)
       ? property.type.join(' | ')
       : (property.type ?? 'value');

--- a/apps/docs/src/app/components/docs-analytics-tracker.tsx
+++ b/apps/docs/src/app/components/docs-analytics-tracker.tsx
@@ -8,39 +8,45 @@ const EDIT_ON_GITHUB_BASE =
   'https://github.com/ShipfoxHQ/shipfox/edit/main/apps/docs/content/docs/';
 const CODE_BLOCK_SELECTOR = 'figure[data-docs-code-block]';
 
+function captureCodeCopy(target: Element): boolean {
+  const copyButton = target.closest(
+    `${CODE_BLOCK_SELECTOR} button[aria-label="Copy Text"], ${CODE_BLOCK_SELECTOR} button[aria-label="Copied Text"]`,
+  );
+  if (!copyButton) return false;
+
+  const codeBlock = copyButton.closest(CODE_BLOCK_SELECTOR);
+  if (!codeBlock) return true;
+  const blocks = Array.from(document.querySelectorAll(CODE_BLOCK_SELECTOR));
+  const code = codeBlock.querySelector('code');
+  const languageClass = code
+    ? Array.from(code.classList).find((name) => name.startsWith('language-'))
+    : undefined;
+  captureDocsEvent('docs_code_copy_clicked', {
+    language: languageClass?.slice('language-'.length) || 'unknown',
+    block_index: blocks.indexOf(codeBlock),
+  });
+  return true;
+}
+
+function captureOutboundLink(target: Element): void {
+  const anchor = target.closest<HTMLAnchorElement>('a[href]');
+  if (!anchor || anchor.dataset.docsAnalyticsCta !== undefined) return;
+  if (anchor.href.startsWith(EDIT_ON_GITHUB_BASE)) return;
+
+  const destination = destinationFromHref(anchor.href, window.location.href);
+  if (!destination || destination.origin === window.location.origin) return;
+  captureDocsEvent('docs_outbound_link_clicked', {
+    destination_origin: destination.origin,
+    destination_path: destination.pathname,
+  });
+}
+
 export function DocsAnalyticsTracker() {
   useEffect(() => {
     function captureClick(event: MouseEvent) {
       if (!(event.target instanceof Element)) return;
-
-      const copyButton = event.target.closest(
-        `${CODE_BLOCK_SELECTOR} button[aria-label="Copy Text"], ${CODE_BLOCK_SELECTOR} button[aria-label="Copied Text"]`,
-      );
-      if (copyButton) {
-        const codeBlock = copyButton.closest(CODE_BLOCK_SELECTOR);
-        if (!codeBlock) return;
-        const blocks = Array.from(document.querySelectorAll(CODE_BLOCK_SELECTOR));
-        const code = codeBlock.querySelector('code');
-        const languageClass = code
-          ? Array.from(code.classList).find((name) => name.startsWith('language-'))
-          : undefined;
-        captureDocsEvent('docs_code_copy_clicked', {
-          language: languageClass?.slice('language-'.length) || 'unknown',
-          block_index: blocks.indexOf(codeBlock),
-        });
-        return;
-      }
-
-      const anchor = event.target.closest<HTMLAnchorElement>('a[href]');
-      if (!anchor || anchor.dataset.docsAnalyticsCta !== undefined) return;
-      if (anchor.href.startsWith(EDIT_ON_GITHUB_BASE)) return;
-
-      const destination = destinationFromHref(anchor.href, window.location.href);
-      if (!destination || destination.origin === window.location.origin) return;
-      captureDocsEvent('docs_outbound_link_clicked', {
-        destination_origin: destination.origin,
-        destination_path: destination.pathname,
-      });
+      if (captureCodeCopy(event.target)) return;
+      captureOutboundLink(event.target);
     }
 
     document.addEventListener('click', captureClick);

--- a/apps/docs/src/lib/integration-catalog-validation.ts
+++ b/apps/docs/src/lib/integration-catalog-validation.ts
@@ -1,5 +1,24 @@
 import type {CatalogCapability, CatalogProvider} from '@/lib/integration-catalog';
 
+function validateProvider(
+  provider: CatalogProvider,
+  expectedCapabilities: readonly CatalogCapability[],
+): void {
+  const prefix = `Integration catalog provider "${provider.slug}"`;
+  for (const capability of expectedCapabilities) {
+    if (!provider.capabilities.includes(capability)) {
+      throw new Error(`${prefix} has a ${capability} DTO catalog but omits that capability.`);
+    }
+  }
+  if (provider.capabilities.includes('events') && provider.eventCount === 0) {
+    throw new Error(`${prefix} declares events but its event count is 0.`);
+  }
+  if (provider.capabilities.includes('agent_tools') && provider.toolCount === 0) {
+    throw new Error(`${prefix} declares agent tools but its tool count is 0.`);
+  }
+  if (!provider.setupHref) throw new Error(`${prefix} has no setup page.`);
+}
+
 export function validateIntegrationCatalog(
   providers: readonly CatalogProvider[],
   expectedCapabilitiesBySlug: Record<string, readonly CatalogCapability[]> = {},
@@ -11,18 +30,7 @@ export function validateIntegrationCatalog(
   }
 
   for (const provider of providers) {
-    const prefix = `Integration catalog provider "${provider.slug}"`;
     const expectedCapabilities = expectedCapabilitiesBySlug[provider.slug] ?? [];
-
-    for (const capability of expectedCapabilities) {
-      if (!provider.capabilities.includes(capability))
-        throw new Error(`${prefix} has a ${capability} DTO catalog but omits that capability.`);
-    }
-
-    if (provider.capabilities.includes('events') && provider.eventCount === 0)
-      throw new Error(`${prefix} declares events but its event count is 0.`);
-    if (provider.capabilities.includes('agent_tools') && provider.toolCount === 0)
-      throw new Error(`${prefix} declares agent tools but its tool count is 0.`);
-    if (!provider.setupHref) throw new Error(`${prefix} has no setup page.`);
+    validateProvider(provider, expectedCapabilities);
   }
 }

--- a/apps/docs/src/lib/integration-docs-completeness.ts
+++ b/apps/docs/src/lib/integration-docs-completeness.ts
@@ -87,24 +87,7 @@ function collectCatalogProviderIssues(
   }
 
   const overview = directory.overview;
-  if (!overview?.catalog) {
-    issues.push(
-      `${prefix}: add a catalog frontmatter block to integrations/${provider.slug}/index.mdx.`,
-    );
-  } else {
-    const catalog = overview.catalog;
-    const actualCapabilities = strings(catalog.capabilities);
-    for (const capability of provider.capabilities) {
-      if (!actualCapabilities.includes(capability))
-        issues.push(`${prefix}: add the "${capability}" capability to catalog frontmatter.`);
-    }
-    for (const capability of actualCapabilities) {
-      if (!provider.capabilities.includes(capability as CatalogCapability))
-        issues.push(
-          `${prefix}: remove the stale "${capability}" capability from catalog frontmatter.`,
-        );
-    }
-  }
+  collectCatalogFrontmatterIssues(overview, provider, prefix, issues);
 
   collectReferencePageIssues(directory, provider, generated, 'events', issues);
   collectReferencePageIssues(directory, provider, generated, 'tools', issues);
@@ -129,6 +112,34 @@ function collectCatalogProviderIssues(
       issues.push(
         `${prefix}: derive event and tool counts from generated reference instead of hardcoding them in ${page}.mdx.`,
       );
+  }
+}
+
+function collectCatalogFrontmatterIssues(
+  overview: IntegrationDocsDirectory['overview'],
+  provider: Extract<RegisteredIntegrationProvider, {kind: 'catalog'}>,
+  prefix: string,
+  issues: string[],
+): void {
+  if (!overview?.catalog) {
+    issues.push(
+      `${prefix}: add a catalog frontmatter block to integrations/${provider.slug}/index.mdx.`,
+    );
+    return;
+  }
+
+  const actualCapabilities = strings(overview.catalog.capabilities);
+  for (const capability of provider.capabilities) {
+    if (!actualCapabilities.includes(capability)) {
+      issues.push(`${prefix}: add the "${capability}" capability to catalog frontmatter.`);
+    }
+  }
+  for (const capability of actualCapabilities) {
+    if (!provider.capabilities.includes(capability as CatalogCapability)) {
+      issues.push(
+        `${prefix}: remove the stale "${capability}" capability from catalog frontmatter.`,
+      );
+    }
   }
 }
 

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -31,6 +31,10 @@ function getResolvedTheme(theme: Theme): 'light' | 'dark' {
   return 'light';
 }
 
+function themeColor(isDark: boolean, dark: string, light: string): string {
+  return isDark ? dark : light;
+}
+
 function getDocsTheme(theme: Theme): ThemeVars {
   const resolvedTheme = getResolvedTheme(theme);
   const baseTheme = storybookThemes[resolvedTheme];
@@ -39,27 +43,27 @@ function getDocsTheme(theme: Theme): ThemeVars {
   return {
     ...baseTheme,
     base: resolvedTheme,
-    appBg: isDark ? '#1a1a1b' : '#ffffff',
-    appContentBg: isDark ? '#030303' : '#fafafa',
-    appHoverBg: isDark ? '#27272a' : '#f4f4f5',
-    appPreviewBg: isDark ? '#1a1a1b' : '#ffffff',
-    appBorderColor: isDark ? '#27272a' : '#d4d4d8',
+    appBg: themeColor(isDark, '#1a1a1b', '#ffffff'),
+    appContentBg: themeColor(isDark, '#030303', '#fafafa'),
+    appHoverBg: themeColor(isDark, '#27272a', '#f4f4f5'),
+    appPreviewBg: themeColor(isDark, '#1a1a1b', '#ffffff'),
+    appBorderColor: themeColor(isDark, '#27272a', '#d4d4d8'),
     colorPrimary: '#ff4b00',
     colorSecondary: '#ff4b00',
-    textColor: isDark ? '#f4f4f5' : '#0f0f10',
-    textInverseColor: isDark ? '#0f0f10' : '#ffffff',
+    textColor: themeColor(isDark, '#f4f4f5', '#0f0f10'),
+    textInverseColor: themeColor(isDark, '#0f0f10', '#ffffff'),
     textMutedColor: '#71717a',
     barTextColor: '#71717a',
-    barHoverColor: isDark ? '#ff9e7a' : '#e63e00',
+    barHoverColor: themeColor(isDark, '#ff9e7a', '#e63e00'),
     barSelectedColor: '#ff4b00',
-    barBg: isDark ? '#1a1a1b' : '#ffffff',
-    buttonBg: isDark ? 'rgba(255, 255, 255, 0.04)' : '#ffffff',
-    buttonBorder: isDark ? 'rgba(255, 255, 255, 0.1)' : '#d4d4d8',
-    booleanBg: isDark ? 'rgba(255, 255, 255, 0.04)' : '#ffffff',
-    booleanSelectedBg: isDark ? '#4d1300' : '#fff4f0',
-    inputBg: isDark ? 'rgba(255, 255, 255, 0.04)' : '#ffffff',
-    inputBorder: isDark ? '#27272a' : '#d4d4d8',
-    inputTextColor: isDark ? '#f4f4f5' : '#0f0f10',
+    barBg: themeColor(isDark, '#1a1a1b', '#ffffff'),
+    buttonBg: themeColor(isDark, 'rgba(255, 255, 255, 0.04)', '#ffffff'),
+    buttonBorder: themeColor(isDark, 'rgba(255, 255, 255, 0.1)', '#d4d4d8'),
+    booleanBg: themeColor(isDark, 'rgba(255, 255, 255, 0.04)', '#ffffff'),
+    booleanSelectedBg: themeColor(isDark, '#4d1300', '#fff4f0'),
+    inputBg: themeColor(isDark, 'rgba(255, 255, 255, 0.04)', '#ffffff'),
+    inputBorder: themeColor(isDark, '#27272a', '#d4d4d8'),
+    inputTextColor: themeColor(isDark, '#f4f4f5', '#0f0f10'),
   };
 }
 

--- a/apps/storybook/scripts/artifact.ts
+++ b/apps/storybook/scripts/artifact.ts
@@ -147,22 +147,31 @@ function findAssetReferences(content: string, includeCssUrls: boolean): string[]
     if (match[1] !== undefined) references.add(match[1]);
   }
 
+  collectCssReferences(content, includeCssUrls, cssPattern, references);
+
+  return [...references];
+}
+
+function collectCssReferences(
+  content: string,
+  includeCssUrls: boolean,
+  cssPattern: RegExp,
+  references: Set<string>,
+): void {
   if (includeCssUrls) {
     for (const match of content.matchAll(cssPattern)) {
       if (match[1] !== undefined) references.add(match[1]);
     }
-  } else {
-    for (const styleBlock of content.matchAll(styleBlockPattern)) {
-      const styleContent = styleBlock[1];
-      if (styleContent === undefined) continue;
-
-      for (const match of styleContent.matchAll(cssPattern)) {
-        if (match[1] !== undefined) references.add(match[1]);
-      }
-    }
+    return;
   }
 
-  return [...references];
+  for (const styleBlock of content.matchAll(styleBlockPattern)) {
+    const styleContent = styleBlock[1];
+    if (styleContent === undefined) continue;
+    for (const match of styleContent.matchAll(cssPattern)) {
+      if (match[1] !== undefined) references.add(match[1]);
+    }
+  }
 }
 
 async function validateReferencedAssets(directory: string, staticRoot: string): Promise<void> {
@@ -380,26 +389,29 @@ export function assertPreviewMetadata(
   if (typeof candidate.buildTime !== 'string' || Number.isNaN(Date.parse(candidate.buildTime))) {
     throw new Error('preview-metadata.json has an invalid buildTime');
   }
-  if (candidate.pullRequest !== null && candidate.pullRequest !== undefined) {
-    if (typeof candidate.pullRequest !== 'object' || candidate.pullRequest === null) {
-      throw new Error('preview-metadata.json has an invalid pullRequest');
-    }
-
-    const pullRequest = candidate.pullRequest as Partial<
-      Exclude<PreviewMetadata['pullRequest'], null>
-    >;
-    if (!Number.isInteger(pullRequest.number) || (pullRequest.number ?? 0) <= 0) {
-      throw new Error('preview-metadata.json has an invalid pull request number');
-    }
-    if (pullRequest.headSha !== null && pullRequest.headSha !== candidate.commitSha) {
-      throw new Error(
-        `preview-metadata.json pull request headSha ${pullRequest.headSha} does not match commitSha ${candidate.commitSha}`,
-      );
-    }
-  }
+  assertPreviewPullRequest(candidate.pullRequest, candidate.commitSha);
   if (expectedCommitSha !== undefined && candidate.commitSha !== expectedCommitSha) {
     throw new Error(
       `preview-metadata.json commitSha ${candidate.commitSha} does not match expected ${expectedCommitSha}`,
+    );
+  }
+}
+
+function assertPreviewPullRequest(
+  value: PreviewMetadata['pullRequest'] | undefined,
+  commitSha: string,
+): void {
+  if (value === null || value === undefined) return;
+  if (typeof value !== 'object') {
+    throw new Error('preview-metadata.json has an invalid pullRequest');
+  }
+  const pullRequest = value as Partial<Exclude<PreviewMetadata['pullRequest'], null>>;
+  if (!Number.isInteger(pullRequest.number) || (pullRequest.number ?? 0) <= 0) {
+    throw new Error('preview-metadata.json has an invalid pull request number');
+  }
+  if (pullRequest.headSha !== null && pullRequest.headSha !== commitSha) {
+    throw new Error(
+      `preview-metadata.json pull request headSha ${pullRequest.headSha} does not match commitSha ${commitSha}`,
     );
   }
 }

--- a/apps/storybook/scripts/assemble.ts
+++ b/apps/storybook/scripts/assemble.ts
@@ -92,48 +92,40 @@ function getPullRequestNumber(event: Record<string, unknown> | null): number | n
   return typeof number === 'number' && Number.isInteger(number) && number > 0 ? number : null;
 }
 
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function stringOr(value: unknown, fallback: string | null): string | null {
+  return typeof value === 'string' ? value : fallback;
+}
+
 async function getPullRequestMetadata(): Promise<PreviewMetadata['pullRequest']> {
   const event = await getGitHubEvent();
-  const eventPullRequest = event?.pull_request;
-  const pullRequest =
-    typeof eventPullRequest === 'object' && eventPullRequest !== null
-      ? (eventPullRequest as Record<string, unknown>)
-      : null;
+  const pullRequest = recordOrNull(event?.pull_request);
   const number = getPullRequestNumber(event);
 
   if (number === null) return null;
 
-  const head =
-    typeof pullRequest?.head === 'object' && pullRequest.head !== null
-      ? (pullRequest.head as Record<string, unknown>)
-      : null;
-  const base =
-    typeof pullRequest?.base === 'object' && pullRequest.base !== null
-      ? (pullRequest.base as Record<string, unknown>)
-      : null;
+  const head = recordOrNull(pullRequest?.head);
+  const base = recordOrNull(pullRequest?.base);
 
   return {
     number,
-    title:
-      typeof pullRequest?.title === 'string'
-        ? pullRequest.title
-        : (process.env.CLOUDFLARE_PAGES_PR_TITLE ?? null),
-    url:
-      typeof pullRequest?.html_url === 'string'
-        ? pullRequest.html_url
-        : (process.env.CLOUDFLARE_PAGES_PR_URL ?? null),
-    headSha:
-      typeof head?.sha === 'string'
-        ? head.sha
-        : process.env.CLOUDFLARE_PAGES_PR_HEAD_SHA || getCommitShaFromEnv() || null,
-    headRef:
-      typeof head?.ref === 'string'
-        ? head.ref
-        : (process.env.CLOUDFLARE_PAGES_PR_HEAD_REF ?? process.env.GITHUB_HEAD_REF ?? null),
-    baseRef:
-      typeof base?.ref === 'string'
-        ? base.ref
-        : (process.env.CLOUDFLARE_PAGES_PR_BASE_REF ?? process.env.GITHUB_BASE_REF ?? null),
+    title: stringOr(pullRequest?.title, process.env.CLOUDFLARE_PAGES_PR_TITLE ?? null),
+    url: stringOr(pullRequest?.html_url, process.env.CLOUDFLARE_PAGES_PR_URL ?? null),
+    headSha: stringOr(
+      head?.sha,
+      process.env.CLOUDFLARE_PAGES_PR_HEAD_SHA || getCommitShaFromEnv() || null,
+    ),
+    headRef: stringOr(
+      head?.ref,
+      process.env.CLOUDFLARE_PAGES_PR_HEAD_REF ?? process.env.GITHUB_HEAD_REF ?? null,
+    ),
+    baseRef: stringOr(
+      base?.ref,
+      process.env.CLOUDFLARE_PAGES_PR_BASE_REF ?? process.env.GITHUB_BASE_REF ?? null,
+    ),
   };
 }
 

--- a/apps/storybook/src/introduction.tsx
+++ b/apps/storybook/src/introduction.tsx
@@ -38,6 +38,48 @@ export function parsePreviewIdentity(value: unknown): PreviewIdentity | null {
   };
 }
 
+function PreviewSource({pullRequest}: {pullRequest: PreviewIdentity['pullRequest']}) {
+  if (pullRequest === null) return 'main';
+  if (pullRequest.url === null) return `Pull request #${pullRequest.number}`;
+  return (
+    <a
+      className="underline underline-offset-4"
+      href={pullRequest.url}
+      rel="noreferrer"
+      target="_blank"
+    >
+      Pull request #{pullRequest.number}
+    </a>
+  );
+}
+
+function PreviewIdentityDetails({previewIdentity}: {previewIdentity: PreviewIdentityState}) {
+  if (previewIdentity.status === 'loading') {
+    return (
+      <Text size="sm" className="mt-8 text-foreground-neutral-subtle">
+        Loading build metadata…
+      </Text>
+    );
+  }
+  if (previewIdentity.status === 'unavailable') {
+    return (
+      <Text size="sm" className="mt-8 text-foreground-neutral-subtle">
+        Build metadata is unavailable on this surface.
+      </Text>
+    );
+  }
+  return (
+    <dl className="mt-12 grid gap-8 text-sm sm:grid-cols-[auto_1fr] sm:gap-x-16">
+      <dt className="text-foreground-neutral-subtle">Source</dt>
+      <dd>
+        <PreviewSource pullRequest={previewIdentity.identity.pullRequest} />
+      </dd>
+      <dt className="text-foreground-neutral-subtle">Commit</dt>
+      <dd className="break-all font-code">{previewIdentity.identity.commitSha}</dd>
+    </dl>
+  );
+}
+
 export function IntroductionPage() {
   const [previewIdentity, setPreviewIdentity] = useState<PreviewIdentityState>({
     status: 'loading',
@@ -86,37 +128,7 @@ export function IntroductionPage() {
           <Code variant="label" bold id="preview-identity">
             Preview identity
           </Code>
-          {previewIdentity.status === 'loading' ? (
-            <Text size="sm" className="mt-8 text-foreground-neutral-subtle">
-              Loading build metadata…
-            </Text>
-          ) : previewIdentity.status === 'unavailable' ? (
-            <Text size="sm" className="mt-8 text-foreground-neutral-subtle">
-              Build metadata is unavailable on this surface.
-            </Text>
-          ) : (
-            <dl className="mt-12 grid gap-8 text-sm sm:grid-cols-[auto_1fr] sm:gap-x-16">
-              <dt className="text-foreground-neutral-subtle">Source</dt>
-              <dd>
-                {previewIdentity.identity.pullRequest === null ? (
-                  'main'
-                ) : previewIdentity.identity.pullRequest.url === null ? (
-                  `Pull request #${previewIdentity.identity.pullRequest.number}`
-                ) : (
-                  <a
-                    className="underline underline-offset-4"
-                    href={previewIdentity.identity.pullRequest.url}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    Pull request #{previewIdentity.identity.pullRequest.number}
-                  </a>
-                )}
-              </dd>
-              <dt className="text-foreground-neutral-subtle">Commit</dt>
-              <dd className="break-all font-code">{previewIdentity.identity.commitSha}</dd>
-            </dl>
-          )}
+          <PreviewIdentityDetails previewIdentity={previewIdentity} />
         </section>
 
         <section aria-labelledby="storybook-packages">

--- a/biome.json
+++ b/biome.json
@@ -555,6 +555,37 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "apps/**",
+        "e2e/**",
+        "infra/**",
+        "libs/**",
+        "tools/**",
+        ".github/scripts/**",
+        "!**/dist/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": {
+              "level": "error",
+              "options": {
+                "maxAllowedComplexity": 15
+              }
+            }
+          },
+          "style": {
+            "noNestedTernary": "error",
+            "noUselessElse": "error"
+          }
+        }
+      }
     }
   ]
 }

--- a/e2e/core/src/api/client.ts
+++ b/e2e/core/src/api/client.ts
@@ -85,6 +85,36 @@ function appendHeaders(headers: Headers, source: RequestInit['headers'] | undefi
   });
 }
 
+function buildRequestInit(
+  method: ApiMethod,
+  params: ApiClientRequestOptions,
+  token: string,
+): RequestInit {
+  const headers = new Headers();
+  headers.set('authorization', `Bearer ${token}`);
+  appendHeaders(headers, params.headers);
+
+  let body = params.body;
+  if (params.json !== undefined) {
+    headers.set('content-type', 'application/json');
+    body = JSON.stringify(params.json);
+  }
+
+  const requestInit: RequestInit = {headers, method: method.toUpperCase()};
+  if (body !== undefined) requestInit.body = body;
+  if (params.signal) requestInit.signal = params.signal;
+  return requestInit;
+}
+
+function requestFailure(error: unknown, requestLabel: string): E2eApiError {
+  const suffix = error instanceof Error ? `: ${error.message}` : '';
+  return new E2eApiError({
+    message: `E2E API request failed for ${requestLabel}${suffix}`,
+    status: 0,
+    details: error,
+  });
+}
+
 export function createApiClient(options: ApiClientOptions) {
   const fetchImpl = options.fetch ?? fetch;
   const apiUrl = options.apiUrl ?? config.API_URL;
@@ -95,36 +125,14 @@ export function createApiClient(options: ApiClientOptions) {
     params: ApiClientRequestOptions = {},
   ): Promise<Response> {
     const requestLabel = `${method.toUpperCase()} ${path}`;
-    const headers = new Headers();
-    headers.set('authorization', `Bearer ${options.token}`);
-    appendHeaders(headers, params.headers);
-
-    let body = params.body;
-    if (params.json !== undefined) {
-      headers.set('content-type', 'application/json');
-      body = JSON.stringify(params.json);
-    }
-
-    const requestInit: RequestInit = {
-      headers,
-      method: method.toUpperCase(),
-    };
-    if (body !== undefined) requestInit.body = body;
-    if (params.signal) requestInit.signal = params.signal;
+    const requestInit = buildRequestInit(method, params, options.token);
 
     let response: Response;
     try {
       response = await fetchImpl(e2eUrl(path, apiUrl), requestInit);
     } catch (error) {
       if (isAbortError(error)) throw error;
-      throw new E2eApiError({
-        message:
-          error instanceof Error
-            ? `E2E API request failed for ${requestLabel}: ${error.message}`
-            : `E2E API request failed for ${requestLabel}`,
-        status: 0,
-        details: error,
-      });
+      throw requestFailure(error, requestLabel);
     }
 
     if (!response.ok) {

--- a/e2e/drivers/model-provider/src/scripts.ts
+++ b/e2e/drivers/model-provider/src/scripts.ts
@@ -393,34 +393,40 @@ function assertRequest(
   summary: ModelProviderRequestSummary,
   requestIndex: number,
 ): string[] {
-  return assertions.flatMap((assertion) => {
-    if (assertion.minRequestIndex !== undefined && requestIndex < assertion.minRequestIndex) {
-      return [];
-    }
+  return assertions.flatMap((assertion) => assertSingleRequest(assertion, summary, requestIndex));
+}
 
-    if (assertion.kind === 'model' && summary.model !== assertion.equals) {
-      return [`Expected model ${assertion.equals} but received ${summary.model ?? '<missing>'}`];
-    }
-
-    if (assertion.kind === 'tool_present' && !summary.tools.includes(assertion.name)) {
-      return [
-        `Expected tool ${assertion.name} to be present; received ${summary.tools.join(', ') || '<none>'}`,
-      ];
-    }
-
-    if (assertion.kind === 'tool_absent' && summary.tools.includes(assertion.name)) {
-      return [`Expected tool ${assertion.name} to be absent`];
-    }
-
-    if (
-      assertion.kind === 'message_content_includes' &&
-      !summary.messageContent.some((content) => content.includes(assertion.value))
-    ) {
-      return [`Expected message content to include ${assertion.value}`];
-    }
-
+function assertSingleRequest(
+  assertion: FakeOpenAiRequestAssertion,
+  summary: ModelProviderRequestSummary,
+  requestIndex: number,
+): string[] {
+  if (assertion.minRequestIndex !== undefined && requestIndex < assertion.minRequestIndex) {
     return [];
-  });
+  }
+
+  if (assertion.kind === 'model' && summary.model !== assertion.equals) {
+    return [`Expected model ${assertion.equals} but received ${summary.model ?? '<missing>'}`];
+  }
+
+  if (assertion.kind === 'tool_present' && !summary.tools.includes(assertion.name)) {
+    return [
+      `Expected tool ${assertion.name} to be present; received ${summary.tools.join(', ') || '<none>'}`,
+    ];
+  }
+
+  if (assertion.kind === 'tool_absent' && summary.tools.includes(assertion.name)) {
+    return [`Expected tool ${assertion.name} to be absent`];
+  }
+
+  if (
+    assertion.kind === 'message_content_includes' &&
+    !summary.messageContent.some((content) => content.includes(assertion.value))
+  ) {
+    return [`Expected message content to include ${assertion.value}`];
+  }
+
+  return [];
 }
 
 function recordedRequest(params: {

--- a/e2e/drivers/model-provider/src/server.ts
+++ b/e2e/drivers/model-provider/src/server.ts
@@ -48,111 +48,144 @@ export async function createFakeOpenAiModelProviderServer(
   };
 }
 
-async function routeRequest(params: {
+interface RouteParams {
   adminToken: string;
   registry: FakeOpenAiScriptRegistry;
   request: IncomingMessage;
   response: ServerResponse;
-}): Promise<void> {
+}
+
+interface RequestRoute {
+  method: string;
+  pathname: string;
+  url: URL;
+}
+
+function authorizeAdminRoute(params: RouteParams): boolean {
+  if (isAuthorized(params.request, params.adminToken)) return true;
+  writeUnauthorized(params.response);
+  return false;
+}
+
+function handleHealthRoute(params: RouteParams, route: RequestRoute): boolean {
+  if (route.pathname !== '/healthz' || route.method !== 'GET') return false;
+  if (authorizeAdminRoute(params)) writeJson(params.response, 200, {ok: true});
+  return true;
+}
+
+async function handleScriptRegistration(
+  params: RouteParams,
+  route: RequestRoute,
+): Promise<boolean> {
+  if (route.pathname !== '/scripts' || route.method !== 'POST') return false;
+  if (!authorizeAdminRoute(params)) return true;
+
+  const script = await readJson<FakeOpenAiScript>(params.request);
+  validateScriptRegistration(script);
+  const result = params.registry.register(script);
+  writeJson(params.response, 201, {
+    script_id: result.scriptId,
+    model: result.model,
+    model_provider_base_url: `${origin(route.url)}/scripts/${result.scriptId}/v1`,
+    anthropic_model_provider_base_url: `${origin(route.url)}/scripts/${result.scriptId}`,
+  });
+  return true;
+}
+
+function handleScriptReset(params: RouteParams, route: RequestRoute): boolean {
+  const match = resetPathRe.exec(route.pathname);
+  if (!match || route.method !== 'POST') return false;
+  if (!authorizeAdminRoute(params)) return true;
+
+  params.registry.reset(decodeURIComponent(match[1] ?? ''));
+  params.response.statusCode = 204;
+  params.response.end();
+  return true;
+}
+
+function handleRecordedRequests(params: RouteParams, route: RequestRoute): boolean {
+  const match = requestsPathRe.exec(route.pathname);
+  if (!match || route.method !== 'GET') return false;
+  if (!authorizeAdminRoute(params)) return true;
+
+  const scriptId = decodeURIComponent(match[1] ?? '');
+  writeJson(params.response, 200, {
+    script_id: scriptId,
+    requests: params.registry.requests(scriptId),
+  });
+  return true;
+}
+
+async function handleChatCompletion(params: RouteParams, route: RequestRoute): Promise<boolean> {
+  const match = completionsPathRe.exec(route.pathname);
+  if (!match || route.method !== 'POST') return false;
+
+  const scriptId = decodeURIComponent(match[1] ?? '');
+  const body = await readJson(params.request);
+  const result = params.registry.advance(scriptId, {
+    body,
+    method: route.method,
+    path: route.pathname,
+  });
+  if (result.status === 200 && isStreamRequest(body) && isChatCompletion(result.body)) {
+    writeEventStream(params.response, buildChatCompletionChunks(result.body));
+  } else {
+    writeJson(params.response, result.status, result.body);
+  }
+  return true;
+}
+
+async function handleAnthropicMessage(params: RouteParams, route: RequestRoute): Promise<boolean> {
+  const match = messagesPathRe.exec(route.pathname);
+  if (!match || route.method !== 'POST') return false;
+
+  const scriptId = decodeURIComponent(match[1] ?? '');
+  const body = await readJson(params.request);
+  const result = params.registry.advanceAnthropic(scriptId, {
+    body,
+    method: route.method,
+    path: route.pathname,
+  });
+  if (result.status === 200 && isStreamRequest(body) && isAnthropicMessage(result.body)) {
+    writeNamedEventStream(params.response, buildAnthropicMessageStream(result.body));
+  } else {
+    writeJson(params.response, result.status, result.body);
+  }
+  return true;
+}
+
+function handleModelList(params: RouteParams, route: RequestRoute): boolean {
+  const match = modelsPathRe.exec(route.pathname);
+  if (!match || route.method !== 'GET') return false;
+  const script = params.registry.script(decodeURIComponent(match[1] ?? ''));
+  writeJson(params.response, 200, buildOpenAiModelList(script.model));
+  return true;
+}
+
+async function dispatchRequest(params: RouteParams, route: RequestRoute): Promise<void> {
+  if (handleHealthRoute(params, route)) return;
+  if (await handleScriptRegistration(params, route)) return;
+  if (handleScriptReset(params, route)) return;
+  if (handleRecordedRequests(params, route)) return;
+  if (await handleChatCompletion(params, route)) return;
+  if (await handleAnthropicMessage(params, route)) return;
+  if (handleModelList(params, route)) return;
+
+  writeJson(
+    params.response,
+    404,
+    buildOpenAiError('not_found', `Route not found: ${route.method} ${route.pathname}`),
+  );
+}
+
+async function routeRequest(params: RouteParams): Promise<void> {
   try {
     const url = requestUrl(params.request);
-    const pathname = url.pathname;
-    const method = params.request.method ?? 'GET';
-
-    if (pathname === '/healthz' && method === 'GET') {
-      if (!isAuthorized(params.request, params.adminToken)) {
-        writeUnauthorized(params.response);
-        return;
-      }
-
-      writeJson(params.response, 200, {ok: true});
-      return;
-    }
-
-    if (pathname === '/scripts' && method === 'POST') {
-      if (!isAuthorized(params.request, params.adminToken)) {
-        writeUnauthorized(params.response);
-        return;
-      }
-
-      const script = await readJson<FakeOpenAiScript>(params.request);
-      validateScriptRegistration(script);
-      const result = params.registry.register(script);
-      writeJson(params.response, 201, {
-        script_id: result.scriptId,
-        model: result.model,
-        model_provider_base_url: `${origin(url)}/scripts/${result.scriptId}/v1`,
-        anthropic_model_provider_base_url: `${origin(url)}/scripts/${result.scriptId}`,
-      });
-      return;
-    }
-
-    const resetMatch = resetPathRe.exec(pathname);
-    if (resetMatch && method === 'POST') {
-      if (!isAuthorized(params.request, params.adminToken)) {
-        writeUnauthorized(params.response);
-        return;
-      }
-
-      params.registry.reset(decodeURIComponent(resetMatch[1] ?? ''));
-      params.response.statusCode = 204;
-      params.response.end();
-      return;
-    }
-
-    const requestsMatch = requestsPathRe.exec(pathname);
-    if (requestsMatch && method === 'GET') {
-      if (!isAuthorized(params.request, params.adminToken)) {
-        writeUnauthorized(params.response);
-        return;
-      }
-
-      const scriptId = decodeURIComponent(requestsMatch[1] ?? '');
-      writeJson(params.response, 200, {
-        script_id: scriptId,
-        requests: params.registry.requests(scriptId),
-      });
-      return;
-    }
-
-    const completionsMatch = completionsPathRe.exec(pathname);
-    if (completionsMatch && method === 'POST') {
-      const scriptId = decodeURIComponent(completionsMatch[1] ?? '');
-      const body = await readJson(params.request);
-      const result = params.registry.advance(scriptId, {body, method, path: pathname});
-      if (result.status === 200 && isStreamRequest(body) && isChatCompletion(result.body)) {
-        writeEventStream(params.response, buildChatCompletionChunks(result.body));
-        return;
-      }
-      writeJson(params.response, result.status, result.body);
-      return;
-    }
-
-    const messagesMatch = messagesPathRe.exec(pathname);
-    if (messagesMatch && method === 'POST') {
-      const scriptId = decodeURIComponent(messagesMatch[1] ?? '');
-      const body = await readJson(params.request);
-      const result = params.registry.advanceAnthropic(scriptId, {body, method, path: pathname});
-      if (result.status === 200 && isStreamRequest(body) && isAnthropicMessage(result.body)) {
-        writeNamedEventStream(params.response, buildAnthropicMessageStream(result.body));
-        return;
-      }
-      writeJson(params.response, result.status, result.body);
-      return;
-    }
-
-    const modelsMatch = modelsPathRe.exec(pathname);
-    if (modelsMatch && method === 'GET') {
-      const script = params.registry.script(decodeURIComponent(modelsMatch[1] ?? ''));
-      writeJson(params.response, 200, buildOpenAiModelList(script.model));
-      return;
-    }
-
-    writeJson(
-      params.response,
-      404,
-      buildOpenAiError('not_found', `Route not found: ${method} ${pathname}`),
-    );
+    await dispatchRequest(params, {
+      method: params.request.method ?? 'GET',
+      pathname: url.pathname,
+      url,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Fake model provider request failed.';
     writeJson(

--- a/e2e/drivers/model-provider/src/server.ts
+++ b/e2e/drivers/model-provider/src/server.ts
@@ -61,7 +61,7 @@ interface RequestRoute {
   url: URL;
 }
 
-function authorizeAdminRoute(params: RouteParams): boolean {
+function authorizeAdminRouteOrWriteUnauthorized(params: RouteParams): boolean {
   if (isAuthorized(params.request, params.adminToken)) return true;
   writeUnauthorized(params.response);
   return false;
@@ -69,7 +69,7 @@ function authorizeAdminRoute(params: RouteParams): boolean {
 
 function handleHealthRoute(params: RouteParams, route: RequestRoute): boolean {
   if (route.pathname !== '/healthz' || route.method !== 'GET') return false;
-  if (authorizeAdminRoute(params)) writeJson(params.response, 200, {ok: true});
+  if (authorizeAdminRouteOrWriteUnauthorized(params)) writeJson(params.response, 200, {ok: true});
   return true;
 }
 
@@ -78,7 +78,7 @@ async function handleScriptRegistration(
   route: RequestRoute,
 ): Promise<boolean> {
   if (route.pathname !== '/scripts' || route.method !== 'POST') return false;
-  if (!authorizeAdminRoute(params)) return true;
+  if (!authorizeAdminRouteOrWriteUnauthorized(params)) return true;
 
   const script = await readJson<FakeOpenAiScript>(params.request);
   validateScriptRegistration(script);
@@ -95,7 +95,7 @@ async function handleScriptRegistration(
 function handleScriptReset(params: RouteParams, route: RequestRoute): boolean {
   const match = resetPathRe.exec(route.pathname);
   if (!match || route.method !== 'POST') return false;
-  if (!authorizeAdminRoute(params)) return true;
+  if (!authorizeAdminRouteOrWriteUnauthorized(params)) return true;
 
   params.registry.reset(decodeURIComponent(match[1] ?? ''));
   params.response.statusCode = 204;
@@ -106,7 +106,7 @@ function handleScriptReset(params: RouteParams, route: RequestRoute): boolean {
 function handleRecordedRequests(params: RouteParams, route: RequestRoute): boolean {
   const match = requestsPathRe.exec(route.pathname);
   if (!match || route.method !== 'GET') return false;
-  if (!authorizeAdminRoute(params)) return true;
+  if (!authorizeAdminRouteOrWriteUnauthorized(params)) return true;
 
   const scriptId = decodeURIComponent(match[1] ?? '');
   writeJson(params.response, 200, {

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -106,7 +106,8 @@ export async function main(argv) {
 
 export function parseArgs(argv) {
   const args = [...argv];
-  const command = args[0] && !args[0].startsWith('-') ? args.shift() : 'run';
+  let command = 'run';
+  if (args[0] && !args[0].startsWith('-')) command = args.shift();
   if (command !== 'run') {
     throw new Error(`Unknown command: ${command}`);
   }
@@ -126,44 +127,13 @@ export function parseArgs(argv) {
       options.turboArgs.push(...args.slice(index + 1));
       break;
     }
-    if (arg === '--help' || arg === '-h') {
-      options.help = true;
+    if (applyBooleanOption(arg, options)) continue;
+    const valueOptionIndex = applyValueOption(args, index, arg, options);
+    if (valueOptionIndex !== null) {
+      index = valueOptionIndex;
       continue;
     }
-    if (arg === '--keep-open') {
-      options.keepOpen = true;
-      continue;
-    }
-    if (arg === '--log-dir') {
-      index += 1;
-      options.logDir = requireValue(args, index, arg);
-      continue;
-    }
-    if (arg.startsWith('--log-dir=')) {
-      options.logDir = arg.slice('--log-dir='.length);
-      continue;
-    }
-    if (arg === '--timeout-ms') {
-      index += 1;
-      options.readinessTimeoutMs = parsePositiveInteger(requireValue(args, index, arg), arg);
-      continue;
-    }
-    if (arg.startsWith('--timeout-ms=')) {
-      options.readinessTimeoutMs = parsePositiveInteger(
-        arg.slice('--timeout-ms='.length),
-        '--timeout-ms',
-      );
-      continue;
-    }
-    if (arg === '--task') {
-      index += 1;
-      options.turboTask = requireValue(args, index, arg);
-      continue;
-    }
-    if (arg.startsWith('--task=')) {
-      options.turboTask = arg.slice('--task='.length);
-      continue;
-    }
+    if (applyInlineOption(arg, options)) continue;
 
     options.turboArgs.push(arg);
   }
@@ -171,73 +141,168 @@ export function parseArgs(argv) {
   return options;
 }
 
+function applyBooleanOption(arg, options) {
+  if (arg === '--help' || arg === '-h') {
+    options.help = true;
+    return true;
+  }
+  if (arg === '--keep-open') {
+    options.keepOpen = true;
+    return true;
+  }
+  return false;
+}
+
+function applyValueOption(args, index, arg, options) {
+  if (arg === '--log-dir') {
+    options.logDir = requireValue(args, index + 1, arg);
+    return index + 1;
+  }
+  if (arg === '--timeout-ms') {
+    options.readinessTimeoutMs = parsePositiveInteger(requireValue(args, index + 1, arg), arg);
+    return index + 1;
+  }
+  if (arg === '--task') {
+    options.turboTask = requireValue(args, index + 1, arg);
+    return index + 1;
+  }
+  return null;
+}
+
+function applyInlineOption(arg, options) {
+  if (arg.startsWith('--log-dir=')) {
+    options.logDir = arg.slice('--log-dir='.length);
+    return true;
+  }
+  if (arg.startsWith('--timeout-ms=')) {
+    options.readinessTimeoutMs = parsePositiveInteger(
+      arg.slice('--timeout-ms='.length),
+      '--timeout-ms',
+    );
+    return true;
+  }
+  if (arg.startsWith('--task=')) {
+    options.turboTask = arg.slice('--task='.length);
+    return true;
+  }
+  return false;
+}
+
+function valueOr(value, fallback) {
+  if (value !== undefined && value !== null) return value;
+  return typeof fallback === 'function' ? fallback() : fallback;
+}
+
 export function e2eEnv(sourceEnv) {
-  const apiUrl = sourceEnv.API_URL ?? sourceEnv.SHIPFOX_API_URL ?? defaultApiUrl;
-  const clientUrl = sourceEnv.CLIENT_URL ?? sourceEnv.CLIENT_BASE_URL ?? defaultClientUrl;
-  const giteaUrl = sourceEnv.E2E_GITEA_URL ?? sourceEnv.GITEA_BASE_URL ?? 'http://localhost:3000';
-  const linearMcpEndpoint = sourceEnv.LINEAR_MCP_ENDPOINT ?? e2eLinearMcpEndpoint(apiUrl);
-  const githubApiBaseUrl = sourceEnv.GITHUB_API_BASE_URL ?? e2eGithubApiBaseUrl(apiUrl);
-  const slackApiBaseUrl = sourceEnv.SLACK_API_BASE_URL ?? e2eSlackApiBaseUrl(apiUrl);
+  const apiUrl = valueOr(sourceEnv.API_URL, valueOr(sourceEnv.SHIPFOX_API_URL, defaultApiUrl));
+  const clientUrl = valueOr(
+    sourceEnv.CLIENT_URL,
+    valueOr(sourceEnv.CLIENT_BASE_URL, defaultClientUrl),
+  );
+  const giteaUrl = valueOr(
+    sourceEnv.E2E_GITEA_URL,
+    valueOr(sourceEnv.GITEA_BASE_URL, 'http://localhost:3000'),
+  );
+  const linearMcpEndpoint = valueOr(sourceEnv.LINEAR_MCP_ENDPOINT, () =>
+    e2eLinearMcpEndpoint(apiUrl),
+  );
+  const githubApiBaseUrl = valueOr(sourceEnv.GITHUB_API_BASE_URL, () =>
+    e2eGithubApiBaseUrl(apiUrl),
+  );
+  const slackApiBaseUrl = valueOr(sourceEnv.SLACK_API_BASE_URL, () => e2eSlackApiBaseUrl(apiUrl));
   return {
     ...sourceEnv,
     API_URL: apiUrl,
-    CLIENT_BASE_URL: sourceEnv.CLIENT_BASE_URL ?? clientUrl,
+    CLIENT_BASE_URL: valueOr(sourceEnv.CLIENT_BASE_URL, clientUrl),
     CLIENT_URL: clientUrl,
-    E2E_ADMIN_API_KEY: sourceEnv.E2E_ADMIN_API_KEY ?? defaultE2eAdminApiKey,
-    E2E_ENABLED: sourceEnv.E2E_ENABLED ?? 'true',
-    AUTH_ROOT_KEY:
-      sourceEnv.AUTH_ROOT_KEY ?? 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+    E2E_ADMIN_API_KEY: valueOr(sourceEnv.E2E_ADMIN_API_KEY, defaultE2eAdminApiKey),
+    E2E_ENABLED: valueOr(sourceEnv.E2E_ENABLED, 'true'),
+    AUTH_ROOT_KEY: valueOr(sourceEnv.AUTH_ROOT_KEY, 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY='),
     // Impersonation ships disabled by default; the E2E deployment opts in so
     // the mint route is live for the suite that exercises it. The admin
     // bootstrap token is generated per run and never defaults to a well-known
     // literal: claiming the first admin owner requires knowing it, so a
     // harness-defaulted deployment is not bootstrap-able by anyone with
     // repository access.
-    AUTH_IMPERSONATION_ENABLED: sourceEnv.AUTH_IMPERSONATION_ENABLED ?? 'true',
-    ADMIN_BOOTSTRAP_TOKEN: sourceEnv.ADMIN_BOOTSTRAP_TOKEN ?? e2eBootstrapToken(),
-    AUTH_SIGNUP_GATE_ENABLED:
-      sourceEnv.AUTH_SIGNUP_GATE_ENABLED ?? defaultAuthSignupGateEnabled,
-    AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS:
-      sourceEnv.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS ?? defaultAuthSignupAllowedEmailDomains,
-    AUTH_SIGNUP_NOT_ALLOWED_MESSAGE:
-      sourceEnv.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE ?? defaultAuthSignupNotAllowedMessage,
+    AUTH_IMPERSONATION_ENABLED: valueOr(sourceEnv.AUTH_IMPERSONATION_ENABLED, 'true'),
+    ADMIN_BOOTSTRAP_TOKEN: valueOr(sourceEnv.ADMIN_BOOTSTRAP_TOKEN, e2eBootstrapToken),
+    AUTH_SIGNUP_GATE_ENABLED: valueOr(
+      sourceEnv.AUTH_SIGNUP_GATE_ENABLED,
+      defaultAuthSignupGateEnabled,
+    ),
+    AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS: valueOr(
+      sourceEnv.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS,
+      defaultAuthSignupAllowedEmailDomains,
+    ),
+    AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: valueOr(
+      sourceEnv.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE,
+      defaultAuthSignupNotAllowedMessage,
+    ),
     E2E_GITEA_URL: giteaUrl,
-    GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
-    HOST: sourceEnv.HOST ?? '0.0.0.0',
+    GITEA_CLONE_BASE_URL: valueOr(sourceEnv.GITEA_CLONE_BASE_URL, giteaUrl),
+    HOST: valueOr(sourceEnv.HOST, '0.0.0.0'),
     GITHUB_API_BASE_URL: githubApiBaseUrl,
-    GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE:
-      sourceEnv.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE ?? 'enabled',
-    GITHUB_APP_CLIENT_ID: sourceEnv.GITHUB_APP_CLIENT_ID ?? 'e2e-github-client-id',
-    GITHUB_APP_CLIENT_SECRET: sourceEnv.GITHUB_APP_CLIENT_SECRET ?? 'e2e-github-client-secret',
-    GITHUB_APP_ID: sourceEnv.GITHUB_APP_ID ?? '1',
-    GITHUB_APP_PRIVATE_KEY:
-      sourceEnv.GITHUB_APP_PRIVATE_KEY ?? e2eGithubAppPrivateKey(),
-    GITHUB_APP_SLUG: sourceEnv.GITHUB_APP_SLUG ?? 'shipfox-e2e',
-    GITHUB_APP_USERNAME: sourceEnv.GITHUB_APP_USERNAME ?? 'shipfox-e2e',
-    GITHUB_APP_WEBHOOK_SECRET:
-      sourceEnv.GITHUB_APP_WEBHOOK_SECRET ?? 'e2e-github-webhook-secret',
-    GITHUB_INSTALL_STATE_SECRET:
-      sourceEnv.GITHUB_INSTALL_STATE_SECRET ?? 'e2e-github-install-state-secret',
-    INTEGRATIONS_ENABLE_GITHUB_PROVIDER: sourceEnv.INTEGRATIONS_ENABLE_GITHUB_PROVIDER ?? 'true',
-    INTEGRATIONS_ENABLE_LINEAR_PROVIDER: sourceEnv.INTEGRATIONS_ENABLE_LINEAR_PROVIDER ?? 'true',
-    INTEGRATIONS_ENABLE_SLACK_PROVIDER: sourceEnv.INTEGRATIONS_ENABLE_SLACK_PROVIDER ?? 'true',
+    GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE: valueOr(
+      sourceEnv.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE,
+      'enabled',
+    ),
+    GITHUB_APP_CLIENT_ID: valueOr(sourceEnv.GITHUB_APP_CLIENT_ID, 'e2e-github-client-id'),
+    GITHUB_APP_CLIENT_SECRET: valueOr(
+      sourceEnv.GITHUB_APP_CLIENT_SECRET,
+      'e2e-github-client-secret',
+    ),
+    GITHUB_APP_ID: valueOr(sourceEnv.GITHUB_APP_ID, '1'),
+    GITHUB_APP_PRIVATE_KEY: valueOr(sourceEnv.GITHUB_APP_PRIVATE_KEY, e2eGithubAppPrivateKey),
+    GITHUB_APP_SLUG: valueOr(sourceEnv.GITHUB_APP_SLUG, 'shipfox-e2e'),
+    GITHUB_APP_USERNAME: valueOr(sourceEnv.GITHUB_APP_USERNAME, 'shipfox-e2e'),
+    GITHUB_APP_WEBHOOK_SECRET: valueOr(
+      sourceEnv.GITHUB_APP_WEBHOOK_SECRET,
+      'e2e-github-webhook-secret',
+    ),
+    GITHUB_INSTALL_STATE_SECRET: valueOr(
+      sourceEnv.GITHUB_INSTALL_STATE_SECRET,
+      'e2e-github-install-state-secret',
+    ),
+    INTEGRATIONS_ENABLE_GITHUB_PROVIDER: valueOr(
+      sourceEnv.INTEGRATIONS_ENABLE_GITHUB_PROVIDER,
+      'true',
+    ),
+    INTEGRATIONS_ENABLE_LINEAR_PROVIDER: valueOr(
+      sourceEnv.INTEGRATIONS_ENABLE_LINEAR_PROVIDER,
+      'true',
+    ),
+    INTEGRATIONS_ENABLE_SLACK_PROVIDER: valueOr(
+      sourceEnv.INTEGRATIONS_ENABLE_SLACK_PROVIDER,
+      'true',
+    ),
     LINEAR_MCP_ENDPOINT: linearMcpEndpoint,
-    LINEAR_OAUTH_CLIENT_ID: sourceEnv.LINEAR_OAUTH_CLIENT_ID ?? 'e2e-linear-client-id',
-    LINEAR_OAUTH_CLIENT_SECRET:
-      sourceEnv.LINEAR_OAUTH_CLIENT_SECRET ?? 'e2e-linear-client-secret',
-    LINEAR_OAUTH_REDIRECT_URL:
-      sourceEnv.LINEAR_OAUTH_REDIRECT_URL ?? `${clientUrl}/integrations/linear/callback`,
-    LINEAR_WEBHOOK_SIGNING_SECRET:
-      sourceEnv.LINEAR_WEBHOOK_SIGNING_SECRET ?? 'e2e-linear-webhook-secret',
+    LINEAR_OAUTH_CLIENT_ID: valueOr(sourceEnv.LINEAR_OAUTH_CLIENT_ID, 'e2e-linear-client-id'),
+    LINEAR_OAUTH_CLIENT_SECRET: valueOr(
+      sourceEnv.LINEAR_OAUTH_CLIENT_SECRET,
+      'e2e-linear-client-secret',
+    ),
+    LINEAR_OAUTH_REDIRECT_URL: valueOr(
+      sourceEnv.LINEAR_OAUTH_REDIRECT_URL,
+      `${clientUrl}/integrations/linear/callback`,
+    ),
+    LINEAR_WEBHOOK_SIGNING_SECRET: valueOr(
+      sourceEnv.LINEAR_WEBHOOK_SIGNING_SECRET,
+      'e2e-linear-webhook-secret',
+    ),
     SLACK_API_BASE_URL: slackApiBaseUrl,
-    SLACK_OAUTH_CLIENT_ID: sourceEnv.SLACK_OAUTH_CLIENT_ID ?? 'e2e-slack-client-id',
-    SLACK_OAUTH_CLIENT_SECRET: sourceEnv.SLACK_OAUTH_CLIENT_SECRET ?? 'e2e-slack-client-secret',
-    SLACK_OAUTH_REDIRECT_URL:
-      sourceEnv.SLACK_OAUTH_REDIRECT_URL ?? `${clientUrl}/integrations/slack/callback`,
-    SLACK_SIGNING_SECRET: sourceEnv.SLACK_SIGNING_SECRET ?? 'e2e-slack-signing-secret',
-    VITE_API_URL: sourceEnv.VITE_API_URL ?? apiUrl,
-    VITE_ENABLE_TEST_VCS_PROVIDER: sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER ?? 'true',
-    WEBHOOK_PUBLIC_URL: sourceEnv.WEBHOOK_PUBLIC_URL ?? apiUrl,
+    SLACK_OAUTH_CLIENT_ID: valueOr(sourceEnv.SLACK_OAUTH_CLIENT_ID, 'e2e-slack-client-id'),
+    SLACK_OAUTH_CLIENT_SECRET: valueOr(
+      sourceEnv.SLACK_OAUTH_CLIENT_SECRET,
+      'e2e-slack-client-secret',
+    ),
+    SLACK_OAUTH_REDIRECT_URL: valueOr(
+      sourceEnv.SLACK_OAUTH_REDIRECT_URL,
+      `${clientUrl}/integrations/slack/callback`,
+    ),
+    SLACK_SIGNING_SECRET: valueOr(sourceEnv.SLACK_SIGNING_SECRET, 'e2e-slack-signing-secret'),
+    VITE_API_URL: valueOr(sourceEnv.VITE_API_URL, apiUrl),
+    VITE_ENABLE_TEST_VCS_PROVIDER: valueOr(sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER, 'true'),
+    WEBHOOK_PUBLIC_URL: valueOr(sourceEnv.WEBHOOK_PUBLIC_URL, apiUrl),
   };
 }
 

--- a/e2e/kit/src/ui/stable-screenshot.ts
+++ b/e2e/kit/src/ui/stable-screenshot.ts
@@ -104,20 +104,25 @@ async function applyPageWideReplacements(
         value,
       );
 
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-    let node = walker.nextNode();
-    while (node) {
-      const textNode = node as Text;
-      const nextValue = replaceValue(textNode.data);
-      if (nextValue !== textNode.data) {
-        restoreEntries.push({kind: 'text', target: textNode, value: textNode.data});
-        textNode.data = nextValue;
+    function replaceTextNodes(): void {
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+      let node = walker.nextNode();
+      while (node) {
+        const textNode = node as Text;
+        const nextValue = replaceValue(textNode.data);
+        if (nextValue !== textNode.data) {
+          restoreEntries.push({kind: 'text', target: textNode, value: textNode.data});
+          textNode.data = nextValue;
+        }
+        node = walker.nextNode();
       }
-      node = walker.nextNode();
     }
 
-    for (const element of document.querySelectorAll('input, textarea')) {
-      if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    function replaceInputValues(): void {
+      for (const element of document.querySelectorAll('input, textarea')) {
+        if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) {
+          continue;
+        }
         const nextValue = replaceValue(element.value);
         if (nextValue !== element.value) {
           restoreEntries.push({kind: 'value', target: element, value: element.value});
@@ -126,7 +131,13 @@ async function applyPageWideReplacements(
       }
     }
 
-    for (const element of document.querySelectorAll('[aria-label], [placeholder], [title]')) {
+    function replaceAttributes(): void {
+      for (const element of document.querySelectorAll('[aria-label], [placeholder], [title]')) {
+        replaceElementAttributes(element);
+      }
+    }
+
+    function replaceElementAttributes(element: Element): void {
       for (const attribute of ['aria-label', 'placeholder', 'title']) {
         const value = element.getAttribute(attribute);
         if (value == null) continue;
@@ -138,6 +149,9 @@ async function applyPageWideReplacements(
       }
     }
 
+    replaceTextNodes();
+    replaceInputValues();
+    replaceAttributes();
     visualWindow.__shipfoxVisualRestore = restoreEntries;
   }, options);
 }
@@ -154,14 +168,20 @@ async function restorePageWideReplacements(page: Page): Promise<void> {
     };
     const restoreEntries = visualWindow.__shipfoxVisualRestore ?? [];
 
-    for (const entry of restoreEntries.reverse()) {
+    function restoreEntry(entry: RestoreEntry): void {
       if (entry.kind === 'text') {
         entry.target.data = entry.value;
-      } else if (entry.kind === 'value') {
-        entry.target.value = entry.value;
-      } else {
-        entry.target.setAttribute(entry.attribute, entry.value);
+        return;
       }
+      if (entry.kind === 'value') {
+        entry.target.value = entry.value;
+        return;
+      }
+      entry.target.setAttribute(entry.attribute, entry.value);
+    }
+
+    for (const entry of restoreEntries.reverse()) {
+      restoreEntry(entry);
     }
 
     const toaster = document.querySelector('[data-sonner-toaster]');
@@ -205,27 +225,48 @@ async function applyReplacements(
               valueReplacement: string | undefined;
             },
           ): Omit<ElementSnapshot, 'handle'> => {
-            const previous: Omit<ElementSnapshot, 'handle'> = {
-              attributes: Object.fromEntries(
-                Object.keys(options.attributes).map((name) => [name, element.getAttribute(name)]),
-              ),
-            };
-            if (options.textReplacement !== undefined) previous.text = element.textContent;
-            if (options.valueReplacement !== undefined && 'value' in element) {
-              const currentValue = element.value;
-              if (currentValue !== undefined) previous.value = currentValue;
+            function snapshotText(snapshot: Omit<ElementSnapshot, 'handle'>): void {
+              if (options.textReplacement !== undefined) snapshot.text = element.textContent;
             }
 
-            if (options.textReplacement !== undefined)
-              element.textContent = options.textReplacement;
-            if (options.valueReplacement !== undefined && 'value' in element) {
+            function snapshotValue(snapshot: Omit<ElementSnapshot, 'handle'>): void {
+              if (options.valueReplacement === undefined || !('value' in element)) return;
+              const currentValue = element.value;
+              if (currentValue !== undefined) snapshot.value = currentValue;
+            }
+
+            function snapshotElement(): Omit<ElementSnapshot, 'handle'> {
+              const snapshot: Omit<ElementSnapshot, 'handle'> = {
+                attributes: Object.fromEntries(
+                  Object.keys(options.attributes).map((name) => [name, element.getAttribute(name)]),
+                ),
+              };
+              snapshotText(snapshot);
+              snapshotValue(snapshot);
+              return snapshot;
+            }
+
+            function replaceText(): void {
+              if (options.textReplacement !== undefined) {
+                element.textContent = options.textReplacement;
+              }
+            }
+
+            function replaceValue(): void {
+              if (options.valueReplacement === undefined || !('value' in element)) return;
               element.value = options.valueReplacement;
             }
 
-            for (const [name, value] of Object.entries(options.attributes)) {
-              element.setAttribute(name, value);
+            function replaceAttributes(): void {
+              for (const [name, value] of Object.entries(options.attributes)) {
+                element.setAttribute(name, value);
+              }
             }
 
+            const previous = snapshotElement();
+            replaceText();
+            replaceValue();
+            replaceAttributes();
             return previous;
           },
           {
@@ -256,13 +297,16 @@ async function restoreSnapshots(snapshots: LocatorSnapshot[]): Promise<void> {
         if (elementSnapshot.value !== undefined) previous.value = elementSnapshot.value;
         await elementSnapshot.handle.evaluate(
           (element: MutableElement, previous: Omit<ElementSnapshot, 'handle'>) => {
+            function restoreAttributes(): void {
+              for (const [name, value] of Object.entries(previous.attributes)) {
+                if (value === null) element.removeAttribute(name);
+                else element.setAttribute(name, value);
+              }
+            }
+
             if (previous.text !== undefined) element.textContent = previous.text;
             if (previous.value !== undefined && 'value' in element) element.value = previous.value;
-
-            for (const [name, value] of Object.entries(previous.attributes)) {
-              if (value === null) element.removeAttribute(name);
-              else element.setAttribute(name, value);
-            }
+            restoreAttributes();
           },
           previous,
         );

--- a/e2e/observe/workflows/src/index.test.ts
+++ b/e2e/observe/workflows/src/index.test.ts
@@ -20,38 +20,42 @@ const RUN_TERMINAL_TIMEOUT_RE =
   /Timed out waiting for workflow run terminal status: runId=33333333/u;
 const RUN_TERMINAL_OBSERVED_RE = /status=running/u;
 
+function valueOr<T>(value: T | undefined, fallback: T): T {
+  return value ?? fallback;
+}
+
 function run(params: Partial<WorkflowRunListItemDto> = {}): WorkflowRunListItemDto {
   return {
-    id: params.id ?? runId,
-    project_id: params.project_id ?? projectId,
-    definition_id: params.definition_id ?? definitionId,
-    number: params.number ?? 1,
-    name: params.name ?? 'Build',
-    workflow_name: params.workflow_name ?? 'Build',
-    status: params.status ?? 'pending',
-    origin: params.origin ?? 'synced',
-    dev_source: params.dev_source ?? null,
-    current_attempt: params.current_attempt ?? 1,
-    latest_attempt: params.latest_attempt ?? 1,
-    trigger_provider: params.trigger_provider ?? 'gitea',
-    trigger_source: params.trigger_source ?? 'gitea_e2e',
-    trigger_event: params.trigger_event ?? 'push',
-    trigger_payload: params.trigger_payload ?? {
+    id: valueOr(params.id, runId),
+    project_id: valueOr(params.project_id, projectId),
+    definition_id: valueOr(params.definition_id, definitionId),
+    number: valueOr(params.number, 1),
+    name: valueOr(params.name, 'Build'),
+    workflow_name: valueOr(params.workflow_name, 'Build'),
+    status: valueOr(params.status, 'pending'),
+    origin: valueOr(params.origin, 'synced'),
+    dev_source: valueOr(params.dev_source, null),
+    current_attempt: valueOr(params.current_attempt, 1),
+    latest_attempt: valueOr(params.latest_attempt, 1),
+    trigger_provider: valueOr(params.trigger_provider, 'gitea'),
+    trigger_source: valueOr(params.trigger_source, 'gitea_e2e'),
+    trigger_event: valueOr(params.trigger_event, 'push'),
+    trigger_payload: valueOr(params.trigger_payload, {
       provider: 'gitea',
       source: 'gitea_e2e',
       event: 'push',
       deliveryId: 'delivery-1',
       data: {headCommitSha: 'abc123', ref: 'main'},
-    },
-    trigger_reference: params.trigger_reference ?? null,
-    inputs: params.inputs ?? null,
-    source_snapshot: params.source_snapshot ?? null,
-    created_at: params.created_at ?? '2026-07-02T08:00:00.000Z',
-    updated_at: params.updated_at ?? '2026-07-02T08:00:00.000Z',
-    started_at: params.started_at ?? null,
-    finished_at: params.finished_at ?? null,
-    jobs: params.jobs ?? [],
-    job_status_counts: params.job_status_counts ?? [],
+    }),
+    trigger_reference: valueOr(params.trigger_reference, null),
+    inputs: valueOr(params.inputs, null),
+    source_snapshot: valueOr(params.source_snapshot, null),
+    created_at: valueOr(params.created_at, '2026-07-02T08:00:00.000Z'),
+    updated_at: valueOr(params.updated_at, '2026-07-02T08:00:00.000Z'),
+    started_at: valueOr(params.started_at, null),
+    finished_at: valueOr(params.finished_at, null),
+    jobs: valueOr(params.jobs, []),
+    job_status_counts: valueOr(params.job_status_counts, []),
   };
 }
 

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -239,6 +239,178 @@ function intOrNullField(value: Record<string, unknown>, field: string): number |
   return typeof fieldValue === 'number' && Number.isInteger(fieldValue) ? fieldValue : undefined;
 }
 
+function formatOptionalInteger(value: number | null | undefined): string {
+  if (value === undefined) return 'missing';
+  if (value === null) return 'null';
+  return String(value);
+}
+
+type JobExpectation = NonNullable<Expectation['jobs']>[string];
+type StepExpectation = NonNullable<JobExpectation['steps']>[string];
+
+function evaluateStepError(
+  step: WorkflowRunStepDetailDto,
+  expectation: NonNullable<StepExpectation['error']>,
+  path: string,
+  mismatches: Mismatch[],
+): void {
+  if (step.error === null) {
+    mismatches.push({path, expected: 'present', actual: 'null'});
+    return;
+  }
+
+  if (expectation.reason !== undefined && step.error.reason !== expectation.reason) {
+    mismatches.push({
+      path: `${path}.reason`,
+      expected: expectation.reason,
+      actual: step.error.reason ?? 'null',
+    });
+  }
+
+  if (expectation.field !== undefined) {
+    const field = stringField(step.error, 'field');
+    if (field !== expectation.field) {
+      mismatches.push({
+        path: `${path}.field`,
+        expected: expectation.field,
+        actual: field ?? 'null',
+      });
+    }
+  }
+
+  if (expectation.source !== undefined) {
+    const source = stringField(step.error, 'source');
+    if (source === null || !source.includes(expectation.source)) {
+      mismatches.push({
+        path: `${path}.source`,
+        expected: `include ${expectation.source}`,
+        actual: source ?? 'null',
+      });
+    }
+  }
+}
+
+function evaluateGateResult(
+  step: WorkflowRunStepDetailDto,
+  expectation: NonNullable<StepExpectation['gate_result']>,
+  path: string,
+  mismatches: Mismatch[],
+): void {
+  const gateResult = latestGateResult(step);
+  if (gateResult === null) {
+    mismatches.push({path, expected: 'present', actual: 'null'});
+    return;
+  }
+
+  if (expectation.kind !== undefined && gateResult.kind !== expectation.kind) {
+    mismatches.push({path: `${path}.kind`, expected: expectation.kind, actual: gateResult.kind});
+  }
+
+  if (expectation.reason !== undefined) {
+    const reason = stringField(gateResult, 'reason');
+    if (reason !== expectation.reason) {
+      mismatches.push({
+        path: `${path}.reason`,
+        expected: expectation.reason,
+        actual: reason ?? 'null',
+      });
+    }
+  }
+
+  if (expectation.exit_code !== undefined) {
+    const exitCode = intOrNullField(gateResult, 'exit_code');
+    if (exitCode !== expectation.exit_code) {
+      mismatches.push({
+        path: `${path}.exit_code`,
+        expected: formatOptionalInteger(expectation.exit_code),
+        actual: formatOptionalInteger(exitCode),
+      });
+    }
+  }
+}
+
+function evaluateStepExpectation(
+  job: WorkflowRunJobDetailDto,
+  stepKey: string,
+  expectation: StepExpectation,
+  path: string,
+  result: ExpectationResult,
+): void {
+  const step = findStep(job, stepKey);
+  if (!step) {
+    result.mismatches.push({path, expected: 'present', actual: 'missing'});
+    return;
+  }
+
+  if (expectation.status && step.status !== expectation.status) {
+    result.mismatches.push({
+      path: `${path}.status`,
+      expected: expectation.status,
+      actual: step.status,
+    });
+  }
+
+  if (expectation.exit_code !== undefined) {
+    const exitCode = latestExitCode(step);
+    if (exitCode !== expectation.exit_code) {
+      result.mismatches.push({
+        path: `${path}.exit_code`,
+        expected: String(expectation.exit_code),
+        actual: exitCode === null ? 'null' : String(exitCode),
+      });
+    }
+  }
+
+  if (expectation.error) {
+    evaluateStepError(step, expectation.error, `${path}.error`, result.mismatches);
+  }
+  if (expectation.gate_result) {
+    evaluateGateResult(step, expectation.gate_result, `${path}.gate_result`, result.mismatches);
+  }
+  if (expectation.logs) {
+    result.logRequirements.push({
+      path,
+      stepId: step.id,
+      attempt: step.current_attempt,
+      include: expectation.logs.include,
+      exclude: expectation.logs.exclude,
+    });
+  }
+}
+
+function evaluateJobExpectation(
+  runDetail: WorkflowRunDetailResponseDto,
+  jobKey: string,
+  expectation: JobExpectation,
+  result: ExpectationResult,
+): void {
+  const path = `jobs.${jobKey}`;
+  const job = findJob(runDetail, jobKey);
+  if (!job) {
+    result.mismatches.push({path, expected: 'present', actual: 'missing'});
+    return;
+  }
+
+  if (expectation.status && job.status !== expectation.status) {
+    result.mismatches.push({
+      path: `${path}.status`,
+      expected: expectation.status,
+      actual: job.status,
+    });
+  }
+  if (expectation.status_reason !== undefined && job.status_reason !== expectation.status_reason) {
+    result.mismatches.push({
+      path: `${path}.status_reason`,
+      expected: expectation.status_reason,
+      actual: job.status_reason ?? 'null',
+    });
+  }
+
+  for (const [stepKey, stepExpectation] of Object.entries(expectation.steps ?? {})) {
+    evaluateStepExpectation(job, stepKey, stepExpectation, `${path}.steps.${stepKey}`, result);
+  }
+}
+
 /**
  * Compares a run detail against an expectation, returning every structural mismatch
  * (run/job/step status and step exit code) plus the log requirements the harness still
@@ -248,11 +420,10 @@ export function evaluateExpectations(
   runDetail: WorkflowRunDetailResponseDto,
   expectation: Expectation,
 ): ExpectationResult {
-  const mismatches: Mismatch[] = [];
-  const logRequirements: StepLogRequirement[] = [];
+  const result: ExpectationResult = {mismatches: [], logRequirements: []};
 
   if (runDetail.status !== expectation.run.status) {
-    mismatches.push({
+    result.mismatches.push({
       path: 'run.status',
       expected: expectation.run.status,
       actual: runDetail.status,
@@ -260,168 +431,10 @@ export function evaluateExpectations(
   }
 
   for (const [jobKey, jobExpectation] of Object.entries(expectation.jobs ?? {})) {
-    const job = findJob(runDetail, jobKey);
-    if (!job) {
-      mismatches.push({path: `jobs.${jobKey}`, expected: 'present', actual: 'missing'});
-      continue;
-    }
-
-    if (jobExpectation.status && job.status !== jobExpectation.status) {
-      mismatches.push({
-        path: `jobs.${jobKey}.status`,
-        expected: jobExpectation.status,
-        actual: job.status,
-      });
-    }
-
-    if (
-      jobExpectation.status_reason !== undefined &&
-      job.status_reason !== jobExpectation.status_reason
-    ) {
-      mismatches.push({
-        path: `jobs.${jobKey}.status_reason`,
-        expected: jobExpectation.status_reason,
-        actual: job.status_reason ?? 'null',
-      });
-    }
-
-    const steps = jobExpectation.steps;
-    if (!steps) continue;
-    for (const [stepKey, stepExpectation] of Object.entries(steps)) {
-      const stepPath = `jobs.${jobKey}.steps.${stepKey}`;
-      const step = findStep(job, stepKey);
-      if (!step) {
-        mismatches.push({path: stepPath, expected: 'present', actual: 'missing'});
-        continue;
-      }
-
-      if (stepExpectation.status && step.status !== stepExpectation.status) {
-        mismatches.push({
-          path: `${stepPath}.status`,
-          expected: stepExpectation.status,
-          actual: step.status,
-        });
-      }
-
-      if (stepExpectation.exit_code !== undefined) {
-        const exitCode = latestExitCode(step);
-        if (exitCode !== stepExpectation.exit_code) {
-          mismatches.push({
-            path: `${stepPath}.exit_code`,
-            expected: String(stepExpectation.exit_code),
-            actual: exitCode === null ? 'null' : String(exitCode),
-          });
-        }
-      }
-
-      if (stepExpectation.error) {
-        if (step.error === null) {
-          mismatches.push({
-            path: `${stepPath}.error`,
-            expected: 'present',
-            actual: 'null',
-          });
-        } else {
-          if (
-            stepExpectation.error.reason !== undefined &&
-            step.error.reason !== stepExpectation.error.reason
-          ) {
-            mismatches.push({
-              path: `${stepPath}.error.reason`,
-              expected: stepExpectation.error.reason,
-              actual: step.error.reason ?? 'null',
-            });
-          }
-
-          if (stepExpectation.error.field !== undefined) {
-            const field = stringField(step.error, 'field');
-            if (field !== stepExpectation.error.field) {
-              mismatches.push({
-                path: `${stepPath}.error.field`,
-                expected: stepExpectation.error.field,
-                actual: field ?? 'null',
-              });
-            }
-          }
-
-          if (stepExpectation.error.source !== undefined) {
-            const source = stringField(step.error, 'source');
-            if (source === null || !source.includes(stepExpectation.error.source)) {
-              mismatches.push({
-                path: `${stepPath}.error.source`,
-                expected: `include ${stepExpectation.error.source}`,
-                actual: source ?? 'null',
-              });
-            }
-          }
-        }
-      }
-
-      if (stepExpectation.gate_result) {
-        const gateResult = latestGateResult(step);
-        if (gateResult === null) {
-          mismatches.push({
-            path: `${stepPath}.gate_result`,
-            expected: 'present',
-            actual: 'null',
-          });
-        } else {
-          if (
-            stepExpectation.gate_result.kind !== undefined &&
-            gateResult.kind !== stepExpectation.gate_result.kind
-          ) {
-            mismatches.push({
-              path: `${stepPath}.gate_result.kind`,
-              expected: stepExpectation.gate_result.kind,
-              actual: gateResult.kind,
-            });
-          }
-
-          if (stepExpectation.gate_result.reason !== undefined) {
-            const reason = stringField(gateResult, 'reason');
-            if (reason !== stepExpectation.gate_result.reason) {
-              mismatches.push({
-                path: `${stepPath}.gate_result.reason`,
-                expected: stepExpectation.gate_result.reason,
-                actual: reason ?? 'null',
-              });
-            }
-          }
-
-          if (stepExpectation.gate_result.exit_code !== undefined) {
-            const exitCode = intOrNullField(gateResult, 'exit_code');
-            if (exitCode !== stepExpectation.gate_result.exit_code) {
-              mismatches.push({
-                path: `${stepPath}.gate_result.exit_code`,
-                expected:
-                  stepExpectation.gate_result.exit_code === null
-                    ? 'null'
-                    : String(stepExpectation.gate_result.exit_code),
-                actual:
-                  exitCode === undefined
-                    ? 'missing'
-                    : exitCode === null
-                      ? 'null'
-                      : String(exitCode),
-              });
-            }
-          }
-        }
-      }
-
-      if (stepExpectation.logs) {
-        logRequirements.push({
-          path: stepPath,
-          stepId: step.id,
-          attempt: step.current_attempt,
-          include: stepExpectation.logs.include,
-          exclude: stepExpectation.logs.exclude,
-        });
-      }
-    }
+    evaluateJobExpectation(runDetail, jobKey, jobExpectation, result);
   }
 
-  return {mismatches, logRequirements};
+  return result;
 }
 
 // A pattern wrapped in slashes (/foo/) is a regular expression; anything else is a

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -10,7 +10,13 @@ import {
   collectStepLogAttachmentRequests,
   fetchLogAttachment,
 } from './attachments.js';
-import {evaluateExpectations, evaluateLogs, logText, type Mismatch} from './expect.js';
+import {
+  evaluateExpectations,
+  evaluateLogs,
+  logText,
+  type Mismatch,
+  type StepLogRequirement,
+} from './expect.js';
 import {waitForDefinitionSyncTerminal, waitForNoWorkflowRuns} from './polling.js';
 import {evaluateRejection} from './reject.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from './runner.js';
@@ -37,6 +43,305 @@ export interface RunScenarioParams {
   attach: (attachment: Attachment) => Promise<void>;
 }
 
+type RunDetail = Awaited<ReturnType<typeof waitForRunTerminalOrFailedRunner>>;
+
+async function evaluateScenarioResult(params: {
+  expectation: Extract<Scenario, {kind: 'expect'}>['expectation'];
+  logRequirements: StepLogRequirement[];
+  mismatches: Mismatch[];
+  runnerLogFile: string | undefined;
+  token: string;
+}): Promise<{allMismatches: Mismatch[]; fetchedLogs: Attachment[]}> {
+  const allMismatches = [...params.mismatches];
+  const fetchedLogs: Attachment[] = [];
+  for (const requirement of params.logRequirements) {
+    let logs: Awaited<ReturnType<typeof fetchStepLogs>>;
+    try {
+      logs = await fetchStepLogs({
+        stepId: requirement.stepId,
+        attempt: requirement.attempt,
+        token: params.token,
+      });
+    } catch (error) {
+      allMismatches.push({
+        path: `${requirement.path}.logs`,
+        expected: 'readable',
+        actual: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    fetchedLogs.push({
+      name: `logs-${requirement.path.replaceAll('/', '_')}.ndjson`,
+      contentType: 'application/x-ndjson',
+      body: logs.ndjson,
+    });
+    allMismatches.push(
+      ...evaluateLogs({
+        path: requirement.path,
+        text: logText(logs.records),
+        include: requirement.include,
+        exclude: requirement.exclude,
+      }),
+    );
+  }
+
+  if (params.expectation.runner_log) {
+    const runnerLog =
+      params.runnerLogFile === undefined
+        ? ''
+        : await readFile(params.runnerLogFile, 'utf8').catch(() => '');
+    allMismatches.push(
+      ...evaluateLogs({
+        path: 'runner_log',
+        text: runnerLog,
+        include: params.expectation.runner_log.include,
+        exclude: params.expectation.runner_log.exclude,
+      }),
+    );
+  }
+
+  return {allMismatches, fetchedLogs};
+}
+
+async function attachScenarioMismatches(params: {
+  attach: RunScenarioParams['attach'];
+  client: ReturnType<typeof createApiClient>;
+  fetchedLogs: Attachment[];
+  logRequirements: StepLogRequirement[];
+  mismatches: Mismatch[];
+  runDetail: RunDetail;
+  runnerLogFile: string | undefined;
+  scenario: Extract<Scenario, {kind: 'expect'}>;
+  suite: SuiteContext;
+  token: string;
+  webhookDiagnostics: WebhookDiagnosticsRequest | undefined;
+}): Promise<void> {
+  await params.attach({
+    name: 'run-detail.json',
+    contentType: 'application/json',
+    body: JSON.stringify(params.runDetail, null, 2),
+  });
+  await params.attach({
+    name: 'mismatches.json',
+    contentType: 'application/json',
+    body: JSON.stringify(params.mismatches, null, 2),
+  });
+  for (const log of params.fetchedLogs) await params.attach(log);
+  if (params.runnerLogFile !== undefined) {
+    await attachLocalRunnerLog(params.attach, params.runnerLogFile);
+  }
+  await attachFakeModelProviderRequestsBestEffort(params);
+  if (params.webhookDiagnostics !== undefined) {
+    await attachWebhookTriggerDiagnostics({
+      attach: params.attach,
+      client: params.client,
+      deliveryIds: params.webhookDiagnostics.deliveryIds,
+      source: params.webhookDiagnostics.source,
+      workspaceId: params.suite.workspaceId,
+    });
+  }
+
+  const fetchedLogKeys = new Set(
+    params.logRequirements.map((requirement) => `${requirement.stepId}:${requirement.attempt}`),
+  );
+  for (const request of collectStepLogAttachmentRequests(params.runDetail)) {
+    const key = `${request.stepId}:${request.attempt}`;
+    if (fetchedLogKeys.has(key)) continue;
+    await params.attach(await fetchLogAttachment(request, params.token));
+  }
+}
+
+async function attachFailureDiagnostics(params: {
+  attach: RunScenarioParams['attach'];
+  client: ReturnType<typeof createApiClient>;
+  runnerLogFile: string | undefined;
+  scenario: Scenario;
+  suite: SuiteContext;
+  webhookDiagnostics: WebhookDiagnosticsRequest | undefined;
+}): Promise<void> {
+  if (params.webhookDiagnostics !== undefined) {
+    await attachWebhookTriggerDiagnostics({
+      attach: params.attach,
+      client: params.client,
+      deliveryIds: params.webhookDiagnostics.deliveryIds,
+      source: params.webhookDiagnostics.source,
+      workspaceId: params.suite.workspaceId,
+    });
+  }
+  if (params.runnerLogFile !== undefined) {
+    await attachLocalRunnerLog(params.attach, params.runnerLogFile);
+  }
+  await attachFakeModelProviderRequestsBestEffort(params);
+}
+
+async function createScenarioWebhook(params: {
+  client: ReturnType<typeof createApiClient>;
+  scenario: Scenario;
+  suite: SuiteContext;
+  uniqueId: string;
+  webhookSlug: string;
+}): Promise<Awaited<ReturnType<typeof createWebhookConnection>> | undefined> {
+  if (params.scenario.kind !== 'expect' || params.scenario.expectation.trigger !== 'webhook') {
+    return undefined;
+  }
+  return await createWebhookConnection({
+    client: params.client,
+    scenario: params.scenario.name,
+    slug: params.webhookSlug,
+    uniqueId: params.uniqueId,
+    workspaceId: params.suite.workspaceId,
+  });
+}
+
+async function seedScenarioProject(params: {
+  repo: string;
+  runnerLabel: string;
+  scenario: Scenario;
+  suite: SuiteContext;
+  token: string;
+  webhookSlug: string;
+}) {
+  const seedParams = {
+    suite: params.suite,
+    token: params.token,
+    name: params.scenario.name,
+    repo: params.repo,
+    runnerLabel: params.runnerLabel,
+    workflowYaml: params.scenario.workflowYaml,
+    configPath: params.scenario.configPath,
+    webhookSlug: params.webhookSlug,
+    extraFiles: params.scenario.extraFiles,
+  };
+  if (params.scenario.kind === 'reject') {
+    const seeded = await seedWorkflowProject(seedParams);
+    return {definition: undefined, project: seeded.project};
+  }
+  const seeded = await seedAndWaitForDefinition(seedParams);
+  return {definition: seeded.definition, project: seeded.project};
+}
+
+async function seedScenarioValues(params: {
+  projectId: string;
+  scenario: Scenario;
+  workspaceId: string;
+}): Promise<void> {
+  for (const secret of params.scenario.seededSecrets) {
+    await createSecret({
+      workspaceId: params.workspaceId,
+      actorId: E2E_SECRET_ACTOR_ID,
+      key: secret.key,
+      value: secret.value,
+      ...(secret.scope === 'project' ? {projectId: params.projectId} : {}),
+    });
+  }
+
+  for (const variable of params.scenario.seededVariables) {
+    await createVariable({
+      workspaceId: params.workspaceId,
+      actorId: E2E_SECRET_ACTOR_ID,
+      key: variable.key,
+      value: variable.value,
+      ...(variable.scope === 'project' ? {projectId: params.projectId} : {}),
+    });
+  }
+}
+
+async function evaluateRejectedScenario(params: {
+  attach: RunScenarioParams['attach'];
+  projectId: string;
+  scenario: Extract<Scenario, {kind: 'reject'}>;
+  token: string;
+}): Promise<Mismatch[]> {
+  const definitions = await waitForDefinitionSyncTerminal({
+    projectId: params.projectId,
+    token: params.token,
+    timeoutMs: 60_000,
+  });
+  const runs = await waitForNoWorkflowRuns({
+    projectId: params.projectId,
+    token: params.token,
+    timeoutMs: REJECTION_NO_RUN_TIMEOUT_MS,
+  });
+  const mismatches = evaluateRejection(
+    {sync: definitions.sync, runs: runs.runs},
+    params.scenario.rejection,
+  );
+  if (mismatches.length === 0) return mismatches;
+
+  await params.attach({
+    name: 'definition-sync.json',
+    contentType: 'application/json',
+    body: JSON.stringify(definitions, null, 2),
+  });
+  await params.attach({
+    name: 'workflow-runs.json',
+    contentType: 'application/json',
+    body: JSON.stringify(runs, null, 2),
+  });
+  await params.attach({
+    name: 'mismatches.json',
+    contentType: 'application/json',
+    body: JSON.stringify(mismatches, null, 2),
+  });
+  return mismatches;
+}
+
+async function triggerScenario(params: {
+  attach: RunScenarioParams['attach'];
+  client: ReturnType<typeof createApiClient>;
+  definitionId: string;
+  projectId: string;
+  repo: string;
+  scenario: Extract<Scenario, {kind: 'expect'}>;
+  suite: SuiteContext;
+  token: string;
+  uniqueId: string;
+  webhookConnection: Awaited<ReturnType<typeof createWebhookConnection>> | undefined;
+}): Promise<{runId: string; webhookDiagnostics: WebhookDiagnosticsRequest | undefined}> {
+  if (params.scenario.expectation.trigger === 'manual') {
+    const runId = await fireManualAndAwaitRun({
+      client: params.client,
+      definitionId: params.definitionId,
+      inputs: params.scenario.expectation.inputs ?? {},
+      scenario: params.scenario.name,
+    });
+    return {runId, webhookDiagnostics: undefined};
+  }
+  if (params.scenario.expectation.trigger === 'webhook') {
+    if (!params.webhookConnection) {
+      throw new Error(`Webhook connection missing for ${params.scenario.name}`);
+    }
+    const result = await triggerWebhookAndAwaitRun({
+      attach: params.attach,
+      client: params.client,
+      connection: params.webhookConnection,
+      projectId: params.projectId,
+      scenario: params.scenario.name,
+      token: params.token,
+      webhook: params.scenario.expectation.webhook,
+      workspaceId: params.suite.workspaceId,
+    });
+    return {
+      runId: result.runId,
+      webhookDiagnostics: {
+        deliveryIds: result.deliveryIds,
+        source: params.webhookConnection.slug,
+      },
+    };
+  }
+
+  const runId = await triggerPushAndAwaitRun({
+    org: params.suite.org,
+    repo: params.repo,
+    scenario: params.scenario.name,
+    uniqueId: params.uniqueId,
+    message: params.scenario.expectation.push?.message,
+    projectId: params.projectId,
+    token: params.token,
+  });
+  return {runId, webhookDiagnostics: undefined};
+}
+
 /**
  * Drives one declarative scenario end to end: fresh repo and project, seed commit,
  * definition-resolved poll, trigger, terminal-run poll, then expect.yaml evaluation.
@@ -58,102 +363,30 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
   let webhookDiagnostics: WebhookDiagnosticsRequest | undefined;
 
   try {
-    const webhookConnection =
-      scenario.kind === 'expect' && scenario.expectation.trigger === 'webhook'
-        ? await createWebhookConnection({
-            client,
-            scenario: scenario.name,
-            slug: webhookSlug,
-            uniqueId,
-            workspaceId: suite.workspaceId,
-          })
-        : undefined;
-
-    let definition: Awaited<ReturnType<typeof seedAndWaitForDefinition>>['definition'] | undefined;
-    const seeded =
-      scenario.kind === 'reject'
-        ? await seedWorkflowProject({
-            suite,
-            token,
-            name: scenario.name,
-            repo,
-            runnerLabel,
-            workflowYaml: scenario.workflowYaml,
-            configPath: scenario.configPath,
-            webhookSlug,
-            extraFiles: scenario.extraFiles,
-          })
-        : await seedAndWaitForDefinition({
-            suite,
-            token,
-            name: scenario.name,
-            repo,
-            runnerLabel,
-            workflowYaml: scenario.workflowYaml,
-            configPath: scenario.configPath,
-            webhookSlug,
-            extraFiles: scenario.extraFiles,
-          }).then((ready) => {
-            definition = ready.definition;
-            return ready;
-          });
-    const {project} = seeded;
-
-    for (const secret of scenario.seededSecrets) {
-      await createSecret({
-        workspaceId: suite.workspaceId,
-        actorId: E2E_SECRET_ACTOR_ID,
-        key: secret.key,
-        value: secret.value,
-        ...(secret.scope === 'project' ? {projectId: project.id} : {}),
-      });
-    }
-
-    for (const variable of scenario.seededVariables) {
-      await createVariable({
-        workspaceId: suite.workspaceId,
-        actorId: E2E_SECRET_ACTOR_ID,
-        key: variable.key,
-        value: variable.value,
-        ...(variable.scope === 'project' ? {projectId: project.id} : {}),
-      });
-    }
+    const webhookConnection = await createScenarioWebhook({
+      client,
+      scenario,
+      suite,
+      uniqueId,
+      webhookSlug,
+    });
+    const {definition, project} = await seedScenarioProject({
+      repo,
+      runnerLabel,
+      scenario,
+      suite,
+      token,
+      webhookSlug,
+    });
+    await seedScenarioValues({projectId: project.id, scenario, workspaceId: suite.workspaceId});
 
     if (scenario.kind === 'reject') {
-      const definitions = await waitForDefinitionSyncTerminal({
+      return await evaluateRejectedScenario({
+        attach: params.attach,
         projectId: project.id,
+        scenario,
         token,
-        timeoutMs: 60_000,
       });
-      const runs = await waitForNoWorkflowRuns({
-        projectId: project.id,
-        token,
-        timeoutMs: REJECTION_NO_RUN_TIMEOUT_MS,
-      });
-      const mismatches = evaluateRejection(
-        {sync: definitions.sync, runs: runs.runs},
-        scenario.rejection,
-      );
-
-      if (mismatches.length > 0) {
-        await params.attach({
-          name: 'definition-sync.json',
-          contentType: 'application/json',
-          body: JSON.stringify(definitions, null, 2),
-        });
-        await params.attach({
-          name: 'workflow-runs.json',
-          contentType: 'application/json',
-          body: JSON.stringify(runs, null, 2),
-        });
-        await params.attach({
-          name: 'mismatches.json',
-          contentType: 'application/json',
-          body: JSON.stringify(mismatches, null, 2),
-        });
-      }
-
-      return mismatches;
     }
 
     if (definition === undefined) {
@@ -169,141 +402,62 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
     runner = localRunner.runner;
     runnerLogFile = localRunner.logFile;
 
-    let runId: string;
-    if (scenario.expectation.trigger === 'manual') {
-      runId = await fireManualAndAwaitRun({
-        client,
-        definitionId: definition.id,
-        inputs: scenario.expectation.inputs ?? {},
-        scenario: scenario.name,
-      });
-    } else if (scenario.expectation.trigger === 'webhook') {
-      if (!webhookConnection) throw new Error(`Webhook connection missing for ${scenario.name}`);
-      const result = await triggerWebhookAndAwaitRun({
-        attach: params.attach,
-        client,
-        connection: webhookConnection,
-        projectId: project.id,
-        scenario: scenario.name,
-        token,
-        webhook: scenario.expectation.webhook,
-        workspaceId: suite.workspaceId,
-      });
-      webhookDiagnostics = {deliveryIds: result.deliveryIds, source: webhookConnection.slug};
-      runId = result.runId;
-    } else {
-      runId = await triggerPushAndAwaitRun({
-        org: suite.org,
-        repo,
-        scenario: scenario.name,
-        uniqueId,
-        message: scenario.expectation.push?.message,
-        projectId: project.id,
-        token,
-      });
-    }
+    const triggered = await triggerScenario({
+      attach: params.attach,
+      client,
+      definitionId: definition.id,
+      projectId: project.id,
+      repo,
+      scenario,
+      suite,
+      token,
+      uniqueId,
+      webhookConnection,
+    });
+    webhookDiagnostics = triggered.webhookDiagnostics;
 
     const runDetail = await waitForRunTerminalOrFailedRunner({
-      runId,
+      runId: triggered.runId,
       token,
       timeoutMs: scenario.expectation.timeout_seconds * 1000,
       runner,
     });
 
     const {mismatches, logRequirements} = evaluateExpectations(runDetail, scenario.expectation);
-    const allMismatches = [...mismatches];
-    const fetchedLogs: Attachment[] = [];
-    for (const requirement of logRequirements) {
-      let logs: Awaited<ReturnType<typeof fetchStepLogs>>;
-      try {
-        logs = await fetchStepLogs({
-          stepId: requirement.stepId,
-          attempt: requirement.attempt,
-          token,
-        });
-      } catch (error) {
-        allMismatches.push({
-          path: `${requirement.path}.logs`,
-          expected: 'readable',
-          actual: error instanceof Error ? error.message : String(error),
-        });
-        continue;
-      }
-      fetchedLogs.push({
-        name: `logs-${requirement.path.replaceAll('/', '_')}.ndjson`,
-        contentType: 'application/x-ndjson',
-        body: logs.ndjson,
-      });
-      allMismatches.push(
-        ...evaluateLogs({
-          path: requirement.path,
-          text: logText(logs.records),
-          include: requirement.include,
-          exclude: requirement.exclude,
-        }),
-      );
-    }
-
-    if (scenario.expectation.runner_log) {
-      const runnerLog =
-        runnerLogFile === undefined ? '' : await readFile(runnerLogFile, 'utf8').catch(() => '');
-      allMismatches.push(
-        ...evaluateLogs({
-          path: 'runner_log',
-          text: runnerLog,
-          include: scenario.expectation.runner_log.include,
-          exclude: scenario.expectation.runner_log.exclude,
-        }),
-      );
-    }
+    const {allMismatches, fetchedLogs} = await evaluateScenarioResult({
+      expectation: scenario.expectation,
+      logRequirements,
+      mismatches,
+      runnerLogFile,
+      token,
+    });
 
     if (allMismatches.length > 0) {
-      await params.attach({
-        name: 'run-detail.json',
-        contentType: 'application/json',
-        body: JSON.stringify(runDetail, null, 2),
+      await attachScenarioMismatches({
+        attach: params.attach,
+        client,
+        fetchedLogs,
+        logRequirements,
+        mismatches: allMismatches,
+        runDetail,
+        runnerLogFile,
+        scenario,
+        suite,
+        token,
+        webhookDiagnostics,
       });
-      await params.attach({
-        name: 'mismatches.json',
-        contentType: 'application/json',
-        body: JSON.stringify(allMismatches, null, 2),
-      });
-      for (const log of fetchedLogs) await params.attach(log);
-      if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
-      await attachFakeModelProviderRequestsBestEffort({attach: params.attach, scenario, suite});
-      if (webhookDiagnostics !== undefined) {
-        await attachWebhookTriggerDiagnostics({
-          attach: params.attach,
-          client,
-          deliveryIds: webhookDiagnostics.deliveryIds,
-          source: webhookDiagnostics.source,
-          workspaceId: suite.workspaceId,
-        });
-      }
-
-      const fetchedLogKeys = new Set(
-        logRequirements.map((requirement) => `${requirement.stepId}:${requirement.attempt}`),
-      );
-      for (const request of collectStepLogAttachmentRequests(runDetail)) {
-        const key = `${request.stepId}:${request.attempt}`;
-        if (fetchedLogKeys.has(key)) continue;
-        await params.attach(await fetchLogAttachment(request, token));
-      }
     }
 
     return allMismatches;
   } catch (error) {
-    if (webhookDiagnostics !== undefined) {
-      await attachWebhookTriggerDiagnostics({
-        attach: params.attach,
-        client,
-        deliveryIds: webhookDiagnostics.deliveryIds,
-        source: webhookDiagnostics.source,
-        workspaceId: suite.workspaceId,
-      });
-    }
-    if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
-    await attachFakeModelProviderRequestsBestEffort({attach: params.attach, scenario, suite});
+    await attachFailureDiagnostics({
+      attach: params.attach,
+      client,
+      runnerLogFile,
+      scenario,
+      suite,
+      webhookDiagnostics,
+    });
     throw error;
   } finally {
     if (runner !== undefined) {

--- a/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
@@ -23,6 +23,84 @@ import {expect, test} from './fixtures.js';
 const LISTENER_FLOW_OBSERVATION_TIMEOUT_MS = 60_000;
 const LISTENER_RUN_TERMINAL_TIMEOUT_MS = 180_000;
 
+async function assertUntilResolution(params: {
+  testCase: ListenerCase & {definitionId: string};
+  runId: string;
+  firstFire: Awaited<ReturnType<typeof sendFire>>;
+  secondFire: Awaited<ReturnType<typeof sendFire>>;
+  resolveDeliveryId: string;
+  resolved: Awaited<ReturnType<typeof waitForListenerResolution>>;
+}): Promise<void> {
+  const terminal = await waitForRunTerminalOrFailedRunner({
+    runId: params.runId,
+    token: params.testCase.token,
+    timeoutMs: 180_000,
+    runner: params.testCase.runner,
+  });
+
+  const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
+  const deploy = terminal.jobs.find((job) => job.key === 'deploy');
+  const firstExecution = findListenerExecutionByDeliveryIds({
+    runDetail: terminal,
+    jobKey: LISTENER_JOB,
+    deliveryIds: params.firstFire.deliveryIds,
+  })?.execution;
+  const secondExecution = findListenerExecutionByDeliveryIds({
+    runDetail: terminal,
+    jobKey: LISTENER_JOB,
+    deliveryIds: params.secondFire.deliveryIds,
+  })?.execution;
+  if (!firstExecution || !secondExecution) {
+    throw new Error('Expected both listener fire deliveries to create executions');
+  }
+  const firstDeliveryId = firstExecution.trigger_events[0]?.delivery_id;
+  const secondDeliveryId = secondExecution.trigger_events[0]?.delivery_id;
+  if (!firstDeliveryId || !secondDeliveryId) {
+    throw new Error('Expected listener executions to include trigger deliveries');
+  }
+  const firstLogs = await stepLogText({
+    runDetail: terminal,
+    token: params.testCase.token,
+    jobKey: LISTENER_JOB,
+    sequence: firstExecution.sequence,
+    stepKey: 'show_event',
+  });
+  const secondLogs = await stepLogText({
+    runDetail: terminal,
+    token: params.testCase.token,
+    jobKey: LISTENER_JOB,
+    sequence: secondExecution.sequence,
+    stepKey: 'show_event',
+  });
+  const deployExecution = deploy?.job_executions.at(-1);
+  if (!deployExecution) throw new Error('Expected deploy execution');
+  const deployLogs = await stepLogText({
+    runDetail: terminal,
+    token: params.testCase.token,
+    jobKey: 'deploy',
+    sequence: deployExecution.sequence,
+    stepKey: 'after-listener',
+  });
+
+  expect(params.resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
+    'until',
+  );
+  expect(terminal.status).toBe('succeeded');
+  expect(listen?.listener_status).toBe('resolved');
+  expect(listen?.job_executions.length).toBeGreaterThanOrEqual(2);
+  expect(firstExecution.sequence).not.toBe(secondExecution.sequence);
+  expect(deploy?.status).toBe('succeeded');
+  expect(params.firstFire.deliveryIds).toContain(firstDeliveryId);
+  expect(params.secondFire.deliveryIds).toContain(secondDeliveryId);
+  expect(firstLogs).toContain('listener_message=hello-listener');
+  expect(firstLogs).toContain(`listener_delivery=${firstDeliveryId}`);
+  expect(secondLogs).toContain('listener_message=hello-again');
+  expect(secondLogs).toContain(`listener_delivery=${secondDeliveryId}`);
+  expect(deployLogs).toContain('listener_last=hello-again');
+  expect(deployLogs).toContain('listener_count=2');
+  expect(params.resolveDeliveryId).toContain('resolve');
+}
+
 test.describe('listener jobs', () => {
   test('creates multiple executions before resolving on an until event', async ({
     suite,
@@ -68,74 +146,14 @@ test.describe('listener jobs', () => {
         if (!firstFire || !secondFire || !resolveDeliveryId || !resolved) {
           throw new Error('Listener deliveries were not resolved');
         }
-        const terminal = await waitForRunTerminalOrFailedRunner({
+        await assertUntilResolution({
+          testCase,
           runId,
-          token: testCase.token,
-          timeoutMs: 180_000,
-          runner: testCase.runner,
+          firstFire,
+          secondFire,
+          resolveDeliveryId,
+          resolved,
         });
-
-        const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
-        const deploy = terminal.jobs.find((job) => job.key === 'deploy');
-        const firstExecution = findListenerExecutionByDeliveryIds({
-          runDetail: terminal,
-          jobKey: LISTENER_JOB,
-          deliveryIds: firstFire.deliveryIds,
-        })?.execution;
-        const secondExecution = findListenerExecutionByDeliveryIds({
-          runDetail: terminal,
-          jobKey: LISTENER_JOB,
-          deliveryIds: secondFire.deliveryIds,
-        })?.execution;
-        if (!firstExecution || !secondExecution) {
-          throw new Error('Expected both listener fire deliveries to create executions');
-        }
-        const firstDeliveryId = firstExecution.trigger_events[0]?.delivery_id;
-        const secondDeliveryId = secondExecution.trigger_events[0]?.delivery_id;
-        if (!firstDeliveryId || !secondDeliveryId) {
-          throw new Error('Expected listener executions to include trigger deliveries');
-        }
-        const firstLogs = await stepLogText({
-          runDetail: terminal,
-          token: testCase.token,
-          jobKey: LISTENER_JOB,
-          sequence: firstExecution.sequence,
-          stepKey: 'show_event',
-        });
-        const secondLogs = await stepLogText({
-          runDetail: terminal,
-          token: testCase.token,
-          jobKey: LISTENER_JOB,
-          sequence: secondExecution.sequence,
-          stepKey: 'show_event',
-        });
-        const deployExecution = deploy?.job_executions.at(-1);
-        if (!deployExecution) throw new Error('Expected deploy execution');
-        const deployLogs = await stepLogText({
-          runDetail: terminal,
-          token: testCase.token,
-          jobKey: 'deploy',
-          sequence: deployExecution.sequence,
-          stepKey: 'after-listener',
-        });
-
-        expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
-          'until',
-        );
-        expect(terminal.status).toBe('succeeded');
-        expect(listen?.listener_status).toBe('resolved');
-        expect(listen?.job_executions.length).toBeGreaterThanOrEqual(2);
-        expect(firstExecution.sequence).not.toBe(secondExecution.sequence);
-        expect(deploy?.status).toBe('succeeded');
-        expect(firstFire.deliveryIds).toContain(firstDeliveryId);
-        expect(secondFire.deliveryIds).toContain(secondDeliveryId);
-        expect(firstLogs).toContain('listener_message=hello-listener');
-        expect(firstLogs).toContain(`listener_delivery=${firstDeliveryId}`);
-        expect(secondLogs).toContain('listener_message=hello-again');
-        expect(secondLogs).toContain(`listener_delivery=${secondDeliveryId}`);
-        expect(deployLogs).toContain('listener_last=hello-again');
-        expect(deployLogs).toContain('listener_count=2');
-        expect(resolveDeliveryId).toContain('resolve');
       });
     } catch (error) {
       await cleanupListenerCase(testCase, runId);

--- a/infra/images/runner/src/build-runner-image.ts
+++ b/infra/images/runner/src/build-runner-image.ts
@@ -9,16 +9,44 @@ import {
 
 export const AWS_ACCOUNT_ID_PATTERN = /^\d{12}$/u;
 
+function buildEnvironment(env: NodeJS.ProcessEnv): {
+  architecture: 'amd64' | 'arm64';
+  buildAttempt: string;
+  buildNumber: string;
+} {
+  const buildNumber = required(env.BUILD_NUMBER, 'BUILD_NUMBER');
+  const buildAttempt = required(env.BUILD_ATTEMPT, 'BUILD_ATTEMPT');
+  const architecture = env.BUILD_ARCH;
+  if (architecture !== 'amd64' && architecture !== 'arm64') {
+    throw new Error('BUILD_ARCH must be amd64 or arm64.');
+  }
+  return {
+    architecture,
+    buildAttempt,
+    buildNumber,
+  };
+}
+
+function candidatePlatformMetadata(platform: string, env: NodeJS.ProcessEnv) {
+  if (platform !== 'aws') return {};
+  return {
+    candidateKmsKeyId: required(
+      env.BUILD_CANDIDATE_KMS_KEY_ID ?? env.AWS_RUNNER_IMAGE_CANDIDATE_KMS_KEY_ID,
+      'BUILD_CANDIDATE_KMS_KEY_ID',
+    ),
+    candidateConsumerAccountIds: parseCandidateConsumerAccountIds(
+      env.BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS ??
+        env.AWS_RUNNER_IMAGE_CANDIDATE_CONSUMER_ACCOUNT_IDS,
+    ),
+  };
+}
+
 export function parseBuildRunnerImageArgs(args: string[], env = process.env, nodeVersion?: string) {
   const [os, platform, ...extraPackerArgs] = args;
   if (!os || !platform)
     throw new Error('Usage: build-runner-image <os> <aws|qemu> [packer options]');
   if (!['aws', 'qemu'].includes(platform)) throw new Error('Platform must be aws or qemu.');
-  if (!env.BUILD_NUMBER) throw new Error('BUILD_NUMBER is not set.');
-  if (!env.BUILD_ATTEMPT) throw new Error('BUILD_ATTEMPT is not set.');
-  if (!env.BUILD_ARCH || !['amd64', 'arm64'].includes(env.BUILD_ARCH)) {
-    throw new Error('BUILD_ARCH must be amd64 or arm64.');
-  }
+  const validatedEnvironment = buildEnvironment(env);
   const lifecycle = (env.BUILD_IMAGE_LIFECYCLE ?? 'release') as RunnerImageLifecycle;
   if (!['candidate', 'release'].includes(lifecycle)) {
     throw new Error('BUILD_IMAGE_LIFECYCLE must be candidate or release.');
@@ -26,31 +54,16 @@ export function parseBuildRunnerImageArgs(args: string[], env = process.env, nod
   const sharedBuild = {
     os,
     platform: platform as RunnerImagePlatform,
-    architecture: env.BUILD_ARCH as 'amd64' | 'arm64',
-    buildAttempt: env.BUILD_ATTEMPT,
-    buildNumber: env.BUILD_NUMBER,
+    ...validatedEnvironment,
     lifecycle,
     nodeVersion: nodeVersion ?? readMiseNodeVersion(),
     revision: env.BUILD_REVISION ?? env.GITHUB_SHA ?? 'local',
     extraPackerArgs,
   };
   if (lifecycle === 'candidate') {
-    const candidateMetadata =
-      platform === 'aws'
-        ? {
-            candidateKmsKeyId: required(
-              env.BUILD_CANDIDATE_KMS_KEY_ID ?? env.AWS_RUNNER_IMAGE_CANDIDATE_KMS_KEY_ID,
-              'BUILD_CANDIDATE_KMS_KEY_ID',
-            ),
-            candidateConsumerAccountIds: parseCandidateConsumerAccountIds(
-              env.BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS ??
-                env.AWS_RUNNER_IMAGE_CANDIDATE_CONSUMER_ACCOUNT_IDS,
-            ),
-          }
-        : {};
     return {
       ...sharedBuild,
-      ...candidateMetadata,
+      ...candidatePlatformMetadata(platform, env),
       candidateExpiresAt: required(env.BUILD_CANDIDATE_EXPIRES_AT, 'BUILD_CANDIDATE_EXPIRES_AT'),
       candidateId: required(env.BUILD_CANDIDATE_ID, 'BUILD_CANDIDATE_ID'),
     };

--- a/libs/api/agent-dto/src/schemas/catalog.ts
+++ b/libs/api/agent-dto/src/schemas/catalog.ts
@@ -285,64 +285,71 @@ function validateCatalogSeedEntry(
   entry: z.infer<typeof modelProviderCatalogSeedBaseSchema>,
   ctx: z.RefinementCtx,
 ): void {
-  if (entry.support_status === 'supported') {
-    if (!supportedModelProviderIds.has(entry.id)) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['id'],
-        message: 'Supported catalog entries must use a supported model provider id.',
-      });
-    }
-    if (entry.default_model === null) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['default_model'],
-        message: 'Supported model providers must define a default_model.',
-      });
-    }
-    if (entry.credential_fields.length === 0) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['credential_fields'],
-        message: 'Supported model providers must define credential_fields.',
-      });
-    }
-    if (entry.unsupported_reason !== null) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['unsupported_reason'],
-        message: 'Supported model providers must not define unsupported_reason.',
-      });
-    }
-  } else {
-    if (!unsupportedModelProviderIds.has(entry.id)) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['id'],
-        message: 'Unsupported catalog entries must use an unsupported model provider id.',
-      });
-    }
-    if (entry.default_model !== null) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['default_model'],
-        message: 'Unsupported model providers must not define a default_model.',
-      });
-    }
-    if (entry.credential_fields.length > 0) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['credential_fields'],
-        message: 'Unsupported model providers must not define credential_fields.',
-      });
-    }
-    if (entry.unsupported_reason === null) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['unsupported_reason'],
-        message: 'Unsupported model providers must define unsupported_reason.',
-      });
-    }
+  if (entry.support_status === 'supported') validateSupportedEntry(entry, ctx);
+  else validateUnsupportedEntry(entry, ctx);
+}
+
+function addCatalogIssue(ctx: z.RefinementCtx, path: string, message: string): void {
+  ctx.addIssue({code: 'custom', path: [path], message});
+}
+
+function validateSupportedEntry(
+  entry: z.infer<typeof modelProviderCatalogSeedBaseSchema>,
+  ctx: z.RefinementCtx,
+): void {
+  if (!supportedModelProviderIds.has(entry.id)) {
+    addCatalogIssue(ctx, 'id', 'Supported catalog entries must use a supported model provider id.');
+  }
+  if (entry.default_model === null) {
+    addCatalogIssue(ctx, 'default_model', 'Supported model providers must define a default_model.');
+  }
+  if (entry.credential_fields.length === 0) {
+    addCatalogIssue(
+      ctx,
+      'credential_fields',
+      'Supported model providers must define credential_fields.',
+    );
+  }
+  if (entry.unsupported_reason !== null) {
+    addCatalogIssue(
+      ctx,
+      'unsupported_reason',
+      'Supported model providers must not define unsupported_reason.',
+    );
+  }
+}
+
+function validateUnsupportedEntry(
+  entry: z.infer<typeof modelProviderCatalogSeedBaseSchema>,
+  ctx: z.RefinementCtx,
+): void {
+  if (!unsupportedModelProviderIds.has(entry.id)) {
+    addCatalogIssue(
+      ctx,
+      'id',
+      'Unsupported catalog entries must use an unsupported model provider id.',
+    );
+  }
+  if (entry.default_model !== null) {
+    addCatalogIssue(
+      ctx,
+      'default_model',
+      'Unsupported model providers must not define a default_model.',
+    );
+  }
+  if (entry.credential_fields.length > 0) {
+    addCatalogIssue(
+      ctx,
+      'credential_fields',
+      'Unsupported model providers must not define credential_fields.',
+    );
+  }
+  if (entry.unsupported_reason === null) {
+    addCatalogIssue(
+      ctx,
+      'unsupported_reason',
+      'Unsupported model providers must define unsupported_reason.',
+    );
   }
 }
 

--- a/libs/api/agent/src/config.ts
+++ b/libs/api/agent/src/config.ts
@@ -364,21 +364,8 @@ function assertManagedProvider(provider: ManagedModelProvider): void {
 
   const modelIds = new Set<string>();
   for (const model of provider.models) {
-    if (model.id.length === 0 || model.label.length === 0) {
-      throw new Error(`Managed model provider models must have IDs and labels: ${provider.id}.`);
-    }
-    if (modelIds.has(model.id)) {
-      throw new Error(`Managed model provider models must have unique IDs: ${provider.id}.`);
-    }
+    assertManagedModel(provider, model, modelIds);
     modelIds.add(model.id);
-    if (!managedModelApiSchema.safeParse(model.api).success) {
-      throw new Error(`Managed model provider model API is invalid: ${provider.id}/${model.id}.`);
-    }
-    if (!managedModelMetadataSchema.safeParse(model).success) {
-      throw new Error(
-        `Managed model provider model metadata is invalid: ${provider.id}/${model.id}.`,
-      );
-    }
   }
 
   if (!modelIds.has(provider.defaultModel)) {
@@ -392,5 +379,26 @@ function assertManagedProvider(provider: ManagedModelProvider): void {
   }
   if (typeof provider.resolveCredentials !== 'function') {
     throw new Error(`Managed model provider must resolve credentials: ${provider.id}.`);
+  }
+}
+
+function assertManagedModel(
+  provider: ManagedModelProvider,
+  model: ManagedModelProvider['models'][number],
+  modelIds: ReadonlySet<string>,
+): void {
+  if (model.id.length === 0 || model.label.length === 0) {
+    throw new Error(`Managed model provider models must have IDs and labels: ${provider.id}.`);
+  }
+  if (modelIds.has(model.id)) {
+    throw new Error(`Managed model provider models must have unique IDs: ${provider.id}.`);
+  }
+  if (!managedModelApiSchema.safeParse(model.api).success) {
+    throw new Error(`Managed model provider model API is invalid: ${provider.id}/${model.id}.`);
+  }
+  if (!managedModelMetadataSchema.safeParse(model).success) {
+    throw new Error(
+      `Managed model provider model metadata is invalid: ${provider.id}/${model.id}.`,
+    );
   }
 }

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -95,37 +95,11 @@ function resolveProvider(
 ): ModelProviderRef {
   const descriptor = getHarnessDescriptor(harness);
   if (ctx.workspaceProviders === 'disabled') {
-    const managedProvider = ctx.managedProvider;
-    if (managedProvider === undefined) {
-      throw new Error(
-        'workspace provider configuration is disabled but no managed provider is registered',
-      );
-    }
-    if (step.provider !== undefined && step.provider !== managedProvider.id) {
-      throw new WorkspaceProvidersDisabledError(managedProvider.id);
-    }
-
-    const providerConfig = getProviderConfig(managedProvider.id, ctx);
-    if (!isHarnessCompatible(harness, managedProvider.id, providerConfig)) {
-      throw new UnsupportedHarnessProviderError(
-        harness,
-        managedProvider.id,
-        supportedProviderIds(harness, descriptor, ctx),
-      );
-    }
-    return managedProvider.id;
+    return resolveManagedProvider(step, ctx, harness, descriptor);
   }
 
   if (step.provider !== undefined) {
-    const provider = resolveSupportedProvider(step.provider, ctx);
-    if (!isHarnessCompatible(harness, provider, getProviderConfig(provider, ctx))) {
-      throw new UnsupportedHarnessProviderError(
-        harness,
-        step.provider,
-        supportedProviderIds(harness, descriptor, ctx),
-      );
-    }
-    return provider;
+    return resolveExplicitProvider(step.provider, ctx, harness, descriptor);
   }
 
   const candidates = [
@@ -144,6 +118,50 @@ function resolveProvider(
   }
 
   return descriptor.defaultProviderId;
+}
+
+function resolveManagedProvider(
+  step: ContextualAgentConfig,
+  ctx: AgentConfigResolutionContext,
+  harness: Harness,
+  descriptor: ReturnType<typeof getHarnessDescriptor>,
+): ModelProviderRef {
+  const managedProvider = ctx.managedProvider;
+  if (managedProvider === undefined) {
+    throw new Error(
+      'workspace provider configuration is disabled but no managed provider is registered',
+    );
+  }
+  if (step.provider !== undefined && step.provider !== managedProvider.id) {
+    throw new WorkspaceProvidersDisabledError(managedProvider.id);
+  }
+  if (
+    !isHarnessCompatible(harness, managedProvider.id, getProviderConfig(managedProvider.id, ctx))
+  ) {
+    throw new UnsupportedHarnessProviderError(
+      harness,
+      managedProvider.id,
+      supportedProviderIds(harness, descriptor, ctx),
+    );
+  }
+  return managedProvider.id;
+}
+
+function resolveExplicitProvider(
+  providerId: string,
+  ctx: AgentConfigResolutionContext,
+  harness: Harness,
+  descriptor: ReturnType<typeof getHarnessDescriptor>,
+): ModelProviderRef {
+  const provider = resolveSupportedProvider(providerId, ctx);
+  if (!isHarnessCompatible(harness, provider, getProviderConfig(provider, ctx))) {
+    throw new UnsupportedHarnessProviderError(
+      harness,
+      providerId,
+      supportedProviderIds(harness, descriptor, ctx),
+    );
+  }
+  return provider;
 }
 
 function resolveSupportedProvider(

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -56,31 +56,12 @@ export async function resolveRuntimeCredentials(
 ): Promise<AgentRuntimeCredentialsResponseDto> {
   const runtimeConfig = options?.runtimeConfig ?? config;
   const configuredWorkspaceProviders = options?.workspaceProviders ?? workspaceProvidersPolicy;
-  const secrets = options?.secrets;
   const managedProvider = options?.managedProvider;
-  if (managedProvider?.id === params.provider) {
-    const managedRuntimeConfig = await managedProvider.resolveCredentials({
-      workspaceId: params.workspaceId,
-      runId: params.runId,
-      stepAttemptId: params.stepAttemptId,
-      model: params.model,
-    });
-    agentRuntimeConfigResolvedCount.add(1, {source: 'instance', outcome: 'resolved'});
-    return toResponse(params, managedRuntimeConfig.credentials, undefined, {
-      provider: managedProvider,
-      runtimeConfig: managedRuntimeConfig,
-    });
-  }
+  const managedResponse = await resolveManagedCredentials(params, managedProvider);
+  if (managedResponse !== undefined) return managedResponse;
 
   if (configuredWorkspaceProviders === 'disabled') {
-    agentRuntimeConfigResolvedCount.add(1, {
-      source: params.provider === runtimeConfig.AGENT_DEFAULT_PROVIDER ? 'instance' : 'workspace',
-      outcome: 'unavailable',
-    });
-    if (managedProvider !== undefined) {
-      throw new WorkspaceProvidersDisabledError(managedProvider.id);
-    }
-    throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
+    throwWorkspaceProviderUnavailable(params, runtimeConfig, managedProvider);
   }
 
   const providerConfig = await getModelProviderConfig({
@@ -88,44 +69,8 @@ export async function resolveRuntimeCredentials(
     providerId: params.provider,
   });
 
-  if (providerConfig) {
-    try {
-      const values = options?.getCredentialBag
-        ? await options.getCredentialBag({
-            workspaceId: params.workspaceId,
-            namespace: agentSystemNamespace(params.provider),
-          })
-        : (
-            await requireAgentSecretsClient(secrets).getSecretsByNamespace({
-              workspaceId: params.workspaceId,
-              namespace: agentSystemNamespace(params.provider),
-            })
-          ).values;
-      if (providerConfig.kind === 'custom') {
-        const credentials = storeValuesToCustomRuntimeCredentials(values);
-        agentRuntimeConfigResolvedCount.add(1, {source: 'workspace', outcome: 'resolved'});
-        return toResponse(params, credentials, providerConfig);
-      }
-
-      const providerId = params.provider as SupportedModelProviderId;
-      const credentials = storeValuesToRuntimeCredentials(providerId, values);
-      if (!modelProviderCredentialKeysMatch(providerId, credentials)) {
-        throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
-      }
-      agentRuntimeConfigResolvedCount.add(1, {source: 'workspace', outcome: 'resolved'});
-      return toResponse(params, credentials, providerConfig);
-    } catch (error) {
-      if (
-        isInterModuleKnownError(secretsInterModuleContract.methods.getSecretsByNamespace, error)
-      ) {
-        agentRuntimeConfigResolvedCount.add(1, {
-          source: 'workspace',
-          outcome: 'decryption_failed',
-        });
-      }
-      throw error;
-    }
-  }
+  const workspaceResponse = await resolveWorkspaceCredentials(params, providerConfig, options);
+  if (workspaceResponse !== undefined) return workspaceResponse;
 
   const instanceCredentials = instanceFallbackCredentials(params.provider, runtimeConfig);
   if (instanceCredentials) {
@@ -138,6 +83,90 @@ export async function resolveRuntimeCredentials(
     outcome: 'unavailable',
   });
   throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
+}
+
+async function resolveManagedCredentials(
+  params: ResolveRuntimeCredentialsParams,
+  managedProvider: ManagedModelProvider | undefined,
+): Promise<AgentRuntimeCredentialsResponseDto | undefined> {
+  if (managedProvider?.id !== params.provider) return undefined;
+  const managedRuntimeConfig = await managedProvider.resolveCredentials({
+    workspaceId: params.workspaceId,
+    runId: params.runId,
+    stepAttemptId: params.stepAttemptId,
+    model: params.model,
+  });
+  agentRuntimeConfigResolvedCount.add(1, {source: 'instance', outcome: 'resolved'});
+  return toResponse(params, managedRuntimeConfig.credentials, undefined, {
+    provider: managedProvider,
+    runtimeConfig: managedRuntimeConfig,
+  });
+}
+
+function throwWorkspaceProviderUnavailable(
+  params: ResolveRuntimeCredentialsParams,
+  runtimeConfig: RuntimeCredentialsConfig,
+  managedProvider: ManagedModelProvider | undefined,
+): never {
+  agentRuntimeConfigResolvedCount.add(1, {
+    source: params.provider === runtimeConfig.AGENT_DEFAULT_PROVIDER ? 'instance' : 'workspace',
+    outcome: 'unavailable',
+  });
+  if (managedProvider !== undefined) throw new WorkspaceProvidersDisabledError(managedProvider.id);
+  throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
+}
+
+async function readWorkspaceCredentialValues(
+  params: ResolveRuntimeCredentialsParams,
+  options: ResolveRuntimeCredentialsOptions | undefined,
+): Promise<Record<string, string>> {
+  if (options?.getCredentialBag) {
+    return await options.getCredentialBag({
+      workspaceId: params.workspaceId,
+      namespace: agentSystemNamespace(params.provider),
+    });
+  }
+  return (
+    await requireAgentSecretsClient(options?.secrets).getSecretsByNamespace({
+      workspaceId: params.workspaceId,
+      namespace: agentSystemNamespace(params.provider),
+    })
+  ).values;
+}
+
+function workspaceCredentialsResponse(
+  params: ResolveRuntimeCredentialsParams,
+  providerConfig: ModelProviderConfig,
+  values: Record<string, string>,
+): AgentRuntimeCredentialsResponseDto {
+  if (providerConfig.kind === 'custom') {
+    return toResponse(params, storeValuesToCustomRuntimeCredentials(values), providerConfig);
+  }
+  const providerId = params.provider as SupportedModelProviderId;
+  const credentials = storeValuesToRuntimeCredentials(providerId, values);
+  if (!modelProviderCredentialKeysMatch(providerId, credentials)) {
+    throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
+  }
+  return toResponse(params, credentials, providerConfig);
+}
+
+async function resolveWorkspaceCredentials(
+  params: ResolveRuntimeCredentialsParams,
+  providerConfig: ModelProviderConfig | undefined,
+  options: ResolveRuntimeCredentialsOptions | undefined,
+): Promise<AgentRuntimeCredentialsResponseDto | undefined> {
+  if (!providerConfig) return undefined;
+  try {
+    const values = await readWorkspaceCredentialValues(params, options);
+    const response = workspaceCredentialsResponse(params, providerConfig, values);
+    agentRuntimeConfigResolvedCount.add(1, {source: 'workspace', outcome: 'resolved'});
+    return response;
+  } catch (error) {
+    if (isInterModuleKnownError(secretsInterModuleContract.methods.getSecretsByNamespace, error)) {
+      agentRuntimeConfigResolvedCount.add(1, {source: 'workspace', outcome: 'decryption_failed'});
+    }
+    throw error;
+  }
 }
 
 export function getInstanceDefaultModelProviderApiKeyField(
@@ -187,47 +216,60 @@ function toResponse(
     credentials,
   };
 
-  if (providerConfig?.kind === 'custom') {
-    response.custom_provider = {
-      api: providerConfig.api ?? 'openai-responses',
-      base_url: providerConfig.baseUrl ?? '',
-      headers: providerConfig.headers ?? [],
-      secret_header_names: Object.keys(credentials)
-        .filter((key) => key.startsWith('header:'))
-        .map((key) => key.slice('header:'.length))
-        .sort(),
-      models: providerConfig.models ?? [],
-      requires_api_key: providerConfig.requiresApiKey,
-    };
-  }
-
-  if (managed !== undefined) {
-    const modelDescriptor = toCustomAgentModelDto(
-      managedModel ?? {id: params.model, label: params.model},
-    );
-    const clientApi =
-      params.harness === 'claude' ? 'anthropic-messages' : managed.runtimeConfig.api;
-
-    if (params.harness === 'pi') {
-      response.custom_provider = {
-        api: managed.runtimeConfig.api,
-        base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
-        headers: [],
-        secret_header_names: [],
-        models: [modelDescriptor],
-        requires_api_key: true,
-      };
-    } else {
-      const authToken = managed.runtimeConfig.credentials.api_key;
-      if (authToken === undefined) {
-        throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
-      }
-      response.claude = {
-        base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
-        auth_token: authToken,
-      };
-    }
-  }
-
+  appendCustomProviderResponse(response, providerConfig, credentials);
+  appendManagedProviderResponse(response, params, managed, managedModel);
   return response;
+}
+
+function appendCustomProviderResponse(
+  response: AgentRuntimeCredentialsResponseDto,
+  providerConfig: ModelProviderConfig | undefined,
+  credentials: Record<string, string>,
+): void {
+  if (providerConfig?.kind !== 'custom') return;
+  response.custom_provider = {
+    api: providerConfig.api ?? 'openai-responses',
+    base_url: providerConfig.baseUrl ?? '',
+    headers: providerConfig.headers ?? [],
+    secret_header_names: Object.keys(credentials)
+      .filter((key) => key.startsWith('header:'))
+      .map((key) => key.slice('header:'.length))
+      .sort(),
+    models: providerConfig.models ?? [],
+    requires_api_key: providerConfig.requiresApiKey,
+  };
+}
+
+function appendManagedProviderResponse(
+  response: AgentRuntimeCredentialsResponseDto,
+  params: ResolveRuntimeCredentialsParams,
+  managed:
+    | {provider: ManagedModelProvider; runtimeConfig: ManagedProviderRuntimeConfig}
+    | undefined,
+  managedModel: ManagedModelProvider['models'][number] | undefined,
+): void {
+  if (managed === undefined) return;
+  const modelDescriptor = toCustomAgentModelDto(
+    managedModel ?? {id: params.model, label: params.model},
+  );
+  const clientApi = params.harness === 'claude' ? 'anthropic-messages' : managed.runtimeConfig.api;
+  if (params.harness === 'pi') {
+    response.custom_provider = {
+      api: managed.runtimeConfig.api,
+      base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
+      headers: [],
+      secret_header_names: [],
+      models: [modelDescriptor],
+      requires_api_key: true,
+    };
+    return;
+  }
+  const authToken = managed.runtimeConfig.credentials.api_key;
+  if (authToken === undefined) {
+    throw new ModelProviderConfigNotFoundError(params.workspaceId, params.provider);
+  }
+  response.claude = {
+    base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
+    auth_token: authToken,
+  };
 }

--- a/libs/api/agent/src/core/session-artifacts/deletable-object-keys.ts
+++ b/libs/api/agent/src/core/session-artifacts/deletable-object-keys.ts
@@ -1,0 +1,17 @@
+import type {Transaction} from '#db/db.js';
+import {hasSessionReferencingObjectKey} from '#db/retention.js';
+
+export async function deletableSessionObjectKeys(
+  tx: Transaction,
+  sessionId: string,
+  headObjectKey: string | null,
+  keys: string[],
+): Promise<string[]> {
+  if (headObjectKey === null) return keys;
+  if (await hasSessionReferencingObjectKey(tx, sessionId, headObjectKey)) {
+    return keys.filter((key) => key !== headObjectKey);
+  }
+  // Carried-over rows can point outside their own prefix.
+  if (!keys.includes(headObjectKey)) return [...keys, headObjectKey];
+  return keys;
+}

--- a/libs/api/agent/src/core/session-artifacts/store.ts
+++ b/libs/api/agent/src/core/session-artifacts/store.ts
@@ -7,9 +7,14 @@ import {
   db,
   hasSessionReferencingObjectKey,
   sessions,
+  type Transaction,
 } from '#db/index.js';
 import {toAgentSession} from '#db/schema/sessions.js';
-import {sessionCommitsCount, sessionCommittedBytes} from '#metrics/instance.js';
+import {
+  type SessionCommitOutcome,
+  sessionCommitsCount,
+  sessionCommittedBytes,
+} from '#metrics/instance.js';
 import {AgentSessionUnavailableError} from '../errors.js';
 import {aadForSessionObject, openSessionBlob, sealSessionBlob} from './crypto.js';
 import type {SessionDekManager} from './dek-manager.js';
@@ -64,6 +69,20 @@ export interface ReadSessionHeadResult {
   /** The decrypted, still-gzipped harness-native session file. */
   blob: Buffer;
   manifest: SegmentManifest;
+}
+
+async function deletableSessionObjectKeys(
+  tx: Transaction,
+  sessionId: string,
+  headObjectKey: string | null,
+  keys: string[],
+): Promise<string[]> {
+  if (headObjectKey === null) return keys;
+  if (await hasSessionReferencingObjectKey(tx, sessionId, headObjectKey)) {
+    return keys.filter((key) => key !== headObjectKey);
+  }
+  if (!keys.includes(headObjectKey)) return [...keys, headObjectKey];
+  return keys;
 }
 
 export interface SessionArtifactStore {
@@ -200,14 +219,10 @@ export function createSessionArtifactStore(params: {
         );
       });
 
-      sessionCommitsCount.add(1, {
-        outcome:
-          result.outcome === 'committed'
-            ? 'committed'
-            : result.outcome === 'retry-acked'
-              ? 'retry_acked'
-              : 'conflict',
-      });
+      let metricOutcome: SessionCommitOutcome = 'conflict';
+      if (result.outcome === 'committed') metricOutcome = 'committed';
+      else if (result.outcome === 'retry-acked') metricOutcome = 'retry_acked';
+      sessionCommitsCount.add(1, {outcome: metricOutcome});
       if (result.outcome === 'committed' && committedSizeBytes !== undefined) {
         sessionCommittedBytes.record(committedSizeBytes);
       }
@@ -274,19 +289,9 @@ export function createSessionArtifactStore(params: {
         const prefix = sessionPrefix(session);
         const keys = await listSessionObjectKeys(prefix);
 
-        let deletable = keys;
-        if (row.headObjectKey !== null) {
-          if (await hasSessionReferencingObjectKey(tx, session.id, row.headObjectKey)) {
-            // A carried-over rerun row still references this head object; keep it
-            // until every referencing row is gone, mirroring the retention sweep's
-            // carried-over guard in deleteExpiredSession.
-            deletable = deletable.filter((key) => key !== row.headObjectKey);
-          } else if (!keys.includes(row.headObjectKey)) {
-            // Carried-over rows point at the source run attempt's prefix; the exact
-            // head key must be removed here because the source prefix is not ours.
-            deletable = [...deletable, row.headObjectKey];
-          }
-        }
+        // A referenced head belongs to a carried-over rerun and stays until the
+        // last row is gone. A head outside this session's prefix is added explicitly.
+        const deletable = await deletableSessionObjectKeys(tx, session.id, row.headObjectKey, keys);
 
         if (deletable.length > 0) await deleteSessionObjects(deletable);
       });

--- a/libs/api/agent/src/core/session-artifacts/store.ts
+++ b/libs/api/agent/src/core/session-artifacts/store.ts
@@ -1,14 +1,7 @@
 import {eq, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import type {AgentSession} from '#core/entities/agent-session.js';
-import {
-  type CommitSessionHeadResult,
-  commitSessionHead,
-  db,
-  hasSessionReferencingObjectKey,
-  sessions,
-  type Transaction,
-} from '#db/index.js';
+import {type CommitSessionHeadResult, commitSessionHead, db, sessions} from '#db/index.js';
 import {toAgentSession} from '#db/schema/sessions.js';
 import {
   type SessionCommitOutcome,
@@ -18,6 +11,7 @@ import {
 import {AgentSessionUnavailableError} from '../errors.js';
 import {aadForSessionObject, openSessionBlob, sealSessionBlob} from './crypto.js';
 import type {SessionDekManager} from './dek-manager.js';
+import {deletableSessionObjectKeys} from './deletable-object-keys.js';
 import {
   type SegmentManifest,
   segmentManifestFromMetadata,
@@ -69,20 +63,6 @@ export interface ReadSessionHeadResult {
   /** The decrypted, still-gzipped harness-native session file. */
   blob: Buffer;
   manifest: SegmentManifest;
-}
-
-async function deletableSessionObjectKeys(
-  tx: Transaction,
-  sessionId: string,
-  headObjectKey: string | null,
-  keys: string[],
-): Promise<string[]> {
-  if (headObjectKey === null) return keys;
-  if (await hasSessionReferencingObjectKey(tx, sessionId, headObjectKey)) {
-    return keys.filter((key) => key !== headObjectKey);
-  }
-  if (!keys.includes(headObjectKey)) return [...keys, headObjectKey];
-  return keys;
 }
 
 export interface SessionArtifactStore {

--- a/libs/api/agent/src/core/session-retention.ts
+++ b/libs/api/agent/src/core/session-retention.ts
@@ -3,15 +3,15 @@ import {logger} from '@shipfox/node-opentelemetry';
 import {eq, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import type {AgentSession} from '#core/entities/agent-session.js';
-import {db, type Transaction} from '#db/db.js';
+import {db} from '#db/db.js';
 import {
   type ExpiredSessionsCursor,
-  hasSessionReferencingObjectKey,
   listExpiredSessions,
   listSegmentPruneCandidates,
   type PruneCandidatesCursor,
 } from '#db/retention.js';
 import {sessions, toAgentSession} from '#db/schema/sessions.js';
+import {deletableSessionObjectKeys} from './session-artifacts/deletable-object-keys.js';
 import {parseSessionObjectKey, sessionObjectKeyPrefix} from './session-artifacts/object-key.js';
 import {deleteSessionObjects, listSessionObjectKeys} from './session-artifacts/object-storage.js';
 
@@ -210,7 +210,7 @@ async function deleteExpiredSession(session: AgentSession): Promise<void> {
     });
     const keys = await listSessionObjectKeys(prefix);
 
-    const deletable = await deletableExpiredSessionKeys(tx, session.id, row.headObjectKey, keys);
+    const deletable = await deletableSessionObjectKeys(tx, session.id, row.headObjectKey, keys);
 
     if (deletable.length > 0) await deleteSessionObjects(deletable);
 
@@ -220,21 +220,6 @@ async function deleteExpiredSession(session: AgentSession): Promise<void> {
       .returning({id: sessions.id});
     if (rows.length === 0) throw new Error(`Session row disappeared mid-retention: ${session.id}`);
   });
-}
-
-async function deletableExpiredSessionKeys(
-  tx: Transaction,
-  sessionId: string,
-  headObjectKey: string | null,
-  keys: string[],
-): Promise<string[]> {
-  if (headObjectKey === null) return keys;
-  if (await hasSessionReferencingObjectKey(tx, sessionId, headObjectKey)) {
-    return keys.filter((key) => key !== headObjectKey);
-  }
-  // Carried-over rows can point outside their own prefix.
-  if (!keys.includes(headObjectKey)) return [...keys, headObjectKey];
-  return keys;
 }
 
 function classifySessionSegment(

--- a/libs/api/agent/src/core/session-retention.ts
+++ b/libs/api/agent/src/core/session-retention.ts
@@ -3,7 +3,7 @@ import {logger} from '@shipfox/node-opentelemetry';
 import {eq, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import type {AgentSession} from '#core/entities/agent-session.js';
-import {db} from '#db/db.js';
+import {db, type Transaction} from '#db/db.js';
 import {
   type ExpiredSessionsCursor,
   hasSessionReferencingObjectKey,
@@ -210,17 +210,7 @@ async function deleteExpiredSession(session: AgentSession): Promise<void> {
     });
     const keys = await listSessionObjectKeys(prefix);
 
-    const deletable = [...keys];
-    if (row.headObjectKey !== null) {
-      if (await hasSessionReferencingObjectKey(tx, session.id, row.headObjectKey)) {
-        const index = deletable.indexOf(row.headObjectKey);
-        if (index >= 0) deletable.splice(index, 1);
-      } else if (!keys.includes(row.headObjectKey)) {
-        // Carried-over rows point at the source run attempt's prefix; the exact
-        // head key must be removed here because the source prefix is not ours.
-        deletable.push(row.headObjectKey);
-      }
-    }
+    const deletable = await deletableExpiredSessionKeys(tx, session.id, row.headObjectKey, keys);
 
     if (deletable.length > 0) await deleteSessionObjects(deletable);
 
@@ -230,6 +220,36 @@ async function deleteExpiredSession(session: AgentSession): Promise<void> {
       .returning({id: sessions.id});
     if (rows.length === 0) throw new Error(`Session row disappeared mid-retention: ${session.id}`);
   });
+}
+
+async function deletableExpiredSessionKeys(
+  tx: Transaction,
+  sessionId: string,
+  headObjectKey: string | null,
+  keys: string[],
+): Promise<string[]> {
+  if (headObjectKey === null) return keys;
+  if (await hasSessionReferencingObjectKey(tx, sessionId, headObjectKey)) {
+    return keys.filter((key) => key !== headObjectKey);
+  }
+  // Carried-over rows can point outside their own prefix.
+  if (!keys.includes(headObjectKey)) return [...keys, headObjectKey];
+  return keys;
+}
+
+function classifySessionSegment(
+  key: string,
+  fresh: AgentSession,
+  superseded: string[],
+  orphans: string[],
+): void {
+  const parsed = parseSessionObjectKey(key, config.AGENT_SESSION_STORAGE_S3_PREFIX);
+  if (!parsed || parsed.segment === fresh.headSegment) return;
+  if (parsed.segment < fresh.headSegment) {
+    superseded.push(key);
+    return;
+  }
+  if (fresh.claimedByStepAttempt === null) orphans.push(key);
 }
 
 /**
@@ -268,14 +288,7 @@ function pruneSessionSegments(
     const superseded: string[] = [];
     const orphans: string[] = [];
     for (const key of keys) {
-      const parsed = parseSessionObjectKey(key, config.AGENT_SESSION_STORAGE_S3_PREFIX);
-      if (!parsed) continue;
-      if (parsed.segment === fresh.headSegment) continue;
-      if (parsed.segment < fresh.headSegment) {
-        superseded.push(key);
-      } else if (fresh.claimedByStepAttempt === null) {
-        orphans.push(key);
-      }
+      classifySessionSegment(key, fresh, superseded, orphans);
     }
 
     if (superseded.length > 0) await deleteSessionObjects(superseded);

--- a/libs/api/agent/src/db/model-provider-configs.ts
+++ b/libs/api/agent/src/db/model-provider-configs.ts
@@ -32,6 +32,38 @@ export type InsertCustomModelProviderConfigParams = Omit<
   'kind' | 'requiresApiKey'
 > & {kind: 'custom'; requiresApiKey: boolean};
 
+type ModelProviderConfigValues = Pick<
+  typeof modelProviderConfigs.$inferInsert,
+  | 'api'
+  | 'baseUrl'
+  | 'defaultModel'
+  | 'defaultThinking'
+  | 'displayName'
+  | 'headers'
+  | 'kind'
+  | 'models'
+  | 'requiresApiKey'
+  | 'secretHeaderNames'
+>;
+
+function modelProviderConfigValues(
+  params: UpsertModelProviderConfigParams,
+): ModelProviderConfigValues {
+  const values: ModelProviderConfigValues = {
+    defaultModel: params.defaultModel,
+    defaultThinking: params.defaultThinking,
+  };
+  if (params.kind !== undefined) values.kind = params.kind;
+  if (params.displayName !== undefined) values.displayName = params.displayName;
+  if (params.api !== undefined) values.api = params.api;
+  if (params.baseUrl !== undefined) values.baseUrl = params.baseUrl;
+  if (params.headers !== undefined) values.headers = params.headers;
+  if (params.secretHeaderNames !== undefined) values.secretHeaderNames = params.secretHeaderNames;
+  if (params.models !== undefined) values.models = params.models;
+  if (params.requiresApiKey !== undefined) values.requiresApiKey = params.requiresApiKey;
+  return values;
+}
+
 export async function insertCustomModelProviderConfig(
   params: InsertCustomModelProviderConfigParams,
 ): Promise<ModelProviderConfig | undefined> {
@@ -84,39 +116,18 @@ export async function upsertModelProviderConfig(
   params: UpsertModelProviderConfigParams,
 ): Promise<ModelProviderConfig> {
   return await db().transaction(async (tx) => {
+    const values = modelProviderConfigValues(params);
     const rows = await tx
       .insert(modelProviderConfigs)
       .values({
         workspaceId: params.workspaceId,
         providerId: params.providerId,
-        ...(params.kind !== undefined ? {kind: params.kind} : {}),
-        ...(params.displayName !== undefined ? {displayName: params.displayName} : {}),
-        ...(params.api !== undefined ? {api: params.api} : {}),
-        ...(params.baseUrl !== undefined ? {baseUrl: params.baseUrl} : {}),
-        ...(params.headers !== undefined ? {headers: params.headers} : {}),
-        ...(params.secretHeaderNames !== undefined
-          ? {secretHeaderNames: params.secretHeaderNames}
-          : {}),
-        ...(params.models !== undefined ? {models: params.models} : {}),
-        ...(params.requiresApiKey !== undefined ? {requiresApiKey: params.requiresApiKey} : {}),
-        defaultModel: params.defaultModel,
-        defaultThinking: params.defaultThinking,
+        ...values,
       })
       .onConflictDoUpdate({
         target: [modelProviderConfigs.workspaceId, modelProviderConfigs.providerId],
         set: {
-          ...(params.kind !== undefined ? {kind: params.kind} : {}),
-          ...(params.displayName !== undefined ? {displayName: params.displayName} : {}),
-          ...(params.api !== undefined ? {api: params.api} : {}),
-          ...(params.baseUrl !== undefined ? {baseUrl: params.baseUrl} : {}),
-          ...(params.headers !== undefined ? {headers: params.headers} : {}),
-          ...(params.secretHeaderNames !== undefined
-            ? {secretHeaderNames: params.secretHeaderNames}
-            : {}),
-          ...(params.models !== undefined ? {models: params.models} : {}),
-          ...(params.requiresApiKey !== undefined ? {requiresApiKey: params.requiresApiKey} : {}),
-          defaultModel: params.defaultModel,
-          defaultThinking: params.defaultThinking,
+          ...values,
           updatedAt: sql`NOW()`,
         },
       })

--- a/libs/api/agent/src/db/sessions.ts
+++ b/libs/api/agent/src/db/sessions.ts
@@ -145,6 +145,57 @@ function throwSessionHeld(row: AgentSessionDb, params: ClaimSessionParams): neve
   });
 }
 
+function claimSessionIdentity(params: ClaimSessionParams) {
+  return and(
+    eq(sessions.workflowRunAttemptId, params.workflowRunAttemptId),
+    eq(sessions.key, params.key),
+  );
+}
+
+async function acquireExistingSessionClaim(
+  tx: Transaction,
+  row: AgentSessionDb | undefined,
+  params: ClaimSessionParams,
+): Promise<void> {
+  if (!row) return;
+  assertSessionScopeMatches(row, params);
+  if (!(await tryAcquireSessionClaimLock(tx, params))) throwSessionHeld(row, params);
+}
+
+async function assertClaimLockAvailable(
+  tx: Transaction,
+  params: ClaimSessionParams,
+): Promise<void> {
+  if (await tryAcquireSessionClaimLock(tx, params)) return;
+  const [visibleRow] = await tx.select().from(sessions).where(claimSessionIdentity(params));
+  if (!visibleRow) throw new Error('Session missing after claim lock contention');
+  throwSessionHeld(visibleRow, params);
+}
+
+async function lockClaimableSession(
+  tx: Transaction,
+  params: ClaimSessionParams,
+): Promise<AgentSessionDb> {
+  const [row] = await tx
+    .select()
+    .from(sessions)
+    .where(claimSessionIdentity(params))
+    .for('update', {skipLocked: true});
+  if (row) {
+    assertSessionClaimable(row, params);
+    return row;
+  }
+
+  const [visibleRow] = await tx.select().from(sessions).where(claimSessionIdentity(params));
+  if (!visibleRow) throw new Error('Session missing after claim create');
+  assertSessionClaimable(visibleRow, params);
+  throw new AgentSessionLockUnavailableError({
+    sessionId: visibleRow.id,
+    workflowRunAttemptId: params.workflowRunAttemptId,
+    key: visibleRow.key,
+  });
+}
+
 /**
  * Claims a session exclusively for a step attempt, in one short transaction
  * with a non-blocking `FOR UPDATE SKIP LOCKED` row lock. First use creates the session (empty head,
@@ -162,17 +213,8 @@ export async function claimSession(params: ClaimSessionParams): Promise<AgentSes
   assertValidSessionHarness(params.harness);
 
   return await db().transaction(async (tx) => {
-    const sessionIdentity = and(
-      eq(sessions.workflowRunAttemptId, params.workflowRunAttemptId),
-      eq(sessions.key, params.key),
-    );
-    const [existingRow] = await tx.select().from(sessions).where(sessionIdentity);
-    if (existingRow) {
-      assertSessionScopeMatches(existingRow, params);
-      if (!(await tryAcquireSessionClaimLock(tx, params))) {
-        throwSessionHeld(existingRow, params);
-      }
-    }
+    const [existingRow] = await tx.select().from(sessions).where(claimSessionIdentity(params));
+    await acquireExistingSessionClaim(tx, existingRow, params);
 
     await tx
       .insert(sessions)
@@ -185,32 +227,8 @@ export async function claimSession(params: ClaimSessionParams): Promise<AgentSes
       })
       .onConflictDoNothing();
 
-    if (!(await tryAcquireSessionClaimLock(tx, params))) {
-      const [visibleRow] = await tx.select().from(sessions).where(sessionIdentity);
-      if (!visibleRow) throw new Error('Session missing after claim lock contention');
-
-      throwSessionHeld(visibleRow, params);
-    }
-
-    const [row] = await tx
-      .select()
-      .from(sessions)
-      .where(sessionIdentity)
-      .for('update', {skipLocked: true});
-    if (!row) {
-      const [visibleRow] = await tx.select().from(sessions).where(sessionIdentity);
-      if (!visibleRow) throw new Error('Session missing after claim create');
-
-      assertSessionClaimable(visibleRow, params);
-
-      throw new AgentSessionLockUnavailableError({
-        sessionId: visibleRow.id,
-        workflowRunAttemptId: params.workflowRunAttemptId,
-        key: visibleRow.key,
-      });
-    }
-
-    assertSessionClaimable(row, params);
+    await assertClaimLockAvailable(tx, params);
+    const row = await lockClaimableSession(tx, params);
 
     const updated = await tx
       .update(sessions)

--- a/libs/api/annotations/src/core/write-annotations.ts
+++ b/libs/api/annotations/src/core/write-annotations.ts
@@ -1,6 +1,10 @@
 import type {LeasedWriteAnnotationOperationDto} from '@shipfox/annotations-dto';
 import {config} from '#config.js';
-import {type StoredAnnotation, withAnnotationLock} from '#db/annotations.js';
+import {
+  type AnnotationWriteRepository,
+  type StoredAnnotation,
+  withAnnotationLock,
+} from '#db/annotations.js';
 import {
   AnnotationBodyTooLargeError,
   AnnotationCountLimitExceededError,
@@ -28,88 +32,97 @@ export interface WriteAnnotationsResult {
   };
 }
 
-export function writeAnnotations(params: WriteAnnotationsParams): Promise<WriteAnnotationsResult> {
-  return withAnnotationLock(params.jobExecutionId, async (repo) => {
-    const current = await repo.loadCurrentAnnotations(params.jobExecutionId);
-    let nextSequence =
-      Math.max(0, ...Array.from(current.values()).map((annotation) => annotation.sequence)) + 1;
-    const results: WriteAnnotationsResult['annotations'] = [];
+interface AnnotationWriteState {
+  current: Map<string, StoredAnnotation>;
+  nextSequence: number;
+  results: WriteAnnotationsResult['annotations'];
+}
 
-    for (const operation of params.operations) {
-      if (operation.op === 'remove') {
-        await repo.removeAnnotation(params.jobExecutionId, operation.context);
-        current.delete(operation.context);
-        results.push({context: operation.context, id: null});
-        continue;
-      }
+async function applyAnnotationOperation(
+  repo: AnnotationWriteRepository,
+  params: WriteAnnotationsParams,
+  operation: LeasedWriteAnnotationOperationDto,
+  state: AnnotationWriteState,
+): Promise<void> {
+  if (operation.op === 'remove') {
+    await repo.removeAnnotation(params.jobExecutionId, operation.context);
+    state.current.delete(operation.context);
+    state.results.push({context: operation.context, id: null});
+    return;
+  }
 
-      const existing = current.get(operation.context);
-      const body =
-        operation.op === 'append' ? `${existing?.body ?? ''}${operation.body}` : operation.body;
-      const bodyBytes = Buffer.byteLength(body);
-      ensureBodyBudget(bodyBytes);
+  const existing = state.current.get(operation.context);
+  const body =
+    operation.op === 'append' ? `${existing?.body ?? ''}${operation.body}` : operation.body;
+  const bodyBytes = Buffer.byteLength(body);
+  ensureBodyBudget(bodyBytes);
+  const unchanged =
+    operation.op === 'replace' &&
+    existing !== undefined &&
+    existing.body === body &&
+    existing.style === operation.style;
+  if (unchanged) {
+    state.results.push({context: operation.context, id: existing.id});
+    return;
+  }
 
-      const isUnchangedReplace =
-        operation.op === 'replace' &&
-        existing !== undefined &&
-        existing.body === body &&
-        existing.style === operation.style;
-      if (isUnchangedReplace) {
-        results.push({context: operation.context, id: existing.id});
-        continue;
-      }
+  const draft = new Map(state.current);
+  draft.set(operation.context, {
+    id: existing?.id ?? '',
+    context: operation.context,
+    style: operation.style,
+    body,
+    bodyBytes,
+    sequence: existing?.sequence ?? state.nextSequence,
+  });
+  ensureExecutionBudgets(draft);
 
-      const draft = new Map(current);
-      draft.set(operation.context, {
-        id: existing?.id ?? '',
+  const row = existing
+    ? await repo.updateAnnotation({
+        id: existing.id,
+        originStepId: params.originStepId,
+        originStepAttempt: params.originStepAttempt,
+        style: operation.style,
+        body,
+        bodyBytes,
+      })
+    : await repo.createAnnotation({
+        workspaceId: params.workspaceId,
+        projectId: params.projectId,
+        workflowRunId: params.workflowRunId,
+        workflowRunAttempt: params.workflowRunAttempt,
+        workflowRunAttemptId: params.workflowRunAttemptId,
+        jobId: params.jobId,
+        jobExecutionId: params.jobExecutionId,
+        originStepId: params.originStepId,
+        originStepAttempt: params.originStepAttempt,
         context: operation.context,
         style: operation.style,
         body,
         bodyBytes,
-        sequence: existing?.sequence ?? nextSequence,
+        sequence: state.nextSequence,
       });
-      ensureExecutionBudgets(draft);
+  state.current.set(operation.context, row);
+  if (!existing) state.nextSequence += 1;
+  state.results.push({context: operation.context, id: row.id});
+}
 
-      const row = existing
-        ? await repo.updateAnnotation({
-            id: existing.id,
-            originStepId: params.originStepId,
-            originStepAttempt: params.originStepAttempt,
-            style: operation.style,
-            body,
-            bodyBytes,
-          })
-        : await repo.createAnnotation({
-            workspaceId: params.workspaceId,
-            projectId: params.projectId,
-            workflowRunId: params.workflowRunId,
-            workflowRunAttempt: params.workflowRunAttempt,
-            workflowRunAttemptId: params.workflowRunAttemptId,
-            jobId: params.jobId,
-            jobExecutionId: params.jobExecutionId,
-            originStepId: params.originStepId,
-            originStepAttempt: params.originStepAttempt,
-            context: operation.context,
-            style: operation.style,
-            body,
-            bodyBytes,
-            sequence: nextSequence,
-          });
+export function writeAnnotations(params: WriteAnnotationsParams): Promise<WriteAnnotationsResult> {
+  return withAnnotationLock(params.jobExecutionId, async (repo) => {
+    const current = await repo.loadCurrentAnnotations(params.jobExecutionId);
+    const state: AnnotationWriteState = {
+      current,
+      nextSequence:
+        Math.max(0, ...Array.from(current.values()).map((annotation) => annotation.sequence)) + 1,
+      results: [],
+    };
 
-      current.set(operation.context, {
-        id: row.id,
-        context: row.context,
-        style: row.style,
-        body: row.body,
-        bodyBytes: row.bodyBytes,
-        sequence: row.sequence,
-      });
-      if (!existing) nextSequence += 1;
-      results.push({context: operation.context, id: row.id});
+    for (const operation of params.operations) {
+      await applyAnnotationOperation(repo, params, operation, state);
     }
 
     return {
-      annotations: results,
+      annotations: state.results,
       accounting: currentAccounting(current),
     };
   });

--- a/libs/api/annotations/src/presentation/routes/read-annotations.test.ts
+++ b/libs/api/annotations/src/presentation/routes/read-annotations.test.ts
@@ -5,6 +5,12 @@ import {annotationFactory} from '#test/index.js';
 import {readAnnotationSummaryRoute} from './read-annotation-summary.js';
 import {readAnnotationsRoute} from './read-annotations.js';
 
+function workspaceStatus(value: string | undefined): 'active' | 'suspended' | 'deleted' {
+  if (value === 'suspended') return 'suspended';
+  if (value === 'deleted') return 'deleted';
+  return 'active';
+}
+
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
   authenticate: (request: FastifyRequest) => {
@@ -20,9 +26,7 @@ const fakeUserAuth: AuthMethod = {
       .map((value) => {
         const [workspaceId, status] = value.split('|');
         if (!workspaceId) throw new Error('missing test workspace id');
-        const workspaceStatus: 'active' | 'suspended' | 'deleted' =
-          status === 'suspended' ? 'suspended' : status === 'deleted' ? 'deleted' : 'active';
-        return {workspaceId, role: 'admin' as const, workspaceStatus};
+        return {workspaceId, role: 'admin' as const, workspaceStatus: workspaceStatus(status)};
       });
 
     setUserContext(

--- a/libs/api/auth-context/src/index.ts
+++ b/libs/api/auth-context/src/index.ts
@@ -197,6 +197,14 @@ function joinRoutePath(parent: string, child: string): string {
   return `${parent.replace(TRAILING_SLASHES, '')}/${child.replace(LEADING_SLASHES, '')}`;
 }
 
+function routePreHandlers(
+  preHandler: RoutePreHandler | RoutePreHandler[] | undefined,
+): RoutePreHandler[] {
+  if (preHandler === undefined) return [];
+  if (Array.isArray(preHandler)) return preHandler;
+  return [preHandler];
+}
+
 function adoptAdministrationGuardIn(route: RouteExport, parentPrefix: string): RouteExport {
   if (isRouteGroup(route)) {
     return {
@@ -215,11 +223,7 @@ function adoptAdministrationGuardIn(route: RouteExport, parentPrefix: string): R
       requireAdministrationActor(request);
       return undefined;
     },
-    ...(route.preHandler === undefined
-      ? []
-      : Array.isArray(route.preHandler)
-        ? route.preHandler
-        : [route.preHandler]),
+    ...routePreHandlers(route.preHandler),
   ];
   return {...route, preHandler};
 }

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -442,11 +442,9 @@ export type CreateSessionForUserError =
 export async function createSessionForUser(
   params: CreateSessionForUserParams,
 ): Promise<CreateSessionForUserResult> {
-  const user = params.userId
-    ? await findUserById({id: params.userId})
-    : params.email
-      ? await findUserByEmail({email: emailSchema.parse(params.email)})
-      : undefined;
+  let user: User | undefined;
+  if (params.userId) user = await findUserById({id: params.userId});
+  else if (params.email) user = await findUserByEmail({email: emailSchema.parse(params.email)});
 
   if (!user) {
     throw new UserNotFoundError(params.userId ?? params.email ?? 'unknown');

--- a/libs/api/auth/src/db/admin-user-moderation.ts
+++ b/libs/api/auth/src/db/admin-user-moderation.ts
@@ -139,6 +139,58 @@ async function revokeActiveSessions(tx: Tx, userId: string): Promise<number> {
   return new Set(revoked.map(({sessionId}) => sessionId)).size;
 }
 
+async function suspendUser(tx: Tx, user: Awaited<ReturnType<typeof readTargetUserForUpdate>>) {
+  if (user.status !== 'active') return;
+  const activeOwners = await tx
+    .select({id: adminGrants.id})
+    .from(adminGrants)
+    .innerJoin(users, eq(adminGrants.userId, users.id))
+    .where(
+      and(
+        eq(adminGrants.role, 'admin-owner'),
+        isNull(adminGrants.revokedAt),
+        eq(users.status, 'active'),
+      ),
+    )
+    .limit(2);
+  const targetIsActiveOwner = await tx
+    .select({id: adminGrants.id})
+    .from(adminGrants)
+    .where(
+      and(
+        eq(adminGrants.userId, user.id),
+        eq(adminGrants.role, 'admin-owner'),
+        isNull(adminGrants.revokedAt),
+      ),
+    )
+    .limit(1);
+  if (targetIsActiveOwner.length > 0 && activeOwners.length <= 1) throw new LastAdminOwnerError();
+  await tx
+    .update(users)
+    .set({status: 'suspended', updatedAt: sql`now()`})
+    .where(eq(users.id, user.id));
+}
+
+async function applyModerationOperation(
+  tx: Tx,
+  user: Awaited<ReturnType<typeof readTargetUserForUpdate>>,
+  operation: 'suspend' | 'reactivate' | 'revoke-sessions',
+): Promise<number> {
+  if (operation === 'suspend') {
+    await suspendUser(tx, user);
+    return await revokeActiveSessions(tx, user.id);
+  }
+  if (operation === 'reactivate' && user.status === 'suspended') {
+    await tx
+      .update(users)
+      .set({status: 'active', updatedAt: sql`now()`})
+      .where(eq(users.id, user.id));
+    return 0;
+  }
+  if (operation === 'revoke-sessions') return await revokeActiveSessions(tx, user.id);
+  return 0;
+}
+
 async function executeUserModerationCommand(
   params: UserModerationCommandParams & {
     operation: 'suspend' | 'reactivate' | 'revoke-sessions';
@@ -157,51 +209,7 @@ async function executeUserModerationCommand(
     await lockUserSessionMutations(tx, params.userId);
     const user = await readTargetUserForUpdate(tx, params.userId);
     await requireActiveAdminOperator(tx, params.actorId);
-    let sessionsRevoked = 0;
-
-    if (params.operation === 'suspend') {
-      if (user.status === 'active') {
-        const activeOwners = await tx
-          .select({id: adminGrants.id})
-          .from(adminGrants)
-          .innerJoin(users, eq(adminGrants.userId, users.id))
-          .where(
-            and(
-              eq(adminGrants.role, 'admin-owner'),
-              isNull(adminGrants.revokedAt),
-              eq(users.status, 'active'),
-            ),
-          )
-          .limit(2);
-        const targetIsActiveOwner = await tx
-          .select({id: adminGrants.id})
-          .from(adminGrants)
-          .where(
-            and(
-              eq(adminGrants.userId, user.id),
-              eq(adminGrants.role, 'admin-owner'),
-              isNull(adminGrants.revokedAt),
-            ),
-          )
-          .limit(1);
-        if (targetIsActiveOwner.length > 0 && activeOwners.length <= 1) {
-          throw new LastAdminOwnerError();
-        }
-
-        await tx
-          .update(users)
-          .set({status: 'suspended', updatedAt: sql`now()`})
-          .where(eq(users.id, user.id));
-      }
-      sessionsRevoked = await revokeActiveSessions(tx, user.id);
-    } else if (params.operation === 'reactivate' && user.status === 'suspended') {
-      await tx
-        .update(users)
-        .set({status: 'active', updatedAt: sql`now()`})
-        .where(eq(users.id, user.id));
-    } else if (params.operation === 'revoke-sessions') {
-      sessionsRevoked = await revokeActiveSessions(tx, user.id);
-    }
+    const sessionsRevoked = await applyModerationOperation(tx, user, params.operation);
 
     const summary = await findUserSummary(tx, user.id);
     const result: StoredAdminUserModerationResult = {

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -288,11 +288,9 @@ const userLookupRoute = defineRoute({
     const {id, user_id: userId, email} = request.query;
     const lookupId = id ?? userId;
     const actorId = requireActorId(request);
-    const user = lookupId
-      ? await findAdministratorUserSummary({actorId, id: lookupId})
-      : email
-        ? await findAdministratorUserSummary({actorId, email})
-        : undefined;
+    let user: Awaited<ReturnType<typeof findAdministratorUserSummary>>;
+    if (lookupId) user = await findAdministratorUserSummary({actorId, id: lookupId});
+    else if (email) user = await findAdministratorUserSummary({actorId, email});
     if (!user) throw new UserNotFoundError(lookupId ?? email ?? 'unknown');
     return toAdministratorUserSummaryDto(user);
   },

--- a/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.ts
+++ b/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.ts
@@ -4,6 +4,12 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {resendEmailVerification} from '#core/auth.js';
 import {createAuthRateLimitPreHandler} from '#presentation/routes/rate-limit.js';
 
+function emailChallengeStatus(code: EmailChallengeError['code']): 400 | 410 | 429 {
+  if (code === 'limited') return 429;
+  if (code === 'expired') return 410;
+  return 400;
+}
+
 export const verifyEmailResendRoute = defineRoute({
   method: 'POST',
   path: '/verify-email/resend',
@@ -18,7 +24,7 @@ export const verifyEmailResendRoute = defineRoute({
   errorHandler: (error) => {
     if (error instanceof EmailChallengeError) {
       throw new ClientError(error.message, `email-challenge-${error.code}`, {
-        status: error.code === 'limited' ? 429 : error.code === 'expired' ? 410 : 400,
+        status: emailChallengeStatus(error.code),
         ...(error.retryAt ? {details: {retry_at: error.retryAt.toISOString()}} : {}),
       });
     }

--- a/libs/api/auth/src/presentation/routes/registration/signup.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.ts
@@ -15,6 +15,57 @@ import {SIGNUP_DENIAL_MESSAGE_MAX_LENGTH, type SignupPolicy} from '#core/ports.j
 import {setRefreshTokenCookie} from '#presentation/auth/refresh-cookie.js';
 import {toUserDto} from '#presentation/dto/user.js';
 
+function handleEmailChallengeError(error: unknown): void {
+  if (!(error instanceof EmailChallengeError)) return;
+  throw new ClientError(error.message, `email-challenge-${error.code}`, {
+    status: error.code === 'limited' ? 429 : 400,
+    ...(error.retryAt ? {details: {retry_at: error.retryAt.toISOString()}} : {}),
+  });
+}
+
+function handleSignupPolicyError(error: unknown): void {
+  if (error instanceof EmailTakenError) {
+    throw new ClientError('Email already registered', 'email-taken', {status: 409});
+  }
+  if (error instanceof SignupNotAllowedError) {
+    const message = error.message.slice(0, SIGNUP_DENIAL_MESSAGE_MAX_LENGTH);
+    throw new ClientError(message, 'signup-not-allowed', {
+      status: 403,
+      details: {message, ...(error.format ? {format: error.format} : {})},
+    });
+  }
+}
+
+function handleInvitationError(error: unknown): void {
+  if (error instanceof TokenInvalidError) {
+    throw new ClientError('Invitation token is invalid', 'invitation-token-invalid', {status: 410});
+  }
+  if (error instanceof TokenAlreadyUsedError) {
+    throw new ClientError('Invitation has already been accepted', 'invitation-token-used', {
+      status: 410,
+    });
+  }
+  if (error instanceof TokenExpiredError) {
+    throw new ClientError('Invitation has expired', 'invitation-token-expired', {status: 410});
+  }
+  if (error instanceof InvitationEmailMismatchError) {
+    throw new ClientError(
+      'Signup email does not match the invitation',
+      'invitation-email-mismatch',
+      {
+        status: 403,
+      },
+    );
+  }
+}
+
+function handleSignupError(error: unknown): never {
+  handleEmailChallengeError(error);
+  handleSignupPolicyError(error);
+  handleInvitationError(error);
+  throw error;
+}
+
 export function createSignupRoute(
   workspaces: WorkspacesInterModuleClient,
   signupPolicy?: SignupPolicy,
@@ -30,47 +81,7 @@ export function createSignupRoute(
         201: signupResponseSchema,
       },
     },
-    errorHandler: (error) => {
-      if (error instanceof EmailChallengeError) {
-        throw new ClientError(error.message, `email-challenge-${error.code}`, {
-          status: error.code === 'limited' ? 429 : 400,
-          ...(error.retryAt ? {details: {retry_at: error.retryAt.toISOString()}} : {}),
-        });
-      }
-      if (error instanceof EmailTakenError) {
-        throw new ClientError('Email already registered', 'email-taken', {status: 409});
-      }
-      if (error instanceof SignupNotAllowedError) {
-        const message = error.message.slice(0, SIGNUP_DENIAL_MESSAGE_MAX_LENGTH);
-        throw new ClientError(message, 'signup-not-allowed', {
-          status: 403,
-          details: {message, ...(error.format ? {format: error.format} : {})},
-        });
-      }
-      if (error instanceof TokenInvalidError) {
-        throw new ClientError('Invitation token is invalid', 'invitation-token-invalid', {
-          status: 410,
-        });
-      }
-      if (error instanceof TokenAlreadyUsedError) {
-        throw new ClientError('Invitation has already been accepted', 'invitation-token-used', {
-          status: 410,
-        });
-      }
-      if (error instanceof TokenExpiredError) {
-        throw new ClientError('Invitation has expired', 'invitation-token-expired', {
-          status: 410,
-        });
-      }
-      if (error instanceof InvitationEmailMismatchError) {
-        throw new ClientError(
-          'Signup email does not match the invitation',
-          'invitation-email-mismatch',
-          {status: 403},
-        );
-      }
-      throw error;
-    },
+    errorHandler: handleSignupError,
     handler: async (request, reply) => {
       const {email, password, name, invitation_token} = request.body;
 

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -151,7 +151,9 @@ export function extractToken(url: string): string {
 
 export function getSetCookie(res: {headers: OutgoingHttpHeaders}): string {
   const header = res.headers['set-cookie'];
-  const value = Array.isArray(header) ? header[0] : typeof header === 'string' ? header : undefined;
+  let value: string | undefined;
+  if (Array.isArray(header)) value = header[0];
+  else if (typeof header === 'string') value = header;
   expect(value).toBeDefined();
   return value ?? '';
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-dependencies.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-dependencies.ts
@@ -90,50 +90,79 @@ function findCyclicSourceNames(
   jobNames: readonly string[],
   adjacency: ReadonlyMap<string, readonly string[]>,
 ): readonly string[] {
-  const indexes = new Map<string, number>();
-  const lowLinks = new Map<string, number>();
-  const stack: string[] = [];
-  const onStack = new Set<string>();
-  const cyclicNames = new Set<string>();
-  let index = 0;
-
-  const visit = (node: string) => {
-    indexes.set(node, index);
-    lowLinks.set(node, index);
-    index += 1;
-    stack.push(node);
-    onStack.add(node);
-
-    for (const neighbor of adjacency.get(node) ?? []) {
-      if (!indexes.has(neighbor)) {
-        visit(neighbor);
-        lowLinks.set(
-          node,
-          Math.min(lowLinks.get(node) as number, lowLinks.get(neighbor) as number),
-        );
-      } else if (onStack.has(neighbor)) {
-        lowLinks.set(node, Math.min(lowLinks.get(node) as number, indexes.get(neighbor) as number));
-      }
-    }
-
-    if (lowLinks.get(node) !== indexes.get(node)) return;
-
-    const component: string[] = [];
-    while (stack.length > 0) {
-      const member = stack.pop() as string;
-      onStack.delete(member);
-      component.push(member);
-      if (member === node) break;
-    }
-
-    if (component.length > 1) {
-      for (const member of component) cyclicNames.add(member);
-    }
+  const state: CyclicSearchState = {
+    indexes: new Map(),
+    lowLinks: new Map(),
+    stack: [],
+    onStack: new Set(),
+    cyclicNames: new Set(),
+    index: 0,
   };
 
   for (const name of jobNames) {
-    if (!indexes.has(name)) visit(name);
+    if (!state.indexes.has(name)) visitDependencyNode(name, adjacency, state);
   }
 
-  return jobNames.filter((name) => cyclicNames.has(name));
+  return jobNames.filter((name) => state.cyclicNames.has(name));
+}
+
+interface CyclicSearchState {
+  indexes: Map<string, number>;
+  lowLinks: Map<string, number>;
+  stack: string[];
+  onStack: Set<string>;
+  cyclicNames: Set<string>;
+  index: number;
+}
+
+function visitDependencyNode(
+  node: string,
+  adjacency: ReadonlyMap<string, readonly string[]>,
+  state: CyclicSearchState,
+): void {
+  state.indexes.set(node, state.index);
+  state.lowLinks.set(node, state.index);
+  state.index += 1;
+  state.stack.push(node);
+  state.onStack.add(node);
+
+  for (const neighbor of adjacency.get(node) ?? []) {
+    visitDependencyNeighbor(node, neighbor, adjacency, state);
+  }
+  if (state.lowLinks.get(node) === state.indexes.get(node)) collectComponent(node, state);
+}
+
+function visitDependencyNeighbor(
+  node: string,
+  neighbor: string,
+  adjacency: ReadonlyMap<string, readonly string[]>,
+  state: CyclicSearchState,
+): void {
+  if (!state.indexes.has(neighbor)) {
+    visitDependencyNode(neighbor, adjacency, state);
+    state.lowLinks.set(
+      node,
+      Math.min(state.lowLinks.get(node) as number, state.lowLinks.get(neighbor) as number),
+    );
+    return;
+  }
+  if (state.onStack.has(neighbor)) {
+    state.lowLinks.set(
+      node,
+      Math.min(state.lowLinks.get(node) as number, state.indexes.get(neighbor) as number),
+    );
+  }
+}
+
+function collectComponent(node: string, state: CyclicSearchState): void {
+  const component: string[] = [];
+  while (state.stack.length > 0) {
+    const member = state.stack.pop() as string;
+    state.onStack.delete(member);
+    component.push(member);
+    if (member === node) break;
+  }
+  if (component.length > 1) {
+    for (const member of component) state.cyclicNames.add(member);
+  }
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
@@ -23,6 +23,27 @@ export {DEFAULT_JOB_CHECKOUT};
 
 const DEFAULT_CHECKOUT_FETCH_DEPTH = 1;
 
+function normalizeCheckoutTemplates(params: Parameters<typeof normalizeCheckout>[0]) {
+  const templates: Partial<Record<WorkflowModelCheckoutTargetKey, WorkflowFieldTemplate>> = {};
+  for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
+    const source = params.checkout[key];
+    if (source === undefined) continue;
+    const template = parseInterpolationField({
+      field,
+      source,
+      path: [...params.path, key],
+      issues: params.issues,
+      fillSite: params.fillSite,
+      ...(params.allowedJobReferences === undefined
+        ? {}
+        : {allowedJobReferences: params.allowedJobReferences}),
+      ...(params.typeOverlay === undefined ? {} : {typeOverlay: params.typeOverlay}),
+    });
+    if (template !== undefined) templates[key] = template;
+  }
+  return Object.keys(templates).length === 0 ? undefined : templates;
+}
+
 export function normalizeJobCheckout(params: {
   checkout: WorkflowDocumentJob['checkout'];
 }): WorkflowModelJobCheckout | false {
@@ -48,43 +69,22 @@ export function normalizeCheckout(params: {
   typeOverlay?: ExpressionTypeEnvironment | undefined;
 }): WorkflowModelCheckout {
   validateCheckoutTargetShape(params);
-
-  const templates: Partial<Record<WorkflowModelCheckoutTargetKey, WorkflowFieldTemplate>> = {};
-  for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
-    const source = params.checkout[key];
-    if (source === undefined) continue;
-
-    const template = parseInterpolationField({
-      field,
-      source,
-      path: [...params.path, key],
-      issues: params.issues,
-      fillSite: params.fillSite,
-      ...(params.allowedJobReferences === undefined
-        ? {}
-        : {allowedJobReferences: params.allowedJobReferences}),
-      ...(params.typeOverlay === undefined ? {} : {typeOverlay: params.typeOverlay}),
-    });
-    if (template === undefined) continue;
-
-    templates[key] = template;
-  }
-
-  const normalized = {
-    ...(params.checkout.project === undefined ? {} : {project: params.checkout.project}),
-    ...(params.checkout.connection === undefined ? {} : {connection: params.checkout.connection}),
-    ...(params.checkout.repository === undefined ? {} : {repository: params.checkout.repository}),
-    ...(params.checkout.ref === undefined ? {} : {ref: params.checkout.ref}),
+  const normalized: {-readonly [Key in keyof WorkflowModelCheckout]: WorkflowModelCheckout[Key]} = {
     fetchDepth: params.checkout['fetch-depth'] ?? DEFAULT_CHECKOUT_FETCH_DEPTH,
-    ...(params.checkout.path === undefined ? {} : {path: params.checkout.path}),
     permissions: {
       contents: params.checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
     },
     persistCredentials:
       params.checkout['persist-credentials'] ?? DEFAULT_JOB_CHECKOUT.persistCredentials,
-    ...(params.checkout.force === undefined ? {} : {force: params.checkout.force}),
-    ...(Object.keys(templates).length === 0 ? {} : {templates}),
-  } satisfies WorkflowModelCheckout;
+  };
+  if (params.checkout.project !== undefined) normalized.project = params.checkout.project;
+  if (params.checkout.connection !== undefined) normalized.connection = params.checkout.connection;
+  if (params.checkout.repository !== undefined) normalized.repository = params.checkout.repository;
+  if (params.checkout.ref !== undefined) normalized.ref = params.checkout.ref;
+  if (params.checkout.path !== undefined) normalized.path = params.checkout.path;
+  if (params.checkout.force !== undefined) normalized.force = params.checkout.force;
+  const templates = normalizeCheckoutTemplates(params);
+  if (templates !== undefined) normalized.templates = templates;
 
   return normalized;
 }
@@ -95,12 +95,12 @@ function validateCheckoutTargetShape(params: {
   path: readonly WorkflowModelValidationIssuePathSegment[];
 }): void {
   for (const validationIssue of checkoutTargetValidationIssues(params.checkout)) {
-    const message =
-      validationIssue.kind === 'project-with-connection'
-        ? 'Checkout target "connection" cannot be combined with "project".'
-        : validationIssue.kind === 'project-with-repository'
-          ? 'Checkout target "repository" cannot be combined with "project".'
-          : 'Checkout target "connection" requires "repository".';
+    let message = 'Checkout target "connection" requires "repository".';
+    if (validationIssue.kind === 'project-with-connection') {
+      message = 'Checkout target "connection" cannot be combined with "project".';
+    } else if (validationIssue.kind === 'project-with-repository') {
+      message = 'Checkout target "repository" cannot be combined with "project".';
+    }
     params.issues.push(
       issue({
         code: 'checkout-target-invalid',

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-listening.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-listening.ts
@@ -8,6 +8,49 @@ import {parseDurationMs} from './parse-duration-ms.js';
 import {validatePredicateExpression} from './validate-predicate-expression.js';
 import {issue} from './validation-issue.js';
 
+type ListeningConfig = NonNullable<WorkflowDocumentJob['listening']>;
+type ListeningMatcher = WorkflowModelJobListening['on'][number];
+
+function normalizeListeningMatchers(
+  triggers: ListeningConfig['on'] | ListeningConfig['until'] | undefined,
+  field: 'listener.on' | 'listener.until',
+  path: readonly (string | number)[],
+  params: Parameters<typeof normalizeJobListening>[0],
+): ListeningMatcher[] | undefined {
+  if (triggers === undefined) return undefined;
+  return triggers
+    .map((trigger, index) =>
+      normalizeListeningTrigger({
+        trigger,
+        field,
+        path: [...path, index],
+        issues: params.issues,
+        allowedJobReferences: params.allowedJobReferences,
+        integrationValidationContext: params.integrationValidationContext,
+      }),
+    )
+    .filter((matcher): matcher is ListeningMatcher => matcher !== undefined);
+}
+
+function normalizeListeningBatch(
+  listening: ListeningConfig,
+  debounceMs: number | undefined,
+  maxWaitMs: number | undefined,
+): WorkflowModelJobListening['batch'] | undefined {
+  if (
+    debounceMs === undefined &&
+    listening.batch?.max_size === undefined &&
+    maxWaitMs === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    ...(debounceMs === undefined ? {} : {debounceMs}),
+    ...(listening.batch?.max_size === undefined ? {} : {maxSize: listening.batch.max_size}),
+    ...(maxWaitMs === undefined ? {} : {maxWaitMs}),
+  };
+}
+
 export function normalizeJobListening(params: {
   job: WorkflowDocumentJob;
   sourceName: string;
@@ -41,18 +84,9 @@ export function normalizeJobListening(params: {
     issues: params.issues,
   });
 
-  const on = listening.on
-    .map((trigger, index) =>
-      normalizeListeningTrigger({
-        trigger,
-        field: 'listener.on',
-        path: [...path, 'listening', 'on', index],
-        issues: params.issues,
-        allowedJobReferences: params.allowedJobReferences,
-        integrationValidationContext: params.integrationValidationContext,
-      }),
-    )
-    .filter((matcher): matcher is WorkflowModelJobListening['on'][number] => matcher !== undefined);
+  const on =
+    normalizeListeningMatchers(listening.on, 'listener.on', [...path, 'listening', 'on'], params) ??
+    [];
 
   if (on.length === 0) {
     params.issues.push(
@@ -64,23 +98,12 @@ export function normalizeJobListening(params: {
     );
   }
 
-  const until =
-    listening.until === undefined
-      ? undefined
-      : listening.until
-          .map((trigger, index) =>
-            normalizeListeningTrigger({
-              trigger,
-              field: 'listener.until',
-              path: [...path, 'listening', 'until', index],
-              issues: params.issues,
-              allowedJobReferences: params.allowedJobReferences,
-              integrationValidationContext: params.integrationValidationContext,
-            }),
-          )
-          .filter(
-            (matcher): matcher is WorkflowModelJobListening['on'][number] => matcher !== undefined,
-          );
+  const until = normalizeListeningMatchers(
+    listening.until,
+    'listener.until',
+    [...path, 'listening', 'until'],
+    params,
+  );
 
   // Inert `until` matchers do not resolve the listening job; the check runs on
   // the matchers that stay active.
@@ -98,14 +121,7 @@ export function normalizeJobListening(params: {
     );
   }
 
-  const batch =
-    debounceMs === undefined && listening.batch?.max_size === undefined && maxWaitMs === undefined
-      ? undefined
-      : {
-          ...(debounceMs === undefined ? {} : {debounceMs}),
-          ...(listening.batch?.max_size === undefined ? {} : {maxSize: listening.batch.max_size}),
-          ...(maxWaitMs === undefined ? {} : {maxWaitMs}),
-        };
+  const batch = normalizeListeningBatch(listening, debounceMs, maxWaitMs);
 
   return {
     on,

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -68,6 +68,65 @@ export interface NormalizeContext {
   readonly integrationValidationContext?: IntegrationValidationContext | undefined;
 }
 
+interface NormalizeJobsState {
+  pending: Set<string>;
+  modelsBySourceName: Map<string, WorkflowModelJob>;
+  jobOutputTypesBySourceName: Map<string, Readonly<Record<string, ExpressionType>>>;
+  issuesBySourceName: Map<string, WorkflowModelValidationIssue[]>;
+}
+
+interface NormalizeJobsSharedParams {
+  document: WorkflowDocument;
+  jobIdBySourceName: ReadonlyMap<string, string>;
+  stepSourceLocations: WorkflowStepSourceLocationMap | undefined;
+  context: NormalizeContext;
+}
+
+function normalizeAndStoreJob(
+  sourceName: string,
+  job: WorkflowDocumentJob,
+  shared: NormalizeJobsSharedParams,
+  state: NormalizeJobsState,
+): void {
+  const model = normalizeJob({
+    ...shared,
+    sourceName,
+    job,
+    issues: issuesForSourceName(state.issuesBySourceName, sourceName),
+    jobOutputTypesBySourceName: state.jobOutputTypesBySourceName,
+  });
+  if (model !== undefined) state.modelsBySourceName.set(sourceName, model);
+}
+
+function normalizeReadyJobs(
+  entries: ReadonlyArray<readonly [string, WorkflowDocumentJob]>,
+  shared: NormalizeJobsSharedParams,
+  state: NormalizeJobsState,
+): boolean {
+  let progressed = false;
+  for (const [sourceName, job] of entries) {
+    if (!state.pending.has(sourceName)) continue;
+    const dependencies = normalizeNeeds(job.needs).filter((dependency) =>
+      shared.jobIdBySourceName.has(dependency),
+    );
+    if (dependencies.some((dependency) => state.pending.has(dependency))) continue;
+    normalizeAndStoreJob(sourceName, job, shared, state);
+    state.pending.delete(sourceName);
+    progressed = true;
+  }
+  return progressed;
+}
+
+function normalizeRemainingJobs(
+  shared: NormalizeJobsSharedParams,
+  state: NormalizeJobsState,
+): void {
+  for (const sourceName of state.pending) {
+    const job = shared.document.jobs[sourceName];
+    if (job !== undefined) normalizeAndStoreJob(sourceName, job, shared, state);
+  }
+}
+
 export function normalizeJobs(
   document: WorkflowDocument,
   jobIdBySourceName: ReadonlyMap<string, string>,
@@ -76,65 +135,28 @@ export function normalizeJobs(
   context: NormalizeContext,
 ): readonly WorkflowModelJob[] {
   const entries = Object.entries(document.jobs);
-  const pending = new Set(entries.map(([sourceName]) => sourceName));
-  const modelsBySourceName = new Map<string, WorkflowModelJob>();
-  const jobOutputTypesBySourceName = new Map<string, Readonly<Record<string, ExpressionType>>>();
-  const issuesBySourceName = new Map<string, WorkflowModelValidationIssue[]>();
+  const state: NormalizeJobsState = {
+    pending: new Set(entries.map(([sourceName]) => sourceName)),
+    modelsBySourceName: new Map(),
+    jobOutputTypesBySourceName: new Map(),
+    issuesBySourceName: new Map(),
+  };
+  const shared = {document, jobIdBySourceName, stepSourceLocations, context};
 
-  while (pending.size > 0) {
-    let progressed = false;
-
-    for (const [sourceName, job] of entries) {
-      if (!pending.has(sourceName)) continue;
-
-      const dependencySourceNames = normalizeNeeds(job.needs).filter((dependency) =>
-        jobIdBySourceName.has(dependency),
-      );
-      if (dependencySourceNames.some((dependency) => pending.has(dependency))) continue;
-
-      const model = normalizeJob({
-        document,
-        sourceName,
-        job,
-        jobIdBySourceName,
-        issues: issuesForSourceName(issuesBySourceName, sourceName),
-        stepSourceLocations,
-        context,
-        jobOutputTypesBySourceName,
-      });
-      if (model !== undefined) modelsBySourceName.set(sourceName, model);
-      pending.delete(sourceName);
-      progressed = true;
-    }
-
-    if (progressed) continue;
-
-    for (const sourceName of pending) {
-      const job = document.jobs[sourceName];
-      if (job === undefined) continue;
-      const model = normalizeJob({
-        document,
-        sourceName,
-        job,
-        jobIdBySourceName,
-        issues: issuesForSourceName(issuesBySourceName, sourceName),
-        stepSourceLocations,
-        context,
-        jobOutputTypesBySourceName,
-      });
-      if (model !== undefined) modelsBySourceName.set(sourceName, model);
-    }
+  while (state.pending.size > 0) {
+    if (normalizeReadyJobs(entries, shared, state)) continue;
+    normalizeRemainingJobs(shared, state);
     break;
   }
 
   for (const [sourceName] of entries) {
-    issues.push(...(issuesBySourceName.get(sourceName) ?? []));
+    issues.push(...(state.issuesBySourceName.get(sourceName) ?? []));
   }
 
   validateAgentSessionSharing(document, issues, context.agentValidationCatalog.default_harness_id);
 
   return entries.flatMap(([sourceName]) => {
-    const model = modelsBySourceName.get(sourceName);
+    const model = state.modelsBySourceName.get(sourceName);
     return model === undefined ? [] : [model];
   });
 }
@@ -271,6 +293,35 @@ function normalizeJob(params: {
     allowedJobReferences,
     integrationValidationContext: params.context.integrationValidationContext,
   });
+  const {name, executionName} = normalizeJobNames(
+    params,
+    allowedJobReferences,
+    upstreamJobsTypeOverlay,
+  );
+
+  return buildNormalizedJob({
+    id,
+    checkout,
+    condition,
+    dependencies,
+    executionName,
+    executionTimeoutMs,
+    jobEnv,
+    key: params.sourceName,
+    listening,
+    name,
+    outputs,
+    runner,
+    success,
+    steps,
+  });
+}
+
+function normalizeJobNames(
+  params: Parameters<typeof normalizeJob>[0],
+  allowedJobReferences: ReadonlySet<string>,
+  typeOverlay: ExpressionTypeEnvironment | undefined,
+): {name: string | undefined; executionName: WorkflowFieldTemplate | undefined} {
   if (params.job.name !== undefined) {
     validateLiteralName({
       field: 'job.name',
@@ -282,37 +333,55 @@ function normalizeJob(params: {
     });
   }
   const name = params.job.name === undefined ? undefined : unescapeLiteralName(params.job.name);
-  const executionName =
-    params.job.execution_name === undefined
-      ? undefined
-      : (parseInterpolationField({
-          field: 'job.execution_name',
-          source: params.job.execution_name,
-          path: ['jobs', params.sourceName, 'execution_name'],
-          issues: params.issues,
-          fillSite: 'execution-creation',
-          allowedJobReferences,
-          typeOverlay: upstreamJobsTypeOverlay,
-        }) ?? [{kind: 'literal' as const, value: params.job.execution_name}]);
+  if (params.job.execution_name === undefined) return {name, executionName: undefined};
+  const executionName = parseInterpolationField({
+    field: 'job.execution_name',
+    source: params.job.execution_name,
+    path: ['jobs', params.sourceName, 'execution_name'],
+    issues: params.issues,
+    fillSite: 'execution-creation',
+    allowedJobReferences,
+    typeOverlay,
+  }) ?? [{kind: 'literal' as const, value: params.job.execution_name}];
+  return {name, executionName};
+}
 
+function buildNormalizedJob(params: {
+  id: string;
+  key: string;
+  runner: ReturnType<typeof normalizeRunner>;
+  checkout: ReturnType<typeof normalizeJobCheckout>;
+  condition: ReturnType<typeof normalizeIfCondition>;
+  success: ReturnType<typeof normalizeJobSuccess>;
+  outputs: ReturnType<typeof normalizeJobOutputs>;
+  executionTimeoutMs: number | undefined;
+  listening: ReturnType<typeof normalizeJobListening>;
+  name: string | undefined;
+  executionName: WorkflowFieldTemplate | undefined;
+  jobEnv: ReturnType<typeof normalizeEnv>;
+  dependencies: readonly string[];
+  steps: readonly WorkflowModelStep[];
+}): WorkflowModelJob {
   return {
-    id,
-    key: params.sourceName,
-    mode: listening === undefined ? 'one_shot' : 'listening',
-    runner: runner.labels,
-    ...(runner.templates.length === 0 ? {} : {runnerTemplates: runner.templates}),
-    checkout,
-    ...(condition === undefined ? {} : {if: condition}),
-    ...(success === undefined ? {} : {success}),
-    ...(outputs === undefined ? {} : {outputs: outputs.templates}),
-    ...(outputs?.types === undefined ? {} : {outputTypes: outputs.types}),
-    ...(executionTimeoutMs === undefined ? {} : {executionTimeoutMs}),
-    ...(listening === undefined ? {} : {listening}),
-    ...(name === undefined ? {} : {name}),
-    ...(executionName === undefined ? {} : {executionName}),
-    ...jobEnv,
-    dependencies,
-    steps,
+    id: params.id,
+    key: params.key,
+    mode: params.listening === undefined ? 'one_shot' : 'listening',
+    runner: params.runner.labels,
+    ...(params.runner.templates.length === 0 ? {} : {runnerTemplates: params.runner.templates}),
+    checkout: params.checkout,
+    ...(params.condition === undefined ? {} : {if: params.condition}),
+    ...(params.success === undefined ? {} : {success: params.success}),
+    ...(params.outputs === undefined ? {} : {outputs: params.outputs.templates}),
+    ...(params.outputs?.types === undefined ? {} : {outputTypes: params.outputs.types}),
+    ...(params.executionTimeoutMs === undefined
+      ? {}
+      : {executionTimeoutMs: params.executionTimeoutMs}),
+    ...(params.listening === undefined ? {} : {listening: params.listening}),
+    ...(params.name === undefined ? {} : {name: params.name}),
+    ...(params.executionName === undefined ? {} : {executionName: params.executionName}),
+    ...params.jobEnv,
+    dependencies: params.dependencies,
+    steps: params.steps,
   };
 }
 
@@ -486,6 +555,141 @@ function normalizeJobSteps(params: {
   });
 }
 
+type NormalizeStepParams = Parameters<typeof normalizeStep>[0];
+
+function registerStepId(params: NormalizeStepParams, stepId: string): void {
+  const existingIndex = params.usedStepIds.get(stepId);
+  if (existingIndex === undefined) {
+    params.usedStepIds.set(stepId, params.index);
+    return;
+  }
+  params.issues.push(
+    issue({
+      code: 'duplicate-step-id',
+      message: `Steps ${existingIndex} and ${params.index} in job "${params.sourceName}" resolve to the same stable id "${stepId}".`,
+      path: ['jobs', params.sourceName, 'steps', params.index],
+      details: {id: stepId, indexes: [existingIndex, params.index]},
+    }),
+  );
+}
+
+function previousStepTypeContext(params: NormalizeStepParams): {
+  shouldBuild: boolean;
+  overlays: readonly WorkflowStepTypeOverlay[];
+  environment: ExpressionTypeEnvironment | undefined;
+} {
+  const shouldBuild =
+    params.typeOverlay !== undefined ||
+    params.upstreamJobs.length > 0 ||
+    params.toolOverlayByKey.size > 0;
+  const overlays = previousStepOverlays(params.allSteps, params.index, params.toolOverlayByKey);
+  const environment = shouldBuild
+    ? buildTypedRootsEnvironment({
+        steps: overlays,
+        ...(params.upstreamJobs.length === 0 ? {} : {jobs: params.upstreamJobs}),
+      })
+    : undefined;
+  return {shouldBuild, overlays, environment};
+}
+
+function currentStepTypeContext(
+  params: NormalizeStepParams,
+  previous: ReturnType<typeof previousStepTypeContext>,
+  currentStep: WorkflowStepTypeOverlay | undefined,
+): {
+  typeOverlay: ExpressionTypeEnvironment | undefined;
+  conditionTypeOverlay: ExpressionTypeEnvironment;
+} {
+  const currentStepRoot = currentStep === undefined ? {} : {currentStep};
+  const typeOverlay = previous.shouldBuild
+    ? buildTypedRootsEnvironment({
+        steps: previous.overlays,
+        ...currentStepRoot,
+        ...(params.upstreamJobs.length === 0 ? {} : {jobs: params.upstreamJobs}),
+      })
+    : undefined;
+  const conditionTypeOverlay = buildTypedRootsEnvironment({
+    steps: previous.overlays,
+    ...currentStepRoot,
+    jobs: params.directNeedJobs,
+    needs: params.directNeedJobs,
+  });
+  return {typeOverlay, conditionTypeOverlay};
+}
+
+function normalizeStepWorkingDirectory(
+  params: NormalizeStepParams,
+  typeOverlay: ExpressionTypeEnvironment | undefined,
+): WorkflowFieldTemplate | undefined {
+  if (params.step.working_directory === undefined) return undefined;
+  return parseInterpolationField({
+    field: 'step.working_directory',
+    source: params.step.working_directory,
+    path: ['jobs', params.sourceName, 'steps', params.index, 'working_directory'],
+    issues: params.issues,
+    fillSite: params.fillSite,
+    allowedJobReferences: params.allowedJobReferences,
+    typeOverlay,
+  });
+}
+
+function normalizeConcreteStep(params: {
+  normalization: NormalizeStepParams;
+  stepId: string;
+  stepKey: string | undefined;
+  stepBase: WorkflowModelStepBaseFields;
+  outputs: ReturnType<typeof normalizeStepOutputs>;
+  condition: ReturnType<typeof normalizeIfCondition>;
+  gate: ReturnType<typeof normalizeStepGate>;
+  toolStepResult: ReturnType<typeof normalizeToolStep> | undefined;
+  name: WorkflowFieldTemplate | undefined;
+  workingDirectory: WorkflowFieldTemplate | undefined;
+  typeOverlay: ExpressionTypeEnvironment | undefined;
+}): WorkflowModelStep {
+  const source = params.normalization;
+  if (params.toolStepResult !== undefined) {
+    if (params.stepKey !== undefined) {
+      source.toolOverlayByKey.set(params.stepKey, params.toolStepResult.overlay);
+    }
+    return {
+      ...params.toolStepResult.step,
+      ...(params.condition === undefined ? {} : {if: params.condition}),
+      ...(params.gate === undefined ? {} : {gate: params.gate}),
+    };
+  }
+  const stepBaseWithOutputs = {
+    ...params.stepBase,
+    ...(params.outputs === undefined ? {} : {outputs: params.outputs}),
+    ...(params.condition === undefined ? {} : {if: params.condition}),
+    ...(params.gate === undefined ? {} : {gate: params.gate}),
+  };
+  const shared = {
+    step: source.step,
+    stepBase: stepBaseWithOutputs,
+    sourceName: source.sourceName,
+    stepIndex: source.index,
+    name: params.name,
+    workingDirectory: params.workingDirectory,
+    issues: source.issues,
+    fillSite: source.fillSite,
+    allowedJobReferences: source.allowedJobReferences,
+    typeOverlay: params.typeOverlay,
+  };
+  if (source.step.run !== undefined) {
+    return normalizeRunStep({
+      ...shared,
+      workflowEnvKeys: source.workflowEnvKeys,
+      jobEnvKeys: source.jobEnvKeys,
+    });
+  }
+  if (source.step.prompt !== undefined)
+    return normalizeAgentStep({...shared, context: source.context});
+  if (source.step.checkout !== undefined) return normalizeCheckoutStep(shared);
+  throw new Error(
+    `Workflow step "${params.stepId}" is neither a run, agent, tool, nor checkout step`,
+  );
+}
+
 function normalizeStep(params: {
   step: WorkflowDocumentStep;
   index: number;
@@ -510,39 +714,12 @@ function normalizeStep(params: {
     stepKey === undefined
       ? `${params.jobId}-step-${params.index + 1}`
       : `${params.jobId}-${stableId(stepKey)}`;
-  const existingIndex = params.usedStepIds.get(stepId);
-
-  if (existingIndex !== undefined) {
-    params.issues.push(
-      issue({
-        code: 'duplicate-step-id',
-        message: `Steps ${existingIndex} and ${params.index} in job "${params.sourceName}" resolve to the same stable id "${stepId}".`,
-        path: ['jobs', params.sourceName, 'steps', params.index],
-        details: {id: stepId, indexes: [existingIndex, params.index]},
-      }),
-    );
-  } else {
-    params.usedStepIds.set(stepId, params.index);
-  }
-
-  const shouldBuildTypeOverlay =
-    params.typeOverlay !== undefined ||
-    params.upstreamJobs.length > 0 ||
-    params.toolOverlayByKey.size > 0;
+  registerStepId(params, stepId);
   // Compute the previous-steps overlay list once and reuse it in every typed
   // environment for this step; the environments differ only in the extra
   // roots (current step, upstream jobs, direct needs).
-  const previousStepsTypeOverlays = previousStepOverlays(
-    params.allSteps,
-    params.index,
-    params.toolOverlayByKey,
-  );
-  const previousStepsOverlay = !shouldBuildTypeOverlay
-    ? undefined
-    : buildTypedRootsEnvironment({
-        steps: previousStepsTypeOverlays,
-        ...(params.upstreamJobs.length === 0 ? {} : {jobs: params.upstreamJobs}),
-      });
+  const previousContext = previousStepTypeContext(params);
+  const previousStepsOverlay = previousContext.environment;
   const sourceLocation = params.stepSourceLocations?.get(params.sourceName)?.get(params.index);
   const stepBase = {
     id: stepId,
@@ -579,28 +756,20 @@ function normalizeStep(params: {
           issues: params.issues,
         })
       : undefined;
-  const currentStepOverlay =
-    stepKey === undefined
-      ? undefined
-      : toolStepResult !== undefined
-        ? toolStepResult.overlay
-        : ({
-            key: stepKey,
-            ...(outputs === undefined ? {} : {outputs}),
-          } satisfies WorkflowStepTypeOverlay);
-  const typeOverlay = !shouldBuildTypeOverlay
-    ? undefined
-    : buildTypedRootsEnvironment({
-        steps: previousStepsTypeOverlays,
-        ...(currentStepOverlay === undefined ? {} : {currentStep: currentStepOverlay}),
-        ...(params.upstreamJobs.length === 0 ? {} : {jobs: params.upstreamJobs}),
-      });
-  const conditionTypeOverlay = buildTypedRootsEnvironment({
-    steps: previousStepsTypeOverlays,
-    ...(currentStepOverlay === undefined ? {} : {currentStep: currentStepOverlay}),
-    jobs: params.directNeedJobs,
-    needs: params.directNeedJobs,
-  });
+  let currentStepOverlay: WorkflowStepTypeOverlay | undefined;
+  if (stepKey !== undefined) {
+    currentStepOverlay =
+      toolStepResult?.overlay ??
+      ({
+        key: stepKey,
+        ...(outputs === undefined ? {} : {outputs}),
+      } satisfies WorkflowStepTypeOverlay);
+  }
+  const {typeOverlay, conditionTypeOverlay} = currentStepTypeContext(
+    params,
+    previousContext,
+    currentStepOverlay,
+  );
 
   const condition = normalizeIfCondition({
     field: 'step.if',
@@ -631,83 +800,19 @@ function normalizeStep(params: {
     toolStepResult === undefined
       ? normalizeStepName({...params, typeOverlay})
       : (toolStepResult.step.templates?.name ?? undefined);
-  const workingDirectory =
-    params.step.working_directory === undefined
-      ? undefined
-      : parseInterpolationField({
-          field: 'step.working_directory',
-          source: params.step.working_directory,
-          path: ['jobs', params.sourceName, 'steps', params.index, 'working_directory'],
-          issues: params.issues,
-          fillSite: params.fillSite,
-          allowedJobReferences: params.allowedJobReferences,
-          typeOverlay,
-        });
-  const stepBaseWithOutputs = {
-    ...stepBase,
-    ...(outputs === undefined ? {} : {outputs}),
-    ...(condition === undefined ? {} : {if: condition}),
-    ...(gate === undefined ? {} : {gate}),
-  };
-
-  if (toolStepResult !== undefined) {
-    if (stepKey !== undefined) params.toolOverlayByKey.set(stepKey, toolStepResult.overlay);
-    return {
-      ...toolStepResult.step,
-      ...(condition === undefined ? {} : {if: condition}),
-      ...(gate === undefined ? {} : {gate}),
-    };
-  }
-
-  if (params.step.run !== undefined) {
-    return normalizeRunStep({
-      step: params.step,
-      stepBase: stepBaseWithOutputs,
-      sourceName: params.sourceName,
-      stepIndex: params.index,
-      workflowEnvKeys: params.workflowEnvKeys,
-      jobEnvKeys: params.jobEnvKeys,
-      name,
-      workingDirectory,
-      issues: params.issues,
-      fillSite: params.fillSite,
-      allowedJobReferences: params.allowedJobReferences,
-      typeOverlay,
-    });
-  }
-
-  if (params.step.prompt !== undefined) {
-    return normalizeAgentStep({
-      step: params.step,
-      stepBase: stepBaseWithOutputs,
-      sourceName: params.sourceName,
-      stepIndex: params.index,
-      name,
-      workingDirectory,
-      issues: params.issues,
-      fillSite: params.fillSite,
-      allowedJobReferences: params.allowedJobReferences,
-      typeOverlay,
-      context: params.context,
-    });
-  }
-
-  if (params.step.checkout !== undefined) {
-    return normalizeCheckoutStep({
-      step: params.step,
-      stepBase: stepBaseWithOutputs,
-      name,
-      sourceName: params.sourceName,
-      stepIndex: params.index,
-      issues: params.issues,
-      fillSite: params.fillSite,
-      allowedJobReferences: params.allowedJobReferences,
-      typeOverlay,
-    });
-  }
-
-  // Keep the model-step union honest if callers bypass the document parser.
-  throw new Error(`Workflow step "${stepId}" is neither a run, agent, tool, nor checkout step`);
+  return normalizeConcreteStep({
+    normalization: params,
+    stepId,
+    stepKey,
+    stepBase,
+    outputs,
+    condition,
+    gate,
+    toolStepResult,
+    name,
+    workingDirectory: normalizeStepWorkingDirectory(params, typeOverlay),
+    typeOverlay,
+  });
 }
 
 function normalizeStepName(params: {
@@ -1126,6 +1231,175 @@ const RUN_GLOBAL_SESSION_KEY_CONTEXT_ROOTS = new Set<string>([
   'secrets',
 ]);
 
+function collectSessionSharingSteps(
+  document: WorkflowDocument,
+  defaultHarnessId: string,
+): SessionSharingStep[] {
+  const steps: SessionSharingStep[] = [];
+  for (const [jobName, job] of Object.entries(document.jobs)) {
+    job.steps.forEach((step, stepIndex) => {
+      if (step.session === undefined) return;
+      steps.push({
+        jobName,
+        stepIndex,
+        stepKey: step.key,
+        keySource: typeof step.session === 'string' ? step.session : step.session.key,
+        mode: typeof step.session === 'string' ? 'resume' : (step.session.mode ?? 'resume'),
+        harness: step.harness ?? defaultHarnessId,
+      });
+    });
+  }
+  return steps;
+}
+
+function sessionFieldIssueStepKeys(issues: readonly WorkflowModelValidationIssue[]): Set<string> {
+  const keys = new Set<string>();
+  for (const entry of issues) {
+    const path = entry.path;
+    if (path.length >= 5 && path[0] === 'jobs' && path[2] === 'steps' && path[4] === 'session') {
+      keys.add(`${path[1]}\u0000${path[3]}`);
+    }
+  }
+  return keys;
+}
+
+function isRunGlobalSessionKey(keySource: string, cache: Map<string, boolean>): boolean {
+  const cached = cache.get(keySource);
+  if (cached !== undefined) return cached;
+  const runGlobalOnly = referencesRunGlobalOnlySessionKey(keySource);
+  cache.set(keySource, runGlobalOnly);
+  return runGlobalOnly;
+}
+
+function groupSessionSharingSteps(
+  steps: readonly SessionSharingStep[],
+  invalidSteps: ReadonlySet<string>,
+): Map<string, SessionSharingStep[]> {
+  const groups = new Map<string, SessionSharingStep[]>();
+  const runGlobalOnlyByKeySource = new Map<string, boolean>();
+  for (const step of steps) {
+    if (invalidSteps.has(sessionStepPathKey(step))) continue;
+    if (!isRunGlobalSessionKey(step.keySource, runGlobalOnlyByKeySource)) continue;
+    const group = groups.get(step.keySource) ?? [];
+    if (group.length === 0) groups.set(step.keySource, group);
+    group.push(step);
+  }
+  return groups;
+}
+
+interface SessionSharingValidationState {
+  ancestorsByJobName: Map<string, ReadonlySet<string>>;
+  parallelResumeReportedKeys: Set<string>;
+  harnessMismatchReportedKeys: Set<string>;
+  evaluatedPairs: number;
+}
+
+function reportParallelResumeConflict(
+  document: WorkflowDocument,
+  keySource: string,
+  prior: SessionSharingStep,
+  later: SessionSharingStep,
+  issues: WorkflowModelValidationIssue[],
+  state: SessionSharingValidationState,
+): void {
+  if (prior.jobName === later.jobName || prior.mode !== 'resume' || later.mode !== 'resume') return;
+  if (state.parallelResumeReportedKeys.has(keySource)) return;
+  const priorAncestors = transitiveNeedsAncestors(
+    document,
+    prior.jobName,
+    state.ancestorsByJobName,
+  );
+  const laterAncestors = transitiveNeedsAncestors(
+    document,
+    later.jobName,
+    state.ancestorsByJobName,
+  );
+  if (priorAncestors.has(later.jobName) || laterAncestors.has(prior.jobName)) return;
+  state.parallelResumeReportedKeys.add(keySource);
+  issues.push(
+    issue({
+      code: 'agent-session-parallel-resume',
+      message: `Agent steps ${sessionSharingStepLabel(prior)} (job "${prior.jobName}") and ${sessionSharingStepLabel(later)} (job "${later.jobName}") both resume session key "${keySource}", but their jobs have no transitive "needs" ancestry, so they can run in parallel and would conflict on the session. Add a "needs" edge between the jobs, fork the session on one step, or use distinct session keys.`,
+      path: ['jobs', later.jobName, 'steps', later.stepIndex, 'session'],
+      details: {
+        key: keySource,
+        jobs: [prior.jobName, later.jobName],
+        stepIndexes: [prior.stepIndex, later.stepIndex],
+      },
+    }),
+  );
+}
+
+function reportHarnessMismatch(
+  keySource: string,
+  prior: SessionSharingStep,
+  later: SessionSharingStep,
+  issues: WorkflowModelValidationIssue[],
+  state: SessionSharingValidationState,
+): void {
+  if (prior.harness === later.harness || state.harnessMismatchReportedKeys.has(keySource)) return;
+  state.harnessMismatchReportedKeys.add(keySource);
+  issues.push(
+    issue({
+      code: 'agent-session-harness-mismatch',
+      message: `Agent steps ${sessionSharingStepLabel(prior)} (job "${prior.jobName}") and ${sessionSharingStepLabel(later)} (job "${later.jobName}") share session key "${keySource}" but resolve to different harnesses: "${prior.harness}" and "${later.harness}". A session is pinned to the harness that created it. Ensure every step that shares the session key resolves to the same harness.`,
+      path: ['jobs', later.jobName, 'steps', later.stepIndex, 'session'],
+      details: {
+        key: keySource,
+        jobs: [prior.jobName, later.jobName],
+        stepIndexes: [prior.stepIndex, later.stepIndex],
+        harnesses: [prior.harness, later.harness],
+      },
+    }),
+  );
+}
+
+function evaluatePriorSessionPairs(
+  document: WorkflowDocument,
+  keySource: string,
+  group: readonly SessionSharingStep[],
+  index: number,
+  issues: WorkflowModelValidationIssue[],
+  state: SessionSharingValidationState,
+): boolean {
+  const later = group[index];
+  if (later === undefined) return true;
+  for (let priorIndex = 0; priorIndex < index; priorIndex += 1) {
+    if (state.evaluatedPairs >= MAX_SESSION_SHARING_PAIR_EVALUATIONS) return false;
+    state.evaluatedPairs += 1;
+    const prior = group[priorIndex];
+    if (prior === undefined) continue;
+    reportParallelResumeConflict(document, keySource, prior, later, issues, state);
+    reportHarnessMismatch(keySource, prior, later, issues, state);
+  }
+  return true;
+}
+
+function validateSessionSharingGroups(
+  document: WorkflowDocument,
+  groups: ReadonlyMap<string, readonly SessionSharingStep[]>,
+  issues: WorkflowModelValidationIssue[],
+): void {
+  const state: SessionSharingValidationState = {
+    ancestorsByJobName: new Map(),
+    parallelResumeReportedKeys: new Set(),
+    harnessMismatchReportedKeys: new Set(),
+    evaluatedPairs: 0,
+  };
+  for (const [keySource, sharingSteps] of groups) {
+    const group = selectSessionSharingWindow(sharingSteps);
+    for (let index = 1; index < group.length; index += 1) {
+      if (
+        state.parallelResumeReportedKeys.has(keySource) &&
+        state.harnessMismatchReportedKeys.has(keySource)
+      ) {
+        break;
+      }
+      if (!evaluatePriorSessionPairs(document, keySource, group, index, issues, state)) return;
+    }
+  }
+}
+
 // Cross-job authoring checks for shared agent sessions: two resume-mode steps
 // with statically identical session key templates from jobs without a
 // transitive needs ancestry would claim the same session in parallel, and
@@ -1150,44 +1424,13 @@ function validateAgentSessionSharing(
   issues: WorkflowModelValidationIssue[],
   defaultHarnessId: string,
 ): void {
-  const steps: SessionSharingStep[] = [];
-  for (const [jobName, job] of Object.entries(document.jobs)) {
-    job.steps.forEach((step, stepIndex) => {
-      if (step.session === undefined) return;
-      steps.push({
-        jobName,
-        stepIndex,
-        stepKey: step.key,
-        keySource: typeof step.session === 'string' ? step.session : step.session.key,
-        mode: typeof step.session === 'string' ? 'resume' : (step.session.mode ?? 'resume'),
-        harness: step.harness ?? defaultHarnessId,
-      });
-    });
-  }
+  const steps = collectSessionSharingSteps(document, defaultHarnessId);
 
   // Steps whose session field already produced an issue in the per-step pass
   // can never name a session; stacking sharing issues on them would double-
   // report a broken key. This mirrors the per-step suppression of
   // invalid-agent-session-key when any other session issue was raised.
-  const sessionFieldIssueSteps = new Set<string>();
-  for (const entry of issues) {
-    const path = entry.path;
-    if (path.length >= 5 && path[0] === 'jobs' && path[2] === 'steps' && path[4] === 'session') {
-      sessionFieldIssueSteps.add(`${path[1]}\u0000${path[3]}`);
-    }
-  }
-
-  // referencesRunGlobalOnlySessionKey is a pure function of the template text;
-  // memoize it per keySource so a key shared by many steps is parsed once
-  // instead of once per pair.
-  const runGlobalOnlyByKeySource = new Map<string, boolean>();
-  const isRunGlobalOnlyKeySource = (keySource: string): boolean => {
-    const cached = runGlobalOnlyByKeySource.get(keySource);
-    if (cached !== undefined) return cached;
-    const runGlobalOnly = referencesRunGlobalOnlySessionKey(keySource);
-    runGlobalOnlyByKeySource.set(keySource, runGlobalOnly);
-    return runGlobalOnly;
-  };
+  const sessionFieldIssueSteps = sessionFieldIssueStepKeys(issues);
 
   // Group eligible steps by keySource so pairs are only ever evaluated inside
   // one key group: the pair budget then counts relevant work only and cannot
@@ -1199,96 +1442,8 @@ function validateAgentSessionSharing(
   // job -- or a fork step hiding its job's resume step -- cannot hide another
   // job's sharing step behind the window. Keys that reference per-job context
   // resolve per job and stay out.
-  const stepsByKeySource = new Map<string, SessionSharingStep[]>();
-  for (const step of steps) {
-    if (sessionFieldIssueSteps.has(sessionStepPathKey(step))) continue;
-    if (!isRunGlobalOnlyKeySource(step.keySource)) continue;
-    let group = stepsByKeySource.get(step.keySource);
-    if (group === undefined) {
-      group = [];
-      stepsByKeySource.set(step.keySource, group);
-    }
-    group.push(step);
-  }
-
-  const ancestorsByJobName = new Map<string, ReadonlySet<string>>();
-  const parallelResumeReportedKeys = new Set<string>();
-  const harnessMismatchReportedKeys = new Set<string>();
-  let evaluatedPairs = 0;
-
-  for (const [keySource, sharingSteps] of stepsByKeySource) {
-    const group = selectSessionSharingWindow(sharingSteps);
-    for (let index = 1; index < group.length; index += 1) {
-      // At most one issue per key per code; nothing left to report for keys
-      // that already produced both.
-      if (parallelResumeReportedKeys.has(keySource) && harnessMismatchReportedKeys.has(keySource)) {
-        break;
-      }
-      const later = group[index];
-      if (later === undefined) continue;
-
-      for (let priorIndex = 0; priorIndex < index; priorIndex += 1) {
-        if (evaluatedPairs >= MAX_SESSION_SHARING_PAIR_EVALUATIONS) return;
-        evaluatedPairs += 1;
-
-        const prior = group[priorIndex];
-        if (prior === undefined) continue;
-
-        // Serial steps within one job never claim concurrently, so the parallel
-        // resume check only spans jobs. Harness agreement is checked for every
-        // sharing pair, including same-job pairs, because a session is pinned
-        // to the harness that created it.
-        if (prior.jobName !== later.jobName && prior.mode === 'resume' && later.mode === 'resume') {
-          const priorAncestors = transitiveNeedsAncestors(
-            document,
-            prior.jobName,
-            ancestorsByJobName,
-          );
-          const laterAncestors = transitiveNeedsAncestors(
-            document,
-            later.jobName,
-            ancestorsByJobName,
-          );
-          if (
-            !priorAncestors.has(later.jobName) &&
-            !laterAncestors.has(prior.jobName) &&
-            !parallelResumeReportedKeys.has(keySource)
-          ) {
-            parallelResumeReportedKeys.add(keySource);
-            issues.push(
-              issue({
-                code: 'agent-session-parallel-resume',
-                message: `Agent steps ${sessionSharingStepLabel(prior)} (job "${prior.jobName}") and ${sessionSharingStepLabel(later)} (job "${later.jobName}") both resume session key "${keySource}", but their jobs have no transitive "needs" ancestry, so they can run in parallel and would conflict on the session. Add a "needs" edge between the jobs, fork the session on one step, or use distinct session keys.`,
-                path: ['jobs', later.jobName, 'steps', later.stepIndex, 'session'],
-                details: {
-                  key: keySource,
-                  jobs: [prior.jobName, later.jobName],
-                  stepIndexes: [prior.stepIndex, later.stepIndex],
-                },
-              }),
-            );
-          }
-        }
-
-        if (prior.harness !== later.harness && !harnessMismatchReportedKeys.has(keySource)) {
-          harnessMismatchReportedKeys.add(keySource);
-          issues.push(
-            issue({
-              code: 'agent-session-harness-mismatch',
-              message: `Agent steps ${sessionSharingStepLabel(prior)} (job "${prior.jobName}") and ${sessionSharingStepLabel(later)} (job "${later.jobName}") share session key "${keySource}" but resolve to different harnesses: "${prior.harness}" and "${later.harness}". A session is pinned to the harness that created it. Ensure every step that shares the session key resolves to the same harness.`,
-              path: ['jobs', later.jobName, 'steps', later.stepIndex, 'session'],
-              details: {
-                key: keySource,
-                jobs: [prior.jobName, later.jobName],
-                stepIndexes: [prior.stepIndex, later.stepIndex],
-                harnesses: [prior.harness, later.harness],
-              },
-            }),
-          );
-        }
-      }
-    }
-  }
+  const stepsByKeySource = groupSessionSharingSteps(steps, sessionFieldIssueSteps);
+  validateSessionSharingGroups(document, stepsByKeySource, issues);
 }
 
 function sessionStepPathKey(step: SessionSharingStep): string {
@@ -1405,52 +1560,66 @@ function validateAgentStep(params: {
       ? undefined
       : params.agentValidationCatalog.providers.find((entry) => entry.id === providerId);
 
-  if (params.validateLiteralProvider && providerId !== undefined) {
-    if (provider === undefined) {
-      if (harness === undefined || harness === 'pi') return;
-      params.issues.push(
-        issue({
-          code: 'invalid-provider',
-          message: `Provider "${providerId}" is not supported.`,
-          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
-          details: {provider: providerId},
-        }),
-      );
-      return;
-    }
+  if (!validateAgentProvider(params, providerId, harness, provider)) return;
+  validateAgentModel(params, providerId, harness, provider);
+}
 
-    if (provider.support_status !== 'supported') {
-      params.issues.push(
-        issue({
-          code: 'invalid-provider',
-          message: `Provider "${providerId}" is not supported.`,
-          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
-          details: {provider: providerId},
-        }),
-      );
-      return;
-    }
+type ValidateAgentStepParams = Parameters<typeof validateAgentStep>[0];
+type AgentCatalogProvider = AgentValidationCatalogV2['providers'][number];
 
-    const descriptor = params.agentValidationCatalog.harnesses.find(
-      (entry) => entry.id === harness,
+function validateAgentProvider(
+  params: ValidateAgentStepParams,
+  providerId: string | undefined,
+  harness: string | undefined,
+  provider: AgentCatalogProvider | undefined,
+): boolean {
+  if (!params.validateLiteralProvider || providerId === undefined) return true;
+  if (provider === undefined) {
+    if (harness === undefined || harness === 'pi') return false;
+    params.issues.push(
+      issue({
+        code: 'invalid-provider',
+        message: `Provider "${providerId}" is not supported.`,
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+        details: {provider: providerId},
+      }),
     );
-    if (!descriptor?.supported_provider_ids.includes(providerId)) {
-      params.issues.push(
-        issue({
-          code: 'harness-provider-incompatible',
-          message: `Harness "${harness}" does not support provider: ${providerId}. Supported providers: ${descriptor?.supported_provider_ids.join(', ') ?? ''}.`,
-          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
-          details: {
-            harness,
-            provider: providerId,
-            supportedProviders: descriptor?.supported_provider_ids ?? [],
-          },
-        }),
-      );
-      return;
-    }
+    return false;
   }
+  if (provider.support_status !== 'supported') {
+    params.issues.push(
+      issue({
+        code: 'invalid-provider',
+        message: `Provider "${providerId}" is not supported.`,
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+        details: {provider: providerId},
+      }),
+    );
+    return false;
+  }
+  const descriptor = params.agentValidationCatalog.harnesses.find((entry) => entry.id === harness);
+  if (descriptor?.supported_provider_ids.includes(providerId)) return true;
+  params.issues.push(
+    issue({
+      code: 'harness-provider-incompatible',
+      message: `Harness "${harness}" does not support provider: ${providerId}. Supported providers: ${descriptor?.supported_provider_ids.join(', ') ?? ''}.`,
+      path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+      details: {
+        harness,
+        provider: providerId,
+        supportedProviders: descriptor?.supported_provider_ids ?? [],
+      },
+    }),
+  );
+  return false;
+}
 
+function validateAgentModel(
+  params: ValidateAgentStepParams,
+  providerId: string | undefined,
+  harness: string | undefined,
+  provider: AgentCatalogProvider | undefined,
+): void {
   if (!params.validateLiteralModel || providerId === undefined) return;
   if (provider === undefined || provider.support_status !== 'supported') return;
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-tool-step.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-tool-step.ts
@@ -43,6 +43,51 @@ export interface NormalizedToolStep {
   readonly overlay: WorkflowStepTypeOverlay;
 }
 
+type NormalizeToolStepParams = Parameters<typeof normalizeToolStep>[0];
+type ParsedToolId = {readonly id: string; readonly method?: string};
+
+function validateToolConnection(params: NormalizeToolStepParams): boolean {
+  const interpolated =
+    params.step.connection !== undefined && isInterpolated(params.step.connection);
+  if (!interpolated) return false;
+  params.issues.push(
+    issue({
+      code: 'tool-id-invalid',
+      message: `Connection slug "${params.step.connection}" must be literal. Interpolation is rejected.`,
+      path: toolConnectionPath(params),
+      details: {connection: params.step.connection},
+    }),
+  );
+  return true;
+}
+
+function resolveToolCatalogEntry(
+  params: NormalizeToolStepParams,
+  tool: ParsedToolId | undefined,
+  connectionIsInterpolated: boolean,
+): ToolCatalogEntry | undefined {
+  if (tool === undefined || connectionIsInterpolated) return undefined;
+  return validateConnectionAndTool({...params, tool});
+}
+
+function validateResolvedTool(
+  params: NormalizeToolStepParams,
+  tool: ParsedToolId | undefined,
+  catalogEntry: ToolCatalogEntry | undefined,
+): void {
+  if (catalogEntry !== undefined && tool !== undefined) {
+    validateToolInputs({
+      ...params,
+      tool,
+      withValue: params.step.with,
+      schema: catalogEntry.inputSchema,
+    });
+  }
+  if (tool?.method !== undefined && params.step.with !== undefined) {
+    rejectWithMethod({...params, tool, withValue: params.step.with});
+  }
+}
+
 export function normalizeToolStep(params: {
   step: WorkflowDocumentStep;
   stepBase: WorkflowModelStepBaseFields;
@@ -66,25 +111,8 @@ export function normalizeToolStep(params: {
     stepIndex: params.stepIndex,
     issues: params.issues,
   });
-  const connectionIsInterpolated =
-    params.step.connection !== undefined && isInterpolated(params.step.connection);
-  if (connectionIsInterpolated) {
-    params.issues.push(
-      issue({
-        code: 'tool-id-invalid',
-        message: `Connection slug "${params.step.connection}" must be literal. Interpolation is rejected.`,
-        path: toolConnectionPath(params),
-        details: {connection: params.step.connection},
-      }),
-    );
-  }
-  const catalogEntry =
-    tool === undefined || connectionIsInterpolated
-      ? undefined
-      : validateConnectionAndTool({
-          ...params,
-          tool,
-        });
+  const connectionIsInterpolated = validateToolConnection(params);
+  const catalogEntry = resolveToolCatalogEntry(params, tool, connectionIsInterpolated);
   const outputSchema = catalogEntry?.outputSchema;
 
   const withTemplates = normalizeWithTemplates({
@@ -97,50 +125,64 @@ export function normalizeToolStep(params: {
     resultTypeOverlay:
       outputSchema === undefined ? undefined : {result: jsonSchemaToExpressionType(outputSchema)},
   });
-  if (catalogEntry !== undefined && tool !== undefined) {
-    validateToolInputs({
-      ...params,
-      tool,
-      withValue: params.step.with,
-      schema: catalogEntry.inputSchema,
-    });
-  }
-  if (tool !== undefined && tool.method !== undefined && params.step.with !== undefined) {
-    rejectWithMethod({...params, tool, withValue: params.step.with});
-  }
+  validateResolvedTool(params, tool, catalogEntry);
 
-  const step: WorkflowModelToolStep = {
-    ...params.stepBase,
+  const step = createNormalizedToolModelStep({
+    params,
+    tool,
+    withTemplates,
+    outputMappings,
+  });
+
+  return {
+    step,
+    overlay: createToolStepOverlay(params, step, outputMappings, outputSchema),
+  };
+}
+
+function createNormalizedToolModelStep(params: {
+  params: NormalizeToolStepParams;
+  tool: ParsedToolId | undefined;
+  withTemplates: WorkflowJsonTemplateTree | undefined;
+  outputMappings: Record<string, WorkflowExpression> | undefined;
+}): WorkflowModelToolStep {
+  const {params: input, tool, withTemplates, outputMappings} = params;
+  return {
+    ...input.stepBase,
     kind: 'tool',
     // An invalid id (interpolated or mis-shaped) is frozen unsplit; the emitted
     // `tool-id-invalid` issue fails normalization, so the model is never used.
-    tool: tool ?? {id: params.step.tool ?? ''},
-    ...(params.step.connection === undefined ? {} : {connection: params.step.connection}),
-    ...(params.step.with === undefined ? {} : {with: params.step.with}),
+    tool: tool ?? {id: input.step.tool ?? ''},
+    ...(input.step.connection === undefined ? {} : {connection: input.step.connection}),
+    ...(input.step.with === undefined ? {} : {with: input.step.with}),
     ...(outputMappings === undefined
       ? {}
       : {outputs: outputMappingsToDeclarations(outputMappings)}),
     ...(outputMappings === undefined ? {} : {outputMappings}),
-    ...(withTemplates === undefined && params.name === undefined
+    ...(withTemplates === undefined && input.name === undefined
       ? {}
       : {
           templates: {
             ...(withTemplates === undefined ? {} : {with: withTemplates}),
-            ...(params.name === undefined ? {} : {name: params.name}),
+            ...(input.name === undefined ? {} : {name: input.name}),
           },
         }),
   };
+}
 
+function createToolStepOverlay(
+  params: NormalizeToolStepParams,
+  step: WorkflowModelToolStep,
+  outputMappings: Record<string, WorkflowExpression> | undefined,
+  outputSchema: Readonly<Record<string, unknown>> | undefined,
+): WorkflowStepTypeOverlay {
   return {
-    step,
-    overlay: {
-      key: params.stepBase.key ?? step.id,
-      kind: 'tool',
-      ...(outputMappings === undefined
-        ? {}
-        : {outputs: outputMappingsToDeclarations(outputMappings)}),
-      ...(outputSchema === undefined ? {} : {outputSchema}),
-    },
+    key: params.stepBase.key ?? step.id,
+    kind: 'tool',
+    ...(outputMappings === undefined
+      ? {}
+      : {outputs: outputMappingsToDeclarations(outputMappings)}),
+    ...(outputSchema === undefined ? {} : {outputSchema}),
   };
 }
 
@@ -557,24 +599,40 @@ function validateInputRecord(params: {
   const serverInjectedMethod =
     params.tool.method === undefined || params.path.length !== 1 ? undefined : 'method';
 
-  if (params.schema.additionalProperties === false) {
-    for (const key of Object.keys(params.record)) {
-      if (key === serverInjectedMethod) continue;
-      if (Object.hasOwn(properties, key)) continue;
-      params.issues.push(
-        issue({
-          code: 'tool-input-unknown-key',
-          message: `Unknown tool input "${key}" for tool "${toolDisplayName}".`,
-          path: ['jobs', params.sourceName, 'steps', params.stepIndex, ...params.path, key],
-          details: {tool: toolDisplayName, key},
-        }),
-      );
-    }
-  }
+  validateUnknownInputKeys(params, properties, serverInjectedMethod, toolDisplayName);
+  validateRequiredInputKeys(params, serverInjectedMethod, toolDisplayName);
+  validateNestedInputValues(params, properties);
+}
 
+type ValidateInputRecordParams = Parameters<typeof validateInputRecord>[0];
+
+function validateUnknownInputKeys(
+  params: ValidateInputRecordParams,
+  properties: Readonly<Record<string, unknown>>,
+  serverInjectedMethod: string | undefined,
+  toolDisplayName: string,
+): void {
+  if (params.schema.additionalProperties !== false) return;
+  for (const key of Object.keys(params.record)) {
+    if (key === serverInjectedMethod || Object.hasOwn(properties, key)) continue;
+    params.issues.push(
+      issue({
+        code: 'tool-input-unknown-key',
+        message: `Unknown tool input "${key}" for tool "${toolDisplayName}".`,
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, ...params.path, key],
+        details: {tool: toolDisplayName, key},
+      }),
+    );
+  }
+}
+
+function validateRequiredInputKeys(
+  params: ValidateInputRecordParams,
+  serverInjectedMethod: string | undefined,
+  toolDisplayName: string,
+): void {
   for (const key of requiredKeys(params.schema)) {
-    if (key === serverInjectedMethod) continue;
-    if (Object.hasOwn(params.record, key)) continue;
+    if (key === serverInjectedMethod || Object.hasOwn(params.record, key)) continue;
     params.issues.push(
       issue({
         code: 'tool-input-invalid',
@@ -584,7 +642,12 @@ function validateInputRecord(params: {
       }),
     );
   }
+}
 
+function validateNestedInputValues(
+  params: ValidateInputRecordParams,
+  properties: Readonly<Record<string, unknown>>,
+): void {
   for (const [key, value] of Object.entries(params.record)) {
     const propertySchema = properties[key];
     if (propertySchema === undefined || !isPlainRecord(propertySchema)) continue;
@@ -688,7 +751,9 @@ function schemaAllowsType(schema: Readonly<Record<string, unknown>>, type: strin
 
 function expectedTypeLabel(schema: Readonly<Record<string, unknown>>): string {
   const type = schema.type;
-  const types = type === undefined ? [] : Array.isArray(type) ? type : [type];
+  let types: unknown[] = [];
+  if (Array.isArray(type)) types = type;
+  else if (type !== undefined) types = [type];
   return types.length === 0 ? 'a supported type' : types.join(' or ');
 }
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
@@ -73,6 +73,7 @@ function normalizeTopLevelTrigger(params: {
     issues: triggerIssues,
     integrationValidationContext: params.integrationValidationContext,
   });
+  validateAdditionalManualTrigger(params, triggerIssues);
   params.issues.push(...triggerIssues);
   const triggerIsInert = triggerIssues.some(
     (candidate) => candidate.scope === 'trigger' && candidate.severity === 'error',
@@ -108,6 +109,13 @@ function validateTopLevelTrigger(
     trigger: params.trigger,
     issues: triggerIssues,
   });
+  return triggerIssues;
+}
+
+function validateAdditionalManualTrigger(
+  params: Parameters<typeof normalizeTopLevelTrigger>[0],
+  triggerIssues: WorkflowModelValidationIssue[],
+): void {
   if (params.trigger.source === manualTriggerSource && params.state.manualTriggerSeen) {
     triggerIssues.push(
       issue({
@@ -119,7 +127,6 @@ function validateTopLevelTrigger(
       }),
     );
   }
-  return triggerIssues;
 }
 
 function normalizeCronTrigger(

--- a/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
@@ -17,6 +17,11 @@ const manualTriggerSource = 'manual';
 const cronTriggerSource = 'cron';
 type WorkflowDocumentTrigger = NonNullable<WorkflowDocument['triggers']>[string];
 
+interface NormalizeTriggersState {
+  manualTriggerSeen: boolean;
+  usedTriggerIds: Map<string, string>;
+}
+
 export function normalizeTriggers(
   document: WorkflowDocument,
   issues: WorkflowModelValidationIssue[],
@@ -26,83 +31,118 @@ export function normalizeTriggers(
   const manualTriggerKeys = Object.entries(triggers)
     .filter(([, trigger]) => trigger.source === manualTriggerSource)
     .map(([sourceKey]) => sourceKey);
-  const usedTriggerIds = new Map<string, string>();
-  let manualTriggerSeen = false;
-
-  return Object.entries(triggers).flatMap(([sourceKey, trigger]) => {
-    const id = stableId(sourceKey);
-    const existingSourceKey = usedTriggerIds.get(id);
-    if (existingSourceKey !== undefined) {
-      issues.push(
-        issue({
-          code: 'duplicate-trigger-id',
-          message: `Trigger keys "${existingSourceKey}" and "${sourceKey}" resolve to the same stable id "${id}".`,
-          path: ['triggers', sourceKey],
-          details: {id, sourceKeys: [existingSourceKey, sourceKey]},
-          scope: 'trigger',
-        }),
-      );
-      return [];
-    }
-    usedTriggerIds.set(id, sourceKey);
-
-    const triggerIssues: WorkflowModelValidationIssue[] = [];
-    validateTriggerFilter({sourceKey, trigger, issues: triggerIssues});
-    const normalizedTrigger = normalizeTriggerEntry(trigger, {
-      path: ['triggers', sourceKey],
-      issues: triggerIssues,
+  const state: NormalizeTriggersState = {manualTriggerSeen: false, usedTriggerIds: new Map()};
+  return Object.entries(triggers).flatMap(([sourceKey, trigger]) =>
+    normalizeTopLevelTrigger({
+      sourceKey,
+      trigger,
+      issues,
+      manualTriggerKeys,
       integrationValidationContext,
-    });
-    if (trigger.source === manualTriggerSource && manualTriggerSeen) {
-      triggerIssues.push(
-        issue({
-          code: 'multiple-manual-triggers',
-          message: `A workflow may declare at most one manual trigger; found ${manualTriggerKeys.length}: ${manualTriggerKeys.join(', ')}. This trigger is inert because it is not the first manual trigger in document order.`,
-          path: ['triggers', sourceKey],
-          details: {manualTriggerKeys},
-          scope: 'trigger',
-        }),
-      );
-    }
-    issues.push(...triggerIssues);
-    const triggerIsInert = triggerIssues.some(
-      (candidate) => candidate.scope === 'trigger' && candidate.severity === 'error',
+      state,
+    }),
+  );
+}
+
+function normalizeTopLevelTrigger(params: {
+  sourceKey: string;
+  trigger: WorkflowDocumentTrigger;
+  issues: WorkflowModelValidationIssue[];
+  manualTriggerKeys: string[];
+  integrationValidationContext: IntegrationValidationContext | undefined;
+  state: NormalizeTriggersState;
+}): WorkflowModelTrigger[] {
+  const id = stableId(params.sourceKey);
+  const existingSourceKey = params.state.usedTriggerIds.get(id);
+  if (existingSourceKey !== undefined) {
+    params.issues.push(
+      issue({
+        code: 'duplicate-trigger-id',
+        message: `Trigger keys "${existingSourceKey}" and "${params.sourceKey}" resolve to the same stable id "${id}".`,
+        path: ['triggers', params.sourceKey],
+        details: {id, sourceKeys: [existingSourceKey, params.sourceKey]},
+        scope: 'trigger',
+      }),
     );
-    if (trigger.source !== cronTriggerSource) {
-      if (trigger.source === manualTriggerSource) manualTriggerSeen = true;
-      if (triggerIsInert) return [];
-      return [
-        {
-          id,
-          key: sourceKey,
-          ...normalizedTrigger,
-          ...(trigger.config === undefined ? {} : {config: trigger.config}),
-        },
-      ];
-    }
-
-    const cronConfig = triggerSourceConfigSchemas.cron.parse(trigger.config ?? {});
-    const normalizedCronConfig = {
-      ...cronConfig,
-      timezone: cronConfig.timezone ?? cronTriggerDefaultTimezone,
-    };
-
-    const cronIssues: WorkflowModelValidationIssue[] = [];
-    validateCronTrigger({config: cronConfig, sourceKey, issues: cronIssues});
-    issues.push(...cronIssues);
-
-    const cronIsInert = cronIssues.some((candidate) => candidate.scope === 'trigger');
-    if (triggerIsInert || cronIsInert) return [];
-
-    return [
-      {
-        id,
-        key: sourceKey,
-        ...normalizedTrigger,
-        config: normalizedCronConfig,
-      },
-    ];
+    return [];
+  }
+  params.state.usedTriggerIds.set(id, params.sourceKey);
+  const triggerIssues = validateTopLevelTrigger(params);
+  const normalizedTrigger = normalizeTriggerEntry(params.trigger, {
+    path: ['triggers', params.sourceKey],
+    issues: triggerIssues,
+    integrationValidationContext: params.integrationValidationContext,
   });
+  params.issues.push(...triggerIssues);
+  const triggerIsInert = triggerIssues.some(
+    (candidate) => candidate.scope === 'trigger' && candidate.severity === 'error',
+  );
+  if (params.trigger.source === cronTriggerSource) {
+    return normalizeCronTrigger(
+      params.sourceKey,
+      id,
+      params.trigger,
+      normalizedTrigger,
+      triggerIsInert,
+      params.issues,
+    );
+  }
+  if (params.trigger.source === manualTriggerSource) params.state.manualTriggerSeen = true;
+  if (triggerIsInert) return [];
+  return [
+    {
+      id,
+      key: params.sourceKey,
+      ...normalizedTrigger,
+      ...(params.trigger.config === undefined ? {} : {config: params.trigger.config}),
+    },
+  ];
+}
+
+function validateTopLevelTrigger(
+  params: Parameters<typeof normalizeTopLevelTrigger>[0],
+): WorkflowModelValidationIssue[] {
+  const triggerIssues: WorkflowModelValidationIssue[] = [];
+  validateTriggerFilter({
+    sourceKey: params.sourceKey,
+    trigger: params.trigger,
+    issues: triggerIssues,
+  });
+  if (params.trigger.source === manualTriggerSource && params.state.manualTriggerSeen) {
+    triggerIssues.push(
+      issue({
+        code: 'multiple-manual-triggers',
+        message: `A workflow may declare at most one manual trigger; found ${params.manualTriggerKeys.length}: ${params.manualTriggerKeys.join(', ')}. This trigger is inert because it is not the first manual trigger in document order.`,
+        path: ['triggers', params.sourceKey],
+        details: {manualTriggerKeys: params.manualTriggerKeys},
+        scope: 'trigger',
+      }),
+    );
+  }
+  return triggerIssues;
+}
+
+function normalizeCronTrigger(
+  sourceKey: string,
+  id: string,
+  trigger: WorkflowDocumentTrigger,
+  normalizedTrigger: WorkflowModelListeningTrigger,
+  triggerIsInert: boolean,
+  issues: WorkflowModelValidationIssue[],
+): WorkflowModelTrigger[] {
+  const cronConfig = triggerSourceConfigSchemas.cron.parse(trigger.config ?? {});
+  const cronIssues: WorkflowModelValidationIssue[] = [];
+  validateCronTrigger({config: cronConfig, sourceKey, issues: cronIssues});
+  issues.push(...cronIssues);
+  if (triggerIsInert || cronIssues.some((candidate) => candidate.scope === 'trigger')) return [];
+  return [
+    {
+      id,
+      key: sourceKey,
+      ...normalizedTrigger,
+      config: {...cronConfig, timezone: cronConfig.timezone ?? cronTriggerDefaultTimezone},
+    },
+  ];
 }
 
 function validateTriggerFilter(params: {
@@ -198,50 +238,88 @@ export function validateTriggerSourceEvent(params: {
   const integrationValidationContext = params.integrationValidationContext;
 
   if (source === manualTriggerSource || source === cronTriggerSource) {
-    if (event === '') {
-      issues.push(
-        issue({
-          code: 'invalid-trigger-event',
-          message: `A ${source} trigger event cannot be blank.`,
-          path: eventPath,
-          details: {event, source},
-          scope: 'trigger',
-        }),
-      );
-      return;
-    }
-
-    const expectedEvent = source === manualTriggerSource ? 'fire' : 'tick';
-    if (event !== undefined && event !== expectedEvent) {
-      issues.push(
-        issue({
-          code: 'invalid-trigger-event',
-          message: `A ${source} trigger must use event "${expectedEvent}"; found "${event}".`,
-          path: eventPath,
-          details: {event, source},
-          scope: 'trigger',
-        }),
-      );
-    }
+    validateBuiltinTriggerEvent(source, event, eventPath, issues);
     return;
   }
 
   // Integration-source checks are intentionally skipped when the caller has
   // no workspace context. Keep that contract even for blank event values.
   if (integrationValidationContext === undefined) return;
+  validateIntegrationTriggerEvent(
+    source,
+    event,
+    path,
+    eventPath,
+    integrationValidationContext,
+    issues,
+  );
+}
+
+function pushInvalidTriggerEvent(
+  source: string,
+  event: string | undefined,
+  path: readonly WorkflowModelValidationIssuePathSegment[],
+  message: string,
+  issues: WorkflowModelValidationIssue[],
+  provider?: string,
+): void {
+  issues.push(
+    issue({
+      code: 'invalid-trigger-event',
+      message,
+      path,
+      details: provider === undefined ? {event, source} : {event, source, provider},
+      scope: 'trigger',
+    }),
+  );
+}
+
+function validateBuiltinTriggerEvent(
+  source: string,
+  event: string | undefined,
+  eventPath: readonly WorkflowModelValidationIssuePathSegment[],
+  issues: WorkflowModelValidationIssue[],
+): void {
   if (event === '') {
-    issues.push(
-      issue({
-        code: 'invalid-trigger-event',
-        message: `A ${source} trigger event cannot be blank.`,
-        path: eventPath,
-        details: {event, source},
-        scope: 'trigger',
-      }),
+    pushInvalidTriggerEvent(
+      source,
+      event,
+      eventPath,
+      `A ${source} trigger event cannot be blank.`,
+      issues,
     );
     return;
   }
+  const expectedEvent = source === manualTriggerSource ? 'fire' : 'tick';
+  if (event !== undefined && event !== expectedEvent) {
+    pushInvalidTriggerEvent(
+      source,
+      event,
+      eventPath,
+      `A ${source} trigger must use event "${expectedEvent}"; found "${event}".`,
+      issues,
+    );
+  }
+}
 
+function validateIntegrationTriggerEvent(
+  source: string,
+  event: string | undefined,
+  path: readonly WorkflowModelValidationIssuePathSegment[],
+  eventPath: readonly WorkflowModelValidationIssuePathSegment[],
+  integrationValidationContext: IntegrationValidationContext,
+  issues: WorkflowModelValidationIssue[],
+): void {
+  if (event === '') {
+    pushInvalidTriggerEvent(
+      source,
+      event,
+      eventPath,
+      `A ${source} trigger event cannot be blank.`,
+      issues,
+    );
+    return;
+  }
   const connection = integrationValidationContext.workspaceConnectionSnapshot.get(source);
   if (connection === undefined) {
     // The connection may be created later; INTEGRATION_CONNECTION_AVAILABLE
@@ -266,25 +344,7 @@ export function validateTriggerSourceEvent(params: {
   const {provider} = connection;
   const catalog = integrationValidationContext.eventCatalogs.get(provider);
   if (integrationValidationContext.fixedEventProviders.has(provider)) {
-    // Shipfox-minted event name (custom webhook `received` today): any other
-    // explicit value is provably never delivered, so the trigger is inert.
-    if (catalog === undefined || !catalog.has(event)) {
-      const singleEvent = catalog?.size === 1 ? [...catalog][0] : undefined;
-      issues.push(
-        issue({
-          code: 'invalid-trigger-event',
-          message:
-            catalog === undefined
-              ? `Provider "${provider}" has no fixed event catalog; event "${event}" cannot be validated.`
-              : singleEvent === undefined
-                ? `Event "${event}" is never delivered by provider "${provider}".`
-                : `A ${provider} trigger must use event "${singleEvent}"; found "${event}".`,
-          path: eventPath,
-          details: {event, source, provider},
-          scope: 'trigger',
-        }),
-      );
-    }
+    validateFixedProviderEvent(source, event, provider, catalog, eventPath, issues);
     return;
   }
 
@@ -303,6 +363,25 @@ export function validateTriggerSourceEvent(params: {
       }),
     );
   }
+}
+
+function validateFixedProviderEvent(
+  source: string,
+  event: string,
+  provider: string,
+  catalog: ReadonlySet<string> | undefined,
+  eventPath: readonly WorkflowModelValidationIssuePathSegment[],
+  issues: WorkflowModelValidationIssue[],
+): void {
+  if (catalog?.has(event)) return;
+  const singleEvent = catalog?.size === 1 ? [...catalog][0] : undefined;
+  let message = `Event "${event}" is never delivered by provider "${provider}".`;
+  if (catalog === undefined) {
+    message = `Provider "${provider}" has no fixed event catalog; event "${event}" cannot be validated.`;
+  } else if (singleEvent !== undefined) {
+    message = `A ${provider} trigger must use event "${singleEvent}"; found "${event}".`;
+  }
+  pushInvalidTriggerEvent(source, event, eventPath, message, issues, provider);
 }
 
 function builtinEventForSource(source: string, event: string | undefined): string | undefined {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -5957,6 +5957,28 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.triggers.map((trigger) => trigger.key)).toEqual(['one']);
   });
 
+  it('reports an invalid event before the duplicate-manual diagnostic', () => {
+    const document: WorkflowDocument = {
+      name: 'invalid duplicate manual trigger',
+      triggers: {
+        one: {source: 'manual', event: 'fire'},
+        two: {source: 'manual', event: 'run'},
+      },
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const {diagnostics} = normalizeWithDiagnostics(document);
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'invalid-trigger-event',
+      'multiple-manual-triggers',
+    ]);
+  });
+
   it('counts an earlier inert manual trigger toward the manual-trigger limit', () => {
     const document: WorkflowDocument = {
       name: 'manual triggers with an inert first trigger',

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -206,16 +206,7 @@ function validateExpressionSegment(params: {
     return undefined;
   }
 
-  const invalidJobReferenceIssue =
-    params.allowedJobReferences === undefined
-      ? undefined
-      : validateDirectJobReferences({
-          source: params.source,
-          expression: params.segment.expression,
-          field: params.field,
-          path: params.path,
-          allowedJobReferences: params.allowedJobReferences,
-        });
+  const invalidJobReferenceIssue = validateAllowedJobReferences(params);
   if (invalidJobReferenceIssue !== undefined) {
     params.issues.push(invalidJobReferenceIssue);
     return undefined;
@@ -241,16 +232,10 @@ function validateExpressionSegment(params: {
     return undefined;
   }
 
-  const fillSite = params.fillSite;
-  if (fillSite !== undefined) {
-    const serverRoots = knownRoots.filter((root) => resolveContextRootHost(root) === 'server');
-    const unavailableRoots = unavailableRootsAt(serverRoots, fillSite);
-    if (unavailableRoots.length > 0) {
-      params.issues.push(
-        unavailableContextIssue({...params, contextRoots, unavailableRoots, fillSite}),
-      );
-      return undefined;
-    }
+  const unavailableIssue = unavailableContextAtFillSite(params, contextRoots, knownRoots);
+  if (unavailableIssue !== undefined) {
+    params.issues.push(unavailableIssue);
+    return undefined;
   }
 
   if (
@@ -293,6 +278,36 @@ function validateExpressionSegment(params: {
     );
     return undefined;
   }
+}
+
+function validateAllowedJobReferences(
+  params: Parameters<typeof validateExpressionSegment>[0],
+): WorkflowModelValidationIssue | undefined {
+  if (params.allowedJobReferences === undefined) return undefined;
+  return validateDirectJobReferences({
+    source: params.source,
+    expression: params.segment.expression,
+    field: params.field,
+    path: params.path,
+    allowedJobReferences: params.allowedJobReferences,
+  });
+}
+
+function unavailableContextAtFillSite(
+  params: Parameters<typeof validateExpressionSegment>[0],
+  contextRoots: readonly string[],
+  knownRoots: readonly (WorkflowContextName | WorkflowContextReservedRoot)[],
+): WorkflowModelValidationIssue | undefined {
+  if (params.fillSite === undefined) return undefined;
+  const serverRoots = knownRoots.filter((root) => resolveContextRootHost(root) === 'server');
+  const unavailableRoots = unavailableRootsAt(serverRoots, params.fillSite);
+  if (unavailableRoots.length === 0) return undefined;
+  return unavailableContextIssue({
+    ...params,
+    contextRoots,
+    unavailableRoots,
+    fillSite: params.fillSite,
+  });
 }
 
 function runnerContextInFieldIssue(params: {

--- a/libs/api/definitions/src/core/workflow-yaml/source-locations.ts
+++ b/libs/api/definitions/src/core/workflow-yaml/source-locations.ts
@@ -15,22 +15,29 @@ export function extractWorkflowStepSourceLocations(source: string): WorkflowStep
   const locations = new Map<string, Map<number, WorkflowSourceLocation>>();
 
   for (const jobPair of jobs.items) {
-    const jobName = scalarString(jobPair.key);
-    if (jobName === undefined || !isMap(jobPair.value)) continue;
-
-    const steps = getMapValue(jobPair.value, 'steps');
-    if (!isSeq(steps)) continue;
-
-    const stepLocations = new Map<number, WorkflowSourceLocation>();
-    for (const [index, step] of steps.items.entries()) {
-      const location = sourceLocationFor(step, lineCounter);
-      if (location) stepLocations.set(index, location);
-    }
-
-    if (stepLocations.size > 0) locations.set(jobName, stepLocations);
+    addJobStepLocations(jobPair.key, jobPair.value, lineCounter, locations);
   }
 
   return locations;
+}
+
+function addJobStepLocations(
+  key: unknown,
+  value: unknown,
+  lineCounter: LineCounter,
+  locations: Map<string, Map<number, WorkflowSourceLocation>>,
+): void {
+  const jobName = scalarString(key);
+  if (jobName === undefined || !isMap(value)) return;
+  const steps = getMapValue(value, 'steps');
+  if (!isSeq(steps)) return;
+
+  const stepLocations = new Map<number, WorkflowSourceLocation>();
+  for (const [index, step] of steps.items.entries()) {
+    const location = sourceLocationFor(step, lineCounter);
+    if (location) stepLocations.set(index, location);
+  }
+  if (stepLocations.size > 0) locations.set(jobName, stepLocations);
 }
 
 function getMapValue(map: YAMLMap, key: string): unknown {

--- a/libs/api/definitions/src/db/definitions.ts
+++ b/libs/api/definitions/src/db/definitions.ts
@@ -131,9 +131,11 @@ async function findOrCreateWorkflows(
   tx: Tx,
   params: {projectId: string; configPaths: string[]},
 ): Promise<Map<string, string>> {
-  const configPaths = [...new Set(params.configPaths)].sort((left, right) =>
-    left < right ? -1 : left > right ? 1 : 0,
-  );
+  const configPaths = [...new Set(params.configPaths)].sort((left, right) => {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+  });
   if (configPaths.length === 0) return new Map();
 
   await tx
@@ -502,40 +504,97 @@ export interface ApplyVcsDefinitionsBatchResult {
   deletedCount: number;
 }
 
+interface PreparedVcsDefinition {
+  item: ApplyVcsDefinitionsBatchParams['upserts'][number];
+  unchanged: boolean;
+  workflowId: string | null | undefined;
+}
+
+async function prepareVcsDefinition(
+  tx: Tx,
+  params: ApplyVcsDefinitionsBatchParams,
+  item: ApplyVcsDefinitionsBatchParams['upserts'][number],
+): Promise<PreparedVcsDefinition> {
+  const existing = await tx
+    .select({
+      contentHash: workflowDefinitions.contentHash,
+      deletedAt: workflowDefinitions.deletedAt,
+      workflowId: workflowDefinitions.workflowId,
+    })
+    .from(workflowDefinitions)
+    .where(
+      and(
+        eq(workflowDefinitions.projectId, params.projectId),
+        eq(workflowDefinitions.ref, params.ref),
+        eq(workflowDefinitions.configPath, item.configPath),
+      ),
+    )
+    .limit(1);
+  const previous = existing[0];
+  const unchanged =
+    previous !== undefined &&
+    previous.deletedAt === null &&
+    previous.contentHash === item.contentHash;
+  return {item, unchanged, workflowId: previous?.workflowId};
+}
+
+async function applyPreparedVcsDefinition(
+  tx: Tx,
+  params: ApplyVcsDefinitionsBatchParams,
+  prepared: PreparedVcsDefinition,
+  workflowIds: ReadonlyMap<string, string>,
+): Promise<boolean> {
+  let workflowId = workflowIds.get(prepared.item.configPath);
+  if (prepared.unchanged) {
+    workflowId =
+      prepared.workflowId ??
+      (await findOrCreateWorkflow(tx, {
+        projectId: params.projectId,
+        configPath: prepared.item.configPath,
+      }));
+  }
+  if (!workflowId) {
+    throw new Error(
+      `Workflow lineage missing for project ${params.projectId} and config path ${prepared.item.configPath}`,
+    );
+  }
+  const rows = await buildUpsertQuery(tx, {
+    projectId: params.projectId,
+    workspaceId: params.workspaceId,
+    workflowId,
+    configPath: prepared.item.configPath,
+    source: 'vcs',
+    ref: params.ref,
+    name: prepared.item.name,
+    document: prepared.item.document,
+    model: prepared.item.model,
+    sourceSnapshot: prepared.item.sourceSnapshot ?? null,
+    contentHash: prepared.item.contentHash,
+  });
+  const row = rows[0];
+  if (!row) throw new Error('Upsert returned no rows');
+  if (prepared.unchanged) return false;
+  await writeOutboxEvent<DefinitionsEventMap>(tx, definitionsOutbox, {
+    type: DEFINITION_RESOLVED,
+    payload: {
+      definitionId: row.id,
+      projectId: row.projectId,
+      workspaceId: params.workspaceId,
+      configPath: row.configPath,
+      triggers: definitionTriggersFor(row.definition.model),
+    },
+  });
+  return true;
+}
+
 export async function applyVcsDefinitionsBatch(
   params: ApplyVcsDefinitionsBatchParams,
 ): Promise<ApplyVcsDefinitionsBatchResult> {
   return await db().transaction(async (tx) => {
     let appliedCount = 0;
-    const prepared: Array<{
-      item: (typeof params.upserts)[number];
-      unchanged: boolean;
-      workflowId: string | null | undefined;
-    }> = [];
+    const prepared: PreparedVcsDefinition[] = [];
     for (const item of params.upserts) {
-      const existing = await tx
-        .select({
-          contentHash: workflowDefinitions.contentHash,
-          deletedAt: workflowDefinitions.deletedAt,
-          workflowId: workflowDefinitions.workflowId,
-        })
-        .from(workflowDefinitions)
-        .where(
-          and(
-            eq(workflowDefinitions.projectId, params.projectId),
-            eq(workflowDefinitions.ref, params.ref),
-            eq(workflowDefinitions.configPath, item.configPath),
-          ),
-        )
-        .limit(1);
-
-      const previous = existing[0];
-      const unchanged =
-        previous !== undefined &&
-        previous.deletedAt === null &&
-        previous.contentHash === item.contentHash;
-
-      prepared.push({item, unchanged, workflowId: previous?.workflowId});
+      prepared.push(await prepareVcsDefinition(tx, params, item));
     }
 
     const workflowIds = await findOrCreateWorkflows(tx, {
@@ -543,48 +602,8 @@ export async function applyVcsDefinitionsBatch(
       configPaths: prepared.filter(({unchanged}) => !unchanged).map(({item}) => item.configPath),
     });
 
-    for (const {item, unchanged, workflowId: previousWorkflowId} of prepared) {
-      const workflowId = unchanged
-        ? (previousWorkflowId ??
-          (await findOrCreateWorkflow(tx, {
-            projectId: params.projectId,
-            configPath: item.configPath,
-          })))
-        : workflowIds.get(item.configPath);
-      if (!workflowId) {
-        throw new Error(
-          `Workflow lineage missing for project ${params.projectId} and config path ${item.configPath}`,
-        );
-      }
-      const rows = await buildUpsertQuery(tx, {
-        projectId: params.projectId,
-        workspaceId: params.workspaceId,
-        workflowId,
-        configPath: item.configPath,
-        source: 'vcs',
-        ref: params.ref,
-        name: item.name,
-        document: item.document,
-        model: item.model,
-        sourceSnapshot: item.sourceSnapshot ?? null,
-        contentHash: item.contentHash,
-      });
-      const row = rows[0];
-      if (!row) throw new Error('Upsert returned no rows');
-
-      if (!unchanged) {
-        await writeOutboxEvent<DefinitionsEventMap>(tx, definitionsOutbox, {
-          type: DEFINITION_RESOLVED,
-          payload: {
-            definitionId: row.id,
-            projectId: row.projectId,
-            workspaceId: params.workspaceId,
-            configPath: row.configPath,
-            triggers: definitionTriggersFor(row.definition.model),
-          },
-        });
-        appliedCount += 1;
-      }
+    for (const item of prepared) {
+      if (await applyPreparedVcsDefinition(tx, params, item, workflowIds)) appliedCount += 1;
     }
 
     const keepConfigPaths = params.upserts.map((upsert) => upsert.configPath);

--- a/libs/api/definitions/test/agent-validation-catalog.ts
+++ b/libs/api/definitions/test/agent-validation-catalog.ts
@@ -7,18 +7,16 @@ import {
 } from '@shipfox/api-agent-dto';
 import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 
+function modelsForProvider(entry: (typeof MODEL_PROVIDER_CATALOG_SEED)[number]): string[] {
+  if (entry.id === 'anthropic') return ['claude-opus-4-8'];
+  if (entry.id === 'openai') return ['gpt-4.1', 'gpt-5.5-pro'];
+  if (entry.default_model === null) return [];
+  return [entry.default_model];
+}
+
 const piModelIdsByProvider = Object.fromEntries(
   MODEL_PROVIDER_CATALOG_SEED.filter((entry) => entry.support_status === 'supported').map(
-    (entry) => [
-      entry.id,
-      entry.id === 'anthropic'
-        ? ['claude-opus-4-8']
-        : entry.id === 'openai'
-          ? ['gpt-4.1', 'gpt-5.5-pro']
-          : entry.default_model === null
-            ? []
-            : [entry.default_model],
-    ],
+    (entry) => [entry.id, modelsForProvider(entry)],
   ),
 );
 

--- a/libs/api/email-challenges/src/core/email-challenges.ts
+++ b/libs/api/email-challenges/src/core/email-challenges.ts
@@ -168,6 +168,104 @@ async function deliver(email: string, value: string) {
   await mailer.send({to: email, ...message});
 }
 
+type ChallengeRow = typeof challenges.$inferSelect;
+type CreatedChallenge =
+  | {handle: EmailChallengeHandle; deliver: false}
+  | {
+      handle: EmailChallengeHandle;
+      email: string;
+      value: string;
+      deliveryAttemptedAt: Date;
+      deliver: true;
+    };
+
+async function recoverExistingChallenge(
+  tx: Tx,
+  current: ChallengeRow,
+  params: CreateEmailChallengeParams,
+  now: Date,
+): Promise<CreatedChallenge> {
+  if (
+    !current.email ||
+    current.purpose !== params.purpose ||
+    !current.continuationHmac ||
+    !equal(current.continuationHmac, digest('continuation', params.continuation))
+  ) {
+    throw new EmailChallengeError('invalid', 'Email challenge is invalid');
+  }
+  if (current.expiresAt <= now) {
+    await tx
+      .update(challenges)
+      .set({...terminalUpdate(now), invalidatedAt: now})
+      .where(eq(challenges.id, current.id));
+    throw new EmailChallengeError('expired', 'Email challenge has expired');
+  }
+  if (current.terminalAt || current.confirmedAt) {
+    throw new EmailChallengeError('invalid', 'Email challenge is invalid');
+  }
+  const deliveryStale =
+    current.deliveryState === 'pending' &&
+    (!current.deliveryAttemptedAt ||
+      current.deliveryAttemptedAt.getTime() + deliveryRecoveryMs <= now.getTime());
+  if (current.deliveryState !== 'failed' && !deliveryStale) {
+    return {handle: handle(current), deliver: false};
+  }
+  if (current.sentCount >= maxSends) {
+    throw new EmailChallengeError('exhausted', 'Email challenge resends are exhausted');
+  }
+
+  const value = code();
+  await consumeSendLimits(tx, current.email, params.sourceIp, now);
+  const updated = await tx
+    .update(challenges)
+    .set({
+      codeHmac: digest('code', value),
+      sentCount: current.sentCount + 1,
+      resendCount: current.resendCount + 1,
+      lastSentAt: now,
+      expiresAt: new Date(now.getTime() + ttlMs),
+      deliveryState: 'pending',
+      deliveryAttemptedAt: now,
+      deliveryFailedAt: null,
+    })
+    .where(eq(challenges.id, current.id))
+    .returning();
+  if (!updated[0]) throw new Error('Update returned no email challenge');
+  return {
+    handle: handle(updated[0]),
+    email: current.email,
+    value,
+    deliveryAttemptedAt: now,
+    deliver: true,
+  };
+}
+
+async function insertEmailChallenge(
+  tx: Tx,
+  email: string,
+  params: CreateEmailChallengeParams,
+  idempotencyHmac: string,
+  now: Date,
+): Promise<CreatedChallenge> {
+  const value = code();
+  await consumeSendLimits(tx, email, params.sourceIp, now);
+  const inserted = await tx
+    .insert(challenges)
+    .values({
+      email,
+      purpose: params.purpose,
+      continuationHmac: digest('continuation', params.continuation),
+      idempotencyHmac,
+      codeHmac: digest('code', value),
+      expiresAt: new Date(now.getTime() + ttlMs),
+      lastSentAt: now,
+      deliveryAttemptedAt: now,
+    })
+    .returning();
+  if (!inserted[0]) throw new Error('Insert returned no email challenge');
+  return {handle: handle(inserted[0]), email, value, deliveryAttemptedAt: now, deliver: true};
+}
+
 export async function createEmailChallenge(
   params: CreateEmailChallengeParams,
 ): Promise<EmailChallengeHandle> {
@@ -191,83 +289,8 @@ export async function createEmailChallenge(
         .limit(1)
         .for('update');
       const current = existing[0];
-      if (current) {
-        if (
-          !current.email ||
-          current.purpose !== params.purpose ||
-          !current.continuationHmac ||
-          !equal(current.continuationHmac, digest('continuation', params.continuation))
-        )
-          throw new EmailChallengeError('invalid', 'Email challenge is invalid');
-        if (current.expiresAt <= now) {
-          await tx
-            .update(challenges)
-            .set({...terminalUpdate(now), invalidatedAt: now})
-            .where(eq(challenges.id, current.id));
-          throw new EmailChallengeError('expired', 'Email challenge has expired');
-        }
-        if (current.terminalAt || current.confirmedAt)
-          throw new EmailChallengeError('invalid', 'Email challenge is invalid');
-        const deliveryStale =
-          current.deliveryState === 'pending' &&
-          (!current.deliveryAttemptedAt ||
-            current.deliveryAttemptedAt.getTime() + deliveryRecoveryMs <= now.getTime());
-        const shouldRecoverDelivery = current.deliveryState === 'failed' || deliveryStale;
-        if (!shouldRecoverDelivery) return {handle: handle(current), deliver: false as const};
-        if (current.sentCount >= maxSends)
-          throw new EmailChallengeError('exhausted', 'Email challenge resends are exhausted');
-
-        const value = code();
-        const expiresAt = new Date(now.getTime() + ttlMs);
-        await consumeSendLimits(tx, current.email, params.sourceIp, now);
-        const updated = await tx
-          .update(challenges)
-          .set({
-            codeHmac: digest('code', value),
-            sentCount: current.sentCount + 1,
-            resendCount: current.resendCount + 1,
-            lastSentAt: now,
-            expiresAt,
-            deliveryState: 'pending',
-            deliveryAttemptedAt: now,
-            deliveryFailedAt: null,
-          })
-          .where(eq(challenges.id, current.id))
-          .returning();
-        if (!updated[0]) throw new Error('Update returned no email challenge');
-        return {
-          handle: handle(updated[0]),
-          email: current.email,
-          value,
-          deliveryAttemptedAt: now,
-          deliver: true as const,
-        };
-      }
-
-      const value = code();
-      const expiresAt = new Date(now.getTime() + ttlMs);
-      await consumeSendLimits(tx, email, params.sourceIp, now);
-      const inserted = await tx
-        .insert(challenges)
-        .values({
-          email,
-          purpose: params.purpose,
-          continuationHmac: digest('continuation', params.continuation),
-          idempotencyHmac,
-          codeHmac: digest('code', value),
-          expiresAt,
-          lastSentAt: now,
-          deliveryAttemptedAt: now,
-        })
-        .returning();
-      if (!inserted[0]) throw new Error('Insert returned no email challenge');
-      return {
-        handle: handle(inserted[0]),
-        email,
-        value,
-        deliveryAttemptedAt: now,
-        deliver: true as const,
-      };
+      if (current) return await recoverExistingChallenge(tx, current, params, now);
+      return await insertEmailChallenge(tx, email, params, idempotencyHmac, now);
     });
     if (!created.deliver) return created.handle;
     try {
@@ -434,20 +457,7 @@ export async function confirmEmailChallenge(params: {
         return 'expired' as const;
       }
       if (!current.codeHmac || !equal(current.codeHmac, digest('code', params.code))) {
-        const failedAttemptCount = current.failedAttemptCount + 1;
-        if (failedAttemptCount >= maxFailedAttempts)
-          await tx
-            .update(challenges)
-            .set({...terminalUpdate(now), failedAttemptCount, invalidatedAt: now})
-            .where(eq(challenges.id, current.id));
-        else
-          await tx
-            .update(challenges)
-            .set({failedAttemptCount})
-            .where(eq(challenges.id, current.id));
-        return failedAttemptCount >= maxFailedAttempts
-          ? ('exhausted' as const)
-          : ('invalid' as const);
+        return await recordFailedConfirmation(tx, current, now);
       }
       await tx
         .update(challenges)
@@ -467,6 +477,23 @@ export async function confirmEmailChallenge(params: {
     recordEmailChallenge('confirm', 'rejected');
     throw error;
   }
+}
+
+async function recordFailedConfirmation(
+  tx: Tx,
+  current: ChallengeRow,
+  now: Date,
+): Promise<'exhausted' | 'invalid'> {
+  const failedAttemptCount = current.failedAttemptCount + 1;
+  if (failedAttemptCount >= maxFailedAttempts) {
+    await tx
+      .update(challenges)
+      .set({...terminalUpdate(now), failedAttemptCount, invalidatedAt: now})
+      .where(eq(challenges.id, current.id));
+    return 'exhausted';
+  }
+  await tx.update(challenges).set({failedAttemptCount}).where(eq(challenges.id, current.id));
+  return 'invalid';
 }
 
 export async function consumeEmailChallengeProof(params: {

--- a/libs/api/integration/core-dto/src/webhooks.ts
+++ b/libs/api/integration/core-dto/src/webhooks.ts
@@ -23,7 +23,9 @@ export type WebhookRouteId = z.infer<typeof webhookRouteIdSchema>;
 const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 function decodedBase64Length(value: string): number {
-  const paddingLength = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0;
+  let paddingLength = 0;
+  if (value.endsWith('==')) paddingLength = 2;
+  else if (value.endsWith('=')) paddingLength = 1;
 
   return (value.length / 4) * 3 - paddingLength;
 }

--- a/libs/api/integration/core/src/core/secret-cleanup.ts
+++ b/libs/api/integration/core/src/core/secret-cleanup.ts
@@ -135,32 +135,7 @@ async function scheduleRetry(
   // Keep escalating past the threshold. A stuck row means secrets may still exist, and
   // one missed alert would hide that forever. The bounded per-cleanup cache suppresses
   // duplicate reports in this worker while allowing a fresh process to re-alert.
-  if (cleanup.attemptCount >= STUCK_CLEANUP_ATTEMPT_COUNT) {
-    const stuckErrorMessage = 'Integration connection secret cleanup exceeded its retry threshold';
-    logger().error(
-      {
-        provider: cleanup.provider,
-        connectionId: cleanup.connectionId,
-        attempt: cleanup.attemptCount,
-      },
-      stuckErrorMessage,
-    );
-    if (!reportedStuckCleanupIds.has(cleanup.id)) {
-      const eventId = reportError(new Error(stuckErrorMessage), {
-        boundary: 'integration.secret-cleanup',
-        operation: 'stuck-cleanup',
-        tags: {provider: cleanup.provider},
-        extra: {cleanupId: cleanup.id},
-      });
-      if (eventId) {
-        reportedStuckCleanupIds.add(cleanup.id);
-        if (reportedStuckCleanupIds.size > STUCK_CLEANUP_ALERT_CACHE_LIMIT) {
-          const oldestCleanupId = reportedStuckCleanupIds.values().next().value;
-          if (oldestCleanupId !== undefined) reportedStuckCleanupIds.delete(oldestCleanupId);
-        }
-      }
-    }
-  }
+  if (cleanup.attemptCount >= STUCK_CLEANUP_ATTEMPT_COUNT) reportStuckCleanup(cleanup);
 
   try {
     const rescheduled = await retryIntegrationSecretCleanup({
@@ -186,6 +161,26 @@ async function scheduleRetry(
     });
     return false;
   }
+}
+
+function reportStuckCleanup(cleanup: IntegrationSecretCleanup): void {
+  const message = 'Integration connection secret cleanup exceeded its retry threshold';
+  logger().error(
+    {provider: cleanup.provider, connectionId: cleanup.connectionId, attempt: cleanup.attemptCount},
+    message,
+  );
+  if (reportedStuckCleanupIds.has(cleanup.id)) return;
+  const eventId = reportError(new Error(message), {
+    boundary: 'integration.secret-cleanup',
+    operation: 'stuck-cleanup',
+    tags: {provider: cleanup.provider},
+    extra: {cleanupId: cleanup.id},
+  });
+  if (!eventId) return;
+  reportedStuckCleanupIds.add(cleanup.id);
+  if (reportedStuckCleanupIds.size <= STUCK_CLEANUP_ALERT_CACHE_LIMIT) return;
+  const oldestCleanupId = reportedStuckCleanupIds.values().next().value;
+  if (oldestCleanupId !== undefined) reportedStuckCleanupIds.delete(oldestCleanupId);
 }
 
 function retryDelayMs(attemptCount: number): number {

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -62,96 +62,100 @@ export interface IntegrationToolCallInput {
   reportError?: typeof reportError;
 }
 
+interface ToolSessionState {
+  session: AgentToolSession<CallToolResult> | undefined;
+  openingSession: Promise<AgentToolSession<CallToolResult>> | undefined;
+}
+
+async function executeIntegrationTool(
+  input: IntegrationToolCallInput,
+  state: ToolSessionState,
+): Promise<IntegrationToolCallOutcome> {
+  if (input.signal?.aborted) return {outcome: 'error', error: abortOutcome(input.signal)};
+  const adapter = input.registry.getAdapter(
+    input.integration.provider,
+    'agent_tools',
+  ) as AgentToolsProvider<
+    typeof input.connection,
+    unknown,
+    typeof input.integration,
+    CallToolResult
+  >;
+  state.openingSession = adapter.openSession({
+    connection: input.connection,
+    tools: [agentToolCatalogEntry(input)],
+    scope: input.integration,
+  });
+  state.session = await raceWithSignal(state.openingSession, input.signal);
+  if (input.signal?.aborted) return {outcome: 'error', error: abortOutcome(input.signal)};
+  const result = await raceWithSignal(
+    state.session.call({toolId: input.tool.id, arguments: input.arguments}),
+    input.signal,
+  );
+  if (result.isError === true) return {outcome: 'error', error: providerToolError(result)};
+  return {outcome: 'success', result};
+}
+
+function logIntegrationToolError(
+  input: IntegrationToolCallInput,
+  error: unknown,
+  errorRecord: IntegrationToolCallError,
+  log: typeof logger,
+  report: typeof reportError,
+): void {
+  if (!['provider-unavailable', 'provider-timeout', 'unknown'].includes(errorRecord.code)) return;
+  let message = 'Integration agent tool call failed';
+  if (errorRecord.code === 'provider-unavailable') {
+    message = 'Integration agent tool provider was unavailable';
+  } else if (errorRecord.code === 'provider-timeout') {
+    message = 'Integration agent tool provider timed out';
+  }
+  log().error(
+    {
+      ...toolCallLogContext(input),
+      err: error,
+      errorCode: errorRecord.code,
+      ...(errorRecord.status === undefined ? {} : {providerStatus: errorRecord.status}),
+    },
+    message,
+  );
+  report(error, {boundary: 'integration.agent-tool'});
+}
+
+function handleIntegrationToolError(
+  input: IntegrationToolCallInput,
+  error: unknown,
+  state: ToolSessionState,
+  log: typeof logger,
+  report: typeof reportError,
+): IntegrationToolCallOutcome {
+  if (input.signal?.aborted) {
+    if (state.openingSession !== undefined && state.session === undefined) {
+      void state.openingSession.then(
+        (opened) => closeSession(opened, log, report),
+        () => undefined,
+      );
+    }
+    return {outcome: 'error', error: abortOutcome(input.signal)};
+  }
+  const errorRecord = errorResult(error);
+  logIntegrationToolError(input, error, errorRecord, log, report);
+  return {outcome: 'error', error: errorRecord};
+}
+
 export async function callIntegrationTool(
   input: IntegrationToolCallInput,
 ): Promise<IntegrationToolCallOutcome> {
   const log = input.logger ?? logger;
   const report = input.reportError ?? reportError;
-  let session: AgentToolSession<CallToolResult> | undefined;
-  let openingSession: Promise<AgentToolSession<CallToolResult>> | undefined;
+  const state: ToolSessionState = {session: undefined, openingSession: undefined};
 
   try {
-    // A caller that already cancelled must not trigger a provider round-trip:
-    // for a write tool that would run a mutation after cancellation.
-    if (input.signal?.aborted) {
-      return {outcome: 'error', error: abortOutcome(input.signal)};
-    }
-
-    const adapter = input.registry.getAdapter(
-      input.integration.provider,
-      'agent_tools',
-    ) as AgentToolsProvider<
-      typeof input.connection,
-      unknown,
-      typeof input.integration,
-      CallToolResult
-    >;
-    openingSession = adapter.openSession({
-      connection: input.connection,
-      tools: [agentToolCatalogEntry(input)],
-      scope: input.integration,
-    });
-    session = await raceWithSignal(openingSession, input.signal);
-
-    // The signal may have aborted while the session was opening: the session
-    // is closed by the `finally` below, but the call must not be dispatched.
-    if (input.signal?.aborted) {
-      return {outcome: 'error', error: abortOutcome(input.signal)};
-    }
-
-    const result = await raceWithSignal(
-      session.call({
-        toolId: input.tool.id,
-        arguments: input.arguments,
-      }),
-      input.signal,
-    );
-    if (result.isError === true) {
-      // GitHub, gitea, jira, and slack surface provider tool-level failures as
-      // `isError` results instead of throwing; surface them as the bounded
-      // error outcome the same way the MCP gateway classifies them.
-      return {outcome: 'error', error: providerToolError(result)};
-    }
-    return {outcome: 'success', result};
+    return await executeIntegrationTool(input, state);
   } catch (error) {
-    // A caller-initiated abort is a cancellation, not a provider failure: keep
-    // it out of the timeout/unknown error classes and out of error monitoring.
-    if (input.signal?.aborted) {
-      // An abort that fired while the session was still opening leaves the
-      // `session` handle unset for `finally`; close the session when the
-      // opening promise settles so it cannot leak.
-      if (openingSession !== undefined && session === undefined) {
-        void openingSession.then(
-          (opened) => closeSession(opened, log, report),
-          () => undefined,
-        );
-      }
-      return {outcome: 'error', error: abortOutcome(input.signal)};
-    }
-    const errorRecord = errorResult(error);
-    if (
-      errorRecord.code === 'provider-unavailable' ||
-      errorRecord.code === 'provider-timeout' ||
-      errorRecord.code === 'unknown'
-    ) {
-      log().error(
-        {
-          ...toolCallLogContext(input),
-          err: error,
-          errorCode: errorRecord.code,
-          ...(errorRecord.status === undefined ? {} : {providerStatus: errorRecord.status}),
-        },
-        errorRecord.code === 'provider-unavailable'
-          ? 'Integration agent tool provider was unavailable'
-          : errorRecord.code === 'provider-timeout'
-            ? 'Integration agent tool provider timed out'
-            : 'Integration agent tool call failed',
-      );
-      report(error, {boundary: 'integration.agent-tool'});
-    }
-    return {outcome: 'error', error: errorRecord};
+    return handleIntegrationToolError(input, error, state, log, report);
   } finally {
-    await closeSession(session, log, report);
+    await closeSession(state.session, log, report);
   }
 }
 

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -445,6 +445,16 @@ function mapError(
   input: {connectionId?: string; defaultConnectionId?: string; ref?: string | undefined},
   error: unknown,
 ): unknown {
+  const connectionError = mapConnectionError(method, input, error);
+  if (connectionError !== undefined) return connectionError;
+  return mapProviderError(method, input, error);
+}
+
+function mapConnectionError(
+  method: InterModuleMethodContract,
+  input: {connectionId?: string; defaultConnectionId?: string},
+  error: unknown,
+): unknown | undefined {
   if (error instanceof IntegrationConnectionNotFoundError)
     return createInterModuleKnownError(method, 'connection-not-found', {
       connectionId: input.connectionId ?? input.defaultConnectionId,
@@ -470,6 +480,14 @@ function mapError(
     });
   if (error instanceof IntegrationCheckoutUnsupportedError)
     return createInterModuleKnownError(method, 'checkout-unsupported', {provider: error.provider});
+  return undefined;
+}
+
+function mapProviderError(
+  method: InterModuleMethodContract,
+  input: {ref?: string | undefined},
+  error: unknown,
+): unknown {
   if (error instanceof IntegrationProviderError) {
     // Only methods that resolve refs declare these codes; other methods keep
     // seeing the failure as a generic provider failure.

--- a/libs/api/integration/gitea/src/api/client.ts
+++ b/libs/api/integration/gitea/src/api/client.ts
@@ -421,12 +421,9 @@ async function giteaResponseErrorMessage(response: Response, fallback: string): 
   try {
     const parsed: unknown = JSON.parse(trimmedBody);
     if (isRecord(parsed)) {
-      const providerMessage =
-        typeof parsed.message === 'string'
-          ? parsed.message
-          : typeof parsed.error === 'string'
-            ? parsed.error
-            : undefined;
+      let providerMessage: string | undefined;
+      if (typeof parsed.message === 'string') providerMessage = parsed.message;
+      else if (typeof parsed.error === 'string') providerMessage = parsed.error;
       if (providerMessage?.trim()) return `${fallback}: ${truncate(providerMessage)}`;
     }
   } catch {

--- a/libs/api/integration/gitea/src/core/agent-tools.ts
+++ b/libs/api/integration/gitea/src/core/agent-tools.ts
@@ -126,26 +126,44 @@ export function validateGiteaToolArguments(
   for (const [name, value] of Object.entries(args)) {
     const schema = properties[name];
     if (!isRecord(schema)) return `Unknown parameter: ${name}`;
-
-    if (schema.type === 'string') {
-      if (typeof value !== 'string') return `Parameter ${name} must be a string`;
-      if (value.trim().length === 0) return `Parameter ${name} must not be empty`;
-      if (typeof schema.maxLength === 'number' && [...value].length > schema.maxLength) {
-        return `Parameter ${name} must be at most ${schema.maxLength} characters`;
-      }
-      if (name === 'repo' && !isSafeRepositoryName(value)) {
-        return `Parameter ${name} must be a repository name`;
-      }
-    }
-
-    if (schema.type === 'integer') {
-      if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
-        return `Parameter ${name} must be an integer`;
-      }
-      if (value < 1) return `Parameter ${name} must be a positive integer`;
-    }
+    const invalid = validateGiteaArgument(name, value, schema);
+    if (invalid !== undefined) return invalid;
   }
 
+  return undefined;
+}
+
+function validateGiteaArgument(
+  name: string,
+  value: unknown,
+  schema: Record<string, unknown>,
+): string | undefined {
+  if (schema.type === 'string') return validateGiteaStringArgument(name, value, schema);
+  if (schema.type === 'integer') return validateGiteaIntegerArgument(name, value);
+  return undefined;
+}
+
+function validateGiteaStringArgument(
+  name: string,
+  value: unknown,
+  schema: Record<string, unknown>,
+): string | undefined {
+  if (typeof value !== 'string') return `Parameter ${name} must be a string`;
+  if (value.trim().length === 0) return `Parameter ${name} must not be empty`;
+  if (typeof schema.maxLength === 'number' && [...value].length > schema.maxLength) {
+    return `Parameter ${name} must be at most ${schema.maxLength} characters`;
+  }
+  if (name === 'repo' && !isSafeRepositoryName(value)) {
+    return `Parameter ${name} must be a repository name`;
+  }
+  return undefined;
+}
+
+function validateGiteaIntegerArgument(name: string, value: unknown): string | undefined {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+    return `Parameter ${name} must be an integer`;
+  }
+  if (value < 1) return `Parameter ${name} must be a positive integer`;
   return undefined;
 }
 

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -40,6 +40,54 @@ const REFS_TAGS_PREFIX = 'refs/tags/';
 const SEARCH_PAGE_SIZE = 100;
 const SEARCH_MAX_PAGES_PER_REQUEST = 5;
 
+function buildGiteaTriggerReference(
+  repositoryId: string | null,
+  ref: string | null,
+  commit: string | null,
+  actor: ReturnType<typeof giteaEventActor>,
+): TriggerReference | null {
+  if (!repositoryId || !ref || !commit) return null;
+  if (!isValidGitObjectId(commit) || !isValidTriggerRef(ref)) return null;
+  return {
+    externalRepositoryId: buildProviderRepositoryId(giteaProviderKind, repositoryId),
+    ref,
+    commit,
+    actor,
+  };
+}
+
+function giteaPullRequestReference(
+  payload: Record<string, unknown>,
+  pullRequest: Record<string, unknown>,
+  actor: ReturnType<typeof giteaEventActor>,
+): TriggerReference | null {
+  const head = asRecord(pullRequest.head);
+  const repository = asRecord(head?.repo);
+  const baseRepository = asRecord(asRecord(pullRequest.base)?.repo) ?? asRecord(payload.repository);
+  if (!repository || !baseRepository || !sameGiteaRepository(repository, baseRepository))
+    return null;
+  const number = positiveInteger(pullRequest.number);
+  const ref = number === null ? null : `refs/pull/${number}/head`;
+  return buildGiteaTriggerReference(
+    giteaRepositoryId(repository),
+    ref,
+    nonEmptyString(head?.sha),
+    actor,
+  );
+}
+
+function giteaPushReference(
+  payload: Record<string, unknown>,
+  actor: ReturnType<typeof giteaEventActor>,
+): TriggerReference | null {
+  return buildGiteaTriggerReference(
+    giteaRepositoryId(asRecord(payload.repository)),
+    nonEmptyString(payload.ref),
+    nonEmptyString(payload.after),
+    actor,
+  );
+}
+
 export class GiteaSourceControlProvider
   implements SourceControlProvider<GiteaIntegrationConnection>
 {
@@ -151,41 +199,8 @@ export class GiteaSourceControlProvider
 
     const actor = giteaEventActor(payload);
     const pullRequest = asRecord(payload.pull_request);
-    if (pullRequest) {
-      const head = asRecord(pullRequest.head);
-      const repository = asRecord(head?.repo);
-      const base = asRecord(pullRequest.base);
-      const baseRepository = asRecord(base?.repo) ?? asRecord(payload.repository);
-      if (!repository || !baseRepository || !sameGiteaRepository(repository, baseRepository)) {
-        return null;
-      }
-      const repositoryId = giteaRepositoryId(repository);
-      const number = positiveInteger(pullRequest.number);
-      const commit = nonEmptyString(head?.sha);
-      const ref = number === null ? null : `refs/pull/${number}/head`;
-      if (!repositoryId || !ref || !commit) return null;
-      const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
-      if (!hasValidReference) return null;
-      return {
-        externalRepositoryId: buildProviderRepositoryId(giteaProviderKind, repositoryId),
-        ref,
-        commit,
-        actor,
-      };
-    }
-
-    const repositoryId = giteaRepositoryId(asRecord(payload.repository));
-    const ref = nonEmptyString(payload.ref);
-    const commit = nonEmptyString(payload.after);
-    if (!repositoryId || !ref || !commit) return null;
-    const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
-    if (!hasValidReference) return null;
-    return {
-      externalRepositoryId: buildProviderRepositoryId(giteaProviderKind, repositoryId),
-      ref,
-      commit,
-      actor,
-    };
+    if (pullRequest) return giteaPullRequestReference(payload, pullRequest, actor);
+    return giteaPushReference(payload, actor);
   }
 
   async resolveRef(input: ResolveRefInput<GiteaIntegrationConnection>): Promise<ResolvedRef> {
@@ -203,13 +218,9 @@ export class GiteaSourceControlProvider
     const providerRef = providerRefName(input.ref);
     const branchLookup = () => this.gitea.getBranch({owner, repo, branch: providerRef});
     const tagLookup = () => this.gitea.getTag({owner, repo, tag: providerRef});
-    const lookups: Array<() => Promise<{commitSha: string}>> = input.ref.startsWith(
-      REFS_TAGS_PREFIX,
-    )
-      ? [tagLookup]
-      : input.ref.startsWith(REFS_HEADS_PREFIX)
-        ? [branchLookup]
-        : [branchLookup, tagLookup];
+    let lookups: Array<() => Promise<{commitSha: string}>> = [branchLookup, tagLookup];
+    if (input.ref.startsWith(REFS_TAGS_PREFIX)) lookups = [tagLookup];
+    else if (input.ref.startsWith(REFS_HEADS_PREFIX)) lookups = [branchLookup];
     for (const lookup of lookups) {
       try {
         const resolved = await lookup();

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -240,6 +240,14 @@ describe('mapGithubError', () => {
     });
   });
 
+  it('rethrows request errors without an HTTP error status', async () => {
+    const error = new RequestErrorMock('Unexpected redirect response', 399);
+
+    const result = mapGithubError(() => Promise.reject(error));
+
+    await expect(result).rejects.toBe(error);
+  });
+
   it('preserves the status when mapping provider unavailability', async () => {
     const error = new RequestErrorMock('GitHub is unavailable', 503);
 

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -307,51 +307,49 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     const overflowLimit = start + input.limit + 1;
 
     type GetContentData = Awaited<ReturnType<typeof octokit.rest.repos.getContent>>['data'];
+    type GetContentEntry = Extract<GetContentData, unknown[]>[number];
+
+    const fetchContent = async (path: string): Promise<GetContentData | undefined> => {
+      try {
+        const response = await mapGithubError(
+          () => octokit.rest.repos.getContent({owner, repo, path, ref: input.ref}),
+          'file-not-found',
+        );
+        return response.data;
+      } catch (error) {
+        if (error instanceof GithubIntegrationProviderError && error.reason === 'file-not-found') {
+          return undefined;
+        }
+        throw error;
+      }
+    };
+
+    const collectFile = (data: {path?: string; size?: number; type: string}): void => {
+      if (data.type !== 'file' || !data.path) return;
+      collected.push({path: data.path, size: typeof data.size === 'number' ? data.size : null});
+    };
 
     const walk = async (path: string, depth: number): Promise<void> => {
       if (collected.length >= overflowLimit) return;
       if (depth > MAX_TREE_WALK_DEPTH) return;
-
-      let data: GetContentData;
-      try {
-        const response = await mapGithubError(
-          () =>
-            octokit.rest.repos.getContent({
-              owner,
-              repo,
-              path,
-              ref: input.ref,
-            }),
-          'file-not-found',
-        );
-        data = response.data;
-      } catch (error) {
-        if (error instanceof GithubIntegrationProviderError && error.reason === 'file-not-found') {
-          return;
-        }
-        throw error;
-      }
-
+      const data = await fetchContent(path);
+      if (data === undefined) return;
       if (!Array.isArray(data)) {
-        if (data.type === 'file' && data.path) {
-          collected.push({path: data.path, size: typeof data.size === 'number' ? data.size : null});
-        }
+        collectFile(data);
         return;
       }
-
       const entries = [...data].sort((a, b) => (a.path ?? '').localeCompare(b.path ?? ''));
       for (const entry of entries) {
-        if (collected.length >= overflowLimit) return;
-        if (!entry.path) continue;
-        if (entry.type === 'file') {
-          collected.push({
-            path: entry.path,
-            size: typeof entry.size === 'number' ? entry.size : null,
-          });
-        } else if (entry.type === 'dir') {
-          await walk(entry.path, depth + 1);
-        }
+        if (!(await collectGithubEntry(entry, depth))) return;
       }
+    };
+
+    const collectGithubEntry = async (entry: GetContentEntry, depth: number): Promise<boolean> => {
+      if (collected.length >= overflowLimit) return false;
+      if (!entry.path) return true;
+      if (entry.type === 'file') collectFile(entry);
+      else if (entry.type === 'dir') await walk(entry.path, depth + 1);
+      return true;
     };
 
     await walk(startPath, 0);
@@ -612,58 +610,38 @@ export async function mapGithubError<T>(
     if (isGithubTimeoutError(error)) {
       throw new GithubIntegrationProviderError('timeout', 'GitHub request timed out');
     }
-    if (error instanceof RequestError) {
-      if (error.status === 404) {
-        throw new GithubIntegrationProviderError(
-          notFoundReason === 'ref-not-found' ? 'repository-not-found' : notFoundReason,
-          error.message,
-          undefined,
-          error.status,
-        );
-      }
-      if (notFoundReason === 'ref-not-found' && (error.status === 409 || error.status === 422)) {
-        throw new GithubIntegrationProviderError(
-          'ref-not-found',
-          error.message,
-          undefined,
-          error.status,
-        );
-      }
-      if (error.status === 429 || isGithubRateLimitError(error)) {
-        throw new GithubIntegrationProviderError(
-          'rate-limited',
-          error.message,
-          retryAfterSeconds(error),
-          error.status,
-        );
-      }
-      if (error.status === 401 || error.status === 403) {
-        throw new GithubIntegrationProviderError(
-          'access-denied',
-          error.message,
-          retryAfterSeconds(error),
-          error.status,
-        );
-      }
-      if (error.status >= 500) {
-        throw new GithubIntegrationProviderError(
-          'provider-unavailable',
-          error.message,
-          undefined,
-          error.status,
-        );
-      }
-      if (error.status >= 400) {
-        throw new GithubIntegrationProviderError(
-          'provider-rejected',
-          error.message,
-          undefined,
-          error.status,
-        );
-      }
-    }
+    if (error instanceof RequestError) throw mapGithubRequestError(error, notFoundReason);
     throw error;
   }
+}
+
+function mapGithubRequestError(
+  error: RequestError,
+  notFoundReason:
+    | 'repository-not-found'
+    | 'installation-not-found'
+    | 'file-not-found'
+    | 'ref-not-found'
+    | 'provider-rejected',
+): GithubIntegrationProviderError {
+  let reason: ConstructorParameters<typeof GithubIntegrationProviderError>[0];
+  let retryAfter: number | undefined;
+  if (error.status === 404) {
+    reason = notFoundReason === 'ref-not-found' ? 'repository-not-found' : notFoundReason;
+  } else if (notFoundReason === 'ref-not-found' && (error.status === 409 || error.status === 422)) {
+    reason = 'ref-not-found';
+  } else if (error.status === 429 || isGithubRateLimitError(error)) {
+    reason = 'rate-limited';
+    retryAfter = retryAfterSeconds(error);
+  } else if (error.status === 401 || error.status === 403) {
+    reason = 'access-denied';
+    retryAfter = retryAfterSeconds(error);
+  } else if (error.status >= 500) {
+    reason = 'provider-unavailable';
+  } else {
+    reason = 'provider-rejected';
+  }
+  return new GithubIntegrationProviderError(reason, error.message, retryAfter, error.status);
 }
 
 function isGithubTimeoutError(error: unknown): boolean {

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -638,9 +638,9 @@ function mapGithubRequestError(
     retryAfter = retryAfterSeconds(error);
   } else if (error.status >= 500) {
     reason = 'provider-unavailable';
-  } else {
+  } else if (error.status >= 400) {
     reason = 'provider-rejected';
-  }
+  } else throw error;
   return new GithubIntegrationProviderError(reason, error.message, retryAfter, error.status);
 }
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -208,51 +208,38 @@ export class GithubAgentToolsProvider
         const client = (this.options.createClient ?? createOctokitClient)(token.token);
         const method =
           typeof call.arguments.method === 'string' ? call.arguments.method : undefined;
-
-        if (operation.kind === 'graphql') {
-          const data = await mapGithubError(() =>
-            executeGithubGraphqlOperation(
-              client,
-              tool.id as GithubAgentToolId,
-              method,
-              operation.parameters,
-            ),
-          );
-          if (data === undefined && tool.id === 'add_comment_to_pending_review') {
-            return githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected');
-          }
-          return githubToolResult(tool.id as GithubAgentToolId, data);
-        }
-
-        const operationParameters = await mapGithubError(() =>
-          resolveGithubOperationParameters(
-            client,
-            operation.parameters,
-            tool.id as GithubAgentToolId,
-            method,
-          ),
-        );
-        if (operationParameters === undefined) {
-          return githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected');
-        }
-        const response = await mapGithubError(() =>
-          executeGithubRestOperation(
-            client,
-            operation.route,
-            operationParameters,
-            tool.id as GithubAgentToolId,
-          ),
-        );
-        return githubToolResult(
-          tool.id as GithubAgentToolId,
-          response.data,
-          response,
-          operationParameters,
-          operation.route,
-        );
+        return await executeGithubToolOperation(client, tool, operation, method);
       },
     };
   }
+}
+
+async function executeGithubToolOperation(
+  client: GithubToolClient,
+  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
+  operation: GithubToolOperation,
+  method: string | undefined,
+): Promise<GithubToolCallResult> {
+  const toolId = tool.id as GithubAgentToolId;
+  if (operation.kind === 'graphql') {
+    const data = await mapGithubError(() =>
+      executeGithubGraphqlOperation(client, toolId, method, operation.parameters),
+    );
+    if (data === undefined && tool.id === 'add_comment_to_pending_review') {
+      return githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected');
+    }
+    return githubToolResult(toolId, data);
+  }
+  const parameters = await mapGithubError(() =>
+    resolveGithubOperationParameters(client, operation.parameters, toolId, method),
+  );
+  if (parameters === undefined) {
+    return githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected');
+  }
+  const response = await mapGithubError(() =>
+    executeGithubRestOperation(client, operation.route, parameters, toolId),
+  );
+  return githubToolResult(toolId, response.data, response, parameters, operation.route);
 }
 
 export interface GithubAgentToolsProviderOptions {
@@ -1050,26 +1037,35 @@ function latestPendingReviewOnPage(
   for (let index = data.length - 1; index >= 0; index -= 1) {
     const review = data[index];
     if (!isRecord(review) || review.state !== 'PENDING') continue;
-    const userLogin = isRecord(review.user) ? review.user.login : undefined;
-    if (typeof userLogin !== 'string' || userLogin.trim().length === 0) {
+    const candidate = pendingReviewCandidate(review, appLogin);
+    if (candidate === 'malformed') {
       malformed = true;
       continue;
     }
-    if (userLogin.trim().toLowerCase() !== appLogin) continue;
-    const id =
-      typeof review.id === 'number' && Number.isSafeInteger(review.id) && review.id > 0
-        ? review.id
-        : undefined;
-    const nodeId =
-      typeof review.node_id === 'string' && review.node_id.trim().length > 0
-        ? review.node_id.trim()
-        : undefined;
-    const reference = {id, nodeId};
-    if (reference[requiredIdentifier] !== undefined) return {malformed, review: reference};
+    if (candidate === undefined) continue;
+    if (candidate[requiredIdentifier] !== undefined) return {malformed, review: candidate};
     malformed = true;
   }
 
   return {malformed};
+}
+
+function pendingReviewCandidate(
+  review: Record<string, unknown>,
+  appLogin: string,
+): PendingReviewReference | 'malformed' | undefined {
+  const userLogin = isRecord(review.user) ? review.user.login : undefined;
+  if (typeof userLogin !== 'string' || userLogin.trim().length === 0) return 'malformed';
+  if (userLogin.trim().toLowerCase() !== appLogin) return undefined;
+  const id =
+    typeof review.id === 'number' && Number.isSafeInteger(review.id) && review.id > 0
+      ? review.id
+      : undefined;
+  const nodeId =
+    typeof review.node_id === 'string' && review.node_id.trim().length > 0
+      ? review.node_id.trim()
+      : undefined;
+  return {id, nodeId};
 }
 
 function githubToolResult(
@@ -1225,19 +1221,29 @@ function validateGithubToolArguments(
   }
   const propertySchemas = properties as Record<string, unknown>;
   for (const [name, value] of Object.entries(arguments_)) {
-    const schema = propertySchemas[name];
-    if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) continue;
-    const type = (schema as {type?: unknown}).type;
-    if (type === 'integer' && (!Number.isInteger(value) || typeof value !== 'number')) {
-      return `Parameter ${name} must be an integer`;
-    }
-    if (type === 'array' && !Array.isArray(value)) return `Parameter ${name} must be an array`;
+    const invalid = validateGithubArgument(name, value, propertySchemas[name]);
+    if (invalid !== undefined) return invalid;
   }
   if (tool.id === 'create_commit') return validateCreateCommitArguments(arguments_);
   return undefined;
 }
 
+function validateGithubArgument(name: string, value: unknown, schema: unknown): string | undefined {
+  if (!isRecord(schema)) return undefined;
+  if (schema.type === 'integer' && (!Number.isInteger(value) || typeof value !== 'number')) {
+    return `Parameter ${name} must be an integer`;
+  }
+  if (schema.type === 'array' && !Array.isArray(value)) return `Parameter ${name} must be an array`;
+  return undefined;
+}
+
 function validateCreateCommitArguments(arguments_: Record<string, unknown>): string | undefined {
+  const metadataError = validateCreateCommitMetadata(arguments_);
+  if (metadataError !== undefined) return metadataError;
+  return validateCreateCommitChanges(arguments_.additions, arguments_.deletions);
+}
+
+function validateCreateCommitMetadata(arguments_: Record<string, unknown>): string | undefined {
   const repository = arguments_.repository;
   if (typeof repository !== 'string' || !CREATE_COMMIT_REPOSITORY_PATTERN.test(repository)) {
     return 'Parameter repository must be a repository in owner/name format';
@@ -1259,11 +1265,13 @@ function validateCreateCommitArguments(arguments_: Record<string, unknown>): str
   ) {
     return 'Parameter message must be an object with a headline string and optional body string';
   }
-  const additions = arguments_.additions;
+  return undefined;
+}
+
+function validateCreateCommitChanges(additions: unknown, deletions: unknown): string | undefined {
   if (additions !== undefined && !isFileAdditionList(additions)) {
     return 'Parameter additions must be an array of {path, contents, encoding?} objects';
   }
-  const deletions = arguments_.deletions;
   if (deletions !== undefined && !isFileDeletionList(deletions)) {
     return 'Parameter deletions must be an array of {path} objects';
   }
@@ -1285,20 +1293,20 @@ function validateCreateCommitArguments(arguments_: Record<string, unknown>): str
 
 function isFileAdditionList(value: unknown): value is readonly Record<string, unknown>[] {
   if (!Array.isArray(value)) return false;
-  return value.every((item) => {
-    if (!isRecord(item)) return false;
-    if (typeof item.path !== 'string' || !isSafeRepositoryPath(item.path)) return false;
-    if (typeof item.contents !== 'string') return false;
-    if (item.encoding !== undefined) {
-      if (typeof item.encoding !== 'string' || !CREATE_COMMIT_ENCODINGS.has(item.encoding)) {
-        return false;
-      }
-      return item.encoding === 'base64'
-        ? isWellFormedBase64(item.contents)
-        : !CREATE_COMMIT_UNPAIRED_SURROGATE_PATTERN.test(item.contents);
-    }
+  return value.every(isFileAddition);
+}
+
+function isFileAddition(item: unknown): item is Record<string, unknown> {
+  if (!isRecord(item)) return false;
+  if (typeof item.path !== 'string' || !isSafeRepositoryPath(item.path)) return false;
+  if (typeof item.contents !== 'string') return false;
+  if (item.encoding === undefined) {
     return !CREATE_COMMIT_UNPAIRED_SURROGATE_PATTERN.test(item.contents);
-  });
+  }
+  if (typeof item.encoding !== 'string' || !CREATE_COMMIT_ENCODINGS.has(item.encoding))
+    return false;
+  if (item.encoding === 'base64') return isWellFormedBase64(item.contents);
+  return !CREATE_COMMIT_UNPAIRED_SURROGATE_PATTERN.test(item.contents);
 }
 
 function isFileDeletionList(value: unknown): value is readonly Record<string, unknown>[] {

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -38,6 +38,53 @@ const GITHUB_PROVIDER = 'github';
 const SEARCH_PAGE_SIZE = 100;
 const SEARCH_MAX_PAGES_PER_REQUEST = 5;
 
+function buildGithubTriggerReference(
+  repositoryId: string | null,
+  ref: string | null,
+  commit: string | null,
+  actor: ReturnType<typeof githubEventActor>,
+): TriggerReference | null {
+  if (!repositoryId || !ref || !commit) return null;
+  if (!isValidGitObjectId(commit) || !isValidTriggerRef(ref)) return null;
+  return {
+    externalRepositoryId: buildProviderRepositoryId(GITHUB_PROVIDER, repositoryId),
+    ref,
+    commit,
+    actor,
+  };
+}
+
+function githubPullRequestReference(
+  payload: Record<string, unknown>,
+  pullRequest: Record<string, unknown>,
+  actor: ReturnType<typeof githubEventActor>,
+): TriggerReference | null {
+  const head = asRecord(pullRequest.head);
+  const repository = asRecord(head?.repo);
+  const baseRepository = asRecord(asRecord(pullRequest.base)?.repo) ?? asRecord(payload.repository);
+  if (!repository || !baseRepository || !sameGithubRepository(repository, baseRepository))
+    return null;
+  const number = positiveInteger(pullRequest.number);
+  return buildGithubTriggerReference(
+    githubRepositoryId(repository),
+    number === null ? null : `refs/pull/${number}/head`,
+    nonEmptyString(head?.sha),
+    actor,
+  );
+}
+
+function githubPushReference(
+  payload: Record<string, unknown>,
+  actor: ReturnType<typeof githubEventActor>,
+): TriggerReference | null {
+  return buildGithubTriggerReference(
+    githubRepositoryId(asRecord(payload.repository)),
+    nonEmptyString(payload.ref),
+    nonEmptyString(payload.after),
+    actor,
+  );
+}
+
 export class GithubSourceControlProvider
   implements SourceControlProvider<GithubIntegrationConnection>
 {
@@ -154,41 +201,8 @@ export class GithubSourceControlProvider
 
     const actor = githubEventActor(payload);
     const pullRequest = asRecord(payload.pull_request);
-    if (pullRequest) {
-      const head = asRecord(pullRequest.head);
-      const repository = asRecord(head?.repo);
-      const base = asRecord(pullRequest.base);
-      const baseRepository = asRecord(base?.repo) ?? asRecord(payload.repository);
-      if (!repository || !baseRepository || !sameGithubRepository(repository, baseRepository)) {
-        return null;
-      }
-      const repositoryId = githubRepositoryId(repository);
-      const number = positiveInteger(pullRequest.number);
-      const commit = nonEmptyString(head?.sha);
-      const ref = number === null ? null : `refs/pull/${number}/head`;
-      if (!repositoryId || !ref || !commit) return null;
-      const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
-      if (!hasValidReference) return null;
-      return {
-        externalRepositoryId: buildProviderRepositoryId(GITHUB_PROVIDER, repositoryId),
-        ref,
-        commit,
-        actor,
-      };
-    }
-
-    const repositoryId = githubRepositoryId(asRecord(payload.repository));
-    const ref = nonEmptyString(payload.ref);
-    const commit = nonEmptyString(payload.after);
-    if (!repositoryId || !ref || !commit) return null;
-    const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
-    if (!hasValidReference) return null;
-    return {
-      externalRepositoryId: buildProviderRepositoryId(GITHUB_PROVIDER, repositoryId),
-      ref,
-      commit,
-      actor,
-    };
+    if (pullRequest) return githubPullRequestReference(payload, pullRequest, actor);
+    return githubPushReference(payload, actor);
   }
 
   async resolveRef(input: ResolveRefInput<GithubIntegrationConnection>): Promise<ResolvedRef> {

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -107,6 +107,80 @@ function pullRequestRepositories(
   return {head, base};
 }
 
+type GithubConnection = NonNullable<Awaited<ReturnType<GetIntegrationConnectionByIdFn>>>;
+
+async function dispatchGithubEvent(
+  params: HandleGithubEventParams,
+  connection: GithubConnection,
+  installationId: number,
+  action: string | undefined,
+): Promise<HandleGithubEventResult> {
+  if (params.event === 'push') {
+    const validated = githubPushPayloadSchema.safeParse(params.payload);
+    if (!validated.success) {
+      logger().warn(
+        {deliveryId: params.deliveryId, issues: validated.error.issues},
+        'github webhook push payload failed schema validation; publishing generic envelope only',
+      );
+      return publishGithubEnvelopeOnly({
+        tx: params.tx,
+        deliveryId: params.deliveryId,
+        payload: params.payload,
+        publishIntegrationEventReceived: params.publishIntegrationEventReceived,
+        connection,
+        event: 'push',
+      });
+    }
+    return publishGithubPush({
+      ...params,
+      eventPayload: validated.data,
+      rawPayload: params.payload,
+      connection,
+    });
+  }
+
+  const eventName = action ? `${params.event}.${action}` : params.event;
+  const repositories = normalizeRepositoryUpdates(params.event, action, params.payload);
+  if (repositories) {
+    const result = await params.publishSourceRepositoryUpdated({
+      tx: params.tx,
+      provider: GITHUB_SOURCE,
+      source: connection.slug,
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      connectionName: connection.displayName,
+      deliveryId: params.deliveryId,
+      receivedAt: new Date().toISOString(),
+      rawPayload: params.payload,
+      event: eventName,
+      repositories,
+    });
+    return withInstallationTokenCleanup(
+      {outcome: result.published ? 'published' : 'duplicate'},
+      params.event,
+      action,
+      connection.workspaceId,
+      installationId,
+    );
+  }
+
+  const result = await publishGithubEnvelopeOnly({
+    tx: params.tx,
+    deliveryId: params.deliveryId,
+    payload: params.payload,
+    publishIntegrationEventReceived: params.publishIntegrationEventReceived,
+    connection,
+    event: eventName,
+  });
+  return withInstallationTokenCleanup(
+    result,
+    params.event,
+    action,
+    connection.workspaceId,
+    installationId,
+  );
+}
+
 export async function handleGithubEvent(
   params: HandleGithubEventParams,
 ): Promise<HandleGithubEventResult> {
@@ -214,71 +288,7 @@ export async function handleGithubEvent(
     );
   }
 
-  if (params.event === 'push') {
-    const validated = githubPushPayloadSchema.safeParse(params.payload);
-    if (!validated.success) {
-      logger().warn(
-        {deliveryId: params.deliveryId, issues: validated.error.issues},
-        'github webhook push payload failed schema validation; publishing generic envelope only',
-      );
-      return publishGithubEnvelopeOnly({
-        tx: params.tx,
-        deliveryId: params.deliveryId,
-        payload: params.payload,
-        publishIntegrationEventReceived: params.publishIntegrationEventReceived,
-        connection,
-        event: 'push',
-      });
-    }
-
-    return publishGithubPush({
-      ...params,
-      eventPayload: validated.data,
-      rawPayload: params.payload,
-      connection,
-    });
-  }
-
-  const eventName = action ? `${params.event}.${action}` : params.event;
-  const repositories = normalizeRepositoryUpdates(params.event, action, params.payload);
-  if (repositories) {
-    const result = await params.publishSourceRepositoryUpdated({
-      tx: params.tx,
-      provider: GITHUB_SOURCE,
-      source: connection.slug,
-      workspaceId: connection.workspaceId,
-      connectionId: connection.id,
-      connectionName: connection.displayName,
-      deliveryId: params.deliveryId,
-      receivedAt: new Date().toISOString(),
-      rawPayload: params.payload,
-      event: eventName,
-      repositories,
-    });
-    return withInstallationTokenCleanup(
-      {outcome: result.published ? 'published' : 'duplicate'},
-      params.event,
-      action,
-      connection.workspaceId,
-      installationId,
-    );
-  }
-
-  const result = await publishGithubEnvelopeOnly({
-    tx: params.tx,
-    deliveryId: params.deliveryId,
-    payload: params.payload,
-    publishIntegrationEventReceived: params.publishIntegrationEventReceived,
-    connection,
-    event: eventName,
-  });
-  return withInstallationTokenCleanup(
-    result,
-    params.event,
-    action,
-    connection.workspaceId,
-    installationId,
-  );
+  return dispatchGithubEvent(params, connection, installationId, action);
 }
 
 function normalizeRepositoryUpdates(

--- a/libs/api/integration/jira/src/api/client.ts
+++ b/libs/api/integration/jira/src/api/client.ts
@@ -425,42 +425,51 @@ export async function mapJiraError<T>(operation: string, request: () => Promise<
     return await request();
   } catch (error) {
     if (error instanceof JiraIntegrationProviderError) throw error;
-    if (error instanceof HTTPError) {
-      const {status, statusText, headers} = error.response;
-      logger().warn({operation, status, statusText}, 'Jira API request rejected');
-      if (status === 429) {
-        throw new JiraIntegrationProviderError(
-          'rate-limited',
-          'Jira request was rate limited',
-          retryAfterSeconds(headers),
-        );
-      }
-      if (status >= 500)
-        throw new JiraIntegrationProviderError('provider-unavailable', 'Jira request failed');
-      if (status === 401 || status === 403) {
-        throw new JiraIntegrationProviderError('access-denied', 'Jira request was rejected');
-      }
-      if (status === 400 && operation === 'refresh-access-token') {
-        const errorCode = readJiraOAuthErrorCode(error.data);
-        if (errorCode && JIRA_REFRESH_TOKEN_TERMINAL_ERROR_CODES.has(errorCode)) {
-          throw new JiraIntegrationProviderError(
-            'access-denied',
-            'Jira refresh token was rejected; reconnect is required',
-          );
-        }
-      }
-      throw malformed('Jira request was rejected');
-    }
-    if (error instanceof TimeoutError) {
-      logger().warn({operation}, 'Jira API request timed out');
-      throw new JiraIntegrationProviderError('timeout', 'Jira request timed out');
-    }
-    logger().warn(
-      {operation, errName: error instanceof Error ? error.name : typeof error},
-      'Jira API request failed',
-    );
-    throw new JiraIntegrationProviderError('provider-unavailable', 'Jira request failed');
+    throw mapUnknownJiraError(operation, error);
   }
+}
+
+function mapUnknownJiraError(operation: string, error: unknown): JiraIntegrationProviderError {
+  if (error instanceof HTTPError) return mapJiraHttpError(operation, error);
+  if (error instanceof TimeoutError) {
+    logger().warn({operation}, 'Jira API request timed out');
+    return new JiraIntegrationProviderError('timeout', 'Jira request timed out');
+  }
+  logger().warn(
+    {operation, errName: error instanceof Error ? error.name : typeof error},
+    'Jira API request failed',
+  );
+  return new JiraIntegrationProviderError('provider-unavailable', 'Jira request failed');
+}
+
+function mapJiraHttpError(operation: string, error: HTTPError): JiraIntegrationProviderError {
+  const {status, statusText, headers} = error.response;
+  logger().warn({operation, status, statusText}, 'Jira API request rejected');
+  if (status === 429) {
+    return new JiraIntegrationProviderError(
+      'rate-limited',
+      'Jira request was rate limited',
+      retryAfterSeconds(headers),
+    );
+  }
+  if (status >= 500)
+    return new JiraIntegrationProviderError('provider-unavailable', 'Jira request failed');
+  if (status === 401 || status === 403) {
+    return new JiraIntegrationProviderError('access-denied', 'Jira request was rejected');
+  }
+  if (isTerminalRefreshRejection(operation, status, error.data)) {
+    return new JiraIntegrationProviderError(
+      'access-denied',
+      'Jira refresh token was rejected; reconnect is required',
+    );
+  }
+  return malformed('Jira request was rejected');
+}
+
+function isTerminalRefreshRejection(operation: string, status: number, data: unknown): boolean {
+  if (status !== 400 || operation !== 'refresh-access-token') return false;
+  const errorCode = readJiraOAuthErrorCode(data);
+  return errorCode !== undefined && JIRA_REFRESH_TOKEN_TERMINAL_ERROR_CODES.has(errorCode);
 }
 
 function malformed(message: string): JiraIntegrationProviderError {

--- a/libs/api/integration/jira/src/core/agent-tools-provider.ts
+++ b/libs/api/integration/jira/src/core/agent-tools-provider.ts
@@ -16,6 +16,7 @@ import {
 import {JiraIntegrationProviderError} from './errors.js';
 
 type JiraIntegrationConnection = IntegrationConnection<'jira'>;
+type JiraToolCall = Parameters<AgentToolSession<JiraToolCallResult>['call']>[0];
 
 export type JiraToolCallResult = {
   isError?: boolean | undefined;
@@ -60,53 +61,84 @@ export class JiraAgentToolsProvider
     const cloudId = input.connection.externalAccountId;
 
     return {
-      call: async (call) => {
-        const tool = input.tools.find((candidate) => candidate.id === call.toolId);
-        if (!tool) return jiraToolError(`Unknown Jira tool: ${call.toolId}`);
-
-        const operation = JIRA_TOOL_OPERATIONS[call.toolId as keyof typeof JIRA_TOOL_OPERATIONS];
-        if (!operation) return jiraToolError(`Unknown Jira tool: ${call.toolId}`);
-
-        const missingParameter = missingRequiredParameter(tool, call.arguments);
-        if (missingParameter) {
-          return jiraToolError(`Missing required parameter: ${missingParameter}`);
-        }
-
-        let response: JiraAgentToolResponse;
-        try {
-          response = await this.options.jira.request({
-            accessToken,
-            cloudId,
-            method: operation.method,
-            path: operation.path(call.arguments),
-            ...(operation.query === undefined ? {} : {query: operation.query(call.arguments)}),
-            ...(operation.body === undefined ? {} : {body: operation.body(call.arguments)}),
-            operation: call.toolId,
-          });
-        } catch (error) {
-          if (error instanceof JiraIntegrationProviderError) {
-            return jiraToolError(error.message, {
-              code: error.reason,
-              retryAfterSeconds: error.retryAfterSeconds,
-            });
-          }
-          throw error;
-        }
-
-        if (response.status === 400 || response.status === 404) {
-          return jiraRequestError(
-            response.body,
-            response.status === 404 ? 'Jira resource was not found' : 'Jira request was rejected',
-          );
-        }
-        if (response.status < 200 || response.status >= 300) {
-          return jiraToolError(`Jira request returned HTTP ${response.status}`);
-        }
-        return jiraToolResult(response.body, response.status);
-      },
+      call: (call) =>
+        executeJiraToolCall({
+          call,
+          tools: input.tools,
+          accessToken,
+          cloudId,
+          jira: this.options.jira,
+        }),
       close: () => Promise.resolve(),
     };
   }
+}
+
+async function executeJiraToolCall(params: {
+  call: JiraToolCall;
+  tools: readonly AgentToolCatalogEntry<JiraAgentToolRequiredScope>[];
+  accessToken: string;
+  cloudId: string;
+  jira: Pick<JiraAgentToolsClient, 'request'>;
+}): Promise<JiraToolCallResult> {
+  const tool = params.tools.find((candidate) => candidate.id === params.call.toolId);
+  if (!tool) return jiraToolError(`Unknown Jira tool: ${params.call.toolId}`);
+  const operation = JIRA_TOOL_OPERATIONS[params.call.toolId as keyof typeof JIRA_TOOL_OPERATIONS];
+  if (!operation) return jiraToolError(`Unknown Jira tool: ${params.call.toolId}`);
+  const missingParameter = missingRequiredParameter(tool, params.call.arguments);
+  if (missingParameter) return jiraToolError(`Missing required parameter: ${missingParameter}`);
+
+  const response = await requestJiraTool({
+    ...params,
+    operation,
+  });
+  if (response instanceof JiraIntegrationProviderError) {
+    return jiraToolError(response.message, {
+      code: response.reason,
+      retryAfterSeconds: response.retryAfterSeconds,
+    });
+  }
+  return mapJiraToolResponse(response);
+}
+
+async function requestJiraTool(params: {
+  call: JiraToolCall;
+  accessToken: string;
+  cloudId: string;
+  jira: Pick<JiraAgentToolsClient, 'request'>;
+  operation: (typeof JIRA_TOOL_OPERATIONS)[keyof typeof JIRA_TOOL_OPERATIONS];
+}): Promise<JiraAgentToolResponse | JiraIntegrationProviderError> {
+  try {
+    return await params.jira.request({
+      accessToken: params.accessToken,
+      cloudId: params.cloudId,
+      method: params.operation.method,
+      path: params.operation.path(params.call.arguments),
+      ...(params.operation.query === undefined
+        ? {}
+        : {query: params.operation.query(params.call.arguments)}),
+      ...(params.operation.body === undefined
+        ? {}
+        : {body: params.operation.body(params.call.arguments)}),
+      operation: params.call.toolId,
+    });
+  } catch (error) {
+    if (error instanceof JiraIntegrationProviderError) return error;
+    throw error;
+  }
+}
+
+function mapJiraToolResponse(response: JiraAgentToolResponse): JiraToolCallResult {
+  if (response.status === 400 || response.status === 404) {
+    return jiraRequestError(
+      response.body,
+      response.status === 404 ? 'Jira resource was not found' : 'Jira request was rejected',
+    );
+  }
+  if (response.status < 200 || response.status >= 300) {
+    return jiraToolError(`Jira request returned HTTP ${response.status}`);
+  }
+  return jiraToolResult(response.body, response.status);
 }
 
 function missingRequiredParameter(
@@ -121,7 +153,9 @@ function missingRequiredParameter(
 }
 
 function jiraToolResult(body: unknown, status: number): JiraToolCallResult {
-  const structuredContent = body === undefined ? {status} : isRecord(body) ? body : {result: body};
+  let structuredContent: Record<string, unknown> = {status};
+  if (isRecord(body)) structuredContent = body;
+  else if (body !== undefined) structuredContent = {result: body};
   return {
     content: [{type: 'text', text: JSON.stringify(structuredContent)}],
     structuredContent,

--- a/libs/api/integration/jira/src/core/install.ts
+++ b/libs/api/integration/jira/src/core/install.ts
@@ -151,77 +151,100 @@ async function verifyClaims(
   return claims;
 }
 
-function resolveJiraSite(
-  params: Omit<HandleJiraCallbackParams, 'code'> & {
-    authorization: JiraAuthorization;
-    site: JiraAccessibleResource;
-    claims: {workspaceId: string; userId: string};
-  },
-): Promise<IntegrationConnection<'jira'>> {
+type ResolveJiraSiteParams = Omit<HandleJiraCallbackParams, 'code'> & {
+  authorization: JiraAuthorization;
+  site: JiraAccessibleResource;
+  claims: {workspaceId: string; userId: string};
+};
+
+function resolveJiraSite(params: ResolveJiraSiteParams): Promise<IntegrationConnection<'jira'>> {
   const withInstallationLock = params.withJiraInstallationLock ?? withJiraInstallationLock;
-  return withInstallationLock(params.site.cloudId, async () => {
-    const existing = await params.getExistingJiraConnection({cloudId: params.site.cloudId});
-    if (existing && existing.workspaceId !== params.claims.workspaceId)
-      throw new JiraInstallationAlreadyLinkedError(params.site.cloudId);
-    const identity = await params.jira.getMyself({
-      accessToken: params.authorization.accessToken,
-      cloudId: params.site.cloudId,
-    });
-    const installationInput = {
-      workspaceId: params.claims.workspaceId,
-      cloudId: params.site.cloudId,
-      siteUrl: params.site.url,
-      siteName: params.site.name,
-      authorizingAccountId: identity.accountId,
-      scopes: params.site.scopes,
-      tokenExpiresAt: params.authorization.expiresAt ?? null,
-      displayName: `Jira ${params.site.name}`,
-    };
-    let connection = existing;
-    try {
-      if (!connection) connection = await params.connectJiraInstallation(installationInput);
-      await params.tokenStore.storeTokens({
-        connectionId: connection.id,
-        accessToken: params.authorization.accessToken,
-        refreshToken: params.authorization.refreshToken,
-        editedBy: params.claims.userId,
-      });
-      if (existing) connection = await params.connectJiraInstallation(installationInput);
-    } catch (error) {
-      if (existing) {
-        const markedError = await bestEffortMarkConnectionError(params, existing.id);
-        if (!markedError) await bestEffortMarkConnectionError(params, existing.id);
-      } else if (connection) {
-        await bestEffortDisconnect(params, connection.id);
-      }
-      throw error;
-    }
+  return withInstallationLock(params.site.cloudId, () => resolveJiraSiteWithLock(params));
+}
 
-    let registrationFailureHandled = false;
-    try {
-      await params.registerJiraWebhook({
-        connectionId: connection.id,
-        cloudId: params.site.cloudId,
-        accessToken: params.authorization.accessToken,
-        withRegistrationLock: async (_lockKey, fn) => fn(),
-        onRegistrationSuccess: async ({tx}) => {
-          await params.markConnectionActive(connectionLifecycleInput(connection.id, tx));
-        },
-        onRegistrationFailure: async ({tx}) => {
-          registrationFailureHandled = await bestEffortMarkConnectionError(
-            params,
-            connection.id,
-            tx,
-          );
-        },
-      });
-    } catch (error) {
-      if (!registrationFailureHandled) await bestEffortMarkConnectionError(params, connection.id);
-      throw error;
-    }
-
-    return connection;
+async function resolveJiraSiteWithLock(
+  params: ResolveJiraSiteParams,
+): Promise<IntegrationConnection<'jira'>> {
+  const existing = await params.getExistingJiraConnection({cloudId: params.site.cloudId});
+  if (existing && existing.workspaceId !== params.claims.workspaceId) {
+    throw new JiraInstallationAlreadyLinkedError(params.site.cloudId);
+  }
+  const identity = await params.jira.getMyself({
+    accessToken: params.authorization.accessToken,
+    cloudId: params.site.cloudId,
   });
+  const installationInput: ConnectJiraInstallationInput = {
+    workspaceId: params.claims.workspaceId,
+    cloudId: params.site.cloudId,
+    siteUrl: params.site.url,
+    siteName: params.site.name,
+    authorizingAccountId: identity.accountId,
+    scopes: params.site.scopes,
+    tokenExpiresAt: params.authorization.expiresAt ?? null,
+    displayName: `Jira ${params.site.name}`,
+  };
+  const connection = await connectAndStoreJiraTokens(params, installationInput, existing);
+  await registerJiraConnectionWebhook(params, connection);
+  return connection;
+}
+
+async function connectAndStoreJiraTokens(
+  params: ResolveJiraSiteParams,
+  installationInput: ConnectJiraInstallationInput,
+  existing: IntegrationConnection<'jira'> | undefined,
+): Promise<IntegrationConnection<'jira'>> {
+  let connection = existing;
+  try {
+    if (!connection) connection = await params.connectJiraInstallation(installationInput);
+    await params.tokenStore.storeTokens({
+      connectionId: connection.id,
+      accessToken: params.authorization.accessToken,
+      refreshToken: params.authorization.refreshToken,
+      editedBy: params.claims.userId,
+    });
+    if (existing) connection = await params.connectJiraInstallation(installationInput);
+    return connection;
+  } catch (error) {
+    await compensateFailedJiraConnection(params, existing, connection);
+    throw error;
+  }
+}
+
+async function compensateFailedJiraConnection(
+  params: ResolveJiraSiteParams,
+  existing: IntegrationConnection<'jira'> | undefined,
+  connection: IntegrationConnection<'jira'> | undefined,
+): Promise<void> {
+  if (existing) {
+    const markedError = await bestEffortMarkConnectionError(params, existing.id);
+    if (!markedError) await bestEffortMarkConnectionError(params, existing.id);
+    return;
+  }
+  if (connection) await bestEffortDisconnect(params, connection.id);
+}
+
+async function registerJiraConnectionWebhook(
+  params: ResolveJiraSiteParams,
+  connection: IntegrationConnection<'jira'>,
+): Promise<void> {
+  let registrationFailureHandled = false;
+  try {
+    await params.registerJiraWebhook({
+      connectionId: connection.id,
+      cloudId: params.site.cloudId,
+      accessToken: params.authorization.accessToken,
+      withRegistrationLock: async (_lockKey, fn) => fn(),
+      onRegistrationSuccess: async ({tx}) => {
+        await params.markConnectionActive(connectionLifecycleInput(connection.id, tx));
+      },
+      onRegistrationFailure: async ({tx}) => {
+        registrationFailureHandled = await bestEffortMarkConnectionError(params, connection.id, tx);
+      },
+    });
+  } catch (error) {
+    if (!registrationFailureHandled) await bestEffortMarkConnectionError(params, connection.id);
+    throw error;
+  }
 }
 
 async function bestEffortDisconnect(

--- a/libs/api/integration/jira/src/core/tokens.ts
+++ b/libs/api/integration/jira/src/core/tokens.ts
@@ -114,28 +114,34 @@ export function createJiraTokenStore(params: CreateJiraTokenStoreParams): JiraTo
     if (!token) throw new JiraAccessTokenMissingError(connectionId);
     return token;
   }
+  async function storeTokensForGeneration(
+    input: StoreJiraTokensParams,
+    credentialGeneration: number,
+  ): Promise<void> {
+    if (currentCredentialGeneration(input.connectionId) !== credentialGeneration) return;
+    const workspaceId = await resolveWorkspaceId(input.connectionId);
+    if (currentCredentialGeneration(input.connectionId) !== credentialGeneration) return;
+    const values: Record<string, string> = {[ACCESS_TOKEN_KEY]: input.accessToken};
+    if (input.refreshToken) values[REFRESH_TOKEN_KEY] = input.refreshToken;
+    await params.secrets.setSecrets({
+      workspaceId,
+      namespace: jiraSecretsNamespace(input.connectionId),
+      values,
+      editedBy: input.editedBy,
+    });
+    if (currentCredentialGeneration(input.connectionId) === credentialGeneration) {
+      refreshStateUnknownConnections.delete(input.connectionId);
+    }
+  }
 
   return {
     async storeTokens(input) {
       const credentialGeneration = advanceCredentialGeneration(input.connectionId);
       tokenRefreshes.delete(input.connectionId);
       await withJiraRefreshLockAndWait(input.connectionId, () =>
-        withCredentialWrite(input.connectionId, async () => {
-          if (currentCredentialGeneration(input.connectionId) !== credentialGeneration) return;
-          const workspaceId = await resolveWorkspaceId(input.connectionId);
-          if (currentCredentialGeneration(input.connectionId) !== credentialGeneration) return;
-          const values: Record<string, string> = {[ACCESS_TOKEN_KEY]: input.accessToken};
-          if (input.refreshToken) values[REFRESH_TOKEN_KEY] = input.refreshToken;
-          await params.secrets.setSecrets({
-            workspaceId,
-            namespace: jiraSecretsNamespace(input.connectionId),
-            values,
-            editedBy: input.editedBy,
-          });
-          if (currentCredentialGeneration(input.connectionId) === credentialGeneration) {
-            refreshStateUnknownConnections.delete(input.connectionId);
-          }
-        }),
+        withCredentialWrite(input.connectionId, () =>
+          storeTokensForGeneration(input, credentialGeneration),
+        ),
       );
     },
     async getAccessToken(input) {
@@ -197,7 +203,7 @@ function shouldRefresh(expiresAt: Date | null): boolean {
   return expiresAt !== null && expiresAt.getTime() <= Date.now() + TOKEN_REFRESH_MARGIN_MS;
 }
 
-async function refreshAccessTokenWithLock(params: {
+type RefreshAccessTokenParams = {
   connectionId: string;
   workspaceId: string;
   originalAccessToken: string;
@@ -214,7 +220,9 @@ async function refreshAccessTokenWithLock(params: {
   withCredentialWrite<T>(connectionId: string, operation: () => Promise<T>): Promise<T>;
   waitForCredentialWrites(connectionId: string): Promise<void>;
   isCurrentCredentialGeneration(): boolean;
-}): Promise<string> {
+};
+
+async function refreshAccessTokenWithLock(params: RefreshAccessTokenParams): Promise<string> {
   const lock = await withJiraRefreshLock(params.connectionId, () =>
     refreshAccessTokenForConnection(params),
   );
@@ -230,26 +238,22 @@ async function refreshAccessTokenWithLock(params: {
   );
 }
 
-async function refreshAccessTokenForConnection(params: {
-  connectionId: string;
-  workspaceId: string;
-  originalAccessToken: string;
-  forceRefresh: boolean;
-  client: JiraApiClient;
-  secrets: JiraSecretsStore;
-  readAccessToken(workspaceId: string, connectionId: string): Promise<string>;
-  readSecretToken(
-    workspaceId: string,
-    connectionId: string,
-    key: typeof ACCESS_TOKEN_KEY | typeof REFRESH_TOKEN_KEY,
-  ): Promise<string | null>;
-  markConnectionError?: ((params: {connectionId: string}) => Promise<void>) | undefined;
-  withCredentialWrite<T>(connectionId: string, operation: () => Promise<T>): Promise<T>;
-  waitForCredentialWrites(connectionId: string): Promise<void>;
-  isCurrentCredentialGeneration(): boolean;
-}): Promise<string> {
+async function refreshAccessTokenForConnection(params: RefreshAccessTokenParams): Promise<string> {
+  const refreshState = await resolveRefreshState(params);
+  if ('accessToken' in refreshState) return refreshState.accessToken;
+  try {
+    return await refreshAndPersistAccessToken(params, refreshState.refreshToken);
+  } catch (error) {
+    await handleRefreshFailure(params, error);
+    throw error;
+  }
+}
+
+async function resolveRefreshState(
+  params: RefreshAccessTokenParams,
+): Promise<{accessToken: string} | {refreshToken: string}> {
   if (!params.isCurrentCredentialGeneration()) {
-    return params.readAccessToken(params.workspaceId, params.connectionId);
+    return {accessToken: await params.readAccessToken(params.workspaceId, params.connectionId)};
   }
   const current = await params.readAccessToken(params.workspaceId, params.connectionId);
   const installation = await getJiraInstallationByConnectionId(params.connectionId);
@@ -257,7 +261,7 @@ async function refreshAccessTokenForConnection(params: {
     current !== params.originalAccessToken ||
     (!params.forceRefresh && !shouldRefresh(installation?.tokenExpiresAt ?? null))
   )
-    return current;
+    return {accessToken: current};
   const refreshToken = await params.readSecretToken(
     params.workspaceId,
     params.connectionId,
@@ -266,46 +270,54 @@ async function refreshAccessTokenForConnection(params: {
   if (!refreshToken) {
     if (params.forceRefresh || shouldRefresh(installation?.tokenExpiresAt ?? null))
       throw new JiraTokenUnrefreshableError(params.connectionId);
-    return current;
+    return {accessToken: current};
   }
-  try {
-    const refreshed = await params.client.refreshAccessToken({refreshToken});
-    const refreshedRefreshToken = refreshed.refreshToken;
-    if (!refreshedRefreshToken) throw new JiraTokenUnrefreshableError(params.connectionId);
-    const persisted = await params.withCredentialWrite(params.connectionId, async () => {
-      if (!params.isCurrentCredentialGeneration()) return false;
-      await params.secrets.setSecrets({
-        workspaceId: params.workspaceId,
-        namespace: jiraSecretsNamespace(params.connectionId),
-        values: {
-          [ACCESS_TOKEN_KEY]: refreshed.accessToken,
-          [REFRESH_TOKEN_KEY]: refreshedRefreshToken,
-        },
-      });
-      if (!params.isCurrentCredentialGeneration()) return false;
-      await updateJiraInstallationTokenExpiry({
-        connectionId: params.connectionId,
-        tokenExpiresAt: refreshed.expiresAt ?? null,
-        scopes: refreshed.scopes.length > 0 ? refreshed.scopes : undefined,
-      });
-      return true;
+  return {refreshToken};
+}
+
+async function refreshAndPersistAccessToken(
+  params: RefreshAccessTokenParams,
+  refreshToken: string,
+): Promise<string> {
+  const refreshed = await params.client.refreshAccessToken({refreshToken});
+  const refreshedRefreshToken = refreshed.refreshToken;
+  if (!refreshedRefreshToken) throw new JiraTokenUnrefreshableError(params.connectionId);
+  const persisted = await params.withCredentialWrite(params.connectionId, async () => {
+    if (!params.isCurrentCredentialGeneration()) return false;
+    await params.secrets.setSecrets({
+      workspaceId: params.workspaceId,
+      namespace: jiraSecretsNamespace(params.connectionId),
+      values: {
+        [ACCESS_TOKEN_KEY]: refreshed.accessToken,
+        [REFRESH_TOKEN_KEY]: refreshedRefreshToken,
+      },
     });
-    if (!persisted || !params.isCurrentCredentialGeneration()) {
-      await params.waitForCredentialWrites(params.connectionId);
-      return params.readAccessToken(params.workspaceId, params.connectionId);
-    }
-    return refreshed.accessToken;
-  } catch (error) {
-    if (isTerminalRefreshFailure(error)) {
-      await markConnectionError({
-        callback: params.markConnectionError,
-        connectionId: params.connectionId,
-        isCurrentCredentialGeneration: params.isCurrentCredentialGeneration,
-        withCredentialWrite: params.withCredentialWrite,
-      });
-    }
-    throw error;
+    if (!params.isCurrentCredentialGeneration()) return false;
+    await updateJiraInstallationTokenExpiry({
+      connectionId: params.connectionId,
+      tokenExpiresAt: refreshed.expiresAt ?? null,
+      scopes: refreshed.scopes.length > 0 ? refreshed.scopes : undefined,
+    });
+    return true;
+  });
+  if (!persisted || !params.isCurrentCredentialGeneration()) {
+    await params.waitForCredentialWrites(params.connectionId);
+    return params.readAccessToken(params.workspaceId, params.connectionId);
   }
+  return refreshed.accessToken;
+}
+
+async function handleRefreshFailure(
+  params: RefreshAccessTokenParams,
+  error: unknown,
+): Promise<void> {
+  if (!isTerminalRefreshFailure(error)) return;
+  await markConnectionError({
+    callback: params.markConnectionError,
+    connectionId: params.connectionId,
+    isCurrentCredentialGeneration: params.isCurrentCredentialGeneration,
+    withCredentialWrite: params.withCredentialWrite,
+  });
 }
 
 function isTerminalRefreshFailure(error: unknown): boolean {

--- a/libs/api/integration/jira/src/core/webhook-registration.ts
+++ b/libs/api/integration/jira/src/core/webhook-registration.ts
@@ -24,110 +24,136 @@ export interface RegisterJiraWebhookParams {
   onRegistrationFailure?: (input: {tx?: unknown}) => Promise<void>;
 }
 
+type JiraInstallation = Awaited<ReturnType<typeof getJiraInstallationByConnectionId>>;
+
+interface JiraWebhookRegistrationState {
+  callbackFailed: boolean;
+  registeredWebhookId: number | undefined;
+  previous: JiraInstallation;
+  metadataPersisted: boolean;
+  cleanupSupersededWebhooks: (() => Promise<void>) | undefined;
+}
+
 /** Register Jira's curated webhook and replace local metadata as one serialized state transition. */
 export async function registerJiraWebhook(
   params: RegisterJiraWebhookParams,
 ): Promise<{webhookId: number; webhookExpiresAt: Date}> {
   const withRegistrationLock = params.withRegistrationLock ?? withJiraInstallationLock;
-  let callbackFailed = false;
-  let registeredWebhookId: number | undefined;
-  let previous: Awaited<ReturnType<typeof getJiraInstallationByConnectionId>>;
-  let metadataPersisted = false;
-  let cleanupSupersededWebhooks: (() => Promise<void>) | undefined;
+  const state: JiraWebhookRegistrationState = {
+    callbackFailed: false,
+    registeredWebhookId: undefined,
+    previous: undefined,
+    metadataPersisted: false,
+    cleanupSupersededWebhooks: undefined,
+  };
   let result: {webhookId: number; webhookExpiresAt: Date};
   try {
-    result = await withRegistrationLock(params.cloudId, async () => {
-      try {
-        const getInstallation = params.getInstallation ?? getJiraInstallationByConnectionId;
-        previous = await getInstallation(params.connectionId);
-        const registration = await params.jira.registerDynamicWebhook({
-          accessToken: params.accessToken,
-          cloudId: params.cloudId,
-          url: params.webhookUrl,
-        });
-        registeredWebhookId = registration.webhookId;
-        const now = params.now ?? (() => new Date());
-        const webhookExpiresAt = new Date(now().getTime() + JIRA_WEBHOOK_TTL_MS);
-
-        const updateInstallation = params.updateInstallation ?? updateJiraInstallationWebhook;
-        const updateInput = {
-          connectionId: params.connectionId,
-          webhookIds: params.replaceExistingWebhooks
-            ? [registration.webhookId]
-            : [...new Set([registration.webhookId, ...(previous?.webhookIds ?? [])])],
-          webhookExpiresAt,
-        };
-        const installation = await updateInstallation(updateInput);
-        if (!installation)
-          throw new Error('Jira webhook registration lost its installation record');
-        metadataPersisted = true;
-        await params.onRegistrationSuccess?.({});
-
-        cleanupSupersededWebhooks = () =>
-          finishSupersededWebhookCleanup(
-            params,
-            previous,
-            registration.webhookId,
-            webhookExpiresAt,
-          );
-        return {webhookId: registration.webhookId, webhookExpiresAt};
-      } catch (error) {
-        callbackFailed = true;
-        if (registeredWebhookId !== undefined) {
-          const deleted = await deleteNewWebhookAfterPersistenceFailure(
-            params,
-            registeredWebhookId,
-          );
-          if (metadataPersisted || !deleted) {
-            await restorePreviousWebhookMetadata(
-              params,
-              previous,
-              deleted ? undefined : registeredWebhookId,
-            );
-          }
-        } else if (metadataPersisted) {
-          await restorePreviousWebhookMetadata(params, previous);
-        }
-        await bestEffortRegistrationFailure(params);
-        throw error;
-      }
-    });
+    result = await withRegistrationLock(params.cloudId, () =>
+      registerJiraWebhookWithLock(params, state),
+    );
   } catch (error) {
-    if (!callbackFailed) {
-      if (registeredWebhookId !== undefined) {
-        const deleted = await deleteNewWebhookAfterPersistenceFailure(params, registeredWebhookId);
-        if (metadataPersisted || !deleted) {
-          await restorePreviousWebhookMetadata(
-            params,
-            previous,
-            deleted ? undefined : registeredWebhookId,
-          );
-        }
-      } else if (metadataPersisted) {
-        await restorePreviousWebhookMetadata(params, previous);
-      }
-      await bestEffortRegistrationFailure(params);
-    }
+    if (!state.callbackFailed) await compensateFailedRegistration(params, state);
     throw error;
   }
 
-  if (cleanupSupersededWebhooks) {
-    try {
-      await withRegistrationLock(params.cloudId, cleanupSupersededWebhooks);
-    } catch (error) {
-      logger().warn(
-        {err: error, connectionId: params.connectionId},
-        'Jira superseded webhook cleanup persistence failed',
-      );
-    }
-  }
+  await runSupersededWebhookCleanup(params, withRegistrationLock, state);
 
   return result;
 }
 
+async function registerJiraWebhookWithLock(
+  params: RegisterJiraWebhookParams,
+  state: JiraWebhookRegistrationState,
+): Promise<{webhookId: number; webhookExpiresAt: Date}> {
+  try {
+    const getInstallation = params.getInstallation ?? getJiraInstallationByConnectionId;
+    state.previous = await getInstallation(params.connectionId);
+    const registration = await params.jira.registerDynamicWebhook({
+      accessToken: params.accessToken,
+      cloudId: params.cloudId,
+      url: params.webhookUrl,
+    });
+    state.registeredWebhookId = registration.webhookId;
+    const now = params.now ?? (() => new Date());
+    const webhookExpiresAt = new Date(now().getTime() + JIRA_WEBHOOK_TTL_MS);
+    await persistJiraWebhookRegistration(params, state, registration.webhookId, webhookExpiresAt);
+    state.cleanupSupersededWebhooks = () =>
+      finishSupersededWebhookCleanup(
+        params,
+        state.previous,
+        registration.webhookId,
+        webhookExpiresAt,
+      );
+    return {webhookId: registration.webhookId, webhookExpiresAt};
+  } catch (error) {
+    state.callbackFailed = true;
+    await compensateFailedRegistration(params, state);
+    throw error;
+  }
+}
+
+async function persistJiraWebhookRegistration(
+  params: RegisterJiraWebhookParams,
+  state: JiraWebhookRegistrationState,
+  webhookId: number,
+  webhookExpiresAt: Date,
+): Promise<void> {
+  const updateInstallation = params.updateInstallation ?? updateJiraInstallationWebhook;
+  const previousWebhookIds = state.previous?.webhookIds ?? [];
+  const webhookIds = params.replaceExistingWebhooks
+    ? [webhookId]
+    : [...new Set([webhookId, ...previousWebhookIds])];
+  const installation = await updateInstallation({
+    connectionId: params.connectionId,
+    webhookIds,
+    webhookExpiresAt,
+  });
+  if (!installation) throw new Error('Jira webhook registration lost its installation record');
+  state.metadataPersisted = true;
+  await params.onRegistrationSuccess?.({});
+}
+
+async function compensateFailedRegistration(
+  params: RegisterJiraWebhookParams,
+  state: JiraWebhookRegistrationState,
+): Promise<void> {
+  if (state.registeredWebhookId !== undefined) {
+    const deleted = await deleteNewWebhookAfterPersistenceFailure(
+      params,
+      state.registeredWebhookId,
+    );
+    if (state.metadataPersisted || !deleted) {
+      await restorePreviousWebhookMetadata(
+        params,
+        state.previous,
+        deleted ? undefined : state.registeredWebhookId,
+      );
+    }
+  } else if (state.metadataPersisted) {
+    await restorePreviousWebhookMetadata(params, state.previous);
+  }
+  await bestEffortRegistrationFailure(params);
+}
+
+async function runSupersededWebhookCleanup(
+  params: RegisterJiraWebhookParams,
+  withRegistrationLock: JiraInstallationLock,
+  state: JiraWebhookRegistrationState,
+): Promise<void> {
+  if (!state.cleanupSupersededWebhooks) return;
+  try {
+    await withRegistrationLock(params.cloudId, state.cleanupSupersededWebhooks);
+  } catch (error) {
+    logger().warn(
+      {err: error, connectionId: params.connectionId},
+      'Jira superseded webhook cleanup persistence failed',
+    );
+  }
+}
+
 async function finishSupersededWebhookCleanup(
   params: RegisterJiraWebhookParams,
-  previous: Awaited<ReturnType<typeof getJiraInstallationByConnectionId>>,
+  previous: JiraInstallation,
   registeredWebhookId: number,
   webhookExpiresAt: Date,
 ): Promise<void> {
@@ -177,7 +203,7 @@ async function bestEffortRegistrationFailure(params: RegisterJiraWebhookParams):
 
 async function restorePreviousWebhookMetadata(
   params: RegisterJiraWebhookParams,
-  previous: Awaited<ReturnType<typeof getJiraInstallationByConnectionId>>,
+  previous: JiraInstallation,
   retainedWebhookId?: number,
 ): Promise<void> {
   try {

--- a/libs/api/integration/jira/src/db/installations.ts
+++ b/libs/api/integration/jira/src/db/installations.ts
@@ -138,17 +138,24 @@ export async function upsertJiraInstallation(
       })
       .returning();
   } catch (error) {
-    if (isUniqueViolation(error, 'integrations_jira_installations_connection_unique')) {
-      throw new JiraConnectionAlreadyLinkedError(params.connectionId);
-    }
-    if (isUniqueViolation(error, 'integrations_jira_installations_cloud_id_unique')) {
-      throw new JiraInstallationAlreadyLinkedError(params.cloudId);
-    }
-    throw error;
+    throw mapJiraInstallationUpsertError(error, params);
   }
 
   if (!row) throw new JiraInstallationSiteMismatchError(params.connectionId, params.cloudId);
   return toJiraInstallation(row);
+}
+
+function mapJiraInstallationUpsertError(
+  error: unknown,
+  params: Pick<UpsertJiraInstallationParams, 'connectionId' | 'cloudId'>,
+): unknown {
+  if (isUniqueViolation(error, 'integrations_jira_installations_connection_unique')) {
+    return new JiraConnectionAlreadyLinkedError(params.connectionId);
+  }
+  if (isUniqueViolation(error, 'integrations_jira_installations_cloud_id_unique')) {
+    return new JiraInstallationAlreadyLinkedError(params.cloudId);
+  }
+  return error;
 }
 
 export async function getJiraInstallationByCloudId(

--- a/libs/api/integration/jira/src/temporal/activities/refresh-jira-tokens.test.ts
+++ b/libs/api/integration/jira/src/temporal/activities/refresh-jira-tokens.test.ts
@@ -34,15 +34,12 @@ describe('Jira proactive token refresh activity', () => {
       installation(failedConnectionId),
     ];
     const listInstallations = vi.fn().mockResolvedValue(installations);
-    const resolveConnection = vi
-      .fn()
-      .mockImplementation(async (connectionId: string) =>
-        connectionId === activeConnectionId
-          ? {lifecycleStatus: 'active'}
-          : connectionId === failedConnectionId
-            ? {lifecycleStatus: 'active'}
-            : {lifecycleStatus: 'error'},
-      );
+    const resolveConnection = vi.fn().mockImplementation((connectionId: string) => {
+      if (connectionId === activeConnectionId || connectionId === failedConnectionId) {
+        return Promise.resolve({lifecycleStatus: 'active'});
+      }
+      return Promise.resolve({lifecycleStatus: 'error'});
+    });
     const getAccessToken = vi.fn().mockImplementation(({connectionId}: {connectionId: string}) => {
       if (connectionId === failedConnectionId) throw new Error('refresh failed');
       return 'fresh-access-token';

--- a/libs/api/integration/jira/src/temporal/activities/renew-jira-webhooks.ts
+++ b/libs/api/integration/jira/src/temporal/activities/renew-jira-webhooks.ts
@@ -66,58 +66,17 @@ export function createJiraWebhookRenewalActivities(
         const heartbeatInterval = setInterval(heartbeat, JIRA_WEBHOOK_HEARTBEAT_INTERVAL_MS);
         try {
           heartbeat();
-          if (!isDueForRenewal(installation, renewalDeadline)) {
-            skipped += 1;
-            continue;
-          }
-
-          const connection = await options.resolveConnection(installation.connectionId);
-          if (connection?.lifecycleStatus !== 'active') {
-            skipped += 1;
-            continue;
-          }
-
-          if (!options.jira || !options.webhookUrlForConnection) {
-            throw new Error('Jira webhook renewal dependencies are not configured');
-          }
-
-          const accessToken = await options.tokenStore.getAccessToken({
-            connectionId: installation.connectionId,
+          const outcome = await renewJiraWebhook({
+            options,
+            installation,
+            renewalDeadline,
+            now,
+            updateInstallation,
+            registerWebhook,
           });
-          const webhookExpiresAt =
-            installation.webhookIds.length === 0
-              ? undefined
-              : await options.jira.refreshDynamicWebhooks({
-                  accessToken,
-                  cloudId: installation.cloudId,
-                  webhookIds: installation.webhookIds,
-                });
-
-          if (webhookExpiresAt === undefined) {
-            await registerWebhook({
-              jira: options.jira,
-              connectionId: installation.connectionId,
-              cloudId: installation.cloudId,
-              accessToken,
-              webhookUrl: options.webhookUrlForConnection(installation.connectionId),
-              now,
-              replaceExistingWebhooks: true,
-            });
-            reregistered += 1;
-          } else {
-            const updated = await updateInstallation({
-              connectionId: installation.connectionId,
-              webhookIds: installation.webhookIds,
-              webhookExpiresAt,
-              expectedWebhookIds: installation.webhookIds,
-              expectedWebhookExpiresAt: installation.webhookExpiresAt,
-            });
-            if (!updated) {
-              skipped += 1;
-              continue;
-            }
-            renewed += 1;
-          }
+          if (outcome === 'renewed') renewed += 1;
+          if (outcome === 'reregistered') reregistered += 1;
+          if (outcome === 'skipped') skipped += 1;
         } catch (error) {
           failed += 1;
           logger().warn(
@@ -133,6 +92,63 @@ export function createJiraWebhookRenewalActivities(
       return {renewed, reregistered, skipped, failed};
     },
   };
+}
+
+type JiraWebhookRenewalOutcome = 'renewed' | 'reregistered' | 'skipped';
+
+async function renewJiraWebhook(params: {
+  options: CreateJiraWebhookRenewalActivitiesOptions;
+  installation: JiraInstallation;
+  renewalDeadline: Date;
+  now: () => Date;
+  updateInstallation: typeof updateJiraInstallationWebhookIfUnchanged;
+  registerWebhook: typeof registerJiraWebhook;
+}): Promise<JiraWebhookRenewalOutcome> {
+  if (!isDueForRenewal(params.installation, params.renewalDeadline)) return 'skipped';
+  const connection = await params.options.resolveConnection(params.installation.connectionId);
+  if (connection?.lifecycleStatus !== 'active') return 'skipped';
+  const jira = params.options.jira;
+  const webhookUrlForConnection = params.options.webhookUrlForConnection;
+  if (!jira || !webhookUrlForConnection) {
+    throw new Error('Jira webhook renewal dependencies are not configured');
+  }
+  const accessToken = await params.options.tokenStore.getAccessToken({
+    connectionId: params.installation.connectionId,
+  });
+  const webhookExpiresAt = await refreshJiraWebhook(jira, params.installation, accessToken);
+  if (webhookExpiresAt === undefined) {
+    await params.registerWebhook({
+      jira,
+      connectionId: params.installation.connectionId,
+      cloudId: params.installation.cloudId,
+      accessToken,
+      webhookUrl: webhookUrlForConnection(params.installation.connectionId),
+      now: params.now,
+      replaceExistingWebhooks: true,
+    });
+    return 'reregistered';
+  }
+  const updated = await params.updateInstallation({
+    connectionId: params.installation.connectionId,
+    webhookIds: params.installation.webhookIds,
+    webhookExpiresAt,
+    expectedWebhookIds: params.installation.webhookIds,
+    expectedWebhookExpiresAt: params.installation.webhookExpiresAt,
+  });
+  return updated ? 'renewed' : 'skipped';
+}
+
+function refreshJiraWebhook(
+  jira: NonNullable<CreateJiraWebhookRenewalActivitiesOptions['jira']>,
+  installation: JiraInstallation,
+  accessToken: string,
+): Promise<Date | undefined> {
+  if (installation.webhookIds.length === 0) return Promise.resolve(undefined);
+  return jira.refreshDynamicWebhooks({
+    accessToken,
+    cloudId: installation.cloudId,
+    webhookIds: installation.webhookIds,
+  });
 }
 
 function isDueForRenewal(installation: JiraInstallation, renewalDeadline: Date): boolean {

--- a/libs/api/integration/linear/src/api/client.ts
+++ b/libs/api/integration/linear/src/api/client.ts
@@ -241,32 +241,46 @@ async function mapLinearError<T>(
     return await request();
   } catch (error) {
     if (error instanceof LinearIntegrationProviderError) throw error;
-    if (error instanceof HTTPError) {
-      const {status, statusText, headers} = error.response;
-      logger().warn({operation, status, statusText}, 'Linear API request rejected');
-      if (status === 429) {
-        throw new LinearIntegrationProviderError(
-          'rate-limited',
-          'Linear request was rate limited',
-          retryAfterSeconds(headers),
-        );
-      }
-      if (status >= 500) {
-        throw new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
-      }
-      const reason = options.classifyHttp4xx?.(status) ?? 'access-denied';
-      throw new LinearIntegrationProviderError(reason, 'Linear request was rejected');
-    }
-    if (error instanceof TimeoutError) {
-      logger().warn({operation}, 'Linear API request timed out');
-      throw new LinearIntegrationProviderError('timeout', 'Linear request timed out');
-    }
-    logger().warn(
-      {operation, errName: error instanceof Error ? error.name : typeof error},
-      'Linear API request failed',
-    );
-    throw new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
+    throw mapUnknownLinearError(operation, error, options);
   }
+}
+
+function mapUnknownLinearError(
+  operation: string,
+  error: unknown,
+  options: MapLinearErrorOptions,
+): LinearIntegrationProviderError {
+  if (error instanceof HTTPError) return mapLinearHttpError(operation, error, options);
+  if (error instanceof TimeoutError) {
+    logger().warn({operation}, 'Linear API request timed out');
+    return new LinearIntegrationProviderError('timeout', 'Linear request timed out');
+  }
+  logger().warn(
+    {operation, errName: error instanceof Error ? error.name : typeof error},
+    'Linear API request failed',
+  );
+  return new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
+}
+
+function mapLinearHttpError(
+  operation: string,
+  error: HTTPError,
+  options: MapLinearErrorOptions,
+): LinearIntegrationProviderError {
+  const {status, statusText, headers} = error.response;
+  logger().warn({operation, status, statusText}, 'Linear API request rejected');
+  if (status === 429) {
+    return new LinearIntegrationProviderError(
+      'rate-limited',
+      'Linear request was rate limited',
+      retryAfterSeconds(headers),
+    );
+  }
+  if (status >= 500) {
+    return new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
+  }
+  const reason = options.classifyHttp4xx?.(status) ?? 'access-denied';
+  return new LinearIntegrationProviderError(reason, 'Linear request was rejected');
 }
 
 function classifyGraphqlHttp4xx(status: number): 'access-denied' | 'malformed-provider-response' {

--- a/libs/api/integration/sentry/src/core/webhook.ts
+++ b/libs/api/integration/sentry/src/core/webhook.ts
@@ -120,73 +120,30 @@ export async function handleSentryInstallationCreated(
   params: HandleSentryInstallationCreatedParams,
 ): Promise<void> {
   const existing = await params.getSentryInstallation({installationUuid: params.installationUuid});
-  if (existing && (existing.status === 'installed' || existing.status === 'deleted')) {
-    logger().debug(
-      {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
-      'sentry webhook: installation.created for an existing row, reconciling',
-    );
-    await params.recordDelivery(params.deliveryId);
-    return;
-  }
+  if (await reconcileExistingSentryInstallation(params, existing)) return;
+  if (await dropSentryInstallationWithoutClaimInput(params)) return;
+  const code = params.code as string;
+  const orgSlug = params.orgSlug as string;
 
-  if (!params.code || !params.orgSlug) {
-    logger().warn(
-      {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
-      'sentry webhook: installation.created without claim input, dropping',
-    );
-    await params.recordDelivery(params.deliveryId);
-    return;
-  }
-
-  const codeHash = hashAuthorizationCode(params.code);
+  const codeHash = hashAuthorizationCode(code);
   let claimed =
     existing ??
     (await claimSentryInstallationVerification({
       installationUuid: params.installationUuid,
-      orgSlug: params.orgSlug,
+      orgSlug,
       codeHash,
     }));
   if (claimed.status === 'installed' || claimed.status === 'deleted') {
     await params.recordDelivery(params.deliveryId);
     return;
   }
-  if (claimed.codeHash !== codeHash) {
-    logger().warn(
-      {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
-      'sentry webhook: installation.created does not match the pending claim, dropping',
-    );
-    await params.recordDelivery(params.deliveryId);
-    return;
-  }
+  if (await dropMismatchedSentryClaim(params, claimed, codeHash)) return;
 
-  let authorization: Awaited<ReturnType<SentryApiClient['exchangeAuthorizationCode']>> | undefined;
+  let authorization: SentryAuthorization | undefined;
   if (claimed.status === 'pending') {
-    try {
-      authorization = await params.sentry.exchangeAuthorizationCode({
-        installationUuid: params.installationUuid,
-        code: params.code,
-      });
-    } catch (error) {
-      if (!(error instanceof SentryIntegrationProviderError) || error.reason !== 'access-denied') {
-        throw error;
-      }
-
-      const current = await params.getSentryInstallation({
-        installationUuid: params.installationUuid,
-      });
-      const concurrentAttemptSucceeded =
-        current?.codeHash === codeHash &&
-        (current.status === 'exchange-succeeded' || current.status === 'installed');
-      if (!current || !concurrentAttemptSucceeded) throw error;
-      claimed = current;
-    }
-
-    if (authorization) {
-      await markSentryInstallationExchangeSucceeded({
-        installationUuid: params.installationUuid,
-        codeHash,
-      });
-    }
+    const exchange = await exchangeSentryAuthorization(params, claimed, code, codeHash);
+    claimed = exchange.claimed;
+    authorization = exchange.authorization;
   }
 
   const completed = await params.persistUnclaimedAndRecordDelivery({
@@ -202,6 +159,89 @@ export async function handleSentryInstallationCreated(
       token: authorization.token,
     });
   }
+}
+
+type SentryAuthorization = Awaited<ReturnType<SentryApiClient['exchangeAuthorizationCode']>>;
+
+async function reconcileExistingSentryInstallation(
+  params: HandleSentryInstallationCreatedParams,
+  existing: SentryInstallation | undefined,
+): Promise<boolean> {
+  if (!existing || (existing.status !== 'installed' && existing.status !== 'deleted')) return false;
+  logger().debug(
+    {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
+    'sentry webhook: installation.created for an existing row, reconciling',
+  );
+  await params.recordDelivery(params.deliveryId);
+  return true;
+}
+
+async function dropSentryInstallationWithoutClaimInput(
+  params: HandleSentryInstallationCreatedParams,
+): Promise<boolean> {
+  if (params.code && params.orgSlug) return false;
+  logger().warn(
+    {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
+    'sentry webhook: installation.created without claim input, dropping',
+  );
+  await params.recordDelivery(params.deliveryId);
+  return true;
+}
+
+async function dropMismatchedSentryClaim(
+  params: HandleSentryInstallationCreatedParams,
+  claimed: SentryInstallation,
+  codeHash: string,
+): Promise<boolean> {
+  if (claimed.codeHash === codeHash) return false;
+  logger().warn(
+    {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
+    'sentry webhook: installation.created does not match the pending claim, dropping',
+  );
+  await params.recordDelivery(params.deliveryId);
+  return true;
+}
+
+async function exchangeSentryAuthorization(
+  params: HandleSentryInstallationCreatedParams,
+  claimed: SentryInstallation,
+  code: string,
+  codeHash: string,
+): Promise<{claimed: SentryInstallation; authorization: SentryAuthorization | undefined}> {
+  let authorization: SentryAuthorization | undefined;
+  try {
+    authorization = await params.sentry.exchangeAuthorizationCode({
+      installationUuid: params.installationUuid,
+      code,
+    });
+  } catch (error) {
+    claimed = await recoverConcurrentSentryExchange(params, error, codeHash);
+  }
+  if (authorization) {
+    await markSentryInstallationExchangeSucceeded({
+      installationUuid: params.installationUuid,
+      codeHash,
+    });
+  }
+  return {claimed, authorization};
+}
+
+async function recoverConcurrentSentryExchange(
+  params: HandleSentryInstallationCreatedParams,
+  error: unknown,
+  codeHash: string,
+): Promise<SentryInstallation> {
+  if (!(error instanceof SentryIntegrationProviderError) || error.reason !== 'access-denied') {
+    throw error;
+  }
+  const current = await params.getSentryInstallation({
+    installationUuid: params.installationUuid,
+  });
+  const concurrentAttemptSucceeded =
+    current?.codeHash === codeHash &&
+    (current.status === 'exchange-succeeded' || current.status === 'installed');
+  if (!current || !concurrentAttemptSucceeded) throw error;
+  return current;
 }
 
 export interface HandleSentryInstallationDeletedParams {

--- a/libs/api/integration/slack/src/api/client.ts
+++ b/libs/api/integration/slack/src/api/client.ts
@@ -176,47 +176,53 @@ async function mapSlackWebApiError<T>(method: string, request: () => Promise<T>)
     return await request();
   } catch (error) {
     if (error instanceof SlackIntegrationProviderError) throw error;
-    if (error instanceof HTTPError) {
-      const {status, statusText, headers} = error.response;
-      logger().warn(
-        {operation: 'call-method', method, status, statusText},
-        'Slack API request rejected',
-      );
-      if (status === 429) {
-        throw new SlackIntegrationProviderError(
-          'rate-limited',
-          'Slack request was rate limited',
-          retryAfterSeconds(headers),
-        );
-      }
-      if (status === 413) {
-        throw new SlackIntegrationProviderError(
-          'content-too-large',
-          'Slack request content was too large',
-        );
-      }
-      if (status >= 500) {
-        throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
-      }
-      throw new SlackIntegrationProviderError(
-        'malformed-provider-response',
-        'Slack request was rejected',
-      );
-    }
-    if (error instanceof TimeoutError) {
-      logger().warn({operation: 'call-method', method}, 'Slack API request timed out');
-      throw new SlackIntegrationProviderError('timeout', 'Slack request timed out');
-    }
-    logger().warn(
-      {
-        operation: 'call-method',
-        method,
-        errName: error instanceof Error ? error.name : typeof error,
-      },
-      'Slack API request failed',
-    );
-    throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+    throw mapUnknownSlackWebApiError(method, error);
   }
+}
+
+function mapUnknownSlackWebApiError(method: string, error: unknown): SlackIntegrationProviderError {
+  if (error instanceof HTTPError) return mapSlackWebApiHttpError(method, error);
+  if (error instanceof TimeoutError) {
+    logger().warn({operation: 'call-method', method}, 'Slack API request timed out');
+    return new SlackIntegrationProviderError('timeout', 'Slack request timed out');
+  }
+  logger().warn(
+    {
+      operation: 'call-method',
+      method,
+      errName: error instanceof Error ? error.name : typeof error,
+    },
+    'Slack API request failed',
+  );
+  return new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+}
+
+function mapSlackWebApiHttpError(method: string, error: HTTPError): SlackIntegrationProviderError {
+  const {status, statusText, headers} = error.response;
+  logger().warn(
+    {operation: 'call-method', method, status, statusText},
+    'Slack API request rejected',
+  );
+  if (status === 429) {
+    return new SlackIntegrationProviderError(
+      'rate-limited',
+      'Slack request was rate limited',
+      retryAfterSeconds(headers),
+    );
+  }
+  if (status === 413) {
+    return new SlackIntegrationProviderError(
+      'content-too-large',
+      'Slack request content was too large',
+    );
+  }
+  if (status >= 500) {
+    return new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+  }
+  return new SlackIntegrationProviderError(
+    'malformed-provider-response',
+    'Slack request was rejected',
+  );
 }
 
 function slackMethodArguments(input: Record<string, unknown>): URLSearchParams {

--- a/libs/api/integration/slack/src/core/agent-tools-provider.ts
+++ b/libs/api/integration/slack/src/core/agent-tools-provider.ts
@@ -19,6 +19,7 @@ import {SlackIntegrationProviderError} from '#core/errors.js';
 import type {SlackTokenStore} from '#core/tokens.js';
 
 type SlackIntegrationConnection = IntegrationConnection<'slack'>;
+type SlackToolCall = Parameters<AgentToolSession<SlackToolCallResult>['call']>[0];
 
 export type SlackToolCallResult = {
   isError?: boolean | undefined;
@@ -60,56 +61,86 @@ export class SlackAgentToolsProvider
     const token = await this.options.tokenStore.getAccessToken({connectionId: input.connection.id});
 
     return {
-      call: async (call) => {
-        const tool = input.tools.find((candidate) => candidate.id === call.toolId);
-        if (!tool) return slackToolError(`Unknown Slack tool: ${call.toolId}`);
-        const operation = slackToolOperation(tool.id);
-        if (!operation) return slackToolError(`Unknown Slack tool method: ${tool.id}`);
-        const missingParameter = missingRequiredParameter(tool, call.arguments);
-        if (missingParameter) {
-          return slackToolError(`Missing required parameter: ${missingParameter}`);
-        }
-        const validationError = operation.validate?.(call.arguments);
-        if (validationError) {
-          return slackToolError(validationError.message, {code: validationError.code});
-        }
-
-        let body: SlackWebApiResponse;
-        try {
-          body = await this.options.slack.callMethod({
-            method: operation.method,
-            token,
-            arguments: operation.mapArguments(call.arguments),
-          });
-        } catch (error) {
-          if (error instanceof SlackIntegrationProviderError) {
-            return slackToolError(error.message, {
-              code: error.reason,
-              retryAfterSeconds: error.retryAfterSeconds,
-            });
-          }
-          throw error;
-        }
-
-        if (body.ok) {
-          return slackToolResult(operation.mapOutput?.(body, call.arguments) ?? body);
-        }
-        const slackError = typeof body.error === 'string' ? body.error : 'Slack request failed';
-        if (isSlackAccessError(slackError)) {
-          logger().warn(
-            {connectionId: input.connection.id, slackError},
-            'Slack API rejected integration credentials',
-          );
-          return slackToolError(slackError, {code: 'access-denied'});
-        }
-        if (slackError === 'ratelimited') {
-          return slackToolError(slackError, {code: 'rate-limited'});
-        }
-        return slackToolError(slackError);
-      },
+      call: (call) =>
+        executeSlackToolCall({
+          call,
+          tools: input.tools,
+          connectionId: input.connection.id,
+          token,
+          slack: this.options.slack,
+        }),
       close: () => Promise.resolve(),
     };
   }
+}
+
+async function executeSlackToolCall(params: {
+  call: SlackToolCall;
+  tools: readonly SlackAgentToolCatalogEntry[];
+  connectionId: string;
+  token: string;
+  slack: Pick<SlackApiClient, 'callMethod'>;
+}): Promise<SlackToolCallResult> {
+  const tool = params.tools.find((candidate) => candidate.id === params.call.toolId);
+  if (!tool) return slackToolError(`Unknown Slack tool: ${params.call.toolId}`);
+  const operation = slackToolOperation(tool.id);
+  if (!operation) return slackToolError(`Unknown Slack tool method: ${tool.id}`);
+  const validationError = validateSlackToolCall(tool, operation, params.call);
+  if (validationError) return validationError;
+  const body = await callSlackTool(params, operation);
+  if (body instanceof SlackIntegrationProviderError) {
+    return slackToolError(body.message, {
+      code: body.reason,
+      retryAfterSeconds: body.retryAfterSeconds,
+    });
+  }
+  return mapSlackToolResponse(body, operation, params.call, params.connectionId);
+}
+
+function validateSlackToolCall(
+  tool: SlackAgentToolCatalogEntry,
+  operation: SlackToolOperation,
+  call: SlackToolCall,
+): SlackToolCallResult | undefined {
+  const missingParameter = missingRequiredParameter(tool, call.arguments);
+  if (missingParameter) return slackToolError(`Missing required parameter: ${missingParameter}`);
+  const validationError = operation.validate?.(call.arguments);
+  if (!validationError) return undefined;
+  return slackToolError(validationError.message, {code: validationError.code});
+}
+
+async function callSlackTool(
+  params: Pick<Parameters<typeof executeSlackToolCall>[0], 'call' | 'token' | 'slack'>,
+  operation: SlackToolOperation,
+): Promise<SlackWebApiResponse | SlackIntegrationProviderError> {
+  try {
+    return await params.slack.callMethod({
+      method: operation.method,
+      token: params.token,
+      arguments: operation.mapArguments(params.call.arguments),
+    });
+  } catch (error) {
+    if (error instanceof SlackIntegrationProviderError) return error;
+    throw error;
+  }
+}
+
+function mapSlackToolResponse(
+  body: SlackWebApiResponse,
+  operation: SlackToolOperation,
+  call: SlackToolCall,
+  connectionId: string,
+): SlackToolCallResult {
+  if (body.ok) return slackToolResult(operation.mapOutput?.(body, call.arguments) ?? body);
+  const slackError = typeof body.error === 'string' ? body.error : 'Slack request failed';
+  if (isSlackAccessError(slackError)) {
+    logger().warn({connectionId, slackError}, 'Slack API rejected integration credentials');
+    return slackToolError(slackError, {code: 'access-denied'});
+  }
+  if (slackError === 'ratelimited') {
+    return slackToolError(slackError, {code: 'rate-limited'});
+  }
+  return slackToolError(slackError);
 }
 
 function slackToolOperation(toolId: string): SlackToolOperation | undefined {

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -142,13 +142,7 @@ export function createSlackIntegrationProvider(
         }),
       }
     : {};
-  if (
-    options.routes &&
-    !hasSlackInstallationRoutesOptions(options.routes) &&
-    !hasSlackWebhookRoutesOptions(options.routes)
-  ) {
-    throw new Error('Slack webhook routes require every core persistence dependency');
-  }
+  assertValidSlackRouteOptions(options.routes);
   const routes: RouteGroup[] = [];
   const webhookProcessor =
     options.routes && hasSlackWebhookRoutesOptions(options.routes)
@@ -194,6 +188,12 @@ export function createSlackIntegrationProvider(
       ? [{routeIds: ['slack.event', 'slack.command'] as const, processor: webhookProcessor}]
       : undefined,
   };
+}
+
+function assertValidSlackRouteOptions(routes: SlackRouteOptions | undefined): void {
+  if (!routes) return;
+  if (hasSlackInstallationRoutesOptions(routes) || hasSlackWebhookRoutesOptions(routes)) return;
+  throw new Error('Slack webhook routes require every core persistence dependency');
 }
 
 function hasSlackInstallationRoutesOptions(

--- a/libs/api/integration/slack/src/presentation/routes/errors.ts
+++ b/libs/api/integration/slack/src/presentation/routes/errors.ts
@@ -27,20 +27,7 @@ export function slackRouteErrorHandler(error: unknown): never {
   if (
     isInterModuleKnownError(workspacesInterModuleContract.methods.requireActiveMembership, error)
   ) {
-    if (error.code === 'workspace-not-found')
-      throw new ClientError('Workspace not found', 'not-found', {
-        status: 404,
-        details: {workspace_id: error.details.workspaceId},
-      });
-    if (error.code === 'membership-required')
-      throw new ClientError('Workspace membership required', 'forbidden', {
-        status: 403,
-        details: {workspace_id: error.details.workspaceId},
-      });
-    throw new ClientError('Workspace is inactive', 'workspace-inactive', {
-      status: 403,
-      details: {workspace_id: error.details.workspaceId},
-    });
+    throwSlackWorkspaceMembershipError(error);
   }
   if (error instanceof SlackInstallStateError) {
     throw new ClientError(error.message, 'invalid-slack-install-state', {status: 400});
@@ -85,4 +72,26 @@ export function slackRouteErrorHandler(error: unknown): never {
     });
   }
   throw error;
+}
+
+function throwSlackWorkspaceMembershipError(error: {
+  code: 'workspace-not-found' | 'membership-required' | 'workspace-inactive';
+  details: {workspaceId: string};
+}): never {
+  if (error.code === 'workspace-not-found') {
+    throw new ClientError('Workspace not found', 'not-found', {
+      status: 404,
+      details: {workspace_id: error.details.workspaceId},
+    });
+  }
+  if (error.code === 'membership-required') {
+    throw new ClientError('Workspace membership required', 'forbidden', {
+      status: 403,
+      details: {workspace_id: error.details.workspaceId},
+    });
+  }
+  throw new ClientError('Workspace is inactive', 'workspace-inactive', {
+    status: 403,
+    details: {workspace_id: error.details.workspaceId},
+  });
 }

--- a/libs/api/logs/src/core/append-chunk.ts
+++ b/libs/api/logs/src/core/append-chunk.ts
@@ -7,7 +7,7 @@ import type {Transaction} from '#db/db.js';
 import type {ChunkOrigin} from '#db/schema/chunks.js';
 import {getAttemptStream, setDeclaredTotalBytes} from '#db/streams.js';
 import {allowedBudget} from './budget.js';
-import {controlTombstone} from './close-stream.js';
+import {closeStream, controlTombstone} from './close-stream.js';
 import {LeaseStreamMismatchError} from './errors.js';
 
 /**
@@ -28,6 +28,12 @@ export interface AppendIdentity {
 export interface AppendLogsResult {
   committedLength: number;
   capped: boolean;
+}
+
+export interface AppendChunkMetrics {
+  readonly recordCounts: Partial<Record<LogRecord['type'], number>>;
+  streamClosedReason: 'declared' | undefined;
+  storedBytes: number;
 }
 
 /**
@@ -152,4 +158,35 @@ export async function storeChunk(
     stored: true,
     recordCounts: won ? {capped: 1} : {},
   };
+}
+
+export function recordStoredChunk(
+  metrics: AppendChunkMetrics,
+  storedBytes: number,
+  ...recordCounts: Array<Partial<Record<LogRecord['type'], number>>>
+): void {
+  metrics.storedBytes += storedBytes;
+  for (const counts of recordCounts) addRecordCounts(metrics.recordCounts, counts);
+}
+
+export function addRecordCounts(
+  target: Partial<Record<LogRecord['type'], number>>,
+  source: Partial<Record<LogRecord['type'], number>>,
+): void {
+  for (const [kind, count] of Object.entries(source)) {
+    const recordKind = kind as LogRecord['type'];
+    target[recordKind] = (target[recordKind] ?? 0) + (count ?? 0);
+  }
+}
+
+export async function closeDeclaredStream(
+  tx: Transaction,
+  streamId: string,
+  declaredTotalBytes: number | undefined,
+  chunkStored: boolean,
+  metrics: Pick<AppendChunkMetrics, 'streamClosedReason'>,
+): Promise<void> {
+  if (declaredTotalBytes === undefined || !chunkStored) return;
+  const closed = await closeStream(tx, {streamId, reason: 'declared'});
+  if (closed) metrics.streamClosedReason = 'declared';
 }

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -30,10 +30,12 @@ import {
 import {
   type AppendIdentity,
   type AppendLogsResult,
+  addRecordCounts,
+  closeDeclaredStream,
   readHeartbeat,
+  recordStoredChunk,
   storeChunk,
 } from './append-chunk.js';
-import {closeStream} from './close-stream.js';
 import {LogWriterConflictError, MalformedLogChunkError, OffsetGapError} from './errors.js';
 import {flushPendingToolRows} from './session/claude/rows.js';
 import {
@@ -486,9 +488,10 @@ async function storeRunnerAppend(
     declaredTotalBytes: parsed.declaredTotalBytes,
     origin: 'runner',
   });
-  recordStoredRunnerChunk(stored, chunkStored, recordCounts, metrics);
+  if (chunkStored) recordStoredChunk(metrics, stored.body.length, stored.recordCounts);
+  addRecordCounts(metrics.recordCounts, recordCounts);
   await persistClaudeParseContext(tx, stream.id, stored, chunkStored, result.capped);
-  await closeDeclaredRunnerStream(tx, stream.id, parsed.declaredTotalBytes, chunkStored, metrics);
+  await closeDeclaredStream(tx, stream.id, parsed.declaredTotalBytes, chunkStored, metrics);
   return result;
 }
 
@@ -521,19 +524,6 @@ function runnerStoredBody(
   );
 }
 
-function recordStoredRunnerChunk(
-  stored: StoredBody,
-  chunkStored: boolean,
-  chunkRecordCounts: Partial<Record<LogRecordMetricKind, number>>,
-  metrics: AppendLogsMetrics,
-): void {
-  if (chunkStored) {
-    metrics.storedBytes += stored.body.length;
-    addRecordCounts(metrics.recordCounts, stored.recordCounts);
-  }
-  addRecordCounts(metrics.recordCounts, chunkRecordCounts);
-}
-
 async function persistClaudeParseContext(
   tx: Transaction,
   streamId: string,
@@ -551,25 +541,4 @@ async function persistClaudeParseContext(
     pendingResult: stored.claudePendingResult ?? null,
     pendingToolRows: stored.claudePendingToolRows ?? [],
   });
-}
-
-async function closeDeclaredRunnerStream(
-  tx: Transaction,
-  streamId: string,
-  declaredTotalBytes: number | undefined,
-  chunkStored: boolean,
-  metrics: AppendLogsMetrics,
-): Promise<void> {
-  if (declaredTotalBytes === undefined || !chunkStored) return;
-  const closed = await closeStream(tx, {streamId, reason: 'declared'});
-  if (closed) metrics.streamClosedReason = 'declared';
-}
-
-function addRecordCounts(
-  target: Partial<Record<LogRecordMetricKind, number>>,
-  source: Partial<Record<LogRecordMetricKind, number>>,
-): void {
-  for (const [kind, count] of Object.entries(source)) {
-    target[kind as LogRecordMetricKind] = (target[kind as LogRecordMetricKind] ?? 0) + (count ?? 0);
-  }
 }

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -13,7 +13,7 @@ import {DEFAULT_HARNESS, type Harness} from '@shipfox/workflow-document';
 import {config} from '#config.js';
 import {isJobCapped} from '#db/accounting.js';
 import {getStreamWriterOrigin} from '#db/chunks.js';
-import {db} from '#db/db.js';
+import {db, type Transaction} from '#db/db.js';
 import {
   casExtendCommittedLength,
   getOrCreateAttemptStreamWithStatus,
@@ -48,6 +48,14 @@ import type {AgentSessionRecord} from './session/session-record.js';
 export interface AppendLogsParams extends AppendIdentity {
   offset: number;
   body: Buffer;
+}
+
+interface AppendLogsMetrics {
+  readonly recordCounts: Partial<Record<LogRecordMetricKind, number>>;
+  streamClosedReason: 'declared' | undefined;
+  streamOpened: boolean;
+  ingestedBytes: number;
+  storedBytes: number;
 }
 
 export type {AppendLogsResult} from './append-chunk.js';
@@ -146,6 +154,15 @@ interface StoredBody {
   claudePendingToolRows: readonly SessionViewRow[] | undefined;
 }
 
+interface StoredBodyBuildState {
+  readonly storedRecords: LogRecord[];
+  readonly parseContext: SessionParseContext | undefined;
+  readonly latestClaudeInitIndicesBySessionId: ReadonlyMap<string, number> | undefined;
+  readonly harness: Harness;
+  readonly isStreamFinal: boolean;
+  pendingResult: SessionViewLifecycleRow | null;
+}
+
 function buildStoredBody(
   records: readonly RawLogRecord[],
   harness: Harness,
@@ -153,7 +170,6 @@ function buildStoredBody(
   initialClaudePendingResult?: SessionViewLifecycleRow | null,
   isStreamFinal = false,
 ): StoredBody {
-  const storedRecords: LogRecord[] = [];
   const parseContext: SessionParseContext | undefined =
     harness === 'claude'
       ? {
@@ -161,72 +177,117 @@ function buildStoredBody(
           isFinalResult: true,
         }
       : undefined;
-  const latestClaudeInitIndicesBySessionId =
-    harness === 'claude' ? latestClaudeInitIndices(records) : undefined;
-  let pendingResult = initialClaudePendingResult ?? null;
-
-  if (parseContext?.claude !== undefined && pendingResult !== null) {
-    const firstInit = firstClaudeInit(records);
-    if (isStreamFinal || firstInit.hasInit) {
-      storedRecords.push(
-        storedAgentSessionRow(
-          finalizePendingResult(
-            pendingResult,
-            firstInit.sessionId !== undefined &&
-              firstInit.sessionId === parseContext.claude.sessionId,
-            parseContext.claude.turn,
-          ),
-        ),
-      );
-      pendingResult = null;
-    }
-  }
+  const state: StoredBodyBuildState = {
+    storedRecords: [],
+    parseContext,
+    latestClaudeInitIndicesBySessionId:
+      harness === 'claude' ? latestClaudeInitIndices(records) : undefined,
+    harness,
+    isStreamFinal,
+    pendingResult: initialClaudePendingResult ?? null,
+  };
+  appendPendingClaudeResult(records, state);
 
   for (const [index, record] of records.entries()) {
-    if (record.type !== 'agent_session') {
-      storedRecords.push(record);
-      continue;
-    }
-
-    if (parseContext?.claude !== undefined && latestClaudeInitIndicesBySessionId !== undefined) {
-      parseContext.isFinalResult = !hasFutureClaudeInit(
-        latestClaudeInitIndicesBySessionId,
-        index,
-        parseContext.claude.sessionId,
-      );
-    }
-
-    for (const row of parseSessionRecord(agentSessionRecord(record), harness, parseContext)) {
-      if (parseContext?.claude !== undefined && !isStreamFinal && isClaudeFinalResultRow(row)) {
-        if (pendingResult !== null) {
-          storedRecords.push(storedAgentSessionRow(pendingResult));
-        }
-        pendingResult = row;
-        continue;
-      }
-      storedRecords.push(storedAgentSessionRow(row));
-    }
+    appendStoredRecord(record, index, state);
   }
 
-  if (isStreamFinal && parseContext?.claude !== undefined) {
-    for (const row of flushPendingToolRows(parseContext.claude)) {
-      storedRecords.push(storedAgentSessionRow(row));
-    }
-  }
+  appendPendingClaudeToolRows(state);
 
-  const body = Buffer.from(storedRecords.map((record) => `${JSON.stringify(record)}\n`).join(''));
-  const recordCounts: Partial<Record<LogRecord['type'], number>> = {};
-  for (const record of storedRecords) {
-    recordCounts[record.type] = (recordCounts[record.type] ?? 0) + 1;
-  }
+  const body = Buffer.from(
+    state.storedRecords.map((record) => `${JSON.stringify(record)}\n`).join(''),
+  );
 
   return {
     body,
-    recordCounts,
+    recordCounts: countStoredRecords(state.storedRecords),
     claudeParseContext: parseContext?.claude,
-    claudePendingResult: parseContext?.claude === undefined ? undefined : pendingResult,
+    claudePendingResult: parseContext?.claude === undefined ? undefined : state.pendingResult,
     claudePendingToolRows: parseContext?.claude?.pendingToolRows,
   };
+}
+
+function appendPendingClaudeResult(
+  records: readonly RawLogRecord[],
+  state: StoredBodyBuildState,
+): void {
+  const claude = state.parseContext?.claude;
+  if (claude === undefined || state.pendingResult === null) return;
+  const firstInit = firstClaudeInit(records);
+  if (!state.isStreamFinal && !firstInit.hasInit) return;
+  state.storedRecords.push(
+    storedAgentSessionRow(
+      finalizePendingResult(
+        state.pendingResult,
+        firstInit.sessionId !== undefined && firstInit.sessionId === claude.sessionId,
+        claude.turn,
+      ),
+    ),
+  );
+  state.pendingResult = null;
+}
+
+function appendStoredRecord(
+  record: RawLogRecord,
+  index: number,
+  state: StoredBodyBuildState,
+): void {
+  if (record.type !== 'agent_session') {
+    state.storedRecords.push(record);
+    return;
+  }
+  updateClaudeFinalResult(index, state);
+  for (const row of parseSessionRecord(
+    agentSessionRecord(record),
+    state.harness,
+    state.parseContext,
+  )) {
+    appendParsedSessionRow(row, state);
+  }
+}
+
+function updateClaudeFinalResult(index: number, state: StoredBodyBuildState): void {
+  const parseContext = state.parseContext;
+  if (parseContext?.claude === undefined || state.latestClaudeInitIndicesBySessionId === undefined)
+    return;
+  parseContext.isFinalResult = !hasFutureClaudeInit(
+    state.latestClaudeInitIndicesBySessionId,
+    index,
+    parseContext.claude.sessionId,
+  );
+}
+
+function appendParsedSessionRow(row: SessionViewRow, state: StoredBodyBuildState): void {
+  if (
+    state.parseContext?.claude !== undefined &&
+    !state.isStreamFinal &&
+    isClaudeFinalResultRow(row)
+  ) {
+    if (state.pendingResult !== null) {
+      state.storedRecords.push(storedAgentSessionRow(state.pendingResult));
+    }
+    state.pendingResult = row;
+    return;
+  }
+  state.storedRecords.push(storedAgentSessionRow(row));
+}
+
+function appendPendingClaudeToolRows(state: StoredBodyBuildState): void {
+  const claude = state.parseContext?.claude;
+  if (!state.isStreamFinal || claude === undefined) return;
+  for (const row of flushPendingToolRows(claude)) {
+    state.storedRecords.push(storedAgentSessionRow(row));
+  }
+}
+
+function countStoredRecords(
+  records: readonly LogRecord[],
+): Partial<Record<LogRecord['type'], number>> {
+  const recordCounts: Partial<Record<LogRecord['type'], number>> = {};
+  for (const record of records) {
+    recordCounts[record.type] = (recordCounts[record.type] ?? 0) + 1;
+  }
+  return recordCounts;
 }
 
 function storedAgentSessionRow(row: SessionViewRow): LogRecord {
@@ -321,11 +382,9 @@ export async function appendLogs(
     }
     throw error;
   }
-  const {declaredTotalBytes} = parsed;
   const sessionHarness = parsed.hasAgentSessionRecord
     ? await getSessionHarness(workflows, params.stepId)
     : DEFAULT_HARNESS;
-  const commitByteLen = params.body.length;
   const metrics = {
     recordCounts: {} as Partial<Record<LogRecordMetricKind, number>>,
     streamClosedReason: undefined as 'declared' | undefined,
@@ -338,112 +397,9 @@ export async function appendLogs(
     storedBytes: 0,
   };
 
-  const result = await db().transaction(async (tx) => {
-    if (commitByteLen === 0) return readHeartbeat(tx, params);
-
-    const {created, stream} = await getOrCreateAttemptStreamWithStatus(tx, {
-      jobId: params.jobId,
-      stepId: params.stepId,
-      attempt: params.attempt,
-      workspaceId: params.workspaceId,
-      projectId: params.projectId,
-      workflowRunAttemptId: params.workflowRunAttemptId,
-    });
-    metrics.streamOpened = created;
-
-    // Closed stream (the runner's end already landed, or the job-terminated sweep ran):
-    // accept-and-drop so a late chunk can never race compaction. committed_length is
-    // frozen at close, so this reports the final offset and the runner stops cleanly.
-    if (stream.state === 'closed') {
-      return {committedLength: stream.committedLength, capped: await isJobCapped(tx, params.jobId)};
-    }
-
-    if ((await getStreamWriterOrigin(tx, stream.id)) === 'server') {
-      throw new LogWriterConflictError('server');
-    }
-
-    const cas = await casExtendCommittedLength(tx, {
-      streamId: stream.id,
-      offset: params.offset,
-      byteLen: commitByteLen,
-    });
-    if (cas.outcome === 'gap') throw new OffsetGapError(cas.committedLength);
-    if (cas.outcome === 'retry') {
-      return {committedLength: cas.committedLength, capped: await isJobCapped(tx, params.jobId)};
-    }
-    // In-order CAS extension: the raw body is accepted. Retries and gaps returned above, and
-    // closed streams / empty heartbeats never reach the CAS, so each body is counted once.
-    metrics.ingestedBytes += commitByteLen;
-
-    const parseHarness =
-      sessionHarness === 'claude' ||
-      stream.claudePendingResult !== null ||
-      stream.claudePendingToolRows.length > 0
-        ? 'claude'
-        : sessionHarness;
-    const stored = buildStoredBody(
-      parsed.records,
-      parseHarness,
-      parseHarness === 'claude'
-        ? createClaudeParseContext(stream.claudePendingToolRows, {
-            hasInit: stream.claudeHasInit,
-            sessionId: stream.claudeSessionId,
-            turn: stream.claudeTurn,
-          })
-        : undefined,
-      parseHarness === 'claude' ? stream.claudePendingResult : undefined,
-      declaredTotalBytes !== undefined,
-    );
-
-    const {
-      recordCounts,
-      stored: chunkStored,
-      ...result
-    } = await storeChunk(tx, {
-      params,
-      streamId: stream.id,
-      streamOffset: params.offset,
-      body: stored.body,
-      committedLength: cas.committedLength,
-      declaredTotalBytes,
-      origin: 'runner',
-    });
-    if (chunkStored) {
-      // Normalized durable bytes; a cap-dropped straggler never reaches this branch.
-      metrics.storedBytes += stored.body.length;
-      addRecordCounts(metrics.recordCounts, stored.recordCounts);
-    }
-    // A Claude append may normalize to no rows while still advancing its parser state for the
-    // next append. Zero-byte normalization is not a stored chunk, but its state is durable unless
-    // the job is capped and the raw append was dropped.
-    if (
-      stored.claudeParseContext !== undefined &&
-      (chunkStored || (stored.body.length === 0 && !result.capped))
-    ) {
-      await setClaudeParseContext(tx, {
-        streamId: stream.id,
-        hasInit: stored.claudeParseContext.hasInit,
-        sessionId: stored.claudeParseContext.sessionId,
-        turn: stored.claudeParseContext.turn,
-        pendingResult: stored.claudePendingResult ?? null,
-        pendingToolRows: stored.claudePendingToolRows ?? [],
-      });
-    }
-    addRecordCounts(metrics.recordCounts, recordCounts);
-
-    // The runner's end record was committed in this append (offset-CAS guarantees
-    // everything before it is already committed), so the stream is whole. Declared-close
-    // it in-band so compaction starts at once instead of waiting for the timeout sweep.
-    // Only when the chunk was actually stored: an end body dropped because the job was
-    // already capped persists nothing, so the stream is not whole and stays open for the
-    // timeout sweep to close it as truncated.
-    if (declaredTotalBytes !== undefined && chunkStored) {
-      const closed = await closeStream(tx, {streamId: stream.id, reason: 'declared'});
-      if (closed) metrics.streamClosedReason = 'declared';
-    }
-
-    return result;
-  });
+  const result = await db().transaction((tx) =>
+    appendLogsTransaction(tx, params, parsed, sessionHarness, metrics),
+  );
 
   if (metrics.streamOpened) streamOpenedCount.add(1);
   if (metrics.ingestedBytes > 0) bytesIngestedCount.add(metrics.ingestedBytes);
@@ -456,6 +412,157 @@ export async function appendLogs(
   }
 
   return result;
+}
+
+type AppendStream = Awaited<ReturnType<typeof getOrCreateAttemptStreamWithStatus>>['stream'];
+
+async function appendLogsTransaction(
+  tx: Transaction,
+  params: AppendLogsParams,
+  parsed: ParsedBody,
+  sessionHarness: Harness,
+  metrics: AppendLogsMetrics,
+): Promise<AppendLogsResult> {
+  const commitByteLen = params.body.length;
+  if (commitByteLen === 0) return readHeartbeat(tx, params);
+  const {created, stream} = await getOrCreateAttemptStreamWithStatus(tx, params);
+  metrics.streamOpened = created;
+  // Closed streams accept-and-drop late chunks and keep their final cursor.
+  if (stream.state === 'closed') return closedAppendResult(tx, stream, params.jobId);
+  if ((await getStreamWriterOrigin(tx, stream.id)) === 'server') {
+    throw new LogWriterConflictError('server');
+  }
+
+  const cas = await casExtendCommittedLength(tx, {
+    streamId: stream.id,
+    offset: params.offset,
+    byteLen: commitByteLen,
+  });
+  if (cas.outcome === 'gap') throw new OffsetGapError(cas.committedLength);
+  if (cas.outcome === 'retry') {
+    return {committedLength: cas.committedLength, capped: await isJobCapped(tx, params.jobId)};
+  }
+  metrics.ingestedBytes += commitByteLen;
+  return storeRunnerAppend(
+    tx,
+    params,
+    parsed,
+    sessionHarness,
+    stream,
+    cas.committedLength,
+    metrics,
+  );
+}
+
+async function closedAppendResult(
+  tx: Transaction,
+  stream: AppendStream,
+  jobId: string,
+): Promise<AppendLogsResult> {
+  return {committedLength: stream.committedLength, capped: await isJobCapped(tx, jobId)};
+}
+
+async function storeRunnerAppend(
+  tx: Transaction,
+  params: AppendLogsParams,
+  parsed: ParsedBody,
+  sessionHarness: Harness,
+  stream: AppendStream,
+  committedLength: number,
+  metrics: AppendLogsMetrics,
+): Promise<AppendLogsResult> {
+  const parseHarness = runnerParseHarness(sessionHarness, stream);
+  const stored = runnerStoredBody(parsed, parseHarness, stream);
+  const {
+    recordCounts,
+    stored: chunkStored,
+    ...result
+  } = await storeChunk(tx, {
+    params,
+    streamId: stream.id,
+    streamOffset: params.offset,
+    body: stored.body,
+    committedLength,
+    declaredTotalBytes: parsed.declaredTotalBytes,
+    origin: 'runner',
+  });
+  recordStoredRunnerChunk(stored, chunkStored, recordCounts, metrics);
+  await persistClaudeParseContext(tx, stream.id, stored, chunkStored, result.capped);
+  await closeDeclaredRunnerStream(tx, stream.id, parsed.declaredTotalBytes, chunkStored, metrics);
+  return result;
+}
+
+function runnerParseHarness(sessionHarness: Harness, stream: AppendStream): Harness {
+  if (sessionHarness === 'claude') return 'claude';
+  if (stream.claudePendingResult !== null || stream.claudePendingToolRows.length > 0)
+    return 'claude';
+  return sessionHarness;
+}
+
+function runnerStoredBody(
+  parsed: ParsedBody,
+  parseHarness: Harness,
+  stream: AppendStream,
+): StoredBody {
+  const context =
+    parseHarness === 'claude'
+      ? createClaudeParseContext(stream.claudePendingToolRows, {
+          hasInit: stream.claudeHasInit,
+          sessionId: stream.claudeSessionId,
+          turn: stream.claudeTurn,
+        })
+      : undefined;
+  return buildStoredBody(
+    parsed.records,
+    parseHarness,
+    context,
+    parseHarness === 'claude' ? stream.claudePendingResult : undefined,
+    parsed.declaredTotalBytes !== undefined,
+  );
+}
+
+function recordStoredRunnerChunk(
+  stored: StoredBody,
+  chunkStored: boolean,
+  chunkRecordCounts: Partial<Record<LogRecordMetricKind, number>>,
+  metrics: AppendLogsMetrics,
+): void {
+  if (chunkStored) {
+    metrics.storedBytes += stored.body.length;
+    addRecordCounts(metrics.recordCounts, stored.recordCounts);
+  }
+  addRecordCounts(metrics.recordCounts, chunkRecordCounts);
+}
+
+async function persistClaudeParseContext(
+  tx: Transaction,
+  streamId: string,
+  stored: StoredBody,
+  chunkStored: boolean,
+  capped: boolean,
+): Promise<void> {
+  if (stored.claudeParseContext === undefined) return;
+  if (!chunkStored && (stored.body.length > 0 || capped)) return;
+  await setClaudeParseContext(tx, {
+    streamId,
+    hasInit: stored.claudeParseContext.hasInit,
+    sessionId: stored.claudeParseContext.sessionId,
+    turn: stored.claudeParseContext.turn,
+    pendingResult: stored.claudePendingResult ?? null,
+    pendingToolRows: stored.claudePendingToolRows ?? [],
+  });
+}
+
+async function closeDeclaredRunnerStream(
+  tx: Transaction,
+  streamId: string,
+  declaredTotalBytes: number | undefined,
+  chunkStored: boolean,
+  metrics: AppendLogsMetrics,
+): Promise<void> {
+  if (declaredTotalBytes === undefined || !chunkStored) return;
+  const closed = await closeStream(tx, {streamId, reason: 'declared'});
+  if (closed) metrics.streamClosedReason = 'declared';
 }
 
 function addRecordCounts(

--- a/libs/api/logs/src/core/append-server-records.ts
+++ b/libs/api/logs/src/core/append-server-records.ts
@@ -3,7 +3,7 @@ import {type LogRecord, type ServerLogRecord, serverLogRecordSchema} from '@ship
 import {config} from '#config.js';
 import {isJobCapped} from '#db/accounting.js';
 import {getStreamWriterOrigin} from '#db/chunks.js';
-import {db} from '#db/db.js';
+import {db, type Transaction} from '#db/db.js';
 import {casExtendCommittedLength, getOrCreateAttemptStreamWithStatus} from '#db/streams.js';
 import {
   bytesIngestedCount,
@@ -36,6 +36,14 @@ export interface AppendServerRecordsParams extends AppendIdentity {
    * newline-terminated NDJSON line.
    */
   records: ServerLogRecord[];
+}
+
+interface AppendServerMetrics {
+  readonly recordCounts: Partial<Record<LogRecordMetricKind, number>>;
+  streamClosedReason: 'declared' | undefined;
+  streamOpened: boolean;
+  ingestedBytes: number;
+  storedBytes: number;
 }
 
 interface ServerBody {
@@ -106,80 +114,9 @@ export async function appendServerRecords(
     storedBytes: 0,
   };
 
-  const result = await db().transaction(async (tx) => {
-    if (body.length === 0) return readHeartbeat(tx, params);
-
-    // Tail append: the stream upsert locks the row for the transaction, so this fresh tail
-    // cannot race another append. A retry outcome would violate that invariant and is treated
-    // as an internal consistency failure instead of looping over dead code.
-    const {created, stream} = await getOrCreateAttemptStreamWithStatus(tx, {
-      jobId: params.jobId,
-      stepId: params.stepId,
-      attempt: params.attempt,
-      workspaceId: params.workspaceId,
-      projectId: params.projectId,
-      workflowRunAttemptId: params.workflowRunAttemptId,
-    });
-    metrics.streamOpened = created;
-
-    // Closed stream (an end already landed, or the job-terminated sweep ran):
-    // accept-and-drop so a late batch can never race compaction. committed_length is
-    // frozen at close, so this reports the final offset and the caller stops cleanly.
-    if (stream.state === 'closed') {
-      return {
-        committedLength: stream.committedLength,
-        capped: await isJobCapped(tx, params.jobId),
-      };
-    }
-
-    if ((await getStreamWriterOrigin(tx, stream.id)) === 'runner') {
-      throw new LogWriterConflictError('runner');
-    }
-
-    const cas = await casExtendCommittedLength(tx, {
-      streamId: stream.id,
-      offset: stream.committedLength,
-      byteLen: body.length,
-    });
-    if (cas.outcome === 'gap') throw new OffsetGapError(cas.committedLength);
-    if (cas.outcome === 'retry') {
-      throw new Error('Server append CAS did not extend the locked stream tail');
-    }
-    // In-order CAS extension: the batch is accepted at the tail and counted once.
-    metrics.ingestedBytes += body.length;
-
-    const {
-      recordCounts: chunkRecordCounts,
-      stored: chunkStored,
-      ...chunkResult
-    } = await storeChunk(tx, {
-      params,
-      streamId: stream.id,
-      streamOffset: stream.committedLength,
-      body,
-      committedLength: cas.committedLength,
-      declaredTotalBytes,
-      origin: 'server',
-    });
-    if (chunkStored) {
-      // Normalized durable bytes; a cap-dropped straggler never reaches this branch.
-      metrics.storedBytes += body.length;
-      addRecordCounts(metrics.recordCounts, chunkRecordCounts);
-      addRecordCounts(metrics.recordCounts, recordCounts);
-    }
-
-    // An `end` record committed in this batch (the offset-CAS guarantees everything
-    // before it is already committed), so the stream is whole. Declared-close it
-    // in-band exactly like the runner path, and only when the chunk was actually
-    // stored: an end body dropped because the job was already capped persists
-    // nothing, so the stream is not whole and stays open for the timeout sweep.
-    if (declaredTotalBytes !== undefined && chunkStored) {
-      const closed = await closeStream(tx, {streamId: stream.id, reason: 'declared'});
-      if (closed) metrics.streamClosedReason = 'declared';
-    }
-
-    return chunkResult;
-  });
+  const result = await db().transaction((tx) =>
+    appendServerRecordsTransaction(tx, params, body, declaredTotalBytes, recordCounts, metrics),
+  );
 
   if (metrics.streamOpened) streamOpenedCount.add(1);
   if (metrics.ingestedBytes > 0) bytesIngestedCount.add(metrics.ingestedBytes);
@@ -192,6 +129,91 @@ export async function appendServerRecords(
   }
 
   return result;
+}
+
+async function appendServerRecordsTransaction(
+  tx: Transaction,
+  params: AppendServerRecordsParams,
+  body: Buffer,
+  declaredTotalBytes: number | undefined,
+  recordCounts: Partial<Record<LogRecord['type'], number>>,
+  metrics: AppendServerMetrics,
+): Promise<AppendLogsResult> {
+  if (body.length === 0) return readHeartbeat(tx, params);
+  const {created, stream} = await getOrCreateAttemptStreamWithStatus(tx, params);
+  metrics.streamOpened = created;
+  if (stream.state === 'closed') {
+    return {committedLength: stream.committedLength, capped: await isJobCapped(tx, params.jobId)};
+  }
+  if ((await getStreamWriterOrigin(tx, stream.id)) === 'runner') {
+    throw new LogWriterConflictError('runner');
+  }
+  const cas = await casExtendCommittedLength(tx, {
+    streamId: stream.id,
+    offset: stream.committedLength,
+    byteLen: body.length,
+  });
+  if (cas.outcome === 'gap') throw new OffsetGapError(cas.committedLength);
+  if (cas.outcome === 'retry') {
+    throw new Error('Server append CAS did not extend the locked stream tail');
+  }
+  metrics.ingestedBytes += body.length;
+  return storeServerAppend(
+    tx,
+    params,
+    stream.id,
+    stream.committedLength,
+    cas.committedLength,
+    body,
+    declaredTotalBytes,
+    recordCounts,
+    metrics,
+  );
+}
+
+async function storeServerAppend(
+  tx: Transaction,
+  params: AppendServerRecordsParams,
+  streamId: string,
+  streamOffset: number,
+  committedLength: number,
+  body: Buffer,
+  declaredTotalBytes: number | undefined,
+  recordCounts: Partial<Record<LogRecord['type'], number>>,
+  metrics: AppendServerMetrics,
+): Promise<AppendLogsResult> {
+  const {
+    recordCounts: chunkRecordCounts,
+    stored: chunkStored,
+    ...result
+  } = await storeChunk(tx, {
+    params,
+    streamId,
+    streamOffset,
+    body,
+    committedLength,
+    declaredTotalBytes,
+    origin: 'server',
+  });
+  if (chunkStored) {
+    metrics.storedBytes += body.length;
+    addRecordCounts(metrics.recordCounts, chunkRecordCounts);
+    addRecordCounts(metrics.recordCounts, recordCounts);
+  }
+  await closeDeclaredServerStream(tx, streamId, declaredTotalBytes, chunkStored, metrics);
+  return result;
+}
+
+async function closeDeclaredServerStream(
+  tx: Transaction,
+  streamId: string,
+  declaredTotalBytes: number | undefined,
+  chunkStored: boolean,
+  metrics: AppendServerMetrics,
+): Promise<void> {
+  if (declaredTotalBytes === undefined || !chunkStored) return;
+  const closed = await closeStream(tx, {streamId, reason: 'declared'});
+  if (closed) metrics.streamClosedReason = 'declared';
 }
 
 function addRecordCounts(

--- a/libs/api/logs/src/core/append-server-records.ts
+++ b/libs/api/logs/src/core/append-server-records.ts
@@ -16,10 +16,11 @@ import {
 import {
   type AppendIdentity,
   type AppendLogsResult,
+  closeDeclaredStream,
   readHeartbeat,
+  recordStoredChunk,
   storeChunk,
 } from './append-chunk.js';
-import {closeStream} from './close-stream.js';
 import {
   LogAppendBodyTooLargeError,
   LogWriterConflictError,
@@ -196,31 +197,8 @@ async function storeServerAppend(
     origin: 'server',
   });
   if (chunkStored) {
-    metrics.storedBytes += body.length;
-    addRecordCounts(metrics.recordCounts, chunkRecordCounts);
-    addRecordCounts(metrics.recordCounts, recordCounts);
+    recordStoredChunk(metrics, body.length, chunkRecordCounts, recordCounts);
   }
-  await closeDeclaredServerStream(tx, streamId, declaredTotalBytes, chunkStored, metrics);
+  await closeDeclaredStream(tx, streamId, declaredTotalBytes, chunkStored, metrics);
   return result;
-}
-
-async function closeDeclaredServerStream(
-  tx: Transaction,
-  streamId: string,
-  declaredTotalBytes: number | undefined,
-  chunkStored: boolean,
-  metrics: AppendServerMetrics,
-): Promise<void> {
-  if (declaredTotalBytes === undefined || !chunkStored) return;
-  const closed = await closeStream(tx, {streamId, reason: 'declared'});
-  if (closed) metrics.streamClosedReason = 'declared';
-}
-
-function addRecordCounts(
-  target: Partial<Record<LogRecordMetricKind, number>>,
-  source: Partial<Record<LogRecordMetricKind, number>>,
-): void {
-  for (const [kind, count] of Object.entries(source)) {
-    target[kind as LogRecordMetricKind] = (target[kind as LogRecordMetricKind] ?? 0) + (count ?? 0);
-  }
 }

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -98,92 +98,134 @@ export async function runRetentionSweep(
     });
     if (batch.length === 0) break;
 
-    let timedOutMidBatch = false;
-    for (const stream of batch) {
-      // Per-stream checks keep long batches within the heartbeat and wall-clock budgets.
-      params.onProgress?.();
-      if (now() >= deadline) {
-        result.timedOut = true;
-        timedOutMidBatch = true;
-        break;
-      }
-
-      try {
-        await deleteExpiredStreamObjects(stream);
-      } catch (error) {
-        result.failed += 1;
-        skip.add(stream.id);
-        logger().error(
-          {err: error, streamId: stream.id},
-          'Failed to delete expired log stream objects',
-        );
-        reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
-        continue;
-      }
-
-      let outcome: {deleted: boolean; prunedAccounting: boolean};
-      try {
-        outcome = await deleteExpiredStreamRow({stream, retentionDays: params.retentionDays});
-      } catch (error) {
-        result.failed += 1;
-        skip.add(stream.id);
-        logger().error(
-          {err: error, streamId: stream.id},
-          'Failed to delete expired log stream row',
-        );
-        reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
-        continue;
-      }
-
-      if (!outcome.deleted) {
-        let current: AttemptStream | null;
-        try {
-          current = await getAttemptStreamById(stream.id);
-        } catch (error) {
-          result.failed += 1;
-          skip.add(stream.id);
-          logger().error(
-            {err: error, streamId: stream.id},
-            'Failed to reload raced expired log stream',
-          );
-          reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
-          continue;
-        }
-        if (current) {
-          try {
-            await deleteExpiredStreamObjects(current);
-            outcome = await deleteExpiredStreamRow({
-              stream: current,
-              retentionDays: params.retentionDays,
-            });
-          } catch (error) {
-            result.failed += 1;
-            skip.add(stream.id);
-            logger().error(
-              {err: error, streamId: stream.id},
-              'Failed to delete raced expired log stream',
-            );
-            reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
-            continue;
-          }
-        }
-        if (!current || !outcome.deleted) {
-          // `object_key` changed again or the row disappeared; the next sweep will re-read it.
-          result.raced += 1;
-          skip.add(stream.id);
-          continue;
-        }
-      }
-
-      result.deleted += 1;
-      if (outcome.prunedAccounting) result.accountingPruned += 1;
-    }
-
-    if (timedOutMidBatch) break;
+    if (await processRetentionBatch(batch, params, result, skip, now, deadline)) break;
 
     result.iterations += 1;
     if (batch.length < params.batchLimit) break;
   }
 
   return result;
+}
+
+async function processRetentionBatch(
+  batch: readonly AttemptStream[],
+  params: RunRetentionSweepParams,
+  result: RetentionSweepResult,
+  skip: Set<string>,
+  now: () => number,
+  deadline: number,
+): Promise<boolean> {
+  for (const stream of batch) {
+    params.onProgress?.();
+    if (now() >= deadline) {
+      result.timedOut = true;
+      return true;
+    }
+    await processExpiredStream(stream, params.retentionDays, result, skip);
+  }
+  return false;
+}
+
+type RetentionAttempt<T> = {readonly ok: true; readonly value: T} | {readonly ok: false};
+
+async function attemptRetentionOperation<T>(
+  streamId: string,
+  result: RetentionSweepResult,
+  skip: Set<string>,
+  message: string,
+  operation: () => Promise<T>,
+): Promise<RetentionAttempt<T>> {
+  try {
+    return {ok: true, value: await operation()};
+  } catch (error) {
+    result.failed += 1;
+    skip.add(streamId);
+    logger().error({err: error, streamId}, message);
+    reportError(error, {boundary: 'logs.maintenance', extra: {streamId}});
+    return {ok: false};
+  }
+}
+
+async function processExpiredStream(
+  stream: AttemptStream,
+  retentionDays: number,
+  result: RetentionSweepResult,
+  skip: Set<string>,
+): Promise<void> {
+  const objectDelete = await attemptRetentionOperation(
+    stream.id,
+    result,
+    skip,
+    'Failed to delete expired log stream objects',
+    () => deleteExpiredStreamObjects(stream),
+  );
+  if (!objectDelete.ok) return;
+
+  const rowDelete = await attemptRetentionOperation(
+    stream.id,
+    result,
+    skip,
+    'Failed to delete expired log stream row',
+    () => deleteExpiredStreamRow({stream, retentionDays}),
+  );
+  if (!rowDelete.ok) return;
+  if (rowDelete.value.deleted) {
+    recordRetentionDeletion(rowDelete.value, result);
+    return;
+  }
+  await retryRacedExpiredStream(stream.id, retentionDays, result, skip);
+}
+
+async function retryRacedExpiredStream(
+  streamId: string,
+  retentionDays: number,
+  result: RetentionSweepResult,
+  skip: Set<string>,
+): Promise<void> {
+  const reload = await attemptRetentionOperation(
+    streamId,
+    result,
+    skip,
+    'Failed to reload raced expired log stream',
+    () => getAttemptStreamById(streamId),
+  );
+  if (!reload.ok) return;
+  if (reload.value === null) {
+    recordRetentionRace(streamId, result, skip);
+    return;
+  }
+  const current = reload.value;
+  const retry = await attemptRetentionOperation(
+    streamId,
+    result,
+    skip,
+    'Failed to delete raced expired log stream',
+    async () => {
+      await deleteExpiredStreamObjects(current);
+      return deleteExpiredStreamRow({stream: current, retentionDays});
+    },
+  );
+  if (!retry.ok) return;
+  if (!retry.value.deleted) {
+    recordRetentionRace(streamId, result, skip);
+    return;
+  }
+  recordRetentionDeletion(retry.value, result);
+}
+
+function recordRetentionRace(
+  streamId: string,
+  result: RetentionSweepResult,
+  skip: Set<string>,
+): void {
+  result.raced += 1;
+  skip.add(streamId);
+}
+
+function recordRetentionDeletion(
+  outcome: {deleted: boolean; prunedAccounting: boolean},
+  result: RetentionSweepResult,
+): void {
+  result.deleted += 1;
+  if (outcome.prunedAccounting) result.accountingPruned += 1;
 }

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -44,6 +44,19 @@ type SystemEventMapping = {
   meta?: (message: Record<string, unknown>) => readonly SessionViewRowMeta[];
 };
 
+function hookResponseLabel(outcome: string | undefined): string {
+  if (outcome === 'error') return 'Hook failed';
+  if (outcome === 'cancelled') return 'Hook cancelled';
+  if (outcome === 'success') return 'Hook completed';
+  return 'Hook response';
+}
+
+function hookResponseTone(outcome: string | undefined): SessionViewLifecycleRow['tone'] {
+  if (outcome === 'error') return 'error';
+  if (outcome === 'cancelled') return 'warning';
+  return 'default';
+}
+
 export const SYSTEM_EVENT_MAPPINGS: Record<string, SystemEventMapping> = {
   permission_denied: {
     label: 'Permission denied',
@@ -94,17 +107,11 @@ export const SYSTEM_EVENT_MAPPINGS: Record<string, SystemEventMapping> = {
   hook_response: {
     label: (message) => {
       const outcome = stringField(message, 'outcome');
-      return outcome === 'error'
-        ? 'Hook failed'
-        : outcome === 'cancelled'
-          ? 'Hook cancelled'
-          : outcome === 'success'
-            ? 'Hook completed'
-            : 'Hook response';
+      return hookResponseLabel(outcome);
     },
     tone: (message) => {
       const outcome = stringField(message, 'outcome');
-      return outcome === 'error' ? 'error' : outcome === 'cancelled' ? 'warning' : 'default';
+      return hookResponseTone(outcome);
     },
     detail: (message) =>
       stringField(message, 'output') ??
@@ -173,35 +180,9 @@ export function systemRow(
     ),
   ].filter(isMeta);
 
-  if (!isInit) {
-    const mapping = subtype === undefined ? undefined : SYSTEM_EVENT_MAPPINGS[subtype];
-    const label =
-      mapping === undefined
-        ? `Session event (${subtype ?? 'unknown'})`
-        : typeof mapping.label === 'function'
-          ? mapping.label(message)
-          : mapping.label;
-    const tone =
-      mapping === undefined
-        ? 'default'
-        : typeof mapping.tone === 'function'
-          ? mapping.tone(message)
-          : mapping.tone;
-    const detail = mapping?.detail?.(message) ?? null;
-    const meta = [...baseMeta, ...(mapping?.meta?.(message) ?? [])];
+  if (!isInit) return systemEventRow(timestamp, message, subtype, baseMeta);
 
-    return lifecycleRow(timestamp, label, detail, tone, false, meta);
-  }
-
-  const isNewSession =
-    !context.hasInit || sessionId === undefined || sessionId !== context.sessionId;
-  if (isNewSession) {
-    context.pendingToolRows.length = 0;
-    context.toolCallRows.clear();
-  }
-  context.hasInit = true;
-  context.sessionId = sessionId ?? null;
-  context.turn = isNewSession ? 1 : context.turn + 1;
+  const isNewSession = initializeClaudeSession(context, sessionId);
 
   const label = isNewSession ? 'Session started' : `Turn ${context.turn} started`;
   const meta = [
@@ -213,6 +194,41 @@ export function systemRow(
   return lifecycleRow(timestamp, label, null, 'default', false, meta);
 }
 
+function systemEventRow(
+  timestamp: number,
+  message: Record<string, unknown>,
+  subtype: string | undefined,
+  baseMeta: readonly SessionViewRowMeta[],
+): SessionViewLifecycleRow {
+  const mapping = subtype === undefined ? undefined : SYSTEM_EVENT_MAPPINGS[subtype];
+  let label = `Session event (${subtype ?? 'unknown'})`;
+  let tone: SessionViewLifecycleRow['tone'] = 'default';
+  if (mapping !== undefined) {
+    label = typeof mapping.label === 'function' ? mapping.label(message) : mapping.label;
+    tone = typeof mapping.tone === 'function' ? mapping.tone(message) : mapping.tone;
+  }
+  return lifecycleRow(timestamp, label, mapping?.detail?.(message) ?? null, tone, false, [
+    ...baseMeta,
+    ...(mapping?.meta?.(message) ?? []),
+  ]);
+}
+
+function initializeClaudeSession(
+  context: ClaudeParseContext,
+  sessionId: string | undefined,
+): boolean {
+  const isNewSession =
+    !context.hasInit || sessionId === undefined || sessionId !== context.sessionId;
+  if (isNewSession) {
+    context.pendingToolRows.length = 0;
+    context.toolCallRows.clear();
+  }
+  context.hasInit = true;
+  context.sessionId = sessionId ?? null;
+  context.turn = isNewSession ? 1 : context.turn + 1;
+  return isNewSession;
+}
+
 export function authStatusRow(
   timestamp: number,
   message: Record<string, unknown>,
@@ -221,13 +237,13 @@ export function authStatusRow(
   const output = stringList(field(message, 'output')).join('\n');
   const isAuthenticating = booleanField(message, 'isAuthenticating');
 
+  let label = 'Authentication complete';
+  if (error) label = 'Authentication failed';
+  else if (isAuthenticating) label = 'Authenticating';
+
   return lifecycleRow(
     timestamp,
-    error
-      ? 'Authentication failed'
-      : isAuthenticating
-        ? 'Authenticating'
-        : 'Authentication complete',
+    label,
     (error ?? output) || null,
     error ? 'error' : 'default',
     false,
@@ -276,12 +292,8 @@ export function toolUseSummary(
 
   const precedingToolUseIds = stringList(field(message, 'preceding_tool_use_ids'));
   const toolUseId = stringField(message, 'tool_use_id');
-  const candidateIds =
-    precedingToolUseIds.length > 0
-      ? precedingToolUseIds
-      : toolUseId === undefined
-        ? []
-        : [toolUseId];
+  let candidateIds = precedingToolUseIds;
+  if (candidateIds.length === 0 && toolUseId !== undefined) candidateIds = [toolUseId];
 
   for (const id of [...candidateIds].reverse()) {
     const row = context.toolCallRows.get(id);
@@ -323,65 +335,91 @@ export function assistantRows(
   context: ClaudeParseContext,
 ): readonly SessionViewRow[] {
   const sdkMessage = asLooseObject(message.message) ?? message;
-  const rows: SessionViewRow[] = [];
-  const textParts: string[] = [];
-  const thinkingParts: string[] = [];
-  let queueRows = context.toolCallRows.size > 0;
-
-  const pushRow = (row: SessionViewRow) => {
-    if (queueRows) {
-      context.pendingToolRows.push(row);
-    } else {
-      rows.push(row);
-    }
-  };
-
-  const pushText = () => {
-    if (textParts.length === 0) return;
-    pushRow(messageRow(timestamp, 'assistant', 'assistant', textParts.join('\n\n'), false));
-    textParts.length = 0;
-  };
-  const pushThinking = () => {
-    if (thinkingParts.length === 0) return;
-    pushRow(thinkingRow(timestamp, thinkingParts.join('\n\n')));
-    thinkingParts.length = 0;
+  const state: ClaudeAssistantRowState = {
+    context,
+    rows: [],
+    textParts: [],
+    thinkingParts: [],
+    queueRows: context.toolCallRows.size > 0,
   };
 
   for (const block of contentBlocks(sdkMessage)) {
-    const type = stringField(block, 'type');
-    if (type === 'tool_use' || type === 'tool-use' || type === 'toolCall') {
-      pushText();
-      pushThinking();
-      const row = toolCallRow(timestamp, block);
-      if (row.id === null) {
-        pushRow(row);
-      } else {
-        queueRows = true;
-        context.pendingToolRows.push(row);
-        context.toolCallRows.set(row.id, row);
-      }
-      continue;
-    }
-
-    if (type === 'thinking' || type === 'reasoning') {
-      pushText();
-      const text = blockText(block);
-      if (text) thinkingParts.push(text);
-      continue;
-    }
-
-    pushThinking();
-    const text = blockText(block);
-    if (text) textParts.push(text);
+    appendClaudeAssistantBlock(timestamp, block, state);
   }
 
-  pushText();
-  pushThinking();
+  flushClaudeAssistantText(timestamp, state);
+  flushClaudeAssistantThinking(timestamp, state);
 
-  if (rows.length > 0 || queueRows) return rows;
+  if (state.rows.length > 0 || state.queueRows) return state.rows;
 
   const text = stringField(sdkMessage, 'content') ?? stringField(message, 'result');
   return [messageRow(timestamp, 'assistant', 'assistant', text ?? toJson(message), false)];
+}
+
+interface ClaudeAssistantRowState {
+  readonly context: ClaudeParseContext;
+  readonly rows: SessionViewRow[];
+  readonly textParts: string[];
+  readonly thinkingParts: string[];
+  queueRows: boolean;
+}
+
+function pushClaudeAssistantRow(row: SessionViewRow, state: ClaudeAssistantRowState): void {
+  if (state.queueRows) state.context.pendingToolRows.push(row);
+  else state.rows.push(row);
+}
+
+function flushClaudeAssistantText(timestamp: number, state: ClaudeAssistantRowState): void {
+  if (state.textParts.length === 0) return;
+  pushClaudeAssistantRow(
+    messageRow(timestamp, 'assistant', 'assistant', state.textParts.join('\n\n'), false),
+    state,
+  );
+  state.textParts.length = 0;
+}
+
+function flushClaudeAssistantThinking(timestamp: number, state: ClaudeAssistantRowState): void {
+  if (state.thinkingParts.length === 0) return;
+  pushClaudeAssistantRow(thinkingRow(timestamp, state.thinkingParts.join('\n\n')), state);
+  state.thinkingParts.length = 0;
+}
+
+function appendClaudeAssistantBlock(
+  timestamp: number,
+  block: Record<string, unknown>,
+  state: ClaudeAssistantRowState,
+): void {
+  const type = stringField(block, 'type');
+  if (type === 'tool_use' || type === 'tool-use' || type === 'toolCall') {
+    appendClaudeToolCall(timestamp, block, state);
+    return;
+  }
+  if (type === 'thinking' || type === 'reasoning') {
+    flushClaudeAssistantText(timestamp, state);
+    const text = blockText(block);
+    if (text) state.thinkingParts.push(text);
+    return;
+  }
+  flushClaudeAssistantThinking(timestamp, state);
+  const text = blockText(block);
+  if (text) state.textParts.push(text);
+}
+
+function appendClaudeToolCall(
+  timestamp: number,
+  block: Record<string, unknown>,
+  state: ClaudeAssistantRowState,
+): void {
+  flushClaudeAssistantText(timestamp, state);
+  flushClaudeAssistantThinking(timestamp, state);
+  const row = toolCallRow(timestamp, block);
+  if (row.id === null) {
+    pushClaudeAssistantRow(row, state);
+    return;
+  }
+  state.queueRows = true;
+  state.context.pendingToolRows.push(row);
+  state.context.toolCallRows.set(row.id, row);
 }
 
 export function userRows(
@@ -402,19 +440,9 @@ export function userRows(
   };
 
   for (const block of contentBlocks(sdkMessage)) {
-    const type = stringField(block, 'type');
-    if (type === 'tool_result' || type === 'tool-result') {
-      pushText();
-      const row = toolResultRow(timestamp, block);
-      if (row.toolCallId !== null && context.toolCallRows.has(row.toolCallId)) {
-        matchedToolResult = true;
-      }
-      rows.push(row);
-      continue;
-    }
-
-    const text = blockText(block);
-    if (text) textParts.push(text);
+    matchedToolResult =
+      appendClaudeUserBlock(timestamp, block, context, rows, textParts, pushText) ||
+      matchedToolResult;
   }
 
   pushText();
@@ -424,14 +452,40 @@ export function userRows(
     rows.push(messageRow(timestamp, role, role, content ?? toJson(message), false));
   }
 
-  if (hadPendingToolCall) {
-    if (matchedToolResult) {
-      context.pendingToolRows.push(...rows);
-      return [];
-    }
-    return [...flushPendingToolRows(context), ...rows];
-  }
+  if (hadPendingToolCall) return resolvePendingClaudeUserRows(context, rows, matchedToolResult);
   return rows;
+}
+
+function appendClaudeUserBlock(
+  timestamp: number,
+  block: Record<string, unknown>,
+  context: ClaudeParseContext,
+  rows: SessionViewRow[],
+  textParts: string[],
+  pushText: () => void,
+): boolean {
+  const type = stringField(block, 'type');
+  if (type !== 'tool_result' && type !== 'tool-result') {
+    const text = blockText(block);
+    if (text) textParts.push(text);
+    return false;
+  }
+  pushText();
+  const row = toolResultRow(timestamp, block);
+  rows.push(row);
+  return row.toolCallId !== null && context.toolCallRows.has(row.toolCallId);
+}
+
+function resolvePendingClaudeUserRows(
+  context: ClaudeParseContext,
+  rows: readonly SessionViewRow[],
+  matchedToolResult: boolean,
+): readonly SessionViewRow[] {
+  if (matchedToolResult) {
+    context.pendingToolRows.push(...rows);
+    return [];
+  }
+  return [...flushPendingToolRows(context), ...rows];
 }
 
 export function resultRow(
@@ -456,13 +510,13 @@ export function resultRow(
     costMeta(message),
   ].filter(isMeta);
 
+  let label = `Turn ${turn} completed`;
+  if (terminalFailure) label = 'Session failed';
+  else if (isFinalResult || turn === 0) label = 'Session completed';
+
   return lifecycleRow(
     timestamp,
-    terminalFailure
-      ? 'Session failed'
-      : isFinalResult || turn === 0
-        ? 'Session completed'
-        : `Turn ${turn} completed`,
+    label,
     detail,
     terminalFailure ? 'error' : 'default',
     terminalFailure,
@@ -521,7 +575,9 @@ function blockText(block: Record<string, unknown>): string {
     return content
       .map((item) => {
         const object = asLooseObject(item);
-        return object ? blockText(object) : typeof item === 'string' ? item : '';
+        if (object) return blockText(object);
+        if (typeof item === 'string') return item;
+        return '';
       })
       .filter(Boolean)
       .join('\n\n');

--- a/libs/api/logs/src/core/session/pi/message-rows.ts
+++ b/libs/api/logs/src/core/session/pi/message-rows.ts
@@ -169,24 +169,34 @@ function expandAssistantMessage(
 
   pushTextParts();
   pushThinkingParts();
-  if (terminalFailure && !rows.some((row) => row.kind === 'message' && row.terminalFailure)) {
-    rows.push(
-      messageRow(
-        timestamp,
-        'assistant',
-        'assistant',
-        terminalStopDetail(message) || toJson(message),
-        true,
-        meta,
-      ),
-    );
-  }
+  appendTerminalFailureRow(timestamp, message, terminalFailure, meta, rows);
   if (rows.length === 0)
     rows.push(
       messageRow(timestamp, 'assistant', 'assistant', toJson(message), terminalFailure, meta),
     );
 
   return rows;
+}
+
+function appendTerminalFailureRow(
+  timestamp: number,
+  message: AgentMessage,
+  terminalFailure: boolean,
+  meta: Parameters<typeof messageRow>[5],
+  rows: SessionViewRow[],
+): void {
+  if (!terminalFailure) return;
+  if (rows.some((row) => row.kind === 'message' && row.terminalFailure)) return;
+  rows.push(
+    messageRow(
+      timestamp,
+      'assistant',
+      'assistant',
+      terminalStopDetail(message) || toJson(message),
+      true,
+      meta,
+    ),
+  );
 }
 
 function toolCallRow(timestamp: number, block: ContentBlock): SessionViewToolCallRow {

--- a/libs/api/projects/src/core/projects.ts
+++ b/libs/api/projects/src/core/projects.ts
@@ -21,6 +21,8 @@ import {
 } from './errors.js';
 
 const PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT = 'projects_workspace_slug_unique';
+type ProjectsDb = ReturnType<typeof db>;
+type ProjectsTx = Parameters<Parameters<ProjectsDb['transaction']>[0]>[0];
 
 export interface CreateProjectFromSourceParams {
   actorId: string;
@@ -62,31 +64,15 @@ export async function createProjectFromSource(
           })
           .returning();
       } catch (error) {
-        if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
-          throw new ProjectSlugConflictError(params.slug);
-        }
-        throw error;
+        throw mapProjectInsertError(error, params.slug);
       }
 
-      if (!projectRow) {
-        const [existing] = await tx
-          .select()
-          .from(projects)
-          .where(
-            and(
-              eq(projects.sourceConnectionId, source.connection.id),
-              eq(projects.sourceExternalRepositoryId, source.repository.externalRepositoryId),
-            ),
-          )
-          .limit(1);
-        if (existing) {
-          throw new ProjectAlreadyExistsError(
-            existing.id,
-            source.connection.id,
-            source.repository.externalRepositoryId,
-          );
-        }
-      }
+      if (!projectRow)
+        await assertSourceProjectDoesNotExist(
+          tx,
+          source.connection.id,
+          source.repository.externalRepositoryId,
+        );
     }
 
     if (!projectRow) {
@@ -122,6 +108,37 @@ export async function createProjectFromSource(
   });
   recordProjectCreated();
   return project;
+}
+
+function mapProjectInsertError(error: unknown, slug: string): unknown {
+  if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
+    return new ProjectSlugConflictError(slug);
+  }
+  return error;
+}
+
+async function assertSourceProjectDoesNotExist(
+  tx: ProjectsTx,
+  sourceConnectionId: string,
+  sourceExternalRepositoryId: string,
+): Promise<void> {
+  const [existing] = await tx
+    .select()
+    .from(projects)
+    .where(
+      and(
+        eq(projects.sourceConnectionId, sourceConnectionId),
+        eq(projects.sourceExternalRepositoryId, sourceExternalRepositoryId),
+      ),
+    )
+    .limit(1);
+  if (existing) {
+    throw new ProjectAlreadyExistsError(
+      existing.id,
+      sourceConnectionId,
+      sourceExternalRepositoryId,
+    );
+  }
 }
 
 export interface UpdateProjectDetailsParams {

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -99,31 +99,10 @@ export async function createProject(params: CreateProjectParams): Promise<Projec
           })
           .returning();
       } catch (error) {
-        if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
-          throw new ProjectSlugConflictError(params.slug);
-        }
-        throw error;
+        throw mapProjectInsertError(error, params.slug);
       }
 
-      if (!projectRow) {
-        const [conflict] = await tx
-          .select()
-          .from(projects)
-          .where(
-            and(
-              eq(projects.sourceConnectionId, params.sourceConnectionId),
-              eq(projects.sourceExternalRepositoryId, params.sourceExternalRepositoryId),
-            ),
-          )
-          .limit(1);
-        if (conflict) {
-          throw new ProjectAlreadyExistsError(
-            conflict.id,
-            params.sourceConnectionId,
-            params.sourceExternalRepositoryId,
-          );
-        }
-      }
+      if (!projectRow) await assertSourceProjectDoesNotExist(tx, params);
     }
 
     if (!projectRow) {
@@ -134,6 +113,36 @@ export async function createProject(params: CreateProjectParams): Promise<Projec
   });
   recordProjectCreated();
   return project;
+}
+
+function mapProjectInsertError(error: unknown, slug: string): unknown {
+  if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
+    return new ProjectSlugConflictError(slug);
+  }
+  return error;
+}
+
+async function assertSourceProjectDoesNotExist(
+  tx: ProjectTransaction,
+  params: Pick<CreateProjectParams, 'sourceConnectionId' | 'sourceExternalRepositoryId'>,
+): Promise<void> {
+  const [conflict] = await tx
+    .select()
+    .from(projects)
+    .where(
+      and(
+        eq(projects.sourceConnectionId, params.sourceConnectionId),
+        eq(projects.sourceExternalRepositoryId, params.sourceExternalRepositoryId),
+      ),
+    )
+    .limit(1);
+  if (conflict) {
+    throw new ProjectAlreadyExistsError(
+      conflict.id,
+      params.sourceConnectionId,
+      params.sourceExternalRepositoryId,
+    );
+  }
 }
 
 export async function updateProject(
@@ -316,20 +325,20 @@ export async function resolveCheckoutTarget(
   const separator = params.target.repository.indexOf('/');
   if (separator === 0 || separator === params.target.repository.length - 1) return undefined;
 
-  const repository =
-    separator === -1
-      ? {
-          connectionId: params.target.connection ?? params.defaults.connectionId,
-          owner: params.defaults.owner,
-          name: params.target.repository,
-        }
-      : params.target.repository.indexOf('/', separator + 1) === -1
-        ? {
-            connectionId: params.target.connection ?? params.defaults.connectionId,
-            owner: params.target.repository.slice(0, separator),
-            name: params.target.repository.slice(separator + 1),
-          }
-        : undefined;
+  let repository: {connectionId: string; owner: string; name: string} | undefined;
+  if (separator === -1) {
+    repository = {
+      connectionId: params.target.connection ?? params.defaults.connectionId,
+      owner: params.defaults.owner,
+      name: params.target.repository,
+    };
+  } else if (params.target.repository.indexOf('/', separator + 1) === -1) {
+    repository = {
+      connectionId: params.target.connection ?? params.defaults.connectionId,
+      owner: params.target.repository.slice(0, separator),
+      name: params.target.repository.slice(separator + 1),
+    };
+  }
   if (repository === undefined) return undefined;
 
   const matches = await db()

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -82,11 +82,10 @@ export function createProjectsInterModulePresentation(params: {
           );
         }
 
-        const separator = input.target.repository.indexOf('/');
-        const requestedOwner =
-          separator === -1 ? input.defaults.owner : input.target.repository.slice(0, separator);
-        const requestedName =
-          separator === -1 ? input.target.repository : input.target.repository.slice(separator + 1);
+        const {owner: requestedOwner, name: requestedName} = requestedRepository(
+          input.target.repository,
+          input.defaults.owner,
+        );
         const repositoryMatches =
           source.repository.owner.toLowerCase() === requestedOwner.toLowerCase() &&
           source.repository.name.toLowerCase() === requestedName.toLowerCase();
@@ -119,4 +118,13 @@ export function createProjectsInterModulePresentation(params: {
       return target;
     },
   });
+}
+
+function requestedRepository(
+  repository: string,
+  defaultOwner: string,
+): {owner: string; name: string} {
+  const separator = repository.indexOf('/');
+  if (separator === -1) return {owner: defaultOwner, name: repository};
+  return {owner: repository.slice(0, separator), name: repository.slice(separator + 1)};
 }

--- a/libs/api/projects/src/presentation/routes/create-project.ts
+++ b/libs/api/projects/src/presentation/routes/create-project.ts
@@ -32,41 +32,13 @@ export function createProjectRoute(integrations: IntegrationsModuleClient) {
       },
     },
     errorHandler: (error) => {
+      handleResolveSourceRepositoryError(error);
       const known = isInterModuleKnownError(
         integrationsInterModuleContract.methods.resolveSourceRepository,
         error,
       )
         ? error
         : undefined;
-      if (known?.code === 'connection-not-found') {
-        throw new ClientError('Source connection not found', 'source-connection-not-found', {
-          status: 404,
-        });
-      }
-      if (known?.code === 'connection-workspace-mismatch') {
-        throw new ClientError('Source connection does not belong to this workspace', 'forbidden', {
-          status: 403,
-        });
-      }
-      if (known?.code === 'connection-inactive') {
-        throw new ClientError('Source connection is not active', 'source-connection-inactive', {
-          status: 422,
-        });
-      }
-      if (known?.code === 'provider-unavailable') {
-        throw new ClientError(
-          'Integration provider is unavailable',
-          'integration-provider-unavailable',
-          {status: 422},
-        );
-      }
-      if (known?.code === 'capability-unavailable') {
-        throw new ClientError(
-          'Integration capability is unavailable',
-          'integration-capability-unavailable',
-          {status: 422},
-        );
-      }
       if (error instanceof ProjectAlreadyExistsError) {
         throw new ClientError(error.message, 'project-already-exists', {
           details: {
@@ -107,4 +79,40 @@ export function createProjectRoute(integrations: IntegrationsModuleClient) {
       return toProjectDto(project);
     },
   });
+}
+
+function handleResolveSourceRepositoryError(error: unknown): void {
+  if (
+    !isInterModuleKnownError(integrationsInterModuleContract.methods.resolveSourceRepository, error)
+  )
+    return;
+  if (error.code === 'connection-not-found') {
+    throw new ClientError('Source connection not found', 'source-connection-not-found', {
+      status: 404,
+    });
+  }
+  if (error.code === 'connection-workspace-mismatch') {
+    throw new ClientError('Source connection does not belong to this workspace', 'forbidden', {
+      status: 403,
+    });
+  }
+  if (error.code === 'connection-inactive') {
+    throw new ClientError('Source connection is not active', 'source-connection-inactive', {
+      status: 422,
+    });
+  }
+  if (error.code === 'provider-unavailable') {
+    throw new ClientError(
+      'Integration provider is unavailable',
+      'integration-provider-unavailable',
+      {status: 422},
+    );
+  }
+  if (error.code === 'capability-unavailable') {
+    throw new ClientError(
+      'Integration capability is unavailable',
+      'integration-capability-unavailable',
+      {status: 422},
+    );
+  }
 }

--- a/libs/api/runners/src/core/admin-runner-instances.ts
+++ b/libs/api/runners/src/core/admin-runner-instances.ts
@@ -70,24 +70,21 @@ function toRunnerAdministratorInstance(
   const isActivated = row.runnerSessionId !== null;
   const hasClaim = row.firstClaimedAt !== null;
   const isTerminal = isTerminalState(row.state);
+  let lifecycleState: RunnerAdministratorInstance['lifecycleState'] = 'claimed';
+  if (!isAssigned) lifecycleState = 'unassigned';
+  else if (isTerminal) lifecycleState = 'completed';
+  else if (!isActivated) lifecycleState = 'assigned';
+  else if (!hasClaim) lifecycleState = 'activated';
+
+  let enrollmentState: RunnerAdministratorInstance['enrollmentState'] = 'pending';
+  if (isActivated) enrollmentState = 'activated';
+  else if (row.hasActiveControlSession) enrollmentState = 'enrolled';
 
   return {
     id: row.id,
-    lifecycleState: !isAssigned
-      ? 'unassigned'
-      : isTerminal
-        ? 'completed'
-        : !isActivated
-          ? 'assigned'
-          : !hasClaim
-            ? 'activated'
-            : 'claimed',
+    lifecycleState,
     computeState: row.state,
-    enrollmentState: isActivated
-      ? 'activated'
-      : row.hasActiveControlSession
-        ? 'enrolled'
-        : 'pending',
+    enrollmentState,
     assignmentPresence: isAssigned ? 'assigned' : 'unassigned',
     assignedWorkspace: row.workspaceId ? {id: row.workspaceId} : null,
     labels: row.labels,

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -311,52 +311,7 @@ export async function enrollRunnerControlSession(params: {
         promotionFailureReason: null,
       };
 
-    try {
-      const promotion = await tx.transaction(async (promotionTx) => {
-        const assignment = await assignRunnerInstancesTx(promotionTx, {
-          provisionerId: params.provisionerId,
-          reservationId: intendedReservationId,
-          runnerInstanceIds: [params.runnerInstanceId],
-          surface: 'enrollment',
-        });
-        const activationToken = await issueRunnerActivationTokenTx(promotionTx, {
-          runnerInstanceId: params.runnerInstanceId,
-          provisionerId: params.provisionerId,
-          ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
-          surface: 'enrollment',
-        });
-        return {activationToken, controlSessionToAssignment: assignment.controlSessionToAssignment};
-      });
-      return {
-        activationToken: promotion.activationToken,
-        controlSessionToAssignment: promotion.controlSessionToAssignment,
-        assignmentRejectedReason: null,
-        promotionFailureReason: null,
-      };
-    } catch (error) {
-      const assignmentRejectionReason = getRunnerAssignmentRejectionReason(error);
-      const expectedFailureReason = getRunnerReservationPromotionFailureReason(error);
-      const details = {
-        err: error,
-        runnerInstanceId: params.runnerInstanceId,
-        provisionerId: params.provisionerId,
-        reservationId: intendedReservationId,
-      };
-      if (expectedFailureReason) {
-        logger().debug(details, 'Runner reservation could not be promoted during enrollment');
-      } else {
-        logger().error(
-          details,
-          'Unexpected failure promoting runner reservation during enrollment',
-        );
-      }
-      return {
-        activationToken: null,
-        controlSessionToAssignment: [],
-        assignmentRejectedReason: assignmentRejectionReason,
-        promotionFailureReason: expectedFailureReason,
-      };
-    }
+    return promoteEnrollmentReservation(tx, params, intendedReservationId);
   });
   for (const observation of result.controlSessionToAssignment)
     recordProviderRunnerControlSessionToAssignment(observation);
@@ -371,6 +326,58 @@ export async function enrollRunnerControlSession(params: {
   if (result.promotionFailureReason)
     recordRunnerReservationPromotionFailure(result.promotionFailureReason);
   return result.activationToken;
+}
+
+async function promoteEnrollmentReservation(
+  tx: Tx,
+  params: {runnerInstanceId: string; provisionerId: string},
+  reservationId: string,
+) {
+  try {
+    const promotion = await tx.transaction(async (promotionTx) => {
+      const assignment = await assignRunnerInstancesTx(promotionTx, {
+        provisionerId: params.provisionerId,
+        reservationId,
+        runnerInstanceIds: [params.runnerInstanceId],
+        surface: 'enrollment',
+      });
+      const activationToken = await issueRunnerActivationTokenTx(promotionTx, {
+        runnerInstanceId: params.runnerInstanceId,
+        provisionerId: params.provisionerId,
+        ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
+        surface: 'enrollment',
+      });
+      return {activationToken, controlSessionToAssignment: assignment.controlSessionToAssignment};
+    });
+    return {
+      ...promotion,
+      assignmentRejectedReason: null,
+      promotionFailureReason: null,
+    };
+  } catch (error) {
+    return failedEnrollmentPromotion(error, params, reservationId);
+  }
+}
+
+function failedEnrollmentPromotion(
+  error: unknown,
+  params: {runnerInstanceId: string; provisionerId: string},
+  reservationId: string,
+) {
+  const assignmentRejectedReason = getRunnerAssignmentRejectionReason(error);
+  const promotionFailureReason = getRunnerReservationPromotionFailureReason(error);
+  const details = {...params, err: error, reservationId};
+  if (promotionFailureReason) {
+    logger().debug(details, 'Runner reservation could not be promoted during enrollment');
+  } else {
+    logger().error(details, 'Unexpected failure promoting runner reservation during enrollment');
+  }
+  return {
+    activationToken: null,
+    controlSessionToAssignment: [],
+    assignmentRejectedReason,
+    promotionFailureReason,
+  };
 }
 
 function getRunnerReservationPromotionFailureReason(

--- a/libs/api/runners/src/core/runner-instances.ts
+++ b/libs/api/runners/src/core/runner-instances.ts
@@ -270,46 +270,19 @@ function mergeActiveRunners(
   providerRunners: RunnerInstance[],
   jobExecutions: ActiveRunningJobExecution[],
 ): ActiveRunner[] {
-  const jobExecutionsByRunnerSessionId = new Map<string, ActiveRunningJobExecution[]>();
-  const jobExecutionsByRunnerInstanceId = new Map<string, ActiveRunningJobExecution[]>();
-  for (const jobExecution of jobExecutions) {
-    const runnerJobExecutions =
-      jobExecutionsByRunnerSessionId.get(jobExecution.runnerSessionId) ?? [];
-    runnerJobExecutions.push(jobExecution);
-    jobExecutionsByRunnerSessionId.set(jobExecution.runnerSessionId, runnerJobExecutions);
-
-    if (jobExecution.provisionerId && jobExecution.providerRunnerId) {
-      const key = providerRunnerKey(jobExecution.provisionerId, jobExecution.providerRunnerId);
-      const providerRunnerJobExecutions = jobExecutionsByRunnerInstanceId.get(key) ?? [];
-      providerRunnerJobExecutions.push(jobExecution);
-      jobExecutionsByRunnerInstanceId.set(key, providerRunnerJobExecutions);
-    }
-  }
+  const {bySessionId, byInstanceId} = indexActiveJobExecutions(jobExecutions);
 
   const merged: ActiveRunner[] = [];
   const usedJobExecutionIds = new Set<string>();
 
   for (const providerRunner of providerRunners) {
-    const providerRunnerJobExecutions =
-      jobExecutionsByRunnerInstanceId.get(
-        providerRunnerKey(providerRunner.provisionerId, providerRunner.providerRunnerId),
-      ) ??
-      (providerRunner.runnerSessionId
-        ? jobExecutionsByRunnerSessionId.get(providerRunner.runnerSessionId)
-        : undefined);
-    if (!providerRunnerJobExecutions || providerRunnerJobExecutions.length === 0) {
-      merged.push(toActiveRunner(providerRunner, undefined));
-      continue;
-    }
-
-    let emitted = false;
-    for (const jobExecution of providerRunnerJobExecutions) {
-      if (usedJobExecutionIds.has(jobExecution.jobExecutionId)) continue;
-      usedJobExecutionIds.add(jobExecution.jobExecutionId);
-      merged.push(toActiveRunner(providerRunner, jobExecution));
-      emitted = true;
-    }
-    if (!emitted) merged.push(toActiveRunner(providerRunner, undefined));
+    appendActiveProviderRunner(
+      providerRunner,
+      bySessionId,
+      byInstanceId,
+      usedJobExecutionIds,
+      merged,
+    );
   }
 
   for (const jobExecution of jobExecutions) {
@@ -318,6 +291,66 @@ function mergeActiveRunners(
   }
 
   return merged.sort(compareActiveRunners);
+}
+
+function indexActiveJobExecutions(jobExecutions: readonly ActiveRunningJobExecution[]): {
+  bySessionId: Map<string, ActiveRunningJobExecution[]>;
+  byInstanceId: Map<string, ActiveRunningJobExecution[]>;
+} {
+  const bySessionId = new Map<string, ActiveRunningJobExecution[]>();
+  const byInstanceId = new Map<string, ActiveRunningJobExecution[]>();
+  for (const execution of jobExecutions) {
+    appendActiveExecution(bySessionId, execution.runnerSessionId, execution);
+    if (execution.provisionerId && execution.providerRunnerId) {
+      appendActiveExecution(
+        byInstanceId,
+        providerRunnerKey(execution.provisionerId, execution.providerRunnerId),
+        execution,
+      );
+    }
+  }
+  return {bySessionId, byInstanceId};
+}
+
+function appendActiveExecution(
+  map: Map<string, ActiveRunningJobExecution[]>,
+  key: string,
+  execution: ActiveRunningJobExecution,
+): void {
+  const executions = map.get(key) ?? [];
+  executions.push(execution);
+  map.set(key, executions);
+}
+
+function appendActiveProviderRunner(
+  runner: RunnerInstance,
+  bySessionId: ReadonlyMap<string, readonly ActiveRunningJobExecution[]>,
+  byInstanceId: ReadonlyMap<string, readonly ActiveRunningJobExecution[]>,
+  usedJobExecutionIds: Set<string>,
+  merged: ActiveRunner[],
+): void {
+  const executions = activeProviderRunnerExecutions(runner, bySessionId, byInstanceId);
+  let emitted = false;
+  for (const execution of executions) {
+    if (usedJobExecutionIds.has(execution.jobExecutionId)) continue;
+    usedJobExecutionIds.add(execution.jobExecutionId);
+    merged.push(toActiveRunner(runner, execution));
+    emitted = true;
+  }
+  if (!emitted) merged.push(toActiveRunner(runner, undefined));
+}
+
+function activeProviderRunnerExecutions(
+  runner: RunnerInstance,
+  bySessionId: ReadonlyMap<string, readonly ActiveRunningJobExecution[]>,
+  byInstanceId: ReadonlyMap<string, readonly ActiveRunningJobExecution[]>,
+): readonly ActiveRunningJobExecution[] {
+  const instanceExecutions = byInstanceId.get(
+    providerRunnerKey(runner.provisionerId, runner.providerRunnerId),
+  );
+  if (instanceExecutions !== undefined) return instanceExecutions;
+  if (!runner.runnerSessionId) return [];
+  return bySessionId.get(runner.runnerSessionId) ?? [];
 }
 
 function providerRunnerKey(provisionerId: string, providerRunnerId: string): string {

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -220,13 +220,23 @@ export interface RunnerInstanceBoundJobExecution {
   cancellationReason: RunnerJobStopReasonDto | null;
 }
 
-export async function claimPendingJobExecution(params: {
+interface ClaimPendingJobExecutionParams {
   workspaceId: string;
   runnerSessionId: string;
   sessionLabels: string[];
   maxClaims: number | null;
   runnerSessionLivenessThrottleSeconds: number;
-}): Promise<ClaimedJobExecution | null> {
+}
+
+interface ClaimRunnerContext {
+  provisionerId: string | null;
+  providerRunnerId: string | null;
+  runnerInstanceCondition: ReturnType<typeof eq> | undefined;
+}
+
+export async function claimPendingJobExecution(
+  params: ClaimPendingJobExecutionParams,
+): Promise<ClaimedJobExecution | null> {
   await touchRunnerSessionLiveness({
     workspaceId: params.workspaceId,
     runnerSessionId: params.runnerSessionId,
@@ -239,126 +249,16 @@ export async function claimPendingJobExecution(params: {
   let queueTimeObservation: JobExecutionQueueTimeObservation | null = null;
   let firstClaimReservationReleaseCount = 0;
   const result = await db().transaction(async (tx) => {
-    let provisionerId: string | null = null;
-    let providerRunnerId: string | null = null;
-    let runnerInstanceId: string | null = null;
-
-    if (params.maxClaims !== null) {
-      const [session] = await tx
-        .select({
-          maxClaims: runnerSessions.maxClaims,
-          claimsUsed: runnerSessions.claimsUsed,
-          revokedAt: runnerSessions.revokedAt,
-          runnerInstanceId: runnerSessions.runnerInstanceId,
-          provisionerId: runnerSessions.provisionerId,
-          providerRunnerId: runnerSessions.providerRunnerId,
-        })
-        .from(runnerSessions)
-        .where(eq(runnerSessions.id, params.runnerSessionId))
-        .limit(1)
-        .for('update');
-
-      if (
-        !session ||
-        session.revokedAt ||
-        session.maxClaims === null ||
-        session.claimsUsed >= session.maxClaims
-      ) {
-        throw new RunnerSessionExhaustedError(params.runnerSessionId);
-      }
-
-      // Ephemeral sessions are the only capped sessions, and the DB check keeps
-      // their provisioned-runner link present as a pair.
-      runnerInstanceId = session.runnerInstanceId;
-      provisionerId = session.provisionerId;
-      providerRunnerId = session.providerRunnerId;
-    }
-
-    const runnerInstanceCondition = runnerInstanceId
-      ? eq(providerRunners.id, runnerInstanceId)
-      : provisionerId && providerRunnerId
-        ? and(
-            eq(providerRunners.provisionerId, provisionerId),
-            eq(providerRunners.providerRunnerId, providerRunnerId),
-          )
-        : null;
-    if (runnerInstanceCondition && provisionerId) {
-      const [runner] = await tx
-        .select({
-          reservationId: providerRunners.reservationId,
-          intendedReservationId: providerRunners.intendedReservationId,
-        })
-        .from(providerRunners)
-        .where(runnerInstanceCondition)
-        .limit(1);
-      await lockRunnerReservationAdvisoryKeysTx(tx, {
-        provisionerId,
-        reservationIds: [runner?.reservationId, runner?.intendedReservationId].filter(
-          (reservationId): reservationId is string =>
-            reservationId !== null && reservationId !== undefined,
-        ),
-      });
-    }
+    const {provisionerId, providerRunnerId, runnerInstanceCondition} =
+      await loadClaimRunnerContextTx(tx, params);
 
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
     // for rows sharing a created_at within a batch. Lock only the FIFO candidate before
     // attempting its execution advisory lock; putting pg_try_advisory_xact_lock in this
     // predicate would evaluate it while scanning and temporarily lock many queue entries.
-    const candidate = tx
-      .select()
-      .from(pendingJobExecutions)
-      .where(
-        and(
-          eq(pendingJobExecutions.workspaceId, params.workspaceId),
-          arrayContained(pendingJobExecutions.requiredLabels, params.sessionLabels),
-        ),
-      )
-      .orderBy(asc(pendingJobExecutions.createdAt), asc(pendingJobExecutions.id))
-      .limit(1)
-      .for('update', {skipLocked: true})
-      .as('pending_candidate');
-
-    const [row] = await tx
-      .select()
-      .from(candidate)
-      .where(
-        sql`
-          pg_try_advisory_xact_lock(
-            hashtext(${runnerJobExecutionLockPrefix} || ${candidate.jobExecutionId}::text)
-          )
-        `,
-      );
-
-    if (!row) return null;
-
-    await tx.delete(pendingJobExecutions).where(eq(pendingJobExecutions.id, row.id));
-
-    // An enqueue retry that lands after a prior claim can leave an orphan pending
-    // row whose jobExecutionId is already in `runners_running_jobs`. Insert-or-skip
-    // on the jobExecutionId unique constraint: when the job execution is already running
-    // the insert touches no row, so we commit the orphan's deletion and return
-    // null rather than let the unique violation roll the claim back into a poison
-    // loop. The runner just re-polls for a real job execution.
-    const inserted = await tx
-      .insert(runningJobExecutions)
-      .values({
-        workspaceId: row.workspaceId,
-        workflowRunId: row.workflowRunId,
-        workflowRunAttemptId: row.workflowRunAttemptId,
-        jobId: row.jobId,
-        jobExecutionId: row.jobExecutionId,
-        projectId: row.projectId,
-        runnerSessionId: params.runnerSessionId,
-        provisionerId,
-        providerRunnerId,
-        requiredLabels: row.requiredLabels,
-        runnerLabels: params.sessionLabels,
-      })
-      .onConflictDoNothing({target: runningJobExecutions.jobExecutionId})
-      .returning({claimedAt: runningJobExecutions.startedAt});
-
-    const claimed = inserted[0];
-    if (!claimed) return null;
+    const pendingClaim = await claimPendingCandidateTx(tx, params, provisionerId, providerRunnerId);
+    if (!pendingClaim) return null;
+    const {row, claimed} = pendingClaim;
 
     queueTimeObservation = {
       durationMilliseconds: claimed.claimedAt.getTime() - row.createdAt.getTime(),
@@ -367,85 +267,18 @@ export async function claimPendingJobExecution(params: {
     };
 
     if (runnerInstanceCondition) {
-      const [claimedRunner] = await tx
-        .update(providerRunners)
-        .set({
-          firstClaimedAt: sql`coalesce(${providerRunners.firstClaimedAt}, ${claimed.claimedAt})`,
-          updatedAt: sql`now()`,
-        })
-        .where(runnerInstanceCondition)
-        .returning({
-          firstClaimedAt: providerRunners.firstClaimedAt,
-          isFirstClaim: sql<boolean>`${providerRunners.firstClaimedAt} = ${claimed.claimedAt}`,
-          provider: providerRunners.providerKind,
-          launchKind: providerRunners.launchKind,
-          runnerInstanceId: providerRunners.id,
-          reservationId: providerRunners.reservationId,
-          intendedReservationId: providerRunners.intendedReservationId,
-          sessionCreatedAtEpochMs: sql<number | null>`(
-            select extract(epoch from ${runnerSessions.createdAt})::double precision * 1000
-            from ${runnerSessions}
-            where ${runnerSessions.id} = ${params.runnerSessionId}
-          )`,
-        });
-      if (claimedRunner && queueTimeObservation) {
-        queueTimeObservation.provider = claimedRunner.provider;
-        queueTimeObservation.launchKind = claimedRunner.launchKind;
+      const runnerClaim = await recordClaimedRunnerTx(
+        tx,
+        params.runnerSessionId,
+        runnerInstanceCondition,
+        claimed.claimedAt,
+      );
+      if (runnerClaim.claimedRunner && queueTimeObservation) {
+        queueTimeObservation.provider = runnerClaim.claimedRunner.providerKind;
+        queueTimeObservation.launchKind = runnerClaim.claimedRunner.launchKind;
       }
-      if (claimedRunner?.isFirstClaim) {
-        const [releasedRunner] = await tx
-          .update(providerRunners)
-          .set({
-            intendedReservationId: null,
-            reservationReleasedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          })
-          .where(
-            and(
-              eq(providerRunners.id, claimedRunner.runnerInstanceId),
-              or(
-                isNotNull(providerRunners.reservationId),
-                isNotNull(providerRunners.intendedReservationId),
-              ),
-              isNull(providerRunners.reservationReleasedAt),
-            ),
-          )
-          .returning({
-            provisionerId: providerRunners.provisionerId,
-          });
-        const reservationId = claimedRunner.intendedReservationId ?? claimedRunner.reservationId;
-        if (releasedRunner?.provisionerId && reservationId) {
-          const [reservation] = await tx
-            .select({workspaceId: reservations.workspaceId})
-            .from(reservations)
-            .where(
-              and(
-                eq(reservations.id, reservationId),
-                eq(reservations.provisionerId, releasedRunner.provisionerId),
-              ),
-            )
-            .limit(1);
-          if (reservation)
-            firstClaimReservationReleaseCount += await releaseReservationUnits(tx, {
-              workspaceId: reservation.workspaceId,
-              provisionerId: releasedRunner.provisionerId,
-              releases: [{reservationId, count: 1}],
-            });
-        }
-      }
-      if (
-        claimedRunner?.isFirstClaim &&
-        claimedRunner.firstClaimedAt !== null &&
-        claimedRunner.sessionCreatedAtEpochMs !== null &&
-        claimedRunner.sessionCreatedAtEpochMs !== undefined
-      )
-        activationToFirstClaimObservation = {
-          durationMilliseconds:
-            claimedRunner.firstClaimedAt.getTime() - claimedRunner.sessionCreatedAtEpochMs,
-          provider: claimedRunner.provider,
-          launchKind: claimedRunner.launchKind,
-          runnerInstanceId: claimedRunner.runnerInstanceId,
-        };
+      firstClaimReservationReleaseCount += runnerClaim.reservationReleaseCount;
+      activationToFirstClaimObservation = runnerClaim.activationToFirstClaimObservation;
     }
 
     if (params.maxClaims !== null) {
@@ -485,6 +318,247 @@ export async function claimPendingJobExecution(params: {
   if (activationToFirstClaimObservation)
     recordProviderRunnerActivationToFirstClaim(activationToFirstClaimObservation);
   return result;
+}
+
+async function loadClaimRunnerContextTx(
+  tx: Tx,
+  params: ClaimPendingJobExecutionParams,
+): Promise<ClaimRunnerContext> {
+  let runnerInstanceId: string | null = null;
+  let provisionerId: string | null = null;
+  let providerRunnerId: string | null = null;
+  if (params.maxClaims !== null) {
+    const [session] = await tx
+      .select({
+        maxClaims: runnerSessions.maxClaims,
+        claimsUsed: runnerSessions.claimsUsed,
+        revokedAt: runnerSessions.revokedAt,
+        runnerInstanceId: runnerSessions.runnerInstanceId,
+        provisionerId: runnerSessions.provisionerId,
+        providerRunnerId: runnerSessions.providerRunnerId,
+      })
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, params.runnerSessionId))
+      .limit(1)
+      .for('update');
+    assertClaimSessionAvailable(session, params.runnerSessionId);
+    runnerInstanceId = session.runnerInstanceId;
+    provisionerId = session.provisionerId;
+    providerRunnerId = session.providerRunnerId;
+  }
+  const runnerInstanceCondition = claimRunnerInstanceCondition(
+    runnerInstanceId,
+    provisionerId,
+    providerRunnerId,
+  );
+  if (runnerInstanceCondition && provisionerId) {
+    await lockClaimRunnerReservationIdsTx(tx, provisionerId, runnerInstanceCondition);
+  }
+  return {provisionerId, providerRunnerId, runnerInstanceCondition};
+}
+
+function assertClaimSessionAvailable<
+  T extends {revokedAt: Date | null; maxClaims: number | null; claimsUsed: number},
+>(session: T | undefined, runnerSessionId: string): asserts session is T {
+  if (
+    !session ||
+    session.revokedAt ||
+    session.maxClaims === null ||
+    session.claimsUsed >= session.maxClaims
+  ) {
+    throw new RunnerSessionExhaustedError(runnerSessionId);
+  }
+}
+
+function claimRunnerInstanceCondition(
+  runnerInstanceId: string | null,
+  provisionerId: string | null,
+  providerRunnerId: string | null,
+): ReturnType<typeof eq> | undefined {
+  if (runnerInstanceId) return eq(providerRunners.id, runnerInstanceId);
+  if (provisionerId && providerRunnerId) {
+    return and(
+      eq(providerRunners.provisionerId, provisionerId),
+      eq(providerRunners.providerRunnerId, providerRunnerId),
+    );
+  }
+  return undefined;
+}
+
+async function lockClaimRunnerReservationIdsTx(
+  tx: Tx,
+  provisionerId: string,
+  runnerInstanceCondition: ReturnType<typeof eq>,
+): Promise<void> {
+  const [runner] = await tx
+    .select({
+      reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
+    })
+    .from(providerRunners)
+    .where(runnerInstanceCondition)
+    .limit(1);
+  await lockRunnerReservationAdvisoryKeysTx(tx, {
+    provisionerId,
+    reservationIds: [runner?.reservationId, runner?.intendedReservationId].filter(
+      (reservationId): reservationId is string =>
+        reservationId !== null && reservationId !== undefined,
+    ),
+  });
+}
+
+async function claimPendingCandidateTx(
+  tx: Tx,
+  params: ClaimPendingJobExecutionParams,
+  provisionerId: string | null,
+  providerRunnerId: string | null,
+): Promise<{
+  row: typeof pendingJobExecutions.$inferSelect;
+  claimed: {claimedAt: Date};
+} | null> {
+  const candidate = tx
+    .select()
+    .from(pendingJobExecutions)
+    .where(
+      and(
+        eq(pendingJobExecutions.workspaceId, params.workspaceId),
+        arrayContained(pendingJobExecutions.requiredLabels, params.sessionLabels),
+      ),
+    )
+    .orderBy(asc(pendingJobExecutions.createdAt), asc(pendingJobExecutions.id))
+    .limit(1)
+    .for('update', {skipLocked: true})
+    .as('pending_candidate');
+  const [row] = await tx
+    .select()
+    .from(candidate)
+    .where(
+      sql`pg_try_advisory_xact_lock(
+        hashtext(${runnerJobExecutionLockPrefix} || ${candidate.jobExecutionId}::text)
+      )`,
+    );
+  if (!row) return null;
+  await tx.delete(pendingJobExecutions).where(eq(pendingJobExecutions.id, row.id));
+  const [claimed] = await tx
+    .insert(runningJobExecutions)
+    .values({
+      workspaceId: row.workspaceId,
+      workflowRunId: row.workflowRunId,
+      workflowRunAttemptId: row.workflowRunAttemptId,
+      jobId: row.jobId,
+      jobExecutionId: row.jobExecutionId,
+      projectId: row.projectId,
+      runnerSessionId: params.runnerSessionId,
+      provisionerId,
+      providerRunnerId,
+      requiredLabels: row.requiredLabels,
+      runnerLabels: params.sessionLabels,
+    })
+    .onConflictDoNothing({target: runningJobExecutions.jobExecutionId})
+    .returning({claimedAt: runningJobExecutions.startedAt});
+  return claimed ? {row, claimed} : null;
+}
+
+type ClaimedProviderRunner = Pick<
+  typeof providerRunners.$inferSelect,
+  | 'firstClaimedAt'
+  | 'providerKind'
+  | 'launchKind'
+  | 'id'
+  | 'reservationId'
+  | 'intendedReservationId'
+> & {isFirstClaim: boolean; sessionCreatedAtEpochMs: number | null};
+
+async function recordClaimedRunnerTx(
+  tx: Tx,
+  runnerSessionId: string,
+  runnerInstanceCondition: ReturnType<typeof eq>,
+  claimedAt: Date,
+): Promise<{
+  claimedRunner: ClaimedProviderRunner | undefined;
+  reservationReleaseCount: number;
+  activationToFirstClaimObservation: ProviderRunnerLifecycleObservation | null;
+}> {
+  const [row] = await tx
+    .update(providerRunners)
+    .set({
+      firstClaimedAt: sql`coalesce(${providerRunners.firstClaimedAt}, ${claimedAt})`,
+      updatedAt: sql`now()`,
+    })
+    .where(runnerInstanceCondition)
+    .returning({
+      firstClaimedAt: providerRunners.firstClaimedAt,
+      isFirstClaim: sql<boolean>`${providerRunners.firstClaimedAt} = ${claimedAt}`,
+      providerKind: providerRunners.providerKind,
+      launchKind: providerRunners.launchKind,
+      id: providerRunners.id,
+      reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
+      sessionCreatedAtEpochMs: sql<number | null>`(
+        select extract(epoch from ${runnerSessions.createdAt})::double precision * 1000
+        from ${runnerSessions}
+        where ${runnerSessions.id} = ${runnerSessionId}
+      )`,
+    });
+  const reservationReleaseCount = row?.isFirstClaim
+    ? await releaseFirstClaimReservationTx(tx, row)
+    : 0;
+  return {
+    claimedRunner: row,
+    reservationReleaseCount,
+    activationToFirstClaimObservation: activationToFirstClaimObservationFor(row),
+  };
+}
+
+async function releaseFirstClaimReservationTx(
+  tx: Tx,
+  runner: ClaimedProviderRunner,
+): Promise<number> {
+  const [releasedRunner] = await tx
+    .update(providerRunners)
+    .set({intendedReservationId: null, reservationReleasedAt: sql`now()`, updatedAt: sql`now()`})
+    .where(
+      and(
+        eq(providerRunners.id, runner.id),
+        or(
+          isNotNull(providerRunners.reservationId),
+          isNotNull(providerRunners.intendedReservationId),
+        ),
+        isNull(providerRunners.reservationReleasedAt),
+      ),
+    )
+    .returning({provisionerId: providerRunners.provisionerId});
+  const reservationId = runner.intendedReservationId ?? runner.reservationId;
+  if (!releasedRunner?.provisionerId || !reservationId) return 0;
+  const [reservation] = await tx
+    .select({workspaceId: reservations.workspaceId})
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.id, reservationId),
+        eq(reservations.provisionerId, releasedRunner.provisionerId),
+      ),
+    )
+    .limit(1);
+  if (!reservation) return 0;
+  return releaseReservationUnits(tx, {
+    workspaceId: reservation.workspaceId,
+    provisionerId: releasedRunner.provisionerId,
+    releases: [{reservationId, count: 1}],
+  });
+}
+
+function activationToFirstClaimObservationFor(
+  runner: ClaimedProviderRunner | undefined,
+): ProviderRunnerLifecycleObservation | null {
+  if (!runner?.isFirstClaim || runner.firstClaimedAt === null) return null;
+  if (runner.sessionCreatedAtEpochMs === null) return null;
+  return {
+    durationMilliseconds: runner.firstClaimedAt.getTime() - runner.sessionCreatedAtEpochMs,
+    provider: runner.providerKind,
+    launchKind: runner.launchKind,
+    runnerInstanceId: runner.id,
+  };
 }
 
 async function touchRunnerSessionLiveness(params: {

--- a/libs/api/runners/src/db/provisioner-tokens.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.ts
@@ -204,20 +204,7 @@ export async function createInstallationProvisionerTokenWithAudit(
       requestFingerprint: params.requestFingerprint,
       command,
     });
-    if (existing) {
-      const rows = await tx
-        .select()
-        .from(provisionerTokens)
-        .where(eq(provisionerTokens.id, existing.result.provisionerTokenId))
-        .limit(1);
-      const row = rows[0];
-      if (!row) throw new Error('Idempotent provisioner token result is missing');
-      return {
-        token: toProvisionerToken(row),
-        correlationId: existing.result.correlationId,
-        replayed: true,
-      };
-    }
+    if (existing) return replayedProvisionerTokenRevocation(tx, existing.result);
 
     const expiresAt =
       params.ttlSeconds === undefined ? undefined : new Date(Date.now() + params.ttlSeconds * 1000);
@@ -316,19 +303,7 @@ export async function revokeInstallationProvisionerTokenWithAudit(
     const row = updatedRows[0];
     if (row) await cascadeProvisionerRevocation(tx, params.tokenId);
 
-    const existingRows = row
-      ? [row]
-      : await tx
-          .select()
-          .from(provisionerTokens)
-          .where(
-            and(
-              eq(provisionerTokens.id, params.tokenId),
-              eq(provisionerTokens.scope, 'installation'),
-            ),
-          )
-          .limit(1);
-    const tokenRow = existingRows[0];
+    const tokenRow = await revokedInstallationTokenRow(tx, params.tokenId, row);
     if (!tokenRow) return undefined;
 
     const changed = row !== undefined;
@@ -344,6 +319,33 @@ export async function revokeInstallationProvisionerTokenWithAudit(
       replayed: false,
     };
   });
+}
+
+async function replayedProvisionerTokenRevocation(
+  tx: Tx,
+  result: {provisionerTokenId: string; correlationId: string},
+) {
+  const [row] = await tx
+    .select()
+    .from(provisionerTokens)
+    .where(eq(provisionerTokens.id, result.provisionerTokenId))
+    .limit(1);
+  if (!row) throw new Error('Idempotent provisioner token result is missing');
+  return {token: toProvisionerToken(row), correlationId: result.correlationId, replayed: true};
+}
+
+async function revokedInstallationTokenRow(
+  tx: Tx,
+  tokenId: string,
+  updated: typeof provisionerTokens.$inferSelect | undefined,
+): Promise<typeof provisionerTokens.$inferSelect | undefined> {
+  if (updated) return updated;
+  const [existing] = await tx
+    .select()
+    .from(provisionerTokens)
+    .where(and(eq(provisionerTokens.id, tokenId), eq(provisionerTokens.scope, 'installation')))
+    .limit(1);
+  return existing;
 }
 
 export type InstallationProvisionerTokenStatus = 'active' | 'expired' | 'revoked';

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -134,6 +134,16 @@ interface PollDemandAndReserveResult {
   newlyReservedUnits: NewReservationUnits[];
 }
 
+interface DemandReservationState {
+  readonly templates: NormalizedTemplate[];
+  readonly reservedByLabels: ReadonlyMap<string, number>;
+  readonly stats: DemandStat[];
+  readonly grants: ReservationGrant[];
+  readonly newlyReservedUnits: NewReservationUnits[];
+  readonly workspaceIdField: {workspaceId?: string};
+  remainingMaxReservations: number;
+}
+
 export async function pollDemandAndReserve(
   params: PollDemandAndReserveParams,
 ): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
@@ -277,111 +287,144 @@ async function pollDemandAndReserveLockedTx(
       (reservation) => reservation.provisionerId === params.provisionerId,
     ),
   );
-  const stats: DemandStat[] = [];
-  const grants: ReservationGrant[] = [];
-  const newlyReservedUnits: NewReservationUnits[] = [];
-  let remainingMaxReservations = params.maxReservations;
-  const workspaceIdField =
-    params.capabilityWindowSeconds === undefined ? {} : {workspaceId: params.workspaceId};
+  const state: DemandReservationState = {
+    templates,
+    reservedByLabels,
+    stats: [],
+    grants: [],
+    newlyReservedUnits: [],
+    workspaceIdField:
+      params.capabilityWindowSeconds === undefined ? {} : {workspaceId: params.workspaceId},
+    remainingMaxReservations: params.maxReservations,
+  };
 
   for (const demand of sortDemandRows(demandRows)) {
-    const satisfyingTemplates = templates
-      .filter((template) => isSubset(demand.requiredLabels, template.labels))
-      .sort(
-        (a, b) => a.labels.length - b.labels.length || a.templateKey.localeCompare(b.templateKey),
-      );
-
-    if (satisfyingTemplates.length === 0) continue;
-
-    const reserved = reservedByLabels.get(labelKey(demand.requiredLabels)) ?? 0;
-    const unreserved = Math.max(0, demand.queued - reserved);
-    const capacity = satisfyingTemplates.reduce(
-      (total, template) => total + template.remainingSlots,
-      0,
-    );
-    const grant = Math.min(unreserved, capacity, remainingMaxReservations);
-    let reservedAfterGrant = reserved;
-
-    if (grant > 0 && params.maxReservations > 0) {
-      const idleRunners = await listIdleRunnerInstancesTx(tx, {
-        provisionerId: params.provisionerId,
-        requiredLabels: demand.requiredLabels,
-        count: grant,
-        workspaceId: params.workspaceId,
-        scope: params.scope,
-      });
-
-      remainingMaxReservations -= grant;
-
-      const boundCount = idleRunners.length;
-      if (boundCount > 0) {
-        const [boundReservation] = await tx
-          .insert(reservations)
-          .values({
-            workspaceId: params.workspaceId,
-            provisionerId: params.provisionerId,
-            requiredLabels: demand.requiredLabels,
-            count: boundCount,
-            kind: 'bound',
-            expiresAt: sql`now() + (${params.activationGraceSeconds ?? params.ttlSeconds} || ' seconds')::interval`,
-          })
-          .returning({id: reservations.id});
-
-        if (!boundReservation) throw new Error('Insert returned no rows');
-
-        await bindIdleRunnerInstancesTx(tx, {
-          provisionerId: params.provisionerId,
-          reservationId: boundReservation.id,
-          workspaceId: params.workspaceId,
-          requiredLabels: demand.requiredLabels,
-          scope: params.scope,
-          idleRunners,
-        });
-      }
-
-      const launchCount = grant - boundCount;
-      drawSlots(satisfyingTemplates, launchCount);
-      let launchReservation: {id: string; expiresAt: Date} | undefined;
-      if (launchCount > 0) {
-        const [inserted] = await tx
-          .insert(reservations)
-          .values({
-            workspaceId: params.workspaceId,
-            provisionerId: params.provisionerId,
-            requiredLabels: demand.requiredLabels,
-            count: launchCount,
-            kind: 'launch',
-            expiresAt: sql`now() + (${params.ttlSeconds} || ' seconds')::interval`,
-          })
-          .returning({id: reservations.id, expiresAt: reservations.expiresAt});
-
-        if (!inserted) throw new Error('Insert returned no rows');
-        launchReservation = inserted;
-      }
-
-      newlyReservedUnits.push({labels: demand.requiredLabels, count: grant});
-      reservedAfterGrant += grant;
-      if (launchReservation) {
-        grants.push({
-          reservationId: launchReservation.id,
-          ...workspaceIdField,
-          labels: demand.requiredLabels,
-          count: launchCount,
-          expiresAt: launchReservation.expiresAt,
-        });
-      }
-    }
-
-    stats.push({
-      ...workspaceIdField,
-      labels: demand.requiredLabels,
-      queued: demand.queued,
-      reserved: reservedAfterGrant,
-      oldestQueuedAt: demand.oldestQueuedAt,
-    });
+    await reserveDemandRowTx(tx, params, demand, state);
   }
 
-  return {stats, reservations: grants, newlyReservedUnits};
+  return {
+    stats: state.stats,
+    reservations: state.grants,
+    newlyReservedUnits: state.newlyReservedUnits,
+  };
+}
+
+async function reserveDemandRowTx(
+  tx: Tx,
+  params: PollDemandAndReserveLockedParams,
+  demand: DemandRow,
+  state: DemandReservationState,
+): Promise<void> {
+  const satisfyingTemplates = state.templates
+    .filter((template) => isSubset(demand.requiredLabels, template.labels))
+    .sort(
+      (a, b) => a.labels.length - b.labels.length || a.templateKey.localeCompare(b.templateKey),
+    );
+  if (satisfyingTemplates.length === 0) return;
+  const reserved = state.reservedByLabels.get(labelKey(demand.requiredLabels)) ?? 0;
+  const capacity = satisfyingTemplates.reduce(
+    (total, template) => total + template.remainingSlots,
+    0,
+  );
+  const grant = Math.min(
+    Math.max(0, demand.queued - reserved),
+    capacity,
+    state.remainingMaxReservations,
+  );
+  if (grant > 0 && params.maxReservations > 0) {
+    await grantDemandReservationTx(tx, params, demand, satisfyingTemplates, grant, state);
+  }
+  state.stats.push({
+    ...state.workspaceIdField,
+    labels: demand.requiredLabels,
+    queued: demand.queued,
+    reserved: reserved + grant,
+    oldestQueuedAt: demand.oldestQueuedAt,
+  });
+}
+
+async function grantDemandReservationTx(
+  tx: Tx,
+  params: PollDemandAndReserveLockedParams,
+  demand: DemandRow,
+  satisfyingTemplates: NormalizedTemplate[],
+  grant: number,
+  state: DemandReservationState,
+): Promise<void> {
+  const idleRunners = await listIdleRunnerInstancesTx(tx, {
+    provisionerId: params.provisionerId,
+    requiredLabels: demand.requiredLabels,
+    count: grant,
+    workspaceId: params.workspaceId,
+    scope: params.scope,
+  });
+  state.remainingMaxReservations -= grant;
+  if (idleRunners.length > 0) {
+    await bindDemandReservationTx(tx, params, demand, idleRunners);
+  }
+  const launchCount = grant - idleRunners.length;
+  drawSlots(satisfyingTemplates, launchCount);
+  const launchReservation = await insertLaunchReservationTx(tx, params, demand, launchCount);
+  state.newlyReservedUnits.push({labels: demand.requiredLabels, count: grant});
+  if (launchReservation) {
+    state.grants.push({
+      reservationId: launchReservation.id,
+      ...state.workspaceIdField,
+      labels: demand.requiredLabels,
+      count: launchCount,
+      expiresAt: launchReservation.expiresAt,
+    });
+  }
+}
+
+async function bindDemandReservationTx(
+  tx: Tx,
+  params: PollDemandAndReserveLockedParams,
+  demand: DemandRow,
+  idleRunners: IdleRunnerCandidate[],
+): Promise<void> {
+  const [reservation] = await tx
+    .insert(reservations)
+    .values({
+      workspaceId: params.workspaceId,
+      provisionerId: params.provisionerId,
+      requiredLabels: demand.requiredLabels,
+      count: idleRunners.length,
+      kind: 'bound',
+      expiresAt: sql`now() + (${params.activationGraceSeconds ?? params.ttlSeconds} || ' seconds')::interval`,
+    })
+    .returning({id: reservations.id});
+  if (!reservation) throw new Error('Insert returned no rows');
+  await bindIdleRunnerInstancesTx(tx, {
+    provisionerId: params.provisionerId,
+    reservationId: reservation.id,
+    workspaceId: params.workspaceId,
+    requiredLabels: demand.requiredLabels,
+    scope: params.scope,
+    idleRunners,
+  });
+}
+
+async function insertLaunchReservationTx(
+  tx: Tx,
+  params: PollDemandAndReserveLockedParams,
+  demand: DemandRow,
+  launchCount: number,
+): Promise<{id: string; expiresAt: Date} | undefined> {
+  if (launchCount === 0) return undefined;
+  const [inserted] = await tx
+    .insert(reservations)
+    .values({
+      workspaceId: params.workspaceId,
+      provisionerId: params.provisionerId,
+      requiredLabels: demand.requiredLabels,
+      count: launchCount,
+      kind: 'launch',
+      expiresAt: sql`now() + (${params.ttlSeconds} || ' seconds')::interval`,
+    })
+    .returning({id: reservations.id, expiresAt: reservations.expiresAt});
+  if (!inserted) throw new Error('Insert returned no rows');
+  return inserted;
 }
 
 async function listActiveProvisionerReservationRowsTx(
@@ -402,22 +445,7 @@ async function listActiveProvisionerReservationRowsTx(
   const candidateIds = candidateRows.map((row) => row.id);
   if (candidateIds.length === 0) return [];
 
-  if (lockForMutation) {
-    // Assignment and provider-report transactions use this key before changing runner
-    // links. Lock it before counting so an in-flight assignment cannot expose its unit twice.
-    const candidateIdsByProvisioner = new Map<string, string[]>();
-    for (const row of candidateRows) {
-      const reservationIds = candidateIdsByProvisioner.get(row.provisionerId) ?? [];
-      reservationIds.push(row.id);
-      candidateIdsByProvisioner.set(row.provisionerId, reservationIds);
-    }
-    for (const provisionerId of [...candidateIdsByProvisioner.keys()].sort()) {
-      await lockRunnerReservationAdvisoryKeysTx(tx, {
-        provisionerId,
-        reservationIds: candidateIdsByProvisioner.get(provisionerId) ?? [],
-      });
-    }
-  }
+  if (lockForMutation) await lockActiveReservationCandidates(tx, candidateRows);
 
   const activeRowsQuery = tx
     .select({
@@ -461,19 +489,7 @@ async function listActiveProvisionerReservationRowsTx(
         ),
       ),
     );
-  const unclaimedByReservation = new Map<string, Set<string>>();
-  for (const runner of linkedRunnerRows) {
-    const isTerminal = terminalStates.some((state) => state === runner.state);
-    const isUnclaimed =
-      runner.firstClaimedAt === null && runner.reservationReleasedAt === null && !isTerminal;
-    if (!isUnclaimed) continue;
-    if (runner.reservationId && activeIdSet.has(runner.reservationId)) {
-      addUsedRunner(unclaimedByReservation, runner.reservationId, runner.id);
-    }
-    if (runner.intendedReservationId && activeIdSet.has(runner.intendedReservationId)) {
-      addUsedRunner(unclaimedByReservation, runner.intendedReservationId, runner.id);
-    }
-  }
+  const unclaimedByReservation = indexUnclaimedRunnersByReservation(linkedRunnerRows, activeIdSet);
 
   return activeRows.map((reservation) => {
     const unclaimed = unclaimedByReservation.get(reservation.id)?.size ?? 0;
@@ -484,6 +500,63 @@ async function listActiveProvisionerReservationRowsTx(
       leaked: Math.max(0, reservation.count - unclaimed),
     };
   });
+}
+
+async function lockActiveReservationCandidates(
+  tx: Tx,
+  rows: readonly {id: string; provisionerId: string}[],
+): Promise<void> {
+  const idsByProvisioner = new Map<string, string[]>();
+  for (const row of rows) {
+    const ids = idsByProvisioner.get(row.provisionerId) ?? [];
+    ids.push(row.id);
+    idsByProvisioner.set(row.provisionerId, ids);
+  }
+  for (const provisionerId of [...idsByProvisioner.keys()].sort()) {
+    await lockRunnerReservationAdvisoryKeysTx(tx, {
+      provisionerId,
+      reservationIds: idsByProvisioner.get(provisionerId) ?? [],
+    });
+  }
+}
+
+function indexUnclaimedRunnersByReservation(
+  runners: readonly {
+    id: string;
+    firstClaimedAt: Date | null;
+    reservationId: string | null;
+    intendedReservationId: string | null;
+    reservationReleasedAt: Date | null;
+    state: (typeof providerRunners.$inferSelect)['state'];
+  }[],
+  activeIds: ReadonlySet<string>,
+): Map<string, Set<string>> {
+  const unclaimed = new Map<string, Set<string>>();
+  for (const runner of runners) {
+    if (!runnerIsUnclaimed(runner)) continue;
+    addActiveReservationRunner(unclaimed, activeIds, runner.reservationId, runner.id);
+    addActiveReservationRunner(unclaimed, activeIds, runner.intendedReservationId, runner.id);
+  }
+  return unclaimed;
+}
+
+function runnerIsUnclaimed(runner: {
+  firstClaimedAt: Date | null;
+  reservationReleasedAt: Date | null;
+  state: (typeof providerRunners.$inferSelect)['state'];
+}): boolean {
+  if (runner.firstClaimedAt !== null || runner.reservationReleasedAt !== null) return false;
+  return !terminalStates.some((state) => state === runner.state);
+}
+
+function addActiveReservationRunner(
+  target: Map<string, Set<string>>,
+  activeIds: ReadonlySet<string>,
+  reservationId: string | null,
+  runnerId: string,
+): void {
+  if (reservationId === null || !activeIds.has(reservationId)) return;
+  addUsedRunner(target, reservationId, runnerId);
 }
 
 export async function countLiveReservationLeakUnits(): Promise<number> {
@@ -611,42 +684,49 @@ async function selectIdleRunnerInstancesTx(
   // path locks runner rows by id, so the locking pass must use that same order. A skipped row
   // rolls back only this nested savepoint and retries the bounded candidate scan, allowing the
   // next-oldest eligible runner to refill the grant without retaining a partial lock set.
+  return lockIdleRunnerCandidatesWithRetry(tx, params);
+}
+
+async function lockIdleRunnerCandidatesWithRetry(
+  tx: Tx,
+  params: IdleRunnerSelectionParams & {count: number},
+): Promise<IdleRunnerCandidate[]> {
   const retrySelection = Symbol('retry bindable runner selection');
-  const idleRunners = await (async () => {
-    while (true) {
-      try {
-        return await tx.transaction(async (lockTx) => {
-          const candidateRunners = await lockTx
-            .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
-            .from(providerRunners)
-            .where(isBindableRunner(lockTx, params))
-            .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
-            .limit(params.count);
-
-          if (candidateRunners.length === 0) return candidateRunners;
-
-          // PostgreSQL can acquire row locks before sorting a multi-row FOR UPDATE result. Lock
-          // each selected candidate individually so both polling and cleanup use id order.
-          const lockedRunners: typeof candidateRunners = [];
-          for (const candidate of [...candidateRunners].sort(compareRunnerIds)) {
-            const [runner] = await lockTx
-              .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
-              .from(providerRunners)
-              .where(and(eq(providerRunners.id, candidate.id), isBindableRunner(lockTx, params)))
-              .for('update');
-            if (runner) lockedRunners.push(runner);
-          }
-
-          if (lockedRunners.length !== candidateRunners.length) throw retrySelection;
-          return lockedRunners;
-        });
-      } catch (error) {
-        if (error !== retrySelection) throw error;
-      }
+  while (true) {
+    try {
+      return await tx.transaction((lockTx) =>
+        lockIdleRunnerCandidateBatch(lockTx, params, retrySelection),
+      );
+    } catch (error) {
+      if (error !== retrySelection) throw error;
     }
-  })();
+  }
+}
 
-  return idleRunners;
+async function lockIdleRunnerCandidateBatch(
+  tx: Tx,
+  params: IdleRunnerSelectionParams & {count: number},
+  retrySelection: symbol,
+): Promise<IdleRunnerCandidate[]> {
+  const candidateRunners = await tx
+    .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
+    .from(providerRunners)
+    .where(isBindableRunner(tx, params))
+    .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
+    .limit(params.count);
+  if (candidateRunners.length === 0) return candidateRunners;
+
+  const lockedRunners: typeof candidateRunners = [];
+  for (const candidate of [...candidateRunners].sort(compareRunnerIds)) {
+    const [runner] = await tx
+      .select({id: providerRunners.id, launchKind: providerRunners.launchKind})
+      .from(providerRunners)
+      .where(and(eq(providerRunners.id, candidate.id), isBindableRunner(tx, params)))
+      .for('update');
+    if (runner) lockedRunners.push(runner);
+  }
+  if (lockedRunners.length !== candidateRunners.length) throw retrySelection;
+  return lockedRunners;
 }
 
 async function bindIdleRunnerInstancesTx(
@@ -948,18 +1028,20 @@ export async function releaseReservationUnits(
   return releasedFromDeleted + releasedFromDecremented;
 }
 
+interface ReleaseTerminalRunnerReservationsParams {
+  workspaceId: string | null;
+  provisionerId: string;
+  providerRunnerIds?: string[];
+  runnerInstanceIds?: string[];
+  reportedAtByProviderRunnerId?: ReadonlyMap<string, Date>;
+  requireUnlinkedSession?: boolean;
+  /** Lock linked runners before rechecking terminal state for lease finalization. */
+  requireTerminalState?: boolean;
+}
+
 export async function releaseTerminalRunnerInstanceReservationsByIds(
   tx: Tx,
-  params: {
-    workspaceId: string | null;
-    provisionerId: string;
-    providerRunnerIds?: string[];
-    runnerInstanceIds?: string[];
-    reportedAtByProviderRunnerId?: ReadonlyMap<string, Date>;
-    requireUnlinkedSession?: boolean;
-    /** Lock linked runners before rechecking terminal state for lease finalization. */
-    requireTerminalState?: boolean;
-  },
+  params: ReleaseTerminalRunnerReservationsParams,
 ): Promise<number> {
   if (
     (params.providerRunnerIds?.length ?? 0) === 0 &&
@@ -967,46 +1049,12 @@ export async function releaseTerminalRunnerInstanceReservationsByIds(
   )
     return 0;
 
-  const reservationWorkspacePredicate =
-    params.workspaceId === null
-      ? sql``
-      : sql`and ${eq(reservations.workspaceId, params.workspaceId)}`;
-  // Cancellation keeps the lease row so the provisioner can observe its terminate intent.
-  // Once the runner is terminal, only an uncancelled lease should block reservation release.
-  const noUncancelledRunningJobPredicate = notExists(
-    tx
-      .select({id: runningJobExecutions.id})
-      .from(runningJobExecutions)
-      .where(
-        and(
-          eq(runningJobExecutions.provisionerId, params.provisionerId),
-          eq(runningJobExecutions.providerRunnerId, providerRunners.providerRunnerId),
-          isNull(runningJobExecutions.cancellationRequestedAt),
-          params.workspaceId === null
-            ? undefined
-            : eq(runningJobExecutions.workspaceId, params.workspaceId),
-        ),
-      ),
-  );
-  const reportFreshnessPredicate =
-    params.reportedAtByProviderRunnerId && params.reportedAtByProviderRunnerId.size > 0
-      ? or(
-          ...[...params.reportedAtByProviderRunnerId].map(([providerRunnerId, reportedAt]) =>
-            and(
-              eq(providerRunners.providerRunnerId, providerRunnerId),
-              lte(providerRunners.reportedAt, reportedAt),
-            ),
-          ),
-        )
-      : undefined;
-  const runnerIdentityPredicate = or(
-    params.providerRunnerIds && params.providerRunnerIds.length > 0
-      ? inArray(providerRunners.providerRunnerId, params.providerRunnerIds)
-      : undefined,
-    params.runnerInstanceIds && params.runnerInstanceIds.length > 0
-      ? inArray(providerRunners.id, params.runnerInstanceIds)
-      : undefined,
-  );
+  const {
+    reservationWorkspacePredicate,
+    noUncancelledRunningJobPredicate,
+    reportFreshnessPredicate,
+    runnerIdentityPredicate,
+  } = terminalReservationReleasePredicates(tx, params);
 
   // Assignment locks these keys before changing runner links. Acquire them before locking or
   // marking terminal runners so an assignment cannot consume a reservation concurrently with
@@ -1150,10 +1198,7 @@ export async function releaseTerminalRunnerInstanceReservationsByIds(
   // The lease-finalization path deliberately locks active rows too. If a terminal report is
   // concurrently projecting the runner state, PostgreSQL rechecks this row after the lock and
   // lets cleanup observe the committed terminal state without a cross-module advisory lock.
-  const terminalRows =
-    params.requireTerminalState === false
-      ? rows.filter((row) => terminalStates.some((terminalState) => terminalState === row.state))
-      : rows;
+  const terminalRows = terminalReservationReleaseRows(rows, params.requireTerminalState);
   if (terminalRows.length === 0) return 0;
 
   const updated = await tx
@@ -1179,42 +1224,120 @@ export async function releaseTerminalRunnerInstanceReservationsByIds(
     )
     .returning({id: providerRunners.id});
 
-  const releasesByReservationId = new Map<
-    string,
-    {workspaceId: string; reservationId: string; count: number}
-  >();
+  return releaseUpdatedRunnerReservationsTx(tx, params.provisionerId, terminalRows, updated);
+}
+
+function terminalReservationReleasePredicates(
+  tx: Tx,
+  params: ReleaseTerminalRunnerReservationsParams,
+) {
+  const reservationWorkspacePredicate =
+    params.workspaceId === null
+      ? sql``
+      : sql`and ${eq(reservations.workspaceId, params.workspaceId)}`;
+  const noUncancelledRunningJobPredicate = notExists(
+    tx
+      .select({id: runningJobExecutions.id})
+      .from(runningJobExecutions)
+      .where(
+        and(
+          eq(runningJobExecutions.provisionerId, params.provisionerId),
+          eq(runningJobExecutions.providerRunnerId, providerRunners.providerRunnerId),
+          isNull(runningJobExecutions.cancellationRequestedAt),
+          params.workspaceId === null
+            ? undefined
+            : eq(runningJobExecutions.workspaceId, params.workspaceId),
+        ),
+      ),
+  );
+  const reportFreshnessPredicate =
+    params.reportedAtByProviderRunnerId && params.reportedAtByProviderRunnerId.size > 0
+      ? or(
+          ...[...params.reportedAtByProviderRunnerId].map(([providerRunnerId, reportedAt]) =>
+            and(
+              eq(providerRunners.providerRunnerId, providerRunnerId),
+              lte(providerRunners.reportedAt, reportedAt),
+            ),
+          ),
+        )
+      : undefined;
+  const runnerIdentityPredicate = or(
+    params.providerRunnerIds && params.providerRunnerIds.length > 0
+      ? inArray(providerRunners.providerRunnerId, params.providerRunnerIds)
+      : undefined,
+    params.runnerInstanceIds && params.runnerInstanceIds.length > 0
+      ? inArray(providerRunners.id, params.runnerInstanceIds)
+      : undefined,
+  );
+  return {
+    reservationWorkspacePredicate,
+    noUncancelledRunningJobPredicate,
+    reportFreshnessPredicate,
+    runnerIdentityPredicate,
+  };
+}
+
+type TerminalReservationReleaseRow = {
+  id: string;
+  state: (typeof providerRunners.$inferSelect)['state'];
+  releaseReservationId: string | null;
+  releaseReservationWorkspaceId: string | null;
+};
+
+function terminalReservationReleaseRows(
+  rows: readonly TerminalReservationReleaseRow[],
+  requireTerminalState: boolean | undefined,
+): readonly TerminalReservationReleaseRow[] {
+  if (requireTerminalState !== false) return rows;
+  return rows.filter((row) => terminalStates.some((terminalState) => terminalState === row.state));
+}
+
+async function releaseUpdatedRunnerReservationsTx(
+  tx: Tx,
+  provisionerId: string,
+  terminalRows: readonly TerminalReservationReleaseRow[],
+  updated: readonly {id: string}[],
+): Promise<number> {
+  const releasesByReservation = groupRunnerReservationReleases(terminalRows, updated);
+  const releasesByWorkspace = groupReservationReleasesByWorkspace(releasesByReservation.values());
+  let released = 0;
+  for (const [workspaceId, releases] of releasesByWorkspace) {
+    released += await releaseReservationUnits(tx, {workspaceId, provisionerId, releases});
+  }
+  return released;
+}
+
+function groupRunnerReservationReleases(
+  rows: readonly TerminalReservationReleaseRow[],
+  updated: readonly {id: string}[],
+): Map<string, {workspaceId: string; reservationId: string; count: number}> {
+  const releases = new Map<string, {workspaceId: string; reservationId: string; count: number}>();
   const updatedIds = new Set(updated.map((row) => row.id));
-  for (const row of terminalRows) {
+  for (const row of rows) {
     if (!updatedIds.has(row.id)) continue;
     if (!row.releaseReservationId || !row.releaseReservationWorkspaceId) continue;
     const key = `${row.releaseReservationWorkspaceId}:${row.releaseReservationId}`;
-    const release = releasesByReservationId.get(key) ?? {
+    const release = releases.get(key) ?? {
       workspaceId: row.releaseReservationWorkspaceId,
       reservationId: row.releaseReservationId,
       count: 0,
     };
     release.count += 1;
-    releasesByReservationId.set(key, release);
+    releases.set(key, release);
   }
+  return releases;
+}
 
-  if (releasesByReservationId.size === 0) return 0;
-
-  const releasesByWorkspaceId = new Map<string, Array<{reservationId: string; count: number}>>();
-  for (const release of releasesByReservationId.values()) {
-    const releases = releasesByWorkspaceId.get(release.workspaceId) ?? [];
-    releases.push({reservationId: release.reservationId, count: release.count});
-    releasesByWorkspaceId.set(release.workspaceId, releases);
+function groupReservationReleasesByWorkspace(
+  releases: Iterable<{workspaceId: string; reservationId: string; count: number}>,
+): Map<string, Array<{reservationId: string; count: number}>> {
+  const grouped = new Map<string, Array<{reservationId: string; count: number}>>();
+  for (const release of releases) {
+    const workspaceReleases = grouped.get(release.workspaceId) ?? [];
+    workspaceReleases.push({reservationId: release.reservationId, count: release.count});
+    grouped.set(release.workspaceId, workspaceReleases);
   }
-
-  let released = 0;
-  for (const [workspaceId, releases] of releasesByWorkspaceId) {
-    released += await releaseReservationUnits(tx, {
-      workspaceId,
-      provisionerId: params.provisionerId,
-      releases,
-    });
-  }
-  return released;
+  return grouped;
 }
 
 function deductProvisionerReservations(
@@ -1232,7 +1355,9 @@ function deductProvisionerReservations(
 }
 
 function compareRunnerIds(left: {id: string}, right: {id: string}): number {
-  return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  if (left.id < right.id) return -1;
+  if (left.id > right.id) return 1;
+  return 0;
 }
 
 function sortDemandRows(rows: DemandRow[]): DemandRow[] {

--- a/libs/api/runners/src/db/runner-assignments.test.ts
+++ b/libs/api/runners/src/db/runner-assignments.test.ts
@@ -209,6 +209,31 @@ describe('assignRunnerInstances', () => {
     await expect(assignment).rejects.toThrow(RunnerInstanceAlreadyAssignedError);
   });
 
+  it('reports the first assigned runner when a later runner conflicts', async () => {
+    const reservation = await createReservation();
+    const otherReservation = await createReservation();
+    const firstRunner = await createEnrolledRunner();
+    const conflictingRunner = await createEnrolledRunner();
+    await assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [firstRunner.id],
+    });
+    await assignRunnerInstances({
+      provisionerId,
+      reservationId: otherReservation.id,
+      runnerInstanceIds: [conflictingRunner.id],
+    });
+
+    const assignment = assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [firstRunner.id, conflictingRunner.id],
+    });
+
+    await expect(assignment).rejects.toMatchObject({runnerInstanceId: firstRunner.id});
+  });
+
   it('rejects assignments that exceed reservation capacity', async () => {
     const reservation = await createReservation();
     const firstRunner = await createEnrolledRunner();

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -75,16 +75,7 @@ export async function assignRunnerInstancesTx(
 
   // The assignment outlives its short reservation row. A retry after maintenance
   // cleanup is complete when every owned runner already carries the committed assignment.
-  if (
-    runnerInstanceIds.length > 0 &&
-    runnerRows.length === runnerInstanceIds.length &&
-    runnerRows.every(
-      (runner) =>
-        runner.reservationId === params.reservationId &&
-        runner.assignedAt !== null &&
-        runner.workspaceId !== null,
-    )
-  ) {
+  if (assignmentAlreadyCommitted(runnerInstanceIds, runnerRows, params.reservationId)) {
     await tx
       .update(providerRunners)
       .set({intendedReservationId: null, updatedAt: sql`now()`})
@@ -112,10 +103,8 @@ export async function assignRunnerInstancesTx(
     )
     .limit(1)
     .for('update');
-  if (!reservation) throw new ReservationNotFoundError(params.reservationId);
-  if (reservation.expiresAt <= new Date()) throw new ReservationExpiredError(params.reservationId);
-  if (runnerRows.length !== runnerInstanceIds.length)
-    throw new RunnerInstanceNotAssignableError(runnerInstanceIds[0] ?? '', 'runner-not-found');
+  assertAssignmentReservation(reservation, params.reservationId);
+  assertAllAssignmentRunnersFound(runnerRows.length, runnerInstanceIds);
 
   const activeControlSessions = await tx
     .select({
@@ -144,9 +133,7 @@ export async function assignRunnerInstancesTx(
     controlSessionCreatedAt: controlSessionCreatedAtByRunner.get(runner.id) ?? null,
   }));
 
-  const alreadyAssigned = runners.filter((runner) => runner.reservationId !== null);
-  if (alreadyAssigned.some((runner) => runner.reservationId !== reservation.id))
-    throw new RunnerInstanceAlreadyAssignedError(alreadyAssigned[0]?.id ?? '');
+  assertNoConflictingRunnerAssignment(runners, reservation.id);
   const newRunners = runners.filter(
     (runner) =>
       runner.reservationId === null ||
@@ -175,18 +162,8 @@ export async function assignRunnerInstancesTx(
         ),
       ),
     );
-  if ((assignedCount[0]?.count ?? 0) + newRunners.length > reservation.count)
-    throw new RunnerInstanceNotAssignableError(newRunners[0]?.id ?? '', 'capacity-exhausted');
-  for (const runner of newRunners) {
-    if (runner.state !== 'running')
-      throw new RunnerInstanceNotAssignableError(runner.id, 'runner-not-running');
-    if (!runner.providerRunnerId)
-      throw new RunnerInstanceNotAssignableError(runner.id, 'provider-identity-missing');
-    if (!runner.controlSessionId)
-      throw new RunnerInstanceNotAssignableError(runner.id, 'control-session-not-active');
-    if (!reservation.requiredLabels.every((label) => runner.labels.includes(label)))
-      throw new RunnerInstanceNotAssignableError(runner.id, 'labels-mismatch');
-  }
+  assertRunnerAssignmentCapacity(assignedCount[0]?.count ?? 0, newRunners, reservation.count);
+  assertRunnersAssignable(newRunners, reservation.requiredLabels);
   if (newRunners.length > 0) {
     const assignedRows = await tx
       .update(providerRunners)
@@ -229,6 +206,87 @@ export async function assignRunnerInstancesTx(
   };
 }
 
+type AssignmentRunnerRow = Pick<
+  typeof providerRunners.$inferSelect,
+  'id' | 'reservationId' | 'assignedAt' | 'workspaceId' | 'state' | 'providerRunnerId' | 'labels'
+> & {controlSessionId?: string | null};
+
+function assignmentAlreadyCommitted(
+  runnerInstanceIds: readonly string[],
+  runnerRows: readonly AssignmentRunnerRow[],
+  reservationId: string,
+): boolean {
+  if (runnerInstanceIds.length === 0 || runnerRows.length !== runnerInstanceIds.length)
+    return false;
+  return runnerRows.every(
+    (runner) =>
+      runner.reservationId === reservationId &&
+      runner.assignedAt !== null &&
+      runner.workspaceId !== null,
+  );
+}
+
+function assertAssignmentReservation<T extends {expiresAt: Date}>(
+  reservation: T | undefined,
+  reservationId: string,
+): asserts reservation is T {
+  if (!reservation) throw new ReservationNotFoundError(reservationId);
+  if (reservation.expiresAt <= new Date()) throw new ReservationExpiredError(reservationId);
+}
+
+function assertAllAssignmentRunnersFound(
+  foundCount: number,
+  runnerInstanceIds: readonly string[],
+): void {
+  if (foundCount !== runnerInstanceIds.length) {
+    throw new RunnerInstanceNotAssignableError(runnerInstanceIds[0] ?? '', 'runner-not-found');
+  }
+}
+
+function assertNoConflictingRunnerAssignment(
+  runners: readonly AssignmentRunnerRow[],
+  reservationId: string,
+): void {
+  const conflicting = runners.find(
+    (runner) => runner.reservationId !== null && runner.reservationId !== reservationId,
+  );
+  if (conflicting) throw new RunnerInstanceAlreadyAssignedError(conflicting.id);
+}
+
+function assertRunnerAssignmentCapacity(
+  assignedCount: number,
+  newRunners: readonly AssignmentRunnerRow[],
+  reservationCount: number,
+): void {
+  if (assignedCount + newRunners.length <= reservationCount) return;
+  throw new RunnerInstanceNotAssignableError(newRunners[0]?.id ?? '', 'capacity-exhausted');
+}
+
+function assertRunnersAssignable(
+  runners: readonly AssignmentRunnerRow[],
+  requiredLabels: readonly string[],
+): void {
+  for (const runner of runners) assertRunnerAssignable(runner, requiredLabels);
+}
+
+function assertRunnerAssignable(
+  runner: AssignmentRunnerRow,
+  requiredLabels: readonly string[],
+): void {
+  if (runner.state !== 'running') {
+    throw new RunnerInstanceNotAssignableError(runner.id, 'runner-not-running');
+  }
+  if (!runner.providerRunnerId) {
+    throw new RunnerInstanceNotAssignableError(runner.id, 'provider-identity-missing');
+  }
+  if (!runner.controlSessionId) {
+    throw new RunnerInstanceNotAssignableError(runner.id, 'control-session-not-active');
+  }
+  if (!requiredLabels.every((label) => runner.labels.includes(label))) {
+    throw new RunnerInstanceNotAssignableError(runner.id, 'labels-mismatch');
+  }
+}
+
 export type RunnerReservationCapacityFailureReason =
   | 'reservation-not-found'
   | 'reservation-kind-mismatch'
@@ -251,14 +309,7 @@ export async function validateRunnerReservationCapacityTx(
   },
   options: {advisoryLocksHeld?: boolean} = {},
 ): Promise<RunnerReservationCapacityValidation> {
-  const requestedByReservation = new Map<string, number>();
-  for (const request of params.requests) {
-    if (request.count <= 0) continue;
-    requestedByReservation.set(
-      request.reservationId,
-      (requestedByReservation.get(request.reservationId) ?? 0) + request.count,
-    );
-  }
+  const requestedByReservation = requestedReservationCounts(params.requests);
   const reservationIds = [...requestedByReservation.keys()].sort();
   if (reservationIds.length === 0)
     return {acceptedByReservation: new Map(), unavailableByReservation: new Map()};
@@ -302,8 +353,6 @@ export async function validateRunnerReservationCapacityTx(
   const nonLaunchReservationIds = new Set(
     nonLaunchReservationRows.map((reservation) => reservation.id),
   );
-  const requestedReservationIds = new Set(reservationIds);
-  const usedRunnerIdsByReservation = new Map<string, Set<string>>();
   const usedRunnerRows = await tx
     .select({
       id: providerRunners.id,
@@ -327,56 +376,118 @@ export async function validateRunnerReservationCapacityTx(
         ),
       ),
     );
-  for (const runner of usedRunnerRows) {
-    if (runner.reservationId && requestedReservationIds.has(runner.reservationId)) {
-      const usedRunnerIds =
-        usedRunnerIdsByReservation.get(runner.reservationId) ?? new Set<string>();
-      usedRunnerIds.add(runner.id);
-      usedRunnerIdsByReservation.set(runner.reservationId, usedRunnerIds);
-    }
-    if (runner.intendedReservationId && requestedReservationIds.has(runner.intendedReservationId)) {
-      const usedRunnerIds =
-        usedRunnerIdsByReservation.get(runner.intendedReservationId) ?? new Set<string>();
-      usedRunnerIds.add(runner.id);
-      usedRunnerIdsByReservation.set(runner.intendedReservationId, usedRunnerIds);
-    }
-  }
+  const usedRunnerIdsByReservation = indexUsedRunnerReservations(
+    usedRunnerRows,
+    new Set(reservationIds),
+  );
+  return evaluateRunnerReservationCapacity(
+    reservationIds,
+    requestedByReservation,
+    reservationsById,
+    nonLaunchReservationIds,
+    usedRunnerIdsByReservation,
+  );
+}
 
-  const acceptedByReservation = new Map<string, number>();
-  const unavailableByReservation = new Map<
-    string,
-    {reason: RunnerReservationCapacityFailureReason; count: number}
-  >();
+function requestedReservationCounts(
+  requests: readonly {reservationId: string; count: number}[],
+): Map<string, number> {
+  const requested = new Map<string, number>();
+  for (const request of requests) {
+    if (request.count <= 0) continue;
+    requested.set(
+      request.reservationId,
+      (requested.get(request.reservationId) ?? 0) + request.count,
+    );
+  }
+  return requested;
+}
+
+function indexUsedRunnerReservations(
+  runners: readonly {
+    id: string;
+    reservationId: string | null;
+    intendedReservationId: string | null;
+  }[],
+  requestedReservationIds: ReadonlySet<string>,
+): Map<string, Set<string>> {
+  const used = new Map<string, Set<string>>();
+  for (const runner of runners) {
+    addUsedRunnerReservation(used, requestedReservationIds, runner.reservationId, runner.id);
+    addUsedRunnerReservation(
+      used,
+      requestedReservationIds,
+      runner.intendedReservationId,
+      runner.id,
+    );
+  }
+  return used;
+}
+
+function addUsedRunnerReservation(
+  used: Map<string, Set<string>>,
+  requestedReservationIds: ReadonlySet<string>,
+  reservationId: string | null,
+  runnerId: string,
+): void {
+  if (reservationId === null || !requestedReservationIds.has(reservationId)) return;
+  const runnerIds = used.get(reservationId) ?? new Set<string>();
+  runnerIds.add(runnerId);
+  used.set(reservationId, runnerIds);
+}
+
+function evaluateRunnerReservationCapacity(
+  reservationIds: readonly string[],
+  requestedByReservation: ReadonlyMap<string, number>,
+  reservationsById: ReadonlyMap<string, {count: number; isExpired: boolean}>,
+  nonLaunchReservationIds: ReadonlySet<string>,
+  usedRunnerIdsByReservation: ReadonlyMap<string, ReadonlySet<string>>,
+): RunnerReservationCapacityValidation {
+  const result: RunnerReservationCapacityValidation = {
+    acceptedByReservation: new Map(),
+    unavailableByReservation: new Map(),
+  };
   for (const reservationId of reservationIds) {
-    const requested = requestedByReservation.get(reservationId) ?? 0;
-    const reservation = reservationsById.get(reservationId);
-    if (!reservation) {
-      unavailableByReservation.set(reservationId, {
-        reason: nonLaunchReservationIds.has(reservationId)
-          ? 'reservation-kind-mismatch'
-          : 'reservation-not-found',
-        count: requested,
-      });
-      continue;
-    }
-    if (reservation.isExpired) {
-      unavailableByReservation.set(reservationId, {
-        reason: 'reservation-expired',
-        count: requested,
-      });
-      continue;
-    }
-
-    const used = usedRunnerIdsByReservation.get(reservationId)?.size ?? 0;
-    const accepted = Math.min(requested, Math.max(0, reservation.count - used));
-    acceptedByReservation.set(reservationId, accepted);
-    if (accepted < requested) {
-      unavailableByReservation.set(reservationId, {
-        reason: 'capacity-exhausted',
-        count: requested - accepted,
-      });
-    }
+    evaluateReservationCapacity(
+      reservationId,
+      requestedByReservation.get(reservationId) ?? 0,
+      reservationsById.get(reservationId),
+      nonLaunchReservationIds,
+      usedRunnerIdsByReservation.get(reservationId)?.size ?? 0,
+      result,
+    );
   }
+  return result;
+}
 
-  return {acceptedByReservation, unavailableByReservation};
+function evaluateReservationCapacity(
+  reservationId: string,
+  requested: number,
+  reservation: {count: number; isExpired: boolean} | undefined,
+  nonLaunchReservationIds: ReadonlySet<string>,
+  used: number,
+  result: RunnerReservationCapacityValidation,
+): void {
+  if (!reservation) {
+    const reason = nonLaunchReservationIds.has(reservationId)
+      ? 'reservation-kind-mismatch'
+      : 'reservation-not-found';
+    result.unavailableByReservation.set(reservationId, {reason, count: requested});
+    return;
+  }
+  if (reservation.isExpired) {
+    result.unavailableByReservation.set(reservationId, {
+      reason: 'reservation-expired',
+      count: requested,
+    });
+    return;
+  }
+  const accepted = Math.min(requested, Math.max(0, reservation.count - used));
+  result.acceptedByReservation.set(reservationId, accepted);
+  if (accepted < requested) {
+    result.unavailableByReservation.set(reservationId, {
+      reason: 'capacity-exhausted',
+      count: requested - accepted,
+    });
+  }
 }

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -247,10 +247,9 @@ function assertNoConflictingRunnerAssignment(
   runners: readonly AssignmentRunnerRow[],
   reservationId: string,
 ): void {
-  const conflicting = runners.find(
-    (runner) => runner.reservationId !== null && runner.reservationId !== reservationId,
-  );
-  if (conflicting) throw new RunnerInstanceAlreadyAssignedError(conflicting.id);
+  const assigned = runners.filter((runner) => runner.reservationId !== null);
+  const hasConflict = assigned.some((runner) => runner.reservationId !== reservationId);
+  if (hasConflict) throw new RunnerInstanceAlreadyAssignedError(assigned[0]?.id ?? '');
 }
 
 function assertRunnerAssignmentCapacity(

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -436,34 +436,66 @@ async function guardReportedReservationIdsTx(
     recordRunnerReservationCapacityFailure(reason, count);
 
   const remainingAcceptedByReservation = new Map(validation.acceptedByReservation);
-  return events.map((event) => {
-    const existing = existingByProviderRunnerId.get(event.providerRunnerId);
-    const reservationId = candidateReservationByProviderRunnerId.get(event.providerRunnerId);
-    if (!reservationId) {
-      if (event.reservationId && isTerminalState(event.state)) {
-        // Terminal cleanup releases the IDs stored on the projection row. An arbitrary
-        // terminal report must not consume reservation capacity during that cleanup.
-        const matchesExistingReservation =
-          existing !== undefined &&
-          (existing.reservationId === event.reservationId ||
-            existing.intendedReservationId === event.reservationId);
-        if (!matchesExistingReservation) return {...event, reservationId: null};
-      }
-      if (
-        event.reservationId &&
-        existing?.intendedReservationId &&
-        existing.intendedReservationId !== event.reservationId
-      )
-        return {...event, reservationId: null};
-      if (event.reservationId && existing?.reservationReleasedAt)
-        return {...event, reservationId: null};
-      return event;
+  return events.map((event) =>
+    guardReportedReservationEvent(
+      event,
+      existingByProviderRunnerId,
+      candidateReservationByProviderRunnerId,
+      remainingAcceptedByReservation,
+    ),
+  );
+}
+
+function guardReportedReservationEvent(
+  event: RunnerInstanceReportRow,
+  existingByProviderRunnerId: ReadonlyMap<
+    string,
+    {
+      reservationId: string | null;
+      intendedReservationId: string | null;
+      reservationReleasedAt: Date | null;
     }
-    const remaining = remainingAcceptedByReservation.get(reservationId) ?? 0;
-    if (remaining === 0) return {...event, reservationId: null};
-    remainingAcceptedByReservation.set(reservationId, remaining - 1);
-    return event;
-  });
+  >,
+  candidateReservationByProviderRunnerId: ReadonlyMap<string, string>,
+  remainingAcceptedByReservation: Map<string, number>,
+): RunnerInstanceReportRow {
+  const existing = existingByProviderRunnerId.get(event.providerRunnerId);
+  const reservationId = candidateReservationByProviderRunnerId.get(event.providerRunnerId);
+  if (!reservationId) return guardNonCandidateReservationEvent(event, existing);
+  const remaining = remainingAcceptedByReservation.get(reservationId) ?? 0;
+  if (remaining === 0) return {...event, reservationId: null};
+  remainingAcceptedByReservation.set(reservationId, remaining - 1);
+  return event;
+}
+
+function guardNonCandidateReservationEvent(
+  event: RunnerInstanceReportRow,
+  existing:
+    | {
+        reservationId: string | null;
+        intendedReservationId: string | null;
+        reservationReleasedAt: Date | null;
+      }
+    | undefined,
+): RunnerInstanceReportRow {
+  if (event.reservationId && isTerminalState(event.state)) {
+    const matchesExisting =
+      existing !== undefined &&
+      (existing.reservationId === event.reservationId ||
+        existing.intendedReservationId === event.reservationId);
+    if (!matchesExisting) return {...event, reservationId: null};
+  }
+  if (
+    event.reservationId &&
+    existing?.intendedReservationId &&
+    existing.intendedReservationId !== event.reservationId
+  ) {
+    return {...event, reservationId: null};
+  }
+  if (event.reservationId && existing?.reservationReleasedAt) {
+    return {...event, reservationId: null};
+  }
+  return event;
 }
 
 export async function listActiveRunnerInstanceCountsByTemplateTx(
@@ -961,62 +993,11 @@ export async function reconcileRunnerInstances(
       sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId ?? params.provisionerId}))`,
     );
 
-    let absentIds: string[] = [];
-    let reservationsReleased = 0;
-    if (observedRunnerInstanceIds.length > 0) {
-      const staleAbsentRows = await tx
-        .select({
-          id: providerRunners.id,
-          providerRunnerId: providerRunners.providerRunnerId,
-        })
-        .from(providerRunners)
-        .where(
-          and(
-            params.workspaceId
-              ? eq(providerRunners.workspaceId, params.workspaceId)
-              : isNull(providerRunners.workspaceId),
-            eq(providerRunners.provisionerId, params.provisionerId),
-            inArray(providerRunners.state, activeStates),
-            lt(
-              providerRunners.reportedAt,
-              sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
-            ),
-            notInArray(providerRunners.providerRunnerId, observedRunnerInstanceIds),
-          ),
-        );
-
-      if (staleAbsentRows.length > 0) {
-        const updated = await tx
-          .update(providerRunners)
-          .set({
-            state: 'terminated',
-            terminatedAt: sql`coalesce(${providerRunners.terminatedAt}, now())`,
-            updatedAt: sql`now()`,
-          })
-          .where(
-            and(
-              inArray(
-                providerRunners.id,
-                staleAbsentRows.map((row) => row.id),
-              ),
-              inArray(providerRunners.state, activeStates),
-              lt(
-                providerRunners.reportedAt,
-                sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
-              ),
-            ),
-          )
-          .returning({id: providerRunners.id, providerRunnerId: providerRunners.providerRunnerId});
-
-        absentIds = updated.flatMap((row) => (row.providerRunnerId ? [row.providerRunnerId] : []));
-        reservationsReleased = await releaseTerminalRunnerInstanceReservationsByIds(tx, {
-          workspaceId: params.workspaceId,
-          provisionerId: params.provisionerId,
-          runnerInstanceIds: updated.map((row) => row.id),
-          requireUnlinkedSession: false,
-        });
-      }
-    }
+    const {absentIds, reservationsReleased} = await reconcileAbsentRunnerInstancesTx(
+      tx,
+      params,
+      observedRunnerInstanceIds,
+    );
 
     const observedRows =
       observedRunnerInstanceIds.length === 0
@@ -1053,6 +1034,63 @@ export async function reconcileRunnerInstances(
       reservationsReleased,
     };
   });
+}
+
+async function reconcileAbsentRunnerInstancesTx(
+  tx: Tx,
+  params: ReconcileRunnerInstancesParams,
+  observedRunnerInstanceIds: string[],
+): Promise<{absentIds: string[]; reservationsReleased: number}> {
+  if (observedRunnerInstanceIds.length === 0) return {absentIds: [], reservationsReleased: 0};
+  const staleAbsentRows = await tx
+    .select({id: providerRunners.id})
+    .from(providerRunners)
+    .where(
+      and(
+        params.workspaceId
+          ? eq(providerRunners.workspaceId, params.workspaceId)
+          : isNull(providerRunners.workspaceId),
+        eq(providerRunners.provisionerId, params.provisionerId),
+        inArray(providerRunners.state, activeStates),
+        lt(
+          providerRunners.reportedAt,
+          sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
+        ),
+        notInArray(providerRunners.providerRunnerId, observedRunnerInstanceIds),
+      ),
+    );
+  if (staleAbsentRows.length === 0) return {absentIds: [], reservationsReleased: 0};
+  const updated = await tx
+    .update(providerRunners)
+    .set({
+      state: 'terminated',
+      terminatedAt: sql`coalesce(${providerRunners.terminatedAt}, now())`,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        inArray(
+          providerRunners.id,
+          staleAbsentRows.map((row) => row.id),
+        ),
+        inArray(providerRunners.state, activeStates),
+        lt(
+          providerRunners.reportedAt,
+          sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
+        ),
+      ),
+    )
+    .returning({id: providerRunners.id, providerRunnerId: providerRunners.providerRunnerId});
+  const reservationsReleased = await releaseTerminalRunnerInstanceReservationsByIds(tx, {
+    workspaceId: params.workspaceId,
+    provisionerId: params.provisionerId,
+    runnerInstanceIds: updated.map((row) => row.id),
+    requireUnlinkedSession: false,
+  });
+  return {
+    absentIds: updated.flatMap((row) => (row.providerRunnerId ? [row.providerRunnerId] : [])),
+    reservationsReleased,
+  };
 }
 
 export async function reapStaleRunnerInstances(params: {

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -105,8 +105,7 @@ export async function createRunnerSessionConsumingActivationToken(params: {
       )
       .limit(1)
       .for('update');
-    if (!activationToken)
-      throw new Error('Runner activation token is invalid, expired, or has already been used');
+    assertValidActivationToken(activationToken);
 
     const [provisioner] = await tx
       .select({scope: provisionerTokens.scope})
@@ -117,7 +116,7 @@ export async function createRunnerSessionConsumingActivationToken(params: {
       scope: provisioner?.scope ?? 'workspace',
       source: 'activation runner registration',
     });
-    if (labels.length === 0) throw new EmptyRunnerLabelsError();
+    assertNonEmptyRunnerLabels(labels);
     const [session] = await tx
       .insert(runnerSessions)
       .values({
@@ -172,6 +171,16 @@ export async function createRunnerSessionConsumingActivationToken(params: {
   if (assignmentToActivationObservation)
     recordProviderRunnerAssignmentToActivation(assignmentToActivationObservation);
   return session;
+}
+
+function assertValidActivationToken<T>(token: T | undefined): asserts token is T {
+  if (token === undefined) {
+    throw new Error('Runner activation token is invalid, expired, or has already been used');
+  }
+}
+
+function assertNonEmptyRunnerLabels(labels: readonly string[]): void {
+  if (labels.length === 0) throw new EmptyRunnerLabelsError();
 }
 
 export interface DeleteExpiredRunnerSessionsParams {

--- a/libs/api/runners/src/presentation/auth/runner-registration-token-auth.ts
+++ b/libs/api/runners/src/presentation/auth/runner-registration-token-auth.ts
@@ -32,73 +32,81 @@ export function getRunnerContext(request: FastifyRequest): RunnerRegistrationCon
 export function createRunnerRegistrationTokenAuthMethod(): AuthMethod {
   return {
     name: AUTH_RUNNER_REGISTRATION_TOKEN,
-    authenticate: async (request) => {
-      const rawToken = extractBearerToken(request.headers.authorization);
-      if (!rawToken) {
-        throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {
-          status: 401,
-        });
-      }
-
-      const tokenType = getTokenType(rawToken);
-
-      if (tokenType === 'runnerActivationToken') {
-        const [activation] = await db()
-          .select({id: runnerActivationTokens.id, workspaceId: providerRunners.workspaceId})
-          .from(runnerActivationTokens)
-          .innerJoin(
-            providerRunners,
-            eq(providerRunners.id, runnerActivationTokens.runnerInstanceId),
-          )
-          .leftJoin(provisionerTokens, eq(provisionerTokens.id, providerRunners.provisionerId))
-          .where(
-            and(
-              eq(runnerActivationTokens.hashedToken, hashOpaqueToken(rawToken)),
-              isNull(runnerActivationTokens.consumedAt),
-              isNull(runnerActivationTokens.revokedAt),
-              gt(runnerActivationTokens.expiresAt, sql`now()`),
-              or(isNull(provisionerTokens.id), isNull(provisionerTokens.revokedAt)),
-              isNull(providerRunners.runnerSessionId),
-            ),
-          )
-          .limit(1);
-        if (!activation?.workspaceId)
-          throw new ClientError('Invalid runner registration token', 'unauthorized', {status: 401});
-        (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = {
-          kind: 'activation',
-          activationTokenId: activation.id,
-          workspaceId: activation.workspaceId,
-        } satisfies RunnerRegistrationContext;
-        return;
-      }
-
-      if (tokenType !== 'manualRegistrationToken') {
-        throw new ClientError('Invalid runner registration token', 'unauthorized', {status: 401});
-      }
-
-      const token = await resolveManualRegistrationTokenByHash(hashOpaqueToken(rawToken));
-      if (!token) {
-        throw new ClientError('Invalid runner registration token', 'unauthorized', {status: 401});
-      }
-
-      if (token.expiresAt && token.expiresAt < new Date()) {
-        throw new ClientError('Registration token has expired', 'registration-token-expired', {
-          status: 401,
-        });
-      }
-      if (token.revokedAt) {
-        throw new ClientError(
-          'Manual registration token has been revoked',
-          'manual-registration-token-revoked',
-          {status: 401},
-        );
-      }
-
-      (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = {
-        kind: 'manual',
-        registrationTokenId: token.id,
-        workspaceId: token.workspaceId,
-      } satisfies RunnerRegistrationContext;
-    },
+    authenticate: authenticateRunnerRegistrationToken,
   };
+}
+
+async function authenticateRunnerRegistrationToken(request: FastifyRequest): Promise<void> {
+  const rawToken = extractBearerToken(request.headers.authorization);
+  if (!rawToken) {
+    throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {status: 401});
+  }
+  const tokenType = getTokenType(rawToken);
+  if (tokenType === 'runnerActivationToken') {
+    await authenticateActivationToken(request, rawToken);
+    return;
+  }
+  if (tokenType !== 'manualRegistrationToken') throw invalidRunnerRegistrationTokenError();
+  await authenticateManualRegistrationToken(request, rawToken);
+}
+
+async function authenticateActivationToken(
+  request: FastifyRequest,
+  rawToken: string,
+): Promise<void> {
+  const [activation] = await db()
+    .select({id: runnerActivationTokens.id, workspaceId: providerRunners.workspaceId})
+    .from(runnerActivationTokens)
+    .innerJoin(providerRunners, eq(providerRunners.id, runnerActivationTokens.runnerInstanceId))
+    .leftJoin(provisionerTokens, eq(provisionerTokens.id, providerRunners.provisionerId))
+    .where(
+      and(
+        eq(runnerActivationTokens.hashedToken, hashOpaqueToken(rawToken)),
+        isNull(runnerActivationTokens.consumedAt),
+        isNull(runnerActivationTokens.revokedAt),
+        gt(runnerActivationTokens.expiresAt, sql`now()`),
+        or(isNull(provisionerTokens.id), isNull(provisionerTokens.revokedAt)),
+        isNull(providerRunners.runnerSessionId),
+      ),
+    )
+    .limit(1);
+  if (!activation?.workspaceId) throw invalidRunnerRegistrationTokenError();
+  setRunnerContext(request, {
+    kind: 'activation',
+    activationTokenId: activation.id,
+    workspaceId: activation.workspaceId,
+  });
+}
+
+async function authenticateManualRegistrationToken(
+  request: FastifyRequest,
+  rawToken: string,
+): Promise<void> {
+  const token = await resolveManualRegistrationTokenByHash(hashOpaqueToken(rawToken));
+  if (!token) throw invalidRunnerRegistrationTokenError();
+  if (token.expiresAt && token.expiresAt < new Date()) {
+    throw new ClientError('Registration token has expired', 'registration-token-expired', {
+      status: 401,
+    });
+  }
+  if (token.revokedAt) {
+    throw new ClientError(
+      'Manual registration token has been revoked',
+      'manual-registration-token-revoked',
+      {status: 401},
+    );
+  }
+  setRunnerContext(request, {
+    kind: 'manual',
+    registrationTokenId: token.id,
+    workspaceId: token.workspaceId,
+  });
+}
+
+function setRunnerContext(request: FastifyRequest, context: RunnerRegistrationContext): void {
+  (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = context;
+}
+
+function invalidRunnerRegistrationTokenError(): ClientError {
+  return new ClientError('Invalid runner registration token', 'unauthorized', {status: 401});
 }

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -37,7 +37,7 @@ import {
 } from '@shipfox/api-workspaces-dto/inter-module';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {durationToSeconds} from '@shipfox/node-jwt';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import type {ModuleDatabase, ShipfoxModule} from '@shipfox/node-module';
 import {
   createInMemoryInterModuleTransport,
   registerInterModulePresentations,
@@ -286,11 +286,9 @@ function createAgentSecretsClient(
 }
 
 function validateCustomAgentModule(module: ShipfoxModule): void {
-  const databases = module.database
-    ? Array.isArray(module.database)
-      ? module.database
-      : [module.database]
-    : [];
+  let databases: ModuleDatabase[] = [];
+  if (Array.isArray(module.database)) databases = module.database;
+  else if (module.database) databases = [module.database];
   if (
     !databases.some(({databaseNamespace}) => databaseNamespace === agentInterModuleContract.module)
   ) {

--- a/libs/api/triggers/src/core/create-dev-run.ts
+++ b/libs/api/triggers/src/core/create-dev-run.ts
@@ -94,9 +94,23 @@ export async function createDevRun(params: CreateDevRunParams): Promise<DevRunRe
     throw new DevRunTriggerFilteredError(built.reason);
   }
 
-  let run: {id: string; name: string};
+  const run = await startDevRunAndRecordFailure(params, resolved, built, historyBase);
+
+  const history = await beginTriggerHistory({...historyBase, eventRef: run.id});
+  await history.devTriggered(params.triggerKey, resolved.workflow.id, run);
+  devRunsCount.add(1, {trigger_kind: built.triggerKind, outcome: 'routed'});
+  await history.routed(1);
+  return {id: run.id, commit: resolved.commit};
+}
+
+async function startDevRunAndRecordFailure(
+  params: CreateDevRunParams,
+  resolved: Awaited<ReturnType<CreateDevRunParams['definitions']['resolveDefinitionAtRef']>>,
+  built: BuiltDevRunTrigger,
+  historyBase: Omit<Parameters<typeof beginTriggerHistory>[0], 'eventRef'>,
+): Promise<{id: string; name: string}> {
   try {
-    run = await params.workflows.startDevRun({
+    return await params.workflows.startDevRun({
       workspaceId: params.workspaceId,
       projectId: params.projectId,
       workflowId: resolved.workflow.id,
@@ -129,12 +143,6 @@ export async function createDevRun(params: CreateDevRunParams): Promise<DevRunRe
     }
     throw error;
   }
-
-  const history = await beginTriggerHistory({...historyBase, eventRef: run.id});
-  await history.devTriggered(params.triggerKey, resolved.workflow.id, run);
-  devRunsCount.add(1, {trigger_kind: built.triggerKind, outcome: 'routed'});
-  await history.routed(1);
-  return {id: run.id, commit: resolved.commit};
 }
 
 interface ReplaySource {

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -62,56 +62,7 @@ export async function dispatchIntegrationEvent(
     event: params.event,
   });
 
-  let triggeredCount = 0;
-  let triggerEngagedCount = 0;
-  let sawTransientError = false;
-  let firstTransientError: unknown;
-
-  for (const subscription of subscriptions) {
-    const filterResult = evaluateTriggerFilter({
-      subscription,
-      source: params.source,
-      event: params.event,
-      payload: params.payload,
-    });
-    if (filterResult.kind === 'filtered') continue;
-    if (filterResult.kind === 'filter-error') {
-      triggerEngagedCount += 1;
-      await history.filterErrored(subscription, filterResult.reason);
-      continue;
-    }
-    triggerEngagedCount += 1;
-
-    const inputs = readConfigInputs(subscription);
-    try {
-      const run = await params.workflows.startRunFromTrigger({
-        workspaceId: subscription.workspaceId,
-        projectId: subscription.projectId,
-        definitionId: subscription.workflowDefinitionId,
-        triggerConnectionId: params.connectionId,
-        triggerPayload: {
-          provider: params.provider,
-          source: params.source,
-          event: params.event,
-          deliveryId: params.deliveryId,
-          data: params.payload,
-        },
-        ...(inputs === undefined ? {} : {inputs}),
-        idempotencyKey: `${subscription.id}:${params.eventRef}`,
-      });
-      await history.triggered(subscription, run);
-      triggeredCount += 1;
-      subscriptionTriggeredCount.add(1, {provider: params.provider});
-    } catch (error) {
-      await history.dispatchErrored(subscription, toReason(error));
-      // Track presence with a flag, not `firstTransientError === undefined`: a thrown
-      // value of `undefined` is still a transient failure and must drive the replay.
-      if (!isPermanentStartRunError(error) && !sawTransientError) {
-        sawTransientError = true;
-        firstTransientError = error;
-      }
-    }
-  }
+  const dispatch = await dispatchMatchingSubscriptions(params, subscriptions, history);
 
   const listenerResult = await routeEventToJobListeners({
     workflows: params.workflows,
@@ -127,20 +78,20 @@ export async function dispatchIntegrationEvent(
     receivedAt: params.receivedAt,
   });
 
-  if (listenerResult.transientErrored && !sawTransientError) {
-    sawTransientError = true;
-    firstTransientError = listenerResult.transientError;
+  if (listenerResult.transientErrored && !dispatch.sawTransientError) {
+    dispatch.sawTransientError = true;
+    dispatch.firstTransientError = listenerResult.transientError;
   }
 
-  const totalMatchedCount = triggerEngagedCount + listenerResult.engagedCount;
+  const totalMatchedCount = dispatch.triggerEngagedCount + listenerResult.engagedCount;
 
-  if (sawTransientError) {
+  if (dispatch.sawTransientError) {
     eventOutcomeCount.add(1, {provider: params.provider, outcome: 'failed'});
     await history.failed(totalMatchedCount);
-    throw firstTransientError;
+    throw dispatch.firstTransientError;
   }
 
-  if (triggeredCount > 0 || listenerResult.acceptedJobCount > 0) {
+  if (dispatch.triggeredCount > 0 || listenerResult.acceptedJobCount > 0) {
     eventOutcomeCount.add(1, {provider: params.provider, outcome: 'routed'});
     await history.routed(totalMatchedCount);
     return;
@@ -154,4 +105,76 @@ export async function dispatchIntegrationEvent(
 
   eventOutcomeCount.add(1, {provider: params.provider, outcome: 'errored'});
   await history.allErrored(totalMatchedCount);
+}
+
+interface SubscriptionDispatchState {
+  triggeredCount: number;
+  triggerEngagedCount: number;
+  sawTransientError: boolean;
+  firstTransientError: unknown;
+}
+
+async function dispatchMatchingSubscriptions(
+  params: DispatchIntegrationEventParams,
+  subscriptions: Awaited<ReturnType<typeof findMatchingSubscriptions>>,
+  history: Awaited<ReturnType<typeof beginTriggerHistory>>,
+): Promise<SubscriptionDispatchState> {
+  const state: SubscriptionDispatchState = {
+    triggeredCount: 0,
+    triggerEngagedCount: 0,
+    sawTransientError: false,
+    firstTransientError: undefined,
+  };
+  for (const subscription of subscriptions) {
+    const filterResult = evaluateTriggerFilter({
+      subscription,
+      source: params.source,
+      event: params.event,
+      payload: params.payload,
+    });
+    if (filterResult.kind === 'filtered') continue;
+    state.triggerEngagedCount += 1;
+    if (filterResult.kind === 'filter-error') {
+      await history.filterErrored(subscription, filterResult.reason);
+      continue;
+    }
+    await dispatchMatchingSubscription(params, subscription, history, state);
+  }
+  return state;
+}
+
+async function dispatchMatchingSubscription(
+  params: DispatchIntegrationEventParams,
+  subscription: Awaited<ReturnType<typeof findMatchingSubscriptions>>[number],
+  history: Awaited<ReturnType<typeof beginTriggerHistory>>,
+  state: SubscriptionDispatchState,
+): Promise<void> {
+  const inputs = readConfigInputs(subscription);
+  try {
+    const run = await params.workflows.startRunFromTrigger({
+      workspaceId: subscription.workspaceId,
+      projectId: subscription.projectId,
+      definitionId: subscription.workflowDefinitionId,
+      triggerConnectionId: params.connectionId,
+      triggerPayload: {
+        provider: params.provider,
+        source: params.source,
+        event: params.event,
+        deliveryId: params.deliveryId,
+        data: params.payload,
+      },
+      ...(inputs === undefined ? {} : {inputs}),
+      idempotencyKey: `${subscription.id}:${params.eventRef}`,
+    });
+    await history.triggered(subscription, run);
+    state.triggeredCount += 1;
+    subscriptionTriggeredCount.add(1, {provider: params.provider});
+  } catch (error) {
+    await history.dispatchErrored(subscription, toReason(error));
+    // A thrown undefined value is still a transient failure and must drive the replay.
+    if (!isPermanentStartRunError(error) && !state.sawTransientError) {
+      state.sawTransientError = true;
+      state.firstTransientError = error;
+    }
+  }
 }

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.ts
@@ -55,23 +55,10 @@ export async function routeEventToJobListeners(
     source: params.source,
     event: params.event,
   });
-
-  let filterErrorCount = 0;
-  const effectiveMatchByJobId = new Map<string, JobListenerSubscription>();
-  for (const subscription of subscriptions) {
-    const filterResult = evaluateListenerFilter({subscription, payload: params.payload});
-    if (filterResult.kind === 'filtered') continue;
-    if (filterResult.kind === 'filter-error') {
-      filterErrorCount += 1;
-      await params.history.listenerFilterErrored(subscription, filterResult.reason);
-      continue;
-    }
-
-    const previous = effectiveMatchByJobId.get(subscription.jobId);
-    if (!previous || shouldReplaceEffectiveMatcher(previous, subscription)) {
-      effectiveMatchByJobId.set(subscription.jobId, subscription);
-    }
-  }
+  const {filterErrorCount, effectiveMatchByJobId} = await collectEffectiveListenerMatches(
+    params,
+    subscriptions,
+  );
 
   const fireDeliveryNeeded = [...effectiveMatchByJobId.values()].some(
     (subscription) => listenerDisposition(subscription) === 'fire',
@@ -90,51 +77,110 @@ export async function routeEventToJobListeners(
       })
     : null;
 
-  let acceptedJobCount = 0;
-  let deliveredCount = 0;
-  let sawTransientError = false;
-  let dispatchErrorCount = 0;
-  let firstTransientError: unknown;
-
-  for (const subscription of effectiveMatchByJobId.values()) {
-    const disposition = listenerDisposition(subscription);
-    try {
-      const result = await params.workflows.deliverEventToJobListener({
-        jobId: subscription.jobId,
-        disposition,
-        eventRef: params.eventRef,
-        deliveryId: params.deliveryId,
-        source: params.source,
-        event: params.event,
-        provider: params.provider,
-        triggerConnectionId: params.connectionId,
-        triggerReference,
-        payload: params.payload,
-        receivedAt: params.receivedAt.toISOString(),
-      });
-      if (!result.skipped) {
-        acceptedJobCount += 1;
-        await params.history.listenerTriggered(subscription);
-      }
-      if (result.buffered) deliveredCount += 1;
-    } catch (error) {
-      dispatchErrorCount += 1;
-      await params.history.listenerDispatchErrored(subscription, toReason(error));
-      if (!isPermanentDeliverEventToJobListenerError(error) && !sawTransientError) {
-        sawTransientError = true;
-        firstTransientError = error;
-      }
-    }
-  }
+  const delivery = await deliverEventToMatchedListeners(
+    params,
+    effectiveMatchByJobId.values(),
+    triggerReference,
+  );
 
   return {
-    engagedCount: filterErrorCount + acceptedJobCount + dispatchErrorCount,
+    engagedCount: filterErrorCount + delivery.acceptedJobCount + delivery.dispatchErrorCount,
     matchedJobCount: effectiveMatchByJobId.size,
-    acceptedJobCount,
-    deliveredCount,
-    transientErrored: sawTransientError,
-    transientError: sawTransientError ? firstTransientError : undefined,
+    acceptedJobCount: delivery.acceptedJobCount,
+    deliveredCount: delivery.deliveredCount,
+    transientErrored: delivery.sawTransientError,
+    transientError: delivery.sawTransientError ? delivery.firstTransientError : undefined,
   };
+}
+
+async function collectEffectiveListenerMatches(
+  params: Pick<RouteEventToJobListenersParams, 'history' | 'payload'>,
+  subscriptions: readonly JobListenerSubscription[],
+): Promise<{
+  filterErrorCount: number;
+  effectiveMatchByJobId: Map<string, JobListenerSubscription>;
+}> {
+  let filterErrorCount = 0;
+  const effectiveMatchByJobId = new Map<string, JobListenerSubscription>();
+  for (const subscription of subscriptions) {
+    const filterResult = evaluateListenerFilter({subscription, payload: params.payload});
+    if (filterResult.kind === 'filtered') continue;
+    if (filterResult.kind === 'filter-error') {
+      filterErrorCount += 1;
+      await params.history.listenerFilterErrored(subscription, filterResult.reason);
+      continue;
+    }
+    const previous = effectiveMatchByJobId.get(subscription.jobId);
+    if (!previous || shouldReplaceEffectiveMatcher(previous, subscription)) {
+      effectiveMatchByJobId.set(subscription.jobId, subscription);
+    }
+  }
+  return {filterErrorCount, effectiveMatchByJobId};
+}
+
+interface ListenerDeliveryState {
+  acceptedJobCount: number;
+  deliveredCount: number;
+  dispatchErrorCount: number;
+  sawTransientError: boolean;
+  firstTransientError: unknown;
+}
+
+async function deliverEventToMatchedListeners(
+  params: RouteEventToJobListenersParams,
+  subscriptions: Iterable<JobListenerSubscription>,
+  triggerReference: Awaited<
+    ReturnType<WorkflowsModuleClient['resolveWorkflowRunTriggerReference']>
+  > | null,
+): Promise<ListenerDeliveryState> {
+  const state: ListenerDeliveryState = {
+    acceptedJobCount: 0,
+    deliveredCount: 0,
+    dispatchErrorCount: 0,
+    sawTransientError: false,
+    firstTransientError: undefined,
+  };
+  for (const subscription of subscriptions) {
+    await deliverEventToMatchedListener(params, subscription, triggerReference, state);
+  }
+  return state;
+}
+
+async function deliverEventToMatchedListener(
+  params: RouteEventToJobListenersParams,
+  subscription: JobListenerSubscription,
+  triggerReference: Awaited<
+    ReturnType<WorkflowsModuleClient['resolveWorkflowRunTriggerReference']>
+  > | null,
+  state: ListenerDeliveryState,
+): Promise<void> {
+  try {
+    const result = await params.workflows.deliverEventToJobListener({
+      jobId: subscription.jobId,
+      disposition: listenerDisposition(subscription),
+      eventRef: params.eventRef,
+      deliveryId: params.deliveryId,
+      source: params.source,
+      event: params.event,
+      provider: params.provider,
+      triggerConnectionId: params.connectionId,
+      triggerReference,
+      payload: params.payload,
+      receivedAt: params.receivedAt.toISOString(),
+    });
+    if (!result.skipped) {
+      state.acceptedJobCount += 1;
+      await params.history.listenerTriggered(subscription);
+    }
+    if (result.buffered) state.deliveredCount += 1;
+  } catch (error) {
+    state.dispatchErrorCount += 1;
+    await params.history.listenerDispatchErrored(subscription, toReason(error));
+    if (!isPermanentDeliverEventToJobListenerError(error) && !state.sawTransientError) {
+      state.sawTransientError = true;
+      state.firstTransientError = error;
+    }
+  }
 }
 
 interface EvaluateListenerFilterParams {

--- a/libs/api/triggers/src/db/job-listener-subscriptions.ts
+++ b/libs/api/triggers/src/db/job-listener-subscriptions.ts
@@ -41,43 +41,58 @@ export async function projectJobListenerSubscriptions(
       ['until', params.until ?? []],
     ] as const) {
       for (const [matcherOrdinal, matcher] of matchers.entries()) {
-        const config: Record<string, unknown> = {};
-        if (matcher.inputs !== undefined) config.inputs = matcher.inputs;
-        if (matcher.filter !== undefined) config.filter = matcher.filter;
-        if (matcher.filter_snapshot !== undefined) config.filter_snapshot = matcher.filter_snapshot;
-        if (matcher.filter_output_types !== undefined) {
-          config.filter_output_types = matcher.filter_output_types;
-        }
-
-        await tx
-          .insert(jobListenerSubscriptions)
-          .values({
-            workspaceId: params.workspaceId,
-            workflowRunId: params.workflowRunId,
-            jobId: params.jobId,
-            kind,
-            matcherOrdinal,
-            source: matcher.source,
-            event: normalizeSubscriptionEvent({source: matcher.source, event: matcher.event}),
-            config,
-          })
-          .onConflictDoUpdate({
-            target: [
-              jobListenerSubscriptions.jobId,
-              jobListenerSubscriptions.kind,
-              jobListenerSubscriptions.matcherOrdinal,
-            ],
-            set: {
-              workspaceId: params.workspaceId,
-              workflowRunId: params.workflowRunId,
-              source: matcher.source,
-              event: normalizeSubscriptionEvent({source: matcher.source, event: matcher.event}),
-              config,
-            },
-          });
+        await upsertJobListenerMatcher(tx, params, kind, matcherOrdinal, matcher);
       }
     }
   });
+}
+
+async function upsertJobListenerMatcher(
+  tx: Tx,
+  params: ProjectJobListenerSubscriptionsParams,
+  kind: JobListenerMatcherKind,
+  matcherOrdinal: number,
+  matcher: ListenerMatcher,
+): Promise<void> {
+  const config = listenerMatcherConfig(matcher);
+  const event = normalizeSubscriptionEvent({source: matcher.source, event: matcher.event});
+  await tx
+    .insert(jobListenerSubscriptions)
+    .values({
+      workspaceId: params.workspaceId,
+      workflowRunId: params.workflowRunId,
+      jobId: params.jobId,
+      kind,
+      matcherOrdinal,
+      source: matcher.source,
+      event,
+      config,
+    })
+    .onConflictDoUpdate({
+      target: [
+        jobListenerSubscriptions.jobId,
+        jobListenerSubscriptions.kind,
+        jobListenerSubscriptions.matcherOrdinal,
+      ],
+      set: {
+        workspaceId: params.workspaceId,
+        workflowRunId: params.workflowRunId,
+        source: matcher.source,
+        event,
+        config,
+      },
+    });
+}
+
+function listenerMatcherConfig(matcher: ListenerMatcher): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+  if (matcher.inputs !== undefined) config.inputs = matcher.inputs;
+  if (matcher.filter !== undefined) config.filter = matcher.filter;
+  if (matcher.filter_snapshot !== undefined) config.filter_snapshot = matcher.filter_snapshot;
+  if (matcher.filter_output_types !== undefined) {
+    config.filter_output_types = matcher.filter_output_types;
+  }
+  return config;
 }
 
 async function pruneStaleMatchers(

--- a/libs/api/triggers/src/db/subscriptions.ts
+++ b/libs/api/triggers/src/db/subscriptions.ts
@@ -42,45 +42,7 @@ export async function projectDefinitionTriggers(
       );
 
     for (const [name, trigger] of entries) {
-      const config: Record<string, unknown> = {};
-      if (trigger.with !== undefined) config.with = trigger.with;
-      if (trigger.filter !== undefined) config.filter = trigger.filter;
-
-      const [upserted] = await tx
-        .insert(triggerSubscriptions)
-        .values({
-          workspaceId: params.workspaceId,
-          projectId: params.projectId,
-          workflowDefinitionId: params.workflowDefinitionId,
-          name,
-          source: trigger.source,
-          event: normalizeSubscriptionEvent({source: trigger.source, event: trigger.event}),
-          config,
-        })
-        .onConflictDoUpdate({
-          target: [triggerSubscriptions.workflowDefinitionId, triggerSubscriptions.name],
-          set: {
-            workspaceId: params.workspaceId,
-            projectId: params.projectId,
-            source: trigger.source,
-            event: normalizeSubscriptionEvent({source: trigger.source, event: trigger.event}),
-            config,
-            updatedAt: new Date(),
-          },
-        })
-        .returning({id: triggerSubscriptions.id});
-      if (!upserted) throw new Error('Trigger subscription upsert returned no rows');
-
-      if (trigger.source === 'cron') {
-        await syncCronSchedule({
-          tx,
-          subscriptionId: upserted.id,
-          workspaceId: params.workspaceId,
-          triggerConfig: trigger.config,
-        });
-      } else {
-        await deleteCronScheduleForSubscription({tx, subscriptionId: upserted.id});
-      }
+      await upsertDefinitionTrigger(tx, params, name, trigger);
     }
   };
 
@@ -89,6 +51,52 @@ export async function projectDefinitionTriggers(
     return;
   }
   await db().transaction(work);
+}
+
+async function upsertDefinitionTrigger(
+  tx: Tx,
+  params: ProjectDefinitionTriggersParams,
+  name: string,
+  trigger: ProjectDefinitionTrigger,
+): Promise<void> {
+  const config: Record<string, unknown> = {};
+  if (trigger.with !== undefined) config.with = trigger.with;
+  if (trigger.filter !== undefined) config.filter = trigger.filter;
+  const event = normalizeSubscriptionEvent({source: trigger.source, event: trigger.event});
+  const [upserted] = await tx
+    .insert(triggerSubscriptions)
+    .values({
+      workspaceId: params.workspaceId,
+      projectId: params.projectId,
+      workflowDefinitionId: params.workflowDefinitionId,
+      name,
+      source: trigger.source,
+      event,
+      config,
+    })
+    .onConflictDoUpdate({
+      target: [triggerSubscriptions.workflowDefinitionId, triggerSubscriptions.name],
+      set: {
+        workspaceId: params.workspaceId,
+        projectId: params.projectId,
+        source: trigger.source,
+        event,
+        config,
+        updatedAt: new Date(),
+      },
+    })
+    .returning({id: triggerSubscriptions.id});
+  if (!upserted) throw new Error('Trigger subscription upsert returned no rows');
+  if (trigger.source === 'cron') {
+    await syncCronSchedule({
+      tx,
+      subscriptionId: upserted.id,
+      workspaceId: params.workspaceId,
+      triggerConfig: trigger.config,
+    });
+    return;
+  }
+  await deleteCronScheduleForSubscription({tx, subscriptionId: upserted.id});
 }
 
 export interface DeleteSubscriptionsForDefinitionParams {

--- a/libs/api/triggers/src/presentation/routes/create-dev-run.ts
+++ b/libs/api/triggers/src/presentation/routes/create-dev-run.ts
@@ -55,96 +55,8 @@ export function createDevRunRoute(
       },
     },
     errorHandler: (error) => {
-      if (error instanceof DevRunTriggerNotFoundError) {
-        throw new ClientError(error.message, 'trigger-not-found', {status: 422});
-      }
-      if (error instanceof DevRunInputsNotAllowedError) {
-        throw new ClientError(error.message, 'inputs-not-allowed', {status: 422});
-      }
-      if (error instanceof DevRunReplayEventRequiredError) {
-        throw new ClientError(error.message, 'replay-event-required', {status: 422});
-      }
-      if (error instanceof DevRunReplayEventNotAllowedError) {
-        throw new ClientError(error.message, 'replay-event-not-allowed', {status: 422});
-      }
-      if (error instanceof DevRunReplayEventNotFoundError) {
-        throw new ClientError(error.message, 'replay-event-not-found', {
-          status: 404,
-          cause: error,
-        });
-      }
-      if (error instanceof DevRunReplayEventMismatchError) {
-        throw new ClientError(error.message, 'replay-event-mismatch', {
-          status: 409,
-          cause: error,
-        });
-      }
-      if (error instanceof DevRunReplayEventUnavailableError) {
-        throw new ClientError(error.message, 'replay-event-unavailable', {
-          status: 410,
-          cause: error,
-        });
-      }
-      if (error instanceof DevRunTriggerFilteredError) {
-        // The reason travels in `details` so the client can show why; the
-        // events page journal shows the same reason on the `filter-error`
-        // decision.
-        throw new ClientError('The trigger filter refused the replayed event', 'trigger-filtered', {
-          status: 409,
-          details: {reason: error.reason},
-          cause: error,
-        });
-      }
-      if (
-        isInterModuleKnownError(
-          definitionsInterModuleContract.methods.resolveDefinitionAtRef,
-          error,
-        )
-      ) {
-        switch (error.code) {
-          case 'project-not-found':
-            throw new ClientError('Project not found', 'project-not-found', {
-              status: 404,
-              cause: error,
-            });
-          case 'ref-not-found':
-            throw new ClientError('Git ref not found', 'ref-not-found', {
-              status: 404,
-              cause: error,
-            });
-          case 'file-not-found':
-            throw new ClientError('Workflow file not found at the ref', 'file-not-found', {
-              status: 404,
-              cause: error,
-            });
-          case 'ref-invalid':
-            throw new ClientError('Git ref is not a resolvable branch or tag name', 'ref-invalid', {
-              status: 400,
-              cause: error,
-            });
-          case 'ref-moved':
-            throw new ClientError('The ref no longer points at the pinned commit', 'ref-moved', {
-              status: 409,
-              cause: error,
-            });
-          case 'invalid-definition':
-            throw new ClientError('Invalid workflow definition', 'invalid-workflow-definition', {
-              status: 422,
-              details: {errors: error.details.errors},
-              cause: error,
-            });
-          case 'content-too-large':
-            throw new ClientError('Workflow file is too large', 'content-too-large', {
-              status: 422,
-              cause: error,
-            });
-          case 'source-unavailable':
-            throw new ClientError('The source repository is unavailable', 'source-unavailable', {
-              status: 502,
-              cause: error,
-            });
-        }
-      }
+      handleDevRunDomainError(error);
+      handleDefinitionResolutionError(error);
       const clientError = mapStartRunError(error, workflowsInterModuleContract.methods.startDevRun);
       if (clientError) throw clientError;
       throw error;
@@ -172,4 +84,79 @@ export function createDevRunRoute(
       return {workflow_run_id: run.id, commit: run.commit};
     },
   });
+}
+
+function handleDevRunDomainError(error: unknown): void {
+  if (error instanceof DevRunTriggerNotFoundError) {
+    throw new ClientError(error.message, 'trigger-not-found', {status: 422});
+  }
+  if (error instanceof DevRunInputsNotAllowedError) {
+    throw new ClientError(error.message, 'inputs-not-allowed', {status: 422});
+  }
+  if (error instanceof DevRunReplayEventRequiredError) {
+    throw new ClientError(error.message, 'replay-event-required', {status: 422});
+  }
+  if (error instanceof DevRunReplayEventNotAllowedError) {
+    throw new ClientError(error.message, 'replay-event-not-allowed', {status: 422});
+  }
+  if (error instanceof DevRunReplayEventNotFoundError) {
+    throw new ClientError(error.message, 'replay-event-not-found', {status: 404, cause: error});
+  }
+  if (error instanceof DevRunReplayEventMismatchError) {
+    throw new ClientError(error.message, 'replay-event-mismatch', {status: 409, cause: error});
+  }
+  if (error instanceof DevRunReplayEventUnavailableError) {
+    throw new ClientError(error.message, 'replay-event-unavailable', {status: 410, cause: error});
+  }
+  if (error instanceof DevRunTriggerFilteredError) {
+    throw new ClientError('The trigger filter refused the replayed event', 'trigger-filtered', {
+      status: 409,
+      details: {reason: error.reason},
+      cause: error,
+    });
+  }
+}
+
+function handleDefinitionResolutionError(error: unknown): void {
+  if (
+    !isInterModuleKnownError(definitionsInterModuleContract.methods.resolveDefinitionAtRef, error)
+  )
+    return;
+  switch (error.code) {
+    case 'project-not-found':
+      throw new ClientError('Project not found', 'project-not-found', {status: 404, cause: error});
+    case 'ref-not-found':
+      throw new ClientError('Git ref not found', 'ref-not-found', {status: 404, cause: error});
+    case 'file-not-found':
+      throw new ClientError('Workflow file not found at the ref', 'file-not-found', {
+        status: 404,
+        cause: error,
+      });
+    case 'ref-invalid':
+      throw new ClientError('Git ref is not a resolvable branch or tag name', 'ref-invalid', {
+        status: 400,
+        cause: error,
+      });
+    case 'ref-moved':
+      throw new ClientError('The ref no longer points at the pinned commit', 'ref-moved', {
+        status: 409,
+        cause: error,
+      });
+    case 'invalid-definition':
+      throw new ClientError('Invalid workflow definition', 'invalid-workflow-definition', {
+        status: 422,
+        details: {errors: error.details.errors},
+        cause: error,
+      });
+    case 'content-too-large':
+      throw new ClientError('Workflow file is too large', 'content-too-large', {
+        status: 422,
+        cause: error,
+      });
+    case 'source-unavailable':
+      throw new ClientError('The source repository is unavailable', 'source-unavailable', {
+        status: 502,
+        cause: error,
+      });
+  }
 }

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -21,12 +21,12 @@ const checkoutConfigSchema = z
   })
   .superRefine((checkout, context) => {
     for (const validationIssue of checkoutTargetValidationIssues(checkout)) {
-      const message =
-        validationIssue.kind === 'project-with-connection'
-          ? 'Checkout project cannot be combined with a connection.'
-          : validationIssue.kind === 'project-with-repository'
-            ? 'Checkout project cannot be combined with a repository.'
-            : 'Checkout connection requires a repository.';
+      let message = 'Checkout connection requires a repository.';
+      if (validationIssue.kind === 'project-with-connection') {
+        message = 'Checkout project cannot be combined with a connection.';
+      } else if (validationIssue.kind === 'project-with-repository') {
+        message = 'Checkout project cannot be combined with a repository.';
+      }
       context.addIssue({
         code: 'custom',
         path: [validationIssue.path],
@@ -91,18 +91,7 @@ export async function createStepCheckoutSpec({
     },
     target,
   });
-  // Explicit step refs win, followed by same-project event commits (including
-  // replays), then the pinned dev commit for the run's own project. Other targets
-  // intentionally use the provider default branch.
-  const triggerCommitRef =
-    triggerReference?.project?.id === resolvedTarget.projectId
-      ? (triggerReference.commit ?? undefined)
-      : undefined;
-  const devCommitRef =
-    run.origin === 'dev' && resolvedTarget.projectId === projectId
-      ? run.devSource.commit
-      : undefined;
-  const ref = checkout.ref ?? triggerCommitRef ?? devCommitRef;
+  const ref = resolveCheckoutRef({checkout, triggerReference, run, resolvedTarget, projectId});
   const response = await integrations.createCheckoutSpec({
     workspaceId,
     connectionId: resolvedTarget.connectionId,
@@ -111,38 +100,71 @@ export async function createStepCheckoutSpec({
     permissions: checkout.permissions ?? {contents: 'read'},
   });
 
+  return checkoutResult(checkout, response);
+}
+
+function resolveCheckoutRef(params: {
+  checkout: CheckoutConfig;
+  triggerReference: WorkflowRunTriggerReference | null | undefined;
+  run: WorkflowRunOriginState;
+  resolvedTarget: {projectId?: string | undefined};
+  projectId: string;
+}): string | undefined {
+  // Explicit step refs win, followed by same-project event commits (including
+  // replays), then the pinned dev commit for the run's own project. Other targets
+  // intentionally use the provider default branch.
+  let triggerCommitRef: string | undefined;
+  const {triggerReference} = params;
+  if (
+    triggerReference !== null &&
+    triggerReference !== undefined &&
+    triggerReference.project?.id === params.resolvedTarget.projectId
+  ) {
+    triggerCommitRef = triggerReference.commit ?? undefined;
+  }
+  let devCommitRef: string | undefined;
+  if (params.run.origin === 'dev' && params.resolvedTarget.projectId === params.projectId) {
+    devCommitRef = params.run.devSource.commit;
+  }
+  return params.checkout.ref ?? triggerCommitRef ?? devCommitRef;
+}
+
+type CheckoutSpecResponse = Awaited<ReturnType<IntegrationsModuleClient['createCheckoutSpec']>>;
+
+function checkoutResult(checkout: CheckoutConfig, response: CheckoutSpecResponse) {
+  const credentials = checkoutCredentials(response.credentials);
   return {
     spec: {
       repositoryUrl: response.repositoryUrl,
       ref: response.ref,
-      ...(response.credentials
-        ? {
-            credentials: {
-              username: response.credentials.username,
-              token: response.credentials.token,
-              expiresAt: new Date(response.credentials.expiresAt),
-              ...(response.credentials.generation === undefined
-                ? {}
-                : {generation: response.credentials.generation}),
-              ...(response.credentials.renewal === undefined
-                ? {}
-                : {
-                    renewal:
-                      response.credentials.renewal.mode === 'refresh-at'
-                        ? {
-                            mode: 'refresh-at' as const,
-                            refreshAt: new Date(response.credentials.renewal.refreshAt),
-                          }
-                        : {mode: 'on-rejection' as const},
-                  }),
-            },
-          }
-        : {}),
+      ...(credentials === undefined ? {} : {credentials}),
       ...(response.gitAuthor === undefined ? {} : {gitAuthor: response.gitAuthor}),
     },
     fetchDepth: checkout.fetch_depth ?? 1,
     persistCredentials: checkout.persist_credentials ?? true,
   };
+}
+
+function checkoutCredentials(credentials: CheckoutSpecResponse['credentials']) {
+  if (credentials === undefined) return undefined;
+  const renewal = checkoutCredentialRenewal(credentials.renewal);
+  return {
+    username: credentials.username,
+    token: credentials.token,
+    expiresAt: new Date(credentials.expiresAt),
+    ...(credentials.generation === undefined ? {} : {generation: credentials.generation}),
+    ...(renewal === undefined ? {} : {renewal}),
+  };
+}
+
+function checkoutCredentialRenewal(
+  renewal: NonNullable<CheckoutSpecResponse['credentials']>['renewal'],
+) {
+  if (renewal === undefined) return undefined;
+  if (renewal.mode === 'refresh-at') {
+    return {mode: 'refresh-at' as const, refreshAt: new Date(renewal.refreshAt)};
+  }
+  return {mode: 'on-rejection' as const};
 }
 
 function parseCheckoutConfig(step: Step): CheckoutConfig {

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -154,46 +154,7 @@ async function nextStepForJobExecutionInTransaction(
   const running = steps.find((step) => step.status === 'running');
   const hasRunningStep = running !== undefined;
   if (hasRunningStep) {
-    const session =
-      running.type === 'agent' ? readAgentStepSessionIntent(running.config) : undefined;
-    if (session !== undefined) {
-      const jobExecution = await getJobExecutionById(jobExecutionId, tx);
-      if (!jobExecution) throw new JobNotFoundError(jobExecutionId);
-
-      const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
-      const currentAttempt = attempts.find(
-        (attempt) => attempt.stepId === running.id && attempt.attempt === running.currentAttempt,
-      );
-      const stepAttemptId =
-        currentAttempt?.status === 'running'
-          ? currentAttempt.id
-          : await insertRunningStepAttempt(
-              {
-                jobExecutionId,
-                stepId: running.id,
-                attempt: running.currentAttempt,
-                config: running.config,
-                evaluationTrace: running.evaluationTrace,
-              },
-              tx,
-            );
-      const workflowContext = await getWorkflowContextForJob(jobExecution.jobId, tx);
-
-      return {
-        kind: 'session-claim',
-        jobExecutionId,
-        jobId: jobExecution.jobId,
-        stepId: running.id,
-        attempt: running.currentAttempt,
-        stepAttemptId,
-        session,
-        config: running.config,
-        evaluationTrace: currentAttempt?.evaluationTrace ?? running.evaluationTrace,
-        workflowContext,
-        agent,
-      };
-    }
-    return {kind: 'step', step: running, dispatched: false};
+    return resolveRunningStep(jobExecutionId, running, tx, agent);
   }
 
   const firstPending = steps.find((step) => step.status === 'pending');
@@ -218,6 +179,52 @@ async function nextStepForJobExecutionInTransaction(
     tx,
     agent,
   });
+}
+
+async function resolveRunningStep(
+  jobExecutionId: string,
+  running: Step,
+  tx: Tx,
+  agent?: AgentInterModuleClient | undefined,
+): Promise<NextStepResolution> {
+  const session = running.type === 'agent' ? readAgentStepSessionIntent(running.config) : undefined;
+  if (session === undefined) return {kind: 'step', step: running, dispatched: false};
+
+  const jobExecution = await getJobExecutionById(jobExecutionId, tx);
+  if (!jobExecution) throw new JobNotFoundError(jobExecutionId);
+
+  const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
+  const currentAttempt = attempts.find(
+    (attempt) => attempt.stepId === running.id && attempt.attempt === running.currentAttempt,
+  );
+  const stepAttemptId =
+    currentAttempt?.status === 'running'
+      ? currentAttempt.id
+      : await insertRunningStepAttempt(
+          {
+            jobExecutionId,
+            stepId: running.id,
+            attempt: running.currentAttempt,
+            config: running.config,
+            evaluationTrace: running.evaluationTrace,
+          },
+          tx,
+        );
+  const workflowContext = await getWorkflowContextForJob(jobExecution.jobId, tx);
+
+  return {
+    kind: 'session-claim',
+    jobExecutionId,
+    jobId: jobExecution.jobId,
+    stepId: running.id,
+    attempt: running.currentAttempt,
+    stepAttemptId,
+    session,
+    config: running.config,
+    evaluationTrace: currentAttempt?.evaluationTrace ?? running.evaluationTrace,
+    workflowContext,
+    agent,
+  };
 }
 
 async function resolveNextPendingStep({
@@ -907,72 +914,105 @@ async function recordStepResultInTransaction(
     tx,
   );
 
-  let result: ReportedStepResult = {
+  const {result, gateEvaluationAllowed} = normalizeReportedStepResult(params, target.config);
+  const transition = await decideReportedStepTransition({
+    jobId: jobExecution.jobId,
+    stepId: params.stepId,
+    steps,
+    target,
+    reportedAttempt: reported,
+    result,
+    gateEvaluationAllowed,
+    tx,
+  });
+
+  return applyStepTransition(
+    transition.decision,
+    {
+      jobId: jobExecution.jobId,
+      jobExecutionId,
+      result,
+      logOutcome: params.logOutcome ?? 'drained',
+      gateResult: transition.gateResult,
+    },
+    tx,
+  );
+}
+
+function normalizeReportedStepResult(
+  params: RecordStepResultParams,
+  config: Record<string, unknown>,
+): {result: ReportedStepResult; gateEvaluationAllowed: boolean} {
+  const reported: ReportedStepResult = {
     status: params.status,
     error: params.error ?? null,
     output: params.output ?? null,
     response: params.response ?? null,
     exitCode: params.exitCode ?? null,
   };
-  const outputCoercion = coerceReportedStepOutput(target.config, result);
+  const outputCoercion = coerceReportedStepOutput(config, reported);
   if (outputCoercion.kind === 'coerced') {
-    result = {...result, output: outputCoercion.output};
+    return {result: {...reported, output: outputCoercion.output}, gateEvaluationAllowed: true};
   }
   if (outputCoercion.kind === 'failed') {
-    result = {
-      status: 'failed',
-      error: outputInvalidError(outputCoercion.error),
-      output: null,
-      response: result.response,
-      exitCode: result.exitCode,
+    return {
+      result: {
+        status: 'failed',
+        error: outputInvalidError(outputCoercion.error),
+        output: null,
+        response: reported.response,
+        exitCode: reported.exitCode,
+      },
+      gateEvaluationAllowed: false,
     };
   }
+  return {result: reported, gateEvaluationAllowed: true};
+}
 
+async function decideReportedStepTransition(params: {
+  readonly jobId: string;
+  readonly stepId: string;
+  readonly steps: Step[];
+  readonly target: Step;
+  readonly reportedAttempt: number;
+  readonly result: ReportedStepResult;
+  readonly gateEvaluationAllowed: boolean;
+  readonly tx: Tx;
+}): Promise<{decision: StepTransitionDecision; gateResult: Record<string, unknown> | null}> {
   // Evaluate the gate (if any) at the service boundary. This is the only place
   // the CEL engine runs. Pass the precomputed outcome into the pure decision.
-  const shouldEvaluateGate = outputCoercion.kind !== 'failed';
-  const gate = shouldEvaluateGate ? readStepGate(target.config) : undefined;
+  const gate = params.gateEvaluationAllowed ? readStepGate(params.target.config) : undefined;
   const vars =
     gate === undefined
       ? undefined
-      : ((await getWorkflowContextForJob(jobExecution.jobId, tx)).vars ?? undefined);
-  const gateOutcome = shouldEvaluateGate
-    ? evaluateGate(gate, result, vars)
+      : ((await getWorkflowContextForJob(params.jobId, params.tx)).vars ?? undefined);
+  const gateOutcome = params.gateEvaluationAllowed
+    ? evaluateGate(gate, params.result, vars)
     : {kind: 'no-gate' as const};
-  const hasRestartPolicy = gate?.onFailure?.restartFrom !== undefined;
   // The restart cap is bounded on the gating step's OWN attempts, not its
   // current_attempt (which a rewind inflates for downstream steps).
-  const gatingAttemptCount = hasRestartPolicy
-    ? await countStepAttempts(params.stepId, tx)
+  const gatingAttemptCount = gate?.onFailure?.restartFrom
+    ? await countStepAttempts(params.stepId, params.tx)
     : undefined;
   const decision = decideStepTransition({
-    steps,
-    target,
-    reportedAttempt: reported,
-    result,
+    steps: params.steps,
+    target: params.target,
+    reportedAttempt: params.reportedAttempt,
+    result: params.result,
     gateOutcome,
     ...(gate?.onFailure ? {gateOnFailure: gate.onFailure} : {}),
     ...(gatingAttemptCount !== undefined ? {gatingAttemptCount} : {}),
   });
-  const resolvedDecision = resolveRestartFeedback({
-    decision,
-    gate,
-    result,
-    definitionId: jobExecution.jobId,
-    vars,
-  });
-
-  return applyStepTransition(
-    resolvedDecision,
-    {
-      jobId: jobExecution.jobId,
-      jobExecutionId,
-      result,
-      logOutcome: params.logOutcome ?? 'drained',
-      gateResult: gateResultPayload(gateOutcome, result.exitCode),
-    },
-    tx,
-  );
+  return {
+    decision: resolveRestartFeedback({
+      decision,
+      gate,
+      result: params.result,
+      definitionId: params.jobId,
+      vars,
+    }),
+    gateResult: gateResultPayload(gateOutcome, params.result.exitCode),
+  };
 }
 
 type OutputCoercionResult =

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -304,31 +304,39 @@ export function assembleListenerSnapshotContext(params: {
   readonly dependencyJobs: readonly JobContextInput[];
 }): WorkflowExpressionEvaluationContext {
   const context: Record<string, unknown> = {};
-  if (
-    params.plan.roots.has('workflow') ||
-    params.plan.roots.has('run') ||
-    params.plan.roots.has('trigger')
-  ) {
-    const runContext = assembleWorkflowRunContext(
-      {
-        run: params.run,
-        triggerPayload: params.triggerPayload,
-        inputs: params.inputs,
-        vars: params.vars,
-      },
-      {skipCelNativeRehydration: true},
-    );
-    if (params.plan.roots.has('workflow')) context.workflow = runContext.workflow;
-    if (params.plan.roots.has('run')) context.run = runContext.run;
-    if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
-  }
+  addListenerRunContext(context, params);
+  addListenerDirectContext(context, params);
 
-  if (params.plan.roots.has('inputs')) {
-    context.inputs = params.inputs ?? null;
+  return context;
+}
+
+function addListenerRunContext(
+  context: Record<string, unknown>,
+  params: Parameters<typeof assembleListenerSnapshotContext>[0],
+): void {
+  const runRoots = ['workflow', 'run', 'trigger'] as const;
+  if (!runRoots.some((root) => params.plan.roots.has(root))) return;
+
+  const runContext = assembleWorkflowRunContext(
+    {
+      run: params.run,
+      triggerPayload: params.triggerPayload,
+      inputs: params.inputs,
+      vars: params.vars,
+    },
+    {skipCelNativeRehydration: true},
+  );
+  for (const root of runRoots) {
+    if (params.plan.roots.has(root)) context[root] = runContext[root];
   }
-  if (params.plan.roots.has('vars')) {
-    context.vars = params.vars ?? {};
-  }
+}
+
+function addListenerDirectContext(
+  context: Record<string, unknown>,
+  params: Parameters<typeof assembleListenerSnapshotContext>[0],
+): void {
+  if (params.plan.roots.has('inputs')) context.inputs = params.inputs ?? null;
+  if (params.plan.roots.has('vars')) context.vars = params.vars ?? {};
   if (params.plan.roots.has('job')) {
     context.job = {
       key: params.job.key,
@@ -338,8 +346,6 @@ export function assembleListenerSnapshotContext(params: {
   if (params.plan.roots.has('jobs')) {
     context.jobs = requestedJobsContext(params.dependencyJobs, params.plan.jobKeys);
   }
-
-  return context;
 }
 
 function requestedJobsContext(

--- a/libs/api/workflows/src/core/step-config/tool.ts
+++ b/libs/api/workflows/src/core/step-config/tool.ts
@@ -92,65 +92,68 @@ function resolveWith(params: {
   definitionId: string;
 }): {readonly value: unknown; readonly plan?: WorkflowJsonTemplateTree} {
   if (params.tree === undefined) return {value: params.value};
-  if (isFieldTemplate(params.tree)) {
-    const resolved = resolveStepFieldWithType({
-      field: 'tool.with',
-      template: {segments: params.tree},
-      context: params.context,
-      definitionId: params.definitionId,
-      errorField: 'tool.with',
-    });
-    return resolved.kind === 'frozen'
-      ? {value: resolved.value}
-      : {value: undefined, plan: params.tree};
-  }
-  if (Array.isArray(params.tree)) {
-    const values = Array.isArray(params.value) ? [...params.value] : [];
-    const plans: (WorkflowJsonTemplateTree | undefined)[] = [];
-    let hasPlan = false;
-    params.tree.forEach((child, index) => {
-      if (child === undefined) return;
-      const resolved = resolveWith({
-        value: values[index],
-        tree: child,
-        context: params.context,
-        definitionId: params.definitionId,
-      });
-      values[index] = resolved.value;
-      plans[index] = resolved.plan;
-      hasPlan ||= resolved.plan !== undefined;
-    });
-    return {value: values, ...(hasPlan ? {plan: plans} : {})};
-  }
+  if (isFieldTemplate(params.tree)) return resolveWithField(params);
+  if (Array.isArray(params.tree)) return resolveWithArray(params);
   if (typeof params.tree === 'object' && params.tree !== null) {
-    const source =
-      params.value !== null && typeof params.value === 'object' && !Array.isArray(params.value)
-        ? (params.value as Record<string, unknown>)
-        : {};
-    const values: Record<string, unknown> = {...source};
-    const plans: Record<string, WorkflowJsonTemplateTree | undefined> = {};
-    let hasPlan = false;
-    for (const [key, child] of Object.entries(params.tree)) {
-      if (child === undefined) continue;
-      const resolved = resolveWith({
-        value: source[key],
-        tree: child,
-        context: params.context,
-        definitionId: params.definitionId,
-      });
-      if (resolved.value !== undefined) values[key] = resolved.value;
-      if (resolved.plan !== undefined) {
-        // A nested object/array can contain both frozen values and a residual
-        // field. Drop only an unresolved leaf; retaining a partially resolved
-        // container preserves its static siblings for dispatch-time merging.
-        if (resolved.value === undefined) delete values[key];
-        plans[key] = resolved.plan;
-        hasPlan = true;
-      }
-    }
-    return {value: values, ...(hasPlan ? {plan: plans} : {})};
+    return resolveWithObject(params);
   }
   throw new Error('Invalid tool input template tree');
+}
+
+type ResolveWithParams = Parameters<typeof resolveWith>[0];
+type ResolveWithResult = ReturnType<typeof resolveWith>;
+
+function resolveWithField(params: ResolveWithParams): ResolveWithResult {
+  const resolved = resolveStepFieldWithType({
+    field: 'tool.with',
+    template: {segments: params.tree as readonly ResolvedFieldSegment[]},
+    context: params.context,
+    definitionId: params.definitionId,
+    errorField: 'tool.with',
+  });
+  if (resolved.kind === 'frozen') return {value: resolved.value};
+  return {value: undefined, plan: params.tree};
+}
+
+function resolveWithArray(params: ResolveWithParams): ResolveWithResult {
+  const values = Array.isArray(params.value) ? [...params.value] : [];
+  const plans: (WorkflowJsonTemplateTree | undefined)[] = [];
+  let hasPlan = false;
+  (params.tree as readonly (WorkflowJsonTemplateTree | undefined)[]).forEach((child, index) => {
+    if (child === undefined) return;
+    const resolved = resolveWith({...params, value: values[index], tree: child});
+    values[index] = resolved.value;
+    plans[index] = resolved.plan;
+    hasPlan ||= resolved.plan !== undefined;
+  });
+  return {value: values, ...(hasPlan ? {plan: plans} : {})};
+}
+
+function resolveWithObject(params: ResolveWithParams): ResolveWithResult {
+  const source = objectWithValue(params.value);
+  const values: Record<string, unknown> = {...source};
+  const plans: Record<string, WorkflowJsonTemplateTree | undefined> = {};
+  let hasPlan = false;
+  for (const [key, child] of Object.entries(
+    params.tree as Record<string, WorkflowJsonTemplateTree>,
+  )) {
+    if (child === undefined) continue;
+    const resolved = resolveWith({...params, value: source[key], tree: child});
+    if (resolved.value !== undefined) values[key] = resolved.value;
+    if (resolved.plan === undefined) continue;
+    // A nested object/array can contain both frozen values and a residual
+    // field. Drop only an unresolved leaf; retaining a partially resolved
+    // container preserves its static siblings for dispatch-time merging.
+    if (resolved.value === undefined) delete values[key];
+    plans[key] = resolved.plan;
+    hasPlan = true;
+  }
+  return {value: values, ...(hasPlan ? {plan: plans} : {})};
+}
+
+function objectWithValue(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
 }
 
 function isFieldTemplate(

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
@@ -39,6 +39,16 @@ export interface ApplyStepTransitionContext {
   gateResult?: Record<string, unknown> | null;
 }
 
+type SuccessfulStepDecision = Extract<
+  StepTransitionDecision,
+  {kind: 'complete-step' | 'complete-job'}
+>;
+type FailedStepDecision = Extract<
+  StepTransitionDecision,
+  {kind: 'fail-job' | 'fail-job-restart-exhausted'}
+>;
+type RestartStepDecision = Extract<StepTransitionDecision, {kind: 'restart-job-from-step'}>;
+
 // Durable side of the decision: writes the attempt + projection for a transition,
 // then derives job completion from the post-apply projection and enqueues the
 // completion event in the same transaction. Only called for a running target, so
@@ -52,98 +62,129 @@ export async function applyStepTransition(
   switch (decision.kind) {
     case 'complete-step':
     case 'complete-job': {
-      // A passing gate makes a step succeed even if the raw command status was
-      // 'failed', so the projection error is cleared regardless of the report.
-      await finishStepAttempt(
-        {
-          stepId: decision.stepId,
-          attempt: decision.attempt,
-          status: 'succeeded',
-          output: ctx.result.output ?? null,
-          response: ctx.result.response ?? null,
-          exitCode: ctx.result.exitCode ?? null,
-          logOutcome: ctx.logOutcome,
-          gateResult: ctx.gateResult ?? null,
-        },
-        tx,
-      );
-      await applyStepResult(
-        {
-          jobExecutionId: ctx.jobExecutionId,
-          stepId: decision.stepId,
-          status: 'succeeded',
-          error: null,
-        },
-        tx,
-      );
+      await applySuccessfulStepTransition(decision, ctx, tx);
       break;
     }
     case 'fail-job':
     case 'fail-job-restart-exhausted': {
-      await finishStepAttempt(
-        {
-          stepId: decision.failedStepId,
-          attempt: decision.attempt,
-          status: 'failed',
-          output: ctx.result.output ?? null,
-          response: ctx.result.response ?? null,
-          error: decision.failureError,
-          exitCode: ctx.result.exitCode ?? null,
-          logOutcome: ctx.logOutcome,
-          gateResult: ctx.gateResult ?? null,
-        },
-        tx,
-      );
-      const status = await settleJobFailed(tx, {
-        jobId: ctx.jobId,
-        jobExecutionId: ctx.jobExecutionId,
-        failedStepId: decision.failedStepId,
-        error: decision.failureError ?? {message: 'Step failed'},
-      });
-      if (status !== null) {
-        return {
-          outcome: {jobFinished: true, status},
-          metrics: {jobStepsSettledStatus: status},
-        };
-      }
-      return {outcome: {jobFinished: false}, metrics: {}};
+      return applyFailedStepTransition(decision, ctx, tx);
     }
     case 'restart-job-from-step': {
-      // Record the failed attempt FIRST (audit, with the restart feedback), then
-      // rewind the projection from restart_from so the prior result is preserved
-      // only in the attempt history. All in one transaction with the report.
-      await finishStepAttempt(
-        {
-          stepId: decision.failedStepId,
-          attempt: decision.attempt,
-          status: 'failed',
-          output: ctx.result.output ?? null,
-          response: ctx.result.response ?? null,
-          error: decision.failureError,
-          exitCode: ctx.result.exitCode ?? null,
-          logOutcome: ctx.logOutcome,
-          gateResult: ctx.gateResult ?? null,
-          restartFeedback: decision.feedback,
-        },
-        tx,
-      );
-      await rewindStepsToPending(
-        {jobExecutionId: ctx.jobExecutionId, fromPosition: decision.restartFromPosition},
-        tx,
-      );
-      await writeStepRestartEnqueuedOutbox(tx, {
-        jobId: ctx.jobId,
-        failedStepId: decision.failedStepId,
-        failedStepAttempt: decision.attempt,
-        restartFromStepId: decision.restartFromStepId,
-        feedback: decision.feedback,
-      });
-      // The job stays running; the next pull re-dispatches restart_from. Do not
-      // derive completion or emit a completion event.
-      return {outcome: {jobFinished: false}, metrics: {stepRestartEnqueued: true}};
+      return applyRestartStepTransition(decision, ctx, tx);
     }
   }
 
+  return settleCompletedStepTransition(ctx, tx);
+}
+
+async function applySuccessfulStepTransition(
+  decision: SuccessfulStepDecision,
+  ctx: ApplyStepTransitionContext,
+  tx: Tx,
+): Promise<void> {
+  // A passing gate makes a step succeed even if the raw command status was
+  // 'failed', so the projection error is cleared regardless of the report.
+  await finishStepAttempt(
+    {
+      stepId: decision.stepId,
+      attempt: decision.attempt,
+      status: 'succeeded',
+      output: ctx.result.output ?? null,
+      response: ctx.result.response ?? null,
+      exitCode: ctx.result.exitCode ?? null,
+      logOutcome: ctx.logOutcome,
+      gateResult: ctx.gateResult ?? null,
+    },
+    tx,
+  );
+  await applyStepResult(
+    {
+      jobExecutionId: ctx.jobExecutionId,
+      stepId: decision.stepId,
+      status: 'succeeded',
+      error: null,
+    },
+    tx,
+  );
+}
+
+async function applyFailedStepTransition(
+  decision: FailedStepDecision,
+  ctx: ApplyStepTransitionContext,
+  tx: Tx,
+): Promise<StepProgressionResult> {
+  await finishStepAttempt(
+    {
+      stepId: decision.failedStepId,
+      attempt: decision.attempt,
+      status: 'failed',
+      output: ctx.result.output ?? null,
+      response: ctx.result.response ?? null,
+      error: decision.failureError,
+      exitCode: ctx.result.exitCode ?? null,
+      logOutcome: ctx.logOutcome,
+      gateResult: ctx.gateResult ?? null,
+    },
+    tx,
+  );
+  const status = await settleJobFailed(tx, {
+    jobId: ctx.jobId,
+    jobExecutionId: ctx.jobExecutionId,
+    failedStepId: decision.failedStepId,
+    error: decision.failureError ?? {message: 'Step failed'},
+  });
+  if (status !== null) {
+    return {
+      outcome: {jobFinished: true, status},
+      metrics: {jobStepsSettledStatus: status},
+    };
+  }
+  return {outcome: {jobFinished: false}, metrics: {}};
+}
+
+async function applyRestartStepTransition(
+  decision: RestartStepDecision,
+  ctx: ApplyStepTransitionContext,
+  tx: Tx,
+): Promise<StepProgressionResult> {
+  // Record the failed attempt FIRST (audit, with the restart feedback), then
+  // rewind the projection from restart_from so the prior result is preserved
+  // only in the attempt history. All in one transaction with the report.
+  await finishStepAttempt(
+    {
+      stepId: decision.failedStepId,
+      attempt: decision.attempt,
+      status: 'failed',
+      output: ctx.result.output ?? null,
+      response: ctx.result.response ?? null,
+      error: decision.failureError,
+      exitCode: ctx.result.exitCode ?? null,
+      logOutcome: ctx.logOutcome,
+      gateResult: ctx.gateResult ?? null,
+      restartFeedback: decision.feedback,
+    },
+    tx,
+  );
+  await rewindStepsToPending(
+    {jobExecutionId: ctx.jobExecutionId, fromPosition: decision.restartFromPosition},
+    tx,
+  );
+  await writeStepRestartEnqueuedOutbox(tx, {
+    jobId: ctx.jobId,
+    failedStepId: decision.failedStepId,
+    failedStepAttempt: decision.attempt,
+    restartFromStepId: decision.restartFromStepId,
+    feedback: decision.feedback,
+  });
+  // The job stays running; the next pull re-dispatches restart_from. Do not
+  // derive completion or emit a completion event.
+  return {outcome: {jobFinished: false}, metrics: {stepRestartEnqueued: true}};
+}
+
+async function settleCompletedStepTransition(
+  ctx: ApplyStepTransitionContext,
+  tx: Tx,
+): Promise<StepProgressionResult> {
   // Re-derive completion from the post-apply projection and emit the
   // steps-settled signal exactly once, here on the applied path.
   const after = await getStepsByJobExecutionIdForUpdate(ctx.jobExecutionId, tx);

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -134,7 +134,7 @@ export function decideStepTransition(input: DecideStepTransitionInput): StepTran
 
   // 1. Did the step pass? The gate (when present and checkable) is authoritative
   //    over the raw command status.
-  if (gate.kind === 'no-gate' ? result.status === 'succeeded' : gate.kind === 'passed') {
+  if (stepReportPassed(gate, result)) {
     return succeed(target, reportedAttempt, steps);
   }
 
@@ -142,59 +142,73 @@ export function decideStepTransition(input: DecideStepTransitionInput): StepTran
   //    `uncheckable` (no exit code / eval error) is a plain command failure that
   //    never restarts.
   const uncheckable = gate.kind === 'uncheckable';
-  const failureError: Record<string, unknown> | null =
-    gate.kind === 'failed'
-      ? {kind: 'gate_failed', message: 'gate condition not met', source: gate.source}
-      : gate.kind === 'uncheckable'
-        ? (result.error ?? {kind: 'gate_uncheckable', message: gate.reason})
-        : (result.error ?? null);
+  const failureError = stepFailureError(gate, result);
 
   // 3. Restart when a policy is configured and the failure is checkable.
   if (gateOnFailure?.restartFrom && !uncheckable) {
-    // Exclude the synthetic setup step: a user step legitimately named "Set up job"
-    // would otherwise resolve to position 0 and rewind setup (deleting the workspace
-    // mid-job). Duplicate user-step names are already impossible (normalize rejects
-    // them with duplicate-step-id), so this is the only collision to guard.
-    const restartStep = steps.find(
-      (step) =>
-        step.type !== 'setup' &&
-        step.position < target.position &&
-        step.key === gateOnFailure.restartFrom,
-    );
-    if (!restartStep) {
-      // The model validates restart_from to an earlier named step, but fail closed
-      // if it can't be resolved at runtime rather than silently restarting wrong.
-      return fail(target, reportedAttempt, {
-        kind: 'restart_unresolved',
-        message: `could not resolve restart_from "${gateOnFailure.restartFrom}"`,
-        restart_from: gateOnFailure.restartFrom,
-      });
-    }
-    const gatingAttemptCount = input.gatingAttemptCount ?? reportedAttempt;
-    if (gatingAttemptCount >= maxAttempts) {
-      return {
-        kind: 'fail-job-restart-exhausted',
-        failedStepId: target.id,
-        attempt: reportedAttempt,
-        maxAttempts,
-        failureError: {
-          kind: 'restart_exhausted',
-          maxAttempts,
-          restart_from: gateOnFailure.restartFrom,
-        },
-      };
-    }
-    return {
-      kind: 'restart-job-from-step',
-      failedStepId: target.id,
-      restartFromStepId: restartStep.id,
-      restartFromPosition: restartStep.position,
-      attempt: reportedAttempt,
-      feedback: input.restartFeedback ?? gateOnFailure.feedback ?? 'gate condition not met',
-      failureError,
-    };
+    return restartStepTransition(input, gateOnFailure, failureError, maxAttempts);
   }
 
   // 4. No restart → plain fail-and-cancel.
   return fail(target, reportedAttempt, failureError);
+}
+
+function stepReportPassed(gate: GateOutcome, result: StepReport): boolean {
+  if (gate.kind === 'no-gate') return result.status === 'succeeded';
+  return gate.kind === 'passed';
+}
+
+function stepFailureError(gate: GateOutcome, result: StepReport): Record<string, unknown> | null {
+  if (gate.kind === 'failed') {
+    return {kind: 'gate_failed', message: 'gate condition not met', source: gate.source};
+  }
+  if (gate.kind === 'uncheckable') {
+    return result.error ?? {kind: 'gate_uncheckable', message: gate.reason};
+  }
+  return result.error ?? null;
+}
+
+function restartStepTransition(
+  input: DecideStepTransitionInput,
+  gateOnFailure: NonNullable<DecideStepTransitionInput['gateOnFailure']>,
+  failureError: Record<string, unknown> | null,
+  maxAttempts: number,
+): StepTransitionDecision {
+  const {steps, target, reportedAttempt} = input;
+  const restartStep = steps.find(
+    (step) =>
+      step.type !== 'setup' &&
+      step.position < target.position &&
+      step.key === gateOnFailure.restartFrom,
+  );
+  if (!restartStep) {
+    return fail(target, reportedAttempt, {
+      kind: 'restart_unresolved',
+      message: `could not resolve restart_from "${gateOnFailure.restartFrom}"`,
+      restart_from: gateOnFailure.restartFrom,
+    });
+  }
+  const gatingAttemptCount = input.gatingAttemptCount ?? reportedAttempt;
+  if (gatingAttemptCount >= maxAttempts) {
+    return {
+      kind: 'fail-job-restart-exhausted',
+      failedStepId: target.id,
+      attempt: reportedAttempt,
+      maxAttempts,
+      failureError: {
+        kind: 'restart_exhausted',
+        maxAttempts,
+        restart_from: gateOnFailure.restartFrom,
+      },
+    };
+  }
+  return {
+    kind: 'restart-job-from-step',
+    failedStepId: target.id,
+    restartFromStepId: restartStep.id,
+    restartFromPosition: restartStep.position,
+    attempt: reportedAttempt,
+    feedback: input.restartFeedback ?? gateOnFailure.feedback ?? 'gate condition not met',
+    failureError,
+  };
 }

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -28,37 +28,41 @@ export function readStepGate(config: Record<string, unknown>): StepGate | undefi
   if (!gate || typeof gate !== 'object') return undefined;
   const raw = gate as Record<string, unknown>;
 
-  const successRaw = raw.success as Record<string, unknown> | undefined;
-  const success =
-    successRaw && typeof successRaw.source === 'string'
-      ? // The model validated this expression before materialization; the stored
-        // JSON is structurally a WorkflowExpression.
-        (successRaw as unknown as WorkflowExpression)
-      : undefined;
-
-  const onFailureRaw = raw.on_failure as Record<string, unknown> | undefined;
-  const feedbackTemplateRaw = onFailureRaw?.feedback_template as
-    | Record<string, unknown>
-    | undefined;
-  const feedbackTemplate =
-    Array.isArray(feedbackTemplateRaw?.segments) &&
-    feedbackTemplateRaw.segments.every((segment) => typeof segment === 'object' && segment !== null)
-      ? (feedbackTemplateRaw as unknown as ResolvedField)
-      : undefined;
-  const onFailure =
-    onFailureRaw && typeof onFailureRaw.restart_from === 'string'
-      ? {
-          restartFrom: onFailureRaw.restart_from,
-          ...(typeof onFailureRaw.feedback === 'string' ? {feedback: onFailureRaw.feedback} : {}),
-          ...(feedbackTemplate === undefined ? {} : {feedbackTemplate}),
-        }
-      : undefined;
+  const success = readGateSuccess(raw.success);
+  const onFailure = readGateOnFailure(raw.on_failure);
 
   if (!success && !onFailure) return undefined;
   return {
     ...(success ? {success} : {}),
     ...(onFailure ? {onFailure} : {}),
   };
+}
+
+function readGateSuccess(value: unknown): WorkflowExpression | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  if (typeof (value as Record<string, unknown>).source !== 'string') return undefined;
+  return value as WorkflowExpression;
+}
+
+function readGateOnFailure(value: unknown): StepGate['onFailure'] {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.restart_from !== 'string') return undefined;
+  const feedbackTemplate = readGateFeedbackTemplate(raw.feedback_template);
+  return {
+    restartFrom: raw.restart_from,
+    ...(typeof raw.feedback === 'string' ? {feedback: raw.feedback} : {}),
+    ...(feedbackTemplate === undefined ? {} : {feedbackTemplate}),
+  };
+}
+
+function readGateFeedbackTemplate(value: unknown): ResolvedField | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const segments = (value as Record<string, unknown>).segments;
+  if (!Array.isArray(segments)) return undefined;
+  if (!segments.every((segment) => typeof segment === 'object' && segment !== null))
+    return undefined;
+  return value as ResolvedField;
 }
 
 /**

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -84,22 +84,10 @@ export async function activateJobListener(
   params: ActivateJobListenerParams,
 ): Promise<ActivateJobListenerResult> {
   return await db().transaction(async (tx) => {
-    const [target] = await tx
-      .select({job: jobs, attempt: workflowRunAttempts, run: workflowRuns})
-      .from(jobs)
-      .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
-      .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
-      .where(eq(jobs.id, params.jobId))
-      .limit(1)
-      .for('update');
-    if (!target) throw new Error(`Job not found: ${params.jobId}`);
+    const target = await loadListenerActivationTarget(params.jobId, tx);
+    const executionCount = await countJobExecutions(params.jobId, tx);
 
-    const [{value: executionCount} = {value: 0}] = await tx
-      .select({value: count()})
-      .from(jobExecutions)
-      .where(eq(jobExecutions.jobId, params.jobId));
-
-    if (['succeeded', 'failed', 'cancelled', 'skipped'].includes(target.job.status)) {
+    if (isJobTerminal(target.job.status)) {
       return {
         status: 'terminal',
         jobStatus: target.job.status,
@@ -108,25 +96,7 @@ export async function activateJobListener(
       };
     }
 
-    let job = toJob(target.job);
-    if (target.job.status === 'pending') {
-      const updated = await updateJobStatusAtVersion(tx, {
-        jobId: params.jobId,
-        status: 'running',
-        expectedVersion: params.expectedVersion,
-      });
-      if (!updated) {
-        const [existing] = await tx.select().from(jobs).where(eq(jobs.id, params.jobId)).limit(1);
-        if (existing?.status !== 'running') {
-          throw new Error(
-            `Optimistic lock failure activating listener job ${params.jobId} version ${params.expectedVersion}`,
-          );
-        }
-        job = toJob(existing);
-      } else {
-        job = updated.job;
-      }
-    }
+    const job = await activatePendingListenerJob(target.job, params, tx);
 
     const listenerRows = await tx
       .update(jobs)
@@ -134,52 +104,98 @@ export async function activateJobListener(
       .where(and(eq(jobs.id, params.jobId), eq(jobs.listenerStatus, 'inactive')))
       .returning();
 
-    if (listenerRows[0]) {
-      const matchers = {
-        on: target.job.listeningOn ?? [],
-        until: target.job.listeningUntil ?? null,
-      };
-      const snapshotPlan = planListenerFilterSnapshots(matchers);
-      const dependencyJobs =
-        snapshotPlan.jobKeys.size === 0
-          ? []
-          : await getDirectDependencyJobContexts(params.jobId, tx);
-      const snapshotContext = assembleListenerSnapshotContext({
-        job: toJob(target.job),
-        run: toWorkflowRun(target.run),
-        triggerPayload: target.run.triggerPayload,
-        inputs: target.run.inputs,
-        vars: target.attempt.vars ?? undefined,
-        plan: snapshotPlan,
-        dependencyJobs,
-      });
-      const listenerOutputTypes = listenerFilterOutputTypesForJobs(dependencyJobs);
-
-      await writeWorkflowsOutboxEvent(tx, {
-        type: WORKFLOWS_JOB_ACTIVATED,
-        payload: {
-          jobId: params.jobId,
-          workflowRunId: target.run.id,
-          workspaceId: target.run.workspaceId,
-          mode: 'listening',
-          on: applyActivatedListenerFilterSnapshots(
-            snapshotPlan.on,
-            snapshotContext,
-            listenerOutputTypes,
-          ),
-          until:
-            matchers.until === null
-              ? null
-              : applyActivatedListenerFilterSnapshots(
-                  snapshotPlan.until,
-                  snapshotContext,
-                  listenerOutputTypes,
-                ),
-        },
-      });
-    }
+    if (listenerRows[0]) await writeListenerActivatedEvent(target, params.jobId, tx);
 
     return {status: 'running', jobStatus: job.status, jobVersion: job.version, executionCount};
+  });
+}
+
+async function loadListenerActivationTarget(jobId: string, tx: Tx) {
+  const [target] = await tx
+    .select({job: jobs, attempt: workflowRunAttempts, run: workflowRuns})
+    .from(jobs)
+    .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
+    .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
+    .where(eq(jobs.id, jobId))
+    .limit(1)
+    .for('update');
+  if (!target) throw new Error(`Job not found: ${jobId}`);
+  return target;
+}
+
+async function countJobExecutions(jobId: string, tx: Tx): Promise<number> {
+  const [{value} = {value: 0}] = await tx
+    .select({value: count()})
+    .from(jobExecutions)
+    .where(eq(jobExecutions.jobId, jobId));
+  return value;
+}
+
+async function activatePendingListenerJob(
+  row: typeof jobs.$inferSelect,
+  params: ActivateJobListenerParams,
+  tx: Tx,
+) {
+  if (row.status !== 'pending') return toJob(row);
+
+  const updated = await updateJobStatusAtVersion(tx, {
+    jobId: params.jobId,
+    status: 'running',
+    expectedVersion: params.expectedVersion,
+  });
+  if (updated) return updated.job;
+
+  const [existing] = await tx.select().from(jobs).where(eq(jobs.id, params.jobId)).limit(1);
+  if (existing?.status === 'running') return toJob(existing);
+  throw new Error(
+    `Optimistic lock failure activating listener job ${params.jobId} version ${params.expectedVersion}`,
+  );
+}
+
+async function writeListenerActivatedEvent(
+  target: Awaited<ReturnType<typeof loadListenerActivationTarget>>,
+  jobId: string,
+  tx: Tx,
+): Promise<void> {
+  const matchers = {
+    on: target.job.listeningOn ?? [],
+    until: target.job.listeningUntil ?? null,
+  };
+  const snapshotPlan = planListenerFilterSnapshots(matchers);
+  const dependencyJobs =
+    snapshotPlan.jobKeys.size === 0 ? [] : await getDirectDependencyJobContexts(jobId, tx);
+  const snapshotContext = assembleListenerSnapshotContext({
+    job: toJob(target.job),
+    run: toWorkflowRun(target.run),
+    triggerPayload: target.run.triggerPayload,
+    inputs: target.run.inputs,
+    vars: target.attempt.vars ?? undefined,
+    plan: snapshotPlan,
+    dependencyJobs,
+  });
+  const listenerOutputTypes = listenerFilterOutputTypesForJobs(dependencyJobs);
+
+  await writeWorkflowsOutboxEvent(tx, {
+    type: WORKFLOWS_JOB_ACTIVATED,
+    payload: {
+      jobId,
+      workflowRunId: target.run.id,
+      workspaceId: target.run.workspaceId,
+      mode: 'listening',
+      on: applyActivatedListenerFilterSnapshots(
+        snapshotPlan.on,
+        snapshotContext,
+        listenerOutputTypes,
+      ),
+      until:
+        matchers.until === null
+          ? null
+          : applyActivatedListenerFilterSnapshots(
+              snapshotPlan.until,
+              snapshotContext,
+              listenerOutputTypes,
+            ),
+    },
   });
 }
 

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -176,93 +176,7 @@ export async function evaluateJobActivations(
 ): Promise<JobActivationDecision[]> {
   if (params.jobs.length === 0) return [];
 
-  const result = await db().transaction(async (tx) => {
-    const expectedVersions = new Map(
-      params.jobs.map((job) => [job.jobId, job.expectedVersion] as const),
-    );
-    const jobIds = params.jobs.map((job) => job.jobId);
-    const targets = await tx
-      .select({job: jobs, attempt: workflowRunAttempts, run: workflowRuns})
-      .from(jobs)
-      .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
-      .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
-      .where(and(eq(jobs.workflowRunAttemptId, params.runAttemptId), inArray(jobs.id, jobIds)))
-      .for('update');
-
-    if (targets.length !== jobIds.length) {
-      const found = new Set(targets.map((target) => target.job.id));
-      const missing = jobIds.filter((jobId) => !found.has(jobId));
-      throw new Error(`Cannot evaluate missing activation jobs: ${missing.join(', ')}`);
-    }
-
-    const contextsByJobKey = await directDependencyContextsByJobKey(
-      tx,
-      params.runAttemptId,
-      targets.map((target) => toJob(target.job)),
-    );
-    const targetsByJobId = new Map(targets.map((target) => [target.job.id, target]));
-    const decisions: InternalJobActivationDecision[] = [];
-
-    for (const input of params.jobs) {
-      const target = targetsByJobId.get(input.jobId);
-      if (!target) throw new Error(`Cannot evaluate missing activation job: ${input.jobId}`);
-      const job = toJob(target.job);
-      const model =
-        target.attempt.model === null ? null : readPersistedWorkflowModel(target.attempt.model);
-      const modelJob = model?.jobs.find((item) => item.key === target.job.key);
-      const decision = decideJobActivation({
-        run: toWorkflowRun(target.run),
-        job,
-        condition: modelJob?.if,
-        vars: target.attempt.vars ?? undefined,
-        dependencies: job.dependencies.flatMap((key) => {
-          const dependency = contextsByJobKey.get(key);
-          return dependency === undefined ? [] : [dependency];
-        }),
-      });
-
-      if (decision.kind === 'terminal-job' || decision.kind === 'start-job') {
-        decisions.push(decision);
-        continue;
-      }
-
-      const expectedVersion = expectedVersions.get(job.id);
-      if (expectedVersion === undefined) {
-        throw new Error(`Missing expected version for activation job ${job.id}`);
-      }
-      const updated = await updateJobStatusAtVersion(tx, {
-        jobId: job.id,
-        status: decision.status,
-        expectedVersion,
-        statusReason: decision.statusReason,
-        evaluationTrace: decision.evaluationTrace,
-      });
-      if (updated) {
-        decisions.push({
-          kind: 'terminal-job',
-          jobId: job.id,
-          status: 'skipped',
-          jobVersion: updated.job.version,
-          changed: updated.changed,
-        });
-        continue;
-      }
-
-      const [existing] = await tx.select().from(jobs).where(eq(jobs.id, job.id)).limit(1);
-      if (existing && isJobTerminal(existing.status)) {
-        decisions.push({
-          kind: 'terminal-job',
-          jobId: job.id,
-          status: runtimeCompletionStatusForJob(existing.status),
-          jobVersion: existing.version,
-        });
-        continue;
-      }
-      throw new Error(`Optimistic lock failure evaluating activation for job ${job.id}`);
-    }
-
-    return decisions;
-  });
+  const result = await db().transaction((tx) => evaluateJobActivationsInTransaction(params, tx));
 
   for (const decision of result) {
     if (decision.kind === 'terminal-job' && decision.changed) {
@@ -271,6 +185,104 @@ export async function evaluateJobActivations(
   }
 
   return result.map(({changed: _changed, ...decision}) => decision);
+}
+
+async function evaluateJobActivationsInTransaction(
+  params: EvaluateJobActivationsParams,
+  tx: Tx,
+): Promise<InternalJobActivationDecision[]> {
+  const jobIds = params.jobs.map((job) => job.jobId);
+  const targets = await loadJobActivationTargets(params.runAttemptId, jobIds, tx);
+  assertAllActivationTargetsFound(targets, jobIds);
+
+  const contextsByJobKey = await directDependencyContextsByJobKey(
+    tx,
+    params.runAttemptId,
+    targets.map((target) => toJob(target.job)),
+  );
+  const targetsByJobId = new Map(targets.map((target) => [target.job.id, target]));
+  const decisions: InternalJobActivationDecision[] = [];
+
+  for (const input of params.jobs) {
+    const target = targetsByJobId.get(input.jobId);
+    if (!target) throw new Error(`Cannot evaluate missing activation job: ${input.jobId}`);
+    decisions.push(
+      await evaluateJobActivationTarget(target, input.expectedVersion, contextsByJobKey, tx),
+    );
+  }
+  return decisions;
+}
+
+async function loadJobActivationTargets(runAttemptId: string, jobIds: string[], tx: Tx) {
+  return await tx
+    .select({job: jobs, attempt: workflowRunAttempts, run: workflowRuns})
+    .from(jobs)
+    .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
+    .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
+    .where(and(eq(jobs.workflowRunAttemptId, runAttemptId), inArray(jobs.id, jobIds)))
+    .for('update');
+}
+
+function assertAllActivationTargetsFound(
+  targets: Awaited<ReturnType<typeof loadJobActivationTargets>>,
+  jobIds: string[],
+): void {
+  if (targets.length === jobIds.length) return;
+  const found = new Set(targets.map((target) => target.job.id));
+  const missing = jobIds.filter((jobId) => !found.has(jobId));
+  throw new Error(`Cannot evaluate missing activation jobs: ${missing.join(', ')}`);
+}
+
+async function evaluateJobActivationTarget(
+  target: Awaited<ReturnType<typeof loadJobActivationTargets>>[number],
+  expectedVersion: number,
+  contextsByJobKey: ReadonlyMap<string, JobContextInput>,
+  tx: Tx,
+): Promise<InternalJobActivationDecision> {
+  const job = toJob(target.job);
+  const model =
+    target.attempt.model === null ? null : readPersistedWorkflowModel(target.attempt.model);
+  const modelJob = model?.jobs.find((item) => item.key === target.job.key);
+  const decision = decideJobActivation({
+    run: toWorkflowRun(target.run),
+    job,
+    condition: modelJob?.if,
+    vars: target.attempt.vars ?? undefined,
+    dependencies: job.dependencies.flatMap((key) => {
+      const dependency = contextsByJobKey.get(key);
+      return dependency === undefined ? [] : [dependency];
+    }),
+  });
+
+  if (decision.kind === 'terminal-job' || decision.kind === 'start-job') return decision;
+
+  const updated = await updateJobStatusAtVersion(tx, {
+    jobId: job.id,
+    status: decision.status,
+    expectedVersion,
+    statusReason: decision.statusReason,
+    evaluationTrace: decision.evaluationTrace,
+  });
+  if (updated) {
+    return {
+      kind: 'terminal-job',
+      jobId: job.id,
+      status: 'skipped',
+      jobVersion: updated.job.version,
+      changed: updated.changed,
+    };
+  }
+
+  const [existing] = await tx.select().from(jobs).where(eq(jobs.id, job.id)).limit(1);
+  if (existing && isJobTerminal(existing.status)) {
+    return {
+      kind: 'terminal-job',
+      jobId: job.id,
+      status: runtimeCompletionStatusForJob(existing.status),
+      jobVersion: existing.version,
+    };
+  }
+  throw new Error(`Optimistic lock failure evaluating activation for job ${job.id}`);
 }
 
 async function directDependencyContextsByJobKey(

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -98,163 +98,12 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     model: params.model,
     context: agentToolContext,
   });
-  const result = await db().transaction(async (tx) => {
-    // Serialize idempotent trigger resolution separately from per-definition number
-    // allocation so a replay never consumes a number, including when two deliveries
-    // race before either run is visible.
-    if (params.triggerIdempotencyKey) {
-      await tx.execute(
-        sql`select pg_advisory_xact_lock(hashtext(${params.triggerIdempotencyKey}))`,
-      );
-      const existing = await tx
-        .select()
-        .from(workflowRuns)
-        .where(eq(workflowRuns.triggerIdempotencyKey, params.triggerIdempotencyKey))
-        .limit(1);
-      const existingRow = existing[0];
-      if (existingRow) return {run: toWorkflowRun(existingRow), created: false};
-    }
-
-    // Keep allocation on the existing transaction so a trigger burst cannot pin
-    // every pool connection and then wait for a second connection per run.
-    const number = await allocateWorkflowRunNumber(tx, params.definitionId);
-
-    const insertResult = await tx
-      .insert(workflowRuns)
-      .values({
-        workspaceId: params.workspaceId,
-        projectId: params.projectId,
-        definitionId: params.definitionId,
-        number,
-        name: null,
-        workflowName: staticName,
-        status: 'pending',
-        currentAttempt: 1,
-        triggerProvider: params.triggerPayload.provider ?? null,
-        triggerSource: params.triggerPayload.source,
-        triggerEvent: params.triggerPayload.event,
-        triggerPayload: params.triggerPayload,
-        triggerReference,
-        inputs: params.inputs ?? null,
-        sourceSnapshot: params.sourceSnapshot ?? null,
-        triggerIdempotencyKey: params.triggerIdempotencyKey ?? null,
-        origin: params.origin ?? 'synced',
-        devSource:
-          params.devSource === undefined || params.devSource === null
-            ? null
-            : toWorkflowRunDevSourceDb(params.devSource),
-      })
-      .onConflictDoNothing({target: workflowRuns.triggerIdempotencyKey})
-      .returning();
-
-    const runRow = insertResult[0];
-    if (!runRow) {
-      // Conflict path: skip jobs/steps/outbox so the first insert keeps ownership of side effects.
-      if (!params.triggerIdempotencyKey) {
-        throw new Error('Insert returned no rows');
-      }
-      const existing = await tx
-        .select()
-        .from(workflowRuns)
-        .where(eq(workflowRuns.triggerIdempotencyKey, params.triggerIdempotencyKey))
-        .limit(1);
-      const existingRow = existing[0];
-      if (!existingRow) {
-        throw new Error(
-          `Idempotency conflict but existing run missing for key ${params.triggerIdempotencyKey}`,
-        );
-      }
-      return {run: toWorkflowRun(existingRow), created: false};
-    }
-
-    // Resolving run-creation templates and predicates here gives them a stable variable snapshot
-    // and interpolation access to the inserted run id. Run-name resolution is display-only and
-    // persists only a resolved override. If resolution fails, the transaction rolls back the run,
-    // jobs, steps, and outbox event together. Listening steps are resolved later when a job
-    // execution is created.
-    const provisionalRun = toWorkflowRun(runRow);
-    const oneShotJobs = params.model.jobs.filter((job) => job.mode !== 'listening');
-    const vars = await loadReferencedVariables({
-      model: params.model,
-      jobs: oneShotJobs,
-      workspaceId: params.workspaceId,
-      projectId: params.projectId,
-      definitionId: params.definitionId,
-      secrets: params.secrets,
-    });
-    const runNameResolution = resolveWorkflowRunName({
-      runName: params.model.runName,
-      context: assembleCreationContext({
-        run: provisionalRun,
-        triggerPayload: params.triggerPayload,
-        inputs: params.inputs ?? null,
-        vars,
-      }).values,
-    });
-    const [resolvedRunRow] = await tx
-      .update(workflowRuns)
-      .set({name: runNameResolution.value, updatedAt: new Date()})
-      .where(eq(workflowRuns.id, provisionalRun.id))
-      .returning();
-    if (!resolvedRunRow)
-      throw new Error(`Workflow run missing after name resolution: ${runRow.id}`);
-    const run = toWorkflowRun(resolvedRunRow);
-    const [attemptRow] = await tx
-      .insert(workflowRunAttempts)
-      .values({
-        workflowRunId: runRow.id,
-        attempt: 1,
-        status: 'pending',
-        model: createWorkflowModelSnapshot(params.model),
-        vars,
-        agentToolMaterialization,
-      })
-      .returning();
-    if (!attemptRow) throw new Error('Insert returned no rows');
-
-    const materializedJobs = await materializeWorkflowRunJobs({
-      run,
-      model: params.model,
-      triggerPayload: params.triggerPayload,
-      inputs: params.inputs ?? null,
-      vars,
-      resolveAgentDefaults: params.resolveAgentDefaults,
-      definitionId: params.definitionId,
-      agentToolContext,
-      agentToolSnapshot: agentToolMaterialization,
-    });
-
-    const graphJobs = materializeRunGraphJobs({
-      params,
-      run,
-      vars,
-      materializedJobs,
-    });
-    await persistMaterializedRunGraph(tx, {
-      run,
-      workflowRunAttempt: attemptRow,
-      materializedJobs: graphJobs,
-    });
-
-    logTemplateDiagnostics({
-      workflowRunId: runRow.id,
-      diagnostics: materializedJobs.flatMap((job) =>
-        job.steps.flatMap((step) =>
-          (step.diagnostics ?? []).map((diagnostic) => ({
-            jobKey: job.key,
-            stepName: step.name,
-            ...diagnostic,
-          })),
-        ),
-      ),
-    });
-
-    return {
-      run,
-      created: true,
-      nameDegradation: runNameResolution.degradation,
-    };
-  });
+  const result = await db().transaction((tx) =>
+    createWorkflowRunInTransaction(
+      {params, staticName, triggerReference, agentToolContext, agentToolMaterialization},
+      tx,
+    ),
+  );
 
   if (result.created && result.nameDegradation !== undefined) {
     recordWorkflowDisplayNameResolutionDegraded('workflow.run_name', result.nameDegradation.cause);
@@ -277,6 +126,190 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
   }
 
   return result.run;
+}
+
+interface CreateWorkflowRunTransactionContext {
+  readonly params: CreateWorkflowRunParams;
+  readonly staticName: string;
+  readonly triggerReference: Awaited<ReturnType<typeof resolveWorkflowRunTriggerReference>>;
+  readonly agentToolContext: Awaited<ReturnType<typeof loadAgentToolMaterializationContext>>;
+  readonly agentToolMaterialization: ReturnType<typeof createAgentToolMaterializationSnapshot>;
+}
+
+async function createWorkflowRunInTransaction(
+  context: CreateWorkflowRunTransactionContext,
+  tx: Tx,
+) {
+  const existing = await findIdempotentWorkflowRun(context.params.triggerIdempotencyKey, tx);
+  if (existing) return {run: existing, created: false as const};
+
+  const insertion = await insertWorkflowRun(context, tx);
+  if (insertion.kind === 'existing') return {run: insertion.run, created: false as const};
+  return materializeCreatedWorkflowRun(context, insertion.row, tx);
+}
+
+async function findIdempotentWorkflowRun(
+  idempotencyKey: string | undefined,
+  tx: Tx,
+): Promise<WorkflowRun | undefined> {
+  if (!idempotencyKey) return undefined;
+
+  // Serialize idempotent trigger resolution separately from per-definition number
+  // allocation so a replay never consumes a number, including when two deliveries
+  // race before either run is visible.
+  await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${idempotencyKey}))`);
+  const [existing] = await tx
+    .select()
+    .from(workflowRuns)
+    .where(eq(workflowRuns.triggerIdempotencyKey, idempotencyKey))
+    .limit(1);
+  return existing === undefined ? undefined : toWorkflowRun(existing);
+}
+
+async function insertWorkflowRun(
+  context: CreateWorkflowRunTransactionContext,
+  tx: Tx,
+): Promise<
+  {kind: 'created'; row: typeof workflowRuns.$inferSelect} | {kind: 'existing'; run: WorkflowRun}
+> {
+  const {params} = context;
+  // Keep allocation on the existing transaction so a trigger burst cannot pin
+  // every pool connection and then wait for a second connection per run.
+  const number = await allocateWorkflowRunNumber(tx, params.definitionId);
+  const [runRow] = await tx
+    .insert(workflowRuns)
+    .values({
+      workspaceId: params.workspaceId,
+      projectId: params.projectId,
+      definitionId: params.definitionId,
+      number,
+      name: null,
+      workflowName: context.staticName,
+      status: 'pending',
+      currentAttempt: 1,
+      triggerProvider: params.triggerPayload.provider ?? null,
+      triggerSource: params.triggerPayload.source,
+      triggerEvent: params.triggerPayload.event,
+      triggerPayload: params.triggerPayload,
+      triggerReference: context.triggerReference,
+      inputs: params.inputs ?? null,
+      sourceSnapshot: params.sourceSnapshot ?? null,
+      triggerIdempotencyKey: params.triggerIdempotencyKey ?? null,
+      origin: params.origin ?? 'synced',
+      devSource:
+        params.devSource === undefined || params.devSource === null
+          ? null
+          : toWorkflowRunDevSourceDb(params.devSource),
+    })
+    .onConflictDoNothing({target: workflowRuns.triggerIdempotencyKey})
+    .returning();
+  if (runRow) return {kind: 'created', row: runRow};
+  return loadConflictingWorkflowRun(params.triggerIdempotencyKey, tx);
+}
+
+async function loadConflictingWorkflowRun(
+  idempotencyKey: string | undefined,
+  tx: Tx,
+): Promise<{kind: 'existing'; run: WorkflowRun}> {
+  if (!idempotencyKey) throw new Error('Insert returned no rows');
+  const [existing] = await tx
+    .select()
+    .from(workflowRuns)
+    .where(eq(workflowRuns.triggerIdempotencyKey, idempotencyKey))
+    .limit(1);
+  if (!existing) {
+    throw new Error(`Idempotency conflict but existing run missing for key ${idempotencyKey}`);
+  }
+  return {kind: 'existing', run: toWorkflowRun(existing)};
+}
+
+async function materializeCreatedWorkflowRun(
+  context: CreateWorkflowRunTransactionContext,
+  runRow: typeof workflowRuns.$inferSelect,
+  tx: Tx,
+) {
+  const {params} = context;
+  // Resolving run-creation templates and predicates here gives them a stable variable snapshot
+  // and interpolation access to the inserted run id. Run-name resolution is display-only and
+  // persists only a resolved override. If resolution fails, the transaction rolls back the run,
+  // jobs, steps, and outbox event together. Listening steps are resolved later when a job
+  // execution is created.
+  const provisionalRun = toWorkflowRun(runRow);
+  const oneShotJobs = params.model.jobs.filter((job) => job.mode !== 'listening');
+  const vars = await loadReferencedVariables({
+    model: params.model,
+    jobs: oneShotJobs,
+    workspaceId: params.workspaceId,
+    projectId: params.projectId,
+    definitionId: params.definitionId,
+    secrets: params.secrets,
+  });
+  const runNameResolution = resolveWorkflowRunName({
+    runName: params.model.runName,
+    context: assembleCreationContext({
+      run: provisionalRun,
+      triggerPayload: params.triggerPayload,
+      inputs: params.inputs ?? null,
+      vars,
+    }).values,
+  });
+  const [resolvedRunRow] = await tx
+    .update(workflowRuns)
+    .set({name: runNameResolution.value, updatedAt: new Date()})
+    .where(eq(workflowRuns.id, provisionalRun.id))
+    .returning();
+  if (!resolvedRunRow) throw new Error(`Workflow run missing after name resolution: ${runRow.id}`);
+  const run = toWorkflowRun(resolvedRunRow);
+  const [attemptRow] = await tx
+    .insert(workflowRunAttempts)
+    .values({
+      workflowRunId: runRow.id,
+      attempt: 1,
+      status: 'pending',
+      model: createWorkflowModelSnapshot(params.model),
+      vars,
+      agentToolMaterialization: context.agentToolMaterialization,
+    })
+    .returning();
+  if (!attemptRow) throw new Error('Insert returned no rows');
+
+  const materializedJobs = await materializeWorkflowRunJobs({
+    run,
+    model: params.model,
+    triggerPayload: params.triggerPayload,
+    inputs: params.inputs ?? null,
+    vars,
+    resolveAgentDefaults: params.resolveAgentDefaults,
+    definitionId: params.definitionId,
+    agentToolContext: context.agentToolContext,
+    agentToolSnapshot: context.agentToolMaterialization,
+  });
+  await persistMaterializedRunGraph(tx, {
+    run,
+    workflowRunAttempt: attemptRow,
+    materializedJobs: materializeRunGraphJobs({params, run, vars, materializedJobs}),
+  });
+  logMaterializedJobDiagnostics(runRow.id, materializedJobs);
+
+  return {run, created: true as const, nameDegradation: runNameResolution.degradation};
+}
+
+function logMaterializedJobDiagnostics(
+  workflowRunId: string,
+  materializedJobs: readonly MaterializedWorkflowJob[],
+): void {
+  logTemplateDiagnostics({
+    workflowRunId,
+    diagnostics: materializedJobs.flatMap((job) =>
+      job.steps.flatMap((step) =>
+        (step.diagnostics ?? []).map((diagnostic) => ({
+          jobKey: job.key,
+          stepName: step.name,
+          ...diagnostic,
+        })),
+      ),
+    ),
+  });
 }
 
 async function allocateWorkflowRunNumber(tx: Tx, definitionId: string): Promise<number> {
@@ -425,7 +458,17 @@ function referencedVariables(
   jobs: readonly WorkflowModelJob[],
 ): readonly ReferencedVariable[] {
   const references: ReferencedVariable[] = [];
+  collectWorkflowPredicateVariableReferences(model, references);
+  collectFieldVariableReferences(model.runName, references, {field: 'workflow.run_name'});
+  if (jobs.length > 0) collectTemplateVariableReferences(model.templates?.env, references);
+  for (const job of jobs) collectJobVariableReferences(job, references);
+  return references;
+}
 
+function collectWorkflowPredicateVariableReferences(
+  model: WorkflowModel,
+  references: ReferencedVariable[],
+): void {
   for (const job of model.jobs) {
     collectPredicateVariableReferences(job.if, references);
     collectPredicateVariableReferences(job.success, references);
@@ -439,59 +482,65 @@ function referencedVariables(
       collectPredicateVariableReferences(step.gate?.success, references);
     }
   }
+}
 
-  collectFieldVariableReferences(model.runName, references, {field: 'workflow.run_name'});
-
-  if (jobs.length > 0) {
-    collectTemplateVariableReferences(model.templates?.env, references);
+function collectJobVariableReferences(
+  job: WorkflowModelJob,
+  references: ReferencedVariable[],
+): void {
+  collectFieldVariableReferences(job.executionName, references, {field: 'job.execution_name'});
+  for (const template of job.runnerTemplates ?? []) {
+    collectFieldVariableReferences(template, references, {field: 'job.runner'});
   }
+  collectTemplateVariableReferences(job.outputs, references, {field: 'job.outputs'});
+  collectTemplateVariableReferences(job.templates?.env, references);
+  for (const step of job.steps) collectStepVariableReferences(step, references);
+}
 
-  for (const job of jobs) {
-    collectFieldVariableReferences(job.executionName, references, {field: 'job.execution_name'});
-    for (const template of job.runnerTemplates ?? []) {
-      collectFieldVariableReferences(template, references, {field: 'job.runner'});
-    }
-    collectTemplateVariableReferences(job.outputs, references, {field: 'job.outputs'});
-    collectTemplateVariableReferences(job.templates?.env, references);
-
-    for (const step of job.steps) {
-      collectFieldVariableReferences(step.templates?.name, references, {field: 'step.name'});
-      collectFieldVariableReferences(
-        step.kind === 'tool' ? undefined : step.templates?.workingDirectory,
-        references,
-        {
-          field: 'step.working_directory',
-        },
-      );
-      if (step.kind === 'run') {
-        collectFieldVariableReferences(step.templates?.command, references, {field: 'run'});
-        collectTemplateVariableReferences(step.templates?.env, references);
-      } else if (step.kind === 'agent') {
-        collectFieldVariableReferences(step.templates?.prompt, references, {field: 'agent.prompt'});
-        collectFieldVariableReferences(step.templates?.model, references, {field: 'agent.model'});
-        collectFieldVariableReferences(step.templates?.provider, references, {
-          field: 'agent.provider',
-        });
-        collectFieldVariableReferences(step.session?.key, references, {field: 'agent.session'});
-      } else if (step.kind === 'tool') {
-        collectTemplateTreeVariableReferences(step.templates?.with, references, {
-          field: 'tool.with',
-        });
-        for (const [key, expression] of Object.entries(step.outputMappings ?? {})) {
-          collectExpressionVariableReferences(expression, references, {
-            field: 'tool.outputs',
-            envKey: key,
-          });
-        }
-      } else if (step.kind === 'checkout') {
-        for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
-          collectFieldVariableReferences(step.checkout.templates?.[key], references, {field});
-        }
+function collectStepVariableReferences(
+  step: WorkflowModelJob['steps'][number],
+  references: ReferencedVariable[],
+): void {
+  collectFieldVariableReferences(step.templates?.name, references, {field: 'step.name'});
+  collectFieldVariableReferences(
+    step.kind === 'tool' ? undefined : step.templates?.workingDirectory,
+    references,
+    {field: 'step.working_directory'},
+  );
+  switch (step.kind) {
+    case 'run':
+      collectFieldVariableReferences(step.templates?.command, references, {field: 'run'});
+      collectTemplateVariableReferences(step.templates?.env, references);
+      return;
+    case 'agent':
+      collectFieldVariableReferences(step.templates?.prompt, references, {field: 'agent.prompt'});
+      collectFieldVariableReferences(step.templates?.model, references, {field: 'agent.model'});
+      collectFieldVariableReferences(step.templates?.provider, references, {
+        field: 'agent.provider',
+      });
+      collectFieldVariableReferences(step.session?.key, references, {field: 'agent.session'});
+      return;
+    case 'tool':
+      collectToolStepVariableReferences(step, references);
+      return;
+    case 'checkout':
+      for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
+        collectFieldVariableReferences(step.checkout.templates?.[key], references, {field});
       }
-    }
   }
+}
 
-  return references;
+function collectToolStepVariableReferences(
+  step: Extract<WorkflowModelJob['steps'][number], {kind: 'tool'}>,
+  references: ReferencedVariable[],
+): void {
+  collectTemplateTreeVariableReferences(step.templates?.with, references, {field: 'tool.with'});
+  for (const [key, expression] of Object.entries(step.outputMappings ?? {})) {
+    collectExpressionVariableReferences(expression, references, {
+      field: 'tool.outputs',
+      envKey: key,
+    });
+  }
 }
 
 function collectPredicateVariableReferences(

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -168,7 +168,7 @@ async function loadRerunSourceGraph(
   return {sourceJobExecutionByJobId, sourceJobByJobExecutionId, sourceSteps};
 }
 
-function materializeRerunGraphJobs(params: {
+interface MaterializeRerunGraphParams {
   readonly mode: CreateRerunWorkflowRunParams['mode'];
   readonly sourceRun: WorkflowRun;
   readonly sourceAttempt: WorkflowRunAttemptDb;
@@ -176,7 +176,11 @@ function materializeRerunGraphJobs(params: {
   readonly sourceJobExecutionByJobId: ReadonlyMap<string, JobExecutionDb>;
   readonly sourceJobByJobExecutionId: ReadonlyMap<string, JobDb>;
   readonly sourceSteps: readonly StepDb[];
-}): readonly MaterializedRunGraphJob[] {
+}
+
+function materializeRerunGraphJobs(
+  params: MaterializeRerunGraphParams,
+): readonly MaterializedRunGraphJob[] {
   const sourceModel =
     params.sourceAttempt.model === null
       ? null
@@ -191,89 +195,112 @@ function materializeRerunGraphJobs(params: {
     sourceStepsByJobId.set(sourceJob.id, sourceJobSteps);
   }
 
-  return params.sourceJobs.map((sourceJob) => {
-    const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
-    const modelJob = sourceModelJobByKey.get(sourceJob.key);
-    const modelCheckout = modelJob?.checkout;
-    const resolvedModelCheckout = modelCheckout === false ? undefined : modelCheckout;
+  return params.sourceJobs.map((sourceJob) =>
+    materializeRerunGraphJob(
+      params,
+      sourceJob,
+      sourceModelJobByKey.get(sourceJob.key),
+      sourceStepsByJobId.get(sourceJob.id) ?? [],
+    ),
+  );
+}
 
-    return {
-      job: {
-        key: sourceJob.key,
-        name: sourceJob.name,
-        mode: sourceJob.mode,
-        status: carriedOver ? ('succeeded' as const) : ('pending' as const),
-        statusReason: null,
-        carriedOver,
-        checkoutPersistCredentials:
-          resolvedModelCheckout?.persistCredentials ?? sourceJob.checkoutPersistCredentials,
-        checkoutPermissionsContents:
-          resolvedModelCheckout?.permissions?.contents ?? sourceJob.checkoutPermissionsContents,
-        success: sourceJob.success,
-        executionTimeoutMs: sourceJob.executionTimeoutMs,
-        listeningTimeoutMs: sourceJob.listeningTimeoutMs,
-        maxExecutions: sourceJob.maxExecutions,
-        onResolve: sourceJob.onResolve,
-        batchDebounceMs: sourceJob.batchDebounceMs,
-        batchMaxSize: sourceJob.batchMaxSize,
-        batchMaxWaitMs: sourceJob.batchMaxWaitMs,
-        listenerStatus: 'inactive' as const,
-        resolutionReason: null,
-        listeningOn: sourceJob.listeningOn ? [...sourceJob.listeningOn] : null,
-        listeningUntil: sourceJob.listeningUntil ? [...sourceJob.listeningUntil] : null,
-        outputs: carriedOver && sourceJob.outputs ? {...sourceJob.outputs} : null,
-        dependencies: [...sourceJob.dependencies],
-        runner: sourceJob.runner ? [...sourceJob.runner] : null,
-        position: sourceJob.position,
-      },
-      createExecution: (job) => {
-        if (job.mode === 'listening') return undefined;
+function materializeRerunGraphJob(
+  params: MaterializeRerunGraphParams,
+  sourceJob: JobDb,
+  modelJob: ReturnType<typeof readPersistedWorkflowModel>['jobs'][number] | undefined,
+  sourceJobSteps: readonly StepDb[],
+): MaterializedRunGraphJob {
+  const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
+  const modelCheckout = modelJob?.checkout;
+  const resolvedModelCheckout = modelCheckout === false ? undefined : modelCheckout;
 
-        const sourceExecution = params.sourceJobExecutionByJobId.get(sourceJob.id);
-        const nameOverride = sourceExecution?.name ?? null;
-        const executionName = nameOverride ?? job.name ?? job.key;
-        const runner =
-          carriedOver || modelJob === undefined
-            ? (sourceExecution?.runner ?? job.runner ?? null)
-            : deriveJobExecutionRunner({
-                run: params.sourceRun,
-                modelJob,
-                jobId: job.id,
-                sequence: 1,
-                nameOverride,
-                executionName,
-                jobName: job.name,
-                status: 'pending',
-              });
+  return {
+    job: {
+      key: sourceJob.key,
+      name: sourceJob.name,
+      mode: sourceJob.mode,
+      status: carriedOver ? 'succeeded' : 'pending',
+      statusReason: null,
+      carriedOver,
+      checkoutPersistCredentials:
+        resolvedModelCheckout?.persistCredentials ?? sourceJob.checkoutPersistCredentials,
+      checkoutPermissionsContents:
+        resolvedModelCheckout?.permissions?.contents ?? sourceJob.checkoutPermissionsContents,
+      success: sourceJob.success,
+      executionTimeoutMs: sourceJob.executionTimeoutMs,
+      listeningTimeoutMs: sourceJob.listeningTimeoutMs,
+      maxExecutions: sourceJob.maxExecutions,
+      onResolve: sourceJob.onResolve,
+      batchDebounceMs: sourceJob.batchDebounceMs,
+      batchMaxSize: sourceJob.batchMaxSize,
+      batchMaxWaitMs: sourceJob.batchMaxWaitMs,
+      listenerStatus: 'inactive',
+      resolutionReason: null,
+      listeningOn: sourceJob.listeningOn ? [...sourceJob.listeningOn] : null,
+      listeningUntil: sourceJob.listeningUntil ? [...sourceJob.listeningUntil] : null,
+      outputs: carriedOver && sourceJob.outputs ? {...sourceJob.outputs} : null,
+      dependencies: [...sourceJob.dependencies],
+      runner: sourceJob.runner ? [...sourceJob.runner] : null,
+      position: sourceJob.position,
+    },
+    createExecution: (job) =>
+      createRerunJobExecution({params, sourceJob, modelJob, carriedOver, job}),
+    createSteps: () =>
+      sourceJobSteps.map((step) => ({
+        key: step.key,
+        name: step.name,
+        sourceLocation: step.sourceLocation,
+        status: carriedOver ? step.status : 'pending',
+        statusReason: carriedOver ? step.statusReason : null,
+        type: step.type,
+        config: step.config,
+        condition: step.condition ?? null,
+        configPlan: step.configPlan,
+        authoredConfig: step.authoredConfig,
+        error: null,
+        position: step.position,
+        currentAttempt: 1,
+      })),
+  };
+}
 
-        return {
+function createRerunJobExecution(params: {
+  readonly params: MaterializeRerunGraphParams;
+  readonly sourceJob: JobDb;
+  readonly modelJob: ReturnType<typeof readPersistedWorkflowModel>['jobs'][number] | undefined;
+  readonly carriedOver: boolean;
+  readonly job: Parameters<NonNullable<MaterializedRunGraphJob['createExecution']>>[0];
+}) {
+  const {job, sourceJob, carriedOver, modelJob} = params;
+  if (job.mode === 'listening') return undefined;
+
+  const sourceExecution = params.params.sourceJobExecutionByJobId.get(sourceJob.id);
+  const nameOverride = sourceExecution?.name ?? null;
+  const executionName = nameOverride ?? job.name ?? job.key;
+  const runner =
+    carriedOver || modelJob === undefined
+      ? (sourceExecution?.runner ?? job.runner ?? null)
+      : deriveJobExecutionRunner({
+          run: params.params.sourceRun,
+          modelJob,
+          jobId: job.id,
           sequence: 1,
-          // Reruns preserve the authored/resolved override, never the
-          // effective fallback exposed by the core entity.
-          name: nameOverride,
-          runner: runner ? [...runner] : null,
-          status: carriedOver ? ('succeeded' as const) : ('pending' as const),
-          statusReason: null,
-          outputs: carriedOver && sourceExecution?.outputs ? {...sourceExecution.outputs} : null,
-          ...(carriedOver ? {finishedAt: sql`now()`} : {}),
-        };
-      },
-      createSteps: () =>
-        (sourceStepsByJobId.get(sourceJob.id) ?? []).map((step) => ({
-          key: step.key,
-          name: step.name,
-          sourceLocation: step.sourceLocation,
-          status: carriedOver ? step.status : ('pending' as const),
-          statusReason: carriedOver ? step.statusReason : null,
-          type: step.type,
-          config: step.config,
-          condition: step.condition ?? null,
-          configPlan: step.configPlan,
-          authoredConfig: step.authoredConfig,
-          error: null,
-          position: step.position,
-          currentAttempt: 1,
-        })),
-    };
-  });
+          nameOverride,
+          executionName,
+          jobName: job.name,
+          status: 'pending',
+        });
+
+  return {
+    sequence: 1,
+    // Reruns preserve the authored/resolved override, never the
+    // effective fallback exposed by the core entity.
+    name: nameOverride,
+    runner: runner ? [...runner] : null,
+    status: carriedOver ? ('succeeded' as const) : ('pending' as const),
+    statusReason: null,
+    outputs: carriedOver && sourceExecution?.outputs ? {...sourceExecution.outputs} : null,
+    ...(carriedOver ? {finishedAt: sql`now()`} : {}),
+  };
 }

--- a/libs/api/workflows/src/db/workflow-runs/run-status.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-status.ts
@@ -285,121 +285,142 @@ export async function updateWorkflowRunStatus(
   params: UpdateWorkflowRunStatusParams,
 ): Promise<WorkflowRun> {
   const result = await db().transaction(async (tx) => {
-    const [attemptRef] = params.workflowRunAttemptId
-      ? await tx
-          .select({
-            id: workflowRunAttempts.id,
-            workflowRunId: workflowRunAttempts.workflowRunId,
-          })
-          .from(workflowRunAttempts)
-          .where(eq(workflowRunAttempts.id, params.workflowRunAttemptId))
-          .limit(1)
-      : [];
-
-    const workflowRunId = attemptRef?.workflowRunId ?? params.workflowRunId ?? '';
-    const lockedRun = await lockWorkflowRun(workflowRunId, tx);
-
-    if (!lockedRun) {
-      throw new WorkflowRunNotFoundError(params.workflowRunId ?? params.workflowRunAttemptId ?? '');
-    }
-
-    const [lockedAttempt] = await tx
-      .select()
-      .from(workflowRunAttempts)
-      .where(
-        params.workflowRunAttemptId
-          ? eq(workflowRunAttempts.id, params.workflowRunAttemptId)
-          : and(
-              eq(workflowRunAttempts.workflowRunId, lockedRun.id),
-              eq(workflowRunAttempts.attempt, lockedRun.currentAttempt),
-            ),
-      )
-      .limit(1)
-      .for('update');
-
-    if (!lockedAttempt) {
-      throw new WorkflowRunNotFoundError(params.workflowRunId ?? params.workflowRunAttemptId ?? '');
-    }
-
-    const target = {run: lockedRun, attempt: lockedAttempt};
-
-    const rows = await tx
-      .update(workflowRunAttempts)
-      .set({
-        status: params.status,
-        version: sql`${workflowRunAttempts.version} + 1`,
-        updatedAt: new Date(),
-        ...(params.status === 'running'
-          ? {startedAt: sql`coalesce(${workflowRunAttempts.startedAt}, now())`}
-          : {}),
-        ...(isWorkflowRunTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
-      })
-      .where(
-        and(
-          eq(workflowRunAttempts.id, target.attempt.id),
-          eq(workflowRunAttempts.version, params.expectedVersion),
-          notInArray(workflowRunAttempts.status, TERMINAL_WORKFLOW_RUN_STATUSES),
-        ),
-      )
-      .returning();
-
-    const attemptRow = rows[0];
-    if (!attemptRow) {
-      const existing = await tx
-        .select()
-        .from(workflowRunAttempts)
-        .where(eq(workflowRunAttempts.id, target.attempt.id))
-        .limit(1);
-      const existingRow = existing[0];
-      if (
-        existingRow &&
-        (existingRow.status === params.status || isWorkflowRunTerminal(existingRow.status))
-      ) {
-        return {
-          run: {...toWorkflowRun(target.run), version: existingRow.version},
-          changed: false,
-        };
-      }
-      throw new Error(
-        `Optimistic lock failure: run attempt ${target.attempt.id} version ${params.expectedVersion}`,
-      );
-    }
+    const target = await loadWorkflowRunStatusTarget(params, tx);
+    const attemptRow = await updateWorkflowRunAttemptStatus(target.attempt.id, params, tx);
+    if (!attemptRow) return resolveWorkflowRunStatusConflict(target, params, tx);
 
     const shouldMirror = target.run.currentAttempt === attemptRow.attempt;
-    const [runRow] = shouldMirror
-      ? await tx
-          .update(workflowRuns)
-          .set({
-            status: params.status,
-            version: sql`${workflowRuns.version} + 1`,
-            updatedAt: new Date(),
-            ...(params.status === 'running'
-              ? {startedAt: sql`coalesce(${workflowRuns.startedAt}, now())`}
-              : {}),
-            ...(isWorkflowRunTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
-          })
-          .where(eq(workflowRuns.id, target.run.id))
-          .returning()
-      : [target.run];
-
-    const run = {...toWorkflowRun(runRow ?? target.run), version: attemptRow.version};
-
-    if (shouldMirror && isWorkflowRunTerminal(run.status)) {
-      await writeWorkflowsOutboxEvent(tx, {
-        type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
-        payload: {
-          workflowRunId: run.id,
-          workflowRunAttemptId: attemptRow.id,
-          projectId: run.projectId,
-          status: run.status,
-        },
-      });
-    }
-
+    const run = await mirrorWorkflowRunStatus(
+      target.run,
+      attemptRow.version,
+      params,
+      shouldMirror,
+      tx,
+    );
+    await writeRunTerminatedIfNeeded(run, attemptRow.id, shouldMirror, tx);
     return {run, changed: true};
   });
 
   if (result.changed) recordWorkflowRunStatusChanged(result.run.status);
 
   return result.run;
+}
+
+async function loadWorkflowRunStatusTarget(params: UpdateWorkflowRunStatusParams, tx: Tx) {
+  const [attemptRef] = params.workflowRunAttemptId
+    ? await tx
+        .select({workflowRunId: workflowRunAttempts.workflowRunId})
+        .from(workflowRunAttempts)
+        .where(eq(workflowRunAttempts.id, params.workflowRunAttemptId))
+        .limit(1)
+    : [];
+  const requestedId = params.workflowRunId ?? params.workflowRunAttemptId ?? '';
+  const lockedRun = await lockWorkflowRun(
+    attemptRef?.workflowRunId ?? params.workflowRunId ?? '',
+    tx,
+  );
+  if (!lockedRun) throw new WorkflowRunNotFoundError(requestedId);
+
+  const [lockedAttempt] = await tx
+    .select()
+    .from(workflowRunAttempts)
+    .where(
+      params.workflowRunAttemptId
+        ? eq(workflowRunAttempts.id, params.workflowRunAttemptId)
+        : and(
+            eq(workflowRunAttempts.workflowRunId, lockedRun.id),
+            eq(workflowRunAttempts.attempt, lockedRun.currentAttempt),
+          ),
+    )
+    .limit(1)
+    .for('update');
+  if (!lockedAttempt) throw new WorkflowRunNotFoundError(requestedId);
+  return {run: lockedRun, attempt: lockedAttempt};
+}
+
+async function updateWorkflowRunAttemptStatus(
+  attemptId: string,
+  params: UpdateWorkflowRunStatusParams,
+  tx: Tx,
+) {
+  const [attemptRow] = await tx
+    .update(workflowRunAttempts)
+    .set({
+      status: params.status,
+      version: sql`${workflowRunAttempts.version} + 1`,
+      updatedAt: new Date(),
+      ...(params.status === 'running'
+        ? {startedAt: sql`coalesce(${workflowRunAttempts.startedAt}, now())`}
+        : {}),
+      ...(isWorkflowRunTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
+    })
+    .where(
+      and(
+        eq(workflowRunAttempts.id, attemptId),
+        eq(workflowRunAttempts.version, params.expectedVersion),
+        notInArray(workflowRunAttempts.status, TERMINAL_WORKFLOW_RUN_STATUSES),
+      ),
+    )
+    .returning();
+  return attemptRow;
+}
+
+async function resolveWorkflowRunStatusConflict(
+  target: Awaited<ReturnType<typeof loadWorkflowRunStatusTarget>>,
+  params: UpdateWorkflowRunStatusParams,
+  tx: Tx,
+) {
+  const [existing] = await tx
+    .select()
+    .from(workflowRunAttempts)
+    .where(eq(workflowRunAttempts.id, target.attempt.id))
+    .limit(1);
+  if (existing && (existing.status === params.status || isWorkflowRunTerminal(existing.status))) {
+    return {run: {...toWorkflowRun(target.run), version: existing.version}, changed: false};
+  }
+  throw new Error(
+    `Optimistic lock failure: run attempt ${target.attempt.id} version ${params.expectedVersion}`,
+  );
+}
+
+async function mirrorWorkflowRunStatus(
+  runRow: typeof workflowRuns.$inferSelect,
+  attemptVersion: number,
+  params: UpdateWorkflowRunStatusParams,
+  shouldMirror: boolean,
+  tx: Tx,
+): Promise<WorkflowRun> {
+  if (!shouldMirror) return {...toWorkflowRun(runRow), version: attemptVersion};
+  const [updated] = await tx
+    .update(workflowRuns)
+    .set({
+      status: params.status,
+      version: sql`${workflowRuns.version} + 1`,
+      updatedAt: new Date(),
+      ...(params.status === 'running'
+        ? {startedAt: sql`coalesce(${workflowRuns.startedAt}, now())`}
+        : {}),
+      ...(isWorkflowRunTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
+    })
+    .where(eq(workflowRuns.id, runRow.id))
+    .returning();
+  return {...toWorkflowRun(updated ?? runRow), version: attemptVersion};
+}
+
+async function writeRunTerminatedIfNeeded(
+  run: WorkflowRun,
+  attemptId: string,
+  shouldMirror: boolean,
+  tx: Tx,
+): Promise<void> {
+  if (!shouldMirror || !isWorkflowRunTerminal(run.status)) return;
+  await writeWorkflowsOutboxEvent(tx, {
+    type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+    payload: {
+      workflowRunId: run.id,
+      workflowRunAttemptId: attemptId,
+      projectId: run.projectId,
+      status: run.status,
+    },
+  });
 }

--- a/libs/api/workflows/src/presentation/dto/job.ts
+++ b/libs/api/workflows/src/presentation/dto/job.ts
@@ -16,28 +16,7 @@ export function toJobDto(job: Job): JobDto {
     success: job.success ?? null,
     runner: job.runner,
     evaluation_trace: toEvaluationTraceDto(job.evaluationTrace),
-    listening:
-      job.listeningOn === null
-        ? null
-        : {
-            on: job.listeningOn,
-            until: job.listeningUntil,
-            timeout_ms: job.listeningTimeoutMs,
-            max_executions: job.maxExecutions,
-            batch:
-              job.batchDebounceMs === null &&
-              job.batchMaxSize === null &&
-              job.batchMaxWaitMs === null
-                ? null
-                : {
-                    ...(job.batchDebounceMs === null ? {} : {debounce_ms: job.batchDebounceMs}),
-                    ...(job.batchMaxSize === null ? {} : {max_size: job.batchMaxSize}),
-                    ...(job.batchMaxWaitMs === null ? {} : {max_wait_ms: job.batchMaxWaitMs}),
-                  },
-            on_resolve: job.onResolve ?? 'finish',
-            execution_timeout_ms: job.executionTimeoutMs ?? null,
-            name: job.name,
-          },
+    listening: toJobListeningDto(job),
     listener_status: job.listenerStatus,
     resolution_reason: job.resolutionReason,
     outputs: job.outputs,
@@ -45,6 +24,31 @@ export function toJobDto(job: Job): JobDto {
     position: job.position,
     created_at: job.createdAt.toISOString(),
     updated_at: job.updatedAt.toISOString(),
+  };
+}
+
+function toJobListeningDto(job: Job): JobDto['listening'] {
+  if (job.listeningOn === null) return null;
+  return {
+    on: job.listeningOn,
+    until: job.listeningUntil,
+    timeout_ms: job.listeningTimeoutMs,
+    max_executions: job.maxExecutions,
+    batch: toJobListeningBatchDto(job),
+    on_resolve: job.onResolve ?? 'finish',
+    execution_timeout_ms: job.executionTimeoutMs ?? null,
+    name: job.name,
+  };
+}
+
+function toJobListeningBatchDto(job: Job): NonNullable<JobDto['listening']>['batch'] {
+  if (job.batchDebounceMs === null && job.batchMaxSize === null && job.batchMaxWaitMs === null) {
+    return null;
+  }
+  return {
+    ...(job.batchDebounceMs === null ? {} : {debounce_ms: job.batchDebounceMs}),
+    ...(job.batchMaxSize === null ? {} : {max_size: job.batchMaxSize}),
+    ...(job.batchMaxWaitMs === null ? {} : {max_wait_ms: job.batchMaxWaitMs}),
   };
 }
 

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -32,15 +32,39 @@ function toStepErrorDto(error: Record<string, unknown> | null, stepType: string)
   const category = deriveStepErrorCategory(stepType, reason.success ? reason.data : undefined);
   return {
     message,
-    ...(code === undefined ? {} : {code}),
-    ...(managedProviderId === undefined ? {} : {managed_provider_id: managedProviderId}),
-    ...(exitCode === null || typeof exitCode === 'number' ? {exit_code: exitCode} : {}),
-    ...(signal === undefined ? {} : {signal}),
+    ...toStepErrorScalarFields({code, managedProviderId, exitCode, signal}),
     ...(reason.success ? {reason: reason.data} : {}),
-    ...(field === undefined ? {} : {field}),
-    ...(source === undefined ? {} : {source}),
+    ...toStepErrorSourceFields(field, source),
     ...(agentConfigIssue.success ? {agent_config_issue: agentConfigIssue.data} : {}),
     category,
+  };
+}
+
+function toStepErrorScalarFields(params: {
+  code: string | undefined;
+  managedProviderId: string | undefined;
+  exitCode: unknown;
+  signal: string | undefined;
+}): Partial<StepErrorDto> {
+  return {
+    ...(params.code === undefined ? {} : {code: params.code}),
+    ...(params.managedProviderId === undefined
+      ? {}
+      : {managed_provider_id: params.managedProviderId}),
+    ...(params.exitCode === null || typeof params.exitCode === 'number'
+      ? {exit_code: params.exitCode}
+      : {}),
+    ...(params.signal === undefined ? {} : {signal: params.signal}),
+  };
+}
+
+function toStepErrorSourceFields(
+  field: string | undefined,
+  source: string | undefined,
+): Partial<StepErrorDto> {
+  return {
+    ...(field === undefined ? {} : {field}),
+    ...(source === undefined ? {} : {source}),
   };
 }
 
@@ -113,6 +137,7 @@ export function toStepDto(step: Step): StepDto {
     sessionValue === undefined || sessionValue === null
       ? null
       : agentStepSessionDescriptorSchema.safeParse(sessionValue);
+  const sessionDto = session?.success ? session.data : null;
   return {
     id: step.id,
     job_execution_id: step.jobExecutionId,
@@ -125,7 +150,7 @@ export function toStepDto(step: Step): StepDto {
     config: step.config,
     evaluation_trace: toEvaluationTraceDto(step.evaluationTrace),
     error: toStepErrorDto(step.error, step.type),
-    session: session === null ? null : session.success ? session.data : null,
+    session: sessionDto,
     position: step.position,
     current_attempt: step.currentAttempt,
     created_at: step.createdAt.toISOString(),

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -596,8 +596,9 @@ async function createRunningCheckoutStep(
   await db().update(jobsTable).set({status: 'running'}).where(eq(jobsTable.id, job.id));
 
   const stepRows = await getStepsByJobId(job.id);
-  const targetType =
-    options.kind === 'checkout' ? 'checkout' : options.kind === 'run' ? 'run' : 'setup';
+  let targetType: 'checkout' | 'run' | 'setup' = 'setup';
+  if (options.kind === 'checkout') targetType = 'checkout';
+  else if (options.kind === 'run') targetType = 'run';
   const step = stepRows.find((candidate) => candidate.type === targetType);
   if (!step) throw new Error(`Expected ${targetType} step`);
   const status = options.status ?? 'running';

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -34,91 +34,7 @@ export function createCheckoutTokenRoute(clients: {
       querystring: checkoutTokenQuerySchema,
       response: {200: checkoutTokenResponseSchema},
     },
-    errorHandler: (error) => {
-      const known = isInterModuleKnownError(
-        integrationsInterModuleContract.methods.createCheckoutSpec,
-        error,
-      )
-        ? error
-        : undefined;
-      const targetError = isInterModuleKnownError(
-        projectsInterModuleContract.methods.resolveCheckoutTarget,
-        error,
-      )
-        ? error
-        : undefined;
-      if (error instanceof CheckoutIntentUnresolvedError)
-        throw new ClientError(error.message, 'checkout-unavailable', {status: 404});
-      if (error instanceof CheckoutConfigInvalidError)
-        throw new ClientError('Checkout configuration is invalid', 'checkout-config-invalid', {
-          status: 409,
-        });
-      if (targetError?.code === 'checkout-repository-not-authorized')
-        throw new ClientError(
-          'Checkout repository is not authorized for this workspace',
-          'checkout-repository-not-authorized',
-          {status: 404},
-        );
-      if (known?.code === 'connection-not-found')
-        throw new ClientError(
-          'Integration connection not found',
-          'integration-connection-not-found',
-          {
-            status: 404,
-          },
-        );
-      if (known?.code === 'connection-inactive')
-        throw new ClientError(
-          'Integration connection is not active',
-          'integration-connection-inactive',
-          {
-            status: 422,
-          },
-        );
-      if (known?.code === 'connection-workspace-mismatch')
-        throw new ClientError(
-          'Integration connection does not belong to this workspace',
-          'forbidden',
-          {status: 403},
-        );
-      if (known?.code === 'provider-unavailable')
-        throw new ClientError(
-          'Integration provider is unavailable',
-          'integration-provider-unavailable',
-          {
-            status: 422,
-          },
-        );
-      if (known?.code === 'capability-unavailable')
-        throw new ClientError(
-          'Integration capability is unavailable',
-          'integration-capability-unavailable',
-          {
-            status: 422,
-          },
-        );
-      if (known?.code === 'checkout-unsupported')
-        throw new ClientError(
-          'Integration checkout is unsupported',
-          'integration-checkout-unsupported',
-          {
-            status: 422,
-          },
-        );
-      if (known?.code === 'provider-failure') {
-        const status =
-          known.details.reason === 'rate-limited'
-            ? 429
-            : known.details.reason === 'timeout' || known.details.reason === 'provider-unavailable'
-              ? 503
-              : 422;
-        throw new ClientError('Integration provider request failed', known.details.reason, {
-          details: {retry_after_seconds: known.details.retryAfterSeconds},
-          status,
-        });
-      }
-      throw error;
-    },
+    errorHandler: handleCheckoutTokenError,
     handler: async (request, reply) => {
       const {stepId} = request.params;
       const {attempt} = request.query;
@@ -149,4 +65,91 @@ export function createCheckoutTokenRoute(clients: {
       });
     },
   });
+}
+
+function handleCheckoutTokenError(error: unknown): never {
+  if (error instanceof CheckoutIntentUnresolvedError) {
+    throw new ClientError(error.message, 'checkout-unavailable', {status: 404});
+  }
+  if (error instanceof CheckoutConfigInvalidError) {
+    throw new ClientError('Checkout configuration is invalid', 'checkout-config-invalid', {
+      status: 409,
+    });
+  }
+  if (
+    isInterModuleKnownError(projectsInterModuleContract.methods.resolveCheckoutTarget, error) &&
+    error.code === 'checkout-repository-not-authorized'
+  ) {
+    throw new ClientError(
+      'Checkout repository is not authorized for this workspace',
+      'checkout-repository-not-authorized',
+      {status: 404},
+    );
+  }
+  if (isInterModuleKnownError(integrationsInterModuleContract.methods.createCheckoutSpec, error)) {
+    throwIntegrationCheckoutError(error);
+  }
+  throw error;
+}
+
+function throwIntegrationCheckoutError(
+  error: Parameters<typeof handleCheckoutTokenError>[0] & {code: string},
+): never {
+  switch (error.code) {
+    case 'connection-not-found':
+      throw new ClientError(
+        'Integration connection not found',
+        'integration-connection-not-found',
+        {status: 404},
+      );
+    case 'connection-inactive':
+      throw new ClientError(
+        'Integration connection is not active',
+        'integration-connection-inactive',
+        {status: 422},
+      );
+    case 'connection-workspace-mismatch':
+      throw new ClientError(
+        'Integration connection does not belong to this workspace',
+        'forbidden',
+        {status: 403},
+      );
+    case 'provider-unavailable':
+      throw new ClientError(
+        'Integration provider is unavailable',
+        'integration-provider-unavailable',
+        {status: 422},
+      );
+    case 'capability-unavailable':
+      throw new ClientError(
+        'Integration capability is unavailable',
+        'integration-capability-unavailable',
+        {status: 422},
+      );
+    case 'checkout-unsupported':
+      throw new ClientError(
+        'Integration checkout is unsupported',
+        'integration-checkout-unsupported',
+        {status: 422},
+      );
+    case 'provider-failure': {
+      const details = (
+        error as unknown as {
+          details: {reason: string; retryAfterSeconds?: number};
+        }
+      ).details;
+      throw new ClientError('Integration provider request failed', details.reason, {
+        details: {retry_after_seconds: details.retryAfterSeconds},
+        status: providerFailureStatus(details.reason),
+      });
+    }
+    default:
+      throw error;
+  }
+}
+
+function providerFailureStatus(reason: string): 422 | 429 | 503 {
+  if (reason === 'rate-limited') return 429;
+  if (reason === 'timeout' || reason === 'provider-unavailable') return 503;
+  return 422;
 }

--- a/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.ts
@@ -36,22 +36,7 @@ export function onStepAttemptTerminatedFailureAnnotation(
     }
 
     try {
-      const initialDetail = await getStepAttemptDetail({
-        stepId: payload.stepId,
-        attempt: payload.attempt,
-      });
-      if (!initialDetail) return;
-
-      // The detail query joins the requested attempt to the step's current projection. A
-      // delayed event can therefore return an old attempt alongside a newer step status. Read
-      // the canonical current attempt before deciding whether to replace or remove the card.
-      const detail =
-        initialDetail.attempt.attempt === initialDetail.step.currentAttempt
-          ? initialDetail
-          : await getStepAttemptDetail({
-              stepId: initialDetail.step.id,
-              attempt: initialDetail.step.currentAttempt,
-            });
+      const detail = await getCurrentStepAttemptDetail(payload);
       if (!detail || detail.attempt.attempt !== detail.step.currentAttempt) return;
 
       const runAttempt = await getWorkflowRunAttemptById(payload.workflowRunAttemptId);
@@ -71,11 +56,7 @@ export function onStepAttemptTerminatedFailureAnnotation(
           originStepAttempt: detail.attempt.attempt,
         },
         context: failureContext('step', detail.step.id),
-        failed:
-          detail.step.status === 'failed' ||
-          (detail.attempt.status === 'failed' &&
-            detail.step.status !== 'succeeded' &&
-            detail.step.status !== 'cancelled'),
+        failed: currentStepAttemptFailed(detail),
         body: stepFailureBody(
           detail.step.name,
           detail.attempt.error ?? detail.step.error,
@@ -89,6 +70,31 @@ export function onStepAttemptTerminatedFailureAnnotation(
       });
     }
   };
+}
+
+async function getCurrentStepAttemptDetail(payload: WorkflowsStepAttemptTerminatedEventDto) {
+  const initialDetail = await getStepAttemptDetail({
+    stepId: payload.stepId,
+    attempt: payload.attempt,
+  });
+  if (!initialDetail) return undefined;
+
+  // The detail query joins the requested attempt to the step's current projection. A
+  // delayed event can therefore return an old attempt alongside a newer step status. Read
+  // the canonical current attempt before deciding whether to replace or remove the card.
+  if (initialDetail.attempt.attempt === initialDetail.step.currentAttempt) return initialDetail;
+  return getStepAttemptDetail({
+    stepId: initialDetail.step.id,
+    attempt: initialDetail.step.currentAttempt,
+  });
+}
+
+function currentStepAttemptFailed(
+  detail: NonNullable<Awaited<ReturnType<typeof getStepAttemptDetail>>>,
+): boolean {
+  if (detail.step.status === 'failed') return true;
+  if (detail.attempt.status !== 'failed') return false;
+  return detail.step.status !== 'succeeded' && detail.step.status !== 'cancelled';
 }
 
 export function onJobTerminatedFailureAnnotation(annotations: AnnotationsInterModuleClient) {

--- a/libs/api/workflows/src/temporal/workflows/job-listener-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-listener-orchestration.ts
@@ -85,143 +85,190 @@ interface ListenerBufferPeek {
   newestAgeMs: number;
 }
 
+interface ListenerRuntimeState {
+  eventsAvailable: boolean;
+  latchedReason: ResolutionLatch;
+  nextSequence: number;
+  firingsInCurrentRun: number;
+}
+
 export async function jobListenerOrchestration(
   input: JobListenerOrchestrationInput,
 ): Promise<JobListenerOrchestrationResult> {
-  let eventsAvailable = false;
-  let latchedReason = input.continuation?.latchedReason;
+  const state: ListenerRuntimeState = {
+    eventsAvailable: false,
+    latchedReason: input.continuation?.latchedReason,
+    nextSequence: input.continuation?.nextSequence ?? 1,
+    firingsInCurrentRun: 0,
+  };
 
   setHandler(listenerEventsAvailableSignal, () => {
-    eventsAvailable = true;
+    state.eventsAvailable = true;
   });
   setHandler(listenerResolveSignal, () => {
-    latchedReason = 'until';
+    state.latchedReason = 'until';
   });
 
   const listenerDeadline = input.continuation?.listenerDeadline ?? initialListenerDeadline(input);
+  const terminal = await initializeListenerState(input, state);
+  if (terminal) return terminal;
 
-  let nextSequence: number;
-  if (input.continuation) {
-    nextSequence = input.continuation.nextSequence;
-  } else {
-    const activated = await activateJobListenerActivity({
-      jobId: input.jobId,
-      expectedVersion: input.jobVersion,
-    });
-    if (activated.status === 'terminal') {
-      return {
-        status: runtimeStatusForTerminalJobExecutionStatus(activated.jobStatus),
-        jobVersion: activated.jobVersion,
-      };
-    }
-    nextSequence = activated.executionCount + 1;
-  }
-
-  let firingsInCurrentRun = 0;
   const maxExecutions = input.maxExecutions ?? undefined;
   const batchConfig = listenerBatchConfig(input);
-  while (true) {
-    if (deadlineReached(listenerDeadline)) latchedReason ??= 'timeout';
-    await continueListenerAsNewIfNeeded({
+  while (await prepareListenerIteration(input, state, listenerDeadline, maxExecutions)) {
+    const batchReady = await waitForConfiguredBatch(input, state, listenerDeadline, batchConfig);
+    if (!batchReady) break;
+    const continueLoop = await drainAndProcessListenerEvents(
       input,
-      nextSequence,
-      latchedReason,
+      state,
       listenerDeadline,
-      firingsInCurrentRun,
-    });
-    if (latchedReason !== undefined) break;
-    if (maxExecutions !== undefined) {
-      if (nextSequence > maxExecutions) {
-        latchedReason = 'max_executions';
-        await continueListenerAsNewIfNeeded({
-          input,
-          nextSequence,
-          latchedReason,
-          listenerDeadline,
-          firingsInCurrentRun,
-        });
-        break;
-      }
-    }
-
-    if (batchConfig !== undefined) {
-      const decision = await awaitBatchFiringWindow({
-        jobId: input.jobId,
-        batchConfig,
-        listenerDeadline,
-        hasEventsHint: () => eventsAvailable,
-        clearEventsHint: () => {
-          eventsAvailable = false;
-        },
-        hasResolutionHint: () => latchedReason !== undefined,
-      });
-      if (decision === 'resolve') {
-        latchedReason ??= 'until';
-        break;
-      }
-      if (decision === 'deadline') {
-        latchedReason ??= 'timeout';
-        break;
-      }
-    }
-
-    eventsAvailable = false;
-    const drained = await drainListenerEventsActivity({
-      jobId: input.jobId,
-      expectedSequence: nextSequence,
-      ...(batchConfig?.maxSizeEvents === undefined ? {} : {maxSize: batchConfig.maxSizeEvents}),
-    });
-
-    if (drained.kind === 'resolve-requested') {
-      latchedReason = 'until';
-      break;
-    }
-
-    if (drained.kind === 'empty') {
-      const woke = await waitForListenerWakeup(
-        () => eventsAvailable || latchedReason !== undefined,
-        {deadline: listenerDeadline},
-      );
-      if (!woke && deadlineReached(listenerDeadline)) latchedReason = 'timeout';
-      continue;
-    }
-
-    if (drained.status === 'failed') {
-      await recordListenerFiringOutcomeActivity({outcome: 'failed'});
-      nextSequence = drained.sequence + 1;
-      firingsInCurrentRun += 1;
-      if (maxExecutions !== undefined && drained.sequence >= maxExecutions) {
-        latchedReason = 'max_executions';
-      }
-      continue;
-    }
-
-    await runListenerExecution({
-      input,
-      jobExecutionId: drained.jobExecutionId,
-      executionVersion: drained.executionVersion,
-      requiredLabels: drained.requiredLabels,
-      shouldCancelForResolution: () =>
-        input.onResolve === 'cancel' &&
-        (latchedReason !== undefined || deadlineReached(listenerDeadline)),
-      waitForResolution: () =>
-        waitForListenerWakeup(
-          () => latchedReason !== undefined || deadlineReached(listenerDeadline),
-          {deadline: listenerDeadline},
-        ),
-    });
-
-    if (deadlineReached(listenerDeadline)) latchedReason ??= 'timeout';
-    nextSequence = drained.sequence + 1;
-    firingsInCurrentRun += 1;
-    if (maxExecutions !== undefined && drained.sequence >= maxExecutions) {
-      latchedReason = 'max_executions';
-    }
+      maxExecutions,
+      batchConfig,
+    );
+    if (!continueLoop) break;
   }
 
-  const reason = latchedReason ?? 'timeout';
+  const reason = state.latchedReason ?? 'timeout';
   const resolved = await resolveJobListenerActivity({jobId: input.jobId, reason});
   return {status: resolved.status, jobVersion: resolved.jobVersion};
+}
+
+async function initializeListenerState(
+  input: JobListenerOrchestrationInput,
+  state: ListenerRuntimeState,
+): Promise<JobListenerOrchestrationResult | undefined> {
+  if (input.continuation) return undefined;
+  const activated = await activateJobListenerActivity({
+    jobId: input.jobId,
+    expectedVersion: input.jobVersion,
+  });
+  if (activated.status === 'terminal') {
+    return {
+      status: runtimeStatusForTerminalJobExecutionStatus(activated.jobStatus),
+      jobVersion: activated.jobVersion,
+    };
+  }
+  state.nextSequence = activated.executionCount + 1;
+  return undefined;
+}
+
+async function prepareListenerIteration(
+  input: JobListenerOrchestrationInput,
+  state: ListenerRuntimeState,
+  listenerDeadline: number | undefined,
+  maxExecutions: number | undefined,
+): Promise<boolean> {
+  if (deadlineReached(listenerDeadline)) state.latchedReason ??= 'timeout';
+  await continueListenerAsNewIfNeeded({
+    input,
+    nextSequence: state.nextSequence,
+    latchedReason: state.latchedReason,
+    listenerDeadline,
+    firingsInCurrentRun: state.firingsInCurrentRun,
+  });
+  if (state.latchedReason !== undefined) return false;
+  if (maxExecutions === undefined || state.nextSequence <= maxExecutions) return true;
+
+  state.latchedReason = 'max_executions';
+  await continueListenerAsNewIfNeeded({
+    input,
+    nextSequence: state.nextSequence,
+    latchedReason: state.latchedReason,
+    listenerDeadline,
+    firingsInCurrentRun: state.firingsInCurrentRun,
+  });
+  return false;
+}
+
+async function waitForConfiguredBatch(
+  input: JobListenerOrchestrationInput,
+  state: ListenerRuntimeState,
+  listenerDeadline: number | undefined,
+  batchConfig: ListenerBatchConfig | undefined,
+): Promise<boolean> {
+  if (batchConfig === undefined) return true;
+  const decision = await awaitBatchFiringWindow({
+    jobId: input.jobId,
+    batchConfig,
+    listenerDeadline,
+    hasEventsHint: () => state.eventsAvailable,
+    clearEventsHint: () => {
+      state.eventsAvailable = false;
+    },
+    hasResolutionHint: () => state.latchedReason !== undefined,
+  });
+  if (decision === 'fire') return true;
+  state.latchedReason ??= decision === 'resolve' ? 'until' : 'timeout';
+  return false;
+}
+
+async function drainAndProcessListenerEvents(
+  input: JobListenerOrchestrationInput,
+  state: ListenerRuntimeState,
+  listenerDeadline: number | undefined,
+  maxExecutions: number | undefined,
+  batchConfig: ListenerBatchConfig | undefined,
+): Promise<boolean> {
+  state.eventsAvailable = false;
+  const drained = await drainListenerEventsActivity({
+    jobId: input.jobId,
+    expectedSequence: state.nextSequence,
+    ...(batchConfig?.maxSizeEvents === undefined ? {} : {maxSize: batchConfig.maxSizeEvents}),
+  });
+  if (drained.kind === 'resolve-requested') {
+    state.latchedReason = 'until';
+    return false;
+  }
+  if (drained.kind === 'empty') {
+    await waitForMoreListenerEvents(state, listenerDeadline);
+    return true;
+  }
+  if (drained.status === 'failed') {
+    await recordListenerFiringOutcomeActivity({outcome: 'failed'});
+    recordListenerFiring(state, drained.sequence, maxExecutions);
+    return true;
+  }
+
+  await runListenerExecution({
+    input,
+    jobExecutionId: drained.jobExecutionId,
+    executionVersion: drained.executionVersion,
+    requiredLabels: drained.requiredLabels,
+    shouldCancelForResolution: () =>
+      input.onResolve === 'cancel' &&
+      (state.latchedReason !== undefined || deadlineReached(listenerDeadline)),
+    waitForResolution: () =>
+      waitForListenerWakeup(
+        () => state.latchedReason !== undefined || deadlineReached(listenerDeadline),
+        {deadline: listenerDeadline},
+      ),
+  });
+  if (deadlineReached(listenerDeadline)) state.latchedReason ??= 'timeout';
+  recordListenerFiring(state, drained.sequence, maxExecutions);
+  return true;
+}
+
+async function waitForMoreListenerEvents(
+  state: ListenerRuntimeState,
+  listenerDeadline: number | undefined,
+): Promise<void> {
+  const woke = await waitForListenerWakeup(
+    () => state.eventsAvailable || state.latchedReason !== undefined,
+    {deadline: listenerDeadline},
+  );
+  if (!woke && deadlineReached(listenerDeadline)) state.latchedReason = 'timeout';
+}
+
+function recordListenerFiring(
+  state: ListenerRuntimeState,
+  sequence: number,
+  maxExecutions: number | undefined,
+): void {
+  state.nextSequence = sequence + 1;
+  state.firingsInCurrentRun += 1;
+  if (maxExecutions !== undefined && sequence >= maxExecutions) {
+    state.latchedReason = 'max_executions';
+  }
 }
 
 function initialListenerDeadline(input: JobListenerOrchestrationInput): number | undefined {
@@ -295,24 +342,21 @@ async function awaitBatchFiringWindow(
     const peekDecision = bufferedResolveOrDeadlineDecision(params, peek);
     if (peekDecision !== undefined) return peekDecision;
 
-    if (peek.fireCount === 0) {
-      const waitDecision = await waitForAnyBatchWakeup(params);
-      if (waitDecision !== undefined) return waitDecision;
-      continue;
-    }
-
-    if (batchIsReadyToFire(params.batchConfig, peek)) return 'fire';
-
-    const sleepMs = nextBatchWindowMs(params.batchConfig, peek);
-    if (sleepMs === undefined) {
-      const waitDecision = await waitForAnyBatchWakeup(params);
-      if (waitDecision !== undefined) return waitDecision;
-      continue;
-    }
-
-    const waitDecision = await waitForBatchWindow(params, sleepMs);
-    if (waitDecision !== undefined) return waitDecision;
+    const windowDecision = await awaitPeekedBatchWindow(params, peek);
+    if (windowDecision !== 'retry') return windowDecision;
   }
+}
+
+async function awaitPeekedBatchWindow(
+  params: BatchFiringWindowParams,
+  peek: ListenerBufferPeek,
+): Promise<BatchFiringDecision | 'retry'> {
+  if (peek.fireCount === 0) return (await waitForAnyBatchWakeup(params)) ?? 'retry';
+  if (batchIsReadyToFire(params.batchConfig, peek)) return 'fire';
+
+  const sleepMs = nextBatchWindowMs(params.batchConfig, peek);
+  if (sleepMs === undefined) return (await waitForAnyBatchWakeup(params)) ?? 'retry';
+  return (await waitForBatchWindow(params, sleepMs)) ?? 'retry';
 }
 
 function resolutionOrDeadlineDecision(

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -16,6 +16,7 @@ import {
   shouldContinueStartedRun,
 } from '#core/workflow-scheduling/run-progress.js';
 import type {RuntimeCompletionStatus} from '#core/workflow-scheduling/runtime-dag.js';
+import type {RuntimeSchedulingCommand} from '#core/workflow-scheduling/runtime-scheduling-command.js';
 import {scheduleRuntimeDag} from '#core/workflow-scheduling/schedule-runtime-dag.js';
 
 import type {createOrchestrationActivities} from '../activities/index.js';
@@ -67,9 +68,7 @@ export async function runOrchestration(input: RunOrchestrationInput): Promise<vo
   const inFlight = new Map<string, Promise<{job: DagJob; result: LaunchResult}>>();
 
   while (true) {
-    if (cancelRequested) {
-      return;
-    }
+    if (cancelRequested) return;
     if (deadlineReached(runDeadline)) {
       await failRunAsTimedOutActivity({runAttemptId: input.runAttemptId});
       return;
@@ -80,48 +79,12 @@ export async function runOrchestration(input: RunOrchestrationInput): Promise<vo
       completed: progress.completed,
       running: new Set(inFlight.keys()),
     });
-    const completeRun = commands.find((command) => command.kind === 'complete-run');
-    const startJobs = new Map<string, DagJob>();
-
-    for (const command of commands) {
-      if (command.kind !== 'skip-job') continue;
-      await skipJob(command.job, progress, command.statusReason);
-    }
-
-    for (const command of commands) {
-      if (command.kind !== 'evaluate-job-activation') continue;
-      const activationJobsById = new Map(command.jobs.map((job) => [job.id, job]));
-      const decisions = await evaluateJobActivationsActivity({
-        runAttemptId: input.runAttemptId,
-        jobs: command.jobs.map((job) => ({
-          jobId: job.id,
-          expectedVersion: runtimeJobVersion(job, progress),
-        })),
-      });
-      for (const decision of decisions) {
-        const job = activationJobsById.get(decision.jobId);
-        if (!job) continue;
-        if (decision.kind === 'start-job') {
-          startJobs.set(job.key, job);
-          continue;
-        }
-        recordRuntimeJobResult(job, progress, {
-          status: decision.status,
-          jobVersion: decision.jobVersion,
-        });
-      }
-    }
-
-    for (const command of commands) {
-      if (command.kind !== 'start-job') continue;
-      startJobs.set(command.job.key, command.job);
-    }
-
-    for (const job of startJobs.values()) {
-      if (!inFlight.has(job.key)) {
-        inFlight.set(job.key, launchJob(job, dag, progress));
-      }
-    }
+    const {completeRun, startJobs} = await processRunCommands(
+      commands,
+      input.runAttemptId,
+      progress,
+    );
+    launchScheduledJobs(startJobs, inFlight, dag, progress);
 
     if (completeRun) {
       await setRunAttemptStatus({
@@ -144,6 +107,87 @@ export async function runOrchestration(input: RunOrchestrationInput): Promise<vo
     }
     inFlight.delete(settled.job.key);
     recordRuntimeJobResult(settled.job, progress, settled.result);
+  }
+}
+
+type RuntimeRunCommand = RuntimeSchedulingCommand<DagJob>;
+
+async function processRunCommands(
+  commands: readonly RuntimeRunCommand[],
+  runAttemptId: string,
+  progress: RuntimeRunProgress,
+) {
+  const startJobs = new Map<string, DagJob>();
+  await applySkippedJobCommands(commands, progress);
+  await applyActivationCommands(commands, runAttemptId, progress, startJobs);
+  for (const command of commands) {
+    if (command.kind === 'start-job') startJobs.set(command.job.key, command.job);
+  }
+  return {
+    completeRun: commands.find((command) => command.kind === 'complete-run'),
+    startJobs,
+  };
+}
+
+async function applySkippedJobCommands(
+  commands: readonly RuntimeRunCommand[],
+  progress: RuntimeRunProgress,
+): Promise<void> {
+  for (const command of commands) {
+    if (command.kind === 'skip-job') {
+      await skipJob(command.job, progress, command.statusReason);
+    }
+  }
+}
+
+async function applyActivationCommands(
+  commands: readonly RuntimeRunCommand[],
+  runAttemptId: string,
+  progress: RuntimeRunProgress,
+  startJobs: Map<string, DagJob>,
+): Promise<void> {
+  for (const command of commands) {
+    if (command.kind !== 'evaluate-job-activation') continue;
+    await applyActivationCommand(command, runAttemptId, progress, startJobs);
+  }
+}
+
+async function applyActivationCommand(
+  command: Extract<RuntimeRunCommand, {kind: 'evaluate-job-activation'}>,
+  runAttemptId: string,
+  progress: RuntimeRunProgress,
+  startJobs: Map<string, DagJob>,
+): Promise<void> {
+  const activationJobsById = new Map(command.jobs.map((job) => [job.id, job]));
+  const decisions = await evaluateJobActivationsActivity({
+    runAttemptId,
+    jobs: command.jobs.map((job) => ({
+      jobId: job.id,
+      expectedVersion: runtimeJobVersion(job, progress),
+    })),
+  });
+  for (const decision of decisions) {
+    const job = activationJobsById.get(decision.jobId);
+    if (!job) continue;
+    if (decision.kind === 'start-job') {
+      startJobs.set(job.key, job);
+      continue;
+    }
+    recordRuntimeJobResult(job, progress, {
+      status: decision.status,
+      jobVersion: decision.jobVersion,
+    });
+  }
+}
+
+function launchScheduledJobs(
+  startJobs: ReadonlyMap<string, DagJob>,
+  inFlight: Map<string, Promise<{job: DagJob; result: LaunchResult}>>,
+  dag: RunDag,
+  progress: RuntimeRunProgress,
+): void {
+  for (const job of startJobs.values()) {
+    if (!inFlight.has(job.key)) inFlight.set(job.key, launchJob(job, dag, progress));
   }
 }
 
@@ -172,52 +216,67 @@ function launchJob(
   run: RunDag,
   progress: RuntimeRunProgress,
 ): Promise<{job: DagJob; result: LaunchResult}> {
-  if (job.mode === 'listening') {
-    return executeChild(jobListenerOrchestration, {
-      workflowId: `job-listener:${job.id}`,
-      args: [
-        {
-          jobId: job.id,
-          runAttemptId: run.runAttemptId,
-          jobVersion: runtimeJobVersion(job, progress),
-          ...(job.executionTimeoutMs === undefined
-            ? {}
-            : {executionTimeoutMs: job.executionTimeoutMs}),
-          ...(job.listeningTimeoutMs === undefined
-            ? {}
-            : {listeningTimeoutMs: job.listeningTimeoutMs}),
-          ...(job.maxExecutions === undefined ? {} : {maxExecutions: job.maxExecutions}),
-          ...(job.onResolve === undefined ? {} : {onResolve: job.onResolve}),
-          ...(job.batchDebounceMs === undefined ? {} : {batchDebounceMs: job.batchDebounceMs}),
-          ...(job.batchMaxSize === undefined ? {} : {batchMaxSize: job.batchMaxSize}),
-          ...(job.batchMaxWaitMs === undefined ? {} : {batchMaxWaitMs: job.batchMaxWaitMs}),
-          requiredLabels: job.runner,
-        },
-      ],
-      parentClosePolicy: ParentClosePolicy.TERMINATE,
-    })
-      .then((result) => ({job, result}))
-      .catch(async (error) => {
-        log.warn('listener child failed; marking runtime job failed', {
-          jobId: job.id,
-          error: String(error),
-        });
-        const failed = await setJobStatus({
-          jobId: job.id,
-          status: 'failed',
-          version: runtimeJobVersion(job, progress),
-          statusReason: 'unknown',
-        });
-        return {
-          job,
-          result: {status: 'failed' as const, jobVersion: failed.newVersion},
-        };
-      });
-  }
+  if (job.mode === 'listening') return launchListenerJob(job, run, progress);
+  return launchOneShotJob(job, run, progress);
+}
 
-  if (job.jobExecutionId === undefined) {
+function launchListenerJob(
+  job: DagJob,
+  run: RunDag,
+  progress: RuntimeRunProgress,
+): Promise<{job: DagJob; result: LaunchResult}> {
+  return executeChild(jobListenerOrchestration, {
+    workflowId: `job-listener:${job.id}`,
+    args: [
+      {
+        jobId: job.id,
+        runAttemptId: run.runAttemptId,
+        jobVersion: runtimeJobVersion(job, progress),
+        ...(job.executionTimeoutMs === undefined
+          ? {}
+          : {executionTimeoutMs: job.executionTimeoutMs}),
+        ...(job.listeningTimeoutMs === undefined
+          ? {}
+          : {listeningTimeoutMs: job.listeningTimeoutMs}),
+        ...(job.maxExecutions === undefined ? {} : {maxExecutions: job.maxExecutions}),
+        ...(job.onResolve === undefined ? {} : {onResolve: job.onResolve}),
+        ...(job.batchDebounceMs === undefined ? {} : {batchDebounceMs: job.batchDebounceMs}),
+        ...(job.batchMaxSize === undefined ? {} : {batchMaxSize: job.batchMaxSize}),
+        ...(job.batchMaxWaitMs === undefined ? {} : {batchMaxWaitMs: job.batchMaxWaitMs}),
+        requiredLabels: job.runner,
+      },
+    ],
+    parentClosePolicy: ParentClosePolicy.TERMINATE,
+  })
+    .then((result) => ({job, result}))
+    .catch((error) => failListenerJob(job, progress, error));
+}
+
+async function failListenerJob(
+  job: DagJob,
+  progress: RuntimeRunProgress,
+  error: unknown,
+): Promise<{job: DagJob; result: LaunchResult}> {
+  log.warn('listener child failed; marking runtime job failed', {
+    jobId: job.id,
+    error: String(error),
+  });
+  const failed = await setJobStatus({
+    jobId: job.id,
+    status: 'failed',
+    version: runtimeJobVersion(job, progress),
+    statusReason: 'unknown',
+  });
+  return {job, result: {status: 'failed', jobVersion: failed.newVersion}};
+}
+
+function launchOneShotJob(
+  job: DagJob,
+  run: RunDag,
+  progress: RuntimeRunProgress,
+): Promise<{job: DagJob; result: LaunchResult}> {
+  if (job.jobExecutionId === undefined)
     throw new Error(`Cannot start job without an execution: ${job.id}`);
-  }
   return executeChild(jobExecutionOrchestration, {
     workflowId: `job:${job.id}`,
     args: [

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -88,39 +88,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
       steps: [{run: 'echo hello'}],
     },
   };
-  const modelJobs = Object.entries(jobs).map(([key, job]) => {
-    const jobId = stableId(key);
-    return {
-      id: jobId,
-      key,
-      mode: job.listening === undefined ? ('one_shot' as const) : ('listening' as const),
-      runner: normalizeStringArray(job.runner ?? input.runner ?? DEFAULT_RUNNER_LABELS),
-      ...(job.runnerTemplates === undefined
-        ? {}
-        : {
-            runnerTemplates: job.runnerTemplates.map((template) =>
-              requiredFieldTemplate('job.runner', template),
-            ),
-          }),
-      checkout: job.checkout ?? DEFAULT_JOB_CHECKOUT,
-      ...(job.if === undefined ? {} : {if: workflowExpression(job.if)}),
-      ...(job.success === undefined ? {} : {success: job.success}),
-      ...(job.outputs === undefined ? {} : {outputs: outputTemplates(job.outputs)}),
-      ...(job.outputTypes === undefined ? {} : {outputTypes: job.outputTypes}),
-      ...(job.name === undefined ? {} : {name: job.name}),
-      ...(job.executionName === undefined
-        ? {}
-        : {
-            executionName: fieldTemplate('job.execution_name', job.executionName) ?? [
-              {kind: 'literal' as const, value: job.executionName},
-            ],
-          }),
-      ...(job.listening === undefined ? {} : {listening: job.listening}),
-      ...optionalScopedEnv(job.env),
-      dependencies: normalizeStringArray(job.needs).map(stableId),
-      steps: job.steps.map((step, stepIndex) => normalizeStep(step, jobId, stepIndex)),
-    };
-  });
+  const modelJobs = Object.entries(jobs).map(([key, job]) => normalizeJob(key, job, input.runner));
 
   return {
     kind: 'workflow',
@@ -138,6 +106,44 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
     dependencies: modelJobs.flatMap((job) =>
       job.dependencies.map((dependency) => ({from: dependency, to: job.id})),
     ),
+  };
+}
+
+function normalizeJob(
+  key: string,
+  job: TestWorkflowJob,
+  workflowRunner: TestWorkflowModelInput['runner'],
+): WorkflowModel['jobs'][number] {
+  const jobId = stableId(key);
+  return {
+    id: jobId,
+    key,
+    mode: job.listening === undefined ? 'one_shot' : 'listening',
+    runner: normalizeStringArray(job.runner ?? workflowRunner ?? DEFAULT_RUNNER_LABELS),
+    ...(job.runnerTemplates === undefined
+      ? {}
+      : {
+          runnerTemplates: job.runnerTemplates.map((template) =>
+            requiredFieldTemplate('job.runner', template),
+          ),
+        }),
+    checkout: job.checkout ?? DEFAULT_JOB_CHECKOUT,
+    ...(job.if === undefined ? {} : {if: workflowExpression(job.if)}),
+    ...(job.success === undefined ? {} : {success: job.success}),
+    ...(job.outputs === undefined ? {} : {outputs: outputTemplates(job.outputs)}),
+    ...(job.outputTypes === undefined ? {} : {outputTypes: job.outputTypes}),
+    ...(job.name === undefined ? {} : {name: job.name}),
+    ...(job.executionName === undefined
+      ? {}
+      : {
+          executionName: fieldTemplate('job.execution_name', job.executionName) ?? [
+            {kind: 'literal' as const, value: job.executionName},
+          ],
+        }),
+    ...(job.listening === undefined ? {} : {listening: job.listening}),
+    ...optionalScopedEnv(job.env),
+    dependencies: normalizeStringArray(job.needs).map(stableId),
+    steps: job.steps.map((step, stepIndex) => normalizeStep(step, jobId, stepIndex)),
   };
 }
 
@@ -159,48 +165,47 @@ function outputTemplates(outputs: Readonly<Record<string, string>>) {
 
 function normalizeStep(step: TestWorkflowStep, jobId: string, stepIndex: number): ModelStep {
   const base = stepBase(step, jobId, stepIndex);
-  if ('run' in step) {
-    return {
-      ...base,
-      kind: 'run',
-      command: {kind: 'shell', value: step.run},
-      ...optionalRunTemplates(step),
-      ...optionalStepEnv(step.env),
-    };
-  }
+  if ('run' in step) return normalizeRunStep(step, base);
+  if ('prompt' in step) return normalizeAgentStep(step, base);
+  if ('tool' in step) return normalizeToolStep(step, base);
+  return {...base, kind: 'checkout', checkout: step.checkout};
+}
 
-  if ('prompt' in step) {
-    return {
-      ...base,
-      kind: 'agent',
-      ...(step.harness === undefined ? {} : {harness: step.harness}),
-      ...(step.model === undefined ? {} : {model: step.model}),
-      ...(step.provider === undefined ? {} : {provider: step.provider}),
-      ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
-      ...(step.tools === undefined ? {} : {tools: step.tools}),
-      ...(step.integrations === undefined ? {} : {integrations: step.integrations}),
-      ...(step.session === undefined ? {} : {session: testAgentStepSession(step.session)}),
-      prompt: step.prompt,
-      ...optionalAgentTemplates(step),
-    };
-  }
-
-  if ('tool' in step) {
-    return {
-      ...base,
-      kind: 'tool',
-      tool: splitToolId(step.tool),
-      ...(step.connection === undefined ? {} : {connection: step.connection}),
-      ...(step.with === undefined ? {} : {with: step.with}),
-      ...(step.outputs === undefined ? {} : {outputMappings: outputMappings(step.outputs)}),
-      ...optionalToolTemplates(step),
-    };
-  }
-
+function normalizeRunStep(step: TestRunStep, base: ReturnType<typeof stepBase>): ModelStep {
   return {
     ...base,
-    kind: 'checkout',
-    checkout: step.checkout,
+    kind: 'run',
+    command: {kind: 'shell', value: step.run},
+    ...optionalRunTemplates(step),
+    ...optionalStepEnv(step.env),
+  };
+}
+
+function normalizeAgentStep(step: TestAgentStep, base: ReturnType<typeof stepBase>): ModelStep {
+  return {
+    ...base,
+    kind: 'agent',
+    ...(step.harness === undefined ? {} : {harness: step.harness}),
+    ...(step.model === undefined ? {} : {model: step.model}),
+    ...(step.provider === undefined ? {} : {provider: step.provider}),
+    ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+    ...(step.tools === undefined ? {} : {tools: step.tools}),
+    ...(step.integrations === undefined ? {} : {integrations: step.integrations}),
+    ...(step.session === undefined ? {} : {session: testAgentStepSession(step.session)}),
+    prompt: step.prompt,
+    ...optionalAgentTemplates(step),
+  };
+}
+
+function normalizeToolStep(step: TestToolStep, base: ReturnType<typeof stepBase>): ModelStep {
+  return {
+    ...base,
+    kind: 'tool',
+    tool: splitToolId(step.tool),
+    ...(step.connection === undefined ? {} : {connection: step.connection}),
+    ...(step.with === undefined ? {} : {with: step.with}),
+    ...(step.outputs === undefined ? {} : {outputMappings: outputMappings(step.outputs)}),
+    ...optionalToolTemplates(step),
   };
 }
 

--- a/libs/api/workspaces/src/db/invitations.ts
+++ b/libs/api/workspaces/src/db/invitations.ts
@@ -15,7 +15,7 @@ import {
   recordWorkspaceMembershipChanged,
 } from '#metrics/instance.js';
 import {db} from './db.js';
-import {membershipValues} from './memberships.js';
+import {findMembership, membershipValues} from './memberships.js';
 import {invitations, toInvitation} from './schema/invitations.js';
 import {memberships, toMembership} from './schema/memberships.js';
 import {workspacesOutbox} from './schema/outbox.js';
@@ -228,20 +228,6 @@ async function reconcileInvitationInTransaction(
   } as const;
 }
 
-async function findMembership(
-  tx: WorkspacesTx,
-  userId: string,
-  workspaceId: string,
-): Promise<Membership | undefined> {
-  const rows = await tx
-    .select()
-    .from(memberships)
-    .where(and(eq(memberships.userId, userId), eq(memberships.workspaceId, workspaceId)))
-    .limit(1);
-  const row = rows[0];
-  return row ? toMembership(row) : undefined;
-}
-
 async function reconcileAlreadyAcceptedInvitation(
   tx: WorkspacesTx,
   params: ReconcileInvitationAcceptanceParams,
@@ -250,7 +236,10 @@ async function reconcileAlreadyAcceptedInvitation(
   if (invitation.acceptedByUserId !== params.acceptedByUserId) {
     return {status: 'consumed_by_another_user'};
   }
-  const membership = await findMembership(tx, params.acceptedByUserId, invitation.workspaceId);
+  const membership = await findMembership(
+    {userId: params.acceptedByUserId, workspaceId: invitation.workspaceId},
+    {tx},
+  );
   if (!membership) throw new Error('Accepted invitation has no membership');
   return {status: 'already_accepted', invitation, membership};
 }
@@ -270,7 +259,10 @@ async function ensureInvitationMembership(
   params: ReconcileInvitationAcceptanceParams,
   invitation: Invitation,
 ): Promise<{membership: Membership; alreadyMember: boolean}> {
-  const existing = await findMembership(tx, params.acceptedByUserId, invitation.workspaceId);
+  const existing = await findMembership(
+    {userId: params.acceptedByUserId, workspaceId: invitation.workspaceId},
+    {tx},
+  );
   if (existing) return {membership: existing, alreadyMember: true};
   const created = await tx
     .insert(memberships)

--- a/libs/api/workspaces/src/db/invitations.ts
+++ b/libs/api/workspaces/src/db/invitations.ts
@@ -167,97 +167,133 @@ export type ReconcileInvitationAcceptanceResult =
   | {status: 'already_accepted'; invitation: Invitation; membership: Membership}
   | {status: 'invalid' | 'expired' | 'revoked' | 'consumed_by_another_user' | 'email_mismatch'};
 
-export async function reconcileInvitationAcceptance(params: {
+type WorkspacesTx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
+type ReconcileInvitationAcceptanceParams = {
   invitationId: string;
   acceptedByUserId: string;
   email: string;
   acceptedByUserName?: string | null | undefined;
-}): Promise<ReconcileInvitationAcceptanceResult> {
-  const result = await db().transaction(async (tx) => {
-    const findMembership = async (userId: string, workspaceId: string) => {
-      const rows = await tx
-        .select()
-        .from(memberships)
-        .where(and(eq(memberships.userId, userId), eq(memberships.workspaceId, workspaceId)))
-        .limit(1);
-      const row = rows[0];
-      return row ? toMembership(row) : undefined;
-    };
-    const rows = await tx
-      .select()
-      .from(invitations)
-      .where(eq(invitations.id, params.invitationId))
-      .limit(1)
-      .for('update');
-    const row = rows[0];
-    if (!row) return {status: 'invalid'} as const;
+};
 
-    const invitation = toInvitation(row);
-    if (invitation.acceptedAt !== null) {
-      if (invitation.acceptedByUserId !== params.acceptedByUserId) {
-        return {status: 'consumed_by_another_user'} as const;
-      }
-      const membership = await findMembership(params.acceptedByUserId, invitation.workspaceId);
-      if (!membership) throw new Error('Accepted invitation has no membership');
-      return {status: 'already_accepted', invitation, membership} as const;
-    }
-    if (invitation.revokedAt !== null) return {status: 'revoked'} as const;
-    if (invitation.expiresAt.getTime() <= Date.now()) return {status: 'expired'} as const;
-    if (invitation.email !== params.email) return {status: 'email_mismatch'} as const;
-
-    const existingMembership = await findMembership(
-      params.acceptedByUserId,
-      invitation.workspaceId,
-    );
-    let membership = existingMembership;
-    if (!membership) {
-      const created = await tx
-        .insert(memberships)
-        .values(
-          membershipValues({
-            userId: params.acceptedByUserId,
-            userEmail: invitation.email,
-            userName: params.acceptedByUserName ?? null,
-            workspaceId: invitation.workspaceId,
-          }),
-        )
-        .returning();
-      const createdRow = created[0];
-      if (!createdRow) throw new Error('Insert returned no rows');
-      membership = toMembership(createdRow);
-      await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
-        type: WORKSPACES_MEMBER_JOINED,
-        payload: {
-          workspaceId: invitation.workspaceId,
-          userId: params.acceptedByUserId,
-          email: invitation.email,
-          viaInvitation: true,
-        },
-      });
-    }
-
-    const updated = await tx
-      .update(invitations)
-      .set({
-        acceptedAt: sql`now()`,
-        acceptedByUserId: params.acceptedByUserId,
-        updatedAt: sql`now()`,
-      })
-      .where(eq(invitations.id, params.invitationId))
-      .returning();
-    const updatedRow = updated[0];
-    if (!updatedRow) throw new Error('Update returned no rows');
-    return {
-      status: 'accepted',
-      invitation: toInvitation(updatedRow),
-      membership,
-      alreadyMember: existingMembership !== undefined,
-    } as const;
-  });
+export async function reconcileInvitationAcceptance(
+  params: ReconcileInvitationAcceptanceParams,
+): Promise<ReconcileInvitationAcceptanceResult> {
+  const result = await db().transaction((tx) => reconcileInvitationInTransaction(tx, params));
 
   if (result.status === 'accepted') {
     if (!result.alreadyMember) recordWorkspaceMembershipChanged('added');
     recordWorkspaceInvitationAccepted(result.alreadyMember ? 'already_member' : 'added');
   }
   return result;
+}
+
+async function reconcileInvitationInTransaction(
+  tx: WorkspacesTx,
+  params: ReconcileInvitationAcceptanceParams,
+): Promise<ReconcileInvitationAcceptanceResult> {
+  const rows = await tx
+    .select()
+    .from(invitations)
+    .where(eq(invitations.id, params.invitationId))
+    .limit(1)
+    .for('update');
+  const row = rows[0];
+  if (!row) return {status: 'invalid'} as const;
+
+  const invitation = toInvitation(row);
+  if (invitation.acceptedAt !== null) {
+    return reconcileAlreadyAcceptedInvitation(tx, params, invitation);
+  }
+  const invalidStatus = invitationAcceptanceInvalidStatus(invitation, params.email);
+  if (invalidStatus) return {status: invalidStatus};
+
+  const {membership, alreadyMember} = await ensureInvitationMembership(tx, params, invitation);
+
+  const updated = await tx
+    .update(invitations)
+    .set({
+      acceptedAt: sql`now()`,
+      acceptedByUserId: params.acceptedByUserId,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(invitations.id, params.invitationId))
+    .returning();
+  const updatedRow = updated[0];
+  if (!updatedRow) throw new Error('Update returned no rows');
+  return {
+    status: 'accepted',
+    invitation: toInvitation(updatedRow),
+    membership,
+    alreadyMember,
+  } as const;
+}
+
+async function findMembership(
+  tx: WorkspacesTx,
+  userId: string,
+  workspaceId: string,
+): Promise<Membership | undefined> {
+  const rows = await tx
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.userId, userId), eq(memberships.workspaceId, workspaceId)))
+    .limit(1);
+  const row = rows[0];
+  return row ? toMembership(row) : undefined;
+}
+
+async function reconcileAlreadyAcceptedInvitation(
+  tx: WorkspacesTx,
+  params: ReconcileInvitationAcceptanceParams,
+  invitation: Invitation,
+): Promise<ReconcileInvitationAcceptanceResult> {
+  if (invitation.acceptedByUserId !== params.acceptedByUserId) {
+    return {status: 'consumed_by_another_user'};
+  }
+  const membership = await findMembership(tx, params.acceptedByUserId, invitation.workspaceId);
+  if (!membership) throw new Error('Accepted invitation has no membership');
+  return {status: 'already_accepted', invitation, membership};
+}
+
+function invitationAcceptanceInvalidStatus(
+  invitation: Invitation,
+  email: string,
+): 'expired' | 'revoked' | 'email_mismatch' | undefined {
+  if (invitation.revokedAt !== null) return 'revoked';
+  if (invitation.expiresAt.getTime() <= Date.now()) return 'expired';
+  if (invitation.email !== email) return 'email_mismatch';
+  return undefined;
+}
+
+async function ensureInvitationMembership(
+  tx: WorkspacesTx,
+  params: ReconcileInvitationAcceptanceParams,
+  invitation: Invitation,
+): Promise<{membership: Membership; alreadyMember: boolean}> {
+  const existing = await findMembership(tx, params.acceptedByUserId, invitation.workspaceId);
+  if (existing) return {membership: existing, alreadyMember: true};
+  const created = await tx
+    .insert(memberships)
+    .values(
+      membershipValues({
+        userId: params.acceptedByUserId,
+        userEmail: invitation.email,
+        userName: params.acceptedByUserName ?? null,
+        workspaceId: invitation.workspaceId,
+      }),
+    )
+    .returning();
+  const createdRow = created[0];
+  if (!createdRow) throw new Error('Insert returned no rows');
+  const membership = toMembership(createdRow);
+  await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
+    type: WORKSPACES_MEMBER_JOINED,
+    payload: {
+      workspaceId: invitation.workspaceId,
+      userId: params.acceptedByUserId,
+      email: invitation.email,
+      viaInvitation: true,
+    },
+  });
+  return {membership, alreadyMember: false};
 }

--- a/libs/api/workspaces/src/db/memberships.ts
+++ b/libs/api/workspaces/src/db/memberships.ts
@@ -91,6 +91,9 @@ export interface MembershipWithUser extends Membership {
   userName: string | null;
 }
 
+type WorkspaceDatabase = ReturnType<typeof db>;
+type WorkspaceTransaction = Parameters<Parameters<WorkspaceDatabase['transaction']>[0]>[0];
+
 export async function listMembershipsByWorkspace(params: {
   workspaceId: string;
 }): Promise<MembershipWithUser[]> {
@@ -102,11 +105,12 @@ export async function listMembershipsByWorkspace(params: {
   return rows.map(toMembership);
 }
 
-export async function findMembership(params: {
-  userId: string;
-  workspaceId: string;
-}): Promise<Membership | undefined> {
-  const rows = await db()
+export async function findMembership(
+  params: {userId: string; workspaceId: string},
+  options: {tx?: WorkspaceDatabase | WorkspaceTransaction | undefined} = {},
+): Promise<Membership | undefined> {
+  const executor = options.tx ?? db();
+  const rows = await executor
     .select()
     .from(memberships)
     .where(

--- a/libs/api/workspaces/test/routes.ts
+++ b/libs/api/workspaces/test/routes.ts
@@ -124,7 +124,9 @@ export function extractToken(url: string): string {
 
 export function getSetCookie(res: {headers: OutgoingHttpHeaders}): string {
   const header = res.headers['set-cookie'];
-  const value = Array.isArray(header) ? header[0] : typeof header === 'string' ? header : undefined;
+  let value: string | undefined;
+  if (Array.isArray(header)) value = header[0];
+  else if (typeof header === 'string') value = header;
   expect(value).toBeDefined();
   return value ?? '';
 }

--- a/libs/client/agent/src/components/form-errors.ts
+++ b/libs/client/agent/src/components/form-errors.ts
@@ -29,57 +29,59 @@ export function modelProviderConfigErrorToFormError(
 function apiErrorMessage(error: ApiError): string {
   const details = modelProviderErrorDetails(error.details);
 
-  if (error.code === 'provider-validation-failed') {
-    return typeof details.message === 'string' ? details.message : error.message;
+  switch (error.code) {
+    case 'provider-validation-failed':
+    case 'workspace-providers-disabled':
+      return typeof details.message === 'string' ? details.message : error.message;
+    case 'invalid-credential-fields':
+      return invalidCredentialFieldsMessage(details);
+    case 'invalid-agent-model':
+      return 'Choose a model from the models list.';
+    case 'slug-collision':
+      return 'A provider with this id already exists in this workspace.';
+    case 'egress-denied':
+      return egressDeniedMessage(details);
+    case 'invalid-header-keep':
+      return 'A kept secret header no longer exists - re-enter its value.';
+    case 'stored-secret-base-url-changed':
+      return 'Re-enter stored secret values before testing against a different base URL.';
+    case 'not-found':
+      return 'This custom provider no longer exists. Refresh and try again.';
+    case 'workspace-secret-cap-exceeded':
+      return workspaceSecretCapMessage(details);
+    case 'value-too-large':
+      return 'A key or header value is too large to store.';
+    case 'provider-unsupported':
+      return 'This provider is not supported for workspace-managed credentials.';
+    case 'provider-not-configured':
+      return 'Configure this provider before setting it as the default.';
+    default:
+      return error.message;
   }
-  if (error.code === 'invalid-credential-fields') {
-    const expectedKeys = Array.isArray(details.expected_keys)
-      ? details.expected_keys.filter((key): key is string => typeof key === 'string')
-      : [];
-    if (expectedKeys.length > 0) {
-      return `Credentials must include exactly these fields: ${expectedKeys.join(', ')}.`;
-    }
+}
+
+function invalidCredentialFieldsMessage(details: ModelProviderErrorDetails): string {
+  const expectedKeys = Array.isArray(details.expected_keys)
+    ? details.expected_keys.filter((key): key is string => typeof key === 'string')
+    : [];
+  if (expectedKeys.length === 0) {
     return 'Credentials do not match the fields required by this provider.';
   }
-  if (error.code === 'invalid-agent-model') {
-    return 'Choose a model from the models list.';
+  return `Credentials must include exactly these fields: ${expectedKeys.join(', ')}.`;
+}
+
+function egressDeniedMessage(details: ModelProviderErrorDetails): string {
+  const target = typeof details.target === 'string' ? details.target : undefined;
+  const reason = typeof details.reason === 'string' ? details.reason : undefined;
+  const prefix = target && reason ? `Requests to ${target} are blocked (${reason}). ` : '';
+  return `${prefix}On Shipfox Cloud the endpoint must be reachable from the internet. Use a public HTTPS URL for hosted providers.`;
+}
+
+function workspaceSecretCapMessage(details: ModelProviderErrorDetails): string {
+  if (typeof details.cap === 'number') {
+    return `This workspace has reached its secrets limit of ${details.cap}.`;
   }
-  if (error.code === 'slug-collision') {
-    return 'A provider with this id already exists in this workspace.';
-  }
-  if (error.code === 'egress-denied') {
-    const target = typeof details.target === 'string' ? details.target : undefined;
-    const reason = typeof details.reason === 'string' ? details.reason : undefined;
-    const prefix = target && reason ? `Requests to ${target} are blocked (${reason}). ` : '';
-    return `${prefix}On Shipfox Cloud the endpoint must be reachable from the internet. Use a public HTTPS URL for hosted providers.`;
-  }
-  if (error.code === 'invalid-header-keep') {
-    return 'A kept secret header no longer exists - re-enter its value.';
-  }
-  if (error.code === 'stored-secret-base-url-changed') {
-    return 'Re-enter stored secret values before testing against a different base URL.';
-  }
-  if (error.code === 'not-found') {
-    return 'This custom provider no longer exists. Refresh and try again.';
-  }
-  if (error.code === 'workspace-secret-cap-exceeded') {
-    return typeof details.cap === 'number'
-      ? `This workspace has reached its secrets limit of ${details.cap}.`
-      : 'This workspace has reached its secrets limit.';
-  }
-  if (error.code === 'value-too-large') {
-    return 'A key or header value is too large to store.';
-  }
-  if (error.code === 'provider-unsupported') {
-    return 'This provider is not supported for workspace-managed credentials.';
-  }
-  if (error.code === 'provider-not-configured') {
-    return 'Configure this provider before setting it as the default.';
-  }
-  if (error.code === 'workspace-providers-disabled') {
-    return typeof details.message === 'string' ? details.message : error.message;
-  }
-  return error.message;
+  return 'This workspace has reached its secrets limit.';
 }
 
 export function modelProviderConfigErrorField(error: unknown): ModelProviderConfigFormErrorMapping {

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -22,7 +22,16 @@ import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Header, Text} from '@shipfox/react-ui/typography';
-import {useEffect, useMemo, useReducer, useRef, useState} from 'react';
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 import {
   type ManagementModal,
   managementModalReducer,
@@ -33,6 +42,7 @@ import type {
   ProviderCatalogEntry,
   ProviderConfig,
   SupportedProvider,
+  UnsupportedProvider,
 } from '#core/models.js';
 import {
   customProviderCardMatchesSearch,
@@ -68,6 +78,8 @@ type UsageTarget = {
 };
 
 const USAGE_MODAL_OPEN_DELAY_MS = 250;
+type ManagementModalDispatch = Dispatch<Parameters<typeof managementModalReducer>[1]>;
+type SetPendingUsageTarget = Dispatch<SetStateAction<UsageTarget | null>>;
 
 function ManagedProviderSection({
   provider,
@@ -141,6 +153,368 @@ function ManagedProviderSection({
   );
 }
 
+function ConfiguredProvidersSection({
+  workspaceId,
+  regionRef,
+  query,
+  configs,
+  providerById,
+  defaultProviderId,
+  dispatchModal,
+  setPendingUsageTarget,
+}: {
+  workspaceId: string;
+  regionRef: RefObject<HTMLElement | null>;
+  query: ReturnType<typeof useModelProviderConfigsQuery>;
+  configs: readonly ProviderConfig[];
+  providerById: ReadonlyMap<string, ProviderCatalogEntry>;
+  defaultProviderId: string | null;
+  dispatchModal: ManagementModalDispatch;
+  setPendingUsageTarget: SetPendingUsageTarget;
+}) {
+  return (
+    <section
+      ref={regionRef}
+      className="flex flex-col gap-group outline-none"
+      aria-label="Configured providers"
+      tabIndex={-1}
+    >
+      <div className="flex flex-col gap-tight">
+        <Header variant="h3">Configured providers</Header>
+      </div>
+      {query.isPending ? <ModelProviderRowsSkeleton label="Loading configured providers" /> : null}
+      {query.isError && query.data === undefined ? (
+        <Panel>
+          <QueryLoadError query={query} subject="model provider configs" variant="panel" />
+        </Panel>
+      ) : null}
+      {query.data !== undefined && configs.length === 0 ? (
+        <Panel>
+          <EmptyState
+            icon="key2Line"
+            title="No providers configured"
+            description="Configure a provider below to run agent steps with workspace-managed credentials."
+            variant="panel"
+          />
+        </Panel>
+      ) : null}
+      {configs.length > 0 ? (
+        <Panel>
+          <PanelBody asChild>
+            <ul>
+              {configs.map((config) => (
+                <ConfiguredProviderRowController
+                  key={config.providerId}
+                  workspaceId={workspaceId}
+                  config={config}
+                  catalogEntry={providerById.get(config.providerId)}
+                  isDefault={config.providerId === defaultProviderId}
+                  dispatchModal={dispatchModal}
+                  setPendingUsageTarget={setPendingUsageTarget}
+                />
+              ))}
+            </ul>
+          </PanelBody>
+        </Panel>
+      ) : null}
+    </section>
+  );
+}
+
+function ConfiguredProviderRowController({
+  workspaceId,
+  config,
+  catalogEntry,
+  isDefault,
+  dispatchModal,
+  setPendingUsageTarget,
+}: {
+  workspaceId: string;
+  config: ProviderConfig;
+  catalogEntry: ProviderCatalogEntry | undefined;
+  isDefault: boolean;
+  dispatchModal: ManagementModalDispatch;
+  setPendingUsageTarget: SetPendingUsageTarget;
+}) {
+  const entry = catalogEntry && isSupportedProvider(catalogEntry) ? catalogEntry : undefined;
+  const builtinConfig = isBuiltinModelProviderConfig(config) ? config : undefined;
+  const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
+
+  function editProvider() {
+    if (entry && builtinConfig) {
+      dispatchModal({type: 'edit-builtin', provider: entry, config: builtinConfig});
+    } else if (customConfig) {
+      dispatchModal({type: 'edit-custom', config: customConfig});
+    }
+  }
+
+  function changeDefaultModel() {
+    if (!entry || !builtinConfig) return;
+    dispatchModal({type: 'change-default-model', provider: entry, config: builtinConfig});
+  }
+
+  function showUsage() {
+    setPendingUsageTarget(null);
+    if (entry && builtinConfig) {
+      dispatchModal({
+        type: 'show-usage',
+        providerId: entry.id,
+        initialModel: builtinConfig.defaultModel,
+        restoreFocusToConfiguredProviders: false,
+      });
+    } else if (customConfig) {
+      dispatchModal({
+        type: 'show-usage',
+        providerId: customConfig.providerId,
+        initialModel: customConfig.defaultModel,
+        restoreFocusToConfiguredProviders: false,
+      });
+    }
+  }
+
+  return (
+    <ConfiguredProviderRow
+      workspaceId={workspaceId}
+      config={config}
+      entry={entry}
+      isDefault={isDefault}
+      onEdit={editProvider}
+      onChangeDefaultModel={changeDefaultModel}
+      onShowUsage={showUsage}
+    />
+  );
+}
+
+function AvailableProvidersSection({
+  catalogQuery,
+  configsPending,
+  configsLoaded,
+  providers,
+  dispatchModal,
+}: {
+  catalogQuery: ReturnType<typeof useModelProviderCatalogQuery>;
+  configsPending: boolean;
+  configsLoaded: boolean;
+  providers: SupportedProvider[];
+  dispatchModal: ManagementModalDispatch;
+}) {
+  return (
+    <section className="flex flex-col gap-group" aria-label="Available providers">
+      <div className="flex flex-col gap-tight">
+        <Header variant="h3">Available providers</Header>
+      </div>
+      {catalogQuery.isPending || configsPending ? (
+        <ModelProviderGridSkeleton label="Loading available providers" />
+      ) : null}
+      {catalogQuery.isError && catalogQuery.data === undefined ? (
+        <Panel>
+          <QueryLoadError query={catalogQuery} subject="model provider catalog" variant="panel" />
+        </Panel>
+      ) : null}
+      {configsLoaded ? (
+        <AvailableProvidersGrid
+          entries={providers}
+          onSelect={(provider) => dispatchModal({type: 'configure-builtin', provider})}
+          trailingCard={
+            <AddCustomProviderCard onConfigure={() => dispatchModal({type: 'create-custom'})} />
+          }
+          trailingCardMatchesSearch={customProviderCardMatchesSearch}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function UnsupportedProvidersSection({
+  loading,
+  providers,
+}: {
+  loading: boolean;
+  providers: readonly UnsupportedProvider[];
+}) {
+  return (
+    <section className="flex flex-col gap-group" aria-label="Unsupported providers">
+      <div className="flex flex-col gap-tight">
+        <Header variant="h3">Unsupported providers</Header>
+      </div>
+      {loading ? <ModelProviderRowsSkeleton label="Loading unsupported providers" /> : null}
+      {providers.length > 0 ? (
+        <Panel>
+          <PanelBody asChild>
+            <ul>
+              {providers.map((entry) => (
+                <PanelRow
+                  asChild
+                  className="items-start justify-start gap-cluster opacity-70 hover:bg-background-neutral-base"
+                  key={entry.id}
+                >
+                  <li>
+                    <Icon
+                      name="forbid2Line"
+                      className="mt-[2px] size-18 shrink-0 text-foreground-neutral-muted"
+                      aria-hidden
+                    />
+                    <div className="flex min-w-0 flex-1 flex-col gap-tight">
+                      <Text size="md" bold className="truncate">
+                        {entry.label}
+                      </Text>
+                      <Text size="sm" className="text-foreground-neutral-muted">
+                        {entry.unsupportedReason}
+                      </Text>
+                    </div>
+                  </li>
+                </PanelRow>
+              ))}
+            </ul>
+          </PanelBody>
+        </Panel>
+      ) : null}
+    </section>
+  );
+}
+
+function BuiltinProviderModal({
+  workspaceId,
+  modal,
+  configuredCount,
+  dispatchModal,
+  setPendingUsageTarget,
+}: {
+  workspaceId: string;
+  modal: ManagementModal;
+  configuredCount: number;
+  dispatchModal: ManagementModalDispatch;
+  setPendingUsageTarget: SetPendingUsageTarget;
+}) {
+  const builtin =
+    modal.kind === 'configure-builtin' || modal.kind === 'edit-builtin' ? modal : null;
+  return (
+    <Modal
+      open={builtin !== null}
+      onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
+    >
+      <ModalContent aria-describedby={undefined}>
+        <ModalTitle className="sr-only">{modelProviderFormTitle(modal)}</ModalTitle>
+        <ModalHeader>
+          <Text
+            size="lg"
+            aria-hidden="true"
+            className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+          >
+            {modelProviderFormTitle(modal)}
+          </Text>
+        </ModalHeader>
+        {builtin ? (
+          <ModelProviderTestAndSaveForm
+            workspaceId={workspaceId}
+            entry={builtin.provider}
+            existingConfig={builtin.kind === 'edit-builtin' ? builtin.config : undefined}
+            onSaved={(savedDefaultModel) => {
+              toast.success(`${builtin.provider.label} saved`);
+              if (builtin.kind === 'configure-builtin' && configuredCount === 0) {
+                setPendingUsageTarget({
+                  target: usageTargetFromCatalogEntry(builtin.provider),
+                  initialModel: savedDefaultModel,
+                  restoreFocusToConfiguredProviders: true,
+                });
+              }
+              dispatchModal({type: 'close'});
+            }}
+          />
+        ) : null}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function ChangeDefaultModelModal({
+  workspaceId,
+  modal,
+  dispatchModal,
+}: {
+  workspaceId: string;
+  modal: ManagementModal;
+  dispatchModal: ManagementModalDispatch;
+}) {
+  const change = modal.kind === 'change-default-model' ? modal : null;
+  return (
+    <Modal
+      open={change !== null}
+      onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
+    >
+      <ModalContent aria-describedby={undefined}>
+        <ModalTitle className="sr-only">Change default model</ModalTitle>
+        <ModalHeader>
+          <Text
+            size="lg"
+            aria-hidden="true"
+            className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+          >
+            Change default model for {change?.provider.label ?? ''}
+          </Text>
+        </ModalHeader>
+        {change ? (
+          <ChangeDefaultModelForm
+            workspaceId={workspaceId}
+            entry={change.provider}
+            config={change.config}
+            onSaved={() => {
+              toast.success(`${change.provider.label} default model saved`);
+              dispatchModal({type: 'close'});
+            }}
+          />
+        ) : null}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function CustomProviderModal({
+  workspaceId,
+  modal,
+  dispatchModal,
+}: {
+  workspaceId: string;
+  modal: ManagementModal;
+  dispatchModal: ManagementModalDispatch;
+}) {
+  const custom = modal.kind === 'create-custom' || modal.kind === 'edit-custom' ? modal : null;
+  return (
+    <Modal
+      open={custom !== null}
+      onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
+    >
+      <ModalContent aria-describedby={undefined} className="max-h-[calc(100vh-32px)] max-w-[760px]">
+        <ModalTitle className="sr-only">{customModelProviderFormTitle(modal)}</ModalTitle>
+        <ModalHeader>
+          <div className="flex min-w-0 flex-col gap-tight">
+            <Text size="lg" aria-hidden="true" className="truncate">
+              {customModelProviderFormTitle(modal)}
+            </Text>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Connect an OpenAI-, Anthropic-, or Gemini-compatible endpoint.
+            </Text>
+          </div>
+        </ModalHeader>
+        {custom ? (
+          <CustomModelProviderForm
+            workspaceId={workspaceId}
+            existingConfig={custom.kind === 'edit-custom' ? custom.config : undefined}
+            onSaved={() => {
+              const message =
+                custom.kind === 'edit-custom'
+                  ? `${custom.config.displayName} saved`
+                  : 'Custom provider saved';
+              toast.success(message);
+              dispatchModal({type: 'close'});
+            }}
+          />
+        ) : null}
+      </ModalContent>
+    </Modal>
+  );
+}
+
 export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: string}) {
   const catalogQuery = useModelProviderCatalogQuery();
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
@@ -160,7 +534,9 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
     [providers],
   );
   const availableProviders = configsLoaded ? selectAvailableProviders(providers, configs) : [];
-  const unsupportedProviders = providers.filter((provider) => !isSupportedProvider(provider));
+  const unsupportedProviders = providers.filter(
+    (provider): provider is UnsupportedProvider => !isSupportedProvider(provider),
+  );
 
   useEffect(() => {
     if (pendingUsageTarget === null || modal.kind !== 'closed') return undefined;
@@ -205,251 +581,43 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         />
       ) : (
         <>
-          <section
-            ref={configuredProvidersRegionRef}
-            className="flex flex-col gap-group outline-none"
-            aria-label="Configured providers"
-            tabIndex={-1}
-          >
-            <div className="flex flex-col gap-tight">
-              <Header variant="h3">Configured providers</Header>
-            </div>
+          <ConfiguredProvidersSection
+            workspaceId={workspaceId}
+            regionRef={configuredProvidersRegionRef}
+            query={configsQuery}
+            configs={configs}
+            providerById={providerById}
+            defaultProviderId={defaultProviderId}
+            dispatchModal={dispatchModal}
+            setPendingUsageTarget={setPendingUsageTarget}
+          />
 
-            {configsQuery.isPending ? (
-              <ModelProviderRowsSkeleton label="Loading configured providers" />
-            ) : null}
-
-            {configsQuery.isError && configsQuery.data === undefined ? (
-              <Panel>
-                <QueryLoadError
-                  query={configsQuery}
-                  subject="model provider configs"
-                  variant="panel"
-                />
-              </Panel>
-            ) : null}
-
-            {configsQuery.data !== undefined && configs.length === 0 ? (
-              <Panel>
-                <EmptyState
-                  icon="key2Line"
-                  title="No providers configured"
-                  description="Configure a provider below to run agent steps with workspace-managed credentials."
-                  variant="panel"
-                />
-              </Panel>
-            ) : null}
-
-            {configs.length > 0 ? (
-              <Panel>
-                <PanelBody asChild>
-                  <ul>
-                    {configs.map((config) => {
-                      const catalogEntry = providerById.get(config.providerId);
-                      const entry =
-                        catalogEntry && isSupportedProvider(catalogEntry)
-                          ? catalogEntry
-                          : undefined;
-                      const builtinConfig = isBuiltinModelProviderConfig(config)
-                        ? config
-                        : undefined;
-                      const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
-                      return (
-                        <ConfiguredProviderRow
-                          key={config.providerId}
-                          workspaceId={workspaceId}
-                          config={config}
-                          entry={entry}
-                          isDefault={config.providerId === defaultProviderId}
-                          onEdit={() => {
-                            if (entry && builtinConfig) {
-                              dispatchModal({
-                                type: 'edit-builtin',
-                                provider: entry,
-                                config: builtinConfig,
-                              });
-                            } else if (customConfig) {
-                              dispatchModal({type: 'edit-custom', config: customConfig});
-                            }
-                          }}
-                          onChangeDefaultModel={() => {
-                            if (entry && builtinConfig)
-                              dispatchModal({
-                                type: 'change-default-model',
-                                provider: entry,
-                                config: builtinConfig,
-                              });
-                          }}
-                          onShowUsage={() => {
-                            if (entry && builtinConfig) {
-                              setPendingUsageTarget(null);
-                              dispatchModal({
-                                type: 'show-usage',
-                                providerId: entry.id,
-                                initialModel: builtinConfig.defaultModel,
-                                restoreFocusToConfiguredProviders: false,
-                              });
-                            } else if (customConfig) {
-                              setPendingUsageTarget(null);
-                              dispatchModal({
-                                type: 'show-usage',
-                                providerId: customConfig.providerId,
-                                initialModel: customConfig.defaultModel,
-                                restoreFocusToConfiguredProviders: false,
-                              });
-                            }
-                          }}
-                        />
-                      );
-                    })}
-                  </ul>
-                </PanelBody>
-              </Panel>
-            ) : null}
-          </section>
-
-          <section className="flex flex-col gap-group" aria-label="Available providers">
-            <div className="flex flex-col gap-tight">
-              <Header variant="h3">Available providers</Header>
-            </div>
-
-            {catalogQuery.isPending || configsQuery.isPending ? (
-              <ModelProviderGridSkeleton label="Loading available providers" />
-            ) : null}
-
-            {catalogQuery.isError && catalogQuery.data === undefined ? (
-              <Panel>
-                <QueryLoadError
-                  query={catalogQuery}
-                  subject="model provider catalog"
-                  variant="panel"
-                />
-              </Panel>
-            ) : null}
-
-            {configsLoaded ? (
-              <AvailableProvidersGrid
-                entries={availableProviders}
-                onSelect={(entry) => dispatchModal({type: 'configure-builtin', provider: entry})}
-                trailingCard={
-                  <AddCustomProviderCard
-                    onConfigure={() => dispatchModal({type: 'create-custom'})}
-                  />
-                }
-                trailingCardMatchesSearch={customProviderCardMatchesSearch}
-              />
-            ) : null}
-          </section>
-
-          <section className="flex flex-col gap-group" aria-label="Unsupported providers">
-            <div className="flex flex-col gap-tight">
-              <Header variant="h3">Unsupported providers</Header>
-            </div>
-
-            {catalogQuery.isPending ? (
-              <ModelProviderRowsSkeleton label="Loading unsupported providers" />
-            ) : null}
-
-            {unsupportedProviders.length > 0 ? (
-              <Panel>
-                <PanelBody asChild>
-                  <ul>
-                    {unsupportedProviders.map((entry) => (
-                      <PanelRow
-                        asChild
-                        className="items-start justify-start gap-cluster opacity-70 hover:bg-background-neutral-base"
-                        key={entry.id}
-                      >
-                        <li>
-                          <Icon
-                            name="forbid2Line"
-                            className="mt-[2px] size-18 shrink-0 text-foreground-neutral-muted"
-                            aria-hidden
-                          />
-                          <div className="flex min-w-0 flex-1 flex-col gap-tight">
-                            <Text size="md" bold className="truncate">
-                              {entry.label}
-                            </Text>
-                            <Text size="sm" className="text-foreground-neutral-muted">
-                              {entry.unsupportedReason}
-                            </Text>
-                          </div>
-                        </li>
-                      </PanelRow>
-                    ))}
-                  </ul>
-                </PanelBody>
-              </Panel>
-            ) : null}
-          </section>
+          <AvailableProvidersSection
+            catalogQuery={catalogQuery}
+            configsPending={configsQuery.isPending}
+            configsLoaded={configsLoaded}
+            providers={availableProviders}
+            dispatchModal={dispatchModal}
+          />
+          <UnsupportedProvidersSection
+            loading={catalogQuery.isPending}
+            providers={unsupportedProviders}
+          />
         </>
       )}
 
-      <Modal
-        open={modal.kind === 'configure-builtin' || modal.kind === 'edit-builtin'}
-        onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
-      >
-        <ModalContent aria-describedby={undefined}>
-          <ModalTitle className="sr-only">{modelProviderFormTitle(modal)}</ModalTitle>
-          <ModalHeader>
-            <Text
-              size="lg"
-              aria-hidden="true"
-              className="overflow-ellipsis overflow-hidden whitespace-nowrap"
-            >
-              {modelProviderFormTitle(modal)}
-            </Text>
-          </ModalHeader>
-          {modal.kind === 'configure-builtin' || modal.kind === 'edit-builtin' ? (
-            <ModelProviderTestAndSaveForm
-              workspaceId={workspaceId}
-              entry={modal.provider}
-              existingConfig={modal.kind === 'edit-builtin' ? modal.config : undefined}
-              onSaved={(savedDefaultModel) => {
-                toast.success(`${modal.provider.label} saved`);
-                if (modal.kind === 'configure-builtin' && configs.length === 0) {
-                  setPendingUsageTarget({
-                    target: usageTargetFromCatalogEntry(modal.provider),
-                    initialModel: savedDefaultModel,
-                    restoreFocusToConfiguredProviders: true,
-                  });
-                }
-                dispatchModal({type: 'close'});
-              }}
-            />
-          ) : null}
-        </ModalContent>
-      </Modal>
-
-      <Modal
-        open={modal.kind === 'change-default-model'}
-        onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
-      >
-        <ModalContent aria-describedby={undefined}>
-          <ModalTitle className="sr-only">Change default model</ModalTitle>
-          <ModalHeader>
-            <Text
-              size="lg"
-              aria-hidden="true"
-              className="overflow-ellipsis overflow-hidden whitespace-nowrap"
-            >
-              Change default model for{' '}
-              {modal.kind === 'change-default-model' ? modal.provider.label : ''}
-            </Text>
-          </ModalHeader>
-          {modal.kind === 'change-default-model' ? (
-            <ChangeDefaultModelForm
-              workspaceId={workspaceId}
-              entry={modal.provider}
-              config={modal.config}
-              onSaved={() => {
-                toast.success(`${modal.provider.label} default model saved`);
-                dispatchModal({type: 'close'});
-              }}
-            />
-          ) : null}
-        </ModalContent>
-      </Modal>
+      <BuiltinProviderModal
+        workspaceId={workspaceId}
+        modal={modal}
+        configuredCount={configs.length}
+        dispatchModal={dispatchModal}
+        setPendingUsageTarget={setPendingUsageTarget}
+      />
+      <ChangeDefaultModelModal
+        workspaceId={workspaceId}
+        modal={modal}
+        dispatchModal={dispatchModal}
+      />
 
       <ModelProviderUsageModal
         target={usageTarget}
@@ -466,41 +634,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         }}
       />
 
-      <Modal
-        open={modal.kind === 'create-custom' || modal.kind === 'edit-custom'}
-        onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
-      >
-        <ModalContent
-          aria-describedby={undefined}
-          className="max-h-[calc(100vh-32px)] max-w-[760px]"
-        >
-          <ModalTitle className="sr-only">{customModelProviderFormTitle(modal)}</ModalTitle>
-          <ModalHeader>
-            <div className="flex min-w-0 flex-col gap-tight">
-              <Text size="lg" aria-hidden="true" className="truncate">
-                {customModelProviderFormTitle(modal)}
-              </Text>
-              <Text size="sm" className="text-foreground-neutral-muted">
-                Connect an OpenAI-, Anthropic-, or Gemini-compatible endpoint.
-              </Text>
-            </div>
-          </ModalHeader>
-          {modal.kind === 'create-custom' || modal.kind === 'edit-custom' ? (
-            <CustomModelProviderForm
-              workspaceId={workspaceId}
-              existingConfig={modal.kind === 'edit-custom' ? modal.config : undefined}
-              onSaved={() => {
-                toast.success(
-                  modal.kind === 'edit-custom'
-                    ? `${modal.config.displayName} saved`
-                    : 'Custom provider saved',
-                );
-                dispatchModal({type: 'close'});
-              }}
-            />
-          ) : null}
-        </ModalContent>
-      </Modal>
+      <CustomProviderModal workspaceId={workspaceId} modal={modal} dispatchModal={dispatchModal} />
     </div>
   );
 }

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -6,14 +6,19 @@ import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/mo
 import {Panel, PanelBody, PanelCell, PanelCellAction, PanelGrid} from '@shipfox/react-ui/panel';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import {useEffect, useMemo, useReducer, useRef} from 'react';
+import {type Dispatch, useEffect, useMemo, useReducer, useRef} from 'react';
 import {AvailableProvidersGrid} from '#components/available-providers-grid.js';
 import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
 import {ModelProviderGridSkeleton} from '#components/model-provider-grid-skeleton.js';
 import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
 import {DEFAULT_HARNESS, harnessSupportsProvider, listHarnesses} from '#core/harness-policy.js';
 import type {HarnessDescriptor, HarnessId, SupportedProvider} from '#core/models.js';
-import {initialOnboardingState, onboardingReducer} from '#core/onboarding-reducer.js';
+import {
+  initialOnboardingState,
+  type OnboardingAction,
+  type OnboardingState,
+  onboardingReducer,
+} from '#core/onboarding-reducer.js';
 import {isManagedOnlyCatalog, isSupportedProvider} from '#core/provider-policy.js';
 import {
   useModelProviderCatalogQuery,
@@ -35,8 +40,6 @@ export function ModelProviderOnboardingPage({
   const [onboarding, dispatch] = useReducer(onboardingReducer, initialOnboardingState);
   const supportedProviders = catalogQuery.data?.providers.filter(isSupportedProvider) ?? [];
   const catalogLoaded = catalogQuery.data !== undefined;
-  const catalogLoading = catalogQuery.isPending;
-  const catalogLoadError = catalogQuery.isError && catalogQuery.data === undefined;
   const managedOnly = isManagedOnlyCatalog(catalogQuery.data);
   const managedOnlyForwarded = useRef(false);
   const filteredProviders = useMemo(() => {
@@ -112,7 +115,6 @@ export function ModelProviderOnboardingPage({
     onboarding.step === 'choose-harness'
       ? 'model-provider-harness-step'
       : 'model-provider-provider-step';
-
   return (
     <div className="flex w-full flex-col gap-section">
       <header className="flex flex-col gap-cluster">
@@ -134,101 +136,144 @@ export function ModelProviderOnboardingPage({
       </header>
 
       <section aria-labelledby={headingId} className="flex flex-col gap-group">
-        {catalogLoading ? <ModelProviderGridSkeleton label="Loading model providers" /> : null}
-        {catalogLoadError ? (
-          <QueryLoadError query={catalogQuery} subject="model provider catalog" />
-        ) : null}
-        {!catalogLoading && !catalogLoadError ? (
-          onboarding.step === 'choose-harness' ? (
-            <HarnessPicker
-              onSelect={(harnessId) => dispatch({type: 'harness-selected', harnessId})}
-            />
-          ) : (
-            <>
-              <div>
-                <Button
-                  type="button"
-                  variant="transparent"
-                  onClick={() => dispatch({type: 'back'})}
-                >
-                  Back
-                </Button>
-              </div>
-              <ModelProviderPicker
-                key={onboarding.harnessId}
-                supportedProviders={filteredProviders}
-                onSelect={(entry) => {
-                  dispatch({type: 'provider-selected', provider: entry});
-                }}
-              />
-            </>
-          )
-        ) : null}
+        <OnboardingCatalog
+          query={catalogQuery}
+          onboarding={onboarding}
+          filteredProviders={filteredProviders}
+          dispatch={dispatch}
+        />
       </section>
 
-      <Modal
-        open={
-          onboarding.step === 'configure-provider' || onboarding.step === 'saving-default-harness'
-        }
-        onOpenChange={(open) => {
-          if (!open && onboarding.step === 'configure-provider') dispatch({type: 'back'});
-        }}
-      >
-        <ModalContent aria-describedby={undefined}>
-          <ModalTitle className="sr-only">
-            {onboarding.step === 'configure-provider' ||
-            onboarding.step === 'saving-default-harness'
-              ? `Configure ${onboarding.provider.label}`
-              : ''}
-          </ModalTitle>
-          <ModalHeader>
-            <Text
-              size="lg"
-              aria-hidden="true"
-              className="overflow-ellipsis overflow-hidden whitespace-nowrap"
-            >
-              {onboarding.step === 'configure-provider' ||
-              onboarding.step === 'saving-default-harness'
-                ? `Configure ${onboarding.provider.label}`
-                : ''}
-            </Text>
-          </ModalHeader>
-          {onboarding.step === 'configure-provider' ||
-          onboarding.step === 'saving-default-harness' ? (
-            <div className="flex min-h-0 flex-1 flex-col gap-inline">
-              {onboarding.step === 'saving-default-harness' ? (
-                <div role="status" className="px-row">
-                  <Text size="sm" className="text-foreground-neutral-muted">
-                    Saving harness default...
-                  </Text>
-                </div>
-              ) : null}
-              {onboarding.step === 'saving-default-harness' && onboarding.error ? (
-                <div className="px-row">
-                  <Callout role="alert" type="error">
-                    <div className="flex flex-col gap-inline">
-                      <Text size="sm" bold>
-                        Could not save default harness
-                      </Text>
-                      <Text size="sm">{onboarding.error}</Text>
-                    </div>
-                  </Callout>
-                </div>
-              ) : null}
-              <div className="flex min-h-0 flex-1 flex-col">
-                <ModelProviderTestAndSaveForm
-                  workspaceId={workspaceId}
-                  entry={onboarding.provider}
-                  setAsDefaultOnSave
-                  onSaved={() => {
-                    void handleProviderSaved();
-                  }}
-                />
-              </div>
+      <ProviderConfigurationModal
+        workspaceId={workspaceId}
+        onboarding={onboarding}
+        dispatch={dispatch}
+        onSaved={handleProviderSaved}
+      />
+    </div>
+  );
+}
+
+function OnboardingCatalog({
+  query,
+  onboarding,
+  filteredProviders,
+  dispatch,
+}: {
+  query: ReturnType<typeof useModelProviderCatalogQuery>;
+  onboarding: OnboardingState;
+  filteredProviders: SupportedProvider[];
+  dispatch: Dispatch<OnboardingAction>;
+}) {
+  if (query.isPending) return <ModelProviderGridSkeleton label="Loading model providers" />;
+  if (query.isError && query.data === undefined) {
+    return <QueryLoadError query={query} subject="model provider catalog" />;
+  }
+  if (onboarding.step === 'choose-harness') {
+    return (
+      <HarnessPicker onSelect={(harnessId) => dispatch({type: 'harness-selected', harnessId})} />
+    );
+  }
+  return (
+    <>
+      <div>
+        <Button type="button" variant="transparent" onClick={() => dispatch({type: 'back'})}>
+          Back
+        </Button>
+      </div>
+      <ModelProviderPicker
+        key={onboarding.harnessId}
+        supportedProviders={filteredProviders}
+        onSelect={(provider) => dispatch({type: 'provider-selected', provider})}
+      />
+    </>
+  );
+}
+
+function ProviderConfigurationModal({
+  workspaceId,
+  onboarding,
+  dispatch,
+  onSaved,
+}: {
+  workspaceId: string;
+  onboarding: OnboardingState;
+  dispatch: Dispatch<OnboardingAction>;
+  onSaved: () => Promise<void>;
+}) {
+  const configuration =
+    onboarding.step === 'configure-provider' || onboarding.step === 'saving-default-harness'
+      ? onboarding
+      : null;
+  const title = configuration ? `Configure ${configuration.provider.label}` : '';
+  return (
+    <Modal
+      open={configuration !== null}
+      onOpenChange={(open) => {
+        if (!open && onboarding.step === 'configure-provider') dispatch({type: 'back'});
+      }}
+    >
+      <ModalContent aria-describedby={undefined}>
+        <ModalTitle className="sr-only">{title}</ModalTitle>
+        <ModalHeader>
+          <Text
+            size="lg"
+            aria-hidden="true"
+            className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+          >
+            {title}
+          </Text>
+        </ModalHeader>
+        {configuration ? (
+          <ProviderConfigurationContent
+            workspaceId={workspaceId}
+            onboarding={configuration}
+            onSaved={onSaved}
+          />
+        ) : null}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function ProviderConfigurationContent({
+  workspaceId,
+  onboarding,
+  onSaved,
+}: {
+  workspaceId: string;
+  onboarding: Extract<OnboardingState, {step: 'configure-provider' | 'saving-default-harness'}>;
+  onSaved: () => Promise<void>;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-inline">
+      {onboarding.step === 'saving-default-harness' ? (
+        <div role="status" className="px-row">
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Saving harness default...
+          </Text>
+        </div>
+      ) : null}
+      {onboarding.step === 'saving-default-harness' && onboarding.error ? (
+        <div className="px-row">
+          <Callout role="alert" type="error">
+            <div className="flex flex-col gap-inline">
+              <Text size="sm" bold>
+                Could not save default harness
+              </Text>
+              <Text size="sm">{onboarding.error}</Text>
             </div>
-          ) : null}
-        </ModalContent>
-      </Modal>
+          </Callout>
+        </div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ModelProviderTestAndSaveForm
+          workspaceId={workspaceId}
+          entry={onboarding.provider}
+          setAsDefaultOnSave
+          onSaved={() => void onSaved()}
+        />
+      </div>
     </div>
   );
 }

--- a/libs/client/agent/src/state/model-provider-onboarding.ts
+++ b/libs/client/agent/src/state/model-provider-onboarding.ts
@@ -10,7 +10,9 @@ const dismissedStorageKey = {
   principalScope: 'workspace',
   serialize: (dismissed: boolean) => JSON.stringify(dismissed),
   parse: (raw) => {
-    return raw === 'true' ? true : raw === 'false' ? false : undefined;
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    return undefined;
   },
 } satisfies BrowserStorageKey<boolean>;
 

--- a/libs/client/auth/src/components/auth-provider.test.tsx
+++ b/libs/client/auth/src/components/auth-provider.test.tsx
@@ -28,6 +28,21 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
+function principalRefreshResponse(requestCount: number): Promise<Response> {
+  if (requestCount === 1) {
+    return Promise.resolve(jsonResponse({token: 'access-token', user}));
+  }
+  return Promise.resolve(jsonResponse({token: 'other-token-2', user: otherUser}));
+}
+
+function principalWorkspaceResponse(
+  requestCount: number,
+  initialWorkspaceRefresh: Promise<Response>,
+): Promise<Response> {
+  if (requestCount === 1) return initialWorkspaceRefresh;
+  return Promise.resolve(jsonResponse({memberships: []}));
+}
+
 function StatusProbe() {
   const auth = useAuthState();
   const logout = useLogoutAuth();
@@ -259,17 +274,13 @@ describe('AuthProvider', () => {
       const url = (input as Request).url;
       if (url.endsWith('/auth/refresh')) {
         refreshRequestCount += 1;
-        return refreshRequestCount === 1
-          ? Promise.resolve(jsonResponse({token: 'access-token', user}))
-          : Promise.resolve(jsonResponse({token: 'other-token-2', user: otherUser}));
+        return principalRefreshResponse(refreshRequestCount);
       }
       if (url.endsWith('/auth/login'))
         return Promise.resolve(jsonResponse({token: 'other-token', user: otherUser}));
       if (url.endsWith('/workspaces')) {
         workspaceRequestCount += 1;
-        return workspaceRequestCount === 1
-          ? initialWorkspaceRefresh
-          : Promise.resolve(jsonResponse({memberships: []}));
+        return principalWorkspaceResponse(workspaceRequestCount, initialWorkspaceRefresh);
       }
       return Promise.resolve(jsonResponse({token: 'access-token', user}));
     });

--- a/libs/client/auth/src/components/email-code-verification.tsx
+++ b/libs/client/auth/src/components/email-code-verification.tsx
@@ -110,6 +110,10 @@ export function EmailCodeVerification({
     return error === undefined;
   }
 
+  let resendLabel = 'Resend verification email';
+  if (isResending) resendLabel = 'Sending email...';
+  else if (isResendCoolingDown) resendLabel = `Resend in ${resendRemainingSeconds}s`;
+
   return (
     <AuthShell
       title={title}
@@ -155,11 +159,7 @@ export function EmailCodeVerification({
             if (!isResendCoolingDown && !isResending) void onResend();
           }}
         >
-          {isResending
-            ? 'Sending email...'
-            : isResendCoolingDown
-              ? `Resend in ${resendRemainingSeconds}s`
-              : 'Resend verification email'}
+          {resendLabel}
         </Button>
       </form>
       <Button

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -15,6 +15,96 @@ function emailChallenge() {
   };
 }
 
+type InvitationSignupState = {signupCompleted: boolean; refreshFailures: number};
+
+function invitationSignupFetch(
+  user: ReturnType<typeof pageUserFactory.build>,
+  workspaceId: string,
+  session: {token: string; user: ReturnType<typeof pageUserFactory.build>},
+  state: InvitationSignupState,
+) {
+  return vi.fn().mockImplementation((input: RequestInfo | URL) => {
+    const url = requestUrl(input);
+    if (url === 'https://api.example.test/auth/me') {
+      return jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401});
+    }
+    if (url.includes('/invitations/preview?')) return invitationPreviewResponse(user, workspaceId);
+    if (url === 'https://api.example.test/auth/signup') {
+      state.signupCompleted = true;
+      return invitationSignupResponse(user, workspaceId);
+    }
+    if (url === 'https://api.example.test/auth/refresh') {
+      return invitationRefreshResponse(session, state);
+    }
+    if (url === 'https://api.example.test/workspaces') {
+      return invitationWorkspaceResponse(user, workspaceId);
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  });
+}
+
+function invitationPreviewResponse(
+  user: ReturnType<typeof pageUserFactory.build>,
+  workspaceId: string,
+) {
+  return jsonResponse({
+    status: 'pending',
+    workspace_id: workspaceId,
+    workspace_name: 'Invite Workspace',
+    email: user.email,
+    invited_by_display: 'owner@example.com',
+    expires_at: '2026-05-18T00:00:00.000Z',
+  });
+}
+
+function invitationSignupResponse(
+  user: ReturnType<typeof pageUserFactory.build>,
+  workspaceId: string,
+) {
+  return jsonResponse(
+    {
+      user,
+      membership: {
+        id: '22222222-2222-4222-8222-222222222222',
+        user_id: user.id,
+        workspace_id: workspaceId,
+      },
+    },
+    {status: 201},
+  );
+}
+
+function invitationRefreshResponse(
+  session: {token: string; user: ReturnType<typeof pageUserFactory.build>},
+  state: InvitationSignupState,
+) {
+  if (state.signupCompleted && state.refreshFailures < 2) {
+    state.refreshFailures += 1;
+    return jsonResponse({code: 'server-error', message: 'Refresh failed'}, {status: 500});
+  }
+  return jsonResponse(session);
+}
+
+function invitationWorkspaceResponse(
+  user: ReturnType<typeof pageUserFactory.build>,
+  workspaceId: string,
+) {
+  return jsonResponse({
+    memberships: [
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        user_id: user.id,
+        workspace_id: workspaceId,
+        created_at: '2026-05-01T00:00:00.000Z',
+        updated_at: '2026-05-01T00:00:00.000Z',
+        workspace_name: 'Invite Workspace',
+        workspace_slug: 'invite-workspace',
+        workspace_status: 'active',
+      },
+    ],
+  });
+}
+
 describe('SignupPage', () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -165,62 +255,8 @@ describe('SignupPage', () => {
     const user = pageUserFactory.build({email: 'invitee@example.com', name: 'Invitee'});
     const workspaceId = '11111111-1111-4111-8111-111111111111';
     const session = {token: 'access-token', user};
-    let signupCompleted = false;
-    let postSignupRefreshFailures = 0;
-    const fetchImpl = vi.fn().mockImplementation((input: RequestInfo | URL) => {
-      const url = requestUrl(input);
-      if (url === 'https://api.example.test/auth/me') {
-        return jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401});
-      }
-      if (url.includes('/invitations/preview?')) {
-        return jsonResponse({
-          status: 'pending',
-          workspace_id: workspaceId,
-          workspace_name: 'Invite Workspace',
-          email: user.email,
-          invited_by_display: 'owner@example.com',
-          expires_at: '2026-05-18T00:00:00.000Z',
-        });
-      }
-      if (url === 'https://api.example.test/auth/signup') {
-        signupCompleted = true;
-        return jsonResponse(
-          {
-            user,
-            membership: {
-              id: '22222222-2222-4222-8222-222222222222',
-              user_id: user.id,
-              workspace_id: workspaceId,
-            },
-          },
-          {status: 201},
-        );
-      }
-      if (url === 'https://api.example.test/auth/refresh') {
-        if (signupCompleted && postSignupRefreshFailures < 2) {
-          postSignupRefreshFailures += 1;
-          return jsonResponse({code: 'server-error', message: 'Refresh failed'}, {status: 500});
-        }
-        return jsonResponse(session);
-      }
-      if (url === 'https://api.example.test/workspaces') {
-        return jsonResponse({
-          memberships: [
-            {
-              id: '33333333-3333-4333-8333-333333333333',
-              user_id: user.id,
-              workspace_id: workspaceId,
-              created_at: '2026-05-01T00:00:00.000Z',
-              updated_at: '2026-05-01T00:00:00.000Z',
-              workspace_name: 'Invite Workspace',
-              workspace_slug: 'invite-workspace',
-              workspace_status: 'active',
-            },
-          ],
-        });
-      }
-      throw new Error(`Unexpected request: ${url}`);
-    });
+    const state: InvitationSignupState = {signupCompleted: false, refreshFailures: 0};
+    const fetchImpl = invitationSignupFetch(user, workspaceId, session, state);
     configureApiClient({fetchImpl});
 
     renderAuthPage(`/auth/signup?redirect=${encodeURIComponent(redirect)}`, <SignupPage />);

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -78,6 +78,42 @@ export function SignupPage() {
     return false;
   }
 
+  async function handleSignupResult(result: Awaited<ReturnType<typeof signup.mutateAsync>>) {
+    skipDraftPersistRef.current = true;
+    setAuthFormDraft(initialAuthFormDraft);
+
+    if (invitationToken && result.membership && invitationPending) {
+      const joinedWorkspace = await refreshInvitationWorkspace(result.membership.workspaceId);
+      if (!joinedWorkspace) {
+        setInvitationRefreshFailure({
+          workspaceId: result.membership.workspaceId,
+          workspaceName: invitationPending.workspaceName,
+          userId: result.user?.id,
+        });
+        return;
+      }
+      toast.success(`You joined ${invitationPending.workspaceName}.`);
+      if (result.user?.id) {
+        rememberLastWorkspaceId(result.user.id, result.membership.workspaceId);
+      }
+      await navigate({to: '/'});
+      return;
+    }
+
+    if (invitationToken && result.acceptError) {
+      toast.error(result.acceptError.message);
+      await navigate({to: '/invitations/accept', search: {token: invitationToken}});
+      return;
+    }
+
+    if (!result.emailChallenge) {
+      throw new Error('Signup did not return an email verification challenge');
+    }
+    setEmailChallenge({email: result.user.email, id: result.emailChallenge.id});
+    setResendError(undefined);
+    setNextResendAvailableAt(result.emailChallenge.nextResendAvailableAt);
+  }
+
   const form = useForm({
     defaultValues: {email: authFormDraft.email, password: authFormDraft.password, name: ''},
     onSubmit: async ({value}) => {
@@ -95,42 +131,7 @@ export function SignupPage() {
           name: parsed.name,
           ...(parsed.invitation_token ? {invitationToken: parsed.invitation_token} : {}),
         });
-        skipDraftPersistRef.current = true;
-        setAuthFormDraft(initialAuthFormDraft);
-
-        if (invitationToken && result.membership && invitationPending) {
-          const joinedWorkspace = await refreshInvitationWorkspace(result.membership.workspaceId);
-          if (!joinedWorkspace) {
-            setInvitationRefreshFailure({
-              workspaceId: result.membership.workspaceId,
-              workspaceName: invitationPending.workspaceName,
-              userId: result.user?.id,
-            });
-            return;
-          }
-          toast.success(`You joined ${invitationPending.workspaceName}.`);
-          if (result.user?.id) {
-            rememberLastWorkspaceId(result.user.id, result.membership.workspaceId);
-          }
-          await navigate({to: '/'});
-          return;
-        }
-
-        if (invitationToken && result.acceptError) {
-          toast.error(result.acceptError.message);
-          await navigate({
-            to: '/invitations/accept',
-            search: {token: invitationToken},
-          });
-          return;
-        }
-
-        if (!result.emailChallenge) {
-          throw new Error('Signup did not return an email verification challenge');
-        }
-        setEmailChallenge({email: result.user.email, id: result.emailChallenge.id});
-        setResendError(undefined);
-        setNextResendAvailableAt(result.emailChallenge.nextResendAvailableAt);
+        await handleSignupResult(result);
       } catch (error) {
         const mapped = signupErrorToFormError(error);
         if (mapped.kind === 'field') {

--- a/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
@@ -5,6 +5,70 @@ import {pageUserFactory} from '#test/factories/user.js';
 import {renderAuthPage} from '#test/pages.js';
 import {jsonResponse, requestUrl} from '#test/utils.js';
 
+type WorkspaceCreationState = {didCreate: boolean; body: unknown};
+
+function workspaceCreationFetch(
+  user: ReturnType<typeof pageUserFactory.build>,
+  state: WorkspaceCreationState,
+) {
+  return vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+    const url = requestUrl(input);
+    const method = input instanceof Request ? input.method : 'GET';
+    if (url.endsWith('/auth/refresh')) return workspaceRefreshResponse(user, state.didCreate);
+    if (url.endsWith('/workspaces') && method === 'GET') {
+      return workspaceMembershipsResponse(user, state.didCreate);
+    }
+    if (url.endsWith('/workspaces') && method === 'POST') {
+      state.didCreate = true;
+      state.body = input instanceof Request ? await input.json() : undefined;
+      return createdWorkspaceResponse();
+    }
+    return jsonResponse({code: 'not-found', message: 'Not found'}, {status: 404});
+  });
+}
+
+function workspaceRefreshResponse(
+  user: ReturnType<typeof pageUserFactory.build>,
+  didCreate: boolean,
+) {
+  return jsonResponse({token: didCreate ? 'workspace-access-token' : 'access-token', user});
+}
+
+function workspaceMembershipsResponse(
+  user: ReturnType<typeof pageUserFactory.build>,
+  didCreate: boolean,
+) {
+  if (!didCreate) return jsonResponse({memberships: []});
+  return jsonResponse({
+    memberships: [
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        user_id: user.id,
+        workspace_id: '33333333-3333-4333-8333-333333333333',
+        workspace_name: 'Acme',
+        workspace_slug: 'acme',
+        created_at: '2026-04-27T00:00:00.000Z',
+        updated_at: '2026-04-27T00:00:00.000Z',
+      },
+    ],
+  });
+}
+
+function createdWorkspaceResponse() {
+  return jsonResponse(
+    {
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'Acme',
+      slug: 'acme',
+      status: 'active',
+      settings: {},
+      created_at: '2026-04-27T00:00:00.000Z',
+      updated_at: '2026-04-27T00:00:00.000Z',
+    },
+    {status: 201},
+  );
+}
+
 describe('WorkspaceOnboardingPage', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -17,53 +81,8 @@ describe('WorkspaceOnboardingPage', () => {
 
   test('creates a workspace before showing the signed-in app', async () => {
     const user = pageUserFactory.build({email: 'workspace@example.com'});
-    let didCreateWorkspace = false;
-    let createWorkspaceBody: unknown;
-    const fetchImpl = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
-      const url = requestUrl(input);
-      const method = input instanceof Request ? input.method : 'GET';
-      if (url.endsWith('/auth/refresh')) {
-        return jsonResponse({
-          token: didCreateWorkspace ? 'workspace-access-token' : 'access-token',
-          user,
-        });
-      }
-      if (url.endsWith('/workspaces') && method === 'GET') {
-        return jsonResponse({
-          memberships: didCreateWorkspace
-            ? [
-                {
-                  id: '22222222-2222-4222-8222-222222222222',
-                  user_id: user.id,
-                  workspace_id: '33333333-3333-4333-8333-333333333333',
-                  workspace_name: 'Acme',
-                  workspace_slug: 'acme',
-                  created_at: '2026-04-27T00:00:00.000Z',
-                  updated_at: '2026-04-27T00:00:00.000Z',
-                },
-              ]
-            : [],
-        });
-      }
-      if (url.endsWith('/workspaces') && method === 'POST') {
-        didCreateWorkspace = true;
-        createWorkspaceBody = input instanceof Request ? await input.json() : undefined;
-        return jsonResponse(
-          {
-            id: '33333333-3333-4333-8333-333333333333',
-            name: 'Acme',
-            slug: 'acme',
-            status: 'active',
-            settings: {},
-            created_at: '2026-04-27T00:00:00.000Z',
-            updated_at: '2026-04-27T00:00:00.000Z',
-          },
-          {status: 201},
-        );
-      }
-
-      return jsonResponse({code: 'not-found', message: 'Not found'}, {status: 404});
-    });
+    const state: WorkspaceCreationState = {didCreate: false, body: undefined};
+    const fetchImpl = workspaceCreationFetch(user, state);
     configureApiClient({fetchImpl});
 
     const {container} = renderAuthPage(
@@ -85,8 +104,8 @@ describe('WorkspaceOnboardingPage', () => {
     });
     fireEvent.click(screen.getByRole('button', {name: 'Create workspace'}));
 
-    await waitFor(() => expect(didCreateWorkspace).toBe(true));
-    expect(createWorkspaceBody).toEqual({name: 'Acme', slug: 'acme'});
+    await waitFor(() => expect(state.didCreate).toBe(true));
+    expect(state.body).toEqual({name: 'Acme', slug: 'acme'});
   });
 
   test('prefills the slug from the name until the slug is edited', async () => {

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -190,65 +190,99 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     const url = requestUrl(input);
     const method = init?.method ?? 'GET';
     if (scenario === 'loading') return new Promise<Response>(() => undefined);
-    if (url.pathname === '/integration-providers') {
-      if (scenario === 'providers-error') return Promise.resolve(errorResponse());
-      return Promise.resolve(
-        jsonResponse({providers: scenario === 'no-providers' ? [] : PROVIDERS}),
-      );
-    }
-    if (url.pathname.startsWith('/integration-connections/') && method === 'PATCH') {
-      return Promise.resolve(
-        jsonResponse({
-          ...connection(),
-          id: url.pathname.split('/').at(-1),
-          lifecycle_status: 'disabled',
-        }),
-      );
-    }
-    if (url.pathname.startsWith('/integration-connections/') && method === 'DELETE') {
-      return Promise.resolve(jsonResponse(undefined, {status: 204}));
-    }
-    if (url.pathname.startsWith('/integrations/webhook/connections/') && method === 'PATCH') {
-      return Promise.resolve(
-        jsonResponse({
-          id: url.pathname.split('/').at(-1),
+    return scenarioResponse(url, method, scenario);
+  };
+}
+
+function scenarioResponse(url: URL, method: string, scenario: Scenario): Promise<Response> {
+  if (url.pathname === '/integration-providers') {
+    return providersScenarioResponse(scenario);
+  }
+  const integrationMutation = integrationConnectionMutationResponse(url, method);
+  if (integrationMutation) return integrationMutation;
+  const webhookMutation = webhookConnectionMutationResponse(url, method);
+  if (webhookMutation) return webhookMutation;
+  if (url.pathname === '/integration-connections') {
+    return connectionsScenarioResponse(scenario);
+  }
+  if (url.pathname === '/integrations/webhook/connections') {
+    return webhookConnectionsResponse();
+  }
+  return Promise.resolve(jsonResponse({}, {status: 404}));
+}
+
+function integrationConnectionMutationResponse(
+  url: URL,
+  method: string,
+): Promise<Response> | undefined {
+  if (!url.pathname.startsWith('/integration-connections/')) return undefined;
+  if (method === 'PATCH') return integrationConnectionPatchResponse(url);
+  if (method === 'DELETE') return Promise.resolve(jsonResponse(undefined, {status: 204}));
+  return undefined;
+}
+
+function webhookConnectionMutationResponse(
+  url: URL,
+  method: string,
+): Promise<Response> | undefined {
+  if (!url.pathname.startsWith('/integrations/webhook/connections/')) return undefined;
+  if (method === 'PATCH') return webhookConnectionPatchResponse(url);
+  if (method === 'DELETE') return Promise.resolve(jsonResponse(undefined, {status: 204}));
+  return undefined;
+}
+
+function providersScenarioResponse(scenario: Scenario) {
+  if (scenario === 'providers-error') return Promise.resolve(errorResponse());
+  return Promise.resolve(jsonResponse({providers: scenario === 'no-providers' ? [] : PROVIDERS}));
+}
+
+function integrationConnectionPatchResponse(url: URL) {
+  return Promise.resolve(
+    jsonResponse({
+      ...connection(),
+      id: url.pathname.split('/').at(-1),
+      lifecycle_status: 'disabled',
+    }),
+  );
+}
+
+function webhookConnectionPatchResponse(url: URL) {
+  return Promise.resolve(
+    jsonResponse({
+      id: url.pathname.split('/').at(-1),
+      workspace_id: WORKSPACE_ID,
+      name: 'Stripe production',
+      slug: 'stripe-prod',
+      lifecycle_status: 'disabled',
+      inbound_url: 'https://api.example.test/webhook/77777777-7777-4777-8777-777777777777',
+      created_at: '2026-04-12T00:00:00.000Z',
+      updated_at: '2026-04-12T00:00:00.000Z',
+    }),
+  );
+}
+
+function connectionsScenarioResponse(scenario: Scenario) {
+  if (scenario === 'connections-error') return Promise.resolve(errorResponse());
+  return Promise.resolve(jsonResponse({connections: connectionsForScenario(scenario)}));
+}
+
+function webhookConnectionsResponse() {
+  return Promise.resolve(
+    jsonResponse({
+      connections: [
+        {
+          id: '77777777-7777-4777-8777-777777777777',
           workspace_id: WORKSPACE_ID,
           name: 'Stripe production',
           slug: 'stripe-prod',
-          lifecycle_status: 'disabled',
+          lifecycle_status: 'active',
           inbound_url: 'https://api.example.test/webhook/77777777-7777-4777-8777-777777777777',
           created_at: '2026-04-12T00:00:00.000Z',
           updated_at: '2026-04-12T00:00:00.000Z',
-        }),
-      );
-    }
-    if (url.pathname.startsWith('/integrations/webhook/connections/') && method === 'DELETE') {
-      return Promise.resolve(jsonResponse(undefined, {status: 204}));
-    }
-    if (url.pathname === '/integration-connections') {
-      if (scenario === 'connections-error') return Promise.resolve(errorResponse());
-      return Promise.resolve(jsonResponse({connections: connectionsForScenario(scenario)}));
-    }
-    if (url.pathname === '/integrations/webhook/connections') {
-      return Promise.resolve(
-        jsonResponse({
-          connections: [
-            {
-              id: '77777777-7777-4777-8777-777777777777',
-              workspace_id: WORKSPACE_ID,
-              name: 'Stripe production',
-              slug: 'stripe-prod',
-              lifecycle_status: 'active',
-              inbound_url: 'https://api.example.test/webhook/77777777-7777-4777-8777-777777777777',
-              created_at: '2026-04-12T00:00:00.000Z',
-              updated_at: '2026-04-12T00:00:00.000Z',
-            },
-          ],
-        }),
-      );
-    }
-    return Promise.resolve(jsonResponse({}, {status: 404}));
-  };
+        },
+      ],
+    }),
+  );
 }
 
 function connectionsForScenario(scenario: Scenario): IntegrationConnectionDto[] {

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -105,84 +105,147 @@ function fetchForGallery(options: FetchOptions = {}) {
   } = options;
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : undefined;
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const url = galleryRequestUrl(input);
     const method = init?.method ?? request?.method ?? 'GET';
-    if (url.includes('/integrations/webhook/connections/')) {
-      const connectionId = url.split('/integrations/webhook/connections/')[1]?.split('?')[0];
-      if (!connectionId) return Promise.resolve(jsonResponse({}, {status: 404}));
-      if (method === 'PATCH') {
-        const rawBody =
-          init?.body !== undefined ? String(init.body) : (await request?.clone().text()) || '{}';
-        const body = JSON.parse(rawBody) as {lifecycle_status?: string};
-        onUpdateConnection?.(connectionId, body);
-        const connection = webhookConnections.find(
-          (candidate) =>
-            typeof candidate === 'object' &&
-            candidate !== null &&
-            'id' in candidate &&
-            candidate.id === connectionId,
-        ) as Record<string, unknown> | undefined;
-        return Promise.resolve(
-          jsonResponse({...connection, lifecycle_status: body.lifecycle_status}),
-        );
-      }
-      if (method === 'DELETE') {
-        return Promise.resolve(jsonResponse(undefined, {status: 204}));
-      }
-    }
     if (url.includes('/integrations/webhook/connections')) {
-      if (webhookConnectionsFail)
-        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
-      if (method === 'POST') {
-        const rawBody =
-          init?.body !== undefined ? String(init.body) : (await request?.clone().text()) || '{}';
-        const body = JSON.parse(rawBody) as {name?: string; slug?: string; workspace_id?: string};
-        return Promise.resolve(
-          jsonResponse({
-            ...webhookConnectionDto,
-            workspace_id: body.workspace_id ?? webhookConnectionDto.workspace_id,
-            name: body.name ?? webhookConnectionDto.name,
-            slug: body.slug ?? webhookConnectionDto.slug,
-          }),
-        );
-      }
-      return Promise.resolve(jsonResponse({connections: webhookConnections}));
+      return await webhookRouteResponse({
+        url,
+        method,
+        init,
+        request,
+        connections: webhookConnections,
+        onUpdateConnection,
+        failed: webhookConnectionsFail,
+      });
     }
     if (url.includes('/integration-providers')) {
-      if (providersFail)
-        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
-      return Promise.resolve(jsonResponse({providers}));
-    }
-    if (url.includes('/integration-connections/')) {
-      const connectionId = url.split('/integration-connections/')[1]?.split('?')[0];
-      if (!connectionId) return Promise.resolve(jsonResponse({}, {status: 404}));
-      if (method === 'PATCH') {
-        const rawBody =
-          init?.body !== undefined ? String(init.body) : (await request?.clone().text()) || '{}';
-        const body = JSON.parse(rawBody) as {lifecycle_status?: string};
-        onUpdateConnection?.(connectionId, body);
-        const connection = connections.find(
-          (candidate) =>
-            typeof candidate === 'object' &&
-            candidate !== null &&
-            'id' in candidate &&
-            candidate.id === connectionId,
-        ) as Record<string, unknown> | undefined;
-        return Promise.resolve(
-          jsonResponse({...connection, lifecycle_status: body.lifecycle_status}),
-        );
-      }
-      if (method === 'DELETE') {
-        return Promise.resolve(jsonResponse(undefined, {status: 204}));
-      }
+      return collectionResponse('providers', providers, providersFail);
     }
     if (url.includes('/integration-connections')) {
-      if (connectionsFail)
-        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
-      return Promise.resolve(jsonResponse({connections}));
+      return await integrationConnectionRouteResponse({
+        url,
+        method,
+        init,
+        request,
+        connections,
+        onUpdateConnection,
+        failed: connectionsFail,
+      });
     }
     return Promise.resolve(jsonResponse({}, {status: 404}));
   });
+}
+
+async function webhookRouteResponse(
+  params: Omit<Parameters<typeof connectionMutationResponse>[0], 'route'> & {failed: boolean},
+) {
+  if (params.url.includes('/integrations/webhook/connections/')) {
+    const response = await connectionMutationResponse({
+      ...params,
+      route: '/integrations/webhook/connections/',
+    });
+    if (response) return response;
+  }
+  return await webhookCollectionResponse(params);
+}
+
+async function integrationConnectionRouteResponse(
+  params: Omit<Parameters<typeof connectionMutationResponse>[0], 'route'> & {failed: boolean},
+) {
+  if (params.url.includes('/integration-connections/')) {
+    const response = await connectionMutationResponse({
+      ...params,
+      route: '/integration-connections/',
+    });
+    if (response) return response;
+  }
+  return collectionResponse('connections', params.connections, params.failed);
+}
+
+function galleryRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+async function connectionMutationResponse({
+  url,
+  route,
+  method,
+  init,
+  request,
+  connections,
+  onUpdateConnection,
+}: {
+  url: string;
+  route: string;
+  method: string;
+  init: RequestInit | undefined;
+  request: Request | undefined;
+  connections: unknown[];
+  onUpdateConnection: FetchOptions['onUpdateConnection'];
+}): Promise<Response | undefined> {
+  const connectionId = url.split(route)[1]?.split('?')[0];
+  if (!connectionId) return jsonResponse({}, {status: 404});
+  if (method === 'DELETE') return jsonResponse(undefined, {status: 204});
+  if (method !== 'PATCH') return undefined;
+
+  const body = await requestLifecycleBody(init, request);
+  onUpdateConnection?.(connectionId, body);
+  const connection = connections.find((candidate) => connectionIdFor(candidate) === connectionId);
+  return jsonResponse({...asRecord(connection), lifecycle_status: body.lifecycle_status});
+}
+
+async function webhookCollectionResponse({
+  method,
+  init,
+  request,
+  connections,
+  failed,
+}: {
+  method: string;
+  init: RequestInit | undefined;
+  request: Request | undefined;
+  connections: unknown[];
+  failed: boolean;
+}): Promise<Response> {
+  if (failed) return jsonResponse({code: 'server-error'}, {status: 500});
+  if (method !== 'POST') return jsonResponse({connections});
+  const body = await requestJsonBody(init, request);
+  return jsonResponse({
+    ...webhookConnectionDto,
+    workspace_id: body.workspace_id ?? webhookConnectionDto.workspace_id,
+    name: body.name ?? webhookConnectionDto.name,
+    slug: body.slug ?? webhookConnectionDto.slug,
+  });
+}
+
+function collectionResponse(key: string, values: unknown[], failed: boolean): Response {
+  if (failed) return jsonResponse({code: 'server-error'}, {status: 500});
+  return jsonResponse({[key]: values});
+}
+
+async function requestLifecycleBody(init: RequestInit | undefined, request: Request | undefined) {
+  return (await requestJsonBody(init, request)) as {lifecycle_status?: string};
+}
+
+async function requestJsonBody(
+  init: RequestInit | undefined,
+  request: Request | undefined,
+): Promise<Record<string, string | undefined>> {
+  const rawBody =
+    init?.body !== undefined ? String(init.body) : (await request?.clone().text()) || '{}';
+  return JSON.parse(rawBody) as Record<string, string | undefined>;
+}
+
+function connectionIdFor(candidate: unknown): unknown {
+  if (typeof candidate !== 'object' || candidate === null || !('id' in candidate)) return undefined;
+  return candidate.id;
+}
+
+function asRecord(candidate: unknown): Record<string, unknown> {
+  if (typeof candidate !== 'object' || candidate === null) return {};
+  return candidate as Record<string, unknown>;
 }
 
 function renderGallery(

--- a/libs/client/integrations/src/hooks/api/integrations.test.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.test.ts
@@ -38,8 +38,9 @@ describe('listSourceConnections', () => {
   test('requests the source_control capability and drops non-active connections', async () => {
     let requestedUrl = '';
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
-      requestedUrl =
-        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (typeof input === 'string') requestedUrl = input;
+      else if (input instanceof URL) requestedUrl = input.href;
+      else requestedUrl = input.url;
       return Promise.resolve(
         jsonResponse({
           connections: [

--- a/libs/client/integrations/src/linear-callback.ts
+++ b/libs/client/integrations/src/linear-callback.ts
@@ -71,38 +71,41 @@ export type LinearCallbackFailure = {
 };
 
 export function classifyLinearCallbackError(error: unknown): LinearCallbackFailure {
-  if (error instanceof ApiError) {
-    if (error.code === 'invalid-linear-install-state') {
+  if (error instanceof ApiError) return classifyLinearApiError(error);
+  return {
+    message: 'Could not complete the Linear install. Start again from workspace settings.',
+    startOver: true,
+    signIn: false,
+  };
+}
+
+function classifyLinearApiError(error: ApiError): LinearCallbackFailure {
+  switch (error.code) {
+    case 'invalid-linear-install-state':
       return {
         title: 'Linear install link expired',
         message: 'Linear install link expired. Start again from workspace settings.',
         startOver: true,
         signIn: false,
       };
-    }
-    if (error.code === 'linear-install-state-actor-mismatch' || error.code === 'unauthorized') {
+    case 'linear-install-state-actor-mismatch':
+    case 'unauthorized':
       return {
         title: 'Different Shipfox account',
         message: 'Different Shipfox account. Sign in with the account that started this install.',
         startOver: true,
         signIn: true,
       };
-    }
-    if (
-      error.code === 'linear-installation-already-linked' ||
-      error.code === 'linear-connection-already-linked'
-    ) {
+    case 'linear-installation-already-linked':
+    case 'linear-connection-already-linked':
       return {
         title: 'Linear already linked',
         message: 'This Linear organization is already linked to another workspace.',
         startOver: false,
         signIn: false,
       };
-    }
-    if (
-      error.code === 'linear-authorization-scope-mismatch' ||
-      error.code === 'linear-oauth-callback-error'
-    ) {
+    case 'linear-authorization-scope-mismatch':
+    case 'linear-oauth-callback-error':
       return {
         title: 'Linear permissions needed',
         message:
@@ -110,27 +113,34 @@ export function classifyLinearCallbackError(error: unknown): LinearCallbackFailu
         startOver: true,
         signIn: false,
       };
-    }
-    if (error.status === 0 || error.code === 'network-error') {
+    case 'network-error':
       return {
         message: 'Could not reach Shipfox. Check your connection and start again.',
         startOver: true,
         signIn: false,
       };
-    }
-    if (
-      error.status >= 500 ||
-      error.status === 429 ||
-      error.code === 'provider-unavailable' ||
-      error.code === 'timeout' ||
-      error.code === 'rate-limited'
-    ) {
+    case 'provider-unavailable':
+    case 'timeout':
+    case 'rate-limited':
       return {
         message: 'Linear is temporarily unavailable. Start a new install when it is available.',
         startOver: true,
         signIn: false,
       };
-    }
+  }
+  if (error.status === 0) {
+    return {
+      message: 'Could not reach Shipfox. Check your connection and start again.',
+      startOver: true,
+      signIn: false,
+    };
+  }
+  if (error.status >= 500 || error.status === 429) {
+    return {
+      message: 'Linear is temporarily unavailable. Start a new install when it is available.',
+      startOver: true,
+      signIn: false,
+    };
   }
   return {
     message: 'Could not complete the Linear install. Start again from workspace settings.',

--- a/libs/client/integrations/src/pages/jira-callback-page.tsx
+++ b/libs/client/integrations/src/pages/jira-callback-page.tsx
@@ -9,7 +9,16 @@ import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useQueryClient} from '@tanstack/react-query';
 import {Link, useNavigate} from '@tanstack/react-router';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   useCompleteIntegrationCallback,
   useCompleteIntegrationCallbackResult,
@@ -36,6 +45,62 @@ import {
 import {classifyJiraCallbackError, type JiraCallbackFailure} from '#jira-form-errors.js';
 import {rememberCallbackKey, resolveWorkspaceSlug} from '#workspace-navigation.js';
 
+type CompletedWorkspace = {slug?: string | undefined};
+type JiraConnectionCompletion = {
+  connection: IntegrationConnection;
+  isActive: () => boolean;
+  disposedRef: MutableRefObject<boolean>;
+  workspaces: ReturnType<typeof useAuthState>['workspaces'];
+  queryClient: ReturnType<typeof useQueryClient>;
+  setCompletedWorkspace: Dispatch<SetStateAction<CompletedWorkspace | undefined>>;
+};
+
+function jiraCompletionInactive(
+  disposedRef: MutableRefObject<boolean>,
+  isActive: () => boolean,
+): boolean {
+  return disposedRef.current || !isActive();
+}
+
+async function restoreCompletedJiraConnection(params: JiraConnectionCompletion) {
+  const workspaceSlug = await resolveWorkspaceSlug({
+    workspaceId: params.connection.workspaceId,
+    fallbackWorkspaces: params.workspaces,
+    queryClient: params.queryClient,
+  });
+  if (!jiraCompletionInactive(params.disposedRef, params.isActive)) {
+    params.setCompletedWorkspace(workspaceSlug ? {slug: workspaceSlug} : {});
+  }
+}
+
+async function navigateFromCompletedJiraConnection(
+  params: JiraConnectionCompletion & {navigate: ReturnType<typeof useNavigate>},
+) {
+  let workspaceSlug: string | undefined;
+  try {
+    workspaceSlug = await resolveWorkspaceSlug({
+      workspaceId: params.connection.workspaceId,
+      fallbackWorkspaces: params.workspaces,
+      queryClient: params.queryClient,
+    });
+    if (jiraCompletionInactive(params.disposedRef, params.isActive)) return;
+    if (!workspaceSlug) {
+      params.setCompletedWorkspace({});
+      return;
+    }
+    params.setCompletedWorkspace({slug: workspaceSlug});
+    await params.navigate({
+      to: '/w/$workspaceSlug/settings/integrations',
+      params: {workspaceSlug},
+      replace: true,
+    });
+  } catch {
+    if (!jiraCompletionInactive(params.disposedRef, params.isActive)) {
+      params.setCompletedWorkspace({slug: workspaceSlug});
+    }
+  }
+}
+
 export function JiraCallbackPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -51,9 +116,7 @@ export function JiraCallbackPage() {
   const [sites, setSites] = useState<JiraSite[] | undefined>();
   const [failure, setFailure] = useState<JiraCallbackFailure | undefined>();
   const [selectedCloudId, setSelectedCloudId] = useState<string | undefined>();
-  const [completedWorkspace, setCompletedWorkspace] = useState<{
-    slug?: string | undefined;
-  }>();
+  const [completedWorkspace, setCompletedWorkspace] = useState<CompletedWorkspace>();
   const disposedRef = useRef(false);
   const callbackKeyRef = useRef(callbackKey);
   callbackKeyRef.current = callbackKey;
@@ -72,16 +135,17 @@ export function JiraCallbackPage() {
       callbackKey: string,
       isActive: () => boolean = () => true,
     ) => {
-      if (disposedRef.current || !isActive()) return;
+      if (jiraCompletionInactive(disposedRef, isActive)) return;
       const completedConnection = jiraCompletedConnections.get(callbackKey);
       if (completedConnection) {
-        const workspaceSlug = await resolveWorkspaceSlug({
-          workspaceId: completedConnection.workspaceId,
-          fallbackWorkspaces: workspaces,
+        await restoreCompletedJiraConnection({
+          connection: completedConnection,
+          isActive,
+          disposedRef,
+          workspaces,
           queryClient,
+          setCompletedWorkspace,
         });
-        if (!disposedRef.current && isActive())
-          setCompletedWorkspace(workspaceSlug ? {slug: workspaceSlug} : {});
         return;
       }
       rememberCompletedConnection(callbackKey, connection);
@@ -90,32 +154,20 @@ export function JiraCallbackPage() {
       } catch {
         // The successful API response remains the source of truth for navigation.
       }
-      if (disposedRef.current || !isActive()) return;
+      if (jiraCompletionInactive(disposedRef, isActive)) return;
       if (!jiraToastedCallbacks.has(callbackKey)) {
         rememberCallbackKey(jiraToastedCallbacks, callbackKey);
         toast.success('Jira installed.');
       }
-      let workspaceSlug: string | undefined;
-      try {
-        workspaceSlug = await resolveWorkspaceSlug({
-          workspaceId: connection.workspaceId,
-          fallbackWorkspaces: workspaces,
-          queryClient,
-        });
-        if (disposedRef.current || !isActive()) return;
-        if (!workspaceSlug) {
-          setCompletedWorkspace({});
-          return;
-        }
-        setCompletedWorkspace({slug: workspaceSlug});
-        await navigate({
-          to: '/w/$workspaceSlug/settings/integrations',
-          params: {workspaceSlug},
-          replace: true,
-        });
-      } catch {
-        if (!disposedRef.current && isActive()) setCompletedWorkspace({slug: workspaceSlug});
-      }
+      await navigateFromCompletedJiraConnection({
+        connection,
+        isActive,
+        disposedRef,
+        workspaces,
+        queryClient,
+        setCompletedWorkspace,
+        navigate,
+      });
     },
     [navigate, queryClient, workspaces],
   );

--- a/libs/client/integrations/src/pages/linear-callback-page.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.tsx
@@ -5,7 +5,7 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate} from '@tanstack/react-router';
-import {useEffect, useMemo, useState} from 'react';
+import {type Dispatch, type SetStateAction, useEffect, useMemo, useState} from 'react';
 import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import {CallbackStatusShell} from '#components/callback-status-shell.js';
 import type {IntegrationConnection} from '#core/models.js';
@@ -29,6 +29,7 @@ const completedCallbacks = new Set<string>();
 // Keeps the success toast firing once per distinct callback even though the
 // effect re-runs against the cached request as the mutation identity churns.
 const toastedCallbacks = new Set<string>();
+type CompletedLinearWorkspace = {slug?: string | undefined};
 
 export function LinearCallbackPage() {
   const navigate = useNavigate();
@@ -40,9 +41,7 @@ export function LinearCallbackPage() {
   const params = useRouteSearch(parseLinearCallbackQuery);
   const workspaceId = useMemo(() => readLinearInstallWorkspace(sessionStorageOrUndefined()), []);
   const [failure, setFailure] = useState<LinearCallbackFailure | undefined>();
-  const [completedWorkspace, setCompletedWorkspace] = useState<{
-    slug?: string | undefined;
-  }>();
+  const [completedWorkspace, setCompletedWorkspace] = useState<CompletedLinearWorkspace>();
   useEffect(() => {
     if (!params || isLoading) return;
 
@@ -59,52 +58,16 @@ export function LinearCallbackPage() {
     );
 
     request.then(
-      async (connection) => {
-        if (disposed) return;
-        if (completedCallbacks.has(key)) {
-          const workspaceSlug = await resolveWorkspaceSlug({
-            workspaceId: connection.workspaceId,
-            fallbackWorkspaces: workspaces,
-            queryClient,
-          });
-          if (!disposed) setCompletedWorkspace(workspaceSlug ? {slug: workspaceSlug} : {});
-          return;
-        }
-        rememberCallbackKey(completedCallbacks, key);
-        try {
-          clearLinearInstallWorkspace(sessionStorageOrUndefined());
-        } catch {
-          // The successful API response remains the source of truth for navigation.
-        }
-        if (disposed) return;
-        if (!toastedCallbacks.has(key)) {
-          rememberCallbackKey(toastedCallbacks, key);
-          toast.success('Linear installed.');
-        }
-        let workspaceSlug: string | undefined;
-        try {
-          if (disposed) return;
-          workspaceSlug = await resolveWorkspaceSlug({
-            workspaceId: connection.workspaceId,
-            fallbackWorkspaces: workspaces,
-            queryClient,
-          });
-          if (disposed) return;
-          if (!workspaceSlug) {
-            setCompletedWorkspace({});
-            return;
-          }
-          setCompletedWorkspace({slug: workspaceSlug});
-          await navigate({
-            to: '/w/$workspaceSlug/settings/integrations',
-            params: {workspaceSlug},
-            replace: true,
-          });
-        } catch {
-          // Keep the completed callback page visible if client navigation is interrupted.
-          if (!disposed) setCompletedWorkspace({slug: workspaceSlug});
-        }
-      },
+      async (connection) =>
+        await handleLinearCallbackSuccess({
+          connection,
+          key,
+          isDisposed: () => disposed,
+          workspaces,
+          queryClient,
+          navigate,
+          setCompletedWorkspace,
+        }),
       (error: unknown) => {
         if (disposed) return;
         setFailure(classifyLinearCallbackError(error));
@@ -162,6 +125,100 @@ export function LinearCallbackPage() {
       workspaceSlug={workspaces.find(({id}) => id === workspaceId)?.slug}
     />
   );
+}
+
+async function handleLinearCallbackSuccess({
+  connection,
+  key,
+  isDisposed,
+  workspaces,
+  queryClient,
+  navigate,
+  setCompletedWorkspace,
+}: {
+  connection: IntegrationConnection;
+  key: string;
+  isDisposed: () => boolean;
+  workspaces: ReturnType<typeof useAuthState>['workspaces'];
+  queryClient: ReturnType<typeof useQueryClient>;
+  navigate: ReturnType<typeof useNavigate>;
+  setCompletedWorkspace: Dispatch<SetStateAction<CompletedLinearWorkspace | undefined>>;
+}) {
+  if (isDisposed()) return;
+  if (completedCallbacks.has(key)) {
+    await showResolvedLinearWorkspace({
+      connection,
+      isDisposed,
+      workspaces,
+      queryClient,
+      setCompletedWorkspace,
+    });
+    return;
+  }
+  rememberCallbackKey(completedCallbacks, key);
+  try {
+    clearLinearInstallWorkspace(sessionStorageOrUndefined());
+  } catch {
+    // The successful API response remains the source of truth for navigation.
+  }
+  if (isDisposed()) return;
+  if (!toastedCallbacks.has(key)) {
+    rememberCallbackKey(toastedCallbacks, key);
+    toast.success('Linear installed.');
+  }
+  await navigateToLinearWorkspace({
+    connection,
+    isDisposed,
+    workspaces,
+    queryClient,
+    navigate,
+    setCompletedWorkspace,
+  });
+}
+
+type LinearWorkspaceResolution = {
+  connection: IntegrationConnection;
+  isDisposed: () => boolean;
+  workspaces: ReturnType<typeof useAuthState>['workspaces'];
+  queryClient: ReturnType<typeof useQueryClient>;
+  setCompletedWorkspace: Dispatch<SetStateAction<CompletedLinearWorkspace | undefined>>;
+};
+
+async function showResolvedLinearWorkspace(params: LinearWorkspaceResolution) {
+  const workspaceSlug = await resolveWorkspaceSlug({
+    workspaceId: params.connection.workspaceId,
+    fallbackWorkspaces: params.workspaces,
+    queryClient: params.queryClient,
+  });
+  if (!params.isDisposed()) {
+    params.setCompletedWorkspace(workspaceSlug ? {slug: workspaceSlug} : {});
+  }
+}
+
+async function navigateToLinearWorkspace(
+  params: LinearWorkspaceResolution & {navigate: ReturnType<typeof useNavigate>},
+) {
+  let workspaceSlug: string | undefined;
+  try {
+    workspaceSlug = await resolveWorkspaceSlug({
+      workspaceId: params.connection.workspaceId,
+      fallbackWorkspaces: params.workspaces,
+      queryClient: params.queryClient,
+    });
+    if (params.isDisposed()) return;
+    if (!workspaceSlug) {
+      params.setCompletedWorkspace({});
+      return;
+    }
+    params.setCompletedWorkspace({slug: workspaceSlug});
+    await params.navigate({
+      to: '/w/$workspaceSlug/settings/integrations',
+      params: {workspaceSlug},
+      replace: true,
+    });
+  } catch {
+    if (!params.isDisposed()) params.setCompletedWorkspace({slug: workspaceSlug});
+  }
 }
 
 function LinearCallbackFailurePage({

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -9,7 +9,15 @@ import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useQueryClient} from '@tanstack/react-query';
 import {Link, useNavigate} from '@tanstack/react-router';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import type {IntegrationConnection} from '#core/models.js';
 import {connectSentry} from '#hooks/api/integrations.js';
@@ -123,50 +131,23 @@ export function SentryCallbackPage() {
     );
 
     request
-      .then(async () => {
-        clearSentryInstallWorkspace(sessionStorageOrUndefined());
-        if (disposedRef.current) return;
-        toast.success('Sentry installed.');
-        const workspaceSlug = await resolveWorkspaceSlug({
-          workspaceId,
-          fallbackWorkspaces: workspaces,
-          queryClient,
-        });
-        if (disposedRef.current) return;
-        await navigate(
-          workspaceSlug
-            ? {
-                to: '/w/$workspaceSlug/settings/integrations',
-                params: {workspaceSlug},
-                replace: true,
-              }
-            : {to: '/', replace: true},
-        );
-      })
-      .catch((error: unknown) => {
-        if (disposedRef.current) return;
-        const classified = classifySentryConnectError(error);
-        if (classified.kind === 'terminal') {
-          // Only a fresh install (new grant code) can recover; the stored
-          // handoff has served its purpose either way.
-          clearSentryInstallWorkspace(sessionStorageOrUndefined());
-        }
-        setConnectingId(undefined);
-        setFailure({workspaceId, failure: classified});
-      });
+      .then(
+        async () =>
+          await handleSentryConnectSuccess({
+            workspaceId,
+            workspaces,
+            queryClient,
+            navigate,
+            disposedRef,
+          }),
+      )
+      .catch((error: unknown) =>
+        handleSentryConnectFailure({error, workspaceId, disposedRef, setConnectingId, setFailure}),
+      );
   };
 
-  const orderedWorkspaces = preselectedId
-    ? [
-        ...workspaces.filter((workspace) => workspace.id === preselectedId),
-        ...workspaces.filter((workspace) => workspace.id !== preselectedId),
-      ]
-    : workspaces;
-
-  const failureWorkspaceId = failure?.workspaceId ?? preselectedId ?? workspaces[0]?.id;
-  const failureWorkspace = failureWorkspaceId
-    ? workspaces.find(({id}) => id === failureWorkspaceId)
-    : undefined;
+  const orderedWorkspaces = prioritizeWorkspace(workspaces, preselectedId);
+  const failureWorkspace = resolveFailureWorkspace(workspaces, failure?.workspaceId, preselectedId);
 
   return (
     <CallbackColumn>
@@ -242,6 +223,85 @@ export function SentryCallbackPage() {
       ) : null}
     </CallbackColumn>
   );
+}
+
+function prioritizeWorkspace(
+  workspaces: ReturnType<typeof useAuthState>['workspaces'],
+  preselectedId: string | undefined,
+) {
+  if (!preselectedId) return workspaces;
+  return [
+    ...workspaces.filter((workspace) => workspace.id === preselectedId),
+    ...workspaces.filter((workspace) => workspace.id !== preselectedId),
+  ];
+}
+
+function resolveFailureWorkspace(
+  workspaces: ReturnType<typeof useAuthState>['workspaces'],
+  failedWorkspaceId: string | undefined,
+  preselectedId: string | undefined,
+) {
+  const workspaceId = failedWorkspaceId ?? preselectedId ?? workspaces[0]?.id;
+  if (!workspaceId) return undefined;
+  return workspaces.find(({id}) => id === workspaceId);
+}
+
+async function handleSentryConnectSuccess({
+  workspaceId,
+  workspaces,
+  queryClient,
+  navigate,
+  disposedRef,
+}: {
+  workspaceId: string;
+  workspaces: ReturnType<typeof useAuthState>['workspaces'];
+  queryClient: ReturnType<typeof useQueryClient>;
+  navigate: ReturnType<typeof useNavigate>;
+  disposedRef: MutableRefObject<boolean>;
+}) {
+  clearSentryInstallWorkspace(sessionStorageOrUndefined());
+  if (disposedRef.current) return;
+  toast.success('Sentry installed.');
+  const workspaceSlug = await resolveWorkspaceSlug({
+    workspaceId,
+    fallbackWorkspaces: workspaces,
+    queryClient,
+  });
+  if (disposedRef.current) return;
+  if (workspaceSlug) {
+    await navigate({
+      to: '/w/$workspaceSlug/settings/integrations',
+      params: {workspaceSlug},
+      replace: true,
+    });
+    return;
+  }
+  await navigate({to: '/', replace: true});
+}
+
+function handleSentryConnectFailure({
+  error,
+  workspaceId,
+  disposedRef,
+  setConnectingId,
+  setFailure,
+}: {
+  error: unknown;
+  workspaceId: string;
+  disposedRef: MutableRefObject<boolean>;
+  setConnectingId: Dispatch<SetStateAction<string | undefined>>;
+  setFailure: Dispatch<
+    SetStateAction<{workspaceId: string; failure: SentryConnectFailure} | undefined>
+  >;
+}) {
+  if (disposedRef.current) return;
+  const classified = classifySentryConnectError(error);
+  if (classified.kind === 'terminal') {
+    // Only a fresh install (new grant code) can recover; the stored handoff has served its purpose.
+    clearSentryInstallWorkspace(sessionStorageOrUndefined());
+  }
+  setConnectingId(undefined);
+  setFailure({workspaceId, failure: classified});
 }
 
 function CallbackColumn({children}: {children: React.ReactNode}) {

--- a/libs/client/integrations/src/pages/slack-callback-page.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.tsx
@@ -5,7 +5,7 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate} from '@tanstack/react-router';
-import {useEffect, useMemo, useState} from 'react';
+import {type Dispatch, type SetStateAction, useEffect, useMemo, useState} from 'react';
 import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import {CallbackStatusShell} from '#components/callback-status-shell.js';
 import type {IntegrationConnection} from '#core/models.js';
@@ -56,51 +56,16 @@ export function SlackCallbackPage() {
         }),
     );
     request.then(
-      async (connection) => {
-        if (disposed) return;
-        if (completedCallbacks.has(key)) {
-          const workspaceSlug = await resolveWorkspaceSlug({
-            workspaceId: connection.workspaceId,
-            fallbackWorkspaces: workspaces,
-            queryClient,
-          });
-          if (!disposed) setCompletedWorkspace(workspaceSlug ? {slug: workspaceSlug} : {});
-          return;
-        }
-        rememberCallbackKey(completedCallbacks, key);
-        try {
-          clearSlackInstallWorkspace(sessionStorageOrUndefined());
-        } catch {
-          // The successful API response remains the source of truth.
-        }
-        if (disposed) return;
-        if (!toastedCallbacks.has(key)) {
-          rememberCallbackKey(toastedCallbacks, key);
-          toast.success('Slack installed.');
-        }
-        let workspaceSlug: string | undefined;
-        try {
-          if (disposed) return;
-          workspaceSlug = await resolveWorkspaceSlug({
-            workspaceId: connection.workspaceId,
-            fallbackWorkspaces: workspaces,
-            queryClient,
-          });
-          if (disposed) return;
-          if (!workspaceSlug) {
-            setCompletedWorkspace({});
-            return;
-          }
-          setCompletedWorkspace({slug: workspaceSlug});
-          await navigate({
-            to: '/w/$workspaceSlug/settings/integrations',
-            params: {workspaceSlug},
-            replace: true,
-          });
-        } catch {
-          if (!disposed) setCompletedWorkspace({slug: workspaceSlug});
-        }
-      },
+      async (connection) =>
+        await handleSlackCallbackSuccess({
+          connection,
+          key,
+          isDisposed: () => disposed,
+          workspaces,
+          queryClient,
+          navigate,
+          setCompletedWorkspace,
+        }),
       (error: unknown) => {
         if (!disposed) setFailure(classifySlackCallbackError(error));
       },
@@ -153,4 +118,71 @@ export function SlackCallbackPage() {
       />
     );
   return <FullPageLoader aria-label="Connecting Slack" />;
+}
+
+type SlackWorkspaceResolution = {
+  connection: IntegrationConnection;
+  isDisposed: () => boolean;
+  workspaces: ReturnType<typeof useAuthState>['workspaces'];
+  queryClient: ReturnType<typeof useQueryClient>;
+  setCompletedWorkspace: Dispatch<SetStateAction<{slug?: string | undefined} | undefined>>;
+};
+
+async function handleSlackCallbackSuccess(
+  params: SlackWorkspaceResolution & {key: string; navigate: ReturnType<typeof useNavigate>},
+) {
+  if (params.isDisposed()) return;
+  if (completedCallbacks.has(params.key)) {
+    await showResolvedSlackWorkspace(params);
+    return;
+  }
+  rememberCallbackKey(completedCallbacks, params.key);
+  try {
+    clearSlackInstallWorkspace(sessionStorageOrUndefined());
+  } catch {
+    // The successful API response remains the source of truth.
+  }
+  if (params.isDisposed()) return;
+  if (!toastedCallbacks.has(params.key)) {
+    rememberCallbackKey(toastedCallbacks, params.key);
+    toast.success('Slack installed.');
+  }
+  await navigateToSlackWorkspace(params);
+}
+
+async function showResolvedSlackWorkspace(params: SlackWorkspaceResolution) {
+  const workspaceSlug = await resolveWorkspaceSlug({
+    workspaceId: params.connection.workspaceId,
+    fallbackWorkspaces: params.workspaces,
+    queryClient: params.queryClient,
+  });
+  if (!params.isDisposed()) {
+    params.setCompletedWorkspace(workspaceSlug ? {slug: workspaceSlug} : {});
+  }
+}
+
+async function navigateToSlackWorkspace(
+  params: SlackWorkspaceResolution & {navigate: ReturnType<typeof useNavigate>},
+) {
+  let workspaceSlug: string | undefined;
+  try {
+    workspaceSlug = await resolveWorkspaceSlug({
+      workspaceId: params.connection.workspaceId,
+      fallbackWorkspaces: params.workspaces,
+      queryClient: params.queryClient,
+    });
+    if (params.isDisposed()) return;
+    if (!workspaceSlug) {
+      params.setCompletedWorkspace({});
+      return;
+    }
+    params.setCompletedWorkspace({slug: workspaceSlug});
+    await params.navigate({
+      to: '/w/$workspaceSlug/settings/integrations',
+      params: {workspaceSlug},
+      replace: true,
+    });
+  } catch {
+    if (!params.isDisposed()) params.setCompletedWorkspace({slug: workspaceSlug});
+  }
 }

--- a/libs/client/integrations/src/slack-callback.ts
+++ b/libs/client/integrations/src/slack-callback.ts
@@ -65,14 +65,24 @@ export type SlackCallbackFailure = {
   signIn: boolean;
 };
 export function classifySlackCallbackError(error: unknown): SlackCallbackFailure {
-  if (error instanceof ApiError) {
-    if (error.code === 'invalid-slack-install-state')
+  if (error instanceof ApiError) return classifySlackApiError(error);
+  return failure(
+    'Slack install could not be completed',
+    'Could not complete the Slack install. Start again from workspace settings.',
+    true,
+  );
+}
+
+function classifySlackApiError(error: ApiError): SlackCallbackFailure {
+  switch (error.code) {
+    case 'invalid-slack-install-state':
       return failure(
         'Slack install link expired',
         'Slack install link expired. Start again from workspace settings.',
         true,
       );
-    if (error.code === 'slack-install-state-actor-mismatch' || error.code === 'unauthorized')
+    case 'slack-install-state-actor-mismatch':
+    case 'unauthorized':
       return {
         ...failure(
           'Different Shipfox account',
@@ -81,59 +91,58 @@ export function classifySlackCallbackError(error: unknown): SlackCallbackFailure
         ),
         signIn: true,
       };
-    if (['not-found', 'forbidden', 'workspace-inactive'].includes(error.code))
+    case 'not-found':
+    case 'forbidden':
+    case 'workspace-inactive':
       return failure(
         'Workspace access changed',
         'You no longer have access to this workspace. Return to Shipfox to continue.',
         false,
       );
-    if (
-      [
-        'slack-installation-already-linked',
-        'slack-connection-already-linked',
-        'slug-conflict',
-      ].includes(error.code)
-    )
+    case 'slack-installation-already-linked':
+    case 'slack-connection-already-linked':
+    case 'slug-conflict':
       return failure(
         'Slack already linked',
         'This Slack workspace is already linked and cannot be installed again here.',
         false,
       );
-    if (
-      [
-        'slack-authorization-scope-mismatch',
-        'slack-oauth-callback-error',
-        'access-denied',
-      ].includes(error.code)
-    )
+    case 'slack-authorization-scope-mismatch':
+    case 'slack-oauth-callback-error':
+    case 'access-denied':
       return failure(
         'Slack permissions needed',
         'Slack did not authorize the permissions Shipfox needs. Review the consent and start again.',
         true,
       );
-    if (
-      error.code === 'slack-enterprise-install-unsupported' ||
-      error.code === 'slack-token-rotation-unsupported'
-    )
+    case 'slack-enterprise-install-unsupported':
+    case 'slack-token-rotation-unsupported':
       return failure(
         'Slack install unsupported',
         'This Slack installation is not supported. Return to Shipfox to continue.',
         false,
       );
-    if (error.status === 0 || error.code === 'network-error')
+    case 'network-error':
       return failure('Could not reach Shipfox', 'Check your connection and start again.', true);
-    if (
-      error.status >= 500 ||
-      error.status === 429 ||
-      ['rate-limited', 'timeout', 'provider-unavailable', 'malformed-provider-response'].includes(
-        error.code,
-      )
-    )
+    case 'rate-limited':
+    case 'timeout':
+    case 'provider-unavailable':
+    case 'malformed-provider-response':
       return failure(
         'Slack is temporarily unavailable',
         'Start a new install when Slack is available.',
         true,
       );
+  }
+  if (error.status === 0) {
+    return failure('Could not reach Shipfox', 'Check your connection and start again.', true);
+  }
+  if (error.status >= 500 || error.status === 429) {
+    return failure(
+      'Slack is temporarily unavailable',
+      'Start a new install when Slack is available.',
+      true,
+    );
   }
   return failure(
     'Slack install could not be completed',

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -138,26 +138,8 @@ export function InvitationAcceptPage() {
     );
   }
 
-  if (preview.isLoading) {
-    return (
-      <AuthShell title="Loading invitation" description="One moment please.">
-        <CenteredLoader />
-      </AuthShell>
-    );
-  }
-
-  if (preview.isError) {
-    return (
-      <AuthShell title="Couldn't load invitation" description="Try again in a moment.">
-        <Callout role="alert" type="error">
-          We couldn't reach the server. Check your connection and retry.
-        </Callout>
-        <Button className="w-full" onClick={() => preview.refetch()}>
-          Try again
-        </Button>
-      </AuthShell>
-    );
-  }
+  const previewState = renderPreviewState(preview);
+  if (previewState !== undefined) return previewState;
 
   const data = preview.data;
   if (!data) {
@@ -321,6 +303,28 @@ export function InvitationAcceptPage() {
           Adding you to {data.workspaceName}…
         </Text>
       </div>
+    </AuthShell>
+  );
+}
+
+function renderPreviewState(preview: ReturnType<typeof usePreviewInvitation>) {
+  if (preview.isLoading) {
+    return (
+      <AuthShell title="Loading invitation" description="One moment please.">
+        <CenteredLoader />
+      </AuthShell>
+    );
+  }
+
+  if (!preview.isError) return undefined;
+  return (
+    <AuthShell title="Couldn't load invitation" description="Try again in a moment.">
+      <Callout role="alert" type="error">
+        We couldn't reach the server. Check your connection and retry.
+      </Callout>
+      <Button className="w-full" onClick={() => preview.refetch()}>
+        Try again
+      </Button>
     </AuthShell>
   );
 }

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {Icon} from '@shipfox/react-ui/icon';
+import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {
   LogContent,
   LogDisclosure,
@@ -67,198 +67,280 @@ function AgentSessionRowView({
 
   switch (row.kind) {
     case 'message':
-      return (
-        <LogRow
-          lineNumber={null}
-          timestamp={new Date(row.timestamp)}
-          indent={indent}
-          tone={row.terminalFailure ? 'error' : 'default'}
-          data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
-        >
-          <LogContent className="text-foreground-contrast-primary">
-            <span className="flex min-w-0 items-start gap-inline">
-              <MessageIcon role={row.role} terminalFailure={row.terminalFailure} />
-              <span className="flex min-w-0 flex-1 flex-col gap-tight">
-                <span className="flex min-w-0 items-center gap-inline">
-                  <MessageRoleLabel label={row.label} terminalFailure={row.terminalFailure} />
-                  <RowMetadata meta={row.meta} className="ml-auto flex-none" />
-                </span>
-                <span className="block min-w-0">
-                  <PreviewText text={row.text} />
-                </span>
-              </span>
-            </span>
-          </LogContent>
-        </LogRow>
-      );
+      return <SessionMessageRow row={row} indent={indent} />;
     case 'thinking':
+      return <SessionThinkingRow row={row} indent={indent} disclosure={disclosureProps} />;
+    case 'tool-call':
       return (
-        <LogDisclosure indent={indent} {...disclosureProps}>
-          <LogDisclosureTrigger
-            summary={wordSummary(row.text)}
-            timestamp={new Date(row.timestamp)}
-            className="text-foreground-contrast-secondary"
-          >
-            thinking
-          </LogDisclosureTrigger>
-          <LogDisclosureContent className="text-foreground-contrast-secondary">
-            <LogContent className="text-foreground-contrast-secondary">
-              <PreviewText text={row.text} />
-            </LogContent>
-          </LogDisclosureContent>
-        </LogDisclosure>
-      );
-    case 'tool-call': {
-      const awaitingResult = row.id != null && !resolvedToolCallIds.has(row.id);
-      return (
-        <LogDisclosure indent={indent} {...disclosureProps}>
-          <LogDisclosureTrigger
-            timestamp={new Date(row.timestamp)}
-            summary={compactPreview(row.summary ?? row.input)}
-            trailing={
-              awaitingResult ? (
-                <span className="inline-flex items-center gap-tight">
-                  <Icon
-                    name="loader4Line"
-                    className="size-12 motion-safe:animate-spin"
-                    aria-hidden="true"
-                  />
-                  awaiting result
-                </span>
-              ) : null
-            }
-          >
-            <span className="inline-flex min-w-0 items-center gap-inline">
-              <Icon name="terminalBoxLine" className="size-14 flex-none" aria-hidden="true" />
-              <span className="truncate">tool {row.name}</span>
-            </span>
-          </LogDisclosureTrigger>
-          <LogDisclosureContent>
-            {row.summary != null ? (
-              <>
-                <LogContent>
-                  <PreviewText text={row.summary} />
-                </LogContent>
-                <LogContent variant="code">
-                  <PreviewText text={row.input} />
-                </LogContent>
-              </>
-            ) : (
-              <LogContent variant="code">
-                <PreviewText text={row.input} />
-              </LogContent>
-            )}
-          </LogDisclosureContent>
-        </LogDisclosure>
-      );
-    }
-    case 'tool-result': {
-      const toolName =
-        row.toolName === 'tool'
-          ? ((row.toolCallId != null ? toolCallNames.get(row.toolCallId) : undefined) ??
-            '(unmatched)')
-          : row.toolName;
-      return (
-        <LogDisclosure indent={indent} {...disclosureProps}>
-          <LogDisclosureTrigger
-            timestamp={new Date(row.timestamp)}
-            summary={compactPreview(row.output)}
-            trailing={
-              <span
-                className={cn(
-                  'inline-flex items-center gap-tight',
-                  row.isError ? 'text-tag-error-icon' : 'text-foreground-contrast-secondary',
-                )}
-              >
-                <Icon
-                  name={row.isError ? 'closeCircleLine' : 'checkLine'}
-                  className="size-12"
-                  aria-hidden="true"
-                />
-                {row.isError ? 'error' : 'ok'}
-              </span>
-            }
-          >
-            <span className="inline-flex min-w-0 items-center gap-inline">
-              <Icon name="terminalWindowLine" className="size-14 flex-none" aria-hidden="true" />
-              <span className="truncate">result {toolName}</span>
-            </span>
-          </LogDisclosureTrigger>
-          <LogDisclosureContent>
-            <LogContent variant="code" className="text-foreground-contrast-primary">
-              <PreviewText text={row.output} />
-            </LogContent>
-          </LogDisclosureContent>
-        </LogDisclosure>
-      );
-    }
-    case 'lifecycle':
-      return (
-        <LogRow
-          lineNumber={null}
-          timestamp={new Date(row.timestamp)}
+        <SessionToolCallRow
+          row={row}
           indent={indent}
-          tone={row.tone}
-          data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
-        >
-          <LogContent className="text-foreground-contrast-secondary">
-            <span className="inline-flex w-full items-center gap-inline">
-              <Icon name="informationLine" className="size-14 flex-none" aria-hidden="true" />
-              <span className="min-w-0">
-                <span className="font-medium">{row.label}</span>
-                {row.detail != null ? (
-                  <>
-                    {' · '}
-                    <span className="text-foreground-contrast-secondary">{row.detail}</span>
-                  </>
-                ) : null}
-              </span>
-              <span
-                aria-hidden="true"
-                className="h-px flex-1 border-t border-dashed border-current opacity-30"
-              />
-              <RowMetadata meta={row.meta} />
-            </span>
-          </LogContent>
-        </LogRow>
+          disclosure={disclosureProps}
+          resolvedToolCallIds={resolvedToolCallIds}
+        />
       );
-    case 'raw':
+    case 'tool-result':
       return (
-        <LogDisclosure indent={indent} {...disclosureProps}>
-          <LogDisclosureTrigger
-            timestamp={new Date(row.timestamp)}
-            summary={compactPreview(row.raw)}
-            className="text-foreground-contrast-primary"
-          >
-            <span className="inline-flex min-w-0 items-center gap-inline">
-              <Icon
-                name="errorWarningLine"
-                className="size-14 flex-none text-tag-warning-icon"
-                aria-hidden="true"
-              />
-              <span className="truncate">{row.label}</span>
-            </span>
-          </LogDisclosureTrigger>
-          <LogDisclosureContent>
-            <LogContent variant="code">
-              <PreviewText text={row.raw} />
-            </LogContent>
-          </LogDisclosureContent>
-        </LogDisclosure>
+        <SessionToolResultRow
+          row={row}
+          indent={indent}
+          disclosure={disclosureProps}
+          toolCallNames={toolCallNames}
+        />
       );
+    case 'lifecycle':
+      return <SessionLifecycleRow row={row} indent={indent} />;
+    case 'raw':
+      return <SessionRawRow row={row} indent={indent} disclosure={disclosureProps} />;
     default:
       return assertNever(row);
   }
 }
 
+type DisclosureState = {open: boolean; onOpenChange: (open: boolean) => void};
+
+function SessionMessageRow({
+  row,
+  indent,
+}: {
+  row: Extract<SessionViewRow, {kind: 'message'}>;
+  indent: number;
+}) {
+  return (
+    <LogRow
+      lineNumber={null}
+      timestamp={new Date(row.timestamp)}
+      indent={indent}
+      tone={row.terminalFailure ? 'error' : 'default'}
+      data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
+    >
+      <LogContent className="text-foreground-contrast-primary">
+        <span className="flex min-w-0 items-start gap-inline">
+          <MessageIcon role={row.role} terminalFailure={row.terminalFailure} />
+          <span className="flex min-w-0 flex-1 flex-col gap-tight">
+            <span className="flex min-w-0 items-center gap-inline">
+              <MessageRoleLabel label={row.label} terminalFailure={row.terminalFailure} />
+              <RowMetadata meta={row.meta} className="ml-auto flex-none" />
+            </span>
+            <span className="block min-w-0">
+              <PreviewText text={row.text} />
+            </span>
+          </span>
+        </span>
+      </LogContent>
+    </LogRow>
+  );
+}
+
+function SessionThinkingRow({
+  row,
+  indent,
+  disclosure,
+}: {
+  row: Extract<SessionViewRow, {kind: 'thinking'}>;
+  indent: number;
+  disclosure: DisclosureState;
+}) {
+  return (
+    <LogDisclosure indent={indent} {...disclosure}>
+      <LogDisclosureTrigger
+        summary={wordSummary(row.text)}
+        timestamp={new Date(row.timestamp)}
+        className="text-foreground-contrast-secondary"
+      >
+        thinking
+      </LogDisclosureTrigger>
+      <LogDisclosureContent className="text-foreground-contrast-secondary">
+        <LogContent className="text-foreground-contrast-secondary">
+          <PreviewText text={row.text} />
+        </LogContent>
+      </LogDisclosureContent>
+    </LogDisclosure>
+  );
+}
+
+function SessionToolCallRow({
+  row,
+  indent,
+  disclosure,
+  resolvedToolCallIds,
+}: {
+  row: Extract<SessionViewRow, {kind: 'tool-call'}>;
+  indent: number;
+  disclosure: DisclosureState;
+  resolvedToolCallIds: ReadonlySet<string>;
+}) {
+  const awaitingResult = row.id != null && !resolvedToolCallIds.has(row.id);
+  return (
+    <LogDisclosure indent={indent} {...disclosure}>
+      <LogDisclosureTrigger
+        timestamp={new Date(row.timestamp)}
+        summary={compactPreview(row.summary ?? row.input)}
+        trailing={
+          awaitingResult ? (
+            <span className="inline-flex items-center gap-tight">
+              <Icon
+                name="loader4Line"
+                className="size-12 motion-safe:animate-spin"
+                aria-hidden="true"
+              />
+              awaiting result
+            </span>
+          ) : null
+        }
+      >
+        <span className="inline-flex min-w-0 items-center gap-inline">
+          <Icon name="terminalBoxLine" className="size-14 flex-none" aria-hidden="true" />
+          <span className="truncate">tool {row.name}</span>
+        </span>
+      </LogDisclosureTrigger>
+      <LogDisclosureContent>
+        {row.summary != null ? (
+          <>
+            <LogContent>
+              <PreviewText text={row.summary} />
+            </LogContent>
+            <LogContent variant="code">
+              <PreviewText text={row.input} />
+            </LogContent>
+          </>
+        ) : (
+          <LogContent variant="code">
+            <PreviewText text={row.input} />
+          </LogContent>
+        )}
+      </LogDisclosureContent>
+    </LogDisclosure>
+  );
+}
+
+function SessionToolResultRow({
+  row,
+  indent,
+  disclosure,
+  toolCallNames,
+}: {
+  row: Extract<SessionViewRow, {kind: 'tool-result'}>;
+  indent: number;
+  disclosure: DisclosureState;
+  toolCallNames: ReadonlyMap<string, string>;
+}) {
+  const toolName =
+    row.toolName === 'tool'
+      ? ((row.toolCallId != null ? toolCallNames.get(row.toolCallId) : undefined) ?? '(unmatched)')
+      : row.toolName;
+  return (
+    <LogDisclosure indent={indent} {...disclosure}>
+      <LogDisclosureTrigger
+        timestamp={new Date(row.timestamp)}
+        summary={compactPreview(row.output)}
+        trailing={
+          <span
+            className={cn(
+              'inline-flex items-center gap-tight',
+              row.isError ? 'text-tag-error-icon' : 'text-foreground-contrast-secondary',
+            )}
+          >
+            <Icon
+              name={row.isError ? 'closeCircleLine' : 'checkLine'}
+              className="size-12"
+              aria-hidden="true"
+            />
+            {row.isError ? 'error' : 'ok'}
+          </span>
+        }
+      >
+        <span className="inline-flex min-w-0 items-center gap-inline">
+          <Icon name="terminalWindowLine" className="size-14 flex-none" aria-hidden="true" />
+          <span className="truncate">result {toolName}</span>
+        </span>
+      </LogDisclosureTrigger>
+      <LogDisclosureContent>
+        <LogContent variant="code" className="text-foreground-contrast-primary">
+          <PreviewText text={row.output} />
+        </LogContent>
+      </LogDisclosureContent>
+    </LogDisclosure>
+  );
+}
+
+function SessionLifecycleRow({
+  row,
+  indent,
+}: {
+  row: Extract<SessionViewRow, {kind: 'lifecycle'}>;
+  indent: number;
+}) {
+  return (
+    <LogRow
+      lineNumber={null}
+      timestamp={new Date(row.timestamp)}
+      indent={indent}
+      tone={row.tone}
+      data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
+    >
+      <LogContent className="text-foreground-contrast-secondary">
+        <span className="inline-flex w-full items-center gap-inline">
+          <Icon name="informationLine" className="size-14 flex-none" aria-hidden="true" />
+          <span className="min-w-0">
+            <span className="font-medium">{row.label}</span>
+            {row.detail != null ? (
+              <>
+                {' · '}
+                <span className="text-foreground-contrast-secondary">{row.detail}</span>
+              </>
+            ) : null}
+          </span>
+          <span
+            aria-hidden="true"
+            className="h-px flex-1 border-t border-dashed border-current opacity-30"
+          />
+          <RowMetadata meta={row.meta} />
+        </span>
+      </LogContent>
+    </LogRow>
+  );
+}
+
+function SessionRawRow({
+  row,
+  indent,
+  disclosure,
+}: {
+  row: Extract<SessionViewRow, {kind: 'raw'}>;
+  indent: number;
+  disclosure: DisclosureState;
+}) {
+  return (
+    <LogDisclosure indent={indent} {...disclosure}>
+      <LogDisclosureTrigger
+        timestamp={new Date(row.timestamp)}
+        summary={compactPreview(row.raw)}
+        className="text-foreground-contrast-primary"
+      >
+        <span className="inline-flex min-w-0 items-center gap-inline">
+          <Icon
+            name="errorWarningLine"
+            className="size-14 flex-none text-tag-warning-icon"
+            aria-hidden="true"
+          />
+          <span className="truncate">{row.label}</span>
+        </span>
+      </LogDisclosureTrigger>
+      <LogDisclosureContent>
+        <LogContent variant="code">
+          <PreviewText text={row.raw} />
+        </LogContent>
+      </LogDisclosureContent>
+    </LogDisclosure>
+  );
+}
+
 function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: boolean}) {
-  const name = terminalFailure
-    ? 'closeCircleLine'
-    : role === 'user'
-      ? 'userLine'
-      : role === 'assistant'
-        ? 'robot2Line'
-        : 'message2Line';
+  let name: IconName = 'message2Line';
+  if (terminalFailure) name = 'closeCircleLine';
+  else if (role === 'user') name = 'userLine';
+  else if (role === 'assistant') name = 'robot2Line';
 
   return (
     <Icon

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -70,11 +70,13 @@ export function LogView({
   const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(tree.nodes), [tree.nodes]);
   const noOutputState = normalizedSearch ? null : getNoOutputState(tree, emptyState);
   const anchorRecordCount = records.length;
-  const searchStatus = normalizedSearch
-    ? visibleNodes.length === 0
-      ? `No log lines match “${deferredSearch.trim()}”.`
-      : `Log search updated for “${deferredSearch.trim()}”.`
-    : null;
+  let searchStatus: string | null = null;
+  if (normalizedSearch) {
+    searchStatus =
+      visibleNodes.length === 0
+        ? `No log lines match “${deferredSearch.trim()}”.`
+        : `Log search updated for “${deferredSearch.trim()}”.`;
+  }
 
   useEffect(() => {
     if (!anchorToFailure) return;

--- a/libs/client/logs/src/core/log-tree.ts
+++ b/libs/client/logs/src/core/log-tree.ts
@@ -86,115 +86,128 @@ export function assertNever(value: never): never {
 }
 
 export function buildLogTree(records: readonly LogRecord[]): LogTree {
-  const nodes: LogNode[] = [];
-  const stack: GroupLogNode[] = [];
-  let seq = 0;
-  let lineNumber = 0;
-  let lineCount = 0;
-  let terminated = false;
-  let originTs: number | null = null;
-
-  const childrenOf = (): LogNode[] => stack[stack.length - 1]?.children ?? nodes;
-
-  // Bubble a failure signal (a runner_lost only) to every currently-open ancestor group
-  // in one pass, so `hasError` is read in O(1) at render time instead of re-walking subtrees.
-  const markOpenGroupsError = (): void => {
-    for (const frame of stack) frame.hasError = true;
+  const state: LogTreeBuildState = {
+    nodes: [],
+    stack: [],
+    seq: 0,
+    lineNumber: 0,
+    lineCount: 0,
+    terminated: false,
+    originTs: null,
   };
 
   for (const record of records) {
-    if (originTs === null) originTs = record.ts;
-    switch (record.type) {
-      case 'output': {
-        lineNumber += 1;
-        lineCount += 1;
-        for (const frame of stack) frame.lineCount += 1;
-        childrenOf().push({kind: 'output', seq: seq++, lineNumber, record});
-        break;
-      }
-      case 'group_start': {
-        // Reconcile the open stack to the declared parent before nesting. `parent_group_id`
-        // is the runner's stack top at emit time (null at the root), so any reader frame
-        // below that parent (or every open frame, when the parent is root) is a group whose
-        // own `group_end` was dropped under backlog pressure. Orphan-close those frames so a
-        // dropped end never mis-parents the groups that follow. A parent whose own start was
-        // dropped is not on the stack: it falls through to best-effort root placement.
-        const parentId = record.parentGroupId;
-        let parentIndex = -1;
-        if (parentId !== null) {
-          for (let i = stack.length - 1; i >= 0; i -= 1) {
-            if (stack[i]?.record.groupId === parentId) {
-              parentIndex = i;
-              break;
-            }
-          }
-        }
-        for (let i = stack.length - 1; i > parentIndex; i -= 1) {
-          const frame = stack[i];
-          if (frame) frame.closed = true;
-        }
-        stack.length = parentIndex + 1;
-
-        const group: GroupLogNode = {
-          kind: 'group',
-          seq: seq++,
-          record,
-          closed: false,
-          endTs: null,
-          hasError: false,
-          lineCount: 0,
-          children: [],
-        };
-        childrenOf().push(group);
-        stack.push(group);
-        break;
-      }
-      case 'group_end': {
-        // Close the matching open group_id; any inner frames orphaned by a dropped
-        // group_end close with it. An end with no matching open start is ignored.
-        let matchIndex = -1;
-        for (let i = stack.length - 1; i >= 0; i -= 1) {
-          if (stack[i]?.record.groupId === record.groupId) {
-            matchIndex = i;
-            break;
-          }
-        }
-        if (matchIndex !== -1) {
-          for (let i = stack.length - 1; i >= matchIndex; i -= 1) {
-            const frame = stack[i];
-            if (frame) frame.closed = true;
-          }
-          const matched = stack[matchIndex];
-          if (matched) matched.endTs = record.ts;
-          stack.length = matchIndex;
-        }
-        break;
-      }
-      case 'end':
-      case 'gap':
-      case 'capped': {
-        if (record.type === 'end') terminated = true;
-        childrenOf().push({kind: 'marker', seq: seq++, record});
-        break;
-      }
-      case 'runner_lost': {
-        terminated = true;
-        childrenOf().push({kind: 'marker', seq: seq++, record});
-        markOpenGroupsError();
-        break;
-      }
-      case 'agent_session':
-        childrenOf().push({kind: 'session', seq: seq++, record});
-        break;
-      default:
-        assertNever(record);
-    }
+    if (state.originTs === null) state.originTs = record.ts;
+    appendLogRecord(state, record);
   }
 
   return {
-    nodes,
-    terminated,
-    originTs,
-    lineCount,
+    nodes: state.nodes,
+    terminated: state.terminated,
+    originTs: state.originTs,
+    lineCount: state.lineCount,
   };
+}
+
+interface LogTreeBuildState {
+  nodes: LogNode[];
+  stack: GroupLogNode[];
+  seq: number;
+  lineNumber: number;
+  lineCount: number;
+  terminated: boolean;
+  originTs: number | null;
+}
+
+function childrenOf(state: LogTreeBuildState): LogNode[] {
+  return state.stack[state.stack.length - 1]?.children ?? state.nodes;
+}
+
+function appendLogRecord(state: LogTreeBuildState, record: LogRecord): void {
+  switch (record.type) {
+    case 'output':
+      appendOutputRecord(state, record);
+      return;
+    case 'group_start':
+      appendGroupStartRecord(state, record);
+      return;
+    case 'group_end':
+      appendGroupEndRecord(state, record);
+      return;
+    case 'end':
+    case 'gap':
+    case 'capped':
+      if (record.type === 'end') state.terminated = true;
+      childrenOf(state).push({kind: 'marker', seq: state.seq++, record});
+      return;
+    case 'runner_lost':
+      state.terminated = true;
+      childrenOf(state).push({kind: 'marker', seq: state.seq++, record});
+      for (const frame of state.stack) frame.hasError = true;
+      return;
+    case 'agent_session':
+      childrenOf(state).push({kind: 'session', seq: state.seq++, record});
+      return;
+    default:
+      assertNever(record);
+  }
+}
+
+function appendOutputRecord(
+  state: LogTreeBuildState,
+  record: Extract<LogRecord, {type: 'output'}>,
+): void {
+  state.lineNumber += 1;
+  state.lineCount += 1;
+  for (const frame of state.stack) frame.lineCount += 1;
+  childrenOf(state).push({kind: 'output', seq: state.seq++, lineNumber: state.lineNumber, record});
+}
+
+function appendGroupStartRecord(
+  state: LogTreeBuildState,
+  record: Extract<LogRecord, {type: 'group_start'}>,
+): void {
+  let parentIndex = -1;
+  if (record.parentGroupId !== null) {
+    parentIndex = findOpenGroupIndex(state.stack, record.parentGroupId);
+  }
+  for (let index = state.stack.length - 1; index > parentIndex; index -= 1) {
+    const frame = state.stack[index];
+    if (frame) frame.closed = true;
+  }
+  state.stack.length = parentIndex + 1;
+  const group: GroupLogNode = {
+    kind: 'group',
+    seq: state.seq++,
+    record,
+    closed: false,
+    endTs: null,
+    hasError: false,
+    lineCount: 0,
+    children: [],
+  };
+  childrenOf(state).push(group);
+  state.stack.push(group);
+}
+
+function appendGroupEndRecord(
+  state: LogTreeBuildState,
+  record: Extract<LogRecord, {type: 'group_end'}>,
+): void {
+  const matchIndex = findOpenGroupIndex(state.stack, record.groupId);
+  if (matchIndex === -1) return;
+  for (let index = state.stack.length - 1; index >= matchIndex; index -= 1) {
+    const frame = state.stack[index];
+    if (frame) frame.closed = true;
+  }
+  const matched = state.stack[matchIndex];
+  if (matched) matched.endTs = record.ts;
+  state.stack.length = matchIndex;
+}
+
+function findOpenGroupIndex(stack: readonly GroupLogNode[], groupId: string): number {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    if (stack[index]?.record.groupId === groupId) return index;
+  }
+  return -1;
 }

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -1,7 +1,7 @@
 import {readLogsResponseSchema} from '@shipfox/api-logs-dto';
 import {ApiError, checkedApiRequest} from '@shipfox/client-api';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {useCallback, useRef} from 'react';
+import {type MutableRefObject, useCallback, useRef} from 'react';
 import {
   mergeLogRead,
   STEP_LOG_LIVE_REFETCH_MS,
@@ -101,52 +101,17 @@ export function useStepAttemptLogsQuery(
   const query = useQuery({
     queryKey,
     enabled,
-    queryFn: async ({signal}) => {
-      const previous = queryClient.getQueryData<StepLogSnapshot>(queryKey);
-      const manualRefetch = manualRefetchRef.current;
-      manualRefetchRef.current = false;
-      let response: Awaited<ReturnType<typeof readStepAttemptLogsPage>>;
-      try {
-        response = await readStepAttemptLogsPage({
-          stepId: stepId ?? '',
-          attempt: attempt ?? 0,
-          cursor: previous?.nextCursor ?? 0,
-          signal,
-        });
-      } catch (error) {
-        if (
-          options.retryMissingStream &&
-          previous === undefined &&
-          isMissingStepLogStreamError(error) &&
-          !manualRefetch
-        ) {
-          const retryCount = options.missingStreamRetryCount;
-          if (retryCount === undefined) throw error;
-          if (missingStreamFailureCountRef.current >= retryCount) {
-            return emptyCompleteLogSnapshot();
-          }
-          missingStreamFailureCountRef.current += 1;
-        }
-        throw error;
-      }
-
-      missingStreamFailureCountRef.current = 0;
-
-      if (response.mode === 'presigned') {
-        const ndjson = await readPresignedLogObject(response.url, signal);
-        return mergeLogRead(previous, {
-          mode: 'presigned',
-          response,
-          records: parseLogNdjson(ndjson),
-        });
-      }
-
-      return mergeLogRead(previous, {
-        mode: 'inline',
-        response,
-        records: parseLogNdjson(response.ndjson),
-      });
-    },
+    queryFn: ({signal}) =>
+      loadStepLogsQuery({
+        signal,
+        stepId,
+        attempt,
+        queryKey,
+        queryClient,
+        options,
+        manualRefetchRef,
+        missingStreamFailureCountRef,
+      }),
     retry: (failureCount, error) => {
       if (initialErrorRetryCount <= 0) return false;
       if (queryClient.getQueryData<StepLogSnapshot>(queryKey) !== undefined) return false;
@@ -182,6 +147,67 @@ export function useStepAttemptLogsQuery(
   }, [query.data, query.isFetching, query.refetch]);
 
   return {...query, refetchLogs};
+}
+
+async function loadStepLogsQuery(params: {
+  signal: AbortSignal;
+  stepId: string | undefined;
+  attempt: number | undefined;
+  queryKey: readonly unknown[];
+  queryClient: ReturnType<typeof useQueryClient>;
+  options: UseStepAttemptLogsQueryOptions;
+  manualRefetchRef: MutableRefObject<boolean>;
+  missingStreamFailureCountRef: MutableRefObject<number>;
+}): Promise<StepLogSnapshot> {
+  const previous = params.queryClient.getQueryData<StepLogSnapshot>(params.queryKey);
+  const manualRefetch = params.manualRefetchRef.current;
+  params.manualRefetchRef.current = false;
+  let response: Awaited<ReturnType<typeof readStepAttemptLogsPage>>;
+  try {
+    response = await readStepAttemptLogsPage({
+      stepId: params.stepId ?? '',
+      attempt: params.attempt ?? 0,
+      cursor: previous?.nextCursor ?? 0,
+      signal: params.signal,
+    });
+  } catch (error) {
+    return handleMissingStreamLoadError(error, previous, manualRefetch, params);
+  }
+  params.missingStreamFailureCountRef.current = 0;
+  if (response.mode === 'presigned') {
+    const ndjson = await readPresignedLogObject(response.url, params.signal);
+    return mergeLogRead(previous, {
+      mode: 'presigned',
+      response,
+      records: parseLogNdjson(ndjson),
+    });
+  }
+  return mergeLogRead(previous, {
+    mode: 'inline',
+    response,
+    records: parseLogNdjson(response.ndjson),
+  });
+}
+
+function handleMissingStreamLoadError(
+  error: unknown,
+  previous: StepLogSnapshot | undefined,
+  manualRefetch: boolean,
+  params: Pick<Parameters<typeof loadStepLogsQuery>[0], 'options' | 'missingStreamFailureCountRef'>,
+): never | StepLogSnapshot {
+  const retryable =
+    params.options.retryMissingStream &&
+    previous === undefined &&
+    isMissingStepLogStreamError(error) &&
+    !manualRefetch;
+  if (!retryable) throw error;
+  const retryCount = params.options.missingStreamRetryCount;
+  if (retryCount === undefined) throw error;
+  if (params.missingStreamFailureCountRef.current >= retryCount) {
+    return emptyCompleteLogSnapshot();
+  }
+  params.missingStreamFailureCountRef.current += 1;
+  throw error;
 }
 
 function emptyCompleteLogSnapshot(): StepLogSnapshot {

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -1,7 +1,7 @@
 import {readLogsResponseSchema} from '@shipfox/api-logs-dto';
 import {ApiError, checkedApiRequest} from '@shipfox/client-api';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {type MutableRefObject, useCallback, useRef} from 'react';
+import {type RefObject, useCallback, useRef} from 'react';
 import {
   mergeLogRead,
   STEP_LOG_LIVE_REFETCH_MS,
@@ -156,8 +156,8 @@ async function loadStepLogsQuery(params: {
   queryKey: readonly unknown[];
   queryClient: ReturnType<typeof useQueryClient>;
   options: UseStepAttemptLogsQueryOptions;
-  manualRefetchRef: MutableRefObject<boolean>;
-  missingStreamFailureCountRef: MutableRefObject<number>;
+  manualRefetchRef: RefObject<boolean>;
+  missingStreamFailureCountRef: RefObject<number>;
 }): Promise<StepLogSnapshot> {
   const previous = params.queryClient.getQueryData<StepLogSnapshot>(params.queryKey);
   const manualRefetch = params.manualRefetchRef.current;

--- a/libs/client/onboarding/src/components/setup-checklist-completion.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-completion.tsx
@@ -53,108 +53,16 @@ function ConfettiBurst({
 
   useEffect(() => {
     if (!active || typeof window === 'undefined') return;
-    let completed = false;
-    const finish = () => {
-      if (completed) return;
-      completed = true;
-      onComplete?.();
-    };
-
+    const finish = createSingleCompletion(onComplete);
     const prefersReducedMotion =
       window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
     if (typeof navigator !== 'undefined' && JSDOM_USER_AGENT_RE.test(navigator.userAgent)) {
       finish();
       return;
     }
-
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      finish();
-      return;
-    }
-    const bounds = canvas.getBoundingClientRect();
-    if (bounds.width === 0 && bounds.height === 0) {
-      finish();
-      return;
-    }
-    const context = canvas.getContext('2d');
-    if (!context) {
-      finish();
-      return;
-    }
-
-    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
-    const width = Math.max(bounds.width, 1);
-    const height = Math.max(bounds.height, 1);
-    canvas.width = Math.floor(width * pixelRatio);
-    canvas.height = Math.floor(height * pixelRatio);
-    context.scale(pixelRatio, pixelRatio);
-
-    const styles = getComputedStyle(canvas);
-    const colors = [
-      styles.getPropertyValue('--color-background-accent-blue-base').trim(),
-      styles.getPropertyValue('--color-background-accent-purple-base').trim(),
-      styles.getPropertyValue('--color-background-accent-success-base').trim(),
-      styles.getPropertyValue('--color-background-accent-warning-base').trim(),
-    ].filter(Boolean);
-    if (colors.length === 0) {
-      finish();
-      return;
-    }
-    const particles = createConfettiParticles(
-      width,
-      height,
-      colors,
-      prefersReducedMotion ? CONFETTI_RANDOM_SEED : undefined,
-    );
-    let frame = 0;
-    const startedAt = performance.now();
-
-    const draw = (now: number, advance = true) => {
-      const elapsed = now - startedAt;
-      context.clearRect(0, 0, width, height);
-      context.globalAlpha = Math.max(0, 1 - elapsed / CONFETTI_DURATION_MS);
-      for (const particle of particles) {
-        if (advance) {
-          particle.vy += 0.025;
-          particle.vx *= 0.985;
-          particle.x += particle.vx;
-          particle.y += particle.vy;
-          particle.rotation += 0.1;
-        }
-        context.save();
-        context.translate(particle.x, particle.y);
-        context.rotate(particle.rotation);
-        context.fillStyle = particle.color;
-        context.fillRect(
-          -particle.size / 2,
-          -particle.size / 2,
-          particle.size,
-          particle.size * 0.6,
-        );
-        context.restore();
-      }
-      context.globalAlpha = 1;
-      if (!advance) return;
-      if (elapsed < CONFETTI_DURATION_MS) {
-        frame = requestAnimationFrame(draw);
-      } else {
-        finish();
-      }
-    };
-
-    if (prefersReducedMotion) {
-      draw(startedAt, false);
-      finish();
-      // Keep the static frame after hosts consume the burst immediately.
-      return;
-    }
-
-    frame = requestAnimationFrame(draw);
-    return () => {
-      cancelAnimationFrame(frame);
-      context.clearRect(0, 0, width, height);
-    };
+    const animation = createConfettiAnimation(canvasRef.current, prefersReducedMotion, finish);
+    if (!animation) return;
+    return animation.start();
   }, [active, onComplete]);
 
   return (
@@ -162,4 +70,118 @@ function ConfettiBurst({
       <canvas ref={canvasRef} className="size-full" />
     </div>
   );
+}
+
+function createSingleCompletion(onComplete: (() => void) | undefined) {
+  let completed = false;
+  return () => {
+    if (completed) return;
+    completed = true;
+    onComplete?.();
+  };
+}
+
+function createConfettiAnimation(
+  canvas: HTMLCanvasElement | null,
+  prefersReducedMotion: boolean,
+  finish: () => void,
+) {
+  if (!canvas) {
+    finish();
+    return undefined;
+  }
+  const bounds = canvas.getBoundingClientRect();
+  if (bounds.width === 0 && bounds.height === 0) {
+    finish();
+    return undefined;
+  }
+  const context = canvas.getContext('2d');
+  if (!context) {
+    finish();
+    return undefined;
+  }
+
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+  const width = Math.max(bounds.width, 1);
+  const height = Math.max(bounds.height, 1);
+  canvas.width = Math.floor(width * pixelRatio);
+  canvas.height = Math.floor(height * pixelRatio);
+  context.scale(pixelRatio, pixelRatio);
+
+  const colors = confettiColors(canvas);
+  if (colors.length === 0) {
+    finish();
+    return undefined;
+  }
+  const particles = createConfettiParticles(
+    width,
+    height,
+    colors,
+    prefersReducedMotion ? CONFETTI_RANDOM_SEED : undefined,
+  );
+  const startedAt = performance.now();
+  let frame = 0;
+
+  const draw = (now: number, advance = true) => {
+    const elapsed = now - startedAt;
+    context.clearRect(0, 0, width, height);
+    context.globalAlpha = Math.max(0, 1 - elapsed / CONFETTI_DURATION_MS);
+    for (const particle of particles) {
+      advanceConfettiParticle(particle, advance);
+      drawConfettiParticle(context, particle);
+    }
+    context.globalAlpha = 1;
+    if (!advance) return;
+    if (elapsed < CONFETTI_DURATION_MS) frame = requestAnimationFrame(draw);
+    else finish();
+  };
+
+  return {
+    start() {
+      if (prefersReducedMotion) {
+        draw(startedAt, false);
+        finish();
+        return undefined;
+      }
+      frame = requestAnimationFrame(draw);
+      return () => {
+        cancelAnimationFrame(frame);
+        context.clearRect(0, 0, width, height);
+      };
+    },
+  };
+}
+
+function confettiColors(canvas: HTMLCanvasElement): string[] {
+  const styles = getComputedStyle(canvas);
+  return [
+    styles.getPropertyValue('--color-background-accent-blue-base').trim(),
+    styles.getPropertyValue('--color-background-accent-purple-base').trim(),
+    styles.getPropertyValue('--color-background-accent-success-base').trim(),
+    styles.getPropertyValue('--color-background-accent-warning-base').trim(),
+  ].filter(Boolean);
+}
+
+function advanceConfettiParticle(
+  particle: ReturnType<typeof createConfettiParticles>[number],
+  advance: boolean,
+) {
+  if (!advance) return;
+  particle.vy += 0.025;
+  particle.vx *= 0.985;
+  particle.x += particle.vx;
+  particle.y += particle.vy;
+  particle.rotation += 0.1;
+}
+
+function drawConfettiParticle(
+  context: CanvasRenderingContext2D,
+  particle: ReturnType<typeof createConfettiParticles>[number],
+) {
+  context.save();
+  context.translate(particle.x, particle.y);
+  context.rotate(particle.rotation);
+  context.fillStyle = particle.color;
+  context.fillRect(-particle.size / 2, -particle.size / 2, particle.size, particle.size * 0.6);
+  context.restore();
 }

--- a/libs/client/onboarding/src/components/setup-checklist-row.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-row.tsx
@@ -18,14 +18,10 @@ export function ChecklistRow({
 }) {
   const pointer = !item.tracked;
   const showDetails = pointer || item.status === 'open';
-  const statusLabel =
-    item.status === 'done'
-      ? 'done'
-      : pointer
-        ? 'next step'
-        : item.attention
-          ? 'needs attention'
-          : 'to do';
+  let statusLabel = 'to do';
+  if (item.status === 'done') statusLabel = 'done';
+  else if (pointer) statusLabel = 'next step';
+  else if (item.attention) statusLabel = 'needs attention';
 
   return (
     <li className="flex min-w-0 items-start gap-group border-b border-border-neutral-base px-row py-row last:border-b-0">

--- a/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
+++ b/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
@@ -61,6 +61,21 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
 
   if (queryState.baseSettled && queryState.checklist.complete && !showCompletion) return null;
 
+  let checklistBody = <ChecklistSkeleton />;
+  if (queryState.baseSettled) {
+    checklistBody = (
+      <SetupChecklistBody
+        checklist={queryState.checklist}
+        workspaceSlug={workspace.slug}
+        completion={showCompletion}
+        showBurst={burstPending}
+        onBurstComplete={consumeBurst}
+        onAction={handleAction}
+        onDone={dismiss}
+      />
+    );
+  }
+
   return (
     <Panel asChild className="w-full">
       <section aria-label="Get started">
@@ -68,23 +83,7 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
           count={queryState.baseSettled ? checklistCountLabel(queryState.checklist) : undefined}
           onDismiss={dismiss}
         />
-        <PanelBody>
-          {queryState.baseSettled ? (
-            queryState.checklist.complete && !showCompletion ? null : (
-              <SetupChecklistBody
-                checklist={queryState.checklist}
-                workspaceSlug={workspace.slug}
-                completion={showCompletion}
-                showBurst={burstPending}
-                onBurstComplete={consumeBurst}
-                onAction={handleAction}
-                onDone={dismiss}
-              />
-            )
-          ) : (
-            <ChecklistSkeleton />
-          )}
-        </PanelBody>
+        <PanelBody>{checklistBody}</PanelBody>
       </section>
     </Panel>
   );

--- a/libs/client/onboarding/src/hooks/api/setup-checklist.ts
+++ b/libs/client/onboarding/src/hooks/api/setup-checklist.ts
@@ -39,7 +39,7 @@ export function useSetupChecklistQueryState(
   workspaceId: string,
   subscribed: boolean,
 ): ChecklistQueryState {
-  const queryEnabled = subscribed && Boolean(workspaceId);
+  const queryEnabled = shouldEnableChecklistQueries(subscribed, workspaceId);
   const queryPolicy = {
     enabled: queryEnabled,
     subscribed: queryEnabled,
@@ -85,20 +85,18 @@ export function useSetupChecklistQueryState(
   const baseSettled = isSettled(providersQuery) && isSettled(connectionsQuery);
   const runnerSettled = isSettled(activeProvisionersQuery) && isSettled(runnersStatusQuery);
   const runnerReady = activeProvisionersQuery.isSuccess && runnersStatusQuery.isSuccess;
-  const catalogInstallationProvided =
-    catalogQuery.data !== undefined &&
-    (catalogQuery.data.managedProviderId !== null ||
-      catalogQuery.data.instanceDefaultProviderId !== null);
+  const catalogInstallationProvided = hasInstallationProvider(catalogQuery.data);
   const modelReady = catalogQuery.isSuccess && configsQuery.isSuccess;
   const membersReady = membersQuery.isSuccess && invitationsQuery.isSuccess;
   const modelSettled = isSettled(catalogQuery) && isSettled(configsQuery);
   const membersSettled = isSettled(membersQuery) && isSettled(invitationsQuery);
-  const completionReady =
-    providersQuery.isSuccess &&
-    connectionsQuery.isSuccess &&
-    runnerSettled &&
-    modelSettled &&
-    membersSettled;
+  const completionReady = allChecklistQueriesReady({
+    providersReady: providersQuery.isSuccess,
+    connectionsReady: connectionsQuery.isSuccess,
+    runnerSettled,
+    modelSettled,
+    membersSettled,
+  });
 
   const rawChecklist = deriveSetupChecklist({
     readiness: deriveIntegrationReadiness({
@@ -108,7 +106,10 @@ export function useSetupChecklistQueryState(
     installationRunners: runnersStatusQuery.data ?? 'managed',
     workspaceRunnerCapacity: (activeProvisionersQuery.data?.length ?? 0) > 0,
     modelProvider: {
-      installationProvided: catalogQuery.isSuccess ? catalogInstallationProvided : true,
+      installationProvided: installationProviderReadiness(
+        catalogQuery.isSuccess,
+        catalogInstallationProvided,
+      ),
       configured: (configsQuery.data?.configs.length ?? 0) > 0,
     },
     membership: {
@@ -117,11 +118,13 @@ export function useSetupChecklistQueryState(
     },
   });
 
-  const hiddenRows = new Set<SetupChecklistItemId>();
-  if (!providersQuery.isSuccess || !connectionsQuery.isSuccess) hiddenRows.add('tools');
-  if (!runnerReady) hiddenRows.add('runner');
-  if (!modelReady) hiddenRows.add('model-provider');
-  if (!membersReady) hiddenRows.add('teammates');
+  const hiddenRows = hiddenChecklistRows({
+    providersReady: providersQuery.isSuccess,
+    connectionsReady: connectionsQuery.isSuccess,
+    runnerReady,
+    modelReady,
+    membersReady,
+  });
 
   const items = rawChecklist.items.filter((item) => !hiddenRows.has(item.id));
   const trackedItems = items.filter((item) => item.tracked);
@@ -139,6 +142,56 @@ export function useSetupChecklistQueryState(
   };
 }
 
+function hiddenChecklistRows(readiness: {
+  providersReady: boolean;
+  connectionsReady: boolean;
+  runnerReady: boolean;
+  modelReady: boolean;
+  membersReady: boolean;
+}): Set<SetupChecklistItemId> {
+  const hiddenRows = new Set<SetupChecklistItemId>();
+  if (!readiness.providersReady || !readiness.connectionsReady) hiddenRows.add('tools');
+  if (!readiness.runnerReady) hiddenRows.add('runner');
+  if (!readiness.modelReady) hiddenRows.add('model-provider');
+  if (!readiness.membersReady) hiddenRows.add('teammates');
+  return hiddenRows;
+}
+
+function hasInstallationProvider(
+  catalog: {managedProviderId: string | null; instanceDefaultProviderId: string | null} | undefined,
+): boolean {
+  if (catalog === undefined) return false;
+  return catalog.managedProviderId !== null || catalog.instanceDefaultProviderId !== null;
+}
+
+function allChecklistQueriesReady(readiness: {
+  providersReady: boolean;
+  connectionsReady: boolean;
+  runnerSettled: boolean;
+  modelSettled: boolean;
+  membersSettled: boolean;
+}): boolean {
+  return (
+    readiness.providersReady &&
+    readiness.connectionsReady &&
+    readiness.runnerSettled &&
+    readiness.modelSettled &&
+    readiness.membersSettled
+  );
+}
+
+function installationProviderReadiness(
+  catalogReady: boolean,
+  installationProvided: boolean,
+): boolean {
+  if (!catalogReady) return true;
+  return installationProvided;
+}
+
 function isSettled(query: {isError: boolean; isSuccess: boolean}) {
   return query.isSuccess || query.isError;
+}
+
+function shouldEnableChecklistQueries(subscribed: boolean, workspaceId: string): boolean {
+  return subscribed && Boolean(workspaceId);
 }

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -104,54 +104,85 @@ function setupFetch(options: SetupFetchOptions = {}) {
   return vi.fn((input: RequestInfo | URL) => {
     const url = input instanceof Request ? input.url : String(input);
     if (url.endsWith('/workspaces')) {
-      return Promise.resolve(
-        jsonResponse({
-          memberships: [
-            {
-              id: MEMBERSHIP_ID,
-              user_id: USER_ID,
-              workspace_id: WORKSPACE_ID,
-              workspace_name: 'Workspace',
-              workspace_slug: 'workspace',
-              workspace_status: workspaceStatus,
-              created_at: new Date().toISOString(),
-              updated_at: new Date().toISOString(),
-            },
-          ],
-        }),
-      );
+      return workspaceResponse(workspaceStatus);
     }
     if (url.includes('/projects?')) {
-      if (projectsPending) return new Promise<Response>(() => undefined);
-      if (projectsFail) return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
-      return Promise.resolve(jsonResponse({projects, next_cursor: null}));
+      return projectsResponse({projects, projectsFail, projectsPending});
     }
     if (url.includes('/integration-connections?')) {
-      if (connectionsFail)
-        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
-      return Promise.resolve(jsonResponse({connections}));
+      return connectionsResponse(connections, connectionsFail);
     }
     if (url.endsWith('/agent/model-providers')) {
-      if (providerConfigsFail)
-        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
-      return Promise.resolve(
-        jsonResponse({
-          configs: providerConfigs,
-          default_provider_id: defaultProviderId,
-          default_harness_id: null,
-        }),
-      );
+      return modelProvidersResponse(providerConfigs, defaultProviderId, providerConfigsFail);
     }
     if (url.endsWith('/agent/model-provider-catalog')) {
-      return Promise.resolve(
-        jsonResponse({
-          providers: [],
-          ...(workspaceProviders === undefined ? {} : {workspace_providers: workspaceProviders}),
-        }),
-      );
+      return modelProviderCatalogResponse(workspaceProviders);
     }
     return Promise.resolve(jsonResponse({}, {status: 404}));
   });
+}
+
+function workspaceResponse(workspaceStatus: NonNullable<SetupFetchOptions['workspaceStatus']>) {
+  return Promise.resolve(
+    jsonResponse({
+      memberships: [
+        {
+          id: MEMBERSHIP_ID,
+          user_id: USER_ID,
+          workspace_id: WORKSPACE_ID,
+          workspace_name: 'Workspace',
+          workspace_slug: 'workspace',
+          workspace_status: workspaceStatus,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+    }),
+  );
+}
+
+function projectsResponse({
+  projects,
+  projectsFail,
+  projectsPending,
+}: {
+  projects: unknown[];
+  projectsFail: boolean;
+  projectsPending: boolean;
+}) {
+  if (projectsPending) return new Promise<Response>(() => undefined);
+  if (projectsFail) return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+  return Promise.resolve(jsonResponse({projects, next_cursor: null}));
+}
+
+function connectionsResponse(connections: unknown[], connectionsFail: boolean) {
+  if (connectionsFail) return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+  return Promise.resolve(jsonResponse({connections}));
+}
+
+function modelProvidersResponse(
+  providerConfigs: unknown[],
+  defaultProviderId: string | null,
+  providerConfigsFail: boolean,
+) {
+  if (providerConfigsFail)
+    return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+  return Promise.resolve(
+    jsonResponse({
+      configs: providerConfigs,
+      default_provider_id: defaultProviderId,
+      default_harness_id: null,
+    }),
+  );
+}
+
+function modelProviderCatalogResponse(workspaceProviders: SetupFetchOptions['workspaceProviders']) {
+  return Promise.resolve(
+    jsonResponse({
+      providers: [],
+      ...(workspaceProviders === undefined ? {} : {workspace_providers: workspaceProviders}),
+    }),
+  );
 }
 
 function renderSetupRoute(

--- a/libs/client/projects/src/components/project-switcher.tsx
+++ b/libs/client/projects/src/components/project-switcher.tsx
@@ -79,6 +79,11 @@ export function ProjectSwitcher({
     handleCreate();
   };
 
+  let emptyMessage = 'No projects found.';
+  if (query.isError) emptyMessage = "Couldn't load projects.";
+  else if (query.isLoading) emptyMessage = 'Loading projects...';
+  else if (projects.length === 0) emptyMessage = 'No projects yet.';
+
   return (
     <Command onKeyDown={handleCommandKeyDown}>
       <CommandInput
@@ -87,15 +92,7 @@ export function ProjectSwitcher({
         onValueChange={setSearchValue}
       />
       <CommandList>
-        {query.isError ? (
-          <CommandEmpty>Couldn&apos;t load projects.</CommandEmpty>
-        ) : query.isLoading ? (
-          <CommandEmpty>Loading projects...</CommandEmpty>
-        ) : projects.length === 0 ? (
-          <CommandEmpty>No projects yet.</CommandEmpty>
-        ) : (
-          <CommandEmpty>No projects found.</CommandEmpty>
-        )}
+        <CommandEmpty>{emptyMessage}</CommandEmpty>
         <CommandGroup>
           <CommandItem value="__all" keywords={['all projects']} onSelect={handleSelectAll}>
             <Icon

--- a/libs/client/projects/src/pages/create-project-page.stories.tsx
+++ b/libs/client/projects/src/pages/create-project-page.stories.tsx
@@ -147,7 +147,7 @@ function createStoryRouter() {
 function fetchForScenario(scenario: Scenario): typeof fetch {
   return (input, init) => {
     const url = requestUrl(input);
-    const method = input instanceof Request ? input.method : (init?.method ?? 'GET');
+    const method = requestMethod(input, init);
     if (url.pathname === `/workspaces/${WORKSPACE_ID}/agent/model-providers`) {
       return Promise.resolve(
         jsonResponse({
@@ -158,36 +158,53 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
       );
     }
     if (url.pathname === '/integration-connections') {
-      if (scenario === 'connections-error') return Promise.resolve(errorResponse());
-      return Promise.resolve(jsonResponse({connections: connectionsForScenario(scenario)}));
+      return connectionScenarioResponse(scenario);
     }
     if (
       url.pathname.startsWith('/integration-connections/') &&
       url.pathname.endsWith('/repositories')
     ) {
-      if (scenario === 'repository-loading') return new Promise<Response>(() => undefined);
-      return Promise.resolve(
-        jsonResponse({repositories: repositoriesForScenario(scenario), next_cursor: null}),
-      );
+      return repositoryScenarioResponse(scenario);
     }
     if (url.pathname === '/projects' && method === 'POST') {
-      return Promise.resolve(
-        jsonResponse({
-          id: '99999999-9999-4999-8999-999999999999',
-          workspace_id: WORKSPACE_ID,
-          name: 'Platform',
-          slug: 'platform',
-          source: {
-            connection_id: GITHUB_CONNECTION_ID,
-            external_repository_id: 'platform',
-          },
-          created_at: '2026-01-01T00:00:00.000Z',
-          updated_at: '2026-01-01T00:00:00.000Z',
-        }),
-      );
+      return createdProjectResponse();
     }
     return Promise.resolve(jsonResponse({}, {status: 404}));
   };
+}
+
+function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
+  if (input instanceof Request) return input.method;
+  return init?.method ?? 'GET';
+}
+
+function connectionScenarioResponse(scenario: Scenario) {
+  if (scenario === 'connections-error') return Promise.resolve(errorResponse());
+  return Promise.resolve(jsonResponse({connections: connectionsForScenario(scenario)}));
+}
+
+function repositoryScenarioResponse(scenario: Scenario) {
+  if (scenario === 'repository-loading') return new Promise<Response>(() => undefined);
+  return Promise.resolve(
+    jsonResponse({repositories: repositoriesForScenario(scenario), next_cursor: null}),
+  );
+}
+
+function createdProjectResponse() {
+  return Promise.resolve(
+    jsonResponse({
+      id: '99999999-9999-4999-8999-999999999999',
+      workspace_id: WORKSPACE_ID,
+      name: 'Platform',
+      slug: 'platform',
+      source: {
+        connection_id: GITHUB_CONNECTION_ID,
+        external_repository_id: 'platform',
+      },
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    }),
+  );
 }
 
 function connectionsForScenario(scenario: Scenario): IntegrationConnectionDto[] {

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -17,43 +17,76 @@ const REPOSITORY_NOT_FOUND_RE = /Repository not found/;
 const PROJECT_REQUEST_FAILED_RE = /Project request failed/;
 const GITEA_RADIO_LABEL_RE = /^Gitea Source$/;
 
+function firstProjectFetch(state: {createProjectBody: unknown}) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const request = input as Request;
+    if (request.url.includes('/integration-connections?')) {
+      return jsonResponse({connections: [connectionDto()]});
+    }
+    if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+      return jsonResponse({repositories: [repositoryDto()], next_cursor: null});
+    }
+    if (request.url.includes('/projects?')) return firstProjectListResponse(request.url);
+    if (request.url.endsWith('/projects') && request.method === 'POST') {
+      state.createProjectBody = await request.json();
+    }
+    return jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'}));
+  });
+}
+
+function firstProjectListResponse(requestUrl: string) {
+  const url = new URL(requestUrl);
+  if (url.searchParams.get('search') || url.searchParams.get('limit') === '1') {
+    return jsonResponse({projects: [], next_cursor: null});
+  }
+  return jsonResponse({
+    projects: [projectDto({id: '44444444-4444-4444-8444-444444444444'})],
+    next_cursor: null,
+  });
+}
+
+function doubleSubmitFetch(existenceReadGate: Promise<void>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const request = input as Request;
+    if (request.url.includes('/integration-connections?')) {
+      return jsonResponse({connections: [connectionDto()]});
+    }
+    if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+      return jsonResponse({repositories: [repositoryDto()], next_cursor: null});
+    }
+    if (request.url.includes('/projects?')) {
+      return await doubleSubmitProjectListResponse(request.url, existenceReadGate);
+    }
+    if (request.url.endsWith('/projects') && request.method === 'POST') {
+      return jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'}));
+    }
+    return jsonResponse({});
+  });
+}
+
+async function doubleSubmitProjectListResponse(
+  requestUrl: string,
+  existenceReadGate: Promise<void>,
+) {
+  const url = new URL(requestUrl);
+  if (url.searchParams.get('limit') === '1') {
+    await existenceReadGate;
+    return jsonResponse({projects: [], next_cursor: null});
+  }
+  return jsonResponse({
+    projects: [projectDto({id: '44444444-4444-4444-8444-444444444444'})],
+    next_cursor: null,
+  });
+}
+
 describe('CreateProjectPage', () => {
   beforeEach(() => {
     window.sessionStorage.clear();
   });
 
   test('with a single connection: pre-selects, renders repos, and lands the first project on the workspace home', async () => {
-    let createProjectBody: unknown;
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      const request = input as Request;
-      if (request.url.includes('/integration-connections?')) {
-        return jsonResponse({connections: [connectionDto()]});
-      }
-      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
-        return jsonResponse({repositories: [repositoryDto()], next_cursor: null});
-      }
-      if (request.url.includes('/projects?')) {
-        const url = new URL(request.url);
-        // The pre-create existence snapshot (limit=1) sees an empty workspace;
-        // the home list (limit=50) sees the created project, so the home does
-        // not fall back to the pre-create empty state.
-        if (url.searchParams.get('search')) {
-          return jsonResponse({projects: [], next_cursor: null});
-        }
-        if (url.searchParams.get('limit') === '1') {
-          return jsonResponse({projects: [], next_cursor: null});
-        }
-        return jsonResponse({
-          projects: [projectDto({id: '44444444-4444-4444-8444-444444444444'})],
-          next_cursor: null,
-        });
-      }
-      if (request.url.endsWith('/projects') && request.method === 'POST') {
-        createProjectBody = await request.json();
-        return jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'}));
-      }
-      return jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'}));
-    });
+    const state = {createProjectBody: undefined as unknown};
+    const fetchImpl = firstProjectFetch(state);
     configureApiClient({fetchImpl});
 
     renderProjectPage(`/w/${PROJECT_TEST_WSLUG}/projects/new`, <CreateProjectPage />);
@@ -99,7 +132,7 @@ describe('CreateProjectPage', () => {
     expect(await screen.findByText('Project Detail')).toBeInTheDocument();
     expect(screen.queryByText('Create your first project')).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', {name: 'Runs'})).not.toBeInTheDocument();
-    expect(createProjectBody).toEqual({
+    expect(state.createProjectBody).toEqual({
       workspace_id: PROJECT_TEST_WID,
       name: 'Launch Pad',
       slug: 'launchpad',
@@ -115,30 +148,7 @@ describe('CreateProjectPage', () => {
     const existenceReadGate = new Promise<void>((resolve) => {
       releaseExistenceRead = resolve;
     });
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      const request = input as Request;
-      if (request.url.includes('/integration-connections?')) {
-        return jsonResponse({connections: [connectionDto()]});
-      }
-      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
-        return jsonResponse({repositories: [repositoryDto()], next_cursor: null});
-      }
-      if (request.url.includes('/projects?')) {
-        const url = new URL(request.url);
-        if (url.searchParams.get('limit') === '1') {
-          await existenceReadGate;
-          return jsonResponse({projects: [], next_cursor: null});
-        }
-        return jsonResponse({
-          projects: [projectDto({id: '44444444-4444-4444-8444-444444444444'})],
-          next_cursor: null,
-        });
-      }
-      if (request.url.endsWith('/projects') && request.method === 'POST') {
-        return jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'}));
-      }
-      return jsonResponse({});
-    });
+    const fetchImpl = doubleSubmitFetch(existenceReadGate);
     configureApiClient({fetchImpl});
 
     renderProjectPage(`/w/${PROJECT_TEST_WSLUG}/projects/new`, <CreateProjectPage />);

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -55,7 +55,7 @@ export function CreateProjectPage() {
   const connections = connectionsQuery.data ?? [];
 
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | undefined>();
-  const singleConnectionId = connections.length === 1 ? connections[0]?.id : undefined;
+  const singleConnectionId = onlyConnectionId(connections);
   const effectiveSelectedConnectionId = selectedConnectionId ?? singleConnectionId;
   useEffect(() => {
     if (singleConnectionId && selectedConnectionId !== singleConnectionId) {
@@ -73,7 +73,7 @@ export function CreateProjectPage() {
 
   const repositoriesQuery = useRepositoriesInfiniteQuery(
     effectiveSelectedConnectionId,
-    trimmedFilter ? {search: trimmedFilter} : undefined,
+    repositorySearch(trimmedFilter),
   );
   const repositories = repositoriesQuery.data?.pages.flatMap((page) => page.repositories) ?? [];
 
@@ -89,7 +89,7 @@ export function CreateProjectPage() {
 
   const [nameTouched, setNameTouched] = useState(false);
   const defaultProjectName = projectNameFromRepository(
-    selectedRepository?.name ?? selectedRepositoryId ?? '',
+    selectedRepositoryName(selectedRepository, selectedRepositoryId),
   );
   const defaultProjectSlug = slugifyName(defaultProjectName, {fallback: 'project'});
 
@@ -183,67 +183,68 @@ export function CreateProjectPage() {
       };
       const project = await createProject.mutateAsync(command);
       toast.success('Project created.');
-      if (wasFirstProject) {
-        // The setup checklist panel is the first thing on the home, so the
-        // first project lands where the Get-started guide lives. Seed the
-        // workspace list so the home does not re-render the pre-create empty
-        // state, then fetch the authoritative list: the seeded entry has no
-        // queryFn of its own (no observer mounted it), so refetching it would
-        // fail and a project created concurrently (another tab, import, or
-        // API) would stay hidden for the stale window. Fetching with
-        // staleTime: 0 forces a fresh read that replaces the seed; a failed
-        // fetch is swallowed so the seeded project remains the fallback and
-        // the home never shows a stale empty state.
-        const listQueryKey = projectsInfiniteQueryOptions(workspace.id).queryKey;
-        queryClient.setQueryData<InfiniteData<ProjectList, string | undefined>>(listQueryKey, {
-          pages: [{projects: [project], nextCursor: null}],
-          pageParams: [undefined],
-        });
-        await queryClient
-          .fetchInfiniteQuery({
-            ...projectsInfiniteQueryOptions(workspace.id),
-            staleTime: 0,
-            retry: false,
-          })
-          .catch(() => undefined);
-        await navigate({
-          to: '/w/$workspaceSlug',
-          params: {workspaceSlug: workspace.slug},
-        });
-        return;
-      }
-      await navigate({
-        to: '/w/$workspaceSlug/p/$projectSlug',
-        params: {workspaceSlug: workspace.slug, projectSlug: project.slug},
-      });
+      await navigateAfterProjectCreation(project, wasFirstProject, workspace.id, workspace.slug);
     } catch (error) {
-      const copy = projectErrorCopy(error);
-      if (copy.existingProjectId) {
-        toast.info('Project already exists.');
-        try {
-          const project = await getProject(copy.existingProjectId);
-          await navigate({
-            to: '/w/$workspaceSlug/p/$projectSlug',
-            params: {workspaceSlug: workspace.slug, projectSlug: project.slug},
-          });
-        } catch (recoveryError) {
-          const recoveryCopy = projectErrorCopy(recoveryError);
-          setFormError(`${recoveryCopy.title}: ${recoveryCopy.message}`);
-          requestAnimationFrame(() => errorRef.current?.focus());
-        }
-        return;
-      }
-      if (copy.slugConflict) {
-        setSlugConflict(true);
-        requestAnimationFrame(() => document.getElementById('project-slug')?.focus());
-        return;
-      }
-      setFormError(`${copy.title}: ${copy.message}`);
-      requestAnimationFrame(() => errorRef.current?.focus());
+      await handleProjectCreationError(error, workspace.slug);
     } finally {
       submittingRef.current = false;
       setSubmitting(false);
     }
+  }
+
+  async function navigateAfterProjectCreation(
+    project: Awaited<ReturnType<typeof createProject.mutateAsync>>,
+    wasFirstProject: boolean,
+    workspaceId: string,
+    workspaceSlug: string,
+  ) {
+    if (!wasFirstProject) {
+      await navigate({
+        to: '/w/$workspaceSlug/p/$projectSlug',
+        params: {workspaceSlug, projectSlug: project.slug},
+      });
+      return;
+    }
+    // Seed the first project so the workspace home never flashes its old empty state, then refresh.
+    const listQueryKey = projectsInfiniteQueryOptions(workspaceId).queryKey;
+    queryClient.setQueryData<InfiniteData<ProjectList, string | undefined>>(listQueryKey, {
+      pages: [{projects: [project], nextCursor: null}],
+      pageParams: [undefined],
+    });
+    await queryClient
+      .fetchInfiniteQuery({
+        ...projectsInfiniteQueryOptions(workspaceId),
+        staleTime: 0,
+        retry: false,
+      })
+      .catch(() => undefined);
+    await navigate({to: '/w/$workspaceSlug', params: {workspaceSlug}});
+  }
+
+  async function handleProjectCreationError(error: unknown, workspaceSlug: string) {
+    const copy = projectErrorCopy(error);
+    if (copy.existingProjectId) {
+      toast.info('Project already exists.');
+      try {
+        const project = await getProject(copy.existingProjectId);
+        await navigate({
+          to: '/w/$workspaceSlug/p/$projectSlug',
+          params: {workspaceSlug, projectSlug: project.slug},
+        });
+      } catch (recoveryError) {
+        const recoveryCopy = projectErrorCopy(recoveryError);
+        setFormError(`${recoveryCopy.title}: ${recoveryCopy.message}`);
+        requestAnimationFrame(() => errorRef.current?.focus());
+      }
+      return;
+    }
+    if (copy.slugConflict) {
+      setSlugConflict(true);
+      requestAnimationFrame(() => document.getElementById('project-slug')?.focus());
+      return;
+    }
+    setFormError(`${copy.title}: ${copy.message}`);
+    requestAnimationFrame(() => errorRef.current?.focus());
   }
 
   const showRepoPicker = Boolean(selectedConnection);
@@ -461,6 +462,23 @@ export function CreateProjectPage() {
       </form>
     </div>
   );
+}
+
+function onlyConnectionId(connections: readonly IntegrationConnection[]): string | undefined {
+  if (connections.length !== 1) return undefined;
+  return connections[0]?.id;
+}
+
+function repositorySearch(search: string): {search: string} | undefined {
+  if (!search) return undefined;
+  return {search};
+}
+
+function selectedRepositoryName(
+  repository: {name: string} | undefined,
+  repositoryId: string | undefined,
+): string {
+  return repository?.name ?? repositoryId ?? '';
 }
 
 function ProjectSummary({

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -203,7 +203,7 @@ describe('ProjectsHubPage', () => {
   test.each([
     ['', 'Create your first project'],
     ['missing', 'No projects match “missing”'],
-  ])('does not hide a cached-empty refresh failure for search %j', async (search, emptyState) => {
+  ])('keeps the cached empty state after a refresh failure for search %j', async (search, emptyState) => {
     let projectRequests = 0;
     configureApiClient({
       fetchImpl: createHubFetch({
@@ -227,7 +227,7 @@ describe('ProjectsHubPage', () => {
         queryClient.getQueryState(projectsQueryKeys.list(PROJECT_TEST_WID, search))?.status,
       ).toBe('error'),
     );
-    expect(screen.queryByText(emptyState)).not.toBeInTheDocument();
+    expect(screen.getByText(emptyState)).toBeInTheDocument();
   });
 
   test('shows no status pill or repository id for a connected source', async () => {

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -1,5 +1,7 @@
 import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient} from '@tanstack/react-query';
 import {fireEvent, screen, waitFor, within} from '@testing-library/react';
+import {projectsQueryKeys} from '#hooks/api/projects.js';
 import {
   jsonResponse,
   PROJECT_TEST_WID,
@@ -198,6 +200,36 @@ describe('ProjectsHubPage', () => {
     expect(screen.getByRole('button', {name: 'Retry loading projects'})).toBeInTheDocument();
   });
 
+  test.each([
+    ['', 'Create your first project'],
+    ['missing', 'No projects match “missing”'],
+  ])('does not hide a cached-empty refresh failure for search %j', async (search, emptyState) => {
+    let projectRequests = 0;
+    configureApiClient({
+      fetchImpl: createHubFetch({
+        projects: () => {
+          projectRequests += 1;
+          return projectRequests === 1
+            ? jsonResponse({projects: [], next_cursor: null})
+            : jsonResponse({code: 'server-error'}, {status: 500});
+        },
+      }),
+    });
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+
+    renderProjectPage(`/w/${PROJECT_TEST_WSLUG}`, <ProjectsHubPage search={search} />, queryClient);
+    expect(await screen.findByText(emptyState)).toBeInTheDocument();
+
+    await queryClient.refetchQueries({queryKey: projectsQueryKeys.list(PROJECT_TEST_WID, search)});
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryState(projectsQueryKeys.list(PROJECT_TEST_WID, search))?.status,
+      ).toBe('error'),
+    );
+    expect(screen.queryByText(emptyState)).not.toBeInTheDocument();
+  });
+
   test('shows no status pill or repository id for a connected source', async () => {
     configureApiClient({
       fetchImpl: createHubFetch({
@@ -295,7 +327,7 @@ function createHubFetch({
   }),
   connections = jsonResponse(connectionsDto()),
 }: {
-  projects?: Response;
+  projects?: Response | (() => Response);
   connections?: Response;
 } = {}) {
   return vi.fn((input: RequestInfo | URL) => {
@@ -304,7 +336,7 @@ function createHubFetch({
       return Promise.resolve(connections.clone());
     }
     if (url.pathname === '/projects') {
-      return Promise.resolve(projects.clone());
+      return Promise.resolve(typeof projects === 'function' ? projects() : projects.clone());
     }
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
   });

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -123,19 +123,20 @@ function ProjectsPanelContent({
   onClear: () => void;
 }) {
   const hasNoData = !query.data;
+  const hasNoProjects = projects.length === 0;
   if (query.isPending || (Boolean(search) && hasNoData && query.isFetching)) {
     return <ProjectsSkeleton />;
   }
   if (query.isError && hasNoData) {
     return <QueryLoadError query={query} subject="projects" variant="panel" />;
   }
-  if (projects.length === 0 && !search && !query.isError) {
+  if (hasNoProjects && !search) {
     return <EmptyProjects workspaceSlug={workspaceSlug} />;
   }
-  if (!query.isFetching && projects.length === 0 && search && !query.isError) {
+  if (!query.isFetching && hasNoProjects && search) {
     return <NoSearchResults search={search} onClear={onClear} />;
   }
-  if (projects.length === 0) return null;
+  if (hasNoProjects) return null;
   return (
     <ProjectsList
       query={query}

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -129,8 +129,10 @@ function ProjectsPanelContent({
   if (query.isError && hasNoData) {
     return <QueryLoadError query={query} subject="projects" variant="panel" />;
   }
-  if (projects.length === 0 && !search) return <EmptyProjects workspaceSlug={workspaceSlug} />;
-  if (!query.isFetching && projects.length === 0 && search) {
+  if (projects.length === 0 && !search && !query.isError) {
+    return <EmptyProjects workspaceSlug={workspaceSlug} />;
+  }
+  if (!query.isFetching && projects.length === 0 && search && !query.isError) {
     return <NoSearchResults search={search} onClear={onClear} />;
   }
   if (projects.length === 0) return null;

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -44,9 +44,7 @@ export function ProjectsHubPage({search = ''}: {search?: string}) {
     (connectionsQuery.data ?? []).map((connection) => [connection.id, connection]),
   );
 
-  const isInitialLoading = query.isPending;
   const isSearching = Boolean(search) && query.isFetching && !query.isFetchingNextPage;
-  const hasNoData = !query.data;
 
   return (
     <div className="flex w-full flex-col gap-section">
@@ -88,65 +86,114 @@ export function ProjectsHubPage({search = ''}: {search?: string}) {
           </PanelHeader>
 
           <PanelBody>
-            {isInitialLoading || (search && hasNoData && query.isFetching) ? (
-              <ProjectsSkeleton />
-            ) : null}
-
-            {query.isError && hasNoData ? (
-              <QueryLoadError query={query} subject="projects" variant="panel" />
-            ) : null}
-
-            {!isInitialLoading && !query.isError && projects.length === 0 && !search ? (
-              <EmptyProjects workspaceSlug={workspace.slug} />
-            ) : null}
-
-            {!query.isFetching && !query.isError && projects.length === 0 && search ? (
-              <NoSearchResults
-                search={search}
-                onClear={() => navigate({search: {} as never, replace: true})}
-              />
-            ) : null}
-
-            {projects.length > 0 ? (
-              <>
-                <PanelGrid aria-label="Projects list">
-                  {projects.map((project) => (
-                    <ProjectCell
-                      project={project}
-                      connection={connectionsById.get(project.source.connectionId)}
-                      connectionsResolved={connectionsQuery.isSuccess}
-                      connectionsSettled={connectionsQuery.isSuccess || connectionsQuery.isError}
-                      key={project.id}
-                      workspaceSlug={workspace.slug}
-                    />
-                  ))}
-                </PanelGrid>
-                {query.error && query.data ? (
-                  <div className="border-t border-border-neutral-base p-panel-compact">
-                    <Callout role="alert" type="error">
-                      <Text size="sm">
-                        Could not load the next page. Existing projects are still shown.
-                      </Text>
-                    </Callout>
-                  </div>
-                ) : null}
-                {query.hasNextPage ? (
-                  <div className="flex justify-center border-t border-border-neutral-base p-panel-compact">
-                    <Button
-                      variant="secondary"
-                      isLoading={query.isFetchingNextPage}
-                      onClick={() => query.fetchNextPage()}
-                    >
-                      Load more
-                    </Button>
-                  </div>
-                ) : null}
-              </>
-            ) : null}
+            <ProjectsPanelContent
+              query={query}
+              projects={projects}
+              search={search}
+              workspaceSlug={workspace.slug}
+              connectionsById={connectionsById}
+              connectionsResolved={connectionsQuery.isSuccess}
+              connectionsSettled={connectionsQuery.isSuccess || connectionsQuery.isError}
+              onClear={() => navigate({search: {} as never, replace: true})}
+            />
           </PanelBody>
         </Panel>
       </section>
     </div>
+  );
+}
+
+function ProjectsPanelContent({
+  query,
+  projects,
+  search,
+  workspaceSlug,
+  connectionsById,
+  connectionsResolved,
+  connectionsSettled,
+  onClear,
+}: {
+  query: ReturnType<typeof useProjectsInfiniteQuery>;
+  projects: Project[];
+  search: string;
+  workspaceSlug: string;
+  connectionsById: ReadonlyMap<string, IntegrationConnection>;
+  connectionsResolved: boolean;
+  connectionsSettled: boolean;
+  onClear: () => void;
+}) {
+  const hasNoData = !query.data;
+  if (query.isPending || (Boolean(search) && hasNoData && query.isFetching)) {
+    return <ProjectsSkeleton />;
+  }
+  if (query.isError && hasNoData) {
+    return <QueryLoadError query={query} subject="projects" variant="panel" />;
+  }
+  if (projects.length === 0 && !search) return <EmptyProjects workspaceSlug={workspaceSlug} />;
+  if (!query.isFetching && projects.length === 0 && search) {
+    return <NoSearchResults search={search} onClear={onClear} />;
+  }
+  if (projects.length === 0) return null;
+  return (
+    <ProjectsList
+      query={query}
+      projects={projects}
+      workspaceSlug={workspaceSlug}
+      connectionsById={connectionsById}
+      connectionsResolved={connectionsResolved}
+      connectionsSettled={connectionsSettled}
+    />
+  );
+}
+
+function ProjectsList({
+  query,
+  projects,
+  workspaceSlug,
+  connectionsById,
+  connectionsResolved,
+  connectionsSettled,
+}: {
+  query: ReturnType<typeof useProjectsInfiniteQuery>;
+  projects: Project[];
+  workspaceSlug: string;
+  connectionsById: ReadonlyMap<string, IntegrationConnection>;
+  connectionsResolved: boolean;
+  connectionsSettled: boolean;
+}) {
+  return (
+    <>
+      <PanelGrid aria-label="Projects list">
+        {projects.map((project) => (
+          <ProjectCell
+            project={project}
+            connection={connectionsById.get(project.source.connectionId)}
+            connectionsResolved={connectionsResolved}
+            connectionsSettled={connectionsSettled}
+            key={project.id}
+            workspaceSlug={workspaceSlug}
+          />
+        ))}
+      </PanelGrid>
+      {query.error && query.data ? (
+        <div className="border-t border-border-neutral-base p-panel-compact">
+          <Callout role="alert" type="error">
+            <Text size="sm">Could not load the next page. Existing projects are still shown.</Text>
+          </Callout>
+        </div>
+      ) : null}
+      {query.hasNextPage ? (
+        <div className="flex justify-center border-t border-border-neutral-base p-panel-compact">
+          <Button
+            variant="secondary"
+            isLoading={query.isFetchingNextPage}
+            onClick={() => query.fetchNextPage()}
+          >
+            Load more
+          </Button>
+        </div>
+      ) : null}
+    </>
   );
 }
 

--- a/libs/client/runners/src/components/token-settings-sections.stories.tsx
+++ b/libs/client/runners/src/components/token-settings-sections.stories.tsx
@@ -249,41 +249,47 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     const url = requestUrl(input);
     if (scenario === 'loading') return new Promise<Response>(() => undefined);
     if (url.pathname.endsWith('/runners/manual-registration-tokens')) {
-      if (scenario === 'errors') return Promise.resolve(errorResponse());
-      return Promise.resolve(
-        jsonResponse({
-          manual_registration_tokens: scenario === 'empty' ? [] : [manualToken()],
-        }),
-      );
+      return manualRegistrationTokensResponse(scenario);
     }
     if (url.pathname.endsWith('/provisioners/tokens')) {
-      if (scenario === 'errors') return Promise.resolve(errorResponse());
-      return Promise.resolve(
-        jsonResponse({
-          tokens: scenario === 'empty' ? [] : provisionerTokens(),
-        }),
-      );
+      return provisionerTokensResponse(scenario);
     }
     if (url.pathname.endsWith('/provisioners/active')) {
-      return Promise.resolve(
-        jsonResponse({
-          provisioners:
-            scenario === 'empty'
-              ? []
-              : [
-                  {
-                    id: '33333333-3333-4333-8333-333333333333',
-                    name: 'Docker autoscaler',
-                    prefix: 'sf_pt_docker',
-                    last_seen_at: NOW,
-                  },
-                ],
-          installation_runners: 'none',
-        }),
-      );
+      return activeProvisionersResponse(scenario);
     }
     return Promise.resolve(jsonResponse({}, {status: 404}));
   };
+}
+
+function manualRegistrationTokensResponse(scenario: Scenario) {
+  if (scenario === 'errors') return Promise.resolve(errorResponse());
+  return Promise.resolve(
+    jsonResponse({
+      manual_registration_tokens: scenario === 'empty' ? [] : [manualToken()],
+    }),
+  );
+}
+
+function provisionerTokensResponse(scenario: Scenario) {
+  if (scenario === 'errors') return Promise.resolve(errorResponse());
+  return Promise.resolve(jsonResponse({tokens: scenario === 'empty' ? [] : provisionerTokens()}));
+}
+
+function activeProvisionersResponse(scenario: Scenario) {
+  const provisioners = [
+    {
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'Docker autoscaler',
+      prefix: 'sf_pt_docker',
+      last_seen_at: NOW,
+    },
+  ];
+  return Promise.resolve(
+    jsonResponse({
+      provisioners: scenario === 'empty' ? [] : provisioners,
+      installation_runners: 'none',
+    }),
+  );
 }
 
 function provisionerTokens(): ProvisionerTokenDto[] {

--- a/libs/client/shell/src/compose/compose-routes.ts
+++ b/libs/client/shell/src/compose/compose-routes.ts
@@ -176,6 +176,25 @@ export function composeRoutes(
 ): ComposedRoute[] {
   const layouts = providedLayouts ? [...providedLayouts] : composeLayouts(features);
   const layoutById = validateLayoutParents(layouts);
+  const layoutPaths = indexLayoutPaths(layouts);
+  const routes = new Map<string, ComposedRoute>();
+  for (const feature of features) {
+    for (const contribution of feature.routes ?? []) {
+      addRouteContribution(feature, contribution, layoutPaths, routes);
+    }
+  }
+
+  for (const layout of layouts) {
+    validateNestedRoute(layout.path, layout.parent, layoutById, layout.featureId);
+  }
+  for (const route of routes.values()) {
+    validateRoutePathInvariants(route.path);
+    validateNestedRoute(route.path, route.parent, layoutById, route.featureId);
+  }
+  return [...routes.values()];
+}
+
+function indexLayoutPaths(layouts: readonly ComposedLayout[]): Map<string, ComposedLayout> {
   const layoutPaths = new Map<string, ComposedLayout>();
   for (const layout of layouts) {
     validateRoutePathInvariants(layout.path);
@@ -189,75 +208,79 @@ export function composeRoutes(
     }
     layoutPaths.set(layout.path, layout);
   }
+  return layoutPaths;
+}
 
-  const routes = new Map<string, ComposedRoute>();
-  for (const feature of features) {
-    for (const contribution of feature.routes ?? []) {
-      const normalizedContribution = {
-        ...contribution,
-        path: normalizeRoutePath(contribution.path),
-      };
-      const layoutAtPath = layoutPaths.get(normalizedContribution.path);
-      if (layoutAtPath) {
-        const message = normalizedContribution.override
-          ? `Route override for "${normalizedContribution.path}" from feature "${feature.id}" cannot replace layout "${layoutAtPath.id}" contributed by feature "${layoutAtPath.featureId}".`
-          : `Route "${normalizedContribution.path}" from feature "${feature.id}" conflicts with layout "${layoutAtPath.id}" contributed by feature "${layoutAtPath.featureId}". Routes cannot replace layouts.`;
-        throw new RouteCompositionError(normalizedContribution.path, message, [
-          layoutAtPath.featureId,
-          feature.id,
-        ]);
-      }
-      const existing = routes.get(normalizedContribution.path);
-      if (!existing) {
-        if (normalizedContribution.override) {
-          throw new RouteCompositionError(
-            normalizedContribution.path,
-            `Route override for "${normalizedContribution.path}" from feature "${feature.id}" has no route to replace.`,
-            [feature.id],
-          );
-        }
-        routes.set(normalizedContribution.path, {
-          ...normalizedContribution,
-          featureId: feature.id,
-          ownerFeatureId: feature.id,
-        });
-        continue;
-      }
-      if (!normalizedContribution.override) {
-        throw new RouteCompositionError(
-          normalizedContribution.path,
-          `Route "${normalizedContribution.path}" is contributed by both features "${existing.featureId}" and "${feature.id}". Set override: true to replace it explicitly.`,
-          [existing.featureId, feature.id],
-        );
-      }
-      if (existing.override) {
-        throw new RouteCompositionError(
-          normalizedContribution.path,
-          `Route "${normalizedContribution.path}" has competing overrides from features "${existing.featureId}" and "${feature.id}".`,
-          [existing.featureId, feature.id],
-        );
-      }
-      if (existing.parent !== normalizedContribution.parent) {
-        throw new RouteCompositionError(
-          normalizedContribution.path,
-          `Route override for "${normalizedContribution.path}" from feature "${feature.id}" cannot change anchor from "${existing.parent}" in feature "${existing.featureId}" to "${normalizedContribution.parent}".`,
-          [existing.featureId, feature.id],
-        );
-      }
-      routes.set(normalizedContribution.path, {
-        ...normalizedContribution,
-        featureId: feature.id,
-        ownerFeatureId: existing.ownerFeatureId,
-      });
+function addRouteContribution(
+  feature: ClientFeature,
+  contribution: NonNullable<ClientFeature['routes']>[number],
+  layoutPaths: ReadonlyMap<string, ComposedLayout>,
+  routes: Map<string, ComposedRoute>,
+): void {
+  const normalizedContribution = {...contribution, path: normalizeRoutePath(contribution.path)};
+  const layoutAtPath = layoutPaths.get(normalizedContribution.path);
+  if (layoutAtPath) {
+    throwRouteLayoutConflict(feature.id, normalizedContribution, layoutAtPath);
+  }
+  const existing = routes.get(normalizedContribution.path);
+  if (!existing) {
+    if (normalizedContribution.override) {
+      throw new RouteCompositionError(
+        normalizedContribution.path,
+        `Route override for "${normalizedContribution.path}" from feature "${feature.id}" has no route to replace.`,
+        [feature.id],
+      );
     }
+    routes.set(normalizedContribution.path, {
+      ...normalizedContribution,
+      featureId: feature.id,
+      ownerFeatureId: feature.id,
+    });
+    return;
   }
+  validateRouteOverride(feature.id, normalizedContribution, existing);
+  routes.set(normalizedContribution.path, {
+    ...normalizedContribution,
+    featureId: feature.id,
+    ownerFeatureId: existing.ownerFeatureId,
+  });
+}
 
-  for (const layout of layouts) {
-    validateNestedRoute(layout.path, layout.parent, layoutById, layout.featureId);
+function throwRouteLayoutConflict(
+  featureId: string,
+  contribution: NonNullable<ClientFeature['routes']>[number],
+  layout: ComposedLayout,
+): never {
+  const message = contribution.override
+    ? `Route override for "${contribution.path}" from feature "${featureId}" cannot replace layout "${layout.id}" contributed by feature "${layout.featureId}".`
+    : `Route "${contribution.path}" from feature "${featureId}" conflicts with layout "${layout.id}" contributed by feature "${layout.featureId}". Routes cannot replace layouts.`;
+  throw new RouteCompositionError(contribution.path, message, [layout.featureId, featureId]);
+}
+
+function validateRouteOverride(
+  featureId: string,
+  contribution: NonNullable<ClientFeature['routes']>[number],
+  existing: ComposedRoute,
+): void {
+  if (!contribution.override) {
+    throw new RouteCompositionError(
+      contribution.path,
+      `Route "${contribution.path}" is contributed by both features "${existing.featureId}" and "${featureId}". Set override: true to replace it explicitly.`,
+      [existing.featureId, featureId],
+    );
   }
-  for (const route of routes.values()) {
-    validateRoutePathInvariants(route.path);
-    validateNestedRoute(route.path, route.parent, layoutById, route.featureId);
+  if (existing.override) {
+    throw new RouteCompositionError(
+      contribution.path,
+      `Route "${contribution.path}" has competing overrides from features "${existing.featureId}" and "${featureId}".`,
+      [existing.featureId, featureId],
+    );
   }
-  return [...routes.values()];
+  if (existing.parent !== contribution.parent) {
+    throw new RouteCompositionError(
+      contribution.path,
+      `Route override for "${contribution.path}" from feature "${featureId}" cannot change anchor from "${existing.parent}" in feature "${existing.featureId}" to "${contribution.parent}".`,
+      [existing.featureId, featureId],
+    );
+  }
 }

--- a/libs/client/shell/src/compose/validate-registries.ts
+++ b/libs/client/shell/src/compose/validate-registries.ts
@@ -76,63 +76,112 @@ export function validateNavigation(
   const entries = new Map<string, string>();
   for (const feature of features) {
     for (const entry of feature.navigation ?? []) {
-      validateRoleMetadata(entry, feature);
-      const existingFeatureId = entries.get(entry.id);
-      if (existingFeatureId) {
-        throw new NavCompositionError(
-          entry.id,
-          `Navigation entry "${entry.id}" is contributed by both features "${existingFeatureId}" and "${feature.id}".`,
-          [existingFeatureId, feature.id],
-        );
-      }
-      const target = normalizeRoutePath(entry.to);
-      const routeOwner = routes.get(target);
-      if (routeOwner === undefined && !routes.has(target)) {
-        throw new NavCompositionError(
-          entry.id,
-          `Navigation entry "${entry.id}" in feature "${feature.id}" targets missing route "${target}".`,
-          [feature.id],
-        );
-      }
-      if (entry.scope === 'layout') {
-        if (typeof entry.layout !== 'string' || entry.layout.trim() === '') {
-          throw new NavCompositionError(
-            entry.id,
-            `Navigation entry "${entry.id}" in feature "${feature.id}" has invalid layout metadata. Expected a non-empty layout id.`,
-            [feature.id],
-          );
-        }
-        const layout = layouts.get(entry.layout);
-        if (!layout) {
-          throw new NavCompositionError(
-            entry.id,
-            `Navigation entry "${entry.id}" in feature "${feature.id}" targets missing layout "${entry.layout}".`,
-            [feature.id],
-          );
-        }
-        const route = routeReferencesForPath(routeReferencesWithLayouts, target);
-        const isLayoutRoot = route?.path === layout.path;
-        const isLayoutDescendant = routeDescendsFromLayout(route, entry.layout, layouts);
-        if (!isLayoutRoot && !isLayoutDescendant) {
-          throw new NavCompositionError(
-            entry.id,
-            `Navigation entry "${entry.id}" in feature "${feature.id}" targets route "${target}" outside layout "${entry.layout}".`,
-            [feature.id],
-          );
-        }
-        entries.set(entry.id, feature.id);
-        continue;
-      }
-      if (routeOwner && routeOwner !== feature.id && !hasExplicitCoordinator(feature)) {
-        throw new NavCompositionError(
-          entry.id,
-          `Navigation entry "${entry.id}" in feature "${feature.id}" targets route "${target}" owned by feature "${routeOwner}". Declare coordinator: "${feature.id}" to own this cross-feature contribution.`,
-          [routeOwner, feature.id],
-        );
-      }
-      entries.set(entry.id, feature.id);
+      validateNavigationEntry({
+        entry,
+        feature,
+        entries,
+        routes,
+        layouts,
+        routeReferences: routeReferencesWithLayouts,
+      });
     }
   }
+}
+
+function validateNavigationEntry({
+  entry,
+  feature,
+  entries,
+  routes,
+  layouts,
+  routeReferences,
+}: {
+  entry: NavTabEntry;
+  feature: ClientFeature;
+  entries: Map<string, string>;
+  routes: ReadonlyMap<string, string | undefined>;
+  layouts: ReadonlyMap<string, LayoutReference>;
+  routeReferences: RouteReferences;
+}): void {
+  validateRoleMetadata(entry, feature);
+  validateUniqueNavigationEntry(entry, feature, entries);
+  const target = normalizeRoutePath(entry.to);
+  const routeOwner = routes.get(target);
+  if (routeOwner === undefined && !routes.has(target)) {
+    throw new NavCompositionError(
+      entry.id,
+      `Navigation entry "${entry.id}" in feature "${feature.id}" targets missing route "${target}".`,
+      [feature.id],
+    );
+  }
+  if (entry.scope === 'layout') {
+    validateLayoutNavigationEntry(entry, feature, target, routeReferences, layouts);
+  } else {
+    validateCrossFeatureNavigationEntry(entry, feature, target, routeOwner);
+  }
+  entries.set(entry.id, feature.id);
+}
+
+function validateUniqueNavigationEntry(
+  entry: NavTabEntry,
+  feature: ClientFeature,
+  entries: ReadonlyMap<string, string>,
+): void {
+  const existingFeatureId = entries.get(entry.id);
+  if (!existingFeatureId) return;
+  throw new NavCompositionError(
+    entry.id,
+    `Navigation entry "${entry.id}" is contributed by both features "${existingFeatureId}" and "${feature.id}".`,
+    [existingFeatureId, feature.id],
+  );
+}
+
+function validateLayoutNavigationEntry(
+  entry: Extract<NavTabEntry, {scope: 'layout'}>,
+  feature: ClientFeature,
+  target: string,
+  routeReferences: RouteReferences,
+  layouts: ReadonlyMap<string, LayoutReference>,
+): void {
+  if (typeof entry.layout !== 'string' || entry.layout.trim() === '') {
+    throw new NavCompositionError(
+      entry.id,
+      `Navigation entry "${entry.id}" in feature "${feature.id}" has invalid layout metadata. Expected a non-empty layout id.`,
+      [feature.id],
+    );
+  }
+  const layout = layouts.get(entry.layout);
+  if (!layout) {
+    throw new NavCompositionError(
+      entry.id,
+      `Navigation entry "${entry.id}" in feature "${feature.id}" targets missing layout "${entry.layout}".`,
+      [feature.id],
+    );
+  }
+  const route = routeReferencesForPath(routeReferences, target);
+  const isLayoutRoot = route?.path === layout.path;
+  const isLayoutDescendant = routeDescendsFromLayout(route, entry.layout, layouts);
+  if (!isLayoutRoot && !isLayoutDescendant) {
+    throw new NavCompositionError(
+      entry.id,
+      `Navigation entry "${entry.id}" in feature "${feature.id}" targets route "${target}" outside layout "${entry.layout}".`,
+      [feature.id],
+    );
+  }
+}
+
+function validateCrossFeatureNavigationEntry(
+  entry: NavTabEntry,
+  feature: ClientFeature,
+  target: string,
+  routeOwner: string | undefined,
+): void {
+  if (!routeOwner || routeOwner === feature.id || hasExplicitCoordinator(feature)) return;
+  throw new NavCompositionError(
+    entry.id,
+    `Navigation entry "${entry.id}" in feature "${feature.id}" targets route "${target}" owned by feature "${routeOwner}". Declare coordinator: "${feature.id}" to own this cross-feature contribution.`,
+    [routeOwner, feature.id],
+  );
 }
 
 function routeReferencesForPath(
@@ -169,35 +218,50 @@ export function validateSettingsSections(
   const sections = new Map<string, string>();
   for (const feature of features) {
     for (const section of feature.settingsSections ?? []) {
-      const existingFeatureId = sections.get(section.id);
-      if (existingFeatureId) {
-        throw new SettingsCompositionError(
-          section.id,
-          `Settings section "${section.id}" is contributed by both features "${existingFeatureId}" and "${feature.id}".`,
-          [existingFeatureId, feature.id],
-        );
-      }
-      const path =
-        section.scope === 'project'
-          ? `/w/$workspaceSlug/p/$projectSlug/settings/${section.pathSegment}`
-          : `/w/$workspaceSlug/settings/${section.pathSegment}`;
-      const normalizedPath = normalizeRoutePath(path);
-      const routeOwner = routes.get(normalizedPath);
-      if (routeOwner === undefined && !routes.has(normalizedPath)) {
-        throw new SettingsCompositionError(
-          section.id,
-          `Settings section "${section.id}" in feature "${feature.id}" requires route "${path}".`,
-          [feature.id],
-        );
-      }
-      if (routeOwner && routeOwner !== feature.id && !hasExplicitCoordinator(feature)) {
-        throw new SettingsCompositionError(
-          section.id,
-          `Settings section "${section.id}" in feature "${feature.id}" targets route "${path}" owned by feature "${routeOwner}". Declare coordinator: "${feature.id}" to own this cross-feature contribution.`,
-          [routeOwner, feature.id],
-        );
-      }
-      sections.set(section.id, feature.id);
+      validateSettingsSection(feature, section, routes, sections);
     }
   }
+}
+
+function validateSettingsSection(
+  feature: ClientFeature,
+  section: NonNullable<ClientFeature['settingsSections']>[number],
+  routes: ReadonlyMap<string, string | undefined>,
+  sections: Map<string, string>,
+): void {
+  const existingFeatureId = sections.get(section.id);
+  if (existingFeatureId) {
+    throw new SettingsCompositionError(
+      section.id,
+      `Settings section "${section.id}" is contributed by both features "${existingFeatureId}" and "${feature.id}".`,
+      [existingFeatureId, feature.id],
+    );
+  }
+  const path = settingsSectionPath(section);
+  const normalizedPath = normalizeRoutePath(path);
+  const routeOwner = routes.get(normalizedPath);
+  if (routeOwner === undefined && !routes.has(normalizedPath)) {
+    throw new SettingsCompositionError(
+      section.id,
+      `Settings section "${section.id}" in feature "${feature.id}" requires route "${path}".`,
+      [feature.id],
+    );
+  }
+  if (routeOwner && routeOwner !== feature.id && !hasExplicitCoordinator(feature)) {
+    throw new SettingsCompositionError(
+      section.id,
+      `Settings section "${section.id}" in feature "${feature.id}" targets route "${path}" owned by feature "${routeOwner}". Declare coordinator: "${feature.id}" to own this cross-feature contribution.`,
+      [routeOwner, feature.id],
+    );
+  }
+  sections.set(section.id, feature.id);
+}
+
+function settingsSectionPath(
+  section: NonNullable<ClientFeature['settingsSections']>[number],
+): string {
+  if (section.scope === 'project') {
+    return `/w/$workspaceSlug/p/$projectSlug/settings/${section.pathSegment}`;
+  }
+  return `/w/$workspaceSlug/settings/${section.pathSegment}`;
 }

--- a/libs/client/shell/src/compose/validate-registries.ts
+++ b/libs/client/shell/src/compose/validate-registries.ts
@@ -1,4 +1,4 @@
-import type {ClientFeature, NavTabEntry, RouteParentId} from '#contract.js';
+import type {ClientFeature, LayoutNavigationEntry, NavTabEntry, RouteParentId} from '#contract.js';
 import {NavCompositionError, SettingsCompositionError} from './errors.js';
 import {normalizeRoutePath} from './normalize-route-path.js';
 
@@ -137,7 +137,7 @@ function validateUniqueNavigationEntry(
 }
 
 function validateLayoutNavigationEntry(
-  entry: Extract<NavTabEntry, {scope: 'layout'}>,
+  entry: LayoutNavigationEntry,
   feature: ClientFeature,
   target: string,
   routeReferences: RouteReferences,

--- a/libs/client/shell/src/runtime/adopted-session.test.tsx
+++ b/libs/client/shell/src/runtime/adopted-session.test.tsx
@@ -577,6 +577,27 @@ describe('adopted-session runtime seam', () => {
     await waitFor(() => expect(apiRef.current?.adoptedSession?.expiresAt).toBe(laterExpiresAt));
   });
 
+  test('adopts a valid renewal when the current expiry is malformed', async () => {
+    const {apiRef, store} = renderAuthHarness();
+    await waitForCookieSession(store, ADMIN_SESSION_DTO.token);
+    const renewal: AdoptedSessionRenewal = {
+      session: {...ADOPTED_SESSION, accessToken: 'repaired-token'},
+      expiresAt: EXPIRES_AT,
+      serverTime: SERVER_TIME,
+    };
+    const renew = vi.fn(() => Promise.resolve(renewal));
+    const api = harnessApi(apiRef);
+
+    await api.adoptSession(ADOPTED_SESSION, {
+      expiresAt: 'malformed-expiry',
+      serverTime: SERVER_TIME,
+      renew,
+    });
+
+    await waitFor(() => expect(store.get(authStateAtom).token).toBe('repaired-token'));
+    expect(apiRef.current?.adoptedSession?.expiresAt).toBe(EXPIRES_AT);
+  });
+
   test('renewals that lose a race to a longer reserved window do not count as stalls', async () => {
     const {apiRef, fetchImpl, store} = renderAuthHarness();
     await waitForCookieSession(store, ADMIN_SESSION_DTO.token);

--- a/libs/client/shell/src/runtime/adopted-session.test.tsx
+++ b/libs/client/shell/src/runtime/adopted-session.test.tsx
@@ -120,47 +120,14 @@ function renderAuthHarness(
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
   const store = createStore();
   const apiRef: {current: AdoptedSessionApi | null} = {current: null};
-  let refreshCalls = 0;
-  let workspacesCalls = 0;
-  let releaseSecondRefresh: (() => void) | undefined;
-  let releaseHeldWorkspaces: (() => void) | undefined;
+  const fetchState: AuthHarnessFetchState = {refreshCalls: 0, workspacesCalls: 0};
   const fetchImpl = vi.fn((input: RequestInfo | URL) => {
     const url = input instanceof Request ? input.url : String(input);
-    if (url.endsWith('/auth/refresh')) {
-      refreshCalls += 1;
-      if (
-        options.failRefreshFromCall !== undefined &&
-        refreshCalls >= options.failRefreshFromCall
-      ) {
-        return Promise.reject(new TypeError('Failed to fetch'));
-      }
-      // Only the mount refresh carries the caller-provided token; later
-      // refreshes restore the plain cookie session token.
-      if (options.holdSecondRefresh && refreshCalls === 2) {
-        return new Promise<Response>((resolve) => {
-          releaseSecondRefresh = () => resolve(jsonResponse(ADMIN_SESSION_DTO));
-        });
-      }
-      return jsonResponsePromise({
-        ...ADMIN_SESSION_DTO,
-        token: refreshCalls === 1 ? adminToken : ADMIN_SESSION_DTO.token,
-      });
-    }
+    if (url.endsWith('/auth/refresh')) return authHarnessRefresh(adminToken, options, fetchState);
     if (options.unauthorizedPaths?.some((path) => url.endsWith(path))) {
       return jsonResponsePromise({message: 'Unauthorized', code: 'unauthorized'}, {status: 401});
     }
-    if (url.endsWith('/workspaces')) {
-      workspacesCalls += 1;
-      if (
-        options.holdWorkspacesFromCall !== undefined &&
-        workspacesCalls >= options.holdWorkspacesFromCall
-      ) {
-        return new Promise<Response>((resolve) => {
-          releaseHeldWorkspaces = () => resolve(jsonResponse({memberships: []}));
-        });
-      }
-      return jsonResponsePromise({memberships: []});
-    }
+    if (url.endsWith('/workspaces')) return authHarnessWorkspaces(options, fetchState);
     return jsonResponsePromise({message: 'Not found', code: 'not-found'}, {status: 404});
   });
   resetApiClient();
@@ -180,9 +147,62 @@ function renderAuthHarness(
     fetchImpl,
     queryClient,
     store,
-    releaseSecondRefresh: () => releaseSecondRefresh?.(),
-    releaseHeldWorkspaces: () => releaseHeldWorkspaces?.(),
+    releaseSecondRefresh: () => fetchState.releaseSecondRefresh?.(),
+    releaseHeldWorkspaces: () => fetchState.releaseHeldWorkspaces?.(),
   };
+}
+
+type AuthHarnessOptions = {
+  holdSecondRefresh?: boolean;
+  failRefreshFromCall?: number;
+  unauthorizedPaths?: string[];
+  holdWorkspacesFromCall?: number;
+};
+
+type AuthHarnessFetchState = {
+  refreshCalls: number;
+  workspacesCalls: number;
+  releaseSecondRefresh?: () => void;
+  releaseHeldWorkspaces?: () => void;
+};
+
+function authHarnessRefresh(
+  adminToken: string,
+  options: AuthHarnessOptions,
+  state: AuthHarnessFetchState,
+): Promise<Response> {
+  state.refreshCalls += 1;
+  if (
+    options.failRefreshFromCall !== undefined &&
+    state.refreshCalls >= options.failRefreshFromCall
+  ) {
+    return Promise.reject(new TypeError('Failed to fetch'));
+  }
+  if (options.holdSecondRefresh && state.refreshCalls === 2) {
+    return new Promise<Response>((resolve) => {
+      state.releaseSecondRefresh = () => resolve(jsonResponse(ADMIN_SESSION_DTO));
+    });
+  }
+  return jsonResponsePromise({
+    ...ADMIN_SESSION_DTO,
+    token: state.refreshCalls === 1 ? adminToken : ADMIN_SESSION_DTO.token,
+  });
+}
+
+function authHarnessWorkspaces(
+  options: AuthHarnessOptions,
+  state: AuthHarnessFetchState,
+): Promise<Response> {
+  state.workspacesCalls += 1;
+  if (
+    options.holdWorkspacesFromCall !== undefined &&
+    state.workspacesCalls >= options.holdWorkspacesFromCall
+  ) {
+    return new Promise<Response>((resolve) => {
+      state.releaseHeldWorkspaces = () => resolve(jsonResponse({memberships: []}));
+    });
+  }
+  return jsonResponsePromise({memberships: []});
 }
 
 function harnessApi(apiRef: {current: AdoptedSessionApi | null}): AdoptedSessionApi {

--- a/libs/client/shell/src/runtime/anchor-paths.ts
+++ b/libs/client/shell/src/runtime/anchor-paths.ts
@@ -25,50 +25,85 @@ export function validateRoutePathInvariants(path: string): void {
   const segments = path.split('/').filter(Boolean);
   const seenSlugParams = new Set<string>();
 
-  if (segments[0] === 'workspaces' && segments[1]?.startsWith('$')) {
-    throw new Error(
-      `Route "${path}" must use the slug-based workspace prefix "w" instead of the legacy "/workspaces" path.`,
-    );
-  }
+  validateLegacyWorkspacePrefix(path, segments);
 
   for (const [index, segment] of segments.entries()) {
-    const nextSegment = segments[index + 1];
-    if (segment.length === 1 && Object.hasOwn(entityPrefixRegistry, segment)) {
-      if (!nextSegment?.startsWith('$')) {
-        throw new Error(
-          `Route "${path}" uses prefix "${segment}" without a dynamic parameter immediately after it.`,
-        );
-      }
-    }
-
-    if (!segment.startsWith('$')) continue;
-    const param = segment.slice(1) as keyof typeof slugParamPrefixes;
-    const prefix = Object.hasOwn(slugParamPrefixes, param) ? slugParamPrefixes[param] : undefined;
-    if (prefix !== undefined) {
-      if (seenSlugParams.has(param)) {
-        throw new Error(`Route "${path}" repeats slug parameter "${param}".`);
-      }
-      seenSlugParams.add(param);
-      if (segments[index - 1] !== prefix) {
-        throw new Error(
-          `Route "${path}" places slug parameter "${param}" outside prefix "${prefix}".`,
-        );
-      }
-    }
-    if (prefix === undefined) {
-      const previousSegment = segments[index - 1];
-      if (
-        !previousSegment ||
-        previousSegment.startsWith('$') ||
-        Object.hasOwn(entityPrefixRegistry, previousSegment)
-      ) {
-        throw new Error(
-          `Route "${path}" must place UUID parameter "${param}" after a page segment.`,
-        );
-      }
-    }
+    validateRouteSegment(path, segments, index, segment, seenSlugParams);
   }
 
+  validateEntityPrefixOrder(path, segments);
+}
+
+function validateLegacyWorkspacePrefix(path: string, segments: string[]): void {
+  if (segments[0] !== 'workspaces' || !segments[1]?.startsWith('$')) return;
+  throw new Error(
+    `Route "${path}" must use the slug-based workspace prefix "w" instead of the legacy "/workspaces" path.`,
+  );
+}
+
+function validateRouteSegment(
+  path: string,
+  segments: string[],
+  index: number,
+  segment: string,
+  seenSlugParams: Set<string>,
+): void {
+  validateEntityPrefix(path, segment, segments[index + 1]);
+  if (!segment.startsWith('$')) return;
+
+  const param = segment.slice(1) as keyof typeof slugParamPrefixes;
+  const prefix = Object.hasOwn(slugParamPrefixes, param) ? slugParamPrefixes[param] : undefined;
+  if (prefix !== undefined) {
+    validateSlugParameter(path, param, prefix, segments[index - 1], seenSlugParams);
+    return;
+  }
+  validateUuidParameter(path, param, segments[index - 1]);
+}
+
+function validateEntityPrefix(
+  path: string,
+  segment: string,
+  nextSegment: string | undefined,
+): void {
+  if (segment.length !== 1 || !Object.hasOwn(entityPrefixRegistry, segment)) return;
+  if (nextSegment?.startsWith('$')) return;
+  throw new Error(
+    `Route "${path}" uses prefix "${segment}" without a dynamic parameter immediately after it.`,
+  );
+}
+
+function validateSlugParameter(
+  path: string,
+  param: keyof typeof slugParamPrefixes,
+  prefix: string,
+  previousSegment: string | undefined,
+  seenSlugParams: Set<string>,
+): void {
+  if (seenSlugParams.has(param)) {
+    throw new Error(`Route "${path}" repeats slug parameter "${param}".`);
+  }
+  seenSlugParams.add(param);
+  if (previousSegment !== prefix) {
+    throw new Error(`Route "${path}" places slug parameter "${param}" outside prefix "${prefix}".`);
+  }
+}
+
+function validateUuidParameter(
+  path: string,
+  param: string,
+  previousSegment: string | undefined,
+): void {
+  if (
+    previousSegment &&
+    !previousSegment.startsWith('$') &&
+    !Object.hasOwn(entityPrefixRegistry, previousSegment)
+  ) {
+    return;
+  }
+  throw new Error(`Route "${path}" must place UUID parameter "${param}" after a page segment.`);
+}
+
+function validateEntityPrefixOrder(path: string, segments: string[]): void {
   const workspacePrefixIndex = segments.indexOf('w');
   const projectPrefixIndex = segments.indexOf('p');
   if (

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -69,11 +69,11 @@ export function buildAnchorSkeleton({
         unavailable?: boolean;
       };
       const workspace = useMaybeActiveWorkspace();
-      return setupState.hideProjectNavigation === undefined ? (
-        <WorkspaceSetupPending />
-      ) : setupState.unavailable ? (
-        <WorkspaceUnavailablePage workspaceName={workspace?.name} />
-      ) : (
+      if (setupState.hideProjectNavigation === undefined) return <WorkspaceSetupPending />;
+      if (setupState.unavailable) {
+        return <WorkspaceUnavailablePage workspaceName={workspace?.name} />;
+      }
+      return (
         <MainLayout
           navigation={navigation}
           hideProjectNavigation={setupState.hideProjectNavigation}

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -64,6 +64,41 @@ interface AdoptedSessionRuntimeState extends AdoptedSessionState {
   stalledRenewals: number;
 }
 
+type RenewalCandidate = {
+  expiryMs: number;
+  currentExpiryMs: number;
+  valid: boolean;
+  advancesWindow: boolean;
+};
+
+function renewalCandidate(
+  result: AdoptedSessionRenewal,
+  current: AdoptedSessionRuntimeState,
+  reservedExpiryMs: number,
+): RenewalCandidate {
+  const expiryMs = Date.parse(result.expiresAt);
+  const serverTimeMs = Date.parse(result.serverTime);
+  const currentExpiryMs = Date.parse(current.expiresAt);
+  const valid =
+    Number.isFinite(expiryMs) && Number.isFinite(serverTimeMs) && expiryMs > serverTimeMs;
+  return {
+    expiryMs,
+    currentExpiryMs,
+    valid,
+    advancesWindow: valid && expiryMs > Math.max(currentExpiryMs, reservedExpiryMs),
+  };
+}
+
+async function requestAdoptedRenewal(
+  adopted: AdoptedSessionRuntimeState,
+): Promise<AdoptedSessionRenewal | null> {
+  try {
+    return await adopted.renew();
+  } catch {
+    return null;
+  }
+}
+
 const adoptedSessionAtom = atom<AdoptedSessionRuntimeState | null>(null);
 const adoptionGenerationAtom = atom(0);
 /**
@@ -385,18 +420,68 @@ export function useAdoptedSession() {
     [beginAuthTransition, enterAuthenticated, queryClient, store],
   );
 
+  const handleNonAdvancingRenewal = useCallback(
+    async (
+      candidate: RenewalCandidate,
+      current: AdoptedSessionRuntimeState,
+      adopted: AdoptedSessionRuntimeState,
+    ): Promise<void> => {
+      const lostRace =
+        candidate.valid &&
+        (candidate.expiryMs > candidate.currentExpiryMs ||
+          candidate.currentExpiryMs > Date.parse(adopted.expiresAt));
+      if (candidate.valid && lostRace) return;
+
+      const stalled = {...current, stalledRenewals: current.stalledRenewals + 1};
+      store.set(adoptedSessionAtom, stalled);
+      if (stalled.stalledRenewals >= ADOPTED_RENEWAL_STALL_LIMIT) await endAdoption();
+    },
+    [endAdoption, store],
+  );
+
+  const adoptRenewalResult = useCallback(
+    async ({
+      result,
+      candidateExpiryMs,
+      generation,
+      adopted,
+    }: {
+      result: AdoptedSessionRenewal;
+      candidateExpiryMs: number;
+      generation: number;
+      adopted: AdoptedSessionRuntimeState;
+    }): Promise<AdoptedSessionRenewal | null> => {
+      const receivedAtMs = performance.now();
+      const transitionEpoch = beginAuthTransition();
+      invalidateRefresh(queryClient);
+      const accepted = await enterAuthenticated(result.session, transitionEpoch);
+      if (!accepted || store.get(adoptionGenerationAtom) !== generation) {
+        if (store.get(adoptedRenewalReservationAtom) === candidateExpiryMs) {
+          store.set(adoptedRenewalReservationAtom, 0);
+        }
+        return null;
+      }
+      store.set(adoptedRenewalReservationAtom, 0);
+      store.set(adoptedSessionAtom, {
+        generation,
+        receivedAtMs,
+        session: result.session,
+        expiresAt: result.expiresAt,
+        serverTime: result.serverTime,
+        renew: adopted.renew,
+        stalledRenewals: 0,
+      });
+      return result;
+    },
+    [beginAuthTransition, enterAuthenticated, queryClient, store],
+  );
+
   const renewAdoptedSession = useCallback(async (): Promise<AdoptedSessionRenewal | null> => {
     const adopted = store.get(adoptedSessionAtom);
     if (adopted === null) return null;
     const generation = store.get(adoptionGenerationAtom);
 
-    let result: AdoptedSessionRenewal | null;
-    try {
-      result = await adopted.renew();
-    } catch {
-      // A failed renewal degrades like a refused one: back to the cookie.
-      result = null;
-    }
+    const result = await requestAdoptedRenewal(adopted);
 
     // The generation is captured when the request started; a response that
     // resolves after a release is discarded.
@@ -406,77 +491,27 @@ export function useAdoptedSession() {
       return null;
     }
 
-    const candidateExpiryMs = Date.parse(result.expiresAt);
-    const candidateServerTimeMs = Date.parse(result.serverTime);
-    const candidateValid =
-      Number.isFinite(candidateExpiryMs) &&
-      Number.isFinite(candidateServerTimeMs) &&
-      candidateExpiryMs > candidateServerTimeMs;
     const current = store.get(adoptedSessionAtom);
     if (current === null) return null;
-    const currentExpiryMs = Date.parse(current.expiresAt);
-    const bestReservedExpiryMs = Math.max(
-      currentExpiryMs,
-      store.get(adoptedRenewalReservationAtom),
-    );
-    // A candidate that is malformed, stuck on the expiry the adoption already
-    // holds, or shorter than the best expiry adopted or reserved by another
-    // renewal did not advance the window and is never adopted.
-    const windowDidNotAdvance = !candidateValid || candidateExpiryMs <= bestReservedExpiryMs;
-    if (windowDidNotAdvance) {
-      // Count a stall only when the window really did not move: a malformed
-      // response, or one stuck on an expiry the adoption already holds. A
-      // valid response that merely lost a race to a longer expiry adopted or
-      // reserved while this renewal was in flight is a healthy concurrent
-      // renewal; counting it would burn the stall budget and fire extra
-      // supplier requests. The cap ends the adoption instead of driving an
-      // unbounded zero-delay renew loop and falls back to the cookie refresh.
-      const lostRace =
-        candidateValid &&
-        (candidateExpiryMs > currentExpiryMs || currentExpiryMs > Date.parse(adopted.expiresAt));
-      if (!candidateValid || !lostRace) {
-        const stalled = {...current, stalledRenewals: current.stalledRenewals + 1};
-        store.set(adoptedSessionAtom, stalled);
-        if (stalled.stalledRenewals >= ADOPTED_RENEWAL_STALL_LIMIT) {
-          await endAdoption();
-        }
-      }
+    const candidate = renewalCandidate(result, current, store.get(adoptedRenewalReservationAtom));
+    if (!candidate.advancesWindow) {
+      await handleNonAdvancingRenewal(candidate, current, adopted);
       return null;
     }
-    if (candidateExpiryMs > store.get(adoptedRenewalReservationAtom)) {
+    if (candidate.expiryMs > store.get(adoptedRenewalReservationAtom)) {
       // Reserve the candidate expiry before the asynchronous transition so an
       // overlapping shorter response cannot overwrite the longer token. The
       // reservation lives outside adoptedSessionAtom so this write does not
       // re-run the renew effect while the transition is still pending.
-      store.set(adoptedRenewalReservationAtom, candidateExpiryMs);
+      store.set(adoptedRenewalReservationAtom, candidate.expiryMs);
     }
-
-    const receivedAtMs = performance.now();
-    const transitionEpoch = beginAuthTransition();
-    // The renewal transition supersedes any cookie refresh still in flight;
-    // release must not reuse a promise that will reject as superseded.
-    invalidateRefresh(queryClient);
-    const accepted = await enterAuthenticated(result.session, transitionEpoch);
-    if (!accepted || store.get(adoptionGenerationAtom) !== generation) {
-      // Drop our reservation only while it is still the current one; another
-      // renewal may have reserved a later expiry meanwhile.
-      if (store.get(adoptedRenewalReservationAtom) === candidateExpiryMs) {
-        store.set(adoptedRenewalReservationAtom, 0);
-      }
-      return null;
-    }
-    store.set(adoptedRenewalReservationAtom, 0);
-    store.set(adoptedSessionAtom, {
+    return await adoptRenewalResult({
+      result,
+      candidateExpiryMs: candidate.expiryMs,
       generation,
-      receivedAtMs,
-      session: result.session,
-      expiresAt: result.expiresAt,
-      serverTime: result.serverTime,
-      renew: adopted.renew,
-      stalledRenewals: 0,
+      adopted,
     });
-    return result;
-  }, [beginAuthTransition, endAdoption, enterAuthenticated, queryClient, store]);
+  }, [adoptRenewalResult, endAdoption, handleNonAdvancingRenewal, store]);
 
   const releaseAdoptedSession = useCallback(async () => {
     // Always advance the generation and fall back to the cookie: a release

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -78,7 +78,8 @@ function renewalCandidate(
 ): RenewalCandidate {
   const expiryMs = Date.parse(result.expiresAt);
   const serverTimeMs = Date.parse(result.serverTime);
-  const currentExpiryMs = Date.parse(current.expiresAt);
+  const parsedCurrentExpiryMs = Date.parse(current.expiresAt);
+  const currentExpiryMs = Number.isFinite(parsedCurrentExpiryMs) ? parsedCurrentExpiryMs : 0;
   const valid =
     Number.isFinite(expiryMs) && Number.isFinite(serverTimeMs) && expiryMs > serverTimeMs;
   return {

--- a/libs/client/shell/src/runtime/workspace-setup.tsx
+++ b/libs/client/shell/src/runtime/workspace-setup.tsx
@@ -53,12 +53,9 @@ export function WorkspaceLayoutErrorRoute({error, reset}: ErrorComponentProps) {
     void router.invalidate();
   };
   const setupError = error instanceof WorkspaceSetupLoadError;
-  const message =
-    error instanceof ApiError
-      ? error.message
-      : setupError && error.cause instanceof ApiError
-        ? error.cause.message
-        : 'Try again in a moment.';
+  let message = 'Try again in a moment.';
+  if (error instanceof ApiError) message = error.message;
+  else if (setupError && error.cause instanceof ApiError) message = error.cause.message;
   return (
     <main className="min-h-screen bg-background-subtle-base px-frame py-frame max-[520px]:px-row">
       <FocusedFrame className="flex flex-col gap-section">

--- a/libs/client/shell/src/vite/evaluate-features.ts
+++ b/libs/client/shell/src/vite/evaluate-features.ts
@@ -32,16 +32,12 @@ function loadedModuleGraph(namespaceQuery: string): {
   function visit(cachedModule: NodeJS.Module): void {
     if (visited.has(cachedModule)) return;
     visited.add(cachedModule);
-
-    for (const cacheKey of keysByModule.get(cachedModule) ?? []) {
-      const path = cacheKey.endsWith(namespaceQuery)
-        ? cacheKey.slice(0, -namespaceQuery.length)
-        : cacheKey;
-      const isLocal = !nodeModulesPathPattern.test(path);
-      if (isLocal) loadedPaths.add(path);
-      if (isLocal || cacheKey.endsWith(namespaceQuery)) cacheKeys.add(cacheKey);
-    }
-
+    recordLoadedModuleKeys(
+      keysByModule.get(cachedModule) ?? [],
+      namespaceQuery,
+      cacheKeys,
+      loadedPaths,
+    );
     for (const child of cachedModule.children) visit(child);
   }
 
@@ -50,6 +46,21 @@ function loadedModuleGraph(namespaceQuery: string): {
   }
 
   return {cacheKeys, loadedPaths};
+}
+
+function recordLoadedModuleKeys(
+  moduleKeys: readonly string[],
+  namespaceQuery: string,
+  cacheKeys: Set<string>,
+  loadedPaths: Set<string>,
+): void {
+  for (const cacheKey of moduleKeys) {
+    const namespaced = cacheKey.endsWith(namespaceQuery);
+    const path = namespaced ? cacheKey.slice(0, -namespaceQuery.length) : cacheKey;
+    const isLocal = !nodeModulesPathPattern.test(path);
+    if (isLocal) loadedPaths.add(path);
+    if (isLocal || namespaced) cacheKeys.add(cacheKey);
+  }
 }
 
 async function localFiles(paths: Iterable<string>): Promise<string[]> {
@@ -82,22 +93,13 @@ export async function evaluateFeatures(featuresModule: string): Promise<Evaluate
       {cause: error},
     );
   } finally {
-    const graph = loadedModuleGraph(namespaceQuery);
-    for (const path of graph.loadedPaths) loadedPaths.add(path);
-    for (const cacheKey of graph.cacheKeys) cacheKeys.add(cacheKey);
-    for (const cacheKey of Object.keys(require.cache)) {
-      if (initialCacheKeys.has(cacheKey)) continue;
-      const path = cacheKey.endsWith(namespaceQuery)
-        ? cacheKey.slice(0, -namespaceQuery.length)
-        : cacheKey;
-      const isLocal = !nodeModulesPathPattern.test(path);
-      if (isLocal) loadedPaths.add(path);
-      if (isLocal || cacheKey.endsWith(namespaceQuery)) cacheKeys.add(cacheKey);
-    }
-    loader.unregister();
-    for (const cacheKey of cacheKeys) delete require.cache[cacheKey];
-    for (const cacheKey of Object.keys(require.cache))
-      if (cacheKey.endsWith(namespaceQuery)) delete require.cache[cacheKey];
+    collectAndClearLoadedModules({
+      namespaceQuery,
+      initialCacheKeys,
+      loadedPaths,
+      cacheKeys,
+      unregister: () => loader.unregister(),
+    });
   }
 
   const features = module.features ?? module.default;
@@ -111,4 +113,31 @@ export async function evaluateFeatures(featuresModule: string): Promise<Evaluate
     features: features as readonly ClientFeature[],
     loadedFiles: await localFiles(loadedPaths),
   };
+}
+
+function collectAndClearLoadedModules({
+  namespaceQuery,
+  initialCacheKeys,
+  loadedPaths,
+  cacheKeys,
+  unregister,
+}: {
+  namespaceQuery: string;
+  initialCacheKeys: ReadonlySet<string>;
+  loadedPaths: Set<string>;
+  cacheKeys: Set<string>;
+  unregister: () => void;
+}): void {
+  const graph = loadedModuleGraph(namespaceQuery);
+  for (const path of graph.loadedPaths) loadedPaths.add(path);
+  for (const cacheKey of graph.cacheKeys) cacheKeys.add(cacheKey);
+  const newCacheKeys = Object.keys(require.cache).filter(
+    (cacheKey) => !initialCacheKeys.has(cacheKey),
+  );
+  recordLoadedModuleKeys(newCacheKeys, namespaceQuery, cacheKeys, loadedPaths);
+  unregister();
+  for (const cacheKey of cacheKeys) delete require.cache[cacheKey];
+  for (const cacheKey of Object.keys(require.cache)) {
+    if (cacheKey.endsWith(namespaceQuery)) delete require.cache[cacheKey];
+  }
 }

--- a/libs/client/triggers/src/components/events-filter-bar.tsx
+++ b/libs/client/triggers/src/components/events-filter-bar.tsx
@@ -55,13 +55,7 @@ export function EventsFilterBar({
 }: EventsFilterBarProps) {
   const [open, setOpen] = useState(false);
 
-  const dateRange: DateRange | undefined =
-    filters.from || filters.to
-      ? {
-          start: filters.from ? new Date(filters.from) : undefined,
-          end: filters.to ? new Date(filters.to) : undefined,
-        }
-      : undefined;
+  const dateRange = filterDateRange(filters);
 
   const selectedOutcomes = new Set(filters.outcome ?? []);
   const resultValue = RESULT_FILTERS.filter(({selects}) =>
@@ -69,11 +63,7 @@ export function EventsFilterBar({
   ).map(({value}) => value);
 
   // Count active dimensions, not selected options, so the badge stays stable as chips grow.
-  const activeCount =
-    (dateRange ? 1 : 0) +
-    (filters.source?.length ? 1 : 0) +
-    (filters.event?.length ? 1 : 0) +
-    (resultValue.length > 0 ? 1 : 0);
+  const activeCount = activeFilterCount(filters, dateRange, resultValue);
 
   function handleResultValue(values: string[]) {
     const next = RESULT_FILTERS.filter(({value}) => values.includes(value)).flatMap(
@@ -177,6 +167,24 @@ export function EventsFilterBar({
       </Collapsible>
     </PanelHeader>
   );
+}
+
+function filterDateRange(filters: TriggerEventFilters): DateRange | undefined {
+  if (!filters.from && !filters.to) return undefined;
+  return {
+    start: filters.from ? new Date(filters.from) : undefined,
+    end: filters.to ? new Date(filters.to) : undefined,
+  };
+}
+
+function activeFilterCount(
+  filters: TriggerEventFilters,
+  dateRange: DateRange | undefined,
+  resultValue: readonly string[],
+): number {
+  return [dateRange, filters.source?.length, filters.event?.length, resultValue.length].filter(
+    Boolean,
+  ).length;
 }
 
 function FilterField({

--- a/libs/client/ui/src/annotation-card.tsx
+++ b/libs/client/ui/src/annotation-card.tsx
@@ -3,7 +3,16 @@ import {Button} from '@shipfox/react-ui/button';
 import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {Markdown} from '@shipfox/react-ui/markdown';
 import {cn} from '@shipfox/react-ui/utils';
-import {type ReactNode, useEffect, useId, useRef, useState} from 'react';
+import {
+  type Dispatch,
+  type ReactNode,
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 
 /**
  * Rendered height of a body before it clamps, in pixels. The server permits 1 MiB per body and
@@ -188,58 +197,100 @@ function AnnotationCard({
       />
 
       <div className="flex min-w-0 flex-1 flex-col gap-inline">
-        {hasHeader ? (
-          <div className="flex min-w-0 items-start justify-between gap-cluster">
-            <div className="flex min-w-0 flex-col gap-tight">
-              {title ? (
-                <TitleTag className="min-w-0 break-words text-sm font-medium leading-20 text-foreground-neutral-base">
-                  {title}
-                </TitleTag>
-              ) : null}
-              {provenance}
-            </div>
-            {action ? <div className="shrink-0">{action}</div> : null}
-          </div>
-        ) : null}
-
-        {hasBody ? (
-          <div className="flex min-w-0 flex-col gap-tight">
-            <div
-              id={bodyId}
-              className={cn(
-                'relative min-w-0',
-                collapsed && 'overflow-hidden',
-                collapsed && disclosable && BODY_CLAMP_FADE,
-              )}
-              style={collapsed ? {maxHeight: maxBodyHeight} : undefined}
-              // Tabbing to a link inside a clipped body cannot scroll it into view, so reveal the
-              // body rather than move focus somewhere invisible.
-              onFocusCapture={collapsed && disclosable ? () => setExpanded(true) : undefined}
-            >
-              <div ref={contentRef}>
-                <Markdown className={cn(BODY_MEASURE, '[&>*:last-child]:mb-0')}>
-                  {rendered}
-                </Markdown>
-              </div>
-            </div>
-            {disclosable ? (
-              // The fade above it carries the "there is more" signal, so the control itself
-              // stays quiet rather than competing with the body it reveals.
-              <Button
-                type="button"
-                size="xs"
-                variant="transparent"
-                aria-expanded={expanded}
-                aria-controls={bodyId}
-                onClick={() => setExpanded((current) => !current)}
-                className="-mx-inline self-start [@media(pointer:coarse)]:min-h-44"
-              >
-                {expanded ? 'Show less' : 'Show more'}
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
+        <AnnotationHeader
+          visible={hasHeader}
+          title={title}
+          TitleTag={TitleTag}
+          provenance={provenance}
+          action={action}
+        />
+        <AnnotationBody
+          visible={hasBody}
+          bodyId={bodyId}
+          contentRef={contentRef}
+          collapsed={collapsed}
+          disclosable={disclosable}
+          maxBodyHeight={maxBodyHeight}
+          rendered={rendered}
+          expanded={expanded}
+          setExpanded={setExpanded}
+        />
       </div>
+    </div>
+  );
+}
+
+function AnnotationHeader({
+  visible,
+  title,
+  TitleTag,
+  provenance,
+  action,
+}: Pick<AnnotationCardProps, 'title' | 'provenance' | 'action'> & {
+  visible: boolean;
+  TitleTag: NonNullable<AnnotationCardProps['titleAs']>;
+}) {
+  if (!visible) return null;
+  return (
+    <div className="flex min-w-0 items-start justify-between gap-cluster">
+      <div className="flex min-w-0 flex-col gap-tight">
+        {title ? (
+          <TitleTag className="min-w-0 break-words text-sm font-medium leading-20 text-foreground-neutral-base">
+            {title}
+          </TitleTag>
+        ) : null}
+        {provenance}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}
+
+function AnnotationBody(props: {
+  visible: boolean;
+  bodyId: string;
+  contentRef: RefObject<HTMLDivElement | null>;
+  collapsed: boolean;
+  disclosable: boolean;
+  maxBodyHeight: number;
+  rendered: string;
+  expanded: boolean;
+  setExpanded: Dispatch<SetStateAction<boolean>>;
+}) {
+  if (!props.visible) return null;
+  return (
+    <div className="flex min-w-0 flex-col gap-tight">
+      <div
+        id={props.bodyId}
+        className={cn(
+          'relative min-w-0',
+          props.collapsed && 'overflow-hidden',
+          props.collapsed && props.disclosable && BODY_CLAMP_FADE,
+        )}
+        style={props.collapsed ? {maxHeight: props.maxBodyHeight} : undefined}
+        onFocusCapture={
+          props.collapsed && props.disclosable ? () => props.setExpanded(true) : undefined
+        }
+      >
+        <div ref={props.contentRef}>
+          <Markdown className={cn(BODY_MEASURE, '[&>*:last-child]:mb-0')}>
+            {props.rendered}
+          </Markdown>
+        </div>
+      </div>
+      {props.disclosable ? (
+        <Button
+          type="button"
+          size="xs"
+          variant="transparent"
+          aria-expanded={props.expanded}
+          aria-controls={props.bodyId}
+          onClick={() => props.setExpanded((current) => !current)}
+          className="-mx-inline self-start [@media(pointer:coarse)]:min-h-44"
+        >
+          {props.expanded ? 'Show less' : 'Show more'}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/libs/client/ui/src/slug-field.tsx
+++ b/libs/client/ui/src/slug-field.tsx
@@ -93,14 +93,12 @@ export function SlugField({
     (availability.value === value && availability.status === 'taken'
       ? 'This slug is already taken.'
       : undefined);
-  const liveStatus =
-    availability.value !== value
-      ? undefined
-      : availability.status === 'checking'
-        ? 'Checking availability…'
-        : availability.status === 'available'
-          ? 'Slug is available.'
-          : undefined;
+  let liveStatus: string | undefined;
+  if (availability.value === value && availability.status === 'checking') {
+    liveStatus = 'Checking availability…';
+  } else if (availability.value === value && availability.status === 'available') {
+    liveStatus = 'Slug is available.';
+  }
 
   return (
     <FormField

--- a/libs/client/workflows/src/components/identifier/identifier.tsx
+++ b/libs/client/workflows/src/components/identifier/identifier.tsx
@@ -87,19 +87,15 @@ export function Identifier({
     }
   }
 
-  const ariaLabel =
-    copyState === 'copied'
-      ? `Copied ${label} ${value}`
-      : copyState === 'failed'
-        ? `Could not copy ${label} ${value}`
-        : `Copy ${label} ${value}`;
-
-  const feedback =
-    copyState === 'copied'
-      ? {kind: copyState, label: 'Copied'}
-      : copyState === 'failed'
-        ? {kind: copyState, label: 'Could not copy'}
-        : null;
+  let ariaLabel = `Copy ${label} ${value}`;
+  let feedback: {kind: 'copied' | 'failed'; label: string} | null = null;
+  if (copyState === 'copied') {
+    ariaLabel = `Copied ${label} ${value}`;
+    feedback = {kind: copyState, label: 'Copied'};
+  } else if (copyState === 'failed') {
+    ariaLabel = `Could not copy ${label} ${value}`;
+    feedback = {kind: copyState, label: 'Could not copy'};
+  }
 
   return (
     <>

--- a/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-header.tsx
@@ -115,8 +115,15 @@ function JobDurationMeta({execution, kind}: {execution: JobExecution; kind: 'que
 
   const to = kind === 'queue' ? execution.startedAt : execution.finishedAt;
   const live = time.state === 'live';
-  const label = kind === 'queue' ? 'queued' : live ? 'running' : 'ran';
-  const tooltipLabel = kind === 'queue' ? 'Queued' : live ? 'Running' : 'Ran';
+  let label = 'ran';
+  let tooltipLabel = 'Ran';
+  if (kind === 'queue') {
+    label = 'queued';
+    tooltipLabel = 'Queued';
+  } else if (live) {
+    label = 'running';
+    tooltipLabel = 'Running';
+  }
   const tooltip = `${tooltipLabel} ${formatTimestamp(from)}${to ? ` – ${formatTimestamp(to)}` : ' – now'}`;
 
   return (

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.stories.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.stories.tsx
@@ -15,7 +15,13 @@ import {
 import {type ReactNode, useState} from 'react';
 import {userEvent, within} from 'storybook/test';
 import type {RunAnnotationSummary} from '#core/run-annotation.js';
-import type {Job, JobExecution, StepAttemptDetail, WorkflowRunDetail} from '#core/workflow-run.js';
+import type {
+  Job,
+  JobExecution,
+  Step,
+  StepAttemptDetail,
+  WorkflowRunDetail,
+} from '#core/workflow-run.js';
 import {workflowRunAnnotationsQueryKeys} from '#hooks/api/annotations.js';
 import {stepAttemptDetailQueryKeys} from '#hooks/api/step-attempt-detail.js';
 import type {useWorkflowRunAttemptQuery} from '#hooks/api/workflow-runs.js';
@@ -265,56 +271,76 @@ function StoryQueryProvider({
   stepDetails?: readonly StepAttemptDetail[];
   children: ReactNode;
 }) {
-  const [queryClient] = useState(() => {
-    const client = new QueryClient({
-      defaultOptions: {queries: {staleTime: Number.POSITIVE_INFINITY}},
-    });
-    if (run) {
-      for (const job of run.jobs) {
-        for (const execution of job.jobExecutions) {
-          for (const step of execution.steps) {
-            for (const attempt of step.attempts) {
-              client.setQueryData<StepLogSnapshot>(
-                stepLogsQueryKeys.detail(step.id, attempt.attempt),
-                storyLogSnapshot(),
-              );
-            }
-          }
-        }
-      }
-      client.setQueryData(workflowRunsQueryKeys.detail(run.id), run);
-      for (const detail of stepDetails) {
-        client.setQueryData(
-          stepAttemptDetailQueryKeys.detail(detail.stepId, detail.attempt),
-          detail,
-        );
-      }
-      const summary: RunAnnotationSummary = {
-        total: 0,
-        error: 0,
-        warning: 0,
-        info: 0,
-        success: 0,
-        truncated: false,
-        stepCounts: [],
-      };
-      for (const job of run.jobs) {
-        for (const execution of job.jobExecutions) {
-          client.setQueryData(
-            workflowRunAnnotationsQueryKeys.summary(run.id, run.runAttempt.attempt, execution.id),
-            summary,
-          );
-        }
-      }
-      client.setQueryData(
-        workflowRunAnnotationsQueryKeys.summary(run.id, run.runAttempt.attempt),
-        summary,
-      );
-    }
-    return client;
-  });
+  const [queryClient] = useState(() => createStoryQueryClient(run, stepDetails));
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function createStoryQueryClient(
+  run: WorkflowRunDetail | undefined,
+  stepDetails: readonly StepAttemptDetail[],
+) {
+  const client = new QueryClient({
+    defaultOptions: {queries: {staleTime: Number.POSITIVE_INFINITY}},
+  });
+  if (!run) return client;
+  seedStoryLogs(client, run);
+  client.setQueryData(workflowRunsQueryKeys.detail(run.id), run);
+  for (const detail of stepDetails) {
+    client.setQueryData(stepAttemptDetailQueryKeys.detail(detail.stepId, detail.attempt), detail);
+  }
+  seedStoryAnnotationSummaries(client, run);
+  return client;
+}
+
+function seedStoryLogs(client: QueryClient, run: WorkflowRunDetail): void {
+  for (const job of run.jobs) seedJobLogs(client, job);
+}
+
+function seedJobLogs(client: QueryClient, job: Job): void {
+  for (const execution of job.jobExecutions) seedExecutionLogs(client, execution);
+}
+
+function seedExecutionLogs(client: QueryClient, execution: JobExecution): void {
+  for (const step of execution.steps) {
+    for (const attempt of step.attempts) {
+      client.setQueryData<StepLogSnapshot>(
+        stepLogsQueryKeys.detail(step.id, attempt.attempt),
+        storyLogSnapshot(),
+      );
+    }
+  }
+}
+
+function seedStoryAnnotationSummaries(client: QueryClient, run: WorkflowRunDetail): void {
+  const summary: RunAnnotationSummary = {
+    total: 0,
+    error: 0,
+    warning: 0,
+    info: 0,
+    success: 0,
+    truncated: false,
+    stepCounts: [],
+  };
+  for (const job of run.jobs) seedJobAnnotationSummaries(client, run, job, summary);
+  client.setQueryData(
+    workflowRunAnnotationsQueryKeys.summary(run.id, run.runAttempt.attempt),
+    summary,
+  );
+}
+
+function seedJobAnnotationSummaries(
+  client: QueryClient,
+  run: WorkflowRunDetail,
+  job: Job,
+  summary: RunAnnotationSummary,
+): void {
+  for (const execution of job.jobExecutions) {
+    client.setQueryData(
+      workflowRunAnnotationsQueryKeys.summary(run.id, run.runAttempt.attempt, execution.id),
+      summary,
+    );
+  }
 }
 
 function storyLogSnapshot(): StepLogSnapshot {
@@ -858,58 +884,63 @@ function storyRun({
         timed_out_at: execution.timedOutAt,
         created_at: execution.createdAt,
         updated_at: execution.updatedAt,
-        steps: execution.steps.map((step) => ({
-          id: step.id,
-          job_execution_id: step.jobExecutionId,
-          key: step.key,
-          name: step.name,
-          source_location: null,
-          status: step.status,
-          type: step.type,
-          config: step.config,
-          evaluation_trace: step.evaluationTrace,
-          error: step.error
-            ? {
-                message: step.error.message,
-                ...(step.error.exitCode !== null ? {exit_code: step.error.exitCode} : {}),
-                ...(step.error.signal ? {signal: step.error.signal} : {}),
-                ...(step.error.reason ? {reason: step.error.reason} : {}),
-                ...(step.error.agentConfigIssue
-                  ? {agent_config_issue: step.error.agentConfigIssue}
-                  : {}),
-                ...(step.error.category ? {category: step.error.category} : {}),
-              }
-            : null,
-          position: step.position,
-          current_attempt: step.currentAttempt,
-          exit_code: null,
-          outputs: null,
-          response: null,
-          gate_result: null,
-          created_at: step.createdAt,
-          updated_at: step.updatedAt,
-          attempts: step.attempts.map((attempt) => ({
-            id: attempt.id,
-            step_id: attempt.stepId,
-            attempt: attempt.attempt,
-            execution_order: attempt.executionOrder,
-            status: attempt.status,
-            exit_code: attempt.exitCode,
-            output: attempt.output,
-            outputs: attempt.outputs,
-            response: attempt.response,
-            error: attempt.error,
-            gate_result: null,
-            restart_feedback: attempt.restartFeedback,
-            started_at: attempt.startedAt,
-            finished_at: attempt.finishedAt,
-          })),
-        })),
+        steps: execution.steps.map(storyStepDto),
       })),
       outputs: job.outputs ?? job.jobExecutions[0]?.outputs ?? null,
       resolution_reason: job.resolutionReason,
     })),
   });
+}
+
+function storyStepDto(step: Step) {
+  return {
+    id: step.id,
+    job_execution_id: step.jobExecutionId,
+    key: step.key,
+    name: step.name,
+    source_location: null,
+    status: step.status,
+    type: step.type,
+    config: step.config,
+    evaluation_trace: step.evaluationTrace,
+    error: storyStepErrorDto(step),
+    position: step.position,
+    current_attempt: step.currentAttempt,
+    exit_code: null,
+    outputs: null,
+    response: null,
+    gate_result: null,
+    created_at: step.createdAt,
+    updated_at: step.updatedAt,
+    attempts: step.attempts.map((attempt) => ({
+      id: attempt.id,
+      step_id: attempt.stepId,
+      attempt: attempt.attempt,
+      execution_order: attempt.executionOrder,
+      status: attempt.status,
+      exit_code: attempt.exitCode,
+      output: attempt.output,
+      outputs: attempt.outputs,
+      response: attempt.response,
+      error: attempt.error,
+      gate_result: null,
+      restart_feedback: attempt.restartFeedback,
+      started_at: attempt.startedAt,
+      finished_at: attempt.finishedAt,
+    })),
+  };
+}
+
+function storyStepErrorDto(step: Step) {
+  if (!step.error) return null;
+  return {
+    message: step.error.message,
+    ...(step.error.exitCode !== null ? {exit_code: step.error.exitCode} : {}),
+    ...(step.error.signal ? {signal: step.error.signal} : {}),
+    ...(step.error.reason ? {reason: step.error.reason} : {}),
+    ...(step.error.agentConfigIssue ? {agent_config_issue: step.error.agentConfigIssue} : {}),
+    ...(step.error.category ? {category: step.error.category} : {}),
+  };
 }
 
 function makeJob({

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -20,7 +20,7 @@ import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
-import {type RefObject, useCallback, useEffect, useRef, useState} from 'react';
+import {type ReactNode, type RefObject, useCallback, useEffect, useRef, useState} from 'react';
 import type {RunAnnotationSummary} from '#core/run-annotation.js';
 import {summarizeJobAnnotations} from '#core/run-annotation.js';
 import {isWorkflowRunTerminal, type Job, type JobExecution} from '#core/workflow-run.js';
@@ -100,11 +100,7 @@ export function JobDetailView({
     workflowRunId,
     runAttempt: query.data?.runAttempt.attempt,
   });
-  const jobAnnotationSummary = annotations.annotations
-    ? summarizeJobAnnotations(annotations.annotations, jobId, {
-        truncated: annotations.summary?.truncated ?? false,
-      })
-    : undefined;
+  const jobAnnotationSummary = summarizeLoadedJobAnnotations(annotations, jobId);
   const inspectorResetKey = `${jobId}:${search.jobExecutionId ?? ''}`;
   const [inspectorState, setInspectorState] = useState<InspectorState>(() => ({
     key: inspectorResetKey,
@@ -112,13 +108,8 @@ export function JobDetailView({
   }));
   const inspectorOpenAttemptId =
     inspectorState.key === inspectorResetKey ? inspectorState.attemptId : null;
-  const annotationJob = query.data?.jobs.find((candidate) => candidate.id === jobId);
-  const annotationExecutionId = annotationJob
-    ? resolveWorkflowJobSelection({job: annotationJob, selection: search}).jobExecution?.id
-    : search.jobExecutionId;
-  const annotationPolling = query.data
-    ? !isWorkflowRunTerminal(query.data.runAttempt.status)
-    : true;
+  const annotationExecutionId = resolveAnnotationExecutionId(query.data, jobId, search);
+  const annotationPolling = shouldPollJobAnnotations(query.data);
   const annotationSummaryQuery = useWorkflowRunAnnotationSummaryQuery(
     query.data?.id,
     query.data?.runAttempt.attempt,
@@ -141,18 +132,10 @@ export function JobDetailView({
     });
   }, []);
 
-  if (query.isPending) return <JobDetailSkeleton />;
+  const queryBoundary = jobDetailQueryBoundary(query);
+  if (queryBoundary !== undefined) return queryBoundary;
 
-  if (query.isError && query.data === undefined) {
-    if (query.error instanceof ApiError && query.error.status === 404) {
-      return <WorkflowRunNotFound />;
-    }
-    return <QueryLoadError query={query} subject="workflow run" icon="pulseLine" />;
-  }
-
-  if (query.data === undefined) return <JobDetailSkeleton />;
-
-  const run = query.data;
+  const run = query.data as NonNullable<typeof query.data>;
   const job = run.jobs.find((candidate) => candidate.id === jobId);
   if (!job) {
     return (
@@ -165,60 +148,25 @@ export function JobDetailView({
     );
   }
 
-  const resolvedSelection = resolveWorkflowJobSelection({job, selection: search});
-  const selectedJobExecution = resolvedSelection.jobExecution;
-  const hasExplicitStep = Boolean(search.stepId && resolvedSelection.step);
-  const stepListModel = buildStepListModel({job, jobExecution: selectedJobExecution});
-  const currentLandingSelection = workflowJobLandingSelection(selectedJobExecution);
-  if (selectedJobExecution) {
-    const frozenLanding = landingSelectionRef.current;
-    if (
-      !frozenLanding ||
-      frozenLanding.jobId !== job.id ||
-      frozenLanding.jobExecutionId !== selectedJobExecution.id
-    ) {
-      landingSelectionRef.current = {
-        jobId: job.id,
-        jobExecutionId: selectedJobExecution.id,
-        selection: currentLandingSelection,
-        hasSelection: currentLandingSelection !== undefined,
-      };
-    } else if (!frozenLanding.hasSelection && currentLandingSelection) {
-      landingSelectionRef.current = {
-        ...frozenLanding,
-        selection: currentLandingSelection,
-        hasSelection: true,
-      };
-    }
-  } else {
-    landingSelectionRef.current = undefined;
-  }
-  const landingSelection = landingSelectionRef.current?.selection;
-  const selectedAttemptId = hasExplicitStep ? resolvedSelection.selectedAttemptId : undefined;
-  const runningSelection = runningStepSelection(selectedJobExecution, stepListModel);
-  const selectedStepId = resolvedSelection.step?.id ?? landingSelection?.stepId;
-  const selectedAttemptForNotice = hasExplicitStep
-    ? resolvedSelection.selectedAttemptId
-    : landingSelection?.attemptId;
-  const expandedLogSelection = findExpandedLogSelection(
-    selectedJobExecution,
+  const detailState = resolveJobDetailState({
+    job,
+    search,
+    landingSelectionRef,
     expandedLogAttemptIds,
-    stepListModel,
-  );
-  const selectedLogStep = expandedLogSelection?.step;
-  const selectedLogAttempt = expandedLogSelection?.attempt;
-  const selectedLogStatus = selectedLogAttempt?.status ?? selectedLogStep?.status;
-  const logIsFetching = Boolean(
-    selectedLogAttempt && logFetchingByAttemptId[selectedLogAttempt.id],
-  );
-  const showRetargetNotice =
-    runningSelection !== undefined &&
-    (selectedStepId !== runningSelection.stepId ||
-      selectedAttemptForNotice !== runningSelection.attemptId);
-  const succeededSummary =
-    !hasExplicitStep && landingSelection === undefined && selectedJobExecution
-      ? jobSucceededSummary(job, selectedJobExecution)
-      : undefined;
+    logFetchingByAttemptId,
+  });
+  const {
+    selectedJobExecution,
+    landingSelection,
+    selectedAttemptId,
+    runningSelection,
+    expandedLogSelection,
+    selectedLogAttempt,
+    selectedLogStatus,
+    logIsFetching,
+    showRetargetNotice,
+    succeededSummary,
+  } = detailState;
 
   function selectExecution(jobExecutionId: string) {
     onSelectionChange({
@@ -408,6 +356,46 @@ export function JobDetailView({
       </div>
     </TimeTickerProvider>
   );
+}
+
+function summarizeLoadedJobAnnotations(
+  annotations: ReturnType<typeof useRunAnnotationsQuery>,
+  jobId: string,
+): RunAnnotationSummary | undefined {
+  if (!annotations.annotations) return undefined;
+  return summarizeJobAnnotations(annotations.annotations, jobId, {
+    truncated: annotations.summary?.truncated ?? false,
+  });
+}
+
+function resolveAnnotationExecutionId(
+  run: ReturnType<typeof useWorkflowRunAttemptQuery>['data'],
+  jobId: string,
+  search: WorkflowJobSearch,
+): string | undefined {
+  const job = run?.jobs.find((candidate) => candidate.id === jobId);
+  if (!job) return search.jobExecutionId;
+  return resolveWorkflowJobSelection({job, selection: search}).jobExecution?.id;
+}
+
+function shouldPollJobAnnotations(
+  run: ReturnType<typeof useWorkflowRunAttemptQuery>['data'],
+): boolean {
+  if (!run) return true;
+  return !isWorkflowRunTerminal(run.runAttempt.status);
+}
+
+function jobDetailQueryBoundary(
+  query: ReturnType<typeof useWorkflowRunAttemptQuery>,
+): ReactNode | undefined {
+  if (query.isPending || query.data === undefined) {
+    if (!query.isError) return <JobDetailSkeleton />;
+  }
+  if (!query.isError || query.data !== undefined) return undefined;
+  if (query.error instanceof ApiError && query.error.status === 404) {
+    return <WorkflowRunNotFound />;
+  }
+  return <QueryLoadError query={query} subject="workflow run" icon="pulseLine" />;
 }
 
 function ExpandedStep({
@@ -690,6 +678,117 @@ function annotationCountForStep(
 ): number | undefined {
   return summary?.stepCounts?.find((entry) => entry.stepId === stepId && entry.attempt === attempt)
     ?.total;
+}
+
+function resolveJobDetailState({
+  job,
+  search,
+  landingSelectionRef,
+  expandedLogAttemptIds,
+  logFetchingByAttemptId,
+}: {
+  job: Job;
+  search: WorkflowJobSearch;
+  landingSelectionRef: {current: FrozenLandingSelection | undefined};
+  expandedLogAttemptIds: readonly string[];
+  logFetchingByAttemptId: Readonly<Record<string, boolean>>;
+}) {
+  const resolvedSelection = resolveWorkflowJobSelection({job, selection: search});
+  const selectedJobExecution = resolvedSelection.jobExecution;
+  const hasExplicitStep = Boolean(search.stepId && resolvedSelection.step);
+  const stepListModel = buildStepListModel({job, jobExecution: selectedJobExecution});
+  updateFrozenLandingSelection(
+    landingSelectionRef,
+    job,
+    selectedJobExecution,
+    workflowJobLandingSelection(selectedJobExecution),
+  );
+  const landingSelection = landingSelectionRef.current?.selection;
+  const selectedAttemptId = hasExplicitStep ? resolvedSelection.selectedAttemptId : undefined;
+  const runningSelection = runningStepSelection(selectedJobExecution, stepListModel);
+  const selectedStepId = resolvedSelection.step?.id ?? landingSelection?.stepId;
+  const selectedAttemptForNotice = hasExplicitStep
+    ? resolvedSelection.selectedAttemptId
+    : landingSelection?.attemptId;
+  const expandedLogSelection = findExpandedLogSelection(
+    selectedJobExecution,
+    expandedLogAttemptIds,
+    stepListModel,
+  );
+  const selectedLogAttempt = expandedLogSelection?.attempt;
+  const selectedLogStatus = selectedLogAttempt?.status ?? expandedLogSelection?.step.status;
+  const logIsFetching = Boolean(
+    selectedLogAttempt && logFetchingByAttemptId[selectedLogAttempt.id],
+  );
+  const showRetargetNotice = shouldShowRetargetNotice(
+    runningSelection,
+    selectedStepId,
+    selectedAttemptForNotice,
+  );
+  const succeededSummary = successfulJobSummary(
+    job,
+    selectedJobExecution,
+    hasExplicitStep,
+    landingSelection,
+  );
+  return {
+    selectedJobExecution,
+    landingSelection,
+    selectedAttemptId,
+    runningSelection,
+    expandedLogSelection,
+    selectedLogAttempt,
+    selectedLogStatus,
+    logIsFetching,
+    showRetargetNotice,
+    succeededSummary,
+  };
+}
+
+function updateFrozenLandingSelection(
+  ref: {current: FrozenLandingSelection | undefined},
+  job: Job,
+  execution: JobExecution | undefined,
+  currentSelection: WorkflowJobLandingSelection | undefined,
+): void {
+  if (!execution) {
+    ref.current = undefined;
+    return;
+  }
+  const frozen = ref.current;
+  if (!frozen || frozen.jobId !== job.id || frozen.jobExecutionId !== execution.id) {
+    ref.current = {
+      jobId: job.id,
+      jobExecutionId: execution.id,
+      selection: currentSelection,
+      hasSelection: currentSelection !== undefined,
+    };
+    return;
+  }
+  if (!frozen.hasSelection && currentSelection) {
+    ref.current = {...frozen, selection: currentSelection, hasSelection: true};
+  }
+}
+
+function shouldShowRetargetNotice(
+  runningSelection: ReturnType<typeof runningStepSelection>,
+  selectedStepId: string | undefined,
+  selectedAttemptId: string | null | undefined,
+): boolean {
+  if (!runningSelection) return false;
+  return (
+    selectedStepId !== runningSelection.stepId || selectedAttemptId !== runningSelection.attemptId
+  );
+}
+
+function successfulJobSummary(
+  job: Job,
+  execution: JobExecution | undefined,
+  hasExplicitStep: boolean,
+  landingSelection: WorkflowJobLandingSelection | undefined,
+): string | undefined {
+  if (hasExplicitStep || landingSelection !== undefined || !execution) return undefined;
+  return jobSucceededSummary(job, execution);
 }
 
 function JobDetailSkeleton() {

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -272,34 +272,16 @@ export function toSelectedAttemptError(
 ): StepError | null {
   if (error === null) return null;
 
-  const rawReason = error.reason;
-  const parsedReason =
-    typeof rawReason === 'string' &&
-    STEP_ERROR_REASONS.has(rawReason as StepError['reason'] & string)
-      ? (rawReason as NonNullable<StepError['reason']>)
-      : undefined;
+  const parsedReason = parsedStepErrorReason(error.reason);
   const rawAgentConfigIssue = error.agentConfigIssue ?? error.agent_config_issue;
-  const agentConfigIssue =
-    typeof rawAgentConfigIssue === 'string' &&
-    AGENT_CONFIG_ISSUES.has(rawAgentConfigIssue as NonNullable<StepError['agentConfigIssue']>)
-      ? (rawAgentConfigIssue as NonNullable<StepError['agentConfigIssue']>)
-      : undefined;
+  const agentConfigIssue = parsedAgentConfigIssue(rawAgentConfigIssue);
   const exitCode = error.exitCode ?? error.exit_code;
-  const resolvedReason = parsedReason
-    ? parsedReason
-    : agentConfigIssue
-      ? 'agent_config_invalid'
-      : undefined;
+  const resolvedReason = parsedReason ?? (agentConfigIssue ? 'agent_config_invalid' : undefined);
 
   if (resolvedReason === undefined) return null;
 
   const code = typeof error.code === 'string' ? error.code : undefined;
-  const managedProviderId =
-    typeof error.managedProviderId === 'string'
-      ? error.managedProviderId
-      : typeof error.managed_provider_id === 'string'
-        ? error.managed_provider_id
-        : undefined;
+  const managedProviderId = selectedManagedProviderId(error);
 
   return {
     message: typeof error.message === 'string' ? error.message : '',
@@ -311,6 +293,27 @@ export function toSelectedAttemptError(
     agentConfigIssue,
     category: deriveStepErrorCategory(step.type, resolvedReason),
   };
+}
+
+function parsedStepErrorReason(value: unknown): NonNullable<StepError['reason']> | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (!STEP_ERROR_REASONS.has(value as StepError['reason'] & string)) return undefined;
+  return value as NonNullable<StepError['reason']>;
+}
+
+function parsedAgentConfigIssue(
+  value: unknown,
+): NonNullable<StepError['agentConfigIssue']> | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (!AGENT_CONFIG_ISSUES.has(value as NonNullable<StepError['agentConfigIssue']>))
+    return undefined;
+  return value as NonNullable<StepError['agentConfigIssue']>;
+}
+
+function selectedManagedProviderId(error: Record<string, unknown>): string | undefined {
+  if (typeof error.managedProviderId === 'string') return error.managedProviderId;
+  if (typeof error.managed_provider_id === 'string') return error.managed_provider_id;
+  return undefined;
 }
 
 export function isAgentConfigFailure(step: Step, error: StepError | null): boolean {

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -52,7 +52,7 @@ export function StepAttemptLogPanel({
 }: StepAttemptLogPanelProps) {
   const shouldFollowTailRef = useRef(true);
   const missingStreamRetryCount = attemptStatus === 'running' ? undefined : initialErrorRetryCount;
-  const retryMissingStream = attemptStatus === 'running' || isTerminalAttemptStatus(attemptStatus);
+  const retryMissingStream = shouldRetryMissingStream(attemptStatus);
   const query = useStepAttemptLogsQuery(stepId, attempt, {
     retryMissingStream,
     missingStreamRetryCount,
@@ -167,11 +167,15 @@ export function StepAttemptLogPanel({
         showLineNumbers={showLineNumbers}
         emptyState={query.data?.complete ? 'complete' : 'pending'}
         anchorToFailure={anchorToFailure}
-        ariaLive={search.trim() ? 'off' : attemptStatus === 'running' ? 'polite' : 'off'}
+        ariaLive={!search.trim() && attemptStatus === 'running' ? 'polite' : 'off'}
         className={surfaceClassName}
       />
     </div>
   );
+}
+
+function shouldRetryMissingStream(attemptStatus: string): boolean {
+  return attemptStatus === 'running' || isTerminalAttemptStatus(attemptStatus);
 }
 
 function StepLogsLoadingSurface({

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -183,16 +183,7 @@ function StepInspector({
   annotationCount: number | undefined;
 }) {
   const detail = query.data;
-  const trace = detail?.evaluationTrace ?? null;
-  const resolvedConfig = detail?.config ?? null;
-  const hasInputs =
-    detail !== undefined &&
-    (countConfigValues(detail.authoredConfig) > 0 || countConfigValues(resolvedConfig) > 0);
-  const hasOutputs =
-    attempt.outputs !== null || attempt.output !== null || attempt.response !== null;
-  const hasTrace = trace !== null && trace.length > 0;
   const hasAnnotations = annotationCount !== undefined && annotationCount > 0;
-  const detailCount = Number(hasInputs) + Number(hasOutputs) + Number(hasTrace);
 
   return (
     <div className="flex min-w-0 flex-col gap-section">
@@ -207,65 +198,13 @@ function StepInspector({
           runAttempt={runAttempt}
         />
       ) : null}
-      {query.isPending ? <InspectorLoading /> : null}
-      {query.isError ? (
-        <Callout
-          role="alert"
-          type="warning"
-          variant="secondary"
-          className="rounded-8 border border-tag-warning-border p-panel-compact shadow-none"
-        >
-          <CalloutContent>
-            <CalloutTitle>Details unavailable</CalloutTitle>
-            <CalloutDescription className="flex items-center justify-between gap-inline">
-              <span>We could not load the resolved configuration for this attempt.</span>
-              <Button
-                type="button"
-                size="2xs"
-                variant="secondary"
-                onClick={() => void query.refetch()}
-              >
-                Retry
-              </Button>
-            </CalloutDescription>
-          </CalloutContent>
-        </Callout>
-      ) : null}
-      {detail ? (
-        <div className="flex min-w-0 flex-col gap-group">
-          {hasInputs ? (
-            <InspectorSection title="Inputs">
-              <ConfigCode authoredConfig={detail.authoredConfig} resolvedConfig={resolvedConfig} />
-            </InspectorSection>
-          ) : null}
-          {hasOutputs ? (
-            <InspectorSection title="Outputs">
-              {attempt.outputs !== null || attempt.output !== null ? (
-                <JsonCode
-                  value={attempt.outputs ?? attempt.output ?? {}}
-                  emptyMessage="No outputs declared; the `outputs:` mapping is empty."
-                />
-              ) : null}
-              {attempt.response !== null ? (
-                <div className="flex min-w-0 flex-col gap-tight">
-                  <Text size="xs" className="text-foreground-neutral-muted">
-                    Response
-                  </Text>
-                  <pre className="max-h-160 min-w-0 overflow-auto rounded-6 border border-border-neutral-base bg-background-neutral-subtle p-tight font-code text-xs leading-18 text-foreground-neutral-muted scrollbar">
-                    {attempt.response}
-                  </pre>
-                </div>
-              ) : null}
-            </InspectorSection>
-          ) : null}
-          {hasTrace ? (
-            <InspectorSection title="Evaluation">
-              <EvaluationTrace trace={trace ?? []} />
-            </InspectorSection>
-          ) : null}
-          {detailCount === 0 && !showFailure && !hasAnnotations ? <EmptyInspector /> : null}
-        </div>
-      ) : null}
+      <InspectorQueryContent
+        query={query}
+        detail={detail}
+        attempt={attempt}
+        showFailure={showFailure}
+        hasAnnotations={hasAnnotations}
+      />
       {hasAnnotations ? (
         <Link
           to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
@@ -280,6 +219,118 @@ function StepInspector({
         <EmptyInspector />
       ) : null}
     </div>
+  );
+}
+
+function InspectorQueryContent({
+  query,
+  detail,
+  attempt,
+  showFailure,
+  hasAnnotations,
+}: {
+  query: ReturnType<typeof useStepAttemptDetailQuery>;
+  detail: ReturnType<typeof useStepAttemptDetailQuery>['data'];
+  attempt: StepAttempt;
+  showFailure: boolean;
+  hasAnnotations: boolean;
+}) {
+  if (query.isPending) return <InspectorLoading />;
+  if (query.isError) {
+    return (
+      <Callout
+        role="alert"
+        type="warning"
+        variant="secondary"
+        className="rounded-8 border border-tag-warning-border p-panel-compact shadow-none"
+      >
+        <CalloutContent>
+          <CalloutTitle>Details unavailable</CalloutTitle>
+          <CalloutDescription className="flex items-center justify-between gap-inline">
+            <span>We could not load the resolved configuration for this attempt.</span>
+            <Button
+              type="button"
+              size="2xs"
+              variant="secondary"
+              onClick={() => void query.refetch()}
+            >
+              Retry
+            </Button>
+          </CalloutDescription>
+        </CalloutContent>
+      </Callout>
+    );
+  }
+  if (!detail) {
+    return showFailure || hasAnnotations ? null : <EmptyInspector />;
+  }
+  return (
+    <InspectorDetailContent
+      detail={detail}
+      attempt={attempt}
+      showFailure={showFailure}
+      hasAnnotations={hasAnnotations}
+    />
+  );
+}
+
+function InspectorDetailContent({
+  detail,
+  attempt,
+  showFailure,
+  hasAnnotations,
+}: {
+  detail: NonNullable<ReturnType<typeof useStepAttemptDetailQuery>['data']>;
+  attempt: StepAttempt;
+  showFailure: boolean;
+  hasAnnotations: boolean;
+}) {
+  const trace = detail.evaluationTrace ?? null;
+  const resolvedConfig = detail.config ?? null;
+  const hasInputs =
+    countConfigValues(detail.authoredConfig) > 0 || countConfigValues(resolvedConfig) > 0;
+  const hasOutputs =
+    attempt.outputs !== null || attempt.output !== null || attempt.response !== null;
+  const hasTrace = trace !== null && trace.length > 0;
+  const detailCount = Number(hasInputs) + Number(hasOutputs) + Number(hasTrace);
+  return (
+    <div className="flex min-w-0 flex-col gap-group">
+      {hasInputs ? (
+        <InspectorSection title="Inputs">
+          <ConfigCode authoredConfig={detail.authoredConfig} resolvedConfig={resolvedConfig} />
+        </InspectorSection>
+      ) : null}
+      {hasOutputs ? <InspectorOutputs attempt={attempt} /> : null}
+      {hasTrace ? (
+        <InspectorSection title="Evaluation">
+          <EvaluationTrace trace={trace ?? []} />
+        </InspectorSection>
+      ) : null}
+      {detailCount === 0 && !showFailure && !hasAnnotations ? <EmptyInspector /> : null}
+    </div>
+  );
+}
+
+function InspectorOutputs({attempt}: {attempt: StepAttempt}) {
+  return (
+    <InspectorSection title="Outputs">
+      {attempt.outputs !== null || attempt.output !== null ? (
+        <JsonCode
+          value={attempt.outputs ?? attempt.output ?? {}}
+          emptyMessage="No outputs declared; the `outputs:` mapping is empty."
+        />
+      ) : null}
+      {attempt.response !== null ? (
+        <div className="flex min-w-0 flex-col gap-tight">
+          <Text size="xs" className="text-foreground-neutral-muted">
+            Response
+          </Text>
+          <pre className="max-h-160 min-w-0 overflow-auto rounded-6 border border-border-neutral-base bg-background-neutral-subtle p-tight font-code text-xs leading-18 text-foreground-neutral-muted scrollbar">
+            {attempt.response}
+          </pre>
+        </div>
+      ) : null}
+    </InspectorSection>
   );
 }
 
@@ -331,56 +382,57 @@ export function EvaluationTrace({trace}: {trace: readonly EvaluationTraceEntry[]
 
   return (
     <dl className="flex min-w-0 flex-col divide-y divide-border-neutral-base rounded-6 border border-border-neutral-base">
-      {trace.map((entry) => {
-        if ('dropped' in entry) {
-          const keyBase = `limit-${entry.dropped}`;
-          const occurrence = keyCounts.get(keyBase) ?? 0;
-          keyCounts.set(keyBase, occurrence + 1);
-          return (
-            <div
-              key={`${keyBase}-${occurrence}`}
-              className="px-row py-row text-xs text-foreground-neutral-muted"
-            >
-              {entry.dropped} more evaluation{entry.dropped === 1 ? '' : 's'} not recorded
-            </div>
-          );
-        }
-
-        const empty = entry.value === undefined || entry.value === '';
-        const keyBase = `evaluation-${entry.field}-${entry.expression}-${entry.evaluatedAt}-${entry.fillTarget}`;
-        const occurrence = keyCounts.get(keyBase) ?? 0;
-        keyCounts.set(keyBase, occurrence + 1);
-        return (
-          <div
-            key={`${keyBase}-${occurrence}`}
-            className={cn(
-              'grid min-w-0 grid-cols-1 gap-inline px-row py-row min-[768px]:grid-cols-[160px_minmax(0,1fr)]',
-              entry.degraded && 'border-l border-tag-error-icon',
-            )}
-          >
-            <dt
-              className="flex min-w-0 flex-col gap-tight font-code text-xs text-foreground-neutral-muted"
-              title={entry.field}
-            >
-              <span className="block truncate">{entry.field}</span>
-              <span className="block break-all text-foreground-neutral-subtle">
-                {entry.expression}
-              </span>
-            </dt>
-            <dd className="flex min-w-0 flex-col gap-tight text-xs text-foreground-neutral-base">
-              {entry.degraded ? <span className="sr-only">Degraded evaluation</span> : null}
-              <div className="break-words font-code">
-                {empty ? <span className="text-tag-error-text">(empty)</span> : entry.value}
-              </div>
-              <div className="flex min-w-0 flex-wrap gap-x-inline gap-y-tight text-foreground-neutral-muted">
-                {entry.degraded ? <span className="text-tag-error-text">degraded</span> : null}
-                {entry.truncated || entry.exprTruncated ? <span>truncated</span> : null}
-              </div>
-            </dd>
-          </div>
-        );
-      })}
+      {trace.map((entry) => (
+        <EvaluationTraceRow entry={entry} key={evaluationTraceKey(entry, keyCounts)} />
+      ))}
     </dl>
+  );
+}
+
+function evaluationTraceKey(entry: EvaluationTraceEntry, keyCounts: Map<string, number>): string {
+  const keyBase =
+    'dropped' in entry
+      ? `limit-${entry.dropped}`
+      : `evaluation-${entry.field}-${entry.expression}-${entry.evaluatedAt}-${entry.fillTarget}`;
+  const occurrence = keyCounts.get(keyBase) ?? 0;
+  keyCounts.set(keyBase, occurrence + 1);
+  return `${keyBase}-${occurrence}`;
+}
+
+function EvaluationTraceRow({entry}: {entry: EvaluationTraceEntry}) {
+  if ('dropped' in entry) {
+    return (
+      <div className="px-row py-row text-xs text-foreground-neutral-muted">
+        {entry.dropped} more evaluation{entry.dropped === 1 ? '' : 's'} not recorded
+      </div>
+    );
+  }
+  const empty = entry.value === undefined || entry.value === '';
+  return (
+    <div
+      className={cn(
+        'grid min-w-0 grid-cols-1 gap-inline px-row py-row min-[768px]:grid-cols-[160px_minmax(0,1fr)]',
+        entry.degraded && 'border-l border-tag-error-icon',
+      )}
+    >
+      <dt
+        className="flex min-w-0 flex-col gap-tight font-code text-xs text-foreground-neutral-muted"
+        title={entry.field}
+      >
+        <span className="block truncate">{entry.field}</span>
+        <span className="block break-all text-foreground-neutral-subtle">{entry.expression}</span>
+      </dt>
+      <dd className="flex min-w-0 flex-col gap-tight text-xs text-foreground-neutral-base">
+        {entry.degraded ? <span className="sr-only">Degraded evaluation</span> : null}
+        <div className="break-words font-code">
+          {empty ? <span className="text-tag-error-text">(empty)</span> : entry.value}
+        </div>
+        <div className="flex min-w-0 flex-wrap gap-x-inline gap-y-tight text-foreground-neutral-muted">
+          {entry.degraded ? <span className="text-tag-error-text">degraded</span> : null}
+          {entry.truncated || entry.exprTruncated ? <span>truncated</span> : null}
+        </div>
+      </dd>
+    </div>
   );
 }
 

--- a/libs/client/workflows/src/components/job-graph/job-node.test.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.test.tsx
@@ -22,9 +22,12 @@ type NodeOverrides = Omit<Partial<WorkflowRunJobDetailDto>, 'job_executions'> & 
 
 function makeNode(overrides: NodeOverrides): JobGraphNode {
   const {queued_at, started_at, finished_at, job_executions, ...jobOverrides} = overrides;
-  const shouldCreateExecution =
-    job_executions === undefined &&
-    (queued_at !== undefined || started_at !== undefined || finished_at !== undefined);
+  const shouldCreateExecution = needsSyntheticExecution({
+    jobExecutions: job_executions,
+    queuedAt: queued_at,
+    startedAt: started_at,
+    finishedAt: finished_at,
+  });
   const jobOverrideWithExecutions: NodeOverrides = {...jobOverrides};
   if (shouldCreateExecution) {
     jobOverrideWithExecutions.job_executions = [
@@ -50,6 +53,21 @@ function makeNode(overrides: NodeOverrides): JobGraphNode {
     row: 0,
     currentDependencyCount: 0,
   });
+}
+
+function needsSyntheticExecution({
+  jobExecutions,
+  queuedAt,
+  startedAt,
+  finishedAt,
+}: {
+  jobExecutions: WorkflowRunJobDetailDto['job_executions'] | undefined;
+  queuedAt: string | null | undefined;
+  startedAt: string | null | undefined;
+  finishedAt: string | null | undefined;
+}): boolean {
+  if (jobExecutions !== undefined) return false;
+  return queuedAt !== undefined || startedAt !== undefined || finishedAt !== undefined;
 }
 
 function renderNode(

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -127,13 +127,11 @@ function StepListContent({
   className,
 }: Omit<StepListProps, 'job' | 'jobExecution'> & {model: StepListModel}) {
   const titleId = useId();
-  const [localSelectedAttemptIds, setLocalSelectedAttemptIds] = useState<string[]>(() =>
-    selectedAttemptId
-      ? [selectedAttemptId]
-      : defaultSelectedAttemptId
-        ? [defaultSelectedAttemptId]
-        : [],
-  );
+  const [localSelectedAttemptIds, setLocalSelectedAttemptIds] = useState<string[]>(() => {
+    if (selectedAttemptId) return [selectedAttemptId];
+    if (defaultSelectedAttemptId) return [defaultSelectedAttemptId];
+    return [];
+  });
   const [userSelectedAttempt, setUserSelectedAttempt] = useState(false);
   const lastNotifiedSelectedAttemptId = useRef<string | null>(null);
   const autoSelectedAttemptIdRef = useRef<string | undefined>(undefined);
@@ -149,15 +147,11 @@ function StepListContent({
     () => (autoSelectedAttemptId ? [autoSelectedAttemptId] : []),
     [autoSelectedAttemptId],
   );
-  const selectedAttemptIds = useMemo(
-    () =>
-      shouldUseControlledCollapsedState
-        ? []
-        : localSelectedAttemptIds.length > 0
-          ? localSelectedAttemptIds
-          : autoSelectedAttemptIds,
-    [autoSelectedAttemptIds, localSelectedAttemptIds, shouldUseControlledCollapsedState],
-  );
+  const selectedAttemptIds = useMemo(() => {
+    if (shouldUseControlledCollapsedState) return [];
+    if (localSelectedAttemptIds.length > 0) return localSelectedAttemptIds;
+    return autoSelectedAttemptIds;
+  }, [autoSelectedAttemptIds, localSelectedAttemptIds, shouldUseControlledCollapsedState]);
   const hasExpandedContent = renderExpandedStep !== undefined;
 
   useEffect(() => {
@@ -274,13 +268,11 @@ function StepListContent({
                     hasExpandedContent={hasExpandedContent}
                     isLast={index === model.entries.length - 1}
                     onSelect={() => {
-                      selectAttempt(
-                        hasExpandedContent
-                          ? toggleAttemptId(selectedAttemptIds, entry.id)
-                          : selected
-                            ? []
-                            : [entry.id],
-                      );
+                      if (hasExpandedContent) {
+                        selectAttempt(toggleAttemptId(selectedAttemptIds, entry.id));
+                      } else {
+                        selectAttempt(selected ? [] : [entry.id]);
+                      }
                     }}
                     onInspect={
                       onInspectorOpenChange && !entry.carriedOver

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-content.tsx
@@ -37,12 +37,12 @@ export function WorkflowRunListContent({
   isFetchNextPageError,
   onLoadMore,
 }: WorkflowRunListContentProps) {
-  const {isPending, isError} = query;
+  const {isPending} = query;
   // A refetch that fails after a prior success keeps the rows on screen behind a slim
   // banner. QueryLoadError owns the inverse case (errored before anything loaded) and
   // self-gates to nothing here once data exists. A failed fetch never renders as an empty
   // list: "nothing here" and "we could not find out" are different answers.
-  const refreshFailed = isError && query.data !== undefined;
+  const refreshFailed = hasStaleQueryError(query);
   // Keyed off "we have an answer" rather than "no error", so a stale refresh still reports
   // whether the filters match anything instead of leaving the list blank under the banner.
   const hasLoaded = !isPending && query.data !== undefined;
@@ -83,4 +83,8 @@ export function WorkflowRunListContent({
       ) : null}
     </>
   );
+}
+
+function hasStaleQueryError(query: WorkflowRunListQuery): boolean {
+  return query.isError && query.data !== undefined;
 }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -66,10 +66,7 @@ export function WorkflowRunSummary({
   const status = getWorkflowStatusVisual(run.runAttempt.status);
   const action = workflowRunActionForRun(run);
   const hasAction = canRenderWorkflowRunAction(action, onCancel, onRerun);
-  const attemptSwitcher =
-    latestAttempt && latestAttempt > 1 && workspaceSlug && projectSlug
-      ? {workspaceSlug, projectSlug, latestAttempt}
-      : null;
+  const attemptSwitcher = workflowAttemptSwitcher(latestAttempt, workspaceSlug, projectSlug);
   const displayDuration = run.runAttempt.displayDuration;
   const hasStarted = run.hasStartedJobExecution;
   const {ref: headingTextRef, isTruncated: isHeadingTruncated} =
@@ -83,11 +80,15 @@ export function WorkflowRunSummary({
   const isDevRun = run.origin === 'dev';
   // The provenance segment only earns a leading separator when something already sits on the
   // line; a run with nothing else (no number, no trigger label) must not start with a dot.
-  const metadataHasLeading =
-    run.number !== null || attemptSwitcher !== null || Boolean(run.triggerDisplayLabel);
-  const hasProvenance = isDevRun
-    ? Boolean(devSourceLabel || initiator || replayOfEvent)
-    : Boolean(branch || commit);
+  const metadataHasLeading = metadataHasLeadingContent(run, attemptSwitcher);
+  const hasProvenance = runHasProvenance({
+    isDevRun,
+    devSourceLabel,
+    initiator,
+    replayOfEvent,
+    branch,
+    commit,
+  });
 
   return (
     <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
@@ -228,6 +229,41 @@ export function WorkflowRunSummary({
       </section>
     </TimeTickerProvider>
   );
+}
+
+function workflowAttemptSwitcher(
+  latestAttempt: number | undefined,
+  workspaceSlug: string | undefined,
+  projectSlug: string | undefined,
+) {
+  if (!latestAttempt || latestAttempt <= 1 || !workspaceSlug || !projectSlug) return null;
+  return {workspaceSlug, projectSlug, latestAttempt};
+}
+
+function metadataHasLeadingContent(
+  run: WorkflowRunDetail,
+  attemptSwitcher: ReturnType<typeof workflowAttemptSwitcher>,
+): boolean {
+  return run.number !== null || attemptSwitcher !== null || Boolean(run.triggerDisplayLabel);
+}
+
+function runHasProvenance({
+  isDevRun,
+  devSourceLabel,
+  initiator,
+  replayOfEvent,
+  branch,
+  commit,
+}: {
+  isDevRun: boolean;
+  devSourceLabel: string | null | undefined;
+  initiator: string | null | undefined;
+  replayOfEvent: string | null | undefined;
+  branch: string | null | undefined;
+  commit: string | null | undefined;
+}): boolean {
+  if (isDevRun) return Boolean(devSourceLabel || initiator || replayOfEvent);
+  return Boolean(branch || commit);
 }
 
 function WorkflowRunActionSlot({

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -89,78 +89,88 @@ export function RunAnnotationList({
   const hiddenCount = entries.length - visible.length;
   const totalCount = entries.length + derivedAnnotations.length;
   const hasContent = totalCount > 0;
+  let content: ReactNode;
+  if (!hasContent) {
+    content = filtered ? (
+      <RunAnnotationsFilteredEmpty
+        jobName={filteredJobName}
+        severity={filteredSeverity}
+        incomplete={query.hasNextPage}
+        onClearFilters={onClearFilters}
+      />
+    ) : (
+      <RunAnnotationsEmpty />
+    );
+  } else {
+    content = (
+      <PanelBody asChild>
+        <ol>
+          {/* A job that failed before it ever created an execution is the most upstream thing
+              in the run, and it has no step to link to. It leads rather than trailing behind a
+              render window that could bury it. */}
+          {derivedAnnotations.map((annotation) => (
+            <RunDerivedAnnotationItem
+              key={annotation.id}
+              style={annotation.style}
+              jobName={annotation.jobName}
+              body={annotation.body}
+            />
+          ))}
+          {visible.map((entry) => (
+            <RunAnnotationItem
+              key={entry.annotation.id}
+              entry={entry}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              workflowRunId={workflowRunId}
+              runAttempt={runAttempt}
+            />
+          ))}
+        </ol>
+      </PanelBody>
+    );
+  }
+
+  let footer: ReactNode = null;
+  if (hiddenCount > 0) {
+    footer = (
+      <RunAnnotationListFooter>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="[@media(pointer:coarse)]:min-h-44"
+          onClick={() => setVisibleCount((current) => current + RENDER_WINDOW)}
+        >
+          Show {Math.min(hiddenCount, RENDER_WINDOW)} more of {totalCount}
+        </Button>
+      </RunAnnotationListFooter>
+    );
+  } else if (query.hasNextPage) {
+    footer = (
+      <RunAnnotationListFooter>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="[@media(pointer:coarse)]:min-h-44"
+          isLoading={query.isFetchingNextPage}
+          onClick={() => {
+            void query.fetchNextPage();
+          }}
+        >
+          Load more annotations
+        </Button>
+      </RunAnnotationListFooter>
+    );
+  }
 
   return (
     <>
       {query.isError ? <RunAnnotationStaleError query={query} /> : null}
 
-      {!hasContent ? (
-        filtered ? (
-          <RunAnnotationsFilteredEmpty
-            jobName={filteredJobName}
-            severity={filteredSeverity}
-            incomplete={query.hasNextPage}
-            onClearFilters={onClearFilters}
-          />
-        ) : (
-          <RunAnnotationsEmpty />
-        )
-      ) : (
-        <PanelBody asChild>
-          <ol>
-            {/* A job that failed before it ever created an execution is the most upstream thing
-                in the run, and it has no step to link to. It leads rather than trailing behind a
-                render window that could bury it. */}
-            {derivedAnnotations.map((annotation) => (
-              <RunDerivedAnnotationItem
-                key={annotation.id}
-                style={annotation.style}
-                jobName={annotation.jobName}
-                body={annotation.body}
-              />
-            ))}
-            {visible.map((entry) => (
-              <RunAnnotationItem
-                key={entry.annotation.id}
-                entry={entry}
-                workspaceSlug={workspaceSlug}
-                projectSlug={projectSlug}
-                workflowRunId={workflowRunId}
-                runAttempt={runAttempt}
-              />
-            ))}
-          </ol>
-        </PanelBody>
-      )}
-
-      {hiddenCount > 0 ? (
-        <RunAnnotationListFooter>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="[@media(pointer:coarse)]:min-h-44"
-            onClick={() => setVisibleCount((current) => current + RENDER_WINDOW)}
-          >
-            Show {Math.min(hiddenCount, RENDER_WINDOW)} more of {totalCount}
-          </Button>
-        </RunAnnotationListFooter>
-      ) : query.hasNextPage ? (
-        <RunAnnotationListFooter>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="[@media(pointer:coarse)]:min-h-44"
-            isLoading={query.isFetchingNextPage}
-            onClick={() => {
-              void query.fetchNextPage();
-            }}
-          >
-            Load more annotations
-          </Button>
-        </RunAnnotationListFooter>
-      ) : null}
+      {content}
+      {footer}
     </>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -23,6 +23,17 @@ const BUILD_EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
 const BUILD_STEP_ID = '55555555-5555-4555-8555-00000000000b';
 const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
 
+function responseForPath(path: string, annotations: readonly AnnotationDto[]) {
+  if (path === '/annotations') {
+    return {body: {annotations, has_more: false, next_cursor: null}, status: 200};
+  }
+  if (path === `/workflows/runs/${RUN_ID}/attempts`) {
+    return {body: RUN_ATTEMPTS_RESPONSE, status: 200};
+  }
+  if (path === `/workflows/runs/${RUN_ID}`) return {body: RUN_RESPONSE, status: 200};
+  return {body: {code: 'not-found'}, status: 404};
+}
+
 const RUN_RESPONSE: WorkflowRunDetailResponseDto = workflowRunDetailDto({
   id: RUN_ID,
   project_id: PROJECT_ID,
@@ -193,20 +204,12 @@ function RunWorkspaceStoryProviders({
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl: (input) => {
-        const url =
-          input instanceof Request ? input.url : input instanceof URL ? input.href : String(input);
+        let url: string;
+        if (input instanceof Request) url = input.url;
+        else if (input instanceof URL) url = input.href;
+        else url = String(input);
         const path = new URL(url, 'https://api.example.test').pathname;
-        const response =
-          path === '/annotations'
-            ? {
-                body: {annotations, has_more: false, next_cursor: null},
-                status: 200,
-              }
-            : path === `/workflows/runs/${RUN_ID}/attempts`
-              ? {body: RUN_ATTEMPTS_RESPONSE, status: 200}
-              : path === `/workflows/runs/${RUN_ID}`
-                ? {body: RUN_RESPONSE, status: 200}
-                : {body: {code: 'not-found'}, status: 404};
+        const response = responseForPath(path, annotations);
         return new Response(JSON.stringify(response.body), {
           status: response.status,
           headers: {'content-type': 'application/json'},

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -154,7 +154,6 @@ function RunViewContent({
 }) {
   const navigate = useNavigate();
   const runData = query.data;
-  const annotationSummary = annotations.summary;
   const activeSection = runWorkspaceSection(tab);
   const cancelMutation = useCancelWorkflowRunMutation(runData);
   const sourceSnapshot = runData?.sourceSnapshot ?? null;
@@ -163,23 +162,20 @@ function RunViewContent({
   const highlightedLineRange = resolvedSelection?.step?.sourceLocation ?? null;
 
   useEffect(() => {
-    const hasLegacyJobSelection = Boolean(
-      selection?.jobId ||
-        selection?.jobExecutionId ||
-        selection?.stepId ||
-        selection?.stepAttemptId,
-    );
+    const hasLegacyJobSelection = containsLegacyJobSelection(selection);
     if (
-      activeJobId ||
-      activeSection !== 'summary' ||
-      !hasLegacyJobSelection ||
-      !resolvedSelection?.job ||
-      !runData ||
-      !workspaceSlug ||
-      !projectSlug
-    ) {
+      !shouldRedirectLegacyJob({
+        activeJobId,
+        activeSection,
+        hasLegacyJobSelection,
+        hasResolvedJob: Boolean(resolvedSelection?.job),
+        hasRunData: Boolean(runData),
+        workspaceSlug,
+        projectSlug,
+      })
+    )
       return;
-    }
+    if (!resolvedSelection?.job || !runData || !workspaceSlug || !projectSlug) return;
 
     void navigate({
       to: '/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId/jobs/$jobId',
@@ -278,17 +274,77 @@ function RunViewContent({
     });
   }
 
-  const fatalError = query.isError && runData === undefined;
-  const loadingOrError = fatalError ? (
-    query.error instanceof ApiError && query.error.status === 404 ? (
-      <WorkflowRunNotFound />
-    ) : (
-      <QueryLoadError query={query} subject="workflow run" icon="pulseLine" />
-    )
-  ) : query.isPending || runData === undefined ? (
-    <WorkflowRunContentSkeleton />
-  ) : null;
+  return (
+    <RunViewLayout
+      workspaceSlug={workspaceSlug}
+      projectSlug={projectSlug}
+      query={query}
+      annotations={annotations}
+      rerunPending={rerunMutation.isPending}
+      runData={runData}
+      activeSection={activeSection}
+      activeJobId={activeJobId}
+      jobSearch={jobSearch}
+      selection={selection}
+      jobContent={jobContent}
+      sourceSnapshot={sourceSnapshot}
+      highlightedLineRange={highlightedLineRange}
+      onCancel={cancelRun}
+      cancelling={cancelMutation.isPending}
+      onRerun={(mode) => void rerun(mode)}
+      onSelectGraphJob={selectGraphJob}
+      onSelectAnnotationJob={selectAnnotationJob}
+      onClearAnnotationFilters={clearAnnotationFilters}
+    />
+  );
+}
 
+function RunViewLayout({
+  workspaceSlug,
+  projectSlug,
+  query,
+  annotations,
+  rerunPending,
+  runData,
+  activeSection,
+  activeJobId,
+  jobSearch,
+  selection,
+  jobContent,
+  sourceSnapshot,
+  highlightedLineRange,
+  onCancel,
+  cancelling,
+  onRerun,
+  onSelectGraphJob,
+  onSelectAnnotationJob,
+  onClearAnnotationFilters,
+}: {
+  workspaceSlug: string | undefined;
+  projectSlug: string | undefined;
+  query: ReturnType<typeof useWorkflowRunAttemptQuery>;
+  annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  rerunPending: boolean;
+  runData: ReturnType<typeof useWorkflowRunAttemptQuery>['data'];
+  activeSection: RunWorkspaceSection;
+  activeJobId: string | undefined;
+  jobSearch: WorkflowJobSearch | undefined;
+  selection: WorkflowRunsSearch | undefined;
+  jobContent: ReactNode | undefined;
+  sourceSnapshot: NonNullable<
+    ReturnType<typeof useWorkflowRunAttemptQuery>['data']
+  >['sourceSnapshot'];
+  highlightedLineRange: NonNullable<
+    ReturnType<typeof useWorkflowRunAttemptQuery>['data']
+  >['jobs'][number]['jobExecutions'][number]['steps'][number]['sourceLocation'];
+  onCancel: () => void;
+  cancelling: boolean;
+  onRerun: (mode: WorkflowRunRerunMode) => void;
+  onSelectGraphJob: (jobId: string | undefined, source?: JobGraphSelectionSource) => void;
+  onSelectAnnotationJob: (jobId: string | undefined) => void;
+  onClearAnnotationFilters: () => void;
+}) {
+  const annotationSummary = annotations.summary;
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       {runData ? (
@@ -296,17 +352,16 @@ function RunViewContent({
           workspaceSlug={workspaceSlug}
           projectSlug={projectSlug}
           run={runData}
-          cancelling={cancelMutation.isPending}
-          onCancel={cancelRun}
-          rerunPending={rerunMutation.isPending}
-          onRerun={(mode) => void rerun(mode)}
+          cancelling={cancelling}
+          onCancel={onCancel}
+          rerunPending={rerunPending}
+          onRerun={onRerun}
           latestAttempt={runData.latestAttempt}
         />
       ) : (
         <WorkflowRunSkeleton />
       )}
       {runData && query.isError ? <WorkflowRunStaleError query={query} /> : null}
-
       <div
         data-run-workspace-layout
         className="flex min-h-0 min-w-0 flex-1 flex-col border-t border-border-neutral-base"
@@ -328,33 +383,132 @@ function RunViewContent({
           ) : (
             <RunWorkspaceNavSkeleton />
           )}
-
           <div data-run-workspace-content className="flex min-h-0 min-w-0 flex-1 flex-col">
-            {runData && jobContent ? (
-              jobContent
-            ) : runData ? (
-              <RunSectionContent
-                section={activeSection}
-                run={runData}
-                annotations={annotations}
-                annotationSummary={annotationSummary}
-                workspaceSlug={workspaceSlug}
-                projectSlug={projectSlug}
-                selection={selection}
-                selectedJobId={selection?.jobId}
-                onSelectGraphJob={selectGraphJob}
-                onSelectAnnotationJob={selectAnnotationJob}
-                onClearAnnotationFilters={clearAnnotationFilters}
-                sourceSnapshot={sourceSnapshot}
-                highlightedLineRange={highlightedLineRange}
-              />
-            ) : (
-              <div className="min-h-0 flex-1 overflow-auto p-panel">{loadingOrError}</div>
-            )}
+            <RunWorkspaceContent
+              query={query}
+              runData={runData}
+              jobContent={jobContent}
+              activeSection={activeSection}
+              annotations={annotations}
+              annotationSummary={annotationSummary}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              selection={selection}
+              onSelectGraphJob={onSelectGraphJob}
+              onSelectAnnotationJob={onSelectAnnotationJob}
+              onClearAnnotationFilters={onClearAnnotationFilters}
+              sourceSnapshot={sourceSnapshot}
+              highlightedLineRange={highlightedLineRange}
+            />
           </div>
         </div>
       </div>
     </div>
+  );
+}
+
+function RunWorkspaceContent({
+  query,
+  runData,
+  jobContent,
+  activeSection,
+  annotations,
+  annotationSummary,
+  workspaceSlug,
+  projectSlug,
+  selection,
+  onSelectGraphJob,
+  onSelectAnnotationJob,
+  onClearAnnotationFilters,
+  sourceSnapshot,
+  highlightedLineRange,
+}: {
+  query: ReturnType<typeof useWorkflowRunAttemptQuery>;
+  runData: ReturnType<typeof useWorkflowRunAttemptQuery>['data'];
+  jobContent: ReactNode | undefined;
+  activeSection: RunWorkspaceSection;
+  annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  annotationSummary: RunAnnotationSummary | undefined;
+  workspaceSlug: string | undefined;
+  projectSlug: string | undefined;
+  selection: WorkflowRunsSearch | undefined;
+  onSelectGraphJob: (jobId: string | undefined, source?: JobGraphSelectionSource) => void;
+  onSelectAnnotationJob: (jobId: string | undefined) => void;
+  onClearAnnotationFilters: () => void;
+  sourceSnapshot: NonNullable<
+    ReturnType<typeof useWorkflowRunAttemptQuery>['data']
+  >['sourceSnapshot'];
+  highlightedLineRange: NonNullable<
+    ReturnType<typeof useWorkflowRunAttemptQuery>['data']
+  >['jobs'][number]['jobExecutions'][number]['steps'][number]['sourceLocation'];
+}) {
+  if (query.isError && runData === undefined) {
+    const error =
+      query.error instanceof ApiError && query.error.status === 404 ? (
+        <WorkflowRunNotFound />
+      ) : (
+        <QueryLoadError query={query} subject="workflow run" icon="pulseLine" />
+      );
+    return <div className="min-h-0 flex-1 overflow-auto p-panel">{error}</div>;
+  }
+  if (query.isPending || runData === undefined) {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto p-panel">
+        <WorkflowRunContentSkeleton />
+      </div>
+    );
+  }
+  if (jobContent) return jobContent;
+  return (
+    <RunSectionContent
+      section={activeSection}
+      run={runData}
+      annotations={annotations}
+      annotationSummary={annotationSummary}
+      workspaceSlug={workspaceSlug}
+      projectSlug={projectSlug}
+      selection={selection}
+      selectedJobId={selection?.jobId}
+      onSelectGraphJob={onSelectGraphJob}
+      onSelectAnnotationJob={onSelectAnnotationJob}
+      onClearAnnotationFilters={onClearAnnotationFilters}
+      sourceSnapshot={sourceSnapshot}
+      highlightedLineRange={highlightedLineRange}
+    />
+  );
+}
+
+function containsLegacyJobSelection(selection: WorkflowRunsSearch | undefined): boolean {
+  return Boolean(
+    selection?.jobId || selection?.jobExecutionId || selection?.stepId || selection?.stepAttemptId,
+  );
+}
+
+function shouldRedirectLegacyJob({
+  activeJobId,
+  activeSection,
+  hasLegacyJobSelection,
+  hasResolvedJob,
+  hasRunData,
+  workspaceSlug,
+  projectSlug,
+}: {
+  activeJobId: string | undefined;
+  activeSection: ReturnType<typeof runWorkspaceSection>;
+  hasLegacyJobSelection: boolean;
+  hasResolvedJob: boolean;
+  hasRunData: boolean;
+  workspaceSlug: string | undefined;
+  projectSlug: string | undefined;
+}): boolean {
+  return (
+    !activeJobId &&
+    activeSection === 'summary' &&
+    hasLegacyJobSelection &&
+    hasResolvedJob &&
+    hasRunData &&
+    Boolean(workspaceSlug) &&
+    Boolean(projectSlug)
   );
 }
 

--- a/libs/client/workflows/src/core/entities/job.ts
+++ b/libs/client/workflows/src/core/entities/job.ts
@@ -148,12 +148,9 @@ export function deriveJobDisplayStatus(
 ): JobDisplayStatus {
   if (isTerminalJobStatus(job.status)) return job.status;
   if (job.mode === 'listening' && job.listenerStatus === 'listening') return 'listening';
-  const execution =
-    job.executionStatus === undefined
-      ? defaultJobExecution(job)
-      : job.executionStatus === null
-        ? undefined
-        : {status: job.executionStatus, steps: []};
+  let execution: Pick<JobExecution, 'status' | 'steps'> | undefined;
+  if (job.executionStatus === undefined) execution = defaultJobExecution(job);
+  else if (job.executionStatus !== null) execution = {status: job.executionStatus, steps: []};
   // A running execution is the shared display rule for both list previews and detail jobs.
   // The list has no step tree, while the detail path can still use the execution's steps for
   // other non-running states.

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -324,25 +324,24 @@ function toStepGateResult(dto: StepGateResultDto): StepGateResult {
 }
 
 function toEvaluationTrace(trace: EvaluationTraceDto | null): EvaluationTraceEntry[] | null {
-  return (
-    trace?.map((entry) =>
-      'dropped' in entry
-        ? entry
-        : {
-            expression: entry.expression,
-            roots: entry.roots,
-            fillTarget: entry.fill_target,
-            evaluatedAt: entry.evaluated_at,
-            field: entry.field,
-            ...(entry.value === undefined ? {} : {value: entry.value}),
-            ...(entry.truncated === undefined ? {} : {truncated: entry.truncated}),
-            ...(entry.expr_truncated === undefined ? {} : {exprTruncated: entry.expr_truncated}),
-            ...(entry.reference === undefined ? {} : {reference: entry.reference}),
-            ...(entry.degraded === undefined ? {} : {degraded: entry.degraded}),
-            ...(entry.env_key === undefined ? {} : {envKey: entry.env_key}),
-          },
-    ) ?? null
-  );
+  return trace?.map(toEvaluationTraceEntry) ?? null;
+}
+
+function toEvaluationTraceEntry(entry: EvaluationTraceDto[number]): EvaluationTraceEntry {
+  if ('dropped' in entry) return entry;
+  return {
+    expression: entry.expression,
+    roots: entry.roots,
+    fillTarget: entry.fill_target,
+    evaluatedAt: entry.evaluated_at,
+    field: entry.field,
+    ...(entry.value === undefined ? {} : {value: entry.value}),
+    ...(entry.truncated === undefined ? {} : {truncated: entry.truncated}),
+    ...(entry.expr_truncated === undefined ? {} : {exprTruncated: entry.expr_truncated}),
+    ...(entry.reference === undefined ? {} : {reference: entry.reference}),
+    ...(entry.degraded === undefined ? {} : {degraded: entry.degraded}),
+    ...(entry.env_key === undefined ? {} : {envKey: entry.env_key}),
+  };
 }
 
 function toAgentStepConfig(dto: WorkflowRunStepDetailDto): Step['agentConfig'] {

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -34,7 +34,7 @@ import {
 } from '@shipfox/react-ui/table';
 import {toast} from '@shipfox/react-ui/toast';
 import {Code, Header, Text} from '@shipfox/react-ui/typography';
-import {useState} from 'react';
+import {type ReactNode, useState} from 'react';
 import {useFireManualWorkflowMutation} from '#hooks/api/workflow-runs.js';
 
 export function ProjectWorkflowsPage({projectId}: {projectId: string}) {
@@ -67,6 +67,20 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
     }
   }
 
+  let projectErrorContent: ReactNode = null;
+  if (projectQuery.isError && projectQuery.data === undefined) {
+    projectErrorContent =
+      projectQuery.error instanceof ApiError && projectQuery.error.status === 404 ? (
+        <EmptyState
+          icon="errorWarningLine"
+          title="Project not found"
+          description="This project doesn't exist, or you don't have access to it."
+        />
+      ) : (
+        <QueryLoadError query={projectQuery} subject="project" />
+      );
+  }
+
   return (
     <div className="flex w-full flex-col gap-section">
       <Header variant="h1" className="sr-only">
@@ -80,17 +94,7 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
         </div>
       ) : null}
 
-      {projectQuery.isError && projectQuery.data === undefined ? (
-        projectQuery.error instanceof ApiError && projectQuery.error.status === 404 ? (
-          <EmptyState
-            icon="errorWarningLine"
-            title="Project not found"
-            description="This project doesn't exist, or you don't have access to it."
-          />
-        ) : (
-          <QueryLoadError query={projectQuery} subject="project" />
-        )
-      ) : null}
+      {projectErrorContent}
 
       {projectQuery.data ? (
         <>
@@ -352,16 +356,16 @@ function sourceIcon(source: 'manual' | 'vcs'): IconName {
 }
 
 function WorkflowEmptyState({sync}: {sync: DefinitionSyncSummary | null}) {
-  const message =
-    sync?.status === 'failed' && sync.lastErrorCode === 'no-workflow-files'
-      ? 'No workflow files found under .shipfox/workflows/.'
-      : sync?.status === 'failed'
-        ? (sync.lastErrorMessage ?? 'Workflow definitions could not be synced.')
-        : sync?.status === 'syncing'
-          ? 'Workflow definitions are being discovered.'
-          : sync?.status === 'succeeded'
-            ? 'No workflow definitions found.'
-            : 'Workflow sync has not reported yet.';
+  let message = 'Workflow sync has not reported yet.';
+  if (sync?.status === 'failed' && sync.lastErrorCode === 'no-workflow-files') {
+    message = 'No workflow files found under .shipfox/workflows/.';
+  } else if (sync?.status === 'failed') {
+    message = sync.lastErrorMessage ?? 'Workflow definitions could not be synced.';
+  } else if (sync?.status === 'syncing') {
+    message = 'Workflow definitions are being discovered.';
+  } else if (sync?.status === 'succeeded') {
+    message = 'No workflow definitions found.';
+  }
 
   return <EmptyState icon="flowChart" title="No workflows" description={message} variant="panel" />;
 }
@@ -389,12 +393,9 @@ function WorkflowSyncDiagnostics({sync}: {sync: DefinitionSyncSummary | null | u
   const hasErrors = sync.diagnostics.some((diagnostic) => diagnostic.severity === 'error');
   const hasWarnings = sync.diagnostics.some((diagnostic) => diagnostic.severity === 'warning');
   const groups = groupDiagnosticsByFilePath(sync.diagnostics);
-  const title =
-    hasErrors && hasWarnings
-      ? 'Workflow definition diagnostics'
-      : hasErrors
-        ? 'Workflow definition errors'
-        : 'Workflow definition warnings';
+  let title = 'Workflow definition warnings';
+  if (hasErrors && hasWarnings) title = 'Workflow definition diagnostics';
+  else if (hasErrors) title = 'Workflow definition errors';
 
   return (
     <Callout role="status" type={hasErrors ? 'error' : 'warning'}>

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -371,32 +371,39 @@ describe('WorkflowRunPages', () => {
 function renderRunsPath(search = '') {
   return renderProjectPage(
     `/w/${PROJECT_TEST_WSLUG}/p/project/runs${search}`,
-    ({workflowRunId, jobId, search}) =>
-      workflowRunId && jobId ? (
-        <WorkflowJobDetailPage
-          projectId={PROJECT_ID}
-          workspaceSlug={PROJECT_TEST_WSLUG}
-          projectSlug="project"
-          workflowRunId={workflowRunId}
-          jobId={jobId}
-          search={search as WorkflowJobSearch}
-        />
-      ) : workflowRunId ? (
-        <WorkflowRunDetailPage
-          projectId={PROJECT_ID}
-          workspaceSlug={PROJECT_TEST_WSLUG}
-          projectSlug="project"
-          workflowRunId={workflowRunId}
-          search={search as WorkflowRunsSearch}
-        />
-      ) : (
+    ({workflowRunId, jobId, search}) => {
+      if (workflowRunId && jobId) {
+        return (
+          <WorkflowJobDetailPage
+            projectId={PROJECT_ID}
+            workspaceSlug={PROJECT_TEST_WSLUG}
+            projectSlug="project"
+            workflowRunId={workflowRunId}
+            jobId={jobId}
+            search={search as WorkflowJobSearch}
+          />
+        );
+      }
+      if (workflowRunId) {
+        return (
+          <WorkflowRunDetailPage
+            projectId={PROJECT_ID}
+            workspaceSlug={PROJECT_TEST_WSLUG}
+            projectSlug="project"
+            workflowRunId={workflowRunId}
+            search={search as WorkflowRunsSearch}
+          />
+        );
+      }
+      return (
         <WorkflowRunsPage
           projectId={PROJECT_ID}
           workspaceSlug={PROJECT_TEST_WSLUG}
           projectSlug="project"
           search={search as WorkflowRunsSearch}
         />
-      ),
+      );
+    },
   );
 }
 

--- a/libs/client/workflows/src/routes/inputs.ts
+++ b/libs/client/workflows/src/routes/inputs.ts
@@ -63,23 +63,17 @@ const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 export function validateWorkflowRunsSearch(input: Record<string, unknown>): WorkflowRunsSearch {
   const search = string(input.search);
   const status = repeatable(input.status).filter(isWorkflowRunListStatus);
-  const originValue = string(input.origin);
-  const origin =
-    originValue && ORIGIN_VALUES.has(originValue)
-      ? (originValue as WorkflowRunListOrigin)
-      : undefined;
+  const origin = enumSearchValue<WorkflowRunListOrigin>(input.origin, ORIGIN_VALUES);
   const branch = repeatable(input.branch);
   const actor = repeatable(input.actor);
   const event = repeatable(input.event);
   const after = calendarDate(input.after);
   const before = calendarDate(input.before);
-  const tabValue = string(input.tab);
-  const tab = tabValue && TAB_VALUES.has(tabValue) ? (tabValue as WorkflowRunTab) : undefined;
-  const severityValue = string(input.severity);
-  const severity =
-    severityValue && ANNOTATION_SEVERITY_VALUES.has(severityValue)
-      ? (severityValue as WorkflowRunAnnotationSeverity)
-      : undefined;
+  const tab = enumSearchValue<WorkflowRunTab>(input.tab, TAB_VALUES);
+  const severity = enumSearchValue<WorkflowRunAnnotationSeverity>(
+    input.severity,
+    ANNOTATION_SEVERITY_VALUES,
+  );
 
   return {
     ...(search ? {search} : {}),
@@ -94,6 +88,15 @@ export function validateWorkflowRunsSearch(input: Record<string, unknown>): Work
     ...(severity ? {severity} : {}),
     ...workflowSelectionFromSearch(input, true),
   };
+}
+
+function enumSearchValue<T extends string>(
+  input: unknown,
+  values: ReadonlySet<string>,
+): T | undefined {
+  const value = string(input);
+  if (!value || !values.has(value)) return undefined;
+  return value as T;
 }
 
 /** Reads the job-detail query string without allowing a job id to leak back into URL state. */

--- a/libs/provisioner/core/src/health.ts
+++ b/libs/provisioner/core/src/health.ts
@@ -92,92 +92,18 @@ export function reduceHealth(state: HealthState, event: HealthEvent): HealthRedu
   let hasEverBeenReady = state.hasEverBeenReady;
   const logs: HealthLog[] = [];
 
-  if (event.type === 'facet_failed') {
-    active.set(event.facet, {
-      cause: event.cause,
-      impact: event.impact,
-      ...(event.failureCount !== undefined ? {failureCount: event.failureCount} : {}),
-    });
-    const fingerprint = activeFingerprint(active);
-    if (!incident) {
-      incident = {
-        fingerprint,
-        startedAt: event.at,
-        attempts: 1,
-        suppressed: 0,
-      };
-      logs.push({
-        level: 'error',
-        event: 'provisioner.degraded',
-        facet: event.facet,
-        cause: event.cause,
-        impact: event.impact,
-        attempts: incident.attempts,
-        suppressed: incident.suppressed,
-      });
-    } else {
-      const changed = incident.fingerprint !== fingerprint;
-      incident = {
-        ...incident,
-        fingerprint,
-        attempts: incident.attempts + 1,
-        suppressed: incident.suppressed + (changed ? 0 : 1),
-      };
-      if (changed) {
-        logs.push({
-          level: 'error',
-          event: 'provisioner.degraded',
-          facet: event.facet,
-          cause: event.cause,
-          changed: true,
-          impact: event.impact,
-          attempts: incident.attempts,
-          suppressed: incident.suppressed,
-        });
-      } else if (incident.suppressed > 0 && incident.suppressed % REMINDER_EVERY_SUPPRESSED === 0) {
-        logs.push({
-          level: 'warn',
-          event: 'provisioner.degraded_reminder',
-          facet: event.facet,
-          cause: event.cause,
-          impact: event.impact,
-          attempts: incident.attempts,
-          suppressed: incident.suppressed,
-        });
+  switch (event.type) {
+    case 'facet_failed':
+      incident = reduceFacetFailure(active, incident, event, logs);
+      break;
+    case 'facet_recovered':
+      incident = reduceFacetRecovery(active, incident, event, logs);
+      break;
+    case 'ready_confirmed':
+      if (!hasEverBeenReady && readinessAvailable(active)) {
+        hasEverBeenReady = true;
+        logs.push({level: 'info', event: 'provisioner.ready'});
       }
-    }
-  } else if (event.type === 'facet_recovered') {
-    if (active.has(event.facet)) {
-      active.delete(event.facet);
-      if (active.size === 0 && incident) {
-        logs.push({
-          level: 'info',
-          event: 'provisioner.recovered',
-          attempts: incident.attempts,
-          suppressed: incident.suppressed,
-          outageDurationMs: Math.max(0, event.at.getTime() - incident.startedAt.getTime()),
-        });
-        incident = undefined;
-      } else if (incident) {
-        const fingerprint = activeFingerprint(active);
-        const changed = incident.fingerprint !== fingerprint;
-        incident = {...incident, fingerprint};
-        if (changed) {
-          logs.push({
-            level: 'info',
-            event: 'provisioner.partially_recovered',
-            recoveredFacet: event.facet,
-            remainingFacetCount: active.size,
-            impact: currentImpact(active),
-            attempts: incident.attempts,
-            suppressed: incident.suppressed,
-          });
-        }
-      }
-    }
-  } else if (event.type === 'ready_confirmed' && !hasEverBeenReady && readinessAvailable(active)) {
-    hasEverBeenReady = true;
-    logs.push({level: 'info', event: 'provisioner.ready'});
   }
 
   const nextState: HealthState = {
@@ -186,6 +112,107 @@ export function reduceHealth(state: HealthState, event: HealthEvent): HealthRedu
     hasEverBeenReady,
   };
   return {state: nextState, derived: deriveHealth(nextState), logs};
+}
+
+function reduceFacetFailure(
+  active: Map<HealthFacet, HealthFailure>,
+  incident: HealthIncident | undefined,
+  event: Extract<HealthEvent, {type: 'facet_failed'}>,
+  logs: HealthLog[],
+): HealthIncident {
+  active.set(event.facet, {
+    cause: event.cause,
+    impact: event.impact,
+    ...(event.failureCount !== undefined ? {failureCount: event.failureCount} : {}),
+  });
+  const fingerprint = activeFingerprint(active);
+  if (!incident) {
+    const started = {
+      fingerprint,
+      startedAt: event.at,
+      attempts: 1,
+      suppressed: 0,
+    } satisfies HealthIncident;
+    logs.push({
+      level: 'error',
+      event: 'provisioner.degraded',
+      facet: event.facet,
+      cause: event.cause,
+      impact: event.impact,
+      attempts: started.attempts,
+      suppressed: started.suppressed,
+    });
+    return started;
+  }
+
+  const changed = incident.fingerprint !== fingerprint;
+  const updated = {
+    ...incident,
+    fingerprint,
+    attempts: incident.attempts + 1,
+    suppressed: incident.suppressed + (changed ? 0 : 1),
+  };
+  if (changed) {
+    logs.push({
+      level: 'error',
+      event: 'provisioner.degraded',
+      facet: event.facet,
+      cause: event.cause,
+      changed: true,
+      impact: event.impact,
+      attempts: updated.attempts,
+      suppressed: updated.suppressed,
+    });
+  } else if (updated.suppressed > 0 && updated.suppressed % REMINDER_EVERY_SUPPRESSED === 0) {
+    logs.push({
+      level: 'warn',
+      event: 'provisioner.degraded_reminder',
+      facet: event.facet,
+      cause: event.cause,
+      impact: event.impact,
+      attempts: updated.attempts,
+      suppressed: updated.suppressed,
+    });
+  }
+  return updated;
+}
+
+function reduceFacetRecovery(
+  active: Map<HealthFacet, HealthFailure>,
+  incident: HealthIncident | undefined,
+  event: Extract<HealthEvent, {type: 'facet_recovered'}>,
+  logs: HealthLog[],
+): HealthIncident | undefined {
+  if (!active.has(event.facet)) return incident;
+  active.delete(event.facet);
+  if (active.size === 0 && incident) {
+    logs.push({
+      level: 'info',
+      event: 'provisioner.recovered',
+      attempts: incident.attempts,
+      suppressed: incident.suppressed,
+      outageDurationMs: Math.max(0, event.at.getTime() - incident.startedAt.getTime()),
+    });
+    return undefined;
+  }
+  if (incident) {
+    const fingerprint = activeFingerprint(active);
+    const changed = incident.fingerprint !== fingerprint;
+    const updated = {...incident, fingerprint};
+    if (changed) {
+      logs.push({
+        level: 'info',
+        event: 'provisioner.partially_recovered',
+        recoveredFacet: event.facet,
+        remainingFacetCount: active.size,
+        impact: currentImpact(active),
+        attempts: updated.attempts,
+        suppressed: updated.suppressed,
+      });
+    }
+    return updated;
+  }
+  return incident;
 }
 
 export function deriveHealth(state: HealthState): HealthDerivedState {

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -97,24 +97,7 @@ export async function startProvisioner<Spec>(
   shutdownController.start();
 
   const templates = await options.adapter.loadTemplates();
-  if (templates.length === 0) {
-    throw new Error('Provisioner started with no templates; configure at least one template.');
-  }
-  if (templates.length > MAX_TEMPLATES_PER_POLL) {
-    throw new Error(
-      `Provisioner has ${templates.length} templates; the demand poll accepts at most ${MAX_TEMPLATES_PER_POLL}. Reduce the configured templates.`,
-    );
-  }
-  if (
-    options.adapter.reservationTtlSeconds !== undefined &&
-    (!Number.isInteger(options.adapter.reservationTtlSeconds) ||
-      options.adapter.reservationTtlSeconds < 1)
-  ) {
-    throw new Error(
-      `Provisioner adapter reservationTtlSeconds is ${options.adapter.reservationTtlSeconds}; the demand poll accepts a whole number of seconds of at least 1. Set a positive integer.`,
-    );
-  }
-
+  validateProvisionerTemplates(options.adapter, templates);
   const providerConfiguration = (await options.adapter.onConfigure?.({templates})) ?? {};
   logger().info(
     {
@@ -130,34 +113,7 @@ export async function startProvisioner<Spec>(
     baseUrl: config.SHIPFOX_API_URL,
     token: config.SHIPFOX_PROVISIONER_TOKEN,
   });
-
-  let identity: Awaited<ReturnType<ProvisionerClient['getIdentity']>>;
-  try {
-    identity = await client.getIdentity();
-  } catch (error) {
-    if (error instanceof ProvisionerAuthenticationError) {
-      logger().error(
-        {
-          event: 'provisioner.authentication_failed',
-          operation: error.action,
-          status: error.status,
-          reason: 'token_rejected',
-        },
-        `Provisioner token rejected during ${error.action}`,
-      );
-    }
-    throw error;
-  }
-  logger().info(
-    {
-      event: 'provisioner.authenticated',
-      provisionerId: identity.id,
-      workspaceId: identity.scope === 'workspace' ? identity.workspace_id : undefined,
-      scope: identity.scope,
-      templateCount: templates.length,
-    },
-    'Provisioner authenticated',
-  );
+  const identity = await authenticateProvisioner(client, templates.length);
 
   const tracker = createInMemoryTracker();
   const health = createHealthState();
@@ -226,6 +182,59 @@ export async function startProvisioner<Spec>(
   logger().info({event: 'provisioner.stopped'}, 'Provisioner stopped');
 }
 
+function validateProvisionerTemplates<Spec>(
+  adapter: ProvisionerAdapter<Spec>,
+  templates: readonly ProvisionerTemplate<Spec>[],
+): void {
+  if (templates.length === 0) {
+    throw new Error('Provisioner started with no templates; configure at least one template.');
+  }
+  if (templates.length > MAX_TEMPLATES_PER_POLL) {
+    throw new Error(
+      `Provisioner has ${templates.length} templates; the demand poll accepts at most ${MAX_TEMPLATES_PER_POLL}. Reduce the configured templates.`,
+    );
+  }
+  if (
+    adapter.reservationTtlSeconds !== undefined &&
+    (!Number.isInteger(adapter.reservationTtlSeconds) || adapter.reservationTtlSeconds < 1)
+  ) {
+    throw new Error(
+      `Provisioner adapter reservationTtlSeconds is ${adapter.reservationTtlSeconds}; the demand poll accepts a whole number of seconds of at least 1. Set a positive integer.`,
+    );
+  }
+}
+
+async function authenticateProvisioner(client: ProvisionerClient, templateCount: number) {
+  let identity: Awaited<ReturnType<ProvisionerClient['getIdentity']>>;
+  try {
+    identity = await client.getIdentity();
+  } catch (error) {
+    if (error instanceof ProvisionerAuthenticationError) {
+      logger().error(
+        {
+          event: 'provisioner.authentication_failed',
+          operation: error.action,
+          status: error.status,
+          reason: 'token_rejected',
+        },
+        `Provisioner token rejected during ${error.action}`,
+      );
+    }
+    throw error;
+  }
+  logger().info(
+    {
+      event: 'provisioner.authenticated',
+      provisionerId: identity.id,
+      workspaceId: identity.scope === 'workspace' ? identity.workspace_id : undefined,
+      scope: identity.scope,
+      templateCount,
+    },
+    'Provisioner authenticated',
+  );
+  return identity;
+}
+
 export async function runProvisionerIteration<Spec>(
   deps: RunProvisionerIterationDeps<Spec>,
 ): Promise<RunProvisionerIterationResult> {
@@ -250,54 +259,8 @@ export async function runConvergeIteration<Spec>(
   let failed = false;
   const withProviderLock = deps.withProviderLock ?? inlineProviderPass;
   await withProviderLock(async () => {
-    if (deps.adapter.onTick) {
-      try {
-        await deps.adapter.onTick();
-        applyHealthEvent(health, {
-          type: 'facet_recovered',
-          facet: 'provider_observation',
-          at: new Date(),
-        });
-        applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
-      } catch (error) {
-        if (deps.signal?.aborted) throw error;
-        failed = true;
-        applyHealthEvent(health, {
-          type: 'facet_failed',
-          facet: 'provider_observation',
-          cause: errorReason(error),
-          impact: 'capacity',
-          at: new Date(),
-        });
-      }
-    }
-
-    // Only take intents a pass can actually act on; taking them without a terminate
-    // port would drop them, since take() clears the queue.
-    if (!deps.adapter.terminate) return;
-    const terminationIntents = [...(deps.takeTerminationIntents?.() ?? [])];
-    if (terminationIntents.length === 0) return;
-    try {
-      await deps.adapter.terminate(terminationIntents);
-      applyHealthEvent(health, {
-        type: 'facet_recovered',
-        facet: 'provider_termination',
-        at: new Date(),
-      });
-    } catch (error) {
-      // Requeue before the abort rethrow: a terminate that fails during shutdown is
-      // exactly the case where the intents must survive into the next pass.
-      deps.requeueTerminationIntents?.(terminationIntents);
-      if (deps.signal?.aborted) throw error;
-      failed = true;
-      applyHealthEvent(health, {
-        type: 'facet_failed',
-        facet: 'provider_termination',
-        cause: errorReason(error),
-        impact: 'cleanup',
-        at: new Date(),
-      });
-    }
+    failed = (await runProviderObservation(deps, health)) || failed;
+    failed = (await runProviderTerminations(deps, health)) || failed;
   });
 
   const derived = healthDerived(health);
@@ -309,31 +272,106 @@ export async function runConvergeIteration<Spec>(
   };
 }
 
+async function runProviderObservation<Spec>(
+  deps: RunConvergeIterationDeps<Spec>,
+  health: ProvisionerHealthState,
+): Promise<boolean> {
+  if (!deps.adapter.onTick) return false;
+  try {
+    await deps.adapter.onTick();
+    applyHealthEvent(health, {
+      type: 'facet_recovered',
+      facet: 'provider_observation',
+      at: new Date(),
+    });
+    applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
+    return false;
+  } catch (error) {
+    if (deps.signal?.aborted) throw error;
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'provider_observation',
+      cause: errorReason(error),
+      impact: 'capacity',
+      at: new Date(),
+    });
+    return true;
+  }
+}
+
+async function runProviderTerminations<Spec>(
+  deps: RunConvergeIterationDeps<Spec>,
+  health: ProvisionerHealthState,
+): Promise<boolean> {
+  // Only take intents a pass can actually act on; taking them without a terminate
+  // port would drop them, since take() clears the queue.
+  if (!deps.adapter.terminate) return false;
+  const terminationIntents = [...(deps.takeTerminationIntents?.() ?? [])];
+  if (terminationIntents.length === 0) return false;
+  try {
+    await deps.adapter.terminate(terminationIntents);
+    applyHealthEvent(health, {
+      type: 'facet_recovered',
+      facet: 'provider_termination',
+      at: new Date(),
+    });
+    return false;
+  } catch (error) {
+    // Requeue before the abort rethrow: a terminate that fails during shutdown is
+    // exactly the case where the intents must survive into the next pass.
+    deps.requeueTerminationIntents?.(terminationIntents);
+    if (deps.signal?.aborted) throw error;
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'provider_termination',
+      cause: errorReason(error),
+      impact: 'cleanup',
+      at: new Date(),
+    });
+    return true;
+  }
+}
+
 export async function runDemandIteration<Spec>(
   deps: RunProvisionerIterationDeps<Spec>,
 ): Promise<RunProvisionerIterationResult> {
   const health = deps.health ?? createHealthState();
   const launchBudget = () => deriveLaunchBudget(health);
+  const result = await runDemandTick(deps, health, launchBudget);
+  notifyDemandStats(deps.adapter, result.stats, health);
+  updateProviderTerminationHealth(deps, result, health);
+  updateRunnerCapacityHealth(result, health);
+  logDemandIteration(result);
+  if (result.launchedCount > 0) applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
+  const derived = healthDerived(health);
+  return {
+    nextInterval: derived.shouldBackOff
+      ? nextBackoffInterval(deps.currentInterval)
+      : config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS,
+    degraded: derived.capacityDegraded,
+  };
+}
 
-  const reservationLimit = config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS;
+type ProvisionerTickResult = Awaited<ReturnType<typeof runProvisionerTick>>;
 
-  let result: Awaited<ReturnType<typeof runProvisionerTick>>;
+async function runDemandTick<Spec>(
+  deps: RunProvisionerIterationDeps<Spec>,
+  health: ProvisionerHealthState,
+  launchBudget: () => number,
+): Promise<ProvisionerTickResult> {
+  const terminate = deps.deferTermination ?? deps.adapter.terminate;
   try {
-    result = await runProvisionerTick({
+    const result = await runProvisionerTick({
       client: deps.client,
       templates: deps.templates,
       tracker: deps.tracker,
       launch: deps.adapter.launch,
-      ...(deps.deferTermination
-        ? {terminate: deps.deferTermination}
-        : deps.adapter.terminate
-          ? {terminate: deps.adapter.terminate}
-          : {}),
+      ...(terminate ? {terminate} : {}),
       ...(deps.adapter.reservationTtlSeconds !== undefined
         ? {reservationTtlSeconds: deps.adapter.reservationTtlSeconds}
         : {}),
       buildRunnerEnv,
-      reservationLimit,
+      reservationLimit: config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS,
       launchBudget,
       waitSeconds: config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS,
       runnerInstanceBatchSize: config.SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE,
@@ -343,6 +381,7 @@ export async function runDemandIteration<Spec>(
     });
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'poll_demand', at: new Date()});
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'authentication', at: new Date()});
+    return result;
   } catch (error) {
     if (deps.signal?.aborted) throw error;
     const facet: HealthFacet =
@@ -354,33 +393,43 @@ export async function runDemandIteration<Spec>(
       impact: 'control_plane',
       at: new Date(),
     });
-    // Do not let a provider retain a demand snapshot after a failed poll.
     notifyDemandStats(deps.adapter, [], health);
     throw error;
   }
-  notifyDemandStats(deps.adapter, result.stats, health);
+}
 
-  if (!deps.deferTermination) {
-    if (result.providerTermination.status === 'failed') {
-      applyHealthEvent(health, {
-        type: 'facet_failed',
-        facet: 'provider_termination',
-        cause: result.providerTermination.cause,
-        impact: 'cleanup',
-        at: new Date(),
-      });
-    } else if (
-      result.providerTermination.status === 'succeeded' ||
-      result.providerTermination.status === 'not_needed'
-    ) {
-      applyHealthEvent(health, {
-        type: 'facet_recovered',
-        facet: 'provider_termination',
-        at: new Date(),
-      });
-    }
+function updateProviderTerminationHealth<Spec>(
+  deps: RunProvisionerIterationDeps<Spec>,
+  result: ProvisionerTickResult,
+  health: ProvisionerHealthState,
+): void {
+  if (deps.deferTermination) return;
+  if (result.providerTermination.status === 'failed') {
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'provider_termination',
+      cause: result.providerTermination.cause,
+      impact: 'cleanup',
+      at: new Date(),
+    });
+    return;
   }
+  if (
+    result.providerTermination.status === 'succeeded' ||
+    result.providerTermination.status === 'not_needed'
+  ) {
+    applyHealthEvent(health, {
+      type: 'facet_recovered',
+      facet: 'provider_termination',
+      at: new Date(),
+    });
+  }
+}
 
+function updateRunnerCapacityHealth(
+  result: ProvisionerTickResult,
+  health: ProvisionerHealthState,
+): void {
   const hasCapacityFailure =
     result.runnerInstanceCreationFailureCount > 0 ||
     result.providerLaunchFailureCount > 0 ||
@@ -400,7 +449,9 @@ export async function runDemandIteration<Spec>(
   } else if (result.launchedCount > 0) {
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'runner_capacity', at: new Date()});
   }
+}
 
+function logDemandIteration(result: ProvisionerTickResult): void {
   if (result.reservationConsumedOrStaleCount > 0) {
     logger().info(
       {
@@ -410,38 +461,28 @@ export async function runDemandIteration<Spec>(
       'Runner reservation was consumed or stale; skipping unavailable launches',
     );
   }
-
-  if (result.launchedCount > 0) {
-    applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
-  }
-
-  const derived = healthDerived(health);
-
-  if (result.reservationCount > 0 || result.launchedCount > 0 || result.launchAttemptedCount > 0) {
-    logger().info(
-      {
-        event: 'runner.launch_batch_completed',
-        reserved: result.reservedRunnerCount,
-        planned: result.plannedCount,
-        attempted: result.launchAttemptedCount,
-        started: result.launchedCount,
-        failed: result.launchAttemptedCount - result.launchedCount,
-        lifecycleIncomplete: result.launchLifecycleIncompleteCount,
-        ...(result.launchLifecycleIncompleteReason
-          ? {launchLifecycleIncompleteReason: result.launchLifecycleIncompleteReason}
-          : {}),
-        reservations: result.reservationCount,
-      },
-      'Runner launch batch completed',
-    );
-  }
-
-  return {
-    nextInterval: derived.shouldBackOff
-      ? nextBackoffInterval(deps.currentInterval)
-      : config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS,
-    degraded: derived.capacityDegraded,
-  };
+  if (
+    result.reservationCount === 0 &&
+    result.launchedCount === 0 &&
+    result.launchAttemptedCount === 0
+  )
+    return;
+  logger().info(
+    {
+      event: 'runner.launch_batch_completed',
+      reserved: result.reservedRunnerCount,
+      planned: result.plannedCount,
+      attempted: result.launchAttemptedCount,
+      started: result.launchedCount,
+      failed: result.launchAttemptedCount - result.launchedCount,
+      lifecycleIncomplete: result.launchLifecycleIncompleteCount,
+      ...(result.launchLifecycleIncompleteReason
+        ? {launchLifecycleIncompleteReason: result.launchLifecycleIncompleteReason}
+        : {}),
+      reservations: result.reservationCount,
+    },
+    'Runner launch batch completed',
+  );
 }
 
 /** Best-effort delivery for deferred terminations before the provider stops. */

--- a/libs/provisioner/core/src/template-file.ts
+++ b/libs/provisioner/core/src/template-file.ts
@@ -110,48 +110,55 @@ export function parseTemplateFile(raw: unknown): ProvisionerTemplateFile {
  * evaluated and validated before the first cartesian product is materialized.
  */
 export function enumerateVariants(file: ProvisionerTemplateFile): Variant[] {
+  const preparedBlocks = prepareMatrixBlocks(file);
+  assertTemplateCountWithinLimit(preparedBlocks, file.templates);
+
+  const variants: Variant[] = [];
+  for (const block of preparedBlocks) appendPreparedBlockVariants(block, variants);
+
+  return variants;
+}
+
+function prepareMatrixBlocks(file: ProvisionerTemplateFile): PreparedBlock[] {
   const preparedBlocks: PreparedBlock[] = [];
   const errors: string[] = [];
-
   for (const [blockName, block] of Object.entries(file.matrix ?? {})) {
     const prepared = evaluateBlockAxes(blockName, block, file.vars ?? {}, errors);
     if (prepared !== undefined) preparedBlocks.push(prepared);
   }
-
   if (errors.length > 0) {
     throw new ProvisionerTemplateFileError(`Invalid template matrix: ${errors.join('; ')}`);
   }
+  return preparedBlocks;
+}
 
+function assertTemplateCountWithinLimit(
+  preparedBlocks: readonly PreparedBlock[],
+  templates: ProvisionerTemplateFile['templates'],
+): void {
   const contributions = preparedBlocks.map(({name, cartesianCount, include}) => ({
     name,
     count: cartesianCount + BigInt(include.length),
   }));
   const matrixCount = contributions.reduce((total, contribution) => total + contribution.count, 0n);
-  const handWrittenCount = BigInt(Object.keys(file.templates).length);
-  const totalCount = matrixCount + handWrittenCount;
+  const handWrittenCount = BigInt(Object.keys(templates).length);
+  if (matrixCount + handWrittenCount <= BigInt(MAX_TEMPLATES)) return;
 
-  if (totalCount > BigInt(MAX_TEMPLATES)) {
-    const contributionText = contributions.map(({name, count}) => `${name}: ${count}`).join(', ');
-    const matrixText = contributionText.length > 0 ? ` (${contributionText})` : '';
-    throw new ProvisionerTemplateFileError(
-      `matrix expands to ${matrixCount} templates${matrixText} plus ${handWrittenCount} hand-written; the maximum is ${MAX_TEMPLATES}`,
-    );
-  }
+  const contributionText = contributions.map(({name, count}) => `${name}: ${count}`).join(', ');
+  const matrixText = contributionText.length > 0 ? ` (${contributionText})` : '';
+  throw new ProvisionerTemplateFileError(
+    `matrix expands to ${matrixCount} templates${matrixText} plus ${handWrittenCount} hand-written; the maximum is ${MAX_TEMPLATES}`,
+  );
+}
 
-  const variants: Variant[] = [];
-  for (const block of preparedBlocks) {
-    const cartesian = materializeCartesianProduct(block.axisNames, block.axisValues);
-    for (const bindings of cartesian) {
-      if (!block.exclude.some((entry) => matchesPartial(bindings, entry))) {
-        variants.push({block: block.name, bindings});
-      }
-    }
-    for (const bindings of block.include) {
+function appendPreparedBlockVariants(block: PreparedBlock, variants: Variant[]): void {
+  const cartesian = materializeCartesianProduct(block.axisNames, block.axisValues);
+  for (const bindings of cartesian) {
+    if (!block.exclude.some((entry) => matchesPartial(bindings, entry))) {
       variants.push({block: block.name, bindings});
     }
   }
-
-  return variants;
+  for (const bindings of block.include) variants.push({block: block.name, bindings});
 }
 
 export const parseProvisionerTemplateFile = parseTemplateFile;
@@ -172,33 +179,8 @@ export function renderTemplateVariants(file: ProvisionerTemplateFile): RenderedT
   const renderedGenerated: RenderedVariant[] = [];
 
   for (const variant of variants) {
-    const block = file.matrix?.[variant.block];
-    if (block === undefined) {
-      failures.record(variant.block, variant.bindings, 'block', 'Matrix block is missing.');
-      continue;
-    }
-
-    const evaluation = evaluateVariant(variant, block, file.vars ?? {}, failures);
-    if (evaluation === undefined) continue;
-
-    const mergedTemplate = mergeTemplateObjects(file.defaults, block.template);
-    const rendered = renderTemplateObject(
-      mergedTemplate,
-      evaluation.context,
-      evaluation.environment,
-      variant.block,
-      evaluation.displayBindings,
-      failures,
-    );
-    if (rendered.failed) continue;
-
-    renderedGenerated.push({
-      block: variant.block,
-      bindings: variant.bindings,
-      displayBindings: evaluation.displayBindings,
-      key: evaluation.key,
-      template: rendered.value,
-    });
+    const rendered = renderGeneratedVariant(file, variant, failures);
+    if (rendered !== undefined) renderedGenerated.push(rendered);
   }
 
   if (failures.hasFailures()) throw failures.toError();
@@ -241,6 +223,36 @@ export function renderTemplateVariants(file: ProvisionerTemplateFile): RenderedT
   }
 
   return templates;
+}
+
+function renderGeneratedVariant(
+  file: ProvisionerTemplateFile,
+  variant: Variant,
+  failures: RenderFailureCollector,
+): RenderedVariant | undefined {
+  const block = file.matrix?.[variant.block];
+  if (block === undefined) {
+    failures.record(variant.block, variant.bindings, 'block', 'Matrix block is missing.');
+    return undefined;
+  }
+  const evaluation = evaluateVariant(variant, block, file.vars ?? {}, failures);
+  if (evaluation === undefined) return undefined;
+  const rendered = renderTemplateObject(
+    mergeTemplateObjects(file.defaults, block.template),
+    evaluation.context,
+    evaluation.environment,
+    variant.block,
+    evaluation.displayBindings,
+    failures,
+  );
+  if (rendered.failed) return undefined;
+  return {
+    block: variant.block,
+    bindings: variant.bindings,
+    displayBindings: evaluation.displayBindings,
+    key: evaluation.key,
+    template: rendered.value,
+  };
 }
 
 export const renderVariants = renderTemplateVariants;
@@ -795,34 +807,33 @@ function parseVariantList(
     return [];
   }
 
-  return value.flatMap((entry, index) => {
-    const entryPath = `${path}.${index}`;
-    if (!isRecord(entry)) {
-      errors.push(`${entryPath} must be a map`);
-      return [];
-    }
+  return value.flatMap((entry, index) =>
+    parseVariantEntry(entry, `${path}.${index}`, errors, axes, requireComplete),
+  );
+}
 
-    const axisNames = Object.keys(axes);
-    const missing = axisNames.filter((axisName) => !Object.hasOwn(entry, axisName));
-    const extra = Object.keys(entry).filter((axisName) => !Object.hasOwn(axes, axisName));
-    if (requireComplete && missing.length > 0) {
-      errors.push(`${entryPath} must bind every declared axis; missing ${missing.join(', ')}`);
-    }
-    if (extra.length > 0) {
-      errors.push(`${entryPath} has unknown axes: ${extra.join(', ')}`);
-    }
-    if (requireComplete && (missing.length > 0 || extra.length > 0)) return [];
-    if (!requireComplete && extra.length > 0) return [];
-
-    return [
-      Object.fromEntries(
-        (requireComplete ? axisNames : Object.keys(entry)).map((axisName) => [
-          axisName,
-          entry[axisName],
-        ]),
-      ),
-    ];
-  });
+function parseVariantEntry(
+  entry: unknown,
+  entryPath: string,
+  errors: string[],
+  axes: Readonly<Record<string, MatrixAxis>>,
+  requireComplete: boolean,
+): VariantBindings[] {
+  if (!isRecord(entry)) {
+    errors.push(`${entryPath} must be a map`);
+    return [];
+  }
+  const axisNames = Object.keys(axes);
+  const missing = axisNames.filter((axisName) => !Object.hasOwn(entry, axisName));
+  const extra = Object.keys(entry).filter((axisName) => !Object.hasOwn(axes, axisName));
+  if (requireComplete && missing.length > 0) {
+    errors.push(`${entryPath} must bind every declared axis; missing ${missing.join(', ')}`);
+  }
+  if (extra.length > 0) errors.push(`${entryPath} has unknown axes: ${extra.join(', ')}`);
+  if (requireComplete && (missing.length > 0 || extra.length > 0)) return [];
+  if (!requireComplete && extra.length > 0) return [];
+  const keys = requireComplete ? axisNames : Object.keys(entry);
+  return [Object.fromEntries(keys.map((axisName) => [axisName, entry[axisName]]))];
 }
 
 function parseExpressionMap(

--- a/libs/provisioner/core/src/template-selection.ts
+++ b/libs/provisioner/core/src/template-selection.ts
@@ -53,5 +53,7 @@ function compareTemplatePreference<Spec>(
 ): number {
   if (a.cost !== b.cost) return a.cost - b.cost;
   if (a.labels.length !== b.labels.length) return a.labels.length - b.labels.length;
-  return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  if (a.key < b.key) return -1;
+  if (a.key > b.key) return 1;
+  return 0;
 }

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -21,6 +21,10 @@ type WarmLaunchGroup<Spec> = {
   readonly count: number;
 };
 type LaunchGroup<Spec> = PlannedLaunchGroup<Spec> | WarmLaunchGroup<Spec>;
+type PlannedRunner<Spec> = {
+  readonly providerRunnerId: string;
+  readonly template: ProvisionerTemplate<Spec>;
+};
 
 export type RunnerEnvFactory<Spec> = (args: {
   template: ProvisionerTemplate<Spec>;
@@ -126,37 +130,69 @@ async function completeProvisionerTick<Spec>(
   deps: ProvisionerTickDeps<Spec>,
   response: Awaited<ReturnType<ProvisionerClient['pollDemand']>>,
 ): Promise<ProvisionerTickResult> {
-  let providerTermination: ProvisionerTerminationOutcome;
-  if (deps.signal?.aborted) {
-    providerTermination = {status: 'cancelled'};
-  } else if (deps.terminate) {
-    try {
-      await deps.terminate(response.terminate_provider_runner_ids);
-      providerTermination = {status: 'succeeded'};
-    } catch (error) {
-      if (deps.signal?.aborted) {
-        providerTermination = {status: 'cancelled'};
-      } else if (error instanceof ProvisionerAuthenticationError) {
-        throw error;
-      } else {
-        providerTermination = {
-          status: 'failed',
-          cause: errorReason(error),
-        };
-      }
-    }
-  } else if (response.terminate_provider_runner_ids.length > 0) {
-    providerTermination = {status: 'not_attempted'};
-  } else {
-    providerTermination = {status: 'not_needed'};
-  }
+  const providerTermination = await resolveProviderTermination(deps, response);
+  const allGroups = planTickLaunchGroups(deps, response);
+  const plannedCount = allGroups.reduce((sum, group) => sum + group.count, 0);
+  const reservedRunnerCount =
+    response.newly_reserved_count ??
+    response.reservations.reduce((sum, reservation) => sum + reservation.count, 0);
+  const launchStats = await launchTickGroups(
+    limitLaunchGroups(allGroups, resolveLaunchBudget(deps.launchBudget)),
+    deps,
+  );
 
+  return {
+    stats: response.stats,
+    reservationCount: response.reservations.length,
+    reservedRunnerCount,
+    providerTermination,
+    plannedCount,
+    launchAttemptedCount: launchStats.attempted,
+    launchedCount: launchStats.launched,
+    runnerInstanceCreationFailureCount: launchStats.runnerInstanceCreationFailureCount,
+    ...(launchStats.runnerInstanceCreationFailureReason
+      ? {runnerInstanceCreationFailureReason: launchStats.runnerInstanceCreationFailureReason}
+      : {}),
+    reservationConsumedOrStaleCount: launchStats.reservationConsumedOrStaleCount,
+    providerLaunchFailureCount: launchStats.providerLaunchFailureCount,
+    ...(launchStats.providerLaunchFailureReason
+      ? {providerLaunchFailureReason: launchStats.providerLaunchFailureReason}
+      : {}),
+    launchLifecycleIncompleteCount: launchStats.launchLifecycleIncompleteCount,
+    ...(launchStats.launchLifecycleIncompleteReason
+      ? {launchLifecycleIncompleteReason: launchStats.launchLifecycleIncompleteReason}
+      : {}),
+  };
+}
+
+async function resolveProviderTermination<Spec>(
+  deps: ProvisionerTickDeps<Spec>,
+  response: Awaited<ReturnType<ProvisionerClient['pollDemand']>>,
+): Promise<ProvisionerTerminationOutcome> {
+  if (deps.signal?.aborted) return {status: 'cancelled'};
+  if (!deps.terminate) {
+    return response.terminate_provider_runner_ids.length > 0
+      ? {status: 'not_attempted'}
+      : {status: 'not_needed'};
+  }
+  try {
+    await deps.terminate(response.terminate_provider_runner_ids);
+    return {status: 'succeeded'};
+  } catch (error) {
+    if (deps.signal?.aborted) return {status: 'cancelled'};
+    if (error instanceof ProvisionerAuthenticationError) throw error;
+    return {status: 'failed', cause: errorReason(error)};
+  }
+}
+
+function planTickLaunchGroups<Spec>(
+  deps: ProvisionerTickDeps<Spec>,
+  response: Awaited<ReturnType<ProvisionerClient['pollDemand']>>,
+): LaunchGroup<Spec>[] {
+  const countsByTemplate = deps.tracker.countsByTemplate();
   const availableByKey = new Map(
     deps.templates.map((template) => {
-      const counts = deps.tracker.countsByTemplate().get(template.key) ?? {
-        starting: 0,
-        running: 0,
-      };
+      const counts = countsByTemplate.get(template.key) ?? {starting: 0, running: 0};
       return [template.key, templateAvailableSlots(template, counts)];
     }),
   );
@@ -169,21 +205,6 @@ async function completeProvisionerTick<Spec>(
     templates: deps.templates,
     availableByKey,
   });
-
-  let plannedCount = planned.reduce((sum, group) => sum + group.count, 0);
-  const reservedRunnerCount =
-    response.newly_reserved_count ??
-    response.reservations.reduce((sum, reservation) => sum + reservation.count, 0);
-
-  let launchAttemptedCount = 0;
-  let launchedCount = 0;
-  let runnerInstanceCreationFailureCount = 0;
-  let runnerInstanceCreationFailureReason: string | undefined;
-  let reservationConsumedOrStaleCount = 0;
-  let providerLaunchFailureCount = 0;
-  let providerLaunchFailureReason: string | undefined;
-  let launchLifecycleIncompleteCount = 0;
-  let launchLifecycleIncompleteReason: string | undefined;
   const plannedByTemplate = new Map<string, number>();
   for (const group of planned) {
     plannedByTemplate.set(
@@ -192,7 +213,7 @@ async function completeProvisionerTick<Spec>(
     );
   }
   const hotGroups = deps.templates.flatMap((template) => {
-    const counts = deps.tracker.countsByTemplate().get(template.key) ?? {starting: 0, running: 0};
+    const counts = countsByTemplate.get(template.key) ?? {starting: 0, running: 0};
     const count = Math.max(
       0,
       (template.targetConcurrency ?? 0) -
@@ -202,9 +223,37 @@ async function completeProvisionerTick<Spec>(
     );
     return count > 0 ? [{reservationId: undefined, template, count}] : [];
   });
-  const allGroups: LaunchGroup<Spec>[] = [...planned, ...hotGroups];
-  plannedCount = allGroups.reduce((sum, group) => sum + group.count, 0);
-  const budgetedGroups = limitLaunchGroups(allGroups, resolveLaunchBudget(deps.launchBudget));
+  return [...planned, ...hotGroups];
+}
+
+interface LaunchStats {
+  attempted: number;
+  launched: number;
+  runnerInstanceCreationFailureCount: number;
+  runnerInstanceCreationFailureReason?: string | undefined;
+  reservationConsumedOrStaleCount: number;
+  providerLaunchFailureCount: number;
+  providerLaunchFailureReason?: string | undefined;
+  launchLifecycleIncompleteCount: number;
+  launchLifecycleIncompleteReason?: string | undefined;
+}
+
+function emptyLaunchStats(): LaunchStats {
+  return {
+    attempted: 0,
+    launched: 0,
+    runnerInstanceCreationFailureCount: 0,
+    reservationConsumedOrStaleCount: 0,
+    providerLaunchFailureCount: 0,
+    launchLifecycleIncompleteCount: 0,
+  };
+}
+
+async function launchTickGroups<Spec>(
+  budgetedGroups: readonly LaunchGroup<Spec>[],
+  deps: ProvisionerTickDeps<Spec>,
+): Promise<LaunchStats> {
+  const totals = emptyLaunchStats();
   const reservationGroups = budgetedGroups.filter(
     (group): group is PlannedLaunchGroup<Spec> => group.reservationId !== undefined,
   );
@@ -213,47 +262,25 @@ async function completeProvisionerTick<Spec>(
   );
   for (const [reservationId, groups] of groupByReservation(reservationGroups)) {
     if (deps.signal?.aborted) break;
-    const result = await launchReservation(reservationId, groups, deps);
-    launchAttemptedCount += result.attempted;
-    launchedCount += result.launched;
-    runnerInstanceCreationFailureCount += result.runnerInstanceCreationFailureCount;
-    runnerInstanceCreationFailureReason ??= result.runnerInstanceCreationFailureReason;
-    reservationConsumedOrStaleCount += result.reservationConsumedOrStaleCount;
-    providerLaunchFailureCount += result.providerLaunchFailureCount;
-    providerLaunchFailureReason ??= result.providerLaunchFailureReason;
-    launchLifecycleIncompleteCount += result.launchLifecycleIncompleteCount;
-    launchLifecycleIncompleteReason ??= result.launchLifecycleIncompleteReason;
+    mergeLaunchStats(totals, await launchReservation(reservationId, groups, deps));
   }
 
   if (!deps.signal?.aborted && warmGroups.length > 0) {
-    const result = await launchReservation(undefined, warmGroups, deps);
-    launchAttemptedCount += result.attempted;
-    launchedCount += result.launched;
-    runnerInstanceCreationFailureCount += result.runnerInstanceCreationFailureCount;
-    runnerInstanceCreationFailureReason ??= result.runnerInstanceCreationFailureReason;
-    reservationConsumedOrStaleCount += result.reservationConsumedOrStaleCount;
-    providerLaunchFailureCount += result.providerLaunchFailureCount;
-    providerLaunchFailureReason ??= result.providerLaunchFailureReason;
-    launchLifecycleIncompleteCount += result.launchLifecycleIncompleteCount;
-    launchLifecycleIncompleteReason ??= result.launchLifecycleIncompleteReason;
+    mergeLaunchStats(totals, await launchReservation(undefined, warmGroups, deps));
   }
+  return totals;
+}
 
-  return {
-    stats: response.stats,
-    reservationCount: response.reservations.length,
-    reservedRunnerCount,
-    providerTermination,
-    plannedCount,
-    launchAttemptedCount,
-    launchedCount,
-    runnerInstanceCreationFailureCount,
-    ...(runnerInstanceCreationFailureReason ? {runnerInstanceCreationFailureReason} : {}),
-    reservationConsumedOrStaleCount,
-    providerLaunchFailureCount,
-    ...(providerLaunchFailureReason ? {providerLaunchFailureReason} : {}),
-    launchLifecycleIncompleteCount,
-    ...(launchLifecycleIncompleteReason ? {launchLifecycleIncompleteReason} : {}),
-  };
+function mergeLaunchStats(target: LaunchStats, source: LaunchStats): void {
+  target.attempted += source.attempted;
+  target.launched += source.launched;
+  target.runnerInstanceCreationFailureCount += source.runnerInstanceCreationFailureCount;
+  target.runnerInstanceCreationFailureReason ??= source.runnerInstanceCreationFailureReason;
+  target.reservationConsumedOrStaleCount += source.reservationConsumedOrStaleCount;
+  target.providerLaunchFailureCount += source.providerLaunchFailureCount;
+  target.providerLaunchFailureReason ??= source.providerLaunchFailureReason;
+  target.launchLifecycleIncompleteCount += source.launchLifecycleIncompleteCount;
+  target.launchLifecycleIncompleteReason ??= source.launchLifecycleIncompleteReason;
 }
 
 async function launchReservation<Spec>(
@@ -263,17 +290,7 @@ async function launchReservation<Spec>(
     | {reservationId: undefined; template: ProvisionerTemplate<Spec>; count: number}
   )[],
   deps: ProvisionerTickDeps<Spec>,
-): Promise<{
-  attempted: number;
-  launched: number;
-  runnerInstanceCreationFailureCount: number;
-  runnerInstanceCreationFailureReason?: string;
-  reservationConsumedOrStaleCount: number;
-  providerLaunchFailureCount: number;
-  providerLaunchFailureReason?: string;
-  launchLifecycleIncompleteCount: number;
-  launchLifecycleIncompleteReason?: string;
-}> {
+): Promise<LaunchStats> {
   // A fresh, never-reused provider identity per runner names the compute resource;
   // names the resource, and keys idempotent reporting and reconciliation. UUIDv7 keeps
   // generated ids time-ordered without adding a dependency.
@@ -283,128 +300,140 @@ async function launchReservation<Spec>(
       template: group.template,
     })),
   );
-  const templateById = new Map<string, ProvisionerTemplate<Spec>>(
-    plannedRunners.map((runner) => [runner.providerRunnerId, runner.template]),
-  );
-
-  let attempted = 0;
-  let launched = 0;
-  let runnerInstanceCreationFailureCount = 0;
-  let runnerInstanceCreationFailureReason: string | undefined;
-  let reservationConsumedOrStaleCount = 0;
-  let providerLaunchFailureCount = 0;
-  let providerLaunchFailureReason: string | undefined;
-  let launchLifecycleIncompleteCount = 0;
-  let launchLifecycleIncompleteReason: string | undefined;
+  const stats = emptyLaunchStats();
   const batches = chunk(plannedRunners, deps.runnerInstanceBatchSize);
   let batchStartIndex = 0;
   for (const batch of batches) {
     if (deps.signal?.aborted) break;
-    let created: CreateRunnerInstancesResponseDto;
-    try {
-      created = await deps.client.createRunnerInstances(
-        {
-          runner_instances: batch.map((runner) => ({
-            template_key: runner.template.key,
-            ...(reservationId ? {reservation_id: reservationId} : {}),
-          })),
-        },
-        deps.signal ? {signal: deps.signal} : {},
-      );
-    } catch (error) {
-      if (error instanceof ProvisionerAuthenticationError) throw error;
-      if (deps.signal?.aborted) throw error;
-      // Leave these slots free: the reservation TTL releases the demand and another
-      // tick (or another provisioner) can pick it up.
-      attempted += batch.length;
-      runnerInstanceCreationFailureCount += batch.length;
-      runnerInstanceCreationFailureReason ??= instanceCreationFailureReason(error);
+    const creation = await createRunnerBatch(reservationId, batch, deps);
+    if (creation.kind === 'failed') {
+      stats.attempted += batch.length;
+      stats.runnerInstanceCreationFailureCount += batch.length;
+      stats.runnerInstanceCreationFailureReason ??= creation.reason;
       batchStartIndex += batch.length;
       continue;
     }
 
-    const missingCount = Math.max(0, batch.length - created.runner_instances.length);
-    // Reservation shortfalls are expected control-plane races. The reservation id
-    // fallback keeps a new provisioner compatible with an older API that returns an
-    // empty runner list without reservation_unavailable when capacity is consumed.
-    const reservationShortfall =
-      missingCount > 0 && (reservationId !== undefined || created.reservation_unavailable === true);
-    if (missingCount > 0 && !reservationShortfall) {
-      attempted += missingCount;
-      runnerInstanceCreationFailureCount += missingCount;
-      runnerInstanceCreationFailureReason ??= `Runner instance creation returned ${created.runner_instances.length} of ${batch.length} requested instances.`;
-    }
-
-    for (const [responseIndex, createdRunner] of created.runner_instances.entries()) {
-      if (deps.signal?.aborted) break;
-      // New API responses carry the request index. Older responses are accepted
-      // prefixes, so the response position remains a safe compatibility fallback.
-      const requestedIndex = createdRunner.request_index ?? responseIndex;
-      const plannedRunner = batch[requestedIndex];
-      if (!plannedRunner) continue;
-      const template = templateById.get(plannedRunner.providerRunnerId);
-      if (!template) continue;
-
-      deps.tracker.recordStarting({
-        providerRunnerId: plannedRunner.providerRunnerId,
-        templateKey: template.key,
-      });
-      attempted += 1;
-      try {
-        const outcome = (await deps.launch({
-          runnerInstanceId: createdRunner.runner_instance_id,
-          providerRunnerId: plannedRunner.providerRunnerId,
-          ...(reservationId ? {reservationId} : {}),
-          template,
-          bootstrapToken: createdRunner.bootstrap_token,
-          runnerEnv: deps.buildRunnerEnv({
-            template,
-            bootstrapToken: createdRunner.bootstrap_token,
-          }),
-        })) ?? {containerStarted: true, identityAttached: true, reported: true};
-        if (!outcome.containerStarted) {
-          providerLaunchFailureCount += 1;
-          deps.tracker.remove(plannedRunner.providerRunnerId);
-          providerLaunchFailureReason ??= launchLifecycleFailureReason(outcome);
-          continue;
-        }
-        launched += 1;
-        if (!outcome.identityAttached || !outcome.reported) {
-          launchLifecycleIncompleteCount += 1;
-          launchLifecycleIncompleteReason ??= launchLifecycleFailureReason(outcome);
-        }
-      } catch (error) {
-        providerLaunchFailureCount += 1;
-        // The launch call rejected, so no resource was created: free the slot now instead
-        // of leaving a phantom `starting` runner. A persistent failure (bad image, daemon
-        // down) would otherwise drain capacity to zero and wedge the loop until restart.
-        deps.tracker.remove(plannedRunner.providerRunnerId);
-        if (error instanceof ProvisionerAuthenticationError) throw error;
-        providerLaunchFailureReason ??= launchFailureReason(error);
-      }
-    }
+    const reservationShortfall = recordRunnerCreationShortfall(
+      stats,
+      reservationId,
+      batch.length,
+      creation.response,
+    );
+    await launchCreatedRunnerBatch(reservationId, batch, creation.response, deps, stats);
 
     if (reservationShortfall) {
-      reservationConsumedOrStaleCount +=
+      stats.reservationConsumedOrStaleCount +=
         plannedRunners.length -
         batchStartIndex -
-        Math.min(created.runner_instances.length, batch.length);
+        Math.min(creation.response.runner_instances.length, batch.length);
       break;
     }
     batchStartIndex += batch.length;
   }
 
-  return {
-    attempted,
-    launched,
-    runnerInstanceCreationFailureCount,
-    ...(runnerInstanceCreationFailureReason ? {runnerInstanceCreationFailureReason} : {}),
-    reservationConsumedOrStaleCount,
-    providerLaunchFailureCount,
-    ...(providerLaunchFailureReason ? {providerLaunchFailureReason} : {}),
-    launchLifecycleIncompleteCount,
-    ...(launchLifecycleIncompleteReason ? {launchLifecycleIncompleteReason} : {}),
-  };
+  return stats;
+}
+
+async function createRunnerBatch<Spec>(
+  reservationId: string | undefined,
+  batch: readonly PlannedRunner<Spec>[],
+  deps: ProvisionerTickDeps<Spec>,
+): Promise<
+  {kind: 'created'; response: CreateRunnerInstancesResponseDto} | {kind: 'failed'; reason: string}
+> {
+  try {
+    const response = await deps.client.createRunnerInstances(
+      {
+        runner_instances: batch.map((runner) => ({
+          template_key: runner.template.key,
+          ...(reservationId ? {reservation_id: reservationId} : {}),
+        })),
+      },
+      deps.signal ? {signal: deps.signal} : {},
+    );
+    return {kind: 'created', response};
+  } catch (error) {
+    if (error instanceof ProvisionerAuthenticationError || deps.signal?.aborted) throw error;
+    return {kind: 'failed', reason: instanceCreationFailureReason(error)};
+  }
+}
+
+function recordRunnerCreationShortfall(
+  stats: LaunchStats,
+  reservationId: string | undefined,
+  requestedCount: number,
+  response: CreateRunnerInstancesResponseDto,
+): boolean {
+  const missingCount = Math.max(0, requestedCount - response.runner_instances.length);
+  // Reservation shortfalls are expected control-plane races. The reservation id
+  // fallback keeps a new provisioner compatible with an older API.
+  const reservationShortfall =
+    missingCount > 0 && (reservationId !== undefined || response.reservation_unavailable === true);
+  if (missingCount > 0 && !reservationShortfall) {
+    stats.attempted += missingCount;
+    stats.runnerInstanceCreationFailureCount += missingCount;
+    stats.runnerInstanceCreationFailureReason ??= `Runner instance creation returned ${response.runner_instances.length} of ${requestedCount} requested instances.`;
+  }
+  return reservationShortfall;
+}
+
+async function launchCreatedRunnerBatch<Spec>(
+  reservationId: string | undefined,
+  batch: readonly PlannedRunner<Spec>[],
+  response: CreateRunnerInstancesResponseDto,
+  deps: ProvisionerTickDeps<Spec>,
+  stats: LaunchStats,
+): Promise<void> {
+  for (const [responseIndex, createdRunner] of response.runner_instances.entries()) {
+    if (deps.signal?.aborted) break;
+    // New API responses carry the request index. Older responses are accepted
+    // prefixes, so the response position remains a safe compatibility fallback.
+    const plannedRunner = batch[createdRunner.request_index ?? responseIndex];
+    if (!plannedRunner) continue;
+    await launchCreatedRunner(reservationId, plannedRunner, createdRunner, deps, stats);
+  }
+}
+
+async function launchCreatedRunner<Spec>(
+  reservationId: string | undefined,
+  plannedRunner: PlannedRunner<Spec>,
+  createdRunner: CreateRunnerInstancesResponseDto['runner_instances'][number],
+  deps: ProvisionerTickDeps<Spec>,
+  stats: LaunchStats,
+): Promise<void> {
+  const {template} = plannedRunner;
+  deps.tracker.recordStarting({
+    providerRunnerId: plannedRunner.providerRunnerId,
+    templateKey: template.key,
+  });
+  stats.attempted += 1;
+  try {
+    const outcome = (await deps.launch({
+      runnerInstanceId: createdRunner.runner_instance_id,
+      providerRunnerId: plannedRunner.providerRunnerId,
+      ...(reservationId ? {reservationId} : {}),
+      template,
+      bootstrapToken: createdRunner.bootstrap_token,
+      runnerEnv: deps.buildRunnerEnv({template, bootstrapToken: createdRunner.bootstrap_token}),
+    })) ?? {containerStarted: true, identityAttached: true, reported: true};
+    if (!outcome.containerStarted) {
+      stats.providerLaunchFailureCount += 1;
+      deps.tracker.remove(plannedRunner.providerRunnerId);
+      stats.providerLaunchFailureReason ??= launchLifecycleFailureReason(outcome);
+      return;
+    }
+    stats.launched += 1;
+    if (!outcome.identityAttached || !outcome.reported) {
+      stats.launchLifecycleIncompleteCount += 1;
+      stats.launchLifecycleIncompleteReason ??= launchLifecycleFailureReason(outcome);
+    }
+  } catch (error) {
+    stats.providerLaunchFailureCount += 1;
+    deps.tracker.remove(plannedRunner.providerRunnerId);
+    if (error instanceof ProvisionerAuthenticationError) throw error;
+    stats.providerLaunchFailureReason ??= launchFailureReason(error);
+  }
 }
 
 function instanceCreationFailureReason(error: unknown): string {

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -139,67 +139,9 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
       } catch (error) {
         throw addLoggingDriverContext(error, selectedLoggingDriver());
       }
-      let container: Docker.Container | undefined;
-
-      try {
-        container = await docker.createContainer({
-          Image: args.image,
-          name: args.name,
-          Labels: {...args.labels},
-          Env: Object.entries(args.env).map(([key, value]) => `${key}=${value}`),
-          HostConfig: {
-            NanoCpus: args.nanoCpus,
-            Memory: args.memoryBytes,
-            RestartPolicy: {Name: 'no'},
-            ...(options.network ? {NetworkMode: options.network} : {}),
-            ...(options.extraHosts ? {ExtraHosts: [...options.extraHosts]} : {}),
-            ...(options.loggingDriver
-              ? {
-                  LogConfig: {
-                    Type: options.loggingDriver,
-                    Config: {...(options.loggingOptions ?? {})},
-                  },
-                }
-              : {}),
-          },
-        });
-      } catch (error) {
-        const selectedDriver = options.loggingDriver ?? effectiveLoggingDriver;
-        throw addLoggingDriverContext(
-          mapError(
-            error,
-            isConflict(error) ? 'name-conflict' : 'create-failed',
-            selectedDriver
-              ? `Cannot create runner container with logging driver ${selectedDriver}.`
-              : 'Cannot create runner container with the Docker daemon logging driver.',
-          ),
-          selectedDriver,
-        );
-      }
-
-      try {
-        await args.beforeStart?.();
-      } catch (error) {
-        await removeContainer(container).catch(() => undefined);
-        throw error;
-      }
-
-      try {
-        await container.start();
-      } catch (error) {
-        await removeContainer(container).catch(() => undefined);
-        const selectedDriver = selectedLoggingDriver();
-        throw addLoggingDriverContext(
-          mapError(
-            error,
-            'start-failed',
-            selectedDriver
-              ? `Cannot start runner container with logging driver ${selectedDriver}.`
-              : 'Cannot start runner container with the Docker daemon logging driver.',
-          ),
-          selectedDriver,
-        );
-      }
+      const container = await createRunnerContainer(args);
+      await runBeforeContainerStart(container, args.beforeStart);
+      await startRunnerContainer(container);
     },
 
     async listManaged(provisionerId) {
@@ -209,52 +151,7 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
           filters: {label: [`${SHIPFOX_LABELS.provisionerId}=${provisionerId}`]},
         });
 
-        return Promise.all(
-          containers.map(async (container) => {
-            const state = normalizeState(container.State);
-            const inspectTerminalState = state === 'exited' || state === 'dead';
-            let inspected: Docker.ContainerInspectInfo | undefined;
-            let terminalInspectFailed = false;
-            if (inspectTerminalState) {
-              try {
-                inspected = await inspectContainer(container.Id);
-                terminalInspectFailed = !inspected;
-              } catch {
-                // Keep one transient or racing inspect from failing the entire observation pass.
-                inspected = undefined;
-                terminalInspectFailed = true;
-              }
-            }
-            const startedAt = parseDockerDate(inspected?.State?.StartedAt);
-            const finishedAt = parseDockerDate(inspected?.State?.FinishedAt);
-            const loggingDriver =
-              inspected?.HostConfig?.LogConfig?.Type ??
-              options.loggingDriver ??
-              effectiveLoggingDriver;
-            const createdAt = new Date(container.Created * 1000);
-            const exitCode =
-              inspected?.State?.ExitCode ??
-              parseDockerExitCode((container as {Status?: string}).Status);
-            return {
-              id: container.Id,
-              name: container.Names?.[0]?.replace(LEADING_SLASH, '') ?? container.Id,
-              labels: container.Labels ?? {},
-              state,
-              ...(exitCode !== undefined ? {exitCode} : {}),
-              ...(inspected?.State?.OOMKilled !== undefined
-                ? {oomKilled: inspected.State.OOMKilled}
-                : {}),
-              ...(container.Image || inspected?.Config?.Image
-                ? {image: inspected?.Config?.Image ?? container.Image}
-                : {}),
-              ...(loggingDriver ? {loggingDriver} : {}),
-              createdAt: Number.isNaN(createdAt.getTime()) ? new Date() : createdAt,
-              ...(startedAt ? {startedAt} : {}),
-              ...(finishedAt ? {finishedAt} : {}),
-              ...(terminalInspectFailed ? {terminalInspectFailed: true} : {}),
-            };
-          }),
-        );
+        return Promise.all(containers.map(toManagedContainerView));
       } catch (error) {
         throw mapError(error, 'unknown', 'Cannot list managed Docker containers.');
       }
@@ -300,6 +197,141 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
       throw error;
     }
   }
+
+  async function createRunnerContainer(
+    args: Parameters<DockerEngine['createAndStart']>[0],
+  ): Promise<Docker.Container> {
+    try {
+      return await docker.createContainer({
+        Image: args.image,
+        name: args.name,
+        Labels: {...args.labels},
+        Env: Object.entries(args.env).map(([key, value]) => `${key}=${value}`),
+        HostConfig: {
+          NanoCpus: args.nanoCpus,
+          Memory: args.memoryBytes,
+          RestartPolicy: {Name: 'no'},
+          ...(options.network ? {NetworkMode: options.network} : {}),
+          ...(options.extraHosts ? {ExtraHosts: [...options.extraHosts]} : {}),
+          ...(options.loggingDriver
+            ? {
+                LogConfig: {
+                  Type: options.loggingDriver,
+                  Config: {...(options.loggingOptions ?? {})},
+                },
+              }
+            : {}),
+        },
+      });
+    } catch (error) {
+      const driver = selectedLoggingDriver();
+      throw addLoggingDriverContext(
+        mapError(
+          error,
+          isConflict(error) ? 'name-conflict' : 'create-failed',
+          driver
+            ? `Cannot create runner container with logging driver ${driver}.`
+            : 'Cannot create runner container with the Docker daemon logging driver.',
+        ),
+        driver,
+      );
+    }
+  }
+
+  async function runBeforeContainerStart(
+    container: Docker.Container,
+    beforeStart: (() => Promise<void>) | undefined,
+  ): Promise<void> {
+    try {
+      await beforeStart?.();
+    } catch (error) {
+      await removeContainer(container).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async function startRunnerContainer(container: Docker.Container): Promise<void> {
+    try {
+      await container.start();
+    } catch (error) {
+      await removeContainer(container).catch(() => undefined);
+      const driver = selectedLoggingDriver();
+      throw addLoggingDriverContext(
+        mapError(
+          error,
+          'start-failed',
+          driver
+            ? `Cannot start runner container with logging driver ${driver}.`
+            : 'Cannot start runner container with the Docker daemon logging driver.',
+        ),
+        driver,
+      );
+    }
+  }
+
+  async function toManagedContainerView(
+    container: Docker.ContainerInfo,
+  ): Promise<DockerContainerView> {
+    const state = normalizeState(container.State);
+    const {inspected, terminalInspectFailed} = await inspectTerminalContainer(container.Id, state);
+    const startedAt = parseDockerDate(inspected?.State?.StartedAt);
+    const finishedAt = parseDockerDate(inspected?.State?.FinishedAt);
+    const loggingDriver = inspected?.HostConfig?.LogConfig?.Type ?? selectedLoggingDriver();
+    const createdAt = new Date(container.Created * 1000);
+    const exitCode =
+      inspected?.State?.ExitCode ?? parseDockerExitCode((container as {Status?: string}).Status);
+    return {
+      id: container.Id,
+      name: container.Names?.[0]?.replace(LEADING_SLASH, '') ?? container.Id,
+      labels: container.Labels ?? {},
+      state,
+      createdAt: Number.isNaN(createdAt.getTime()) ? new Date() : createdAt,
+      ...optionalContainerViewFields({
+        container,
+        inspected,
+        exitCode,
+        loggingDriver,
+        startedAt,
+        finishedAt,
+        terminalInspectFailed,
+      }),
+    };
+  }
+
+  async function inspectTerminalContainer(id: string, state: DockerContainerState) {
+    if (state !== 'exited' && state !== 'dead') {
+      return {inspected: undefined, terminalInspectFailed: false};
+    }
+    try {
+      const inspected = await inspectContainer(id);
+      return {inspected, terminalInspectFailed: !inspected};
+    } catch {
+      return {inspected: undefined, terminalInspectFailed: true};
+    }
+  }
+}
+
+function optionalContainerViewFields(params: {
+  container: Docker.ContainerInfo;
+  inspected: Docker.ContainerInspectInfo | undefined;
+  exitCode: number | undefined;
+  loggingDriver: string | undefined;
+  startedAt: Date | undefined;
+  finishedAt: Date | undefined;
+  terminalInspectFailed: boolean;
+}): Partial<DockerContainerView> {
+  const fields: {-readonly [Key in keyof DockerContainerView]?: DockerContainerView[Key]} = {};
+  if (params.exitCode !== undefined) fields.exitCode = params.exitCode;
+  if (params.inspected?.State?.OOMKilled !== undefined) {
+    fields.oomKilled = params.inspected.State.OOMKilled;
+  }
+  const image = params.inspected?.Config?.Image ?? params.container.Image;
+  if (image) fields.image = image;
+  if (params.loggingDriver) fields.loggingDriver = params.loggingDriver;
+  if (params.startedAt) fields.startedAt = params.startedAt;
+  if (params.finishedAt) fields.finishedAt = params.finishedAt;
+  if (params.terminalInspectFailed) fields.terminalInspectFailed = true;
+  return fields;
 }
 
 async function followProgress(docker: Docker, stream: NodeJS.ReadableStream): Promise<void> {

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -404,16 +404,23 @@ function recordContainerObservation(
     logMissingLabels(context, parsed.providerRunnerId, parsed.templateKey);
     return;
   }
+  logMissingLabelsRecovery(context, parsed.providerRunnerId);
+  if (recordStaleContainer(context, plan, container, parsed, staleRegistration, staleEpisodeKey))
+    return;
+  recordMappedContainer(context, plan, container, parsed, labels);
+}
+
+function logMissingLabelsRecovery(context: DockerLifecycleContext, providerRunnerId: string): void {
   const missingLabelsRecovery = closeEpisode(
     context.episodes,
-    episodeKey('missing-labels', parsed.providerRunnerId),
+    episodeKey('missing-labels', providerRunnerId),
     context.now(),
   );
   if (missingLabelsRecovery) {
     logger().info(
       {
         event: 'runner.report_resumed',
-        providerRunnerId: parsed.providerRunnerId,
+        providerRunnerId,
         durationMs: missingLabelsRecovery.durationMs,
         attempts: missingLabelsRecovery.attempts,
         suppressed: missingLabelsRecovery.suppressed,
@@ -421,35 +428,51 @@ function recordContainerObservation(
       'Runner report resumed after labels became available',
     );
   }
+}
 
-  if (staleRegistration) {
-    const update = recordEpisode(
-      context.episodes,
-      staleEpisodeKey,
-      `${container.id}:${parsed.templateKey ?? 'unknown'}`,
-      context.now(),
+function recordStaleContainer(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+  container: DockerContainerView,
+  parsed: ParsedContainerIdentity,
+  staleRegistration: boolean,
+  staleEpisodeKey: string,
+): boolean {
+  if (!staleRegistration) return false;
+  const update = recordEpisode(
+    context.episodes,
+    staleEpisodeKey,
+    `${container.id}:${parsed.templateKey ?? 'unknown'}`,
+    context.now(),
+  );
+  if (shouldLogEpisode(update)) {
+    logger().info(
+      {
+        event: 'runner.container_stale_reap_requested',
+        operation: 'kill_and_remove',
+        providerRunnerId: parsed.providerRunnerId,
+        containerId: container.id,
+        containerName: container.name,
+        templateKey: parsed.templateKey,
+        ageMs: Math.max(0, context.now().getTime() - container.createdAt.getTime()),
+        attempts: update.state.attempts,
+        suppressed: update.state.suppressed,
+        ...(update.transition === 'changed' ? {changed: true} : {}),
+      },
+      'Stale runner container reap requested before registration',
     );
-    if (shouldLogEpisode(update)) {
-      logger().info(
-        {
-          event: 'runner.container_stale_reap_requested',
-          operation: 'kill_and_remove',
-          providerRunnerId: parsed.providerRunnerId,
-          containerId: container.id,
-          containerName: container.name,
-          templateKey: parsed.templateKey,
-          ageMs: Math.max(0, context.now().getTime() - container.createdAt.getTime()),
-          attempts: update.state.attempts,
-          suppressed: update.state.suppressed,
-          ...(update.transition === 'changed' ? {changed: true} : {}),
-        },
-        'Stale runner container reap requested before registration',
-      );
-    }
-    plan.terminalActions.push(terminalActionFor(context, container, 'registration-deadline'));
-    return;
   }
+  plan.terminalActions.push(terminalActionFor(context, container, 'registration-deadline'));
+  return true;
+}
 
+function recordMappedContainer(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+  container: DockerContainerView,
+  parsed: ParsedContainerIdentity,
+  labels: readonly string[],
+): void {
   const mapped = mapContainerState(container);
   if (mapped.state === 'starting' || mapped.state === 'running') {
     const liveState: LiveContainerState = {
@@ -461,36 +484,7 @@ function recordContainerObservation(
   }
 
   if (mapped.state === 'failed') {
-    const previousContainerId = context.reportedFailedContainerIds.get(parsed.providerRunnerId);
-    if (previousContainerId && previousContainerId !== container.id) {
-      context.reportedFailedIds.delete(parsed.providerRunnerId);
-      context.reportedFailedContainerIds.delete(parsed.providerRunnerId);
-    }
-    rememberFirstObservedFailure(context, container);
-    const retained = shouldRetainFailedContainer(context);
-    const shouldReport = !context.reportedFailedIds.has(parsed.providerRunnerId);
-    if (shouldReport) {
-      context.reportedFailedIds.add(parsed.providerRunnerId);
-      context.reportedFailedContainerIds.set(parsed.providerRunnerId, container.id);
-      logFailedContainer(context, container, parsed, mapped.reason);
-    }
-
-    plan.terminalActions.push({
-      providerRunnerId: parsed.providerRunnerId,
-      ...(shouldReport
-        ? {
-            event: eventFor(
-              container,
-              mapped.state,
-              labels,
-              context.providerKind,
-              context.now(),
-              mapped.reason,
-            ),
-          }
-        : {}),
-      ...(retained ? {retained: true} : {remove: container.name}),
-    });
+    recordFailedContainer(context, plan, container, parsed, labels, mapped.reason);
     return;
   }
 
@@ -505,6 +499,35 @@ function recordContainerObservation(
       mapped.reason,
     ),
     remove: container.name,
+  });
+}
+
+function recordFailedContainer(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+  container: DockerContainerView,
+  parsed: ParsedContainerIdentity,
+  labels: readonly string[],
+  reason: string | undefined,
+): void {
+  const previousContainerId = context.reportedFailedContainerIds.get(parsed.providerRunnerId);
+  if (previousContainerId && previousContainerId !== container.id) {
+    context.reportedFailedIds.delete(parsed.providerRunnerId);
+    context.reportedFailedContainerIds.delete(parsed.providerRunnerId);
+  }
+  rememberFirstObservedFailure(context, container);
+  const shouldReport = !context.reportedFailedIds.has(parsed.providerRunnerId);
+  if (shouldReport) {
+    context.reportedFailedIds.add(parsed.providerRunnerId);
+    context.reportedFailedContainerIds.set(parsed.providerRunnerId, container.id);
+    logFailedContainer(context, container, parsed, reason);
+  }
+  plan.terminalActions.push({
+    providerRunnerId: parsed.providerRunnerId,
+    ...(shouldReport
+      ? {event: eventFor(container, 'failed', labels, context.providerKind, context.now(), reason)}
+      : {}),
+    ...(shouldRetainFailedContainer(context) ? {retained: true} : {remove: container.name}),
   });
 }
 
@@ -693,6 +716,14 @@ async function applyTerminalActions(
   context: DockerLifecycleContext,
   actions: readonly TerminalAction[],
 ): Promise<void> {
+  logRequestedTerminalActions(context, actions);
+  for (const action of actions) await applyTerminalAction(context, action);
+}
+
+function logRequestedTerminalActions(
+  context: DockerLifecycleContext,
+  actions: readonly TerminalAction[],
+): void {
   const requestedIds = actions
     .filter((action) => action.reason === 'backend-terminate')
     .filter((action) => {
@@ -716,54 +747,66 @@ async function applyTerminalActions(
       'Runner container termination batch requested',
     );
   }
-  for (const action of actions) {
-    const reportBeforeRemove = action.event?.state === 'failed' && action.remove;
-    let reportError: unknown;
-    if (reportBeforeRemove && action.event) {
-      try {
-        await reportEvents(context, [action.event]);
-      } catch (error) {
-        reportError = error;
-      }
+}
+
+async function applyTerminalAction(
+  context: DockerLifecycleContext,
+  action: TerminalAction,
+): Promise<void> {
+  const reportBeforeRemove = action.event?.state === 'failed' && action.remove;
+  let reportError: unknown;
+  if (reportBeforeRemove && action.event) {
+    try {
+      await reportEvents(context, [action.event]);
+    } catch (error) {
+      reportError = error;
     }
-    if (action.killAndRemove) await context.engine.killAndRemove(action.killAndRemove);
-    if (action.remove) await context.engine.remove(action.remove);
-    if (reportError) throw reportError;
-    if (!reportBeforeRemove && action.event) await reportEvents(context, [action.event]);
-    if (action.event?.state === 'stopped') {
-      logger().debug?.(
-        {event: 'runner.container_stopped', providerRunnerId: action.providerRunnerId},
-        'Runner container stopped successfully',
-      );
-    }
-    if (action.remove || action.killAndRemove) {
-      logger().debug?.(
-        {
-          event: 'runner.container_removed',
-          providerRunnerId: action.providerRunnerId,
-          operation: action.killAndRemove ? 'kill_and_remove' : 'remove',
-        },
-        'Runner container removed',
-      );
-    }
-    if (action.reason === 'registration-deadline') {
-      closeEpisode(context.episodes, episodeKey('stale-reap', action.providerRunnerId));
-    }
-    if (action.reason === 'backend-terminate') {
-      const requestedIds =
-        action.requestSource === 'poll'
-          ? context.pollTerminationRequestedIds
-          : context.backendTerminationRequestedIds;
-      requestedIds.delete(action.providerRunnerId);
-      syncTerminationEpisodes(context);
-    }
-    context.knownLiveIds.delete(action.providerRunnerId);
-    context.knownTemplateKeys.delete(action.providerRunnerId);
-    context.tracker.remove(action.providerRunnerId);
-    if (!action.retained) {
-      context.reportedFailedIds.delete(action.providerRunnerId);
-      context.reportedFailedContainerIds.delete(action.providerRunnerId);
-    }
+  }
+  if (action.killAndRemove) await context.engine.killAndRemove(action.killAndRemove);
+  if (action.remove) await context.engine.remove(action.remove);
+  if (reportError) throw reportError;
+  if (!reportBeforeRemove && action.event) await reportEvents(context, [action.event]);
+  logTerminalAction(action);
+  clearTerminalActionState(context, action);
+}
+
+function logTerminalAction(action: TerminalAction): void {
+  if (action.event?.state === 'stopped') {
+    logger().debug?.(
+      {event: 'runner.container_stopped', providerRunnerId: action.providerRunnerId},
+      'Runner container stopped successfully',
+    );
+  }
+  if (action.remove || action.killAndRemove) {
+    logger().debug?.(
+      {
+        event: 'runner.container_removed',
+        providerRunnerId: action.providerRunnerId,
+        operation: action.killAndRemove ? 'kill_and_remove' : 'remove',
+      },
+      'Runner container removed',
+    );
+  }
+}
+
+function clearTerminalActionState(context: DockerLifecycleContext, action: TerminalAction): void {
+  if (action.reason === 'registration-deadline') {
+    closeEpisode(context.episodes, episodeKey('stale-reap', action.providerRunnerId));
+  }
+  if (action.reason === 'backend-terminate') {
+    const requestedIds =
+      action.requestSource === 'poll'
+        ? context.pollTerminationRequestedIds
+        : context.backendTerminationRequestedIds;
+    requestedIds.delete(action.providerRunnerId);
+    syncTerminationEpisodes(context);
+  }
+  context.knownLiveIds.delete(action.providerRunnerId);
+  context.knownTemplateKeys.delete(action.providerRunnerId);
+  context.tracker.remove(action.providerRunnerId);
+  if (!action.retained) {
+    context.reportedFailedIds.delete(action.providerRunnerId);
+    context.reportedFailedContainerIds.delete(action.providerRunnerId);
   }
 }
 
@@ -1190,35 +1233,11 @@ function logFailedContainer(
 ): void {
   const finishedAtUnavailable =
     !container.finishedAt || Number.isNaN(container.finishedAt.getTime());
-  if (finishedAtUnavailable) {
-    logger().debug?.(
-      {
-        event: 'runner.container_failure_timestamp_fallback',
-        operation: 'failed_container_retention',
-        containerId: container.id,
-        containerName: container.name,
-        fallback: 'firstObservedAt',
-        reason: container.terminalInspectFailed
-          ? 'terminal-inspect-unavailable'
-          : 'finished-at-unavailable',
-      },
-      container.terminalInspectFailed
-        ? 'Failure timestamp unavailable; TTL cleanup is deferred but count-bounded cleanup still applies'
-        : 'Failure timestamp unavailable; first-observed failure time will drive TTL cleanup',
-    );
-  }
+  if (finishedAtUnavailable) logFailureTimestampFallback(container);
   const runtimeEndAt = failureAtForRetention(context, container, context.now());
-  const runtimeMs =
-    container.startedAt && !Number.isNaN(container.startedAt.getTime())
-      ? Math.max(0, runtimeEndAt.getTime() - container.startedAt.getTime())
-      : undefined;
-  const retentionDeadline =
-    shouldRetainFailedContainer(context) && !container.terminalInspectFailed
-      ? new Date(
-          failureAtForRetention(context, container, context.now()).getTime() +
-            context.failedContainerRetentionMs,
-        )
-      : undefined;
+  const runtimeMs = containerRuntimeMs(container, runtimeEndAt);
+  const retentionDeadline = failedContainerRetentionDeadline(context, container);
+  const retained = shouldRetainFailedContainer(context);
   const forensicFields = forensicLogFields(container, context);
   logger().error(
     {
@@ -1238,9 +1257,46 @@ function logFailedContainer(
       ...(retentionDeadline ? {retentionDeadline: retentionDeadline.toISOString()} : {}),
       ...forensicFields,
     },
-    shouldRetainFailedContainer(context)
+    retained
       ? 'Runner container failed and was retained for forensic inspection'
       : 'Runner container failed',
+  );
+}
+
+function logFailureTimestampFallback(container: DockerContainerView): void {
+  logger().debug?.(
+    {
+      event: 'runner.container_failure_timestamp_fallback',
+      operation: 'failed_container_retention',
+      containerId: container.id,
+      containerName: container.name,
+      fallback: 'firstObservedAt',
+      reason: container.terminalInspectFailed
+        ? 'terminal-inspect-unavailable'
+        : 'finished-at-unavailable',
+    },
+    container.terminalInspectFailed
+      ? 'Failure timestamp unavailable; TTL cleanup is deferred but count-bounded cleanup still applies'
+      : 'Failure timestamp unavailable; first-observed failure time will drive TTL cleanup',
+  );
+}
+
+function containerRuntimeMs(
+  container: DockerContainerView,
+  runtimeEndAt: Date,
+): number | undefined {
+  if (!container.startedAt || Number.isNaN(container.startedAt.getTime())) return undefined;
+  return Math.max(0, runtimeEndAt.getTime() - container.startedAt.getTime());
+}
+
+function failedContainerRetentionDeadline(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+): Date | undefined {
+  if (!shouldRetainFailedContainer(context) || container.terminalInspectFailed) return undefined;
+  return new Date(
+    failureAtForRetention(context, container, context.now()).getTime() +
+      context.failedContainerRetentionMs,
   );
 }
 

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -334,16 +334,24 @@ function fakeEc2(
       }
       if (command instanceof DescribeInstancesCommand)
         return Promise.resolve(describeOutputs.shift() ?? {});
-      if (command instanceof TerminateInstancesCommand) {
-        const instanceId = command.input.InstanceIds?.[0];
-        const terminateError =
-          options.terminateErrorById?.get(instanceId ?? '') ?? options.terminateError;
-        if (terminateError) return Promise.reject(terminateError);
-        return Promise.resolve({});
-      }
+      if (command instanceof TerminateInstancesCommand)
+        return terminateInstanceResponse(command, options);
       return Promise.reject(new Error('Unexpected EC2 command'));
     },
   };
+}
+
+function terminateInstanceResponse(
+  command: TerminateInstancesCommand,
+  options: {
+    terminateError?: Error;
+    terminateErrorById?: Map<string, Error>;
+  },
+): Promise<unknown> {
+  const instanceId = command.input.InstanceIds?.[0];
+  const terminateError =
+    options.terminateErrorById?.get(instanceId ?? '') ?? options.terminateError;
+  return terminateError ? Promise.reject(terminateError) : Promise.resolve({});
 }
 
 function commandInput<T extends {input: unknown}>(command: unknown): T['input'] {

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -280,27 +280,26 @@ function mapEc2Error(error: unknown, message: string): Ec2EngineError {
   if (error instanceof Ec2EngineError) return error;
 
   const name = errorName(error);
-  const reason =
-    name === 'InsufficientInstanceCapacity'
-      ? 'insufficient-capacity'
-      : name === 'SpotMaxPriceTooLow'
-        ? 'spot-price-too-low'
-        : name === 'RequestLimitExceeded' ||
-            name.startsWith('Throttling') ||
-            name === 'EC2ThrottledException' ||
-            name === 'SlowDown'
-          ? 'throttled'
-          : name.startsWith('InvalidAMIID.')
-            ? 'image-not-found'
-            : ['AuthFailure', 'UnauthorizedOperation', 'Blocked', 'OptInRequired'].includes(name)
-              ? 'auth'
-              : name.startsWith('Invalid') ||
-                  name.startsWith('Missing') ||
-                  name.startsWith('Unsupported')
-                ? 'config-invalid'
-                : isUnreachable(error, name)
-                  ? 'unreachable'
-                  : 'unknown';
+  let reason: Ec2EngineErrorReason = 'unknown';
+  if (name === 'InsufficientInstanceCapacity') reason = 'insufficient-capacity';
+  else if (name === 'SpotMaxPriceTooLow') reason = 'spot-price-too-low';
+  else if (
+    name === 'RequestLimitExceeded' ||
+    name.startsWith('Throttling') ||
+    name === 'EC2ThrottledException' ||
+    name === 'SlowDown'
+  ) {
+    reason = 'throttled';
+  } else if (name.startsWith('InvalidAMIID.')) reason = 'image-not-found';
+  else if (['AuthFailure', 'UnauthorizedOperation', 'Blocked', 'OptInRequired'].includes(name)) {
+    reason = 'auth';
+  } else if (
+    name.startsWith('Invalid') ||
+    name.startsWith('Missing') ||
+    name.startsWith('Unsupported')
+  ) {
+    reason = 'config-invalid';
+  } else if (isUnreachable(error, name)) reason = 'unreachable';
 
   return new Ec2EngineError(reason, message, {cause: error});
 }

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -282,138 +282,219 @@ async function applyObservedInstances(
   instances: readonly Ec2InstanceView[],
   terminateIntentIds: ReadonlySet<string>,
 ): Promise<void> {
-  const trackerRunners: TrackerSeed[] = [];
-  const events: RunnerInstanceReportEventDto[] = [];
-  const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
-  const assignmentCandidates: AssignmentCandidate[] = [];
-  const observedIds = new Set<string>();
-  const observedInstanceIds = new Set<string>();
-  const observedRunnerInstanceIds = new Set<string>();
-  const reapInstances: Ec2InstanceView[] = [];
-  const terminateIntentInstances: Ec2InstanceView[] = [];
+  const plan = createEc2ObservationPlan();
   const observedAt = context.now().getTime();
+  for (const instance of instances)
+    recordObservedInstance(context, plan, instance, terminateIntentIds, observedAt);
+  pruneTerminalReportedInstances(context, plan.observedInstanceIds, context.now().getTime());
+  pruneTerminationActionedInstances(context, plan.observedInstanceIds, context.now().getTime());
+  synthesizeAbsentLaunchedRunners(context, plan.observedIds, plan.trackerRunners, plan.events);
+  context.tracker.replaceAll(plan.trackerRunners);
+  await assignEnrolledReservations(
+    context,
+    plan.assignmentCandidates,
+    plan.observedRunnerInstanceIds,
+  );
+  await terminateInstances(context, plan.terminateIntentInstances, 'backend-terminate');
+  await terminateInstances(context, plan.reapInstances, 'registration-deadline');
+  if (plan.events.length > 0)
+    await reportEvents(context, plan.events, plan.terminalReportInstanceIds);
+}
 
-  for (const instance of instances) {
-    const identity = parseInstanceIdentity(instance);
-    observedInstanceIds.add(instance.instanceId);
-    if (context.terminalReportedInstanceIds.has(instance.instanceId)) {
-      context.terminalReportedInstanceIds.set(instance.instanceId, observedAt);
-    }
-    if (context.terminationActionedInstanceIds.has(instance.instanceId)) {
-      context.terminationActionedInstanceIds.set(instance.instanceId, observedAt);
-    }
-    if (identity.runnerInstanceId) observedRunnerInstanceIds.add(identity.runnerInstanceId);
-    if (!identity.providerRunnerId) continue;
-    observedIds.add(identity.providerRunnerId);
-    const pendingLaunch = context.pendingLaunches.get(identity.providerRunnerId);
-    // An observed instance is no longer eligible for absent-launch synthesis. Keep the
-    // separate pending metric candidate through listing gaps after this point.
-    context.locallyLaunched.delete(identity.providerRunnerId);
-    if (instance.state === 'running' && pendingLaunch) {
-      const templateKey = resolveTemplateKey(context, [
-        identity.templateKey,
-        pendingLaunch.templateKey,
-      ]);
-      const template = context.templatesByKey.get(templateKey);
-      context.pendingLaunches.delete(identity.providerRunnerId);
-      if (template) {
-        recordEc2PendingDuration({
-          durationMs: context.now().getTime() - pendingLaunch.launchedAt.getTime(),
-          templateKey,
-          market: template.spec.market,
-          architecture: instance.architecture ?? 'unknown',
-          availabilityZone: instance.availabilityZone ?? 'unknown',
-        });
-      }
-    } else if (pendingLaunch && isTerminalPendingState(instance.state)) {
-      context.pendingLaunches.delete(identity.providerRunnerId);
-    }
+interface Ec2ObservationPlan {
+  trackerRunners: TrackerSeed[];
+  events: RunnerInstanceReportEventDto[];
+  terminalReportInstanceIds: Map<RunnerInstanceReportEventDto, string>;
+  assignmentCandidates: AssignmentCandidate[];
+  observedIds: Set<string>;
+  observedInstanceIds: Set<string>;
+  observedRunnerInstanceIds: Set<string>;
+  reapInstances: Ec2InstanceView[];
+  terminateIntentInstances: Ec2InstanceView[];
+}
 
-    const hasTerminateIntent = terminateIntentIds.has(identity.providerRunnerId);
-    const pastRegistrationDeadline = isPastRegistrationDeadline(instance, context);
-    const terminationRequested = hasTerminateIntent || pastRegistrationDeadline;
-    const canTerminate = canTerminateInstance(instance);
-    const shouldTerminate = terminationRequested && canTerminate;
-    if (hasTerminateIntent && canTerminate) {
-      terminateIntentInstances.push(instance);
-    } else if (pastRegistrationDeadline && canTerminate) {
-      reapInstances.push(instance);
-    }
+function createEc2ObservationPlan(): Ec2ObservationPlan {
+  return {
+    trackerRunners: [],
+    events: [],
+    terminalReportInstanceIds: new Map(),
+    assignmentCandidates: [],
+    observedIds: new Set(),
+    observedInstanceIds: new Set(),
+    observedRunnerInstanceIds: new Set(),
+    reapInstances: [],
+    terminateIntentInstances: [],
+  };
+}
 
-    if (shouldTerminate) {
-      // terminateInstances reports the provider-initiated reason: backend-terminate or registration-deadline.
-      continue;
-    }
+function recordObservedInstance(
+  context: Ec2LifecycleContext,
+  plan: Ec2ObservationPlan,
+  instance: Ec2InstanceView,
+  terminateIntentIds: ReadonlySet<string>,
+  observedAt: number,
+): void {
+  const identity = parseInstanceIdentity(instance);
+  recordObservedIdentity(context, plan, instance, identity.runnerInstanceId, observedAt);
+  if (!identity.providerRunnerId) return;
+  plan.observedIds.add(identity.providerRunnerId);
+  const pendingLaunch = context.pendingLaunches.get(identity.providerRunnerId);
+  context.locallyLaunched.delete(identity.providerRunnerId);
+  recordPendingLaunchObservation(context, instance, identity, pendingLaunch);
+  const termination = recordTerminationCandidate(
+    context,
+    plan,
+    instance,
+    identity.providerRunnerId,
+    terminateIntentIds,
+  );
+  if (termination.skipObservation) return;
 
-    const template = identity.templateKey
-      ? context.templatesByKey.get(identity.templateKey)
-      : undefined;
-    const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
-    if (labels.length === 0) continue;
-
-    const mapped = mapInstanceState(instance);
-    const liveState =
-      mapped.state === 'starting' || mapped.state === 'running' ? mapped.state : undefined;
-    const terminalObservation = mapped.state === 'failed' || mapped.state === 'terminated';
-    const alreadyReportedTerminal =
-      terminalObservation && hasTerminalReport(context, instance.instanceId);
-    if (!alreadyReportedTerminal) {
-      if (terminalObservation) {
-        const terminationReason =
-          mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
-        const templateKey = resolveTemplateKey(context, [
-          identity.templateKey,
-          pendingLaunch?.templateKey,
-        ]);
-        const template = context.templatesByKey.get(templateKey);
-        recordEc2Termination(terminationReason, templateKey);
-        logger().info(
-          terminationLogFields(instance, identity, templateKey, template, terminationReason),
-          'Observed EC2 runner instance termination',
-        );
-      }
-      const event = eventForInstance(context, instance, mapped.state, labels, mapped.reason);
-      events.push(event);
-      if (terminalObservation) terminalReportInstanceIds.set(event, instance.instanceId);
-    }
-    if (!terminationRequested && liveState && identity.runnerInstanceId) {
-      const hasCanonicalAssignment = context.canonicalReservationIdsByRunner.has(
-        identity.providerRunnerId,
-      );
-      const canonicalReservationId = context.canonicalReservationIdsByRunner.get(
-        identity.providerRunnerId,
-      );
-      const reservationId = hasCanonicalAssignment
-        ? canonicalReservationId
-        : identity.reservationId;
-      if (reservationId) {
-        assignmentCandidates.push({
-          runnerInstanceId: identity.runnerInstanceId,
-          reservationId,
-          ...(identity.reservationId ? {observedReservationId: identity.reservationId} : {}),
-          ...(canonicalReservationId ? {canonicalReservationId} : {}),
-        });
-      }
-    }
-    if (!terminationRequested && liveState && identity.templateKey) {
-      trackerRunners.push({
-        providerRunnerId: identity.providerRunnerId,
-        templateKey: identity.templateKey,
-        state: liveState,
-      });
-    }
+  const template = identity.templateKey
+    ? context.templatesByKey.get(identity.templateKey)
+    : undefined;
+  const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
+  if (labels.length === 0) return;
+  const mapped = mapInstanceState(instance);
+  recordObservedInstanceEvent(context, plan, instance, identity, pendingLaunch, labels, mapped);
+  recordObservedAssignment(context, plan, identity, mapped.state, termination.requested);
+  if (
+    !termination.requested &&
+    (mapped.state === 'starting' || mapped.state === 'running') &&
+    identity.templateKey
+  ) {
+    plan.trackerRunners.push({
+      providerRunnerId: identity.providerRunnerId,
+      templateKey: identity.templateKey,
+      state: mapped.state,
+    });
   }
+}
 
-  pruneTerminalReportedInstances(context, observedInstanceIds, context.now().getTime());
-  pruneTerminationActionedInstances(context, observedInstanceIds, context.now().getTime());
-  synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
-  context.tracker.replaceAll(trackerRunners);
-  await assignEnrolledReservations(context, assignmentCandidates, observedRunnerInstanceIds);
-  await terminateInstances(context, terminateIntentInstances, 'backend-terminate');
-  await terminateInstances(context, reapInstances, 'registration-deadline');
-  if (events.length > 0) {
-    await reportEvents(context, events, terminalReportInstanceIds);
+function recordObservedIdentity(
+  context: Ec2LifecycleContext,
+  plan: Ec2ObservationPlan,
+  instance: Ec2InstanceView,
+  runnerInstanceId: string | undefined,
+  observedAt: number,
+): void {
+  plan.observedInstanceIds.add(instance.instanceId);
+  if (context.terminalReportedInstanceIds.has(instance.instanceId)) {
+    context.terminalReportedInstanceIds.set(instance.instanceId, observedAt);
   }
+  if (context.terminationActionedInstanceIds.has(instance.instanceId)) {
+    context.terminationActionedInstanceIds.set(instance.instanceId, observedAt);
+  }
+  if (runnerInstanceId) plan.observedRunnerInstanceIds.add(runnerInstanceId);
+}
+
+function recordPendingLaunchObservation(
+  context: Ec2LifecycleContext,
+  instance: Ec2InstanceView,
+  identity: ReturnType<typeof parseInstanceIdentity>,
+  pendingLaunch: LocallyLaunchedRunner | undefined,
+): void {
+  if (!pendingLaunch) return;
+  if (instance.state !== 'running') {
+    if (isTerminalPendingState(instance.state))
+      context.pendingLaunches.delete(identity.providerRunnerId);
+    return;
+  }
+  const templateKey = resolveTemplateKey(context, [
+    identity.templateKey,
+    pendingLaunch.templateKey,
+  ]);
+  const template = context.templatesByKey.get(templateKey);
+  context.pendingLaunches.delete(identity.providerRunnerId);
+  if (!template) return;
+  recordEc2PendingDuration({
+    durationMs: context.now().getTime() - pendingLaunch.launchedAt.getTime(),
+    templateKey,
+    market: template.spec.market,
+    architecture: instance.architecture ?? 'unknown',
+    availabilityZone: instance.availabilityZone ?? 'unknown',
+  });
+}
+
+function recordTerminationCandidate(
+  context: Ec2LifecycleContext,
+  plan: Ec2ObservationPlan,
+  instance: Ec2InstanceView,
+  providerRunnerId: string,
+  terminateIntentIds: ReadonlySet<string>,
+): {requested: boolean; skipObservation: boolean} {
+  const hasTerminateIntent = terminateIntentIds.has(providerRunnerId);
+  const pastRegistrationDeadline = isPastRegistrationDeadline(instance, context);
+  const requested = hasTerminateIntent || pastRegistrationDeadline;
+  if (!canTerminateInstance(instance)) return {requested, skipObservation: false};
+  if (hasTerminateIntent) plan.terminateIntentInstances.push(instance);
+  else if (pastRegistrationDeadline) plan.reapInstances.push(instance);
+  return {requested, skipObservation: requested};
+}
+
+function recordObservedInstanceEvent(
+  context: Ec2LifecycleContext,
+  plan: Ec2ObservationPlan,
+  instance: Ec2InstanceView,
+  identity: ReturnType<typeof parseInstanceIdentity>,
+  pendingLaunch: LocallyLaunchedRunner | undefined,
+  labels: readonly string[],
+  mapped: ReturnType<typeof mapInstanceState>,
+): void {
+  const terminal = mapped.state === 'failed' || mapped.state === 'terminated';
+  if (terminal && hasTerminalReport(context, instance.instanceId)) return;
+  if (terminal) logObservedTermination(context, instance, identity, pendingLaunch, mapped.reason);
+  const event = eventForInstance(context, instance, mapped.state, labels, mapped.reason);
+  plan.events.push(event);
+  if (terminal) plan.terminalReportInstanceIds.set(event, instance.instanceId);
+}
+
+function logObservedTermination(
+  context: Ec2LifecycleContext,
+  instance: Ec2InstanceView,
+  identity: ReturnType<typeof parseInstanceIdentity>,
+  pendingLaunch: LocallyLaunchedRunner | undefined,
+  reason: string | undefined,
+): void {
+  const terminationReason =
+    reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
+  const templateKey = resolveTemplateKey(context, [
+    identity.templateKey,
+    pendingLaunch?.templateKey,
+  ]);
+  const template = context.templatesByKey.get(templateKey);
+  recordEc2Termination(terminationReason, templateKey);
+  logger().info(
+    terminationLogFields(instance, identity, templateKey, template, terminationReason),
+    'Observed EC2 runner instance termination',
+  );
+}
+
+function recordObservedAssignment(
+  context: Ec2LifecycleContext,
+  plan: Ec2ObservationPlan,
+  identity: ReturnType<typeof parseInstanceIdentity>,
+  state: ReturnType<typeof mapInstanceState>['state'],
+  terminationRequested: boolean,
+): void {
+  if (
+    terminationRequested ||
+    (state !== 'starting' && state !== 'running') ||
+    !identity.runnerInstanceId
+  )
+    return;
+  const hasCanonical = context.canonicalReservationIdsByRunner.has(identity.providerRunnerId);
+  const canonicalReservationId = context.canonicalReservationIdsByRunner.get(
+    identity.providerRunnerId,
+  );
+  const reservationId = hasCanonical ? canonicalReservationId : identity.reservationId;
+  if (!reservationId) return;
+  plan.assignmentCandidates.push({
+    runnerInstanceId: identity.runnerInstanceId,
+    reservationId,
+    ...(identity.reservationId ? {observedReservationId: identity.reservationId} : {}),
+    ...(canonicalReservationId ? {canonicalReservationId} : {}),
+  });
 }
 
 async function assignEnrolledReservations(
@@ -432,43 +513,54 @@ async function assignEnrolledReservations(
     assignments.set(reservationId, assignmentCandidates);
   }
   for (const [reservationId, assignmentCandidates] of assignments) {
-    const runnerInstanceIds = assignmentCandidates.map((candidate) => candidate.runnerInstanceId);
-    try {
-      await context.client.assignRunnerInstances(reservationId, runnerInstanceIds);
-    } catch (error) {
-      const status = responseStatus(error);
-      const code = status === 409 ? responseCode(error) : undefined;
-      const disposition = assignmentFailureDisposition({status, code});
-      if (disposition.permanent) {
-        const suppressedRunnerInstanceIds =
-          context.suppressedReservationRunnerIds.get(reservationId) ?? new Set<string>();
-        for (const runnerInstanceId of runnerInstanceIds) {
-          suppressedRunnerInstanceIds.add(runnerInstanceId);
-        }
-        context.suppressedReservationRunnerIds.set(reservationId, suppressedRunnerInstanceIds);
-      }
-      const observedReservationIds = uniqueReservationIds({
+    await assignReservationGroup(context, reservationId, assignmentCandidates);
+  }
+}
+
+async function assignReservationGroup(
+  context: Ec2LifecycleContext,
+  reservationId: string,
+  assignmentCandidates: readonly AssignmentCandidate[],
+): Promise<void> {
+  const runnerInstanceIds = assignmentCandidates.map((candidate) => candidate.runnerInstanceId);
+  try {
+    await context.client.assignRunnerInstances(reservationId, runnerInstanceIds);
+  } catch (error) {
+    const status = responseStatus(error);
+    const code = status === 409 ? responseCode(error) : undefined;
+    const disposition = assignmentFailureDisposition({status, code});
+    if (disposition.permanent) {
+      suppressReservationRunners(context, reservationId, runnerInstanceIds);
+    }
+    const details = {
+      reservationId,
+      runnerInstanceIds,
+      observedReservationIds: uniqueReservationIds({
         candidates: assignmentCandidates,
         select: (candidate) => candidate.observedReservationId,
-      });
-      const canonicalReservationIds = uniqueReservationIds({
+      }),
+      canonicalReservationIds: uniqueReservationIds({
         candidates: assignmentCandidates,
         select: (candidate) => candidate.canonicalReservationId,
-      });
-      const details = {
-        reservationId,
-        runnerInstanceIds,
-        observedReservationIds,
-        canonicalReservationIds,
-        err: error,
-        status,
-        ...(code ? {code} : {}),
-        retryable: !disposition.permanent,
-      };
-      if (disposition.level === 'debug') logger().debug(details, disposition.message);
-      else logger().warn(details, disposition.message);
-    }
+      }),
+      err: error,
+      status,
+      ...(code ? {code} : {}),
+      retryable: !disposition.permanent,
+    };
+    if (disposition.level === 'debug') logger().debug(details, disposition.message);
+    else logger().warn(details, disposition.message);
   }
+}
+
+function suppressReservationRunners(
+  context: Ec2LifecycleContext,
+  reservationId: string,
+  runnerInstanceIds: readonly string[],
+): void {
+  const suppressed = context.suppressedReservationRunnerIds.get(reservationId) ?? new Set<string>();
+  for (const runnerInstanceId of runnerInstanceIds) suppressed.add(runnerInstanceId);
+  context.suppressedReservationRunnerIds.set(reservationId, suppressed);
 }
 
 function uniqueReservationIds(params: {

--- a/libs/provisioner/ec2/src/metrics/service.ts
+++ b/libs/provisioner/ec2/src/metrics/service.ts
@@ -1,7 +1,7 @@
 import type {DemandStatDto} from '@shipfox/api-runners-dto';
-import {getServiceMetricsProvider, logger} from '@shipfox/node-opentelemetry';
+import {getServiceMetricsProvider, logger, type ObservableGauge} from '@shipfox/node-opentelemetry';
 import {type ProvisionerTemplate, rankTemplatesForLabels} from '@shipfox/provisioner-core';
-import type {Ec2Engine, Ec2InstanceState} from '#ec2-engine.js';
+import type {Ec2Engine, Ec2InstanceState, Ec2InstanceView} from '#ec2-engine.js';
 import {parseInstanceIdentity} from '#instance-identity.js';
 import type {Ec2TemplateSpec} from '#templates.js';
 
@@ -11,6 +11,13 @@ type ServiceMetricLabels = {
 };
 type TemplateRunnerCounts = {starting: number; running: number};
 type TemplateDemand = {queued: number; oldestQueuedAtMs?: number};
+interface BatchMetricObserver {
+  observe(
+    gauge: ObservableGauge<ServiceMetricLabels>,
+    value: number,
+    labels?: ServiceMetricLabels,
+  ): void;
+}
 
 export interface RegisterEc2ServiceMetricsOptions {
   readonly engine: Ec2Engine;
@@ -56,26 +63,11 @@ export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOpti
     async (observer) => {
       try {
         const instances = await options.engine.listManaged(options.provisionerId);
-        const counts = new Map<Ec2InstanceState, number>();
-        for (const instance of instances)
-          counts.set(instance.state, (counts.get(instance.state) ?? 0) + 1);
-        for (const [state, count] of counts) observer.observe(managedInstances, count, {state});
-
-        const countsByTemplate = new Map<string, TemplateRunnerCounts>(
-          options.templates.map((template) => [template.key, {starting: 0, running: 0}]),
+        observeManagedInstanceCounts(observer, managedInstances, instances);
+        const {countsByTemplate, unattributedCount} = countTemplateRunners(
+          options.templates,
+          instances,
         );
-        let unattributedCount = 0;
-        for (const instance of instances) {
-          const templateKey = parseInstanceIdentity(instance).templateKey;
-          if (!templateKey || !countsByTemplate.has(templateKey)) {
-            unattributedCount += 1;
-            continue;
-          }
-          const state = templateRunnerState(instance.state);
-          if (!state) continue;
-          const templateCounts = countsByTemplate.get(templateKey);
-          if (templateCounts) templateCounts[state] += 1;
-        }
         if (unattributedCount !== 0 && unattributedCount !== lastUnattributedCount) {
           logger().warn(
             {
@@ -87,52 +79,14 @@ export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOpti
           );
         }
         lastUnattributedCount = unattributedCount;
-
-        const demandByTemplate = new Map<string, TemplateDemand>(
-          options.templates.map((template) => [template.key, {queued: 0}]),
-        );
-        for (const stat of options.getDemandStats()) {
-          if (stat.queued === 0) continue;
-          const oldestQueuedAtMs = Date.parse(stat.oldest_queued_at);
-          for (const template of rankTemplatesForLabels(stat.labels, options.templates)) {
-            const demand = demandByTemplate.get(template.key);
-            if (!demand) continue;
-            demand.queued += stat.queued;
-            if (Number.isFinite(oldestQueuedAtMs)) {
-              demand.oldestQueuedAtMs =
-                demand.oldestQueuedAtMs === undefined
-                  ? oldestQueuedAtMs
-                  : Math.min(demand.oldestQueuedAtMs, oldestQueuedAtMs);
-            }
-          }
-        }
-
-        for (const template of options.templates) {
-          const labels = {template_key: template.key};
-          const countsForTemplate = countsByTemplate.get(template.key) ?? {
-            starting: 0,
-            running: 0,
-          };
-          const demand = demandByTemplate.get(template.key) ?? {queued: 0};
-          observer.observe(templateRunners, countsForTemplate.starting, {
-            ...labels,
-            state: 'starting',
-          });
-          observer.observe(templateRunners, countsForTemplate.running, {
-            ...labels,
-            state: 'running',
-          });
-          observer.observe(templateMaxConcurrency, template.maxConcurrency, labels);
-          observer.observe(templateTargetConcurrency, template.targetConcurrency ?? 0, labels);
-          observer.observe(templateQueuedDemand, demand.queued, labels);
-          observer.observe(
-            templateOldestQueuedAge,
-            demand.oldestQueuedAtMs === undefined
-              ? 0
-              : Math.max(0, Date.now() - demand.oldestQueuedAtMs),
-            labels,
-          );
-        }
+        const demandByTemplate = calculateTemplateDemand(options);
+        observeTemplateMetrics(observer, options.templates, countsByTemplate, demandByTemplate, {
+          templateRunners,
+          templateMaxConcurrency,
+          templateTargetConcurrency,
+          templateQueuedDemand,
+          templateOldestQueuedAge,
+        });
       } catch (error) {
         logger().warn(
           {
@@ -153,6 +107,93 @@ export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOpti
       templateOldestQueuedAge,
     ],
   );
+}
+
+function observeManagedInstanceCounts(
+  observer: BatchMetricObserver,
+  gauge: ObservableGauge<ServiceMetricLabels>,
+  instances: readonly Ec2InstanceView[],
+): void {
+  const counts = new Map<Ec2InstanceState, number>();
+  for (const instance of instances)
+    counts.set(instance.state, (counts.get(instance.state) ?? 0) + 1);
+  for (const [state, count] of counts) observer.observe(gauge, count, {state});
+}
+
+function countTemplateRunners(
+  templates: RegisterEc2ServiceMetricsOptions['templates'],
+  instances: readonly Ec2InstanceView[],
+): {countsByTemplate: Map<string, TemplateRunnerCounts>; unattributedCount: number} {
+  const countsByTemplate = new Map<string, TemplateRunnerCounts>(
+    templates.map((template) => [template.key, {starting: 0, running: 0}]),
+  );
+  let unattributedCount = 0;
+  for (const instance of instances) {
+    const templateKey = parseInstanceIdentity(instance).templateKey;
+    if (!templateKey || !countsByTemplate.has(templateKey)) {
+      unattributedCount += 1;
+      continue;
+    }
+    const state = templateRunnerState(instance.state);
+    if (!state) continue;
+    const templateCounts = countsByTemplate.get(templateKey);
+    if (templateCounts) templateCounts[state] += 1;
+  }
+  return {countsByTemplate, unattributedCount};
+}
+
+function calculateTemplateDemand(
+  options: RegisterEc2ServiceMetricsOptions,
+): Map<string, TemplateDemand> {
+  const demandByTemplate = new Map<string, TemplateDemand>(
+    options.templates.map((template) => [template.key, {queued: 0}]),
+  );
+  for (const stat of options.getDemandStats()) {
+    if (stat.queued === 0) continue;
+    const oldestQueuedAtMs = Date.parse(stat.oldest_queued_at);
+    for (const template of rankTemplatesForLabels(stat.labels, options.templates)) {
+      const demand = demandByTemplate.get(template.key);
+      if (!demand) continue;
+      demand.queued += stat.queued;
+      if (Number.isFinite(oldestQueuedAtMs)) {
+        demand.oldestQueuedAtMs =
+          demand.oldestQueuedAtMs === undefined
+            ? oldestQueuedAtMs
+            : Math.min(demand.oldestQueuedAtMs, oldestQueuedAtMs);
+      }
+    }
+  }
+  return demandByTemplate;
+}
+
+interface TemplateMetricGauges {
+  templateRunners: ObservableGauge<ServiceMetricLabels>;
+  templateMaxConcurrency: ObservableGauge<ServiceMetricLabels>;
+  templateTargetConcurrency: ObservableGauge<ServiceMetricLabels>;
+  templateQueuedDemand: ObservableGauge<ServiceMetricLabels>;
+  templateOldestQueuedAge: ObservableGauge<ServiceMetricLabels>;
+}
+
+function observeTemplateMetrics(
+  observer: BatchMetricObserver,
+  templates: RegisterEc2ServiceMetricsOptions['templates'],
+  countsByTemplate: ReadonlyMap<string, TemplateRunnerCounts>,
+  demandByTemplate: ReadonlyMap<string, TemplateDemand>,
+  gauges: TemplateMetricGauges,
+): void {
+  for (const template of templates) {
+    const labels = {template_key: template.key};
+    const counts = countsByTemplate.get(template.key) ?? {starting: 0, running: 0};
+    const demand = demandByTemplate.get(template.key) ?? {queued: 0};
+    observer.observe(gauges.templateRunners, counts.starting, {...labels, state: 'starting'});
+    observer.observe(gauges.templateRunners, counts.running, {...labels, state: 'running'});
+    observer.observe(gauges.templateMaxConcurrency, template.maxConcurrency, labels);
+    observer.observe(gauges.templateTargetConcurrency, template.targetConcurrency ?? 0, labels);
+    observer.observe(gauges.templateQueuedDemand, demand.queued, labels);
+    const oldestAge =
+      demand.oldestQueuedAtMs === undefined ? 0 : Math.max(0, Date.now() - demand.oldestQueuedAtMs);
+    observer.observe(gauges.templateOldestQueuedAge, oldestAge, labels);
+  }
 }
 
 function templateRunnerState(state: Ec2InstanceState): 'starting' | 'running' | undefined {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -266,59 +266,25 @@ interface ClaudeAuth {
 }
 
 async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessResult> {
+  assertClaudeInvocation(invocation);
   const {
     cwd,
     agentStateDir,
     model,
-    provider,
     thinking,
     prompt,
     tools,
     credentials,
-    customProvider,
     gitConfigGlobal,
     signal,
     onSessionEntry,
   } = invocation;
   const collector = new OutputCollector(invocation.outputs);
 
-  if (signal.aborted) throw new Error('Agent step aborted before the Claude session started');
-  if (agentStateDir === undefined) throw new Error('Agent state directory is required');
-  // The server-issued per-step claude block is the discriminator for a managed
-  // provider serving the anthropic-messages dialect; its provider ID (e.g.
-  // "shipfox") is preserved for policy and usage attribution. The adapter is an
-  // unvalidated surface for direct harness callers, so the block shape is
-  // checked here rather than only at the runner DTO boundary.
-  const claudeBlock = invocation.claude;
-  if (claudeBlock !== undefined && !claudeRuntimeConfigSchema.safeParse(claudeBlock).success) {
-    throw new AgentConfigError(
-      'Harness "claude" received a malformed per-step claude runtime block.',
-      'step_config_invalid',
-    );
-  }
-  const providerUnsupported = provider !== 'anthropic' && claudeBlock === undefined;
-  if (providerUnsupported) {
-    const unsupportedReason = isReservedModelProviderId(provider)
-      ? `Harness "claude" only supports provider "anthropic"; received "${provider}".`
-      : `Harness "claude" requires the server-issued per-step claude runtime block for provider "${provider}"; the block was not present in this invocation.`;
-    throw new AgentConfigError(unsupportedReason, 'provider_unsupported');
-  }
-  if (customProvider !== undefined) {
-    throw new AgentConfigError(
-      'Harness "claude" does not support custom model providers.',
-      'provider_unsupported',
-    );
-  }
-
   const override = claudeAnthropicOverride(invocation.claude);
   const auth = claudeAuth(credentials, override);
   const targetUrl = override?.baseUrl ?? ANTHROPIC_API_URL;
-  const targetLabel =
-    invocation.claude !== undefined
-      ? 'Claude Anthropic per-step endpoint'
-      : override === undefined
-        ? 'Claude Anthropic API endpoint'
-        : 'Claude Anthropic base URL override';
+  const targetLabel = claudeTargetLabel(invocation, override);
   const hasDeclaredOutputs =
     invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
   const useOutputTools = hasDeclaredOutputs;
@@ -406,6 +372,43 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     claudeQuery?.close();
     if (configDir !== undefined) await cleanupClaudeConfigDir(configDir);
   }
+}
+
+function assertClaudeInvocation(
+  invocation: HarnessInvocation,
+): asserts invocation is HarnessInvocation & {agentStateDir: string} {
+  if (invocation.signal.aborted) {
+    throw new Error('Agent step aborted before the Claude session started');
+  }
+  if (invocation.agentStateDir === undefined) throw new Error('Agent state directory is required');
+  const claudeBlock = invocation.claude;
+  if (claudeBlock !== undefined && !claudeRuntimeConfigSchema.safeParse(claudeBlock).success) {
+    throw new AgentConfigError(
+      'Harness "claude" received a malformed per-step claude runtime block.',
+      'step_config_invalid',
+    );
+  }
+  if (invocation.provider !== 'anthropic' && claudeBlock === undefined) {
+    const reason = isReservedModelProviderId(invocation.provider)
+      ? `Harness "claude" only supports provider "anthropic"; received "${invocation.provider}".`
+      : `Harness "claude" requires the server-issued per-step claude runtime block for provider "${invocation.provider}"; the block was not present in this invocation.`;
+    throw new AgentConfigError(reason, 'provider_unsupported');
+  }
+  if (invocation.customProvider !== undefined) {
+    throw new AgentConfigError(
+      'Harness "claude" does not support custom model providers.',
+      'provider_unsupported',
+    );
+  }
+}
+
+function claudeTargetLabel(
+  invocation: HarnessInvocation,
+  override: ClaudeAnthropicOverride | undefined,
+): string {
+  if (invocation.claude !== undefined) return 'Claude Anthropic per-step endpoint';
+  if (override === undefined) return 'Claude Anthropic API endpoint';
+  return 'Claude Anthropic base URL override';
 }
 
 function claudeMcpServers(

--- a/libs/runner/agent/src/core/integration-tools-bridge.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.ts
@@ -174,11 +174,9 @@ async function handleHttpRequest(
   try {
     const body = request.method === 'POST' ? await readJsonBody(request) : undefined;
     const sessionId = request.headers['mcp-session-id'];
-    const session = isInitializeRequest(body)
-      ? await createHttpSession()
-      : typeof sessionId === 'string'
-        ? sessions.get(sessionId)
-        : undefined;
+    let session: HttpSession | undefined;
+    if (isInitializeRequest(body)) session = await createHttpSession();
+    else if (typeof sessionId === 'string') session = sessions.get(sessionId);
     if (session === undefined) {
       sendMcpError(response, 404, -32600, 'Unknown MCP session.');
       return;

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -51,6 +51,7 @@ const PI_MCP_TOOL_NAME = 'mcp';
 
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions['thinkingLevel']>;
 type ModelRuntimeInstance = Awaited<ReturnType<typeof ModelRuntime.create>>;
+type PiSession = Awaited<ReturnType<typeof createAgentSessionFromServices>>['session'];
 type CustomProviderConfig = Parameters<ModelRuntimeInstance['registerProvider']>[1];
 type CustomProviderModel = NonNullable<CustomProviderConfig['models']>[number];
 
@@ -65,19 +66,15 @@ export const piHarnessAdapter: HarnessAdapter = {run: runPiAgent};
  * separately from structured outputs.
  */
 async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult> {
+  assertPiInvocation(invocation);
   const {
     cwd,
     agentStateDir,
     sessionFile,
     sessionMode,
-    model: modelId,
-    provider,
     thinking,
     prompt,
     tools,
-    mcpServers,
-    credentials,
-    customProvider,
     gitConfigGlobal,
     signal,
     onSessionEntry,
@@ -91,197 +88,301 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   // before this point (or during the awaits below) would leave pi running and burning
   // tokens after the step loop has moved on. Guard on entry, then again once the
   // session exists so a mid-creation abort still stops pi.
-  if (signal.aborted) throw new Error('Agent step aborted before the pi session started');
-  if (agentStateDir === undefined) throw new Error('Agent state directory is required');
+  const {modelRuntime, model} = await preparePiModelRuntime(invocation);
 
+  let session: PiSession | undefined;
+  let mcpConfig: PiMcpConfig | undefined;
+
+  try {
+    mcpConfig = await createPiMcpConfig(agentStateDir, invocation.mcpServers);
+    const prepared = await preparePiSessionServices({
+      invocation,
+      mcpConfig,
+      modelRuntime,
+    });
+    session = await createPiSession({
+      services: prepared.services,
+      model,
+      thinking,
+      tools,
+      customTools,
+      mcpConfig,
+      cwd,
+      agentStateDir,
+      sessionFile,
+      sessionMode,
+    });
+    return await runPiSession({
+      session,
+      signal,
+      mcpConfig,
+      onSessionEntry,
+      gitConfigGlobal,
+      hasDeclaredOutputs,
+      prompt,
+      collector,
+      sessionMode,
+    });
+  } finally {
+    await closePiSession({session, mcpConfig});
+  }
+}
+
+async function createPiSession(params: {
+  services: Awaited<ReturnType<typeof createAgentSessionServices>>;
+  model: ReturnType<typeof resolveModel>;
+  thinking: string;
+  tools: readonly string[] | undefined;
+  customTools: ReturnType<typeof setOutputTool>[];
+  mcpConfig: PiMcpConfig | undefined;
+  cwd: string;
+  agentStateDir: string;
+  sessionFile: string | undefined;
+  sessionMode: HarnessInvocation['sessionMode'];
+}): Promise<PiSession> {
+  const created = await createAgentSessionFromServices({
+    services: params.services,
+    model: params.model,
+    thinkingLevel: params.thinking as PiThinkingLevel,
+    ...toolSelectionOption(params.tools, [
+      ...(params.mcpConfig === undefined ? [] : [PI_MCP_TOOL_NAME]),
+      ...params.customTools.map((tool) => tool.name),
+    ]),
+    ...(params.customTools.length === 0 ? {} : {customTools: params.customTools}),
+    sessionManager: createPiSessionManager(params),
+  });
+  return created.session;
+}
+
+async function runPiSession(params: {
+  session: PiSession;
+  signal: AbortSignal;
+  mcpConfig: PiMcpConfig | undefined;
+  onSessionEntry: HarnessInvocation['onSessionEntry'];
+  gitConfigGlobal: string | undefined;
+  hasDeclaredOutputs: boolean;
+  prompt: string;
+  collector: OutputCollector;
+  sessionMode: HarnessInvocation['sessionMode'];
+}): Promise<HarnessResult> {
+  const abortSession = () => {
+    Promise.resolve(params.session.abort()).catch(() => undefined);
+  };
+  if (params.signal.aborted) {
+    abortSession();
+    throw new Error('Agent step aborted during pi session creation');
+  }
+  params.signal.addEventListener('abort', abortSession, {once: true});
+  try {
+    return await runActivePiSession(params);
+  } finally {
+    params.signal.removeEventListener('abort', abortSession);
+  }
+}
+
+async function runActivePiSession(
+  params: Parameters<typeof runPiSession>[0],
+): Promise<HarnessResult> {
+  if (params.mcpConfig !== undefined) {
+    await params.session.bindExtensions({
+      mode: 'print',
+      onError: (error) => logger().warn({err: error}, 'Pi extension failed'),
+    });
+  }
+  if (params.signal.aborted) throw new Error('Agent step aborted during pi session creation');
+
+  const forwarder = startForwarding(params.session.sessionFile, params.onSessionEntry);
+  const stopForwarder = () => forwarder?.stop();
+  params.signal.addEventListener('abort', stopForwarder, {once: true});
+  const restoreGitConfigGlobal = createGitConfigGlobalRestorer(params.gitConfigGlobal);
+  if (params.gitConfigGlobal) {
+    process.env.GIT_CONFIG_GLOBAL = params.gitConfigGlobal;
+    params.signal.addEventListener('abort', restoreGitConfigGlobal, {once: true});
+  }
+  try {
+    return await runPiOutputTurns(params);
+  } finally {
+    forwarder?.stop();
+    restoreGitConfigGlobal();
+    params.signal.removeEventListener('abort', stopForwarder);
+    params.signal.removeEventListener('abort', restoreGitConfigGlobal);
+  }
+}
+
+async function runPiOutputTurns(
+  params: Parameters<typeof runPiSession>[0],
+): Promise<HarnessResult> {
+  let response = '';
+  try {
+    await runOutputTurnLoop({
+      signal: params.signal,
+      prompt: params.hasDeclaredOutputs
+        ? withOutputGuidance(params.prompt, params.collector.guidanceText())
+        : params.prompt,
+      runTurn: async (message) => {
+        await params.session.prompt(message);
+        const assistantError = lastAssistantError(params.session.messages);
+        if (assistantError !== undefined) {
+          throw new AgentInvocationError(
+            assistantError,
+            params.session.getLastAssistantText() ?? '',
+          );
+        }
+        response = params.session.getLastAssistantText() ?? '';
+      },
+      missingRequired: () => params.collector.missingRequired(),
+      guidanceForMissing: (missing) => params.collector.guidanceTextFor(missing),
+    });
+  } catch (error) {
+    if (error instanceof RequiredOutputsMissingError) {
+      throw new AgentInvocationError(error.message, params.session.getLastAssistantText() ?? '');
+    }
+    throw error;
+  }
+  const outputs = params.collector.snapshot();
+  return {
+    response,
+    ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
+    ...(params.sessionMode === 'fork' ? {} : {sessionFile: params.session.sessionFile}),
+    ...(params.sessionMode === 'fork' ? {} : {sessionId: params.session.sessionId}),
+  };
+}
+
+function createPiSessionManager(
+  params: Pick<
+    Parameters<typeof createPiSession>[0],
+    'cwd' | 'agentStateDir' | 'sessionFile' | 'sessionMode'
+  >,
+): SessionManager {
+  const sessionDirectory = join(params.agentStateDir, 'agent-sessions');
+  if (params.sessionFile === undefined) {
+    return SessionManager.create(params.cwd, sessionDirectory);
+  }
+  return openHarnessSession({
+    cwd: params.cwd,
+    sessionFile: params.sessionFile,
+    sessionDir: sessionDirectory,
+    mode: params.sessionMode ?? 'resume',
+  });
+}
+
+function assertPiInvocation(
+  invocation: HarnessInvocation,
+): asserts invocation is HarnessInvocation & {agentStateDir: string} {
+  if (invocation.signal.aborted)
+    throw new Error('Agent step aborted before the pi session started');
+  if (invocation.agentStateDir === undefined) throw new Error('Agent state directory is required');
+}
+
+async function preparePiModelRuntime(
+  invocation: HarnessInvocation,
+): Promise<{modelRuntime: ModelRuntimeInstance; model: ReturnType<typeof resolveModel>}> {
   const modelRuntime = await ModelRuntime.create({
     credentials: createInMemoryCredentialStore(
-      customProvider === undefined
-        ? {[provider]: toPiRuntimeCredential(provider, credentials)}
+      invocation.customProvider === undefined
+        ? {
+            [invocation.provider]: toPiRuntimeCredential(
+              invocation.provider,
+              invocation.credentials,
+            ),
+          }
         : {},
     ),
   });
-  if (customProvider !== undefined) {
-    await registerCustomProvider(modelRuntime, provider, credentials, customProvider);
+  if (invocation.customProvider !== undefined) {
+    await registerCustomProvider(
+      modelRuntime,
+      invocation.provider,
+      invocation.credentials,
+      invocation.customProvider,
+    );
   }
-  const model = resolveModel(modelRuntime, provider, modelId);
-
-  // Surface a missing key up front as a config error: otherwise it fails deep inside the
-  // provider call as an opaque invocation failure, hiding that the fix is workspace config.
+  const model = resolveModel(modelRuntime, invocation.provider, invocation.model);
   if (!modelRuntime.hasConfiguredAuth(model.provider)) {
     throw new AgentConfigError(
-      `No credentials configured for provider "${provider}". ` +
+      `No credentials configured for provider "${invocation.provider}". ` +
         'Verify the provider is configured for this workspace.',
       'provider_not_configured',
     );
   }
+  return {modelRuntime, model};
+}
 
-  let session: Awaited<ReturnType<typeof createAgentSessionFromServices>>['session'] | undefined;
-  let mcpConfig: PiMcpConfig | undefined;
-
-  try {
-    mcpConfig = await createPiMcpConfig(agentStateDir, mcpServers);
-    const extensionPackageNames = [
-      ...(isPiExtensionAvailable({packageName: 'pi-web-access'}) ? ['pi-web-access'] : []),
-      ...(mcpConfig === undefined ? [] : ['pi-mcp-adapter']),
-    ];
-    let extensionDirectories: string[];
-    try {
-      extensionDirectories = piExtensionDirectories({packageNames: extensionPackageNames});
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new AgentHarnessUnavailableError({
-        diagnostics: [{type: 'error', message}],
-        environment: {
-          cwd,
-          provider,
-          model: modelId,
-          thinking,
-          extensionPaths: extensionPackageNames,
-        },
-      });
-    }
-    const services = await createAgentSessionServices({
+async function preparePiSessionServices(params: {
+  invocation: HarnessInvocation;
+  mcpConfig: PiMcpConfig | undefined;
+  modelRuntime: ModelRuntimeInstance;
+}): Promise<{
+  services: Awaited<ReturnType<typeof createAgentSessionServices>>;
+}> {
+  const {cwd, provider, model, thinking} = params.invocation;
+  const {mcpConfig} = params;
+  const extensionPackageNames = [
+    ...(isPiExtensionAvailable({packageName: 'pi-web-access'}) ? ['pi-web-access'] : []),
+    ...(mcpConfig === undefined ? [] : ['pi-mcp-adapter']),
+  ];
+  const extensionDirectories = resolvePiExtensionDirectories({
+    cwd,
+    provider,
+    model,
+    thinking,
+    extensionPackageNames,
+  });
+  const services = await createAgentSessionServices({
+    cwd,
+    modelRuntime: params.modelRuntime,
+    ...(mcpConfig === undefined
+      ? {}
+      : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
+    resourceLoaderOptions: {additionalExtensionPaths: extensionDirectories},
+  });
+  const extensionResult = services.resourceLoader?.getExtensions?.();
+  assertPiServiceDiagnostics(
+    services.diagnostics,
+    {
       cwd,
-      modelRuntime,
-      ...(mcpConfig === undefined
-        ? {}
-        : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
-      resourceLoaderOptions: {
-        additionalExtensionPaths: extensionDirectories,
-      },
-    });
-    const extensionResult = services.resourceLoader?.getExtensions?.();
-    assertPiServiceDiagnostics(
-      services.diagnostics,
-      {
-        cwd,
-        provider,
-        model: modelId,
-        thinking,
-        extensionPaths: extensionPackageNames,
-        ...(extensionResult === undefined
-          ? {}
-          : {
-              resolvedExtensionPaths: extensionResult.extensions.map(
-                (extension) => extension.resolvedPath,
-              ),
-            }),
-      },
-      extensionResult?.errors,
-    );
-    assertPiExtensionsLoaded({
-      resourceLoader: services.resourceLoader,
-      directories: extensionDirectories,
-    });
-
-    const createdSession = await createAgentSessionFromServices({
-      services,
+      provider,
       model,
-      thinkingLevel: thinking as PiThinkingLevel,
-      ...toolSelectionOption(tools, [
-        ...(mcpConfig === undefined ? [] : [PI_MCP_TOOL_NAME]),
-        ...customTools.map((tool) => tool.name),
-      ]),
-      ...(customTools.length === 0 ? {} : {customTools}),
-      // Keep the session JSONL in the runner-owned agent-state directory so it forwards from a
-      // deterministic path and is cleaned up with the job; pi's default lives under ~/.pi.
-      sessionManager:
-        sessionFile === undefined
-          ? SessionManager.create(cwd, join(agentStateDir, 'agent-sessions'))
-          : openHarnessSession({
-              cwd,
-              sessionFile,
-              sessionDir: join(agentStateDir, 'agent-sessions'),
-              mode: sessionMode ?? 'resume',
-            }),
+      thinking,
+      extensionPaths: extensionPackageNames,
+      ...(extensionResult === undefined
+        ? {}
+        : {
+            resolvedExtensionPaths: extensionResult.extensions.map(
+              (extension) => extension.resolvedPath,
+            ),
+          }),
+    },
+    extensionResult?.errors,
+  );
+  assertPiExtensionsLoaded({
+    resourceLoader: services.resourceLoader,
+    directories: extensionDirectories,
+  });
+  return {services};
+}
+
+function resolvePiExtensionDirectories(params: {
+  cwd: string;
+  provider: string;
+  model: string;
+  thinking: string;
+  extensionPackageNames: string[];
+}): string[] {
+  try {
+    return piExtensionDirectories({packageNames: params.extensionPackageNames});
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new AgentHarnessUnavailableError({
+      diagnostics: [{type: 'error', message}],
+      environment: {
+        cwd: params.cwd,
+        provider: params.provider,
+        model: params.model,
+        thinking: params.thinking,
+        extensionPaths: params.extensionPackageNames,
+      },
     });
-    const piSession = createdSession.session;
-    session = piSession;
-    const abortSession = () => {
-      Promise.resolve(piSession.abort()).catch(() => undefined);
-    };
-
-    if (signal.aborted) {
-      abortSession();
-      throw new Error('Agent step aborted during pi session creation');
-    }
-
-    signal.addEventListener('abort', abortSession, {once: true});
-    try {
-      if (mcpConfig !== undefined) {
-        await piSession.bindExtensions({
-          mode: 'print',
-          onError: (error) => {
-            logger().warn({err: error}, 'Pi extension failed');
-          },
-        });
-      }
-
-      if (signal.aborted) {
-        throw new Error('Agent step aborted during pi session creation');
-      }
-
-      const forwarder = startForwarding(piSession.sessionFile, onSessionEntry);
-      // pi may not settle session.prompt() promptly on abort (step.ts races the call), so the
-      // finally below can be delayed indefinitely. Stop the forwarder on abort too, or its poll
-      // timer leaks past workspace teardown. stop() is idempotent, so the finally re-calling it is
-      // safe, and the early stop still does its final drain.
-      const stopForwarder = () => forwarder?.stop();
-      signal.addEventListener('abort', stopForwarder, {once: true});
-      const restoreGitConfigGlobal = createGitConfigGlobalRestorer(gitConfigGlobal);
-      if (gitConfigGlobal) {
-        // The runner executes one agent step at a time in this process; restore promptly so the
-        // process-global Git config cannot leak into the next step.
-        process.env.GIT_CONFIG_GLOBAL = gitConfigGlobal;
-        signal.addEventListener('abort', restoreGitConfigGlobal, {once: true});
-      }
-      try {
-        let response = '';
-        await runOutputTurnLoop({
-          signal,
-          prompt: hasDeclaredOutputs
-            ? withOutputGuidance(prompt, collector.guidanceText())
-            : prompt,
-          runTurn: async (message) => {
-            await piSession.prompt(message);
-            const assistantError = lastAssistantError(piSession.messages);
-            if (assistantError !== undefined) {
-              throw new AgentInvocationError(
-                assistantError,
-                piSession.getLastAssistantText() ?? '',
-              );
-            }
-            response = piSession.getLastAssistantText() ?? '';
-          },
-          missingRequired: () => collector.missingRequired(),
-          guidanceForMissing: (missing) => collector.guidanceTextFor(missing),
-        });
-        const outputs = collector.snapshot();
-        return {
-          response,
-          ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
-          ...(sessionMode === 'fork' ? {} : {sessionFile: piSession.sessionFile}),
-          ...(sessionMode === 'fork' ? {} : {sessionId: piSession.sessionId}),
-        };
-      } catch (error) {
-        if (error instanceof RequiredOutputsMissingError) {
-          throw new AgentInvocationError(error.message, piSession.getLastAssistantText() ?? '');
-        }
-        throw error;
-      } finally {
-        // A final synchronous read forwards every entry written before the caller closes the log
-        // stream, so all session records precede its end marker.
-        forwarder?.stop();
-        restoreGitConfigGlobal();
-        signal.removeEventListener('abort', stopForwarder);
-        signal.removeEventListener('abort', restoreGitConfigGlobal);
-      }
-    } finally {
-      signal.removeEventListener('abort', abortSession);
-    }
-  } finally {
-    await closePiSession({session, mcpConfig});
   }
 }
 

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -197,39 +197,50 @@ async function runSelectedHarness(params: {
       }),
       signal,
     );
-    return {
-      success: true,
-      response: harnessResult.response ?? '',
-      ...(harnessResult.outputs === undefined ? {} : {outputs: harnessResult.outputs}),
-      ...(sessionMode === 'fork' || harnessResult.sessionFile === undefined
-        ? {}
-        : {sessionFile: harnessResult.sessionFile}),
-      ...(sessionMode === 'fork' || harnessResult.sessionId === undefined
-        ? {}
-        : {sessionId: harnessResult.sessionId}),
-      error: null,
-      exit_code: 0,
-    };
+    return successfulHarnessResult(harnessResult, sessionMode);
   } catch (error) {
-    if (error instanceof AgentHarnessUnavailableError) {
-      logHarnessUnavailable({error, harness, jobExecutionId, stepId, attempt});
-    }
-    if (error instanceof AgentPermissionModeError) {
-      logPermissionModeDowngraded({error, harness, jobExecutionId, stepId, attempt});
-    }
-    const reason: StepErrorReasonDto =
-      error instanceof AgentHarnessUnavailableError
-        ? 'agent_harness_unavailable'
-        : error instanceof AgentConfigError
-          ? 'agent_config_invalid'
-          : 'agent_invocation_failed';
-    return agentFailure(
-      error instanceof Error ? error.message : String(error),
-      reason,
-      error instanceof AgentConfigError ? error.agentConfigIssue : undefined,
-      error instanceof AgentInvocationError ? error.response : undefined,
-    );
+    return harnessFailureResult(error, {harness, jobExecutionId, stepId, attempt});
   }
+}
+
+function successfulHarnessResult(
+  harnessResult: Awaited<ReturnType<HarnessAdapter['run']>>,
+  sessionMode: 'resume' | 'fork' | undefined,
+): StepResult {
+  return {
+    success: true,
+    response: harnessResult.response ?? '',
+    ...(harnessResult.outputs === undefined ? {} : {outputs: harnessResult.outputs}),
+    ...(sessionMode === 'fork' || harnessResult.sessionFile === undefined
+      ? {}
+      : {sessionFile: harnessResult.sessionFile}),
+    ...(sessionMode === 'fork' || harnessResult.sessionId === undefined
+      ? {}
+      : {sessionId: harnessResult.sessionId}),
+    error: null,
+    exit_code: 0,
+  };
+}
+
+function harnessFailureResult(
+  error: unknown,
+  context: {harness: Harness; jobExecutionId: string; stepId: string; attempt: number},
+): StepResult {
+  if (error instanceof AgentHarnessUnavailableError) {
+    logHarnessUnavailable({error, ...context});
+  }
+  if (error instanceof AgentPermissionModeError) {
+    logPermissionModeDowngraded({error, ...context});
+  }
+  let reason: StepErrorReasonDto = 'agent_invocation_failed';
+  if (error instanceof AgentHarnessUnavailableError) reason = 'agent_harness_unavailable';
+  else if (error instanceof AgentConfigError) reason = 'agent_config_invalid';
+  return agentFailure(
+    error instanceof Error ? error.message : String(error),
+    reason,
+    error instanceof AgentConfigError ? error.agentConfigIssue : undefined,
+    error instanceof AgentInvocationError ? error.response : undefined,
+  );
 }
 
 function logPermissionModeDowngraded(params: {

--- a/libs/runner/execution/src/core/checkout-step.ts
+++ b/libs/runner/execution/src/core/checkout-step.ts
@@ -53,20 +53,8 @@ export async function executeCheckoutStep(params: {
 }): Promise<CheckoutStepExecution> {
   const {cwd, gitConfigPath, leaseClient, signal, step, attempt, destinations, log} = params;
   const config = readCheckoutConfig(step.config.checkout);
-
-  if (config.path !== undefined) {
-    try {
-      assertCheckoutPath(config.path);
-    } catch (error) {
-      return pathFailure(error, log);
-    }
-  }
-
-  try {
-    await assertGitAvailable();
-  } catch (error) {
-    return gitUnavailableFailure(error, log);
-  }
+  const preflightFailure = await checkoutPreflight(config.path, log);
+  if (preflightFailure) return preflightFailure;
 
   log?.writeGroupStart('Checkout');
   try {
@@ -87,34 +75,14 @@ export async function executeCheckoutStep(params: {
       repository: requested.value.repository_url,
       ref: requested.value.ref,
     };
-    const previous = destinations.get(destination);
-
-    if (previous !== undefined) {
-      if (sameTarget(previous, target) && !config.force) {
-        log?.writeGroup({
-          name: 'Checkout skipped',
-          lines: [
-            `Path: ${destination}`,
-            `Already checked out ${safeRepositoryUrl(target.repository)} at ${target.ref}.`,
-          ],
-        });
-        return {result: {success: true, error: null, exit_code: 0, checkout: previous.result}};
-      }
-      if (!config.force) throw new CheckoutDestinationOccupiedError(destination);
-      releaseDestinationSubtree(destinations, destination);
-      await replaceCheckoutDestination(destination);
-    } else {
-      const state = await inspectCheckoutDestination(destination);
-      if (state === 'occupied' && !config.force) {
-        throw new CheckoutDestinationOccupiedError(destination);
-      }
-      if (state === 'occupied' && config.force) {
-        releaseDestinationSubtree(destinations, destination);
-        await replaceCheckoutDestination(destination);
-      } else {
-        await createCheckoutDestination(destination);
-      }
-    }
+    const skipped = await prepareCheckoutDestination({
+      destination,
+      destinations,
+      target,
+      force: config.force,
+      log,
+    });
+    if (skipped) return skipped;
 
     const checkout = await checkoutRepositoryAt({
       destination,
@@ -156,6 +124,67 @@ export async function executeCheckoutStep(params: {
   } finally {
     log?.writeGroupEnd();
   }
+}
+
+async function checkoutPreflight(
+  path: unknown,
+  log: CheckoutLogSink | undefined,
+): Promise<CheckoutStepExecution | undefined> {
+  if (path !== undefined) {
+    try {
+      assertCheckoutPath(path);
+    } catch (error) {
+      return pathFailure(error, log);
+    }
+  }
+  try {
+    await assertGitAvailable();
+    return undefined;
+  } catch (error) {
+    return gitUnavailableFailure(error, log);
+  }
+}
+
+async function prepareCheckoutDestination(params: {
+  destination: string;
+  destinations: CheckoutDestinations;
+  target: Pick<CheckoutDestination, 'repository' | 'ref'>;
+  force: boolean;
+  log: CheckoutLogSink | undefined;
+}): Promise<CheckoutStepExecution | undefined> {
+  const previous = params.destinations.get(params.destination);
+  if (previous !== undefined) return prepareTrackedCheckoutDestination(params, previous);
+  const state = await inspectCheckoutDestination(params.destination);
+  if (state === 'occupied' && !params.force) {
+    throw new CheckoutDestinationOccupiedError(params.destination);
+  }
+  if (state === 'occupied') {
+    releaseDestinationSubtree(params.destinations, params.destination);
+    await replaceCheckoutDestination(params.destination);
+  } else {
+    await createCheckoutDestination(params.destination);
+  }
+  return undefined;
+}
+
+async function prepareTrackedCheckoutDestination(
+  params: Parameters<typeof prepareCheckoutDestination>[0],
+  previous: CheckoutDestination,
+): Promise<CheckoutStepExecution | undefined> {
+  if (sameTarget(previous, params.target) && !params.force) {
+    params.log?.writeGroup({
+      name: 'Checkout skipped',
+      lines: [
+        `Path: ${params.destination}`,
+        `Already checked out ${safeRepositoryUrl(params.target.repository)} at ${params.target.ref}.`,
+      ],
+    });
+    return {result: {success: true, error: null, exit_code: 0, checkout: previous.result}};
+  }
+  if (!params.force) throw new CheckoutDestinationOccupiedError(params.destination);
+  releaseDestinationSubtree(params.destinations, params.destination);
+  await replaceCheckoutDestination(params.destination);
+  return undefined;
 }
 
 function readCheckoutConfig(value: unknown): {path?: unknown; force: boolean} {

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -181,45 +181,14 @@ function spawnAndCapture(
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
     // parent chain). We don't unref(): output capture still needs `close`.
-    let child: ReturnType<typeof spawn>;
-    try {
-      child = spawn(shell.executable, shell.args, {
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: true,
-        cwd: options.cwd,
-        env: {
-          ...process.env,
-          ...stepEnv,
-          ...((options.workspace ?? options.cwd)
-            ? {SHIPFOX_WORKSPACE: options.workspace ?? options.cwd}
-            : {}),
-          ...(options.gitConfigGlobal ? {GIT_CONFIG_GLOBAL: options.gitConfigGlobal} : {}),
-          SHIPFOX_OUTPUT: outputPath,
-          ...(annotationSpool?.env ?? {}),
-        },
-      });
-    } catch (err) {
+    const spawned = spawnRunStepProcess(shell, stepEnv, outputPath, annotationSpool, options);
+    if (!spawned.ok) {
       unsubscribeSecrets?.();
-      logger().error({err}, 'Failed to spawn shell process');
-      resolve({
-        success: false,
-        error: {
-          message: `Failed to spawn process: ${err instanceof Error ? err.message : String(err)}`,
-        },
-        exit_code: null,
-      });
+      logger().error({err: spawned.error}, 'Failed to spawn shell process');
+      resolve(spawned.result);
       return;
     }
-
-    if (!child.stdout || !child.stderr) {
-      unsubscribeSecrets?.();
-      resolve({
-        success: false,
-        error: {message: 'Failed to spawn process without output pipes'},
-        exit_code: null,
-      });
-      return;
-    }
+    const child = spawned.child;
 
     // stdout and stderr are two separate pipes, so the sink sees them merged by
     // arrival order, not kernel/wall-clock order; origin is preserved per chunk.
@@ -239,83 +208,17 @@ function spawnAndCapture(
       flushTeeOutput(process.stderr, stderrTeeRedactor);
     });
 
-    let childExited = false;
-    let abortKillSignal: NodeJS.Signals | undefined;
-
-    const killGroup = (): NodeJS.Signals | undefined => {
-      if (child.pid !== undefined) {
-        try {
-          // Negative pid signals the entire process group.
-          const signal: NodeJS.Signals = 'SIGKILL';
-          process.kill(-child.pid, signal);
-          return signal;
-        } catch {
-          // Process already exited.
-        }
-      }
-      return undefined;
-    };
-
-    let onAbort: (() => void) | undefined;
-    if (options.signal) {
-      if (options.signal.aborted) {
-        abortKillSignal = killGroup();
-      } else {
-        onAbort = () => {
-          if (!childExited) {
-            abortKillSignal = killGroup();
-          }
-        };
-        options.signal.addEventListener('abort', onAbort, {once: true});
-      }
-    }
-
-    const cleanupAbortListener = () => {
-      if (onAbort && options.signal) {
-        options.signal.removeEventListener('abort', onAbort);
-        onAbort = undefined;
-      }
-    };
-
-    child.on('exit', () => {
-      childExited = true;
-    });
+    const abort = observeProcessAbort(child, options.signal);
+    child.on('exit', abort.markExited);
 
     child.on('close', (code, signal) => {
-      cleanupAbortListener();
+      abort.cleanup();
       unsubscribeSecrets?.();
-      if (abortKillSignal && isSignalKillResult(code, abortKillSignal)) {
-        const resultSignal = signal ?? abortKillSignal;
-        resolve({
-          success: false,
-          error: {
-            message: `Killed by signal ${resultSignal}`,
-            exit_code: null,
-            signal: resultSignal,
-          },
-          exit_code: null,
-        });
-        return;
-      }
-      if (code === 0) {
-        resolve({success: true, error: null, exit_code: 0});
-        return;
-      }
-      // code === null when the child was terminated by a signal (e.g. SIGKILL
-      // from killGroup() on abort). Otherwise code is the non-zero exit code.
-      const error: StepErrorDto =
-        code === null
-          ? {
-              message: `Killed by signal ${signal ?? 'unknown'}`,
-              exit_code: null,
-              ...(signal ? {signal} : {}),
-            }
-          : {message: `Command exited with code ${code}`, exit_code: code};
-      resolve({success: false, error, exit_code: code});
+      resolve(runStepCloseResult(code, signal, abort.killSignal()));
     });
 
     child.on('error', (err) => {
-      cleanupAbortListener();
+      abort.cleanup();
       unsubscribeSecrets?.();
       logger().error({err}, 'Failed to spawn shell process');
       resolve({
@@ -325,6 +228,136 @@ function spawnAndCapture(
       });
     });
   });
+}
+
+type SpawnedRunStepChild = ReturnType<typeof spawn> & {
+  stdout: NonNullable<ReturnType<typeof spawn>['stdout']>;
+  stderr: NonNullable<ReturnType<typeof spawn>['stderr']>;
+};
+
+type SpawnRunStepResult =
+  | {
+      ok: true;
+      child: SpawnedRunStepChild;
+    }
+  | {ok: false; error: unknown; result: StepResult};
+
+function spawnRunStepProcess(
+  shell: CommandShellMetadata,
+  stepEnv: Readonly<Record<string, string>>,
+  outputPath: string,
+  annotationSpool: AnnotationSpool | undefined,
+  options: RunStepOptions,
+): SpawnRunStepResult {
+  try {
+    const child = spawn(shell.executable, shell.args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      cwd: options.cwd,
+      env: {
+        ...process.env,
+        ...stepEnv,
+        ...((options.workspace ?? options.cwd)
+          ? {SHIPFOX_WORKSPACE: options.workspace ?? options.cwd}
+          : {}),
+        ...(options.gitConfigGlobal ? {GIT_CONFIG_GLOBAL: options.gitConfigGlobal} : {}),
+        SHIPFOX_OUTPUT: outputPath,
+        ...(annotationSpool?.env ?? {}),
+      },
+    });
+    if (!child.stdout || !child.stderr) {
+      return {
+        ok: false,
+        error: new Error('Failed to spawn process without output pipes'),
+        result: {
+          success: false,
+          error: {message: 'Failed to spawn process without output pipes'},
+          exit_code: null,
+        },
+      };
+    }
+    return {ok: true, child: child as SpawnedRunStepChild};
+  } catch (error) {
+    return {
+      ok: false,
+      error,
+      result: {
+        success: false,
+        error: {
+          message: `Failed to spawn process: ${error instanceof Error ? error.message : String(error)}`,
+        },
+        exit_code: null,
+      },
+    };
+  }
+}
+
+function runStepCloseResult(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  abortKillSignal: NodeJS.Signals | undefined,
+): StepResult {
+  if (abortKillSignal && isSignalKillResult(code, abortKillSignal)) {
+    const resultSignal = signal ?? abortKillSignal;
+    return {
+      success: false,
+      error: {
+        message: `Killed by signal ${resultSignal}`,
+        exit_code: null,
+        signal: resultSignal,
+      },
+      exit_code: null,
+    };
+  }
+  if (code === 0) return {success: true, error: null, exit_code: 0};
+  // code === null when the child was terminated by a signal. Otherwise it is non-zero.
+  const error: StepErrorDto =
+    code === null
+      ? {
+          message: `Killed by signal ${signal ?? 'unknown'}`,
+          exit_code: null,
+          ...(signal ? {signal} : {}),
+        }
+      : {message: `Command exited with code ${code}`, exit_code: code};
+  return {success: false, error, exit_code: code};
+}
+
+function observeProcessAbort(
+  child: ReturnType<typeof spawn>,
+  signal: AbortSignal | undefined,
+): {markExited(): void; cleanup(): void; killSignal(): NodeJS.Signals | undefined} {
+  let childExited = false;
+  let abortKillSignal: NodeJS.Signals | undefined;
+  const killGroup = (): NodeJS.Signals | undefined => {
+    if (child.pid === undefined) return undefined;
+    try {
+      // Negative pid signals the entire process group.
+      const killSignal: NodeJS.Signals = 'SIGKILL';
+      process.kill(-child.pid, killSignal);
+      return killSignal;
+    } catch {
+      return undefined;
+    }
+  };
+  let onAbort: (() => void) | undefined;
+  if (signal?.aborted) abortKillSignal = killGroup();
+  if (signal && !signal.aborted) {
+    onAbort = () => {
+      if (!childExited) abortKillSignal = killGroup();
+    };
+    signal.addEventListener('abort', onAbort, {once: true});
+  }
+  return {
+    markExited: () => {
+      childExited = true;
+    },
+    cleanup: () => {
+      if (!onAbort || !signal) return;
+      signal.removeEventListener('abort', onAbort);
+      onAbort = undefined;
+    },
+    killSignal: () => abortKillSignal,
+  };
 }
 
 async function finalizeStepOutput(result: StepResult, outputPath: string): Promise<StepResult> {

--- a/libs/runner/orchestration/src/core/heartbeat-loop.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.ts
@@ -82,6 +82,17 @@ export function startHeartbeatLoop(
     pendingTimer = setTimeout(tick, options.intervalMs);
   };
 
+  const confirmLease = () => {
+    lastServerConfirmationAt = nowMs();
+    scheduleIsolationFence();
+  };
+
+  const abortJob = (reason: string) => {
+    stopped = true;
+    jobAbortController.abort(reason);
+    clearIsolationTimer();
+  };
+
   const tick = async () => {
     if (stopped) return;
 
@@ -100,49 +111,30 @@ export function startHeartbeatLoop(
 
     try {
       const capabilities = options.getToolCapabilities?.();
-      const {
-        cancel,
-        cancellation_reason: cancellationReason,
-        lease_token: renewedLeaseToken,
-      } = await heartbeat(jobId, sentLeaseToken, {
+      const response = await heartbeat(jobId, sentLeaseToken, {
         signal: httpAc.signal,
         ...(capabilities ? {capabilities} : {}),
       });
-      if (stopped) return;
-      if (generation === sentGeneration) {
-        lastServerConfirmationAt = nowMs();
-        scheduleIsolationFence();
-        if (renewedLeaseToken !== getLeaseToken()) {
-          options.onLeaseTokenRenewed?.(renewedLeaseToken);
-        }
-      }
-      if (cancel) {
-        logger().info({jobId}, 'Heartbeat returned cancel:true; aborting job');
-        stopped = true;
-        jobAbortController.abort(cancellationReason ?? 'cancelled');
-        clearIsolationTimer();
-        return;
-      }
-      scheduleNext();
+      handleHeartbeatResponse({
+        response,
+        isStopped: () => stopped,
+        generation,
+        sentGeneration,
+        getLeaseToken,
+        options,
+        jobId,
+        confirmLease,
+        abortJob,
+        scheduleNext,
+      });
     } catch (err) {
-      if (stopped) return;
-      // AbortError = max-stale guard fired; expected control flow, not a failure.
-      if (isAbortError(err)) {
-        scheduleNext();
-        return;
-      }
-      if (err instanceof HTTPError && err.response.status === 404) {
-        logger().info(
-          {jobId},
-          'Heartbeat returned 404; orchestration finalized this job, aborting runner-side',
-        );
-        stopped = true;
-        jobAbortController.abort('orphaned');
-        clearIsolationTimer();
-        return;
-      }
-      logger().warn({jobId, err: String(err)}, 'Heartbeat failed; scheduling next tick');
-      scheduleNext();
+      handleHeartbeatError({
+        err,
+        isStopped: () => stopped,
+        jobId,
+        abortJob,
+        scheduleNext,
+      });
     } finally {
       clearTimeout(staleTimer);
       if (currentHttpAc === httpAc) currentHttpAc = undefined;
@@ -166,6 +158,60 @@ export function startHeartbeatLoop(
       generation += 1;
     },
   };
+}
+
+function handleHeartbeatResponse(params: {
+  response: Awaited<ReturnType<typeof heartbeat>>;
+  isStopped: () => boolean;
+  generation: number;
+  sentGeneration: number;
+  getLeaseToken: () => string;
+  options: HeartbeatLoopOptions;
+  jobId: string;
+  confirmLease: () => void;
+  abortJob: (reason: string) => void;
+  scheduleNext: () => void;
+}): void {
+  if (params.isStopped()) return;
+  if (params.generation === params.sentGeneration) {
+    params.confirmLease();
+    if (params.response.lease_token !== params.getLeaseToken()) {
+      params.options.onLeaseTokenRenewed?.(params.response.lease_token);
+    }
+  }
+  if (params.response.cancel) {
+    logger().info({jobId: params.jobId}, 'Heartbeat returned cancel:true; aborting job');
+    params.abortJob(params.response.cancellation_reason ?? 'cancelled');
+    return;
+  }
+  params.scheduleNext();
+}
+
+function handleHeartbeatError(params: {
+  err: unknown;
+  isStopped: () => boolean;
+  jobId: string;
+  abortJob: (reason: string) => void;
+  scheduleNext: () => void;
+}): void {
+  if (params.isStopped()) return;
+  if (isAbortError(params.err)) {
+    params.scheduleNext();
+    return;
+  }
+  if (params.err instanceof HTTPError && params.err.response.status === 404) {
+    logger().info(
+      {jobId: params.jobId},
+      'Heartbeat returned 404; orchestration finalized this job, aborting runner-side',
+    );
+    params.abortJob('orphaned');
+    return;
+  }
+  logger().warn(
+    {jobId: params.jobId, err: String(params.err)},
+    'Heartbeat failed; scheduling next tick',
+  );
+  params.scheduleNext();
 }
 
 function isAbortError(err: unknown): boolean {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -117,89 +117,136 @@ export async function startRunner(
     'Runner started',
   );
 
-  let currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
-  let runnerSession: RunnerSession | undefined;
+  const state: RunnerPollState = {
+    currentInterval: config.SHIPFOX_POLL_INTERVAL_MS,
+    runnerSession: undefined,
+    pollDeadline: undefined,
+  };
   if (startupMode === 'managed') {
-    runnerSession = await initializeManagedRunnerSession(runnerBootPhaseTimeline);
-    if (!runnerSession) return;
+    state.runnerSession = await initializeManagedRunnerSession(runnerBootPhaseTimeline);
+    if (!state.runnerSession) return;
   } else {
     await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
   }
-  let pollDeadline = nextPollDeadline();
+  state.pollDeadline = nextPollDeadline();
 
   while (running) {
-    try {
-      if (!runnerSession) {
-        runnerSession = await registerRunnerSession({
-          capabilities: runnerToolCapabilities(),
-          lifecycleCapabilities: RUNNER_LIFECYCLE_CAPABILITIES,
-        });
-        logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session registered');
-      }
-
-      const job = await requestJob(runnerSession.session_token, shutdownController.signal);
-
-      if (!job) {
-        if (hasPollDeadlinePassed(pollDeadline)) {
-          logger().info('No jobs available before the poll deadline; runner exiting');
-          return;
-        }
-        currentInterval = nextBackoffInterval(currentInterval);
-        logger().debug({interval: currentInterval}, 'No jobs available, backing off');
-        await interruptableSleep(withJitter(currentInterval));
-        continue;
-      }
-
-      if (!running) return;
-
-      runnerBootPhaseTimeline.mark('first_claim_uptime_seconds');
-      logger().info(
-        {
-          ...runnerBootPhaseTimeline.snapshot(),
-          workflowRunId: job.workflow_run_id,
-          workflowRunAttemptId: job.workflow_run_attempt_id,
-          jobId: job.job_id,
-          jobExecutionId: job.job_execution_id,
-        },
-        'Job claimed',
-      );
-
-      await runJob(job, workspaceRoot);
-      currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
-      pollDeadline = nextPollDeadline();
-    } catch (pollError) {
-      if (!running) return;
-
-      if (isUnauthorized(pollError)) {
-        if (startupMode === 'managed') {
-          logger().info('Activated runner session rejected; runner exiting');
-          return;
-        }
-        runnerSession = undefined;
-        logger().info('Runner session rejected; registering a new session');
-        if (hasPollDeadlinePassed(pollDeadline)) {
-          logger().error({err: pollError}, 'Runner session rejected past the poll deadline');
-          throw pollError;
-        }
-        currentInterval = nextBackoffInterval(currentInterval);
-        await interruptableSleep(withJitter(currentInterval));
-        continue;
-      }
-      if (pollError instanceof RunnerSessionExhaustedError) {
-        logger().info('Runner session exhausted; runner exiting');
-        return;
-      }
-      if (hasPollDeadlinePassed(pollDeadline)) {
-        logger().error({err: pollError}, 'Poll cycle failed past the poll deadline');
-        throw pollError;
-      }
-      logger().error({err: pollError}, 'Poll cycle failed');
-      currentInterval = nextBackoffInterval(currentInterval);
-      await interruptableSleep(withJitter(currentInterval));
-    }
+    const outcome = await runRunnerPollCycle({
+      state,
+      startupMode,
+      runnerBootPhaseTimeline,
+      workspaceRoot,
+    });
+    if (outcome === 'exit') return;
   }
 
   logger().info('Runner stopped');
+}
+
+interface RunnerPollState {
+  currentInterval: number;
+  runnerSession: RunnerSession | undefined;
+  pollDeadline: number | undefined;
+}
+
+async function runRunnerPollCycle(params: {
+  state: RunnerPollState;
+  startupMode: ReturnType<typeof runnerStartupMode>;
+  runnerBootPhaseTimeline: RunnerBootPhaseTimeline;
+  workspaceRoot: string;
+}): Promise<'continue' | 'exit'> {
+  try {
+    const session = await ensureRunnerSession(params.state);
+    const job = await requestJob(session.session_token, shutdownController.signal);
+    if (!job) return await handleNoRunnerJob(params.state);
+    if (!running) return 'exit';
+    logClaimedRunnerJob(params.runnerBootPhaseTimeline, job);
+    await runJob(job, params.workspaceRoot);
+    params.state.currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
+    params.state.pollDeadline = nextPollDeadline();
+    return 'continue';
+  } catch (error) {
+    return handleRunnerPollError(error, params.state, params.startupMode);
+  }
+}
+
+async function ensureRunnerSession(state: RunnerPollState): Promise<RunnerSession> {
+  if (state.runnerSession) return state.runnerSession;
+  state.runnerSession = await registerRunnerSession({
+    capabilities: runnerToolCapabilities(),
+    lifecycleCapabilities: RUNNER_LIFECYCLE_CAPABILITIES,
+  });
+  logger().info({runnerSessionId: state.runnerSession.session_id}, 'Runner session registered');
+  return state.runnerSession;
+}
+
+async function handleNoRunnerJob(state: RunnerPollState): Promise<'continue' | 'exit'> {
+  if (hasPollDeadlinePassed(state.pollDeadline)) {
+    logger().info('No jobs available before the poll deadline; runner exiting');
+    return 'exit';
+  }
+  state.currentInterval = nextBackoffInterval(state.currentInterval);
+  logger().debug({interval: state.currentInterval}, 'No jobs available, backing off');
+  await interruptableSleep(withJitter(state.currentInterval));
+  return 'continue';
+}
+
+function logClaimedRunnerJob(
+  runnerBootPhaseTimeline: RunnerBootPhaseTimeline,
+  job: NonNullable<Awaited<ReturnType<typeof requestJob>>>,
+): void {
+  runnerBootPhaseTimeline.mark('first_claim_uptime_seconds');
+  logger().info(
+    {
+      ...runnerBootPhaseTimeline.snapshot(),
+      workflowRunId: job.workflow_run_id,
+      workflowRunAttemptId: job.workflow_run_attempt_id,
+      jobId: job.job_id,
+      jobExecutionId: job.job_execution_id,
+    },
+    'Job claimed',
+  );
+}
+
+async function handleRunnerPollError(
+  error: unknown,
+  state: RunnerPollState,
+  startupMode: ReturnType<typeof runnerStartupMode>,
+): Promise<'continue' | 'exit'> {
+  if (!running) return 'exit';
+  if (isUnauthorized(error)) return handleUnauthorizedRunnerSession(error, state, startupMode);
+  if (error instanceof RunnerSessionExhaustedError) {
+    logger().info('Runner session exhausted; runner exiting');
+    return 'exit';
+  }
+  if (hasPollDeadlinePassed(state.pollDeadline)) {
+    logger().error({err: error}, 'Poll cycle failed past the poll deadline');
+    throw error;
+  }
+  logger().error({err: error}, 'Poll cycle failed');
+  state.currentInterval = nextBackoffInterval(state.currentInterval);
+  await interruptableSleep(withJitter(state.currentInterval));
+  return 'continue';
+}
+
+async function handleUnauthorizedRunnerSession(
+  error: unknown,
+  state: RunnerPollState,
+  startupMode: ReturnType<typeof runnerStartupMode>,
+): Promise<'continue' | 'exit'> {
+  if (startupMode === 'managed') {
+    logger().info('Activated runner session rejected; runner exiting');
+    return 'exit';
+  }
+  state.runnerSession = undefined;
+  logger().info('Runner session rejected; registering a new session');
+  if (hasPollDeadlinePassed(state.pollDeadline)) {
+    logger().error({err: error}, 'Runner session rejected past the poll deadline');
+    throw error;
+  }
+  state.currentInterval = nextBackoffInterval(state.currentInterval);
+  await interruptableSleep(withJitter(state.currentInterval));
+  return 'continue';
 }
 
 function warnAboutUnavailablePiExtensions(): void {
@@ -419,45 +466,67 @@ async function waitForRunnerActivation(controlSessionToken: string): Promise<str
   const controller = new AbortController();
   const abortOnShutdown = () => controller.abort();
   shutdownController.signal.addEventListener('abort', abortOnShutdown, {once: true});
-  let heartbeatError: unknown;
+  const heartbeatState: {error: unknown} = {error: undefined};
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
   const heartbeat = async () => {
     try {
       await heartbeatRunnerControlSession(controlSessionToken, controller.signal);
     } catch (error) {
-      heartbeatError = error;
+      heartbeatState.error = error;
       controller.abort();
     }
   };
   try {
     await heartbeat();
     if (!running) return undefined;
-    if (heartbeatError) return handleControlSessionError(heartbeatError);
+    if (heartbeatState.error) return handleControlSessionError(heartbeatState.error);
     heartbeatTimer = setInterval(() => void heartbeat(), config.SHIPFOX_HEARTBEAT_INTERVAL_MS);
-    while (running && !controller.signal.aborted) {
-      try {
-        const activationToken = await pollRunnerAssignment(controlSessionToken, controller.signal);
-        if (activationToken) return activationToken;
-        await interruptibleSleep(config.SHIPFOX_POLL_INTERVAL_MS, controller.signal);
-        if (heartbeatError) return handleControlSessionError(heartbeatError);
-      } catch (error) {
-        if (!running) return undefined;
-        if (controller.signal.aborted && heartbeatError)
-          return handleControlSessionError(heartbeatError);
-        if (isTerminalControlSessionError(error)) return handleControlSessionError(error);
-        if (isTimeoutError(error)) {
-          logger().debug('Managed runner assignment poll timed out; retrying');
-          continue;
-        }
-        throw error;
-      }
-    }
-    return undefined;
+    return await pollForRunnerActivation(controlSessionToken, controller, heartbeatState);
   } finally {
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     shutdownController.signal.removeEventListener('abort', abortOnShutdown);
     controller.abort();
   }
+}
+
+async function pollForRunnerActivation(
+  controlSessionToken: string,
+  controller: AbortController,
+  heartbeatState: {error: unknown},
+): Promise<string | undefined> {
+  while (running && !controller.signal.aborted) {
+    try {
+      const activationToken = await pollRunnerAssignment(controlSessionToken, controller.signal);
+      if (activationToken) return activationToken;
+      await interruptibleSleep(config.SHIPFOX_POLL_INTERVAL_MS, controller.signal);
+      if (heartbeatState.error) return handleControlSessionError(heartbeatState.error);
+    } catch (error) {
+      const outcome = handleRunnerActivationPollError(error, controller, heartbeatState);
+      if (outcome === 'stop') return undefined;
+    }
+  }
+  return undefined;
+}
+
+function handleRunnerActivationPollError(
+  error: unknown,
+  controller: AbortController,
+  heartbeatState: {error: unknown},
+): 'retry' | 'stop' {
+  if (!running) return 'stop';
+  if (controller.signal.aborted && heartbeatState.error) {
+    handleControlSessionError(heartbeatState.error);
+    return 'stop';
+  }
+  if (isTerminalControlSessionError(error)) {
+    handleControlSessionError(error);
+    return 'stop';
+  }
+  if (isTimeoutError(error)) {
+    logger().debug('Managed runner assignment poll timed out; retrying');
+    return 'retry';
+  }
+  throw error;
 }
 
 function handleControlSessionError(error: unknown): undefined {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -103,141 +103,177 @@ export async function runJobSteps(params: {
   jobContext: SetupJobContext;
   onLeaseTokenAdopted?: (leaseToken: string) => void;
 }): Promise<void> {
-  const {
-    jobId,
-    leaseClient,
-    secrets,
-    signal,
-    cwd,
-    gitConfigPath,
-    logsDir,
-    agentStateDir,
-    prepareAgentState: prepareAgentStateDirectory,
-    jobContext,
-  } = params;
+  const {signal} = params;
 
   // The setup step prepares the workspace; every run step assumes it ran. A run
   // step pulled before a successful setup is failed cleanly rather than spawned
   // against an unprepared cwd.
-  let workspacePrepared = false;
-  let logsPrepared = false;
-  let agentStatePrepared = false;
-  let ambientGitConfigPath: string | undefined;
-  let ambientGitConfigSecrets: string[] = [];
-  const checkoutDestinations: CheckoutDestinations = new Map();
-
-  // The most recent step's stream, kept until the next
-  // iteration settles it (or the finally does at job end). The step loop is sequential, so
-  // at most one tail drains.
-  let activeStream: LogStreamLifecycle | undefined;
+  const state: JobStepLoopState = {
+    workspacePrepared: false,
+    logsPrepared: false,
+    agentStatePrepared: false,
+    ambientGitConfigPath: undefined,
+    ambientGitConfigSecrets: [],
+    checkoutDestinations: new Map(),
+    activeStream: undefined,
+  };
 
   try {
     while (!signal.aborted) {
-      // Idempotent cleanup for abort/error paths; the normal report path settles and clears
-      // activeStream before the next iteration reaches this point.
-      await settleStream({stream: activeStream, signal});
-      activeStream = undefined;
-
-      const pulled = await pullNextStep({leaseClient, jobId, signal});
-      if (!pulled) return;
-      if (signal.aborted) return;
-
-      params.onLeaseTokenAdopted?.(pulled.leaseToken);
-      const {step, attempt} = pulled;
-      const stepLabel = step.name ?? `step #${step.position}`;
-      logger().info(
-        {jobId, stepId: step.id, stepName: step.name, position: step.position, attempt},
-        `Running ${stepLabel}`,
-      );
-
-      const prepareLogs =
-        step.type === 'setup' && !logsPrepared
-          ? async () => {
-              await createJobLogsDir(logsDir);
-              logsPrepared = true;
-            }
-          : undefined;
-      const prepareAgentState =
-        step.type === 'setup' && !agentStatePrepared && prepareAgentStateDirectory !== undefined
-          ? async () => {
-              await prepareAgentStateDirectory();
-              agentStatePrepared = true;
-            }
-          : undefined;
-      const execution = await executeStep({
-        step,
-        attempt,
-        cwd,
-        agentStateDir,
-        leaseClient,
-        leaseToken: params.leaseToken,
-        secrets,
-        ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
-        signal,
-        workspacePrepared,
-        checkoutDestinations,
-        ambientGitConfigPath,
-        ambientGitConfigSecrets,
-        jobId,
-        stepLabel,
-        logsDir,
-        jobContext,
-        gitConfigPath,
-        ...(prepareLogs ? {prepareLogs} : {}),
-        ...(prepareAgentState ? {prepareAgentState} : {}),
-      });
-      activeStream = execution.stream;
-      if (execution.preparedWorkspace) workspacePrepared = true;
-      if (execution.ambientGitConfigPath) ambientGitConfigPath = execution.ambientGitConfigPath;
-      if (execution.ambientGitConfigSecrets) {
-        params.registerSecrets?.(execution.ambientGitConfigSecrets);
-        ambientGitConfigSecrets = [
-          ...new Set([...ambientGitConfigSecrets, ...execution.ambientGitConfigSecrets]),
-        ];
-      }
-      if (execution.result.success && execution.result.checkout) {
-        rememberCheckoutDestination(checkoutDestinations, execution.result.checkout);
-      }
-
-      if (signal.aborted) return;
-
-      const logOutcome =
-        (await settleStream({stream: activeStream, signal})) ?? execution.logOutcome ?? 'drained';
-      activeStream = undefined;
-
-      await publishStepAnnotations({
-        leaseClient,
-        step,
-        attempt,
-        annotations: execution.result.annotations,
-        jobId,
-        signal,
-      });
-
-      const {cancel} = await reportStepResult({
-        leaseClient,
-        step,
-        attempt,
-        result: execution.result,
-        logOutcome,
-        jobId,
-        jobExecutionId: jobContext.jobExecutionId,
-        stepLabel,
-        signal,
-      });
-      if (cancel) {
-        logger().info(
-          {jobId, stepId: step.id},
-          'Job finished without full success; stopping step loop',
-        );
-        return;
-      }
+      const outcome = await runJobStepIteration(params, state);
+      if (outcome === 'stop') return;
     }
   } finally {
     // Drain the last stream (bounded) before runJob deletes the log spool; an abort
     // cuts the wait short. Whatever did not drain is timeout-closed server-side.
-    await settleStream({stream: activeStream, signal});
+    await settleStream({stream: state.activeStream, signal});
   }
+}
+
+interface JobStepLoopState {
+  workspacePrepared: boolean;
+  logsPrepared: boolean;
+  agentStatePrepared: boolean;
+  ambientGitConfigPath: string | undefined;
+  ambientGitConfigSecrets: string[];
+  checkoutDestinations: CheckoutDestinations;
+  activeStream: LogStreamLifecycle | undefined;
+}
+
+async function runJobStepIteration(
+  params: Parameters<typeof runJobSteps>[0],
+  state: JobStepLoopState,
+): Promise<'continue' | 'stop'> {
+  await settleStream({stream: state.activeStream, signal: params.signal});
+  state.activeStream = undefined;
+  const pulled = await pullNextStep({
+    leaseClient: params.leaseClient,
+    jobId: params.jobId,
+    signal: params.signal,
+  });
+  if (!pulled || params.signal.aborted) return 'stop';
+  params.onLeaseTokenAdopted?.(pulled.leaseToken);
+  const {step, attempt} = pulled;
+  const stepLabel = step.name ?? `step #${step.position}`;
+  logger().info(
+    {
+      jobId: params.jobId,
+      stepId: step.id,
+      stepName: step.name,
+      position: step.position,
+      attempt,
+    },
+    `Running ${stepLabel}`,
+  );
+  const preparation = stepPreparation(params, state, step);
+  const execution = await executeStep({
+    step,
+    attempt,
+    cwd: params.cwd,
+    agentStateDir: params.agentStateDir,
+    leaseClient: params.leaseClient,
+    leaseToken: params.leaseToken,
+    secrets: params.secrets,
+    ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
+    signal: params.signal,
+    workspacePrepared: state.workspacePrepared,
+    checkoutDestinations: state.checkoutDestinations,
+    ambientGitConfigPath: state.ambientGitConfigPath,
+    ambientGitConfigSecrets: state.ambientGitConfigSecrets,
+    jobId: params.jobId,
+    stepLabel,
+    logsDir: params.logsDir,
+    jobContext: params.jobContext,
+    gitConfigPath: params.gitConfigPath,
+    ...preparation,
+  });
+  applyStepExecutionState(params, state, execution);
+  if (params.signal.aborted) return 'stop';
+  return finishStepExecution(params, state, step, attempt, stepLabel, execution);
+}
+
+function stepPreparation(
+  params: Parameters<typeof runJobSteps>[0],
+  state: JobStepLoopState,
+  step: StepDto,
+): Pick<Parameters<typeof executeStep>[0], 'prepareLogs' | 'prepareAgentState'> {
+  const prepareLogs =
+    step.type === 'setup' && !state.logsPrepared
+      ? async () => {
+          await createJobLogsDir(params.logsDir);
+          state.logsPrepared = true;
+        }
+      : undefined;
+  const prepareAgentState =
+    step.type === 'setup' && !state.agentStatePrepared && params.prepareAgentState !== undefined
+      ? async () => {
+          await params.prepareAgentState?.();
+          state.agentStatePrepared = true;
+        }
+      : undefined;
+  return {
+    ...(prepareLogs ? {prepareLogs} : {}),
+    ...(prepareAgentState ? {prepareAgentState} : {}),
+  };
+}
+
+function applyStepExecutionState(
+  params: Parameters<typeof runJobSteps>[0],
+  state: JobStepLoopState,
+  execution: StepExecution,
+): void {
+  state.activeStream = execution.stream;
+  if (execution.preparedWorkspace) state.workspacePrepared = true;
+  if (execution.ambientGitConfigPath) state.ambientGitConfigPath = execution.ambientGitConfigPath;
+  if (execution.ambientGitConfigSecrets) {
+    params.registerSecrets?.(execution.ambientGitConfigSecrets);
+    state.ambientGitConfigSecrets = [
+      ...new Set([...state.ambientGitConfigSecrets, ...execution.ambientGitConfigSecrets]),
+    ];
+  }
+  if (execution.result.success && execution.result.checkout) {
+    rememberCheckoutDestination(state.checkoutDestinations, execution.result.checkout);
+  }
+}
+
+async function finishStepExecution(
+  params: Parameters<typeof runJobSteps>[0],
+  state: JobStepLoopState,
+  step: StepDto,
+  attempt: number,
+  stepLabel: string,
+  execution: StepExecution,
+): Promise<'continue' | 'stop'> {
+  const logOutcome =
+    (await settleStream({stream: state.activeStream, signal: params.signal})) ??
+    execution.logOutcome ??
+    'drained';
+  state.activeStream = undefined;
+  await publishStepAnnotations({
+    leaseClient: params.leaseClient,
+    step,
+    attempt,
+    annotations: execution.result.annotations,
+    jobId: params.jobId,
+    signal: params.signal,
+  });
+  const {cancel} = await reportStepResult({
+    leaseClient: params.leaseClient,
+    step,
+    attempt,
+    result: execution.result,
+    logOutcome,
+    jobId: params.jobId,
+    jobExecutionId: params.jobContext.jobExecutionId,
+    stepLabel,
+    signal: params.signal,
+  });
+  if (!cancel) return 'continue';
+  logger().info(
+    {jobId: params.jobId, stepId: step.id},
+    'Job finished without full success; stopping step loop',
+  );
+  return 'stop';
 }
 
 function rememberCheckoutDestination(
@@ -326,54 +362,26 @@ export async function executeStep(params: {
     step,
     attempt,
     cwd,
-    logsDir,
-    agentStateDir,
-    jobContext,
     leaseClient,
-    leaseToken,
     secrets,
     subscribeSecrets,
-    signal,
     workspacePrepared,
-    checkoutDestinations = new Map(),
-    ambientGitConfigPath,
-    ambientGitConfigSecrets = [],
-    gitConfigPath,
     jobId,
     stepLabel,
-    prepareLogs,
-    prepareAgentState,
   } = params;
 
   let stream: LogStreamLifecycle | undefined;
   let runStream: StepLogStream | undefined;
   const unsubscribeSecrets: Array<() => void> = [];
-  let subscribedSecrets = [...secrets];
-  let crashSecretVariants = buildSecretVariants(secrets);
-  const registerStreamSecrets = (
-    target:
-      | {
-          addSecrets?: (secrets: string[]) => void;
-          setSecrets?: (secrets: string[]) => void;
-          setRotatingSecrets?: (secrets: string[]) => void;
-        }
-      | undefined,
-  ) => {
-    if (!target?.setSecrets && !target?.setRotatingSecrets && !target?.addSecrets) return;
-    const unsubscribe = subscribeSecrets?.((registeredSecrets) => {
-      subscribedSecrets = [...new Set([...subscribedSecrets, ...registeredSecrets])];
-      if (target.setSecrets) {
-        target.setSecrets(registeredSecrets);
-        return;
-      }
-      if (target.setRotatingSecrets) {
-        target.setRotatingSecrets(registeredSecrets);
-        return;
-      }
-      target.addSecrets?.(registeredSecrets);
-    });
-    if (unsubscribe) unsubscribeSecrets.push(unsubscribe);
+  const secretState = {
+    subscribedSecrets: [...secrets],
+    crashSecretVariants: buildSecretVariants(secrets),
   };
+  const registerStreamSecrets = createStreamSecretRegistrar({
+    subscribeSecrets,
+    secretState,
+    unsubscribeSecrets,
+  });
   try {
     // Both step kinds capture to the same per-attempt stream contract (one stream per
     // job/step/attempt). The append port is bound to the lease client, step, and attempt.
@@ -387,69 +395,16 @@ export async function executeStep(params: {
       });
 
     if (step.type === 'setup') {
-      if (prepareLogs) {
-        try {
-          await prepareLogs();
-        } catch (error) {
-          const result = setupPreparationFailure(error, 'workspace_prep_failed');
-          logger().warn(
-            {err: error, jobId, stepId: step.id, attempt, reason: result.error?.reason},
-            'Setup step failed',
-          );
-          return {result, logOutcome: 'abandoned', preparedWorkspace: false};
-        }
-      }
-      if (prepareAgentState) {
-        try {
-          await prepareAgentState();
-        } catch (error) {
-          const result = setupPreparationFailure(error, 'agent_harness_unavailable');
-          logger().warn(
-            {err: error, jobId, stepId: step.id, attempt, reason: result.error?.reason},
-            'Setup step failed',
-          );
-          return {result, logOutcome: 'abandoned', preparedWorkspace: false};
-        }
-      }
-
-      let setupStream: StepLogStream | undefined;
-      try {
-        setupStream = createStepLogStream({
-          logsDir,
-          stepId: step.id,
-          attempt,
-          secrets,
-          append,
-        });
-      } catch (error) {
-        logger().error(
-          {err: error, jobId, stepId: step.id, attempt},
-          'Failed to open setup log capture; running setup without it',
-        );
-      }
-      stream = setupStream;
-      registerStreamSecrets(setupStream);
-
-      const setup = await executeSetupStep({
-        cwd,
-        gitConfigPath,
-        leaseClient,
-        signal,
-        step,
-        attempt,
-        ...(setupStream ? {log: setupStream} : {}),
-        jobContext,
+      const execution = await executeSetupStepBranch({
+        params: {...params, step},
+        append,
+        onStream: (createdStream) => {
+          stream = createdStream;
+        },
+        registerStreamSecrets,
       });
-      return {
-        result: setup.result,
-        stream,
-        logOutcome: setupStream ? undefined : 'abandoned',
-        preparedWorkspace: setup.result.success,
-        ...(setup.ambientGitConfigPath ? {ambientGitConfigPath: setup.ambientGitConfigPath} : {}),
-        ...(setup.ambientGitConfigSecrets
-          ? {ambientGitConfigSecrets: setup.ambientGitConfigSecrets}
-          : {}),
-      };
+      stream = execution.stream;
+      return execution;
     }
 
     if (!workspacePrepared) {
@@ -468,53 +423,81 @@ export async function executeStep(params: {
     }
 
     if (step.type === 'checkout') {
-      let checkoutStream: StepLogStream | undefined;
-      try {
-        checkoutStream = createStepLogStream({
-          logsDir,
-          stepId: step.id,
-          attempt,
-          secrets,
-          append,
-        });
-      } catch (error) {
-        logger().error(
-          {err: error, jobId, stepId: step.id, attempt},
-          'Failed to open checkout log capture; running checkout without it',
-        );
-      }
-      stream = checkoutStream;
-      registerStreamSecrets(checkoutStream);
-
-      const checkout = await executeCheckoutStep({
-        cwd,
-        gitConfigPath,
-        leaseClient,
-        signal,
-        step,
-        attempt,
-        destinations: checkoutDestinations,
-        ...(checkoutStream ? {log: checkoutStream} : {}),
+      const execution = await executeCheckoutStepBranch({
+        params: {...params, step},
+        append,
+        onStream: (createdStream) => {
+          stream = createdStream;
+        },
+        registerStreamSecrets,
       });
-      return {
-        result: checkout.result,
-        stream,
-        logOutcome: checkoutStream ? undefined : 'abandoned',
-        preparedWorkspace: false,
-        ...(checkout.ambientGitConfigPath
-          ? {ambientGitConfigPath: checkout.ambientGitConfigPath}
-          : {}),
-        ...(checkout.ambientGitConfigSecrets
-          ? {ambientGitConfigSecrets: checkout.ambientGitConfigSecrets}
-          : {}),
-      };
+      stream = execution.stream;
+      return execution;
     }
 
-    let stepCwd: string;
-    try {
-      stepCwd = await resolveWorkingDirectory(cwd, step.config.working_directory);
-    } catch (error) {
-      return {
+    const workingDirectory = await resolveStepWorkingDirectory(cwd, step.config.working_directory);
+    if (!workingDirectory.ok) return workingDirectory.execution;
+    const stepCwd = workingDirectory.path;
+
+    // Agent steps run the embedded pi harness and forward every session entry into the log
+    // pipeline as opaque `agent_session` records. Capture is best-effort: if the spool cannot
+    // be opened, run the agent without it rather than failing the step.
+    if (step.type === 'agent') {
+      const execution = await executeAgentStepBranch({
+        params: {...params, step},
+        stepCwd,
+        append,
+        onStream: (createdStream) => {
+          stream = createdStream;
+        },
+        registerStreamSecrets,
+        secretState,
+      });
+      stream = execution.stream;
+      return execution;
+    }
+
+    const execution = await executeRunStepBranch({
+      params: {...params, step},
+      stepCwd,
+      append,
+      onStream: (createdStream) => {
+        stream = createdStream;
+        runStream = createdStream;
+      },
+      registerStreamSecrets,
+      secretState,
+    });
+    stream = execution.stream;
+    runStream = execution.stream as StepLogStream | undefined;
+    return execution;
+  } catch (error) {
+    return crashedStepExecution({
+      error,
+      jobId,
+      step,
+      stepLabel,
+      stream,
+      runStream,
+      secretState,
+      secrets,
+    });
+  } finally {
+    for (const unsubscribe of unsubscribeSecrets) unsubscribe();
+    runStream?.writeGroupEnd();
+  }
+}
+
+async function resolveStepWorkingDirectory(
+  cwd: string,
+  configured: unknown,
+): Promise<{ok: true; path: string} | {ok: false; execution: StepExecution}> {
+  try {
+    return {ok: true, path: await resolveWorkingDirectory(cwd, configured)};
+  } catch (error) {
+    return {
+      ok: false,
+      execution: {
         result: {
           success: false,
           error: {message: error instanceof Error ? error.message : String(error)},
@@ -522,214 +505,436 @@ export async function executeStep(params: {
         },
         logOutcome: 'abandoned',
         preparedWorkspace: false,
-      };
-    }
-
-    // Agent steps run the embedded pi harness and forward every session entry into the log
-    // pipeline as opaque `agent_session` records. Capture is best-effort: if the spool cannot
-    // be opened, run the agent without it rather than failing the step.
-    if (step.type === 'agent') {
-      let runtimeConfig: Awaited<ReturnType<typeof requestAgentRuntimeConfig>>;
-      try {
-        runtimeConfig = await requestAgentRuntimeConfig(leaseClient, {
-          stepId: step.id,
-          attempt,
-          signal,
-        });
-      } catch (error) {
-        return {
-          result: agentRuntimeConfigFailure(error),
-          logOutcome: 'drained',
-          preparedWorkspace: false,
-        };
-      }
-
-      let sessionFile: string | undefined;
-      let sessionBaseSegment: number | undefined;
-      if (runtimeConfig.session !== undefined) {
-        const transcript = await requestSessionTranscript(leaseClient, {
-          stepId: step.id,
-          attempt,
-          signal,
-        });
-        sessionBaseSegment = transcript.segment;
-        if (transcript.blob !== null) {
-          sessionFile = `${agentStateDir}/agent-sessions/dispatch-session.jsonl`;
-          await mkdir(`${agentStateDir}/agent-sessions`, {recursive: true});
-          await writeFile(sessionFile, await gunzipAsync(transcript.blob));
-        }
-      }
-
-      let sessionStream: SessionLogStream | undefined;
-      const runtimeSecretValues = [
-        ...Object.values(runtimeConfig.credentials),
-        ...(runtimeConfig.claude !== undefined ? [runtimeConfig.claude.auth_token] : []),
-      ];
-      const agentSecrets = [...secrets, ...runtimeSecretValues];
-      crashSecretVariants = buildSecretVariants(agentSecrets);
-      try {
-        sessionStream = createSessionLogStream({
-          logsDir,
-          stepId: step.id,
-          attempt,
-          secrets: agentSecrets,
-          append,
-        });
-      } catch (error) {
-        logger().error(
-          {err: error, jobId, stepId: step.id, attempt},
-          'Failed to open agent session capture; running the step without it',
-        );
-      }
-      stream = sessionStream;
-      registerStreamSecrets(sessionStream);
-      const {executeAgentStep} = await loadRunnerAgentStep();
-      const result = await executeAgentStep(step, {
-        signal,
-        cwd: stepCwd,
-        agentStateDir,
-        ...(sessionFile === undefined ? {} : {sessionFile}),
-        ...(runtimeConfig.session === undefined ? {} : {sessionMode: runtimeConfig.session.mode}),
-        ...(ambientGitConfigPath ? {gitConfigGlobal: ambientGitConfigPath} : {}),
-        runtime: {
-          harness: runtimeConfig.harness,
-          provider: runtimeConfig.provider_id,
-          model: runtimeConfig.model,
-          thinking: runtimeConfig.thinking,
-          credentials: runtimeConfig.credentials,
-          ...(runtimeConfig.custom_provider
-            ? {custom_provider: runtimeConfig.custom_provider}
-            : {}),
-          ...(runtimeConfig.claude !== undefined ? {claude: runtimeConfig.claude} : {}),
-        },
-        leaseToken,
-        integrationToolsGatewayUrl: integrationToolsGatewayUrl(),
-        ...(sessionStream
-          ? {onSessionEntry: (line: string) => sessionStream?.writeEntry(line)}
-          : {}),
-      });
-      if (
-        runtimeConfig.session !== undefined &&
-        sessionBaseSegment !== undefined &&
-        result.success &&
-        result.sessionFile !== undefined
-      ) {
-        const transcriptBlob = await gzipAsync(await readFile(result.sessionFile));
-        const commit = await commitSessionTranscript(leaseClient, {
-          stepId: step.id,
-          attempt,
-          baseSegment: sessionBaseSegment,
-          blob: transcriptBlob,
-          harness: runtimeConfig.harness,
-          model: runtimeConfig.model,
-          provider: runtimeConfig.provider_id,
-          sdkVersion: 'pi-coding-agent',
-          ...(result.sessionId === undefined ? {} : {harnessSessionId: result.sessionId}),
-          signal,
-        });
-        if (commit.status === 'conflict') {
-          throw new Error(
-            `Session transcript commit conflict at head segment ${commit.headSegment}`,
-          );
-        }
-      }
-      return {
-        result: maskAgentResult(
-          result,
-          buildSecretVariants([...agentSecrets, ...subscribedSecrets, ...secrets]),
-        ),
-        stream,
-        logOutcome: sessionStream ? undefined : 'abandoned',
-        preparedWorkspace: false,
-      };
-    }
-
-    let runSecretMaterial: RunSecretMaterial | undefined;
-    try {
-      runSecretMaterial = await loadRunSecretMaterial({step, leaseClient, attempt, signal});
-    } catch (error) {
-      return {
-        result: stepSecretsFailure(error),
-        logOutcome: 'drained',
-        preparedWorkspace: false,
-      };
-    }
-
-    // Log capture is best-effort: if the spool cannot be opened (e.g. a broken logs dir),
-    // abandon capture and run the step without a stream rather than failing the step itself.
-    let stepStream: StepLogStream | undefined;
-    const runSecrets = [
-      ...secrets,
-      ...ambientGitConfigSecrets,
-      ...(runSecretMaterial?.secretValues ?? []),
-    ];
-    const runSecretVariants = buildSecretVariants(runSecrets);
-    crashSecretVariants = runSecretVariants;
-    try {
-      stepStream = createStepLogStream({
-        logsDir,
-        stepId: step.id,
-        attempt,
-        secrets: runSecrets,
-        append,
-      });
-    } catch (error) {
-      logger().error(
-        {err: error, jobId, stepId: step.id, attempt},
-        'Failed to open log capture; running the step without it',
-      );
-    }
-    stream = stepStream;
-    runStream = stepStream;
-    registerStreamSecrets(stepStream);
-
-    let result = await executeRunStep(step, {
-      signal,
-      cwd: stepCwd,
-      workspace: cwd,
-      ...(ambientGitConfigPath ? {gitConfigGlobal: ambientGitConfigPath} : {}),
-      ...(runSecretMaterial?.secretEnv ? {secretEnv: runSecretMaterial.secretEnv} : {}),
-      ...(runSecrets.length > 0 ? {secretValues: [...runSecrets]} : {}),
-      ...(subscribeSecrets ? {subscribeSecrets} : {}),
-      onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
-      onOutput: (chunk, source) => stepStream?.write(chunk, source),
-    });
-    result = maskRunStepOutputs(
-      result,
-      buildSecretVariants([...runSecrets, ...subscribedSecrets, ...secrets]),
-    );
-    writeRunFailureContext(stepStream, result);
-    return {
-      result,
-      stream,
-      logOutcome: stepStream ? undefined : 'abandoned',
-      preparedWorkspace: false,
+      },
     };
+  }
+}
+
+function crashedStepExecution(params: {
+  error: unknown;
+  jobId: string;
+  step: StepDto;
+  stepLabel: string;
+  stream: LogStreamLifecycle | undefined;
+  runStream: StepLogStream | undefined;
+  secretState: StepSecretState;
+  secrets: string[];
+}): StepExecution {
+  logger().error(
+    {err: params.error, jobId: params.jobId, stepId: params.step.id},
+    `Step ${params.stepLabel} crashed before producing a result`,
+  );
+  const result: StepResult = {
+    success: false,
+    error: {
+      message: redactSecrets(
+        params.error instanceof Error ? params.error.message : String(params.error),
+        buildSecretVariants([
+          ...params.secretState.crashSecretVariants,
+          ...params.secretState.subscribedSecrets,
+          ...params.secrets,
+        ]),
+      ),
+    },
+    exit_code: null,
+  };
+  writeRunFailureContext(params.runStream, result);
+  let logOutcome: LogOutcomeDto | undefined;
+  if (!params.stream) logOutcome = params.step.type === 'setup' ? 'drained' : 'abandoned';
+  return {result, stream: params.stream, logOutcome, preparedWorkspace: false};
+}
+
+type SecretAwareStream =
+  | {
+      addSecrets?: (secrets: string[]) => void;
+      setSecrets?: (secrets: string[]) => void;
+      setRotatingSecrets?: (secrets: string[]) => void;
+    }
+  | undefined;
+
+function createStreamSecretRegistrar(params: {
+  subscribeSecrets: Parameters<typeof executeStep>[0]['subscribeSecrets'];
+  secretState: StepSecretState;
+  unsubscribeSecrets: Array<() => void>;
+}): (target: SecretAwareStream) => void {
+  return (target) => {
+    if (!target?.setSecrets && !target?.setRotatingSecrets && !target?.addSecrets) return;
+    const unsubscribe = params.subscribeSecrets?.((registeredSecrets) => {
+      params.secretState.subscribedSecrets = [
+        ...new Set([...params.secretState.subscribedSecrets, ...registeredSecrets]),
+      ];
+      if (target.setSecrets) {
+        target.setSecrets(registeredSecrets);
+        return;
+      }
+      if (target.setRotatingSecrets) {
+        target.setRotatingSecrets(registeredSecrets);
+        return;
+      }
+      target.addSecrets?.(registeredSecrets);
+    });
+    if (unsubscribe) params.unsubscribeSecrets.push(unsubscribe);
+  };
+}
+
+async function executeSetupStepBranch(params: {
+  params: Parameters<typeof executeStep>[0];
+  append: LogAppendFn;
+  onStream: (stream: StepLogStream | undefined) => void;
+  registerStreamSecrets: (stream: StepLogStream | undefined) => void;
+}): Promise<StepExecution> {
+  const input = params.params;
+  const logFailure = await runSetupPreparations(input);
+  if (logFailure) return logFailure;
+  let setupStream: StepLogStream | undefined;
+  try {
+    setupStream = createStepLogStream({
+      logsDir: input.logsDir,
+      stepId: input.step.id,
+      attempt: input.attempt,
+      secrets: input.secrets,
+      append: params.append,
+    });
   } catch (error) {
     logger().error(
-      {err: error, jobId, stepId: step.id},
-      `Step ${stepLabel} crashed before producing a result`,
+      {err: error, jobId: input.jobId, stepId: input.step.id, attempt: input.attempt},
+      'Failed to open setup log capture; running setup without it',
     );
-    const result: StepResult = {
-      success: false,
-      error: {
-        message: redactSecrets(
-          error instanceof Error ? error.message : String(error),
-          buildSecretVariants([...crashSecretVariants, ...subscribedSecrets, ...secrets]),
-        ),
-      },
-      exit_code: null,
-    };
-    writeRunFailureContext(runStream, result);
+  }
+  params.onStream(setupStream);
+  params.registerStreamSecrets(setupStream);
+  const setup = await executeSetupStep({
+    cwd: input.cwd,
+    gitConfigPath: input.gitConfigPath,
+    leaseClient: input.leaseClient,
+    signal: input.signal,
+    step: input.step,
+    attempt: input.attempt,
+    ...(setupStream ? {log: setupStream} : {}),
+    jobContext: input.jobContext,
+  });
+  return {
+    result: setup.result,
+    stream: setupStream,
+    logOutcome: setupStream ? undefined : 'abandoned',
+    preparedWorkspace: setup.result.success,
+    ...(setup.ambientGitConfigPath ? {ambientGitConfigPath: setup.ambientGitConfigPath} : {}),
+    ...(setup.ambientGitConfigSecrets
+      ? {ambientGitConfigSecrets: setup.ambientGitConfigSecrets}
+      : {}),
+  };
+}
+
+async function executeCheckoutStepBranch(params: {
+  params: Parameters<typeof executeStep>[0];
+  append: LogAppendFn;
+  onStream: (stream: StepLogStream | undefined) => void;
+  registerStreamSecrets: (stream: StepLogStream | undefined) => void;
+}): Promise<StepExecution> {
+  const input = params.params;
+  let checkoutStream: StepLogStream | undefined;
+  try {
+    checkoutStream = createStepLogStream({
+      logsDir: input.logsDir,
+      stepId: input.step.id,
+      attempt: input.attempt,
+      secrets: input.secrets,
+      append: params.append,
+    });
+  } catch (error) {
+    logger().error(
+      {err: error, jobId: input.jobId, stepId: input.step.id, attempt: input.attempt},
+      'Failed to open checkout log capture; running checkout without it',
+    );
+  }
+  params.onStream(checkoutStream);
+  params.registerStreamSecrets(checkoutStream);
+  const checkout = await executeCheckoutStep({
+    cwd: input.cwd,
+    gitConfigPath: input.gitConfigPath,
+    leaseClient: input.leaseClient,
+    signal: input.signal,
+    step: input.step,
+    attempt: input.attempt,
+    destinations: input.checkoutDestinations ?? new Map(),
+    ...(checkoutStream ? {log: checkoutStream} : {}),
+  });
+  return {
+    result: checkout.result,
+    stream: checkoutStream,
+    logOutcome: checkoutStream ? undefined : 'abandoned',
+    preparedWorkspace: false,
+    ...(checkout.ambientGitConfigPath ? {ambientGitConfigPath: checkout.ambientGitConfigPath} : {}),
+    ...(checkout.ambientGitConfigSecrets
+      ? {ambientGitConfigSecrets: checkout.ambientGitConfigSecrets}
+      : {}),
+  };
+}
+
+interface StepSecretState {
+  subscribedSecrets: string[];
+  crashSecretVariants: string[];
+}
+
+async function executeAgentStepBranch(params: {
+  params: Parameters<typeof executeStep>[0];
+  stepCwd: string;
+  append: LogAppendFn;
+  onStream: (stream: SessionLogStream | undefined) => void;
+  registerStreamSecrets: (stream: SessionLogStream | undefined) => void;
+  secretState: StepSecretState;
+}): Promise<StepExecution> {
+  const input = params.params;
+  let runtimeConfig: Awaited<ReturnType<typeof requestAgentRuntimeConfig>>;
+  try {
+    runtimeConfig = await requestAgentRuntimeConfig(input.leaseClient, {
+      stepId: input.step.id,
+      attempt: input.attempt,
+      signal: input.signal,
+    });
+  } catch (error) {
     return {
-      result,
-      stream,
-      logOutcome: stream ? undefined : step.type === 'setup' ? 'drained' : 'abandoned',
+      result: agentRuntimeConfigFailure(error),
+      logOutcome: 'drained',
       preparedWorkspace: false,
     };
-  } finally {
-    for (const unsubscribe of unsubscribeSecrets) unsubscribe();
-    runStream?.writeGroupEnd();
+  }
+  const session = await prepareAgentSession(input, runtimeConfig);
+  const runtimeSecretValues = [
+    ...Object.values(runtimeConfig.credentials),
+    ...(runtimeConfig.claude !== undefined ? [runtimeConfig.claude.auth_token] : []),
+  ];
+  const agentSecrets = [...input.secrets, ...runtimeSecretValues];
+  params.secretState.crashSecretVariants = buildSecretVariants(agentSecrets);
+  const sessionStream = createAgentSessionLogStream(input, agentSecrets, params.append);
+  params.onStream(sessionStream);
+  params.registerStreamSecrets(sessionStream);
+  const {executeAgentStep} = await loadRunnerAgentStep();
+  const result = await executeAgentStep(input.step, {
+    signal: input.signal,
+    cwd: params.stepCwd,
+    agentStateDir: input.agentStateDir,
+    ...(session.file === undefined ? {} : {sessionFile: session.file}),
+    ...(runtimeConfig.session === undefined ? {} : {sessionMode: runtimeConfig.session.mode}),
+    ...(input.ambientGitConfigPath ? {gitConfigGlobal: input.ambientGitConfigPath} : {}),
+    runtime: {
+      harness: runtimeConfig.harness,
+      provider: runtimeConfig.provider_id,
+      model: runtimeConfig.model,
+      thinking: runtimeConfig.thinking,
+      credentials: runtimeConfig.credentials,
+      ...(runtimeConfig.custom_provider ? {custom_provider: runtimeConfig.custom_provider} : {}),
+      ...(runtimeConfig.claude !== undefined ? {claude: runtimeConfig.claude} : {}),
+    },
+    leaseToken: input.leaseToken,
+    integrationToolsGatewayUrl: integrationToolsGatewayUrl(),
+    ...(sessionStream ? {onSessionEntry: (line: string) => sessionStream.writeEntry(line)} : {}),
+  });
+  await commitAgentSession(input, runtimeConfig, session, result);
+  return {
+    result: maskAgentResult(
+      result,
+      buildSecretVariants([
+        ...agentSecrets,
+        ...params.secretState.subscribedSecrets,
+        ...input.secrets,
+      ]),
+    ),
+    stream: sessionStream,
+    logOutcome: sessionStream ? undefined : 'abandoned',
+    preparedWorkspace: false,
+  };
+}
+
+interface AgentSessionState {
+  file?: string;
+  baseSegment?: number;
+}
+
+async function prepareAgentSession(
+  input: Parameters<typeof executeStep>[0],
+  runtimeConfig: Awaited<ReturnType<typeof requestAgentRuntimeConfig>>,
+): Promise<AgentSessionState> {
+  if (runtimeConfig.session === undefined) return {};
+  const transcript = await requestSessionTranscript(input.leaseClient, {
+    stepId: input.step.id,
+    attempt: input.attempt,
+    signal: input.signal,
+  });
+  if (transcript.blob === null) return {baseSegment: transcript.segment};
+  const file = `${input.agentStateDir}/agent-sessions/dispatch-session.jsonl`;
+  await mkdir(`${input.agentStateDir}/agent-sessions`, {recursive: true});
+  await writeFile(file, await gunzipAsync(transcript.blob));
+  return {file, baseSegment: transcript.segment};
+}
+
+async function commitAgentSession(
+  input: Parameters<typeof executeStep>[0],
+  runtimeConfig: Awaited<ReturnType<typeof requestAgentRuntimeConfig>>,
+  session: AgentSessionState,
+  result: Awaited<ReturnType<RunnerAgentStepModule['executeAgentStep']>>,
+): Promise<void> {
+  if (
+    runtimeConfig.session === undefined ||
+    session.baseSegment === undefined ||
+    !result.success ||
+    result.sessionFile === undefined
+  ) {
+    return;
+  }
+  const transcriptBlob = await gzipAsync(await readFile(result.sessionFile));
+  const commit = await commitSessionTranscript(input.leaseClient, {
+    stepId: input.step.id,
+    attempt: input.attempt,
+    baseSegment: session.baseSegment,
+    blob: transcriptBlob,
+    harness: runtimeConfig.harness,
+    model: runtimeConfig.model,
+    provider: runtimeConfig.provider_id,
+    sdkVersion: 'pi-coding-agent',
+    ...(result.sessionId === undefined ? {} : {harnessSessionId: result.sessionId}),
+    signal: input.signal,
+  });
+  if (commit.status === 'conflict') {
+    throw new Error(`Session transcript commit conflict at head segment ${commit.headSegment}`);
+  }
+}
+
+function createAgentSessionLogStream(
+  input: Pick<Parameters<typeof executeStep>[0], 'logsDir' | 'step' | 'attempt' | 'jobId'>,
+  secrets: string[],
+  append: LogAppendFn,
+): SessionLogStream | undefined {
+  try {
+    return createSessionLogStream({
+      logsDir: input.logsDir,
+      stepId: input.step.id,
+      attempt: input.attempt,
+      secrets,
+      append,
+    });
+  } catch (error) {
+    logger().error(
+      {err: error, jobId: input.jobId, stepId: input.step.id, attempt: input.attempt},
+      'Failed to open agent session capture; running the step without it',
+    );
+    return undefined;
+  }
+}
+
+async function executeRunStepBranch(params: {
+  params: Parameters<typeof executeStep>[0];
+  stepCwd: string;
+  append: LogAppendFn;
+  onStream: (stream: StepLogStream | undefined) => void;
+  registerStreamSecrets: (stream: StepLogStream | undefined) => void;
+  secretState: StepSecretState;
+}): Promise<StepExecution> {
+  const input = params.params;
+  let secretMaterial: RunSecretMaterial | undefined;
+  try {
+    secretMaterial = await loadRunSecretMaterial({
+      step: input.step,
+      leaseClient: input.leaseClient,
+      attempt: input.attempt,
+      signal: input.signal,
+    });
+  } catch (error) {
+    return {
+      result: stepSecretsFailure(error),
+      logOutcome: 'drained',
+      preparedWorkspace: false,
+    };
+  }
+  const runSecrets = [
+    ...input.secrets,
+    ...(input.ambientGitConfigSecrets ?? []),
+    ...(secretMaterial?.secretValues ?? []),
+  ];
+  params.secretState.crashSecretVariants = buildSecretVariants(runSecrets);
+  const stepStream = createRunStepLogStream(input, runSecrets, params.append);
+  params.onStream(stepStream);
+  params.registerStreamSecrets(stepStream);
+  let result = await executeRunStep(input.step, {
+    signal: input.signal,
+    cwd: params.stepCwd,
+    workspace: input.cwd,
+    ...(input.ambientGitConfigPath ? {gitConfigGlobal: input.ambientGitConfigPath} : {}),
+    ...(secretMaterial?.secretEnv ? {secretEnv: secretMaterial.secretEnv} : {}),
+    ...(runSecrets.length > 0 ? {secretValues: [...runSecrets]} : {}),
+    ...(input.subscribeSecrets ? {subscribeSecrets: input.subscribeSecrets} : {}),
+    onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
+    onOutput: (chunk, source) => stepStream?.write(chunk, source),
+  });
+  result = maskRunStepOutputs(
+    result,
+    buildSecretVariants([...runSecrets, ...params.secretState.subscribedSecrets, ...input.secrets]),
+  );
+  writeRunFailureContext(stepStream, result);
+  return {
+    result,
+    stream: stepStream,
+    logOutcome: stepStream ? undefined : 'abandoned',
+    preparedWorkspace: false,
+  };
+}
+
+function createRunStepLogStream(
+  input: Pick<Parameters<typeof executeStep>[0], 'logsDir' | 'step' | 'attempt' | 'jobId'>,
+  secrets: string[],
+  append: LogAppendFn,
+): StepLogStream | undefined {
+  try {
+    return createStepLogStream({
+      logsDir: input.logsDir,
+      stepId: input.step.id,
+      attempt: input.attempt,
+      secrets,
+      append,
+    });
+  } catch (error) {
+    logger().error(
+      {err: error, jobId: input.jobId, stepId: input.step.id, attempt: input.attempt},
+      'Failed to open log capture; running the step without it',
+    );
+    return undefined;
+  }
+}
+
+async function runSetupPreparations(
+  params: Parameters<typeof executeStep>[0],
+): Promise<StepExecution | undefined> {
+  const logsFailure = await runSetupPreparation(
+    params,
+    params.prepareLogs,
+    'workspace_prep_failed',
+  );
+  if (logsFailure) return logsFailure;
+  return runSetupPreparation(params, params.prepareAgentState, 'agent_harness_unavailable');
+}
+
+async function runSetupPreparation(
+  params: Pick<Parameters<typeof executeStep>[0], 'jobId' | 'step' | 'attempt'>,
+  prepare: (() => Promise<void>) | undefined,
+  reason: 'workspace_prep_failed' | 'agent_harness_unavailable',
+): Promise<StepExecution | undefined> {
+  if (!prepare) return undefined;
+  try {
+    await prepare();
+    return undefined;
+  } catch (error) {
+    const result = setupPreparationFailure(error, reason);
+    logger().warn(
+      {
+        err: error,
+        jobId: params.jobId,
+        stepId: params.step.id,
+        attempt: params.attempt,
+        reason: result.error?.reason,
+      },
+      'Setup step failed',
+    );
+    return {result, logOutcome: 'abandoned', preparedWorkspace: false};
   }
 }
 

--- a/libs/runner/workspace/src/checkout-path.ts
+++ b/libs/runner/workspace/src/checkout-path.ts
@@ -126,18 +126,25 @@ async function resolveExistingPrefix(candidate: string): Promise<string> {
 
       // A dangling symlink is not a missing checkout destination. Treating it as one
       // would allow mkdir/rm to follow an unexpected link during a later operation.
-      try {
-        const entry = await lstat(current);
-        if (entry.isSymbolicLink()) throw new CheckoutPathInvalidError(candidate);
-      } catch (lstatError) {
-        if (!isFileSystemError(lstatError, 'ENOENT')) throw lstatError;
-      }
+      await assertMissingPathIsNotDanglingSymlink(current, candidate);
 
       const parent = dirname(current);
       if (parent === current) throw new CheckoutPathInvalidError(candidate);
       missingSegments.push(basename(current));
       current = parent;
     }
+  }
+}
+
+async function assertMissingPathIsNotDanglingSymlink(
+  current: string,
+  candidate: string,
+): Promise<void> {
+  try {
+    const entry = await lstat(current);
+    if (entry.isSymbolicLink()) throw new CheckoutPathInvalidError(candidate);
+  } catch (error) {
+    if (!isFileSystemError(error, 'ENOENT')) throw error;
   }
 }
 

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -233,26 +233,22 @@ export function writeAmbientGitCredential(params: {
     const temporaryConfigPath = `${configPath}.${randomUUID()}.tmp`;
     try {
       if (existing === undefined || existing.trim() === '') {
-        const lines = [
-          ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
-          ...userLines,
-          ...repositoryLines,
-          '',
-        ];
-        await writeFile(temporaryConfigPath, lines.join('\n'), {flag: 'wx', mode: 0o600});
+        await writeNewAmbientGitConfig(
+          temporaryConfigPath,
+          includePath,
+          userLines,
+          repositoryLines,
+        );
       } else {
-        await writeFile(temporaryConfigPath, existing, {flag: 'wx', mode: 0o600});
-        if (auth) await unsetAmbientGitCredential(temporaryConfigPath, repositoryUrl);
-
-        const current = await readFile(temporaryConfigPath, 'utf8');
-        // [user] applies to the whole ambient config. Keep the first author for v1; per-repository
-        // identities need includeIf gitdir: and are intentionally deferred.
-        const additions = [
-          ...(gitAuthor && !hasGitAuthorSection(current) ? userLines : []),
-          ...repositoryLines,
-          '',
-        ].join('\n');
-        await appendFile(temporaryConfigPath, `${current.endsWith('\n') ? '' : '\n'}${additions}`);
+        await updateAmbientGitConfig({
+          temporaryConfigPath,
+          existing,
+          auth,
+          repositoryUrl,
+          gitAuthor,
+          userLines,
+          repositoryLines,
+        });
       }
 
       if (!auth) await validateAmbientGitConfig(temporaryConfigPath);
@@ -263,6 +259,43 @@ export function writeAmbientGitCredential(params: {
     }
     await chmod(configPath, 0o600);
   });
+}
+
+async function writeNewAmbientGitConfig(
+  temporaryConfigPath: string,
+  includePath: string | undefined,
+  userLines: readonly string[],
+  repositoryLines: readonly string[],
+): Promise<void> {
+  const lines = [
+    ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
+    ...userLines,
+    ...repositoryLines,
+    '',
+  ];
+  await writeFile(temporaryConfigPath, lines.join('\n'), {flag: 'wx', mode: 0o600});
+}
+
+async function updateAmbientGitConfig(params: {
+  temporaryConfigPath: string;
+  existing: string;
+  auth: CheckoutTokenAuthDto | undefined;
+  repositoryUrl: string;
+  gitAuthor: {name: string; email: string} | undefined;
+  userLines: readonly string[];
+  repositoryLines: readonly string[];
+}): Promise<void> {
+  await writeFile(params.temporaryConfigPath, params.existing, {flag: 'wx', mode: 0o600});
+  if (params.auth)
+    await unsetAmbientGitCredential(params.temporaryConfigPath, params.repositoryUrl);
+  const current = await readFile(params.temporaryConfigPath, 'utf8');
+  // [user] applies to the whole ambient config. Keep the first author for v1.
+  const additions = [
+    ...(params.gitAuthor && !hasGitAuthorSection(current) ? params.userLines : []),
+    ...params.repositoryLines,
+    '',
+  ].join('\n');
+  await appendFile(params.temporaryConfigPath, `${current.endsWith('\n') ? '' : '\n'}${additions}`);
 }
 
 /** Returns every persisted credential form that can appear in the ambient Git config. */

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -298,35 +298,7 @@ export function createRedactor(options: StructuredRedactionOptions = {}): Redact
   const redactText = (text: string): string => redactSensitiveTextWithWireForms(text, wireForms);
 
   function visit(value: unknown, ancestors: WeakSet<object>): unknown {
-    if (typeof value === 'string') return redactText(value);
-    if (value === null || typeof value !== 'object') return value;
-    if (value instanceof URL) return redactSensitiveUrl(redactText(value.toString()));
-    if (value instanceof Date) {
-      return Number.isNaN(value.getTime()) ? value.toString() : value.toISOString();
-    }
-    if (ancestors.has(value)) return CIRCULAR_PLACEHOLDER;
-
-    ancestors.add(value);
-    try {
-      if (value instanceof Error) {
-        return {
-          cause: value.cause === undefined ? undefined : visit(value.cause, ancestors),
-          message: redactText(value.message),
-          name: redactText(value.name),
-          stack: value.stack ? redactText(value.stack) : undefined,
-        };
-      }
-      if (Array.isArray(value)) return value.map((item) => visit(item, ancestors));
-
-      return Object.fromEntries(
-        Object.entries(value).map(([key, item]) => [
-          redactText(key),
-          SENSITIVE_KEY.test(key) ? REDACTION_PLACEHOLDER : visit(item, ancestors),
-        ]),
-      );
-    } finally {
-      ancestors.delete(value);
-    }
+    return visitRedactedValue(value, ancestors, redactText, visit);
   }
 
   function redact(value: string | Date | URL): string;
@@ -336,4 +308,70 @@ export function createRedactor(options: StructuredRedactionOptions = {}): Redact
   }
 
   return {redact};
+}
+
+function visitRedactedValue(
+  value: unknown,
+  ancestors: WeakSet<object>,
+  redactText: (text: string) => string,
+  visit: (value: unknown, ancestors: WeakSet<object>) => unknown,
+): unknown {
+  if (typeof value === 'string') return redactText(value);
+  if (value === null || typeof value !== 'object') return value;
+  const special = redactSpecialObject(value, redactText);
+  if (special.handled) return special.value;
+  if (ancestors.has(value)) return CIRCULAR_PLACEHOLDER;
+
+  ancestors.add(value);
+  try {
+    if (value instanceof Error) return redactError(value, ancestors, redactText, visit);
+    if (Array.isArray(value)) return value.map((item) => visit(item, ancestors));
+    return redactObject(value, ancestors, redactText, visit);
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function redactSpecialObject(
+  value: object,
+  redactText: (text: string) => string,
+): {handled: true; value: string} | {handled: false} {
+  if (value instanceof URL) {
+    return {handled: true, value: redactSensitiveUrl(redactText(value.toString()))};
+  }
+  if (value instanceof Date) {
+    return {
+      handled: true,
+      value: Number.isNaN(value.getTime()) ? value.toString() : value.toISOString(),
+    };
+  }
+  return {handled: false};
+}
+
+function redactError(
+  value: Error,
+  ancestors: WeakSet<object>,
+  redactText: (text: string) => string,
+  visit: (value: unknown, ancestors: WeakSet<object>) => unknown,
+): Record<string, unknown> {
+  return {
+    cause: value.cause === undefined ? undefined : visit(value.cause, ancestors),
+    message: redactText(value.message),
+    name: redactText(value.name),
+    stack: value.stack ? redactText(value.stack) : undefined,
+  };
+}
+
+function redactObject(
+  value: object,
+  ancestors: WeakSet<object>,
+  redactText: (text: string) => string,
+  visit: (value: unknown, ancestors: WeakSet<object>) => unknown,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      redactText(key),
+      SENSITIVE_KEY.test(key) ? REDACTION_PLACEHOLDER : visit(item, ancestors),
+    ]),
+  );
 }

--- a/libs/shared/common/runner-labels/src/index.ts
+++ b/libs/shared/common/runner-labels/src/index.ts
@@ -7,7 +7,9 @@ export type RunnerCatalog = Readonly<Record<string, readonly string[]>>;
 export function canonicalizeLabels(
   value: string | readonly string[] | undefined,
 ): readonly string[] {
-  const labels = value === undefined ? [] : typeof value === 'string' ? [value] : value;
+  let labels: readonly string[] = [];
+  if (typeof value === 'string') labels = [value];
+  else if (value !== undefined) labels = value;
   const normalized = labels.map((label) => label.trim().toLowerCase()).filter(Boolean);
 
   return [...new Set(normalized)].sort();

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -40,36 +40,7 @@ export function createWorkflowExpression(
   const ast = parseWorkflowExpression(source);
 
   if (params.check.mode === 'typed') {
-    const environment = createTypeCheckingEnvironment();
-    for (const [name, type] of Object.entries(params.check.typeEnvironment ?? {})) {
-      const celType = toCelType(type, environment, name);
-      if (typeof celType === 'string') {
-        environment.registerVariable(name, celType);
-      } else {
-        environment.registerVariable({name, schema: celType.schema});
-      }
-    }
-
-    const typeCheckResult = environment.check(source);
-    if (!typeCheckResult.valid) {
-      throw new InvalidWorkflowExpressionError({
-        source,
-        reason: typeCheckResult.error?.message ?? 'Expression source did not type-check.',
-      });
-    }
-    if (
-      params.check.expectedResultType !== undefined &&
-      typeCheckResult.type !== scalarTypeToCelType[params.check.expectedResultType] &&
-      !(typeCheckResult.type === 'dyn' && containsFromJsonCall(ast))
-    ) {
-      throw new InvalidWorkflowExpressionError({
-        source,
-        reason: `Expression source must return ${scalarTypeToCelType[params.check.expectedResultType]}; got ${typeCheckResult.type ?? 'unknown'}.`,
-      });
-    }
-    resultType =
-      resolveKnownPathType(source, params.check.typeEnvironment) ??
-      fromCelType(typeCheckResult.type, ast);
+    resultType = checkTypedWorkflowExpression(source, ast, params.check);
   }
 
   return {
@@ -78,6 +49,49 @@ export function createWorkflowExpression(
     check: params.check.mode,
     ...(resultType === undefined ? {} : {resultType}),
   };
+}
+
+function checkTypedWorkflowExpression(
+  source: string,
+  ast: ASTNode,
+  check: Extract<CreateWorkflowExpressionParams['check'], {mode: 'typed'}>,
+): ExpressionType | undefined {
+  const environment = createTypeCheckingEnvironment();
+  registerTypeEnvironment(environment, check.typeEnvironment);
+  const result = environment.check(source);
+  if (!result.valid) {
+    throw new InvalidWorkflowExpressionError({
+      source,
+      reason: result.error?.message ?? 'Expression source did not type-check.',
+    });
+  }
+  assertExpectedResultType(source, ast, result.type, check.expectedResultType);
+  return resolveKnownPathType(source, check.typeEnvironment) ?? fromCelType(result.type, ast);
+}
+
+function registerTypeEnvironment(
+  environment: Environment,
+  typeEnvironment: ExpressionTypeEnvironment | undefined,
+): void {
+  for (const [name, type] of Object.entries(typeEnvironment ?? {})) {
+    const celType = toCelType(type, environment, name);
+    if (typeof celType === 'string') environment.registerVariable(name, celType);
+    else environment.registerVariable({name, schema: celType.schema});
+  }
+}
+
+function assertExpectedResultType(
+  source: string,
+  ast: ASTNode,
+  actualType: string | undefined,
+  expectedType: ExpressionScalarType | undefined,
+): void {
+  if (expectedType === undefined || actualType === scalarTypeToCelType[expectedType]) return;
+  if (actualType === 'dyn' && containsFromJsonCall(ast)) return;
+  throw new InvalidWorkflowExpressionError({
+    source,
+    reason: `Expression source must return ${scalarTypeToCelType[expectedType]}; got ${actualType ?? 'unknown'}.`,
+  });
 }
 
 function resolveKnownPathType(

--- a/libs/shared/expression/src/plan/context-key-access.ts
+++ b/libs/shared/expression/src/plan/context-key-access.ts
@@ -147,12 +147,7 @@ function collectContextAccesses(
       }
       return;
     case 'map':
-      for (const [key, value] of node.args) {
-        if (key.op !== 'id') {
-          collectContextAccesses(key, source, scopedIdentifiers, visitor);
-        }
-        collectContextAccesses(value, source, scopedIdentifiers, visitor);
-      }
+      collectMapContextAccesses(node.args, source, scopedIdentifiers, visitor);
       return;
     case '?:':
       collectContextAccesses(node.args[0], source, scopedIdentifiers, visitor);
@@ -166,6 +161,18 @@ function collectContextAccesses(
   }
 
   throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectMapContextAccesses(
+  entries: Array<[ASTNode, ASTNode]>,
+  source: string,
+  scopedIdentifiers: ReadonlySet<string>,
+  visitor: ContextAccessVisitor,
+): void {
+  for (const [key, value] of entries) {
+    if (key.op !== 'id') collectContextAccesses(key, source, scopedIdentifiers, visitor);
+    collectContextAccesses(value, source, scopedIdentifiers, visitor);
+  }
 }
 
 function collectBinaryContextAccesses(

--- a/libs/shared/expression/src/run/shell-code-position.ts
+++ b/libs/shared/expression/src/run/shell-code-position.ts
@@ -88,6 +88,16 @@ interface ShellRedirection {
 }
 
 type ShellToken = ShellWord | ShellControl | ShellRedirection;
+type ReportReference = (
+  reference: ShellVariableReference,
+  construct: ShellReevaluatingConstruct,
+) => void;
+type ReportReferences = (
+  words: readonly ShellWord[],
+  construct: ShellReevaluatingConstruct,
+  kinds?: readonly ShellVariableReference['kind'][],
+  includeSingleQuotedLiterals?: boolean,
+) => void;
 
 /**
  * Finds workflow-controlled values that are passed to shell constructs which
@@ -134,62 +144,7 @@ export function classifyShellCodePosition(params: {
   };
 
   const analyzeCommand = (words: readonly ShellWord[]) => {
-    const commandWords = words.filter((word) => !word.isRedirectionTarget);
-    const firstWord = commandWords[0];
-    if (firstWord !== undefined && shellWordIsStatic(firstWord) && firstWord.value === 'for') {
-      return;
-    }
-    const headIndex = commandHeadIndex(commandWords);
-    const head = commandWords[headIndex];
-    if (head === undefined || !shellWordIsStatic(head)) return;
-
-    const commandName = shellCommandName(head.value);
-    if (commandName === undefined) return;
-
-    const argumentWords = commandWords.slice(headIndex + 1);
-
-    if (commandName === 'eval') {
-      reportReferences(argumentWords, 'eval', ['direct'], true);
-      return;
-    }
-
-    if (commandName === 'sh' || commandName === 'bash') {
-      const program = shellProgramAfterC(argumentWords);
-      if (program !== undefined) {
-        reportReferences([program], commandName === 'sh' ? 'sh-c' : 'bash-c');
-      }
-      return;
-    }
-
-    if (commandName === 'source' || commandName === '.') {
-      reportReferences(argumentWords.slice(0, 1), 'source');
-      return;
-    }
-
-    if (commandName === 'let') {
-      reportReferences(argumentWords, 'let');
-      reportBareArithmeticReferences(argumentWords, 'let', report, workflowDataNames, false);
-      return;
-    }
-
-    if (commandName === 'declare' && argumentWords.some((word) => word.value === '-i')) {
-      reportReferences(argumentWords, 'declare-i');
-      reportBareArithmeticReferences(argumentWords, 'declare-i', report, workflowDataNames, true);
-      return;
-    }
-
-    if (commandName === 'awk' || commandName === 'jq' || commandName === 'sed') {
-      const program = interpreterProgramWord(commandName, argumentWords);
-      if (program !== undefined) reportReferences([program], commandName);
-      return;
-    }
-
-    if (commandName === 'xargs') {
-      const nestedShell = xargsShellProgram(argumentWords);
-      if (nestedShell !== undefined) {
-        reportReferences([nestedShell.program], 'xargs-sh-c');
-      }
-    }
+    analyzeShellCommand(words, reportReferences, report, workflowDataNames);
   };
 
   for (const token of tokens) {
@@ -212,6 +167,107 @@ export function classifyShellCodePosition(params: {
   analyzeCommand(command);
 
   return {matches};
+}
+
+function analyzeShellCommand(
+  words: readonly ShellWord[],
+  reportReferences: ReportReferences,
+  report: ReportReference,
+  workflowDataNames: ReadonlySet<string>,
+): void {
+  const commandWords = words.filter((word) => !word.isRedirectionTarget);
+  const firstWord = commandWords[0];
+  if (firstWord !== undefined && shellWordIsStatic(firstWord) && firstWord.value === 'for') return;
+
+  const headIndex = commandHeadIndex(commandWords);
+  const head = commandWords[headIndex];
+  if (head === undefined || !shellWordIsStatic(head)) return;
+  const commandName = shellCommandName(head.value);
+  if (commandName === undefined) return;
+  const arguments_ = commandWords.slice(headIndex + 1);
+
+  switch (commandName) {
+    case 'eval':
+      reportReferences(arguments_, 'eval', ['direct'], true);
+      return;
+    case 'sh':
+    case 'bash':
+      reportShellProgram(commandName, arguments_, reportReferences);
+      return;
+    case 'source':
+    case '.':
+      reportReferences(arguments_.slice(0, 1), 'source');
+      return;
+    case 'let':
+      reportArithmeticCommand('let', arguments_, reportReferences, report, workflowDataNames);
+      return;
+    case 'declare':
+      reportDeclareArithmetic(arguments_, reportReferences, report, workflowDataNames);
+      return;
+    case 'awk':
+    case 'jq':
+    case 'sed':
+      reportInterpreterProgram(commandName, arguments_, reportReferences);
+      return;
+    case 'xargs':
+      reportXargsShellProgram(arguments_, reportReferences);
+      return;
+  }
+}
+
+function reportShellProgram(
+  command: 'sh' | 'bash',
+  words: readonly ShellWord[],
+  reportReferences: ReportReferences,
+): void {
+  const program = shellProgramAfterC(words);
+  if (program === undefined) return;
+  const construct = command === 'sh' ? 'sh-c' : 'bash-c';
+  reportReferences([program], construct);
+}
+
+function reportArithmeticCommand(
+  construct: 'let' | 'declare-i',
+  words: readonly ShellWord[],
+  reportReferences: ReportReferences,
+  report: ReportReference,
+  workflowDataNames: ReadonlySet<string>,
+): void {
+  reportReferences(words, construct);
+  reportBareArithmeticReferences(
+    words,
+    construct,
+    report,
+    workflowDataNames,
+    construct === 'declare-i',
+  );
+}
+
+function reportDeclareArithmetic(
+  words: readonly ShellWord[],
+  reportReferences: ReportReferences,
+  report: ReportReference,
+  workflowDataNames: ReadonlySet<string>,
+): void {
+  if (!words.some((word) => word.value === '-i')) return;
+  reportArithmeticCommand('declare-i', words, reportReferences, report, workflowDataNames);
+}
+
+function reportInterpreterProgram(
+  command: 'awk' | 'jq' | 'sed',
+  words: readonly ShellWord[],
+  reportReferences: ReportReferences,
+): void {
+  const program = interpreterProgramWord(command, words);
+  if (program !== undefined) reportReferences([program], command);
+}
+
+function reportXargsShellProgram(
+  words: readonly ShellWord[],
+  reportReferences: ReportReferences,
+): void {
+  const nestedShell = xargsShellProgram(words);
+  if (nestedShell !== undefined) reportReferences([nestedShell.program], 'xargs-sh-c');
 }
 
 function tokenizeShell(source: string): readonly ShellToken[] {
@@ -298,7 +354,18 @@ function tokenizeShell(source: string): readonly ShellToken[] {
     isSingleQuotedLiteral = false,
   ): boolean {
     if (source[index] !== '$') return false;
+    if (advanceCompoundExpansion()) return true;
+    if (advanceBracedExpansion(kind, isSingleQuotedLiteral)) return true;
+    if (advanceDollarQuote()) return true;
 
+    const name = readShellIdentifier(source, index + 1);
+    if (name === undefined) return false;
+    addReference(name.value, kind, isSingleQuotedLiteral);
+    advance(source.slice(index, name.index));
+    return true;
+  }
+
+  function advanceCompoundExpansion(): boolean {
     if (source.startsWith('$((', index)) {
       markDynamic();
       arithmeticContext = true;
@@ -318,7 +385,13 @@ function tokenizeShell(source: string): readonly ShellToken[] {
       advance('$(');
       return true;
     }
+    return false;
+  }
 
+  function advanceBracedExpansion(
+    kind: ShellVariableReference['kind'],
+    isSingleQuotedLiteral: boolean,
+  ): boolean {
     if (source.startsWith('${', index)) {
       markDynamic();
       const firstName = readParameterName(source, index + 2);
@@ -328,19 +401,155 @@ function tokenizeShell(source: string): readonly ShellToken[] {
       advance('${');
       return true;
     }
+    return false;
+  }
 
+  function advanceDollarQuote(): boolean {
     if (source.startsWith("$'", index) || source.startsWith('$"', index)) {
       markDynamic();
       advance(source.slice(index, index + 2));
       return true;
     }
+    return false;
+  }
 
-    const name = readShellIdentifier(source, index + 1);
+  function scanLineComment(character: string): void {
+    if (character !== '\n') {
+      advance(character);
+      return;
+    }
+    advance('\n');
+    flushWord();
+    tokens.push({kind: 'control'});
+    wordCanStartComment = true;
+    redirectionTarget = false;
+  }
+
+  function scanUnsafeArithmetic(character: string): boolean {
+    if (character === '[') arithmeticBracketDepth += 1;
+    if (character === ']' && arithmeticBracketDepth > 0) arithmeticBracketDepth -= 1;
+    if (
+      arithmeticBracketDepth === 0 &&
+      (character === "'" || character === '"' || character === '`')
+    ) {
+      markArithmeticShellSyntax();
+    }
+    if (advanceExpansion('arithmetic')) return true;
+
+    const name = readShellIdentifier(source, index);
     if (name === undefined) return false;
-
-    addReference(name.value, kind, isSingleQuotedLiteral);
+    const nextIndex = skipWhitespace(source, name.index);
+    if (!isArithmeticAssignment(source, nextIndex)) addReference(name.value, 'arithmetic');
     advance(source.slice(index, name.index));
     return true;
+  }
+
+  function scanUnsafeParameter(character: string): boolean {
+    if (character === '[') parameterBracketDepth += 1;
+    if (character === ']' && parameterBracketDepth > 0) parameterBracketDepth -= 1;
+    const referenceKind = arithmeticContext || parameterBracketDepth > 0 ? 'arithmetic' : 'direct';
+    return advanceExpansion(referenceKind);
+  }
+
+  function scanUnsafeSite(
+    character: string,
+    site: Extract<ShellSiteContext, {kind: 'unsafe'}>,
+  ): void {
+    if (site.region === 'line-comment') {
+      scanLineComment(character);
+      return;
+    }
+    if (site.region === 'heredoc') {
+      advance(character);
+      return;
+    }
+    if (site.region === 'arith' && scanUnsafeArithmetic(character)) return;
+    if (site.region === 'param-brace' && scanUnsafeParameter(character)) return;
+    if (site.region !== 'arith' && site.region !== 'param-brace') markDynamic();
+    advance(scannerChunkAt(source, index, site));
+  }
+
+  function scanUnquotedWhitespace(character: string): void {
+    flushWord();
+    if (character === '\n') tokens.push({kind: 'control'});
+    wordCanStartComment = true;
+    if (character === '\n') redirectionTarget = false;
+    advance(character);
+  }
+
+  function scanRedirection(): void {
+    flushWord();
+    tokens.push({kind: 'redirection'});
+    redirectionTarget = true;
+    wordCanStartComment = true;
+    const length = shellRedirectionLength(source, index);
+    advance(source.slice(index, index + length));
+  }
+
+  function scanControl(): void {
+    flushWord();
+    tokens.push({kind: 'control'});
+    wordCanStartComment = true;
+    redirectionTarget = false;
+    advance(source.slice(index, index + shellControlLength(source, index)));
+  }
+
+  function scanSafeSyntax(
+    character: string,
+    site: Exclude<ShellSiteContext, {kind: 'unsafe'}>,
+  ): boolean {
+    if (character === '\\') {
+      advanceEscape();
+      return true;
+    }
+    if (character === '#' && wordCanStartComment) {
+      advance('#');
+      return true;
+    }
+    if (character === '$' && advanceExpansion('direct', site.kind === 'single')) return true;
+    if (character === '`') {
+      markDynamic();
+      advance('`');
+      return true;
+    }
+    if (character === "'" || character === '"') {
+      ensureWord();
+      advance(character);
+      return true;
+    }
+    return false;
+  }
+
+  function scanUnquotedSyntax(character: string): boolean {
+    if (isShellWhitespace(character)) {
+      scanUnquotedWhitespace(character);
+      return true;
+    }
+    if (startsShellRedirection(source, index)) {
+      scanRedirection();
+      return true;
+    }
+    if (startsShellArithmetic(source, index)) {
+      markDynamic();
+      arithmeticContext = true;
+      advance('((');
+      return true;
+    }
+    if (startsShellControl(source, index)) {
+      scanControl();
+      return true;
+    }
+    return false;
+  }
+
+  function scanSafeSite(
+    character: string,
+    site: Exclude<ShellSiteContext, {kind: 'unsafe'}>,
+  ): void {
+    if (scanSafeSyntax(character, site)) return;
+    if (site.kind === 'unquoted' && scanUnquotedSyntax(character)) return;
+    ensureWord().value.push(character);
+    advance(character);
   }
 
   while (index < source.length) {
@@ -349,120 +558,10 @@ function tokenizeShell(source: string): readonly ShellToken[] {
 
     const site = classifyShellSite(scanState);
     if (site.kind === 'unsafe') {
-      if (site.region === 'line-comment') {
-        if (character === '\n') {
-          advance('\n');
-          flushWord();
-          tokens.push({kind: 'control'});
-          wordCanStartComment = true;
-          redirectionTarget = false;
-        } else {
-          advance(character);
-        }
-        continue;
-      }
-
-      if (site.region === 'heredoc') {
-        advance(character);
-        continue;
-      }
-
-      if (site.region === 'arith') {
-        if (character === '[') arithmeticBracketDepth += 1;
-        if (character === ']' && arithmeticBracketDepth > 0) arithmeticBracketDepth -= 1;
-        if (
-          arithmeticBracketDepth === 0 &&
-          (character === "'" || character === '"' || character === '`')
-        ) {
-          markArithmeticShellSyntax();
-        }
-
-        if (advanceExpansion('arithmetic')) continue;
-
-        const name = readShellIdentifier(source, index);
-        if (name !== undefined) {
-          const nextIndex = skipWhitespace(source, name.index);
-          if (!isArithmeticAssignment(source, nextIndex)) addReference(name.value, 'arithmetic');
-          advance(source.slice(index, name.index));
-          continue;
-        }
-      } else if (site.region === 'param-brace') {
-        if (character === '[') parameterBracketDepth += 1;
-        if (character === ']' && parameterBracketDepth > 0) parameterBracketDepth -= 1;
-
-        const referenceKind =
-          arithmeticContext || parameterBracketDepth > 0 ? 'arithmetic' : 'direct';
-        if (advanceExpansion(referenceKind)) continue;
-      } else {
-        markDynamic();
-      }
-
-      const chunk = scannerChunkAt(source, index, site);
-      advance(chunk);
+      scanUnsafeSite(character, site);
       continue;
     }
-
-    if (character === '\\') {
-      advanceEscape();
-      continue;
-    }
-
-    if (character === '#' && wordCanStartComment) {
-      advance('#');
-      continue;
-    }
-
-    if (character === '$' && advanceExpansion('direct', site.kind === 'single')) continue;
-
-    if (character === '`') {
-      markDynamic();
-      advance('`');
-      continue;
-    }
-
-    if (site.kind === 'unquoted' && isShellWhitespace(character)) {
-      flushWord();
-      if (character === '\n') tokens.push({kind: 'control'});
-      wordCanStartComment = true;
-      if (character === '\n') redirectionTarget = false;
-      advance(character);
-      continue;
-    }
-
-    if (character === "'" || character === '"') {
-      ensureWord();
-      advance(character);
-      continue;
-    }
-
-    if (site.kind === 'unquoted' && startsShellRedirection(source, index)) {
-      flushWord();
-      tokens.push({kind: 'redirection'});
-      redirectionTarget = true;
-      wordCanStartComment = true;
-      const length = shellRedirectionLength(source, index);
-      advance(source.slice(index, index + length));
-      continue;
-    }
-
-    if (site.kind === 'unquoted' && startsShellArithmetic(source, index)) {
-      markDynamic();
-      arithmeticContext = true;
-      advance('((');
-      continue;
-    }
-
-    if (site.kind === 'unquoted' && startsShellControl(source, index)) {
-      flushWord();
-      tokens.push({kind: 'control'});
-      wordCanStartComment = true;
-      redirectionTarget = false;
-      advance(source.slice(index, index + shellControlLength(source, index)));
-      continue;
-    }
-
-    ensureWord().value.push(character);
-    advance(character);
+    scanSafeSite(character, site);
   }
 
   flushWord();
@@ -474,13 +573,8 @@ function scannerChunkAt(
   index: number,
   site: Extract<ShellSiteContext, {kind: 'unsafe'}>,
 ): string {
-  if (site.region === 'arith' && source[index] === ')') {
-    let closingRunLength = 0;
-    while (source[index + closingRunLength] === ')') closingRunLength += 1;
-    if (closingRunLength > 2) return ')'.repeat(closingRunLength - 2);
-    if (closingRunLength === 2) return '))';
-    return ')';
-  }
+  if (site.region === 'arith' && source[index] === ')')
+    return arithmeticClosingChunk(source, index);
   if (source.startsWith('$((', index)) return '$((';
   if (source.startsWith('((', index)) return '((';
   if (source.startsWith('$[', index)) return '$[';
@@ -490,6 +584,14 @@ function scannerChunkAt(
   if (source.startsWith('<<', index)) return '<<';
   if (source[index] === '\\' && index + 1 < source.length) return source.slice(index, index + 2);
   return source[index] ?? '';
+}
+
+function arithmeticClosingChunk(source: string, index: number): string {
+  let closingRunLength = 0;
+  while (source[index + closingRunLength] === ')') closingRunLength += 1;
+  if (closingRunLength > 2) return ')'.repeat(closingRunLength - 2);
+  if (closingRunLength === 2) return '))';
+  return ')';
 }
 
 function commandHeadIndex(words: readonly ShellWord[]): number {
@@ -600,53 +702,52 @@ function interpreterProgramWord(
 
     if (value === '--') return words[index + 1];
     if (!value.startsWith('-') || value === '-') return word;
-
-    if (command === 'jq' && jqOptionConsumesArguments(value)) {
-      index += 3;
-      continue;
-    }
-
-    if (command === 'awk' && awkOptionConsumesArgument(value)) {
-      index += 2;
-      continue;
-    }
-
-    if (command === 'awk' && (value === '-e' || value === '--source')) {
-      return words[index + 1];
-    }
-
-    if (command === 'sed' && (value === '-e' || value === '--expression')) {
-      return words[index + 1];
-    }
-
-    if (command === 'sed' && sedOptionConsumesArgument(value)) {
-      index += 2;
-      continue;
-    }
-
-    if (command === 'sed' && value.startsWith('--expression=')) return word;
-    if (command === 'sed' && value.startsWith('--file=')) {
-      index += 1;
-      continue;
-    }
-
-    if (command === 'jq' && jqFlag(value)) {
-      index += 1;
-      continue;
-    }
-
-    if (command === 'awk' && awkFlag(value)) {
-      index += 1;
-      continue;
-    }
-
-    if (command === 'sed' && sedFlag(value)) {
-      index += 1;
-      continue;
-    }
-
-    return undefined;
+    const action = interpreterOptionAction(command, value);
+    if (action === undefined) return undefined;
+    if (action.kind === 'program-current') return word;
+    if (action.kind === 'program-next') return words[index + 1];
+    index += action.count;
   }
+  return undefined;
+}
+
+type InterpreterOptionAction =
+  | {readonly kind: 'program-current'}
+  | {readonly kind: 'program-next'}
+  | {readonly kind: 'skip'; readonly count: number};
+
+function interpreterOptionAction(
+  command: 'awk' | 'jq' | 'sed',
+  value: string,
+): InterpreterOptionAction | undefined {
+  switch (command) {
+    case 'jq':
+      return jqOptionAction(value);
+    case 'awk':
+      return awkOptionAction(value);
+    case 'sed':
+      return sedOptionAction(value);
+  }
+}
+
+function jqOptionAction(value: string): InterpreterOptionAction | undefined {
+  if (jqOptionConsumesArguments(value)) return {kind: 'skip', count: 3};
+  if (jqFlag(value)) return {kind: 'skip', count: 1};
+  return undefined;
+}
+
+function awkOptionAction(value: string): InterpreterOptionAction | undefined {
+  if (awkOptionConsumesArgument(value)) return {kind: 'skip', count: 2};
+  if (value === '-e' || value === '--source') return {kind: 'program-next'};
+  if (awkFlag(value)) return {kind: 'skip', count: 1};
+  return undefined;
+}
+
+function sedOptionAction(value: string): InterpreterOptionAction | undefined {
+  if (value === '-e' || value === '--expression') return {kind: 'program-next'};
+  if (sedOptionConsumesArgument(value)) return {kind: 'skip', count: 2};
+  if (value.startsWith('--expression=')) return {kind: 'program-current'};
+  if (value.startsWith('--file=') || sedFlag(value)) return {kind: 'skip', count: 1};
   return undefined;
 }
 
@@ -715,27 +816,30 @@ function sedFlag(value: string): boolean {
 }
 
 function xargsShellProgram(words: readonly ShellWord[]): {readonly program: ShellWord} | undefined {
-  let index = 0;
-  while (index < words.length) {
-    const word = words[index];
-    if (word === undefined) return undefined;
-    const value = word.value;
-    if (value === '--') {
-      index += 1;
-      break;
-    }
-    if (!value.startsWith('-') || value === '-') break;
-    if (xargsOptionConsumesArgument(value)) index += 2;
-    else index += 1;
-  }
-
+  const index = xargsCommandIndex(words);
   const shell = words[index];
-  if (shell === undefined || !shellWordIsStatic(shell)) return undefined;
-  const shellName = shellCommandName(shell.value);
-  if (shellName !== 'sh' && shellName !== 'bash') return undefined;
+  if (!isSupportedXargsShell(shell)) return undefined;
 
   const program = shellProgramAfterC(words.slice(index + 1));
   return program === undefined ? undefined : {program};
+}
+
+function xargsCommandIndex(words: readonly ShellWord[]): number {
+  let index = 0;
+  while (index < words.length) {
+    const value = words[index]?.value;
+    if (value === undefined) return index;
+    if (value === '--') return index + 1;
+    if (!value.startsWith('-') || value === '-') return index;
+    index += xargsOptionConsumesArgument(value) ? 2 : 1;
+  }
+  return index;
+}
+
+function isSupportedXargsShell(shell: ShellWord | undefined): shell is ShellWord {
+  if (shell === undefined || !shellWordIsStatic(shell)) return false;
+  const shellName = shellCommandName(shell.value);
+  return shellName === 'sh' || shellName === 'bash';
 }
 
 function xargsOptionConsumesArgument(value: string): boolean {

--- a/libs/shared/expression/src/run/shell-quoting.ts
+++ b/libs/shared/expression/src/run/shell-quoting.ts
@@ -36,226 +36,273 @@ export const initialShellScanState: ShellScanState = {frames: []};
 
 const shellCommentStarterPrefixPattern = /\s|[;&|()<>]/;
 
+interface ShellLiteralScanContext {
+  readonly text: string;
+  readonly frames: ShellScanFrame[];
+  index: number;
+  pendingEscape: boolean;
+  previousCharacter: string | undefined;
+  previousCharacterEscaped: boolean;
+}
+
+type ShellFrameKind = ShellFrame | 'arith' | 'arith-square' | 'plain';
+
 export function scanShellLiteral(text: string, state: ShellScanState): ShellScanState {
-  const frames = state.frames.map(cloneShellScanFrame);
-  let pendingEscape = state.pendingEscape ?? false;
-  let previousCharacter = state.previousCharacter;
-  let previousCharacterEscaped = state.previousCharacterEscaped ?? false;
-  let index = 0;
+  const context: ShellLiteralScanContext = {
+    text,
+    frames: state.frames.map(cloneShellScanFrame),
+    index: 0,
+    pendingEscape: state.pendingEscape ?? false,
+    previousCharacter: state.previousCharacter,
+    previousCharacterEscaped: state.previousCharacterEscaped ?? false,
+  };
 
-  function advance(nextIndex: number, escaped: boolean): void {
-    if (nextIndex > index) {
-      previousCharacter = text[nextIndex - 1];
-      previousCharacterEscaped = escaped;
-    }
-    index = nextIndex;
-  }
-
-  function consumeShellEscape(): void {
-    const result = skipShellEscape(text, index);
-    pendingEscape = result.pendingEscape;
-    if (result.continuedLine) {
-      index = result.index;
-      return;
-    }
-
-    advance(result.index, result.consumedEscapedCharacter);
-  }
-
-  while (index < text.length) {
-    if (pendingEscape) {
-      pendingEscape = false;
-      advance(index + 1, true);
-      continue;
-    }
-
-    const frame = topFrame(frames);
-
-    if (frame === 'single') {
-      if (text[index] === "'") frames.pop();
-      advance(index + 1, false);
-      continue;
-    }
-
-    if (frame === 'dollar-single') {
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      if (text[index] === "'") frames.pop();
-      advance(index + 1, false);
-      continue;
-    }
-
-    if (frame === 'backtick') {
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      if (text[index] === '`') {
-        frames.pop();
-        advance(index + 1, false);
-        continue;
-      }
-
-      advance(scanShellControlStart(text, index, frames), false);
-      continue;
-    }
-
-    if (frame === 'double' || frame === 'dollar-double') {
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      if (text[index] === '"') {
-        frames.pop();
-        advance(index + 1, false);
-        continue;
-      }
-
-      if (text[index] === '`') {
-        frames.push('backtick');
-        advance(index + 1, false);
-        continue;
-      }
-
-      advance(scanShellControlStart(text, index, frames), false);
-      continue;
-    }
-
-    if (frame === 'param-brace') {
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      if (text[index] === '}') {
-        frames.pop();
-        advance(index + 1, false);
-        continue;
-      }
-
-      if (text[index] === '`') {
-        frames.push('backtick');
-        advance(index + 1, false);
-        continue;
-      }
-
-      advance(scanShellControlStart(text, index, frames), false);
-      continue;
-    }
-
-    if (frame === 'paren-sub') {
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      if (text[index] === ')') {
-        frames.pop();
-        advance(index + 1, false);
-        continue;
-      }
-
-      advance(
-        scanShellPlainStart(text, index, frames, previousCharacter, previousCharacterEscaped),
-        false,
-      );
-      continue;
-    }
-
-    if (isArithFrame(frame)) {
-      const arithEnd = matchShellLogicalPrefix(text, index, '))');
-      if (frame.parenthesisDepth === 0 && arithEnd !== undefined) {
-        frames.pop();
-        advance(arithEnd, false);
-        continue;
-      }
-
-      if (text[index] === ')') {
-        replaceTopArithFrame(frames, Math.max(0, frame.parenthesisDepth - 1));
-        advance(index + 1, false);
-        continue;
-      }
-
-      if (text[index] === '(') {
-        replaceTopArithFrame(frames, frame.parenthesisDepth + 1);
-        advance(index + 1, false);
-        continue;
-      }
-
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      advance(
-        scanShellPlainStart(text, index, frames, previousCharacter, previousCharacterEscaped),
-        false,
-      );
-      continue;
-    }
-
-    if (frame === 'heredoc') {
-      advance(index + 1, false);
-      continue;
-    }
-
-    if (frame === 'line-comment') {
-      if (text[index] === '\n') frames.pop();
-      advance(index + 1, false);
-      continue;
-    }
-
-    if (isArithSquareFrame(frame)) {
-      if (text[index] === '[') {
-        replaceTopArithSquareFrame(frames, frame.bracketDepth + 1);
-        advance(index + 1, false);
-        continue;
-      }
-
-      if (text[index] === ']') {
-        if (frame.bracketDepth === 0) {
-          frames.pop();
-        } else {
-          replaceTopArithSquareFrame(frames, frame.bracketDepth - 1);
-        }
-        advance(index + 1, false);
-        continue;
-      }
-
-      if (text[index] === '\\') {
-        consumeShellEscape();
-        continue;
-      }
-
-      advance(
-        scanShellPlainStart(text, index, frames, previousCharacter, previousCharacterEscaped),
-        false,
-      );
-      continue;
-    }
-
-    if (text[index] === '\\') {
-      consumeShellEscape();
-      continue;
-    }
-
-    advance(
-      scanShellPlainStart(text, index, frames, previousCharacter, previousCharacterEscaped),
-      false,
-    );
-  }
+  while (context.index < text.length) scanNextShellCharacter(context);
 
   return {
-    frames,
-    ...(pendingEscape ? {pendingEscape} : {}),
-    ...(previousCharacter === undefined ? {} : {previousCharacter}),
-    ...(previousCharacterEscaped ? {previousCharacterEscaped} : {}),
+    frames: context.frames,
+    ...(context.pendingEscape ? {pendingEscape: true} : {}),
+    ...(context.previousCharacter === undefined
+      ? {}
+      : {previousCharacter: context.previousCharacter}),
+    ...(context.previousCharacterEscaped ? {previousCharacterEscaped: true} : {}),
   };
+}
+
+function scanNextShellCharacter(context: ShellLiteralScanContext): void {
+  if (context.pendingEscape) {
+    context.pendingEscape = false;
+    advanceShellScan(context, context.index + 1, true);
+    return;
+  }
+
+  const frame = topFrame(context.frames);
+  switch (shellFrameKind(frame)) {
+    case 'single':
+      scanSingleFrame(context);
+      return;
+    case 'dollar-single':
+      scanDollarSingleFrame(context);
+      return;
+    case 'backtick':
+      scanBacktickFrame(context);
+      return;
+    case 'double':
+    case 'dollar-double':
+      scanDoubleFrame(context);
+      return;
+    case 'param-brace':
+      scanParameterBraceFrame(context);
+      return;
+    case 'paren-sub':
+      scanParenthesisSubstitutionFrame(context);
+      return;
+    case 'arith':
+      scanArithmeticFrame(context, frame);
+      return;
+    case 'arith-square':
+      scanArithmeticSquareFrame(context, frame);
+      return;
+    case 'heredoc':
+      advanceShellScan(context, context.index + 1, false);
+      return;
+    case 'line-comment':
+      scanLineCommentFrame(context);
+      return;
+    case 'plain':
+      scanPlainFrame(context);
+      return;
+  }
+}
+
+function shellFrameKind(frame: ShellScanFrame | undefined): ShellFrameKind {
+  if (isArithFrame(frame)) return 'arith';
+  if (isArithSquareFrame(frame)) return 'arith-square';
+  return frame ?? 'plain';
+}
+
+function advanceShellScan(
+  context: ShellLiteralScanContext,
+  nextIndex: number,
+  escaped: boolean,
+): void {
+  if (nextIndex > context.index) {
+    context.previousCharacter = context.text[nextIndex - 1];
+    context.previousCharacterEscaped = escaped;
+  }
+  context.index = nextIndex;
+}
+
+function consumeShellEscape(context: ShellLiteralScanContext): void {
+  const result = skipShellEscape(context.text, context.index);
+  context.pendingEscape = result.pendingEscape;
+  if (result.continuedLine) {
+    context.index = result.index;
+    return;
+  }
+  advanceShellScan(context, result.index, result.consumedEscapedCharacter);
+}
+
+function scanSingleFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === "'") context.frames.pop();
+  advanceShellScan(context, context.index + 1, false);
+}
+
+function scanDollarSingleFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  scanSingleFrame(context);
+}
+
+function scanBacktickFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  if (context.text[context.index] === '`') {
+    context.frames.pop();
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  scanControlStart(context);
+}
+
+function scanDoubleFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  if (context.text[context.index] === '"') {
+    context.frames.pop();
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  if (context.text[context.index] === '`') {
+    context.frames.push('backtick');
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  scanControlStart(context);
+}
+
+function scanParameterBraceFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  if (context.text[context.index] === '}') {
+    context.frames.pop();
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  if (context.text[context.index] === '`') {
+    context.frames.push('backtick');
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  scanControlStart(context);
+}
+
+function scanParenthesisSubstitutionFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  if (context.text[context.index] === ')') {
+    context.frames.pop();
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  scanPlainStart(context);
+}
+
+function scanArithmeticFrame(
+  context: ShellLiteralScanContext,
+  frame: ArithFrame | ShellScanFrame | undefined,
+): void {
+  if (!isArithFrame(frame)) return;
+  const arithEnd = matchShellLogicalPrefix(context.text, context.index, '))');
+  if (frame.parenthesisDepth === 0 && arithEnd !== undefined) {
+    context.frames.pop();
+    advanceShellScan(context, arithEnd, false);
+    return;
+  }
+  if (context.text[context.index] === ')') {
+    replaceTopArithFrame(context.frames, Math.max(0, frame.parenthesisDepth - 1));
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  if (context.text[context.index] === '(') {
+    replaceTopArithFrame(context.frames, frame.parenthesisDepth + 1);
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  scanPlainStart(context);
+}
+
+function scanArithmeticSquareFrame(
+  context: ShellLiteralScanContext,
+  frame: ArithSquareFrame | ShellScanFrame | undefined,
+): void {
+  if (!isArithSquareFrame(frame)) return;
+  if (context.text[context.index] === '[') {
+    replaceTopArithSquareFrame(context.frames, frame.bracketDepth + 1);
+    advanceShellScan(context, context.index + 1, false);
+    return;
+  }
+  if (context.text[context.index] === ']') {
+    closeArithmeticSquareFrame(context, frame);
+    return;
+  }
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  scanPlainStart(context);
+}
+
+function closeArithmeticSquareFrame(
+  context: ShellLiteralScanContext,
+  frame: ArithSquareFrame,
+): void {
+  if (frame.bracketDepth === 0) context.frames.pop();
+  else replaceTopArithSquareFrame(context.frames, frame.bracketDepth - 1);
+  advanceShellScan(context, context.index + 1, false);
+}
+
+function scanLineCommentFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\n') context.frames.pop();
+  advanceShellScan(context, context.index + 1, false);
+}
+
+function scanPlainFrame(context: ShellLiteralScanContext): void {
+  if (context.text[context.index] === '\\') {
+    consumeShellEscape(context);
+    return;
+  }
+  scanPlainStart(context);
+}
+
+function scanPlainStart(context: ShellLiteralScanContext): void {
+  const nextIndex = scanShellPlainStart(
+    context.text,
+    context.index,
+    context.frames,
+    context.previousCharacter,
+    context.previousCharacterEscaped,
+  );
+  advanceShellScan(context, nextIndex, false);
+}
+
+function scanControlStart(context: ShellLiteralScanContext): void {
+  const nextIndex = scanShellControlStart(context.text, context.index, context.frames);
+  advanceShellScan(context, nextIndex, false);
 }
 
 export function classifyShellSite(state: ShellScanState): ShellSiteContext {

--- a/libs/shared/expression/src/template/extract-cel-context-roots.ts
+++ b/libs/shared/expression/src/template/extract-cel-context-roots.ts
@@ -67,10 +67,7 @@ function collectContextRoots(
       }
       return;
     case 'map':
-      for (const [key, value] of node.args) {
-        if (key.op !== 'id') collectContextRoots(key, contextRoots, scopedIdentifiers);
-        collectContextRoots(value, contextRoots, scopedIdentifiers);
-      }
+      collectMapContextRoots(node.args, contextRoots, scopedIdentifiers);
       return;
     case '?:':
       collectContextRoots(node.args[0], contextRoots, scopedIdentifiers);
@@ -84,6 +81,17 @@ function collectContextRoots(
   }
 
   throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectMapContextRoots(
+  entries: Array<[ASTNode, ASTNode]>,
+  contextRoots: Set<string>,
+  scopedIdentifiers: ReadonlySet<string>,
+): void {
+  for (const [key, value] of entries) {
+    if (key.op !== 'id') collectContextRoots(key, contextRoots, scopedIdentifiers);
+    collectContextRoots(value, contextRoots, scopedIdentifiers);
+  }
 }
 
 function collectBinaryContextRoots(

--- a/libs/shared/node/egress-guard/src/index.ts
+++ b/libs/shared/node/egress-guard/src/index.ts
@@ -96,24 +96,26 @@ function assertNotDenylisted(
   denylist: DenylistEntry[],
 ): void {
   for (const entry of denylist) {
-    if (entry.kind === 'host' && hostname === entry.host) {
-      throw new EgressDeniedError('host-denylist', hostname);
-    }
-    if (entry.kind === 'suffix' && hostname.endsWith(entry.suffix)) {
-      throw new EgressDeniedError('host-denylist', hostname);
-    }
+    assertHostnameNotDenylisted(hostname, entry);
+    for (const address of addresses) assertAddressNotDenylisted(address, entry);
+  }
+}
 
-    for (const address of addresses) {
-      if (
-        entry.kind === 'ip' &&
-        address.toNormalizedString() === entry.address.toNormalizedString()
-      ) {
-        throw new EgressDeniedError('host-denylist', address.toString());
-      }
-      if (entry.kind === 'cidr' && addressMatchesRange(address, entry.range)) {
-        throw new EgressDeniedError('host-denylist', address.toString());
-      }
-    }
+function assertHostnameNotDenylisted(hostname: string, entry: DenylistEntry): void {
+  if (entry.kind === 'host' && hostname === entry.host) {
+    throw new EgressDeniedError('host-denylist', hostname);
+  }
+  if (entry.kind === 'suffix' && hostname.endsWith(entry.suffix)) {
+    throw new EgressDeniedError('host-denylist', hostname);
+  }
+}
+
+function assertAddressNotDenylisted(address: ParsedAddress, entry: DenylistEntry): void {
+  if (entry.kind === 'ip' && address.toNormalizedString() === entry.address.toNormalizedString()) {
+    throw new EgressDeniedError('host-denylist', address.toString());
+  }
+  if (entry.kind === 'cidr' && addressMatchesRange(address, entry.range)) {
+    throw new EgressDeniedError('host-denylist', address.toString());
   }
 }
 

--- a/libs/shared/node/envelope-encryption/src/key-provider.ts
+++ b/libs/shared/node/envelope-encryption/src/key-provider.ts
@@ -48,12 +48,9 @@ export function createLocalKeyProvider(params: LocalKeyProviderParams): Envelope
       }
     },
     unwrapDek(keyId, wrappedDek, kekVersion) {
-      const key =
-        kekVersion === currentKeyVersion
-          ? currentKek
-          : kekVersion === previousKeyVersion
-            ? previousKek
-            : undefined;
+      let key: Buffer | undefined;
+      if (kekVersion === currentKeyVersion) key = currentKek;
+      else if (kekVersion === previousKeyVersion) key = previousKek;
       if (!key) throw new DataKeyUnwrapError();
 
       try {

--- a/libs/shared/node/envelope-encryption/src/rotation.ts
+++ b/libs/shared/node/envelope-encryption/src/rotation.ts
@@ -47,9 +47,7 @@ export async function rotateDataKeys(params: {
     throw new DataKeyVersionStrandedError(unknownVersions[0] as string);
   }
 
-  let rotated = 0;
-  let skippedCurrent = 0;
-  let skippedRace = 0;
+  const outcomes: Record<DataKeyRotationOutcome, number> = {rotated: 0, current: 0, race: 0};
   let afterKeyId: string | undefined;
 
   while (true) {
@@ -61,34 +59,39 @@ export async function rotateDataKeys(params: {
 
     for (const row of page) {
       afterKeyId = row.keyId;
-      if (row.kekVersion === params.keyProvider.currentKeyVersion) {
-        skippedCurrent += 1;
-        continue;
-      }
-
-      const plaintextDek = params.keyProvider.unwrapDek(row.keyId, row.wrappedDek, row.kekVersion);
-      try {
-        const wrapped = params.keyProvider.wrapDek(row.keyId, plaintextDek);
-        const updated = await params.repository.updateWrapCas({
-          keyId: row.keyId,
-          oldKekVersion: row.kekVersion,
-          wrappedDek: wrapped.wrappedDek,
-          kekVersion: wrapped.kekVersion,
-        });
-        if (updated) rotated += 1;
-        else skippedRace += 1;
-      } finally {
-        plaintextDek.fill(0);
-      }
+      const outcome = await rotateDataKey(params, row);
+      outcomes[outcome] += 1;
     }
   }
 
   return {
-    rotated,
-    skipped: skippedCurrent + skippedRace,
-    skippedCurrent,
-    skippedRace,
+    rotated: outcomes.rotated,
+    skipped: outcomes.current + outcomes.race,
+    skippedCurrent: outcomes.current,
+    skippedRace: outcomes.race,
   };
+}
+
+type DataKeyRotationOutcome = 'rotated' | 'current' | 'race';
+
+async function rotateDataKey(
+  params: Pick<Parameters<typeof rotateDataKeys>[0], 'keyProvider' | 'repository'>,
+  row: RotatableDataKeyRecord,
+): Promise<DataKeyRotationOutcome> {
+  if (row.kekVersion === params.keyProvider.currentKeyVersion) return 'current';
+  const plaintextDek = params.keyProvider.unwrapDek(row.keyId, row.wrappedDek, row.kekVersion);
+  try {
+    const wrapped = params.keyProvider.wrapDek(row.keyId, plaintextDek);
+    const updated = await params.repository.updateWrapCas({
+      keyId: row.keyId,
+      oldKekVersion: row.kekVersion,
+      wrappedDek: wrapped.wrappedDek,
+      kekVersion: wrapped.kekVersion,
+    });
+    return updated ? 'rotated' : 'race';
+  } finally {
+    plaintextDek.fill(0);
+  }
 }
 
 export interface RotateDataKeysWithTelemetryParams<TOutcome extends string> {

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -68,6 +68,8 @@ interface StartedModuleService {
   handle: ModuleServiceHandle;
 }
 
+type ModuleInitializationState = InitializedModules;
+
 /**
  * Initializes modules in array order. Modules are processed sequentially
  * so migration order is deterministic: list modules with shared dependencies first.
@@ -88,63 +90,54 @@ export async function initializeModules(
   validateModuleDatabaseNamespaces(options.modules);
 
   for (const mod of options.modules) {
-    logger().info({module: mod.name}, 'Initializing module');
-
-    if (mod.database) {
-      const databases = normalizeModuleDatabases(mod.database);
-      for (const database of databases) {
-        logger().info(
-          {module: mod.name, database: database.databaseNamespace},
-          'Running migrations',
-        );
-        await runMigrations(
-          database.db(),
-          database.migrationsPath,
-          migrationHistoryTableName(database.databaseNamespace),
-        );
-        logger().info(
-          {module: mod.name, database: database.databaseNamespace},
-          'Migrations complete',
-        );
-      }
-    }
-
-    if (mod.publishers) {
-      for (const pub of mod.publishers) {
-        registerPublisher(outboxRegistry, pub);
-      }
-    }
-
-    if (mod.subscribers) {
-      for (const sub of mod.subscribers) {
-        subscribe(outboxRegistry, sub.event, sub.handler);
-      }
-    }
-
-    if (mod.auth) {
-      auth.push(...mod.auth);
-    }
-
-    if (mod.routes) {
-      routes.push(...mod.routes);
-    }
-
-    if (mod.e2eRoutes) {
-      e2eRoutes.push(...mod.e2eRoutes);
-    }
-
-    if (mod.workers) {
-      workers.push(...mod.workers.map((worker) => ({...worker, moduleName: mod.name})));
-    }
-
-    if (mod.services) {
-      services.push(...mod.services);
-    }
-
-    logger().info({module: mod.name}, 'Module initialized');
+    await initializeModule(mod, {auth, routes, e2eRoutes, workers, services, outboxRegistry});
   }
 
   return {auth, routes, e2eRoutes, workers, services, outboxRegistry};
+}
+
+async function initializeModule(
+  mod: ShipfoxModule,
+  state: ModuleInitializationState,
+): Promise<void> {
+  logger().info({module: mod.name}, 'Initializing module');
+  await initializeModuleDatabases(mod);
+  registerModuleMessaging(mod, state.outboxRegistry);
+  collectModuleExports(mod, state);
+  logger().info({module: mod.name}, 'Module initialized');
+}
+
+async function initializeModuleDatabases(mod: ShipfoxModule): Promise<void> {
+  if (!mod.database) return;
+  for (const database of normalizeModuleDatabases(mod.database)) {
+    logger().info({module: mod.name, database: database.databaseNamespace}, 'Running migrations');
+    await runMigrations(
+      database.db(),
+      database.migrationsPath,
+      migrationHistoryTableName(database.databaseNamespace),
+    );
+    logger().info({module: mod.name, database: database.databaseNamespace}, 'Migrations complete');
+  }
+}
+
+function registerModuleMessaging(
+  mod: ShipfoxModule,
+  outboxRegistry: ModuleRuntimeContext['outboxRegistry'],
+): void {
+  for (const publisher of mod.publishers ?? []) registerPublisher(outboxRegistry, publisher);
+  for (const subscriber of mod.subscribers ?? []) {
+    subscribe(outboxRegistry, subscriber.event, subscriber.handler);
+  }
+}
+
+function collectModuleExports(mod: ShipfoxModule, state: ModuleInitializationState): void {
+  if (mod.auth) state.auth.push(...mod.auth);
+  if (mod.routes) state.routes.push(...mod.routes);
+  if (mod.e2eRoutes) state.e2eRoutes.push(...mod.e2eRoutes);
+  if (mod.workers) {
+    state.workers.push(...mod.workers.map((worker) => ({...worker, moduleName: mod.name})));
+  }
+  if (mod.services) state.services.push(...mod.services);
 }
 
 function normalizeModuleDatabases(database: ModuleDatabase | ModuleDatabase[]): ModuleDatabase[] {
@@ -378,69 +371,14 @@ export async function startModuleWorkers(
     connection = await createTemporalWorkerConnection();
 
     for (const workerDef of options.workers) {
-      try {
-        const worker = await createTemporalWorker({
-          connection,
-          taskQueue: workerDef.taskQueue,
-          workflowsPath: workerDef.workflowsPath,
-          activities: instrumentModuleActivities({
-            moduleName: workerDef.moduleName ?? 'unknown',
-            taskQueue: workerDef.taskQueue,
-            activities: workerDef.activities(options.context),
-          }),
-        });
-        const startedWorker: StartedModuleWorker = {worker, taskQueue: workerDef.taskQueue};
-        workers.push(startedWorker);
-
-        for (const workflow of workerDef.workflows) {
-          try {
-            await temporalClient().workflow.start(workflow.name, {
-              taskQueue: workerDef.taskQueue,
-              workflowId: workflow.id,
-              ...(workflow.args ? {args: workflow.args} : {}),
-              ...(workflow.cronSchedule ? {cronSchedule: workflow.cronSchedule} : {}),
-            });
-          } catch (error) {
-            if (error instanceof Error && error.name === 'WorkflowExecutionAlreadyStartedError') {
-              logger().info({workflowId: workflow.id}, 'Workflow already running, skipping start');
-            } else {
-              throw error;
-            }
-          }
-        }
-
-        const runPromise = worker.run();
-        startedWorker.runPromise = runPromise;
-        runPromise.catch((error) => {
-          if (stopping) return;
-          if (options.onWorkerFailure) {
-            void Promise.resolve(options.onWorkerFailure(error, workerDef)).catch(
-              (handlerError) => {
-                logger().error(
-                  {err: handlerError, workerErr: error, taskQueue: workerDef.taskQueue},
-                  'Module worker failure handler failed',
-                );
-                reportError(handlerError, {
-                  boundary: 'module.worker',
-                  operation: 'failure-callback',
-                  tags: {taskQueue: workerDef.taskQueue},
-                });
-              },
-            );
-            return;
-          }
-          logger().error(
-            {err: error, taskQueue: workerDef.taskQueue},
-            'Worker stopped unexpectedly',
-          );
-        });
-
-        logger().info({taskQueue: workerDef.taskQueue}, 'Module worker started');
-      } catch (error) {
-        throw new Error(`Failed to start module worker for task queue ${workerDef.taskQueue}`, {
-          cause: error,
-        });
-      }
+      await startModuleWorker({
+        connection,
+        workerDef,
+        context: options.context,
+        onWorkerFailure: options.onWorkerFailure,
+        isStopping: () => stopping,
+        onWorkerCreated: (startedWorker) => workers.push(startedWorker),
+      });
     }
   } catch (error) {
     stopping = true;
@@ -459,6 +397,91 @@ export async function startModuleWorkers(
       return stopPromise;
     },
   };
+}
+
+async function startModuleWorker(params: {
+  connection: NativeConnection;
+  workerDef: ModuleWorker;
+  context: ModuleRuntimeContext;
+  onWorkerFailure: StartModuleWorkersOptions['onWorkerFailure'];
+  isStopping(): boolean;
+  onWorkerCreated(startedWorker: StartedModuleWorker): void;
+}): Promise<void> {
+  try {
+    const worker = await createTemporalWorker({
+      connection: params.connection,
+      taskQueue: params.workerDef.taskQueue,
+      workflowsPath: params.workerDef.workflowsPath,
+      activities: instrumentModuleActivities({
+        moduleName: params.workerDef.moduleName ?? 'unknown',
+        taskQueue: params.workerDef.taskQueue,
+        activities: params.workerDef.activities(params.context),
+      }),
+    });
+    const startedWorker: StartedModuleWorker = {
+      worker,
+      taskQueue: params.workerDef.taskQueue,
+    };
+    params.onWorkerCreated(startedWorker);
+    await startModuleWorkerWorkflows(params.workerDef);
+    startedWorker.runPromise = worker.run();
+    monitorModuleWorker(startedWorker, params);
+    logger().info({taskQueue: params.workerDef.taskQueue}, 'Module worker started');
+  } catch (error) {
+    throw new Error(`Failed to start module worker for task queue ${params.workerDef.taskQueue}`, {
+      cause: error,
+    });
+  }
+}
+
+async function startModuleWorkerWorkflows(workerDef: ModuleWorker): Promise<void> {
+  for (const workflow of workerDef.workflows) {
+    try {
+      await temporalClient().workflow.start(workflow.name, {
+        taskQueue: workerDef.taskQueue,
+        workflowId: workflow.id,
+        ...(workflow.args ? {args: workflow.args} : {}),
+        ...(workflow.cronSchedule ? {cronSchedule: workflow.cronSchedule} : {}),
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'WorkflowExecutionAlreadyStartedError') {
+        logger().info({workflowId: workflow.id}, 'Workflow already running, skipping start');
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+function monitorModuleWorker(
+  startedWorker: StartedModuleWorker,
+  params: {
+    workerDef: ModuleWorker;
+    onWorkerFailure: StartModuleWorkersOptions['onWorkerFailure'];
+    isStopping(): boolean;
+  },
+): void {
+  startedWorker.runPromise?.catch((error) => {
+    if (params.isStopping()) return;
+    if (!params.onWorkerFailure) {
+      logger().error(
+        {err: error, taskQueue: params.workerDef.taskQueue},
+        'Worker stopped unexpectedly',
+      );
+      return;
+    }
+    void Promise.resolve(params.onWorkerFailure(error, params.workerDef)).catch((handlerError) => {
+      logger().error(
+        {err: handlerError, workerErr: error, taskQueue: params.workerDef.taskQueue},
+        'Module worker failure handler failed',
+      );
+      reportError(handlerError, {
+        boundary: 'module.worker',
+        operation: 'failure-callback',
+        tags: {taskQueue: params.workerDef.taskQueue},
+      });
+    });
+  });
 }
 
 async function stopModuleWorkers(options: {

--- a/libs/shared/node/module/src/inter-module/dispatch.ts
+++ b/libs/shared/node/module/src/inter-module/dispatch.ts
@@ -160,43 +160,61 @@ export function runInterModuleCall(callOptions: RunInterModuleCallOptions): Prom
             : createOpaqueError(callOptions);
         }
 
-        return startActiveInterModuleSpan(
-          tracer,
-          'inter_module.presentation',
-          SpanKind.INTERNAL,
-          async (presentationSpan) => {
-            const settlement = await invokeHandlerWithCancellation({
-              methodContract,
-              handler: callOptions.handler,
-              input: inputResolution.value,
-              signal: callOptions.options?.signal,
-            });
-
-            if (settlement.outcome === 'opaque') {
-              drainReport(reportInternalError, settlement.reportError, {
-                phase: settlement.phase,
-                module,
-                method,
-              });
-            }
-
-            const outcome = settlement.outcome === 'opaque' ? 'opaque-error' : settlement.outcome;
-            const knownErrorCode =
-              settlement.outcome === 'known-error' ? settlement.error.code : undefined;
-            endSpan(presentationSpan, outcome, knownErrorCode);
-            endSpan(clientSpan, outcome, knownErrorCode);
-
-            if (settlement.outcome === 'success') return settlement.value;
-            if (settlement.outcome === 'known-error') throw settlement.error;
-            if (settlement.outcome === 'cancelled') throw settlement.reason;
-            throw createOpaqueError(callOptions);
-          },
-        );
+        return runInterModulePresentation({
+          callOptions,
+          input: inputResolution.value,
+          clientSpan,
+          endSpan,
+        });
       },
     );
   } catch (error) {
     return Promise.reject(error);
   }
+}
+
+function runInterModulePresentation(params: {
+  callOptions: RunInterModuleCallOptions;
+  input: unknown;
+  clientSpan: Span;
+  endSpan(span: Span, outcome: InterModuleOutcome, knownErrorCode?: string): void;
+}): Promise<unknown> {
+  const {callOptions} = params;
+  return startActiveInterModuleSpan(
+    callOptions.tracer,
+    'inter_module.presentation',
+    SpanKind.INTERNAL,
+    async (presentationSpan) => {
+      const settlement = await invokeHandlerWithCancellation({
+        methodContract: callOptions.methodContract,
+        handler: callOptions.handler,
+        input: params.input,
+        signal: callOptions.options?.signal,
+      });
+      reportOpaqueSettlement(callOptions, settlement);
+      const outcome = settlement.outcome === 'opaque' ? 'opaque-error' : settlement.outcome;
+      const knownErrorCode =
+        settlement.outcome === 'known-error' ? settlement.error.code : undefined;
+      params.endSpan(presentationSpan, outcome, knownErrorCode);
+      params.endSpan(params.clientSpan, outcome, knownErrorCode);
+      if (settlement.outcome === 'success') return settlement.value;
+      if (settlement.outcome === 'known-error') throw settlement.error;
+      if (settlement.outcome === 'cancelled') throw settlement.reason;
+      throw createOpaqueError(callOptions);
+    },
+  );
+}
+
+function reportOpaqueSettlement(
+  callOptions: RunInterModuleCallOptions,
+  settlement: Awaited<ReturnType<typeof invokeHandlerWithCancellation>>,
+): void {
+  if (settlement.outcome !== 'opaque') return;
+  drainReport(callOptions.reportInternalError, settlement.reportError, {
+    phase: settlement.phase,
+    module: callOptions.module,
+    method: callOptions.method,
+  });
 }
 
 function createOpaqueError(callOptions: RunInterModuleCallOptions): InterModuleOpaqueError {

--- a/libs/shared/node/module/src/inter-module/json.ts
+++ b/libs/shared/node/module/src/inter-module/json.ts
@@ -41,17 +41,21 @@ function checkJsonSafe(value: unknown, activePath: Set<unknown>): boolean {
 
   if (activePath.has(value)) return false;
 
-  if (Array.isArray(value)) {
-    if (!isPlainDenseArray(value)) return false;
+  if (Array.isArray(value)) return checkJsonSafeArray(value, activePath);
+  return checkJsonSafeObject(value, activePath);
+}
 
-    activePath.add(value);
-    try {
-      return value.every((item) => checkJsonSafe(item, activePath));
-    } finally {
-      activePath.delete(value);
-    }
+function checkJsonSafeArray(value: unknown[], activePath: Set<unknown>): boolean {
+  if (!isPlainDenseArray(value)) return false;
+  activePath.add(value);
+  try {
+    return value.every((item) => checkJsonSafe(item, activePath));
+  } finally {
+    activePath.delete(value);
   }
+}
 
+function checkJsonSafeObject(value: object, activePath: Set<unknown>): boolean {
   const proto = Object.getPrototypeOf(value);
   if (proto !== Object.prototype && proto !== null) return false;
 

--- a/libs/shared/node/module/src/metrics.test.ts
+++ b/libs/shared/node/module/src/metrics.test.ts
@@ -8,13 +8,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@shipfox/node-opentelemetry', () => ({
   instanceMetrics: {
     getMeter: () => ({
-      createCounter: (name: string) => ({
-        add: name.endsWith('_execution')
-          ? mocks.executionAdd
-          : name.endsWith('_failure')
-            ? mocks.failureAdd
-            : mocks.retryAdd,
-      }),
+      createCounter: (name: string) => {
+        let add = mocks.retryAdd;
+        if (name.endsWith('_execution')) add = mocks.executionAdd;
+        else if (name.endsWith('_failure')) add = mocks.failureAdd;
+        return {add};
+      },
       createHistogram: () => ({record: mocks.durationRecord}),
     }),
   },

--- a/libs/shared/node/outbox/src/postgres.ts
+++ b/libs/shared/node/outbox/src/postgres.ts
@@ -304,29 +304,31 @@ function serializeFailure(failure: unknown): unknown {
 function toJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
   const primitive = serializePrimitive(value);
   if (primitive.handled) return primitive.value;
-  if (typeof value !== 'object' || value === null) return '[Unserializable]';
+  const objectValue = primitive.value;
 
   try {
-    if (value instanceof Date) {
-      return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
+    if (objectValue instanceof Date) {
+      return Number.isNaN(objectValue.getTime()) ? String(objectValue) : objectValue.toISOString();
     }
-    if (ancestors.has(value)) return '[Circular]';
-    ancestors.add(value);
+    if (ancestors.has(objectValue)) return '[Circular]';
+    ancestors.add(objectValue);
 
     let serialized: unknown;
-    if (value instanceof Error) serialized = serializeError(value, ancestors);
-    else if (Array.isArray(value)) {
-      serialized = value.map((item) => toJsonSafe(item, ancestors));
-    } else serialized = serializeObject(value, ancestors);
-    ancestors.delete(value);
+    if (objectValue instanceof Error) serialized = serializeError(objectValue, ancestors);
+    else if (Array.isArray(objectValue)) {
+      serialized = objectValue.map((item) => toJsonSafe(item, ancestors));
+    } else serialized = serializeObject(objectValue, ancestors);
+    ancestors.delete(objectValue);
     return serialized;
   } catch (_error) {
-    ancestors.delete(value);
+    ancestors.delete(objectValue);
     return '[Unserializable]';
   }
 }
 
-function serializePrimitive(value: unknown): {handled: true; value: unknown} | {handled: false} {
+function serializePrimitive(
+  value: unknown,
+): {handled: true; value: unknown} | {handled: false; value: object} {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') {
     return {handled: true, value};
   }
@@ -335,12 +337,14 @@ function serializePrimitive(value: unknown): {handled: true; value: unknown} | {
   }
   if (typeof value === 'bigint') return {handled: true, value: value.toString()};
   if (typeof value === 'undefined') return {handled: true, value: null};
-  if (typeof value !== 'symbol' && typeof value !== 'function') return {handled: false};
-  try {
-    return {handled: true, value: String(value)};
-  } catch (_error) {
-    return {handled: true, value: '[Unserializable]'};
+  if (typeof value === 'symbol' || typeof value === 'function') {
+    try {
+      return {handled: true, value: String(value)};
+    } catch (_error) {
+      return {handled: true, value: '[Unserializable]'};
+    }
   }
+  return {handled: false, value};
 }
 
 function serializeError(error: Error, ancestors: WeakSet<object>): Record<string, unknown> {

--- a/libs/shared/node/outbox/src/postgres.ts
+++ b/libs/shared/node/outbox/src/postgres.ts
@@ -302,17 +302,9 @@ function serializeFailure(failure: unknown): unknown {
 }
 
 function toJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
-  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
-  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
-  if (typeof value === 'bigint') return value.toString();
-  if (typeof value === 'undefined') return null;
-  if (typeof value === 'symbol' || typeof value === 'function') {
-    try {
-      return String(value);
-    } catch (_error) {
-      return '[Unserializable]';
-    }
-  }
+  const primitive = serializePrimitive(value);
+  if (primitive.handled) return primitive.value;
+  if (typeof value !== 'object' || value === null) return '[Unserializable]';
 
   try {
     if (value instanceof Date) {
@@ -321,17 +313,33 @@ function toJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
     if (ancestors.has(value)) return '[Circular]';
     ancestors.add(value);
 
-    const serialized =
-      value instanceof Error
-        ? serializeError(value, ancestors)
-        : Array.isArray(value)
-          ? value.map((item) => toJsonSafe(item, ancestors))
-          : serializeObject(value, ancestors);
+    let serialized: unknown;
+    if (value instanceof Error) serialized = serializeError(value, ancestors);
+    else if (Array.isArray(value)) {
+      serialized = value.map((item) => toJsonSafe(item, ancestors));
+    } else serialized = serializeObject(value, ancestors);
     ancestors.delete(value);
     return serialized;
   } catch (_error) {
     ancestors.delete(value);
     return '[Unserializable]';
+  }
+}
+
+function serializePrimitive(value: unknown): {handled: true; value: unknown} | {handled: false} {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return {handled: true, value};
+  }
+  if (typeof value === 'number') {
+    return {handled: true, value: Number.isFinite(value) ? value : String(value)};
+  }
+  if (typeof value === 'bigint') return {handled: true, value: value.toString()};
+  if (typeof value === 'undefined') return {handled: true, value: null};
+  if (typeof value !== 'symbol' && typeof value !== 'function') return {handled: false};
+  try {
+    return {handled: true, value: String(value)};
+  } catch (_error) {
+    return {handled: true, value: '[Unserializable]'};
   }
 }
 

--- a/libs/shared/react/ui/src/components/button/icon-button.tsx
+++ b/libs/shared/react/ui/src/components/button/icon-button.tsx
@@ -75,6 +75,10 @@ export function IconButton({
   const Comp = asChild ? Slot : 'button';
   const spinnerSize = spinnerSizeMap[size ?? 'md'];
 
+  let content = children;
+  if (isLoading) content = <Icon name="spinner" className={spinnerSize} />;
+  else if (icon) content = <Icon name={icon} />;
+
   return (
     <Comp
       data-slot="icon-button"
@@ -85,13 +89,7 @@ export function IconButton({
       {...(asChild ? {'aria-disabled': disabled || isLoading} : {})}
       {...props}
     >
-      {isLoading ? (
-        <Icon name="spinner" className={spinnerSize} />
-      ) : icon ? (
-        <Icon name={icon} />
-      ) : (
-        children
-      )}
+      {content}
     </Comp>
   );
 }

--- a/libs/shared/react/ui/src/components/code-block/code-tabs.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-tabs.tsx
@@ -144,11 +144,9 @@ export function CodeTabs({
   const isControlled = controlledValue !== undefined;
   // When uncontrolled, the selected tab can disappear if `codes` changes
   // (dynamic/async sources). Fall back to the first key so a tab is always active.
-  const value = isControlled
-    ? controlledValue
-    : Object.hasOwn(codes, internalValue)
-      ? internalValue
-      : firstKey;
+  let value = firstKey;
+  if (isControlled) value = controlledValue;
+  else if (Object.hasOwn(codes, internalValue)) value = internalValue;
 
   const onValueChange = useCallback(
     (next: string) => {

--- a/libs/shared/react/ui/src/components/combobox/combobox-root.tsx
+++ b/libs/shared/react/ui/src/components/combobox/combobox-root.tsx
@@ -98,15 +98,11 @@ export function ComboboxRoot(props: ComboboxRootProps) {
   const controlledMultiValue = multiple
     ? (props as MultiControlledComboboxRootProps | MultiUncontrolledComboboxRootProps).value
     : undefined;
-  const selectedValues = React.useMemo<string[]>(
-    () =>
-      multiple
-        ? (controlledMultiValue ?? internalMultiValue)
-        : selectedValue
-          ? [selectedValue]
-          : [],
-    [multiple, controlledMultiValue, internalMultiValue, selectedValue],
-  );
+  const selectedValues = React.useMemo<string[]>(() => {
+    if (multiple) return controlledMultiValue ?? internalMultiValue;
+    if (selectedValue) return [selectedValue];
+    return [];
+  }, [multiple, controlledMultiValue, internalMultiValue, selectedValue]);
 
   const visibleOptions = React.useMemo(
     () => filterComboboxOptions(options, searchValue),
@@ -198,64 +194,79 @@ export function ComboboxRoot(props: ComboboxRootProps) {
     updateMultiValue(clearMultiComboboxValues());
   }, [disabled, multiple, updateMultiValue]);
 
+  const handleArrowKey = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>, direction: 1 | -1) => {
+      event.preventDefault();
+      if (!open) {
+        handleOpenChange(true);
+        return;
+      }
+      const values = visibleOptions.map((option) => option.value);
+      setActiveValue(getNextActiveComboboxValue(values, activeValue, direction));
+    },
+    [activeValue, handleOpenChange, open, visibleOptions],
+  );
+
+  const handleBoundaryKey = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>, boundary: 'start' | 'end') => {
+      // Leave Home/End to the text caret while there is a query to navigate.
+      if (!open || searchValue !== '') return;
+      event.preventDefault();
+      const values = visibleOptions.map((option) => option.value);
+      setActiveValue(boundary === 'start' ? (values[0] ?? null) : (values.at(-1) ?? null));
+    },
+    [open, searchValue, visibleOptions],
+  );
+
+  const handleEnterKey = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // Swallow Enter while open so it selects (when an option is active) and
+      // never submits an enclosing form, even with an empty result list.
+      if (!open) return;
+      event.preventDefault();
+      if (activeValue !== null) selectValue(activeValue);
+    },
+    [activeValue, open, selectValue],
+  );
+
+  const handleEscapeKey = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!open) return;
+      event.preventDefault();
+      handleOpenChange(false);
+    },
+    [handleOpenChange, open],
+  );
+
   const onListKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (disabled) {
         return;
       }
 
-      const values = visibleOptions.map((option) => option.value);
-
       switch (event.key) {
         case 'ArrowDown':
-          event.preventDefault();
-          if (!open) {
-            handleOpenChange(true);
-            return;
-          }
-          setActiveValue(getNextActiveComboboxValue(values, activeValue, 1));
+          handleArrowKey(event, 1);
           return;
         case 'ArrowUp':
-          event.preventDefault();
-          if (!open) {
-            handleOpenChange(true);
-            return;
-          }
-          setActiveValue(getNextActiveComboboxValue(values, activeValue, -1));
+          handleArrowKey(event, -1);
           return;
         case 'Home':
-          // Leave Home/End to the text caret while there is a query to navigate.
-          if (open && searchValue === '') {
-            event.preventDefault();
-            setActiveValue(values[0] ?? null);
-          }
+          handleBoundaryKey(event, 'start');
           return;
         case 'End':
-          if (open && searchValue === '') {
-            event.preventDefault();
-            setActiveValue(values.at(-1) ?? null);
-          }
+          handleBoundaryKey(event, 'end');
           return;
         case 'Enter':
-          // Swallow Enter while open so it selects (when an option is active) and
-          // never submits an enclosing form, even with an empty result list.
-          if (open) {
-            event.preventDefault();
-            if (activeValue !== null) {
-              selectValue(activeValue);
-            }
-          }
+          handleEnterKey(event);
           return;
         case 'Escape':
-          if (open) {
-            event.preventDefault();
-            handleOpenChange(false);
-          }
+          handleEscapeKey(event);
           return;
         default:
       }
     },
-    [disabled, open, searchValue, activeValue, visibleOptions, selectValue, handleOpenChange],
+    [disabled, handleArrowKey, handleBoundaryKey, handleEnterKey, handleEscapeKey],
   );
 
   // Keep the active option valid. Preserve the user's highlight as long as it still
@@ -264,13 +275,13 @@ export function ComboboxRoot(props: ComboboxRootProps) {
   // The functional updater intentionally avoids depending on `activeValue` so a stable
   // result bails out instead of looping.
   React.useEffect(() => {
-    setActiveValue((current) =>
-      open
-        ? current !== null && visibleOptions.some((option) => option.value === current)
-          ? current
-          : (visibleOptions[0]?.value ?? null)
-        : null,
-    );
+    setActiveValue((current) => {
+      if (!open) return null;
+      if (current !== null && visibleOptions.some((option) => option.value === current)) {
+        return current;
+      }
+      return visibleOptions[0]?.value ?? null;
+    });
   }, [open, visibleOptions]);
 
   // Focus stays on the input, so the browser will not scroll the active option into

--- a/libs/shared/react/ui/src/components/date-picker/date-picker.tsx
+++ b/libs/shared/react/ui/src/components/date-picker/date-picker.tsx
@@ -69,8 +69,8 @@ export function DatePicker({
   ...props
 }: DatePickerProps) {
   const [open, setOpen] = useState(false);
-  const isDisabled = disabled || state === 'disabled';
-  const validDate = date && isValid(date) ? date : undefined;
+  const isDisabled = pickerIsDisabled(disabled, state);
+  const validDate = validPickerDate(date);
   const displayValue = validDate ? format(validDate, dateFormat) : '';
   const defaultMonth = validDate ?? new Date();
 
@@ -189,4 +189,13 @@ export function DatePicker({
       </PopoverContent>
     </Popover>
   );
+}
+
+function pickerIsDisabled(disabled: boolean | undefined, state: DatePickerProps['state']): boolean {
+  return Boolean(disabled || state === 'disabled');
+}
+
+function validPickerDate(date: Date | undefined): Date | undefined {
+  if (!date || !isValid(date)) return undefined;
+  return date;
 }

--- a/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.tsx
@@ -77,15 +77,13 @@ export function DateRangePicker({
 }: DateRangePickerProps) {
   const [open, setOpen] = useState(false);
 
-  const isDisabled = disabled || state === 'disabled';
-  const startDate = dateRange?.start && isValid(dateRange.start) ? dateRange.start : undefined;
-  const endDate = dateRange?.end && isValid(dateRange.end) ? dateRange.end : undefined;
-  const hasSelection = Boolean(startDate || endDate);
+  const isDisabled = Boolean(disabled || state === 'disabled');
+  const {startDate, endDate} = validDateRange(dateRange);
+  const hasSelection = rangeHasSelection(startDate, endDate);
 
   const displayValue = formatDateRange(startDate, endDate, dateFormat);
 
-  const dayPickerRange: DayPickerDateRange | undefined =
-    startDate || endDate ? {from: startDate, to: endDate} : undefined;
+  const dayPickerRange = toDayPickerRange(startDate, endDate);
 
   const defaultMonth = startDate ?? endDate ?? new Date();
 
@@ -210,6 +208,30 @@ export function DateRangePicker({
       </PopoverContent>
     </Popover>
   );
+}
+
+function validDateRange(dateRange: DateRange | undefined) {
+  return {
+    startDate: validRangeDate(dateRange?.start),
+    endDate: validRangeDate(dateRange?.end),
+  };
+}
+
+function validRangeDate(date: Date | undefined): Date | undefined {
+  if (!date || !isValid(date)) return undefined;
+  return date;
+}
+
+function rangeHasSelection(startDate: Date | undefined, endDate: Date | undefined): boolean {
+  return Boolean(startDate || endDate);
+}
+
+function toDayPickerRange(
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+): DayPickerDateRange | undefined {
+  if (!startDate && !endDate) return undefined;
+  return {from: startDate, to: endDate};
 }
 
 function formatDateRange(

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.tsx
@@ -28,12 +28,9 @@ export function EmptyState({
   className,
   ...props
 }: EmptyStateProps) {
-  const containerClasses =
-    variant === 'compact'
-      ? 'flex flex-col items-center justify-center gap-10'
-      : variant === 'panel'
-        ? 'w-full flex-1 flex-col gap-12'
-        : 'flex flex-col items-center justify-center gap-12 py-48';
+  let containerClasses = 'flex flex-col items-center justify-center gap-12 py-48';
+  if (variant === 'compact') containerClasses = 'flex flex-col items-center justify-center gap-10';
+  else if (variant === 'panel') containerClasses = 'w-full flex-1 flex-col gap-12';
 
   const iconContainerClasses =
     variant === 'compact'

--- a/libs/shared/react/ui/src/components/form-field/form-field.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.tsx
@@ -59,27 +59,35 @@ export function FormField({label, id, error, description, className, children}: 
   const errorId = `${fieldId}-error`;
   const descriptionId = `${fieldId}-description`;
   const invalid = Boolean(error);
-  const describedBy = error ? errorId : description ? descriptionId : undefined;
+  let describedBy: string | undefined;
+  if (error) describedBy = errorId;
+  else if (description) describedBy = descriptionId;
 
   const value = useMemo<FormFieldContextValue>(
     () => ({id: fieldId, errorId, descriptionId, invalid, describedBy}),
     [fieldId, errorId, descriptionId, invalid, describedBy],
   );
+  let supportingText: ReactNode = null;
+  if (error) {
+    supportingText = (
+      <Text as="p" size="xs" className="text-tag-error-text" id={errorId} aria-live="polite">
+        {error}
+      </Text>
+    );
+  } else if (description) {
+    supportingText = (
+      <Text as="p" size="xs" className="text-foreground-neutral-muted" id={descriptionId}>
+        {description}
+      </Text>
+    );
+  }
 
   return (
     <FormFieldContext.Provider value={value}>
       <div className={cn('flex flex-col gap-8', className)}>
         <Label htmlFor={fieldId}>{label}</Label>
         {children}
-        {error ? (
-          <Text as="p" size="xs" className="text-tag-error-text" id={errorId} aria-live="polite">
-            {error}
-          </Text>
-        ) : description ? (
-          <Text as="p" size="xs" className="text-foreground-neutral-muted" id={descriptionId}>
-            {description}
-          </Text>
-        ) : null}
+        {supportingText}
       </div>
     </FormFieldContext.Provider>
   );

--- a/libs/shared/react/ui/src/components/loader/shipfox-loader.tsx
+++ b/libs/shared/react/ui/src/components/loader/shipfox-loader.tsx
@@ -16,6 +16,7 @@ import {
   type BackgroundMode,
   type ColorMode,
   defaultConfig,
+  type FoxPixel,
   foxPixels,
   getColor,
   getPathGenerator,
@@ -53,6 +54,123 @@ function brightenColor(color: string, intensity: number) {
   const brightBlue = Math.min(255, blue + (255 - blue) * intensity);
 
   return [brightRed, brightGreen, brightBlue] as const;
+}
+
+function ghostOpacityFor(
+  config: ShipfoxConfig,
+  sizeMultiplier: number,
+  background: BackgroundMode,
+): number {
+  const opacity = Math.max(
+    0.01,
+    config.ghostOpacity * (1 - (sizeMultiplier - 1) * config.sizeScale),
+  );
+  return background === 'light' ? opacity / LIGHT_BACKGROUND_OPACITY_REDUCTION : opacity;
+}
+
+function nextHoverIntensity(
+  current: number,
+  target: number,
+  ghostOpacity: number,
+  deltaTime: number,
+): number {
+  if (target > current) {
+    return current + (target - current) * (1 - (1 - HOVER_RISE_SPEED) ** (deltaTime / 16));
+  }
+  return Math.max(ghostOpacity, current * Math.exp(-deltaTime / HOVER_DECAY_MS));
+}
+
+type PixelFillOptions = {
+  pixel: FoxPixel;
+  isLit: boolean;
+  hoverIntensity: number;
+  cursorIntensity: number;
+  snakeHead: {x: number; y: number} | null;
+  currentColor: string;
+  background: BackgroundMode;
+  ghostOpacity: number;
+  sizeMultiplier: number;
+  config: ShipfoxConfig;
+};
+
+function pixelFillColor(options: PixelFillOptions): string {
+  if (options.isLit) return litPixelFillColor(options);
+  if (options.background === 'light') {
+    const opacity = options.cursorIntensity > 0 ? 1 : options.ghostOpacity;
+    return `rgba(${options.currentColor},${opacity})`;
+  }
+  const [red = 0, green = 0, blue = 0] = options.currentColor.split(',').map(Number);
+  return `rgba(${red},${green},${blue},${Math.min(1, options.hoverIntensity)})`;
+}
+
+function litPixelFillColor(options: PixelFillOptions): string {
+  const {pixel, snakeHead, background, config, sizeMultiplier, currentColor} = options;
+  if (!snakeHead || background === 'light') return `rgba(${currentColor},1)`;
+
+  const [x, y] = pixel;
+  const distance = Math.max(Math.abs(x - snakeHead.x), Math.abs(y - snakeHead.y));
+  const scaledRadius = Math.max(
+    1,
+    Math.round(config.lightRadius * (1 - (sizeMultiplier - 1) * config.sizeScale)),
+  );
+  if (distance === 0 || distance > scaledRadius) return `rgba(${currentColor},1)`;
+
+  const falloff = (1 - distance / scaledRadius) ** config.lightCurve;
+  const brightness = Math.max(
+    0.05,
+    config.lightBrightness * (1 - (sizeMultiplier - 1) * config.sizeScale),
+  );
+  const [red, green, blue] = brightenColor(currentColor, falloff * brightness);
+  return `rgb(${red},${green},${blue})`;
+}
+
+function drawTrail(
+  context: CanvasRenderingContext2D,
+  trail: Array<{x: number; y: number}>,
+  currentColor: string,
+  cellSize: number,
+): void {
+  for (const [index, trailPixel] of trail.entries()) {
+    const glowIntensity = TRAIL_GLOW_VALUES[index];
+    if (glowIntensity === undefined) continue;
+    const [red, green, blue] = brightenColor(currentColor, glowIntensity * 0.5);
+    context.fillStyle = `rgba(${red},${green},${blue},${glowIntensity})`;
+    context.fillRect(trailPixel.x * cellSize, trailPixel.y * cellSize, cellSize, cellSize);
+  }
+}
+
+function animationMoveDelay(
+  animation: AnimationType,
+  path: FoxPixel[],
+  currentIndex: number,
+  litRatio: number,
+  speed: number,
+): number {
+  const baseDelay = BASE_MOVE_DELAY / speed;
+  if (animation === 'random') return baseDelay * (0.7 + litRatio * 1.1);
+  if (animation !== 'vertical') return baseDelay;
+  const [currentX] = path[currentIndex] ?? [0, 0];
+  return currentX >= 4 && currentX <= 7 ? baseDelay * VERTICAL_CENTER_SLOWDOWN : baseDelay;
+}
+
+function advanceAnimation(
+  path: FoxPixel[],
+  currentIndex: number,
+  litPixels: Set<string>,
+  trail: Array<{x: number; y: number}>,
+): number | undefined {
+  const currentPixel = path[currentIndex];
+  if (!currentPixel) return undefined;
+
+  const [x, y] = currentPixel;
+  trail.unshift({x, y});
+  if (trail.length > TRAIL_GLOW_VALUES.length) trail.pop();
+
+  const pixelKey = `${x},${y}`;
+  if (litPixels.has(pixelKey)) litPixels.delete(pixelKey);
+  else litPixels.add(pixelKey);
+
+  return (currentIndex + 1) % path.length;
 }
 
 export function ShipfoxLoader({
@@ -132,15 +250,7 @@ export function ShipfoxLoader({
       context.clearRect(0, 0, canvas.width, canvas.height);
       const canvasRect = canvas.getBoundingClientRect();
       const sizeMultiplier = canvas.width / BASE_CANVAS_SIZE;
-      let ghostOpacity = Math.max(
-        0.01,
-        finalConfig.ghostOpacity * (1 - (sizeMultiplier - 1) * finalConfig.sizeScale),
-      );
-
-      if (background === 'light') {
-        ghostOpacity /= LIGHT_BACKGROUND_OPACITY_REDUCTION;
-      }
-
+      const ghostOpacity = ghostOpacityFor(finalConfig, sizeMultiplier, background);
       const snakeHead = trailRef.current[0] ?? null;
       const currentColor = getColor(color, background);
 
@@ -154,77 +264,29 @@ export function ShipfoxLoader({
         const pixelKey = `${x},${y}`;
         const targetIntensity = cursorIntensityFor(x, y, canvasRect);
         const currentHoverIntensity = hoverIntensitiesRef.current[index] ?? 0;
-
-        if (targetIntensity > currentHoverIntensity) {
-          hoverIntensitiesRef.current[index] =
-            currentHoverIntensity +
-            (targetIntensity - currentHoverIntensity) *
-              (1 - (1 - HOVER_RISE_SPEED) ** (deltaTime / 16));
-        } else {
-          hoverIntensitiesRef.current[index] = Math.max(
-            ghostOpacity,
-            currentHoverIntensity * Math.exp(-deltaTime / HOVER_DECAY_MS),
-          );
-        }
-
-        let fillColor: string;
-        if (litPixelsRef.current.has(pixelKey)) {
-          fillColor = `rgba(${currentColor},1)`;
-
-          if (snakeHead && background !== 'light') {
-            const distanceX = Math.abs(x - snakeHead.x);
-            const distanceY = Math.abs(y - snakeHead.y);
-            const distance = Math.max(distanceX, distanceY);
-            const scaledRadius = Math.max(
-              1,
-              Math.round(
-                finalConfig.lightRadius * (1 - (sizeMultiplier - 1) * finalConfig.sizeScale),
-              ),
-            );
-
-            if (distance > 0 && distance <= scaledRadius) {
-              const falloff = (1 - distance / scaledRadius) ** finalConfig.lightCurve;
-              const brightness = Math.max(
-                0.05,
-                finalConfig.lightBrightness * (1 - (sizeMultiplier - 1) * finalConfig.sizeScale),
-              );
-              const [brightRed, brightGreen, brightBlue] = brightenColor(
-                currentColor,
-                falloff * brightness,
-              );
-              fillColor = `rgb(${brightRed},${brightGreen},${brightBlue})`;
-            }
-          }
-        } else if (background === 'light') {
-          const hoverTarget = cursorIntensityFor(x, y, canvasRect);
-          fillColor =
-            hoverTarget > 0 ? `rgba(${currentColor},1)` : `rgba(${currentColor},${ghostOpacity})`;
-        } else {
-          const [red = 0, green = 0, blue = 0] = currentColor.split(',').map(Number);
-          const intensity = Math.min(1, hoverIntensitiesRef.current[index] ?? 0);
-          fillColor = `rgba(${red},${green},${blue},${intensity})`;
-        }
-
-        context.fillStyle = fillColor;
+        const hoverIntensity = nextHoverIntensity(
+          currentHoverIntensity,
+          targetIntensity,
+          ghostOpacity,
+          deltaTime,
+        );
+        hoverIntensitiesRef.current[index] = hoverIntensity;
+        context.fillStyle = pixelFillColor({
+          pixel,
+          isLit: litPixelsRef.current.has(pixelKey),
+          hoverIntensity,
+          cursorIntensity: targetIntensity,
+          snakeHead,
+          currentColor,
+          background,
+          ghostOpacity,
+          sizeMultiplier,
+          config: finalConfig,
+        });
         context.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
       }
 
-      if (background !== 'light') {
-        for (let index = 0; index < trailRef.current.length; index += 1) {
-          const trailPixel = trailRef.current[index];
-          const glowIntensity = TRAIL_GLOW_VALUES[index];
-          if (!trailPixel || glowIntensity === undefined) {
-            continue;
-          }
-
-          const [brightRed, brightGreen, brightBlue] = brightenColor(
-            currentColor,
-            glowIntensity * 0.5,
-          );
-          context.fillStyle = `rgba(${brightRed},${brightGreen},${brightBlue},${glowIntensity})`;
-          context.fillRect(trailPixel.x * cellSize, trailPixel.y * cellSize, cellSize, cellSize);
-        }
-      }
+      if (background !== 'light') drawTrail(context, trailRef.current, currentColor, cellSize);
     },
     [background, cellSize, color, cursorIntensityFor, finalConfig],
   );
@@ -239,18 +301,13 @@ export function ShipfoxLoader({
 
       const path = getPathGenerator(animation)();
       const litRatio = litPixelsRef.current.size / foxPixels.length;
-      let moveDelay = BASE_MOVE_DELAY / speed;
-
-      if (animation === 'random') {
-        moveDelay = (BASE_MOVE_DELAY / speed) * (0.7 + litRatio * 1.1);
-      } else if (animation === 'vertical') {
-        const currentPixel = path[currentIndexRef.current];
-        const [currentX] = currentPixel ?? [0, 0];
-        moveDelay =
-          currentX >= 4 && currentX <= 7
-            ? (BASE_MOVE_DELAY / speed) * VERTICAL_CENTER_SLOWDOWN
-            : BASE_MOVE_DELAY / speed;
-      }
+      const moveDelay = animationMoveDelay(
+        animation,
+        path,
+        currentIndexRef.current,
+        litRatio,
+        speed,
+      );
 
       const currentTime = performance.now();
       if (!lastMoveTimeRef.current) {
@@ -258,27 +315,16 @@ export function ShipfoxLoader({
       }
 
       if (currentTime - lastMoveTimeRef.current > moveDelay) {
-        const currentPixel = path[currentIndexRef.current];
-        if (currentPixel) {
-          const [x, y] = currentPixel;
-          trailRef.current.unshift({x, y});
-          if (trailRef.current.length > 4) {
-            trailRef.current.pop();
-          }
-
-          const pixelKey = `${x},${y}`;
-          if (litPixelsRef.current.has(pixelKey)) {
-            litPixelsRef.current.delete(pixelKey);
-          } else {
-            litPixelsRef.current.add(pixelKey);
-          }
-
-          currentIndexRef.current = (currentIndexRef.current + 1) % path.length;
+        const nextIndex = advanceAnimation(
+          path,
+          currentIndexRef.current,
+          litPixelsRef.current,
+          trailRef.current,
+        );
+        if (nextIndex !== undefined) {
+          currentIndexRef.current = nextIndex;
           lastMoveTimeRef.current = currentTime;
-
-          if (currentIndexRef.current === 0) {
-            onAnimationComplete?.();
-          }
+          if (nextIndex === 0) onAnimationComplete?.();
         }
       }
 

--- a/libs/shared/react/ui/src/components/log/ansi.ts
+++ b/libs/shared/react/ui/src/components/log/ansi.ts
@@ -128,33 +128,70 @@ function applyCodes(style: AnsiStyle, raw: string): AnsiStyle {
   for (let i = 0; i < codes.length; i++) {
     const code = codes[i];
     if (code === undefined) continue;
-    if (code === 0) next = {};
-    else if (code === 1) next.bold = true;
-    else if (code === 2) next.dim = true;
-    else if (code === 3) next.italic = true;
-    else if (code === 4) next.underline = true;
-    else if (code === 22) {
-      next.bold = false;
-      next.dim = false;
-    } else if (code === 23) next.italic = false;
-    else if (code === 24) next.underline = false;
-    else if (code === 39) next.fg = undefined;
-    else if (code === 49) next.bg = undefined;
-    else if (FOREGROUND[code]) next.fg = FOREGROUND[code];
-    else if (BACKGROUND[code]) next.bg = BACKGROUND[code];
-    else if (code === 38 || code === 48) {
-      // Extended color: 256/truecolor is unsupported, so clear the channel it
-      // sets rather than leak the previous color, and consume its operands so
-      // the trailing numbers never render as literal text.
-      if (code === 38) next.fg = undefined;
-      else next.bg = undefined;
-      const mode = codes[i + 1];
-      if (mode === 5) i += 2;
-      else if (mode === 2) i += 4;
+    switch (code) {
+      case 0:
+        next = {};
+        break;
+      case 1:
+        next.bold = true;
+        break;
+      case 2:
+        next.dim = true;
+        break;
+      case 3:
+        next.italic = true;
+        break;
+      case 4:
+        next.underline = true;
+        break;
+      case 22:
+        next.bold = false;
+        next.dim = false;
+        break;
+      case 23:
+        next.italic = false;
+        break;
+      case 24:
+        next.underline = false;
+        break;
+      case 39:
+        next.fg = undefined;
+        break;
+      case 49:
+        next.bg = undefined;
+        break;
+      case 38:
+      case 48:
+        clearExtendedColor(next, code);
+        i += extendedColorOperandCount(codes[i + 1]);
+        break;
+      default:
+        applyNamedAnsiColor(next, code);
     }
   }
 
   return next;
+}
+
+function clearExtendedColor(style: AnsiStyle, code: number): void {
+  if (code === 38) style.fg = undefined;
+  else style.bg = undefined;
+}
+
+function extendedColorOperandCount(mode: number | undefined): number {
+  if (mode === 5) return 2;
+  if (mode === 2) return 4;
+  return 0;
+}
+
+function applyNamedAnsiColor(style: AnsiStyle, code: number): void {
+  const foreground = FOREGROUND[code];
+  if (foreground) {
+    style.fg = foreground;
+    return;
+  }
+  const background = BACKGROUND[code];
+  if (background) style.bg = background;
 }
 
 function styleToClassName(style: AnsiStyle): string {

--- a/libs/shared/react/ui/src/components/log/log-content.tsx
+++ b/libs/shared/react/ui/src/components/log/log-content.tsx
@@ -49,12 +49,12 @@ export function LogContent({
   const rowContext = useLogRowContext();
   const resolvedWrap = wrap ?? rowContext?.wrap ?? rowsContext.wrap;
 
-  const codeStyling =
-    variant === 'code'
-      ? resolvedWrap
-        ? 'whitespace-pre-wrap break-words pl-[2ch] [text-indent:-2ch]'
-        : 'w-full overflow-x-auto scrollbar whitespace-pre [mask-image:linear-gradient(to_right,#000_calc(100%_-_1.5rem),transparent)]'
-      : '';
+  let codeStyling = '';
+  if (variant === 'code') {
+    codeStyling = resolvedWrap
+      ? 'whitespace-pre-wrap break-words pl-[2ch] [text-indent:-2ch]'
+      : 'w-full overflow-x-auto scrollbar whitespace-pre [mask-image:linear-gradient(to_right,#000_calc(100%_-_1.5rem),transparent)]';
+  }
 
   const body =
     ansi && typeof children === 'string'

--- a/libs/shared/react/ui/src/components/logo/logo.tsx
+++ b/libs/shared/react/ui/src/components/logo/logo.tsx
@@ -18,7 +18,9 @@ export type LogoProps = Omit<ComponentProps<'img'>, 'src' | 'alt'> & {
 
 export function Logo({variant = 'wordmark', className, alt, ...props}: LogoProps) {
   const resolved = useResolvedTheme();
-  const src = variant === 'mark' ? markOrange : resolved === 'dark' ? wordmarkDark : wordmarkLight;
+  let src = wordmarkLight;
+  if (variant === 'mark') src = markOrange;
+  else if (resolved === 'dark') src = wordmarkDark;
   const sizeClass = variant === 'mark' ? 'h-20 w-auto' : 'h-24 w-auto';
 
   return (

--- a/libs/shared/react/ui/src/components/search/search-context.tsx
+++ b/libs/shared/react/ui/src/components/search/search-context.tsx
@@ -54,27 +54,11 @@ export function useKeyboardShortcut(shortcutKey: string | undefined, onTrigger: 
       const isCtrlKey = key.startsWith('ctrl+');
       const targetKey = key.replace(shortcutKeyRegex, '');
 
-      const shouldTrigger =
-        (isMetaKey && event.metaKey && event.key.toLowerCase() === targetKey) ||
-        (isCtrlKey && event.ctrlKey && event.key.toLowerCase() === targetKey) ||
-        (!isMetaKey &&
-          !isCtrlKey &&
-          event.key.toLowerCase() === targetKey &&
-          !event.metaKey &&
-          !event.ctrlKey);
+      const shouldTrigger = shortcutMatches(event, targetKey, isMetaKey, isCtrlKey);
 
       if (!shouldTrigger) return;
 
-      if (!isMetaKey && !isCtrlKey) {
-        const target = event.target as HTMLElement;
-        if (
-          target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable
-        ) {
-          return;
-        }
-      }
+      if (!isMetaKey && !isCtrlKey && isEditableTarget(event.target)) return;
 
       event.preventDefault();
       onTrigger();
@@ -83,4 +67,20 @@ export function useKeyboardShortcut(shortcutKey: string | undefined, onTrigger: 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [shortcutKey, onTrigger]);
+}
+
+function shortcutMatches(
+  event: KeyboardEvent,
+  targetKey: string,
+  isMetaKey: boolean,
+  isCtrlKey: boolean,
+): boolean {
+  if (isMetaKey) return event.metaKey && event.key.toLowerCase() === targetKey;
+  if (isCtrlKey) return event.ctrlKey && event.key.toLowerCase() === targetKey;
+  return event.key.toLowerCase() === targetKey && !event.metaKey && !event.ctrlKey;
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 }

--- a/libs/shared/react/ui/src/hooks/useResolvedTheme.ts
+++ b/libs/shared/react/ui/src/hooks/useResolvedTheme.ts
@@ -19,12 +19,10 @@ export function useResolvedTheme(): 'light' | 'dark' {
         mql.removeEventListener('change', callback);
       };
     },
-    (): 'light' | 'dark' =>
-      typeof window !== 'undefined' && theme === 'system'
-        ? window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light'
-        : 'light',
+    (): 'light' | 'dark' => {
+      if (typeof window === 'undefined' || theme !== 'system') return 'light';
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    },
     (): 'light' | 'dark' => 'light',
   );
 

--- a/libs/shared/react/ui/src/hooks/useShikiHighlight.ts
+++ b/libs/shared/react/ui/src/hooks/useShikiHighlight.ts
@@ -44,6 +44,7 @@ export function useShikiHighlight({
 }: UseShikiHighlightOptions): {highlightedCode: string; isLoading: boolean} {
   const [highlightedCode, setHighlightedCode] = useState<string>('');
   const [isLoading, setIsLoading] = useState(syntaxHighlighting);
+  const {light: lightTheme, dark: darkTheme} = themes;
 
   useEffect(() => {
     if (!syntaxHighlighting) {
@@ -54,38 +55,23 @@ export function useShikiHighlight({
     setIsLoading(true);
     let cancelled = false;
 
-    const loadHighlightedCode = async () => {
-      try {
-        const {codeToHtml} = await import('shiki');
-
-        const html = await codeToHtml(code, {
-          lang,
-          themes: {
-            light: themes.light,
-            dark: themes.dark,
-          },
-          defaultColor: resolvedTheme === 'dark' ? 'dark' : 'light',
-          ...(lang === 'diff' ? {transformers: [diffLineTransformer()]} : {}),
-        });
-
-        if (!cancelled) {
-          setHighlightedCode(html);
-          setIsLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setHighlightedCode('');
-          setIsLoading(false);
-        }
-      }
-    };
-
-    loadHighlightedCode();
+    void loadHighlightedCode(
+      {code, lang, themes: {light: lightTheme, dark: darkTheme}, resolvedTheme},
+      () => cancelled,
+      (html) => {
+        setHighlightedCode(html);
+        setIsLoading(false);
+      },
+      () => {
+        setHighlightedCode('');
+        setIsLoading(false);
+      },
+    );
 
     return () => {
       cancelled = true;
     };
-  }, [code, lang, themes.light, themes.dark, resolvedTheme, syntaxHighlighting]);
+  }, [code, lang, lightTheme, darkTheme, resolvedTheme, syntaxHighlighting]);
 
   return {highlightedCode, isLoading};
 }
@@ -110,6 +96,7 @@ export function useShikiHighlightMultiple({
 } {
   const [highlightedCodes, setHighlightedCodes] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(syntaxHighlighting);
+  const {light: lightTheme, dark: darkTheme} = themes;
 
   useEffect(() => {
     if (!syntaxHighlighting) {
@@ -120,46 +107,66 @@ export function useShikiHighlightMultiple({
     setIsLoading(true);
     let cancelled = false;
 
-    const loadHighlightedCode = async () => {
-      try {
-        const {codeToHtml} = await import('shiki');
-        const newHighlightedCodes: Record<string, string> = {};
-
-        for (const [command, val] of Object.entries(codes)) {
-          if (cancelled) {
-            return;
-          }
-
-          const highlighted = await codeToHtml(val, {
-            lang,
-            themes: {
-              light: themes.light,
-              dark: themes.dark,
-            },
-            defaultColor: resolvedTheme === 'dark' ? 'dark' : 'light',
-          });
-
-          newHighlightedCodes[command] = highlighted;
-        }
-
-        if (!cancelled) {
-          setHighlightedCodes(newHighlightedCodes);
-          setIsLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setHighlightedCodes({});
-          setIsLoading(false);
-        }
-      }
-    };
-
-    loadHighlightedCode();
+    void loadHighlightedCodes(
+      {codes, lang, themes: {light: lightTheme, dark: darkTheme}, resolvedTheme},
+      () => cancelled,
+      (result) => {
+        setHighlightedCodes(result);
+        setIsLoading(false);
+      },
+      () => {
+        setHighlightedCodes({});
+        setIsLoading(false);
+      },
+    );
 
     return () => {
       cancelled = true;
     };
-  }, [resolvedTheme, lang, themes.light, themes.dark, codes, syntaxHighlighting]);
+  }, [resolvedTheme, lang, lightTheme, darkTheme, codes, syntaxHighlighting]);
 
   return {highlightedCodes, isLoading};
+}
+
+async function loadHighlightedCode(
+  options: Pick<UseShikiHighlightOptions, 'code' | 'lang' | 'themes' | 'resolvedTheme'>,
+  cancelled: () => boolean,
+  onLoaded: (html: string) => void,
+  onError: () => void,
+): Promise<void> {
+  try {
+    const {codeToHtml} = await import('shiki');
+    const html = await codeToHtml(options.code, {
+      lang: options.lang,
+      themes: options.themes,
+      defaultColor: options.resolvedTheme === 'dark' ? 'dark' : 'light',
+      ...(options.lang === 'diff' ? {transformers: [diffLineTransformer()]} : {}),
+    });
+    if (!cancelled()) onLoaded(html);
+  } catch {
+    if (!cancelled()) onError();
+  }
+}
+
+async function loadHighlightedCodes(
+  options: Pick<UseShikiHighlightMultipleOptions, 'codes' | 'lang' | 'themes' | 'resolvedTheme'>,
+  cancelled: () => boolean,
+  onLoaded: (html: Record<string, string>) => void,
+  onError: () => void,
+): Promise<void> {
+  try {
+    const {codeToHtml} = await import('shiki');
+    const highlightedCodes: Record<string, string> = {};
+    for (const [command, value] of Object.entries(options.codes)) {
+      if (cancelled()) return;
+      highlightedCodes[command] = await codeToHtml(value, {
+        lang: options.lang,
+        themes: options.themes,
+        defaultColor: options.resolvedTheme === 'dark' ? 'dark' : 'light',
+      });
+    }
+    if (!cancelled()) onLoaded(highlightedCodes);
+  } catch {
+    if (!cancelled()) onError();
+  }
 }

--- a/libs/shared/react/ui/src/utils/browser-storage.ts
+++ b/libs/shared/react/ui/src/utils/browser-storage.ts
@@ -96,14 +96,10 @@ function resolveBrowserStorageKey<T>(
   if (definition.principalScope === 'global') return definition.key;
 
   const resolvedScope = typeof scope === 'function' ? scope() : scope;
-  const scopeId =
-    definition.principalScope === 'principal'
-      ? resolvedScope && 'principalId' in resolvedScope
-        ? resolvedScope.principalId
-        : undefined
-      : resolvedScope && 'workspaceId' in resolvedScope
-        ? resolvedScope.workspaceId
-        : undefined;
+  let scopeId: string | undefined;
+  if (definition.principalScope === 'principal') {
+    if (resolvedScope && 'principalId' in resolvedScope) scopeId = resolvedScope.principalId;
+  } else if (resolvedScope && 'workspaceId' in resolvedScope) scopeId = resolvedScope.workspaceId;
 
   if (!isValidBrowserStorageScopeId(scopeId)) return undefined;
   return `${definition.key}.${definition.principalScope}.${encodeURIComponent(scopeId)}`;

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -134,120 +134,154 @@ type WorkflowDocumentToolWithValidationTask =
   | {kind: 'end'; value: object; byteLength: number}
   | {kind: 'bytes'; byteLength: number};
 
+interface WorkflowDocumentToolWithValidationState {
+  readonly activeObjects: Set<object>;
+  readonly tasks: WorkflowDocumentToolWithValidationTask[];
+  serializedBytes: number;
+}
+
 function validateWorkflowDocumentToolWith(
   withValue: Readonly<Record<string, unknown>>,
   ctx: z.RefinementCtx,
 ) {
-  const activeObjects = new Set<object>();
-  const tasks: WorkflowDocumentToolWithValidationTask[] = [
-    {kind: 'value', value: withValue, depth: 1, path: []},
-  ];
-  let serializedBytes = 0;
-
-  const addSerializedBytes = (byteLength: number): boolean => {
-    serializedBytes += byteLength;
-    if (serializedBytes <= WORKFLOW_DOCUMENT_TOOL_WITH_MAX_SERIALIZED_BYTES) return true;
-
-    ctx.addIssue({
-      code: 'custom',
-      message: `Tool \`with\` cannot serialize to more than ${WORKFLOW_DOCUMENT_TOOL_WITH_MAX_SERIALIZED_BYTES} bytes.`,
-    });
-    return false;
+  const state: WorkflowDocumentToolWithValidationState = {
+    activeObjects: new Set<object>(),
+    tasks: [{kind: 'value', value: withValue, depth: 1, path: []}],
+    serializedBytes: 0,
   };
 
-  while (tasks.length > 0) {
-    const task = tasks.pop();
+  while (state.tasks.length > 0) {
+    const task = state.tasks.pop();
     if (task === undefined) continue;
-
-    if (task.kind === 'bytes') {
-      if (!addSerializedBytes(task.byteLength)) return;
-      continue;
-    }
-
-    if (task.kind === 'end') {
-      activeObjects.delete(task.value);
-      if (!addSerializedBytes(task.byteLength)) return;
-      continue;
-    }
-
-    const {value, depth, path} = task;
-    if (value === null) {
-      if (!addSerializedBytes(4)) return;
-      continue;
-    }
-    if (typeof value === 'string' || typeof value === 'boolean') {
-      if (!addSerializedBytes(jsonPrimitiveByteLength(value))) return;
-      continue;
-    }
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value)) {
-        ctx.addIssue({
-          code: 'custom',
-          path,
-          message: 'Tool `with` values must be JSON-compatible.',
-        });
-        return;
-      }
-      if (!addSerializedBytes(jsonPrimitiveByteLength(value))) return;
-      continue;
-    }
-    if (typeof value !== 'object' || value === null) {
-      ctx.addIssue({
-        code: 'custom',
-        path,
-        message: 'Tool `with` values must be JSON-compatible.',
-      });
-      return;
-    }
-
-    if (depth > WORKFLOW_DOCUMENT_TOOL_WITH_MAX_DEPTH) {
-      ctx.addIssue({
-        code: 'custom',
-        message: `Tool \`with\` cannot be nested deeper than ${WORKFLOW_DOCUMENT_TOOL_WITH_MAX_DEPTH} levels.`,
-      });
-      return;
-    }
-    if (activeObjects.has(value)) {
-      ctx.addIssue({
-        code: 'custom',
-        path,
-        message: 'Tool `with` values must be a JSON tree.',
-      });
-      return;
-    }
-
-    activeObjects.add(value);
-    if (Array.isArray(value)) {
-      if (!addSerializedBytes(1)) return;
-      tasks.push({kind: 'end', value, byteLength: 1});
-      for (let index = value.length - 1; index >= 0; index -= 1) {
-        tasks.push({kind: 'value', value: value[index], depth: depth + 1, path: [...path, index]});
-        if (index > 0) tasks.push({kind: 'bytes', byteLength: 1});
-      }
-      continue;
-    }
-
-    if (!isJsonRecord(value)) {
-      ctx.addIssue({
-        code: 'custom',
-        path,
-        message: 'Tool `with` values must be a JSON tree.',
-      });
-      return;
-    }
-
-    if (!addSerializedBytes(1)) return;
-    tasks.push({kind: 'end', value, byteLength: 1});
-    const entries = Object.entries(value);
-    for (let index = entries.length - 1; index >= 0; index -= 1) {
-      const entry = entries[index];
-      if (entry === undefined) continue;
-      const [key, child] = entry;
-      tasks.push({kind: 'value', value: child, depth: depth + 1, path: [...path, key]});
-      tasks.push({kind: 'bytes', byteLength: jsonPrimitiveByteLength(key) + 1});
-      if (index > 0) tasks.push({kind: 'bytes', byteLength: 1});
-    }
+    if (!validateWorkflowDocumentToolWithTask(task, state, ctx)) return;
   }
+}
+
+function validateWorkflowDocumentToolWithTask(
+  task: WorkflowDocumentToolWithValidationTask,
+  state: WorkflowDocumentToolWithValidationState,
+  ctx: z.RefinementCtx,
+): boolean {
+  if (task.kind === 'bytes') return addWorkflowDocumentToolWithBytes(task.byteLength, state, ctx);
+  if (task.kind === 'end') {
+    state.activeObjects.delete(task.value);
+    return addWorkflowDocumentToolWithBytes(task.byteLength, state, ctx);
+  }
+  return validateWorkflowDocumentToolWithValue(task, state, ctx);
+}
+
+function addWorkflowDocumentToolWithBytes(
+  byteLength: number,
+  state: WorkflowDocumentToolWithValidationState,
+  ctx: z.RefinementCtx,
+): boolean {
+  state.serializedBytes += byteLength;
+  if (state.serializedBytes <= WORKFLOW_DOCUMENT_TOOL_WITH_MAX_SERIALIZED_BYTES) return true;
+  ctx.addIssue({
+    code: 'custom',
+    message: `Tool \`with\` cannot serialize to more than ${WORKFLOW_DOCUMENT_TOOL_WITH_MAX_SERIALIZED_BYTES} bytes.`,
+  });
+  return false;
+}
+
+function validateWorkflowDocumentToolWithValue(
+  task: Extract<WorkflowDocumentToolWithValidationTask, {kind: 'value'}>,
+  state: WorkflowDocumentToolWithValidationState,
+  ctx: z.RefinementCtx,
+): boolean {
+  const {value, depth, path} = task;
+  if (value === null) return addWorkflowDocumentToolWithBytes(4, state, ctx);
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return addWorkflowDocumentToolWithBytes(jsonPrimitiveByteLength(value), state, ctx);
+  }
+  if (typeof value === 'number')
+    return validateWorkflowDocumentToolWithNumber(value, path, state, ctx);
+  if (typeof value !== 'object') return rejectWorkflowDocumentToolWithValue(path, ctx);
+  if (depth > WORKFLOW_DOCUMENT_TOOL_WITH_MAX_DEPTH) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `Tool \`with\` cannot be nested deeper than ${WORKFLOW_DOCUMENT_TOOL_WITH_MAX_DEPTH} levels.`,
+    });
+    return false;
+  }
+  if (state.activeObjects.has(value)) {
+    ctx.addIssue({code: 'custom', path, message: 'Tool `with` values must be a JSON tree.'});
+    return false;
+  }
+
+  state.activeObjects.add(value);
+  if (Array.isArray(value))
+    return queueWorkflowDocumentToolWithArray(value, depth, path, state, ctx);
+  if (!isJsonRecord(value)) return rejectWorkflowDocumentToolWithTree(path, ctx);
+  return queueWorkflowDocumentToolWithRecord(value, depth, path, state, ctx);
+}
+
+function validateWorkflowDocumentToolWithNumber(
+  value: number,
+  path: (string | number)[],
+  state: WorkflowDocumentToolWithValidationState,
+  ctx: z.RefinementCtx,
+): boolean {
+  if (!Number.isFinite(value)) return rejectWorkflowDocumentToolWithValue(path, ctx);
+  return addWorkflowDocumentToolWithBytes(jsonPrimitiveByteLength(value), state, ctx);
+}
+
+function rejectWorkflowDocumentToolWithValue(
+  path: (string | number)[],
+  ctx: z.RefinementCtx,
+): false {
+  ctx.addIssue({code: 'custom', path, message: 'Tool `with` values must be JSON-compatible.'});
+  return false;
+}
+
+function rejectWorkflowDocumentToolWithTree(
+  path: (string | number)[],
+  ctx: z.RefinementCtx,
+): false {
+  ctx.addIssue({code: 'custom', path, message: 'Tool `with` values must be a JSON tree.'});
+  return false;
+}
+
+function queueWorkflowDocumentToolWithArray(
+  value: unknown[],
+  depth: number,
+  path: (string | number)[],
+  state: WorkflowDocumentToolWithValidationState,
+  ctx: z.RefinementCtx,
+): boolean {
+  if (!addWorkflowDocumentToolWithBytes(1, state, ctx)) return false;
+  state.tasks.push({kind: 'end', value, byteLength: 1});
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    state.tasks.push({
+      kind: 'value',
+      value: value[index],
+      depth: depth + 1,
+      path: [...path, index],
+    });
+    if (index > 0) state.tasks.push({kind: 'bytes', byteLength: 1});
+  }
+  return true;
+}
+
+function queueWorkflowDocumentToolWithRecord(
+  value: Record<string, unknown>,
+  depth: number,
+  path: (string | number)[],
+  state: WorkflowDocumentToolWithValidationState,
+  ctx: z.RefinementCtx,
+): boolean {
+  if (!addWorkflowDocumentToolWithBytes(1, state, ctx)) return false;
+  state.tasks.push({kind: 'end', value, byteLength: 1});
+  const entries = Object.entries(value);
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry === undefined) continue;
+    const [key, child] = entry;
+    state.tasks.push({kind: 'value', value: child, depth: depth + 1, path: [...path, key]});
+    state.tasks.push({kind: 'bytes', byteLength: jsonPrimitiveByteLength(key) + 1});
+    if (index > 0) state.tasks.push({kind: 'bytes', byteLength: 1});
+  }
+  return true;
 }
 
 function jsonPrimitiveByteLength(value: string | number | boolean): number {
@@ -597,12 +631,12 @@ export const workflowDocumentCheckoutSchema = z
   })
   .superRefine((checkout, ctx) => {
     for (const validationIssue of checkoutTargetValidationIssues(checkout)) {
-      const message =
-        validationIssue.kind === 'project-with-connection'
-          ? '"connection" cannot be combined with "project".'
-          : validationIssue.kind === 'project-with-repository'
-            ? '"repository" cannot be combined with "project".'
-            : '"connection" requires "repository".';
+      let message = '"connection" requires "repository".';
+      if (validationIssue.kind === 'project-with-connection') {
+        message = '"connection" cannot be combined with "project".';
+      } else if (validationIssue.kind === 'project-with-repository') {
+        message = '"repository" cannot be combined with "project".';
+      }
       ctx.addIssue({
         code: 'custom',
         path: [validationIssue.path],
@@ -729,25 +763,35 @@ function findWorkflowSessionKeyTemplateClose(source: string, openerIndex: number
       continue;
     }
 
-    if (source.startsWith('//', index)) {
-      const newline = source.indexOf('\n', index + 2);
-      index = newline === -1 ? source.length : newline;
+    const commentEnd = workflowSessionKeyCommentEnd(source, index);
+    if (commentEnd !== undefined) {
+      index = commentEnd;
       continue;
     }
 
     if (depth === 0 && source.startsWith('}}', index)) return index;
 
-    const char = source[index];
-    if (char === '(' || char === '[' || char === '{') {
-      depth += 1;
-    } else if ((char === ')' || char === ']' || char === '}') && depth > 0) {
-      depth -= 1;
-    }
+    depth = workflowSessionKeyDepthAfterCharacter(source[index], depth);
 
     index += 1;
   }
 
   return -1;
+}
+
+function workflowSessionKeyCommentEnd(source: string, index: number): number | undefined {
+  if (!source.startsWith('//', index)) return undefined;
+  const newline = source.indexOf('\n', index + 2);
+  return newline === -1 ? source.length : newline;
+}
+
+function workflowSessionKeyDepthAfterCharacter(
+  character: string | undefined,
+  depth: number,
+): number {
+  if (character === '(' || character === '[' || character === '{') return depth + 1;
+  if ((character === ')' || character === ']' || character === '}') && depth > 0) return depth - 1;
+  return depth;
 }
 
 function scanWorkflowSessionKeyStringLiteral(source: string, index: number): number | null {
@@ -903,117 +947,133 @@ type WorkflowDocumentStepSchemaOutput = Omit<
 > & {
   outputs?: WorkflowDocumentStepOutputs;
 };
+type WorkflowDocumentStepInput = z.infer<typeof workflowDocumentStepBaseSchema>;
 
 export const workflowDocumentStepSchema = workflowDocumentStepBaseSchema
-  .superRefine((step, ctx) => {
-    if (step.agent !== undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['agent'],
-        message: 'The "agent" keyword is reserved for a future step kind and is not supported yet.',
-      });
-      return;
-    }
-
-    const reservedToolField =
-      step.tool !== undefined ? 'tool' : step.connection !== undefined ? 'connection' : undefined;
-    const reservedToolValue =
-      reservedToolField === 'tool'
-        ? step.tool
-        : reservedToolField === 'connection'
-          ? step.connection
-          : undefined;
-    if (reservedToolValue !== undefined && !WORKFLOW_LITERAL_NAME_PATTERN.test(reservedToolValue)) {
-      // The field-level literal-name check already rejected the interpolated
-      // value; skip the reserved-field issue so one defect does not report
-      // twice at the same path.
-      return;
-    }
-    if (reservedToolField !== undefined || step.with !== undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: [reservedToolField ?? 'with'],
-        message: 'Tool steps are not available yet.',
-      });
-      return;
-    }
-
-    if (step.outputs !== undefined && stepOutputsAreMappingForm(step.outputs)) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['outputs'],
-        message: 'The `outputs` mapping form is reserved for tool steps.',
-      });
-    }
-
-    if (step.checkout !== undefined) {
-      if (step.run !== undefined) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['run'],
-          message: '"run" is not valid on a checkout step.',
-        });
-      }
-      for (const key of workflowDocumentAgentStepFields) {
-        if (step[key] !== undefined) {
-          ctx.addIssue({
-            code: 'custom',
-            path: [key],
-            message: `"${key}" is not valid on a checkout step.`,
-          });
-        }
-      }
-      if (step.env !== undefined) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['env'],
-          message: '"env" is not valid on a checkout step.',
-        });
-      }
-      return;
-    }
-
-    if (step.run !== undefined) {
-      for (const key of workflowDocumentAgentStepFields) {
-        if (step[key] !== undefined) {
-          ctx.addIssue({
-            code: 'custom',
-            path: [key],
-            message: `"${key}" is not valid on a run step.`,
-          });
-        }
-      }
-      return;
-    }
-
-    const isAgent = workflowDocumentAgentStepFields.some((field) => step[field] !== undefined);
-
-    if (!isAgent) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'A step must define either "run", an agent "prompt", or "checkout".',
-      });
-      return;
-    }
-
-    if (step.env !== undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['env'],
-        message: '"env" is supported only on run steps.',
-      });
-    }
-    if (step.prompt === undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['prompt'],
-        message: 'An agent step requires "prompt".',
-      });
-    }
-  })
+  .superRefine(validateWorkflowDocumentStep)
   .transform<WorkflowDocumentStepSchemaOutput>(({outputs, ...step}) =>
     outputs === undefined ? step : {...step, outputs: outputs as WorkflowDocumentStepOutputs},
   );
+
+function validateWorkflowDocumentStep(step: WorkflowDocumentStepInput, ctx: z.RefinementCtx): void {
+  if (validateReservedWorkflowDocumentStepFields(step, ctx)) return;
+  validateWorkflowDocumentStepOutputs(step, ctx);
+  if (step.checkout !== undefined) {
+    validateWorkflowDocumentCheckoutStep(step, ctx);
+    return;
+  }
+  if (step.run !== undefined) {
+    addWorkflowDocumentInvalidAgentFields(step, ctx, 'run');
+    return;
+  }
+  validateWorkflowDocumentAgentStep(step, ctx);
+}
+
+function validateReservedWorkflowDocumentStepFields(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+): boolean {
+  if (step.agent !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['agent'],
+      message: 'The "agent" keyword is reserved for a future step kind and is not supported yet.',
+    });
+    return true;
+  }
+  const reservedTool = reservedWorkflowDocumentToolField(step);
+  if (
+    reservedTool?.value !== undefined &&
+    !WORKFLOW_LITERAL_NAME_PATTERN.test(reservedTool.value)
+  ) {
+    // The field-level literal-name check already rejected the interpolated
+    // value; skip the reserved-field issue so one defect does not report twice.
+    return true;
+  }
+  if (reservedTool === undefined && step.with === undefined) return false;
+  ctx.addIssue({
+    code: 'custom',
+    path: [reservedTool?.field ?? 'with'],
+    message: 'Tool steps are not available yet.',
+  });
+  return true;
+}
+
+function reservedWorkflowDocumentToolField(
+  step: WorkflowDocumentStepInput,
+): {readonly field: 'tool' | 'connection'; readonly value: string} | undefined {
+  if (step.tool !== undefined) return {field: 'tool', value: step.tool};
+  if (step.connection !== undefined) return {field: 'connection', value: step.connection};
+  return undefined;
+}
+
+function validateWorkflowDocumentStepOutputs(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+): void {
+  if (step.outputs === undefined || !stepOutputsAreMappingForm(step.outputs)) return;
+  ctx.addIssue({
+    code: 'custom',
+    path: ['outputs'],
+    message: 'The `outputs` mapping form is reserved for tool steps.',
+  });
+}
+
+function validateWorkflowDocumentCheckoutStep(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+): void {
+  if (step.run !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['run'],
+      message: '"run" is not valid on a checkout step.',
+    });
+  }
+  addWorkflowDocumentInvalidAgentFields(step, ctx, 'checkout');
+  if (step.env !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['env'],
+      message: '"env" is not valid on a checkout step.',
+    });
+  }
+}
+
+function addWorkflowDocumentInvalidAgentFields(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+  stepKind: 'checkout' | 'run',
+): void {
+  for (const key of workflowDocumentAgentStepFields) {
+    if (step[key] === undefined) continue;
+    ctx.addIssue({
+      code: 'custom',
+      path: [key],
+      message: `"${key}" is not valid on a ${stepKind} step.`,
+    });
+  }
+}
+
+function validateWorkflowDocumentAgentStep(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+): void {
+  const isAgent = workflowDocumentAgentStepFields.some((field) => step[field] !== undefined);
+  if (!isAgent) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'A step must define either "run", an agent "prompt", or "checkout".',
+    });
+    return;
+  }
+  if (step.env !== undefined) {
+    ctx.addIssue({code: 'custom', path: ['env'], message: '"env" is supported only on run steps.'});
+  }
+  if (step.prompt === undefined) {
+    ctx.addIssue({code: 'custom', path: ['prompt'], message: 'An agent step requires "prompt".'});
+  }
+}
 
 const workflowDocumentJobOutputsSchema = nonEmptyRecordSchema(z.string().min(1)).superRefine(
   (outputs, ctx) => {

--- a/tools/api-architecture-policy/src/platform-architecture-policy.ts
+++ b/tools/api-architecture-policy/src/platform-architecture-policy.ts
@@ -3,6 +3,7 @@ import {createRequire} from 'node:module';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {
+  type ArchitectureClass,
   type ArchitectureClassConfiguration,
   type ArchitectureFacts,
   architecturePolicySchemaVersion,
@@ -89,7 +90,9 @@ export interface PlatformArchitecturePolicyOptions {
 }
 
 function compareText(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function toRepositoryPath(filePath: string): string {
@@ -185,6 +188,13 @@ function packageFactForPath(
   const isPolicyParticipant =
     packagePath.startsWith('libs/api/') || packagePath.startsWith('libs/shared/');
   const hasManifestName = typeof manifest.name === 'string' && manifest.name.length > 0;
+  let architectureClass: ArchitectureClass | null = null;
+  if (isPolicyParticipant) {
+    architectureClass =
+      hasManifestName && classification?.architectureClass
+        ? classification.architectureClass
+        : 'unclassified';
+  }
   return {
     schemaVersion: architecturePolicySchemaVersion,
     name: manifest.name ?? `workspace:${packagePath}`,
@@ -193,11 +203,7 @@ function packageFactForPath(
     origin: 'local',
     policyParticipant: isPolicyParticipant,
     realm: isPolicyParticipant ? platformRealm : null,
-    architectureClass: isPolicyParticipant
-      ? hasManifestName && classification?.architectureClass
-        ? classification.architectureClass
-        : 'unclassified'
-      : null,
+    architectureClass,
     boundedContext: isPolicyParticipant ? (classification?.boundedContext ?? null) : null,
   };
 }
@@ -265,25 +271,26 @@ function exportSubpaths(exportsValue: unknown): Array<[string, unknown]> {
 
 function resolveExportTarget(value: unknown): string | null {
   if (typeof value === 'string') return value;
-  if (Array.isArray(value)) {
-    for (const candidate of value) {
-      const resolved = resolveExportTarget(candidate);
-      if (resolved) return resolved;
-    }
-    return null;
-  }
+  if (Array.isArray(value)) return resolveFirstExportTarget(value);
   if (typeof value !== 'object' || value === null) return null;
-  const records = value as Record<string, unknown>;
+  return resolveExportTargetRecord(value as Record<string, unknown>);
+}
+
+function resolveFirstExportTarget(values: readonly unknown[]): string | null {
+  for (const candidate of values) {
+    const resolved = resolveExportTarget(candidate);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+function resolveExportTargetRecord(records: Record<string, unknown>): string | null {
   for (const condition of ['workspace-source', 'types', 'import', 'require', 'default']) {
     if (!(condition in records)) continue;
     const resolved = resolveExportTarget(records[condition]);
     if (resolved) return resolved;
   }
-  for (const candidate of Object.values(records)) {
-    const resolved = resolveExportTarget(candidate);
-    if (resolved) return resolved;
-  }
-  return null;
+  return resolveFirstExportTarget(Object.values(records));
 }
 
 function sourceTargetCandidates(target: string): string[] {

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -319,16 +319,7 @@ function addSnapshotObjects(
   }
 
   for (const [qualifiedName, table] of Object.entries(snapshot.tables ?? {})) {
-    addObject(objects, table.name || lastIdentifier(qualifiedName), 'table', unit);
-    for (const index of Object.values(table.indexes ?? {})) {
-      if (index.name) addObject(objects, index.name, 'index', unit);
-    }
-    for (const constraint of Object.values(table.uniqueConstraints ?? {})) {
-      if (constraint.name) addObject(objects, constraint.name, 'constraint', unit);
-    }
-    for (const constraint of Object.values(table.checkConstraints ?? {})) {
-      if (constraint.name) addObject(objects, constraint.name, 'constraint', unit);
-    }
+    addSnapshotTableObjects(objects, qualifiedName, table, unit);
   }
   for (const [qualifiedName, enumValue] of Object.entries(snapshot.enums ?? {})) {
     addObject(objects, enumValue.name || lastIdentifier(qualifiedName), 'enum', unit);
@@ -338,6 +329,34 @@ function addSnapshotObjects(
   }
   for (const [qualifiedName, view] of Object.entries(snapshot.views ?? {})) {
     addObject(objects, view.name || lastIdentifier(qualifiedName), 'view', unit);
+  }
+}
+
+function addSnapshotTableObjects(
+  objects: Map<string, DatabaseObject>,
+  qualifiedName: string,
+  table: SnapshotTable,
+  unit: DatabaseMigrationUnit,
+): void {
+  addObject(objects, table.name || lastIdentifier(qualifiedName), 'table', unit);
+  addSnapshotNamedObjects(objects, Object.values(table.indexes ?? {}), 'index', unit);
+  addSnapshotNamedObjects(
+    objects,
+    Object.values(table.uniqueConstraints ?? {}),
+    'constraint',
+    unit,
+  );
+  addSnapshotNamedObjects(objects, Object.values(table.checkConstraints ?? {}), 'constraint', unit);
+}
+
+function addSnapshotNamedObjects(
+  objects: Map<string, DatabaseObject>,
+  values: readonly SnapshotNamedObject[],
+  kind: DatabaseObject['kind'],
+  unit: DatabaseMigrationUnit,
+): void {
+  for (const value of values) {
+    if (value.name) addObject(objects, value.name, kind, unit);
   }
 }
 
@@ -651,24 +670,38 @@ function parseSourceImports(source: string): {
   const directTableCreatorFunctions = new Set<string>();
   const localTableFunctions = new Set<string>();
   for (const match of source.matchAll(/import\s+\{([^}]+)\}\s+from\s+["']([^"']+)["']/gu)) {
-    const imports = match[1] ?? '';
-    const moduleName = match[2] ?? '';
-    for (const item of imports.split(',')) {
-      const [originalValue, localValue] = item.trim().split(importAliasExpression);
-      const original = originalValue?.trim();
-      const local = localValue?.trim() || original;
-      if (!original || !local) continue;
-      if (moduleName === 'drizzle-orm/pg-core' && original === 'pgTable') {
-        directTableFunctions.add(local);
-      } else if (moduleName === 'drizzle-orm/pg-core' && original === 'pgTableCreator') {
-        directTableCreatorFunctions.add(local);
-      } else if (moduleName.endsWith('/common.js') && original === 'pgTable') {
-        localTableFunctions.add(local);
-      }
-    }
+    addSourceImportBindings(
+      match[1] ?? '',
+      match[2] ?? '',
+      directTableFunctions,
+      directTableCreatorFunctions,
+      localTableFunctions,
+    );
   }
   if (registeredFactoryExpression.test(source)) localTableFunctions.add('pgTable');
   return {directTableFunctions, directTableCreatorFunctions, localTableFunctions};
+}
+
+function addSourceImportBindings(
+  imports: string,
+  moduleName: string,
+  directTableFunctions: Set<string>,
+  directTableCreatorFunctions: Set<string>,
+  localTableFunctions: Set<string>,
+): void {
+  for (const item of imports.split(',')) {
+    const [originalValue, localValue] = item.trim().split(importAliasExpression);
+    const original = originalValue?.trim();
+    const local = localValue?.trim() || original;
+    if (!original || !local) continue;
+    if (moduleName === 'drizzle-orm/pg-core' && original === 'pgTable') {
+      directTableFunctions.add(local);
+    } else if (moduleName === 'drizzle-orm/pg-core' && original === 'pgTableCreator') {
+      directTableCreatorFunctions.add(local);
+    } else if (moduleName.endsWith('/common.js') && original === 'pgTable') {
+      localTableFunctions.add(local);
+    }
+  }
 }
 
 function firstCallString(
@@ -718,54 +751,93 @@ function auditFactories(
     for (const match of file.source.matchAll(
       new RegExp(`\\b${escapeRegExp(functionName)}\\s*\\(`, 'gu'),
     )) {
-      const callIndex = match.index ?? 0;
-      const isRegisteredFactory =
-        file.path.endsWith('/schema/common.ts') && registeredFactoryExpression.test(file.source);
-      if (isRegisteredFactory) continue;
-      const body = file.source.slice(callIndex, callIndex + factoryBodyLookaheadLength);
-      const prefix = body.match(inlineFactoryPrefixExpression)?.[1] ?? '';
-      const namespace = prefix.replace(trailingUnderscoreExpression, '');
-      const foreignOwner = namespace ? context.namespaceOwners.get(namespace) : undefined;
-      const factoryBoundary = factoryRuleAndBoundary(fileContext, foreignOwner, namespace);
-      addFinding(
-        findings,
-        context,
-        file.path,
-        file.source,
-        callIndex,
-        functionName,
-        factoryBoundary.rule,
-        factoryBoundary.suggestedBoundary,
-        fileContext,
-      );
-      const bindingExpression = new RegExp(
-        `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*${escapeRegExp(functionName)}\\s*\\(`,
-        'gu',
-      );
-      const tableBinding = [...file.source.matchAll(bindingExpression)].find(
-        (binding) => (binding.index ?? 0) <= callIndex,
-      )?.[1];
-      if (!tableBinding || !prefix) continue;
-      const tableExpression = new RegExp(`\\b${escapeRegExp(tableBinding)}\\s*\\(`, 'gu');
-      for (const tableMatch of file.source.matchAll(tableExpression)) {
-        const tableIndex = tableMatch.index ?? 0;
-        if (tableIndex <= callIndex) continue;
-        const firstArgument = firstCallString(file.source, tableIndex + tableMatch[0].length - 1);
-        if (!firstArgument) continue;
-        const object = `${prefix}${firstArgument.value}`;
-        addFinding(
-          findings,
-          context,
-          file.path,
-          file.source,
-          firstArgument.index,
-          object,
-          factoryBoundary.rule,
-          factoryBoundary.suggestedBoundary,
-          fileContext,
-        );
-      }
+      auditFactoryCall(findings, context, file, fileContext, functionName, match);
     }
+  }
+}
+
+function auditFactoryCall(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  functionName: string,
+  match: RegExpMatchArray,
+): void {
+  const callIndex = match.index ?? 0;
+  const isRegisteredFactory =
+    file.path.endsWith('/schema/common.ts') && registeredFactoryExpression.test(file.source);
+  if (isRegisteredFactory) return;
+  const body = file.source.slice(callIndex, callIndex + factoryBodyLookaheadLength);
+  const prefix = body.match(inlineFactoryPrefixExpression)?.[1] ?? '';
+  const namespace = prefix.replace(trailingUnderscoreExpression, '');
+  const foreignOwner = namespace ? context.namespaceOwners.get(namespace) : undefined;
+  const factoryBoundary = factoryRuleAndBoundary(fileContext, foreignOwner, namespace);
+  addFinding(
+    findings,
+    context,
+    file.path,
+    file.source,
+    callIndex,
+    functionName,
+    factoryBoundary.rule,
+    factoryBoundary.suggestedBoundary,
+    fileContext,
+  );
+  const tableBinding = factoryTableBinding(file.source, functionName, callIndex);
+  if (tableBinding && prefix) {
+    auditFactoryTableCalls(
+      findings,
+      context,
+      file,
+      fileContext,
+      tableBinding,
+      callIndex,
+      prefix,
+      factoryBoundary,
+    );
+  }
+}
+
+function factoryTableBinding(
+  source: string,
+  functionName: string,
+  callIndex: number,
+): string | undefined {
+  const expression = new RegExp(
+    `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*${escapeRegExp(functionName)}\\s*\\(`,
+    'gu',
+  );
+  return [...source.matchAll(expression)].find((binding) => (binding.index ?? 0) <= callIndex)?.[1];
+}
+
+function auditFactoryTableCalls(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  tableBinding: string,
+  factoryCallIndex: number,
+  prefix: string,
+  factoryBoundary: ReturnType<typeof factoryRuleAndBoundary>,
+): void {
+  const tableExpression = new RegExp(`\\b${escapeRegExp(tableBinding)}\\s*\\(`, 'gu');
+  for (const tableMatch of file.source.matchAll(tableExpression)) {
+    const tableIndex = tableMatch.index ?? 0;
+    if (tableIndex <= factoryCallIndex) continue;
+    const firstArgument = firstCallString(file.source, tableIndex + tableMatch[0].length - 1);
+    if (!firstArgument) continue;
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      firstArgument.index,
+      `${prefix}${firstArgument.value}`,
+      factoryBoundary.rule,
+      factoryBoundary.suggestedBoundary,
+      fileContext,
+    );
   }
 }
 
@@ -785,69 +857,90 @@ function auditSourceDeclarations(
   ]);
 
   for (const functionName of tableFunctions) {
-    for (const match of file.source.matchAll(
-      new RegExp(`\\b${escapeRegExp(functionName)}\\s*\\(`, 'gu'),
-    )) {
-      const callIndex = match.index ?? 0;
-      if (functionName === 'pgTableCreator') continue;
-      const firstArgument = firstCallString(file.source, callIndex + match[0].length - 1);
-      if (!firstArgument) continue;
-      const isDirect = imports.directTableFunctions.has(functionName);
-      const physicalName = isDirect
-        ? firstArgument.value
-        : factoryPhysicalName(factory, fileContext.namespace, firstArgument.value);
-      const target = objectByNamespace(context, physicalName);
-      if (
-        !isDirect &&
-        factory?.unprefixedNames.has(firstArgument.value) &&
-        (!target?.owner || target.owner === fileContext.owner)
-      ) {
-        continue;
-      }
-      if (!isDirect || (target?.owner && target.owner !== fileContext.owner)) {
-        validateObjectReference(
-          findings,
-          context,
-          file,
-          {kind: 'table', name: physicalName, index: firstArgument.index},
-          false,
-        );
-        continue;
-      }
-      addFinding(
-        findings,
-        context,
-        file.path,
-        file.source,
-        firstArgument.index,
-        physicalName,
-        'direct-table-declaration',
-        `Declare tables through the registered ${fileContext.namespace} schema factory.`,
-        fileContext,
-      );
-    }
-  }
-
-  for (const match of file.source.matchAll(/\bpgEnum\s*\(/gu)) {
-    const firstArgument = firstCallString(file.source, (match.index ?? 0) + match[0].length - 1);
-    if (!firstArgument) continue;
-    validateObjectReference(
+    auditTableFunctionCalls(
       findings,
       context,
       file,
-      {kind: 'enum', name: firstArgument.value, index: firstArgument.index},
-      false,
+      fileContext,
+      functionName,
+      imports.directTableFunctions.has(functionName),
+      factory,
     );
   }
 
-  for (const match of file.source.matchAll(/\b(?:uniqueIndex|index|check|primaryKey)\s*\(/gu)) {
+  auditNamedSourceCalls(findings, context, file, /\bpgEnum\s*\(/gu, 'enum');
+  auditNamedSourceCalls(
+    findings,
+    context,
+    file,
+    /\b(?:uniqueIndex|index|check|primaryKey)\s*\(/gu,
+    'constraint',
+  );
+}
+
+function auditTableFunctionCalls(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  functionName: string,
+  isDirect: boolean,
+  factory: FactoryInfo | undefined,
+): void {
+  if (functionName === 'pgTableCreator') return;
+  const expression = new RegExp(`\\b${escapeRegExp(functionName)}\\s*\\(`, 'gu');
+  for (const match of file.source.matchAll(expression)) {
+    const callIndex = match.index ?? 0;
+    const firstArgument = firstCallString(file.source, callIndex + match[0].length - 1);
+    if (!firstArgument) continue;
+    const physicalName = isDirect
+      ? firstArgument.value
+      : factoryPhysicalName(factory, fileContext.namespace, firstArgument.value);
+    const target = objectByNamespace(context, physicalName);
+    const allowedUnprefixedName =
+      !isDirect &&
+      factory?.unprefixedNames.has(firstArgument.value) &&
+      (!target?.owner || target.owner === fileContext.owner);
+    if (allowedUnprefixedName) continue;
+    if (!isDirect || (target?.owner && target.owner !== fileContext.owner)) {
+      validateObjectReference(
+        findings,
+        context,
+        file,
+        {kind: 'table', name: physicalName, index: firstArgument.index},
+        false,
+      );
+      continue;
+    }
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      firstArgument.index,
+      physicalName,
+      'direct-table-declaration',
+      `Declare tables through the registered ${fileContext.namespace} schema factory.`,
+      fileContext,
+    );
+  }
+}
+
+function auditNamedSourceCalls(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  expression: RegExp,
+  kind: DatabaseObjectKind,
+): void {
+  for (const match of file.source.matchAll(expression)) {
     const firstArgument = firstCallString(file.source, (match.index ?? 0) + match[0].length - 1);
     if (!firstArgument) continue;
     validateObjectReference(
       findings,
       context,
       file,
-      {kind: 'constraint', name: firstArgument.value, index: firstArgument.index},
+      {kind, name: firstArgument.value, index: firstArgument.index},
       false,
     );
   }
@@ -906,6 +999,24 @@ function auditRawSql(
 ): void {
   const fileContext = ownerContextForPath(context, file.path);
   if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  auditStaticRawSql(findings, context, file, fileContext);
+  auditDynamicSqlExpression(
+    findings,
+    context,
+    file,
+    fileContext,
+    dynamicSqlKeywordExpression,
+    false,
+  );
+  auditDynamicSqlExpression(findings, context, file, fileContext, dynamicRawSqlExpression, true);
+}
+
+function auditStaticRawSql(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+): void {
   for (const {name, expression} of context.sqlObjectReferences) {
     expression.lastIndex = 0;
     for (const match of file.source.matchAll(expression)) {
@@ -931,24 +1042,18 @@ function auditRawSql(
       }
     }
   }
+}
 
-  for (const match of file.source.matchAll(dynamicSqlKeywordExpression)) {
-    const interpolationStart = (match.index ?? 0) + match[0].lastIndexOf('${');
-    if (isRegisteredSqlInterpolation(file.source, interpolationStart)) continue;
-    addFinding(
-      findings,
-      context,
-      file.path,
-      file.source,
-      match.index ?? 0,
-      '<dynamic identifier>',
-      'dynamic-sql-identifier',
-      `Use a registered ${fileContext.namespace} table or an owner operation instead of a dynamic SQL identifier.`,
-      fileContext,
-    );
-  }
-  for (const match of file.source.matchAll(dynamicRawSqlExpression)) {
-    if (!dynamicSqlRawKeywordExpression.test(match[0])) continue;
+function auditDynamicSqlExpression(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  expression: RegExp,
+  requireRawKeyword: boolean,
+): void {
+  for (const match of file.source.matchAll(expression)) {
+    if (requireRawKeyword && !dynamicSqlRawKeywordExpression.test(match[0])) continue;
     const interpolationStart = (match.index ?? 0) + match[0].lastIndexOf('${');
     if (isRegisteredSqlInterpolation(file.source, interpolationStart)) continue;
     addFinding(
@@ -1000,31 +1105,36 @@ function auditForeignDatabaseAccess(
   const fileContext = ownerContextForPath(context, file.path);
   if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
   for (const match of file.source.matchAll(packageImportExpression)) {
-    const importClause = match[1] ?? '';
-    const importedPackage = match[2] ?? '';
-    const targetOwner = ownerForImportedPackage(context, importedPackage);
-    if (!targetOwner || targetOwner === fileContext.owner) continue;
-    for (const binding of parseImportBindings(importClause)) {
-      const accessExpression = new RegExp(
-        `\\b${escapeRegExp(binding)}\\s*\\.\\s*database\\b`,
-        'gu',
+    auditForeignDatabaseImport(findings, context, file, fileContext, match);
+  }
+}
+
+function auditForeignDatabaseImport(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  match: RegExpMatchArray,
+): void {
+  const targetOwner = ownerForImportedPackage(context, match[2] ?? '');
+  if (!targetOwner || targetOwner === fileContext.owner) return;
+  for (const binding of parseImportBindings(match[1] ?? '')) {
+    const accessExpression = new RegExp(`\\b${escapeRegExp(binding)}\\s*\\.\\s*database\\b`, 'gu');
+    for (const access of file.source.matchAll(accessExpression)) {
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        access.index ?? 0,
+        `${binding}.database`,
+        'foreign-database-access',
+        namespaceSuggestion(
+          targetOwner,
+          [...(context.ownerNamespaces.get(targetOwner) ?? [])][0] ?? 'unknown',
+        ),
+        fileContext,
       );
-      for (const access of file.source.matchAll(accessExpression)) {
-        addFinding(
-          findings,
-          context,
-          file.path,
-          file.source,
-          access.index ?? 0,
-          `${binding}.database`,
-          'foreign-database-access',
-          namespaceSuggestion(
-            targetOwner,
-            [...(context.ownerNamespaces.get(targetOwner) ?? [])][0] ?? 'unknown',
-          ),
-          fileContext,
-        );
-      }
     }
   }
 }
@@ -1037,29 +1147,39 @@ function auditSourceForeignKeys(
   const fileContext = ownerContextForPath(context, file.path);
   if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
   for (const match of file.source.matchAll(packageImportExpression)) {
-    const targetOwner = ownerForImportedPackage(context, match[2] ?? '');
-    if (!targetOwner || targetOwner === fileContext.owner) continue;
-    for (const binding of parseImportBindings(match[1] ?? '')) {
-      const referenceExpression = new RegExp(
-        `\\.references\\s*\\(\\s*\\(\\s*\\)\\s*=>\\s*${escapeRegExp(binding)}(?:\\.[A-Za-z_$][\\w$]*)?`,
-        'gu',
+    auditForeignKeyImport(findings, context, file, fileContext, match);
+  }
+}
+
+function auditForeignKeyImport(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  match: RegExpMatchArray,
+): void {
+  const targetOwner = ownerForImportedPackage(context, match[2] ?? '');
+  if (!targetOwner || targetOwner === fileContext.owner) return;
+  for (const binding of parseImportBindings(match[1] ?? '')) {
+    const referenceExpression = new RegExp(
+      `\\.references\\s*\\(\\s*\\(\\s*\\)\\s*=>\\s*${escapeRegExp(binding)}(?:\\.[A-Za-z_$][\\w$]*)?`,
+      'gu',
+    );
+    for (const reference of file.source.matchAll(referenceExpression)) {
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        reference.index ?? 0,
+        `${binding}.references`,
+        'foreign-key',
+        namespaceSuggestion(
+          targetOwner,
+          [...(context.ownerNamespaces.get(targetOwner) ?? [])][0] ?? 'unknown',
+        ),
+        fileContext,
       );
-      for (const reference of file.source.matchAll(referenceExpression)) {
-        addFinding(
-          findings,
-          context,
-          file.path,
-          file.source,
-          reference.index ?? 0,
-          `${binding}.references`,
-          'foreign-key',
-          namespaceSuggestion(
-            targetOwner,
-            [...(context.ownerNamespaces.get(targetOwner) ?? [])][0] ?? 'unknown',
-          ),
-          fileContext,
-        );
-      }
     }
   }
 }
@@ -1071,60 +1191,77 @@ function auditMigrationHistory(
   const fileContext = ownerContextForPath(context, file.path);
   if (!fileContext) return;
   if (fileContext.owner !== 'neutral-infrastructure') {
-    for (const match of file.source.matchAll(migrationHistoryExpression)) {
-      const namespace = match[1] ?? '';
-      const owner = context.namespaceOwners.get(namespace);
-      if (owner && owner !== fileContext.owner) {
-        addFinding(
-          findings,
-          context,
-          file.path,
-          file.source,
-          match.index ?? 0,
-          `__drizzle_migrations_${namespace}`,
-          'foreign-migration',
-          namespaceSuggestion(owner, namespace),
-          fileContext,
-        );
-      }
-    }
+    auditForeignMigrationHistories(findings, context, file, fileContext);
   }
   if (file.path.endsWith('/libs/shared/node/module/src/initialize.ts')) {
-    const fallback = file.source.match(fallbackHistoryExpression);
-    if (fallback?.index !== undefined) {
-      addFinding(
-        findings,
-        context,
-        file.path,
-        file.source,
-        fallback.index,
-        'moduleMigrationTableName',
-        'migration-history-instability',
-        'Require the registered database namespace on every ModuleDatabase declaration.',
-        fileContext,
-        'neutral-infrastructure',
-        'neutral',
-      );
-    }
+    auditUnstableMigrationHistory(
+      findings,
+      context,
+      file,
+      fileContext,
+      fallbackHistoryExpression,
+      'moduleMigrationTableName',
+    );
   }
   if (file.path.endsWith('/libs/shared/node/module/src/types.ts')) {
-    const optionalField = file.source.match(optionalHistoryExpression);
-    if (optionalField?.index !== undefined) {
-      addFinding(
-        findings,
-        context,
-        file.path,
-        file.source,
-        optionalField.index,
-        'migrationsTableName',
-        'migration-history-instability',
-        'Require the registered database namespace on every ModuleDatabase declaration.',
-        fileContext,
-        'neutral-infrastructure',
-        'neutral',
-      );
-    }
+    auditUnstableMigrationHistory(
+      findings,
+      context,
+      file,
+      fileContext,
+      optionalHistoryExpression,
+      'migrationsTableName',
+    );
   }
+}
+
+function auditForeignMigrationHistories(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+): void {
+  for (const match of file.source.matchAll(migrationHistoryExpression)) {
+    const namespace = match[1] ?? '';
+    const owner = context.namespaceOwners.get(namespace);
+    if (!owner || owner === fileContext.owner) continue;
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      match.index ?? 0,
+      `__drizzle_migrations_${namespace}`,
+      'foreign-migration',
+      namespaceSuggestion(owner, namespace),
+      fileContext,
+    );
+  }
+}
+
+function auditUnstableMigrationHistory(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+  expression: RegExp,
+  objectName: string,
+): void {
+  const match = file.source.match(expression);
+  if (match?.index === undefined) return;
+  addFinding(
+    findings,
+    context,
+    file.path,
+    file.source,
+    match.index,
+    objectName,
+    'migration-history-instability',
+    'Require the registered database namespace on every ModuleDatabase declaration.',
+    fileContext,
+    'neutral-infrastructure',
+    'neutral',
+  );
 }
 
 function auditMigrationFile(
@@ -1137,6 +1274,17 @@ function auditMigrationFile(
   const patterns = migrationObjectPatterns(
     '(?:CREATE\\s+TABLE|ALTER\\s+TABLE|DROP\\s+TABLE)\\s+(?:IF\\s+NOT\\s+EXISTS\\s+|IF\\s+EXISTS\\s+)?',
   );
+  auditMigrationObjects(findings, context, file, patterns);
+  auditMigrationForeignKeys(findings, context, file, fileContext);
+  auditDynamicMigrationIdentifiers(findings, context, file, fileContext);
+}
+
+function auditMigrationObjects(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  patterns: ReadonlyArray<readonly [DatabaseObjectKind, RegExp]>,
+): void {
   for (const [kind, expression] of patterns) {
     for (const match of file.source.matchAll(expression)) {
       const name = identifierFromMatch(match);
@@ -1150,6 +1298,14 @@ function auditMigrationFile(
         );
     }
   }
+}
+
+function auditMigrationForeignKeys(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+): void {
   for (const match of file.source.matchAll(
     new RegExp(`\\bREFERENCES\\s+(?:${identifierExpression}\\.)?${identifierExpression}`, 'giu'),
   )) {
@@ -1178,20 +1334,27 @@ function auditMigrationFile(
       );
     }
   }
-  if (interpolationPresenceExpression.test(file.source)) {
-    for (const match of file.source.matchAll(dynamicIdentifierExpression)) {
-      addFinding(
-        findings,
-        context,
-        file.path,
-        file.source,
-        match.index ?? 0,
-        '<dynamic identifier>',
-        'dynamic-sql-identifier',
-        `Keep ${fileContext.namespace} migration identifiers static and owner-local.`,
-        fileContext,
-      );
-    }
+}
+
+function auditDynamicMigrationIdentifiers(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  fileContext: FileOwnerContext,
+): void {
+  if (!interpolationPresenceExpression.test(file.source)) return;
+  for (const match of file.source.matchAll(dynamicIdentifierExpression)) {
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      match.index ?? 0,
+      '<dynamic identifier>',
+      'dynamic-sql-identifier',
+      `Keep ${fileContext.namespace} migration identifiers static and owner-local.`,
+      fileContext,
+    );
   }
 }
 
@@ -1211,43 +1374,62 @@ function auditSnapshotFile(
   } catch {
     return;
   }
-  const references: ObjectReference[] = [];
-  for (const [qualifiedName, table] of Object.entries(snapshot.tables ?? {})) {
-    references.push({
-      kind: 'table',
-      name: table.name || lastIdentifier(qualifiedName),
-      index: file.source.indexOf(table.name || lastIdentifier(qualifiedName)),
-    });
-    for (const index of Object.values(table.indexes ?? {})) {
-      if (index.name)
-        references.push({kind: 'index', name: index.name, index: file.source.indexOf(index.name)});
-    }
-    for (const constraint of Object.values(table.uniqueConstraints ?? {})) {
-      if (constraint.name)
-        references.push({
-          kind: 'constraint',
-          name: constraint.name,
-          index: file.source.indexOf(constraint.name),
-        });
-    }
-    for (const constraint of Object.values(table.checkConstraints ?? {})) {
-      if (constraint.name)
-        references.push({
-          kind: 'constraint',
-          name: constraint.name,
-          index: file.source.indexOf(constraint.name),
-        });
-    }
-  }
-  for (const [qualifiedName, enumValue] of Object.entries(snapshot.enums ?? {})) {
-    references.push({
-      kind: 'enum',
-      name: enumValue.name || lastIdentifier(qualifiedName),
-      index: file.source.indexOf(enumValue.name || lastIdentifier(qualifiedName)),
-    });
-  }
+  const references = snapshotObjectReferences(snapshot, file.source);
   for (const reference of references) {
     if (reference.index >= 0) validateObjectReference(findings, context, file, reference, true);
+  }
+}
+
+function snapshotObjectReferences(
+  snapshot: {tables?: Record<string, SnapshotTable>; enums?: Record<string, SnapshotEnum>},
+  source: string,
+): ObjectReference[] {
+  const references: ObjectReference[] = [];
+  for (const [qualifiedName, table] of Object.entries(snapshot.tables ?? {})) {
+    addSnapshotTableReferences(references, qualifiedName, table, source);
+  }
+  for (const [qualifiedName, enumValue] of Object.entries(snapshot.enums ?? {})) {
+    const name = enumValue.name || lastIdentifier(qualifiedName);
+    references.push({
+      kind: 'enum',
+      name,
+      index: source.indexOf(name),
+    });
+  }
+  return references;
+}
+
+function addSnapshotTableReferences(
+  references: ObjectReference[],
+  qualifiedName: string,
+  table: SnapshotTable,
+  source: string,
+): void {
+  const tableName = table.name || lastIdentifier(qualifiedName);
+  references.push({kind: 'table', name: tableName, index: source.indexOf(tableName)});
+  addSnapshotNamedReferences(references, Object.values(table.indexes ?? {}), 'index', source);
+  addSnapshotNamedReferences(
+    references,
+    Object.values(table.uniqueConstraints ?? {}),
+    'constraint',
+    source,
+  );
+  addSnapshotNamedReferences(
+    references,
+    Object.values(table.checkConstraints ?? {}),
+    'constraint',
+    source,
+  );
+}
+
+function addSnapshotNamedReferences(
+  references: ObjectReference[],
+  values: readonly SnapshotNamedObject[],
+  kind: DatabaseObjectKind,
+  source: string,
+): void {
+  for (const value of values) {
+    if (value.name) references.push({kind, name: value.name, index: source.indexOf(value.name)});
   }
 }
 

--- a/tools/api-database-policy/src/api-database-catalog.ts
+++ b/tools/api-database-policy/src/api-database-catalog.ts
@@ -372,26 +372,36 @@ async function cleanupCatalogResources({
   }
 
   if (targetCreated) {
-    // A failed shutdown can leave the shared client occupied; retry before opening the admin client.
-    try {
-      await closePool();
-    } catch (error) {
-      if (!cleanupError) cleanupError = error;
-    }
-    try {
-      const cleanupPool = createPostgresClient({database: adminDatabaseName});
-      await dropDatabase(cleanupPool, databaseName);
-    } catch (error) {
-      if (!cleanupError) cleanupError = error;
-    }
-    try {
-      await closePool();
-    } catch (error) {
-      if (!cleanupError) cleanupError = error;
-    }
+    cleanupError = await dropCreatedCatalogDatabase(adminDatabaseName, databaseName, cleanupError);
   }
 
   if (cleanupError) throw cleanupError;
+}
+
+async function dropCreatedCatalogDatabase(
+  adminDatabaseName: string,
+  databaseName: string,
+  initialError: unknown,
+): Promise<unknown> {
+  let cleanupError = initialError;
+  // A failed shutdown can leave the shared client occupied; retry before opening the admin client.
+  try {
+    await closePool();
+  } catch (error) {
+    cleanupError ??= error;
+  }
+  try {
+    const cleanupPool = createPostgresClient({database: adminDatabaseName});
+    await dropDatabase(cleanupPool, databaseName);
+  } catch (error) {
+    cleanupError ??= error;
+  }
+  try {
+    await closePool();
+  } catch (error) {
+    cleanupError ??= error;
+  }
+  return cleanupError;
 }
 
 async function verifyRegistry(registry: ApiDatabaseRegistry): Promise<void> {
@@ -421,52 +431,12 @@ export async function verifyFreshCatalog({
   let report: CatalogAuditReport | undefined;
   let verificationError: unknown;
   try {
-    adminPool = createPostgresClient({database: adminDatabaseName});
-    if (await databaseExists(adminPool, databaseName)) {
-      if (generated) throw new Error(`Generated catalog database already exists: ${databaseName}`);
-      await closePool();
-      targetPool = createPostgresClient({database: databaseName});
-      if (await databaseHasUserObjects(targetPool)) {
-        throw new Error(`Catalog target database is not empty: ${databaseName}`);
-      }
-      await closePool();
-      targetPool = undefined;
-    } else {
-      if (!generated) throw new Error(`Catalog target database does not exist: ${databaseName}`);
-      await createDatabase(adminPool, databaseName);
-      targetCreated = true;
-      await closePool();
-      adminPool = undefined;
-    }
-
-    const preparedUnits = await prepareMigrationUnits(registry, root);
-    const expectedObjects = expectedObjectsForUnits(preparedUnits);
-    const expectedHistories = expectedHistoriesForUnits(preparedUnits);
-    const reports = migrationUnitReports(preparedUnits);
-
+    const target = await prepareCatalogTarget(adminDatabaseName, databaseName, generated);
+    adminPool = target.adminPool;
+    targetPool = target.targetPool;
+    targetCreated = target.targetCreated;
     targetPool = createPostgresClient({database: databaseName});
-    const version = await serverVersion(targetPool);
-    if (Math.floor(version.versionNumber / 10_000) !== 18) {
-      throw new Error(`Catalog verification requires PostgreSQL 18, found ${version.version}`);
-    }
-    const database = drizzle(targetPool);
-    for (const prepared of preparedUnits) {
-      await runMigrations(
-        database,
-        path.join(root, prepared.unit.migrationsPath),
-        prepared.runtimeHistoryName,
-      );
-    }
-    const catalog = await readPostgresCatalog(targetPool);
-    report = auditPostgresCatalog({
-      catalog,
-      expectedObjects,
-      expectedHistories,
-      migrationUnits: reports,
-      registry,
-      databaseName,
-      serverVersion: version.version,
-    });
+    report = await auditFreshCatalog(targetPool, databaseName, registry, root);
   } catch (error) {
     verificationError = error;
   }
@@ -490,40 +460,119 @@ export async function verifyFreshCatalog({
   return report;
 }
 
+interface PreparedCatalogTarget {
+  adminPool: Pool | undefined;
+  targetCreated: boolean;
+  targetPool: Pool | undefined;
+}
+
+async function prepareCatalogTarget(
+  adminDatabaseName: string,
+  databaseName: string,
+  generated: boolean,
+): Promise<PreparedCatalogTarget> {
+  const adminPool = createPostgresClient({database: adminDatabaseName});
+  try {
+    if (!(await databaseExists(adminPool, databaseName))) {
+      if (!generated) throw new Error(`Catalog target database does not exist: ${databaseName}`);
+      await createDatabase(adminPool, databaseName);
+      await closePool();
+      return {adminPool: undefined, targetCreated: true, targetPool: undefined};
+    }
+    if (generated) throw new Error(`Generated catalog database already exists: ${databaseName}`);
+    await closePool();
+    const targetPool = createPostgresClient({database: databaseName});
+    if (await databaseHasUserObjects(targetPool)) {
+      throw new Error(`Catalog target database is not empty: ${databaseName}`);
+    }
+    await closePool();
+    return {adminPool: undefined, targetCreated: false, targetPool: undefined};
+  } catch (error) {
+    try {
+      await closePool();
+    } catch {
+      // Preserve the verification error, matching the outer cleanup contract.
+    }
+    throw error;
+  }
+}
+
+async function auditFreshCatalog(
+  targetPool: Pool,
+  databaseName: string,
+  registry: ApiDatabaseRegistry,
+  root: string,
+): Promise<CatalogAuditReport> {
+  const preparedUnits = await prepareMigrationUnits(registry, root);
+  const version = await serverVersion(targetPool);
+  if (Math.floor(version.versionNumber / 10_000) !== 18) {
+    throw new Error(`Catalog verification requires PostgreSQL 18, found ${version.version}`);
+  }
+  const database = drizzle(targetPool);
+  for (const prepared of preparedUnits) {
+    await runMigrations(
+      database,
+      path.join(root, prepared.unit.migrationsPath),
+      prepared.runtimeHistoryName,
+    );
+  }
+  const catalog = await readPostgresCatalog(targetPool);
+  return auditPostgresCatalog({
+    catalog,
+    expectedObjects: expectedObjectsForUnits(preparedUnits),
+    expectedHistories: expectedHistoriesForUnits(preparedUnits),
+    migrationUnits: migrationUnitReports(preparedUnits),
+    registry,
+    databaseName,
+    serverVersion: version.version,
+  });
+}
+
 export function parseCatalogCliArgs(
   argv: readonly string[] = process.argv.slice(2),
 ): CatalogCliOptions {
-  let databaseName: string | undefined;
-  let format: CatalogCliOptions['format'] = 'human';
-  let help = false;
+  const options: CatalogCliOptions = {format: 'human', help: false};
   for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index];
-    if (argument === '--help' || argument === '-h') {
-      help = true;
-    } else if (argument === '--json' || argument === '--format=json') {
-      format = 'json';
-    } else if (argument === '--format') {
-      const value = argv[index + 1];
-      if (value !== 'human' && value !== 'json')
-        throw new Error(`Unsupported catalog format: ${value}`);
-      format = value;
-      index += 1;
-    } else if (argument === '--database') {
-      databaseName = argv[index + 1];
-      if (!databaseName) throw new Error('--database requires a value');
-      index += 1;
-    } else if (argument?.startsWith('--database=')) {
-      databaseName = argument.slice('--database='.length);
-      if (!databaseName) throw new Error('--database requires a value');
-    } else {
-      throw new Error(`Unknown catalog option: ${argument}`);
-    }
+    index += parseCatalogCliArgument(argv, index, options);
   }
-  return {
-    ...(databaseName ? {databaseName} : {}),
-    format,
-    help,
-  };
+  return options;
+}
+
+function parseCatalogCliArgument(
+  argv: readonly string[],
+  index: number,
+  options: CatalogCliOptions,
+): number {
+  const argument = argv[index];
+  if (argument === '--help' || argument === '-h') {
+    options.help = true;
+    return 0;
+  }
+  if (argument === '--json' || argument === '--format=json') {
+    options.format = 'json';
+    return 0;
+  }
+  if (argument === '--format') {
+    const value = argv[index + 1];
+    if (value !== 'human' && value !== 'json') {
+      throw new Error(`Unsupported catalog format: ${value}`);
+    }
+    options.format = value;
+    return 1;
+  }
+  if (argument === '--database') {
+    const value = argv[index + 1];
+    if (!value) throw new Error('--database requires a value');
+    options.databaseName = value;
+    return 1;
+  }
+  if (argument?.startsWith('--database=')) {
+    const value = argument.slice('--database='.length);
+    if (!value) throw new Error('--database requires a value');
+    options.databaseName = value;
+    return 0;
+  }
+  throw new Error(`Unknown catalog option: ${argument}`);
 }
 
 function catalogHelp(): string {

--- a/tools/api-database-policy/src/api-database-registry.ts
+++ b/tools/api-database-policy/src/api-database-registry.ts
@@ -159,113 +159,24 @@ export function validateApiDatabaseRegistry(
   const errors: string[] = [];
   const ownerById = new Map<string, DatabaseOwner>();
   const ownerClassificationById = new Map<string, ClassifiedPath>();
-
-  addUniqueIdentifierError(
-    errors,
-    'database owner ID',
-    registry.owners.map((owner) => owner.id),
-  );
-  addUniqueIdentifierError(
-    errors,
-    'migration unit ID',
-    registry.migrationUnits.map((unit) => unit.id),
-  );
-  addUniqueIdentifierError(
-    errors,
-    'database namespace',
-    registry.migrationUnits.map((unit) => unit.namespace),
-  );
-  addUniqueIdentifierError(
-    errors,
-    'migration unit package path',
-    registry.migrationUnits.map((unit) => unit.packagePath),
-  );
-  addUniqueIdentifierError(
-    errors,
-    'migration unit Drizzle config path',
-    registry.migrationUnits.map((unit) => unit.drizzleConfigPath),
-  );
-  addUniqueIdentifierError(
-    errors,
-    'migration unit migrations path',
-    registry.migrationUnits.map((unit) => unit.migrationsPath),
-  );
-  addUniqueIdentifierError(
-    errors,
-    'database delegate ID',
-    registry.delegates.map((delegate) => delegate.id),
-  );
+  validateUniqueRegistryIdentifiers(registry, errors);
 
   for (const owner of registry.owners) {
     ownerById.set(owner.id, owner);
-    addMissingPathError(errors, options.existingPaths, owner.packagePath);
-
-    const classification = packages.get(owner.packagePath);
-    if (!classification) {
-      errors.push(`Database owner package is not classified: ${owner.packagePath}`);
-      continue;
-    }
-    if (
-      classification.classification !== 'implementations' &&
-      classification.classification !== 'shared-infrastructure'
-    ) {
-      errors.push(
-        `Database owner package has an incompatible classification: ${owner.packagePath}`,
-      );
-      continue;
-    }
-    if (
-      classification.classification === 'implementations' &&
-      classification.context !== owner.id
-    ) {
-      errors.push(
-        `Database owner ID does not match API context: ${owner.id} (${classification.context})`,
-      );
-    }
-    if (
-      classification.classification === 'shared-infrastructure' &&
-      path.posix.basename(owner.packagePath) !== owner.id
-    ) {
-      errors.push(`Database owner ID does not match package path: ${owner.id}`);
-    }
-    ownerClassificationById.set(owner.id, classification);
+    validateRegistryOwner(owner, packages, options.existingPaths, errors, ownerClassificationById);
   }
 
   const namespacesByOwner = new Map<string, number>();
   for (const unit of registry.migrationUnits) {
-    const owner = ownerById.get(unit.ownerId);
-    if (!owner) {
-      errors.push(`Unknown database owner: ${unit.ownerId}`);
-    }
-
-    if (!namespaceExpression.test(unit.namespace)) {
-      errors.push(`Invalid database namespace: ${unit.namespace}`);
-    }
-
-    const ownerNamespaceCount = namespacesByOwner.get(unit.ownerId) ?? 0;
-    namespacesByOwner.set(unit.ownerId, ownerNamespaceCount + 1);
-
-    for (const registeredPath of [unit.packagePath, unit.drizzleConfigPath, unit.migrationsPath]) {
-      addMissingPathError(errors, options.existingPaths, registeredPath);
-    }
-    if (!isNestedPath(unit.packagePath, unit.drizzleConfigPath)) {
-      errors.push(`Drizzle config path is outside migration unit package: ${unit.id}`);
-    }
-    if (!isNestedPath(unit.packagePath, unit.migrationsPath)) {
-      errors.push(`Migrations path is outside migration unit package: ${unit.id}`);
-    }
-
-    const unitClassification = packages.get(unit.packagePath);
-    const ownerClassification = ownerClassificationById.get(unit.ownerId);
-    if (!unitClassification) {
-      errors.push(`Database migration unit package is not classified: ${unit.packagePath}`);
-    } else if (
-      ownerClassification &&
-      (unitClassification.classification !== ownerClassification.classification ||
-        unitClassification.context !== ownerClassification.context)
-    ) {
-      errors.push(`Database migration unit classification mismatch: ${unit.id}`);
-    }
+    validateMigrationUnit(
+      unit,
+      packages,
+      options.existingPaths,
+      ownerById,
+      ownerClassificationById,
+      namespacesByOwner,
+      errors,
+    );
   }
 
   for (const owner of registry.owners) {
@@ -275,37 +186,146 @@ export function validateApiDatabaseRegistry(
   }
 
   for (const delegate of registry.delegates) {
-    addMissingPathError(errors, options.existingPaths, delegate.packagePath);
-    const classification = packages.get(delegate.packagePath);
-    if (!classification) {
-      errors.push(`Database delegate package is not classified: ${delegate.packagePath}`);
-    } else if (classification.classification !== 'shared-infrastructure') {
-      errors.push(`Database delegate is not neutral infrastructure: ${delegate.id}`);
-    }
-    if (!delegate.capability) {
-      errors.push(`Database delegate has no capability: ${delegate.id}`);
-    }
+    validateRegistryDelegate(delegate, packages, options.existingPaths, errors);
   }
 
   validateExpectedDelegates(errors, registry.delegates);
 
-  if (options.discoveredDrizzleConfigPaths) {
-    const registeredDrizzleConfigPaths = new Set(
-      registry.migrationUnits.map((unit) => unit.drizzleConfigPath),
-    );
-    for (const discoveredPath of options.discoveredDrizzleConfigPaths) {
-      if (!registeredDrizzleConfigPaths.has(discoveredPath)) {
-        errors.push(`Unregistered Drizzle config: ${discoveredPath}`);
-      }
-    }
-    for (const registeredPath of registeredDrizzleConfigPaths) {
-      if (!options.discoveredDrizzleConfigPaths.has(registeredPath)) {
-        errors.push(`Registered Drizzle config not discovered: ${registeredPath}`);
-      }
-    }
-  }
+  validateDiscoveredDrizzleConfigs(registry, options.discoveredDrizzleConfigPaths, errors);
 
   return errors.sort(compareText);
+}
+
+function validateUniqueRegistryIdentifiers(registry: ApiDatabaseRegistry, errors: string[]): void {
+  const identifiers: Array<[string, readonly string[]]> = [
+    ['database owner ID', registry.owners.map((owner) => owner.id)],
+    ['migration unit ID', registry.migrationUnits.map((unit) => unit.id)],
+    ['database namespace', registry.migrationUnits.map((unit) => unit.namespace)],
+    ['migration unit package path', registry.migrationUnits.map((unit) => unit.packagePath)],
+    [
+      'migration unit Drizzle config path',
+      registry.migrationUnits.map((unit) => unit.drizzleConfigPath),
+    ],
+    ['migration unit migrations path', registry.migrationUnits.map((unit) => unit.migrationsPath)],
+    ['database delegate ID', registry.delegates.map((delegate) => delegate.id)],
+  ];
+  for (const [kind, values] of identifiers) addUniqueIdentifierError(errors, kind, values);
+}
+
+function validateRegistryOwner(
+  owner: DatabaseOwner,
+  packages: ReadonlyMap<string, ClassifiedPath>,
+  existingPaths: ReadonlySet<string> | undefined,
+  errors: string[],
+  classifications: Map<string, ClassifiedPath>,
+): void {
+  addMissingPathError(errors, existingPaths, owner.packagePath);
+  const classification = packages.get(owner.packagePath);
+  if (!classification) {
+    errors.push(`Database owner package is not classified: ${owner.packagePath}`);
+    return;
+  }
+  if (
+    classification.classification !== 'implementations' &&
+    classification.classification !== 'shared-infrastructure'
+  ) {
+    errors.push(`Database owner package has an incompatible classification: ${owner.packagePath}`);
+    return;
+  }
+  if (classification.classification === 'implementations' && classification.context !== owner.id) {
+    errors.push(
+      `Database owner ID does not match API context: ${owner.id} (${classification.context})`,
+    );
+  }
+  if (
+    classification.classification === 'shared-infrastructure' &&
+    path.posix.basename(owner.packagePath) !== owner.id
+  ) {
+    errors.push(`Database owner ID does not match package path: ${owner.id}`);
+  }
+  classifications.set(owner.id, classification);
+}
+
+function validateMigrationUnit(
+  unit: ApiDatabaseRegistry['migrationUnits'][number],
+  packages: ReadonlyMap<string, ClassifiedPath>,
+  existingPaths: ReadonlySet<string> | undefined,
+  owners: ReadonlyMap<string, DatabaseOwner>,
+  ownerClassifications: ReadonlyMap<string, ClassifiedPath>,
+  namespacesByOwner: Map<string, number>,
+  errors: string[],
+): void {
+  if (!owners.has(unit.ownerId)) errors.push(`Unknown database owner: ${unit.ownerId}`);
+  if (!namespaceExpression.test(unit.namespace)) {
+    errors.push(`Invalid database namespace: ${unit.namespace}`);
+  }
+  namespacesByOwner.set(unit.ownerId, (namespacesByOwner.get(unit.ownerId) ?? 0) + 1);
+  for (const registeredPath of [unit.packagePath, unit.drizzleConfigPath, unit.migrationsPath]) {
+    addMissingPathError(errors, existingPaths, registeredPath);
+  }
+  if (!isNestedPath(unit.packagePath, unit.drizzleConfigPath)) {
+    errors.push(`Drizzle config path is outside migration unit package: ${unit.id}`);
+  }
+  if (!isNestedPath(unit.packagePath, unit.migrationsPath)) {
+    errors.push(`Migrations path is outside migration unit package: ${unit.id}`);
+  }
+  validateMigrationUnitClassification(unit, packages, ownerClassifications, errors);
+}
+
+function validateMigrationUnitClassification(
+  unit: ApiDatabaseRegistry['migrationUnits'][number],
+  packages: ReadonlyMap<string, ClassifiedPath>,
+  ownerClassifications: ReadonlyMap<string, ClassifiedPath>,
+  errors: string[],
+): void {
+  const unitClassification = packages.get(unit.packagePath);
+  const ownerClassification = ownerClassifications.get(unit.ownerId);
+  if (!unitClassification) {
+    errors.push(`Database migration unit package is not classified: ${unit.packagePath}`);
+    return;
+  }
+  if (
+    ownerClassification &&
+    (unitClassification.classification !== ownerClassification.classification ||
+      unitClassification.context !== ownerClassification.context)
+  ) {
+    errors.push(`Database migration unit classification mismatch: ${unit.id}`);
+  }
+}
+
+function validateRegistryDelegate(
+  delegate: DatabaseDelegate,
+  packages: ReadonlyMap<string, ClassifiedPath>,
+  existingPaths: ReadonlySet<string> | undefined,
+  errors: string[],
+): void {
+  addMissingPathError(errors, existingPaths, delegate.packagePath);
+  const classification = packages.get(delegate.packagePath);
+  if (!classification) {
+    errors.push(`Database delegate package is not classified: ${delegate.packagePath}`);
+  } else if (classification.classification !== 'shared-infrastructure') {
+    errors.push(`Database delegate is not neutral infrastructure: ${delegate.id}`);
+  }
+  if (!delegate.capability) errors.push(`Database delegate has no capability: ${delegate.id}`);
+}
+
+function validateDiscoveredDrizzleConfigs(
+  registry: ApiDatabaseRegistry,
+  discoveredPaths: ReadonlySet<string> | undefined,
+  errors: string[],
+): void {
+  if (!discoveredPaths) return;
+  const registeredPaths = new Set(registry.migrationUnits.map((unit) => unit.drizzleConfigPath));
+  for (const discoveredPath of discoveredPaths) {
+    if (!registeredPaths.has(discoveredPath)) {
+      errors.push(`Unregistered Drizzle config: ${discoveredPath}`);
+    }
+  }
+  for (const registeredPath of registeredPaths) {
+    if (!discoveredPaths.has(registeredPath)) {
+      errors.push(`Registered Drizzle config not discovered: ${registeredPath}`);
+    }
+  }
 }
 
 async function findDrizzleConfigPaths(

--- a/tools/api-database-policy/src/catalog.ts
+++ b/tools/api-database-policy/src/catalog.ts
@@ -272,152 +272,108 @@ function dollarQuoteDelimiterAt(source: string, offset: number): string | undefi
 
 function statementEnd(source: string, offset: number): number {
   let cursor = offset;
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
   while (cursor < source.length) {
-    const character = source[cursor];
-    if (inSingleQuote) {
-      if (character === '\\') {
-        cursor += 2;
-        continue;
-      }
-      if (character === "'") {
-        if (source[cursor + 1] === "'") {
-          cursor += 2;
-          continue;
-        }
-        inSingleQuote = false;
-      }
-      cursor += 1;
-      continue;
-    }
-    if (inDoubleQuote) {
-      if (character === '"') {
-        if (source[cursor + 1] === '"') {
-          cursor += 2;
-          continue;
-        }
-        inDoubleQuote = false;
-      }
-      cursor += 1;
-      continue;
-    }
-    if (character === "'") {
-      inSingleQuote = true;
-      cursor += 1;
-      continue;
-    }
-    if (character === '"') {
-      inDoubleQuote = true;
-      cursor += 1;
-      continue;
-    }
-    if (character === '-' && source[cursor + 1] === '-') {
-      const lineEnd = source.indexOf('\n', cursor + 2);
-      cursor = lineEnd === -1 ? source.length : lineEnd + 1;
-      continue;
-    }
-    if (character === '/' && source[cursor + 1] === '*') {
-      const commentEnd = source.indexOf('*/', cursor + 2);
-      cursor = commentEnd === -1 ? source.length : commentEnd + 2;
-      continue;
-    }
-    if (
-      character === '$' &&
-      (cursor === 0 || !identifierPartExpression.test(source[cursor - 1] ?? ''))
-    ) {
-      const delimiter = dollarQuoteDelimiterAt(source, cursor);
-      if (delimiter) {
-        const quoteEnd = source.indexOf(delimiter, cursor + delimiter.length);
-        cursor = quoteEnd === -1 ? source.length : quoteEnd + delimiter.length;
-        continue;
-      }
-    }
-    if (character === ';') return cursor;
-    cursor += 1;
+    const scan = scanStatementCharacter(source, cursor);
+    if (scan.statementEnd !== undefined) return scan.statementEnd;
+    cursor = scan.nextCursor;
   }
   return source.length;
 }
 
+interface StatementScanResult {
+  nextCursor: number;
+  statementEnd?: number;
+}
+
+function scanStatementCharacter(source: string, cursor: number): StatementScanResult {
+  const character = source[cursor];
+  if (character === "'") return {nextCursor: quotedSqlEnd(source, cursor, "'", true)};
+  if (character === '"') return {nextCursor: quotedSqlEnd(source, cursor, '"', false)};
+  if (character === '-' && source[cursor + 1] === '-') {
+    const lineEnd = source.indexOf('\n', cursor + 2);
+    return {nextCursor: lineEnd === -1 ? source.length : lineEnd + 1};
+  }
+  if (character === '/' && source[cursor + 1] === '*') {
+    const commentEnd = source.indexOf('*/', cursor + 2);
+    return {nextCursor: commentEnd === -1 ? source.length : commentEnd + 2};
+  }
+  const delimiter = statementDollarQuoteDelimiter(source, cursor);
+  if (delimiter) {
+    const quoteEnd = source.indexOf(delimiter, cursor + delimiter.length);
+    return {nextCursor: quoteEnd === -1 ? source.length : quoteEnd + delimiter.length};
+  }
+  if (character === ';') return {nextCursor: cursor, statementEnd: cursor};
+  return {nextCursor: cursor + 1};
+}
+
+function statementDollarQuoteDelimiter(source: string, cursor: number): string | undefined {
+  if (source[cursor] !== '$') return undefined;
+  if (cursor > 0 && identifierPartExpression.test(source[cursor - 1] ?? '')) return undefined;
+  return dollarQuoteDelimiterAt(source, cursor);
+}
+
+function quotedSqlEnd(
+  source: string,
+  start: number,
+  quote: string,
+  allowsBackslash: boolean,
+): number {
+  let cursor = start + 1;
+  while (cursor < source.length) {
+    if (allowsBackslash && source[cursor] === '\\') {
+      cursor += 2;
+      continue;
+    }
+    if (source[cursor] !== quote) {
+      cursor += 1;
+      continue;
+    }
+    if (source[cursor + 1] === quote) {
+      cursor += 2;
+      continue;
+    }
+    return cursor + 1;
+  }
+  return source.length;
+}
+
+function blankCharacters(characters: string[], start: number, end: number): void {
+  for (let index = start; index < end; index += 1) {
+    if (characters[index] !== '\n' && characters[index] !== '\r') characters[index] = ' ';
+  }
+}
+
 function maskSqlForStatements(source: string): string {
   const characters = source.split('');
-  const blank = (start: number, end: number): void => {
-    for (let index = start; index < end; index += 1) {
-      if (characters[index] !== '\n' && characters[index] !== '\r') characters[index] = ' ';
-    }
-  };
-
   let cursor = 0;
   while (cursor < source.length) {
-    const character = source[cursor];
-    if (character === '-' && source[cursor + 1] === '-') {
-      const lineEnd = source.indexOf('\n', cursor + 2);
-      const end = lineEnd === -1 ? source.length : lineEnd;
-      blank(cursor, end);
-      cursor = end;
-      continue;
-    }
-    if (character === '/' && source[cursor + 1] === '*') {
-      const commentEnd = source.indexOf('*/', cursor + 2);
-      const end = commentEnd === -1 ? source.length : commentEnd + 2;
-      blank(cursor, end);
-      cursor = end;
-      continue;
-    }
-    if (character === "'") {
-      const start = cursor;
+    const end = maskedSqlRegionEnd(source, cursor);
+    if (end === undefined) {
       cursor += 1;
-      while (cursor < source.length) {
-        if (source[cursor] === '\\') {
-          cursor += 2;
-          continue;
-        }
-        if (source[cursor] === "'") {
-          if (source[cursor + 1] === "'") {
-            cursor += 2;
-            continue;
-          }
-          cursor += 1;
-          break;
-        }
-        cursor += 1;
-      }
-      blank(start, cursor);
       continue;
     }
-    if (character === '"') {
-      const start = cursor;
-      cursor += 1;
-      while (cursor < source.length) {
-        if (source[cursor] === '"') {
-          if (source[cursor + 1] === '"') {
-            cursor += 2;
-            continue;
-          }
-          cursor += 1;
-          break;
-        }
-        cursor += 1;
-      }
-      blank(start, cursor);
-      continue;
-    }
-    if (
-      character === '$' &&
-      (cursor === 0 || !identifierPartExpression.test(source[cursor - 1] ?? ''))
-    ) {
-      const delimiter = dollarQuoteDelimiterAt(source, cursor);
-      if (delimiter) {
-        const start = cursor;
-        const quoteEnd = source.indexOf(delimiter, cursor + delimiter.length);
-        cursor = quoteEnd === -1 ? source.length : quoteEnd + delimiter.length;
-        blank(start, cursor);
-        continue;
-      }
-    }
-    cursor += 1;
+    blankCharacters(characters, cursor, end);
+    cursor = end;
   }
   return characters.join('');
+}
+
+function maskedSqlRegionEnd(source: string, cursor: number): number | undefined {
+  const character = source[cursor];
+  if (character === '-' && source[cursor + 1] === '-') {
+    const lineEnd = source.indexOf('\n', cursor + 2);
+    return lineEnd === -1 ? source.length : lineEnd;
+  }
+  if (character === '/' && source[cursor + 1] === '*') {
+    const commentEnd = source.indexOf('*/', cursor + 2);
+    return commentEnd === -1 ? source.length : commentEnd + 2;
+  }
+  if (character === "'") return quotedSqlEnd(source, cursor, "'", true);
+  if (character === '"') return quotedSqlEnd(source, cursor, '"', false);
+  const delimiter = statementDollarQuoteDelimiter(source, cursor);
+  if (!delimiter) return undefined;
+  const quoteEnd = source.indexOf(delimiter, cursor + delimiter.length);
+  return quoteEnd === -1 ? source.length : quoteEnd + delimiter.length;
 }
 
 function lineNumber(source: string, offset: number): number {
@@ -499,43 +455,13 @@ function readFromRelationReferences(
   const keywordExpression = /\bFROM\b/gi;
   let match = keywordExpression.exec(searchableStatement);
   while (match) {
-    let cursor = start + (match.index ?? 0) + match[0].length;
-    let relation = readFromRelationIdentifier(source, searchableSource, cursor);
-    if (relation) {
-      references.push({
-        schemaName: relation.schemaName ?? 'public',
-        name: relation.name,
-      });
-      cursor = relation.end;
-    }
-
-    let parenthesisDepth = 0;
-    while (relation && cursor < end) {
-      const character = searchableSource[cursor];
-      if (character === '(') {
-        parenthesisDepth += 1;
-      } else if (character === ')') {
-        if (parenthesisDepth === 0) break;
-        parenthesisDepth -= 1;
-      } else if (parenthesisDepth === 0 && character === ',') {
-        const nextRelation = readFromRelationIdentifier(source, searchableSource, cursor + 1);
-        if (!nextRelation) break;
-        references.push({
-          schemaName: nextRelation.schemaName ?? 'public',
-          name: nextRelation.name,
-        });
-        relation = nextRelation;
-        cursor = relation.end;
-        continue;
-      } else if (
-        parenthesisDepth === 0 &&
-        fromClauseBoundaryExpression.test(searchableSource.slice(cursor))
-      ) {
-        break;
-      }
-      cursor += 1;
-    }
-
+    readFromClauseReferences(
+      source,
+      searchableSource,
+      start + (match.index ?? 0) + match[0].length,
+      end,
+      references,
+    );
     match = keywordExpression.exec(searchableStatement);
   }
 
@@ -546,6 +472,54 @@ function readFromRelationReferences(
           candidate.schemaName === reference.schemaName && candidate.name === reference.name,
       ) === index,
   );
+}
+
+function addRelationReference(
+  references: ExpectedRelationReference[],
+  relation: ParsedIdentifier,
+): void {
+  references.push({schemaName: relation.schemaName ?? 'public', name: relation.name});
+}
+
+function readFromClauseReferences(
+  source: string,
+  searchableSource: string,
+  start: number,
+  end: number,
+  references: ExpectedRelationReference[],
+): void {
+  let cursor = start;
+  let relation = readFromRelationIdentifier(source, searchableSource, cursor);
+  if (!relation) return;
+  addRelationReference(references, relation);
+  cursor = relation.end;
+  let separator = nextFromRelationSeparator(searchableSource, cursor, end);
+  while (separator !== undefined) {
+    relation = readFromRelationIdentifier(source, searchableSource, separator + 1);
+    if (!relation) return;
+    addRelationReference(references, relation);
+    cursor = relation.end;
+    separator = nextFromRelationSeparator(searchableSource, cursor, end);
+  }
+}
+
+function nextFromRelationSeparator(source: string, start: number, end: number): number | undefined {
+  let cursor = start;
+  let parenthesisDepth = 0;
+  while (cursor < end) {
+    const character = source[cursor];
+    if (character === '(') parenthesisDepth += 1;
+    if (character === ')') {
+      if (parenthesisDepth === 0) return undefined;
+      parenthesisDepth -= 1;
+    }
+    if (parenthesisDepth === 0 && character === ',') return cursor;
+    if (parenthesisDepth === 0 && fromClauseBoundaryExpression.test(source.slice(cursor))) {
+      return undefined;
+    }
+    cursor += 1;
+  }
+  return undefined;
 }
 
 function addParsedStatement(
@@ -580,6 +554,43 @@ function addParsedStatement(
 function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
   const statements: ParsedMigrationStatement[] = [];
   const searchableSource = maskSqlForStatements(source);
+  collectCreateStatements(source, searchableSource, statements);
+  collectDropStatements(source, searchableSource, statements);
+  const parsedConstraintOffsets = collectAlterTableConstraints(
+    source,
+    searchableSource,
+    statements,
+  );
+  collectInlineConstraints(source, searchableSource, statements, parsedConstraintOffsets);
+  attachConstraintReferences(source, searchableSource, statements);
+  return statements;
+}
+
+function normalizedStatementKind(keyword: string): ParsedMigrationStatement['kind'] {
+  if (keyword === 'materialized view') return 'view';
+  if (keyword === 'foreign table') return 'table';
+  return keyword as ParsedMigrationStatement['kind'];
+}
+
+function attachStatementRelation(
+  source: string,
+  searchableSource: string,
+  statement: ParsedMigrationStatement,
+  end: number,
+): void {
+  const onOffset = firstKeywordOffset(searchableSource, 'ON', statement.name.end, end);
+  if (onOffset === -1) return;
+  const relation = readQualifiedIdentifier(source, onOffset + 2);
+  if (!relation) return;
+  statement.relationName = relation.name;
+  if (relation.schemaName) statement.relationSchemaName = relation.schemaName;
+}
+
+function collectCreateStatements(
+  source: string,
+  searchableSource: string,
+  statements: ParsedMigrationStatement[],
+): void {
   const createExpression =
     /\bCREATE\s+(?:(?:OR\s+REPLACE|UNIQUE|CONCURRENTLY)\s+)*(MATERIALIZED\s+VIEW|FOREIGN\s+TABLE|TABLE|TYPE|INDEX|SEQUENCE|VIEW|TRIGGER)\b/gi;
   let match = createExpression.exec(searchableSource);
@@ -588,9 +599,7 @@ function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
     match = createExpression.exec(searchableSource);
     const keyword = createMatch[1]?.toLowerCase();
     if (!keyword) continue;
-    let kind = keyword as ParsedMigrationStatement['kind'];
-    if (keyword === 'materialized view') kind = 'view';
-    if (keyword === 'foreign table') kind = 'table';
+    const kind = normalizedStatementKind(keyword);
     const statement = addParsedStatement(statements, source, createMatch, kind);
     if (!statement) continue;
     const end = statementEnd(source, statement.name.end);
@@ -601,28 +610,25 @@ function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
       ];
       if (references.length > 0) statement.referencedRelations = references;
     } else if (kind === 'index' || kind === 'trigger') {
-      const onOffset = firstKeywordOffset(searchableSource, 'ON', statement.name.end, end);
-      if (onOffset !== -1) {
-        const relation = readQualifiedIdentifier(source, onOffset + 2);
-        if (relation) {
-          statement.relationName = relation.name;
-          if (relation.schemaName) statement.relationSchemaName = relation.schemaName;
-        }
-      }
+      attachStatementRelation(source, searchableSource, statement, end);
     }
   }
+}
 
+function collectDropStatements(
+  source: string,
+  searchableSource: string,
+  statements: ParsedMigrationStatement[],
+): void {
   const dropExpression =
     /\bDROP\s+((?:MATERIALIZED\s+VIEW|FOREIGN\s+TABLE|TABLE|TYPE|INDEX|SEQUENCE|VIEW|TRIGGER))\b/gi;
-  match = dropExpression.exec(searchableSource);
+  let match = dropExpression.exec(searchableSource);
   while (match) {
     const dropMatch = match;
     match = dropExpression.exec(searchableSource);
     const keyword = dropMatch[1]?.toLowerCase();
     if (!keyword) continue;
-    let kind = keyword as ParsedMigrationStatement['kind'];
-    if (keyword === 'materialized view') kind = 'view';
-    if (keyword === 'foreign table') kind = 'table';
+    const kind = normalizedStatementKind(keyword);
     const statement = addParsedStatement(statements, source, dropMatch, kind, 'drop');
     if (!statement) continue;
     const end = statementEnd(source, statement.name.end);
@@ -630,61 +636,81 @@ function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
       statement.cascade = cascadeExpression.test(searchableSource.slice(statement.name.end, end));
     }
     if (kind === 'trigger') {
-      const onOffset = firstKeywordOffset(searchableSource, 'ON', statement.name.end, end);
-      if (onOffset !== -1) {
-        const relation = readQualifiedIdentifier(source, onOffset + 2);
-        if (relation) {
-          statement.relationName = relation.name;
-          if (relation.schemaName) statement.relationSchemaName = relation.schemaName;
-        }
-      }
+      attachStatementRelation(source, searchableSource, statement, end);
     }
   }
+}
 
+function collectAlterTableConstraints(
+  source: string,
+  searchableSource: string,
+  statements: ParsedMigrationStatement[],
+): Set<number> {
   const alterExpression = /\bALTER\s+TABLE\b/gi;
   const parsedConstraintOffsets = new Set<number>();
-  match = alterExpression.exec(searchableSource);
+  let match = alterExpression.exec(searchableSource);
   while (match) {
     const alterMatch = match;
     match = alterExpression.exec(searchableSource);
-    const tableOffset = skipWhitespace(source, (alterMatch.index ?? 0) + alterMatch[0].length);
-    const afterIfExists = ifExistsExpression.exec(searchableSource.slice(tableOffset));
-    const table = readQualifiedIdentifier(
+    const constraintOffset = collectAlterTableConstraint(
       source,
-      afterIfExists ? tableOffset + afterIfExists[0].length : tableOffset,
+      searchableSource,
+      statements,
+      alterMatch,
     );
-    if (!table) continue;
-    const end = statementEnd(source, table.end);
-    const constraintOffset = firstKeywordOffset(searchableSource, 'CONSTRAINT', table.end, end);
-    if (constraintOffset === -1) continue;
-    const isDroppingConstraint = dropConstraintExpression.test(
-      searchableSource.slice(table.end, end),
-    );
-    const constraintNameOffset = skipWhitespace(source, constraintOffset + 'CONSTRAINT'.length);
-    const afterConstraintIfExists = isDroppingConstraint
-      ? ifExistsExpression.exec(searchableSource.slice(constraintNameOffset))
-      : undefined;
-    const constraint = readIdentifier(
-      source,
-      afterConstraintIfExists
-        ? constraintNameOffset + afterConstraintIfExists[0].length
-        : constraintNameOffset,
-    );
-    if (!constraint) continue;
-    const operation: ParsedMigrationStatement['operation'] = isDroppingConstraint
-      ? 'drop'
-      : 'create';
-    statements.push({
-      operation,
-      kind: 'constraint',
-      name: constraint,
-      relationName: table.name,
-      ...(table.schemaName ? {relationSchemaName: table.schemaName} : {}),
-      start: alterMatch.index ?? 0,
-    });
-    parsedConstraintOffsets.add(constraintOffset);
+    if (constraintOffset !== undefined) parsedConstraintOffsets.add(constraintOffset);
   }
+  return parsedConstraintOffsets;
+}
 
+function collectAlterTableConstraint(
+  source: string,
+  searchableSource: string,
+  statements: ParsedMigrationStatement[],
+  alterMatch: RegExpExecArray,
+): number | undefined {
+  const tableOffset = skipWhitespace(source, (alterMatch.index ?? 0) + alterMatch[0].length);
+  const afterIfExists = ifExistsExpression.exec(searchableSource.slice(tableOffset));
+  const table = readQualifiedIdentifier(
+    source,
+    afterIfExists ? tableOffset + afterIfExists[0].length : tableOffset,
+  );
+  if (!table) return undefined;
+  const end = statementEnd(source, table.end);
+  const constraintOffset = firstKeywordOffset(searchableSource, 'CONSTRAINT', table.end, end);
+  if (constraintOffset === -1) return undefined;
+  const isDroppingConstraint = dropConstraintExpression.test(
+    searchableSource.slice(table.end, end),
+  );
+  const constraintNameOffset = skipWhitespace(source, constraintOffset + 'CONSTRAINT'.length);
+  const afterConstraintIfExists = isDroppingConstraint
+    ? ifExistsExpression.exec(searchableSource.slice(constraintNameOffset))
+    : undefined;
+  const constraint = readIdentifier(
+    source,
+    afterConstraintIfExists
+      ? constraintNameOffset + afterConstraintIfExists[0].length
+      : constraintNameOffset,
+  );
+  if (!constraint) return undefined;
+  const operation: ParsedMigrationStatement['operation'] = isDroppingConstraint ? 'drop' : 'create';
+  statements.push({
+    operation,
+    kind: 'constraint',
+    name: constraint,
+    relationName: table.name,
+    ...(table.schemaName ? {relationSchemaName: table.schemaName} : {}),
+    start: alterMatch.index ?? 0,
+  });
+  return constraintOffset;
+}
+
+function collectInlineConstraints(
+  source: string,
+  searchableSource: string,
+  statements: ParsedMigrationStatement[],
+  parsedConstraintOffsets: ReadonlySet<number>,
+): void {
   const tableRanges: ParsedTableRange[] = statements
     .filter((statement) => statement.kind === 'table')
     .map((statement) => ({
@@ -694,7 +720,7 @@ function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
       name: statement.name.name,
     }));
   const constraintExpression = /\bCONSTRAINT\b/gi;
-  match = constraintExpression.exec(searchableSource);
+  let match = constraintExpression.exec(searchableSource);
   while (match) {
     const constraintMatch = match;
     match = constraintExpression.exec(searchableSource);
@@ -715,7 +741,13 @@ function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
       start: constraintMatch.index ?? 0,
     });
   }
+}
 
+function attachConstraintReferences(
+  source: string,
+  searchableSource: string,
+  statements: ParsedMigrationStatement[],
+): void {
   for (const statement of statements) {
     if (statement.kind !== 'constraint') continue;
     const statementEndOffset = statementEnd(source, statement.name.end);
@@ -735,8 +767,6 @@ function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
     );
     if (references.length > 0) statement.referencedRelations = references;
   }
-
-  return statements;
 }
 
 export function parseMigrationSql({
@@ -779,37 +809,40 @@ function migrationChangesForSource({
   const searchableSource = maskSqlForStatements(source);
   const statements = parseMigrationStatements(source);
   if (sortBySourcePosition) statements.sort((left, right) => left.start - right.start);
-  return statements.flatMap((statement): ParsedMigrationChange[] => {
-    if (statement.kind === 'type') {
-      const end = statementEnd(source, statement.name.end);
-      const statementText = searchableSource.slice(statement.name.end, end);
-      if (statement.operation === 'create' && !enumExpression.test(statementText)) return [];
-    }
-    const kind = statement.kind === 'type' ? 'enum' : statement.kind;
-    return [
-      {
-        operation: statement.operation,
-        ...(statement.cascade ? {cascade: true} : {}),
-        object: {
-          kind,
-          schemaName: statement.name.schemaName ?? 'public',
-          name: statement.name.name,
-          ownerId: unit.ownerId,
-          migrationUnitId: unit.id,
-          namespace: unit.namespace,
-          ...(statement.relationName ? {relationName: statement.relationName} : {}),
-          ...(statement.relationSchemaName
-            ? {relationSchemaName: statement.relationSchemaName}
-            : {}),
-          ...(statement.referencedRelations
-            ? {referencedRelations: statement.referencedRelations}
-            : {}),
-          sourcePath,
-          line: lineNumber(source, statement.start),
-        },
-      },
-    ];
-  });
+  return statements.flatMap((statement) =>
+    migrationChangeForStatement(statement, source, searchableSource, sourcePath, unit),
+  );
+}
+
+function migrationChangeForStatement(
+  statement: ParsedMigrationStatement,
+  source: string,
+  searchableSource: string,
+  sourcePath: string,
+  unit: DatabaseMigrationUnit,
+): ParsedMigrationChange[] {
+  if (statement.kind === 'type') {
+    const end = statementEnd(source, statement.name.end);
+    const statementText = searchableSource.slice(statement.name.end, end);
+    if (statement.operation === 'create' && !enumExpression.test(statementText)) return [];
+  }
+  const kind = statement.kind === 'type' ? 'enum' : statement.kind;
+  const object: ExpectedCatalogObject = {
+    kind,
+    schemaName: statement.name.schemaName ?? 'public',
+    name: statement.name.name,
+    ownerId: unit.ownerId,
+    migrationUnitId: unit.id,
+    namespace: unit.namespace,
+    sourcePath,
+    line: lineNumber(source, statement.start),
+  };
+  if (statement.relationName) object.relationName = statement.relationName;
+  if (statement.relationSchemaName) object.relationSchemaName = statement.relationSchemaName;
+  if (statement.referencedRelations) object.referencedRelations = statement.referencedRelations;
+  const change: ParsedMigrationChange = {operation: statement.operation, object};
+  if (statement.cascade) change.cascade = true;
+  return [change];
 }
 
 export function expectedObjectsAfterMigrations(
@@ -826,39 +859,60 @@ export function expectedObjectsAfterMigrations(
 
     activeObjects.delete(key);
     if (object.kind !== 'table' && object.kind !== 'view') continue;
-
-    const pendingRelations: ExpectedRelationReference[] = [
-      {schemaName: object.schemaName, name: object.name},
-    ];
-    for (const droppedRelation of pendingRelations) {
-      for (const [candidateKey, candidate] of activeObjects) {
-        const relationMatches =
-          candidate.relationName === droppedRelation.name &&
-          (candidate.relationSchemaName ?? 'public') === droppedRelation.schemaName;
-        const referencedRelationMatches =
-          change.cascade === true &&
-          candidate.referencedRelations?.some(
-            (reference) =>
-              reference.name === droppedRelation.name &&
-              reference.schemaName === droppedRelation.schemaName,
-          );
-        if (!relationMatches && !referencedRelationMatches) continue;
-
-        activeObjects.delete(candidateKey);
-        if (
-          change.cascade === true &&
-          (candidate.kind === 'table' || candidate.kind === 'view') &&
-          !pendingRelations.some(
-            (relation) =>
-              relation.name === candidate.name && relation.schemaName === candidate.schemaName,
-          )
-        ) {
-          pendingRelations.push({schemaName: candidate.schemaName, name: candidate.name});
-        }
-      }
-    }
+    removeDependentObjects(activeObjects, object, change.cascade === true);
   }
   return dedupeExpectedObjects([...activeObjects.values()]);
+}
+
+function removeDependentObjects(
+  activeObjects: Map<string, ExpectedCatalogObject>,
+  droppedObject: ExpectedCatalogObject,
+  cascade: boolean,
+): void {
+  const pendingRelations: ExpectedRelationReference[] = [
+    {schemaName: droppedObject.schemaName, name: droppedObject.name},
+  ];
+  for (const droppedRelation of pendingRelations) {
+    for (const [candidateKey, candidate] of activeObjects) {
+      if (!dependsOnDroppedRelation(candidate, droppedRelation, cascade)) continue;
+      activeObjects.delete(candidateKey);
+      if (cascade) addPendingDroppedRelation(candidate, pendingRelations);
+    }
+  }
+}
+
+function dependsOnDroppedRelation(
+  candidate: ExpectedCatalogObject,
+  droppedRelation: ExpectedRelationReference,
+  cascade: boolean,
+): boolean {
+  const relationMatches =
+    candidate.relationName === droppedRelation.name &&
+    (candidate.relationSchemaName ?? 'public') === droppedRelation.schemaName;
+  const referencedRelationMatches =
+    cascade &&
+    candidate.referencedRelations?.some(
+      (reference) =>
+        reference.name === droppedRelation.name &&
+        reference.schemaName === droppedRelation.schemaName,
+    );
+  return relationMatches || referencedRelationMatches === true;
+}
+
+function addPendingDroppedRelation(
+  candidate: ExpectedCatalogObject,
+  pendingRelations: ExpectedRelationReference[],
+): void {
+  if (candidate.kind !== 'table' && candidate.kind !== 'view') return;
+  if (
+    pendingRelations.some(
+      (relation) =>
+        relation.name === candidate.name && relation.schemaName === candidate.schemaName,
+    )
+  ) {
+    return;
+  }
+  pendingRelations.push({schemaName: candidate.schemaName, name: candidate.name});
 }
 
 export function migrationHistoryName(namespace: string): string {
@@ -1010,13 +1064,335 @@ function classifyUnexpectedRelation(
 function sortFindings(left: CatalogFinding, right: CatalogFinding): number {
   const leftKey = [left.classification, left.schemaName, left.name, left.kind].join(':');
   const rightKey = [right.classification, right.schemaName, right.name, right.kind].join(':');
-  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  return compareText(leftKey, rightKey);
 }
 
 function sortObjects(left: CatalogObjectReport, right: CatalogObjectReport): number {
   const leftKey = [left.schemaName, left.name, left.kind].join(':');
   const rightKey = [right.schemaName, right.name, right.kind].join(':');
-  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  return compareText(leftKey, rightKey);
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+type ActualCatalogObject = CatalogRelation | CatalogEnum | CatalogConstraint | CatalogTrigger;
+
+function actualCatalogObjectsByKey(catalog: PostgresCatalog): Map<string, ActualCatalogObject> {
+  const actualByKey = new Map<string, ActualCatalogObject>();
+  for (const relation of catalog.relations) {
+    const kind = actualRelationKind(relation.relkind);
+    if (kind && relation.schemaName !== 'drizzle') {
+      actualByKey.set(objectKey(kind, relation.schemaName, relation.name), relation);
+    }
+  }
+  for (const enumObject of catalog.enums) {
+    actualByKey.set(objectKey('enum', enumObject.schemaName, enumObject.name), enumObject);
+  }
+  for (const constraint of catalog.constraints) {
+    actualByKey.set(objectKey('constraint', constraint.schemaName, constraint.name), constraint);
+  }
+  for (const trigger of catalog.triggers) {
+    actualByKey.set(objectKey('trigger', trigger.schemaName, trigger.name), trigger);
+  }
+  return actualByKey;
+}
+
+interface CatalogAuditAccumulator {
+  consumedActualKeys: Set<string>;
+  findings: CatalogFinding[];
+  objects: CatalogObjectReport[];
+}
+
+function auditExpectedCatalogObject(
+  object: ExpectedCatalogObject,
+  actualByKey: ReadonlyMap<string, ActualCatalogObject>,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+  audit: CatalogAuditAccumulator,
+): void {
+  const key = objectKey(object.kind, object.schemaName, postgresIdentifierName(object.name));
+  const actual = actualByKey.get(key);
+  if (!actual) {
+    const reportObject = reportFromExpected(object, 'missing');
+    audit.objects.push(reportObject);
+    addFinding(
+      audit.findings,
+      reportObject,
+      'missing',
+      `Missing ${object.kind} ${object.schemaName}.${object.name} declared by ${object.migrationUnitId}`,
+    );
+    return;
+  }
+  audit.consumedActualKeys.add(key);
+  let classification = expectedObjectStatus(object, registry);
+  const foreignKeyOwners =
+    object.kind === 'constraint' && 'type' in actual
+      ? crossOwnerForeignKey(actual, tableOwners, registry)
+      : undefined;
+  if (foreignKeyOwners) classification = 'cross-owner';
+  const reportObject = reportFromExpected(object, classification, actual.name);
+  audit.objects.push(reportObject);
+  if (classification === 'misnamed') {
+    reportObject.expectedName = `${object.namespace}_...`;
+    addFinding(
+      audit.findings,
+      reportObject,
+      'misnamed',
+      `${object.kind} ${object.schemaName}.${object.name} is owned by ${object.ownerId} but must use the ${object.namespace}_ namespace`,
+    );
+    return;
+  }
+  if (classification !== 'cross-owner') return;
+  const foreignOwner =
+    foreignKeyOwners?.referencedOwner ?? ownerForObjectName(object.name, registry)?.ownerId;
+  if (foreignOwner) reportObject.referencedOwnerId = foreignOwner;
+  const message = foreignKeyOwners
+    ? `Foreign key ${object.schemaName}.${actual.name} crosses from ${foreignKeyOwners.sourceOwner} to ${foreignKeyOwners.referencedOwner}`
+    : `${object.kind} ${object.schemaName}.${object.name} is declared by ${object.ownerId} but uses the ${foreignOwner ?? 'unknown'} namespace`;
+  addFinding(audit.findings, reportObject, 'cross-owner', message);
+}
+
+function auditMigrationHistories(
+  catalog: PostgresCatalog,
+  expectedHistories: readonly ExpectedMigrationHistory[],
+  audit: CatalogAuditAccumulator,
+): void {
+  const historyByName = new Map(
+    catalog.relations
+      .filter(
+        (relation) =>
+          relation.schemaName === 'drizzle' && actualRelationKind(relation.relkind) === 'table',
+      )
+      .map((relation) => [relation.name, relation]),
+  );
+  for (const history of expectedHistories) {
+    auditMigrationHistory(history, historyByName.get(history.runtimeName), audit);
+  }
+}
+
+function auditMigrationHistory(
+  history: ExpectedMigrationHistory,
+  actual: CatalogRelation | undefined,
+  audit: CatalogAuditAccumulator,
+): void {
+  let classification: CatalogObjectClassification = 'missing';
+  if (actual && history.runtimeName === history.name) classification = 'compliant';
+  else if (actual) classification = 'misnamed';
+  const reportObject: CatalogObjectReport = {
+    classification,
+    kind: 'migration-history',
+    schemaName: history.schemaName,
+    name: actual?.name ?? history.name,
+    ownerId: history.ownerId,
+    migrationUnitId: history.migrationUnitId,
+    namespace: history.namespace,
+    expectedName: history.name,
+    sourcePath: history.sourcePath,
+    line: history.line,
+  };
+  audit.objects.push(reportObject);
+  if (!actual) {
+    addFinding(
+      audit.findings,
+      reportObject,
+      'missing',
+      `Missing migration history drizzle.${history.name} for ${history.migrationUnitId}`,
+    );
+    return;
+  }
+  audit.consumedActualKeys.add(objectKey('migration-history', 'drizzle', actual.name));
+  if (history.runtimeName !== history.name) {
+    addFinding(
+      audit.findings,
+      reportObject,
+      'misnamed',
+      `Migration history for ${history.migrationUnitId} uses ${history.runtimeName} instead of ${history.name}`,
+    );
+  }
+}
+
+function auditUnexpectedRelations(
+  catalog: PostgresCatalog,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+  audit: CatalogAuditAccumulator,
+): void {
+  for (const relation of catalog.relations) {
+    if (relation.schemaName === 'drizzle') {
+      auditUnexpectedHistory(relation, audit);
+      continue;
+    }
+    const kind = actualRelationKind(relation.relkind);
+    if (!kind) continue;
+    const key = objectKey(kind, relation.schemaName, relation.name);
+    if (audit.consumedActualKeys.has(key)) continue;
+    const classification = classifyUnexpectedRelation(relation, catalog, tableOwners, registry);
+    const reportObject: CatalogObjectReport = {
+      classification,
+      kind,
+      schemaName: relation.schemaName,
+      name: relation.name,
+    };
+    audit.objects.push(reportObject);
+    if (classification !== 'compliant') {
+      addFinding(
+        audit.findings,
+        reportObject,
+        classification,
+        `Unknown ${kind} ${relation.schemaName}.${relation.name}`,
+      );
+    }
+  }
+}
+
+function auditUnexpectedHistory(relation: CatalogRelation, audit: CatalogAuditAccumulator): void {
+  if (actualRelationKind(relation.relkind) !== 'table') return;
+  const key = objectKey('migration-history', 'drizzle', relation.name);
+  if (audit.consumedActualKeys.has(key)) return;
+  const reportObject: CatalogObjectReport = {
+    classification: 'unknown',
+    kind: 'migration-history',
+    schemaName: 'drizzle',
+    name: relation.name,
+  };
+  audit.objects.push(reportObject);
+  addFinding(
+    audit.findings,
+    reportObject,
+    'unknown',
+    `Unknown migration history drizzle.${relation.name}`,
+  );
+}
+
+function auditUnexpectedEnums(catalog: PostgresCatalog, audit: CatalogAuditAccumulator): void {
+  for (const enumObject of catalog.enums) {
+    const key = objectKey('enum', enumObject.schemaName, enumObject.name);
+    if (audit.consumedActualKeys.has(key)) continue;
+    const reportObject: CatalogObjectReport = {
+      classification: 'unknown',
+      kind: 'enum',
+      schemaName: enumObject.schemaName,
+      name: enumObject.name,
+    };
+    audit.objects.push(reportObject);
+    addFinding(
+      audit.findings,
+      reportObject,
+      'unknown',
+      `Unknown enum ${enumObject.schemaName}.${enumObject.name}`,
+    );
+  }
+}
+
+function auditUnexpectedConstraints(
+  catalog: PostgresCatalog,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+  audit: CatalogAuditAccumulator,
+): void {
+  for (const constraint of catalog.constraints) {
+    if (constraint.schemaName === 'drizzle') continue;
+    const key = objectKey('constraint', constraint.schemaName, constraint.name);
+    if (audit.consumedActualKeys.has(key)) continue;
+    auditUnexpectedConstraint(constraint, tableOwners, registry, audit);
+  }
+}
+
+function auditUnexpectedConstraint(
+  constraint: CatalogConstraint,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+  audit: CatalogAuditAccumulator,
+): void {
+  const sourceOwner = ownerForRelation(
+    constraint.relationSchemaName,
+    constraint.relationName,
+    tableOwners,
+    registry,
+  );
+  const foreignKeyOwners = crossOwnerForeignKey(constraint, tableOwners, registry);
+  let classification: CatalogObjectClassification = 'unknown';
+  if (foreignKeyOwners) classification = 'cross-owner';
+  else if (sourceOwner) classification = 'compliant';
+  const reportObject: CatalogObjectReport = {
+    classification,
+    kind: 'constraint',
+    schemaName: constraint.schemaName,
+    name: constraint.name,
+    ...(sourceOwner ? {ownerId: sourceOwner} : {}),
+    ...(foreignKeyOwners ? {referencedOwnerId: foreignKeyOwners.referencedOwner} : {}),
+    relationName: constraint.relationName,
+    referencedRelationName: constraint.referencedRelationName,
+  };
+  audit.objects.push(reportObject);
+  if (foreignKeyOwners) {
+    addFinding(
+      audit.findings,
+      reportObject,
+      'cross-owner',
+      `Foreign key ${constraint.schemaName}.${constraint.name} crosses from ${foreignKeyOwners.sourceOwner} to ${foreignKeyOwners.referencedOwner}`,
+    );
+  } else if (!sourceOwner) {
+    addFinding(
+      audit.findings,
+      reportObject,
+      'unknown',
+      `Unknown constraint ${constraint.schemaName}.${constraint.name}`,
+    );
+  }
+}
+
+function auditUnexpectedTriggers(
+  catalog: PostgresCatalog,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+  audit: CatalogAuditAccumulator,
+): void {
+  for (const trigger of catalog.triggers) {
+    const key = objectKey('trigger', trigger.schemaName, trigger.name);
+    if (audit.consumedActualKeys.has(key)) continue;
+    const owner = ownerForRelation(trigger.schemaName, trigger.relationName, tableOwners, registry);
+    const reportObject: CatalogObjectReport = {
+      classification: owner ? 'compliant' : 'unknown',
+      kind: 'trigger',
+      schemaName: trigger.schemaName,
+      name: trigger.name,
+      ...(owner ? {ownerId: owner} : {}),
+      relationName: trigger.relationName,
+    };
+    audit.objects.push(reportObject);
+    if (!owner) {
+      addFinding(
+        audit.findings,
+        reportObject,
+        'unknown',
+        `Unknown trigger ${trigger.schemaName}.${trigger.name}`,
+      );
+    }
+  }
+}
+
+function auditUnexpectedNamespaces(catalog: PostgresCatalog, audit: CatalogAuditAccumulator): void {
+  for (const namespace of catalog.namespaces) {
+    if (namespace.name === 'public' || namespace.name === 'drizzle') continue;
+    const reportObject: CatalogObjectReport = {
+      classification: 'unknown',
+      kind: 'schema',
+      schemaName: namespace.name,
+      name: namespace.name,
+    };
+    audit.objects.push(reportObject);
+    addFinding(
+      audit.findings,
+      reportObject,
+      'unknown',
+      `Unknown PostgreSQL schema ${namespace.name}`,
+    );
+  }
 }
 
 export function auditPostgresCatalog({
@@ -1039,261 +1415,20 @@ export function auditPostgresCatalog({
   const findings: CatalogFinding[] = [];
   const objects: CatalogObjectReport[] = [];
   const consumedActualKeys = new Set<string>();
-  const actualByKey = new Map<
-    string,
-    CatalogRelation | CatalogEnum | CatalogConstraint | CatalogTrigger
-  >();
-
-  for (const relation of catalog.relations) {
-    const kind = actualRelationKind(relation.relkind);
-    if (kind && relation.schemaName !== 'drizzle') {
-      actualByKey.set(objectKey(kind, relation.schemaName, relation.name), relation);
-    }
-  }
-  for (const enumObject of catalog.enums) {
-    actualByKey.set(objectKey('enum', enumObject.schemaName, enumObject.name), enumObject);
-  }
-  for (const constraint of catalog.constraints) {
-    actualByKey.set(objectKey('constraint', constraint.schemaName, constraint.name), constraint);
-  }
-  for (const trigger of catalog.triggers) {
-    actualByKey.set(objectKey('trigger', trigger.schemaName, trigger.name), trigger);
-  }
+  const audit = {consumedActualKeys, findings, objects};
+  const actualByKey = actualCatalogObjectsByKey(catalog);
 
   const tableOwners = tableOwnerLookup(expectedObjects);
   for (const object of expectedObjects) {
-    const key = objectKey(object.kind, object.schemaName, postgresIdentifierName(object.name));
-    const actual = actualByKey.get(key);
-    if (!actual) {
-      const reportObject = reportFromExpected(object, 'missing');
-      objects.push(reportObject);
-      addFinding(
-        findings,
-        reportObject,
-        'missing',
-        `Missing ${object.kind} ${object.schemaName}.${object.name} declared by ${object.migrationUnitId}`,
-      );
-      continue;
-    }
-    consumedActualKeys.add(key);
-    let classification = expectedObjectStatus(object, registry);
-    const foreignKeyOwners =
-      object.kind === 'constraint' && 'type' in actual
-        ? crossOwnerForeignKey(actual, tableOwners, registry)
-        : undefined;
-    if (foreignKeyOwners) classification = 'cross-owner';
-    const reportObject = reportFromExpected(object, classification, actual.name);
-    objects.push(reportObject);
-    if (classification === 'misnamed') {
-      reportObject.expectedName = `${object.namespace}_...`;
-      addFinding(
-        findings,
-        reportObject,
-        'misnamed',
-        `${object.kind} ${object.schemaName}.${object.name} is owned by ${object.ownerId} but must use the ${object.namespace}_ namespace`,
-      );
-    } else if (classification === 'cross-owner') {
-      const foreignOwner =
-        foreignKeyOwners?.referencedOwner ?? ownerForObjectName(object.name, registry)?.ownerId;
-      if (foreignOwner) reportObject.referencedOwnerId = foreignOwner;
-      addFinding(
-        findings,
-        reportObject,
-        'cross-owner',
-        foreignKeyOwners
-          ? `Foreign key ${object.schemaName}.${actual.name} crosses from ${foreignKeyOwners.sourceOwner} to ${foreignKeyOwners.referencedOwner}`
-          : `${object.kind} ${object.schemaName}.${object.name} is declared by ${object.ownerId} but uses the ${foreignOwner ?? 'unknown'} namespace`,
-      );
-    }
+    auditExpectedCatalogObject(object, actualByKey, tableOwners, registry, audit);
   }
 
-  const historyByName = new Map(
-    catalog.relations
-      .filter(
-        (relation) =>
-          relation.schemaName === 'drizzle' && actualRelationKind(relation.relkind) === 'table',
-      )
-      .map((relation) => [relation.name, relation]),
-  );
-  for (const history of expectedHistories) {
-    const actual = historyByName.get(history.runtimeName);
-    const reportObject: CatalogObjectReport = {
-      classification:
-        actual && history.runtimeName === history.name
-          ? 'compliant'
-          : actual
-            ? 'misnamed'
-            : 'missing',
-      kind: 'migration-history',
-      schemaName: history.schemaName,
-      name: actual?.name ?? history.name,
-      ownerId: history.ownerId,
-      migrationUnitId: history.migrationUnitId,
-      namespace: history.namespace,
-      expectedName: history.name,
-      sourcePath: history.sourcePath,
-      line: history.line,
-    };
-    objects.push(reportObject);
-    if (actual) {
-      consumedActualKeys.add(objectKey('migration-history', 'drizzle', actual.name));
-      if (history.runtimeName !== history.name) {
-        addFinding(
-          findings,
-          reportObject,
-          'misnamed',
-          `Migration history for ${history.migrationUnitId} uses ${history.runtimeName} instead of ${history.name}`,
-        );
-      }
-    } else {
-      addFinding(
-        findings,
-        reportObject,
-        'missing',
-        `Missing migration history drizzle.${history.name} for ${history.migrationUnitId}`,
-      );
-    }
-  }
-
-  for (const relation of catalog.relations) {
-    if (relation.schemaName === 'drizzle') {
-      if (actualRelationKind(relation.relkind) === 'table') {
-        const key = objectKey('migration-history', 'drizzle', relation.name);
-        if (!consumedActualKeys.has(key)) {
-          const reportObject: CatalogObjectReport = {
-            classification: 'unknown',
-            kind: 'migration-history',
-            schemaName: 'drizzle',
-            name: relation.name,
-          };
-          objects.push(reportObject);
-          addFinding(
-            findings,
-            reportObject,
-            'unknown',
-            `Unknown migration history drizzle.${relation.name}`,
-          );
-        }
-      }
-      continue;
-    }
-    const kind = actualRelationKind(relation.relkind);
-    if (!kind) continue;
-    const key = objectKey(kind, relation.schemaName, relation.name);
-    if (consumedActualKeys.has(key)) continue;
-    const classification = classifyUnexpectedRelation(relation, catalog, tableOwners, registry);
-    const reportObject: CatalogObjectReport = {
-      classification,
-      kind,
-      schemaName: relation.schemaName,
-      name: relation.name,
-    };
-    objects.push(reportObject);
-    if (classification !== 'compliant') {
-      addFinding(
-        findings,
-        reportObject,
-        classification,
-        `Unknown ${kind} ${relation.schemaName}.${relation.name}`,
-      );
-    }
-  }
-
-  for (const enumObject of catalog.enums) {
-    const key = objectKey('enum', enumObject.schemaName, enumObject.name);
-    if (consumedActualKeys.has(key)) continue;
-    const reportObject: CatalogObjectReport = {
-      classification: 'unknown',
-      kind: 'enum',
-      schemaName: enumObject.schemaName,
-      name: enumObject.name,
-    };
-    objects.push(reportObject);
-    addFinding(
-      findings,
-      reportObject,
-      'unknown',
-      `Unknown enum ${enumObject.schemaName}.${enumObject.name}`,
-    );
-  }
-
-  for (const constraint of catalog.constraints) {
-    if (constraint.schemaName === 'drizzle') continue;
-    const key = objectKey('constraint', constraint.schemaName, constraint.name);
-    if (consumedActualKeys.has(key)) continue;
-    const sourceOwner = ownerForRelation(
-      constraint.relationSchemaName,
-      constraint.relationName,
-      tableOwners,
-      registry,
-    );
-    const foreignKeyOwners = crossOwnerForeignKey(constraint, tableOwners, registry);
-    const classification: CatalogObjectClassification = foreignKeyOwners
-      ? 'cross-owner'
-      : sourceOwner
-        ? 'compliant'
-        : 'unknown';
-    const reportObject: CatalogObjectReport = {
-      classification,
-      kind: 'constraint',
-      schemaName: constraint.schemaName,
-      name: constraint.name,
-      ...(sourceOwner ? {ownerId: sourceOwner} : {}),
-      ...(foreignKeyOwners ? {referencedOwnerId: foreignKeyOwners.referencedOwner} : {}),
-      relationName: constraint.relationName,
-      referencedRelationName: constraint.referencedRelationName,
-    };
-    objects.push(reportObject);
-    if (foreignKeyOwners) {
-      addFinding(
-        findings,
-        reportObject,
-        'cross-owner',
-        `Foreign key ${constraint.schemaName}.${constraint.name} crosses from ${foreignKeyOwners.sourceOwner} to ${foreignKeyOwners.referencedOwner}`,
-      );
-    } else if (!sourceOwner) {
-      addFinding(
-        findings,
-        reportObject,
-        'unknown',
-        `Unknown constraint ${constraint.schemaName}.${constraint.name}`,
-      );
-    }
-  }
-
-  for (const trigger of catalog.triggers) {
-    const key = objectKey('trigger', trigger.schemaName, trigger.name);
-    if (consumedActualKeys.has(key)) continue;
-    const owner = ownerForRelation(trigger.schemaName, trigger.relationName, tableOwners, registry);
-    const reportObject: CatalogObjectReport = {
-      classification: owner ? 'compliant' : 'unknown',
-      kind: 'trigger',
-      schemaName: trigger.schemaName,
-      name: trigger.name,
-      ...(owner ? {ownerId: owner} : {}),
-      relationName: trigger.relationName,
-    };
-    objects.push(reportObject);
-    if (!owner)
-      addFinding(
-        findings,
-        reportObject,
-        'unknown',
-        `Unknown trigger ${trigger.schemaName}.${trigger.name}`,
-      );
-  }
-
-  for (const namespace of catalog.namespaces) {
-    if (namespace.name === 'public' || namespace.name === 'drizzle') continue;
-    const reportObject: CatalogObjectReport = {
-      classification: 'unknown',
-      kind: 'schema',
-      schemaName: namespace.name,
-      name: namespace.name,
-    };
-    objects.push(reportObject);
-    addFinding(findings, reportObject, 'unknown', `Unknown PostgreSQL schema ${namespace.name}`);
-  }
+  auditMigrationHistories(catalog, expectedHistories, audit);
+  auditUnexpectedRelations(catalog, tableOwners, registry, audit);
+  auditUnexpectedEnums(catalog, audit);
+  auditUnexpectedConstraints(catalog, tableOwners, registry, audit);
+  auditUnexpectedTriggers(catalog, tableOwners, registry, audit);
+  auditUnexpectedNamespaces(catalog, audit);
 
   const counts: CatalogReportCounts = {
     compliant: objects.filter((object) => object.classification === 'compliant').length,
@@ -1398,6 +1533,6 @@ export function dedupeExpectedObjects(
   return [...seen.values(), ...ownershipConflicts].sort((left, right) => {
     const leftKey = objectKey(left.kind, left.schemaName, left.name);
     const rightKey = objectKey(right.kind, right.schemaName, right.name);
-    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    return compareText(leftKey, rightKey);
   });
 }

--- a/tools/architecture-policy/src/policy.ts
+++ b/tools/architecture-policy/src/policy.ts
@@ -23,63 +23,75 @@ export function evaluateArchitecturePolicy(
   const diagnostics: PolicyDiagnostic[] = [];
   const exceptions = Array.isArray(configuration?.exceptions) ? configuration.exceptions : [];
   const configurationErrors = validateRepositoryConfiguration(configuration);
-  for (const error of configurationErrors) {
-    const ruleId = configurationRuleId(error);
-    diagnostics.push(
-      diagnostic({
-        ruleId,
-        message: error,
-        expectedBoundary:
-          'A complete versioned repository configuration with explicit relationships',
-        guidanceLocation: configurationGuidanceLocation(ruleId),
-        facts: {configurationError: error},
-      }),
-    );
-  }
+  diagnostics.push(...configurationErrorDiagnostics(configurationErrors));
   const factErrors = validateArchitectureFacts(facts);
-  for (const error of factErrors) {
-    diagnostics.push(
-      diagnostic({
-        ruleId: RULE_IDS.factReference,
-        message: error,
-        expectedBoundary: 'A versioned JSON-compatible architecture fact document',
-        guidanceLocation: guidanceLocations.facts,
-        facts: {factError: error},
-      }),
-    );
-  }
+  diagnostics.push(...factErrorDiagnostics(factErrors));
 
   const packageFacts = Array.isArray(facts?.packages) ? facts.packages : [];
   const packageMap = new Map(packageFacts.map((packageFact) => [packageFact.name, packageFact]));
   const validConfiguration = configurationErrors.length === 0;
   const validFacts = factErrors.length === 0;
 
-  if (
-    validConfiguration &&
-    validFacts &&
-    configuration !== null &&
-    configuration !== undefined &&
-    facts !== null &&
-    facts !== undefined
-  ) {
-    for (const packageFact of facts.packages)
-      evaluatePackageMetadata(packageFact, configuration, diagnostics);
-    evaluateLocalClassifications(facts.packages, configuration, diagnostics);
-
-    for (const edge of facts.importEdges)
-      evaluateImportEdge(edge, packageMap, configuration, diagnostics);
-    for (const edge of facts.manifestEdges)
-      evaluateManifestEdge(edge, packageMap, configuration, diagnostics);
-    for (const exportFact of facts.publicExports)
-      evaluateExport(exportFact, packageMap, diagnostics);
-    evaluateExportIntent(facts.publicExports, packageMap, configuration, diagnostics);
-    for (const compositionFact of facts.compositionFacts)
-      evaluateComposition(compositionFact, packageMap, configuration, diagnostics);
-
-    evaluateExceptions(exceptions, options, diagnostics);
+  if (validConfiguration && validFacts && configuration && facts) {
+    evaluateValidArchitecturePolicy(
+      facts,
+      configuration,
+      packageMap,
+      exceptions,
+      options,
+      diagnostics,
+    );
   }
 
   return applyExactExceptions(diagnostics, exceptions, options);
+}
+
+function configurationErrorDiagnostics(errors: readonly string[]): PolicyDiagnostic[] {
+  return errors.map((error) => {
+    const ruleId = configurationRuleId(error);
+    return diagnostic({
+      ruleId,
+      message: error,
+      expectedBoundary: 'A complete versioned repository configuration with explicit relationships',
+      guidanceLocation: configurationGuidanceLocation(ruleId),
+      facts: {configurationError: error},
+    });
+  });
+}
+
+function factErrorDiagnostics(errors: readonly string[]): PolicyDiagnostic[] {
+  return errors.map((error) =>
+    diagnostic({
+      ruleId: RULE_IDS.factReference,
+      message: error,
+      expectedBoundary: 'A versioned JSON-compatible architecture fact document',
+      guidanceLocation: guidanceLocations.facts,
+      facts: {factError: error},
+    }),
+  );
+}
+
+function evaluateValidArchitecturePolicy(
+  facts: ArchitectureFacts,
+  configuration: RepositoryConfiguration,
+  packageMap: ReadonlyMap<string, PackageFact>,
+  exceptions: readonly ExactException[],
+  options: PolicyEvaluationOptions,
+  diagnostics: PolicyDiagnostic[],
+): void {
+  for (const packageFact of facts.packages)
+    evaluatePackageMetadata(packageFact, configuration, diagnostics);
+  evaluateLocalClassifications(facts.packages, configuration, diagnostics);
+  for (const edge of facts.importEdges)
+    evaluateImportEdge(edge, packageMap, configuration, diagnostics);
+  for (const edge of facts.manifestEdges)
+    evaluateManifestEdge(edge, packageMap, configuration, diagnostics);
+  for (const exportFact of facts.publicExports) evaluateExport(exportFact, packageMap, diagnostics);
+  evaluateExportIntent(facts.publicExports, packageMap, configuration, diagnostics);
+  for (const compositionFact of facts.compositionFacts) {
+    evaluateComposition(compositionFact, packageMap, configuration, diagnostics);
+  }
+  evaluateExceptions(exceptions, options, diagnostics);
 }
 
 export const evaluatePolicy = evaluateArchitecturePolicy;
@@ -453,7 +465,7 @@ function evaluateComposition(
 }
 
 function evaluateExceptions(
-  exceptions: ExactException[],
+  exceptions: readonly ExactException[],
   options: PolicyEvaluationOptions,
   diagnostics: PolicyDiagnostic[],
 ): void {
@@ -477,7 +489,7 @@ function evaluateExceptions(
 
 function applyExactExceptions(
   diagnostics: PolicyDiagnostic[],
-  exceptions: ExactException[],
+  exceptions: readonly ExactException[],
   options: PolicyEvaluationOptions,
 ): PolicyDiagnostic[] {
   const now = resolveNow(options.now);

--- a/tools/architecture-policy/src/validation.ts
+++ b/tools/architecture-policy/src/validation.ts
@@ -106,35 +106,7 @@ export function validateArchitectureFacts(value: unknown): string[] {
   if (!Array.isArray(packages)) {
     errors.push('Architecture facts packages must be an array');
   } else {
-    const names = new Set<string>();
-    for (const [index, packageFact] of packages.entries()) {
-      if (!isRecord(packageFact)) {
-        errors.push(`Package fact ${index} must be an object`);
-        continue;
-      }
-      validateSchemaVersion(packageFact, `Package fact ${index}`, errors);
-      requireNonEmptyString(packageFact.name, `Package fact ${index} name`, errors);
-      requireNullableString(packageFact.version, `Package fact ${index} version`, errors);
-      requireNonEmptyString(packageFact.path, `Package fact ${index} path`, errors);
-      requireEnum(packageFact.origin, packageOrigins, `Package fact ${index} origin`, errors);
-      if (typeof packageFact.policyParticipant !== 'boolean')
-        errors.push(`Package fact ${index} policyParticipant must be a boolean`);
-      requireNullableString(packageFact.realm, `Package fact ${index} realm`, errors);
-      requireNullableString(
-        packageFact.architectureClass,
-        `Package fact ${index} architectureClass`,
-        errors,
-      );
-      requireNullableString(
-        packageFact.boundedContext,
-        `Package fact ${index} boundedContext`,
-        errors,
-      );
-      if (typeof packageFact.name === 'string') {
-        if (names.has(packageFact.name)) errors.push(`Duplicate package fact: ${packageFact.name}`);
-        names.add(packageFact.name);
-      }
-    }
+    validatePackageFacts(packages, errors);
   }
 
   validateArray(value.importEdges, 'import edge', errors, (edge, index) => {
@@ -181,6 +153,38 @@ export function validateArchitectureFacts(value: unknown): string[] {
   return [...new Set(errors)].sort();
 }
 
+function validatePackageFacts(packages: readonly unknown[], errors: string[]): void {
+  const names = new Set<string>();
+  for (const [index, packageFact] of packages.entries()) {
+    if (!isRecord(packageFact)) {
+      errors.push(`Package fact ${index} must be an object`);
+      continue;
+    }
+    validateSchemaVersion(packageFact, `Package fact ${index}`, errors);
+    requireNonEmptyString(packageFact.name, `Package fact ${index} name`, errors);
+    requireNullableString(packageFact.version, `Package fact ${index} version`, errors);
+    requireNonEmptyString(packageFact.path, `Package fact ${index} path`, errors);
+    requireEnum(packageFact.origin, packageOrigins, `Package fact ${index} origin`, errors);
+    if (typeof packageFact.policyParticipant !== 'boolean') {
+      errors.push(`Package fact ${index} policyParticipant must be a boolean`);
+    }
+    requireNullableString(packageFact.realm, `Package fact ${index} realm`, errors);
+    requireNullableString(
+      packageFact.architectureClass,
+      `Package fact ${index} architectureClass`,
+      errors,
+    );
+    requireNullableString(
+      packageFact.boundedContext,
+      `Package fact ${index} boundedContext`,
+      errors,
+    );
+    if (typeof packageFact.name !== 'string') continue;
+    if (names.has(packageFact.name)) errors.push(`Duplicate package fact: ${packageFact.name}`);
+    names.add(packageFact.name);
+  }
+}
+
 export function isArchitectureFacts(value: unknown): value is ArchitectureFacts {
   return validateArchitectureFacts(value).length === 0;
 }
@@ -193,6 +197,15 @@ export function assertArchitectureFacts(value: unknown): asserts value is Archit
 export function validateRepositoryConfiguration(value: unknown): string[] {
   const errors: string[] = [];
   if (!isRecord(value)) return ['Repository configuration must be an object'];
+  validateRepositoryConfigurationShape(value, errors);
+  validateRepositoryConfigurationContents(value, errors);
+  return [...new Set(errors)].sort();
+}
+
+function validateRepositoryConfigurationShape(
+  value: Record<string, unknown>,
+  errors: string[],
+): void {
   if (value.schemaVersion !== architecturePolicySchemaVersion)
     errors.push(
       `Unsupported repository configuration schema version: ${String(value.schemaVersion)}`,
@@ -210,141 +223,176 @@ export function validateRepositoryConfiguration(value: unknown): string[] {
     errors.push('Repository configuration exportIntent must be an object');
   if (!isRecord(value.extensions))
     errors.push('Repository configuration extensions must be an object');
-  if (isRecord(value.extensions)) {
-    for (const [name, extension] of Object.entries(value.extensions)) {
-      if (!isJsonValue(extension))
-        errors.push(`Repository extension is not JSON-compatible: ${name}`);
-    }
-  }
+  if (isRecord(value.extensions)) validateExtensions(value.extensions, errors);
   if (!Array.isArray(value.exceptions))
     errors.push('Repository configuration exceptions must be an array');
+}
 
-  if (Array.isArray(value.localPackages)) {
-    const paths = new Set<string>();
-    for (const [index, entry] of value.localPackages.entries()) {
-      if (!isRecord(entry)) {
-        errors.push(`Local package classification ${index} must be an object`);
-        continue;
-      }
-      requireNonEmptyString(entry.path, `Local package classification ${index} path`, errors);
-      requireNonEmptyString(
-        entry.packageName,
-        `Local package classification ${index} packageName`,
-        errors,
-      );
-      requireNonEmptyString(entry.realm, `Local package classification ${index} realm`, errors);
-      requireNonEmptyString(
-        entry.architectureClass,
-        `Local package classification ${index} architectureClass`,
-        errors,
-      );
-      requireNullableString(
-        entry.boundedContext,
-        `Local package classification ${index} boundedContext`,
-        errors,
-      );
-      if (typeof entry.path === 'string') {
-        if (paths.has(entry.path))
-          errors.push(`Duplicate local package classification: ${entry.path}`);
-        paths.add(entry.path);
-      }
-    }
-  }
-
-  if (Array.isArray(value.compositionRoots)) {
-    for (const [index, root] of value.compositionRoots.entries())
-      requireNonEmptyString(root, `Composition root ${index}`, errors);
-  }
+function validateRepositoryConfigurationContents(
+  value: Record<string, unknown>,
+  errors: string[],
+): void {
+  if (Array.isArray(value.localPackages)) validateLocalPackages(value.localPackages, errors);
+  if (Array.isArray(value.compositionRoots))
+    validateCompositionRoots(value.compositionRoots, errors);
 
   const realmNames = isRecord(value.realms) ? Object.keys(value.realms) : [];
-  if (isRecord(value.realms)) {
-    for (const [realm, realmConfig] of Object.entries(value.realms)) {
-      if (!isRecord(realmConfig) || !Array.isArray(realmConfig.mayDependOn)) {
-        errors.push(`Realm ${realm} must define mayDependOn as an array`);
-        continue;
-      }
-      for (const [index, dependency] of realmConfig.mayDependOn.entries()) {
-        requireNonEmptyString(dependency, `Realm ${realm} mayDependOn[${index}]`, errors);
-        if (typeof dependency === 'string' && !realmNames.includes(dependency))
-          errors.push(`Realm ${realm} references undeclared realm: ${dependency}`);
-      }
-    }
-  }
+  if (isRecord(value.realms)) validateRealms(value.realms, realmNames, errors);
 
   const classNames = isRecord(value.architectureClasses)
     ? Object.keys(value.architectureClasses)
     : [];
-  if (isRecord(value.architectureClasses)) {
-    for (const [architectureClass, classConfig] of Object.entries(value.architectureClasses)) {
-      if (!isRecord(classConfig) || typeof classConfig.requiresBoundedContext !== 'boolean')
-        errors.push(`Architecture class ${architectureClass} must define requiresBoundedContext`);
+  if (isRecord(value.architectureClasses))
+    validateArchitectureClasses(value.architectureClasses, errors);
+  if (isRecord(value.classRelationships))
+    validateClassRelationships(value.classRelationships, classNames, errors);
+  if (isRecord(value.exportIntent)) validateExportIntent(value.exportIntent, errors);
+  if (Array.isArray(value.exceptions)) validateExceptions(value.exceptions, errors);
+}
+
+function validateExtensions(extensions: Record<string, unknown>, errors: string[]): void {
+  for (const [name, extension] of Object.entries(extensions)) {
+    if (!isJsonValue(extension))
+      errors.push(`Repository extension is not JSON-compatible: ${name}`);
+  }
+}
+
+function validateLocalPackages(entries: readonly unknown[], errors: string[]): void {
+  const paths = new Set<string>();
+  for (const [index, entry] of entries.entries()) {
+    if (!isRecord(entry)) {
+      errors.push(`Local package classification ${index} must be an object`);
+      continue;
+    }
+    requireNonEmptyString(entry.path, `Local package classification ${index} path`, errors);
+    requireNonEmptyString(
+      entry.packageName,
+      `Local package classification ${index} packageName`,
+      errors,
+    );
+    requireNonEmptyString(entry.realm, `Local package classification ${index} realm`, errors);
+    requireNonEmptyString(
+      entry.architectureClass,
+      `Local package classification ${index} architectureClass`,
+      errors,
+    );
+    requireNullableString(
+      entry.boundedContext,
+      `Local package classification ${index} boundedContext`,
+      errors,
+    );
+    if (typeof entry.path !== 'string') continue;
+    if (paths.has(entry.path)) errors.push(`Duplicate local package classification: ${entry.path}`);
+    paths.add(entry.path);
+  }
+}
+
+function validateCompositionRoots(roots: readonly unknown[], errors: string[]): void {
+  for (const [index, root] of roots.entries())
+    requireNonEmptyString(root, `Composition root ${index}`, errors);
+}
+
+function validateRealms(
+  realms: Record<string, unknown>,
+  realmNames: readonly string[],
+  errors: string[],
+): void {
+  for (const [realm, realmConfig] of Object.entries(realms)) {
+    if (!isRecord(realmConfig) || !Array.isArray(realmConfig.mayDependOn)) {
+      errors.push(`Realm ${realm} must define mayDependOn as an array`);
+      continue;
+    }
+    for (const [index, dependency] of realmConfig.mayDependOn.entries()) {
+      requireNonEmptyString(dependency, `Realm ${realm} mayDependOn[${index}]`, errors);
+      if (typeof dependency === 'string' && !realmNames.includes(dependency)) {
+        errors.push(`Realm ${realm} references undeclared realm: ${dependency}`);
+      }
     }
   }
+}
 
-  if (isRecord(value.classRelationships)) {
-    for (const architectureClass of classNames) {
-      const row = value.classRelationships[architectureClass];
-      if (!isRecord(row)) {
-        errors.push(`Missing class relationship row: ${architectureClass}`);
-        continue;
-      }
-      for (const targetClass of classNames) {
-        const relationship = row[targetClass];
-        if (!isRecord(relationship)) {
-          errors.push(
-            `Missing class relationship decision: ${architectureClass} -> ${targetClass}`,
-          );
-          continue;
-        }
-        requireEnum(
-          relationship.decision,
-          boundaryDecisions,
-          `Class relationship ${architectureClass} -> ${targetClass} decision`,
-          errors,
-        );
-        if (relationship.ruleId !== undefined) {
-          requireNonEmptyString(
-            relationship.ruleId,
-            `Class relationship ${architectureClass} -> ${targetClass} ruleId`,
-            errors,
-          );
-          if (typeof relationship.ruleId === 'string' && !ruleIds.has(relationship.ruleId))
-            errors.push(`Unknown class relationship rule ID: ${relationship.ruleId}`);
-        }
-        if (relationship.decision !== 'allow' && typeof relationship.ruleId !== 'string') {
-          errors.push(`Class relationship ${architectureClass} -> ${targetClass} needs a ruleId`);
-        }
-      }
-      for (const targetClass of Object.keys(row)) {
-        if (!classNames.includes(targetClass))
-          errors.push(
-            `Class relationship references undeclared class: ${architectureClass} -> ${targetClass}`,
-          );
-      }
-    }
-    for (const architectureClass of Object.keys(value.classRelationships)) {
-      if (!classNames.includes(architectureClass))
-        errors.push(`Class relationship has undeclared row: ${architectureClass}`);
+function validateArchitectureClasses(classes: Record<string, unknown>, errors: string[]): void {
+  for (const [architectureClass, classConfig] of Object.entries(classes)) {
+    if (!isRecord(classConfig) || typeof classConfig.requiresBoundedContext !== 'boolean') {
+      errors.push(`Architecture class ${architectureClass} must define requiresBoundedContext`);
     }
   }
+}
 
-  if (isRecord(value.exportIntent)) {
-    for (const [packageName, subpaths] of Object.entries(value.exportIntent)) {
-      if (!Array.isArray(subpaths)) {
-        errors.push(`Export intent for ${packageName} must be an array`);
-        continue;
-      }
-      for (const [index, subpath] of subpaths.entries())
-        requireNonEmptyString(subpath, `Export intent ${packageName}[${index}]`, errors);
+function validateClassRelationships(
+  relationships: Record<string, unknown>,
+  classNames: readonly string[],
+  errors: string[],
+): void {
+  for (const architectureClass of classNames) {
+    const row = relationships[architectureClass];
+    if (!isRecord(row)) {
+      errors.push(`Missing class relationship row: ${architectureClass}`);
+      continue;
+    }
+    validateClassRelationshipRow(architectureClass, row, classNames, errors);
+  }
+  for (const architectureClass of Object.keys(relationships)) {
+    if (!classNames.includes(architectureClass))
+      errors.push(`Class relationship has undeclared row: ${architectureClass}`);
+  }
+}
+
+function validateClassRelationshipRow(
+  architectureClass: string,
+  row: Record<string, unknown>,
+  classNames: readonly string[],
+  errors: string[],
+): void {
+  for (const targetClass of classNames) {
+    const relationship = row[targetClass];
+    if (!isRecord(relationship)) {
+      errors.push(`Missing class relationship decision: ${architectureClass} -> ${targetClass}`);
+      continue;
+    }
+    validateClassRelationship(architectureClass, targetClass, relationship, errors);
+  }
+  for (const targetClass of Object.keys(row)) {
+    if (!classNames.includes(targetClass))
+      errors.push(
+        `Class relationship references undeclared class: ${architectureClass} -> ${targetClass}`,
+      );
+  }
+}
+
+function validateClassRelationship(
+  architectureClass: string,
+  targetClass: string,
+  relationship: Record<string, unknown>,
+  errors: string[],
+): void {
+  const label = `Class relationship ${architectureClass} -> ${targetClass}`;
+  requireEnum(relationship.decision, boundaryDecisions, `${label} decision`, errors);
+  if (relationship.ruleId !== undefined) {
+    requireNonEmptyString(relationship.ruleId, `${label} ruleId`, errors);
+    if (typeof relationship.ruleId === 'string' && !ruleIds.has(relationship.ruleId)) {
+      errors.push(`Unknown class relationship rule ID: ${relationship.ruleId}`);
     }
   }
-
-  if (Array.isArray(value.exceptions)) {
-    for (const [index, exception] of value.exceptions.entries())
-      validateException(exception, `Exception ${index}`, errors);
+  if (relationship.decision !== 'allow' && typeof relationship.ruleId !== 'string') {
+    errors.push(`${label} needs a ruleId`);
   }
+}
 
-  return [...new Set(errors)].sort();
+function validateExportIntent(intent: Record<string, unknown>, errors: string[]): void {
+  for (const [packageName, subpaths] of Object.entries(intent)) {
+    if (!Array.isArray(subpaths)) {
+      errors.push(`Export intent for ${packageName} must be an array`);
+      continue;
+    }
+    for (const [index, subpath] of subpaths.entries())
+      requireNonEmptyString(subpath, `Export intent ${packageName}[${index}]`, errors);
+  }
+}
+
+function validateExceptions(exceptions: readonly unknown[], errors: string[]): void {
+  for (const [index, exception] of exceptions.entries())
+    validateException(exception, `Exception ${index}`, errors);
 }
 
 export function isRepositoryConfiguration(value: unknown): value is RepositoryConfiguration {

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -318,26 +318,49 @@ function featureContributionOccurrences(file: string, source: string): number {
   const coordinatorId = source.match(coordinatorPattern)?.[1];
   const hasExplicitCoordinator = featureId !== undefined && coordinatorId === featureId;
   let occurrences = featureId === `shipfox.${manifest[1]}` ? 0 : 1;
-
-  for (const implementationPackage of capturedMatches(source, routeImplementationPattern)) {
-    if (implementationPackage !== packageName && !hasExplicitCoordinator) occurrences += 1;
-  }
-
+  occurrences += foreignRouteImplementationCount(source, packageName, hasExplicitCoordinator);
   const routes = new Set(capturedMatches(source, routePathPattern).map(normalizeManifestPath));
-  for (const target of capturedMatches(source, navigationTargetPattern)) {
-    if (!routes.has(normalizeManifestPath(target)) && !hasExplicitCoordinator) occurrences += 1;
-  }
+  occurrences += missingNavigationTargetCount(source, routes, hasExplicitCoordinator);
+  occurrences += missingSettingsRouteCount(source, routes, hasExplicitCoordinator);
+  return occurrences;
+}
+
+function foreignRouteImplementationCount(
+  source: string,
+  packageName: string,
+  hasExplicitCoordinator: boolean,
+): number {
+  if (hasExplicitCoordinator) return 0;
+  return capturedMatches(source, routeImplementationPattern).filter((name) => name !== packageName)
+    .length;
+}
+
+function missingNavigationTargetCount(
+  source: string,
+  routes: ReadonlySet<string>,
+  hasExplicitCoordinator: boolean,
+): number {
+  if (hasExplicitCoordinator) return 0;
+  return capturedMatches(source, navigationTargetPattern).filter(
+    (target) => !routes.has(normalizeManifestPath(target)),
+  ).length;
+}
+
+function missingSettingsRouteCount(
+  source: string,
+  routes: ReadonlySet<string>,
+  hasExplicitCoordinator: boolean,
+): number {
+  if (hasExplicitCoordinator) return 0;
+  let occurrences = 0;
   for (const {segment, scope} of capturedSettingsSections(source)) {
     const workspaceTarget = normalizeManifestPath(`/w/$workspaceSlug/settings/${segment}`);
     const projectTarget = normalizeManifestPath(
       `/w/$workspaceSlug/p/$projectSlug/settings/${segment}`,
     );
     const target = scope === 'project' ? projectTarget : workspaceTarget;
-    if (!routes.has(target) && !hasExplicitCoordinator) {
-      occurrences += 1;
-    }
+    if (!routes.has(target)) occurrences += 1;
   }
-
   return occurrences;
 }
 
@@ -373,95 +396,124 @@ function findRegexLiteralEnd(source: string, start: number): number {
       continue;
     }
     if (character === '/' && !inCharacterClass) {
-      let end = index + 1;
-      while (regexFlagPattern.test(source[end] ?? '')) end += 1;
-      return end;
+      return findRegexFlagsEnd(source, index + 1);
     }
   }
   return source.length;
 }
 
+function findRegexFlagsEnd(source: string, start: number): number {
+  let end = start;
+  while (regexFlagPattern.test(source[end] ?? '')) end += 1;
+  return end;
+}
+
 function findMatchingCallEnd(source: string, openParen: number): number {
-  let depth = 0;
-  let quote: '"' | "'" | '`' | null = null;
-  let escaped = false;
-  let canEndExpression = false;
+  const state: CallScannerState = {depth: 0, quote: null, escaped: false, canEndExpression: false};
 
   for (let index = openParen; index < source.length; index += 1) {
-    const character = source[index];
-    const nextCharacter = source[index + 1];
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (character === '\\') {
-        escaped = true;
-      } else if (character === quote) {
-        quote = null;
-        canEndExpression = true;
-      }
+    const special = scanCallSpecial(source, index, state);
+    if (special.end !== undefined) return special.end;
+    if (special.handled) {
+      index = special.nextIndex;
       continue;
     }
-    if (whitespacePattern.test(character ?? '')) continue;
-    if (character === '/' && nextCharacter === '/') {
-      const newline = source.indexOf('\n', index + 2);
-      if (newline === -1) return source.length;
-      index = newline;
-      continue;
-    }
-    if (character === '/' && nextCharacter === '*') {
-      const commentEnd = source.indexOf('*/', index + 2);
-      if (commentEnd === -1) return source.length;
-      index = commentEnd + 1;
-      continue;
-    }
-    if (character === '"' || character === "'" || character === '`') {
-      quote = character;
-      escaped = false;
-      canEndExpression = false;
-      continue;
-    }
-    if (character === '/' && !canEndExpression) {
-      index = findRegexLiteralEnd(source, index) - 1;
-      canEndExpression = true;
-      continue;
-    }
-    if (isIdentifierStart(character)) {
-      let end = index + 1;
-      while (isIdentifierPart(source[end])) end += 1;
-      canEndExpression = !regexLiteralPrefixKeywords.has(source.slice(index, end));
-      index = end - 1;
-      continue;
-    }
-    if (digitPattern.test(character ?? '')) {
-      canEndExpression = true;
-      continue;
-    }
-    if (character === '(') {
-      depth += 1;
-      canEndExpression = false;
-      continue;
-    }
-    if (character === ')' && --depth === 0) return index;
-    if (character === ')') {
-      canEndExpression = true;
-      continue;
-    }
-    if (character === ']' || character === '}') {
-      canEndExpression = true;
-      continue;
-    }
-    if (character === '+' || character === '-') {
-      if (nextCharacter === character) {
-        index += 1;
-        canEndExpression = true;
-      } else {
-        canEndExpression = false;
-      }
-      continue;
-    }
-    canEndExpression = false;
+    const token = scanCallToken(source, index, state);
+    if (token.end !== undefined) return token.end;
+    index = token.nextIndex;
   }
   return source.length;
+}
+
+interface CallScannerState {
+  depth: number;
+  quote: '"' | "'" | '`' | null;
+  escaped: boolean;
+  canEndExpression: boolean;
+}
+
+interface CallScanResult {
+  handled: boolean;
+  nextIndex: number;
+  end?: number;
+}
+
+function scanCallSpecial(source: string, index: number, state: CallScannerState): CallScanResult {
+  const character = source[index];
+  const nextCharacter = source[index + 1];
+  if (state.quote) return scanQuotedCallCharacter(character, index, state);
+  if (whitespacePattern.test(character ?? '')) return {handled: true, nextIndex: index};
+  const comment = scanCallComment(source, index, character, nextCharacter);
+  if (comment) return comment;
+  if (character === '"' || character === "'" || character === '`') {
+    state.quote = character;
+    state.escaped = false;
+    state.canEndExpression = false;
+    return {handled: true, nextIndex: index};
+  }
+  if (character === '/' && !state.canEndExpression) {
+    state.canEndExpression = true;
+    return {handled: true, nextIndex: findRegexLiteralEnd(source, index) - 1};
+  }
+  return {handled: false, nextIndex: index};
+}
+
+function scanQuotedCallCharacter(
+  character: string | undefined,
+  index: number,
+  state: CallScannerState,
+): CallScanResult {
+  if (state.escaped) state.escaped = false;
+  else if (character === '\\') state.escaped = true;
+  else if (character === state.quote) {
+    state.quote = null;
+    state.canEndExpression = true;
+  }
+  return {handled: true, nextIndex: index};
+}
+
+function scanCallComment(
+  source: string,
+  index: number,
+  character: string | undefined,
+  nextCharacter: string | undefined,
+): CallScanResult | undefined {
+  if (character === '/' && nextCharacter === '/') {
+    const newline = source.indexOf('\n', index + 2);
+    return newline === -1
+      ? {handled: true, nextIndex: index, end: source.length}
+      : {handled: true, nextIndex: newline};
+  }
+  if (character !== '/' || nextCharacter !== '*') return undefined;
+  const commentEnd = source.indexOf('*/', index + 2);
+  return commentEnd === -1
+    ? {handled: true, nextIndex: index, end: source.length}
+    : {handled: true, nextIndex: commentEnd + 1};
+}
+
+function scanCallToken(source: string, index: number, state: CallScannerState): CallScanResult {
+  const character = source[index];
+  const nextCharacter = source[index + 1];
+  if (isIdentifierStart(character)) {
+    let end = index + 1;
+    while (isIdentifierPart(source[end])) end += 1;
+    state.canEndExpression = !regexLiteralPrefixKeywords.has(source.slice(index, end));
+    return {handled: true, nextIndex: end - 1};
+  }
+  if (digitPattern.test(character ?? '')) state.canEndExpression = true;
+  else if (character === '(') {
+    state.depth += 1;
+    state.canEndExpression = false;
+  } else if (character === ')') {
+    state.depth -= 1;
+    if (state.depth === 0) return {handled: true, nextIndex: index, end: index};
+    state.canEndExpression = true;
+  } else if (character === ']' || character === '}') state.canEndExpression = true;
+  else if ((character === '+' || character === '-') && nextCharacter === character) {
+    state.canEndExpression = true;
+    return {handled: true, nextIndex: index + 1};
+  } else state.canEndExpression = false;
+  return {handled: true, nextIndex: index};
 }
 
 function queryHookCalls(source: string): Array<{hasPolicy: boolean}> {
@@ -549,20 +601,37 @@ export function validateExceptionRegistry(
   const testFileSet = new Set(testFiles ?? []);
   const seen = new Set<string>();
   for (const exception of allExceptions(registry)) {
-    const key = `${exception.file}:${exception.test}`;
-    if (seen.has(key)) throw new Error(`Duplicate client architecture exception: ${key}`);
-    seen.add(key);
-    if (!exception.file.trim()) throw new Error('Client architecture exception has no file');
-    if (!exception.owner.trim())
-      throw new Error(`Client architecture exception has no owner: ${exception.file}`);
-    if (!exception.reason.trim())
-      throw new Error(`Client architecture exception has no reason: ${exception.file}`);
-    if (!exception.test.trim())
-      throw new Error(`Client architecture exception has no focused test: ${exception.file}`);
-    if (!fileSet.has(exception.file))
-      throw new Error(`Client architecture exception file is not audited: ${exception.file}`);
-    if (testFiles !== undefined && !testFileSet.has(exception.test))
-      throw new Error(`Client architecture exception test does not exist: ${exception.test}`);
+    validateClientArchitectureException(
+      exception,
+      seen,
+      fileSet,
+      testFileSet,
+      testFiles !== undefined,
+    );
+  }
+}
+
+function validateClientArchitectureException(
+  exception: ClientArchitectureException,
+  seen: Set<string>,
+  fileSet: ReadonlySet<string>,
+  testFileSet: ReadonlySet<string>,
+  validateTestFile: boolean,
+): void {
+  const key = `${exception.file}:${exception.test}`;
+  if (seen.has(key)) throw new Error(`Duplicate client architecture exception: ${key}`);
+  seen.add(key);
+  if (!exception.file.trim()) throw new Error('Client architecture exception has no file');
+  if (!exception.owner.trim())
+    throw new Error(`Client architecture exception has no owner: ${exception.file}`);
+  if (!exception.reason.trim())
+    throw new Error(`Client architecture exception has no reason: ${exception.file}`);
+  if (!exception.test.trim())
+    throw new Error(`Client architecture exception has no focused test: ${exception.file}`);
+  if (!fileSet.has(exception.file))
+    throw new Error(`Client architecture exception file is not audited: ${exception.file}`);
+  if (validateTestFile && !testFileSet.has(exception.test)) {
+    throw new Error(`Client architecture exception test does not exist: ${exception.test}`);
   }
 }
 

--- a/tools/cloudflare-pages/src/cli.ts
+++ b/tools/cloudflare-pages/src/cli.ts
@@ -722,24 +722,14 @@ async function runSummary(options: CliOptions): Promise<void> {
     process.env.ARTIFACT_RESULT === 'success' && process.env.ARTIFACT_UPLOAD_RESULT === 'success';
   const supersededBeforeUpload = process.env.PRE_DEPLOY_HEAD_RESULT === 'failure';
   const supersededDuringUpload = process.env.POST_DEPLOY_HEAD_RESULT === 'failure';
-  const syncMessage =
-    plan.shouldDeploy !== true
-      ? 'No deployment was selected by the affected-target plan; existing Pages URLs are not refreshed for this commit.'
-      : supersededBeforeUpload
-        ? 'A newer commit superseded this run before upload; no Pages deployment was published for this source commit.'
-        : supersededDuringUpload
-          ? 'A newer commit superseded this run during upload; the stale run did not register a GitHub deployment status.'
-          : artifactOnly
-            ? artifactReady
-              ? 'A verified artifact was archived and uploaded; Pages publication is handled by the separate deployment job.'
-              : `The verified artifact was not produced for this commit (archive: ${getMetric(process.env.ARTIFACT_RESULT)}, upload: ${getMetric(process.env.ARTIFACT_UPLOAD_RESULT)}).`
-            : verificationReport?.ok === true
-              ? 'Every selected app was checked and matched the exact source commit above.'
-              : verificationReport !== null
-                ? 'The deployment was attempted, but one or more Pages applications could not be verified against the exact source commit above.'
-                : process.env.DEPLOYMENT_RESULT === 'success'
-                  ? 'The artifact was uploaded, but Pages applications were not verified for this source commit.'
-                  : 'The deployment did not complete, so Pages applications are not available for this commit.';
+  const syncMessage = deploymentSyncMessage({
+    plan,
+    artifactOnly,
+    artifactReady,
+    supersededBeforeUpload,
+    supersededDuringUpload,
+    verificationReport,
+  });
   const lines = [
     `## ${title} metrics`,
     '',
@@ -797,6 +787,41 @@ async function runSummary(options: CliOptions): Promise<void> {
   }
 
   await writeFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function deploymentSyncMessage(params: {
+  plan: DeploymentPlan;
+  artifactOnly: boolean;
+  artifactReady: boolean;
+  supersededBeforeUpload: boolean;
+  supersededDuringUpload: boolean;
+  verificationReport: VerificationSummary | null;
+}): string {
+  if (params.plan.shouldDeploy !== true) {
+    return 'No deployment was selected by the affected-target plan; existing Pages URLs are not refreshed for this commit.';
+  }
+  if (params.supersededBeforeUpload) {
+    return 'A newer commit superseded this run before upload; no Pages deployment was published for this source commit.';
+  }
+  if (params.supersededDuringUpload) {
+    return 'A newer commit superseded this run during upload; the stale run did not register a GitHub deployment status.';
+  }
+  if (params.artifactOnly && params.artifactReady) {
+    return 'A verified artifact was archived and uploaded; Pages publication is handled by the separate deployment job.';
+  }
+  if (params.artifactOnly) {
+    return `The verified artifact was not produced for this commit (archive: ${getMetric(process.env.ARTIFACT_RESULT)}, upload: ${getMetric(process.env.ARTIFACT_UPLOAD_RESULT)}).`;
+  }
+  if (params.verificationReport?.ok === true) {
+    return 'Every selected app was checked and matched the exact source commit above.';
+  }
+  if (params.verificationReport !== null) {
+    return 'The deployment was attempted, but one or more Pages applications could not be verified against the exact source commit above.';
+  }
+  if (process.env.DEPLOYMENT_RESULT === 'success') {
+    return 'The artifact was uploaded, but Pages applications were not verified for this source commit.';
+  }
+  return 'The deployment did not complete, so Pages applications are not available for this commit.';
 }
 
 function printHelp(): void {

--- a/tools/cloudflare-pages/src/deploy.ts
+++ b/tools/cloudflare-pages/src/deploy.ts
@@ -247,54 +247,19 @@ export async function deployCloudflarePages({
     const outputDirectory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-'));
     const outputPath = join(outputDirectory, 'wrangler-output.json');
     try {
-      const args = [
-        'pages',
-        'deploy',
-        resolvedDirectory,
-        `--project-name=${resolvedProject}`,
-        ...(branch === null ? [] : [`--branch=${branch}`]),
-        `--commit-hash=${resolvedCommitSha}`,
-      ];
-      const result = await runner(command, args, {
-        cwd,
-        env: {...process.env, WRANGLER_OUTPUT_FILE_PATH: outputPath},
-        timeoutMs,
-      });
-      const structuredOutput = await readWranglerDeploymentOutput(outputPath);
-      if (environment === 'production') {
-        if (structuredOutput === undefined) {
-          throw new Error(
-            'Cloudflare did not return structured deployment metadata for the production upload',
-          );
-        }
-        if (structuredOutput.environment !== 'production') {
-          throw new Error(
-            `Cloudflare deployment resolved to the ${typeof structuredOutput.environment === 'string' ? structuredOutput.environment : 'missing'} environment instead of production`,
-          );
-        }
-        if (
-          typeof structuredOutput.production_branch !== 'string' ||
-          structuredOutput.production_branch.length === 0 ||
-          branch === null ||
-          branch.length === 0 ||
-          structuredOutput.production_branch !== branch
-        ) {
-          throw new Error(
-            `Cloudflare Pages production branch is ${typeof structuredOutput.production_branch === 'string' ? structuredOutput.production_branch : 'missing'}, expected ${branch !== null && branch.length > 0 ? branch : 'an explicit branch'}`,
-          );
-        }
-      }
-      const url = getCloudflareDeploymentUrl(result.output, structuredOutput);
-      if (url === null) throw new Error('Cloudflare did not return a pages.dev deployment URL');
-
-      return {
-        url,
+      return await deployCloudflarePagesAttempt({
         directory: resolvedDirectory,
         project: resolvedProject,
         branch,
+        environment,
         commitSha: resolvedCommitSha,
-        attempts: attempt,
-      };
+        command,
+        cwd,
+        runner,
+        timeoutMs,
+        outputPath,
+        attempt,
+      });
     } catch (error) {
       lastError = error;
       if (attempt < attempts && retryDelayMs > 0) await wait(attempt * retryDelayMs);
@@ -308,6 +273,75 @@ export async function deployCloudflarePages({
       lastError instanceof Error ? lastError.message : lastError
     }`,
   );
+}
+
+async function deployCloudflarePagesAttempt(params: {
+  directory: string;
+  project: string;
+  branch: string | null;
+  environment: string | undefined;
+  commitSha: string;
+  command: string;
+  cwd: string;
+  runner: CommandRunner;
+  timeoutMs: number;
+  outputPath: string;
+  attempt: number;
+}): Promise<CloudflarePagesSingleDeployment> {
+  const args = [
+    'pages',
+    'deploy',
+    params.directory,
+    `--project-name=${params.project}`,
+    ...(params.branch === null ? [] : [`--branch=${params.branch}`]),
+    `--commit-hash=${params.commitSha}`,
+  ];
+  const result = await params.runner(params.command, args, {
+    cwd: params.cwd,
+    env: {...process.env, WRANGLER_OUTPUT_FILE_PATH: params.outputPath},
+    timeoutMs: params.timeoutMs,
+  });
+  const structuredOutput = await readWranglerDeploymentOutput(params.outputPath);
+  if (params.environment === 'production')
+    assertProductionDeployment(structuredOutput, params.branch);
+  const url = getCloudflareDeploymentUrl(result.output, structuredOutput);
+  if (url === null) throw new Error('Cloudflare did not return a pages.dev deployment URL');
+  return {
+    url,
+    directory: params.directory,
+    project: params.project,
+    branch: params.branch,
+    commitSha: params.commitSha,
+    attempts: params.attempt,
+  };
+}
+
+function assertProductionDeployment(
+  output: Awaited<ReturnType<typeof readWranglerDeploymentOutput>>,
+  branch: string | null,
+): void {
+  if (output === undefined) {
+    throw new Error(
+      'Cloudflare did not return structured deployment metadata for the production upload',
+    );
+  }
+  if (output.environment !== 'production') {
+    const environment = typeof output.environment === 'string' ? output.environment : 'missing';
+    throw new Error(
+      `Cloudflare deployment resolved to the ${environment} environment instead of production`,
+    );
+  }
+  const validBranch =
+    typeof output.production_branch === 'string' &&
+    output.production_branch.length > 0 &&
+    branch !== null &&
+    branch.length > 0 &&
+    output.production_branch === branch;
+  if (validBranch) return;
+  const actual =
+    typeof output.production_branch === 'string' ? output.production_branch : 'missing';
+  const expected = branch !== null && branch.length > 0 ? branch : 'an explicit branch';
+  throw new Error(`Cloudflare Pages production branch is ${actual}, expected ${expected}`);
 }
 
 /**

--- a/tools/cloudflare-pages/src/plan.ts
+++ b/tools/cloudflare-pages/src/plan.ts
@@ -147,57 +147,135 @@ function validateBuildConfig(configPath: string, app: Record<string, unknown>): 
   if (build.task !== undefined && (typeof build.task !== 'string' || build.task.length === 0)) {
     throw new Error(`${configPath} app ${app.id} build.task must be a non-empty string`);
   }
+  validateBuildEnvironmentMap(configPath, app.id, buildEnv);
+  validateBuildFromEnvironmentMap(configPath, app.id, buildFromEnv);
+  validateBuildEnvironmentOverlap(configPath, app.id, buildEnv, buildFromEnv);
+}
 
-  if (buildEnv !== undefined) {
-    if (
-      typeof buildEnv !== 'object' ||
-      buildEnv === null ||
-      Array.isArray(buildEnv) ||
-      Object.entries(buildEnv).some(
-        ([environment, values]) =>
-          environment.length === 0 ||
-          typeof values !== 'object' ||
-          values === null ||
-          Array.isArray(values) ||
-          Object.entries(values).some(
-            ([name, value]) =>
-              !environmentVariableNamePattern.test(name) || typeof value !== 'string',
-          ),
-      )
-    ) {
-      throw new Error(`${configPath} app ${app.id} build.env must map environments to env values`);
-    }
-  }
+function validateBuildEnvironmentMap(configPath: string, appId: unknown, value: unknown): void {
+  if (value === undefined) return;
+  const invalid =
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.entries(value).some(
+      ([environment, values]) =>
+        environment.length === 0 ||
+        typeof values !== 'object' ||
+        values === null ||
+        Array.isArray(values) ||
+        Object.entries(values).some(
+          ([name, item]) => !environmentVariableNamePattern.test(name) || typeof item !== 'string',
+        ),
+    );
+  if (invalid)
+    throw new Error(`${configPath} app ${appId} build.env must map environments to env values`);
+}
 
-  if (buildFromEnv !== undefined) {
-    if (
-      typeof buildFromEnv !== 'object' ||
-      buildFromEnv === null ||
-      Array.isArray(buildFromEnv) ||
-      Object.entries(buildFromEnv).some(
-        ([name, source]) =>
-          !environmentVariableNamePattern.test(name) ||
-          typeof source !== 'string' ||
-          !environmentVariableNamePattern.test(source),
-      )
-    ) {
-      throw new Error(
-        `${configPath} app ${app.id} build.fromEnv must map env names to CI env names`,
-      );
-    }
-  }
+function validateBuildFromEnvironmentMap(configPath: string, appId: unknown, value: unknown): void {
+  if (value === undefined) return;
+  const invalid =
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.entries(value).some(
+      ([name, source]) =>
+        !environmentVariableNamePattern.test(name) ||
+        typeof source !== 'string' ||
+        !environmentVariableNamePattern.test(source),
+    );
+  if (invalid)
+    throw new Error(`${configPath} app ${appId} build.fromEnv must map env names to CI env names`);
+}
 
-  for (const [environment, values] of Object.entries(
-    (buildEnv as Record<string, Record<string, string>> | undefined) ?? {},
-  )) {
-    for (const name of Object.keys((buildFromEnv as Record<string, string> | undefined) ?? {})) {
-      if (Object.hasOwn(values as object, name)) {
+function validateBuildEnvironmentOverlap(
+  configPath: string,
+  appId: unknown,
+  buildEnv: unknown,
+  buildFromEnv: unknown,
+): void {
+  const environments = (buildEnv as Record<string, Record<string, string>> | undefined) ?? {};
+  const names = Object.keys((buildFromEnv as Record<string, string> | undefined) ?? {});
+  for (const [environment, values] of Object.entries(environments)) {
+    for (const name of names) {
+      if (Object.hasOwn(values, name)) {
         throw new Error(
-          `${configPath} app ${app.id} build variable ${name} is defined in both ${environment} env and fromEnv`,
+          `${configPath} app ${appId} build variable ${name} is defined in both ${environment} env and fromEnv`,
         );
       }
     }
   }
+}
+
+function validateCloudflarePagesApp(configPath: string, value: unknown, ids: Set<unknown>): void {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error(`${configPath} apps must contain objects`);
+  }
+  const app = value as Record<string, unknown>;
+  for (const field of ['id', 'target', 'directory']) {
+    if (typeof app[field] !== 'string' || app[field].length === 0) {
+      throw new Error(`${configPath} app ${field} is required`);
+    }
+  }
+  if (
+    app.affectedTargets !== undefined &&
+    (!Array.isArray(app.affectedTargets) ||
+      app.affectedTargets.some((target) => typeof target !== 'string' || target.length === 0))
+  ) {
+    throw new Error(`${configPath} app ${app.id} affectedTargets must be strings`);
+  }
+  if (ids.has(app.id)) throw new Error(`${configPath} contains duplicate app id ${app.id}`);
+  ids.add(app.id);
+  validateCloudflareProjects(configPath, app);
+  validateBuildConfig(configPath, app);
+  validateCloudflareVerification(configPath, app);
+}
+
+function validateCloudflareProjects(configPath: string, app: Record<string, unknown>): void {
+  if (typeof app.project !== 'string' || app.project.length === 0) {
+    throw new Error(`${configPath} app ${app.id} must define a Cloudflare Pages project`);
+  }
+  if (app.projects === undefined) return;
+  const invalid =
+    typeof app.projects !== 'object' ||
+    app.projects === null ||
+    Array.isArray(app.projects) ||
+    Object.entries(app.projects).some(
+      ([environment, project]) =>
+        environment.length === 0 || typeof project !== 'string' || project.length === 0,
+    );
+  if (invalid)
+    throw new Error(`${configPath} app ${app.id} projects must map environments to project names`);
+}
+
+function validateCloudflareVerification(configPath: string, app: Record<string, unknown>): void {
+  if (app.verify === undefined) return;
+  if (typeof app.verify !== 'object' || app.verify === null) {
+    throw new Error(`${configPath} app ${app.id} verify must be an object`);
+  }
+  const verify = app.verify as Record<string, unknown>;
+  if (
+    verify.metadataPath !== undefined &&
+    (typeof verify.metadataPath !== 'string' || verify.metadataPath.length === 0)
+  ) {
+    throw new Error(`${configPath} app ${app.id} metadataPath must be a string`);
+  }
+  if (
+    verify.endpoints !== undefined &&
+    (!Array.isArray(verify.endpoints) || verify.endpoints.some(invalidVerificationEndpoint))
+  ) {
+    throw new Error(`${configPath} app ${app.id} endpoints must define paths`);
+  }
+}
+
+function invalidVerificationEndpoint(endpoint: unknown): boolean {
+  if (typeof endpoint === 'string') return endpoint.length === 0;
+  if (typeof endpoint !== 'object' || endpoint === null) return true;
+  const value = endpoint as {id?: unknown; path?: unknown; requireNonEmpty?: unknown};
+  if (typeof value.path !== 'string' || value.path.length === 0) return true;
+  if (value.id !== undefined && (typeof value.id !== 'string' || value.id.length === 0))
+    return true;
+  return value.requireNonEmpty !== undefined && typeof value.requireNonEmpty !== 'boolean';
 }
 
 /**
@@ -217,121 +295,16 @@ export async function readCloudflarePagesConfig(
 
   const ids = new Set();
   for (const app of config.apps) {
-    if (typeof app !== 'object' || app === null) {
-      throw new Error(`${configPath} apps must contain objects`);
-    }
-    for (const field of ['id', 'target', 'directory']) {
-      if (typeof app[field] !== 'string' || app[field].length === 0) {
-        throw new Error(`${configPath} app ${field} is required`);
-      }
-    }
-    if (
-      app.affectedTargets !== undefined &&
-      (!Array.isArray(app.affectedTargets) ||
-        app.affectedTargets.some(
-          (target: unknown) => typeof target !== 'string' || target.length === 0,
-        ))
-    ) {
-      throw new Error(`${configPath} app ${app.id} affectedTargets must be strings`);
-    }
-    if (ids.has(app.id)) throw new Error(`${configPath} contains duplicate app id ${app.id}`);
-    ids.add(app.id);
-
-    if (typeof app.project !== 'string' || app.project.length === 0) {
-      throw new Error(`${configPath} app ${app.id} must define a Cloudflare Pages project`);
-    }
-    if (
-      app.projects !== undefined &&
-      (typeof app.projects !== 'object' ||
-        app.projects === null ||
-        Array.isArray(app.projects) ||
-        Object.entries(app.projects).some(
-          ([environment, project]) =>
-            environment.length === 0 || typeof project !== 'string' || project.length === 0,
-        ))
-    ) {
-      throw new Error(
-        `${configPath} app ${app.id} projects must map environments to project names`,
-      );
-    }
-
-    validateBuildConfig(configPath, app);
-
-    if (app.verify !== undefined) {
-      if (typeof app.verify !== 'object' || app.verify === null) {
-        throw new Error(`${configPath} app ${app.id} verify must be an object`);
-      }
-      if (
-        app.verify.metadataPath !== undefined &&
-        (typeof app.verify.metadataPath !== 'string' || app.verify.metadataPath.length === 0)
-      ) {
-        throw new Error(`${configPath} app ${app.id} metadataPath must be a string`);
-      }
-      if (
-        app.verify.endpoints !== undefined &&
-        (!Array.isArray(app.verify.endpoints) ||
-          app.verify.endpoints.some((endpoint: unknown) => {
-            if (typeof endpoint === 'string') return endpoint.length === 0;
-            if (typeof endpoint !== 'object' || endpoint === null) return true;
-            const endpointObject = endpoint as {
-              id?: unknown;
-              path?: unknown;
-              requireNonEmpty?: unknown;
-            };
-            return (
-              typeof endpointObject.path !== 'string' ||
-              endpointObject.path.length === 0 ||
-              (endpointObject.id !== undefined &&
-                (typeof endpointObject.id !== 'string' || endpointObject.id.length === 0)) ||
-              (endpointObject.requireNonEmpty !== undefined &&
-                typeof endpointObject.requireNonEmpty !== 'boolean')
-            );
-          }))
-      ) {
-        throw new Error(`${configPath} app ${app.id} endpoints must define paths`);
-      }
-    }
+    validateCloudflarePagesApp(configPath, app, ids);
   }
 
-  const environments = config.environments ?? defaultCloudflarePagesEnvironments;
-  if (
-    typeof environments !== 'object' ||
-    environments === null ||
-    Array.isArray(environments) ||
-    Object.entries(environments).some(([environment, settings]) => {
-      if (
-        environment.length === 0 ||
-        typeof settings !== 'object' ||
-        settings === null ||
-        Array.isArray(settings)
-      ) {
-        return true;
-      }
-      const branch = (settings as {branch?: unknown}).branch;
-      return (
-        branch !== undefined &&
-        branch !== null &&
-        (typeof branch !== 'string' || branch.length === 0)
-      );
-    })
-  ) {
-    throw new Error(`${configPath} environments must define valid branch settings`);
-  }
-
-  const forcePaths = config.forcePaths ?? [];
-  if (!Array.isArray(forcePaths) || forcePaths.some((forcePath) => typeof forcePath !== 'string')) {
-    throw new Error(`${configPath} must contain a string forcePaths array`);
-  }
-
-  const artifact = config.artifact;
-  if (artifact !== undefined && !isArtifactConfig(artifact)) {
-    throw new Error(`${configPath} artifact must define a valid metadataPath`);
-  }
-
-  const validation = config.validation;
-  if (validation !== undefined && !isValidationConfig(validation)) {
-    throw new Error(`${configPath} validation must define commands and string args`);
-  }
+  const environments = validateCloudflareEnvironments(
+    configPath,
+    config.environments ?? defaultCloudflarePagesEnvironments,
+  );
+  const forcePaths = validateForcePaths(configPath, config.forcePaths ?? []);
+  const artifact = validateArtifactConfig(configPath, config.artifact);
+  const validation = validateValidationConfig(configPath, config.validation);
 
   return {
     apps: config.apps as CloudflarePagesApp[],
@@ -345,6 +318,56 @@ export async function readCloudflarePagesConfig(
         }),
     ...(validation === undefined ? {} : {validation}),
   };
+}
+
+function validateCloudflareEnvironments(
+  configPath: string,
+  environments: unknown,
+): Record<string, CloudflarePagesEnvironment> {
+  const invalid =
+    typeof environments !== 'object' ||
+    environments === null ||
+    Array.isArray(environments) ||
+    Object.entries(environments).some(([name, settings]) =>
+      invalidEnvironmentSetting(name, settings),
+    );
+  if (invalid) throw new Error(`${configPath} environments must define valid branch settings`);
+  return environments as Record<string, CloudflarePagesEnvironment>;
+}
+
+function invalidEnvironmentSetting(environment: string, settings: unknown): boolean {
+  if (
+    environment.length === 0 ||
+    typeof settings !== 'object' ||
+    settings === null ||
+    Array.isArray(settings)
+  )
+    return true;
+  const branch = (settings as {branch?: unknown}).branch;
+  return (
+    branch !== undefined && branch !== null && (typeof branch !== 'string' || branch.length === 0)
+  );
+}
+
+function validateForcePaths(configPath: string, value: unknown): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${configPath} must contain a string forcePaths array`);
+  }
+  return value as string[];
+}
+
+function validateArtifactConfig(configPath: string, value: unknown) {
+  if (value !== undefined && !isArtifactConfig(value)) {
+    throw new Error(`${configPath} artifact must define a valid metadataPath`);
+  }
+  return value;
+}
+
+function validateValidationConfig(configPath: string, value: unknown) {
+  if (value !== undefined && !isValidationConfig(value)) {
+    throw new Error(`${configPath} validation must define commands and string args`);
+  }
+  return value;
 }
 
 /**
@@ -390,23 +413,20 @@ export function createCloudflarePagesPlan({
   const isExplicitDeployment = eventName === 'deployment';
   const shouldDeploy =
     isMainPush || isExplicitDeployment || forcedByFile || affectedTargets.length > 0;
-  const selectedApps = shouldDeploy
-    ? isMainPush || isExplicitDeployment || forcedByFile
-      ? apps
-      : affectedApps
-    : [];
+  let selectedApps: CloudflarePagesApp[] = [];
+  if (shouldDeploy) {
+    selectedApps = isMainPush || isExplicitDeployment || forcedByFile ? apps : affectedApps;
+  }
+
+  let reason = 'no Pages target is affected';
+  if (isMainPush) reason = 'main push';
+  else if (isExplicitDeployment) reason = 'explicit deployment';
+  else if (forcedByFile) reason = 'Pages workflow or application configuration changed';
+  else if (affectedTargets.length > 0) reason = 'Turbo affected Pages target detected';
 
   return {
     shouldDeploy,
-    reason: isMainPush
-      ? 'main push'
-      : isExplicitDeployment
-        ? 'explicit deployment'
-        : forcedByFile
-          ? 'Pages workflow or application configuration changed'
-          : affectedTargets.length > 0
-            ? 'Turbo affected Pages target detected'
-            : 'no Pages target is affected',
+    reason,
     affectedPackages,
     affectedTargets,
     affectedApps: affectedApps.map((app) => app.id),

--- a/tools/cloudflare-pages/src/verify.ts
+++ b/tools/cloudflare-pages/src/verify.ts
@@ -205,45 +205,17 @@ export async function verifyPagesDeployment({
     redirect: 'follow',
   });
   const metadataResponse = await checkJson(resolvedBaseUrl, metadataPath, fetchOptions);
-  const metadata: VerificationCheck = {
-    ok: metadataResponse.ok,
-    status: metadataResponse.status,
-  };
-  if (metadataResponse.ok) {
-    try {
-      assertMetadata(metadataResponse.value, resolvedExpectedCommitSha, expectedPullRequest);
-    } catch (error) {
-      metadata.ok = false;
-      metadata.error = errorMessage(error);
-    }
-  } else {
-    if (metadataResponse.error !== undefined) metadata.error = metadataResponse.error;
-  }
+  const metadata = verifyMetadataResponse(
+    metadataResponse,
+    resolvedExpectedCommitSha,
+    expectedPullRequest,
+  );
 
   const verifiedEndpoints: CloudflarePagesEndpointResult[] = [];
   for (const configuredEndpoint of endpoints) {
-    const endpoint =
-      typeof configuredEndpoint === 'string'
-        ? {id: configuredEndpoint, path: configuredEndpoint, requireNonEmpty: false}
-        : configuredEndpoint;
-    const response = await checkJson(resolvedBaseUrl, endpoint.path, fetchOptions);
-    const result: CloudflarePagesEndpointResult = {
-      id: endpoint.id ?? endpoint.path,
-      path: endpoint.path,
-      ok: response.ok,
-      status: response.status,
-    };
-    if (!response.ok) {
-      if (response.error !== undefined) result.error = response.error;
-    } else {
-      try {
-        assertEndpointResponse(response.value, endpoint);
-      } catch (error) {
-        result.ok = false;
-        result.error = errorMessage(error);
-      }
-    }
-    verifiedEndpoints.push(result);
+    verifiedEndpoints.push(
+      await verifyConfiguredEndpoint(resolvedBaseUrl, configuredEndpoint, fetchOptions),
+    );
   }
 
   const errors: string[] = [];
@@ -265,6 +237,54 @@ export async function verifyPagesDeployment({
     endpoints: verifiedEndpoints,
     errors,
   };
+}
+
+function verifyMetadataResponse(
+  response: Awaited<ReturnType<typeof checkJson>>,
+  expectedCommitSha: string,
+  expectedPullRequest: string | undefined,
+): VerificationCheck {
+  const metadata: VerificationCheck = {ok: response.ok, status: response.status};
+  if (!response.ok) {
+    if (response.error !== undefined) metadata.error = response.error;
+    return metadata;
+  }
+  try {
+    assertMetadata(response.value, expectedCommitSha, expectedPullRequest);
+  } catch (error) {
+    metadata.ok = false;
+    metadata.error = errorMessage(error);
+  }
+  return metadata;
+}
+
+async function verifyConfiguredEndpoint(
+  baseUrl: string,
+  configuredEndpoint: CloudflarePagesEndpoint,
+  fetchOptions: Parameters<typeof checkJson>[2],
+): Promise<CloudflarePagesEndpointResult> {
+  const endpoint =
+    typeof configuredEndpoint === 'string'
+      ? {id: configuredEndpoint, path: configuredEndpoint, requireNonEmpty: false}
+      : configuredEndpoint;
+  const response = await checkJson(baseUrl, endpoint.path, fetchOptions);
+  const result: CloudflarePagesEndpointResult = {
+    id: endpoint.id ?? endpoint.path,
+    path: endpoint.path,
+    ok: response.ok,
+    status: response.status,
+  };
+  if (!response.ok) {
+    if (response.error !== undefined) result.error = response.error;
+    return result;
+  }
+  try {
+    assertEndpointResponse(response.value, endpoint);
+  } catch (error) {
+    result.ok = false;
+    result.error = errorMessage(error);
+  }
+  return result;
 }
 
 /**
@@ -294,55 +314,17 @@ export async function verifyCloudflarePagesApps({
   const reports: CloudflarePagesAppVerification[] = [];
 
   for (const app of selectedApps) {
-    const deployment = deploymentByApp.get(app.id);
-    if (deployment === undefined) {
-      reports.push({
-        appId: app.id,
-        ok: false,
-        url: null,
-        commitSha: expectedCommitSha ?? null,
-        pullRequest: expectedPullRequest ?? null,
-        endpoints: [],
-        errors: ['application was not deployed'],
-      });
-      continue;
-    }
-    if (!deployment.ok || deployment.url === undefined) {
-      reports.push({
-        appId: app.id,
-        ok: false,
-        url: null,
-        commitSha: expectedCommitSha ?? deployment.commitSha,
-        pullRequest: expectedPullRequest ?? null,
-        endpoints: [],
-        errors: [deployment.error ?? 'application deployment did not complete'],
-      });
-      continue;
-    }
-
-    try {
-      const report = await verifyPagesDeployment({
-        baseUrl: deployment.url,
+    reports.push(
+      await verifyCloudflarePagesApp({
+        app,
+        deployment: deploymentByApp.get(app.id),
         expectedCommitSha,
         expectedPullRequest,
-        metadataPath: app.verify?.metadataPath ?? '/preview-metadata.json',
-        endpoints: app.verify?.endpoints ?? [],
         attempts,
         retryDelayMs,
         fetchImpl,
-      });
-      reports.push({appId: app.id, ...report});
-    } catch (error) {
-      reports.push({
-        appId: app.id,
-        ok: false,
-        url: deployment.url,
-        commitSha: expectedCommitSha ?? deployment.commitSha,
-        pullRequest: expectedPullRequest ?? null,
-        endpoints: [],
-        errors: [errorMessage(error)],
-      });
-    }
+      }),
+    );
   }
 
   return {
@@ -356,5 +338,60 @@ export async function verifyCloudflarePagesApps({
         report.ok ? [] : report.errors.map((error) => `${report.appId}: ${error}`),
       ),
     ],
+  };
+}
+
+async function verifyCloudflarePagesApp(params: {
+  app: CloudflarePagesApp;
+  deployment: CloudflarePagesDeployment | undefined;
+  expectedCommitSha: string | undefined;
+  expectedPullRequest: string | undefined;
+  attempts: number;
+  retryDelayMs: number;
+  fetchImpl: typeof globalThis.fetch;
+}): Promise<CloudflarePagesAppVerification> {
+  const {app, deployment} = params;
+  if (deployment === undefined) {
+    return failedAppVerification(app.id, null, params, 'application was not deployed');
+  }
+  if (!deployment.ok || deployment.url === undefined) {
+    return failedAppVerification(
+      app.id,
+      null,
+      {...params, expectedCommitSha: params.expectedCommitSha ?? deployment.commitSha},
+      deployment.error ?? 'application deployment did not complete',
+    );
+  }
+  try {
+    const report = await verifyPagesDeployment({
+      baseUrl: deployment.url,
+      expectedCommitSha: params.expectedCommitSha,
+      expectedPullRequest: params.expectedPullRequest,
+      metadataPath: app.verify?.metadataPath ?? '/preview-metadata.json',
+      endpoints: app.verify?.endpoints ?? [],
+      attempts: params.attempts,
+      retryDelayMs: params.retryDelayMs,
+      fetchImpl: params.fetchImpl,
+    });
+    return {appId: app.id, ...report};
+  } catch (error) {
+    return failedAppVerification(app.id, deployment.url, params, errorMessage(error));
+  }
+}
+
+function failedAppVerification(
+  appId: string,
+  url: string | null,
+  params: {expectedCommitSha: string | undefined; expectedPullRequest: string | undefined},
+  error: string,
+): CloudflarePagesAppVerification {
+  return {
+    appId,
+    ok: false,
+    url,
+    commitSha: params.expectedCommitSha ?? null,
+    pullRequest: params.expectedPullRequest ?? null,
+    endpoints: [],
+    errors: [error],
   };
 }

--- a/tools/docker/src/docker.ts
+++ b/tools/docker/src/docker.ts
@@ -5,6 +5,7 @@ import {buildShellCommand, log} from '@shipfox/tool-utils';
 import {setupContext} from './turbo.js';
 
 const DEFAULT_PLATFORMS = 'linux/amd64,linux/arm64';
+const WHITESPACE_PATTERN = /\s+/;
 
 // Matches the :tag / @digest suffix of an image reference's final path segment.
 const TAG_OR_DIGEST_SUFFIX = /[:@].*$/;
@@ -83,7 +84,7 @@ function movingTag(refName: string): string {
 // by name (not a prefix scan of the environment), so a stray credential variable is
 // never mistaken for a registry base and logged. None set is the PR validation path.
 function readRegistries(): string[] {
-  return (process.env.IMAGE_REGISTRIES ?? '').split(/\s+/).filter(Boolean);
+  return (process.env.IMAGE_REGISTRIES ?? '').split(WHITESPACE_PATTERN).filter(Boolean);
 }
 
 // Derive the per-commit tag set from the registry bases plus the GITHUB_SHA /
@@ -141,8 +142,12 @@ if (!hasFlag('--platform'))
 
 // A multi-platform build cannot `--load`, so default to pushing; local validation
 // loads its single-arch image, while CI validation avoids the tar export/import.
-if (!hasFlag('--push', '--load', '--output', '-o'))
-  args.push(ciValidateOnly ? '--output=type=cacheonly' : validateOnly ? '--load' : '--push');
+if (!hasFlag('--push', '--load', '--output', '-o')) {
+  let outputFlag = '--push';
+  if (ciValidateOnly) outputFlag = '--output=type=cacheonly';
+  else if (validateOnly) outputFlag = '--load';
+  args.push(outputFlag);
+}
 
 // Tags: an explicit --tag wins; otherwise derive the per-commit set from --image.
 // CI cache-only validation has no image output for BuildKit to tag.

--- a/tools/engineering-guidance/src/generator.ts
+++ b/tools/engineering-guidance/src/generator.ts
@@ -248,28 +248,43 @@ async function selectSourceFiles(
   while (pending.length > 0) {
     const sourceFile = pending.pop();
     if (!sourceFile) continue;
-    const content = await readSourceText(sourceRoot, sourceFile);
-    for (const link of extractParsedMarkdownLinks(content)) {
-      if (isExternalTarget(link.target)) continue;
-      const target = await resolveLocalTarget(sourceRoot, sourceFile, link.target);
-      if (!target || target.isDirectory) continue;
-      if (!availableFiles.has(target.relativePath)) {
-        if (isExcludedGuidancePath(target.relativePath)) continue;
-        throw new Error(
-          `${sourceFile}:${link.line} links to an untracked or unavailable file: ${link.target}`,
-        );
-      }
-      if (
-        isReachableGuidancePath(target.relativePath, isGuidanceRootEntrypoint) &&
-        !selected.has(target.relativePath)
-      ) {
-        selected.add(target.relativePath);
-        pending.push(target.relativePath);
-      }
-    }
+    await selectLinkedSourceFiles(
+      sourceRoot,
+      sourceFile,
+      availableFiles,
+      selected,
+      pending,
+      isGuidanceRootEntrypoint,
+    );
   }
 
   return [...selected].sort(comparePaths);
+}
+
+async function selectLinkedSourceFiles(
+  sourceRoot: string,
+  sourceFile: string,
+  availableFiles: Set<string>,
+  selected: Set<string>,
+  pending: string[],
+  isGuidanceRootEntrypoint: (relativePath: string) => boolean,
+): Promise<void> {
+  const content = await readSourceText(sourceRoot, sourceFile);
+  for (const link of extractParsedMarkdownLinks(content)) {
+    if (isExternalTarget(link.target)) continue;
+    const target = await resolveLocalTarget(sourceRoot, sourceFile, link.target);
+    if (!target || target.isDirectory) continue;
+    if (!availableFiles.has(target.relativePath)) {
+      if (isExcludedGuidancePath(target.relativePath)) continue;
+      throw new Error(
+        `${sourceFile}:${link.line} links to an untracked or unavailable file: ${link.target}`,
+      );
+    }
+    if (!isReachableGuidancePath(target.relativePath, isGuidanceRootEntrypoint)) continue;
+    if (selected.has(target.relativePath)) continue;
+    selected.add(target.relativePath);
+    pending.push(target.relativePath);
+  }
 }
 
 async function rewriteMarkdown(
@@ -285,53 +300,15 @@ async function rewriteMarkdown(
   const bundledSet = new Set(bundledFiles);
   for (const link of extractParsedMarkdownLinks(content)) {
     if (isExternalTarget(link.target)) continue;
-
-    const parsedTarget = parseTarget(link.target);
-    const target = await resolveLocalTarget(sourceRoot, sourceFile, link.target);
-    if (!target)
-      throw new Error(`${sourceFile}:${link.line} has an invalid local link: ${link.target}`);
-    if (
-      !availableFiles.has(target.relativePath) &&
-      !hasAvailableDescendant(target, availableFiles)
-    ) {
-      if (!isExcludedGuidancePath(target.relativePath)) {
-        throw new Error(`${sourceFile}:${link.line} links to an unavailable file: ${link.target}`);
-      }
-    }
-
-    if (parsedTarget.anchor) {
-      const targetContents = await readTargetText(sourceRoot, target, sourceContents);
-      if (targetContents && isMarkdownPath(target.relativePath)) {
-        const anchors = anchorsFor(targetContents);
-        if (!anchors.has(parsedTarget.anchor)) {
-          throw new Error(
-            `${sourceFile}:${link.line} links to missing anchor ${link.target} in ${target.relativePath}`,
-          );
-        }
-      }
-    }
-
-    let replacement: string | undefined;
-    if (bundledSet.has(target.relativePath)) {
-      const sourceOutputPath = `repository/${sourceFile}`;
-      const targetOutputPath = `repository/${target.relativePath}`;
-      const relativeTarget = posix.relative(posix.dirname(sourceOutputPath), targetOutputPath);
-      replacement = `${relativeTarget || posix.basename(targetOutputPath)}${parsedTarget.query}${parsedTarget.fragment}`;
-    } else if (
-      availableFiles.has(target.relativePath) ||
-      hasAvailableDescendant(target, availableFiles)
-    ) {
-      replacement = `${githubPermalink(target, sourceCommit)}${parsedTarget.query}${parsedTarget.fragment}`;
-    } else {
-      throw new Error(
-        `${sourceFile}:${link.line} links to a disallowed local file: ${link.target}`,
-      );
-    }
-
-    const replacementText =
-      link.usesAngleBrackets || whitespacePattern.test(replacement)
-        ? `<${replacement}>`
-        : replacement;
+    const replacementText = await rewriteMarkdownLink({
+      availableFiles,
+      bundledSet,
+      link,
+      sourceCommit,
+      sourceContents,
+      sourceFile,
+      sourceRoot,
+    });
     if (replacementText !== content.slice(link.destinationStart, link.destinationEnd)) {
       replacements.push({
         start: link.destinationStart,
@@ -349,6 +326,87 @@ async function rewriteMarkdown(
   return normalizeLineEndings(rewritten);
 }
 
+interface RewriteMarkdownLinkOptions {
+  availableFiles: Set<string>;
+  bundledSet: Set<string>;
+  link: ParsedMarkdownLink;
+  sourceCommit: string;
+  sourceContents: Map<string, string>;
+  sourceFile: string;
+  sourceRoot: string;
+}
+
+async function rewriteMarkdownLink(options: RewriteMarkdownLinkOptions): Promise<string> {
+  const {availableFiles, bundledSet, link, sourceCommit, sourceContents, sourceFile, sourceRoot} =
+    options;
+  const parsedTarget = parseTarget(link.target);
+  const target = await resolveLocalTarget(sourceRoot, sourceFile, link.target);
+  if (!target)
+    throw new Error(`${sourceFile}:${link.line} has an invalid local link: ${link.target}`);
+  const isAvailable =
+    availableFiles.has(target.relativePath) || hasAvailableDescendant(target, availableFiles);
+  if (!isAvailable && !isExcludedGuidancePath(target.relativePath)) {
+    throw new Error(`${sourceFile}:${link.line} links to an unavailable file: ${link.target}`);
+  }
+  await validateSourceLinkAnchor(
+    sourceRoot,
+    sourceFile,
+    sourceContents,
+    link,
+    target,
+    parsedTarget,
+  );
+
+  const replacement = bundledSet.has(target.relativePath)
+    ? bundledLinkTarget(sourceFile, target.relativePath, parsedTarget)
+    : externalLinkTarget(sourceFile, sourceCommit, link, target, parsedTarget, isAvailable);
+  return link.usesAngleBrackets || whitespacePattern.test(replacement)
+    ? `<${replacement}>`
+    : replacement;
+}
+
+async function validateSourceLinkAnchor(
+  sourceRoot: string,
+  sourceFile: string,
+  sourceContents: Map<string, string>,
+  link: ParsedMarkdownLink,
+  target: LocalTarget,
+  parsedTarget: ParsedTarget,
+): Promise<void> {
+  if (!parsedTarget.anchor) return;
+  const targetContents = await readTargetText(sourceRoot, target, sourceContents);
+  if (!targetContents || !isMarkdownPath(target.relativePath)) return;
+  if (anchorsFor(targetContents).has(parsedTarget.anchor)) return;
+  throw new Error(
+    `${sourceFile}:${link.line} links to missing anchor ${link.target} in ${target.relativePath}`,
+  );
+}
+
+function bundledLinkTarget(
+  sourceFile: string,
+  targetFile: string,
+  parsedTarget: ParsedTarget,
+): string {
+  const sourceOutputPath = `repository/${sourceFile}`;
+  const targetOutputPath = `repository/${targetFile}`;
+  const relativeTarget = posix.relative(posix.dirname(sourceOutputPath), targetOutputPath);
+  return `${relativeTarget || posix.basename(targetOutputPath)}${parsedTarget.query}${parsedTarget.fragment}`;
+}
+
+function externalLinkTarget(
+  sourceFile: string,
+  sourceCommit: string,
+  link: ParsedMarkdownLink,
+  target: LocalTarget,
+  parsedTarget: ParsedTarget,
+  isAvailable: boolean,
+): string {
+  if (!isAvailable) {
+    throw new Error(`${sourceFile}:${link.line} links to a disallowed local file: ${link.target}`);
+  }
+  return `${githubPermalink(target, sourceCommit)}${parsedTarget.query}${parsedTarget.fragment}`;
+}
+
 async function validatePackagedMarkdown(
   bundleRoot: string,
   relativeFile: string,
@@ -357,29 +415,32 @@ async function validatePackagedMarkdown(
   const repositoryRoot = join(bundleRoot, 'repository');
   for (const link of extractParsedMarkdownLinks(content)) {
     if (isExternalTarget(link.target)) continue;
-    const target = parseTarget(link.target);
-    if (target.path.startsWith('/')) {
-      throw new Error(
-        `${relativeFile}:${link.line} contains an absolute local link: ${link.target}`,
-      );
-    }
-    const sourceAbsolute = join(repositoryRoot, relativeFile.slice('repository/'.length));
-    const targetAbsolute = target.path
-      ? resolve(dirname(sourceAbsolute), target.path)
-      : sourceAbsolute;
-    if (!isWithin(repositoryRoot, targetAbsolute)) {
-      throw new Error(`${relativeFile}:${link.line} escapes the guidance bundle: ${link.target}`);
-    }
-    const resolved = await resolveBundleTarget(targetAbsolute);
-    if (!resolved)
-      throw new Error(`${relativeFile}:${link.line} has a broken link: ${link.target}`);
-    if (target.anchor) {
-      if (!(await isFile(resolved)) || !isMarkdownPath(resolved)) continue;
-      const targetContent = await readFile(resolved, 'utf8');
-      if (!anchorsFor(targetContent).has(target.anchor)) {
-        throw new Error(`${relativeFile}:${link.line} has a missing anchor: ${link.target}`);
-      }
-    }
+    await validatePackagedMarkdownLink(repositoryRoot, relativeFile, link);
+  }
+}
+
+async function validatePackagedMarkdownLink(
+  repositoryRoot: string,
+  relativeFile: string,
+  link: ParsedMarkdownLink,
+): Promise<void> {
+  const target = parseTarget(link.target);
+  if (target.path.startsWith('/')) {
+    throw new Error(`${relativeFile}:${link.line} contains an absolute local link: ${link.target}`);
+  }
+  const sourceAbsolute = join(repositoryRoot, relativeFile.slice('repository/'.length));
+  const targetAbsolute = target.path
+    ? resolve(dirname(sourceAbsolute), target.path)
+    : sourceAbsolute;
+  if (!isWithin(repositoryRoot, targetAbsolute)) {
+    throw new Error(`${relativeFile}:${link.line} escapes the guidance bundle: ${link.target}`);
+  }
+  const resolved = await resolveBundleTarget(targetAbsolute);
+  if (!resolved) throw new Error(`${relativeFile}:${link.line} has a broken link: ${link.target}`);
+  if (!target.anchor || !(await isFile(resolved)) || !isMarkdownPath(resolved)) return;
+  const targetContent = await readFile(resolved, 'utf8');
+  if (!anchorsFor(targetContent).has(target.anchor)) {
+    throw new Error(`${relativeFile}:${link.line} has a missing anchor: ${link.target}`);
   }
 }
 
@@ -629,7 +690,9 @@ function sha256(content: string): string {
 }
 
 function comparePaths(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function slugifyHeading(heading: string): string {
@@ -765,27 +828,32 @@ function collectReferenceLinks(content: string, links: ParsedMarkdownLink[]): vo
       continue;
     }
     if (!inFence) {
-      const match = line.match(referenceLinkPattern);
-      const rawTarget = match?.[1];
-      if (rawTarget) {
-        const definitionEnd = line.indexOf(']:');
-        let rawStartInLine = definitionEnd + 2;
-        while (line[rawStartInLine] === ' ' || line[rawStartInLine] === '\t') {
-          rawStartInLine += 1;
-        }
-        const usesAngleBrackets = rawTarget.startsWith('<') && rawTarget.endsWith('>');
-        const rawStart = offset + rawStartInLine;
-        links.push({
-          line: lineNumberAt(normalizedContent, rawStart),
-          target: usesAngleBrackets ? rawTarget.slice(1, -1) : rawTarget,
-          destinationStart: rawStart + (usesAngleBrackets ? 1 : 0),
-          destinationEnd: rawStart + rawTarget.length - (usesAngleBrackets ? 1 : 0),
-          usesAngleBrackets,
-        });
-      }
+      collectReferenceLinkLine(normalizedContent, line, offset, links);
     }
     offset += line.length + 1;
   }
+}
+
+function collectReferenceLinkLine(
+  content: string,
+  line: string,
+  offset: number,
+  links: ParsedMarkdownLink[],
+): void {
+  const rawTarget = line.match(referenceLinkPattern)?.[1];
+  if (!rawTarget) return;
+  const definitionEnd = line.indexOf(']:');
+  let rawStartInLine = definitionEnd + 2;
+  while (line[rawStartInLine] === ' ' || line[rawStartInLine] === '\t') rawStartInLine += 1;
+  const usesAngleBrackets = rawTarget.startsWith('<') && rawTarget.endsWith('>');
+  const rawStart = offset + rawStartInLine;
+  links.push({
+    line: lineNumberAt(content, rawStart),
+    target: usesAngleBrackets ? rawTarget.slice(1, -1) : rawTarget,
+    destinationStart: rawStart + (usesAngleBrackets ? 1 : 0),
+    destinationEnd: rawStart + rawTarget.length - (usesAngleBrackets ? 1 : 0),
+    usesAngleBrackets,
+  });
 }
 
 function lineNumberAt(content: string, index: number): number {

--- a/tools/engineering-guidance/src/manifest.ts
+++ b/tools/engineering-guidance/src/manifest.ts
@@ -32,38 +32,52 @@ export function assertGuidanceManifest(value: unknown): asserts value is Guidanc
     throw new Error(`Unsupported guidance manifest schema: ${String(value.schemaVersion)}`);
   }
 
-  const packageValue = value.package;
+  assertManifestPackage(value.package);
+  assertManifestSource(value.source);
+  const paths = assertManifestFiles(value.files);
+  assertManifestEntrypoints(value.entrypoints, paths);
+}
+
+function assertManifestPackage(packageValue: unknown): void {
   if (!isRecord(packageValue) || packageValue.name !== guidancePackageName) {
     throw new Error(`Guidance manifest package name must be ${guidancePackageName}`);
   }
   if (!isNonEmptyString(packageValue.version)) {
     throw new Error('Guidance manifest package version must be a non-empty string');
   }
+}
 
-  const sourceValue = value.source;
+function assertManifestSource(sourceValue: unknown): void {
   if (!isRecord(sourceValue) || sourceValue.repository !== guidanceRepository) {
     throw new Error(`Guidance manifest source repository must be ${guidanceRepository}`);
   }
   if (!isCommit(sourceValue.commit)) {
     throw new Error('Guidance manifest source commit must be a full 40-character SHA-1');
   }
+}
 
-  if (!isRecord(value.entrypoints) || typeof value.entrypoints.documentationMap !== 'string') {
+function assertManifestEntrypoints(entrypoints: unknown, paths: ReadonlySet<string>): void {
+  if (!isRecord(entrypoints) || typeof entrypoints.documentationMap !== 'string') {
     throw new Error('Guidance manifest must define entrypoints.documentationMap');
   }
-  for (const [name, entrypoint] of Object.entries(value.entrypoints)) {
+  for (const [name, entrypoint] of Object.entries(entrypoints)) {
     if (!entrypointNamePattern.test(name)) {
       throw new Error(`Invalid guidance manifest entrypoint name: ${name}`);
     }
     assertManifestPath(entrypoint, `entrypoints.${name}`);
+    if (!paths.has(entrypoint)) {
+      throw new Error(`Guidance manifest entrypoint ${name} is not listed in files`);
+    }
   }
+}
 
-  if (!Array.isArray(value.files) || value.files.length === 0) {
+function assertManifestFiles(files: unknown): Set<string> {
+  if (!Array.isArray(files) || files.length === 0) {
     throw new Error('Guidance manifest must list at least one file');
   }
   let previousPath = '';
   const paths = new Set<string>();
-  for (const [index, file] of value.files.entries()) {
+  for (const [index, file] of files.entries()) {
     if (!isRecord(file)) throw new Error(`Manifest file ${index} must be an object`);
     if (!isNonEmptyString(file.path)) throw new Error(`Manifest file ${index} has no path`);
     assertManifestPath(file.path, `files.${index}.path`);
@@ -80,11 +94,7 @@ export function assertGuidanceManifest(value: unknown): asserts value is Guidanc
       throw new Error(`Missing kind for guidance manifest file: ${file.path}`);
     }
   }
-  for (const [name, entrypoint] of Object.entries(value.entrypoints)) {
-    if (typeof entrypoint !== 'string' || !paths.has(entrypoint)) {
-      throw new Error(`Guidance manifest entrypoint ${name} is not listed in files`);
-    }
-  }
+  return paths;
 }
 
 export function isGuidanceManifest(value: unknown): value is GuidanceManifest {

--- a/tools/package-release/src/engineering-guidance-artifact.ts
+++ b/tools/package-release/src/engineering-guidance-artifact.ts
@@ -432,38 +432,43 @@ export async function validatePackagedMarkdown(
 ): Promise<void> {
   const repositoryRoot = join(bundleRoot, 'repository');
   for (const link of extractArtifactMarkdownLinks(content)) {
-    if (link.target.startsWith('file:')) {
-      throw new Error(
-        `${relativeFile}:${link.line} contains an absolute local link: ${link.target}`,
-      );
-    }
-    if (isExternalTarget(link.target)) {
-      validateExternalMarkdownLink(link, sourceCommit, relativeFile);
-      continue;
-    }
+    await validatePackagedMarkdownLink(repositoryRoot, relativeFile, link, sourceCommit);
+  }
+}
 
-    const target = parseMarkdownTarget(link.target);
-    if (absolutePathPattern.test(target.path) || target.path.startsWith('/')) {
-      throw new Error(
-        `${relativeFile}:${link.line} contains an absolute local link: ${link.target}`,
-      );
-    }
-    const sourceAbsolute = join(repositoryRoot, relativeFile.slice('repository/'.length));
-    const targetAbsolute = target.path
-      ? resolve(dirname(sourceAbsolute), target.path)
-      : sourceAbsolute;
-    if (!isWithin(repositoryRoot, targetAbsolute)) {
-      throw new Error(`${relativeFile}:${link.line} escapes the guidance bundle: ${link.target}`);
-    }
-    const resolvedTarget = await resolveBundleMarkdownTarget(targetAbsolute);
-    if (!resolvedTarget) {
-      throw new Error(`${relativeFile}:${link.line} has a broken link: ${link.target}`);
-    }
-    if (!target.anchor || !resolvedTarget.endsWith(markdownExtension)) continue;
-    const anchors = anchorsFor(await readFile(resolvedTarget, 'utf8'));
-    if (!anchors.has(target.anchor)) {
-      throw new Error(`${relativeFile}:${link.line} has a missing anchor: ${link.target}`);
-    }
+async function validatePackagedMarkdownLink(
+  repositoryRoot: string,
+  relativeFile: string,
+  link: MarkdownLink,
+  sourceCommit: string,
+): Promise<void> {
+  if (link.target.startsWith('file:')) {
+    throw new Error(`${relativeFile}:${link.line} contains an absolute local link: ${link.target}`);
+  }
+  if (isExternalTarget(link.target)) {
+    validateExternalMarkdownLink(link, sourceCommit, relativeFile);
+    return;
+  }
+
+  const target = parseMarkdownTarget(link.target);
+  if (absolutePathPattern.test(target.path) || target.path.startsWith('/')) {
+    throw new Error(`${relativeFile}:${link.line} contains an absolute local link: ${link.target}`);
+  }
+  const sourceAbsolute = join(repositoryRoot, relativeFile.slice('repository/'.length));
+  const targetAbsolute = target.path
+    ? resolve(dirname(sourceAbsolute), target.path)
+    : sourceAbsolute;
+  if (!isWithin(repositoryRoot, targetAbsolute)) {
+    throw new Error(`${relativeFile}:${link.line} escapes the guidance bundle: ${link.target}`);
+  }
+  const resolvedTarget = await resolveBundleMarkdownTarget(targetAbsolute);
+  if (!resolvedTarget) {
+    throw new Error(`${relativeFile}:${link.line} has a broken link: ${link.target}`);
+  }
+  if (!target.anchor || !resolvedTarget.endsWith(markdownExtension)) return;
+  const anchors = anchorsFor(await readFile(resolvedTarget, 'utf8'));
+  if (!anchors.has(target.anchor)) {
+    throw new Error(`${relativeFile}:${link.line} has a missing anchor: ${link.target}`);
   }
 }
 
@@ -586,61 +591,98 @@ export function parseGuidanceManifest(value: unknown): GuidanceManifest {
   if (value.schemaVersion !== 1) {
     throw new Error(`Unsupported guidance manifest schema: ${String(value.schemaVersion)}`);
   }
-  const packageValue = value.package;
-  if (!isRecord(packageValue) || packageValue.name !== engineeringGuidancePackageName) {
+  const packageValue = parseManifestPackage(value.package);
+  const sourceValue = parseManifestSource(value.source);
+  const {files, paths} = parseManifestFiles(value.files);
+  const entrypoints = parseManifestEntrypoints(value.entrypoints, paths);
+
+  return {
+    entrypoints,
+    files,
+    package: {name: engineeringGuidancePackageName, version: packageValue.version},
+    schemaVersion: 1,
+    source: {commit: sourceValue.commit, repository: engineeringGuidanceRepository},
+  };
+}
+
+function parseManifestPackage(value: unknown): {version: string} {
+  if (!isRecord(value) || value.name !== engineeringGuidancePackageName) {
     throw new Error(`Guidance manifest package name must be ${engineeringGuidancePackageName}`);
   }
-  if (typeof packageValue.version !== 'string' || !packageValue.version) {
+  if (typeof value.version !== 'string' || !value.version) {
     throw new Error('Guidance manifest package version must be a non-empty string');
   }
-  const sourceValue = value.source;
-  if (!isRecord(sourceValue) || sourceValue.repository !== engineeringGuidanceRepository) {
+  return {version: value.version};
+}
+
+function parseManifestSource(value: unknown): {commit: string} {
+  if (!isRecord(value) || value.repository !== engineeringGuidanceRepository) {
     throw new Error(`Guidance manifest source repository must be ${engineeringGuidanceRepository}`);
   }
-  if (typeof sourceValue.commit !== 'string' || !fullCommitPattern.test(sourceValue.commit)) {
+  if (typeof value.commit !== 'string' || !fullCommitPattern.test(value.commit)) {
     throw new Error('Guidance manifest source commit must be a full 40-character SHA-1');
   }
-  if (!isRecord(value.entrypoints) || typeof value.entrypoints.documentationMap !== 'string') {
-    throw new Error('Guidance manifest must define entrypoints.documentationMap');
-  }
+  return {commit: value.commit};
+}
 
-  if (!Array.isArray(value.files) || value.files.length === 0) {
+function parseManifestFiles(value: unknown): {
+  files: GuidanceManifestFile[];
+  paths: Set<string>;
+} {
+  if (!Array.isArray(value) || value.length === 0) {
     throw new Error('Guidance manifest must list at least one file');
   }
   const paths = new Set<string>();
   let previousPath = '';
   const files: GuidanceManifestFile[] = [];
-  for (const [index, rawFile] of value.files.entries()) {
-    if (!isRecord(rawFile)) throw new Error(`Guidance manifest file ${index} must be an object`);
-    if (
-      typeof rawFile.path !== 'string' ||
-      typeof rawFile.sha256 !== 'string' ||
-      typeof rawFile.kind !== 'string'
-    ) {
-      throw new Error(`Guidance manifest file ${index} has an invalid shape`);
-    }
-    assertManifestPath(rawFile.path, `files.${index}.path`);
-    if (!rawFile.path.endsWith(markdownExtension)) {
-      throw new Error(`Guidance manifest file is not Markdown: ${rawFile.path}`);
-    }
-    if (rawFile.path <= previousPath) {
-      throw new Error('Guidance manifest files must be sorted by path');
-    }
-    if (paths.has(rawFile.path))
-      throw new Error(`Duplicate guidance manifest path: ${rawFile.path}`);
-    if (!sha256Pattern.test(rawFile.sha256)) {
-      throw new Error(`Invalid SHA-256 for guidance manifest file: ${rawFile.path}`);
-    }
-    if (!rawFile.kind) throw new Error(`Missing kind for guidance manifest file: ${rawFile.path}`);
-    if (isPrivateGuidancePath(rawFile.path)) {
-      throw new Error(`Guidance manifest contains a private or Cloud path: ${rawFile.path}`);
-    }
-    paths.add(rawFile.path);
-    previousPath = rawFile.path;
-    files.push({kind: rawFile.kind, path: rawFile.path, sha256: rawFile.sha256});
+  for (const [index, rawFile] of value.entries()) {
+    const file = parseManifestFile(rawFile, index, previousPath, paths);
+    paths.add(file.path);
+    previousPath = file.path;
+    files.push(file);
+  }
+  return {files, paths};
+}
+
+function parseManifestFile(
+  value: unknown,
+  index: number,
+  previousPath: string,
+  paths: ReadonlySet<string>,
+): GuidanceManifestFile {
+  if (!isRecord(value)) throw new Error(`Guidance manifest file ${index} must be an object`);
+  if (
+    typeof value.path !== 'string' ||
+    typeof value.sha256 !== 'string' ||
+    typeof value.kind !== 'string'
+  ) {
+    throw new Error(`Guidance manifest file ${index} has an invalid shape`);
+  }
+  assertManifestPath(value.path, `files.${index}.path`);
+  if (!value.path.endsWith(markdownExtension)) {
+    throw new Error(`Guidance manifest file is not Markdown: ${value.path}`);
+  }
+  if (value.path <= previousPath) throw new Error('Guidance manifest files must be sorted by path');
+  if (paths.has(value.path)) throw new Error(`Duplicate guidance manifest path: ${value.path}`);
+  if (!sha256Pattern.test(value.sha256)) {
+    throw new Error(`Invalid SHA-256 for guidance manifest file: ${value.path}`);
+  }
+  if (!value.kind) throw new Error(`Missing kind for guidance manifest file: ${value.path}`);
+  if (isPrivateGuidancePath(value.path)) {
+    throw new Error(`Guidance manifest contains a private or Cloud path: ${value.path}`);
+  }
+  return {kind: value.kind, path: value.path, sha256: value.sha256};
+}
+
+function parseManifestEntrypoints(
+  value: unknown,
+  paths: ReadonlySet<string>,
+): Record<string, string> {
+  if (!isRecord(value) || typeof value.documentationMap !== 'string') {
+    throw new Error('Guidance manifest must define entrypoints.documentationMap');
   }
   const entrypoints: Record<string, string> = {};
-  for (const [name, entrypoint] of Object.entries(value.entrypoints)) {
+  for (const [name, entrypoint] of Object.entries(value)) {
     if (typeof entrypoint !== 'string') {
       throw new Error(`Guidance manifest entrypoint ${name} must be a string`);
     }
@@ -650,14 +692,7 @@ export function parseGuidanceManifest(value: unknown): GuidanceManifest {
     }
     entrypoints[name] = entrypoint;
   }
-
-  return {
-    entrypoints,
-    files,
-    package: {name: engineeringGuidancePackageName, version: packageValue.version},
-    schemaVersion: 1,
-    source: {commit: sourceValue.commit, repository: engineeringGuidanceRepository},
-  };
+  return entrypoints;
 }
 
 function assertManifestPath(value: string, field: string): void {

--- a/tools/package-release/src/publication-preflight.ts
+++ b/tools/package-release/src/publication-preflight.ts
@@ -243,36 +243,65 @@ function validatePublicationPlan(
 ): void {
   for (const entry of packages) {
     const {manifest} = entry;
-    if (manifest.private === true)
-      throw new Error(`Publication package is private: ${manifest.name}`);
-    if (typeof manifest.version !== 'string')
-      throw new Error(`Publication package has no version: ${manifest.name}`);
-    for (const field of runtimeDependencyFields) {
-      for (const [dependency, reference] of Object.entries(manifest[field] ?? {})) {
-        if (typeof reference !== 'string') {
-          throw new Error(
-            `Publication package ${manifest.name} has invalid ${field} reference for ${dependency}`,
-          );
-        }
-        const workspacePackage = workspacePackages.get(dependency);
-        if (workspacePackage) {
-          if (workspacePackage.private === true) {
-            throw new Error(
-              `Publication package ${manifest.name} has private runtime dependency ${dependency}`,
-            );
-          }
-          if (!packagesByName.has(dependency)) {
-            throw new Error(
-              `Publication package ${manifest.name} depends on ${dependency} outside the release plan`,
-            );
-          }
-        } else if (!reference.startsWith('catalog:') && !semverRange.test(reference)) {
-          throw new Error(
-            `Publication package ${manifest.name} has unsupported external range ${dependency}@${reference}`,
-          );
-        }
-      }
+    validatePublicationPackage(manifest, packagesByName, workspacePackages);
+  }
+}
+
+function validatePublicationPackage(
+  manifest: PackageManifest,
+  packagesByName: ReadonlyMap<string, PublicationPackage>,
+  workspacePackages: ReadonlyMap<string, PackageManifest>,
+): void {
+  if (manifest.private === true)
+    throw new Error(`Publication package is private: ${manifest.name}`);
+  if (typeof manifest.version !== 'string') {
+    throw new Error(`Publication package has no version: ${manifest.name}`);
+  }
+  for (const field of runtimeDependencyFields) {
+    for (const [dependency, reference] of Object.entries(manifest[field] ?? {})) {
+      validateRuntimeDependency(
+        manifest,
+        field,
+        dependency,
+        reference,
+        packagesByName,
+        workspacePackages,
+      );
     }
+  }
+}
+
+function validateRuntimeDependency(
+  manifest: PackageManifest,
+  field: (typeof runtimeDependencyFields)[number],
+  dependency: string,
+  reference: unknown,
+  packagesByName: ReadonlyMap<string, PublicationPackage>,
+  workspacePackages: ReadonlyMap<string, PackageManifest>,
+): void {
+  if (typeof reference !== 'string') {
+    throw new Error(
+      `Publication package ${manifest.name} has invalid ${field} reference for ${dependency}`,
+    );
+  }
+  const workspacePackage = workspacePackages.get(dependency);
+  if (!workspacePackage) {
+    if (!reference.startsWith('catalog:') && !semverRange.test(reference)) {
+      throw new Error(
+        `Publication package ${manifest.name} has unsupported external range ${dependency}@${reference}`,
+      );
+    }
+    return;
+  }
+  if (workspacePackage.private === true) {
+    throw new Error(
+      `Publication package ${manifest.name} has private runtime dependency ${dependency}`,
+    );
+  }
+  if (!packagesByName.has(dependency)) {
+    throw new Error(
+      `Publication package ${manifest.name} depends on ${dependency} outside the release plan`,
+    );
   }
 }
 

--- a/tools/repository-documentation-policy/src/repository-documentation.ts
+++ b/tools/repository-documentation-policy/src/repository-documentation.ts
@@ -141,59 +141,17 @@ export async function checkRepositoryDocumentation(
   const violations: DocumentationViolation[] = [];
 
   for (const source of checkedFiles) {
-    const content = contents.get(source) ?? '';
-    const sourceEdges = new Set<string>();
-    edges.set(source, sourceEdges);
-
-    for (const link of extractMarkdownLinks(content)) {
-      const parsedTarget = parseTarget(link.target);
-      if (parsedTarget.kind === 'ignored') continue;
-
-      if (parsedTarget.kind === 'invalid') {
-        violations.push({
-          kind: 'broken-link',
-          source,
-          line: link.line,
-          target: link.target,
-          reason: parsedTarget.reason,
-        });
-        continue;
-      }
-
-      const targetFile = parsedTarget.path
-        ? await resolveDocumentationTarget(rootDirectory, source, parsedTarget.path)
-        : source;
-
-      if (!targetFile) {
-        violations.push({
-          kind: 'broken-link',
-          source,
-          line: link.line,
-          target: link.target,
-          reason: 'target does not exist',
-        });
-        continue;
-      }
-
-      if (parsedTarget.anchor && shouldCheckAnchor(targetFile, checkedFileSet)) {
-        const targetAnchors =
-          targetFile === source
-            ? anchorsByFile.get(source)
-            : (anchorsByFile.get(targetFile) ??
-              anchorsFor(await readFile(path.join(rootDirectory, targetFile), 'utf8')));
-        if (!targetAnchors?.has(parsedTarget.anchor)) {
-          violations.push({
-            kind: 'missing-anchor',
-            source,
-            line: link.line,
-            target: link.target,
-            reason: 'target heading does not exist',
-          });
-        }
-      }
-
-      if (checkedFileSet.has(targetFile)) sourceEdges.add(targetFile);
-    }
+    edges.set(
+      source,
+      await checkDocumentationFile({
+        anchorsByFile,
+        checkedFileSet,
+        content: contents.get(source) ?? '',
+        rootDirectory,
+        source,
+        violations,
+      }),
+    );
   }
 
   const reachable = reachableFiles(edges, checkedFiles.filter(isApprovedRoot));
@@ -209,6 +167,75 @@ export async function checkRepositoryDocumentation(
   }
 
   return {checkedFiles, violations};
+}
+
+interface DocumentationFileCheckOptions {
+  anchorsByFile: ReadonlyMap<string, Set<string>>;
+  checkedFileSet: Set<string>;
+  content: string;
+  rootDirectory: string;
+  source: string;
+  violations: DocumentationViolation[];
+}
+
+async function checkDocumentationFile(
+  options: DocumentationFileCheckOptions,
+): Promise<Set<string>> {
+  const {checkedFileSet, content, rootDirectory, source, violations} = options;
+  const sourceEdges = new Set<string>();
+  for (const link of extractMarkdownLinks(content)) {
+    const parsedTarget = parseTarget(link.target);
+    if (parsedTarget.kind === 'ignored') continue;
+    if (parsedTarget.kind === 'invalid') {
+      violations.push({
+        kind: 'broken-link',
+        source,
+        line: link.line,
+        target: link.target,
+        reason: parsedTarget.reason,
+      });
+      continue;
+    }
+    const targetFile = parsedTarget.path
+      ? await resolveDocumentationTarget(rootDirectory, source, parsedTarget.path)
+      : source;
+    if (!targetFile) {
+      violations.push({
+        kind: 'broken-link',
+        source,
+        line: link.line,
+        target: link.target,
+        reason: 'target does not exist',
+      });
+      continue;
+    }
+    await checkDocumentationAnchor(options, link, parsedTarget.anchor, targetFile);
+    if (checkedFileSet.has(targetFile)) sourceEdges.add(targetFile);
+  }
+  return sourceEdges;
+}
+
+async function checkDocumentationAnchor(
+  options: DocumentationFileCheckOptions,
+  link: MarkdownLink,
+  anchor: string | null,
+  targetFile: string,
+): Promise<void> {
+  const {anchorsByFile, checkedFileSet, rootDirectory, source, violations} = options;
+  if (!anchor || !shouldCheckAnchor(targetFile, checkedFileSet)) return;
+  let targetAnchors = anchorsByFile.get(targetFile);
+  if (targetFile === source) targetAnchors = anchorsByFile.get(source);
+  if (!targetAnchors) {
+    targetAnchors = anchorsFor(await readFile(path.join(rootDirectory, targetFile), 'utf8'));
+  }
+  if (targetAnchors.has(anchor)) return;
+  violations.push({
+    kind: 'missing-anchor',
+    source,
+    line: link.line,
+    target: link.target,
+    reason: 'target heading does not exist',
+  });
 }
 
 export async function collectDocumentationFiles(rootDirectory: string): Promise<string[]> {

--- a/tools/vite/src/workspace-source.ts
+++ b/tools/vite/src/workspace-source.ts
@@ -175,19 +175,26 @@ function resolveSourceTarget(
   }
 
   for (const mappedTarget of mappedTargets ?? []) {
-    if (!mappedTarget.startsWith('./')) continue;
-
-    const absoluteTarget = resolvePath(packageInfo.directory, mappedTarget);
-    if (!isLexicallyWithinDirectory(packageInfo.directory, absoluteTarget)) continue;
-    if (isDistTarget(packageInfo.directory, absoluteTarget)) continue;
-
-    for (const candidate of sourceCandidates(absoluteTarget)) {
-      if (!isFile(candidate)) continue;
-      if (!isWithinDirectory(packageInfo.directory, candidate)) continue;
-      return absoluteTarget;
-    }
+    const target = resolveMappedSourceTarget(packageInfo.directory, mappedTarget);
+    if (target) return target;
   }
 
+  return undefined;
+}
+
+function resolveMappedSourceTarget(
+  packageDirectory: string,
+  mappedTarget: string,
+): string | undefined {
+  if (!mappedTarget.startsWith('./')) return undefined;
+  const absoluteTarget = resolvePath(packageDirectory, mappedTarget);
+  if (!isLexicallyWithinDirectory(packageDirectory, absoluteTarget)) return undefined;
+  if (isDistTarget(packageDirectory, absoluteTarget)) return undefined;
+  for (const candidate of sourceCandidates(absoluteTarget)) {
+    if (!isFile(candidate)) continue;
+    if (!isWithinDirectory(packageDirectory, candidate)) continue;
+    return absoluteTarget;
+  }
   return undefined;
 }
 
@@ -211,13 +218,10 @@ export function workspaceSourceResolver(): Plugin {
         : (this.environment.config.resolve?.conditions ?? []);
       if (!conditions.includes(workspaceSourceCondition)) return;
 
-      const effectiveConditions = conditions.map((condition) =>
-        condition === 'development|production'
-          ? this.environment.config.isProduction
-            ? 'production'
-            : 'development'
-          : condition,
-      );
+      const effectiveConditions = conditions.map((condition) => {
+        if (condition !== 'development|production') return condition;
+        return this.environment.config.isProduction ? 'production' : 'development';
+      });
       effectiveConditions.push(options.kind === 'require-call' ? 'require' : 'import');
 
       const packageInfo = findOwningPackage(importer, packageCache, ownershipCache);

--- a/tools/worktree-services/src/cli.ts
+++ b/tools/worktree-services/src/cli.ts
@@ -82,16 +82,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       apply = true;
       continue;
     }
-    if (argument === '--config' || argument === '--root' || argument === '--workspace') {
-      const value = rest[index + 1];
-      if (!value) usage();
-      index += 1;
-      if (argument === '--config') configPath = value;
-      if (argument === '--root') rootPath = value;
-      if (argument === '--workspace') workspacePath = value;
-      continue;
-    }
-    usage();
+    const value = parsePathArgument(argument, rest[index + 1]);
+    index += 1;
+    if (argument === '--config') configPath = value;
+    if (argument === '--root') rootPath = value;
+    if (argument === '--workspace') workspacePath = value;
   }
   return {
     apply,
@@ -101,6 +96,12 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     rootPath,
     workspacePath,
   };
+}
+
+function parsePathArgument(argument: string | undefined, value: string | undefined): string {
+  if (argument !== '--config' && argument !== '--root' && argument !== '--workspace') usage();
+  if (!value) usage();
+  return value;
 }
 
 function resolveConfigPath(

--- a/tools/worktree-services/src/index.ts
+++ b/tools/worktree-services/src/index.ts
@@ -579,46 +579,68 @@ function readPortLeaseRegistry(registryFile: string): PortLeaseRegistry {
   }
 
   try {
-    for (const [key, rangeState] of Object.entries(registry.ranges)) {
-      const range = normalizePortRange(rangeState);
-      if (key !== portRangeKey(range) || !isPortBlockStart(rangeState.nextBase, range)) {
-        fail(`Invalid Shipfox port lease registry: ${registryFile}`);
-      }
-    }
-    const leases: Record<string, PortLease> = {};
-    for (const [leaseKey, lease] of Object.entries(registry.leases)) {
-      if (!isRecord(lease)) fail(`Invalid Shipfox port lease registry: ${registryFile}`);
-      const range = normalizePortRange(lease.range);
-      if (
-        !isPortBlockStart(lease.base, range) ||
-        typeof lease.repositoryId !== 'string' ||
-        typeof lease.workspaceId !== 'string' ||
-        typeof lease.workspacePath !== 'string' ||
-        leaseKey !== portLeaseKey(lease.repositoryId, lease.workspaceId)
-      ) {
-        fail(`Invalid Shipfox port lease registry: ${registryFile}`);
-      }
-      leases[leaseKey] = {
-        allocatedAt: String(lease.allocatedAt),
-        base: lease.base,
-        range,
-        repositoryId: lease.repositoryId,
-        workspaceId: lease.workspaceId,
-        workspacePath: lease.workspacePath,
-      };
-    }
-    const ranges: PortLeaseRegistry['ranges'] = {};
-    for (const [key, rangeState] of Object.entries(registry.ranges)) {
-      const range = normalizePortRange(rangeState);
-      if (!isRecord(rangeState) || !isPortBlockStart(rangeState.nextBase, range)) {
-        fail(`Invalid Shipfox port lease registry: ${registryFile}`);
-      }
-      ranges[key] = {...range, nextBase: rangeState.nextBase};
-    }
-    return {version: 3, ranges, leases};
+    validateRegistryRanges(registry.ranges, registryFile);
+    return {
+      version: 3,
+      ranges: normalizeRegistryRanges(registry.ranges, registryFile),
+      leases: normalizeRegistryLeases(registry.leases, registryFile),
+    };
   } catch {
     fail(`Invalid Shipfox port lease registry: ${registryFile}`);
   }
+}
+
+function validateRegistryRanges(ranges: Record<string, unknown>, registryFile: string): void {
+  for (const [key, rangeState] of Object.entries(ranges)) {
+    const range = normalizePortRange(rangeState);
+    if (key !== portRangeKey(range) || !isPortBlockStart(rangeState.nextBase, range)) {
+      fail(`Invalid Shipfox port lease registry: ${registryFile}`);
+    }
+  }
+}
+
+function normalizeRegistryLeases(
+  rawLeases: Record<string, unknown>,
+  registryFile: string,
+): Record<string, PortLease> {
+  const leases: Record<string, PortLease> = {};
+  for (const [leaseKey, lease] of Object.entries(rawLeases)) {
+    if (!isRecord(lease)) fail(`Invalid Shipfox port lease registry: ${registryFile}`);
+    const range = normalizePortRange(lease.range);
+    if (
+      !isPortBlockStart(lease.base, range) ||
+      typeof lease.repositoryId !== 'string' ||
+      typeof lease.workspaceId !== 'string' ||
+      typeof lease.workspacePath !== 'string' ||
+      leaseKey !== portLeaseKey(lease.repositoryId, lease.workspaceId)
+    ) {
+      fail(`Invalid Shipfox port lease registry: ${registryFile}`);
+    }
+    leases[leaseKey] = {
+      allocatedAt: String(lease.allocatedAt),
+      base: lease.base,
+      range,
+      repositoryId: lease.repositoryId,
+      workspaceId: lease.workspaceId,
+      workspacePath: lease.workspacePath,
+    };
+  }
+  return leases;
+}
+
+function normalizeRegistryRanges(
+  rawRanges: Record<string, unknown>,
+  registryFile: string,
+): PortLeaseRegistry['ranges'] {
+  const ranges: PortLeaseRegistry['ranges'] = {};
+  for (const [key, rangeState] of Object.entries(rawRanges)) {
+    const range = normalizePortRange(rangeState);
+    if (!isRecord(rangeState) || !isPortBlockStart(rangeState.nextBase, range)) {
+      fail(`Invalid Shipfox port lease registry: ${registryFile}`);
+    }
+    ranges[key] = {...range, nextBase: rangeState.nextBase};
+  }
+  return ranges;
 }
 
 function migrateLegacyPortLeaseRegistry(


### PR DESCRIPTION
## Summary

Enforces repository-wide errors for nested ternaries, useless `else` branches, and cognitive complexity above 15. Existing violations are refactored into smaller named control-flow units so the stricter rules land without suppressions or behavior changes.

The published-package refactors carry a patch Changeset.

## Validation

The repository-wide targeted Biome rule sweep and Biome checks for all changed files pass. Full type validation completed with 342 of 342 tasks, and 2,243 focused tests passed across API definitions, API workflows, GitHub integration, runner agent, and runner orchestration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces repository-wide errors for nested ternaries, useless `else` branches, and cognitive complexity above 15, refactoring every existing violation without changing behavior; the project refresh path now also preserves empty project states after a failed refresh.

**Configuration and refactors**
- `biome.json` raises `noNestedTernary`, `noUselessElse`, and `noExcessiveCognitiveComplexity` (max 15) to error for `apps`, `e2e`, `infra`, `libs`, `tools`, and `.github/scripts`.
- Existing violations become named helpers and early returns; the refactors add regression tests for diagnostic ordering, error propagation, and runner assignment conflicts.
- Refactors ship one patch Changeset; the refresh fix ships a separate patch Changeset for `@shipfox/client-projects`.

**Validation**
- The targeted Biome rule sweep and Biome checks pass for all changed files.
- Full type validation and 2,243 focused tests pass across API definitions, API workflows, GitHub integration, runner agent, and runner orchestration.

<sup>Written for commit 376790857424fe2347fc62fa7aec40a32f231927. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

