### PR TITLE
Support checkout targets by ID or name with one GitHub mint

### DIFF
--- a/.changeset/checkout-targets-mint.md
+++ b/.changeset/checkout-targets-mint.md
@@ -1,9 +1,9 @@
 ---
-"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core-dto": major
 "@shipfox/api-integration-core": minor
 "@shipfox/api-integration-gitea": minor
 "@shipfox/api-integration-github": minor
 "@shipfox/api-integration-spi": minor
 ---
 
-Adds checkout targets addressed by stable external IDs or owner/name declarations. GitHub mints one contents-scoped installation token and verifies its canonical repository metadata before returning credentials.
+Adds checkout targets addressed by stable external IDs or owner/name declarations. Checkout inputs reject ambiguous targets and caller-supplied metadata.

--- a/.changeset/checkout-targets-mint.md
+++ b/.changeset/checkout-targets-mint.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-gitea": minor
+"@shipfox/api-integration-github": minor
+"@shipfox/api-integration-spi": minor
+---
+
+Adds checkout targets addressed by stable external IDs or owner/name declarations. GitHub mints one contents-scoped installation token and verifies its canonical repository metadata before returning credentials.

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -120,6 +120,24 @@ describe('integrationsInterModuleContract', () => {
     ).toEqual({kind: 'name', owner: 'shipfox', name: 'platform'});
   });
 
