### PR TITLE
[provisioner-ec2] Observe EC2 health checks and submit candidates

### DIFF
--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -18,6 +18,16 @@ lifetime. The image's EC2 bootstrap service formats and mounts the non-root EBS 
 the runner starts. It never renders a workspace ID, workspace registration token, or
 activation token.
 
+## Health checks
+
+Backend reconciliation reads EC2 system, instance, and attached-EBS status checks and scheduled
+events with `ec2:DescribeInstanceStatus`. The provisioner role must grant that action in the
+runner region. An authorization failure fails the reconciliation closed; a transient status-read
+failure keeps the ordinary `DescribeInstances` snapshot and submits no health candidate.
+Candidates require an impairment that is at least one reconciliation interval old or two
+consecutive close observations. Regular observation, termination lookup, and service metrics
+omit status checks so they do not poll the status API unnecessarily.
+
 ## Template config
 
 The template file can contain shared `vars`, a `defaults` fragment, hand-written

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -25,7 +25,8 @@ events with `ec2:DescribeInstanceStatus`. The provisioner role must grant that a
 runner region. An authorization failure fails the reconciliation closed; a transient status-read
 failure keeps the ordinary `DescribeInstances` snapshot and submits no health candidate.
 Candidates require an impairment that is at least one reconciliation interval old or two
-consecutive close observations. Regular observation, termination lookup, and service metrics
+consecutive close observations. Candidates are requests to the existing backend authorization
+gate, not direct termination calls. Regular observation, termination lookup, and service metrics
 omit status checks so they do not poll the status API unnecessarily.
 
 ## Template config

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -22,8 +22,9 @@ activation token.
 
 Backend reconciliation reads EC2 system, instance, and attached-EBS status checks and scheduled
 events with `ec2:DescribeInstanceStatus`. The provisioner role must grant that action in the
