### PR TITLE
Activate exact-scope GitHub checkout credential caching

### DIFF
--- a/.changeset/cache-credentials-l2.md
+++ b/.changeset/cache-credentials-l2.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-github": minor
+"@shipfox/api-server": patch
+---
+
+Activates exact-scope caching for initial GitHub checkout credentials with encrypted Secrets storage, advisory locking, cleanup, and a direct-minting fallback switch.

--- a/.changeset/cache-credentials-l2.md
+++ b/.changeset/cache-credentials-l2.md
@@ -1,7 +1,7 @@
 ---
 "@shipfox/api-integration-core": minor
 "@shipfox/api-integration-github": minor
-"@shipfox/api-server": patch
+"@shipfox/api-server": minor
 ---
 
-Activates exact-scope caching for initial GitHub checkout credentials with encrypted Secrets storage, advisory locking, cleanup, and a direct-minting fallback switch.
+Reuses cached GitHub checkout credentials for repeated checkouts of the same repository scope, with GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED (default true) available for direct minting.

--- a/libs/api/integration/core/src/providers/github.test.ts
+++ b/libs/api/integration/core/src/providers/github.test.ts
@@ -25,6 +25,10 @@ vi.mock('@shipfox/api-integration-github', async (importOriginal) => {
   };
 });
 
