### PR TITLE
[api-auth] Add administrator user directory access

### DIFF
--- a/.changeset/calm-admin-directory.md
+++ b/.changeset/calm-admin-directory.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Adds the administrator user directory operation and route.

--- a/.changeset/calm-admin-directory.md
+++ b/.changeset/calm-admin-directory.md
@@ -2,4 +2,4 @@
 "@shipfox/api-auth": minor
 ---
 
-Adds the administrator user directory operation and route.
+Adds the administrator user directory operation and route while preserving the existing rows result field.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -334,7 +334,7 @@ This app-layer limiter protects semantic auth work such as Argon2 verification a
 
 `GET /admin/auth/users` requires `admin-observer` and accepts exactly one checked query filter: `id`, `user_id`, or normalized `email`. The response is a bounded `AdministratorUserSummary` containing only the stable user identity, verified-email timestamp, display name, account status, creation timestamp, and current administrator role.
 
-`GET /admin/auth/users/directory` requires `admin-observer` and returns at most 100 safe user summaries per page. It accepts optional `search`, `status`, `impersonation_eligible`, `limit`, and opaque `cursor` filters. Empty pages return `200` with an empty `users` array and a null `next_cursor`. Directory reads do not create administration action events.
+`GET /admin/auth/users/directory` requires `admin-observer` and returns at most 100 safe user summaries per page. It accepts optional `search`, `status`, `impersonation_eligible`, `limit`, and opaque `cursor` filters. Empty pages return `200` with an empty `users` array and a null `next_cursor`. Directory reads do not create administration action events. Structured security logs include the actor ID, required role, target type, request ID, result, and bounded directory metadata.
 
 `GET /admin/auth/admin-grants` also requires `admin-observer`. It returns at most 100 newest-first `AdministratorGrantSummary` rows per page, with an opaque cursor and a safe embedded user identity. It does not return credentials, sessions, provider payloads, OAuth tokens, refresh tokens, or raw authentication metadata.
 
@@ -382,7 +382,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `createImpersonatedSessionToken({targetUserId, impersonatorId, workspaces})`: mints an access-token-only impersonated session (capped TTL, `impersonatorId` claim, no refresh material). The `impersonateUser` administration command owns the authorization ladder, idempotency, and audit flow.
 - `getAuthenticatedSessionContext(request)`: reads the user ID and required refresh-session ID from verified access-token claims. It does not check whether the refresh session is still active.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
-- `listAdministratorUsers({actorId, limit, cursor?, search?, status?, eligible?})`: returns `{users, nextCursor}` after requiring an active observer role. Search accepts at most 10 whitespace-separated terms. Each term can contain at most 100 characters.
+- `listAdministratorUsers({actorId, limit, cursor?, search?, status?, eligible?})`: returns `{users, rows, nextCursor}` after requiring an active observer role. `rows` remains as a compatibility alias. Search accepts at most 10 whitespace-separated terms. Each term can contain at most 100 characters.
 - Entity types: `User`, `UserStatus`, `RefreshToken`, `PasswordReset`, and `EmailOwner`.
 
 ### External identity callbacks

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -314,16 +314,17 @@ Bootstrap remains closed only while an active `admin-owner` exists. An owner is 
 
 The public auth endpoints include an application-layer abuse baseline for open source installs:
 
-| Route | IP bucket | Email bucket |
-| --- | --- | --- |
-| `POST /auth/login` | 60 attempts per 5 minutes | 10 attempts per 15 minutes |
-| `POST /auth/password-reset` | 30 email-send attempts per hour | 3 email-send attempts per hour |
-| `POST /auth/verify-email/resend` | Shared with password reset | Shared with password reset |
-| `POST /admin/auth/admin-grants/bootstrap` | 5 attempts per 15 minutes | n/a |
-| `GET /admin/auth/users` | 60 attempts per 5 minutes | n/a |
-| `POST /admin/auth/users/:userId/impersonate` | 20 attempts per 15 minutes | n/a |
+| Route | IP bucket | Actor bucket | Email bucket |
+| --- | --- | --- | --- |
+| `POST /auth/login` | 60 attempts per 5 minutes | n/a | 10 attempts per 15 minutes |
+| `POST /auth/password-reset` | 30 email-send attempts per hour | n/a | 3 email-send attempts per hour |
+| `POST /auth/verify-email/resend` | Shared with password reset | n/a | Shared with password reset |
+| `POST /admin/auth/admin-grants/bootstrap` | 5 attempts per 15 minutes | n/a | n/a |
+| `GET /admin/auth/users` | 60 attempts per 5 minutes | n/a | n/a |
+| `GET /admin/auth/users/directory` | 60 attempts per 5 minutes | 60 attempts per 5 minutes | n/a |
+| `POST /admin/auth/users/:userId/impersonate` | 20 attempts per 15 minutes | 20 attempts per 15 minutes | n/a |
 
