### PR TITLE
Expose catalog and trigger-event read contracts

### DIFF
--- a/.changeset/catalog-trigger-contracts.md
+++ b/.changeset/catalog-trigger-contracts.md
@@ -7,4 +7,4 @@
 "@shipfox/api-triggers-dto": minor
 ---
 
-Exposes producer-owned catalog and trigger-event read contracts for agent access.
+Adds project catalog and workflow-definition reads, plus trigger-event summaries, details, and facets.

--- a/.changeset/catalog-trigger-contracts.md
+++ b/.changeset/catalog-trigger-contracts.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-projects": minor
+"@shipfox/api-projects-dto": minor
+"@shipfox/api-definitions": minor
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-triggers": minor
+"@shipfox/api-triggers-dto": minor
+---
+
+Exposes producer-owned catalog and trigger-event read contracts for agent access.

--- a/libs/api/definitions-dto/src/inter-module.ts
+++ b/libs/api/definitions-dto/src/inter-module.ts
@@ -7,6 +7,55 @@ import {workflowModelSnapshotSchema} from './workflow-model.js';
 const idSchema = z.string().uuid();
 const refSchema = z.string().min(1);
 const configPathSchema = z.string().min(1);
+const definitionListCursorSchema = z.object({value: z.string(), id: idSchema});
+const definitionSyncDiagnosticSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  path: z.string().optional(),
+  filePath: z.string().optional(),
+  severity: z.enum(['error', 'warning']),
+});
+const definitionSyncSummarySchema = z.object({
+  ref: z.string().nullable(),
+  status: z.enum(['pending', 'syncing', 'succeeded', 'failed']),
+  lastSyncAt: z.string().datetime(),
+  startedAt: z.string().datetime().nullable(),
+  finishedAt: z.string().datetime().nullable(),
+  lastErrorCode: z
+    .enum([
+      'no-workflow-files',
+      'invalid-definition',
+      'provider-repository-not-found',
+      'provider-file-not-found',
+      'provider-access-denied',
+      'provider-rate-limited',
+      'provider-timeout',
+      'provider-unavailable',
+      'provider-malformed-response',
+      'content-too-large',
+      'too-many-files',
+      'connection-unavailable',
+      'unknown',
+    ])
+    .nullable(),
+  lastErrorMessage: z.string().nullable(),
+  diagnostics: z.array(definitionSyncDiagnosticSchema),
+});
+const definitionListItemSchema = z.object({
+  id: idSchema,
+  projectId: idSchema,
+  configPath: z.string().nullable(),
+  source: z.enum(['manual', 'vcs']),
+  sha: z.string().nullable(),
+  ref: z.string().nullable(),
+  name: z.string(),
+  workflowDocument: z.unknown(),
+  workflowModel: z.unknown(),
+  manualTrigger: z.object({name: z.string()}).nullable(),
+  fetchedAt: z.string().datetime(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
 const definitionSnapshotSchema = z.object({
   id: idSchema,
   workflowId: idSchema,
@@ -56,6 +105,23 @@ export const definitionsInterModuleContract = defineInterModuleContract({
       input: z.object({definitionId: idSchema}),
       output: z.object({definition: definitionSnapshotSchema.nullable()}),
     },
+    listDefinitionsByProject: {
+      input: z.object({
+        workspaceId: idSchema,
+        projectId: idSchema,
+        limit: z.number().int().min(1).max(100),
+        cursor: definitionListCursorSchema.optional(),
+      }),
+      output: z.object({
+        definitions: z.array(definitionListItemSchema),
+        sync: definitionSyncSummarySchema.nullable(),
+        nextCursor: definitionListCursorSchema.nullable(),
+      }),
+      errors: {
+        'project-not-found': z.object({projectId: idSchema}),
+        'project-workspace-mismatch': z.object({projectId: idSchema, workspaceId: idSchema}),
+      },
+    },
     resolveDefinitionAtRef: {
       input: z.object({
         projectId: idSchema,
@@ -79,3 +145,5 @@ export const definitionsInterModuleContract = defineInterModuleContract({
 
 export type DefinitionsInterModuleClient = InterModuleClient<typeof definitionsInterModuleContract>;
 export type DefinitionWorkflowSnapshot = z.infer<typeof definitionSnapshotSchema>;
+export type DefinitionListItem = z.infer<typeof definitionListItemSchema>;
+export type DefinitionSyncSummary = z.infer<typeof definitionSyncSummarySchema>;

--- a/libs/api/definitions/src/presentation/dto/definition.ts
+++ b/libs/api/definitions/src/presentation/dto/definition.ts
@@ -3,41 +3,84 @@ import type {DefinitionSyncState} from '#core/entities/sync-state.js';
 import type {WorkflowDefinition} from '#core/entities/workflow-definition.js';
 import {UNRESOLVED_SYNC_REF} from '#core/sync-definitions.js';
 
-export function toDefinitionDto(definition: WorkflowDefinition): DefinitionDto {
+/**
+ * Maps a definition to the JSON-safe camelCase shape shared by HTTP and
+ * inter-module presentations.
+ */
+export function toDefinitionReadModel(definition: WorkflowDefinition) {
   // The model excludes inert triggers, so an inert manual trigger yields no Run
   // button instead of a fire-route 404. The document keeps the authored entry.
   const manualTrigger = definition.model.triggers.find((trigger) => trigger.source === 'manual');
   return {
     id: definition.id,
-    project_id: definition.projectId,
-    config_path: definition.configPath,
+    projectId: definition.projectId,
+    configPath: definition.configPath,
     source: definition.source,
     sha: definition.sha,
     ref: definition.ref,
     name: definition.name,
-    workflow_document: definition.document,
-    workflow_model: definition.model,
-    manual_trigger: manualTrigger ? {name: manualTrigger.key} : null,
-    fetched_at: definition.fetchedAt.toISOString(),
-    created_at: definition.createdAt.toISOString(),
-    updated_at: definition.updatedAt.toISOString(),
+    workflowDocument: definition.document,
+    workflowModel: definition.model,
+    manualTrigger: manualTrigger ? {name: manualTrigger.key} : null,
+    fetchedAt: definition.fetchedAt.toISOString(),
+    createdAt: definition.createdAt.toISOString(),
+    updatedAt: definition.updatedAt.toISOString(),
+  };
+}
+
+/** Maps a sync state to the JSON-safe camelCase shape shared by presentations. */
+export function toDefinitionSyncSummary(syncState: DefinitionSyncState | undefined) {
+  if (!syncState) return null;
+
+  return {
+    ref: syncState.ref === UNRESOLVED_SYNC_REF ? null : syncState.ref,
+    status: syncState.status,
+    lastSyncAt: (syncState.finishedAt ?? syncState.updatedAt).toISOString(),
+    startedAt: syncState.startedAt?.toISOString() ?? null,
+    finishedAt: syncState.finishedAt?.toISOString() ?? null,
+    lastErrorCode: syncState.lastErrorCode,
+    lastErrorMessage: syncState.lastErrorMessage,
+    diagnostics: syncState.diagnostics.map(({filePath, ...diagnostic}) => ({
+      ...diagnostic,
+      ...(filePath === undefined ? {} : {filePath}),
+    })),
+  };
+}
+
+export function toDefinitionDto(definition: WorkflowDefinition): DefinitionDto {
+  const readModel = toDefinitionReadModel(definition);
+  return {
+    id: readModel.id,
+    project_id: readModel.projectId,
+    config_path: readModel.configPath,
+    source: readModel.source,
+    sha: readModel.sha,
+    ref: readModel.ref,
+    name: readModel.name,
+    workflow_document: readModel.workflowDocument,
+    workflow_model: readModel.workflowModel,
+    manual_trigger: readModel.manualTrigger,
+    fetched_at: readModel.fetchedAt,
+    created_at: readModel.createdAt,
+    updated_at: readModel.updatedAt,
   };
 }
 
 export function toDefinitionSyncSummaryDto(
   syncState: DefinitionSyncState | undefined,
 ): DefinitionSyncSummaryDto | null {
-  if (!syncState) return null;
+  const readModel = toDefinitionSyncSummary(syncState);
+  if (!readModel) return null;
 
   return {
-    ref: syncState.ref === UNRESOLVED_SYNC_REF ? null : syncState.ref,
-    status: syncState.status,
-    last_sync_at: (syncState.finishedAt ?? syncState.updatedAt).toISOString(),
-    started_at: syncState.startedAt?.toISOString() ?? null,
-    finished_at: syncState.finishedAt?.toISOString() ?? null,
-    last_error_code: syncState.lastErrorCode,
-    last_error_message: syncState.lastErrorMessage,
-    diagnostics: syncState.diagnostics.map(({filePath, ...diagnostic}) => ({
+    ref: readModel.ref,
+    status: readModel.status,
+    last_sync_at: readModel.lastSyncAt,
+    started_at: readModel.startedAt,
+    finished_at: readModel.finishedAt,
+    last_error_code: readModel.lastErrorCode,
+    last_error_message: readModel.lastErrorMessage,
+    diagnostics: readModel.diagnostics.map(({filePath, ...diagnostic}) => ({
       ...diagnostic,
       ...(filePath === undefined ? {} : {file_path: filePath}),
     })),

--- a/libs/api/definitions/src/presentation/dto/index.ts
+++ b/libs/api/definitions/src/presentation/dto/index.ts
@@ -1,2 +1,7 @@
 export {toDefinitionAtRefFileDto} from './at-ref.js';
-export {toDefinitionDto, toDefinitionSyncSummaryDto} from './definition.js';
+export {
+  toDefinitionDto,
+  toDefinitionReadModel,
+  toDefinitionSyncSummary,
+  toDefinitionSyncSummaryDto,
+} from './definition.js';

--- a/libs/api/definitions/src/presentation/inter-module.test.ts
+++ b/libs/api/definitions/src/presentation/inter-module.test.ts
@@ -2,6 +2,7 @@ import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {createInterModuleKnownError, isInterModuleKnownError} from '@shipfox/inter-module';
 import {DefinitionAtRefError} from '#core/errors.js';
+import {UNRESOLVED_SYNC_REF} from '#core/sync-definitions.js';
 import {createDefinitionsInterModulePresentation} from './inter-module.js';
 
 const mocks = vi.hoisted(() => ({
@@ -175,13 +176,127 @@ describe('definitions inter-module presentation', () => {
     });
   });
 
-  it('denies a project from another workspace before reading definitions', async () => {
+  it('maps pending sync states and definition trigger edge cases', async () => {
+    const workspaceId = '00000000-0000-4000-8000-000000000010';
+    const sourceConnectionId = '00000000-0000-4000-8000-000000000011';
+    const project = {
+      id: PROJECT_ID,
+      workspaceId,
+      sourceConnectionId,
+      sourceExternalRepositoryId: 'github:shipfox/project',
+    };
+    const firstDefinition = {
+      id: '00000000-0000-4000-8000-000000000012',
+      projectId: PROJECT_ID,
+      configPath: '.shipfox/workflows/cron.yml',
+      source: 'vcs' as const,
+      sha: 'a1b2c3',
+      ref: 'main',
+      name: 'Cron',
+      document: {name: 'Cron'},
+      model: {triggers: [{source: 'cron', key: 'nightly'}]},
+      fetchedAt: new Date('2026-08-05T12:00:00.000Z'),
+      createdAt: new Date('2026-08-05T12:01:00.000Z'),
+      updatedAt: new Date('2026-08-05T12:02:00.000Z'),
+    };
+    const secondDefinition = {
+      ...firstDefinition,
+      id: '00000000-0000-4000-8000-000000000013',
+      configPath: '.shipfox/workflows/manual.yml',
+      name: 'Manual',
+      model: {
+        triggers: [
+          {source: 'manual', key: 'first'},
+          {source: 'manual', key: 'second'},
+        ],
+      },
+    };
+    const updatedAt = new Date('2026-08-05T12:03:00.000Z');
+    const syncState = {
+      id: '00000000-0000-4000-8000-000000000014',
+      projectId: PROJECT_ID,
+      sourceConnectionId,
+      sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+      ref: UNRESOLVED_SYNC_REF,
+      status: 'pending' as const,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      diagnostics: [
+        {code: 'pending', message: 'Waiting for sync', path: 'jobs', severity: 'warning' as const},
+      ],
+      startedAt: null,
+      finishedAt: null,
+      createdAt: updatedAt,
+      updatedAt,
+    };
+    mocks.requireProjectForWorkspace.mockResolvedValue({project});
+    mocks.listDefinitions.mockResolvedValue({
+      definitions: [firstDefinition, secondDefinition],
+      nextCursor: null,
+    });
+    mocks.getLatestDefinitionSyncState.mockResolvedValue(syncState);
+
+    const result = await presentation().handlers.listDefinitionsByProject(
+      {workspaceId, projectId: PROJECT_ID, limit: 10},
+      {signal: new AbortController().signal},
+    );
+    const parsed =
+      definitionsInterModuleContract.methods.listDefinitionsByProject.output.parse(result);
+
+    expect(parsed.definitions.map(({manualTrigger}) => manualTrigger)).toEqual([
+      null,
+      {name: 'first'},
+    ]);
+    expect(parsed.sync).toEqual({
+      ref: null,
+      status: 'pending',
+      lastSyncAt: updatedAt.toISOString(),
+      startedAt: null,
+      finishedAt: null,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      diagnostics: [
+        {code: 'pending', message: 'Waiting for sync', path: 'jobs', severity: 'warning'},
+      ],
+    });
+  });
+
+  it('returns a null sync summary when no sync state exists', async () => {
+    const workspaceId = '00000000-0000-0000-0000-000000000010';
+    const project = {
+      id: PROJECT_ID,
+      workspaceId,
+      sourceConnectionId: '00000000-0000-0000-0000-000000000011',
+      sourceExternalRepositoryId: 'github:shipfox/project',
+    };
+    mocks.requireProjectForWorkspace.mockResolvedValue({project});
+    mocks.listDefinitions.mockResolvedValue({definitions: [], nextCursor: null});
+    mocks.getLatestDefinitionSyncState.mockResolvedValue(undefined);
+
+    const result = await presentation().handlers.listDefinitionsByProject(
+      {workspaceId, projectId: PROJECT_ID, limit: 10},
+      {signal: new AbortController().signal},
+    );
+
+    expect(
+      definitionsInterModuleContract.methods.listDefinitionsByProject.output.parse(result),
+    ).toEqual({definitions: [], sync: null, nextCursor: null});
+  });
+
+  it.each([
+    ['project-not-found', {projectId: PROJECT_ID}, {projectId: PROJECT_ID}],
+    [
+      'project-workspace-mismatch',
+      {projectId: PROJECT_ID, workspaceId: '00000000-0000-4000-8000-000000000010'},
+      {projectId: PROJECT_ID, workspaceId: '00000000-0000-4000-8000-000000000010'},
+    ],
+  ] as const)('maps %s before reading definitions', async (code, errorDetails, expectedDetails) => {
     const workspaceId = '00000000-0000-4000-8000-000000000010';
     mocks.requireProjectForWorkspace.mockRejectedValue(
       createInterModuleKnownError(
         projectsInterModuleContract.methods.requireProjectForWorkspace,
-        'project-workspace-mismatch',
-        {projectId: PROJECT_ID, workspaceId},
+        code,
+        errorDetails,
       ),
     );
 
@@ -194,7 +309,28 @@ describe('definitions inter-module presentation', () => {
 
     const method = definitionsInterModuleContract.methods.listDefinitionsByProject;
     expect(isInterModuleKnownError(method, error)).toBe(true);
-    expect((error as {code: string}).code).toBe('project-workspace-mismatch');
+    expect((error as {code: string}).code).toBe(code);
+    expect((error as {details: unknown}).details).toEqual(expectedDetails);
+    expect(mocks.listDefinitions).not.toHaveBeenCalled();
+    expect(mocks.getLatestDefinitionSyncState).not.toHaveBeenCalled();
+  });
+
+  it('re-throws unknown project access failures without reading definitions', async () => {
+    const boom = new Error('unexpected project access failure');
+    mocks.requireProjectForWorkspace.mockRejectedValue(boom);
+
+    const error = await rejection(
+      presentation().handlers.listDefinitionsByProject(
+        {
+          workspaceId: '00000000-0000-4000-8000-000000000010',
+          projectId: PROJECT_ID,
+          limit: 10,
+        },
+        {signal: new AbortController().signal},
+      ),
+    );
+
+    expect(error).toBe(boom);
     expect(mocks.listDefinitions).not.toHaveBeenCalled();
     expect(mocks.getLatestDefinitionSyncState).not.toHaveBeenCalled();
   });

--- a/libs/api/definitions/src/presentation/inter-module.test.ts
+++ b/libs/api/definitions/src/presentation/inter-module.test.ts
@@ -1,16 +1,25 @@
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
-import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
+import {createInterModuleKnownError, isInterModuleKnownError} from '@shipfox/inter-module';
 import {DefinitionAtRefError} from '#core/errors.js';
 import {createDefinitionsInterModulePresentation} from './inter-module.js';
 
 const mocks = vi.hoisted(() => ({
   getDefinitionById: vi.fn(),
+  getLatestDefinitionSyncState: vi.fn(),
+  listDefinitions: vi.fn(),
   listDefinitionsAtRef: vi.fn(),
+  requireProjectForWorkspace: vi.fn(),
   resolveDefinitionAtRef: vi.fn(),
 }));
 
 vi.mock('#db/definitions.js', () => ({
   getDefinitionById: mocks.getDefinitionById,
+  listDefinitions: mocks.listDefinitions,
+}));
+
+vi.mock('#db/sync-states.js', () => ({
+  getLatestDefinitionSyncState: mocks.getLatestDefinitionSyncState,
 }));
 
 vi.mock('#core/index.js', async (importOriginal) => {
@@ -29,7 +38,7 @@ const COMMIT = 'a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0';
 
 function presentation() {
   return createDefinitionsInterModulePresentation({
-    projects: {} as never,
+    projects: {requireProjectForWorkspace: mocks.requireProjectForWorkspace} as never,
     agent: {} as never,
     integrations: {} as never,
   });
@@ -44,6 +53,150 @@ describe('definitions inter-module presentation', () => {
     mocks.resolveDefinitionAtRef.mockReset();
     mocks.listDefinitionsAtRef.mockReset();
     mocks.getDefinitionById.mockReset();
+    mocks.getLatestDefinitionSyncState.mockReset();
+    mocks.listDefinitions.mockReset();
+    mocks.requireProjectForWorkspace.mockReset();
+  });
+
+  it('lists project definitions with the route shape and sync summary', async () => {
+    const workspaceId = '00000000-0000-4000-8000-000000000010';
+    const sourceConnectionId = '00000000-0000-4000-8000-000000000011';
+    const project = {
+      id: PROJECT_ID,
+      workspaceId,
+      sourceConnectionId,
+      sourceExternalRepositoryId: 'github:shipfox/project',
+    };
+    const definition = {
+      id: '00000000-0000-4000-8000-000000000012',
+      workflowId: '00000000-0000-4000-8000-000000000013',
+      projectId: PROJECT_ID,
+      configPath: '.shipfox/workflows/ci.yml',
+      source: 'vcs' as const,
+      sha: 'a1b2c3',
+      ref: 'main',
+      name: 'CI',
+      definition: {name: 'CI'},
+      document: {name: 'CI'},
+      model: {triggers: [{source: 'manual', key: 'run_now'}]},
+      sourceSnapshot: null,
+      contentHash: null,
+      fetchedAt: new Date('2026-08-05T12:00:00.000Z'),
+      createdAt: new Date('2026-08-05T12:01:00.000Z'),
+      updatedAt: new Date('2026-08-05T12:02:00.000Z'),
+      deletedAt: null,
+    };
+    const syncState = {
+      id: '00000000-0000-4000-8000-000000000014',
+      projectId: PROJECT_ID,
+      sourceConnectionId,
+      sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+      ref: 'main',
+      status: 'succeeded' as const,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      diagnostics: [
+        {
+          code: 'warning-code',
+          message: 'Warning',
+          path: 'jobs.build',
+          filePath: '.shipfox/workflows/ci.yml',
+          severity: 'warning' as const,
+        },
+      ],
+      startedAt: new Date('2026-08-05T11:59:00.000Z'),
+      finishedAt: new Date('2026-08-05T12:03:00.000Z'),
+      createdAt: new Date('2026-08-05T11:59:00.000Z'),
+      updatedAt: new Date('2026-08-05T12:03:00.000Z'),
+    };
+    const cursor = {value: 'AB', id: '00000000-0000-4000-8000-000000000015'};
+    mocks.requireProjectForWorkspace.mockResolvedValue({project});
+    mocks.listDefinitions.mockResolvedValue({definitions: [definition], nextCursor: cursor});
+    mocks.getLatestDefinitionSyncState.mockResolvedValue(syncState);
+
+    const result = await presentation().handlers.listDefinitionsByProject(
+      {workspaceId, projectId: PROJECT_ID, limit: 1, cursor},
+      {signal: new AbortController().signal},
+    );
+
+    expect(mocks.requireProjectForWorkspace).toHaveBeenCalledWith({
+      workspaceId,
+      projectId: PROJECT_ID,
+    });
+    expect(mocks.listDefinitions).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      limit: 1,
+      cursor,
+    });
+    expect(mocks.getLatestDefinitionSyncState).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      sourceConnectionId,
+      sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+    });
+    expect(
+      definitionsInterModuleContract.methods.listDefinitionsByProject.output.parse(result),
+    ).toEqual({
+      definitions: [
+        {
+          id: definition.id,
+          projectId: definition.projectId,
+          configPath: definition.configPath,
+          source: definition.source,
+          sha: definition.sha,
+          ref: definition.ref,
+          name: definition.name,
+          workflowDocument: definition.document,
+          workflowModel: definition.model,
+          manualTrigger: {name: 'run_now'},
+          fetchedAt: definition.fetchedAt.toISOString(),
+          createdAt: definition.createdAt.toISOString(),
+          updatedAt: definition.updatedAt.toISOString(),
+        },
+      ],
+      sync: {
+        ref: 'main',
+        status: 'succeeded',
+        lastSyncAt: syncState.finishedAt.toISOString(),
+        startedAt: syncState.startedAt.toISOString(),
+        finishedAt: syncState.finishedAt.toISOString(),
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        diagnostics: [
+          {
+            code: 'warning-code',
+            message: 'Warning',
+            path: 'jobs.build',
+            filePath: '.shipfox/workflows/ci.yml',
+            severity: 'warning',
+          },
+        ],
+      },
+      nextCursor: cursor,
+    });
+  });
+
+  it('denies a project from another workspace before reading definitions', async () => {
+    const workspaceId = '00000000-0000-4000-8000-000000000010';
+    mocks.requireProjectForWorkspace.mockRejectedValue(
+      createInterModuleKnownError(
+        projectsInterModuleContract.methods.requireProjectForWorkspace,
+        'project-workspace-mismatch',
+        {projectId: PROJECT_ID, workspaceId},
+      ),
+    );
+
+    const error = await rejection(
+      presentation().handlers.listDefinitionsByProject(
+        {workspaceId, projectId: PROJECT_ID, limit: 50},
+        {signal: new AbortController().signal},
+      ),
+    );
+
+    const method = definitionsInterModuleContract.methods.listDefinitionsByProject;
+    expect(isInterModuleKnownError(method, error)).toBe(true);
+    expect((error as {code: string}).code).toBe('project-workspace-mismatch');
+    expect(mocks.listDefinitions).not.toHaveBeenCalled();
+    expect(mocks.getLatestDefinitionSyncState).not.toHaveBeenCalled();
   });
 
   it('resolves a definition at a ref through the core method', async () => {

--- a/libs/api/definitions/src/presentation/inter-module.ts
+++ b/libs/api/definitions/src/presentation/inter-module.ts
@@ -13,12 +13,10 @@ import {
   type InterModulePresentation,
   isInterModuleKnownError,
 } from '@shipfox/inter-module';
-import type {DefinitionSyncState} from '#core/entities/sync-state.js';
-import type {WorkflowDefinition} from '#core/entities/workflow-definition.js';
 import {DefinitionAtRefError, listDefinitionsAtRef, resolveDefinitionAtRef} from '#core/index.js';
-import {UNRESOLVED_SYNC_REF} from '#core/sync-definitions.js';
-import {getDefinitionById, listDefinitions} from '#db/definitions.js';
-import {getLatestDefinitionSyncState} from '#db/sync-states.js';
+import {getDefinitionById} from '#db/definitions.js';
+import {toDefinitionReadModel, toDefinitionSyncSummary} from '#presentation/dto/index.js';
+import {listDefinitionsWithSync} from '#presentation/list-definitions.js';
 
 export interface CreateDefinitionsInterModulePresentationParams {
   projects: ProjectsModuleClient;
@@ -50,16 +48,17 @@ export function createDefinitionsInterModulePresentation(
         {workspaceId, projectId},
         params.projects,
       );
-      const result = await listDefinitions({projectId, limit, cursor});
-      const syncState = await getLatestDefinitionSyncState({
+      const result = await listDefinitionsWithSync({
         projectId,
+        limit,
+        cursor,
         sourceConnectionId: project.sourceConnectionId,
         sourceExternalRepositoryId: project.sourceExternalRepositoryId,
       });
 
       return {
-        definitions: result.definitions.map(toDefinitionListItem),
-        sync: toDefinitionSyncSummary(syncState),
+        definitions: result.definitions.map(toDefinitionReadModel),
+        sync: toDefinitionSyncSummary(result.syncState),
         nextCursor: result.nextCursor,
       };
     },
@@ -111,43 +110,6 @@ async function requireProjectForDefinitionList(
       }
     }
   }
-}
-
-function toDefinitionListItem(definition: WorkflowDefinition) {
-  const manualTrigger = definition.model.triggers.find((trigger) => trigger.source === 'manual');
-  return {
-    id: definition.id,
-    projectId: definition.projectId,
-    configPath: definition.configPath,
-    source: definition.source,
-    sha: definition.sha,
-    ref: definition.ref,
-    name: definition.name,
-    workflowDocument: definition.document,
-    workflowModel: definition.model,
-    manualTrigger: manualTrigger ? {name: manualTrigger.key} : null,
-    fetchedAt: definition.fetchedAt.toISOString(),
-    createdAt: definition.createdAt.toISOString(),
-    updatedAt: definition.updatedAt.toISOString(),
-  };
-}
-
-function toDefinitionSyncSummary(syncState: DefinitionSyncState | undefined) {
-  if (!syncState) return null;
-
-  return {
-    ref: syncState.ref === UNRESOLVED_SYNC_REF ? null : syncState.ref,
-    status: syncState.status,
-    lastSyncAt: (syncState.finishedAt ?? syncState.updatedAt).toISOString(),
-    startedAt: syncState.startedAt?.toISOString() ?? null,
-    finishedAt: syncState.finishedAt?.toISOString() ?? null,
-    lastErrorCode: syncState.lastErrorCode,
-    lastErrorMessage: syncState.lastErrorMessage,
-    diagnostics: syncState.diagnostics.map(({filePath, ...diagnostic}) => ({
-      ...diagnostic,
-      ...(filePath === undefined ? {} : {filePath}),
-    })),
-  };
 }
 
 function toDefinitionAtRefKnownError(method: InterModuleMethodContract, error: unknown): unknown {

--- a/libs/api/definitions/src/presentation/inter-module.ts
+++ b/libs/api/definitions/src/presentation/inter-module.ts
@@ -2,15 +2,23 @@ import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {createWorkflowModelSnapshot} from '@shipfox/api-definitions-dto';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {
+  type ProjectsModuleClient,
+  projectsInterModuleContract,
+} from '@shipfox/api-projects-dto/inter-module';
 import {
   createInterModuleKnownError,
   defineInterModulePresentation,
   type InterModuleMethodContract,
   type InterModulePresentation,
+  isInterModuleKnownError,
 } from '@shipfox/inter-module';
+import type {DefinitionSyncState} from '#core/entities/sync-state.js';
+import type {WorkflowDefinition} from '#core/entities/workflow-definition.js';
 import {DefinitionAtRefError, listDefinitionsAtRef, resolveDefinitionAtRef} from '#core/index.js';
-import {getDefinitionById} from '#db/definitions.js';
+import {UNRESOLVED_SYNC_REF} from '#core/sync-definitions.js';
+import {getDefinitionById, listDefinitions} from '#db/definitions.js';
+import {getLatestDefinitionSyncState} from '#db/sync-states.js';
 
 export interface CreateDefinitionsInterModulePresentationParams {
   projects: ProjectsModuleClient;
@@ -37,6 +45,24 @@ export function createDefinitionsInterModulePresentation(
         },
       };
     },
+    listDefinitionsByProject: async ({workspaceId, projectId, limit, cursor}) => {
+      const project = await requireProjectForDefinitionList(
+        {workspaceId, projectId},
+        params.projects,
+      );
+      const result = await listDefinitions({projectId, limit, cursor});
+      const syncState = await getLatestDefinitionSyncState({
+        projectId,
+        sourceConnectionId: project.sourceConnectionId,
+        sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+      });
+
+      return {
+        definitions: result.definitions.map(toDefinitionListItem),
+        sync: toDefinitionSyncSummary(syncState),
+        nextCursor: result.nextCursor,
+      };
+    },
     resolveDefinitionAtRef: async (input, context) => {
       try {
         return await resolveDefinitionAtRef({...input, ...params, signal: context.signal});
@@ -58,6 +84,70 @@ export function createDefinitionsInterModulePresentation(
       }
     },
   });
+}
+
+async function requireProjectForDefinitionList(
+  input: {workspaceId: string; projectId: string},
+  projects: ProjectsModuleClient,
+) {
+  try {
+    return (await projects.requireProjectForWorkspace(input)).project;
+  } catch (error) {
+    const projectMethod = projectsInterModuleContract.methods.requireProjectForWorkspace;
+    if (!isInterModuleKnownError(projectMethod, error)) throw error;
+
+    const method = definitionsInterModuleContract.methods.listDefinitionsByProject;
+    const {code} = error;
+    switch (code) {
+      case 'project-not-found':
+        throw createInterModuleKnownError(method, 'project-not-found', {
+          projectId: input.projectId,
+        });
+      case 'project-workspace-mismatch':
+        throw createInterModuleKnownError(method, 'project-workspace-mismatch', input);
+      default: {
+        const exhaustive: never = code;
+        throw new Error(`Unhandled project access error: ${exhaustive}`);
+      }
+    }
+  }
+}
+
+function toDefinitionListItem(definition: WorkflowDefinition) {
+  const manualTrigger = definition.model.triggers.find((trigger) => trigger.source === 'manual');
+  return {
+    id: definition.id,
+    projectId: definition.projectId,
+    configPath: definition.configPath,
+    source: definition.source,
+    sha: definition.sha,
+    ref: definition.ref,
+    name: definition.name,
+    workflowDocument: definition.document,
+    workflowModel: definition.model,
+    manualTrigger: manualTrigger ? {name: manualTrigger.key} : null,
+    fetchedAt: definition.fetchedAt.toISOString(),
+    createdAt: definition.createdAt.toISOString(),
+    updatedAt: definition.updatedAt.toISOString(),
+  };
+}
+
+function toDefinitionSyncSummary(syncState: DefinitionSyncState | undefined) {
+  if (!syncState) return null;
+
+  return {
+    ref: syncState.ref === UNRESOLVED_SYNC_REF ? null : syncState.ref,
+    status: syncState.status,
+    lastSyncAt: (syncState.finishedAt ?? syncState.updatedAt).toISOString(),
+    startedAt: syncState.startedAt?.toISOString() ?? null,
+    finishedAt: syncState.finishedAt?.toISOString() ?? null,
+    lastErrorCode: syncState.lastErrorCode,
+    lastErrorMessage: syncState.lastErrorMessage,
+    diagnostics: syncState.diagnostics.map(({filePath, ...diagnostic}) => ({
+      ...diagnostic,
+      ...(filePath === undefined ? {} : {filePath}),
+    })),
+  };
 }
 
 function toDefinitionAtRefKnownError(method: InterModuleMethodContract, error: unknown): unknown {

--- a/libs/api/definitions/src/presentation/list-definitions.ts
+++ b/libs/api/definitions/src/presentation/list-definitions.ts
@@ -1,0 +1,33 @@
+import type {DefinitionSyncState} from '#core/entities/sync-state.js';
+import type {DefinitionCursor, ListDefinitionsResult} from '#db/definitions.js';
+import {listDefinitions} from '#db/definitions.js';
+import {getLatestDefinitionSyncState} from '#db/sync-states.js';
+
+export interface ListDefinitionsWithSyncParams {
+  projectId: string;
+  limit: number;
+  cursor?: DefinitionCursor | undefined;
+  sourceConnectionId: string;
+  sourceExternalRepositoryId: string;
+}
+
+export interface ListDefinitionsWithSyncResult extends ListDefinitionsResult {
+  syncState: DefinitionSyncState | undefined;
+}
+
+export async function listDefinitionsWithSync(
+  params: ListDefinitionsWithSyncParams,
+): Promise<ListDefinitionsWithSyncResult> {
+  // These are independent reads. The sync summary is the latest state observed
+  // for the project and may advance while the definition page is being read.
+  const [result, syncState] = await Promise.all([
+    listDefinitions({projectId: params.projectId, limit: params.limit, cursor: params.cursor}),
+    getLatestDefinitionSyncState({
+      projectId: params.projectId,
+      sourceConnectionId: params.sourceConnectionId,
+      sourceExternalRepositoryId: params.sourceExternalRepositoryId,
+    }),
+  ]);
+
+  return {...result, syncState};
+}

--- a/libs/api/definitions/src/presentation/routes/list-definitions.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.ts
@@ -5,9 +5,8 @@ import {
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {decodeStringIdCursor, encodeStringIdCursor} from '@shipfox/node-drizzle';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
-import {listDefinitions} from '#db/definitions.js';
-import {getLatestDefinitionSyncState} from '#db/sync-states.js';
 import {toDefinitionDto, toDefinitionSyncSummaryDto} from '#presentation/dto/index.js';
+import {listDefinitionsWithSync} from '#presentation/list-definitions.js';
 import {requireProjectAccess} from './project-access.js';
 
 export function buildListDefinitionsRoute(projects: ProjectsModuleClient) {
@@ -29,16 +28,17 @@ export function buildListDefinitionsRoute(projects: ProjectsModuleClient) {
       }
 
       const project = await requireProjectAccess(request, projectId, projects);
-      const result = await listDefinitions({projectId, limit, cursor: decodedCursor});
-      const syncState = await getLatestDefinitionSyncState({
+      const result = await listDefinitionsWithSync({
         projectId,
+        limit,
+        cursor: decodedCursor,
         sourceConnectionId: project.sourceConnectionId,
         sourceExternalRepositoryId: project.sourceExternalRepositoryId,
       });
 
       return {
         definitions: result.definitions.map(toDefinitionDto),
-        sync: toDefinitionSyncSummaryDto(syncState),
+        sync: toDefinitionSyncSummaryDto(result.syncState),
         next_cursor: result.nextCursor ? encodeStringIdCursor(result.nextCursor) : null,
       };
     },

--- a/libs/api/projects-dto/src/inter-module.test.ts
+++ b/libs/api/projects-dto/src/inter-module.test.ts
@@ -87,6 +87,26 @@ describe('projectsInterModuleContract', () => {
     };
 
     expect(
+      projectsInterModuleContract.methods.listProjectCatalogByWorkspace.output.parse({
+        projects: [project],
+        nextCursor: null,
+      }),
+    ).toEqual({projects: [project], nextCursor: null});
+  });
+
+  test('keeps the base workspace project listing shape compatible', () => {
+    const project = {
+      id: '00000000-0000-4000-8000-000000000001',
+      workspaceId: '00000000-0000-4000-8000-000000000002',
+      sourceConnectionId: '00000000-0000-4000-8000-000000000003',
+      sourceExternalRepositoryId: 'shipfox/project',
+      sourceRepositoryOwner: 'shipfox',
+      sourceRepositoryName: 'project',
+      sourceDefaultBranch: 'main',
+      name: 'Project',
+    };
+
+    expect(
       projectsInterModuleContract.methods.listProjectsByWorkspace.output.parse({
         projects: [project],
         nextCursor: null,

--- a/libs/api/projects-dto/src/inter-module.test.ts
+++ b/libs/api/projects-dto/src/inter-module.test.ts
@@ -71,6 +71,29 @@ describe('projectsInterModuleContract', () => {
     ).toEqual({workspaceId, limit: 100, cursor});
   });
 
+  test('accepts the catalog fields on workspace project listings', () => {
+    const project = {
+      id: '00000000-0000-4000-8000-000000000001',
+      workspaceId: '00000000-0000-4000-8000-000000000002',
+      sourceConnectionId: '00000000-0000-4000-8000-000000000003',
+      sourceExternalRepositoryId: 'shipfox/project',
+      sourceRepositoryOwner: 'shipfox',
+      sourceRepositoryName: 'project',
+      sourceDefaultBranch: 'main',
+      name: 'Project',
+      slug: 'project',
+      createdAt: '2026-08-05T12:00:00.000Z',
+      updatedAt: '2026-08-05T12:01:00.000Z',
+    };
+
+    expect(
+      projectsInterModuleContract.methods.listProjectsByWorkspace.output.parse({
+        projects: [project],
+        nextCursor: null,
+      }),
+    ).toEqual({projects: [project], nextCursor: null});
+  });
+
   test('defines the checkout authorization failure', () => {
     const details = {};
 

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -71,6 +71,17 @@ export const projectsInterModuleContract = defineInterModuleContract({
         cursor: projectCursorSchema.optional(),
       }),
       output: z.object({
+        projects: z.array(projectSchema),
+        nextCursor: projectCursorSchema.nullable(),
+      }),
+    },
+    listProjectCatalogByWorkspace: {
+      input: z.object({
+        workspaceId: idSchema,
+        limit: z.number().int().min(1).max(100),
+        cursor: projectCursorSchema.optional(),
+      }),
+      output: z.object({
         projects: z.array(projectCatalogSchema),
         nextCursor: projectCursorSchema.nullable(),
       }),

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -1,3 +1,4 @@
+import {slugSchema} from '@shipfox/api-common-dto';
 import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
 import {z} from 'zod';
 
@@ -11,6 +12,11 @@ const projectSchema = z.object({
   sourceRepositoryName: z.string().min(1).nullable().optional(),
   sourceDefaultBranch: z.string().min(1).nullable().optional(),
   name: z.string(),
+});
+const projectCatalogSchema = projectSchema.extend({
+  slug: slugSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 const workspaceProjectCountSchema = z.object({
   workspaceId: idSchema,
@@ -65,7 +71,7 @@ export const projectsInterModuleContract = defineInterModuleContract({
         cursor: projectCursorSchema.optional(),
       }),
       output: z.object({
-        projects: z.array(projectSchema),
+        projects: z.array(projectCatalogSchema),
         nextCursor: projectCursorSchema.nullable(),
       }),
     },

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -115,6 +115,29 @@ describe('Projects checkout target inter-module presentation', () => {
     expect(projectIds).toEqual([first.projectId, second.projectId].sort());
   });
 
+  test('lists workspace projects with catalog fields through the catalog contract', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const project = await insertProject({
+      workspaceId,
+      connectionId: crypto.randomUUID(),
+      owner: 'acme',
+      name: 'api',
+    });
+
+    const result = await client.listProjectCatalogByWorkspace({workspaceId, limit: 10});
+
+    expect(result.nextCursor).toBeNull();
+    expect(result.projects).toEqual([
+      expect.objectContaining({
+        id: project.projectId,
+        slug: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      }),
+    ]);
+  });
+
   test('resolves a project by its workspace-scoped source repository', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -28,16 +28,17 @@ export function createProjectsInterModulePresentation(params: {
       projects: await findProjectBySourceRepositoryName(input),
     }),
     listProjectsByWorkspace: async ({workspaceId, limit, cursor}) => {
-      const result = await listProjects({
-        workspaceId,
-        limit,
-        ...(cursor ? {cursor: {createdAt: new Date(cursor.createdAt), id: cursor.id}} : {}),
-      });
+      const result = await listProjectPage({workspaceId, limit, cursor});
+      return {
+        projects: result.projects.map(toProjectInterModule),
+        nextCursor: toProjectCursor(result.nextCursor),
+      };
+    },
+    listProjectCatalogByWorkspace: async ({workspaceId, limit, cursor}) => {
+      const result = await listProjectPage({workspaceId, limit, cursor});
       return {
         projects: result.projects.map(toProjectCatalogInterModule),
-        nextCursor: result.nextCursor
-          ? {createdAt: result.nextCursor.createdAt.toISOString(), id: result.nextCursor.id}
-          : null,
+        nextCursor: toProjectCursor(result.nextCursor),
       };
     },
     requireProjectForWorkspace: async ({projectId, workspaceId}) => {
@@ -125,7 +126,34 @@ export function createProjectsInterModulePresentation(params: {
   });
 }
 
+async function listProjectPage(input: {
+  workspaceId: string;
+  limit: number;
+  cursor?: {createdAt: string; id: string} | undefined;
+}) {
+  return await listProjects({
+    workspaceId: input.workspaceId,
+    limit: input.limit,
+    ...(input.cursor
+      ? {cursor: {createdAt: new Date(input.cursor.createdAt), id: input.cursor.id}}
+      : {}),
+  });
+}
+
+function toProjectCursor(cursor: {createdAt: Date; id: string} | null) {
+  return cursor ? {createdAt: cursor.createdAt.toISOString(), id: cursor.id} : null;
+}
+
 function toProjectCatalogInterModule(project: Project) {
+  return {
+    ...toProjectInterModule(project),
+    slug: project.slug,
+    createdAt: project.createdAt.toISOString(),
+    updatedAt: project.updatedAt.toISOString(),
+  };
+}
+
+function toProjectInterModule(project: Project) {
   return {
     id: project.id,
     workspaceId: project.workspaceId,
@@ -135,9 +163,6 @@ function toProjectCatalogInterModule(project: Project) {
     sourceRepositoryName: project.sourceRepositoryName,
     sourceDefaultBranch: project.sourceDefaultBranch,
     name: project.name,
-    slug: project.slug,
-    createdAt: project.createdAt.toISOString(),
-    updatedAt: project.updatedAt.toISOString(),
   };
 }
 

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -5,6 +5,7 @@ import {
   defineInterModulePresentation,
   type InterModulePresentation,
 } from '@shipfox/inter-module';
+import type {Project} from '#core/entities/project.js';
 import {
   findProjectBySourceRepositoryName,
   getProjectById,
@@ -33,7 +34,7 @@ export function createProjectsInterModulePresentation(params: {
         ...(cursor ? {cursor: {createdAt: new Date(cursor.createdAt), id: cursor.id}} : {}),
       });
       return {
-        projects: result.projects,
+        projects: result.projects.map(toProjectCatalogInterModule),
         nextCursor: result.nextCursor
           ? {createdAt: result.nextCursor.createdAt.toISOString(), id: result.nextCursor.id}
           : null,
@@ -122,6 +123,22 @@ export function createProjectsInterModulePresentation(params: {
       return target;
     },
   });
+}
+
+function toProjectCatalogInterModule(project: Project) {
+  return {
+    id: project.id,
+    workspaceId: project.workspaceId,
+    sourceConnectionId: project.sourceConnectionId,
+    sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+    sourceRepositoryOwner: project.sourceRepositoryOwner,
+    sourceRepositoryName: project.sourceRepositoryName,
+    sourceDefaultBranch: project.sourceDefaultBranch,
+    name: project.name,
+    slug: project.slug,
+    createdAt: project.createdAt.toISOString(),
+    updatedAt: project.updatedAt.toISOString(),
+  };
 }
 
 function requestedRepository(

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -28,6 +28,7 @@ const projects = createFakeInterModuleClients({
     getProjectBySource: () => ({project: null}),
     findProjectBySourceRepositoryName: () => ({projects: []}),
     listProjectsByWorkspace: () => ({projects: [], nextCursor: null}),
+    listProjectCatalogByWorkspace: () => ({projects: [], nextCursor: null}),
     getWorkspaceProjectCounts: () => ({counts: []}),
     requireProjectForWorkspace: async (input) => await requireProjectForWorkspace(input),
     resolveCheckoutTarget: () => ({

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -169,6 +169,7 @@ describe('defaultModules', () => {
           getProjectBySource: () => ({project: null}),
           findProjectBySourceRepositoryName: () => ({projects: []}),
           listProjectsByWorkspace: () => ({projects: [], nextCursor: null}),
+          listProjectCatalogByWorkspace: () => ({projects: [], nextCursor: null}),
           getWorkspaceProjectCounts: () => ({counts: []}),
           requireProjectForWorkspace: () => ({
             project: {

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -237,6 +237,7 @@ describe('defaultModules', () => {
           contract: definitionsInterModuleContract,
           handlers: {
             getDefinitionForWorkflowRun: vi.fn(),
+            listDefinitionsByProject: vi.fn(),
             listDefinitionsAtRef: vi.fn(),
             resolveDefinitionAtRef: vi.fn(),
           },

--- a/libs/api/triggers-dto/package.json
+++ b/libs/api/triggers-dto/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./inter-module": {
+      "workspace-source": {
+        "types": "./src/inter-module.ts",
+        "default": "./src/inter-module.ts"
+      },
+      "default": {
+        "types": "./dist/inter-module.d.ts",
+        "default": "./dist/inter-module.js"
+      }
     }
   },
   "scripts": {
@@ -39,6 +49,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/inter-module": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/libs/api/triggers-dto/src/inter-module.ts
+++ b/libs/api/triggers-dto/src/inter-module.ts
@@ -1,0 +1,149 @@
+import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
+import {z} from 'zod';
+import {
+  listenerMatcherKindSchema,
+  triggerDecisionOutcomeSchema,
+  triggerDecisionSubscriptionKindSchema,
+  triggerEventOriginSchema,
+  triggerEventOutcomeSchema,
+} from './schemas/trigger-events.js';
+
+const idSchema = z.string().uuid();
+const isoDateTimeSchema = z.string().datetime();
+
+const triggerEventCursorSchema = z.object({
+  receivedAt: isoDateTimeSchema,
+  id: idSchema,
+});
+
+const triggerEventListFiltersSchema = z
+  .object({
+    source: z.array(z.string()).optional(),
+    event: z.array(z.string()).optional(),
+    origin: z.array(triggerEventOriginSchema).optional(),
+    outcome: z.array(triggerEventOutcomeSchema).optional(),
+    replayable: z.literal(true).optional(),
+    from: isoDateTimeSchema.optional(),
+    to: isoDateTimeSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.from && value.to && new Date(value.from) > new Date(value.to)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'from must be before or equal to to',
+        path: ['from'],
+      });
+    }
+  });
+
+const triggerEventListItemSchema = z.object({
+  id: idSchema,
+  eventRef: z.string(),
+  origin: triggerEventOriginSchema,
+  workspaceId: idSchema,
+  provider: z.string().nullable(),
+  source: z.string(),
+  event: z.string(),
+  replayOfEventId: idSchema.nullable(),
+  deliveryId: z.string().nullable(),
+  connectionId: idSchema.nullable(),
+  connectionName: z.string().nullable(),
+  outcome: triggerEventOutcomeSchema,
+  matchedCount: z.number().int().nonnegative(),
+  receivedAt: isoDateTimeSchema,
+  processedAt: isoDateTimeSchema.nullable(),
+  createdAt: isoDateTimeSchema,
+});
+
+const triggerEventSchema = triggerEventListItemSchema.extend({
+  payload: z.record(z.string(), z.unknown()).nullable(),
+});
+
+const triggerEventReplaySchema = z.object({
+  id: idSchema,
+  receivedAt: isoDateTimeSchema,
+  outcome: triggerEventOutcomeSchema,
+  runId: idSchema.nullable(),
+});
+
+const triggerDecisionSchema = z
+  .object({
+    id: idSchema,
+    receivedEventId: idSchema,
+    subscriptionKind: triggerDecisionSubscriptionKindSchema,
+    subscriptionId: idSchema.nullable(),
+    subscriptionName: z.string(),
+    workflowDefinitionId: idSchema.nullable(),
+    projectId: idSchema.nullable(),
+    workflowRunId: idSchema.nullable(),
+    jobId: idSchema.nullable(),
+    matcherKind: listenerMatcherKindSchema.nullable(),
+    matcherOrdinal: z.number().int().nonnegative().nullable(),
+    decision: triggerDecisionOutcomeSchema,
+    runId: idSchema.nullable(),
+    runName: z.string().nullable(),
+    reason: z.string().nullable(),
+    createdAt: isoDateTimeSchema,
+  })
+  .superRefine((value, ctx) => {
+    const isDevDecision = value.subscriptionKind === 'dev';
+    const hasNullSubscriptionId = value.subscriptionId === null;
+    if (isDevDecision !== hasNullSubscriptionId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: isDevDecision
+          ? 'dev decisions must have a null subscriptionId'
+          : 'trigger and listener decisions must have a subscriptionId',
+        path: ['subscriptionId'],
+      });
+    }
+  });
+
+const triggerEventFacetSchema = z.object({
+  value: z.string(),
+  count: z.number().int().nonnegative(),
+});
+
+const triggerEventDetailSchema = triggerEventSchema.extend({
+  decisions: z.array(triggerDecisionSchema),
+  replays: z.array(triggerEventReplaySchema),
+});
+
+export const triggersInterModuleContract = defineInterModuleContract({
+  module: 'triggers',
+  methods: {
+    listTriggerEvents: {
+      input: z.object({
+        workspaceId: idSchema,
+        limit: z.number().int().min(1).max(100),
+        cursor: triggerEventCursorSchema.optional(),
+        filters: triggerEventListFiltersSchema.optional(),
+      }),
+      output: z.object({
+        events: z.array(triggerEventListItemSchema),
+        nextCursor: triggerEventCursorSchema.nullable(),
+      }),
+    },
+    getTriggerEvent: {
+      input: z.object({workspaceId: idSchema, eventId: idSchema}),
+      output: triggerEventDetailSchema,
+      errors: {
+        'trigger-event-not-found': z.object({eventId: idSchema}),
+      },
+    },
+    getTriggerEventFacets: {
+      input: z.object({workspaceId: idSchema}),
+      output: z.object({
+        sources: z.array(triggerEventFacetSchema),
+        events: z.array(triggerEventFacetSchema),
+        origins: z.array(triggerEventFacetSchema),
+      }),
+    },
+  },
+});
+
+export type TriggersInterModuleClient = InterModuleClient<typeof triggersInterModuleContract>;
+export type TriggerEventListItem = z.infer<typeof triggerEventListItemSchema>;
+export type TriggerEventDetail = z.infer<typeof triggerEventDetailSchema>;
+export type TriggerDecision = z.infer<typeof triggerDecisionSchema>;
+export type TriggerEventReplay = z.infer<typeof triggerEventReplaySchema>;

--- a/libs/api/triggers/src/index.ts
+++ b/libs/api/triggers/src/index.ts
@@ -22,6 +22,7 @@ import {db, migrationsPath, triggersOutbox} from '#db/index.js';
 import {registerTriggersServiceMetrics} from '#metrics/index.js';
 import {triggersE2eRoutes} from '#presentation/e2e-routes.js';
 import {createTriggerRoutes} from '#presentation/index.js';
+import {createTriggersInterModulePresentation} from '#presentation/inter-module.js';
 import {
   createOnIntegrationEventReceived,
   onDefinitionDeleted,
@@ -96,6 +97,7 @@ export function createTriggersModule({
     routes: createTriggerRoutes(workflows, definitions, projects),
     e2eRoutes: [triggersE2eRoutes],
     metrics: registerTriggersServiceMetrics,
+    interModulePresentations: [createTriggersInterModulePresentation()],
     publishers: [{name: 'triggers', table: triggersOutbox, db}],
     subscribers: [
       subscriber(DEFINITION_RESOLVED, onDefinitionResolved),

--- a/libs/api/triggers/src/presentation/inter-module.test.ts
+++ b/libs/api/triggers/src/presentation/inter-module.test.ts
@@ -127,6 +127,87 @@ describe('triggers inter-module presentation', () => {
     });
   });
 
+  it('lists the first page without optional inputs and returns a terminal cursor', async () => {
+    mocks.listTriggerEvents.mockResolvedValue({events: [], nextCursor: null});
+
+    const result = await presentation().handlers.listTriggerEvents(
+      {workspaceId: WORKSPACE_ID, limit: 10},
+      {signal: new AbortController().signal},
+    );
+
+    expect(mocks.listTriggerEvents).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      limit: 10,
+      cursor: undefined,
+      filters: undefined,
+    });
+    expect(triggersInterModuleContract.methods.listTriggerEvents.output.parse(result)).toEqual({
+      events: [],
+      nextCursor: null,
+    });
+  });
+
+  it('rejects inverted list windows and invalid decision subscription pairings', () => {
+    const listInput = triggersInterModuleContract.methods.listTriggerEvents.input.safeParse({
+      workspaceId: WORKSPACE_ID,
+      limit: 10,
+      filters: {
+        from: '2026-08-31T00:00:00.000Z',
+        to: '2026-08-01T00:00:00.000Z',
+      },
+    });
+    expect(listInput.success).toBe(false);
+
+    const item = event();
+    const baseDecision = {
+      id: '00000000-0000-4000-8000-000000000006',
+      receivedEventId: item.id,
+      subscriptionKind: 'trigger' as const,
+      subscriptionId: '00000000-0000-4000-8000-000000000007',
+      subscriptionName: 'Deploy',
+      workflowDefinitionId: null,
+      projectId: null,
+      workflowRunId: null,
+      jobId: null,
+      matcherKind: null,
+      matcherOrdinal: null,
+      decision: 'triggered' as const,
+      runId: null,
+      runName: null,
+      reason: null,
+      createdAt: '2026-08-05T12:00:03.000Z',
+    };
+    const detail = {
+      ...summary(item),
+      payload: item.payload,
+      receivedAt: item.receivedAt.toISOString(),
+      processedAt: item.processedAt?.toISOString() ?? null,
+      createdAt: item.createdAt.toISOString(),
+      decisions: [],
+      replays: [],
+    };
+    const method = triggersInterModuleContract.methods.getTriggerEvent;
+
+    expect(
+      method.output.safeParse({
+        ...detail,
+        decisions: [{...baseDecision, subscriptionKind: 'dev', subscriptionId: item.id}],
+      }).success,
+    ).toBe(false);
+    expect(
+      method.output.safeParse({
+        ...detail,
+        decisions: [{...baseDecision, subscriptionId: null}],
+      }).success,
+    ).toBe(false);
+    expect(
+      method.output.safeParse({
+        ...detail,
+        decisions: [{...baseDecision, subscriptionKind: 'dev', subscriptionId: null}],
+      }).success,
+    ).toBe(true);
+  });
+
   it('returns event details with decisions and replays', async () => {
     const item = event();
     const decision: TriggerDecision = {

--- a/libs/api/triggers/src/presentation/inter-module.test.ts
+++ b/libs/api/triggers/src/presentation/inter-module.test.ts
@@ -1,0 +1,225 @@
+import {triggersInterModuleContract} from '@shipfox/api-triggers-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import type {TriggerDecision} from '#core/entities/decision.js';
+import type {
+  TriggerEventReplay,
+  TriggerReceivedEvent,
+  TriggerReceivedEventSummary,
+} from '#core/entities/received-event.js';
+import {createTriggersInterModulePresentation} from './inter-module.js';
+
+const mocks = vi.hoisted(() => ({
+  getTriggerEventById: vi.fn(),
+  listDecisionsByReceivedEventId: vi.fn(),
+  listReplaysOfTriggerEvent: vi.fn(),
+  listTriggerEventFacets: vi.fn(),
+  listTriggerEvents: vi.fn(),
+}));
+
+vi.mock('#db/index.js', () => mocks);
+
+const WORKSPACE_ID = '00000000-0000-4000-8000-000000000001';
+const EVENT_ID = '00000000-0000-4000-8000-000000000002';
+
+function event(overrides: Partial<TriggerReceivedEvent> = {}): TriggerReceivedEvent {
+  return {
+    id: EVENT_ID,
+    eventRef: 'event-ref',
+    origin: 'integration',
+    workspaceId: WORKSPACE_ID,
+    provider: 'github',
+    source: 'github',
+    event: 'push',
+    replayOfEventId: null,
+    deliveryId: 'delivery-id',
+    connectionId: '00000000-0000-4000-8000-000000000003',
+    connectionName: 'GitHub',
+    outcome: 'routed',
+    matchedCount: 1,
+    payload: {ref: 'refs/heads/main'},
+    receivedAt: new Date('2026-08-05T12:00:00.000Z'),
+    processedAt: new Date('2026-08-05T12:00:01.000Z'),
+    createdAt: new Date('2026-08-05T12:00:02.000Z'),
+    ...overrides,
+  };
+}
+
+function summary(value: TriggerReceivedEvent): TriggerReceivedEventSummary {
+  const {payload: _payload, ...withoutPayload} = value;
+  return withoutPayload;
+}
+
+function presentation() {
+  return createTriggersInterModulePresentation();
+}
+
+async function rejection(promise: Promise<unknown> | unknown): Promise<unknown> {
+  return await Promise.resolve(promise).catch((error: unknown) => error);
+}
+
+describe('triggers inter-module presentation', () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) mock.mockReset();
+  });
+
+  it('lists events with public filters and preserves the timestamp cursor', async () => {
+    const nextCursor = {
+      receivedAt: new Date('2026-08-05T11:00:00.000Z'),
+      id: '00000000-0000-4000-8000-000000000004',
+    };
+    const item = event();
+    mocks.listTriggerEvents.mockResolvedValue({
+      events: [summary(item)],
+      nextCursor,
+    });
+    const cursor = {
+      receivedAt: '2026-08-05T13:00:00.000Z',
+      id: '00000000-0000-4000-8000-000000000005',
+    };
+    const from = '2026-08-01T00:00:00.000Z';
+    const to = '2026-08-31T23:59:59.000Z';
+
+    const result = await presentation().handlers.listTriggerEvents(
+      {
+        workspaceId: WORKSPACE_ID,
+        limit: 10,
+        cursor,
+        filters: {
+          source: ['github'],
+          event: ['push'],
+          origin: ['integration'],
+          outcome: ['routed'],
+          replayable: true,
+          from,
+          to,
+        },
+      },
+      {signal: new AbortController().signal},
+    );
+
+    expect(mocks.listTriggerEvents).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      limit: 10,
+      cursor: {receivedAt: new Date(cursor.receivedAt), id: cursor.id},
+      filters: {
+        source: ['github'],
+        event: ['push'],
+        origins: ['integration'],
+        outcomes: ['routed'],
+        replayable: true,
+        from: new Date(from),
+        to: new Date(to),
+      },
+    });
+    expect(triggersInterModuleContract.methods.listTriggerEvents.output.parse(result)).toEqual({
+      events: [
+        {
+          ...summary(item),
+          receivedAt: item.receivedAt.toISOString(),
+          processedAt: item.processedAt?.toISOString(),
+          createdAt: item.createdAt.toISOString(),
+        },
+      ],
+      nextCursor: {
+        receivedAt: nextCursor.receivedAt.toISOString(),
+        id: nextCursor.id,
+      },
+    });
+  });
+
+  it('returns event details with decisions and replays', async () => {
+    const item = event();
+    const decision: TriggerDecision = {
+      id: '00000000-0000-4000-8000-000000000006',
+      receivedEventId: item.id,
+      subscriptionKind: 'trigger',
+      subscriptionId: '00000000-0000-4000-8000-000000000007',
+      subscriptionName: 'Deploy',
+      workflowDefinitionId: '00000000-0000-4000-8000-000000000008',
+      projectId: '00000000-0000-4000-8000-000000000009',
+      workflowRunId: '00000000-0000-4000-8000-000000000010',
+      jobId: '00000000-0000-4000-8000-000000000011',
+      matcherKind: null,
+      matcherOrdinal: null,
+      decision: 'triggered',
+      runId: '00000000-0000-4000-8000-000000000012',
+      runName: 'deploy',
+      reason: null,
+      createdAt: new Date('2026-08-05T12:00:03.000Z'),
+    };
+    const replay: TriggerEventReplay = {
+      id: '00000000-0000-4000-8000-000000000013',
+      receivedAt: new Date('2026-08-05T12:01:00.000Z'),
+      outcome: 'routed',
+      runId: '00000000-0000-4000-8000-000000000014',
+    };
+    mocks.getTriggerEventById.mockResolvedValue(item);
+    mocks.listDecisionsByReceivedEventId.mockResolvedValue([decision]);
+    mocks.listReplaysOfTriggerEvent.mockResolvedValue([replay]);
+
+    const result = await presentation().handlers.getTriggerEvent(
+      {workspaceId: WORKSPACE_ID, eventId: item.id},
+      {signal: new AbortController().signal},
+    );
+
+    expect(mocks.listDecisionsByReceivedEventId).toHaveBeenCalledWith(item.id);
+    expect(mocks.listReplaysOfTriggerEvent).toHaveBeenCalledWith(item.id, WORKSPACE_ID);
+    expect(triggersInterModuleContract.methods.getTriggerEvent.output.parse(result)).toEqual({
+      ...summary(item),
+      payload: item.payload,
+      receivedAt: item.receivedAt.toISOString(),
+      processedAt: item.processedAt?.toISOString(),
+      createdAt: item.createdAt.toISOString(),
+      decisions: [
+        {
+          ...decision,
+          createdAt: decision.createdAt.toISOString(),
+        },
+      ],
+      replays: [
+        {
+          ...replay,
+          receivedAt: replay.receivedAt.toISOString(),
+        },
+      ],
+    });
+  });
+
+  it('uses one not-found error for an event outside the requested workspace', async () => {
+    const item = event({workspaceId: '00000000-0000-4000-8000-000000000020'});
+    mocks.getTriggerEventById.mockResolvedValue(item);
+
+    const error = await rejection(
+      presentation().handlers.getTriggerEvent(
+        {workspaceId: WORKSPACE_ID, eventId: item.id},
+        {signal: new AbortController().signal},
+      ),
+    );
+
+    const method = triggersInterModuleContract.methods.getTriggerEvent;
+    expect(isInterModuleKnownError(method, error)).toBe(true);
+    expect((error as {code: string}).code).toBe('trigger-event-not-found');
+    expect((error as {details: unknown}).details).toEqual({eventId: item.id});
+    expect(mocks.listDecisionsByReceivedEventId).not.toHaveBeenCalled();
+    expect(mocks.listReplaysOfTriggerEvent).not.toHaveBeenCalled();
+  });
+
+  it('lists workspace facet counts through the existing query', async () => {
+    const facets = {
+      sources: [{value: 'github', count: 2}],
+      events: [{value: 'push', count: 2}],
+      origins: [{value: 'integration', count: 2}],
+    };
+    mocks.listTriggerEventFacets.mockResolvedValue(facets);
+
+    const result = await presentation().handlers.getTriggerEventFacets(
+      {workspaceId: WORKSPACE_ID},
+      {signal: new AbortController().signal},
+    );
+
+    expect(mocks.listTriggerEventFacets).toHaveBeenCalledWith({workspaceId: WORKSPACE_ID});
+    expect(triggersInterModuleContract.methods.getTriggerEventFacets.output.parse(result)).toEqual(
+      facets,
+    );
+  });
+});

--- a/libs/api/triggers/src/presentation/inter-module.test.ts
+++ b/libs/api/triggers/src/presentation/inter-module.test.ts
@@ -208,6 +208,25 @@ describe('triggers inter-module presentation', () => {
     ).toBe(true);
   });
 
+  it('maps a missing event to not-found without loading related records', async () => {
+    const eventId = '00000000-0000-4000-8000-000000000020';
+    mocks.getTriggerEventById.mockResolvedValue(undefined);
+
+    const error = await rejection(
+      presentation().handlers.getTriggerEvent(
+        {workspaceId: WORKSPACE_ID, eventId},
+        {signal: new AbortController().signal},
+      ),
+    );
+
+    const method = triggersInterModuleContract.methods.getTriggerEvent;
+    expect(isInterModuleKnownError(method, error)).toBe(true);
+    expect((error as {code: string}).code).toBe('trigger-event-not-found');
+    expect((error as {details: unknown}).details).toEqual({eventId});
+    expect(mocks.listDecisionsByReceivedEventId).not.toHaveBeenCalled();
+    expect(mocks.listReplaysOfTriggerEvent).not.toHaveBeenCalled();
+  });
+
   it('returns event details with decisions and replays', async () => {
     const item = event();
     const decision: TriggerDecision = {
@@ -266,6 +285,23 @@ describe('triggers inter-module presentation', () => {
     });
   });
 
+  it('returns empty decisions and replays for an event without related records', async () => {
+    const item = event({origin: 'cron', source: 'cron', event: 'scheduled'});
+    mocks.getTriggerEventById.mockResolvedValue(item);
+    mocks.listDecisionsByReceivedEventId.mockResolvedValue([]);
+    mocks.listReplaysOfTriggerEvent.mockResolvedValue([]);
+
+    const result = await presentation().handlers.getTriggerEvent(
+      {workspaceId: WORKSPACE_ID, eventId: item.id},
+      {signal: new AbortController().signal},
+    );
+
+    expect(triggersInterModuleContract.methods.getTriggerEvent.output.parse(result)).toMatchObject({
+      decisions: [],
+      replays: [],
+    });
+  });
+
   it('uses one not-found error for an event outside the requested workspace', async () => {
     const item = event({workspaceId: '00000000-0000-4000-8000-000000000020'});
     mocks.getTriggerEventById.mockResolvedValue(item);
@@ -299,6 +335,20 @@ describe('triggers inter-module presentation', () => {
     );
 
     expect(mocks.listTriggerEventFacets).toHaveBeenCalledWith({workspaceId: WORKSPACE_ID});
+    expect(triggersInterModuleContract.methods.getTriggerEventFacets.output.parse(result)).toEqual(
+      facets,
+    );
+  });
+
+  it('returns empty facet counts for a workspace without events', async () => {
+    const facets = {sources: [], events: [], origins: []};
+    mocks.listTriggerEventFacets.mockResolvedValue(facets);
+
+    const result = await presentation().handlers.getTriggerEventFacets(
+      {workspaceId: WORKSPACE_ID},
+      {signal: new AbortController().signal},
+    );
+
     expect(triggersInterModuleContract.methods.getTriggerEventFacets.output.parse(result)).toEqual(
       facets,
     );

--- a/libs/api/triggers/src/presentation/inter-module.ts
+++ b/libs/api/triggers/src/presentation/inter-module.ts
@@ -1,0 +1,134 @@
+import {triggersInterModuleContract} from '@shipfox/api-triggers-dto/inter-module';
+import {
+  createInterModuleKnownError,
+  defineInterModulePresentation,
+  type InterModulePresentation,
+} from '@shipfox/inter-module';
+import type {TriggerDecision} from '#core/entities/decision.js';
+import type {
+  TriggerEventReplay,
+  TriggerReceivedEvent,
+  TriggerReceivedEventSummary,
+} from '#core/entities/received-event.js';
+import {
+  getTriggerEventById,
+  listDecisionsByReceivedEventId,
+  listReplaysOfTriggerEvent,
+  listTriggerEventFacets,
+  listTriggerEvents,
+} from '#db/index.js';
+
+export function createTriggersInterModulePresentation(): InterModulePresentation<
+  typeof triggersInterModuleContract
+> {
+  return defineInterModulePresentation(triggersInterModuleContract, {
+    listTriggerEvents: async ({workspaceId, limit, cursor, filters}) => {
+      const result = await listTriggerEvents({
+        workspaceId,
+        limit,
+        cursor: cursor ? {receivedAt: new Date(cursor.receivedAt), id: cursor.id} : undefined,
+        filters: filters
+          ? {
+              source: filters.source,
+              event: filters.event,
+              origins: filters.origin,
+              outcomes: filters.outcome,
+              replayable: filters.replayable,
+              from: filters.from ? new Date(filters.from) : undefined,
+              to: filters.to ? new Date(filters.to) : undefined,
+            }
+          : undefined,
+      });
+
+      return {
+        events: result.events.map(toTriggerEventListItem),
+        nextCursor: result.nextCursor
+          ? {
+              receivedAt: result.nextCursor.receivedAt.toISOString(),
+              id: result.nextCursor.id,
+            }
+          : null,
+      };
+    },
+    getTriggerEvent: async ({workspaceId, eventId}) => {
+      const event = await getTriggerEventById(eventId);
+      if (!event || event.workspaceId !== workspaceId) {
+        throw createInterModuleKnownError(
+          triggersInterModuleContract.methods.getTriggerEvent,
+          'trigger-event-not-found',
+          {eventId},
+        );
+      }
+
+      const [decisions, replays] = await Promise.all([
+        listDecisionsByReceivedEventId(event.id),
+        listReplaysOfTriggerEvent(event.id, event.workspaceId),
+      ]);
+
+      return {
+        ...toTriggerEvent(event),
+        decisions: decisions.map(toTriggerDecision),
+        replays: replays.map(toTriggerEventReplay),
+      };
+    },
+    getTriggerEventFacets: async ({workspaceId}) => await listTriggerEventFacets({workspaceId}),
+  });
+}
+
+function toTriggerEventListItem(event: TriggerReceivedEventSummary) {
+  return {
+    id: event.id,
+    eventRef: event.eventRef,
+    origin: event.origin,
+    workspaceId: event.workspaceId,
+    provider: event.provider,
+    source: event.source,
+    event: event.event,
+    replayOfEventId: event.replayOfEventId,
+    deliveryId: event.deliveryId,
+    connectionId: event.connectionId,
+    connectionName: event.connectionName,
+    outcome: event.outcome,
+    matchedCount: event.matchedCount,
+    receivedAt: event.receivedAt.toISOString(),
+    processedAt: event.processedAt?.toISOString() ?? null,
+    createdAt: event.createdAt.toISOString(),
+  };
+}
+
+function toTriggerEvent(event: TriggerReceivedEvent) {
+  return {
+    ...toTriggerEventListItem(event),
+    payload: event.payload,
+  };
+}
+
+function toTriggerDecision(decision: TriggerDecision) {
+  return {
+    id: decision.id,
+    receivedEventId: decision.receivedEventId,
+    subscriptionKind: decision.subscriptionKind,
+    subscriptionId: decision.subscriptionId,
+    subscriptionName: decision.subscriptionName,
+    workflowDefinitionId: decision.workflowDefinitionId,
+    projectId: decision.projectId,
+    workflowRunId: decision.workflowRunId,
+    jobId: decision.jobId,
+    matcherKind: decision.matcherKind,
+    matcherOrdinal: decision.matcherOrdinal,
+    decision: decision.decision,
+    runId: decision.runId,
+    runName: decision.runName,
+    reason: decision.reason,
+    createdAt: decision.createdAt.toISOString(),
+  };
+}
+
+function toTriggerEventReplay(replay: TriggerEventReplay) {
+  return {
+    id: replay.id,
+    receivedAt: replay.receivedAt.toISOString(),
+    outcome: replay.outcome,
+    runId: replay.runId,
+  };
+}

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -26,6 +26,9 @@ type DefinitionForWorkflowRun = NonNullable<
 let definitionResponse: DefinitionForWorkflowRun | null = null;
 const definitions: DefinitionsInterModuleClient = {
   getDefinitionForWorkflowRun: async () => ({definition: definitionResponse}),
+  listDefinitionsByProject: () => {
+    throw new Error('listDefinitionsByProject is not used by runWorkflow');
+  },
   resolveDefinitionAtRef: () => {
     throw new Error('resolveDefinitionAtRef is not used by runWorkflow');
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4367,6 +4367,9 @@ importers:
 
   libs/api/triggers-dto:
     dependencies:
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
Adds producer-owned inter-module read contracts for agent access to discover workspace projects and workflow definitions, then inspect trigger event summaries, details, and facets. The inter-module presentations wrap the owning modules' existing reads, preserve keyset cursor behavior, and enforce workspace ownership before returning project-scoped data.

The agent gateway consumer and output projections remain out of scope for the follow-up agent-access tools work.

Validation: affected package checks, type checks, builds, package tests, dependency and lockfile checks, published-artifact verification, architecture checks, database-boundary verification, and git diff --check pass.

Closes ENG-1832

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds producer-owned inter-module read contracts for catalog and trigger-event data so agent access can compose them without duplicating read models.

**New Features**
- Adds `listProjectCatalogByWorkspace` with `slug`, `createdAt`, and `updatedAt`, keeping the existing `listProjectsByWorkspace` shape unchanged.
- Extracts shared `toDefinitionReadModel` and `toDefinitionSyncSummary` mappings for both HTTP and inter-module presentations.
- Adds `listDefinitionsByProject`, `listTriggerEvents`, `getTriggerEvent`, and `getTriggerEventFacets` to their contracts, preserving cursor behavior and workspace ownership checks.
- Adds `@shipfox/inter-module` as a dependency of `@shipfox/api-triggers-dto`.
- Agent gateway consumer and output projections remain out of scope for follow-up work.

<sup>Written for commit 86451e5af8454ced13c05ab0891f486272cbeee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