+import type {
+  GithubCheckoutTokenCachePort,
+  GithubCheckoutTokenScope,
+} from '@shipfox/api-integration-github';
 import {
   encodeInstallationTokenEnvelope,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
@@ -33,6 +37,8 @@ import {
   githubInstallationTokenNamespace,
 } from '@shipfox/api-integration-github';
 import {githubProviderModule} from '#providers/github.js';
+
+const checkoutTokenStorageKeyPattern = /^CHECKOUT_TOKEN_V1_[A-F0-9]{64}$/u;
 
 type SecretStore = {
   read: (workspaceId: string, installationId: number, key: string) => Promise<string | null>;
@@ -104,14 +110,21 @@ describe('githubProviderModule', () => {
     const getSecret = vi.fn(() => Promise.resolve(null));
     const getSecretsByNamespace = vi.fn(() => Promise.resolve({}));
     const setSecrets = vi.fn(() => Promise.resolve());
+    const scopedDeleteSecrets = vi.fn(() => Promise.resolve(1));
     const deleteSecrets = vi.fn(() => Promise.resolve(1));
 
-    await githubProviderModule.load({
+    const part = await githubProviderModule.load({
       secrets: {
-        github: {getSecret, getSecretsByNamespace, setSecrets, deleteSecrets},
+        github: {
+          getSecret,
+          getSecretsByNamespace,
+          setSecrets,
+          deleteSecrets: scopedDeleteSecrets,
+        },
         deleteSecrets,
       },
     });
+    expect(part.workers).toHaveLength(1);
 
     const providerOptions = captured.integrationProviderOptions;
     if (!providerOptions || typeof providerOptions !== 'object') {
@@ -119,23 +132,61 @@ describe('githubProviderModule', () => {
     }
     const checkoutTokenCache = (
       providerOptions as {
-        checkoutTokenCache?: {
-          deleteInstallation?: (
-            workspaceId: string,
-            providerInstance: string,
-            installationId: number,
-          ) => Promise<number>;
-        };
+        checkoutTokenCache?: GithubCheckoutTokenCachePort;
       }
     ).checkoutTokenCache;
-    expect(checkoutTokenCache).toBeDefined();
+    if (!checkoutTokenCache) throw new Error('Expected exact-scope cache');
 
     const providerInstance = 'provider-instance';
-    await checkoutTokenCache?.deleteInstallation?.('workspace-1', providerInstance, 123);
+    const scope: GithubCheckoutTokenScope = {
+      workspaceId: 'workspace-1',
+      providerInstance,
+      installationId: 123,
+      repositoryId: 456,
+      permissions: {contents: 'read'},
+    };
+    const mint = vi.fn(() =>
+      Promise.resolve({
+        token: 'ghs_checkout',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+      }),
+    );
+    await checkoutTokenCache.getOrMint(scope, mint);
+    await checkoutTokenCache.getOrMint(scope, mint);
 
-    expect(deleteSecrets).toHaveBeenCalledWith({
+    expect(mint).toHaveBeenCalledOnce();
+    const secretCalls = getSecret.mock.calls as unknown as Array<
+      [{workspaceId: string; namespace: string; key: string}]
+    >;
+    const checkoutSecretCall = secretCalls.find(
+      ([params]) => params.namespace === `system/github/checkout-token/${providerInstance}/123`,
+    );
+    expect(checkoutSecretCall?.[0]).toMatchObject({
+      workspaceId: 'workspace-1',
+      namespace: `system/github/checkout-token/${providerInstance}/123`,
+      key: expect.stringMatching(checkoutTokenStorageKeyPattern),
+    });
+    expect(getSecretsByNamespace).not.toHaveBeenCalled();
+    const setSecretsCalls = setSecrets.mock.calls as unknown as Array<[unknown]>;
+    const setSecretsCall = setSecretsCalls.at(-1)?.[0] as
+      | {workspaceId: string; namespace: string; values: Record<string, string>}
+      | undefined;
+    expect(setSecretsCall).toMatchObject({
       workspaceId: 'workspace-1',
       namespace: `system/github/checkout-token/${providerInstance}/123`,
     });
+    const storageKeys = Object.keys(setSecretsCall?.values ?? {});
+    expect(storageKeys).toHaveLength(1);
+    expect(storageKeys[0]).toBe(checkoutSecretCall?.[0].key);
+    expect(storageKeys[0]).toMatch(checkoutTokenStorageKeyPattern);
+    expect(setSecretsCall?.values[storageKeys[0] ?? '']).toEqual(expect.any(String));
+
+    await checkoutTokenCache.deleteInstallation?.('workspace-1', providerInstance, 123);
+
+    expect(scopedDeleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: `system/github/checkout-token/${providerInstance}/123`,
+    });
+    expect(deleteSecrets).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/core/src/providers/github.test.ts
+++ b/libs/api/integration/core/src/providers/github.test.ts
@@ -1,11 +1,21 @@
-const captured = vi.hoisted(() => ({providerOptions: undefined as unknown}));
+const captured = vi.hoisted(() => ({
+  integrationProviderOptions: undefined as unknown,
+  providerOptions: undefined as unknown,
+}));
 
 vi.mock('@shipfox/api-integration-github', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shipfox/api-integration-github')>();
   const originalCreate = actual.createGithubInstallationTokenProvider;
+  const originalCreateIntegrationProvider = actual.createGithubIntegrationProvider;
 
   return {
     ...actual,
+    createGithubIntegrationProvider: vi.fn(
+      (options: Parameters<typeof originalCreateIntegrationProvider>[0]) => {
+        captured.integrationProviderOptions = options;
+        return originalCreateIntegrationProvider(options);
+      },
+    ),
     createGithubInstallationTokenProvider: vi.fn(
       (options: Parameters<typeof originalCreate>[0]) => {
         captured.providerOptions = options;
@@ -87,6 +97,45 @@ describe('githubProviderModule', () => {
       values: {
         [profileKey]: encodeInstallationTokenEnvelope(envelope),
       },
+    });
+  });
+
+  it('wires the exact-scope cache to the scoped GitHub Secrets adapter', async () => {
+    const getSecret = vi.fn(() => Promise.resolve(null));
+    const getSecretsByNamespace = vi.fn(() => Promise.resolve({}));
+    const setSecrets = vi.fn(() => Promise.resolve());
+    const deleteSecrets = vi.fn(() => Promise.resolve(1));
+
+    await githubProviderModule.load({
+      secrets: {
+        github: {getSecret, getSecretsByNamespace, setSecrets, deleteSecrets},
+        deleteSecrets,
+      },
+    });
+
+    const providerOptions = captured.integrationProviderOptions;
+    if (!providerOptions || typeof providerOptions !== 'object') {
+      throw new Error('GitHub integration provider options were not captured');
+    }
+    const checkoutTokenCache = (
+      providerOptions as {
+        checkoutTokenCache?: {
+          deleteInstallation?: (
+            workspaceId: string,
+            providerInstance: string,
+            installationId: number,
+          ) => Promise<number>;
+        };
+      }
+    ).checkoutTokenCache;
+    expect(checkoutTokenCache).toBeDefined();
+
+    const providerInstance = 'provider-instance';
+    await checkoutTokenCache?.deleteInstallation?.('workspace-1', providerInstance, 123);
+
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: `system/github/checkout-token/${providerInstance}/123`,
     });
   });
 });

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -27,6 +27,7 @@ async function loadGithubModuleParts(
 ): Promise<IntegrationModuleParts> {
   const {
     createGithubInstallationTokenProvider,
+    createGithubCheckoutTokenCache,
     createGithubE2eRoutes,
     encodeInstallationTokenEnvelope,
     createGithubIntegrationProvider,
@@ -36,19 +37,54 @@ async function loadGithubModuleParts(
     migrationsPath: githubMigrationsPath,
     upsertGithubInstallation,
   } = await import('@shipfox/api-integration-github');
+  const githubSecrets = options.secrets?.github;
+  const listGithubSecretsByNamespace = githubSecrets?.getSecretsByNamespace;
+  const checkoutTokenSecretStore = githubSecrets
+    ? {
+        read: async (params: {workspaceId: string; namespace: string; key: string}) =>
+          await githubSecrets.getSecret(params),
+        write: async (params: {
+          workspaceId: string;
+          namespace: string;
+          key: string;
+          value: string;
+        }) => {
+          await githubSecrets.setSecrets({
+            workspaceId: params.workspaceId,
+            namespace: params.namespace,
+            values: {[params.key]: params.value},
+          });
+        },
+        delete: async (params: {workspaceId: string; namespace: string; key: string}) => {
+          await githubSecrets.deleteSecrets({
+            workspaceId: params.workspaceId,
+            namespace: params.namespace,
+            keys: [params.key],
+          });
+        },
+        deleteNamespace: async (params: {workspaceId: string; namespace: string}) =>
+          await githubSecrets.deleteSecrets(params),
+        ...(listGithubSecretsByNamespace
+          ? {
+              list: async (params: {workspaceId: string; namespace: string}) =>
+                await listGithubSecretsByNamespace(params),
+            }
+          : {}),
+      }
+    : undefined;
 
   const tokenProvider = createGithubInstallationTokenProvider({
     getIntegrationConnectionById,
-    secretStore: options.secrets?.github
+    secretStore: githubSecrets
       ? {
           read: async (workspaceId, installationId, key) =>
-            (await options.secrets?.github?.getSecret({
+            (await githubSecrets.getSecret({
               workspaceId,
               namespace: githubInstallationTokenNamespace(installationId),
               key,
             })) ?? null,
           write: async (workspaceId, installationId, key, envelope) => {
-            await options.secrets?.github?.setSecrets({
+            await githubSecrets.setSecrets({
               workspaceId,
               namespace: githubInstallationTokenNamespace(installationId),
               values: {[key]: encodeInstallationTokenEnvelope(envelope)},
@@ -122,6 +158,9 @@ async function loadGithubModuleParts(
     getIntegrationConnectionById,
     coreDb: db,
     deleteSecrets: options.secrets?.deleteSecrets,
+    checkoutTokenCache: createGithubCheckoutTokenCache({
+      secretStore: checkoutTokenSecretStore,
+    }),
     agentTools: {tokenProvider},
     ...(options.requireActiveWorkspaceMembership
       ? {requireActiveWorkspaceMembership: options.requireActiveWorkspaceMembership}

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -5,6 +5,7 @@ import type {IntegrationCapability} from '#core/entities/provider.js';
 import {getIntegrationProviderCapabilities} from '#core/providers/registry.js';
 import {
   getIntegrationConnectionById,
+  listIntegrationConnectionsByProvider,
   resolveUniqueConnectionSlug,
   upsertIntegrationConnection,
 } from '#db/connections.js';
@@ -21,6 +22,7 @@ import type {
   IntegrationProviderModule,
   IntegrationProviderModuleLoadOptions,
 } from '#providers/types.js';
+import {createGithubCheckoutTokenCacheMaintenanceWorker} from '#temporal/worker.js';
 
 async function loadGithubModuleParts(
   options: IntegrationProviderModuleLoadOptions = {},
@@ -148,6 +150,9 @@ async function loadGithubModuleParts(
     );
   }
 
+  const checkoutTokenCache = createGithubCheckoutTokenCache({
+    secretStore: checkoutTokenSecretStore,
+  });
   const integrationProvider = createGithubIntegrationProvider({
     getExistingGithubConnection,
     connectGithubInstallation,
@@ -158,14 +163,20 @@ async function loadGithubModuleParts(
     getIntegrationConnectionById,
     coreDb: db,
     deleteSecrets: options.secrets?.deleteSecrets,
-    checkoutTokenCache: createGithubCheckoutTokenCache({
-      secretStore: checkoutTokenSecretStore,
-    }),
+    checkoutTokenCache,
     agentTools: {tokenProvider},
     ...(options.requireActiveWorkspaceMembership
       ? {requireActiveWorkspaceMembership: options.requireActiveWorkspaceMembership}
       : {}),
   });
+  const checkoutTokenCacheMaintenanceWorker =
+    checkoutTokenCache && checkoutTokenSecretStore?.list
+      ? createGithubCheckoutTokenCacheMaintenanceWorker({
+          cache: checkoutTokenCache,
+          listConnections: async () =>
+            await listIntegrationConnectionsByProvider({provider: 'github'}),
+        })
+      : undefined;
   providerCapabilities = getIntegrationProviderCapabilities(integrationProvider.adapters);
 
   return {
@@ -183,6 +194,9 @@ async function loadGithubModuleParts(
       migrationsPath: githubMigrationsPath,
       databaseNamespace: 'integrations_github',
     },
+    ...(checkoutTokenCacheMaintenanceWorker
+      ? {workers: [checkoutTokenCacheMaintenanceWorker]}
+      : {}),
   };
 }
 

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -59,11 +59,19 @@ export interface IntegrationProviderSecrets {
 
 export interface IntegrationProviderScopedSecrets {
   getSecret(params: {workspaceId: string; namespace: string; key: string}): Promise<string | null>;
+  getSecretsByNamespace?(params: {
+    workspaceId: string;
+    namespace: string;
+  }): Promise<Record<string, string>>;
   setSecrets(params: {
     workspaceId: string;
     namespace: string;
     values: Record<string, string>;
     editedBy?: string | null | undefined;
   }): Promise<void>;
-  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
+  deleteSecrets(params: {
+    workspaceId: string;
+    namespace: string;
+    keys?: string[] | undefined;
+  }): Promise<number>;
 }

--- a/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.test.ts
+++ b/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.test.ts
@@ -44,4 +44,59 @@ describe('createGithubCheckoutTokenCacheMaintenanceActivities', () => {
     });
     expect(cleanupExpiredInstallation).not.toHaveBeenCalled();
   });
+
+  it('continues past more than one batch of clean or malformed connections', async () => {
+    const cleanupExpiredInstallation = vi.fn(() => Promise.resolve(0));
+    const connections = [
+      ...Array.from({length: 100}, (_, index) => ({
+        workspaceId: `malformed-${index}`,
+        externalAccountId: 'not-an-installation',
+      })),
+      ...Array.from({length: 101}, (_, index) => ({
+        workspaceId: `workspace-${index}`,
+        externalAccountId: String(index + 1),
+      })),
+    ];
+    const activities = createGithubCheckoutTokenCacheMaintenanceActivities({
+      cache: {cleanupExpiredInstallation},
+      listConnections: async () => connections,
+      batchSize: 100,
+    });
+
+    await expect(activities.cleanupGithubCheckoutTokenCacheActivity()).resolves.toEqual({
+      deleted: 0,
+      failed: 0,
+      scanned: 101,
+      skipped: 100,
+    });
+    expect(cleanupExpiredInstallation).toHaveBeenCalledTimes(101);
+  });
+
+  it('heartbeats while an installation cleanup is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveCleanup!: (value: number) => void;
+      const cleanupExpiredInstallation = vi.fn(
+        () => new Promise<number>((resolve) => (resolveCleanup = resolve)),
+      );
+      const heartbeat = vi.fn();
+      const activities = createGithubCheckoutTokenCacheMaintenanceActivities({
+        cache: {cleanupExpiredInstallation},
+        listConnections: async () => [{workspaceId: 'workspace-a', externalAccountId: '11'}],
+        heartbeat,
+      });
+
+      const result = activities.cleanupGithubCheckoutTokenCacheActivity();
+      await vi.waitFor(() => expect(cleanupExpiredInstallation).toHaveBeenCalledOnce());
+      const heartbeatCountBeforeCleanup = heartbeat.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(heartbeat.mock.calls.length).toBeGreaterThan(heartbeatCountBeforeCleanup);
+      resolveCleanup(0);
+      await expect(result).resolves.toEqual({deleted: 0, failed: 0, scanned: 1, skipped: 0});
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.test.ts
+++ b/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.test.ts
@@ -1,0 +1,47 @@
+import {createGithubCheckoutTokenCacheMaintenanceActivities} from './cleanup-github-checkout-token-cache.js';
+
+describe('createGithubCheckoutTokenCacheMaintenanceActivities', () => {
+  it('scans GitHub installations with one bounded deletion budget', async () => {
+    const cleanupExpiredInstallation = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+    const heartbeat = vi.fn();
+    const activities = createGithubCheckoutTokenCacheMaintenanceActivities({
+      cache: {cleanupExpiredInstallation},
+      listConnections: async () => [
+        {workspaceId: 'workspace-a', externalAccountId: '11'},
+        {workspaceId: 'workspace-b', externalAccountId: '12'},
+        {workspaceId: 'workspace-c', externalAccountId: 'not-an-installation'},
+      ],
+      batchSize: 3,
+      heartbeat,
+    });
+
+    await expect(activities.cleanupGithubCheckoutTokenCacheActivity()).resolves.toEqual({
+      deleted: 3,
+      failed: 0,
+      scanned: 2,
+      skipped: 0,
+    });
+    expect(cleanupExpiredInstallation).toHaveBeenNthCalledWith(1, 'workspace-a', 11, 3);
+    expect(cleanupExpiredInstallation).toHaveBeenNthCalledWith(2, 'workspace-b', 12, 2);
+    expect(heartbeat).toHaveBeenCalled();
+  });
+
+  it('skips malformed installation identifiers without invoking the cache', async () => {
+    const cleanupExpiredInstallation = vi.fn(() => Promise.resolve(0));
+    const activities = createGithubCheckoutTokenCacheMaintenanceActivities({
+      cache: {cleanupExpiredInstallation},
+      listConnections: async () => [
+        {workspaceId: 'workspace-a', externalAccountId: '0123'},
+        {workspaceId: 'workspace-b', externalAccountId: '0'},
+      ],
+    });
+
+    await expect(activities.cleanupGithubCheckoutTokenCacheActivity()).resolves.toMatchObject({
+      deleted: 0,
+      failed: 0,
+      scanned: 0,
+      skipped: 2,
+    });
+    expect(cleanupExpiredInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.ts
+++ b/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.ts
@@ -1,0 +1,85 @@
+import {logger} from '@shipfox/node-opentelemetry';
+
+const GITHUB_INSTALLATION_ID_PATTERN = /^[1-9]\d*$/u;
+const DEFAULT_BATCH_SIZE = 100;
+
+export interface GithubCheckoutTokenCleanupConnection {
+  workspaceId: string;
+  externalAccountId: string;
+}
+
+export interface GithubCheckoutTokenCacheCleanup {
+  cleanupExpiredInstallation(
+    workspaceId: string,
+    installationId: number,
+    limit?: number,
+  ): Promise<number>;
+}
+
+export interface CreateGithubCheckoutTokenCacheMaintenanceActivitiesOptions {
+  cache: GithubCheckoutTokenCacheCleanup;
+  listConnections(): Promise<readonly GithubCheckoutTokenCleanupConnection[]>;
+  batchSize?: number | undefined;
+  heartbeat?: (() => void) | undefined;
+}
+
+export interface GithubCheckoutTokenCacheCleanupActivityResult {
+  deleted: number;
+  failed: number;
+  scanned: number;
+  skipped: number;
+}
+
+export function createGithubCheckoutTokenCacheMaintenanceActivities(
+  options: CreateGithubCheckoutTokenCacheMaintenanceActivitiesOptions,
+) {
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+    throw new Error(`Invalid GitHub checkout-token cleanup batch size: ${batchSize}`);
+  }
+
+  return {
+    async cleanupGithubCheckoutTokenCacheActivity(): Promise<GithubCheckoutTokenCacheCleanupActivityResult> {
+      const connections = await options.listConnections();
+      let remaining = batchSize;
+      let deleted = 0;
+      let failed = 0;
+      let scanned = 0;
+      let skipped = 0;
+
+      for (const connection of connections) {
+        if (remaining === 0 || scanned + skipped >= batchSize) break;
+        if (!GITHUB_INSTALLATION_ID_PATTERN.test(connection.externalAccountId)) {
+          skipped += 1;
+          continue;
+        }
+        const installationId = Number(connection.externalAccountId);
+        if (!Number.isSafeInteger(installationId)) {
+          skipped += 1;
+          continue;
+        }
+
+        options.heartbeat?.();
+        scanned += 1;
+        try {
+          const removed = await options.cache.cleanupExpiredInstallation(
+            connection.workspaceId,
+            installationId,
+            remaining,
+          );
+          deleted += removed;
+          remaining -= removed;
+        } catch (error) {
+          failed += 1;
+          logger().warn(
+            {installationId, err: error},
+            'GitHub checkout-token cache cleanup failed for installation',
+          );
+        }
+      }
+
+      options.heartbeat?.();
+      return {deleted, failed, scanned, skipped};
+    },
+  };
+}

--- a/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.ts
+++ b/libs/api/integration/core/src/temporal/activities/cleanup-github-checkout-token-cache.ts
@@ -2,6 +2,7 @@ import {logger} from '@shipfox/node-opentelemetry';
 
 const GITHUB_INSTALLATION_ID_PATTERN = /^[1-9]\d*$/u;
 const DEFAULT_BATCH_SIZE = 100;
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 export interface GithubCheckoutTokenCleanupConnection {
   workspaceId: string;
@@ -48,7 +49,7 @@ export function createGithubCheckoutTokenCacheMaintenanceActivities(
       let skipped = 0;
 
       for (const connection of connections) {
-        if (remaining === 0 || scanned + skipped >= batchSize) break;
+        if (remaining === 0) break;
         if (!GITHUB_INSTALLATION_ID_PATTERN.test(connection.externalAccountId)) {
           skipped += 1;
           continue;
@@ -59,22 +60,26 @@ export function createGithubCheckoutTokenCacheMaintenanceActivities(
           continue;
         }
 
-        options.heartbeat?.();
-        scanned += 1;
+        const heartbeatInterval = setInterval(() => options.heartbeat?.(), HEARTBEAT_INTERVAL_MS);
         try {
+          options.heartbeat?.();
+          scanned += 1;
           const removed = await options.cache.cleanupExpiredInstallation(
             connection.workspaceId,
             installationId,
             remaining,
           );
           deleted += removed;
-          remaining -= removed;
+          remaining = Math.max(0, remaining - removed);
         } catch (error) {
           failed += 1;
           logger().warn(
             {installationId, err: error},
             'GitHub checkout-token cache cleanup failed for installation',
           );
+        } finally {
+          clearInterval(heartbeatInterval);
+          options.heartbeat?.();
         }
       }
 

--- a/libs/api/integration/core/src/temporal/constants.ts
+++ b/libs/api/integration/core/src/temporal/constants.ts
@@ -1,4 +1,5 @@
 export const INTEGRATIONS_MAINTENANCE_TASK_QUEUE = 'integrations-maintenance';
+export const INTEGRATIONS_GITHUB_MAINTENANCE_TASK_QUEUE = 'integrations-github-maintenance';
 
 export const WEBHOOK_DELIVERY_RETENTION_DAYS = 30;
 

--- a/libs/api/integration/core/src/temporal/worker.ts
+++ b/libs/api/integration/core/src/temporal/worker.ts
@@ -1,0 +1,39 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {ModuleWorker} from '@shipfox/node-module';
+import {Context} from '@temporalio/activity';
+import {
+  createGithubCheckoutTokenCacheMaintenanceActivities,
+  type GithubCheckoutTokenCacheCleanup,
+  type GithubCheckoutTokenCleanupConnection,
+} from './activities/cleanup-github-checkout-token-cache.js';
+import {INTEGRATIONS_GITHUB_MAINTENANCE_TASK_QUEUE} from './constants.js';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
+
+export interface CreateGithubCheckoutTokenCacheMaintenanceWorkerOptions {
+  cache: GithubCheckoutTokenCacheCleanup;
+  listConnections(): Promise<readonly GithubCheckoutTokenCleanupConnection[]>;
+}
+
+export function createGithubCheckoutTokenCacheMaintenanceWorker(
+  options: CreateGithubCheckoutTokenCacheMaintenanceWorkerOptions,
+): ModuleWorker {
+  return {
+    taskQueue: INTEGRATIONS_GITHUB_MAINTENANCE_TASK_QUEUE,
+    workflowsPath,
+    activities: () =>
+      createGithubCheckoutTokenCacheMaintenanceActivities({
+        ...options,
+        heartbeat: () => Context.current().heartbeat(),
+      }),
+    workflows: [
+      {
+        name: 'cleanupGithubCheckoutTokenCacheCron',
+        id: 'github-cleanup-checkout-token-cache',
+        cronSchedule: '*/15 * * * *',
+      },
+    ],
+  };
+}

--- a/libs/api/integration/core/src/temporal/workflows/cleanup-github-checkout-token-cache-cron.ts
+++ b/libs/api/integration/core/src/temporal/workflows/cleanup-github-checkout-token-cache-cron.ts
@@ -1,0 +1,17 @@
+import {log, proxyActivities} from '@temporalio/workflow';
+import type {createGithubCheckoutTokenCacheMaintenanceActivities} from '../activities/cleanup-github-checkout-token-cache.js';
+
+const {cleanupGithubCheckoutTokenCacheActivity} = proxyActivities<
+  ReturnType<typeof createGithubCheckoutTokenCacheMaintenanceActivities>
+>({
+  startToCloseTimeout: '5 minutes',
+  heartbeatTimeout: '1 minute',
+  retry: {maximumAttempts: 1},
+});
+
+export async function cleanupGithubCheckoutTokenCacheCron(): Promise<void> {
+  const result = await cleanupGithubCheckoutTokenCacheActivity();
+  if (result.deleted > 0 || result.failed > 0) {
+    log.info('Completed GitHub checkout-token cache cleanup', {...result});
+  }
+}

--- a/libs/api/integration/core/src/temporal/workflows/index.ts
+++ b/libs/api/integration/core/src/temporal/workflows/index.ts
@@ -1,2 +1,3 @@
+export {cleanupGithubCheckoutTokenCacheCron} from './cleanup-github-checkout-token-cache-cron.js';
 export {cleanupIntegrationSecretsCron} from './cleanup-integration-secrets-cron.js';
 export {pruneWebhookDeliveriesCron} from './prune-webhook-deliveries-cron.js';

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -67,6 +67,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",

--- a/libs/api/integration/github/src/api/github-checkout-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/github-checkout-token-cache.test.ts
@@ -12,6 +12,7 @@ import {
   parseGithubCheckoutTokenEnvelope,
 } from './github-checkout-token-cache.js';
 
+const secretKeyPattern = /^[A-Z_][A-Z0-9_]*$/u;
 const now = new Date('2026-06-10T11:00:00.000Z');
 const baseScope: GithubCheckoutTokenScope = {
   workspaceId: 'workspace-a',
@@ -113,6 +114,10 @@ describe('GitHub checkout token scope identity', () => {
         runnerId: 'runner',
       } as GithubCheckoutTokenScope),
     );
+  });
+
+  it('uses a Secrets-compatible key for each exact scope', () => {
+    expect(githubCheckoutTokenStorageKey(baseScope)).toMatch(secretKeyPattern);
   });
 
   it('requires the versioned envelope and exact stored permissions', () => {

--- a/libs/api/integration/github/src/api/github-checkout-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/github-checkout-token-cache.test.ts
@@ -1,3 +1,4 @@
+import {SECRET_KEY_PATTERN} from '@shipfox/api-secrets-dto';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import type {
   GithubCheckoutTokenEnvelope,
@@ -12,7 +13,6 @@ import {
   parseGithubCheckoutTokenEnvelope,
 } from './github-checkout-token-cache.js';
 
-const secretKeyPattern = /^[A-Z_][A-Z0-9_]*$/u;
 const now = new Date('2026-06-10T11:00:00.000Z');
 const baseScope: GithubCheckoutTokenScope = {
   workspaceId: 'workspace-a',
@@ -67,10 +67,12 @@ function cache(
     mintTimeoutMs?: number;
     currentTime?: () => Date;
     sleep?: (ms: number) => Promise<void>;
+    providerInstance?: string;
   } = {},
 ) {
   return new GithubCheckoutTokenCache({
     secretStore: options.store,
+    providerInstance: options.providerInstance,
     withLock: options.withLock ?? (async (_digest, fn) => ({acquired: true, value: await fn()})),
     now: options.currentTime ?? (() => now),
     sleep: options.sleep ?? (() => Promise.resolve()),
@@ -117,7 +119,7 @@ describe('GitHub checkout token scope identity', () => {
   });
 
   it('uses a Secrets-compatible key for each exact scope', () => {
-    expect(githubCheckoutTokenStorageKey(baseScope)).toMatch(secretKeyPattern);
+    expect(githubCheckoutTokenStorageKey(baseScope)).toMatch(SECRET_KEY_PATTERN);
   });
 
   it('requires the versioned envelope and exact stored permissions', () => {
@@ -453,6 +455,26 @@ describe('GithubCheckoutTokenCache', () => {
     expect(store.values.has(expiredKey)).toBe(false);
     expect(store.values.has(newerVersionKey)).toBe(true);
     expect(store.values.has(unrelatedKey)).toBe(true);
+  });
+
+  it('cleans expired entries when the maintenance pass only knows an installation', async () => {
+    const store = createStore();
+    const expiredKey = githubCheckoutTokenStorageKey(baseScope);
+    store.values.set(
+      expiredKey,
+      encodeGithubCheckoutTokenEnvelope({
+        version: GITHUB_CHECKOUT_TOKEN_CACHE_VERSION,
+        generation: 'old',
+        token: 'old-token',
+        expiresAt: new Date('2026-06-09T10:00:00.000Z'),
+        repositoryId: 42,
+        permissions: {contents: 'read'},
+      }),
+    );
+    const shared = cache({store, providerInstance: 'provider-a'});
+
+    await expect(shared.cleanupExpiredInstallation('workspace-a', 11, 10)).resolves.toBe(1);
+    expect(store.values.has(expiredKey)).toBe(false);
   });
 
   it('deletes only one provider installation and purges its RAM entries', async () => {

--- a/libs/api/integration/github/src/api/github-checkout-token-cache.ts
+++ b/libs/api/integration/github/src/api/github-checkout-token-cache.ts
@@ -3,7 +3,7 @@ import {setTimeout as sleepTimeout} from 'node:timers/promises';
 import type {IntegrationProviderErrorReason} from '@shipfox/api-integration-spi';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
-import {config} from '#config.js';
+import {config, normalizedGithubApiBaseUrl} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {withGithubCheckoutTokenLock} from '#db/checkout-token-lock.js';
 import {recordGithubCheckoutTokenLookup, recordGithubCheckoutTokenMint} from '#metrics/instance.js';
@@ -100,6 +100,11 @@ export interface GithubCheckoutTokenCachePort {
     mint: () => Promise<GithubInstallationAccessToken>,
     rejectedGeneration?: string,
   ): Promise<GithubCheckoutToken>;
+  cleanupExpiredInstallation?(
+    workspaceId: string,
+    installationId: number,
+    limit?: number,
+  ): Promise<number>;
   deleteInstallation?(
     workspaceId: string,
     providerInstance: string,
@@ -109,6 +114,7 @@ export interface GithubCheckoutTokenCachePort {
 
 export interface GithubCheckoutTokenCacheOptions {
   secretStore?: GithubCheckoutTokenSecretStore | undefined;
+  providerInstance?: string | undefined;
   withLock?: <T>(
     scopeDigest: string,
     fn: () => Promise<T>,
@@ -126,6 +132,10 @@ export function createGithubCheckoutTokenCache(
   if (!config.GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED) return undefined;
   return new GithubCheckoutTokenCache({
     ...(options.secretStore === undefined ? {} : {secretStore: options.secretStore}),
+    providerInstance: githubProviderInstanceFingerprint(
+      normalizedGithubApiBaseUrl(),
+      config.GITHUB_APP_ID,
+    ),
     withLock: withGithubCheckoutTokenLock,
   });
 }
@@ -415,18 +425,41 @@ export class GithubCheckoutTokenCache implements GithubCheckoutTokenCachePort {
 
   /** Deletes expired entries in one bounded namespace pass. */
   async cleanupExpired(scope: GithubCheckoutTokenScope, limit = 100): Promise<number> {
-    const store = this.options.secretStore;
-    if (!store?.list || !store.delete) return 0;
-    if (!Number.isSafeInteger(limit) || limit < 1)
-      throw new Error(`Invalid cleanup limit: ${limit}`);
-
     const normalizedScope = normalizeScope(scope);
     const namespace = githubCheckoutTokenNamespace(
       normalizedScope.providerInstance,
       normalizedScope.installationId,
     );
+    return await this.cleanupExpiredNamespace(normalizedScope.workspaceId, namespace, limit);
+  }
+
+  /** Deletes expired entries from one installation namespace in a bounded pass. */
+  async cleanupExpiredInstallation(
+    workspaceId: string,
+    installationId: number,
+    limit = 100,
+  ): Promise<number> {
+    const providerInstance = this.options.providerInstance;
+    if (!providerInstance) return 0;
+    return await this.cleanupExpiredNamespace(
+      workspaceId,
+      githubCheckoutTokenNamespace(providerInstance, installationId),
+      limit,
+    );
+  }
+
+  private async cleanupExpiredNamespace(
+    workspaceId: string,
+    namespace: string,
+    limit: number,
+  ): Promise<number> {
+    const store = this.options.secretStore;
+    if (!store?.list || !store.delete) return 0;
+    if (!Number.isSafeInteger(limit) || limit < 1)
+      throw new Error(`Invalid cleanup limit: ${limit}`);
+
     const values = await store.list({
-      workspaceId: normalizedScope.workspaceId,
+      workspaceId,
       namespace,
     });
     let deleted = 0;
@@ -437,7 +470,7 @@ export class GithubCheckoutTokenCache implements GithubCheckoutTokenCachePort {
       const envelope = parseGithubCheckoutTokenEnvelope(raw);
       if (!envelope || !isExpiredForCleanup(envelope, now)) continue;
       await store.delete({
-        workspaceId: normalizedScope.workspaceId,
+        workspaceId,
         namespace,
         key,
       });

--- a/libs/api/integration/github/src/api/github-checkout-token-cache.ts
+++ b/libs/api/integration/github/src/api/github-checkout-token-cache.ts
@@ -3,6 +3,7 @@ import {setTimeout as sleepTimeout} from 'node:timers/promises';
 import type {IntegrationProviderErrorReason} from '@shipfox/api-integration-spi';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
+import {config} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {withGithubCheckoutTokenLock} from '#db/checkout-token-lock.js';
 import {recordGithubCheckoutTokenLookup, recordGithubCheckoutTokenMint} from '#metrics/instance.js';
@@ -24,7 +25,7 @@ export const GITHUB_CHECKOUT_TOKEN_RETENTION_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_MAX_RAM_ENTRIES = 1_000;
 const DEFAULT_POLL_DELAYS_MS = [100, 200, 400, 800, 1_600, 3_200, 6_400, 12_800, 4_500];
 const DEFAULT_MINT_TIMEOUT_MS = 30_000;
-const STORAGE_KEY_PREFIX = `v${GITHUB_CHECKOUT_TOKEN_CACHE_VERSION}-`;
+const STORAGE_KEY_PREFIX = `CHECKOUT_TOKEN_V${GITHUB_CHECKOUT_TOKEN_CACHE_VERSION}_`;
 const BASELINE_PERMISSION_KEYS = new Set(['metadata']);
 const PROVIDER_ERROR_REASONS = new Set<IntegrationProviderErrorReason>([
   'repository-not-found',
@@ -99,6 +100,11 @@ export interface GithubCheckoutTokenCachePort {
     mint: () => Promise<GithubInstallationAccessToken>,
     rejectedGeneration?: string,
   ): Promise<GithubCheckoutToken>;
+  deleteInstallation?(
+    workspaceId: string,
+    providerInstance: string,
+    installationId: number,
+  ): Promise<number>;
 }
 
 export interface GithubCheckoutTokenCacheOptions {
@@ -112,6 +118,16 @@ export interface GithubCheckoutTokenCacheOptions {
   pollDelaysMs?: number[] | undefined;
   mintTimeoutMs?: number | undefined;
   maxRamEntries?: number | undefined;
+}
+
+export function createGithubCheckoutTokenCache(
+  options: {secretStore?: GithubCheckoutTokenSecretStore | undefined} = {},
+): GithubCheckoutTokenCache | undefined {
+  if (!config.GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED) return undefined;
+  return new GithubCheckoutTokenCache({
+    ...(options.secretStore === undefined ? {} : {secretStore: options.secretStore}),
+    withLock: withGithubCheckoutTokenLock,
+  });
 }
 
 export function canonicalGithubCheckoutTokenScope(scope: GithubCheckoutTokenScope): string {
@@ -133,7 +149,7 @@ export function githubCheckoutTokenScopeDigest(scope: GithubCheckoutTokenScope):
 }
 
 export function githubCheckoutTokenStorageKey(scope: GithubCheckoutTokenScope): string {
-  return `${STORAGE_KEY_PREFIX}${githubCheckoutTokenScopeDigest(scope)}`;
+  return `${STORAGE_KEY_PREFIX}${githubCheckoutTokenScopeDigest(scope).toUpperCase()}`;
 }
 
 export function deleteGithubCheckoutTokenSecretGroup(params: {

--- a/libs/api/integration/github/src/config.test.ts
+++ b/libs/api/integration/github/src/config.test.ts
@@ -12,3 +12,36 @@ describe('normalizeGithubApiBaseUrl', () => {
     expect(result).toBe(expected);
   });
 });
+
+describe('GitHub checkout token cache config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('enables the exact-scope cache by default', async () => {
+    vi.resetModules();
+
+    const {config} = await import('./config.js');
+
+    expect(config.GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED).toBe(true);
+  });
+
+  it('allows direct minting to be restored with the switch disabled', async () => {
+    vi.stubEnv('GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED', 'false');
+    vi.resetModules();
+
+    const {config} = await import('./config.js');
+
+    expect(config.GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED).toBe(false);
+  });
+
+  it('does not construct the cache when the switch is disabled', async () => {
+    vi.stubEnv('GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED', 'false');
+    vi.resetModules();
+
+    const {createGithubCheckoutTokenCache} = await import('./api/github-checkout-token-cache.js');
+
+    expect(createGithubCheckoutTokenCache()).toBeUndefined();
+  });
+});

--- a/libs/api/integration/github/src/config.test.ts
+++ b/libs/api/integration/github/src/config.test.ts
@@ -20,6 +20,7 @@ describe('GitHub checkout token cache config', () => {
   });
 
   it('enables the exact-scope cache by default', async () => {
+    vi.stubEnv('GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED', 'true');
     vi.resetModules();
 
     const {config} = await import('./config.js');

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -1,4 +1,4 @@
-import {createConfig, str, url} from '@shipfox/config';
+import {bool, createConfig, str, url} from '@shipfox/config';
 
 const trailingSlashesPattern = /\/+$/u;
 
@@ -28,6 +28,10 @@ export const config = createConfig({
   GITHUB_API_BASE_URL: url({
     desc: 'Base URL used for GitHub REST API requests. Set this only for GitHub Enterprise Server or a compatible test server.',
     default: 'https://api.github.com',
+  }),
+  GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED: bool({
+    desc: 'Enables the exact-scope encrypted cache for GitHub checkout credentials. Set this to false to bypass RAM and shared checkout caches and mint directly. Defaults to true.',
+    default: true,
   }),
   GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE: str({
     desc: 'Temporary GitHub installation token format override. Set this to enabled to request stateless tokens, disabled to request stateful tokens, or leave it unset to follow the GitHub rollout.',

--- a/libs/api/integration/github/src/index.test.ts
+++ b/libs/api/integration/github/src/index.test.ts
@@ -1,4 +1,8 @@
 import {githubEventCatalog} from '@shipfox/api-integration-github-dto';
+import {
+  githubCheckoutTokenNamespace,
+  githubProviderInstanceFingerprint,
+} from '#api/github-checkout-token-cache.js';
 import {githubInstallationTokenNamespace} from '#api/installation-token-envelope.js';
 import {createGithubIntegrationProvider} from '#index.js';
 
@@ -47,6 +51,10 @@ describe('createGithubIntegrationProvider', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     };
+    const checkoutNamespace = githubCheckoutTokenNamespace(
+      githubProviderInstanceFingerprint('https://api.github.com', '1'),
+      123,
+    );
     await deleteConnectionSecrets?.(connection);
     await deleteConnectionSecrets?.(connection);
     expect(deleteSecrets).toHaveBeenNthCalledWith(1, {
@@ -55,7 +63,15 @@ describe('createGithubIntegrationProvider', () => {
     });
     expect(deleteSecrets).toHaveBeenNthCalledWith(2, {
       workspaceId: 'workspace-1',
+      namespace: checkoutNamespace,
+    });
+    expect(deleteSecrets).toHaveBeenNthCalledWith(3, {
+      workspaceId: 'workspace-1',
       namespace: githubInstallationTokenNamespace(123),
+    });
+    expect(deleteSecrets).toHaveBeenNthCalledWith(4, {
+      workspaceId: 'workspace-1',
+      namespace: checkoutNamespace,
     });
 
     await expect(
@@ -64,7 +80,7 @@ describe('createGithubIntegrationProvider', () => {
     await expect(
       deleteConnectionSecrets({...connection, externalAccountId: '+123'}),
     ).rejects.toThrow('Invalid GitHub installation id: +123');
-    expect(deleteSecrets).toHaveBeenCalledTimes(2);
+    expect(deleteSecrets).toHaveBeenCalledTimes(4);
 
     const processorOptions = state.processorOptions as {
       deleteInstallationTokenSecret: (params: {
@@ -78,6 +94,52 @@ describe('createGithubIntegrationProvider', () => {
       installationId: 123,
     });
 
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: githubInstallationTokenNamespace(123),
+    });
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: checkoutNamespace,
+    });
+  });
+
+  it('uses the exact cache lifecycle for installation cleanup when it is available', async () => {
+    const deleteSecrets = vi.fn(() => Promise.resolve(1));
+    const deleteInstallation = vi.fn(() => Promise.resolve(1));
+    const provider = createGithubIntegrationProvider({
+      github: {} as never,
+      getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+      connectGithubInstallation: vi.fn() as never,
+      coreDb: vi.fn() as never,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+      publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
+      publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
+      deleteSecrets,
+      checkoutTokenCache: {getOrMint: vi.fn(), deleteInstallation},
+    });
+    const deleteConnectionSecrets = provider.deleteConnectionSecrets;
+    if (!deleteConnectionSecrets) throw new Error('Expected connection secret cleanup');
+
+    await deleteConnectionSecrets({
+      id: 'connection-1',
+      provider: 'github',
+      workspaceId: 'workspace-1',
+      externalAccountId: '123',
+      slug: 'github_shipfox',
+      displayName: 'GitHub',
+      lifecycleStatus: 'active',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    expect(deleteInstallation).toHaveBeenCalledWith(
+      'workspace-1',
+      githubProviderInstanceFingerprint('https://api.github.com', '1'),
+      123,
+    );
     expect(deleteSecrets).toHaveBeenCalledWith({
       workspaceId: 'workspace-1',
       namespace: githubInstallationTokenNamespace(123),

--- a/libs/api/integration/github/src/index.test.ts
+++ b/libs/api/integration/github/src/index.test.ts
@@ -35,6 +35,7 @@ describe('createGithubIntegrationProvider', () => {
       recordDeliveryOnly: vi.fn(() => Promise.resolve()),
       getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
       deleteSecrets,
+      checkoutTokenCache: {getOrMint: vi.fn()},
     });
     expect(provider.eventCatalog).toBe(githubEventCatalog);
     const deleteConnectionSecrets = provider.deleteConnectionSecrets;
@@ -144,5 +145,82 @@ describe('createGithubIntegrationProvider', () => {
       workspaceId: 'workspace-1',
       namespace: githubInstallationTokenNamespace(123),
     });
+  });
+
+  it('falls back to namespace deletion when a cache cannot delete shared entries', async () => {
+    const deleteSecrets = vi.fn(() => Promise.resolve(1));
+    const deleteInstallation = vi.fn(() => Promise.resolve(0));
+    const provider = createGithubIntegrationProvider({
+      github: {} as never,
+      getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+      connectGithubInstallation: vi.fn() as never,
+      coreDb: vi.fn() as never,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+      publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
+      publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
+      deleteSecrets,
+      checkoutTokenCache: {getOrMint: vi.fn(), deleteInstallation},
+    });
+    const deleteConnectionSecrets = provider.deleteConnectionSecrets;
+    if (!deleteConnectionSecrets) throw new Error('Expected connection secret cleanup');
+
+    await deleteConnectionSecrets({
+      id: 'connection-1',
+      provider: 'github',
+      workspaceId: 'workspace-1',
+      externalAccountId: '123',
+      slug: 'github_shipfox',
+      displayName: 'GitHub',
+      lifecycleStatus: 'active',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    expect(deleteInstallation).toHaveBeenCalledOnce();
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: githubCheckoutTokenNamespace(
+        githubProviderInstanceFingerprint('https://api.github.com', '1'),
+        123,
+      ),
+    });
+  });
+
+  it('supports cache-only installation cleanup when shared deletion is unavailable', async () => {
+    const deleteInstallation = vi.fn(() => Promise.resolve(1));
+    const provider = createGithubIntegrationProvider({
+      github: {} as never,
+      getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+      connectGithubInstallation: vi.fn() as never,
+      coreDb: vi.fn() as never,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+      publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
+      publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
+      checkoutTokenCache: {getOrMint: vi.fn(), deleteInstallation},
+    });
+    const deleteConnectionSecrets = provider.deleteConnectionSecrets;
+    if (!deleteConnectionSecrets) throw new Error('Expected connection secret cleanup');
+
+    await deleteConnectionSecrets({
+      id: 'connection-1',
+      provider: 'github',
+      workspaceId: 'workspace-1',
+      externalAccountId: '123',
+      slug: 'github_shipfox',
+      displayName: 'GitHub',
+      lifecycleStatus: 'active',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    expect(deleteInstallation).toHaveBeenCalledWith(
+      'workspace-1',
+      githubProviderInstanceFingerprint('https://api.github.com', '1'),
+      123,
+    );
   });
 });

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -9,12 +9,17 @@ import type {
 } from '@shipfox/api-integration-spi';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {createGithubApiClient, type GithubApiClient} from '#api/client.js';
-import type {GithubCheckoutTokenCachePort} from '#api/github-checkout-token-cache.js';
+import {
+  deleteGithubCheckoutTokenSecretGroup,
+  type GithubCheckoutTokenCachePort,
+  githubProviderInstanceFingerprint,
+} from '#api/github-checkout-token-cache.js';
 import type {GithubInstallationTokenProvider} from '#api/installation-token-provider.js';
 import {
   createGithubInstallationTokenProvider,
   deleteGithubInstallationTokenSecret,
 } from '#api/installation-token-provider.js';
+import {config, normalizedGithubApiBaseUrl} from '#config.js';
 import {GithubAgentToolsProvider} from '#core/agent-tools.js';
 import {GithubSourceControlProvider} from '#core/source-control.js';
 import {createGithubWebhookProcessor} from '#core/webhook-processor.js';
@@ -38,11 +43,17 @@ const GITHUB_INSTALLATION_ID_PATTERN = /^[1-9]\d*$/u;
 
 export type {GithubApiClient} from '#api/client.js';
 export {
+  createGithubCheckoutTokenCache,
+  deleteGithubCheckoutTokenSecretGroup,
   type GithubCheckoutToken,
   GithubCheckoutTokenCache,
   type GithubCheckoutTokenCachePort,
   type GithubCheckoutTokenPermissions,
   type GithubCheckoutTokenScope,
+  type GithubCheckoutTokenSecretStore,
+  githubCheckoutTokenNamespace,
+  githubCheckoutTokenStorageKey,
+  githubProviderInstanceFingerprint,
 } from '#api/github-checkout-token-cache.js';
 export {
   encodeInstallationTokenEnvelope,
@@ -114,15 +125,49 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
   const getInstallationByConnectionId =
     options.getGithubInstallationByConnectionId ?? getGithubInstallationByConnectionId;
   const deleteSecrets = options.deleteSecrets;
-  const deleteInstallationTokenSecret = deleteSecrets
-    ? (params: {workspaceId: string; installationId: number}) =>
-        deleteGithubInstallationTokenSecret({
-          workspaceId: params.workspaceId,
-          installationId: params.installationId,
-          deleteSecrets,
-        })
+  const checkoutTokenCache = options.checkoutTokenCache;
+  const checkoutTokenProviderInstance =
+    deleteSecrets || checkoutTokenCache
+      ? githubProviderInstanceFingerprint(normalizedGithubApiBaseUrl(), config.GITHUB_APP_ID)
+      : undefined;
+  const deleteInstallationSecrets =
+    deleteSecrets || checkoutTokenCache
+      ? async (params: {workspaceId: string; installationId: number}): Promise<void> => {
+          const cleanup: Promise<unknown>[] = [];
+          if (deleteSecrets) {
+            cleanup.push(
+              deleteGithubInstallationTokenSecret({
+                workspaceId: params.workspaceId,
+                installationId: params.installationId,
+                deleteSecrets,
+              }),
+            );
+          }
+          if (checkoutTokenCache?.deleteInstallation && checkoutTokenProviderInstance) {
+            cleanup.push(
+              checkoutTokenCache.deleteInstallation(
+                params.workspaceId,
+                checkoutTokenProviderInstance,
+                params.installationId,
+              ),
+            );
+          } else if (deleteSecrets && checkoutTokenProviderInstance) {
+            cleanup.push(
+              deleteGithubCheckoutTokenSecretGroup({
+                workspaceId: params.workspaceId,
+                providerInstance: checkoutTokenProviderInstance,
+                installationId: params.installationId,
+                deleteSecrets,
+              }),
+            );
+          }
+          await Promise.all(cleanup);
+        }
+      : undefined;
+  const deleteInstallationTokenSecret = deleteInstallationSecrets
+    ? (params: {workspaceId: string; installationId: number}) => deleteInstallationSecrets(params)
     : undefined;
-  const deleteConnectionSecrets = deleteSecrets
+  const deleteConnectionSecrets = deleteInstallationSecrets
     ? async (connection: IntegrationConnection<'github'>): Promise<void> => {
         const {externalAccountId} = connection;
         if (!GITHUB_INSTALLATION_ID_PATTERN.test(externalAccountId)) {
@@ -132,10 +177,9 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
         if (!Number.isSafeInteger(installationId)) {
           throw new Error(`Invalid GitHub installation id: ${externalAccountId}`);
         }
-        await deleteGithubInstallationTokenSecret({
+        await deleteInstallationSecrets({
           workspaceId: connection.workspaceId,
           installationId,
-          deleteSecrets,
         });
       }
     : undefined;
@@ -151,11 +195,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
     repositoryAuthorization: 'unclassified' as const,
     eventCatalog: githubEventCatalog,
     adapters: {
-      source_control: new GithubSourceControlProvider(
-        github,
-        undefined,
-        options.checkoutTokenCache,
-      ),
+      source_control: new GithubSourceControlProvider(github, undefined, checkoutTokenCache),
       agent_tools: new GithubAgentToolsProvider({
         getInstallationByConnectionId: getInstallationByConnectionId,
         tokenProvider:

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -44,16 +44,11 @@ const GITHUB_INSTALLATION_ID_PATTERN = /^[1-9]\d*$/u;
 export type {GithubApiClient} from '#api/client.js';
 export {
   createGithubCheckoutTokenCache,
-  deleteGithubCheckoutTokenSecretGroup,
   type GithubCheckoutToken,
   GithubCheckoutTokenCache,
   type GithubCheckoutTokenCachePort,
   type GithubCheckoutTokenPermissions,
   type GithubCheckoutTokenScope,
-  type GithubCheckoutTokenSecretStore,
-  githubCheckoutTokenNamespace,
-  githubCheckoutTokenStorageKey,
-  githubProviderInstanceFingerprint,
 } from '#api/github-checkout-token-cache.js';
 export {
   encodeInstallationTokenEnvelope,
@@ -143,22 +138,27 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
               }),
             );
           }
-          if (checkoutTokenCache?.deleteInstallation && checkoutTokenProviderInstance) {
+          if (checkoutTokenProviderInstance) {
             cleanup.push(
-              checkoutTokenCache.deleteInstallation(
-                params.workspaceId,
-                checkoutTokenProviderInstance,
-                params.installationId,
-              ),
-            );
-          } else if (deleteSecrets && checkoutTokenProviderInstance) {
-            cleanup.push(
-              deleteGithubCheckoutTokenSecretGroup({
-                workspaceId: params.workspaceId,
-                providerInstance: checkoutTokenProviderInstance,
-                installationId: params.installationId,
-                deleteSecrets,
-              }),
+              (async () => {
+                const deleted = checkoutTokenCache?.deleteInstallation
+                  ? await checkoutTokenCache.deleteInstallation(
+                      params.workspaceId,
+                      checkoutTokenProviderInstance,
+                      params.installationId,
+                    )
+                  : 0;
+                // A cache without a shared store can still evict its RAM copy but
+                // must fall through to the authoritative namespace deletion.
+                if (deleted === 0 && deleteSecrets) {
+                  await deleteGithubCheckoutTokenSecretGroup({
+                    workspaceId: params.workspaceId,
+                    providerInstance: checkoutTokenProviderInstance,
+                    installationId: params.installationId,
+                    deleteSecrets,
+                  });
+                }
+              })(),
             );
           }
           await Promise.all(cleanup);

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -579,6 +579,7 @@ describe('defaultModules', () => {
         github: {
           deleteSecrets: expect.any(Function),
           getSecret: expect.any(Function),
+          getSecretsByNamespace: expect.any(Function),
           setSecrets: expect.any(Function),
         },
         linear: {
@@ -607,7 +608,10 @@ describe('defaultModules', () => {
 
     const integrationsOptions = mocks.createIntegrationsContext.mock.calls[0]?.[0] as {
       secrets: {
-        github: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecret' | 'setSecrets'>;
+        github: Pick<
+          SecretsInterModuleClient,
+          'deleteSecrets' | 'getSecret' | 'getSecretsByNamespace' | 'setSecrets'
+        >;
         linear: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecret' | 'setSecrets'>;
         jira: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecret' | 'setSecrets'>;
         slack: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecret' | 'setSecrets'>;
@@ -635,6 +639,9 @@ describe('defaultModules', () => {
     const githubSecret = await integrationsOptions.secrets.github.getSecret({
       ...githubScope,
       key: 'token',
+    });
+    const githubSecrets = await integrationsOptions.secrets.github.getSecretsByNamespace({
+      ...githubScope,
     });
     const githubDeleted = await integrationsOptions.secrets.github.deleteSecrets({
       ...githubScope,
@@ -725,9 +732,15 @@ describe('defaultModules', () => {
       workspaceId: scope.workspaceId,
     });
     expect(githubSecret).toBe('secret');
+    expect(githubSecrets).toEqual({});
     expect(githubDeleted).toBe(1);
     expect(mocks.getSecret.mock.calls.map(([params]) => params)).toContainEqual({
       key: 'token',
+      namespace: githubScope.namespace,
+      projectId: null,
+      workspaceId: scope.workspaceId,
+    });
+    expect(mocks.getSecretsByNamespace.mock.calls.map(([params]) => params)).toContainEqual({
       namespace: githubScope.namespace,
       projectId: null,
       workspaceId: scope.workspaceId,

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -189,6 +189,13 @@ export async function defaultModules(
               namespace: requireGithubSecretNamespace(params.namespace),
             })
           ).value,
+        getSecretsByNamespace: async (params) =>
+          (
+            await secretsClient.getSecretsByNamespace({
+              ...params,
+              namespace: requireGithubSecretNamespace(params.namespace),
+            })
+          ).values,
         setSecrets: async (params) => {
           const {editedBy, ...secretParams} = params;
           await secretsClient.setSecrets({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3028,6 +3028,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../../secrets-dto
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome


### PR DESCRIPTION
Initial GitHub checkout credentials now use the existing exact-scope L2 cache in production. The composition wires encrypted Secrets storage, per-scope advisory locking, cache metrics, and installation cleanup.

The validated GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED setting restores direct minting without the broader agent-tools cache when disabled. Initial checkout repository and bot-author metadata calls remain unchanged, and provider responses are checked before envelopes are stored.

Closes ENG-1750

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates exact-scope caching for initial GitHub checkout credentials, backed by encrypted Secrets storage with per-scope advisory locking, cache metrics, and cleanup on installation deletion. `GITHUB_CHECKOUT_TOKEN_CACHE_ENABLED` defaults to true; set it to false to skip the checkout caches and mint tokens directly.

- Storage keys are Secrets-compatible (uppercase `CHECKOUT_TOKEN_V` prefix), and the scoped Secrets adapter exposes `getSecretsByNamespace`.
- Cleanup removes checkout token secrets on installation deletion with a namespace fallback, and a 15-minute cron sweep prunes expired entries with a bounded budget, skipping malformed connections and heartbeating through slow namespace passes.

Closes ENG-1750.

<sup>Written for commit b6d0379459fd0bf9ab014ffbee806c0f8cfbd3de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