-runner region. An authorization failure fails the reconciliation closed; a transient status-read
-failure keeps the ordinary `DescribeInstances` snapshot and submits no health candidate.
+runner region. An authorization or other permanent status-read failure fails the reconciliation
+closed; a transient or stale-instance status-read failure keeps the ordinary `DescribeInstances`
+snapshot and submits no health candidate.
 Candidates require an impairment that is at least one reconciliation interval old or two
 consecutive close observations. Candidates are requests to the existing backend authorization
 gate, not direct termination calls. Regular observation, termination lookup, and service metrics

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -187,6 +187,8 @@ describe('createEc2Engine', () => {
     ['RequestLimitExceeded', 'throttled', true],
     ['InvalidAMIID.NotFound', 'image-not-found', false],
     ['AuthFailure', 'auth', false],
+    ['AccessDenied', 'auth', false],
+    ['AccessDeniedException', 'auth', false],
     ['InvalidParameterValue', 'config-invalid', false],
     ['ECONNREFUSED', 'unreachable', true],
     ['UnexpectedFailure', 'unknown', false],
@@ -231,6 +233,7 @@ describe('createEc2Engine', () => {
       NextToken: undefined,
     });
     expect(commandInput<DescribeInstancesCommand>(ec2.commands[1]).NextToken).toBe('next-page');
+    expect(ec2.commands).toHaveLength(2);
     expect(result[0]).toMatchObject({
       instanceId: 'i-123',
       state: 'terminated',
@@ -275,7 +278,7 @@ describe('createEc2Engine', () => {
     });
     const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
 
-    const result = await engine.listManaged('provisioner-1');
+    const result = await engine.listManaged('provisioner-1', {includeStatus: true});
 
     expect(commandInput<DescribeInstanceStatusCommand>(ec2.commands[1])).toEqual({
       InstanceIds: ['i-123'],
@@ -309,7 +312,7 @@ describe('createEc2Engine', () => {
     });
     const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
 
-    const result = await engine.listManaged('provisioner-1');
+    const result = await engine.listManaged('provisioner-1', {includeStatus: true});
 
     expect(result[0]).toMatchObject({
       systemStatus: {status: 'unknown'},
@@ -319,17 +322,71 @@ describe('createEc2Engine', () => {
     });
   });
 
-  it('fails closed when EC2 status checks are unauthorized', async () => {
+  it('returns the instance snapshot when a non-auth status read fails', async () => {
     const ec2 = fakeEc2({
       describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
-      describeStatusError: awsError('UnauthorizedOperation'),
+      describeStatusError: awsError('RequestLimitExceeded'),
     });
     const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
 
-    await expect(engine.listManaged('provisioner-1')).rejects.toMatchObject({
+    const result = await engine.listManaged('provisioner-1', {includeStatus: true});
+
+    expect(result[0]).toMatchObject({instanceId: 'i-123', state: 'running'});
+    expect(result[0]).not.toHaveProperty('systemStatus');
+  });
+
+  it.each([
+    'UnauthorizedOperation',
+    'AccessDenied',
+    'AccessDeniedException',
+  ])('fails closed when EC2 status checks return %s', async (code) => {
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
+      describeStatusError: awsError(code),
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await expect(engine.listManaged('provisioner-1', {includeStatus: true})).rejects.toMatchObject({
       reason: 'auth',
       retryable: false,
     });
+  });
+
+  it('batches and paginates EC2 status checks', async () => {
+    const instances = Array.from({length: 101}, (_, index) => instance({InstanceId: `i-${index}`}));
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: instances}]}],
+      describeStatusOutputs: [
+        {
+          InstanceStatuses: [{InstanceId: 'i-0', SystemStatus: {Status: 'ok'}}],
+          NextToken: 'status-next-page',
+        },
+        {InstanceStatuses: [{InstanceId: 'i-99', SystemStatus: {Status: 'impaired'}}]},
+        {InstanceStatuses: [{InstanceId: 'i-100', SystemStatus: {Status: 'ok'}}]},
+      ],
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1', {includeStatus: true});
+
+    expect(ec2.commands).toHaveLength(4);
+    expect(commandInput<DescribeInstanceStatusCommand>(ec2.commands[1])).toMatchObject({
+      InstanceIds: Array.from({length: 100}, (_, index) => `i-${index}`),
+      IncludeAllInstances: true,
+      NextToken: undefined,
+    });
+    expect(commandInput<DescribeInstanceStatusCommand>(ec2.commands[2])).toMatchObject({
+      InstanceIds: Array.from({length: 100}, (_, index) => `i-${index}`),
+      IncludeAllInstances: true,
+      NextToken: 'status-next-page',
+    });
+    expect(commandInput<DescribeInstanceStatusCommand>(ec2.commands[3])).toMatchObject({
+      InstanceIds: ['i-100'],
+      IncludeAllInstances: true,
+      NextToken: undefined,
+    });
+    expect(result[0]).toMatchObject({systemStatus: {status: 'ok'}});
+    expect(result[99]).toMatchObject({systemStatus: {status: 'impaired'}});
   });
 
   it.each([

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -322,10 +322,13 @@ describe('createEc2Engine', () => {
     });
   });
 
-  it('returns the instance snapshot when a non-auth status read fails', async () => {
+  it.each([
+    'RequestLimitExceeded',
+    'InvalidInstanceID.NotFound',
+  ])('returns the instance snapshot when a non-auth status read fails with %s', async (code) => {
     const ec2 = fakeEc2({
       describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
-      describeStatusError: awsError('RequestLimitExceeded'),
+      describeStatusError: awsError(code),
     });
     const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
 

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -189,6 +189,9 @@ describe('createEc2Engine', () => {
     ['AuthFailure', 'auth', false],
     ['AccessDenied', 'auth', false],
     ['AccessDeniedException', 'auth', false],
+    ['InvalidClientTokenId', 'auth', false],
+    ['SignatureDoesNotMatch', 'auth', false],
+    ['UnrecognizedClientException', 'auth', false],
     ['InvalidParameterValue', 'config-invalid', false],
     ['ECONNREFUSED', 'unreachable', true],
     ['UnexpectedFailure', 'unknown', false],
@@ -325,7 +328,7 @@ describe('createEc2Engine', () => {
   it.each([
     'RequestLimitExceeded',
     'InvalidInstanceID.NotFound',
-  ])('returns the instance snapshot when a non-auth status read fails with %s', async (code) => {
+  ])('returns the instance snapshot when a retryable or stale status read fails with %s', async (code) => {
     const ec2 = fakeEc2({
       describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
       describeStatusError: awsError(code),
@@ -339,9 +342,29 @@ describe('createEc2Engine', () => {
   });
 
   it.each([
+    ['InvalidParameterValue', 'config-invalid'],
+    ['UnsupportedOperation', 'config-invalid'],
+    ['UnexpectedFailure', 'unknown'],
+  ])('propagates permanent status-read failure %s as %s', async (code, reason) => {
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
+      describeStatusError: awsError(code),
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await expect(engine.listManaged('provisioner-1', {includeStatus: true})).rejects.toMatchObject({
+      reason,
+      retryable: false,
+    });
+  });
+
+  it.each([
     'UnauthorizedOperation',
     'AccessDenied',
     'AccessDeniedException',
+    'InvalidClientTokenId',
+    'SignatureDoesNotMatch',
+    'UnrecognizedClientException',
   ])('fails closed when EC2 status checks return %s', async (code) => {
     const ec2 = fakeEc2({
       describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
@@ -390,6 +413,7 @@ describe('createEc2Engine', () => {
     });
     expect(result[0]).toMatchObject({systemStatus: {status: 'ok'}});
     expect(result[99]).toMatchObject({systemStatus: {status: 'impaired'}});
+    expect(result[100]).toMatchObject({systemStatus: {status: 'ok'}});
   });
 
   it.each([

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -416,6 +416,43 @@ describe('createEc2Engine', () => {
     expect(result[100]).toMatchObject({systemStatus: {status: 'ok'}});
   });
 
+  it('retains statuses for other instances when a batch contains a stale instance', async () => {
+    const ec2 = fakeEc2({
+      describeOutputs: [
+        {
+          Reservations: [
+            {
+              Instances: [instance({InstanceId: 'i-live'}), instance({InstanceId: 'i-stale'})],
+            },
+          ],
+        },
+      ],
+      describeStatusErrors: [
+        awsError('InvalidInstanceID.NotFound'),
+        undefined,
+        awsError('InvalidInstanceID.NotFound'),
+      ],
+      describeStatusOutputs: [
+        {InstanceStatuses: [{InstanceId: 'i-live', SystemStatus: {Status: 'impaired'}}]},
+      ],
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1', {includeStatus: true});
+
+    expect(
+      ec2.commands
+        .filter((command) => command instanceof DescribeInstanceStatusCommand)
+        .map((command) => commandInput<DescribeInstanceStatusCommand>(command).InstanceIds),
+    ).toEqual([['i-live', 'i-stale'], ['i-live'], ['i-stale']]);
+    expect(result.find((instance) => instance.instanceId === 'i-live')).toMatchObject({
+      systemStatus: {status: 'impaired'},
+    });
+    expect(result.find((instance) => instance.instanceId === 'i-stale')).not.toHaveProperty(
+      'systemStatus',
+    );
+  });
+
   it.each([
     ['pending', 'pending'],
     ['running', 'running'],
@@ -505,6 +542,7 @@ function fakeEc2(
     describeOutputs?: unknown[];
     describeStatusOutputs?: unknown[];
     describeStatusError?: Error;
+    describeStatusErrors?: Array<Error | undefined>;
     terminateError?: Error;
     terminateErrorById?: Map<string, Error>;
   } = {},
@@ -512,6 +550,7 @@ function fakeEc2(
   const commands: unknown[] = [];
   const describeOutputs = [...(options.describeOutputs ?? [])];
   const describeStatusOutputs = [...(options.describeStatusOutputs ?? [])];
+  const describeStatusErrors = [...(options.describeStatusErrors ?? [])];
 
   return {
     commands,
@@ -523,7 +562,7 @@ function fakeEc2(
       if (command instanceof DescribeInstancesCommand)
         return Promise.resolve(describeOutputs.shift() ?? {});
       if (command instanceof DescribeInstanceStatusCommand)
-        return describeStatusResponse(options, describeStatusOutputs);
+        return describeStatusResponse(options, describeStatusOutputs, describeStatusErrors);
       if (command instanceof TerminateInstancesCommand)
         return terminateInstanceResponse(command, options);
       return Promise.reject(new Error('Unexpected EC2 command'));
@@ -539,8 +578,10 @@ function runInstanceResponse(options: {runOutput?: unknown; runError?: Error}): 
 function describeStatusResponse(
   options: {describeStatusError?: Error},
   outputs: unknown[],
+  errors: Array<Error | undefined>,
 ): Promise<unknown> {
-  if (options.describeStatusError) return Promise.reject(options.describeStatusError);
+  const error = options.describeStatusError ?? errors.shift();
+  if (error) return Promise.reject(error);
   return Promise.resolve(outputs.shift() ?? {});
 }
 

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -1,4 +1,5 @@
 import {
+  DescribeInstanceStatusCommand,
   DescribeInstancesCommand,
   RunInstancesCommand,
   TerminateInstancesCommand,
@@ -241,6 +242,96 @@ describe('createEc2Engine', () => {
     expect(result[1]?.instanceId).toBe('i-456');
   });
 
+  it('maps EC2 status checks and scheduled events for managed instances', async () => {
+    const impairedSince = new Date('2026-07-18T12:02:00.000Z');
+    const notBefore = new Date('2026-07-18T13:00:00.000Z');
+    const notAfter = new Date('2026-07-18T14:00:00.000Z');
+    const notBeforeDeadline = new Date('2026-07-18T13:30:00.000Z');
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
+      describeStatusOutputs: [
+        {
+          InstanceStatuses: [
+            {
+              InstanceId: 'i-123',
+              SystemStatus: {
+                Status: 'impaired',
+                Details: [{Name: 'reachability', Status: 'failed', ImpairedSince: impairedSince}],
+              },
+              InstanceStatus: {Status: 'initializing'},
+              AttachedEbsStatus: {Status: 'insufficient-data'},
+              Events: [
+                {
+                  Code: 'system-reboot',
+                  NotBefore: notBefore,
+                  NotAfter: notAfter,
+                  NotBeforeDeadline: notBeforeDeadline,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1');
+
+    expect(commandInput<DescribeInstanceStatusCommand>(ec2.commands[1])).toEqual({
+      InstanceIds: ['i-123'],
+      IncludeAllInstances: true,
+      NextToken: undefined,
+    });
+    expect(result[0]).toMatchObject({
+      systemStatus: {status: 'impaired', impairedSince},
+      instanceStatus: {status: 'initializing'},
+      attachedEbsStatus: {status: 'insufficient-data'},
+      scheduledEvents: [{code: 'system-reboot', notBefore, notAfter, notBeforeDeadline}],
+    });
+  });
+
+  it('maps unknown status values and scheduled event codes to bounded values', async () => {
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
+      describeStatusOutputs: [
+        {
+          InstanceStatuses: [
+            {
+              InstanceId: 'i-123',
+              SystemStatus: {Status: 'unexpected'},
+              InstanceStatus: {},
+              AttachedEbsStatus: {Status: 'unexpected'},
+              Events: [{Code: 'unexpected'}],
+            },
+          ],
+        },
+      ],
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1');
+
+    expect(result[0]).toMatchObject({
+      systemStatus: {status: 'unknown'},
+      instanceStatus: {status: 'unknown'},
+      attachedEbsStatus: {status: 'unknown'},
+      scheduledEvents: [{code: 'unknown'}],
+    });
+  });
+
+  it('fails closed when EC2 status checks are unauthorized', async () => {
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: [instance()]}]}],
+      describeStatusError: awsError('UnauthorizedOperation'),
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await expect(engine.listManaged('provisioner-1')).rejects.toMatchObject({
+      reason: 'auth',
+      retryable: false,
+    });
+  });
+
   it.each([
     ['pending', 'pending'],
     ['running', 'running'],
@@ -328,28 +419,45 @@ function fakeEc2(
     runOutput?: unknown;
     runError?: Error;
     describeOutputs?: unknown[];
+    describeStatusOutputs?: unknown[];
+    describeStatusError?: Error;
     terminateError?: Error;
     terminateErrorById?: Map<string, Error>;
   } = {},
 ) {
   const commands: unknown[] = [];
   const describeOutputs = [...(options.describeOutputs ?? [])];
+  const describeStatusOutputs = [...(options.describeStatusOutputs ?? [])];
 
   return {
     commands,
     send(command: unknown) {
       commands.push(command);
       if (command instanceof RunInstancesCommand) {
-        if (options.runError) return Promise.reject(options.runError);
-        return Promise.resolve(options.runOutput ?? {Instances: [instance()]});
+        return runInstanceResponse(options);
       }
       if (command instanceof DescribeInstancesCommand)
         return Promise.resolve(describeOutputs.shift() ?? {});
+      if (command instanceof DescribeInstanceStatusCommand)
+        return describeStatusResponse(options, describeStatusOutputs);
       if (command instanceof TerminateInstancesCommand)
         return terminateInstanceResponse(command, options);
       return Promise.reject(new Error('Unexpected EC2 command'));
     },
   };
+}
+
+function runInstanceResponse(options: {runOutput?: unknown; runError?: Error}): Promise<unknown> {
+  if (options.runError) return Promise.reject(options.runError);
+  return Promise.resolve(options.runOutput ?? {Instances: [instance()]});
+}
+
+function describeStatusResponse(
+  options: {describeStatusError?: Error},
+  outputs: unknown[],
+): Promise<unknown> {
+  if (options.describeStatusError) return Promise.reject(options.describeStatusError);
+  return Promise.resolve(outputs.shift() ?? {});
 }
 
 function terminateInstanceResponse(

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -297,16 +297,17 @@ async function readManagedInstanceStatuses(
   instances: readonly Ec2InstanceView[],
 ): Promise<ReadonlyMap<string, Ec2InstanceStatusFields>> {
   try {
-    // The reconciliation path requires ec2:DescribeInstanceStatus. Auth failures are propagated
-    // so health enforcement fails closed; transient status-read failures do not make the core
-    // lose an otherwise valid instance snapshot.
+    // The reconciliation path requires ec2:DescribeInstanceStatus. Auth and other permanent
+    // status-read failures are propagated so health enforcement fails closed. Retryable failures
+    // keep the ordinary instance snapshot, as does the stale-instance race that EC2 reports as
+    // InvalidInstanceID.NotFound.
     return await describeInstanceStatuses(
       client,
       instances.map((instance) => instance.instanceId),
     );
   } catch (error) {
     const mappedError = mapEc2Error(error, 'Cannot read managed EC2 instance statuses.');
-    if (mappedError.reason === 'auth') throw mappedError;
+    if (!mappedError.retryable && !isStaleInstanceStatusError(error)) throw mappedError;
     logger().warn(
       {
         event: 'provisioner.ec2.status_checks_unavailable',
@@ -317,6 +318,10 @@ async function readManagedInstanceStatuses(
     );
     return new Map();
   }
+}
+
+function isStaleInstanceStatusError(error: unknown): boolean {
+  return errorName(error) === 'InvalidInstanceID.NotFound';
 }
 
 const MAX_STATUS_INSTANCE_IDS = 100;
@@ -488,6 +493,9 @@ function mapEc2Error(error: unknown, message: string): Ec2EngineError {
       'AccessDeniedException',
       'AuthFailure',
       'UnauthorizedOperation',
+      'InvalidClientTokenId',
+      'SignatureDoesNotMatch',
+      'UnrecognizedClientException',
       'Blocked',
       'OptInRequired',
     ].includes(name)

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -1,7 +1,12 @@
 import {
+  DescribeInstanceStatusCommand,
   DescribeInstancesCommand,
+  type EbsStatusSummary,
   EC2Client,
   type Instance,
+  type InstanceStatus,
+  type InstanceStatusEvent,
+  type InstanceStatusSummary,
   RunInstancesCommand,
   type RunInstancesCommandInput,
   TerminateInstancesCommand,
@@ -50,6 +55,34 @@ export type Ec2InstanceState =
   | 'terminated'
   | 'unknown';
 
+export type Ec2StatusCheckStatus =
+  | 'ok'
+  | 'impaired'
+  | 'initializing'
+  | 'insufficient-data'
+  | 'not-applicable'
+  | 'unknown';
+
+export interface Ec2StatusCheck {
+  readonly status: Ec2StatusCheckStatus;
+  readonly impairedSince?: Date;
+}
+
+export type Ec2ScheduledEventCode =
+  | 'instance-reboot'
+  | 'system-reboot'
+  | 'system-maintenance'
+  | 'instance-retirement'
+  | 'instance-stop'
+  | 'unknown';
+
+export interface Ec2ScheduledEvent {
+  readonly code: Ec2ScheduledEventCode;
+  readonly notBefore?: Date;
+  readonly notAfter?: Date;
+  readonly notBeforeDeadline?: Date;
+}
+
 export interface Ec2InstanceView {
   readonly instanceId: string;
   readonly ami?: string;
@@ -61,6 +94,10 @@ export interface Ec2InstanceView {
   readonly stateReasonCode?: string;
   readonly stateReasonMessage?: string;
   readonly launchTime?: Date;
+  readonly systemStatus?: Ec2StatusCheck;
+  readonly instanceStatus?: Ec2StatusCheck;
+  readonly attachedEbsStatus?: Ec2StatusCheck;
+  readonly scheduledEvents?: readonly Ec2ScheduledEvent[];
 }
 
 export interface RunInstanceArgs {
@@ -205,7 +242,14 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
           nextToken = output.NextToken;
         } while (nextToken);
 
-        return instances;
+        const statusByInstanceId = await describeInstanceStatuses(
+          client,
+          instances.map((instance) => instance.instanceId),
+        );
+        return instances.map((instance) => {
+          const status = statusByInstanceId.get(instance.instanceId);
+          return status ? {...instance, ...status} : instance;
+        });
       } catch (error) {
         throw mapEc2Error(error, 'Cannot list managed EC2 instances.');
       }
@@ -229,6 +273,104 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
       }
     },
   };
+}
+
+const MAX_STATUS_INSTANCE_IDS = 100;
+
+type Ec2InstanceStatusFields = Pick<
+  Ec2InstanceView,
+  'systemStatus' | 'instanceStatus' | 'attachedEbsStatus' | 'scheduledEvents'
+>;
+
+async function describeInstanceStatuses(
+  client: EC2Client,
+  instanceIds: readonly string[],
+): Promise<ReadonlyMap<string, Ec2InstanceStatusFields>> {
+  if (instanceIds.length === 0) return new Map();
+
+  const statuses = new Map<string, Ec2InstanceStatusFields>();
+  for (let start = 0; start < instanceIds.length; start += MAX_STATUS_INSTANCE_IDS) {
+    const batch = instanceIds.slice(start, start + MAX_STATUS_INSTANCE_IDS);
+    let nextToken: string | undefined;
+    do {
+      const output = await client.send(
+        new DescribeInstanceStatusCommand({
+          InstanceIds: [...batch],
+          IncludeAllInstances: true,
+          NextToken: nextToken,
+        }),
+      );
+      for (const status of output.InstanceStatuses ?? []) {
+        const fields = toInstanceStatusFields(status);
+        if (status.InstanceId && fields) statuses.set(status.InstanceId, fields);
+      }
+      nextToken = output.NextToken;
+    } while (nextToken);
+  }
+  return statuses;
+}
+
+function toInstanceStatusFields(status: InstanceStatus): Ec2InstanceStatusFields {
+  const systemStatus = toStatusCheck(status.SystemStatus);
+  const instanceStatus = toStatusCheck(status.InstanceStatus);
+  const attachedEbsStatus = toStatusCheck(status.AttachedEbsStatus);
+
+  return {
+    ...(systemStatus ? {systemStatus} : {}),
+    ...(instanceStatus ? {instanceStatus} : {}),
+    ...(attachedEbsStatus ? {attachedEbsStatus} : {}),
+    scheduledEvents: (status.Events ?? []).map(toScheduledEvent),
+  };
+}
+
+function toStatusCheck(
+  summary: InstanceStatusSummary | EbsStatusSummary | undefined,
+): Ec2StatusCheck | undefined {
+  if (!summary) return undefined;
+  const reachabilityDetail = summary.Details?.find((detail) => detail.Name === 'reachability');
+  const impairedSince =
+    reachabilityDetail && 'ImpairedSince' in reachabilityDetail
+      ? reachabilityDetail.ImpairedSince
+      : undefined;
+  return {
+    status: normalizeStatusCheckStatus(summary.Status),
+    ...(impairedSince ? {impairedSince} : {}),
+  };
+}
+
+function toScheduledEvent(event: InstanceStatusEvent): Ec2ScheduledEvent {
+  return {
+    code: normalizeScheduledEventCode(event.Code),
+    ...(event.NotBefore ? {notBefore: event.NotBefore} : {}),
+    ...(event.NotAfter ? {notAfter: event.NotAfter} : {}),
+    ...(event.NotBeforeDeadline ? {notBeforeDeadline: event.NotBeforeDeadline} : {}),
+  };
+}
+
+function normalizeStatusCheckStatus(status: string | undefined): Ec2StatusCheckStatus {
+  switch (status) {
+    case 'ok':
+    case 'impaired':
+    case 'initializing':
+    case 'insufficient-data':
+    case 'not-applicable':
+      return status;
+    default:
+      return 'unknown';
+  }
+}
+
+function normalizeScheduledEventCode(code: string | undefined): Ec2ScheduledEventCode {
+  switch (code) {
+    case 'instance-reboot':
+    case 'system-reboot':
+    case 'system-maintenance':
+    case 'instance-retirement':
+    case 'instance-stop':
+      return code;
+    default:
+      return 'unknown';
+  }
 }
 
 function toInstanceView(instance: Instance): Ec2InstanceView {
@@ -296,7 +438,16 @@ function mapEc2Error(error: unknown, message: string): Ec2EngineError {
   ) {
     reason = 'throttled';
   } else if (name.startsWith('InvalidAMIID.')) reason = 'image-not-found';
-  else if (['AuthFailure', 'UnauthorizedOperation', 'Blocked', 'OptInRequired'].includes(name)) {
+  else if (
+    [
+      'AccessDenied',
+      'AccessDeniedException',
+      'AuthFailure',
+      'UnauthorizedOperation',
+      'Blocked',
+      'OptInRequired',
+    ].includes(name)
+  ) {
     reason = 'auth';
   } else if (
     name.startsWith('Invalid') ||

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -340,22 +340,65 @@ async function describeInstanceStatuses(
   const statuses = new Map<string, Ec2InstanceStatusFields>();
   for (let start = 0; start < instanceIds.length; start += MAX_STATUS_INSTANCE_IDS) {
     const batch = instanceIds.slice(start, start + MAX_STATUS_INSTANCE_IDS);
-    let nextToken: string | undefined;
-    do {
-      const output = await client.send(
-        new DescribeInstanceStatusCommand({
-          InstanceIds: [...batch],
-          IncludeAllInstances: true,
-          NextToken: nextToken,
-        }),
-      );
-      for (const status of output.InstanceStatuses ?? []) {
-        const fields = toInstanceStatusFields(status);
-        if (status.InstanceId && fields) statuses.set(status.InstanceId, fields);
-      }
-      nextToken = output.NextToken;
-    } while (nextToken);
+    const batchStatuses = await describeInstanceStatusBatch(client, batch);
+    for (const [instanceId, fields] of batchStatuses) statuses.set(instanceId, fields);
   }
+  return statuses;
+}
+
+async function describeInstanceStatusBatch(
+  client: EC2Client,
+  instanceIds: readonly string[],
+): Promise<ReadonlyMap<string, Ec2InstanceStatusFields>> {
+  try {
+    return await describeInstanceStatusBatchPages(client, instanceIds);
+  } catch (error) {
+    if (!isStaleInstanceStatusError(error) || instanceIds.length <= 1) throw error;
+
+    // DescribeInstanceStatus rejects the whole request when one ID was terminated after
+    // DescribeInstances. Retry each ID to retain the remaining statuses and skip only the stale
+    // instance. This fallback is limited to the stale-ID race and does not mask other errors.
+    return retryStatusBatchByInstance(client, instanceIds);
+  }
+}
+
+async function retryStatusBatchByInstance(
+  client: EC2Client,
+  instanceIds: readonly string[],
+): Promise<ReadonlyMap<string, Ec2InstanceStatusFields>> {
+  const statuses = new Map<string, Ec2InstanceStatusFields>();
+  for (const instanceId of instanceIds) {
+    try {
+      const instanceStatuses = await describeInstanceStatusBatchPages(client, [instanceId]);
+      for (const [statusInstanceId, fields] of instanceStatuses)
+        statuses.set(statusInstanceId, fields);
+    } catch (error) {
+      if (!isStaleInstanceStatusError(error)) throw error;
+    }
+  }
+  return statuses;
+}
+
+async function describeInstanceStatusBatchPages(
+  client: EC2Client,
+  instanceIds: readonly string[],
+): Promise<ReadonlyMap<string, Ec2InstanceStatusFields>> {
+  const statuses = new Map<string, Ec2InstanceStatusFields>();
+  let nextToken: string | undefined;
+  do {
+    const output = await client.send(
+      new DescribeInstanceStatusCommand({
+        InstanceIds: [...instanceIds],
+        IncludeAllInstances: true,
+        NextToken: nextToken,
+      }),
+    );
+    for (const status of output.InstanceStatuses ?? []) {
+      const fields = toInstanceStatusFields(status);
+      if (status.InstanceId && fields) statuses.set(status.InstanceId, fields);
+    }
+    nextToken = output.NextToken;
+  } while (nextToken);
   return statuses;
 }
 

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -11,6 +11,7 @@ import {
   type RunInstancesCommandInput,
   TerminateInstancesCommand,
 } from '@aws-sdk/client-ec2';
+import {logger} from '@shipfox/node-opentelemetry';
 import {SHIPFOX_TAGS} from '#instance-identity.js';
 import {type Ec2Architecture, recordEc2LaunchDuration} from '#metrics/instance.js';
 import {type Ec2Market, UNKNOWN_TEMPLATE_KEY} from '#templates.js';
@@ -119,8 +120,13 @@ export interface RunInstanceArgs {
 
 export interface Ec2Engine {
   runInstance(args: RunInstanceArgs): Promise<Ec2InstanceView>;
-  listManaged(provisionerId: string): Promise<Ec2InstanceView[]>;
+  listManaged(provisionerId: string, options?: Ec2ListManagedOptions): Promise<Ec2InstanceView[]>;
   terminate(instanceIds: readonly string[], options?: {force?: boolean}): Promise<void>;
+}
+
+export interface Ec2ListManagedOptions {
+  /** Reconciliation requires the additional EC2 status-check permission. */
+  readonly includeStatus?: boolean;
 }
 
 export interface CreateEc2EngineOptions {
@@ -223,28 +229,15 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
       }
     },
 
-    async listManaged(provisionerId) {
+    async listManaged(provisionerId, options) {
       try {
-        const instances: Ec2InstanceView[] = [];
-        let nextToken: string | undefined;
+        const instances = await describeManagedInstances(client, provisionerId);
 
-        do {
-          const output = await client.send(
-            new DescribeInstancesCommand({
-              NextToken: nextToken,
-              Filters: [{Name: `tag:${SHIPFOX_TAGS.provisionerId}`, Values: [provisionerId]}],
-            }),
-          );
-          for (const reservation of output.Reservations ?? []) {
-            for (const instance of reservation.Instances ?? [])
-              instances.push(toInstanceView(instance));
-          }
-          nextToken = output.NextToken;
-        } while (nextToken);
-
-        const statusByInstanceId = await describeInstanceStatuses(
+        if (!options?.includeStatus) return instances;
+        const statusByInstanceId = await readManagedInstanceStatuses(
           client,
-          instances.map((instance) => instance.instanceId),
+          provisionerId,
+          instances,
         );
         return instances.map((instance) => {
           const status = statusByInstanceId.get(instance.instanceId);
@@ -273,6 +266,57 @@ export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
       }
     },
   };
+}
+
+async function describeManagedInstances(
+  client: EC2Client,
+  provisionerId: string,
+): Promise<Ec2InstanceView[]> {
+  const instances: Ec2InstanceView[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const output = await client.send(
+      new DescribeInstancesCommand({
+        NextToken: nextToken,
+        Filters: [{Name: `tag:${SHIPFOX_TAGS.provisionerId}`, Values: [provisionerId]}],
+      }),
+    );
+    for (const reservation of output.Reservations ?? []) {
+      for (const instance of reservation.Instances ?? []) instances.push(toInstanceView(instance));
+    }
+    nextToken = output.NextToken;
+  } while (nextToken);
+
+  return instances;
+}
+
+async function readManagedInstanceStatuses(
+  client: EC2Client,
+  provisionerId: string,
+  instances: readonly Ec2InstanceView[],
+): Promise<ReadonlyMap<string, Ec2InstanceStatusFields>> {
+  try {
+    // The reconciliation path requires ec2:DescribeInstanceStatus. Auth failures are propagated
+    // so health enforcement fails closed; transient status-read failures do not make the core
+    // lose an otherwise valid instance snapshot.
+    return await describeInstanceStatuses(
+      client,
+      instances.map((instance) => instance.instanceId),
+    );
+  } catch (error) {
+    const mappedError = mapEc2Error(error, 'Cannot read managed EC2 instance statuses.');
+    if (mappedError.reason === 'auth') throw mappedError;
+    logger().warn(
+      {
+        event: 'provisioner.ec2.status_checks_unavailable',
+        provisioner_id: provisionerId,
+        reason: mappedError.reason,
+      },
+      'EC2 status checks unavailable; continuing with the instance snapshot',
+    );
+    return new Map();
+  }
 }
 
 const MAX_STATUS_INSTANCE_IDS = 100;

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -866,7 +866,10 @@ describe('createEc2Lifecycle', () => {
     const lifecycle = makeLifecycle({engine, client});
 
     await lifecycle.reconcile();
-    instances[0] = instance({state: 'running'});
+    instances[0] = instance({
+      state: 'running',
+      scheduledEvents: [{code: 'system-reboot'}],
+    });
     await lifecycle.reconcile();
     instances[0] = instance({state: 'running', systemStatus: {status: 'impaired'}});
     await lifecycle.reconcile();

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -680,33 +680,35 @@ describe('createEc2Lifecycle', () => {
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
-  it('observes impaired EC2 health without terminating during observe mode', async () => {
+  it('observes impaired EC2 health without terminating locally', async () => {
     const engine = fakeEngine({
       instances: [
         instance({
           state: 'running',
-          systemStatus: {status: 'impaired', impairedSince: new Date(NOW.getTime() - 30_000)},
+          systemStatus: {status: 'impaired'},
           instanceStatus: {status: 'ok'},
           attachedEbsStatus: {status: 'ok'},
         }),
       ],
     });
-    const lifecycle = makeLifecycle({engine});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
 
-    await lifecycle.observe();
+    await lifecycle.reconcile();
 
     expect(engine.terminationCalls).toEqual([]);
     expect(observability.recordEc2HealthImpaired).toHaveBeenCalledWith('system');
-    expect(observability.logger.warn).toHaveBeenCalledWith(
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: ['runner-1']}]);
+    expect(observability.logger.debug).toHaveBeenCalledWith(
       expect.objectContaining({
         event: 'provisioner.ec2.provider_health_observed',
         ec2_state: 'running',
-        health_candidate_decision: 'eligible',
+        health_candidate_decision: 'awaiting-persistence',
         health_checks: expect.arrayContaining([
           expect.objectContaining({check_type: 'system', status: 'impaired'}),
         ]),
       }),
-      'Observed impaired EC2 runner health',
+      'Observed transient EC2 runner health status',
     );
   });
 
@@ -726,8 +728,10 @@ describe('createEc2Lifecycle', () => {
     const lifecycle = makeLifecycle({engine, client});
 
     await lifecycle.reconcile();
+    await lifecycle.reconcile();
 
     expect(client.reconcileBodies).toEqual([
+      {observed_provider_runner_ids: ['runner-1']},
       {
         observed_provider_runner_ids: ['runner-1'],
         termination_candidates: [
@@ -737,14 +741,15 @@ describe('createEc2Lifecycle', () => {
     ]);
     expect(engine.terminationCalls).toEqual([]);
     expect(observability.recordEc2HealthImpaired).toHaveBeenCalledWith('instance');
-    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledTimes(1);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledTimes(2);
     expect(observability.logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
         event: 'provisioner.ec2.provider_health_candidates_submitted',
-        count: 1,
+        requested_count: 1,
+        termination_authorization: 'backend-gated',
         provider_runner_ids: ['runner-1'],
       }),
-      'Submitted EC2 provider health termination candidates',
+      'Sent EC2 provider health termination candidates for backend authorization',
     );
   });
 
@@ -769,6 +774,115 @@ describe('createEc2Lifecycle', () => {
     );
   });
 
+  it('observes scheduled events without submitting a health candidate', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'running',
+          systemStatus: {status: 'ok'},
+          instanceStatus: {status: 'ok'},
+          attachedEbsStatus: {status: 'ok'},
+          scheduledEvents: [{code: 'system-reboot'}],
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: ['runner-1']}]);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).not.toHaveBeenCalled();
+    expect(observability.logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        health_candidate_decision: 'observe-only',
+        scheduled_event_codes: ['system-reboot'],
+      }),
+      'Observed transient EC2 runner health status',
+    );
+  });
+
+  it('does not submit an impaired stopped instance as a health candidate', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'stopped', systemStatus: {status: 'impaired'}})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: ['runner-1']}]);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledWith('system');
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({health_candidate_decision: 'not-running'}),
+      'Observed impaired EC2 runner health',
+    );
+  });
+
+  it('does not submit an impaired instance without a provider runner id', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({state: 'running', providerRunnerId: null, systemStatus: {status: 'impaired'}}),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: []}]);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledWith('system');
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({health_candidate_decision: 'missing-provider-runner-id'}),
+      'Observed impaired EC2 runner health',
+    );
+  });
+
+  it('requires persistent impairment before submitting a health candidate', async () => {
+    const instances = [instance({state: 'running', systemStatus: {status: 'impaired'}})];
+    const engine = fakeEngine({instances});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+    instances[0] = instance({state: 'running', systemStatus: {status: 'ok'}});
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([
+      {observed_provider_runner_ids: ['runner-1']},
+      {observed_provider_runner_ids: ['runner-1']},
+    ]);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls EC2 status checks only during backend reconciliation', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'running'})]});
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.observe();
+    await lifecycle.reconcile();
+    await lifecycle.terminate(['runner-1']);
+
+    expect(engine.listCalls).toEqual([
+      {
+        provisionerId: '00000000-0000-4000-8000-000000000001',
+        options: undefined,
+      },
+      {
+        provisionerId: '00000000-0000-4000-8000-000000000001',
+        options: {includeStatus: true},
+      },
+      {
+        provisionerId: '00000000-0000-4000-8000-000000000001',
+        options: undefined,
+      },
+    ]);
+  });
+
   it('caps provider health candidates at the backend contract limit', async () => {
     const engine = fakeEngine({
       instances: Array.from({length: 101}, (_, index) =>
@@ -776,7 +890,10 @@ describe('createEc2Lifecycle', () => {
           state: 'running',
           instanceId: `i-${index}`,
           providerRunnerId: `runner-${index}`,
-          systemStatus: {status: 'impaired'},
+          systemStatus: {
+            status: 'impaired',
+            impairedSince: new Date(NOW.getTime() - RECONCILE_INTERVAL_MS),
+          },
         }),
       ),
     });
@@ -785,12 +902,28 @@ describe('createEc2Lifecycle', () => {
 
     await lifecycle.reconcile();
 
-    expect(client.reconcileBodies[0]?.termination_candidates).toHaveLength(100);
+    const expectedIds = Array.from({length: 101}, (_, index) => `runner-${index}`).sort(
+      (left, right) => left.localeCompare(right),
+    );
+    expect(
+      client.reconcileBodies[0]?.termination_candidates?.map(
+        (candidate) => candidate.provider_runner_id,
+      ),
+    ).toEqual(expectedIds.slice(0, 100));
+
+    await lifecycle.reconcile();
+
+    expect(
+      client.reconcileBodies[1]?.termination_candidates?.map(
+        (candidate) => candidate.provider_runner_id,
+      ),
+    ).toEqual([...expectedIds.slice(100), ...expectedIds.slice(0, 99)]);
     expect(observability.logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         event: 'provisioner.ec2.provider_health_candidate_limit',
         candidate_count: 101,
         submitted_count: 100,
+        dropped_count: 1,
       }),
       'Capped EC2 provider health termination candidates at the API limit',
     );
@@ -799,7 +932,15 @@ describe('createEc2Lifecycle', () => {
 
   it('fails closed when the health candidate reconcile request is unauthorized', async () => {
     const engine = fakeEngine({
-      instances: [instance({state: 'running', systemStatus: {status: 'impaired'}})],
+      instances: [
+        instance({
+          state: 'running',
+          systemStatus: {
+            status: 'impaired',
+            impairedSince: new Date(NOW.getTime() - RECONCILE_INTERVAL_MS),
+          },
+        }),
+      ],
     });
     const client = fakeClient({reconcileErrors: [new ProvisionerAuthenticationError(403)]});
     const lifecycle = makeLifecycle({engine, client});
@@ -1767,7 +1908,7 @@ type InstanceArgs = {
   attachedEbsStatus?: Ec2InstanceView['attachedEbsStatus'];
   scheduledEvents?: Ec2InstanceView['scheduledEvents'];
   instanceId?: string;
-  providerRunnerId?: string;
+  providerRunnerId?: string | null;
   runnerInstanceId?: string;
   templateKey?: string | null;
   labels?: string;
@@ -1782,7 +1923,9 @@ function instance(args: InstanceArgs): Ec2InstanceView {
     ...(args.availabilityZone ? {availabilityZone: args.availabilityZone} : {}),
     tags: {
       'shipfox.runner_instance_id': args.runnerInstanceId ?? RUNNER_INSTANCE_ID,
-      'shipfox.provider_runner_id': args.providerRunnerId ?? 'runner-1',
+      ...(args.providerRunnerId === null
+        ? {}
+        : {'shipfox.provider_runner_id': args.providerRunnerId ?? 'runner-1'}),
       'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
       'shipfox.reservation_id': '00000000-0000-4000-8000-000000000003',
       ...(args.templateKey === null
@@ -1816,6 +1959,10 @@ function fakeEngine(
   } = {},
 ): Ec2Engine & {
   runArgs: Parameters<Ec2Engine['runInstance']>[0][];
+  listCalls: Array<{
+    provisionerId: string;
+    options: Parameters<Ec2Engine['listManaged']>[1];
+  }>;
   terminated: string[];
   terminationCalls: Array<{
     instanceIds: readonly string[];
@@ -1823,6 +1970,10 @@ function fakeEngine(
   }>;
 } {
   const runArgs: Parameters<Ec2Engine['runInstance']>[0][] = [];
+  const listCalls: Array<{
+    provisionerId: string;
+    options: Parameters<Ec2Engine['listManaged']>[1];
+  }> = [];
   const terminated: string[] = [];
   const terminationCalls: Array<{
     instanceIds: readonly string[];
@@ -1831,6 +1982,7 @@ function fakeEngine(
   const terminateErrors = [...(options.terminateErrors ?? [])];
   return {
     runArgs,
+    listCalls,
     terminated,
     terminationCalls,
     runInstance: (args) => {
@@ -1839,10 +1991,12 @@ function fakeEngine(
         ? Promise.reject(options.runError)
         : Promise.resolve(instance({state: 'pending'}));
     },
-    listManaged: () =>
-      options.listError
+    listManaged: (provisionerId, listOptions) => {
+      listCalls.push({provisionerId, options: listOptions});
+      return options.listError
         ? Promise.reject(options.listError)
-        : Promise.resolve(options.instances ?? []),
+        : Promise.resolve(options.instances ?? []);
+    },
     terminate: (instanceIds, options) => {
       terminationCalls.push({instanceIds: [...instanceIds], options});
       const error = terminateErrors.shift();

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import type {
+  ReconcileRunnerInstancesBodyDto,
   ReconcileRunnerInstancesResponseDto,
   ReportRunnerInstancesBodyDto,
 } from '@shipfox/api-runners-dto';
@@ -22,6 +23,7 @@ const observability = vi.hoisted(() => ({
   recordEc2StoppingTimestampMissing: vi.fn(),
   recordEc2Termination: vi.fn(),
   recordEc2ForcedTerminationRetry: vi.fn(),
+  recordEc2HealthImpaired: vi.fn(),
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
@@ -33,6 +35,7 @@ vi.mock('#metrics/instance.js', () => ({
   recordEc2StoppingTimestampMissing: observability.recordEc2StoppingTimestampMissing,
   recordEc2Termination: observability.recordEc2Termination,
   recordEc2ForcedTerminationRetry: observability.recordEc2ForcedTerminationRetry,
+  recordEc2HealthImpaired: observability.recordEc2HealthImpaired,
 }));
 
 const NOW = new Date('2026-01-01T00:10:00.000Z');
@@ -675,6 +678,138 @@ describe('createEc2Lifecycle', () => {
       'spot-small',
     );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+  });
+
+  it('observes impaired EC2 health without terminating during observe mode', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'running',
+          systemStatus: {status: 'impaired', impairedSince: new Date(NOW.getTime() - 30_000)},
+          instanceStatus: {status: 'ok'},
+          attachedEbsStatus: {status: 'ok'},
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.observe();
+
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledWith('system');
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.provider_health_observed',
+        ec2_state: 'running',
+        health_candidate_decision: 'eligible',
+        health_checks: expect.arrayContaining([
+          expect.objectContaining({check_type: 'system', status: 'impaired'}),
+        ]),
+      }),
+      'Observed impaired EC2 runner health',
+    );
+  });
+
+  it('submits impaired health candidates during reconcile without terminating locally', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'running',
+          systemStatus: {status: 'ok'},
+          instanceStatus: {status: 'impaired'},
+          attachedEbsStatus: {status: 'insufficient-data'},
+          scheduledEvents: [{code: 'system-reboot'}],
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [
+          {provider_runner_id: 'runner-1', reason: 'provider-health-failed'},
+        ],
+      },
+    ]);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledWith('instance');
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledTimes(1);
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.provider_health_candidates_submitted',
+        count: 1,
+        provider_runner_ids: ['runner-1'],
+      }),
+      'Submitted EC2 provider health termination candidates',
+    );
+  });
+
+  it.each([
+    'initializing',
+    'insufficient-data',
+  ] as const)('keeps %s EC2 health observations in observe-only mode', async (status) => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'running', systemStatus: {status}})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: ['runner-1']}]);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(observability.recordEc2HealthImpaired).not.toHaveBeenCalled();
+    expect(observability.logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({health_candidate_decision: 'observe-only'}),
+      'Observed transient EC2 runner health status',
+    );
+  });
+
+  it('caps provider health candidates at the backend contract limit', async () => {
+    const engine = fakeEngine({
+      instances: Array.from({length: 101}, (_, index) =>
+        instance({
+          state: 'running',
+          instanceId: `i-${index}`,
+          providerRunnerId: `runner-${index}`,
+          systemStatus: {status: 'impaired'},
+        }),
+      ),
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies[0]?.termination_candidates).toHaveLength(100);
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.provider_health_candidate_limit',
+        candidate_count: 101,
+        submitted_count: 100,
+      }),
+      'Capped EC2 provider health termination candidates at the API limit',
+    );
+    expect(engine.terminationCalls).toEqual([]);
+  });
+
+  it('fails closed when the health candidate reconcile request is unauthorized', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'running', systemStatus: {status: 'impaired'}})],
+    });
+    const client = fakeClient({reconcileErrors: [new ProvisionerAuthenticationError(403)]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.reconcile()).rejects.toThrow(ProvisionerAuthenticationError);
+
+    expect(client.reconcileBodies[0]?.termination_candidates).toEqual([
+      {provider_runner_id: 'runner-1', reason: 'provider-health-failed'},
+    ]);
+    expect(engine.terminationCalls).toEqual([]);
   });
 
   it('propagates observation failures so the core loop degrades capacity to zero', async () => {
@@ -1618,7 +1753,7 @@ function launch(): ProviderRunnerLaunch<Ec2TemplateSpec> {
   };
 }
 
-function instance(args: {
+type InstanceArgs = {
   state: Ec2InstanceView['state'];
   architecture?: Ec2InstanceView['architecture'];
   availabilityZone?: string;
@@ -1627,12 +1762,18 @@ function instance(args: {
   stateReasonMessage?: string;
   launchTime?: Date;
   ami?: string;
+  systemStatus?: Ec2InstanceView['systemStatus'];
+  instanceStatus?: Ec2InstanceView['instanceStatus'];
+  attachedEbsStatus?: Ec2InstanceView['attachedEbsStatus'];
+  scheduledEvents?: Ec2InstanceView['scheduledEvents'];
   instanceId?: string;
   providerRunnerId?: string;
   runnerInstanceId?: string;
   templateKey?: string | null;
   labels?: string;
-}): Ec2InstanceView {
+};
+
+function instance(args: InstanceArgs): Ec2InstanceView {
   return {
     instanceId: args.instanceId ?? 'i-123',
     state: args.state,
@@ -1653,6 +1794,16 @@ function instance(args: {
     ...(args.stateReasonCode ? {stateReasonCode: args.stateReasonCode} : {}),
     ...(args.stateReasonMessage ? {stateReasonMessage: args.stateReasonMessage} : {}),
     ...(args.launchTime ? {launchTime: args.launchTime} : {}),
+    ...optionalInstanceFields(args),
+  };
+}
+
+function optionalInstanceFields(args: InstanceArgs): Partial<Ec2InstanceView> {
+  return {
+    ...(args.systemStatus ? {systemStatus: args.systemStatus} : {}),
+    ...(args.instanceStatus ? {instanceStatus: args.instanceStatus} : {}),
+    ...(args.attachedEbsStatus ? {attachedEbsStatus: args.attachedEbsStatus} : {}),
+    ...(args.scheduledEvents ? {scheduledEvents: args.scheduledEvents} : {}),
   };
 }
 
@@ -1713,12 +1864,12 @@ function fakeClient(
   } = {},
 ): ProvisionerClient & {
   reportBodies: ReportRunnerInstancesBodyDto[];
-  reconcileBodies: Array<{observed_provider_runner_ids: string[]}>;
+  reconcileBodies: ReconcileRunnerInstancesBodyDto[];
   assignmentBodies: Array<{reservationId: string; runnerInstanceIds: string[]}>;
   attachments: Array<{runnerInstanceId: string; providerRunnerId: string}>;
 } {
   const reportBodies: ReportRunnerInstancesBodyDto[] = [];
-  const reconcileBodies: Array<{observed_provider_runner_ids: string[]}> = [];
+  const reconcileBodies: ReconcileRunnerInstancesBodyDto[] = [];
   const assignmentBodies: Array<{reservationId: string; runnerInstanceIds: string[]}> = [];
   const attachments: Array<{runnerInstanceId: string; providerRunnerId: string}> = [];
   const reportErrors = [...(options.reportErrors ?? [])];

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -859,6 +859,31 @@ describe('createEc2Lifecycle', () => {
     expect(observability.recordEc2HealthImpaired).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves impairment persistence across an unavailable status observation', async () => {
+    const instances = [instance({state: 'running', systemStatus: {status: 'impaired'}})];
+    const engine = fakeEngine({instances});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+    instances[0] = instance({state: 'running'});
+    await lifecycle.reconcile();
+    instances[0] = instance({state: 'running', systemStatus: {status: 'impaired'}});
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([
+      {observed_provider_runner_ids: ['runner-1']},
+      {observed_provider_runner_ids: ['runner-1']},
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [
+          {provider_runner_id: 'runner-1', reason: 'provider-health-failed'},
+        ],
+      },
+    ]);
+    expect(observability.recordEc2HealthImpaired).toHaveBeenCalledTimes(2);
+  });
+
   it('polls EC2 status checks only during backend reconciliation', async () => {
     const engine = fakeEngine({instances: [instance({state: 'running'})]});
     const lifecycle = makeLifecycle({engine});

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -68,6 +68,11 @@ type LocallyLaunchedRunner = {
   launchedAt: Date;
 };
 
+type HealthImpairmentObservation = {
+  lastObservedAt: number;
+  consecutiveObservations: number;
+};
+
 type AssignmentCandidate = {
   reservationId: string;
   runnerInstanceId: string;
@@ -142,6 +147,8 @@ interface Ec2LifecycleContext {
   readonly pendingReports: RunnerInstanceReportEventDto[];
   readonly suppressedReservationRunnerIds: Map<string, Set<string>>;
   readonly canonicalReservationIdsByRunner: Map<string, string | null>;
+  readonly healthImpairmentObservations: Map<string, HealthImpairmentObservation>;
+  healthCandidateCursor: number;
   lastReconciledAt?: Date;
 }
 
@@ -172,6 +179,8 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     pendingReports: [],
     suppressedReservationRunnerIds: new Map(),
     canonicalReservationIdsByRunner: new Map(),
+    healthImpairmentObservations: new Map(),
+    healthCandidateCursor: 0,
   };
 
   return {
@@ -241,14 +250,13 @@ async function launchRunner(
 
 async function observe(context: Ec2LifecycleContext): Promise<void> {
   const instances = await context.engine.listManaged(context.identity.id);
-  observeEc2Health(context, instances, false);
   await applyObservedInstances(context, instances, new Map());
   await reportEvents(context, []);
 }
 
 async function reconcile(context: Ec2LifecycleContext): Promise<void> {
-  const instances = await context.engine.listManaged(context.identity.id);
-  const healthCandidates = observeEc2Health(context, instances, true);
+  const instances = await context.engine.listManaged(context.identity.id, {includeStatus: true});
+  const healthCandidates = observeEc2Health(context, instances);
   await reapRegistrationDeadlineInstances(context, instances);
   const observedProviderRunnerIds = observedRunnerIds(instances);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
@@ -273,12 +281,13 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
     logger().info(
       {
         event: 'provisioner.ec2.provider_health_candidates_submitted',
-        count: healthCandidates.length,
+        requested_count: healthCandidates.length,
+        termination_authorization: 'backend-gated',
         provider_runner_ids: healthCandidates
           .slice(0, MAX_HEALTH_CANDIDATE_IDS_IN_LOG)
           .map((candidate) => candidate.provider_runner_id),
       },
-      'Submitted EC2 provider health termination candidates',
+      'Sent EC2 provider health termination candidates for backend authorization',
     );
   }
   syncCanonicalReservationIds(context, response.runners);
@@ -308,54 +317,46 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
 function observeEc2Health(
   context: Ec2LifecycleContext,
   instances: readonly Ec2InstanceView[],
-  collectCandidates: boolean,
 ): ProviderTerminationCandidateDto[] {
   const candidates = new Map<string, ProviderTerminationCandidateDto>();
+  const observedInstanceIds = new Set(instances.map((instance) => instance.instanceId));
+  for (const instanceId of context.healthImpairmentObservations.keys()) {
+    if (!observedInstanceIds.has(instanceId))
+      context.healthImpairmentObservations.delete(instanceId);
+  }
 
   for (const instance of instances) {
-    const candidate = observeEc2InstanceHealth(context, instance, collectCandidates);
+    const candidate = observeEc2InstanceHealth(context, instance);
     if (candidate) candidates.set(candidate.provider_runner_id, candidate);
   }
 
   const orderedCandidates = [...candidates.values()].sort((left, right) =>
     left.provider_runner_id.localeCompare(right.provider_runner_id),
   );
-  if (orderedCandidates.length > MAX_TERMINATION_CANDIDATES) {
-    logger().warn(
-      {
-        event: 'provisioner.ec2.provider_health_candidate_limit',
-        candidate_count: orderedCandidates.length,
-        submitted_count: MAX_TERMINATION_CANDIDATES,
-      },
-      'Capped EC2 provider health termination candidates at the API limit',
-    );
-  }
-  return orderedCandidates.slice(0, MAX_TERMINATION_CANDIDATES);
+  return selectHealthCandidateWindow(context, orderedCandidates);
 }
 
 function observeEc2InstanceHealth(
   context: Ec2LifecycleContext,
   instance: Ec2InstanceView,
-  collectCandidate: boolean,
 ): ProviderTerminationCandidateDto | undefined {
   const observations = healthObservations(instance);
-  if (!hasHealthSignal(instance, observations)) return undefined;
-
   const impaired = observations.filter((observation) => observation.status === 'impaired');
   for (const observation of impaired) recordEc2HealthImpaired(observation.checkType);
 
   const identity = parseInstanceIdentity(instance);
-  const candidateDecision = healthCandidateDecision(instance, identity.providerRunnerId, impaired);
-  logEc2HealthObservation(
+  const consecutiveObservations = updateHealthImpairmentObservation(context, instance, impaired);
+  if (!hasHealthSignal(instance, observations)) return undefined;
+
+  const candidateDecision = healthCandidateDecision(
     context,
     instance,
-    identity,
-    observations,
-    candidateDecision,
-    collectCandidate,
+    identity.providerRunnerId,
+    impaired,
+    consecutiveObservations,
   );
-  if (!collectCandidate || candidateDecision !== 'eligible' || !identity.providerRunnerId)
-    return undefined;
+  logEc2HealthObservation(context, instance, identity, observations, candidateDecision);
+  if (candidateDecision !== 'eligible' || !identity.providerRunnerId) return undefined;
   return {
     provider_runner_id: identity.providerRunnerId,
     reason: 'provider-health-failed',
@@ -376,13 +377,22 @@ function hasHealthSignal(
 }
 
 function healthCandidateDecision(
+  context: Ec2LifecycleContext,
   instance: Ec2InstanceView,
   providerRunnerId: string | undefined,
   impaired: readonly Ec2HealthObservation[],
-): 'observe-only' | 'not-running' | 'missing-provider-runner-id' | 'eligible' {
+  consecutiveObservations: number,
+):
+  | 'observe-only'
+  | 'awaiting-persistence'
+  | 'not-running'
+  | 'missing-provider-runner-id'
+  | 'eligible' {
   if (impaired.length === 0) return 'observe-only';
   if (instance.state !== 'running') return 'not-running';
   if (!providerRunnerId) return 'missing-provider-runner-id';
+  if (!hasPersistentImpairment(context, impaired, consecutiveObservations))
+    return 'awaiting-persistence';
   return 'eligible';
 }
 
@@ -392,7 +402,6 @@ function logEc2HealthObservation(
   identity: ReturnType<typeof parseInstanceIdentity>,
   observations: readonly Ec2HealthObservation[],
   candidateDecision: ReturnType<typeof healthCandidateDecision>,
-  candidateCollectionEnabled: boolean,
 ): void {
   const fields = {
     event: 'provisioner.ec2.provider_health_observed',
@@ -412,11 +421,91 @@ function logEc2HealthObservation(
       .slice(0, MAX_SCHEDULED_EVENT_CODES_IN_LOG)
       .map((event) => event.code),
     health_candidate_decision: candidateDecision,
-    health_candidate_collection: candidateCollectionEnabled ? 'reconcile' : 'observe-only',
+    health_candidate_collection: 'reconcile',
   };
-  if (candidateDecision !== 'observe-only')
+  if (
+    candidateDecision === 'eligible' ||
+    candidateDecision === 'not-running' ||
+    candidateDecision === 'missing-provider-runner-id'
+  )
     logger().warn(fields, 'Observed impaired EC2 runner health');
   else logger().debug(fields, 'Observed transient EC2 runner health status');
+}
+
+function updateHealthImpairmentObservation(
+  context: Ec2LifecycleContext,
+  instance: Ec2InstanceView,
+  impaired: readonly Ec2HealthObservation[],
+): number {
+  if (impaired.length === 0 || instance.state !== 'running') {
+    context.healthImpairmentObservations.delete(instance.instanceId);
+    return 0;
+  }
+
+  const observedAt = context.now().getTime();
+  const previous = context.healthImpairmentObservations.get(instance.instanceId);
+  const observationWindowMs = Math.max(context.reconcileIntervalMs * 2, 1);
+  const isConsecutive =
+    previous !== undefined &&
+    observedAt >= previous.lastObservedAt &&
+    observedAt - previous.lastObservedAt <= observationWindowMs;
+  const consecutiveObservations = isConsecutive
+    ? Math.min(previous.consecutiveObservations + 1, 2)
+    : 1;
+  context.healthImpairmentObservations.set(instance.instanceId, {
+    lastObservedAt: observedAt,
+    consecutiveObservations,
+  });
+  return consecutiveObservations;
+}
+
+function hasPersistentImpairment(
+  context: Ec2LifecycleContext,
+  impaired: readonly Ec2HealthObservation[],
+  consecutiveObservations: number,
+): boolean {
+  if (consecutiveObservations >= 2) return true;
+
+  const now = context.now().getTime();
+  const graceMs = Math.max(context.reconcileIntervalMs, 0);
+  return impaired.some((observation) => {
+    const impairedSince = observation.impairedSince?.getTime();
+    return (
+      impairedSince !== undefined &&
+      Number.isFinite(impairedSince) &&
+      now >= impairedSince + graceMs
+    );
+  });
+}
+
+function selectHealthCandidateWindow(
+  context: Ec2LifecycleContext,
+  orderedCandidates: readonly ProviderTerminationCandidateDto[],
+): ProviderTerminationCandidateDto[] {
+  if (orderedCandidates.length <= MAX_TERMINATION_CANDIDATES) {
+    context.healthCandidateCursor = 0;
+    return [...orderedCandidates];
+  }
+
+  const start = context.healthCandidateCursor % orderedCandidates.length;
+  const rotatedCandidates = [
+    ...orderedCandidates.slice(start),
+    ...orderedCandidates.slice(0, start),
+  ];
+  const selectedCandidates = rotatedCandidates.slice(0, MAX_TERMINATION_CANDIDATES);
+  context.healthCandidateCursor = (start + selectedCandidates.length) % orderedCandidates.length;
+  logger().warn(
+    {
+      event: 'provisioner.ec2.provider_health_candidate_limit',
+      candidate_count: orderedCandidates.length,
+      submitted_count: selectedCandidates.length,
+      dropped_count: orderedCandidates.length - selectedCandidates.length,
+      start_index: start,
+      next_start_index: context.healthCandidateCursor,
+    },
+    'Capped EC2 provider health termination candidates at the API limit',
+  );
+  return selectedCandidates;
 }
 
 function healthObservations(instance: Ec2InstanceView): Ec2HealthObservation[] {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -437,13 +437,19 @@ function updateHealthImpairmentObservation(
   instance: Ec2InstanceView,
   impaired: readonly Ec2HealthObservation[],
 ): number {
-  if (impaired.length === 0 || instance.state !== 'running') {
+  if (instance.state !== 'running') {
+    context.healthImpairmentObservations.delete(instance.instanceId);
+    return 0;
+  }
+
+  const previous = context.healthImpairmentObservations.get(instance.instanceId);
+  if (!hasEc2StatusData(instance)) return previous?.consecutiveObservations ?? 0;
+  if (impaired.length === 0) {
     context.healthImpairmentObservations.delete(instance.instanceId);
     return 0;
   }
 
   const observedAt = context.now().getTime();
-  const previous = context.healthImpairmentObservations.get(instance.instanceId);
   const observationWindowMs = Math.max(context.reconcileIntervalMs * 2, 1);
   const isConsecutive =
     previous !== undefined &&
@@ -457,6 +463,15 @@ function updateHealthImpairmentObservation(
     consecutiveObservations,
   });
   return consecutiveObservations;
+}
+
+function hasEc2StatusData(instance: Ec2InstanceView): boolean {
+  return (
+    instance.systemStatus !== undefined ||
+    instance.instanceStatus !== undefined ||
+    instance.attachedEbsStatus !== undefined ||
+    instance.scheduledEvents !== undefined
+  );
 }
 
 function hasPersistentImpairment(

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -1,5 +1,7 @@
 import {
   MAX_RECONCILE_OBSERVED_RUNNERS,
+  MAX_TERMINATION_CANDIDATES,
+  type ProviderTerminationCandidateDto,
   RESERVATION_EXPIRED_ERROR_CODE,
   type ReconcileRunnerInstancesResponseDto,
   RUNNER_INSTANCE_NOT_ASSIGNABLE_ERROR_CODE,
@@ -16,11 +18,18 @@ import type {
   ProvisionerTemplate,
 } from '@shipfox/provisioner-core';
 import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
-import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.js';
+import {
+  type Ec2Engine,
+  Ec2EngineError,
+  type Ec2InstanceView,
+  type Ec2StatusCheckStatus,
+} from '#ec2-engine.js';
 import {buildInstanceTags, parseInstanceIdentity} from '#instance-identity.js';
 import {
+  type Ec2HealthCheckType,
   type Ec2TerminationReason,
   recordEc2ForcedTerminationRetry,
+  recordEc2HealthImpaired,
   recordEc2Launch,
   recordEc2PendingDuration,
   recordEc2ReconcileAbsent,
@@ -37,6 +46,14 @@ const MAX_REASON_LENGTH = 500;
 const TERMINAL_REPORT_ABSENCE_GRACE_MS = 60 * 60 * 1000;
 const SPOT_INTERRUPTION_REASON =
   /spot|instance-terminated-by-price|instance-terminated-no-capacity/i;
+const MAX_SCHEDULED_EVENT_CODES_IN_LOG = 20;
+const MAX_HEALTH_CANDIDATE_IDS_IN_LOG = 20;
+
+type Ec2HealthObservation = {
+  checkType: Ec2HealthCheckType;
+  status: Ec2StatusCheckStatus;
+  impairedSince?: Date;
+};
 
 type TrackerSeed = {
   providerRunnerId: string;
@@ -224,12 +241,14 @@ async function launchRunner(
 
 async function observe(context: Ec2LifecycleContext): Promise<void> {
   const instances = await context.engine.listManaged(context.identity.id);
+  observeEc2Health(context, instances, false);
   await applyObservedInstances(context, instances, new Map());
   await reportEvents(context, []);
 }
 
 async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   const instances = await context.engine.listManaged(context.identity.id);
+  const healthCandidates = observeEc2Health(context, instances, true);
   await reapRegistrationDeadlineInstances(context, instances);
   const observedProviderRunnerIds = observedRunnerIds(instances);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
@@ -248,7 +267,20 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
 
   const response = await context.client.reconcileRunnerInstances({
     observed_provider_runner_ids: observedProviderRunnerIds,
+    ...(healthCandidates.length > 0 ? {termination_candidates: healthCandidates} : {}),
   });
+  if (healthCandidates.length > 0) {
+    logger().info(
+      {
+        event: 'provisioner.ec2.provider_health_candidates_submitted',
+        count: healthCandidates.length,
+        provider_runner_ids: healthCandidates
+          .slice(0, MAX_HEALTH_CANDIDATE_IDS_IN_LOG)
+          .map((candidate) => candidate.provider_runner_id),
+      },
+      'Submitted EC2 provider health termination candidates',
+    );
+  }
   syncCanonicalReservationIds(context, response.runners);
   const terminateIntents = new Map<string, TerminationIntent>();
   for (const runner of response.runners) {
@@ -271,6 +303,146 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   await applyObservedInstances(context, instances, terminateIntents);
   await reportEvents(context, []);
   context.lastReconciledAt = new Date(context.now());
+}
+
+function observeEc2Health(
+  context: Ec2LifecycleContext,
+  instances: readonly Ec2InstanceView[],
+  collectCandidates: boolean,
+): ProviderTerminationCandidateDto[] {
+  const candidates = new Map<string, ProviderTerminationCandidateDto>();
+
+  for (const instance of instances) {
+    const candidate = observeEc2InstanceHealth(context, instance, collectCandidates);
+    if (candidate) candidates.set(candidate.provider_runner_id, candidate);
+  }
+
+  const orderedCandidates = [...candidates.values()].sort((left, right) =>
+    left.provider_runner_id.localeCompare(right.provider_runner_id),
+  );
+  if (orderedCandidates.length > MAX_TERMINATION_CANDIDATES) {
+    logger().warn(
+      {
+        event: 'provisioner.ec2.provider_health_candidate_limit',
+        candidate_count: orderedCandidates.length,
+        submitted_count: MAX_TERMINATION_CANDIDATES,
+      },
+      'Capped EC2 provider health termination candidates at the API limit',
+    );
+  }
+  return orderedCandidates.slice(0, MAX_TERMINATION_CANDIDATES);
+}
+
+function observeEc2InstanceHealth(
+  context: Ec2LifecycleContext,
+  instance: Ec2InstanceView,
+  collectCandidate: boolean,
+): ProviderTerminationCandidateDto | undefined {
+  const observations = healthObservations(instance);
+  if (!hasHealthSignal(instance, observations)) return undefined;
+
+  const impaired = observations.filter((observation) => observation.status === 'impaired');
+  for (const observation of impaired) recordEc2HealthImpaired(observation.checkType);
+
+  const identity = parseInstanceIdentity(instance);
+  const candidateDecision = healthCandidateDecision(instance, identity.providerRunnerId, impaired);
+  logEc2HealthObservation(
+    context,
+    instance,
+    identity,
+    observations,
+    candidateDecision,
+    collectCandidate,
+  );
+  if (!collectCandidate || candidateDecision !== 'eligible' || !identity.providerRunnerId)
+    return undefined;
+  return {
+    provider_runner_id: identity.providerRunnerId,
+    reason: 'provider-health-failed',
+  };
+}
+
+function hasHealthSignal(
+  instance: Ec2InstanceView,
+  observations: readonly Ec2HealthObservation[],
+): boolean {
+  if ((instance.scheduledEvents?.length ?? 0) > 0) return true;
+  return observations.some(
+    (observation) =>
+      observation.status === 'impaired' ||
+      observation.status === 'initializing' ||
+      observation.status === 'insufficient-data',
+  );
+}
+
+function healthCandidateDecision(
+  instance: Ec2InstanceView,
+  providerRunnerId: string | undefined,
+  impaired: readonly Ec2HealthObservation[],
+): 'observe-only' | 'not-running' | 'missing-provider-runner-id' | 'eligible' {
+  if (impaired.length === 0) return 'observe-only';
+  if (instance.state !== 'running') return 'not-running';
+  if (!providerRunnerId) return 'missing-provider-runner-id';
+  return 'eligible';
+}
+
+function logEc2HealthObservation(
+  context: Ec2LifecycleContext,
+  instance: Ec2InstanceView,
+  identity: ReturnType<typeof parseInstanceIdentity>,
+  observations: readonly Ec2HealthObservation[],
+  candidateDecision: ReturnType<typeof healthCandidateDecision>,
+  candidateCollectionEnabled: boolean,
+): void {
+  const fields = {
+    event: 'provisioner.ec2.provider_health_observed',
+    ...(identity.providerRunnerId ? {provisioned_runner_id: identity.providerRunnerId} : {}),
+    ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+    aws_instance_id: instance.instanceId,
+    template_key: resolveTemplateKey(context, [identity.templateKey]),
+    ec2_state: instance.state,
+    health_checks: observations.map((observation) => ({
+      check_type: observation.checkType,
+      status: observation.status,
+      ...(observation.impairedSince
+        ? {impaired_since: observation.impairedSince.toISOString()}
+        : {}),
+    })),
+    scheduled_event_codes: (instance.scheduledEvents ?? [])
+      .slice(0, MAX_SCHEDULED_EVENT_CODES_IN_LOG)
+      .map((event) => event.code),
+    health_candidate_decision: candidateDecision,
+    health_candidate_collection: candidateCollectionEnabled ? 'reconcile' : 'observe-only',
+  };
+  if (candidateDecision !== 'observe-only')
+    logger().warn(fields, 'Observed impaired EC2 runner health');
+  else logger().debug(fields, 'Observed transient EC2 runner health status');
+}
+
+function healthObservations(instance: Ec2InstanceView): Ec2HealthObservation[] {
+  return [
+    {
+      checkType: 'system',
+      status: instance.systemStatus?.status ?? 'unknown',
+      ...(instance.systemStatus?.impairedSince
+        ? {impairedSince: instance.systemStatus.impairedSince}
+        : {}),
+    },
+    {
+      checkType: 'instance',
+      status: instance.instanceStatus?.status ?? 'unknown',
+      ...(instance.instanceStatus?.impairedSince
+        ? {impairedSince: instance.instanceStatus.impairedSince}
+        : {}),
+    },
+    {
+      checkType: 'attached-ebs',
+      status: instance.attachedEbsStatus?.status ?? 'unknown',
+      ...(instance.attachedEbsStatus?.impairedSince
+        ? {impairedSince: instance.attachedEbsStatus.impairedSince}
+        : {}),
+    },
+  ];
 }
 
 async function reapRegistrationDeadlineInstances(
@@ -1113,6 +1285,40 @@ function terminationLogFields(
     ...(instance.availabilityZone !== undefined
       ? {availability_zone: instance.availabilityZone}
       : {}),
+    ...healthTerminationLogFields(instance),
+  };
+}
+
+function healthTerminationLogFields(instance: Ec2InstanceView): Record<string, string | string[]> {
+  return {
+    ...healthStatusLogFields('system', instance.systemStatus),
+    ...healthStatusLogFields('instance', instance.instanceStatus),
+    ...healthStatusLogFields('attached_ebs', instance.attachedEbsStatus),
+    ...scheduledEventLogFields(instance.scheduledEvents),
+  };
+}
+
+function healthStatusLogFields(
+  name: 'system' | 'instance' | 'attached_ebs',
+  status: Ec2InstanceView['systemStatus'] | undefined,
+): Record<string, string> {
+  if (!status) return {};
+  return {
+    [`${name}_status`]: status.status,
+    ...(status.impairedSince
+      ? {[`${name}_status_impaired_since`]: status.impairedSince.toISOString()}
+      : {}),
+  };
+}
+
+function scheduledEventLogFields(
+  events: Ec2InstanceView['scheduledEvents'],
+): Record<string, string[]> {
+  if (!events || events.length === 0) return {};
+  return {
+    scheduled_event_codes: events
+      .slice(0, MAX_SCHEDULED_EVENT_CODES_IN_LOG)
+      .map((event) => event.code),
   };
 }
 

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -443,7 +443,7 @@ function updateHealthImpairmentObservation(
   }
 
   const previous = context.healthImpairmentObservations.get(instance.instanceId);
-  if (!hasEc2StatusData(instance)) return previous?.consecutiveObservations ?? 0;
+  if (!hasEc2HealthCheckData(instance)) return previous?.consecutiveObservations ?? 0;
   if (impaired.length === 0) {
     context.healthImpairmentObservations.delete(instance.instanceId);
     return 0;
@@ -465,12 +465,11 @@ function updateHealthImpairmentObservation(
   return consecutiveObservations;
 }
 
-function hasEc2StatusData(instance: Ec2InstanceView): boolean {
+function hasEc2HealthCheckData(instance: Ec2InstanceView): boolean {
   return (
     instance.systemStatus !== undefined ||
     instance.instanceStatus !== undefined ||
-    instance.attachedEbsStatus !== undefined ||
-    instance.scheduledEvents !== undefined
+    instance.attachedEbsStatus !== undefined
   );
 }
 

--- a/libs/provisioner/ec2/src/metrics/instance.test.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.test.ts
@@ -102,6 +102,14 @@ describe('EC2 provisioner metrics', () => {
     expect(counterAdd('ec2_provisioner_reconcile_absent')).toHaveBeenCalledWith(2);
   });
 
+  it('records impaired health checks with a bounded check type', () => {
+    metrics.recordEc2HealthImpaired('attached-ebs');
+
+    expect(counterAdd('ec2_provisioner_health_impaired')).toHaveBeenCalledWith(1, {
+      check_type: 'attached-ebs',
+    });
+  });
+
   it('records EC2 launch duration with bounded labels', () => {
     metrics.recordEc2LaunchDuration({durationMs: 1_250, ...durationLabels});
 

--- a/libs/provisioner/ec2/src/metrics/instance.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.ts
@@ -3,6 +3,7 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 const meter = instanceMetrics.getMeter('provisioner-ec2');
 
 export type Ec2Architecture = 'i386' | 'x86_64' | 'arm64' | 'unknown';
+export type Ec2HealthCheckType = 'system' | 'instance' | 'attached-ebs';
 
 export interface Ec2DurationLabels {
   templateKey: string;
@@ -59,6 +60,11 @@ const stoppingTimestampMissingCount = meter.createCounter<{template_key: string}
 const reconcileAbsentCount = meter.createCounter<Record<string, never>>(
   'ec2_provisioner_reconcile_absent',
   {description: 'EC2 runner instances the backend or AWS reported absent during reconciliation'},
+);
+
+const healthImpairedCount = meter.createCounter<{check_type: Ec2HealthCheckType}>(
+  'ec2_provisioner_health_impaired',
+  {description: 'EC2 runner health observations with an impaired system, instance, or EBS check'},
 );
 
 const launchDuration = meter.createHistogram<{
@@ -118,6 +124,10 @@ export function recordEc2StoppingTimestampMissing(templateKey: string): void {
 
 export function recordEc2ReconcileAbsent(count: number): void {
   reconcileAbsentCount.add(count);
+}
+
+export function recordEc2HealthImpaired(checkType: Ec2HealthCheckType): void {
+  healthImpairedCount.add(1, {check_type: checkType});
 }
 
 export function recordEc2LaunchDuration(params: Ec2DurationObservation): void {


### PR DESCRIPTION
Adds EC2 system, instance, attached EBS, and scheduled-event observation to the provisioner lifecycle. Impaired running instances emit bounded health telemetry and submit `provider-health-failed` candidates through the existing backend authorization gate; initializing and insufficient-data statuses remain observe-only. EC2 permission failures are classified as authentication errors so lifecycle reconciliation fails closed and the core can alert.

Validation: `mise exec -- turbo check --filter=@shipfox/provisioner-ec2-provider`, dependency-closure type checks, and dependency-closure tests all pass (196 EC2 provisioner tests). Live AWS validation was not run.

Closes ENG-1792

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds EC2 system, instance, attached-EBS, and scheduled-event health observation to the provisioner lifecycle. Impaired running instances submit `provider-health-failed` termination candidates through the existing backend authorization gate, but only after the impairment persists for at least one reconciliation interval or two consecutive observations; `initializing` and `insufficient-data` statuses stay observe-only.

**Behavior notes**
- The provisioner role must now grant `ec2:DescribeInstanceStatus` in the runner region; permission failures fail reconciliation closed so the core can alert.
- `listManaged` fetches status checks only during reconciliation, in batches of 100 with pagination; unexpected status and event values map to bounded `unknown` values, and transient status-read failures keep the instance snapshot and submit no health candidate.
- If a status batch is rejected because an instance went stale mid-read, the batch is retried per instance so only the stale instance loses its status.
- Health candidates are deduplicated per runner and capped at the 100-candidate backend limit with a rotating window; a new `ec2_provisioner_health_impaired` metric tracks impaired checks.

Closes ENG-1792.

<sup>Written for commit 1b6529dd8668f24b46a9f8d49913e4d091820295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

