### PR TITLE
[runner-agent] Enable direct Pi tools for integration MCP servers

### DIFF
--- a/libs/runner/agent/src/core/integration-tools-bridge.test.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.test.ts
@@ -62,6 +62,57 @@ describe('createIntegrationToolsBridge', () => {
     ]);
   });
 
+  it('recovers after a transient connection failure', async () => {
+    gateway = await startFakeGateway(() => 'lease');
+    let failNextRequest = true;
+    const bridge = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: (input, init) => {
+        if (failNextRequest) {
+          failNextRequest = false;
+          return Promise.resolve(new Response('temporarily unavailable', {status: 503}));
+        }
+        return leaseFetch(() => 'lease')(input, init);
+      },
+    });
+
+    await expect(bridge.listTools({timeout: 100})).rejects.toThrow();
+    const tools = await bridge.listTools();
+    await bridge.close();
+
+    expect(tools.tools.map((tool) => tool.name)).toEqual(['github_main__issue_read']);
+  });
+
+  it('recreates the client after a connected request failure', async () => {
+    gateway = await startFakeGateway(() => 'lease');
+    let failNextListRequest = true;
+    const fallbackFetch = leaseFetch(() => 'lease');
+    const bridge = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: (input, init) => {
+        const body =
+          typeof init?.body === 'string' ? (JSON.parse(init.body) as {method?: string}) : undefined;
+        if (failNextListRequest && body?.method === 'tools/list') {
+          failNextListRequest = false;
+          return Promise.resolve(new Response('temporarily unavailable', {status: 503}));
+        }
+        return fallbackFetch(input, init);
+      },
+    });
+
+    await expect(bridge.listTools()).rejects.toThrow();
+    const result = await bridge.callTool('github_main__issue_read', {issue_number: 1});
+    await bridge.close();
+
+    expect(result.structuredContent).toEqual({
+      name: 'github_main__issue_read',
+      method: undefined,
+      issue_number: 1,
+    });
+  });
+
   it('relays list and call through the in-process MCP server', async () => {
     let leaseToken = 'lease-initial';
     gateway = await startFakeGateway(() => leaseToken);
@@ -142,6 +193,28 @@ describe('createIntegrationToolsBridge', () => {
     expect(gateway.authorizations.at(-1)).toBe('Bearer lease-next');
     expect(invalidPath.status).toBe(404);
     expect(invalidOrigin.status).toBe(403);
+  });
+
+  it('reuses a preferred loopback port after a bridge is recreated', async () => {
+    gateway = await startFakeGateway(() => 'lease');
+    const first = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: leaseFetch(() => 'lease'),
+    });
+    const firstEndpoint = await first.activateHttp();
+    await first.close();
+
+    const second = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: leaseFetch(() => 'lease'),
+      preferredPort: Number(firstEndpoint.port),
+    });
+    const secondEndpoint = await second.activateHttp();
+    await second.close();
+
+    expect(secondEndpoint.port).toBe(firstEndpoint.port);
   });
 
   it('allows repeated close before activation', async () => {

--- a/libs/runner/agent/src/core/integration-tools-bridge.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.ts
@@ -1,4 +1,3 @@
-import {once} from 'node:events';
 import {
   createServer,
   type Server as HttpServer,
@@ -23,10 +22,15 @@ import {logger} from '@shipfox/node-opentelemetry';
 const MAX_MCP_REQUEST_BYTES = 1_048_576;
 const MCP_REQUEST_TIMEOUT_MS = 30_000;
 
+export interface IntegrationToolsBridgeRequestOptions {
+  readonly signal?: AbortSignal;
+  readonly timeout?: number;
+}
+
 export interface IntegrationToolsBridge {
   readonly name: string;
   readonly server: McpServer;
-  listTools(): Promise<ListToolsResult>;
+  listTools(options?: IntegrationToolsBridgeRequestOptions): Promise<ListToolsResult>;
   callTool(name: string, args?: Record<string, unknown>): Promise<CallToolResult>;
   activateHttp(): Promise<URL>;
   close(): Promise<void>;
@@ -36,34 +40,82 @@ export function createIntegrationToolsBridge(params: {
   url: URL;
   fetch: typeof fetch;
   name: string;
+  preferredPort?: number;
 }): IntegrationToolsBridge {
-  const client = new Client({name: params.name, version: '0.0.0'});
-  const transport = new StreamableHTTPClientTransport(params.url, {fetch: params.fetch});
+  const createClient = () => new Client({name: params.name, version: '0.0.0'});
+  const createTransport = () =>
+    new StreamableHTTPClientTransport(params.url, {fetch: params.fetch});
+  let client = createClient();
+  let transport = createTransport();
   const server = new McpServer({name: params.name, version: '0.0.0'}, {capabilities: {tools: {}}});
   let connectPromise: Promise<void> | undefined;
+  let resetPromise: Promise<void> | undefined;
   let activationPromise: Promise<URL> | undefined;
   let closePromise: Promise<void> | undefined;
+  let closed = false;
   let httpServer: HttpServer | undefined;
   const httpSessions = new Map<string, HttpSession>();
 
-  const ensureConnected = () => {
-    connectPromise ??= client.connect(transport as unknown as Transport);
-    return connectPromise;
+  const resetConnection = (failedClient: Client): Promise<void> => {
+    if (closed || client !== failedClient) return Promise.resolve();
+    resetPromise ??= (async () => {
+      connectPromise = undefined;
+      await failedClient.close().catch(() => undefined);
+      if (!closed && client === failedClient) {
+        client = createClient();
+        transport = createTransport();
+      }
+    })().finally(() => {
+      resetPromise = undefined;
+    });
+    return resetPromise;
+  };
+
+  const ensureConnected = async (options?: IntegrationToolsBridgeRequestOptions) => {
+    if (closed) throw new Error('Integration tools bridge is closed.');
+    await resetPromise;
+    if (closed) throw new Error('Integration tools bridge is closed.');
+    if (connectPromise !== undefined) return connectPromise;
+
+    const connectingClient = client;
+    const connectingTransport = transport;
+    let pendingConnection: Promise<void>;
+    pendingConnection = connectingClient
+      .connect(connectingTransport as unknown as Transport, options)
+      .catch(async (error: unknown) => {
+        if (connectPromise === pendingConnection) connectPromise = undefined;
+        await resetConnection(connectingClient);
+        throw error;
+      });
+    connectPromise = pendingConnection;
+    return pendingConnection;
   };
 
   const bridge: IntegrationToolsBridge = {
     name: params.name,
     server,
-    async listTools() {
-      await ensureConnected();
-      return client.listTools();
+    async listTools(options) {
+      await ensureConnected(options);
+      const requestClient = client;
+      try {
+        return await requestClient.listTools(undefined, options);
+      } catch (error) {
+        await resetConnection(requestClient);
+        throw error;
+      }
     },
     async callTool(name, args) {
       await ensureConnected();
-      return client.callTool(
-        {name, ...(args === undefined ? {} : {arguments: args})},
-        CallToolResultSchema,
-      ) as Promise<CallToolResult>;
+      const requestClient = client;
+      try {
+        return (await requestClient.callTool(
+          {name, ...(args === undefined ? {} : {arguments: args})},
+          CallToolResultSchema,
+        )) as CallToolResult;
+      } catch (error) {
+        await resetConnection(requestClient);
+        throw error;
+      }
     },
     activateHttp() {
       if (closePromise !== undefined) {
@@ -72,13 +124,14 @@ export function createIntegrationToolsBridge(params: {
       activationPromise ??= activateBridgeHttp({
         server,
         setHttpServer: (value) => (httpServer = value),
+        ...(params.preferredPort === undefined ? {} : {preferredPort: params.preferredPort}),
         createHttpSession: async () => {
           const id = crypto.randomUUID();
           const sessionServer = new Server(
             {name: params.name, version: '0.0.0'},
             {capabilities: {tools: {}}},
           );
-          installForwardingHandlers(sessionServer, ensureConnected, client);
+          installForwardingHandlers(sessionServer, ensureConnected, () => client, resetConnection);
           const sessionTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => id,
           });
@@ -90,9 +143,10 @@ export function createIntegrationToolsBridge(params: {
       return activationPromise;
     },
     close() {
+      closed = true;
       closePromise ??= closeBridge({
         activationPromise,
-        client,
+        getClient: () => client,
         server,
         getHttpServer: () => httpServer,
         httpSessions,
@@ -101,7 +155,7 @@ export function createIntegrationToolsBridge(params: {
     },
   };
 
-  installForwardingHandlers(server.server, ensureConnected, client);
+  installForwardingHandlers(server.server, ensureConnected, () => client, resetConnection);
 
   return bridge;
 }
@@ -109,6 +163,7 @@ export function createIntegrationToolsBridge(params: {
 async function activateBridgeHttp(params: {
   server: McpServer;
   setHttpServer: (server: HttpServer) => void;
+  preferredPort?: number;
   createHttpSession: () => Promise<HttpSession>;
   httpSessions: Map<string, HttpSession>;
 }): Promise<URL> {
@@ -120,8 +175,16 @@ async function activateBridgeHttp(params: {
   params.setHttpServer(httpServer);
 
   try {
-    httpServer.listen(0, '127.0.0.1');
-    await once(httpServer, 'listening');
+    try {
+      await listenHttpServer(httpServer, params.preferredPort ?? 0);
+    } catch (error) {
+      if (params.preferredPort === undefined || !isAddressInUseError(error)) throw error;
+      logger().warn(
+        {err: error, port: params.preferredPort},
+        'Stable MCP bridge port is unavailable; using an ephemeral port',
+      );
+      await listenHttpServer(httpServer, 0);
+    }
     const address = httpServer.address();
     if (typeof address !== 'object' || address === null) {
       throw new Error('Integration tools bridge did not bind a TCP address.');
@@ -139,6 +202,36 @@ async function activateBridgeHttp(params: {
     }
     throw error;
   }
+}
+
+async function listenHttpServer(server: HttpServer, port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      server.removeListener('listening', onListening);
+      server.removeListener('error', onError);
+    };
+    const onListening = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    server.once('listening', onListening);
+    server.once('error', onError);
+    try {
+      server.listen(port, '127.0.0.1');
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}
+
+function isAddressInUseError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'EADDRINUSE';
 }
 
 interface HttpSession {
@@ -200,15 +293,28 @@ async function handleHttpRequest(
 function installForwardingHandlers(
   server: Server,
   ensureConnected: () => Promise<void>,
-  client: Client,
+  getClient: () => Client,
+  resetConnection: (failedClient: Client) => Promise<void>,
 ): void {
   server.setRequestHandler(ListToolsRequestSchema, async (request) => {
     await ensureConnected();
-    return client.listTools(request.params);
+    const requestClient = getClient();
+    try {
+      return await requestClient.listTools(request.params);
+    } catch (error) {
+      await resetConnection(requestClient);
+      throw error;
+    }
   });
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     await ensureConnected();
-    return client.callTool(request.params, CallToolResultSchema);
+    const requestClient = getClient();
+    try {
+      return await requestClient.callTool(request.params, CallToolResultSchema);
+    } catch (error) {
+      await resetConnection(requestClient);
+      throw error;
+    }
   });
 }
 
@@ -250,7 +356,7 @@ function sendMcpError(
 
 async function closeBridge(params: {
   activationPromise: Promise<URL> | undefined;
-  client: Client;
+  getClient: () => Client;
   server: McpServer;
   getHttpServer: () => HttpServer | undefined;
   httpSessions: Map<string, HttpSession>;
@@ -263,7 +369,7 @@ async function closeBridge(params: {
 
   const httpServer = params.getHttpServer();
   await releaseResources({
-    client: params.client,
+    client: params.getClient(),
     server: params.server,
     httpSessions: params.httpSessions,
     ...(httpServer === undefined ? {} : {httpServer}),

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -352,6 +352,16 @@ describe('piHarnessAdapter', () => {
     let config: unknown;
     let argvDuringServiceCreation: readonly string[] | undefined;
     const originalArgv = process.argv.slice();
+    process.argv.splice(
+      0,
+      process.argv.length,
+      'node',
+      'runner',
+      '--mcp-config',
+      '/tmp/old-mcp.json',
+      'serve',
+      '--mcp-config=/tmp/equals-mcp.json',
+    );
     createAgentSessionServicesMock.mockImplementation((options) => {
       configPath = options.extensionFlagValues.get('mcp-config');
       config = JSON.parse(readFileSync(configPath, 'utf8'));
@@ -359,14 +369,26 @@ describe('piHarnessAdapter', () => {
       return piServices(sessionDir);
     });
 
-    await piHarnessAdapter.run(invocation({cwd: sessionDir, agentStateDir, mcpServers: [bridge]}));
+    try {
+      await piHarnessAdapter.run(
+        invocation({cwd: sessionDir, agentStateDir, mcpServers: [bridge]}),
+      );
+    } finally {
+      process.argv.splice(0, process.argv.length, ...originalArgv);
+    }
 
     expect(bridge.activateHttp).toHaveBeenCalledTimes(1);
     expect(bridge.listTools).toHaveBeenCalledTimes(1);
     expect(bindExtensionsMock).toHaveBeenCalledWith(expect.objectContaining({mode: 'print'}));
     expect(configPath).toMatch(`${agentStateDir}/pi-mcp-`);
-    const mcpConfigArgIndex = argvDuringServiceCreation?.indexOf('--mcp-config') ?? -1;
-    expect(argvDuringServiceCreation?.[mcpConfigArgIndex + 1]).toBe(configPath);
+    expect(argvDuringServiceCreation).toEqual([
+      'node',
+      'runner',
+      '--mcp-config',
+      configPath,
+      'serve',
+      '--mcp-config=/tmp/equals-mcp.json',
+    ]);
     expect(process.argv).toEqual(originalArgv);
     expect(sessionManagerCreateMock).toHaveBeenCalledWith(
       sessionDir,
@@ -393,6 +415,97 @@ describe('piHarnessAdapter', () => {
     expect(extensionShutdownMock).toHaveBeenCalledWith({type: 'session_shutdown', reason: 'quit'});
     expect(disposeMock).toHaveBeenCalledAfter(extensionShutdownMock);
     expect(existsSync(configPath)).toBe(false);
+  });
+
+  it('serializes Pi MCP config argv setup across concurrent sessions', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const firstAgentStateDir = join(sessionDir, 'first-agent');
+    const secondAgentStateDir = join(sessionDir, 'second-agent');
+    const originalArgv = process.argv.slice();
+    let releaseFirstService!: () => void;
+    const firstServiceReleased = new Promise<void>((resolve) => {
+      releaseFirstService = resolve;
+    });
+    const observed: Array<{configPath: string; argv: readonly string[]}> = [];
+    let startFirstService!: () => void;
+    const firstServiceStarted = new Promise<void>((resolve) => {
+      startFirstService = resolve;
+    });
+    createAgentSessionServicesMock.mockImplementation(async (options) => {
+      observed.push({
+        configPath: options.extensionFlagValues.get('mcp-config'),
+        argv: process.argv.slice(),
+      });
+      if (observed.length === 1) {
+        startFirstService();
+        await firstServiceReleased;
+      }
+      return piServices();
+    });
+
+    const first = piHarnessAdapter.run(
+      invocation({
+        agentStateDir: firstAgentStateDir,
+        mcpServers: [mcpBridge()],
+      }),
+    );
+    await firstServiceStarted;
+
+    const second = piHarnessAdapter.run(
+      invocation({
+        agentStateDir: secondAgentStateDir,
+        mcpServers: [mcpBridge()],
+      }),
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(observed).toHaveLength(1);
+
+    releaseFirstService();
+    await Promise.all([first, second]);
+
+    expect(observed).toHaveLength(2);
+    expect(observed[0]?.argv).toContain(observed[0]?.configPath);
+    expect(observed[1]?.argv).toContain(observed[1]?.configPath);
+    expect(observed[0]?.configPath).not.toBe(observed[1]?.configPath);
+    expect(process.argv).toEqual(originalArgv);
+  });
+
+  it('keeps healthy direct-tool metadata when another server preflight fails', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const failingBridge = mcpBridge({
+      name: 'unavailable_server',
+      listTools: vi.fn().mockRejectedValue(new Error('gateway unavailable')),
+    });
+    const healthyBridge = mcpBridge({
+      name: 'healthy_server',
+      listTools: vi.fn().mockResolvedValue({
+        tools: [{name: 'healthy_tool', inputSchema: {type: 'object'}}],
+      }),
+    });
+    let config: {mcpServers: Record<string, {directTools: boolean}>} | undefined;
+    createAgentSessionServicesMock.mockImplementation((options) => {
+      config = JSON.parse(readFileSync(options.extensionFlagValues.get('mcp-config'), 'utf8')) as {
+        mcpServers: Record<string, {directTools: boolean}>;
+      };
+      return piServices(sessionDir);
+    });
+
+    await piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        agentStateDir: join(sessionDir, 'runner-agent'),
+        mcpServers: [failingBridge, healthyBridge],
+        tools: ['read'],
+      }),
+    );
+
+    expect(config?.mcpServers).toEqual({
+      unavailable_server: expect.objectContaining({directTools: true}),
+      healthy_server: expect.objectContaining({directTools: true}),
+    });
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({tools: ['read', 'mcp', 'healthy_tool']}),
+    );
   });
 
   it('aborts Pi while MCP extensions are binding', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -207,7 +207,7 @@ function mcpBridge(overrides: Partial<IntegrationToolsBridge> = {}): Integration
   return {
     name: 'shipfox_integration_tools',
     server: {} as IntegrationToolsBridge['server'],
-    listTools: vi.fn(),
+    listTools: vi.fn().mockResolvedValue({tools: []}),
     callTool: vi.fn(),
     activateHttp: vi.fn().mockResolvedValue(new URL('http://127.0.0.1:43123/mcp')),
     close: vi.fn(),
@@ -334,23 +334,40 @@ describe('piHarnessAdapter', () => {
     expect(createAgentSessionMock).toHaveBeenCalled();
   });
 
-  it('configures eager loopback MCP proxy access in the runner job agent-state directory', async () => {
+  it('configures eager loopback MCP direct and proxy access in the runner job agent-state directory', async () => {
     sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
     const agentStateDir = join(sessionDir, 'runner-agent');
-    const bridge = mcpBridge();
+    const bridge = mcpBridge({
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: 'linear_main__get_issue',
+            description: 'Read a Linear issue.',
+            inputSchema: {type: 'object', properties: {id: {type: 'string'}}},
+          },
+        ],
+      }),
+    });
     let configPath = '';
     let config: unknown;
+    let argvDuringServiceCreation: readonly string[] | undefined;
+    const originalArgv = process.argv.slice();
     createAgentSessionServicesMock.mockImplementation((options) => {
       configPath = options.extensionFlagValues.get('mcp-config');
       config = JSON.parse(readFileSync(configPath, 'utf8'));
+      argvDuringServiceCreation = process.argv.slice();
       return piServices(sessionDir);
     });
 
     await piHarnessAdapter.run(invocation({cwd: sessionDir, agentStateDir, mcpServers: [bridge]}));
 
     expect(bridge.activateHttp).toHaveBeenCalledTimes(1);
+    expect(bridge.listTools).toHaveBeenCalledTimes(1);
     expect(bindExtensionsMock).toHaveBeenCalledWith(expect.objectContaining({mode: 'print'}));
     expect(configPath).toMatch(`${agentStateDir}/pi-mcp-`);
+    const mcpConfigArgIndex = argvDuringServiceCreation?.indexOf('--mcp-config') ?? -1;
+    expect(argvDuringServiceCreation?.[mcpConfigArgIndex + 1]).toBe(configPath);
+    expect(process.argv).toEqual(originalArgv);
     expect(sessionManagerCreateMock).toHaveBeenCalledWith(
       sessionDir,
       join(agentStateDir, 'agent-sessions'),
@@ -362,6 +379,7 @@ describe('piHarnessAdapter', () => {
           url: 'http://127.0.0.1:43123/mcp',
           auth: false,
           lifecycle: 'eager',
+          directTools: true,
           exposeResources: false,
         },
       },
@@ -601,6 +619,53 @@ describe('piHarnessAdapter', () => {
 
     expect(createAgentSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({tools: ['read', 'web_search', 'mcp']}),
+    );
+  });
+
+  it('adds discovered integration tools to an explicit Pi tool list', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const bridge = mcpBridge({
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {name: 'linear_main__get_issue', inputSchema: {type: 'object'}},
+          {name: 'linear_main__save_comment', inputSchema: {type: 'object'}},
+        ],
+      }),
+    });
+
+    await piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        agentStateDir: join(sessionDir, 'runner-agent'),
+        mcpServers: [bridge],
+        tools: ['read'],
+      }),
+    );
+
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: ['read', 'mcp', 'linear_main__get_issue', 'linear_main__save_comment'],
+      }),
+    );
+  });
+
+  it('keeps the MCP proxy available when direct tool metadata is unavailable', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const bridge = mcpBridge({
+      listTools: vi.fn().mockRejectedValue(new Error('gateway unavailable')),
+    });
+
+    await piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        agentStateDir: join(sessionDir, 'runner-agent'),
+        mcpServers: [bridge],
+        tools: ['read'],
+      }),
+    );
+
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({tools: ['read', 'mcp']}),
     );
   });
 

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -508,6 +508,34 @@ describe('piHarnessAdapter', () => {
     );
   });
 
+  it('propagates aborts that occur during direct-tool metadata discovery', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const abortController = new AbortController();
+    const bridge = mcpBridge({
+      listTools: vi.fn(
+        ({signal}: {signal: AbortSignal}) =>
+          new Promise<never>((_, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason), {once: true});
+          }),
+      ),
+    });
+
+    const result = piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        agentStateDir: join(sessionDir, 'runner-agent'),
+        signal: abortController.signal,
+        mcpServers: [bridge],
+      }),
+    );
+    await vi.waitFor(() => expect(bridge.listTools).toHaveBeenCalledTimes(1));
+
+    abortController.abort();
+
+    await expect(result).rejects.toBe(abortController.signal.reason);
+    expect(createAgentSessionServicesMock).not.toHaveBeenCalled();
+  });
+
   it('aborts Pi while MCP extensions are binding', async () => {
     sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
     const abortController = new AbortController();

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -159,7 +159,9 @@ async function createPiSession(params: {
       model: params.model,
       thinkingLevel: params.thinking as PiThinkingLevel,
       ...toolSelectionOption(params.tools, [
-        ...(params.mcpConfig === undefined ? [] : [PI_MCP_TOOL_NAME]),
+        ...(params.mcpConfig === undefined
+          ? []
+          : [PI_MCP_TOOL_NAME, ...params.mcpConfig.directToolNames]),
         ...params.customTools.map((tool) => tool.name),
       ]),
       ...(params.customTools.length === 0 ? {} : {customTools: params.customTools}),
@@ -398,14 +400,16 @@ async function preparePiSessionServices(params: {
     thinking,
     extensionPackageNames,
   });
-  const services = await createAgentSessionServices({
-    cwd,
-    modelRuntime: params.modelRuntime,
-    ...(mcpConfig === undefined
-      ? {}
-      : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
-    resourceLoaderOptions: {additionalExtensionPaths: extensionDirectories},
-  });
+  const services = await withPiMcpConfigArg(mcpConfig?.path, () =>
+    createAgentSessionServices({
+      cwd,
+      modelRuntime: params.modelRuntime,
+      ...(mcpConfig === undefined
+        ? {}
+        : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
+      resourceLoaderOptions: {additionalExtensionPaths: extensionDirectories},
+    }),
+  );
   const extensionResult = services.resourceLoader?.getExtensions?.();
   assertPiServiceDiagnostics(
     services.diagnostics,
@@ -430,6 +434,26 @@ async function preparePiSessionServices(params: {
     directories: extensionDirectories,
   });
   return {services};
+}
+
+// pi-mcp-adapter resolves its config during module evaluation, before Pi applies
+// extension flags. Keep the CLI-compatible flag visible only while extensions load.
+async function withPiMcpConfigArg<T>(
+  configPath: string | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (configPath === undefined) return operation();
+
+  const originalArgs = process.argv.slice();
+  const configFlagIndex = process.argv.indexOf('--mcp-config');
+  if (configFlagIndex === -1) process.argv.push('--mcp-config', configPath);
+  else process.argv[configFlagIndex + 1] = configPath;
+
+  try {
+    return await operation();
+  } finally {
+    process.argv.splice(0, process.argv.length, ...originalArgs);
+  }
 }
 
 function resolvePiExtensionDirectories(params: {
@@ -526,6 +550,7 @@ async function removeForkedSessionFile(sessionFile: string | undefined): Promise
 interface PiMcpConfig {
   readonly directory: string;
   readonly path: string;
+  readonly directToolNames: readonly string[];
 }
 
 function assertPiServiceDiagnostics(
@@ -574,25 +599,39 @@ async function createPiMcpConfig(
   const directory = await mkdtemp(join(agentStateDir, 'pi-mcp-'));
   const path = join(directory, 'mcp.json');
   try {
-    const serverEntries = await Promise.all(
-      mcpServers.map(async (server) => [
-        server.name,
-        {
-          url: (await server.activateHttp()).toString(),
-          auth: false,
-          lifecycle: 'eager',
-          exposeResources: false,
-        },
-      ]),
+    const preparedServers = await Promise.all(
+      mcpServers.map(async (server) => {
+        const [url, directToolNames] = await Promise.all([
+          server.activateHttp(),
+          listPiMcpToolNames(server),
+        ]);
+        return {
+          entry: [
+            server.name,
+            {
+              url: url.toString(),
+              auth: false,
+              lifecycle: 'eager',
+              directTools: true,
+              exposeResources: false,
+            },
+          ] as const,
+          directToolNames,
+        };
+      }),
     );
     await writeFile(
       path,
       JSON.stringify({
         settings: {toolPrefix: 'none'},
-        mcpServers: Object.fromEntries(serverEntries),
+        mcpServers: Object.fromEntries(preparedServers.map((server) => server.entry)),
       }),
     );
-    return {directory, path};
+    return {
+      directory,
+      path,
+      directToolNames: preparedServers.flatMap((server) => server.directToolNames),
+    };
   } catch (error) {
     try {
       await rm(directory, {recursive: true, force: true});
@@ -600,6 +639,21 @@ async function createPiMcpConfig(
       logger().warn({err: cleanupError}, 'Failed to remove incomplete Pi MCP configuration');
     }
     throw error;
+  }
+}
+
+async function listPiMcpToolNames(
+  server: NonNullable<HarnessInvocation['mcpServers']>[number],
+): Promise<readonly string[]> {
+  try {
+    const result = await server.listTools();
+    return result.tools.map((tool) => tool.name);
+  } catch (error) {
+    logger().warn(
+      {err: error, server: server.name},
+      'Failed to list Pi MCP direct tools; keeping the MCP proxy fallback',
+    );
+    return [];
   }
 }
 

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -50,6 +50,7 @@ const KEYLESS_CUSTOM_PROVIDER_API_KEY = 'shipfox-keyless-custom-provider-placeho
 const SECRET_HEADER_CREDENTIAL_PREFIX = 'header:';
 const PI_MCP_TOOL_NAME = 'mcp';
 const PI_MCP_METADATA_TIMEOUT_MS = 10_000;
+const PI_MCP_CONFIG_ARG_WAIT_TIMEOUT_MS = 30_000;
 
 let piMcpConfigArgTail = Promise.resolve();
 
@@ -403,7 +404,7 @@ async function preparePiSessionServices(params: {
     thinking,
     extensionPackageNames,
   });
-  const services = await withPiMcpConfigArg(mcpConfig?.path, () =>
+  const services = await withPiMcpConfigArg(mcpConfig?.path, params.invocation.signal, () =>
     createAgentSessionServices({
       cwd,
       modelRuntime: params.modelRuntime,
@@ -444,29 +445,73 @@ async function preparePiSessionServices(params: {
 // process-global mutation and keep the CLI-compatible flag visible only while extensions load.
 async function withPiMcpConfigArg<T>(
   configPath: string | undefined,
+  signal: AbortSignal,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (configPath === undefined) return operation();
 
   const previousOperation = piMcpConfigArgTail;
   let releaseOperation!: () => void;
-  piMcpConfigArgTail = new Promise<void>((resolve) => {
+  const operationSlot = new Promise<void>((resolve) => {
     releaseOperation = resolve;
   });
-  await previousOperation;
-
-  const originalArgs = process.argv.slice();
-  const configFlagIndex = process.argv.indexOf('--mcp-config');
-  if (configFlagIndex === -1) process.argv.push('--mcp-config', configPath);
-  else if (configFlagIndex + 1 < process.argv.length)
-    process.argv[configFlagIndex + 1] = configPath;
-  else process.argv.push(configPath);
+  // Keep the queue chained to the prior owner even when this waiter times out. This
+  // lets later waiters fail fast without bypassing an operation that still owns argv.
+  piMcpConfigArgTail = previousOperation.then(() => operationSlot);
 
   try {
-    return await operation();
+    await waitForPiMcpConfigArg(previousOperation, signal);
+    if (signal.aborted)
+      throw signal.reason ?? new Error('Agent step aborted while waiting for Pi MCP setup');
+
+    const originalArgs = process.argv.slice();
+    const configFlagIndex = process.argv.indexOf('--mcp-config');
+    if (configFlagIndex === -1) process.argv.push('--mcp-config', configPath);
+    else if (configFlagIndex + 1 < process.argv.length)
+      process.argv[configFlagIndex + 1] = configPath;
+    else process.argv.push(configPath);
+
+    try {
+      return await operation();
+    } finally {
+      process.argv.splice(0, process.argv.length, ...originalArgs);
+    }
   } finally {
-    process.argv.splice(0, process.argv.length, ...originalArgs);
+    // A timed-out waiter releases its own queue slot, but never the operation that
+    // still owns process.argv. The chained tail keeps later waiters behind that owner.
     releaseOperation();
+  }
+}
+
+async function waitForPiMcpConfigArg(
+  previousOperation: Promise<void>,
+  signal: AbortSignal,
+): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () =>
+      reject(signal.reason ?? new Error('Agent step aborted while waiting for Pi MCP setup'));
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, {once: true});
+  });
+  const timedOut = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () =>
+        reject(
+          new AgentSessionUnavailableError(
+            'Pi MCP configuration setup is blocked by another session.',
+          ),
+        ),
+      PI_MCP_CONFIG_ARG_WAIT_TIMEOUT_MS,
+    );
+  });
+
+  try {
+    await Promise.race([previousOperation, aborted, timedOut]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    if (onAbort !== undefined) signal.removeEventListener('abort', onAbort);
   }
 }
 
@@ -674,6 +719,7 @@ async function listPiMcpToolNames(
     });
     return result.tools.map((tool) => tool.name);
   } catch (error) {
+    if (signal.aborted) throw error;
     logger().warn(
       {err: error, server: server.name},
       'Failed to list Pi MCP direct tools; keeping the MCP proxy fallback',

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -49,6 +49,9 @@ import {toolSelectionOption} from '#core/tool-selection.js';
 const KEYLESS_CUSTOM_PROVIDER_API_KEY = 'shipfox-keyless-custom-provider-placeholder';
 const SECRET_HEADER_CREDENTIAL_PREFIX = 'header:';
 const PI_MCP_TOOL_NAME = 'mcp';
+const PI_MCP_METADATA_TIMEOUT_MS = 10_000;
+
+let piMcpConfigArgTail = Promise.resolve();
 
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions['thinkingLevel']>;
 type ModelRuntimeInstance = Awaited<ReturnType<typeof ModelRuntime.create>>;
@@ -99,7 +102,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   let mcpConfig: PiMcpConfig | undefined;
 
   try {
-    mcpConfig = await createPiMcpConfig(agentStateDir, invocation.mcpServers);
+    mcpConfig = await createPiMcpConfig(agentStateDir, invocation.mcpServers, signal);
     const prepared = await preparePiSessionServices({
       invocation,
       mcpConfig,
@@ -437,22 +440,33 @@ async function preparePiSessionServices(params: {
 }
 
 // pi-mcp-adapter resolves its config during module evaluation, before Pi applies
-// extension flags. Keep the CLI-compatible flag visible only while extensions load.
+// extension flags. Session setup can overlap after an aborted run, so serialize this
+// process-global mutation and keep the CLI-compatible flag visible only while extensions load.
 async function withPiMcpConfigArg<T>(
   configPath: string | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (configPath === undefined) return operation();
 
+  const previousOperation = piMcpConfigArgTail;
+  let releaseOperation!: () => void;
+  piMcpConfigArgTail = new Promise<void>((resolve) => {
+    releaseOperation = resolve;
+  });
+  await previousOperation;
+
   const originalArgs = process.argv.slice();
   const configFlagIndex = process.argv.indexOf('--mcp-config');
   if (configFlagIndex === -1) process.argv.push('--mcp-config', configPath);
-  else process.argv[configFlagIndex + 1] = configPath;
+  else if (configFlagIndex + 1 < process.argv.length)
+    process.argv[configFlagIndex + 1] = configPath;
+  else process.argv.push(configPath);
 
   try {
     return await operation();
   } finally {
     process.argv.splice(0, process.argv.length, ...originalArgs);
+    releaseOperation();
   }
 }
 
@@ -592,6 +606,7 @@ function createInMemoryCredentialStore(credentials: Record<string, Credential>):
 async function createPiMcpConfig(
   agentStateDir: string,
   mcpServers: HarnessInvocation['mcpServers'],
+  signal: AbortSignal,
 ): Promise<PiMcpConfig | undefined> {
   if (mcpServers === undefined || mcpServers.length === 0) return undefined;
 
@@ -603,7 +618,7 @@ async function createPiMcpConfig(
       mcpServers.map(async (server) => {
         const [url, directToolNames] = await Promise.all([
           server.activateHttp(),
-          listPiMcpToolNames(server),
+          listPiMcpToolNames(server, signal),
         ]);
         return {
           entry: [
@@ -644,9 +659,19 @@ async function createPiMcpConfig(
 
 async function listPiMcpToolNames(
   server: NonNullable<HarnessInvocation['mcpServers']>[number],
+  signal: AbortSignal,
 ): Promise<readonly string[]> {
+  const controller = new AbortController();
+  const onAbort = () => controller.abort(signal.reason);
+  const timeout = setTimeout(() => controller.abort(), PI_MCP_METADATA_TIMEOUT_MS);
+  if (signal.aborted) onAbort();
+  else signal.addEventListener('abort', onAbort, {once: true});
+
   try {
-    const result = await server.listTools();
+    const result = await server.listTools({
+      signal: controller.signal,
+      timeout: PI_MCP_METADATA_TIMEOUT_MS,
+    });
     return result.tools.map((tool) => tool.name);
   } catch (error) {
     logger().warn(
@@ -654,6 +679,9 @@ async function listPiMcpToolNames(
       'Failed to list Pi MCP direct tools; keeping the MCP proxy fallback',
     );
     return [];
+  } finally {
+    clearTimeout(timeout);
+    signal.removeEventListener('abort', onAbort);
   }
 }
 

--- a/libs/runner/agent/src/core/pi-mcp-adapter-contract.test.ts
+++ b/libs/runner/agent/src/core/pi-mcp-adapter-contract.test.ts
@@ -1,0 +1,198 @@
+import {once} from 'node:events';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {createServer, type Server as HttpServer} from 'node:http';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import type {ExtensionAPI, ExtensionContext} from '@earendil-works/pi-coding-agent';
+import {Server} from '@modelcontextprotocol/sdk/server/index.js';
+import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
+
+const PI_MCP_ADAPTER_ENTRYPOINT = 'pi-mcp-adapter/index.ts';
+const PI_MCP_METADATA_CACHE_ENTRYPOINT = 'pi-mcp-adapter/metadata-cache.ts';
+
+describe('pi-mcp-adapter contract', () => {
+  let workspace: string | undefined;
+  let gateway: FakeMcpGateway | undefined;
+  const originalAgentDirectory = process.env.PI_CODING_AGENT_DIR;
+  const originalArgv = process.argv.slice();
+
+  afterEach(async () => {
+    if (originalAgentDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDirectory;
+    process.argv.splice(0, process.argv.length, ...originalArgv);
+    await gateway?.close();
+    gateway = undefined;
+    if (workspace !== undefined) await rm(workspace, {recursive: true, force: true});
+    workspace = undefined;
+  });
+
+  it('registers and invokes a cached direct tool with object arguments', async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'shipfox-pi-mcp-contract-'));
+    gateway = await startFakeMcpGateway();
+    const definition = {
+      url: gateway.url.toString(),
+      auth: false,
+      lifecycle: 'eager',
+      directTools: true,
+      exposeResources: false,
+    };
+    const {default: mcpAdapter} = (await import(PI_MCP_ADAPTER_ENTRYPOINT)) as PiMcpAdapterModule;
+    const {computeServerHash} = (await import(
+      PI_MCP_METADATA_CACHE_ENTRYPOINT
+    )) as PiMcpMetadataCacheModule;
+    const tool = {
+      name: 'linear_main__get_issue',
+      description: 'Read a Linear issue.',
+      inputSchema: {type: 'object', properties: {id: {type: 'string'}}},
+    };
+    const configPath = join(workspace, 'mcp.json');
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        settings: {toolPrefix: 'none'},
+        mcpServers: {shipfox_integration_tools: definition},
+      }),
+    );
+    await writeFile(
+      join(workspace, 'mcp-cache.json'),
+      JSON.stringify({
+        version: 1,
+        servers: {
+          shipfox_integration_tools: {
+            configHash: computeServerHash(definition),
+            tools: [tool],
+            resources: [],
+            cachedAt: Date.now(),
+          },
+        },
+      }),
+    );
+    process.env.PI_CODING_AGENT_DIR = workspace;
+    process.argv.splice(0, process.argv.length, 'node', 'pi', '--mcp-config', configPath);
+
+    const registeredTools: RegisteredTool[] = [];
+    const eventHandlers = new Map<string, (...args: unknown[]) => unknown>();
+    const extensionApi = {
+      registerTool: (registeredTool: RegisteredTool) => registeredTools.push(registeredTool),
+      registerFlag: () => undefined,
+      getFlag: (name: string) => (name === 'mcp-config' ? configPath : undefined),
+      registerCommand: () => undefined,
+      on: (event: string, handler: (...args: unknown[]) => unknown) =>
+        eventHandlers.set(event, handler),
+      getAllTools: () => registeredTools,
+    } as unknown as ExtensionAPI;
+    const signal = new AbortController().signal;
+    const context = {
+      cwd: workspace,
+      hasUI: false,
+      mode: 'print',
+      signal,
+    } as unknown as ExtensionContext;
+
+    mcpAdapter(extensionApi);
+    const directTool = registeredTools.find((registeredTool) => registeredTool.name === tool.name);
+    expect(directTool).toBeDefined();
+    if (directTool === undefined) return;
+
+    await eventHandlers.get('session_start')?.({}, context);
+    const result = await directTool.execute('call-1', {id: 'ENG-1857'}, signal, undefined, context);
+    await eventHandlers.get('session_shutdown')?.({}, context);
+
+    expect(gateway.calls).toEqual([{name: tool.name, arguments: {id: 'ENG-1857'}}]);
+    expect(result.content).toEqual([{type: 'text', text: 'called'}]);
+  });
+});
+
+interface PiMcpAdapterModule {
+  readonly default: (extensionApi: ExtensionAPI) => void;
+}
+
+interface PiMcpMetadataCacheModule {
+  readonly computeServerHash: (definition: unknown) => string;
+}
+
+interface RegisteredTool {
+  readonly name: string;
+  readonly execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal,
+    onUpdate: undefined,
+    context: ExtensionContext,
+  ) => Promise<{content: unknown[]}>;
+}
+
+interface FakeMcpGateway {
+  readonly url: URL;
+  readonly calls: Array<{name: string; arguments: Record<string, unknown> | undefined}>;
+  close(): Promise<void>;
+}
+
+async function startFakeMcpGateway(): Promise<FakeMcpGateway> {
+  const calls: Array<{name: string; arguments: Record<string, unknown> | undefined}> = [];
+  const httpServer = createServer(async (request, response) => {
+    const body = await readJsonBody(request);
+    const server = new Server(
+      {name: 'fake-integration-tools', version: '0.0.0'},
+      {capabilities: {tools: {}}},
+    );
+    const transport = new StreamableHTTPServerTransport();
+
+    server.setRequestHandler(ListToolsRequestSchema, () => ({
+      tools: [
+        {
+          name: 'linear_main__get_issue',
+          description: 'Read a Linear issue.',
+          inputSchema: {type: 'object', properties: {id: {type: 'string'}}},
+        },
+      ],
+    }));
+    server.setRequestHandler(CallToolRequestSchema, (toolRequest) => {
+      calls.push({
+        name: toolRequest.params.name,
+        arguments: toolRequest.params.arguments,
+      });
+      return {content: [{type: 'text', text: 'called'}]};
+    });
+
+    await server.connect(transport as unknown as Transport);
+    response.on('close', () => {
+      void transport.close();
+      void server.close();
+    });
+    await transport.handleRequest(request, response, body);
+  });
+  httpServer.listen(0, '127.0.0.1');
+  await once(httpServer, 'listening');
+
+  return {
+    url: new URL('/mcp', address(httpServer)),
+    calls,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+function address(server: HttpServer): string {
+  const addressInfo = server.address();
+  if (typeof addressInfo !== 'object' || addressInfo === null) {
+    throw new Error('Fake MCP gateway did not bind a TCP address.');
+  }
+  return `http://127.0.0.1:${addressInfo.port}`;
+}
+
+async function readJsonBody(request: NodeJS.ReadableStream): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text === '' ? undefined : (JSON.parse(text) as unknown);
+}

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -254,11 +254,14 @@ describe('executeAgentStep', () => {
     );
 
     expect(createIntegrationToolsGatewayFetchMock).toHaveBeenCalledWith(leaseToken, gatewayUrl);
-    expect(createIntegrationToolsBridgeMock).toHaveBeenCalledWith({
-      name: AGENT_INTEGRATION_MCP_SERVER_NAME,
-      url: gatewayUrl,
-      fetch: gatewayFetch,
-    });
+    expect(createIntegrationToolsBridgeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+        url: gatewayUrl,
+        fetch: gatewayFetch,
+        preferredPort: expect.any(Number),
+      }),
+    );
     expect(runAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         mcpServers: [expect.objectContaining({name: AGENT_INTEGRATION_MCP_SERVER_NAME})],

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -11,7 +11,7 @@ const {
 
   return {
     bridgeCloseMock,
-    createIntegrationToolsBridgeMock: vi.fn((params: {name: string}) => ({
+    createIntegrationToolsBridgeMock: vi.fn((params: {name: string; preferredPort?: number}) => ({
       name: params.name,
       server: {},
       listTools: vi.fn(),
@@ -268,6 +268,29 @@ describe('executeAgentStep', () => {
       }),
     );
     expect(bridgeCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives deterministic bridge ports in the non-ephemeral range', async () => {
+    runAgentMock.mockResolvedValue({});
+    const step = buildAgentStep({config: {prompt: 'p', mcpServers: [integrationToolsConfig()]}});
+    const options = {
+      runtime: RUNTIME,
+      leaseToken: 'lease-current',
+      integrationToolsGatewayUrl: new URL(
+        'https://api.example.test/runs/jobs/current/integration-tools/mcp',
+      ),
+    };
+
+    await executeAgentStep(step, options);
+    const firstPreferredPort = createIntegrationToolsBridgeMock.mock.calls[0]?.[0].preferredPort;
+
+    createIntegrationToolsBridgeMock.mockClear();
+    await executeAgentStep(step, options);
+    const secondPreferredPort = createIntegrationToolsBridgeMock.mock.calls[0]?.[0].preferredPort;
+
+    expect(firstPreferredPort).toBeGreaterThanOrEqual(25_000);
+    expect(firstPreferredPort).toBeLessThan(32_768);
+    expect(secondPreferredPort).toBe(firstPreferredPort);
   });
 
   it('closes integration tool bridges when the harness run fails', async () => {

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -34,8 +34,10 @@ import {piHarnessAdapter} from '#core/pi-adapter.js';
 
 const MAX_HARNESS_DIAGNOSTICS = 5;
 const MAX_HARNESS_DIAGNOSTIC_MESSAGE_LENGTH = 500;
-const MCP_BRIDGE_PORT_START = 49_152;
-const MCP_BRIDGE_PORT_RANGE = 16_384;
+// Keep stable bridge ports below the OS ephemeral range and above this checkout's
+// 20000-24999 worktree-service reservation.
+const MCP_BRIDGE_PORT_START = 25_000;
+const MCP_BRIDGE_PORT_RANGE = 7_768;
 
 export async function executeAgentStep(
   step: StepDto,

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -1,3 +1,4 @@
+import {createHash} from 'node:crypto';
 import {
   type AgentIntegrationMcpServerConfigDto,
   agentIntegrationMcpServerSchema,
@@ -33,6 +34,8 @@ import {piHarnessAdapter} from '#core/pi-adapter.js';
 
 const MAX_HARNESS_DIAGNOSTICS = 5;
 const MAX_HARNESS_DIAGNOSTIC_MESSAGE_LENGTH = 500;
+const MCP_BRIDGE_PORT_START = 49_152;
+const MCP_BRIDGE_PORT_RANGE = 16_384;
 
 export async function executeAgentStep(
   step: StepDto,
@@ -91,6 +94,7 @@ export async function executeAgentStep(
   const integrationToolsBridges = integrationToolsBridgesFromConfig(mcpServers, {
     leaseToken: options.leaseToken,
     integrationToolsGatewayUrl: options.integrationToolsGatewayUrl,
+    stablePortSeed: step.job_execution_id,
   });
   if (integrationToolsBridges === 'invalid') {
     return agentFailure(
@@ -411,6 +415,7 @@ function integrationToolsBridgesFromConfig(
   options: {
     leaseToken?: LeaseTokenSource | undefined;
     integrationToolsGatewayUrl?: URL | undefined;
+    stablePortSeed: string;
   },
 ): readonly IntegrationToolsBridge[] | undefined | 'invalid' {
   const {leaseToken, integrationToolsGatewayUrl} = options;
@@ -424,8 +429,16 @@ function integrationToolsBridgesFromConfig(
       name: mcpServer.name,
       url: integrationToolsGatewayUrl,
       fetch: createIntegrationToolsGatewayFetch(leaseToken, integrationToolsGatewayUrl),
+      preferredPort: stableIntegrationToolsBridgePort(options.stablePortSeed, mcpServer.name),
     }),
   );
+}
+
+function stableIntegrationToolsBridgePort(seed: string, serverName: string): number {
+  // pi-mcp-adapter includes the server URL in its metadata-cache hash. Keep the
+  // loopback port stable within a job so cached direct tools remain valid across steps.
+  const digest = createHash('sha256').update(`${seed}:${serverName}`).digest();
+  return MCP_BRIDGE_PORT_START + (digest.readUInt16BE(0) % MCP_BRIDGE_PORT_RANGE);
 }
 
 async function closeIntegrationToolsBridges(


### PR DESCRIPTION
Pi integration MCP servers now opt into pi-mcp-adapter direct tools. The runner discovers the integration tool names for explicit Pi allowlists and exposes the generated MCP config while the adapter extension loads, so cached metadata can register direct tools with object-valued arguments and real schemas.

The `mcp` proxy remains explicitly enabled for cold-start jobs because the adapter populates direct-tool metadata during eager startup; uncached tools can therefore use the proxy while metadata is populated for the next session. Integration tool IDs and the runner-to-gateway boundary remain unchanged.

Closes ENG-1857

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables integration MCP servers to expose direct Pi tools with object-valued arguments and real schemas. The runner discovers integration tool names, adds them to the explicit Pi allowlist, and enables `directTools` in the generated MCP config. The `mcp` proxy remains as a fallback so cold-start jobs can still reach integration tools while cached metadata is being populated.

- Bridge setup is hardened: transient gateway failures reset the client, and a stable loopback port is reused within a job so cached direct-tool metadata stays valid across steps. Direct-tool discovery times out after 10s and propagates step aborts; one failing server doesn't block healthy ones.
- The `--mcp-config` flag is temporarily added to `process.argv` while extensions load, serialized across concurrent sessions with a bounded wait.
- Integration tool IDs and the runner-to-gateway boundary are unchanged.

Closes ENG-1857.

<sup>Written for commit 1d192253c4fc4ab22cc1b8d681c0f4d5213e96bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