-Counters are stored in PostgreSQL as fixed windows in `auth_rate_limits`. IP addresses and email addresses are HMAC-SHA256 values before storage; raw identifiers are not persisted. The identifier key is derived from `AUTH_ROOT_KEY` separately from every token key.
+Counters are stored in PostgreSQL as fixed windows in `auth_rate_limits`. IP addresses, actor IDs, and email addresses are HMAC-SHA256 values before storage; raw identifiers are not persisted. The identifier key is derived from `AUTH_ROOT_KEY` separately from every token key.
 
 The limiter uses `request.ip`, so production deployments behind a reverse proxy must configure the API app's `API_TRUST_PROXY` setting. Keep the default `false` when clients connect directly. Use a positive hop count such as `1`, or a trusted proxy IP/CIDR such as `10.0.0.0/8`, when proxy headers are controlled by infrastructure you operate.
 
@@ -332,6 +333,8 @@ This app-layer limiter protects semantic auth work such as Argon2 verification a
 ### Administrator user reads
 
 `GET /admin/auth/users` requires `admin-observer` and accepts exactly one checked query filter: `id`, `user_id`, or normalized `email`. The response is a bounded `AdministratorUserSummary` containing only the stable user identity, verified-email timestamp, display name, account status, creation timestamp, and current administrator role.
+
+`GET /admin/auth/users/directory` requires `admin-observer` and returns at most 100 safe user summaries per page. It accepts optional `search`, `status`, `impersonation_eligible`, `limit`, and opaque `cursor` filters. Empty pages return `200` with an empty `users` array and a null `next_cursor`. Directory reads do not create administration action events.
 
 `GET /admin/auth/admin-grants` also requires `admin-observer`. It returns at most 100 newest-first `AdministratorGrantSummary` rows per page, with an opaque cursor and a safe embedded user identity. It does not return credentials, sessions, provider payloads, OAuth tokens, refresh tokens, or raw authentication metadata.
 
@@ -379,7 +382,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `createImpersonatedSessionToken({targetUserId, impersonatorId, workspaces})`: mints an access-token-only impersonated session (capped TTL, `impersonatorId` claim, no refresh material). The `impersonateUser` administration command owns the authorization ladder, idempotency, and audit flow.
 - `getAuthenticatedSessionContext(request)`: reads the user ID and required refresh-session ID from verified access-token claims. It does not check whether the refresh session is still active.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
-- `listAdministratorUsers({actorId, limit, cursor?, search?, status?, eligible?})`: lists administrator-safe user summaries after requiring an active observer role. Search accepts at most 10 whitespace-separated terms, each no longer than 100 characters.
+- `listAdministratorUsers({actorId, limit, cursor?, search?, status?, eligible?})`: returns `{users, nextCursor}` after requiring an active observer role. Search accepts at most 10 whitespace-separated terms. Each term can contain at most 100 characters.
 - Entity types: `User`, `UserStatus`, `RefreshToken`, `PasswordReset`, and `EmailOwner`.
 
 ### External identity callbacks

--- a/libs/api/auth/src/core/admin-role.test.ts
+++ b/libs/api/auth/src/core/admin-role.test.ts
@@ -65,6 +65,15 @@ describe('admin role policy', () => {
     ).rejects.toBeInstanceOf(InvalidAdministratorUserDirectoryFilterError);
   });
 