+  test('trims name targets and rejects whitespace-only names', () => {
+    const input = {
+      workspaceId: '00000000-0000-4000-8000-000000000001',
+      connectionId: '00000000-0000-4000-8000-000000000002',
+      target: {kind: 'name' as const, owner: ' shipfox ', name: ' platform '},
+    };
+
+    expect(
+      integrationsInterModuleContract.methods.createCheckoutSpec.input.parse(input),
+    ).toMatchObject({target: {kind: 'name', owner: 'shipfox', name: 'platform'}});
+    expect(() =>
+      integrationsInterModuleContract.methods.createCheckoutSpec.input.parse({
+        ...input,
+        target: {kind: 'name', owner: ' ', name: 'platform'},
+      }),
+    ).toThrow();
+  });
+
   test.each([
     ['a missing target', {}],
     [

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -96,6 +96,56 @@ describe('integrationsInterModuleContract', () => {
     ).toThrow();
   });
 
+  test('accepts checkout targets addressed by an external id or owner/name', () => {
+    const workspaceId = '00000000-0000-4000-8000-000000000001';
+    const connectionId = '00000000-0000-4000-8000-000000000002';
+    const projectId = '00000000-0000-4000-8000-000000000003';
+
+    expect(
+      integrationsInterModuleContract.methods.createCheckoutSpec.input.parse({
+        workspaceId,
+        connectionId,
+        projectId,
+        target: {kind: 'external-id', externalRepositoryId: 'github:42'},
+      }),
+    ).toMatchObject({projectId, target: {kind: 'external-id', externalRepositoryId: 'github:42'}});
+
+    expect(
+      integrationsInterModuleContract.methods.createCheckoutCredentials.input.parse({
+        workspaceId,
+        connectionId,
+        target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+        permissions: {contents: 'read'},
+      }).target,
+    ).toEqual({kind: 'name', owner: 'shipfox', name: 'platform'});
+  });
+
+  test.each([
+    ['a missing target', {}],
+    [
+      'both target forms',
+      {
+        target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+        externalRepositoryId: 'github:42',
+      },
+    ],
+    [
+      'a caller-supplied clone URL',
+      {
+        target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+        repositoryUrl: 'https://github.com/shipfox/platform.git',
+      },
+    ],
+  ])('rejects checkout input with %s', (_label, extra) => {
+    expect(() =>
+      integrationsInterModuleContract.methods.createCheckoutSpec.input.parse({
+        workspaceId: '00000000-0000-4000-8000-000000000001',
+        connectionId: '00000000-0000-4000-8000-000000000002',
+        ...extra,
+      }),
+    ).toThrow();
+  });
+
   test.each([
     ['connection-not-found', {connectionId: '00000000-0000-4000-8000-000000000001'}],
     ['provider-unavailable', {provider: 'github'}],

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -24,6 +24,19 @@ const triggerReference = z.object({
   actor: z.string().nullable(),
 });
 const sourceInput = z.object({workspaceId: id, connectionId: id, externalRepositoryId: z.string()});
+const checkoutTarget = z.discriminatedUnion('kind', [
+  z.object({kind: z.literal('external-id'), externalRepositoryId: z.string().min(1)}).strict(),
+  z.object({kind: z.literal('name'), owner: z.string().min(1), name: z.string().min(1)}).strict(),
+]);
+const checkoutInput = z
+  .object({
+    workspaceId: id,
+    connectionId: id,
+    projectId: id.optional(),
+    target: checkoutTarget.optional(),
+    externalRepositoryId: z.string().min(1).optional(),
+  })
+  .strict();
 const checkoutCredentialRenewal = z.discriminatedUnion('mode', [
   z.object({mode: z.literal('refresh-at'), refreshAt: z.string().datetime()}),
   z.object({mode: z.literal('on-rejection')}),
@@ -168,10 +181,12 @@ export const integrationsInterModuleContract = defineInterModuleContract({
       errors: sourceErrors,
     },
     createCheckoutSpec: {
-      input: sourceInput.extend({
-        ref: z.string().optional(),
-        permissions: z.object({contents: z.enum(['read', 'write'])}).optional(),
-      }),
+      input: checkoutInput
+        .extend({
+          ref: z.string().optional(),
+          permissions: z.object({contents: z.enum(['read', 'write'])}).optional(),
+        })
+        .superRefine(requireCheckoutTarget),
       output: z.object({
         repositoryUrl: z.string(),
         ref: z.string(),
@@ -181,10 +196,12 @@ export const integrationsInterModuleContract = defineInterModuleContract({
       errors: sourceErrors,
     },
     createCheckoutCredentials: {
-      input: sourceInput.extend({
-        permissions: z.object({contents: z.enum(['read', 'write'])}),
-        rejectedGeneration: z.string().optional(),
-      }),
+      input: checkoutInput
+        .extend({
+          permissions: z.object({contents: z.enum(['read', 'write'])}),
+          rejectedGeneration: z.string().optional(),
+        })
+        .superRefine(requireCheckoutTarget),
       output: checkoutCredentials,
       errors: sourceErrors,
     },
@@ -253,5 +270,28 @@ export const integrationsInterModuleContract = defineInterModuleContract({
     },
   },
 });
+
+function requireCheckoutTarget(
+  input: {
+    target?: z.infer<typeof checkoutTarget> | undefined;
+    externalRepositoryId?: string | undefined;
+  },
+  context: z.RefinementCtx,
+): void {
+  if (input.target === undefined && input.externalRepositoryId === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['target'],
+      message: 'Checkout input requires a target or an external repository id',
+    });
+  }
+  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['target'],
+      message: 'Checkout input cannot include both a target and an external repository id',
+    });
+  }
+}
 
 export type IntegrationsModuleClient = InterModuleClient<typeof integrationsInterModuleContract>;

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -24,9 +24,14 @@ const triggerReference = z.object({
   actor: z.string().nullable(),
 });
 const sourceInput = z.object({workspaceId: id, connectionId: id, externalRepositoryId: z.string()});
+// Checkout metadata must come from the provider response. Reject unknown fields
+// such as caller-supplied clone URLs instead of silently stripping them.
+const checkoutTargetValue = z.string().trim().min(1);
 const checkoutTarget = z.discriminatedUnion('kind', [
-  z.object({kind: z.literal('external-id'), externalRepositoryId: z.string().min(1)}).strict(),
-  z.object({kind: z.literal('name'), owner: z.string().min(1), name: z.string().min(1)}).strict(),
+  z.object({kind: z.literal('external-id'), externalRepositoryId: checkoutTargetValue}).strict(),
+  z
+    .object({kind: z.literal('name'), owner: checkoutTargetValue, name: checkoutTargetValue})
+    .strict(),
 ]);
 const checkoutInput = z
   .object({
@@ -278,6 +283,8 @@ function requireCheckoutTarget(
   },
   context: z.RefinementCtx,
 ): void {
+  // This stays at the JSON boundary so malformed checkout payloads are rejected
+  // before they reach the SPI normalizer used by in-memory callers.
   if (input.target === undefined && input.externalRepositoryId === undefined) {
     context.addIssue({
       code: z.ZodIssueCode.custom,

--- a/libs/api/integration/core/src/core/providers/source-control.ts
+++ b/libs/api/integration/core/src/core/providers/source-control.ts
@@ -3,6 +3,8 @@ export type {
   CheckoutCredentials,
   CheckoutPermissions,
   CheckoutSpec,
+  CheckoutTarget,
+  CheckoutTargetInput,
   CreateCheckoutCredentialsInput,
   CreateCheckoutSpecInput,
   FetchFileInput,

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -290,6 +290,28 @@ describe('integration source-control service', () => {
     });
   });
 
+  it('preserves distinct errors for missing and ambiguous checkout targets', async () => {
+    const service = createService();
+
+    await expect(
+      service.createCheckoutSpec({workspaceId, connectionId: connection.id}),
+    ).rejects.toMatchObject({
+      reason: 'repository-not-found',
+      message: 'Checkout input must include exactly one target or external repository id',
+    });
+    await expect(
+      service.createCheckoutSpec({
+        workspaceId,
+        connectionId: connection.id,
+        target: {kind: 'name', owner: 'acme', name: 'platform'},
+        externalRepositoryId: repository.externalRepositoryId,
+      }),
+    ).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: 'Checkout input cannot include both a target and an external repository id',
+    });
+  });
+
   it('rejects a checkout spec for a connection in another workspace', async () => {
     const service = createService();
 

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -256,7 +256,10 @@ describe('integration source-control service', () => {
       ref: 'feature/x',
     });
     expect(createCheckoutSpec).toHaveBeenCalledWith(
-      expect.objectContaining({permissions: {contents: 'write'}}),
+      expect.objectContaining({
+        target: {kind: 'external-id', externalRepositoryId: 'gitea:gitea-owner/platform'},
+        permissions: {contents: 'write'},
+      }),
     );
   });
 

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -260,6 +260,33 @@ describe('integration source-control service', () => {
     );
   });
 
+  it('forwards a name target and optional project association to the provider', async () => {
+    const createCheckoutSpec = vi.fn(
+      async (input: Parameters<NonNullable<SourceControlProvider['createCheckoutSpec']>>[0]) => {
+        await Promise.resolve();
+        return {repositoryUrl: repository.cloneUrl, ref: input.ref ?? repository.defaultBranch};
+      },
+    );
+    const service = createService({createCheckoutSpec});
+    const projectId = crypto.randomUUID();
+
+    await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      projectId,
+      target: {kind: 'name', owner: 'acme', name: 'platform'},
+      ref: 'feature/x',
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      connection,
+      projectId,
+      target: {kind: 'name', owner: 'acme', name: 'platform'},
+      ref: 'feature/x',
+      permissions: undefined,
+    });
+  });
+
   it('rejects a checkout spec for a connection in another workspace', async () => {
     const service = createService();
 

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -11,6 +11,8 @@ import type {
   CheckoutCredentials,
   CheckoutPermissions,
   CheckoutSpec,
+  CheckoutTarget,
+  CheckoutTargetInput,
   FilePage,
   FileSnapshot,
   RepositoryPage,
@@ -68,15 +70,21 @@ export interface FetchSourceFileInput extends ResolveSourceRepositoryInput {
   path: string;
 }
 
-export interface CreateSourceCheckoutSpecInput extends ResolveSourceRepositoryInput {
+export type CreateSourceCheckoutSpecInput = {
+  workspaceId: string;
+  connectionId: string;
+  projectId?: string | undefined;
   ref?: string | undefined;
   permissions?: CheckoutPermissions | undefined;
-}
+} & CheckoutTargetInput;
 
-export interface CreateSourceCheckoutCredentialsInput extends ResolveSourceRepositoryInput {
+export type CreateSourceCheckoutCredentialsInput = {
+  workspaceId: string;
+  connectionId: string;
+  projectId?: string | undefined;
   permissions: CheckoutPermissions;
   rejectedGeneration?: string | undefined;
-}
+} & CheckoutTargetInput;
 
 export interface ResolvedSourceRepository {
   connection: IntegrationConnection;
@@ -187,7 +195,8 @@ export function createSourceControlIntegrationService({
       });
     },
 
-    async createCheckoutSpec({workspaceId, connectionId, externalRepositoryId, ref, permissions}) {
+    async createCheckoutSpec(input) {
+      const {workspaceId, connectionId, projectId, ref, permissions} = input;
       const connection = await getConnection(connectionId);
       if (connection.workspaceId !== workspaceId) {
         throw new IntegrationConnectionWorkspaceMismatchError(connectionId);
@@ -199,19 +208,15 @@ export function createSourceControlIntegrationService({
 
       return await sourceControl.createCheckoutSpec({
         connection,
-        externalRepositoryId,
+        target: checkoutTarget(input),
+        ...(projectId === undefined ? {} : {projectId}),
         ref,
         permissions,
       });
     },
 
-    async createCheckoutCredentials({
-      workspaceId,
-      connectionId,
-      externalRepositoryId,
-      permissions,
-      rejectedGeneration,
-    }) {
+    async createCheckoutCredentials(input) {
+      const {workspaceId, connectionId, projectId, permissions, rejectedGeneration} = input;
       const connection = await getConnection(connectionId);
       if (connection.workspaceId !== workspaceId) {
         throw new IntegrationConnectionWorkspaceMismatchError(connectionId);
@@ -223,7 +228,8 @@ export function createSourceControlIntegrationService({
 
       const credentials = await sourceControl.createCheckoutCredentials({
         connection,
-        externalRepositoryId,
+        target: checkoutTarget(input),
+        ...(projectId === undefined ? {} : {projectId}),
         permissions,
         rejectedGeneration,
       });
@@ -239,4 +245,21 @@ export function createSourceControlIntegrationService({
       return credentials;
     },
   };
+}
+
+function checkoutTarget(input: CheckoutTargetInput): CheckoutTarget {
+  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
+    throw new IntegrationProviderError(
+      'provider-rejected',
+      'Checkout input cannot include both a target and an external repository id',
+    );
+  }
+  if (input.target !== undefined) return input.target;
+  if (input.externalRepositoryId !== undefined) {
+    return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
+  }
+  throw new IntegrationProviderError(
+    'provider-rejected',
+    'Checkout input must include a target or an external repository id',
+  );
 }

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -249,8 +249,14 @@ export function createSourceControlIntegrationService({
 }
 
 function checkoutTarget(input: CheckoutTargetInput): CheckoutTarget {
-  const target = normalizeCheckoutTarget(input);
-  if (target !== undefined) return target;
+  const result = normalizeCheckoutTarget(input);
+  if (result.status === 'valid') return result.target;
+  if (result.status === 'ambiguous') {
+    throw new IntegrationProviderError(
+      'provider-rejected',
+      'Checkout input cannot include both a target and an external repository id',
+    );
+  }
   throw new IntegrationProviderError(
     'repository-not-found',
     'Checkout input must include exactly one target or external repository id',

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -1,3 +1,4 @@
+import {normalizeCheckoutTarget} from '@shipfox/api-integration-spi';
 import type {IntegrationConnection} from './entities/connection.js';
 import {
   IntegrationCheckoutUnsupportedError,
@@ -248,18 +249,10 @@ export function createSourceControlIntegrationService({
 }
 
 function checkoutTarget(input: CheckoutTargetInput): CheckoutTarget {
-  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
-    throw new IntegrationProviderError(
-      'provider-rejected',
-      'Checkout input cannot include both a target and an external repository id',
-    );
-  }
-  if (input.target !== undefined) return input.target;
-  if (input.externalRepositoryId !== undefined) {
-    return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
-  }
+  const target = normalizeCheckoutTarget(input);
+  if (target !== undefined) return target;
   throw new IntegrationProviderError(
-    'provider-rejected',
-    'Checkout input must include a target or an external repository id',
+    'repository-not-found',
+    'Checkout input must include exactly one target or external repository id',
   );
 }

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -104,6 +104,8 @@ export type {
   CheckoutCredentials,
   CheckoutPermissions,
   CheckoutSpec,
+  CheckoutTarget,
+  CheckoutTargetInput,
   CreateCheckoutCredentialsInput,
   CreateCheckoutSpecInput,
   FetchFileInput,

--- a/libs/api/integration/gitea/src/core/source-control.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control.test.ts
@@ -535,6 +535,8 @@ describe('GiteaSourceControlProvider', () => {
     'gitea:shipfox/',
     'gitea:/platform',
     'gitea:shipfox/platform/extra',
+    'gitea:shipfox/.',
+    'gitea:shipfox/..',
     'github:shipfox/platform',
     '',
   ])('rejects the malformed external repository id %s before any api call', async (id) => {
@@ -647,6 +649,22 @@ describe('GiteaSourceControlProvider', () => {
       provider.createCheckoutSpec({
         connection: connection(),
         target: {kind: 'name', owner: 'shipfox', name},
+      }),
+    ).rejects.toMatchObject({reason: 'repository-not-found'});
+    expect(gitea.getRepository).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '.',
+    '..',
+  ])('rejects dot-segment repository name %s in a legacy external id before any api call', async (name) => {
+    const gitea = giteaClient();
+    const provider = new GiteaSourceControlProvider(gitea);
+
+    await expect(
+      provider.createCheckoutSpec({
+        connection: connection(),
+        externalRepositoryId: `gitea:shipfox/${name}`,
       }),
     ).rejects.toMatchObject({reason: 'repository-not-found'});
     expect(gitea.getRepository).not.toHaveBeenCalled();

--- a/libs/api/integration/gitea/src/core/source-control.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control.test.ts
@@ -593,6 +593,65 @@ describe('GiteaSourceControlProvider', () => {
     }
   });
 
+  it('creates a checkout spec from a name target in the connection account', async () => {
+    const gitea = giteaClient();
+    const provider = new GiteaSourceControlProvider(gitea);
+
+    const result = await provider.createCheckoutSpec({
+      connection: connection(),
+      target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+      ref: 'feature/x',
+    });
+
+    expect(result.repositoryUrl).toBe('https://gitea.example.com/shipfox/platform.git');
+    expect(result.ref).toBe('feature/x');
+    expect(gitea.getRepository).toHaveBeenCalledWith({owner: 'shipfox', repo: 'platform'});
+  });
+
+  it('creates credential-only delivery from a name target in the connection account', async () => {
+    const gitea = giteaClient();
+    const provider = new GiteaSourceControlProvider(gitea);
+
+    await expect(
+      provider.createCheckoutCredentials({
+        connection: connection(),
+        target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+        permissions: {contents: 'read'},
+      }),
+    ).resolves.toMatchObject({username: 'shipfox-bot', token: 'test-service-token'});
+    expect(gitea.getRepository).not.toHaveBeenCalled();
+  });
+
+  it('rejects a name target outside the connection account before any api call', async () => {
+    const gitea = giteaClient();
+    const provider = new GiteaSourceControlProvider(gitea);
+
+    await expect(
+      provider.createCheckoutCredentials({
+        connection: connection(),
+        target: {kind: 'name', owner: 'intruder', name: 'platform'},
+        permissions: {contents: 'read'},
+      }),
+    ).rejects.toMatchObject({reason: 'repository-not-found'});
+    expect(gitea.getRepository).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '.',
+    '..',
+  ])('rejects dot-segment repository name %s before any api call', async (name) => {
+    const gitea = giteaClient();
+    const provider = new GiteaSourceControlProvider(gitea);
+
+    await expect(
+      provider.createCheckoutSpec({
+        connection: connection(),
+        target: {kind: 'name', owner: 'shipfox', name},
+      }),
+    ).rejects.toMatchObject({reason: 'repository-not-found'});
+    expect(gitea.getRepository).not.toHaveBeenCalled();
+  });
+
   it('rejects credential-only delivery outside the connection account before returning credentials', async () => {
     const gitea = giteaClient();
     const provider = new GiteaSourceControlProvider(gitea);

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -6,6 +6,7 @@ import {
   buildProviderRepositoryId,
   type CheckoutCredentials,
   type CheckoutSpec,
+  type CheckoutTarget,
   type CreateCheckoutCredentialsInput,
   type CreateCheckoutSpecInput,
   type FetchFileInput,
@@ -243,8 +244,9 @@ export class GiteaSourceControlProvider
   async createCheckoutSpec(
     input: CreateCheckoutSpecInput<GiteaIntegrationConnection>,
   ): Promise<CheckoutSpec> {
+    const target = normalizeCheckoutTarget(input);
     const {owner, repo} = parseGiteaRepositoryLocator(
-      input.externalRepositoryId,
+      checkoutRepositoryId(target),
       input.connection.externalAccountId,
     );
     const repository = await this.gitea.getRepository({owner, repo});
@@ -252,7 +254,7 @@ export class GiteaSourceControlProvider
 
     const credentials = await this.createCheckoutCredentials({
       connection: input.connection,
-      externalRepositoryId: input.externalRepositoryId,
+      target,
       permissions: input.permissions ?? {contents: 'read'},
     });
 
@@ -266,7 +268,10 @@ export class GiteaSourceControlProvider
   async createCheckoutCredentials(
     input: CreateCheckoutCredentialsInput<GiteaIntegrationConnection>,
   ): Promise<CheckoutCredentials> {
-    parseGiteaRepositoryLocator(input.externalRepositoryId, input.connection.externalAccountId);
+    parseGiteaRepositoryLocator(
+      checkoutRepositoryId(normalizeCheckoutTarget(input)),
+      input.connection.externalAccountId,
+    );
     // Gitea has no per-repo, auto-expiring token like a GitHub App installation
     // token, so checkout reuses the long-lived service credential. `expiresAt`
     // remains a synthetic legacy field for old runners; renewal is rejection-only.
@@ -281,6 +286,31 @@ export class GiteaSourceControlProvider
       renewal: {mode: 'on-rejection' as const},
     });
   }
+}
+
+function normalizeCheckoutTarget(input: {
+  target?: CheckoutTarget | undefined;
+  externalRepositoryId?: string | undefined;
+}): CheckoutTarget {
+  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
+    throw new GiteaIntegrationProviderError(
+      'provider-rejected',
+      'Checkout input cannot include both a target and an external repository id',
+    );
+  }
+  if (input.target !== undefined) return input.target;
+  if (input.externalRepositoryId !== undefined) {
+    return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
+  }
+  throw new GiteaIntegrationProviderError(
+    'repository-not-found',
+    'Checkout input must include a target or an external repository id',
+  );
+}
+
+function checkoutRepositoryId(target: CheckoutTarget): string {
+  if (target.kind === 'external-id') return target.externalRepositoryId;
+  return buildProviderRepositoryId(giteaProviderKind, `${target.owner}/${target.name}`);
 }
 
 function giteaRepositoryId(repository: Record<string, unknown> | null): string | null {

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -21,6 +21,7 @@ import {
   type ListRepositoriesInput,
   MAX_REPOSITORY_FILE_BYTES,
   nonEmptyString,
+  normalizeCheckoutTarget as normalizeTarget,
   parseProviderRepositoryId,
   positiveInteger,
   type RepositoryPage,
@@ -292,24 +293,22 @@ function normalizeCheckoutTarget(input: {
   target?: CheckoutTarget | undefined;
   externalRepositoryId?: string | undefined;
 }): CheckoutTarget {
-  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
-    throw new GiteaIntegrationProviderError(
-      'provider-rejected',
-      'Checkout input cannot include both a target and an external repository id',
-    );
-  }
-  if (input.target !== undefined) return input.target;
-  if (input.externalRepositoryId !== undefined) {
-    return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
-  }
+  const target = normalizeTarget(input);
+  if (target !== undefined) return target;
   throw new GiteaIntegrationProviderError(
     'repository-not-found',
-    'Checkout input must include a target or an external repository id',
+    'Checkout input must include exactly one target or external repository id',
   );
 }
 
 function checkoutRepositoryId(target: CheckoutTarget): string {
   if (target.kind === 'external-id') return target.externalRepositoryId;
+  if (target.name === '.' || target.name === '..') {
+    throw new GiteaIntegrationProviderError(
+      'repository-not-found',
+      'Gitea checkout target contains an invalid repository name',
+    );
+  }
   return buildProviderRepositoryId(giteaProviderKind, `${target.owner}/${target.name}`);
 }
 

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -293,8 +293,14 @@ function normalizeCheckoutTarget(input: {
   target?: CheckoutTarget | undefined;
   externalRepositoryId?: string | undefined;
 }): CheckoutTarget {
-  const target = normalizeTarget(input);
-  if (target !== undefined) return target;
+  const result = normalizeTarget(input);
+  if (result.status === 'valid') return result.target;
+  if (result.status === 'ambiguous') {
+    throw new GiteaIntegrationProviderError(
+      'provider-rejected',
+      'Checkout input cannot include both a target and an external repository id',
+    );
+  }
   throw new GiteaIntegrationProviderError(
     'repository-not-found',
     'Checkout input must include exactly one target or external repository id',
@@ -303,12 +309,6 @@ function normalizeCheckoutTarget(input: {
 
 function checkoutRepositoryId(target: CheckoutTarget): string {
   if (target.kind === 'external-id') return target.externalRepositoryId;
-  if (target.name === '.' || target.name === '..') {
-    throw new GiteaIntegrationProviderError(
-      'repository-not-found',
-      'Gitea checkout target contains an invalid repository name',
-    );
-  }
   return buildProviderRepositoryId(giteaProviderKind, `${target.owner}/${target.name}`);
 }
 
@@ -390,7 +390,7 @@ function parseGiteaRepositoryLocator(
   const separatorIndex = value.indexOf('/');
   const owner = separatorIndex > 0 ? value.slice(0, separatorIndex) : '';
   const repo = separatorIndex > 0 ? value.slice(separatorIndex + 1) : '';
-  if (!owner || !repo || repo.includes('/')) {
+  if (!owner || !repo || repo.includes('/') || repo === '.' || repo === '..') {
     throw new GiteaIntegrationProviderError(
       'repository-not-found',
       `Gitea repository id ${externalRepositoryId} must follow the form ${giteaProviderKind}:<owner>/<repo>`,

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -362,12 +362,24 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
     });
   });
 
-  it('maps repository ids and ignores malformed repository ids', async () => {
+  it('maps the repositories granted to the token', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {
         token: GITHUB_STATELESS_INSTALLATION_TOKEN,
         expires_at: '2026-06-10T12:00:00.000Z',
-        repositories: [{id: 42}, {id: 4.5}, {id: '43'}],
+        repositories: [
+          {
+            id: 42,
+            owner: {login: 'shipfox'},
+            name: 'platform',
+            full_name: 'shipfox/platform',
+            default_branch: 'main',
+            private: true,
+            visibility: 'private',
+            clone_url: 'https://github.com/shipfox/platform.git',
+            html_url: 'https://github.com/shipfox/platform',
+          },
+        ],
       },
     });
     const client = createGithubApiClient();
@@ -377,7 +389,42 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
       repositoryId: 42,
     });
 
+    expect(result.repositories).toEqual([
+      {
+        id: 42,
+        ownerLogin: 'shipfox',
+        name: 'platform',
+        fullName: 'shipfox/platform',
+        defaultBranch: 'main',
+        private: true,
+        visibility: 'private',
+        cloneUrl: 'https://github.com/shipfox/platform.git',
+        htmlUrl: 'https://github.com/shipfox/platform',
+      },
+    ]);
     expect(result.repositoryIds).toEqual([42]);
+  });
+
+  it('mints by repository name', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
+    });
+    const client = createGithubApiClient();
+
+    await client.createInstallationAccessToken({
+      installationId: 1,
+      repositoryName: 'platform',
+      permissions: {contents: 'write'},
+    });
+
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
+      installation_id: 1,
+      repositories: ['platform'],
+      permissions: {contents: 'write'},
+    });
   });
 
   it('passes through a stateful repository-scoped write token', async () => {

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -405,6 +405,33 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
     expect(result.repositoryIds).toEqual([42]);
   });
 
+  it('rejects malformed repository metadata in a token response', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+        repositories: [
+          {
+            id: 42,
+            owner: {login: 'shipfox'},
+            name: 'platform',
+            full_name: 'shipfox/platform',
+            default_branch: 'main',
+            private: true,
+            visibility: 42,
+            clone_url: 'https://github.com/shipfox/platform.git',
+            html_url: 'https://github.com/shipfox/platform',
+          },
+        ],
+      },
+    });
+    const client = createGithubApiClient();
+
+    await expect(
+      client.createInstallationAccessToken({installationId: 1, repositoryId: 42}),
+    ).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
   it('mints by repository name', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -113,18 +113,26 @@ export interface GithubApiClient extends Partial<GithubBotUserClient> {
     repositoryId: number;
     ref: string;
   }): Promise<GithubCommit[]>;
-  createInstallationAccessToken(input: {
-    installationId: number;
-    repositoryId: number;
-    permissions?: {contents: 'read' | 'write'} | undefined;
-  }): Promise<GithubInstallationAccessToken>;
+  createInstallationAccessToken(
+    input: GithubInstallationAccessTokenInput,
+  ): Promise<GithubInstallationAccessToken>;
 }
+
+export type GithubInstallationAccessTokenInput = {
+  installationId: number;
+  permissions?: {contents: 'read' | 'write'} | undefined;
+} & (
+  | {repositoryId: number; repositoryName?: never}
+  | {repositoryName: string; repositoryId?: never}
+);
 
 export interface GithubInstallationAccessToken {
   token: string;
   expiresAt: Date;
   permissions?: Record<string, 'read' | 'write' | 'admin'> | undefined;
-  /** GitHub returns this list for repository-scoped installation tokens. */
+  /** GitHub returns the repositories granted to a repository-scoped token. */
+  repositories?: GithubRepository[] | undefined;
+  /** Numeric repository ids retained for exact-scope checkout-cache validation. */
   repositoryIds?: number[] | undefined;
 }
 
@@ -449,15 +457,24 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     });
   }
 
-  async createInstallationAccessToken(input: {
-    installationId: number;
-    repositoryId: number;
-    permissions?: {contents: 'read' | 'write'} | undefined;
-  }): Promise<GithubInstallationAccessToken> {
+  async createInstallationAccessToken(
+    input: GithubInstallationAccessTokenInput,
+  ): Promise<GithubInstallationAccessToken> {
+    let repositorySelector: {repositories: string[]} | {repository_ids: number[]};
+    if (input.repositoryName !== undefined) {
+      repositorySelector = {repositories: [input.repositoryName]};
+    } else if (input.repositoryId !== undefined) {
+      repositorySelector = {repository_ids: [input.repositoryId]};
+    } else {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub installation access token request did not include a repository',
+      );
+    }
     const response = await mapGithubError(() =>
       this.getApp().octokit.rest.apps.createInstallationAccessToken({
         installation_id: input.installationId,
-        repository_ids: [input.repositoryId],
+        ...repositorySelector,
         permissions: input.permissions ?? {contents: 'read'},
       }),
     );
@@ -479,16 +496,16 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
       );
     }
 
-    const repositoryIds = Array.isArray(response.data.repositories)
-      ? response.data.repositories
-          .map((repository) => repository.id)
-          .filter((id): id is number => typeof id === 'number' && Number.isSafeInteger(id))
+    const repositories = Array.isArray(response.data.repositories)
+      ? response.data.repositories.map(toGithubRepository)
       : undefined;
+    const repositoryIds = repositories?.map(({id}) => id);
 
     return {
       token: response.data.token,
       expiresAt,
       ...(response.data.permissions === undefined ? {} : {permissions: response.data.permissions}),
+      ...(repositories === undefined ? {} : {repositories}),
       ...(repositoryIds === undefined ? {} : {repositoryIds}),
     };
   }
@@ -700,11 +717,22 @@ function toGithubRepository(repository: {
   full_name: string;
   default_branch?: string | null | undefined;
   private: boolean;
-  visibility?: string | undefined;
+  visibility?: string | null | undefined;
   clone_url?: string | null | undefined;
   html_url?: string | null | undefined;
 }): GithubRepository {
-  if (!repository.default_branch || !repository.clone_url || !repository.html_url) {
+  const ownerLogin = repository.owner?.login;
+  if (
+    !Number.isSafeInteger(repository.id) ||
+    repository.id <= 0 ||
+    !nonEmptyGithubField(ownerLogin) ||
+    !nonEmptyGithubField(repository.name) ||
+    !nonEmptyGithubField(repository.full_name) ||
+    typeof repository.private !== 'boolean' ||
+    !nonEmptyGithubField(repository.default_branch) ||
+    !nonEmptyGithubField(repository.clone_url) ||
+    !nonEmptyGithubField(repository.html_url)
+  ) {
     throw new GithubIntegrationProviderError(
       'malformed-provider-response',
       'GitHub repository response is missing required fields',
@@ -712,13 +740,17 @@ function toGithubRepository(repository: {
   }
   return {
     id: repository.id,
-    ownerLogin: repository.owner.login,
+    ownerLogin,
     name: repository.name,
     fullName: repository.full_name,
     defaultBranch: repository.default_branch,
     private: repository.private,
-    visibility: repository.visibility,
+    visibility: repository.visibility ?? undefined,
     cloneUrl: repository.clone_url,
     htmlUrl: repository.html_url,
   };
+}
+
+function nonEmptyGithubField(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -729,6 +729,9 @@ function toGithubRepository(repository: {
     !nonEmptyGithubField(repository.name) ||
     !nonEmptyGithubField(repository.full_name) ||
     typeof repository.private !== 'boolean' ||
+    (repository.visibility !== undefined &&
+      repository.visibility !== null &&
+      typeof repository.visibility !== 'string') ||
     !nonEmptyGithubField(repository.default_branch) ||
     !nonEmptyGithubField(repository.clone_url) ||
     !nonEmptyGithubField(repository.html_url)

--- a/libs/api/integration/github/src/api/github-checkout-token-cache.ts
+++ b/libs/api/integration/github/src/api/github-checkout-token-cache.ts
@@ -88,6 +88,11 @@ export interface GithubCheckoutTokenSecretStore {
   deleteNamespace?(params: {workspaceId: string; namespace: string}): Promise<number>;
 }
 
+/**
+ * Exact-scope cache for credential-only checkout delivery. Checkout specs need
+ * the repository metadata returned by the mint and therefore intentionally
+ * bypass this credentials-only interface.
+ */
 export interface GithubCheckoutTokenCachePort {
   getOrMint(
     scope: GithubCheckoutTokenScope,

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -1,10 +1,21 @@
-import type {GithubApiClient} from '#api/client.js';
+import type {GithubApiClient, GithubRepository} from '#api/client.js';
 import type {GithubCheckoutTokenCachePort} from '#api/github-checkout-token-cache.js';
 import {githubInstallationFactory} from '#test/index.js';
 import {GithubIntegrationProviderError} from './errors.js';
 import {GithubSourceControlProvider} from './source-control.js';
 
 const VALID_COMMIT = 'a'.repeat(40);
+const CHECKOUT_REPOSITORY: GithubRepository = {
+  id: 42,
+  ownerLogin: 'shipfox',
+  name: 'platform',
+  fullName: 'shipfox/platform',
+  defaultBranch: 'main',
+  private: true,
+  visibility: 'private',
+  cloneUrl: 'https://github.com/shipfox/platform.git',
+  htmlUrl: 'https://github.com/shipfox/platform',
+};
 
 function githubClient(overrides: Partial<GithubApiClient> = {}): GithubApiClient {
   return {
@@ -65,6 +76,7 @@ function githubClient(overrides: Partial<GithubApiClient> = {}): GithubApiClient
       Promise.resolve({
         token: 'ghs_installationtoken',
         expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+        repositories: [CHECKOUT_REPOSITORY],
       }),
     ),
     ...overrides,
@@ -475,10 +487,128 @@ describe('GithubSourceControlProvider', () => {
       repositoryId: 42,
       permissions: {contents: 'write'},
     });
+    expect(github.createInstallationAccessToken).toHaveBeenCalledTimes(1);
+    expect(github.getRepository).not.toHaveBeenCalled();
+    expect(github.listInstallationRepositories).not.toHaveBeenCalled();
     expect(github.getBotUser).toHaveBeenCalledWith({
       username: 'shipfox-test[bot]',
       installationAccessToken: 'ghs_installationtoken',
     });
+  });
+
+  it('creates a name-target checkout spec from the mint response without metadata lookups', async () => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'ghs_name_target_token',
+          expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+          repositories: [
+            {
+              ...CHECKOUT_REPOSITORY,
+              ownerLogin: 'ShipFox',
+              name: 'Platform',
+              fullName: 'ShipFox/Platform',
+              defaultBranch: 'trunk',
+              cloneUrl: 'https://github.com/ShipFox/Platform.git',
+              htmlUrl: 'https://github.com/ShipFox/Platform',
+            },
+          ],
+        }),
+      ),
+    });
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = await provider.createCheckoutSpec({
+      connection: connection(),
+      target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+      permissions: {contents: 'read'},
+    });
+
+    expect(result.repositoryUrl).toBe('https://github.com/ShipFox/Platform.git');
+    expect(result.ref).toBe('trunk');
+    expect(github.createInstallationAccessToken).toHaveBeenCalledWith({
+      installationId,
+      repositoryName: 'platform',
+      permissions: {contents: 'read'},
+    });
+    expect(github.getRepository).not.toHaveBeenCalled();
+    expect(github.listInstallationRepositories).not.toHaveBeenCalled();
+  });
+
+  it('uses a name target for credential-only delivery without metadata lookups', async () => {
+    await createInstallation();
+    const github = githubClient();
+    const provider = new GithubSourceControlProvider(github);
+
+    await expect(
+      provider.createCheckoutCredentials({
+        connection: connection(),
+        target: {kind: 'name', owner: 'SHIPFOX', name: 'PLATFORM'},
+        permissions: {contents: 'read'},
+      }),
+    ).resolves.toMatchObject({token: 'ghs_installationtoken'});
+
+    expect(github.createInstallationAccessToken).toHaveBeenCalledWith({
+      installationId,
+      repositoryName: 'PLATFORM',
+      permissions: {contents: 'read'},
+    });
+    expect(github.getRepository).not.toHaveBeenCalled();
+    expect(github.listInstallationRepositories).not.toHaveBeenCalled();
+  });
+
+  it('rejects a name target when the mint response has the same name under another owner', async () => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'ghs_mismatched_owner_token',
+          expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+          repositories: [{...CHECKOUT_REPOSITORY, ownerLogin: 'another-owner'}],
+        }),
+      ),
+    });
+    const provider = new GithubSourceControlProvider(github);
+
+    await expect(
+      provider.createCheckoutSpec({
+        connection: connection(),
+        target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+      }),
+    ).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: 'GitHub checkout token response does not match the requested repository',
+    });
+  });
+
+  it.each([
+    ['an empty response', []],
+    [
+      'a response with multiple repositories',
+      [CHECKOUT_REPOSITORY, {...CHECKOUT_REPOSITORY, id: 84}],
+    ],
+    ['an id response for another repository', [{...CHECKOUT_REPOSITORY, id: 84}]],
+  ])('rejects %s instead of returning its token', async (_label, repositories) => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'ghs_rejected_checkout_token',
+          expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+          repositories,
+        }),
+      ),
+    });
+    const provider = new GithubSourceControlProvider(github);
+
+    await expect(
+      provider.createCheckoutCredentials({
+        connection: connection(),
+        externalRepositoryId: 'github:42',
+        permissions: {contents: 'read'},
+      }),
+    ).rejects.toMatchObject({reason: 'provider-rejected'});
   });
 
   it('creates credential-only delivery without repository or bot metadata lookups', async () => {

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -20,6 +20,7 @@ import {
   type ListRepositoriesInput,
   MAX_REPOSITORY_FILE_BYTES,
   nonEmptyString,
+  normalizeCheckoutTarget as normalizeTarget,
   parseProviderRepositoryId,
   positiveInteger,
   type RepositoryPage,
@@ -256,6 +257,9 @@ export class GithubSourceControlProvider
   ): Promise<CheckoutSpec> {
     const installationId = await this.installationId(input.connection.id);
     const target = normalizeCheckoutTarget(input);
+    // Specs need canonical repository metadata from the mint response. The
+    // exact-scope cache returns credentials only, so credential-only requests
+    // are the cache-backed path.
     const permissions = input.permissions ?? {contents: 'read'};
     const minted = await this.mintCheckoutToken({installationId, target, permissions});
     const repository = checkoutRepositoryFromMint(target, minted);
@@ -372,19 +376,11 @@ function normalizeCheckoutTarget(input: {
   target?: CheckoutTarget | undefined;
   externalRepositoryId?: string | undefined;
 }): CheckoutTarget {
-  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
-    throw new GithubIntegrationProviderError(
-      'provider-rejected',
-      'Checkout input cannot include both a target and an external repository id',
-    );
-  }
-  if (input.target !== undefined) return input.target;
-  if (input.externalRepositoryId !== undefined) {
-    return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
-  }
+  const target = normalizeTarget(input);
+  if (target !== undefined) return target;
   throw new GithubIntegrationProviderError(
     'repository-not-found',
-    'Checkout input must include a target or an external repository id',
+    'Checkout input must include exactly one target or external repository id',
   );
 }
 

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -376,8 +376,14 @@ function normalizeCheckoutTarget(input: {
   target?: CheckoutTarget | undefined;
   externalRepositoryId?: string | undefined;
 }): CheckoutTarget {
-  const target = normalizeTarget(input);
-  if (target !== undefined) return target;
+  const result = normalizeTarget(input);
+  if (result.status === 'valid') return result.target;
+  if (result.status === 'ambiguous') {
+    throw new GithubIntegrationProviderError(
+      'provider-rejected',
+      'Checkout input cannot include both a target and an external repository id',
+    );
+  }
   throw new GithubIntegrationProviderError(
     'repository-not-found',
     'Checkout input must include exactly one target or external repository id',

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -5,6 +5,7 @@ import {
   buildProviderRepositoryId,
   type CheckoutCredentials,
   type CheckoutSpec,
+  type CheckoutTarget,
   type CreateCheckoutCredentialsInput,
   type CreateCheckoutSpecInput,
   type FetchFileInput,
@@ -30,11 +31,14 @@ import {
   type SourceControlProvider,
   type TriggerReference,
 } from '@shipfox/api-integration-spi';
-import type {GithubApiClient, GithubRepository} from '#api/client.js';
+import type {
+  GithubApiClient,
+  GithubInstallationAccessToken,
+  GithubRepository,
+} from '#api/client.js';
 import {
   GITHUB_CHECKOUT_TOKEN_REFRESH_MARGIN_MS,
   type GithubCheckoutTokenCachePort,
-  type GithubCheckoutTokenScope,
   githubProviderInstanceFingerprint,
 } from '#api/github-checkout-token-cache.js';
 import {config, normalizedGithubApiBaseUrl} from '#config.js';
@@ -251,14 +255,12 @@ export class GithubSourceControlProvider
     input: CreateCheckoutSpecInput<GithubIntegrationConnection>,
   ): Promise<CheckoutSpec> {
     const installationId = await this.installationId(input.connection.id);
-    const {repositoryId} = parseGithubRepositoryLocator(input.externalRepositoryId);
-    const repository = await this.github.getRepository({installationId, repositoryId});
+    const target = normalizeCheckoutTarget(input);
+    const permissions = input.permissions ?? {contents: 'read'};
+    const minted = await this.mintCheckoutToken({installationId, target, permissions});
+    const repository = checkoutRepositoryFromMint(target, minted);
     const ref = input.ref?.trim() || repository.defaultBranch;
-    const credentials = await this.createCheckoutCredentials({
-      connection: input.connection,
-      externalRepositoryId: input.externalRepositoryId,
-      permissions: input.permissions ?? {contents: 'read'},
-    });
+    const credentials = checkoutCredentialsFromMint(minted);
     const botLogin = this.appBotLogin();
     const gitAuthor =
       botLogin && input.permissions?.contents === 'write'
@@ -277,37 +279,32 @@ export class GithubSourceControlProvider
     input: CreateCheckoutCredentialsInput<GithubIntegrationConnection>,
   ): Promise<CheckoutCredentials> {
     const installationId = await this.installationId(input.connection.id);
-    const {repositoryId} = parseGithubRepositoryLocator(input.externalRepositoryId);
-    const scope: GithubCheckoutTokenScope = {
-      workspaceId: input.connection.workspaceId,
-      providerInstance: githubProviderInstanceFingerprint(
-        normalizedGithubApiBaseUrl(),
-        config.GITHUB_APP_ID,
-      ),
-      installationId,
-      repositoryId,
-      permissions: {...input.permissions},
-    };
-    const cached = this.checkoutTokenCache
-      ? await this.checkoutTokenCache.getOrMint(
-          scope,
-          () =>
-            this.github.createInstallationAccessToken({
+    const target = normalizeCheckoutTarget(input);
+    const mint = () =>
+      this.mintCheckoutToken({
+        installationId,
+        target,
+        permissions: input.permissions,
+      });
+    const cached =
+      target.kind === 'external-id' && this.checkoutTokenCache
+        ? await this.checkoutTokenCache.getOrMint(
+            {
+              workspaceId: input.connection.workspaceId,
+              providerInstance: githubProviderInstanceFingerprint(
+                normalizedGithubApiBaseUrl(),
+                config.GITHUB_APP_ID,
+              ),
               installationId,
-              repositoryId,
-              permissions: input.permissions,
-            }),
-          input.rejectedGeneration,
-        )
-      : await this.github
-          .createInstallationAccessToken({
-            installationId,
-            repositoryId,
-            permissions: input.permissions,
-          })
-          .then(({token, expiresAt}) => ({
-            token,
-            expiresAt,
+              repositoryId: parseGithubRepositoryLocator(target.externalRepositoryId).repositoryId,
+              permissions: {...input.permissions},
+            },
+            mint,
+            input.rejectedGeneration,
+          )
+        : await mint().then((minted) => ({
+            token: minted.token,
+            expiresAt: minted.expiresAt,
             generation: newGeneration(input.rejectedGeneration),
             stale: false,
           }));
@@ -325,6 +322,25 @@ export class GithubSourceControlProvider
       generation: cached.generation,
       renewal,
     };
+  }
+
+  private async mintCheckoutToken(params: {
+    installationId: number;
+    target: CheckoutTarget;
+    permissions: {contents: 'read' | 'write'};
+  }): Promise<GithubInstallationAccessToken> {
+    const minted = await this.github.createInstallationAccessToken({
+      installationId: params.installationId,
+      ...(params.target.kind === 'external-id'
+        ? {
+            repositoryId: parseGithubRepositoryLocator(params.target.externalRepositoryId)
+              .repositoryId,
+          }
+        : {repositoryName: params.target.name}),
+      permissions: params.permissions,
+    });
+    checkoutRepositoryFromMint(params.target, minted);
+    return minted;
   }
 
   private async installationId(connectionId: string): Promise<number> {
@@ -350,6 +366,74 @@ function newGeneration(rejectedGeneration: string | undefined): string {
   let generation = randomUUID();
   while (generation === rejectedGeneration) generation = randomUUID();
   return generation;
+}
+
+function normalizeCheckoutTarget(input: {
+  target?: CheckoutTarget | undefined;
+  externalRepositoryId?: string | undefined;
+}): CheckoutTarget {
+  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
+    throw new GithubIntegrationProviderError(
+      'provider-rejected',
+      'Checkout input cannot include both a target and an external repository id',
+    );
+  }
+  if (input.target !== undefined) return input.target;
+  if (input.externalRepositoryId !== undefined) {
+    return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
+  }
+  throw new GithubIntegrationProviderError(
+    'repository-not-found',
+    'Checkout input must include a target or an external repository id',
+  );
+}
+
+function checkoutCredentialsFromMint(
+  minted: GithubInstallationAccessToken,
+): NonNullable<CheckoutSpec['credentials']> {
+  const generation = newGeneration(undefined);
+  return {
+    username: 'x-access-token',
+    token: minted.token,
+    expiresAt: minted.expiresAt,
+    generation,
+    renewal: {
+      mode: 'refresh-at',
+      refreshAt: new Date(minted.expiresAt.getTime() - GITHUB_CHECKOUT_TOKEN_REFRESH_MARGIN_MS),
+    },
+  };
+}
+
+function checkoutRepositoryFromMint(
+  target: CheckoutTarget,
+  minted: GithubInstallationAccessToken,
+): GithubRepository {
+  if (minted.repositories === undefined || minted.repositories.length !== 1) {
+    throw new GithubIntegrationProviderError(
+      'provider-rejected',
+      'GitHub checkout token response must contain exactly one repository',
+    );
+  }
+  const repository = minted.repositories[0];
+  if (repository === undefined) {
+    throw new GithubIntegrationProviderError(
+      'provider-rejected',
+      'GitHub checkout token response must contain exactly one repository',
+    );
+  }
+
+  const matches =
+    target.kind === 'external-id'
+      ? repository.id === parseGithubRepositoryLocator(target.externalRepositoryId).repositoryId
+      : repository.ownerLogin.toLowerCase() === target.owner.toLowerCase() &&
+        repository.name.toLowerCase() === target.name.toLowerCase();
+  if (!matches) {
+    throw new GithubIntegrationProviderError(
+      'provider-rejected',
+      'GitHub checkout token response does not match the requested repository',
+    );
+  }
+  return repository;
 }
 
 function githubRepositoryId(repository: Record<string, unknown> | null): string | null {

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -99,7 +99,7 @@ export interface CreateGithubIntegrationProviderOptions
     | ((params: {workspaceId: string; namespace: string}) => Promise<number>)
     | undefined;
   agentTools?: {tokenProvider: GithubInstallationTokenProvider} | undefined;
-  /** Optional exact-scope cache seam; omitted until checkout-cache activation. */
+  /** Optional exact-scope cache for credential-only checkout delivery. */
   checkoutTokenCache?: GithubCheckoutTokenCachePort | undefined;
 }
 

--- a/libs/api/integration/spi/src/contracts.test.ts
+++ b/libs/api/integration/spi/src/contracts.test.ts
@@ -101,24 +101,30 @@ describe('provider repository identifiers', () => {
 describe('checkout targets', () => {
   it('normalizes the legacy external id form', () => {
     expect(normalizeCheckoutTarget({externalRepositoryId: 'github:42'})).toEqual({
-      kind: 'external-id',
-      externalRepositoryId: 'github:42',
+      status: 'valid',
+      target: {
+        kind: 'external-id',
+        externalRepositoryId: 'github:42',
+      },
     });
   });
 
   it('preserves an explicit target', () => {
     expect(
       normalizeCheckoutTarget({target: {kind: 'name', owner: 'shipfox', name: 'platform'}}),
-    ).toEqual({kind: 'name', owner: 'shipfox', name: 'platform'});
+    ).toEqual({
+      status: 'valid',
+      target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+    });
   });
 
-  it.each([
-    {},
-    {
-      target: {kind: 'name' as const, owner: 'shipfox', name: 'platform'},
-      externalRepositoryId: 'github:42',
-    },
-  ])('rejects an invalid target shape', (input) => {
-    expect(normalizeCheckoutTarget(input)).toBeUndefined();
+  it('classifies missing and ambiguous target shapes separately', () => {
+    expect(normalizeCheckoutTarget({})).toEqual({status: 'missing'});
+    expect(
+      normalizeCheckoutTarget({
+        target: {kind: 'name', owner: 'shipfox', name: 'platform'},
+        externalRepositoryId: 'github:42',
+      }),
+    ).toEqual({status: 'ambiguous'});
   });
 });

--- a/libs/api/integration/spi/src/contracts.test.ts
+++ b/libs/api/integration/spi/src/contracts.test.ts
@@ -5,6 +5,7 @@ import {
   isValidGitRefName,
   isValidResolvableRef,
   isValidTriggerRef,
+  normalizeCheckoutTarget,
   parseProviderRepositoryId,
 } from './contracts.js';
 
@@ -94,5 +95,30 @@ describe('provider repository identifiers', () => {
     const parse = () => parseProviderRepositoryId(value, 'github');
 
     expect(parse).toThrow(IntegrationProviderError);
+  });
+});
+
+describe('checkout targets', () => {
+  it('normalizes the legacy external id form', () => {
+    expect(normalizeCheckoutTarget({externalRepositoryId: 'github:42'})).toEqual({
+      kind: 'external-id',
+      externalRepositoryId: 'github:42',
+    });
+  });
+
+  it('preserves an explicit target', () => {
+    expect(
+      normalizeCheckoutTarget({target: {kind: 'name', owner: 'shipfox', name: 'platform'}}),
+    ).toEqual({kind: 'name', owner: 'shipfox', name: 'platform'});
+  });
+
+  it.each([
+    {},
+    {
+      target: {kind: 'name' as const, owner: 'shipfox', name: 'platform'},
+      externalRepositoryId: 'github:42',
+    },
+  ])('rejects an invalid target shape', (input) => {
+    expect(normalizeCheckoutTarget(input)).toBeUndefined();
   });
 });

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -129,11 +129,21 @@ export type CheckoutTarget =
 
 /**
  * Checkout callers may use the legacy external repository id field while
- * integrations migrate to the explicit target contract.
+ * integrations migrate to the explicit target contract. Name targets must be
+ * authorized by the owning project/workflow boundary before reaching the SPI.
  */
 export interface CheckoutTargetInput {
   target?: CheckoutTarget | undefined;
   externalRepositoryId?: string | undefined;
+}
+
+/** Returns a canonical target only when exactly one checkout target form is supplied. */
+export function normalizeCheckoutTarget(input: CheckoutTargetInput): CheckoutTarget | undefined {
+  if (input.target !== undefined) {
+    return input.externalRepositoryId === undefined ? input.target : undefined;
+  }
+  if (input.externalRepositoryId === undefined) return undefined;
+  return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
 }
 
 export type CreateCheckoutSpecInput<

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -137,13 +137,26 @@ export interface CheckoutTargetInput {
   externalRepositoryId?: string | undefined;
 }
 
-/** Returns a canonical target only when exactly one checkout target form is supplied. */
-export function normalizeCheckoutTarget(input: CheckoutTargetInput): CheckoutTarget | undefined {
-  if (input.target !== undefined) {
-    return input.externalRepositoryId === undefined ? input.target : undefined;
+export type CheckoutTargetNormalizationResult =
+  | {status: 'valid'; target: CheckoutTarget}
+  | {status: 'missing'}
+  | {status: 'ambiguous'};
+
+/** Classifies checkout input so callers can preserve missing versus ambiguous errors. */
+export function normalizeCheckoutTarget(
+  input: CheckoutTargetInput,
+): CheckoutTargetNormalizationResult {
+  if (input.target !== undefined && input.externalRepositoryId !== undefined) {
+    return {status: 'ambiguous'};
   }
-  if (input.externalRepositoryId === undefined) return undefined;
-  return {kind: 'external-id', externalRepositoryId: input.externalRepositoryId};
+  if (input.target !== undefined) return {status: 'valid', target: input.target};
+  if (input.externalRepositoryId !== undefined) {
+    return {
+      status: 'valid',
+      target: {kind: 'external-id', externalRepositoryId: input.externalRepositoryId},
+    };
+  }
+  return {status: 'missing'};
 }
 
 export type CreateCheckoutSpecInput<

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -123,20 +123,37 @@ export interface CheckoutSpec {
   gitAuthor?: CheckoutGitAuthor | undefined;
 }
 
-export interface CreateCheckoutSpecInput<
-  Connection extends IntegrationConnection = IntegrationConnection,
-> extends ResolveRepositoryInput<Connection> {
-  ref?: string | undefined;
-  permissions?: CheckoutPermissions | undefined;
+export type CheckoutTarget =
+  | {kind: 'external-id'; externalRepositoryId: string}
+  | {kind: 'name'; owner: string; name: string};
+
+/**
+ * Checkout callers may use the legacy external repository id field while
+ * integrations migrate to the explicit target contract.
+ */
+export interface CheckoutTargetInput {
+  target?: CheckoutTarget | undefined;
+  externalRepositoryId?: string | undefined;
 }
 
-/** Requests credentials without asking the provider to resolve repository metadata. */
-export interface CreateCheckoutCredentialsInput<
+export type CreateCheckoutSpecInput<
   Connection extends IntegrationConnection = IntegrationConnection,
-> extends ResolveRepositoryInput<Connection> {
+> = {
+  connection: Connection;
+  projectId?: string | undefined;
+  ref?: string | undefined;
+  permissions?: CheckoutPermissions | undefined;
+} & CheckoutTargetInput;
+
+/** Requests credentials without asking the provider to resolve repository metadata. */
+export type CreateCheckoutCredentialsInput<
+  Connection extends IntegrationConnection = IntegrationConnection,
+> = {
+  connection: Connection;
+  projectId?: string | undefined;
   permissions: CheckoutPermissions;
   rejectedGeneration?: string | undefined;
-}
+} & CheckoutTargetInput;
 
 export interface TriggerReference {
   externalRepositoryId: string;


### PR DESCRIPTION
Adds repository checkout targets addressed by stable external IDs or owner/name declarations. The integration boundary preserves existing external-ID callers while giving GitHub a single contents-scoped mint whose canonical repository metadata is validated before credentials are returned. Workflow and Projects target normalization remains in ENG-1819.

Local validation passed: focused dependency-closure check, type, and test tasks, plus git diff --check.

Closes ENG-1818

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds checkout targets addressed by stable external IDs or owner/name declarations. GitHub mints one contents-scoped installation token per checkout and rejects it unless the response contains exactly one repository matching the requested target.

- Existing external-ID callers keep working unchanged; `target` and `externalRepositoryId` are mutually exclusive.
- Name targets mint with the repository name and match case-insensitively against the mint response.
- Targets are trimmed; empty and dot-segment names are rejected before any provider call, including dot-segment repo names in legacy Gitea external IDs.
- Missing targets fail as `repository-not-found` while ambiguous inputs fail as `provider-rejected`.
- `projectId` is now forwarded to checkout providers when supplied.
- Workflow and Projects target normalization remains in ENG-1819.

Closes ENG-1818.

<sup>Written for commit 3d392ee187f86229cdd2731fb2ff492d79245eda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

