### PR TITLE
Add dark-gated provider-free repository authorization

### DIFF
--- a/.changeset/provider-free-repository-authorization.md
+++ b/.changeset/provider-free-repository-authorization.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-core-dto": minor
+---
+
+Adds the provider-free repository authorization seam and its dark-launch contract error codes.

--- a/.changeset/provider-free-repository-authorization.md
+++ b/.changeset/provider-free-repository-authorization.md
@@ -5,4 +5,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Adds the repository authorization contract with exact-ID/name target resolution and its authorization error codes.
+Adds the repository authorization contract with exact-ID/name target resolution and its authorization error codes. Checkout now surfaces repository-authorization failures as not-granted (404), ambiguous (409), and store-unavailable (503) errors.

--- a/.changeset/provider-free-repository-authorization.md
+++ b/.changeset/provider-free-repository-authorization.md
@@ -1,6 +1,8 @@
 ---
 "@shipfox/api-integration-core": minor
 "@shipfox/api-integration-core-dto": minor
+"@shipfox/api-server": patch
+"@shipfox/api-workflows": patch
 ---
 
-Adds the provider-free repository authorization seam and its dark-launch contract error codes.
+Adds the repository authorization contract with exact-ID/name target resolution and its authorization error codes.

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -1,6 +1,17 @@
-import {integrationsInterModuleContract} from './inter-module.js';
+import {
+  integrationsInterModuleContract,
+  repositoryAuthorizationErrorCodes,
+} from './inter-module.js';
 
 describe('integrationsInterModuleContract', () => {
+  test('owns the repository authorization error codes', () => {
+    expect(repositoryAuthorizationErrorCodes).toEqual({
+      notGranted: 'repository-not-granted',
+      ambiguous: 'repository-ambiguous',
+      storeUnavailable: 'repository-authorization-unavailable',
+    });
+  });
+
   test('accepts a nullable normalized trigger reference', () => {
     const result = integrationsInterModuleContract.methods.resolveTriggerReference.output.parse({
       externalRepositoryId: 'github:42',

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -110,6 +110,16 @@ describe('integrationsInterModuleContract', () => {
   });
 
   test.each([
+    'repository-not-granted',
+    'repository-ambiguous',
+    'repository-authorization-unavailable',
+  ] as const)('defines the %s checkout failure', (code) => {
+    const schema = integrationsInterModuleContract.methods.createCheckoutSpec.errors[code];
+
+    expect(schema.parse({})).toEqual({});
+  });
+
+  test.each([
     ['ref-not-found', {ref: 'refs/heads/missing'}],
     ['ref-invalid', {ref: 'a'.repeat(40)}],
   ] as const)('defines the %s ref failure', (code, details) => {
@@ -260,5 +270,15 @@ describe('integrationsInterModuleContract', () => {
       ];
 
     expect(schema.parse(details)).toEqual(details);
+  });
+
+  test.each([
+    'repository-not-granted',
+    'repository-ambiguous',
+    'repository-authorization-unavailable',
+  ] as const)('defines the %s callTool failure', (code) => {
+    const schema = integrationsInterModuleContract.methods.callTool.errors[code];
+
+    expect(schema.parse({})).toEqual({});
   });
 });

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -96,6 +96,16 @@ const toolCallOutcome = z.discriminatedUnion('outcome', [
     status: z.number().int().min(100).max(599).optional(),
   }),
 ]);
+export const repositoryAuthorizationErrorCodes = {
+  notGranted: 'repository-not-granted',
+  ambiguous: 'repository-ambiguous',
+  storeUnavailable: 'repository-authorization-unavailable',
+} as const;
+const repositoryAuthorizationErrors = {
+  [repositoryAuthorizationErrorCodes.notGranted]: z.object({}),
+  [repositoryAuthorizationErrorCodes.ambiguous]: z.object({}),
+  [repositoryAuthorizationErrorCodes.storeUnavailable]: z.object({}),
+};
 const toolCallErrors = {
   'connection-not-found': z.object({connectionId: id}),
   'connection-inactive': z.object({connectionId: id}),
@@ -103,9 +113,7 @@ const toolCallErrors = {
   'connection-provider-changed': z.object({connectionId: id}),
   'provider-unavailable': z.object({provider}),
   'capability-unavailable': z.object({provider, capability}),
-  'repository-not-granted': z.object({}),
-  'repository-ambiguous': z.object({}),
-  'repository-authorization-unavailable': z.object({}),
+  ...repositoryAuthorizationErrors,
 };
 const providerError = z.object({
   reason: z.string(),
@@ -122,9 +130,7 @@ const sourceErrors = {
 };
 const checkoutErrors = {
   ...sourceErrors,
-  'repository-not-granted': z.object({}),
-  'repository-ambiguous': z.object({}),
-  'repository-authorization-unavailable': z.object({}),
+  ...repositoryAuthorizationErrors,
 };
 
 const refErrors = {

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -103,6 +103,9 @@ const toolCallErrors = {
   'connection-provider-changed': z.object({connectionId: id}),
   'provider-unavailable': z.object({provider}),
   'capability-unavailable': z.object({provider, capability}),
+  'repository-not-granted': z.object({}),
+  'repository-ambiguous': z.object({}),
+  'repository-authorization-unavailable': z.object({}),
 };
 const providerError = z.object({
   reason: z.string(),
@@ -116,6 +119,12 @@ const sourceErrors = {
   'capability-unavailable': z.object({provider, capability}),
   'checkout-unsupported': z.object({provider}),
   'provider-failure': providerError,
+};
+const checkoutErrors = {
+  ...sourceErrors,
+  'repository-not-granted': z.object({}),
+  'repository-ambiguous': z.object({}),
+  'repository-authorization-unavailable': z.object({}),
 };
 
 const refErrors = {
@@ -178,7 +187,7 @@ export const integrationsInterModuleContract = defineInterModuleContract({
         credentials: checkoutCredentials.optional(),
         gitAuthor: z.object({name: z.string(), email: z.string()}).optional(),
       }),
-      errors: sourceErrors,
+      errors: checkoutErrors,
     },
     createCheckoutCredentials: {
       input: sourceInput.extend({
@@ -186,7 +195,7 @@ export const integrationsInterModuleContract = defineInterModuleContract({
         rejectedGeneration: z.string().optional(),
       }),
       output: checkoutCredentials,
-      errors: sourceErrors,
+      errors: checkoutErrors,
     },
     getAgentToolsContext: {
       input: z.object({workspaceId: id, defaultConnectionId: id}),

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -47,6 +47,7 @@
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-spi": "workspace:*",
+    "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/api-integration-gitea": "workspace:*",
     "@shipfox/api-integration-github": "workspace:*",

--- a/libs/api/integration/core/src/config.test.ts
+++ b/libs/api/integration/core/src/config.test.ts
@@ -11,6 +11,7 @@ describe('integration provider config', () => {
 
     expect(config.INTEGRATIONS_ENABLE_CRON_PROVIDER).toBe(true);
     expect(config.INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER).toBe(true);
+    expect(config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION).toBe(false);
   });
 
   it('disables the Linear provider by default', async () => {
@@ -28,5 +29,14 @@ describe('integration provider config', () => {
     const {config} = await import('#config.js');
 
     expect(config.INTEGRATIONS_ENABLE_CRON_PROVIDER).toBe(false);
+  });
+
+  it('allows enabling repository authorization for a dark-launch environment', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION', 'true');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION).toBe(true);
   });
 });

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -5,6 +5,10 @@ export const config = createConfig({
     desc: 'Enables the cron integration provider so workflow schedules can use the built-in cron source. It is enabled by default because it does not require provider setup.',
     default: true,
   }),
+  INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION: bool({
+    desc: 'Enables the provider-free repository authorization guard. It is disabled by default while repository authorization is rolled out.',
+    default: false,
+  }),
   INTEGRATIONS_ENABLE_GITEA_PROVIDER: bool({
     desc: 'Enables the Gitea integration provider so users can connect a Gitea instance.',
     default: false,

--- a/libs/api/integration/core/src/core/errors.ts
+++ b/libs/api/integration/core/src/core/errors.ts
@@ -61,6 +61,13 @@ export class IntegrationProviderUnavailableError extends Error {
   }
 }
 
+export class RepositoryAuthorizerConfigurationError extends Error {
+  constructor() {
+    super('Repository authorization is enabled but the Projects client is not configured');
+    this.name = 'RepositoryAuthorizerConfigurationError';
+  }
+}
+
 export class WebhookProcessorNotConfiguredError extends Error {
   constructor(public readonly routeId: string) {
     super(`No webhook processor is configured for ${routeId}`);

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -1,0 +1,338 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {
+  createRepositoryAuthorizationRequestContext,
+  createRepositoryAuthorizer,
+  RepositoryAuthorizationTargetInvalidError,
+  repositoryAuthorizationClientErrorCode,
+  repositoryAuthorizationClientErrorCodes,
+  resolveRepositoryAuthorization,
+} from './repository-authorizer.js';
+
+const workspaceId = 'workspace-1';
+const connectionId = 'connection-1';
+
+function createProjects(
+  overrides: {
+    getProjectBySource?: ProjectsModuleClient['getProjectBySource'];
+    findProjectBySourceRepositoryName?: ProjectsModuleClient['findProjectBySourceRepositoryName'];
+  } = {},
+): ProjectsModuleClient {
+  return {
+    getProjectBySource: vi.fn().mockResolvedValue({project: null}),
+    findProjectBySourceRepositoryName: vi.fn().mockResolvedValue({projects: []}),
+    ...overrides,
+  } as unknown as ProjectsModuleClient;
+}
+
+function selectedInput(
+  repository:
+    | {kind: 'external-id'; externalRepositoryId: string}
+    | {kind: 'name'; owner: string; name: string},
+) {
+  return {
+    workspaceId,
+    connectionId,
+    mode: 'selected' as const,
+    repository,
+    capability: 'checkout' as const,
+  };
+}
+
+describe('repository authorization', () => {
+  it('authorizes an exact external-id project match and returns stored metadata', async () => {
+    const projects = createProjects({
+      getProjectBySource: vi.fn().mockResolvedValue({
+        project: {
+          id: 'project-1',
+          sourceExternalRepositoryId: 'github:42',
+          sourceRepositoryOwner: 'Shipfox',
+          sourceRepositoryName: 'Platform',
+        },
+      }),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {
+        externalRepositoryId: 'github:42',
+        owner: 'Shipfox',
+        name: 'Platform',
+      },
+      targetProjectId: 'project-1',
+    });
+    expect(projects.getProjectBySource).toHaveBeenCalledWith({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceExternalRepositoryId: 'github:42',
+    });
+    expect(projects.findProjectBySourceRepositoryName).not.toHaveBeenCalled();
+  });
+
+  it('authorizes an external-id project when display metadata is absent', async () => {
+    const projects = createProjects({
+      getProjectBySource: vi.fn().mockResolvedValue({
+        project: {
+          id: 'project-1',
+          sourceExternalRepositoryId: 'github:42',
+          sourceRepositoryOwner: null,
+          sourceRepositoryName: undefined,
+        },
+      }),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {externalRepositoryId: 'github:42'},
+      targetProjectId: 'project-1',
+    });
+  });
+
+  it('denies an external-id with no matching project', async () => {
+    const projects = createProjects();
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:missing'}),
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
+  });
+
+  it('passes selected external IDs through as exact project lookup keys', async () => {
+    const getProjectBySource = vi.fn().mockResolvedValue({
+      project: {
+        id: 'project-1',
+        sourceExternalRepositoryId: 'shipfox/project',
+      },
+    });
+    const projects = createProjects({getProjectBySource});
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'shipfox/project'}),
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {externalRepositoryId: 'shipfox/project'},
+      targetProjectId: 'project-1',
+    });
+    expect(getProjectBySource).toHaveBeenCalledWith(
+      expect.objectContaining({sourceExternalRepositoryId: 'shipfox/project'}),
+    );
+  });
+
+  it('uses the Projects name lookup for case-insensitive selected targets', async () => {
+    const findProjectBySourceRepositoryName = vi.fn().mockResolvedValue({
+      projects: [
+        {
+          id: 'project-1',
+          sourceExternalRepositoryId: 'github:42',
+          sourceRepositoryOwner: 'Shipfox',
+          sourceRepositoryName: 'Platform',
+        },
+      ],
+    });
+    const projects = createProjects({findProjectBySourceRepositoryName});
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'name', owner: 'shipFOX', name: 'PLATFORM'}),
+      }),
+    ).resolves.toMatchObject({
+      authorized: true,
+      repository: {externalRepositoryId: 'github:42'},
+      targetProjectId: 'project-1',
+    });
+    expect(findProjectBySourceRepositoryName).toHaveBeenCalledWith({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceRepositoryOwner: 'shipFOX',
+      sourceRepositoryName: 'PLATFORM',
+    });
+  });
+
+  it('denies a name with no matching project', async () => {
+    const projects = createProjects();
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'missing'}),
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
+  });
+
+  it('denies an ambiguous name after deduplicating rows by external repository id', async () => {
+    const projects = createProjects({
+      findProjectBySourceRepositoryName: vi.fn().mockResolvedValue({
+        projects: [
+          {
+            id: 'project-1',
+            sourceExternalRepositoryId: 'github:42',
+            sourceRepositoryOwner: 'shipfox',
+            sourceRepositoryName: 'platform',
+          },
+          {
+            id: 'project-2',
+            sourceExternalRepositoryId: 'github:42',
+            sourceRepositoryOwner: 'shipfox',
+            sourceRepositoryName: 'platform',
+          },
+          {
+            id: 'project-3',
+            sourceExternalRepositoryId: 'github:43',
+            sourceRepositoryOwner: 'shipfox',
+            sourceRepositoryName: 'platform',
+          },
+        ],
+      }),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'repository_ambiguous'});
+  });
+
+  it.each([
+    'getProjectBySource',
+    'findProjectBySourceRepositoryName',
+  ] as const)('distinguishes a %s failure from a repository denial', async (method) => {
+    const projects = createProjects({
+      [method]: vi.fn().mockRejectedValue(new Error('database unavailable')),
+    });
+    const repository =
+      method === 'getProjectBySource'
+        ? {kind: 'external-id' as const, externalRepositoryId: 'github:42'}
+        : {kind: 'name' as const, owner: 'shipfox', name: 'platform'};
+
+    await expect(
+      resolveRepositoryAuthorization({projects, ...selectedInput(repository)}),
+    ).resolves.toEqual({authorized: false, reason: 'authorization_store_unavailable'});
+  });
+
+  it('accepts valid all-mode declarations without consulting Projects', async () => {
+    const projects = createProjects({
+      getProjectBySource: vi.fn().mockRejectedValue(new Error('must not be called')),
+      findProjectBySourceRepositoryName: vi.fn().mockRejectedValue(new Error('must not be called')),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
+        mode: 'all',
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {externalRepositoryId: 'github:42'},
+    });
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
+        mode: 'all',
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {owner: 'shipfox', name: 'platform'},
+    });
+    expect(projects.getProjectBySource).not.toHaveBeenCalled();
+    expect(projects.findProjectBySourceRepositoryName).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {kind: 'external-id' as const, externalRepositoryId: '42'},
+    {kind: 'external-id' as const, externalRepositoryId: ':42'},
+    {kind: 'name' as const, owner: 'shipfox/team', name: 'platform'},
+    {kind: 'name' as const, owner: 'shipfox', name: 'platform name'},
+  ])('rejects an invalid declaration target: %j', async (repository) => {
+    await expect(
+      resolveRepositoryAuthorization({
+        projects: createProjects(),
+        ...selectedInput(repository),
+        mode: 'all',
+      }),
+    ).rejects.toBeInstanceOf(RepositoryAuthorizationTargetInvalidError);
+  });
+
+  it('memoizes selected lookups within one request context only', async () => {
+    const getProjectBySource = vi.fn().mockResolvedValue({
+      project: {
+        id: 'project-1',
+        sourceExternalRepositoryId: 'github:42',
+        sourceRepositoryOwner: 'shipfox',
+        sourceRepositoryName: 'platform',
+      },
+    });
+    const projects = createProjects({getProjectBySource});
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+    const request = createRepositoryAuthorizationRequestContext();
+
+    await resolveRepositoryAuthorization({projects, ...input, request});
+    await resolveRepositoryAuthorization({projects, ...input, request});
+    await resolveRepositoryAuthorization({
+      projects,
+      ...input,
+      request: createRepositoryAuthorizationRequestContext(),
+    });
+
+    expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not allow a disabled gate to invoke the Projects client', async () => {
+    const projects = createProjects({
+      getProjectBySource: vi.fn().mockRejectedValue(new Error('must not be called')),
+    });
+    const authorizer = createRepositoryAuthorizer({projects});
+
+    expect(authorizer.enabled).toBe(false);
+    await expect(
+      authorizer.resolveRepositoryAuthorization({
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'not-even-a-target'}),
+      }),
+    ).resolves.toBeUndefined();
+    expect(projects.getProjectBySource).not.toHaveBeenCalled();
+  });
+
+  it('runs the provider-free authorizer when the integration gate is enabled', async () => {
+    const projects = createProjects();
+    const authorizer = createRepositoryAuthorizer({projects, enabled: true});
+
+    expect(authorizer.enabled).toBe(true);
+    await expect(
+      authorizer.resolveRepositoryAuthorization({
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
+        mode: 'all',
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {owner: 'shipfox', name: 'platform'},
+    });
+  });
+
+  it('publishes closed client error codes for each denial reason', () => {
+    expect(repositoryAuthorizationClientErrorCodes).toEqual({
+      repository_not_granted: 'repository-not-granted',
+      repository_ambiguous: 'repository-ambiguous',
+      authorization_store_unavailable: 'repository-authorization-unavailable',
+    });
+    expect(repositoryAuthorizationClientErrorCode('repository_ambiguous')).toBe(
+      'repository-ambiguous',
+    );
+  });
+});

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -1,4 +1,5 @@
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {RepositoryAuthorizerConfigurationError} from './errors.js';
 import {
   createRepositoryAuthorizationRequestContext,
   createRepositoryAuthorizer,
@@ -270,6 +271,15 @@ describe('repository authorization', () => {
     ).rejects.toBeInstanceOf(RepositoryAuthorizationTargetInvalidError);
   });
 
