### PR TITLE
[docs] Remove MiniMax M2.7 Turbo from model reference

### DIFF
--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -70,5 +70,4 @@ reference](/reference/workflow-schema#agent-step-fields).
 | Qwen3.5 397 B A17B | `qwen3.5-397b-a17b` |
 | MiMo V2.5 Pro | `mimo-v2.5-pro` |
 | MiniMax M2.7 | `minimax-m2.7` |
-| MiniMax M2.7 Turbo | `minimax-m2.7-turbo` |
 | MiniMax M3 | `minimax-m3` |


### PR DESCRIPTION
Remove the MiniMax M2.7 Turbo entry from the Shipfox Cloud model reference so the documented catalog matches the requested available models. No Changeset is included because this is a documentation-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the MiniMax M2.7 Turbo entry from the Shipfox Cloud model reference so the documented model catalog matches the currently available models. No changelog entry is included because this is a documentation-only change.

<sup>Written for commit a7666c4b899aa67551c2c2073d0b87f37493a890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