+  test('caps the directory page size in the core operation', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await createAdminGrant({userId: user.id, role: 'admin-observer'});
+
+    const result = await listAdministratorUsers({actorId: user.id, limit: 1_000});
+
+    expect(result.users.length).toBeLessThanOrEqual(100);
+  });
+
   test('evaluates the current role from Auth storage for every required minimum', async () => {
     const user = await userFactory.create({emailVerifiedAt: new Date()});
     await createAdminGrant({userId: user.id, role: 'admin-operator'});

--- a/libs/api/auth/src/core/admin-role.test.ts
+++ b/libs/api/auth/src/core/admin-role.test.ts
@@ -1,4 +1,6 @@
 import {createAdminGrant} from '#db/admin-grants.js';
+import {db} from '#db/db.js';
+import {users} from '#db/schema/users.js';
 import {userFactory} from '#test/index.js';
 import {hasMinimumAdminRole, highestAdminRole, requireAdminRole} from './admin-role.js';
 import {listAdministratorUsers} from './administration.js';
@@ -68,10 +70,27 @@ describe('admin role policy', () => {
   test('caps the directory page size in the core operation', async () => {
     const user = await userFactory.create({emailVerifiedAt: new Date()});
     await createAdminGrant({userId: user.id, role: 'admin-observer'});
+    const marker = `admin-directory-cap-${crypto.randomUUID()}`;
+    await db()
+      .insert(users)
+      .values(
+        Array.from({length: 101}, (_, index) => ({
+          email: `${marker}-${index}@example.com`,
+          name: `Directory User ${index}`,
+          hashedPassword: null,
+          emailVerifiedAt: new Date(),
+        })),
+      );
 
-    const result = await listAdministratorUsers({actorId: user.id, limit: 1_000});
+    const result = await listAdministratorUsers({
+      actorId: user.id,
+      limit: 1_000,
+      search: marker,
+    });
 
-    expect(result.users.length).toBeLessThanOrEqual(100);
+    expect(result.users).toHaveLength(100);
+    expect(result.rows).toEqual(result.users);
+    expect(result.nextCursor).not.toBeNull();
   });
 
   test('evaluates the current role from Auth storage for every required minimum', async () => {

--- a/libs/api/auth/src/core/administration.ts
+++ b/libs/api/auth/src/core/administration.ts
@@ -57,9 +57,10 @@ import {
 const ADMIN_OWNER_ROLE: AdminRole = 'admin-owner';
 const ADMIN_OBSERVER_ROLE: AdminRole = 'admin-observer';
 const ADMIN_OPERATOR_ROLE: AdminRole = 'admin-operator';
+const ADMINISTRATOR_DIRECTORY_MAX_PAGE_SIZE = 100;
 const ADMINISTRATOR_DIRECTORY_MAX_SEARCH_TERMS = 10;
 const ADMINISTRATOR_DIRECTORY_MAX_SEARCH_TERM_LENGTH = 100;
-const ADMINISTRATOR_DIRECTORY_SEARCH_TERM_SEPARATOR = /\s+/;
+const ADMINISTRATOR_DIRECTORY_SEARCH_TERM_SEPARATOR = /\s+/g;
 const BOOTSTRAP_COMMAND = 'auth.admin_grant.bootstrap';
 const GRANT_COMMAND = 'auth.admin_grant.grant';
 const REVOKE_COMMAND = 'auth.admin_grant.revoke';
@@ -208,11 +209,18 @@ export interface ListAdministratorUsersParams {
   eligible?: boolean | undefined;
 }
 
-function validateAdministratorUserDirectorySearch(search: string | undefined): void {
-  const normalizedSearch = search?.trim();
+export interface ListAdministratorUsersResult {
+  users: AdministratorUserSummary[];
+  nextCursor: TimestampIdCursor | null;
+}
+
+function normalizeAdministratorUserDirectorySearch(search: string | undefined): string | undefined {
+  const normalizedSearch = search
+    ?.trim()
+    .replace(ADMINISTRATOR_DIRECTORY_SEARCH_TERM_SEPARATOR, ' ');
   if (!normalizedSearch) return;
 
-  const terms = normalizedSearch.split(ADMINISTRATOR_DIRECTORY_SEARCH_TERM_SEPARATOR);
+  const terms = normalizedSearch.split(' ');
   if (terms.length > ADMINISTRATOR_DIRECTORY_MAX_SEARCH_TERMS) {
     throw new InvalidAdministratorUserDirectoryFilterError(
       `Administrator user directory search accepts at most ${ADMINISTRATOR_DIRECTORY_MAX_SEARCH_TERMS} terms`,
@@ -224,21 +232,36 @@ function validateAdministratorUserDirectorySearch(search: string | undefined): v
       `Administrator user directory search terms must be at most ${ADMINISTRATOR_DIRECTORY_MAX_SEARCH_TERM_LENGTH} characters`,
     );
   }
+
+  return normalizedSearch;
 }
 
-function validateAdministratorUserDirectoryFilters(params: ListAdministratorUsersParams): void {
-  validateAdministratorUserDirectorySearch(params.search);
+function validateAdministratorUserDirectoryFilters(
+  params: ListAdministratorUsersParams,
+): string | undefined {
+  const normalizedSearch = normalizeAdministratorUserDirectorySearch(params.search);
   if (params.eligible === true && params.status && params.status !== 'active') {
     throw new InvalidAdministratorUserDirectoryFilterError(
       'eligible users must have active status',
     );
   }
+  return normalizedSearch;
 }
 
-export async function listAdministratorUsers(params: ListAdministratorUsersParams) {
+export async function listAdministratorUsers(
+  params: ListAdministratorUsersParams,
+): Promise<ListAdministratorUsersResult> {
   await requireAdminRole({userId: params.actorId, minimumRole: ADMIN_OBSERVER_ROLE});
-  validateAdministratorUserDirectoryFilters(params);
-  return await listAdministratorUsersInDb(params);
+  const normalizedSearch = validateAdministratorUserDirectoryFilters(params);
+  const result = await listAdministratorUsersInDb({
+    ...params,
+    limit: Math.min(params.limit, ADMINISTRATOR_DIRECTORY_MAX_PAGE_SIZE),
+    search: normalizedSearch,
+  });
+  return {
+    users: result.rows,
+    nextCursor: result.nextCursor,
+  };
 }
 
 export async function listAdministratorGrantSummaries(params: {

--- a/libs/api/auth/src/core/administration.ts
+++ b/libs/api/auth/src/core/administration.ts
@@ -210,6 +210,8 @@ export interface ListAdministratorUsersParams {
 }
 
 export interface ListAdministratorUsersResult {
+  /** Retained for compatibility with the original database-shaped result. */
+  rows: AdministratorUserSummary[];
   users: AdministratorUserSummary[];
   nextCursor: TimestampIdCursor | null;
 }
@@ -259,6 +261,9 @@ export async function listAdministratorUsers(
     search: normalizedSearch,
   });
   return {
+    rows: result.rows,
+    // Keep the original `rows` result while exposing the domain-named field
+    // used by the directory route.
     users: result.rows,
     nextCursor: result.nextCursor,
   };

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -37,7 +37,10 @@ export {
   requireAdminRole,
   revokeAdminGrant,
 } from '#core/admin-role.js';
-export type {ListAdministratorUsersParams} from '#core/administration.js';
+export type {
+  ListAdministratorUsersParams,
+  ListAdministratorUsersResult,
+} from '#core/administration.js';
 export {
   bootstrapFirstAdminOwner,
   grantAdministratorRole,

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -9,6 +9,7 @@ export type AuthRateLimitAction =
   | 'bootstrap'
   | 'bootstrap-state'
   | 'lookup'
+  | 'directory'
   | 'impersonate';
 export type AuthRateLimitScope = 'ip' | 'email' | 'actor';
 export type AuthRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -1,9 +1,9 @@
 import {impersonateResponseSchema} from '@shipfox/api-auth-dto';
 import {ADMINISTRATION_ACTION_PERFORMED} from '@shipfox/api-common-dto';
 import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
+import type {AppConfig, FastifyInstance} from '@shipfox/node-fastify';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {asc, eq, sql} from 'drizzle-orm';
-import type {FastifyInstance} from 'fastify';
 import {signUserToken, verifyUserToken} from '#core/jwt.js';
 import {type AuthRateLimitAction, hashAuthRateLimitIdentifier} from '#core/rate-limit.js';
 import {db} from '#db/db.js';
@@ -78,14 +78,48 @@ async function seedExhaustedIpBucket(params: {
     });
 }
 
+type LoggerInstance = NonNullable<NonNullable<AppConfig['fastifyOptions']>['loggerInstance']>;
+
+interface CapturedLog {
+  level: string;
+  args: unknown[];
+}
+
+function createCapturingLogger(logs: CapturedLog[]): LoggerInstance {
+  const logger = {
+    child: () => logger,
+    level: 'info',
+    silent: (...args: unknown[]) => logs.push({level: 'silent', args}),
+    fatal: (...args: unknown[]) => logs.push({level: 'fatal', args}),
+    error: (...args: unknown[]) => logs.push({level: 'error', args}),
+    warn: (...args: unknown[]) => logs.push({level: 'warn', args}),
+    info: (...args: unknown[]) => logs.push({level: 'info', args}),
+    debug: (...args: unknown[]) => logs.push({level: 'debug', args}),
+    trace: (...args: unknown[]) => logs.push({level: 'trace', args}),
+  };
+  return logger as unknown as LoggerInstance;
+}
+
+function directoryLogContexts(logs: CapturedLog[]): unknown[] {
+  return logs
+    .filter(
+      ({level, args}) => level === 'info' && args[1] === 'Listed administrator user directory',
+    )
+    .map(({args}) => args[0]);
+}
+
 describe('Auth administration routes', () => {
   let app: FastifyInstance;
+  const directoryLogs: CapturedLog[] = [];
 
   beforeAll(async () => {
-    app = await createAuthTestApp();
+    app = await createAuthTestApp({
+      fastifyOptions: {loggerInstance: createCapturingLogger(directoryLogs)},
+    });
   });
 
   beforeEach(async () => {
+    directoryLogs.length = 0;
     resetCapturedMail();
     setImpersonationEnabled(true);
     setAuthJwtExpiresIn('15m');
@@ -526,6 +560,13 @@ describe('Auth administration routes', () => {
     const operator = await createVerifiedSession(`${marker}-operator`);
     const observer = await createVerifiedSession(`${marker}-observer`);
     const target = await createVerifiedSession(`${marker}-target`);
+    const eligibilityMarker = `admin-user-directory-eligibility-${crypto.randomUUID()}`;
+    const eligibleTarget = await createVerifiedSession(`${eligibilityMarker}-eligible`);
+    const ineligibleTarget = await createVerifiedSession(`${eligibilityMarker}-ineligible`);
+    await db()
+      .update(users)
+      .set({status: 'suspended'})
+      .where(eq(users.id, ineligibleTarget.userId));
 
     const bootstrap = await app.inject({
       method: 'POST',
@@ -567,6 +608,21 @@ describe('Auth administration routes', () => {
     expect(firstPage.statusCode).toBe(200);
     expect(firstPage.json().users).toHaveLength(2);
     expect(firstPage.json().next_cursor).toEqual(expect.any(String));
+    const firstPageLog = directoryLogContexts(directoryLogs).at(-1);
+    expect(firstPageLog).toMatchObject({
+      actorId: observer.userId,
+      requiredRole: 'admin-observer',
+      targetType: 'user-directory',
+      requestId: expect.any(String),
+      result: 'succeeded',
+      outcome: 'succeeded',
+      durationMs: expect.any(Number),
+      resultCountBucket: '1-10',
+      filterPresence: {search: true, status: false, impersonationEligible: false},
+      nextPagePresent: true,
+    });
+    expect(JSON.stringify(firstPageLog)).not.toContain(marker);
+    expect(JSON.stringify(firstPageLog)).not.toContain(firstPage.json().next_cursor);
 
     const secondPage = await app.inject({
       method: 'GET',
@@ -628,6 +684,20 @@ describe('Auth administration routes', () => {
     ]);
     expect(eligibleUsers.json().next_cursor).toBeNull();
 
+    const ineligibleUsers = await app.inject({
+      method: 'GET',
+      url: `/admin/auth/users/directory?search=${encodeURIComponent(eligibilityMarker)}&impersonation_eligible=false`,
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(ineligibleUsers.statusCode).toBe(200);
+    expect(ineligibleUsers.json().users).toEqual([
+      expect.objectContaining({id: ineligibleTarget.userId, status: 'suspended'}),
+    ]);
+    expect(ineligibleUsers.json().users).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({id: eligibleTarget.userId})]),
+    );
+    expect(ineligibleUsers.json().next_cursor).toBeNull();
+
     const emptyPage = await app.inject({
       method: 'GET',
       url: `/admin/auth/users/directory?search=${encodeURIComponent(`missing-${marker}`)}`,
@@ -645,6 +715,12 @@ describe('Auth administration routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.json().users).toHaveLength(4);
     }
+
+    const observerActionEvents = await db()
+      .select()
+      .from(authOutbox)
+      .where(sql`${authOutbox.payload}->>'actorId' = ${observer.userId}`);
+    expect(observerActionEvents).toHaveLength(0);
   });
 
   test('translates directory filter errors and rejects ordinary, suspended, and impersonated sessions', async () => {
@@ -773,6 +849,26 @@ describe('Auth administration routes', () => {
     });
     expect(actorBlocked.statusCode).toBe(429);
     expect(actorBlocked.json().code).toBe('rate-limited');
+  });
+
+  test('rate-limits directory requests before checking the observer role', async () => {
+    const ordinary = await createVerifiedSession('admin-directory-rate-limit-ordinary');
+
+    await seedExhaustedIpBucket({
+      action: 'directory',
+      identifier: '127.0.0.1',
+      limit: 60,
+      windowSeconds: 5 * 60,
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory',
+      headers: {authorization: `Bearer ${ordinary.token}`},
+    });
+
+    expect(response.statusCode).toBe(429);
+    expect(response.json().code).toBe('rate-limited');
   });
 
   test('bounds and deterministically paginates administrator grant summaries for observers', async () => {

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -273,6 +273,12 @@ describe('Auth administration routes', () => {
     });
 
     expect(response.statusCode).toBe(404);
+
+    const directoryResponse = await app.inject({
+      method: 'GET',
+      url: '/admin/v1/auth/users/directory',
+    });
+    expect(directoryResponse.statusCode).toBe(404);
   });
 
   test('rejects an invalid bootstrap token without writing a grant or event', async () => {
@@ -512,6 +518,261 @@ describe('Auth administration routes', () => {
     expect(byEmail.statusCode).toBe(200);
     expect(byEmail.json().id).toBe(observer.userId);
     expect(byEmail.json().email).toBe(observer.email);
+  });
+
+  test('lists safe user summaries for owners, operators, and observers with cursor pagination', async () => {
+    const marker = `admin-user-directory-${crypto.randomUUID()}`;
+    const owner = await createVerifiedSession(`${marker}-owner`);
+    const operator = await createVerifiedSession(`${marker}-operator`);
+    const observer = await createVerifiedSession(`${marker}-observer`);
+    const target = await createVerifiedSession(`${marker}-target`);
+
+    const bootstrap = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants/bootstrap',
+      headers: authHeaders(owner.token, 'directory-bootstrap'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(bootstrap.statusCode).toBe(201);
+
+    const observerGrant = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants',
+      headers: authHeaders(owner.token, 'directory-observer-grant'),
+      payload: {
+        user_id: observer.userId,
+        role: 'admin-observer',
+        reason: 'Directory read access',
+      },
+    });
+    expect(observerGrant.statusCode).toBe(201);
+
+    const operatorGrant = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants',
+      headers: authHeaders(owner.token, 'directory-operator-grant'),
+      payload: {
+        user_id: operator.userId,
+        role: 'admin-operator',
+        reason: 'Directory read access',
+      },
+    });
+    expect(operatorGrant.statusCode).toBe(201);
+
+    const firstPage = await app.inject({
+      method: 'GET',
+      url: `/admin/auth/users/directory?search=${encodeURIComponent(` ${marker}   `)}&limit=2`,
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(firstPage.statusCode).toBe(200);
+    expect(firstPage.json().users).toHaveLength(2);
+    expect(firstPage.json().next_cursor).toEqual(expect.any(String));
+
+    const secondPage = await app.inject({
+      method: 'GET',
+      url: `/admin/auth/users/directory?search=${encodeURIComponent(marker)}&limit=2&cursor=${encodeURIComponent(firstPage.json().next_cursor)}`,
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(secondPage.statusCode).toBe(200);
+    expect(secondPage.json().users).toHaveLength(2);
+    expect(secondPage.json().next_cursor).toBeNull();
+
+    const listedUsers = [...firstPage.json().users, ...secondPage.json().users];
+    expect(new Set(listedUsers.map((user: {id: string}) => user.id)).size).toBe(4);
+    expect(listedUsers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: owner.userId,
+          email: owner.email,
+          name: `${marker}-owner`,
+          status: 'active',
+          admin_role: 'admin-owner',
+        }),
+        expect.objectContaining({
+          id: operator.userId,
+          email: operator.email,
+          name: `${marker}-operator`,
+          status: 'active',
+          admin_role: 'admin-operator',
+        }),
+        expect.objectContaining({
+          id: observer.userId,
+          email: observer.email,
+          name: `${marker}-observer`,
+          status: 'active',
+          admin_role: 'admin-observer',
+        }),
+        expect.objectContaining({
+          id: target.userId,
+          email: target.email,
+          name: `${marker}-target`,
+          status: 'active',
+          admin_role: null,
+        }),
+      ]),
+    );
+    for (const user of listedUsers) {
+      expect(user).not.toHaveProperty('hashed_password');
+      expect(user).not.toHaveProperty('sessions');
+      expect(user).not.toHaveProperty('provider_payload');
+    }
+
+    const eligibleUsers = await app.inject({
+      method: 'GET',
+      url: `/admin/auth/users/directory?search=${encodeURIComponent(marker)}&status=active&impersonation_eligible=true`,
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(eligibleUsers.statusCode).toBe(200);
+    expect(eligibleUsers.json().users).toEqual([
+      expect.objectContaining({id: target.userId, admin_role: null}),
+    ]);
+    expect(eligibleUsers.json().next_cursor).toBeNull();
+
+    const emptyPage = await app.inject({
+      method: 'GET',
+      url: `/admin/auth/users/directory?search=${encodeURIComponent(`missing-${marker}`)}`,
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(emptyPage.statusCode).toBe(200);
+    expect(emptyPage.json()).toEqual({users: [], next_cursor: null});
+
+    for (const actor of [owner, operator]) {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/admin/auth/users/directory?search=${encodeURIComponent(marker)}&limit=100`,
+        headers: {authorization: `Bearer ${actor.token}`},
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().users).toHaveLength(4);
+    }
+  });
+
+  test('translates directory filter errors and rejects ordinary, suspended, and impersonated sessions', async () => {
+    const marker = `admin-user-directory-authz-${crypto.randomUUID()}`;
+    const owner = await createVerifiedSession(`${marker}-owner`);
+    const observer = await createVerifiedSession(`${marker}-observer`);
+    const ordinary = await createVerifiedSession(`${marker}-ordinary`);
+    const suspended = await createVerifiedSession(`${marker}-suspended`);
+
+    const bootstrap = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants/bootstrap',
+      headers: authHeaders(owner.token, 'directory-authz-bootstrap'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(bootstrap.statusCode).toBe(201);
+
+    for (const [userId, role, idempotencyKey] of [
+      [observer.userId, 'admin-observer', 'directory-authz-observer-grant'],
+      [suspended.userId, 'admin-observer', 'directory-authz-suspended-grant'],
+    ] as const) {
+      const grant = await app.inject({
+        method: 'POST',
+        url: '/admin/auth/admin-grants',
+        headers: authHeaders(owner.token, idempotencyKey),
+        payload: {user_id: userId, role, reason: 'Directory read access'},
+      });
+      expect(grant.statusCode).toBe(201);
+    }
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, suspended.userId));
+
+    const ordinaryResponse = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory',
+      headers: {authorization: `Bearer ${ordinary.token}`},
+    });
+    expect(ordinaryResponse.statusCode).toBe(403);
+    expect(ordinaryResponse.json()).toEqual({
+      code: 'forbidden',
+      details: {required_role: 'admin-observer'},
+    });
+
+    const suspendedResponse = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory',
+      headers: {authorization: `Bearer ${suspended.token}`},
+    });
+    expect(suspendedResponse.statusCode).toBe(403);
+    expect(suspendedResponse.json().code).toBe('forbidden');
+
+    const impersonatedResponse = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory',
+      headers: {authorization: `Bearer ${await impersonatedToken(owner.userId, owner.email)}`},
+    });
+    expect(impersonatedResponse.statusCode).toBe(403);
+    expect(impersonatedResponse.json()).toEqual({code: 'admin-role-required'});
+
+    const invalidFilter = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory?status=suspended&impersonation_eligible=true',
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(invalidFilter.statusCode).toBe(400);
+    expect(invalidFilter.json().code).toBe('validation-error');
+
+    const invalidCursor = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory?cursor=not-a-real-cursor',
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(invalidCursor.statusCode).toBe(400);
+    expect(invalidCursor.json().code).toBe('invalid-cursor');
+  });
+
+  test('uses independent source-IP and actor buckets for directory reads', async () => {
+    const owner = await createVerifiedSession('admin-directory-rate-limit-owner');
+    const observer = await createVerifiedSession('admin-directory-rate-limit-observer');
+
+    const bootstrap = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants/bootstrap',
+      headers: authHeaders(owner.token, 'directory-rate-limit-bootstrap'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(bootstrap.statusCode).toBe(201);
+
+    const grant = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants',
+      headers: authHeaders(owner.token, 'directory-rate-limit-grant'),
+      payload: {
+        user_id: observer.userId,
+        role: 'admin-observer',
+        reason: 'Directory read access',
+      },
+    });
+    expect(grant.statusCode).toBe(201);
+
+    await seedExhaustedIpBucket({
+      action: 'directory',
+      identifier: '127.0.0.1',
+      limit: 60,
+      windowSeconds: 5 * 60,
+    });
+    const ipBlocked = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory',
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(ipBlocked.statusCode).toBe(429);
+    expect(ipBlocked.json().code).toBe('rate-limited');
+
+    await seedExhaustedIpBucket({
+      action: 'directory',
+      scope: 'actor',
+      identifier: observer.userId,
+      limit: 60,
+      windowSeconds: 5 * 60,
+    });
+    const actorBlocked = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/users/directory',
+      remoteAddress: '10.0.0.2',
+      headers: {authorization: `Bearer ${observer.token}`},
+    });
+    expect(actorBlocked.statusCode).toBe(429);
+    expect(actorBlocked.json().code).toBe('rate-limited');
   });
 
   test('bounds and deterministically paginates administrator grant summaries for observers', async () => {

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -6,6 +6,8 @@ import {
 } from '@shipfox/api-auth-context';
 import {
   adminBootstrapStateSchema,
+  administratorUserDirectoryQuerySchema,
+  administratorUserDirectoryResponseSchema,
   administratorUserLookupQuerySchema,
   administratorUserMutationResponseSchema,
   administratorUserSummarySchema,
@@ -37,6 +39,7 @@ import {
   grantAdministratorRole,
   impersonateUser,
   listAdministratorGrantSummaries,
+  listAdministratorUsers,
   reactivateAdministratorUser,
   revokeAdministratorGrant,
   revokeAdministratorUserSessions,
@@ -60,6 +63,7 @@ import {
   ImpersonationExpiredError,
   ImpersonationTargetNotActiveError,
   InvalidAdminBootstrapTokenError,
+  InvalidAdministratorUserDirectoryFilterError,
   InvalidCredentialsError,
   LastAdminOwnerError,
   UserNotFoundError,
@@ -136,6 +140,41 @@ function toAdministratorUserMutationDto(result: {
   };
 }
 
+function directoryResultCountBucket(count: number): '0' | '1-10' | '11-50' | '51-100' {
+  if (count === 0) return '0';
+  if (count <= 10) return '1-10';
+  if (count <= 50) return '11-50';
+  return '51-100';
+}
+
+function logAdministratorUserDirectoryRead(params: {
+  request: FastifyRequest;
+  outcome: 'succeeded' | 'failed';
+  durationMs: number;
+  resultCount: number;
+  filterPresence: {
+    search: boolean;
+    status: boolean;
+    impersonationEligible: boolean;
+  };
+  nextPagePresent: boolean;
+}): void {
+  try {
+    params.request.log.info(
+      {
+        outcome: params.outcome,
+        durationMs: params.durationMs,
+        resultCountBucket: directoryResultCountBucket(params.resultCount),
+        filterPresence: params.filterPresence,
+        nextPagePresent: params.nextPagePresent,
+      },
+      'Listed administrator user directory',
+    );
+  } catch {
+    // Logging must not change the directory read outcome.
+  }
+}
+
 function translateImpersonationEligibilityError(error: unknown): ClientError | undefined {
   // The mint primitive re-checks login eligibility on the row it reads, and a
   // concurrent suspension or unverification between the in-transaction ladder
@@ -162,6 +201,9 @@ function translateAdministrationError(error: unknown): never {
       status: 403,
       details: {required_role: error.minimumRole},
     });
+  }
+  if (error instanceof InvalidAdministratorUserDirectoryFilterError) {
+    throw new ClientError(error.message, 'validation-error', {status: 400});
   }
   if (error instanceof InvalidAdminBootstrapTokenError) {
     throw new ClientError('Bootstrap token is invalid', 'bootstrap-token-invalid', {
@@ -299,6 +341,68 @@ const userLookupRoute = defineRoute({
     else if (email) user = await findAdministratorUserSummary({actorId, email});
     if (!user) throw new UserNotFoundError(lookupId ?? email ?? 'unknown');
     return toAdministratorUserSummaryDto(user);
+  },
+});
+
+const userDirectoryRoute = defineRoute({
+  method: 'GET',
+  path: '/directory',
+  description: 'List bounded administrator-safe user summaries for directory browsing.',
+  schema: {
+    querystring: administratorUserDirectoryQuerySchema,
+    response: {200: administratorUserDirectoryResponseSchema},
+  },
+  preHandler: [requireAdministratorObserver, createAuthActorRateLimitPreHandler('directory')],
+  errorHandler: translateAdministrationError,
+  handler: async (request) => {
+    const startedAt = performance.now();
+    const {
+      search,
+      status,
+      impersonation_eligible: impersonationEligible,
+      limit,
+      cursor,
+    } = request.query;
+    let resultCount = 0;
+    let nextPagePresent = false;
+    let outcome: 'succeeded' | 'failed' = 'failed';
+
+    try {
+      const decodedCursor = decodeTimestampIdCursor(cursor);
+      if (cursor && !decodedCursor) {
+        throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
+      }
+
+      const result = await listAdministratorUsers({
+        actorId: requireActorId(request),
+        limit,
+        ...(decodedCursor ? {cursor: decodedCursor} : {}),
+        ...(search !== undefined ? {search} : {}),
+        ...(status !== undefined ? {status} : {}),
+        ...(impersonationEligible !== undefined ? {eligible: impersonationEligible} : {}),
+      });
+      resultCount = result.users.length;
+      nextPagePresent = result.nextCursor !== null;
+      outcome = 'succeeded';
+
+      return {
+        users: result.users.map(toAdministratorUserSummaryDto),
+        next_cursor: result.nextCursor ? encodeTimestampIdCursor(result.nextCursor) : null,
+      };
+    } finally {
+      logAdministratorUserDirectoryRead({
+        request,
+        outcome,
+        durationMs: Math.round(performance.now() - startedAt),
+        resultCount,
+        filterPresence: {
+          search: search !== undefined,
+          status: status !== undefined,
+          impersonationEligible: impersonationEligible !== undefined,
+        },
+        nextPagePresent,
+      });
+    }
   },
 });
 
@@ -489,7 +593,13 @@ export function createAdministrationUserRoutes(
     adoptAdministrationActorGuard({
       prefix: '/admin/auth/users',
       auth: AUTH_USER,
-      routes: [userLookupRoute, suspendUserRoute, reactivateUserRoute, revokeUserSessionsRoute],
+      routes: [
+        userDirectoryRoute,
+        userLookupRoute,
+        suspendUserRoute,
+        reactivateUserRoute,
+        revokeUserSessionsRoute,
+      ],
     }),
     // The impersonate route mounts outside the adopted guard on purpose: its
     // limiter must run before the impersonated-session rejection (see

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -149,6 +149,7 @@ function directoryResultCountBucket(count: number): '0' | '1-10' | '11-50' | '51
 
 function logAdministratorUserDirectoryRead(params: {
   request: FastifyRequest;
+  actorId: string;
   outcome: 'succeeded' | 'failed';
   durationMs: number;
   resultCount: number;
@@ -162,6 +163,11 @@ function logAdministratorUserDirectoryRead(params: {
   try {
     params.request.log.info(
       {
+        actorId: params.actorId,
+        requiredRole: 'admin-observer',
+        targetType: 'user-directory',
+        requestId: params.request.id,
+        result: params.outcome,
         outcome: params.outcome,
         durationMs: params.durationMs,
         resultCountBucket: directoryResultCountBucket(params.resultCount),
@@ -352,9 +358,10 @@ const userDirectoryRoute = defineRoute({
     querystring: administratorUserDirectoryQuerySchema,
     response: {200: administratorUserDirectoryResponseSchema},
   },
-  preHandler: [requireAdministratorObserver, createAuthActorRateLimitPreHandler('directory')],
+  preHandler: createAuthActorRateLimitPreHandler('directory'),
   errorHandler: translateAdministrationError,
   handler: async (request) => {
+    const actorId = requireActorId(request);
     const startedAt = performance.now();
     const {
       search,
@@ -374,7 +381,7 @@ const userDirectoryRoute = defineRoute({
       }
 
       const result = await listAdministratorUsers({
-        actorId: requireActorId(request),
+        actorId,
         limit,
         ...(decodedCursor ? {cursor: decodedCursor} : {}),
         ...(search !== undefined ? {search} : {}),
@@ -392,6 +399,7 @@ const userDirectoryRoute = defineRoute({
     } finally {
       logAdministratorUserDirectoryRead({
         request,
+        actorId,
         outcome,
         durationMs: Math.round(performance.now() - startedAt),
         resultCount,

--- a/libs/api/auth/src/presentation/routes/rate-limit.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.ts
@@ -29,6 +29,10 @@ const policies: Record<
   lookup: {
     ip: {limit: 60, windowSeconds: 5 * 60},
   },
+  directory: {
+    ip: {limit: 60, windowSeconds: 5 * 60},
+    actor: {limit: 60, windowSeconds: 5 * 60},
+  },
   impersonate: {
     // Bounds mint and probing attempts: the IP bucket bounds aggregate source
     // traffic, and the actor bucket is a per-actor cap that prevents an actor


### PR DESCRIPTION
## Summary

Add administrator user directory access to the Auth API for observer-scoped administration workflows. The operation supports bounded pagination and filters, applies actor and IP rate limits, and records privacy-safe outcomes.

## Validation

- `mise exec -- turbo check --filter=@shipfox/api-auth...`
- `mise exec -- turbo type --filter=@shipfox/api-auth...`
- `mise exec -- turbo test --filter=@shipfox/api-auth...`
- `mise exec -- pnpm --filter=@shipfox/prose-policy verify`

Closes ENG-1803

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-only user directory endpoint to `@shipfox/api-auth` so observer-scoped admins can browse user summaries with pagination and filters.

`GET /admin/auth/users/directory` returns up to 100 safe user summaries per page, supports `search`, `status`, `impersonation_eligible`, `limit`, and opaque `cursor` parameters, and enforces separate IP and actor rate limits at 60 requests per 5 minutes each. Empty pages return `200` with an empty `users` array. Directory reads log privacy-safe metadata only and do not emit administration action events. The exported `listAdministratorUsers` now returns `{users, rows, nextCursor}` with `rows` kept as a compatibility alias, and requests are rate-limited before role checks.

<sup>Written for commit db4ee5b6d2a616563f9e7cc316342131d5e0f2b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