+  it('rejects an unsafe selected external-id target', async () => {
+    await expect(
+      resolveRepositoryAuthorization({
+        projects: createProjects(),
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:4 2'}),
+      }),
+    ).rejects.toBeInstanceOf(RepositoryAuthorizationTargetInvalidError);
+  });
+
   it('memoizes selected lookups within one request context only', async () => {
     const getProjectBySource = vi.fn().mockResolvedValue({
       project: {
@@ -294,6 +304,38 @@ describe('repository authorization', () => {
     expect(getProjectBySource).toHaveBeenCalledTimes(2);
   });
 
+  it('deduplicates concurrent lookups and does not memoize store failures', async () => {
+    const getProjectBySource = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce({
+        project: {
+          id: 'project-1',
+          sourceExternalRepositoryId: 'github:42',
+        },
+      });
+    const projects = createProjects({getProjectBySource});
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+    const request = createRepositoryAuthorizationRequestContext();
+
+    const [first, second] = await Promise.all([
+      resolveRepositoryAuthorization({projects, ...input, request}),
+      resolveRepositoryAuthorization({projects, ...input, request}),
+    ]);
+
+    expect(first).toEqual({authorized: false, reason: 'authorization_store_unavailable'});
+    expect(second).toEqual({authorized: false, reason: 'authorization_store_unavailable'});
+    expect(getProjectBySource).toHaveBeenCalledOnce();
+    expect(request.memo.size).toBe(0);
+
+    await expect(resolveRepositoryAuthorization({projects, ...input, request})).resolves.toEqual({
+      authorized: true,
+      repository: {externalRepositoryId: 'github:42'},
+      targetProjectId: 'project-1',
+    });
+    expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
   it('does not allow a disabled gate to invoke the Projects client', async () => {
     const projects = createProjects({
       getProjectBySource: vi.fn().mockRejectedValue(new Error('must not be called')),
@@ -307,6 +349,26 @@ describe('repository authorization', () => {
       }),
     ).resolves.toBeUndefined();
     expect(projects.getProjectBySource).not.toHaveBeenCalled();
+  });
+
+  it('rejects an enabled gate without a Projects client', () => {
+    expect(() => createRepositoryAuthorizer({enabled: true})).toThrow(
+      RepositoryAuthorizerConfigurationError,
+    );
+  });
+
+  it('rethrows cancellation errors without converting them to a denial', async () => {
+    const cancellation = Object.assign(new Error('request aborted'), {name: 'AbortError'});
+    const projects = createProjects({
+      getProjectBySource: vi.fn().mockRejectedValue(cancellation),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
+      }),
+    ).rejects.toBe(cancellation);
   });
 
   it('runs the provider-free authorizer when the integration gate is enabled', async () => {

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -388,8 +388,10 @@ describe('repository authorization', () => {
   });
 
   it('rate-limits store failure reports while allowing retries', async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({now: new Date('2026-08-31T00:00:00.000Z')});
+    vi.resetModules();
     try {
+      const {resolveRepositoryAuthorization: resolve} = await import('./repository-authorizer.js');
       vi.advanceTimersByTime(60_001);
       const getProjectBySource = vi
         .fn()
@@ -399,12 +401,12 @@ describe('repository authorization', () => {
       const projects = createProjects({getProjectBySource});
       const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
 
-      await resolveRepositoryAuthorization({projects, ...input});
-      await resolveRepositoryAuthorization({projects, ...input});
+      await resolve({projects, ...input});
+      await resolve({projects, ...input});
       expect(mocks.reportError).toHaveBeenCalledOnce();
 
       vi.advanceTimersByTime(60_000);
-      await resolveRepositoryAuthorization({projects, ...input});
+      await resolve({projects, ...input});
       expect(mocks.reportError).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -9,6 +9,16 @@ import {
   resolveRepositoryAuthorization,
 } from './repository-authorizer.js';
 
+const mocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  reportError: vi.fn(() => 'event-id'),
+}));
+
+vi.mock('@shipfox/node-error-monitoring', () => ({reportError: mocks.reportError}));
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => ({error: mocks.loggerError}),
+}));
+
 const workspaceId = 'workspace-1';
 const connectionId = 'connection-1';
 
@@ -40,6 +50,12 @@ function selectedInput(
 }
 
 describe('repository authorization', () => {
+  beforeEach(() => {
+    mocks.loggerError.mockReset();
+    mocks.reportError.mockReset();
+    mocks.reportError.mockReturnValue('event-id');
+  });
+
   it('authorizes an exact external-id project match and returns stored metadata', async () => {
     const projects = createProjects({
       getProjectBySource: vi.fn().mockResolvedValue({
@@ -369,6 +385,30 @@ describe('repository authorization', () => {
         ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
       }),
     ).rejects.toBe(cancellation);
+  });
+
+  it('rate-limits store failure reports while allowing retries', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.advanceTimersByTime(60_001);
+      const getProjectBySource = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('database unavailable'))
+        .mockRejectedValueOnce(new Error('database unavailable'))
+        .mockRejectedValueOnce(new Error('database unavailable'));
+      const projects = createProjects({getProjectBySource});
+      const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+
+      await resolveRepositoryAuthorization({projects, ...input});
+      await resolveRepositoryAuthorization({projects, ...input});
+      expect(mocks.reportError).toHaveBeenCalledOnce();
+
+      vi.advanceTimersByTime(60_000);
+      await resolveRepositoryAuthorization({projects, ...input});
+      expect(mocks.reportError).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('runs the provider-free authorizer when the integration gate is enabled', async () => {

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -6,6 +6,9 @@ import {RepositoryAuthorizerConfigurationError} from './errors.js';
 
 const REPOSITORY_PART_UNSAFE_PATTERN = /[\s/:\\]/u;
 const EXTERNAL_REPOSITORY_VALUE_UNSAFE_PATTERN = /\s/u;
+// Keep every outage retryable while bounding the Sentry volume process-wide.
+const REPOSITORY_AUTHORIZATION_REPORT_INTERVAL_MS = 60_000;
+let lastRepositoryAuthorizationReportAt = Number.NEGATIVE_INFINITY;
 
 export type RepositoryAuthorizationMode = 'selected' | 'all';
 export type RepositoryAuthorizationCapability = 'checkout' | 'tools';
@@ -225,11 +228,15 @@ function storeUnavailable(
 ): RepositoryAuthorizationResult {
   if (isCancellationError(error)) throw error;
   logger().error({err: error, targetKind}, 'Repository authorization lookup failed');
-  reportError(error, {
-    boundary: 'integration.repository-authorization',
-    operation: 'resolve-selected',
-    tags: {target: targetKind},
-  });
+  const now = Date.now();
+  if (now - lastRepositoryAuthorizationReportAt >= REPOSITORY_AUTHORIZATION_REPORT_INTERVAL_MS) {
+    const eventId = reportError(error, {
+      boundary: 'integration.repository-authorization',
+      operation: 'resolve-selected',
+      tags: {target: targetKind},
+    });
+    if (eventId) lastRepositoryAuthorizationReportAt = now;
+  }
   return deny('authorization_store_unavailable');
 }
 

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -1,4 +1,8 @@
+import {repositoryAuthorizationErrorCodes} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
+import {RepositoryAuthorizerConfigurationError} from './errors.js';
 
 const REPOSITORY_PART_UNSAFE_PATTERN = /[\s/:\\]/u;
 const EXTERNAL_REPOSITORY_VALUE_UNSAFE_PATTERN = /\s/u;
@@ -27,9 +31,9 @@ export type RepositoryAuthorizationDenial =
   | 'authorization_store_unavailable';
 
 export const repositoryAuthorizationClientErrorCodes = {
-  repository_not_granted: 'repository-not-granted',
-  repository_ambiguous: 'repository-ambiguous',
-  authorization_store_unavailable: 'repository-authorization-unavailable',
+  repository_not_granted: repositoryAuthorizationErrorCodes.notGranted,
+  repository_ambiguous: repositoryAuthorizationErrorCodes.ambiguous,
+  authorization_store_unavailable: repositoryAuthorizationErrorCodes.storeUnavailable,
 } as const satisfies Record<RepositoryAuthorizationDenial, string>;
 
 export type RepositoryAuthorizationClientErrorCode =
@@ -66,6 +70,7 @@ export function createRepositoryAuthorizationRequestContext(): RepositoryAuthori
 export interface ResolveRepositoryAuthorizationInput {
   workspaceId: string;
   connectionId: string;
+  /** The `all` mode may only originate from trusted server-side authorization state. */
   mode: RepositoryAuthorizationMode;
   repository: RepositoryAuthorizationTarget;
   capability: RepositoryAuthorizationCapability;
@@ -121,7 +126,15 @@ export async function resolveRepositoryAuthorization({
   const pending = resolve();
   request.memo.set(key, pending);
   try {
-    return await pending;
+    const result = await pending;
+    if (
+      !result.authorized &&
+      result.reason === 'authorization_store_unavailable' &&
+      request.memo.get(key) === pending
+    ) {
+      request.memo.delete(key);
+    }
+    return result;
   } catch (error) {
     if (request.memo.get(key) === pending) request.memo.delete(key);
     throw error;
@@ -136,12 +149,19 @@ export function createRepositoryAuthorizer({
   projects,
   enabled = false,
 }: CreateRepositoryAuthorizerOptions): RepositoryAuthorizer {
-  const isEnabled = enabled && projects !== undefined;
+  if (!enabled) {
+    return {
+      enabled: false,
+      resolveRepositoryAuthorization() {
+        return Promise.resolve(undefined);
+      },
+    };
+  }
+  if (!projects) throw new RepositoryAuthorizerConfigurationError();
 
   return {
-    enabled: isEnabled,
+    enabled: true,
     async resolveRepositoryAuthorization(input) {
-      if (!isEnabled || !projects) return undefined;
       return await resolveRepositoryAuthorization({projects, ...input});
     },
   };
@@ -156,38 +176,70 @@ async function resolveSelectedMode({
   ResolveRepositoryAuthorizationParams,
   'projects' | 'workspaceId' | 'connectionId' | 'repository'
 >): Promise<RepositoryAuthorizationResult> {
-  try {
-    if (repository.kind === 'external-id') {
-      const {project} = await projects.getProjectBySource({
+  if (repository.kind === 'external-id') {
+    let projectResult: Awaited<ReturnType<ProjectsModuleClient['getProjectBySource']>>;
+    try {
+      projectResult = await projects.getProjectBySource({
         workspaceId,
         sourceConnectionId: connectionId,
         sourceExternalRepositoryId: repository.externalRepositoryId,
       });
-
-      return project ? authorizeProject(project) : deny('repository_not_granted');
+    } catch (error) {
+      return storeUnavailable(error, repository.kind);
     }
 
-    const {projects: matchedProjects} = await projects.findProjectBySourceRepositoryName({
+    return projectResult.project
+      ? authorizeProject(projectResult.project)
+      : deny('repository_not_granted');
+  }
+
+  let projectResult: Awaited<ReturnType<ProjectsModuleClient['findProjectBySourceRepositoryName']>>;
+  try {
+    projectResult = await projects.findProjectBySourceRepositoryName({
       workspaceId,
       sourceConnectionId: connectionId,
       sourceRepositoryOwner: repository.owner,
       sourceRepositoryName: repository.name,
     });
-    const projectsByRepositoryId = new Map<string, (typeof matchedProjects)[number]>();
-    for (const project of matchedProjects) {
-      if (!projectsByRepositoryId.has(project.sourceExternalRepositoryId)) {
-        projectsByRepositoryId.set(project.sourceExternalRepositoryId, project);
-      }
-    }
-
-    if (projectsByRepositoryId.size === 0) return deny('repository_not_granted');
-    if (projectsByRepositoryId.size > 1) return deny('repository_ambiguous');
-
-    const project = projectsByRepositoryId.values().next().value;
-    return project ? authorizeProject(project) : deny('repository_not_granted');
-  } catch {
-    return deny('authorization_store_unavailable');
+  } catch (error) {
+    return storeUnavailable(error, repository.kind);
   }
+
+  const projectsByRepositoryId = new Map<string, (typeof projectResult.projects)[number]>();
+  for (const project of projectResult.projects) {
+    if (!projectsByRepositoryId.has(project.sourceExternalRepositoryId)) {
+      projectsByRepositoryId.set(project.sourceExternalRepositoryId, project);
+    }
+  }
+
+  if (projectsByRepositoryId.size === 0) return deny('repository_not_granted');
+  if (projectsByRepositoryId.size > 1) return deny('repository_ambiguous');
+
+  const project = projectsByRepositoryId.values().next().value;
+  return project ? authorizeProject(project) : deny('repository_not_granted');
+}
+
+function storeUnavailable(
+  error: unknown,
+  targetKind: RepositoryAuthorizationTarget['kind'],
+): RepositoryAuthorizationResult {
+  if (isCancellationError(error)) throw error;
+  logger().error({err: error, targetKind}, 'Repository authorization lookup failed');
+  reportError(error, {
+    boundary: 'integration.repository-authorization',
+    operation: 'resolve-selected',
+    tags: {target: targetKind},
+  });
+  return deny('authorization_store_unavailable');
+}
+
+function isCancellationError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' ||
+      error.name === 'CanceledError' ||
+      error.name === 'CancelledError')
+  );
 }
 
 function authorizeAllMode(

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -1,0 +1,310 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+
+const REPOSITORY_PART_UNSAFE_PATTERN = /[\s/:\\]/u;
+const EXTERNAL_REPOSITORY_VALUE_UNSAFE_PATTERN = /\s/u;
+
+export type RepositoryAuthorizationMode = 'selected' | 'all';
+export type RepositoryAuthorizationCapability = 'checkout' | 'tools';
+
+export interface RepositoryAuthorizationExternalIdTarget {
+  kind: 'external-id';
+  externalRepositoryId: string;
+}
+
+export interface RepositoryAuthorizationNameTarget {
+  kind: 'name';
+  owner: string;
+  name: string;
+}
+
+export type RepositoryAuthorizationTarget =
+  | RepositoryAuthorizationExternalIdTarget
+  | RepositoryAuthorizationNameTarget;
+
+export type RepositoryAuthorizationDenial =
+  | 'repository_not_granted'
+  | 'repository_ambiguous'
+  | 'authorization_store_unavailable';
+
+export const repositoryAuthorizationClientErrorCodes = {
+  repository_not_granted: 'repository-not-granted',
+  repository_ambiguous: 'repository-ambiguous',
+  authorization_store_unavailable: 'repository-authorization-unavailable',
+} as const satisfies Record<RepositoryAuthorizationDenial, string>;
+
+export type RepositoryAuthorizationClientErrorCode =
+  (typeof repositoryAuthorizationClientErrorCodes)[RepositoryAuthorizationDenial];
+
+export function repositoryAuthorizationClientErrorCode(
+  reason: RepositoryAuthorizationDenial,
+): RepositoryAuthorizationClientErrorCode {
+  return repositoryAuthorizationClientErrorCodes[reason];
+}
+
+export interface AuthorizedRepository {
+  externalRepositoryId?: string | undefined;
+  owner?: string | undefined;
+  name?: string | undefined;
+}
+
+export type RepositoryAuthorizationResult =
+  | {
+      authorized: true;
+      repository: AuthorizedRepository;
+      targetProjectId?: string | undefined;
+    }
+  | {authorized: false; reason: RepositoryAuthorizationDenial};
+
+export interface RepositoryAuthorizationRequestContext {
+  readonly memo: Map<string, Promise<RepositoryAuthorizationResult>>;
+}
+
+export function createRepositoryAuthorizationRequestContext(): RepositoryAuthorizationRequestContext {
+  return {memo: new Map()};
+}
+
+export interface ResolveRepositoryAuthorizationInput {
+  workspaceId: string;
+  connectionId: string;
+  mode: RepositoryAuthorizationMode;
+  repository: RepositoryAuthorizationTarget;
+  capability: RepositoryAuthorizationCapability;
+  request?: RepositoryAuthorizationRequestContext | undefined;
+}
+
+export interface ResolveRepositoryAuthorizationParams extends ResolveRepositoryAuthorizationInput {
+  projects: ProjectsModuleClient;
+}
+
+export interface CreateRepositoryAuthorizerOptions {
+  projects?: ProjectsModuleClient | undefined;
+  enabled?: boolean | undefined;
+}
+
+export interface RepositoryAuthorizer {
+  readonly enabled: boolean;
+  resolveRepositoryAuthorization(
+    input: ResolveRepositoryAuthorizationInput,
+  ): Promise<RepositoryAuthorizationResult | undefined>;
+}
+
+export class RepositoryAuthorizationTargetInvalidError extends Error {
+  constructor() {
+    super('Repository authorization target is invalid');
+    this.name = 'RepositoryAuthorizationTargetInvalidError';
+  }
+}
+
+/**
+ * Resolves a repository declaration against local project state. This function
+ * accepts only the Projects contract; provider adapters are deliberately not
+ * part of the authorization boundary.
+ */
+export async function resolveRepositoryAuthorization({
+  projects,
+  request,
+  ...input
+}: ResolveRepositoryAuthorizationParams): Promise<RepositoryAuthorizationResult> {
+  assertValidTarget(input.repository, input.mode);
+
+  if (input.mode === 'all') {
+    return authorizeAllMode(input.repository);
+  }
+
+  const resolve = () => resolveSelectedMode({projects, ...input});
+  if (!request) return await resolve();
+
+  const key = authorizationMemoKey(input);
+  const cached = request.memo.get(key);
+  if (cached) return await cached;
+
+  const pending = resolve();
+  request.memo.set(key, pending);
+  try {
+    return await pending;
+  } catch (error) {
+    if (request.memo.get(key) === pending) request.memo.delete(key);
+    throw error;
+  }
+}
+
+/**
+ * Creates the integration-owned dark-gated authorizer. A disabled authorizer
+ * returns `undefined`, allowing its caller to preserve the existing behavior.
+ */
+export function createRepositoryAuthorizer({
+  projects,
+  enabled = false,
+}: CreateRepositoryAuthorizerOptions): RepositoryAuthorizer {
+  const isEnabled = enabled && projects !== undefined;
+
+  return {
+    enabled: isEnabled,
+    async resolveRepositoryAuthorization(input) {
+      if (!isEnabled || !projects) return undefined;
+      return await resolveRepositoryAuthorization({projects, ...input});
+    },
+  };
+}
+
+async function resolveSelectedMode({
+  projects,
+  workspaceId,
+  connectionId,
+  repository,
+}: Pick<
+  ResolveRepositoryAuthorizationParams,
+  'projects' | 'workspaceId' | 'connectionId' | 'repository'
+>): Promise<RepositoryAuthorizationResult> {
+  try {
+    if (repository.kind === 'external-id') {
+      const {project} = await projects.getProjectBySource({
+        workspaceId,
+        sourceConnectionId: connectionId,
+        sourceExternalRepositoryId: repository.externalRepositoryId,
+      });
+
+      return project ? authorizeProject(project) : deny('repository_not_granted');
+    }
+
+    const {projects: matchedProjects} = await projects.findProjectBySourceRepositoryName({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceRepositoryOwner: repository.owner,
+      sourceRepositoryName: repository.name,
+    });
+    const projectsByRepositoryId = new Map<string, (typeof matchedProjects)[number]>();
+    for (const project of matchedProjects) {
+      if (!projectsByRepositoryId.has(project.sourceExternalRepositoryId)) {
+        projectsByRepositoryId.set(project.sourceExternalRepositoryId, project);
+      }
+    }
+
+    if (projectsByRepositoryId.size === 0) return deny('repository_not_granted');
+    if (projectsByRepositoryId.size > 1) return deny('repository_ambiguous');
+
+    const project = projectsByRepositoryId.values().next().value;
+    return project ? authorizeProject(project) : deny('repository_not_granted');
+  } catch {
+    return deny('authorization_store_unavailable');
+  }
+}
+
+function authorizeAllMode(
+  repository: RepositoryAuthorizationTarget,
+): RepositoryAuthorizationResult {
+  if (repository.kind === 'external-id') {
+    return {
+      authorized: true,
+      repository: {externalRepositoryId: repository.externalRepositoryId},
+    };
+  }
+  return {
+    authorized: true,
+    repository: {owner: repository.owner, name: repository.name},
+  };
+}
+
+function authorizeProject(project: {
+  id: string;
+  sourceExternalRepositoryId: string;
+  sourceRepositoryOwner?: string | null | undefined;
+  sourceRepositoryName?: string | null | undefined;
+}): RepositoryAuthorizationResult {
+  return {
+    authorized: true,
+    repository: {
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ...(project.sourceRepositoryOwner == null ? {} : {owner: project.sourceRepositoryOwner}),
+      ...(project.sourceRepositoryName == null ? {} : {name: project.sourceRepositoryName}),
+    },
+    targetProjectId: project.id,
+  };
+}
+
+function deny(reason: RepositoryAuthorizationDenial): RepositoryAuthorizationResult {
+  return {authorized: false, reason};
+}
+
+function authorizationMemoKey({
+  workspaceId,
+  connectionId,
+  mode,
+  capability,
+  repository,
+}: ResolveRepositoryAuthorizationInput): string {
+  return JSON.stringify([
+    workspaceId,
+    connectionId,
+    mode,
+    capability,
+    repository.kind === 'external-id'
+      ? [repository.kind, repository.externalRepositoryId]
+      : [repository.kind, repository.owner.toLowerCase(), repository.name.toLowerCase()],
+  ]);
+}
+
+function assertValidTarget(
+  repository: RepositoryAuthorizationTarget,
+  mode: RepositoryAuthorizationMode,
+): void {
+  if (!repository || typeof repository !== 'object') {
+    throw new RepositoryAuthorizationTargetInvalidError();
+  }
+
+  if (repository.kind === 'external-id') {
+    if (typeof repository.externalRepositoryId !== 'string') {
+      throw new RepositoryAuthorizationTargetInvalidError();
+    }
+    const separatorIndex = repository.externalRepositoryId.indexOf(':');
+    const namespace = repository.externalRepositoryId.slice(0, separatorIndex);
+    const value = repository.externalRepositoryId.slice(separatorIndex + 1);
+    if (mode === 'selected') {
+      if (!isSafeExternalRepositoryValue(repository.externalRepositoryId)) {
+        throw new RepositoryAuthorizationTargetInvalidError();
+      }
+      return;
+    }
+    if (
+      separatorIndex <= 0 ||
+      !isSafeRepositoryPart(namespace) ||
+      !isSafeExternalRepositoryValue(value)
+    ) {
+      throw new RepositoryAuthorizationTargetInvalidError();
+    }
+    return;
+  }
+
+  if (
+    repository.kind !== 'name' ||
+    !isSafeRepositoryPart(repository.owner) ||
+    !isSafeRepositoryPart(repository.name)
+  ) {
+    throw new RepositoryAuthorizationTargetInvalidError();
+  }
+}
+
+function isSafeRepositoryPart(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    !REPOSITORY_PART_UNSAFE_PATTERN.test(value) &&
+    !containsControlCharacter(value)
+  );
+}
+
+function isSafeExternalRepositoryValue(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    !EXTERNAL_REPOSITORY_VALUE_UNSAFE_PATTERN.test(value) &&
+    !containsControlCharacter(value)
+  );
+}
+
+function containsControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return code <= 0x1f || code === 0x7f;
+  });
+}

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -1,4 +1,5 @@
 import type {StoredWebhookRequest, WebhookRequestProcessor} from '@shipfox/api-integration-spi';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {createOutboxRegistry, type ModuleService, startModuleServices} from '@shipfox/node-module';
 import {createIntegrationsContext, WebhookProcessorNotConfiguredError} from './index.js';
 
@@ -105,5 +106,32 @@ describe('createIntegrationsContext', () => {
     });
 
     await expect(result).rejects.toThrow(sourceError);
+  });
+
+  it('keeps the repository authorization gate disabled by default', async () => {
+    const getProjectBySource = vi.fn();
+    const findProjectBySourceRepositoryName = vi.fn();
+    const projects = {
+      getProjectBySource,
+      findProjectBySourceRepositoryName,
+    } as unknown as ProjectsModuleClient;
+    const context = await createIntegrationsContext({
+      parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+      projects,
+    });
+
+    expect(context.repositoryAuthorizer.enabled).toBe(false);
+    expect(context.capabilities.repositoryAuthorizer).toBe(context.repositoryAuthorizer);
+    await expect(
+      context.repositoryAuthorizer.resolveRepositoryAuthorization({
+        workspaceId: 'workspace-1',
+        connectionId: 'connection-1',
+        mode: 'all',
+        repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
+        capability: 'checkout',
+      }),
+    ).resolves.toBeUndefined();
+    expect(getProjectBySource).not.toHaveBeenCalled();
+    expect(findProjectBySourceRepositoryName).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -109,29 +109,77 @@ describe('createIntegrationsContext', () => {
   });
 
   it('keeps the repository authorization gate disabled by default', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION', 'false');
+    vi.resetModules();
+
     const getProjectBySource = vi.fn();
     const findProjectBySourceRepositoryName = vi.fn();
     const projects = {
       getProjectBySource,
       findProjectBySourceRepositoryName,
     } as unknown as ProjectsModuleClient;
-    const context = await createIntegrationsContext({
-      parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
-      projects,
-    });
 
-    expect(context.repositoryAuthorizer.enabled).toBe(false);
-    expect(context.capabilities.repositoryAuthorizer).toBe(context.repositoryAuthorizer);
-    await expect(
-      context.repositoryAuthorizer.resolveRepositoryAuthorization({
+    try {
+      const {createIntegrationsContext: createContext} = await import('./index.js');
+      const context = await createContext({
+        parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+        projects,
+      });
+
+      expect(context.repositoryAuthorizer.enabled).toBe(false);
+      expect(context.capabilities.repositoryAuthorizer).toBe(context.repositoryAuthorizer);
+      await expect(
+        context.repositoryAuthorizer.resolveRepositoryAuthorization({
+          workspaceId: 'workspace-1',
+          connectionId: 'connection-1',
+          mode: 'all',
+          repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
+          capability: 'checkout',
+        }),
+      ).resolves.toBeUndefined();
+      expect(getProjectBySource).not.toHaveBeenCalled();
+      expect(findProjectBySourceRepositoryName).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  it('enables repository authorization through the integration context flag', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION', 'true');
+    vi.resetModules();
+
+    const getProjectBySource = vi.fn().mockResolvedValue({project: null});
+    const projects = {
+      getProjectBySource,
+      findProjectBySourceRepositoryName: vi.fn(),
+    } as unknown as ProjectsModuleClient;
+
+    try {
+      const {createIntegrationsContext: createContext} = await import('./index.js');
+      const context = await createContext({
+        parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+        projects,
+      });
+
+      expect(context.repositoryAuthorizer.enabled).toBe(true);
+      await expect(
+        context.repositoryAuthorizer.resolveRepositoryAuthorization({
+          workspaceId: 'workspace-1',
+          connectionId: 'connection-1',
+          mode: 'selected',
+          repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
+          capability: 'checkout',
+        }),
+      ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
+      expect(getProjectBySource).toHaveBeenCalledWith({
         workspaceId: 'workspace-1',
-        connectionId: 'connection-1',
-        mode: 'all',
-        repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
-        capability: 'checkout',
-      }),
-    ).resolves.toBeUndefined();
-    expect(getProjectBySource).not.toHaveBeenCalled();
-    expect(findProjectBySourceRepositoryName).not.toHaveBeenCalled();
+        sourceConnectionId: 'connection-1',
+        sourceExternalRepositoryId: 'github:42',
+      });
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 });

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -91,6 +91,7 @@ export {
   IntegrationConnectionWorkspaceMismatchError,
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
+  RepositoryAuthorizerConfigurationError,
   WebhookProcessorNotConfiguredError,
 } from '#core/errors.js';
 export type {

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -7,17 +7,23 @@ import {
   type WebhookRequestProcessor,
   type WebhookRouteId,
 } from '@shipfox/api-integration-spi';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import {reportError} from '@shipfox/node-error-monitoring';
 import type {ModuleService, ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
+import {config} from '#config.js';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 import {WebhookProcessorNotConfiguredError} from '#core/errors.js';
 import {
   createIntegrationProviderRegistry,
   type IntegrationProviderRegistry,
 } from '#core/providers/registry.js';
+import {
+  createRepositoryAuthorizer,
+  type RepositoryAuthorizer,
+} from '#core/repository-authorizer.js';
 import {
   createSourceControlIntegrationService,
   type IntegrationSourceControlService,
@@ -122,6 +128,30 @@ export type {
   TriggerReference,
 } from '#core/providers/source-control.js';
 export type {
+  AuthorizedRepository,
+  CreateRepositoryAuthorizerOptions,
+  RepositoryAuthorizationCapability,
+  RepositoryAuthorizationClientErrorCode,
+  RepositoryAuthorizationDenial,
+  RepositoryAuthorizationExternalIdTarget,
+  RepositoryAuthorizationMode,
+  RepositoryAuthorizationNameTarget,
+  RepositoryAuthorizationRequestContext,
+  RepositoryAuthorizationResult,
+  RepositoryAuthorizationTarget,
+  RepositoryAuthorizer,
+  ResolveRepositoryAuthorizationInput,
+  ResolveRepositoryAuthorizationParams,
+} from '#core/repository-authorizer.js';
+export {
+  createRepositoryAuthorizationRequestContext,
+  createRepositoryAuthorizer,
+  RepositoryAuthorizationTargetInvalidError,
+  repositoryAuthorizationClientErrorCode,
+  repositoryAuthorizationClientErrorCodes,
+  resolveRepositoryAuthorization,
+} from '#core/repository-authorizer.js';
+export type {
   CreateSourceCheckoutCredentialsInput,
   IntegrationSourceControlService,
 } from '#core/source-control-service.js';
@@ -185,6 +215,7 @@ export interface CreateIntegrationsModuleOptions {
    */
   parts?: IntegrationModuleParts[] | undefined;
   secrets?: IntegrationProviderSecrets | undefined;
+  projects?: ProjectsModuleClient | undefined;
   workspaces?: WorkspacesInterModuleClient | undefined;
   agentTools?:
     | {
@@ -207,8 +238,10 @@ export interface IntegrationsContext {
   registry: IntegrationProviderRegistry;
   capabilities: {
     sourceControl: IntegrationSourceControlService;
+    repositoryAuthorizer: RepositoryAuthorizer;
   };
   sourceControl: IntegrationSourceControlService;
+  repositoryAuthorizer: RepositoryAuthorizer;
   webhookProcessor: WebhookRequestProcessor;
   /**
    * Runs every enabled provider's one-shot boot-time tasks, after modules are initialized
@@ -258,6 +291,10 @@ export async function createIntegrationsContext(
   const sourceControl = createSourceControlIntegrationService({
     registry,
     getIntegrationConnectionById,
+  });
+  const repositoryAuthorizer = createRepositoryAuthorizer({
+    projects: options.projects,
+    enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
   });
   const webhookProcessor = createComposedWebhookProcessor(
     parts.flatMap((part) => part.webhookProcessors ?? []),
@@ -325,8 +362,9 @@ export async function createIntegrationsContext(
   return {
     module,
     registry,
-    capabilities: {sourceControl},
+    capabilities: {sourceControl, repositoryAuthorizer},
     sourceControl,
+    repositoryAuthorizer,
     webhookProcessor,
     runStartupTasks,
   };

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -588,6 +588,10 @@ describe('defaultModules', () => {
         },
       },
       agentTools: {workflows: expect.objectContaining({getStepLogContext: expect.any(Function)})},
+      projects: expect.objectContaining({
+        getProjectBySource: expect.any(Function),
+        findProjectBySourceRepositoryName: expect.any(Function),
+      }),
       webhookDeliverySource: undefined,
     });
 

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -207,6 +207,7 @@ export async function defaultModules(
       },
     },
     agentTools: {workflows: workflowsClient},
+    projects: projectsClient,
     webhookDeliverySource: options.webhookDeliverySource,
   });
   const projectsModule = createProjectsModule({integrations: integrationsClient, auth: authClient});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -453,6 +453,37 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     expect(createCheckoutSpec).not.toHaveBeenCalled();
   });
 
+  test.each([
+    ['repository-not-granted', 404],
+    ['repository-ambiguous', 409],
+    ['repository-authorization-unavailable', 503],
+  ] as const)('maps the %s integration checkout failure', async (code, status) => {
+    const {project, job, step} = await createRunningCheckoutStep();
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+    });
+    createCheckoutSpec.mockRejectedValue(
+      createInterModuleKnownError(
+        integrationsInterModuleContract.methods.createCheckoutSpec,
+        code,
+        {},
+      ),
+    );
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: checkoutUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(status);
+    expect(res.json().code).toBe(code);
+  });
+
   test('maps provider rate limiting to 429 without leaking credentials', async () => {
     const {project, job, step} = await createRunningCheckoutStep();
     getProjectById.mockResolvedValue({project});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -1,6 +1,7 @@
 import {
   type IntegrationsModuleClient,
   integrationsInterModuleContract,
+  repositoryAuthorizationErrorCodes,
 } from '@shipfox/api-integration-core-dto/inter-module';
 import {
   type ProjectsModuleClient,
@@ -143,6 +144,24 @@ function throwIntegrationCheckoutError(
         status: providerFailureStatus(details.reason),
       });
     }
+    case repositoryAuthorizationErrorCodes.notGranted:
+      throw new ClientError(
+        'Checkout repository is not authorized for this workspace',
+        repositoryAuthorizationErrorCodes.notGranted,
+        {status: 404},
+      );
+    case repositoryAuthorizationErrorCodes.ambiguous:
+      throw new ClientError(
+        'Checkout repository target is ambiguous',
+        repositoryAuthorizationErrorCodes.ambiguous,
+        {status: 409},
+      );
+    case repositoryAuthorizationErrorCodes.storeUnavailable:
+      throw new ClientError(
+        'Repository authorization is unavailable',
+        repositoryAuthorizationErrorCodes.storeUnavailable,
+        {status: 503},
+      );
     default:
       throw error;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2753,6 +2753,9 @@ importers:
       '@shipfox/api-integration-webhook':
         specifier: workspace:*
         version: link:../webhook
+      '@shipfox/api-projects-dto':
+        specifier: workspace:*
+        version: link:../../projects-dto
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../workflows-dto


### PR DESCRIPTION
Adds the provider-independent repository authorization seam required before checkout and tool enforcement can adopt it. The integration context owns a disabled-by-default dark gate; selected targets resolve through the Projects contract with exact-ID/name lookup, ambiguity handling, and request-scoped memoization, while all-mode declarations avoid project lookups. Existing runtime behavior remains unchanged while the gate is off.

Closes ENG-1817

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-free repository authorization seam to the integration context, dark-gated behind `INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION` (off by default). Runtime behavior is unchanged while the gate is disabled.

Closes ENG-1817.

- Selected targets resolve through the Projects contract with exact external-ID or case-insensitive owner/name lookup, ambiguity deduplication, and request-scoped memoization. Store failures return `authorization_store_unavailable` instead of a repository denial, are rate-limited process-wide, and stay retryable; cancellations rethrow.
- All-mode declarations skip project lookups and authorize on target validation only. Invalid targets throw `RepositoryAuthorizationTargetInvalidError`; enabling the gate without a Projects client throws `RepositoryAuthorizerConfigurationError`.
- Adds `repository-not-granted`, `repository-ambiguous`, and `repository-authorization-unavailable` to the checkout and tool call inter-module contract, mapping them at the checkout-token route to 404, 409, and 503.

<sup>Written for commit bfdff815936a7033561d13dc4879506f42100c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

