### PR TITLE
Narrow GitHub agent-tool token permissions

### DIFF
--- a/.changeset/narrow-live-profiles.md
+++ b/.changeset/narrow-live-profiles.md
@@ -1,6 +1,6 @@
 ---
 "@shipfox/api-integration-core": patch
-"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-github": minor
 ---
 
-Narrows GitHub agent-tool installation tokens to permissions required by the live catalog and preserves separate cache profiles for each permission set.
+Narrows GitHub agent-tool installation tokens to the permissions required by the live catalog.

--- a/.changeset/narrow-live-profiles.md
+++ b/.changeset/narrow-live-profiles.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github": patch
+---
+
+Narrows GitHub agent-tool installation tokens to permissions required by the live catalog and preserves separate cache profiles for each permission set.

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -150,7 +150,7 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
           authorization: expect.stringMatching(BEARER_AUTHORIZATION),
           tokenFormatOverride: 'enabled',
           installationId,
-          body: {},
+          body: {permissions: {issues: 'write'}},
         },
         {
           kind: 'read-issue',

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -452,19 +452,19 @@ describe('integrations inter-module callTool', () => {
     expect(result.outcome).toBe('success');
   });
 
-  it('rejects an executed method outside the catalog allowlist as an invalid-request outcome', async () => {
+  it('rejects an executed method outside the frozen catalog allowlist as an invalid-request outcome', async () => {
     const onCall = vi.fn();
     const client = createToolCallClient({onCall});
 
     const result = await client.callTool({
       ...toolCallInput,
-      arguments: {...toolCallInput.arguments, method: 'get_labels'},
+      arguments: {...toolCallInput.arguments, method: 'get_comments'},
     });
 
     expect(result).toEqual({
       outcome: 'error',
       code: 'invalid-request',
-      message: 'Unauthorized integration tool method: get_labels',
+      message: 'Unauthorized integration tool method: get_comments',
     });
     expect(onCall).not.toHaveBeenCalled();
   });

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -401,12 +401,13 @@ describe('integrations inter-module callTool', () => {
     createRecorder:
       | ((caller: IntegrationToolCallCaller) => IntegrationToolCallRecorder)
       | undefined = undefined,
+    catalog = [catalogTool()],
   ) {
     const transport = createInMemoryInterModuleTransport();
     const client = transport.createClient(integrationsInterModuleContract);
     transport.register(
       createIntegrationsInterModulePresentation({
-        registry: registryWithAgentTools([catalogTool()], providerOptions),
+        registry: registryWithAgentTools(catalog, providerOptions),
         sourceControl: createSourceControlIntegrationService({
           registry: createIntegrationProviderRegistry([]),
           getIntegrationConnectionById: async () => undefined,
@@ -495,6 +496,25 @@ describe('integrations inter-module callTool', () => {
       code: 'invalid-request',
       message: 'Unknown integration tool: removed_tool',
     });
+  });
+
+  it('rejects a frozen method that is no longer in the live catalog', async () => {
+    const onCall = vi.fn();
+    const liveCatalogTool = catalogTool();
+    const liveMethod = liveCatalogTool.methods?.find((method) => method.id === 'get_comments');
+    if (!liveMethod) throw new Error('Missing live fixture method');
+    const client = createToolCallClient({onCall}, undefined, undefined, [
+      catalogTool({methods: [liveMethod]}),
+    ]);
+
+    const result = await client.callTool(toolCallInput);
+
+    expect(result).toEqual({
+      outcome: 'error',
+      code: 'invalid-request',
+      message: 'Unauthorized integration tool method: get',
+    });
+    expect(onCall).not.toHaveBeenCalled();
   });
 
   const connectionFailureCases: ReadonlyArray<

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -248,9 +248,15 @@ export function createIntegrationsInterModulePresentation(params: {
         }
 
         // The executed method is the one the provider resolves from the
-        // arguments (`input.arguments.method`), validated against the catalog
-        // allowlist - the same rule the MCP gateway applies.
-        const methodValidation = validateExecutedMethod(catalogEntry, input.arguments);
+        // arguments (`input.arguments.method`), validated against the frozen
+        // method allowlist and then the live catalog - the same rule the MCP
+        // gateway applies.
+        const allowedMethods = frozenToolMethodAllowlist(input.tool);
+        const methodValidation = validateExecutedMethod(
+          catalogEntry,
+          input.arguments,
+          allowedMethods,
+        );
         if (methodValidation.kind === 'error') {
           recordToolCall(recorder, {
             arguments: input.arguments,
@@ -261,7 +267,7 @@ export function createIntegrationsInterModulePresentation(params: {
           return {outcome: 'error', code: 'invalid-request', message: methodValidation.message};
         }
 
-        const tool = toolFromCatalogEntry(catalogEntry);
+        const tool = toolFromCatalogEntry(catalogEntry, allowedMethods);
         const integration: MaterializedAgentIntegrationConfigDto = {
           connectionId: input.connectionId,
           connectionSlug: connection.slug,
@@ -335,6 +341,7 @@ async function resolveToolCatalogEntry(
 
 function toolFromCatalogEntry(
   entry: AgentToolCatalogEntry,
+  allowedMethods?: readonly string[] | undefined,
 ): MaterializedAgentIntegrationToolConfigDto {
   return {
     id: entry.id,
@@ -346,26 +353,51 @@ function toolFromCatalogEntry(
     ...(entry.methods === undefined
       ? {}
       : {
-          methods: entry.methods.map((candidate) => ({
-            id: candidate.id,
-            token: `${entry.id}.${candidate.id}`,
-            description: candidate.description,
-            sensitivity: candidate.sensitivity,
-            sensitive: candidate.sensitive,
-            requiredScope: candidate.requiredScope as unknown[],
-          })),
+          methods: entry.methods
+            .filter(
+              (candidate) => allowedMethods === undefined || allowedMethods.includes(candidate.id),
+            )
+            .map((candidate) => ({
+              id: candidate.id,
+              token: `${entry.id}.${candidate.id}`,
+              description: candidate.description,
+              sensitivity: candidate.sensitivity,
+              sensitive: candidate.sensitive,
+              requiredScope: candidate.requiredScope as unknown[],
+            })),
         }),
   };
+}
+
+function frozenToolMethodAllowlist(
+  tool: Pick<
+    z.output<typeof integrationsInterModuleContract.methods.callTool.input.shape.tool>,
+    'method' | 'methods'
+  >,
+): readonly string[] | undefined {
+  const methods = tool.methods?.map((candidate) => candidate.id);
+  if (tool.method === undefined) return methods;
+  if (methods === undefined) return [tool.method];
+  return methods.includes(tool.method) ? [tool.method] : [];
 }
 
 function validateExecutedMethod(
   entry: AgentToolCatalogEntry,
   args: Record<string, unknown>,
+  allowedMethods?: readonly string[] | undefined,
 ): {kind: 'ok'; method?: string | undefined} | {kind: 'error'; message: string} {
-  if (!entry.methods) return {kind: 'ok'};
+  if (!entry.methods) {
+    if (allowedMethods === undefined) return {kind: 'ok'};
+    const method = args.method;
+    const label = typeof method === 'string' ? method : (allowedMethods[0] ?? 'unknown');
+    return {kind: 'error', message: `Unauthorized integration tool method: ${label}`};
+  }
   const method = args.method;
   if (typeof method !== 'string') {
     return {kind: 'error', message: 'Method-family tools require a string method argument'};
+  }
+  if (allowedMethods !== undefined && !allowedMethods.includes(method)) {
+    return {kind: 'error', message: `Unauthorized integration tool method: ${method}`};
   }
   if (!entry.methods.some((candidate) => candidate.id === method)) {
     return {kind: 'error', message: `Unauthorized integration tool method: ${method}`};

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -249,8 +249,9 @@ export function createIntegrationsInterModulePresentation(params: {
 
         // The executed method is the one the provider resolves from the
         // arguments (`input.arguments.method`), validated against the frozen
-        // method allowlist and then the live catalog - the same rule the MCP
-        // gateway applies.
+        // method allowlist and then the live catalog. This applies the same
+        // frozen allowlist rule as the MCP gateway, with an additional live
+        // catalog check for this transport boundary.
         const allowedMethods = frozenToolMethodAllowlist(input.tool);
         const methodValidation = validateExecutedMethod(
           catalogEntry,
@@ -389,7 +390,7 @@ function validateExecutedMethod(
   if (!entry.methods) {
     if (allowedMethods === undefined) return {kind: 'ok'};
     const method = args.method;
-    const label = typeof method === 'string' ? method : (allowedMethods[0] ?? 'unknown');
+    const label = typeof method === 'string' ? method : NO_METHOD_LABEL;
     return {kind: 'error', message: `Unauthorized integration tool method: ${label}`};
   }
   const method = args.method;

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -84,6 +84,15 @@ export interface ClassifiedMintError {
 export const GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY = 'ENVELOPE';
 
 export type GithubInstallationTokenPermissions = Record<string, 'read' | 'write'>;
+export type MintBackoffScope = 'installation' | 'profile';
+
+const installationWideMintErrorReasons = new Set<IntegrationProviderErrorReason>([
+  'installation-not-found',
+  'malformed-provider-response',
+  'provider-unavailable',
+  'rate-limited',
+  'timeout',
+]);
 
 export function githubInstallationTokenNamespace(installationId: number): string {
   return `system/github/installation-token/${installationId}`;
@@ -103,6 +112,15 @@ export function githubInstallationTokenBackoffKey(permissionFingerprint: string)
   }
 
   return `BACKOFF_${githubInstallationTokenKey(permissionFingerprint).slice('TOKEN_'.length)}`;
+}
+
+export function githubInstallationTokenBackoffKeys(
+  permissionFingerprint: string,
+): readonly string[] {
+  const profileBackoffKey = githubInstallationTokenBackoffKey(permissionFingerprint);
+  return profileBackoffKey === GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY
+    ? [profileBackoffKey]
+    : [profileBackoffKey, GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY];
 }
 
 export function githubInstallationTokenPermissionFingerprint(
@@ -194,6 +212,12 @@ export function classifyMintError(error: unknown): ClassifiedMintError {
 
 export function mintErrorClassForReason(reason: IntegrationProviderErrorReason): MintErrorClass {
   return terminalMintErrorReasons.has(reason) ? 'terminal' : 'transient';
+}
+
+export function mintBackoffScopeForReason(
+  reason: IntegrationProviderErrorReason,
+): MintBackoffScope {
+  return installationWideMintErrorReasons.has(reason) ? 'installation' : 'profile';
 }
 
 export function backoffMs(classified: ClassifiedMintError): number {

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -83,6 +83,8 @@ export interface ClassifiedMintError {
 
 export const GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY = 'ENVELOPE';
 
+export type GithubInstallationTokenPermissions = Record<string, 'read' | 'write'>;
+
 export function githubInstallationTokenNamespace(installationId: number): string {
   return `system/github/installation-token/${installationId}`;
 }
@@ -93,6 +95,16 @@ export function githubInstallationTokenKey(permissionFingerprint: string): strin
   }
 
   return `TOKEN_${createHash('sha256').update(permissionFingerprint, 'utf8').digest('hex').toUpperCase()}`;
+}
+
+export function githubInstallationTokenPermissionFingerprint(
+  permissions: Readonly<GithubInstallationTokenPermissions>,
+): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(permissions).sort(([first], [second]) => first.localeCompare(second)),
+    ),
+  );
 }
 
 export function encodeInstallationTokenEnvelope(envelope: InstallationTokenEnvelope): string {

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -97,12 +97,24 @@ export function githubInstallationTokenKey(permissionFingerprint: string): strin
   return `TOKEN_${createHash('sha256').update(permissionFingerprint, 'utf8').digest('hex').toUpperCase()}`;
 }
 
+export function githubInstallationTokenBackoffKey(permissionFingerprint: string): string {
+  if (permissionFingerprint === GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT) {
+    return GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY;
+  }
+
+  return `BACKOFF_${githubInstallationTokenKey(permissionFingerprint).slice('TOKEN_'.length)}`;
+}
+
 export function githubInstallationTokenPermissionFingerprint(
   permissions: Readonly<GithubInstallationTokenPermissions>,
 ): string {
   return JSON.stringify(
     Object.fromEntries(
-      Object.entries(permissions).sort(([first], [second]) => first.localeCompare(second)),
+      Object.entries(permissions).sort(([first], [second]) => {
+        if (first < second) return -1;
+        if (first > second) return 1;
+        return 0;
+      }),
     ),
   );
 }

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -9,6 +9,7 @@ import {
   encodeInstallationTokenEnvelope,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
   githubInstallationTokenKey,
+  githubInstallationTokenPermissionFingerprint,
 } from './installation-token-envelope.js';
 import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
 
@@ -78,6 +79,34 @@ describe('GithubInstallationTokenProvider', () => {
     expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
       installation_id: 1,
     });
+  });
+
+  it('mints an installation token with the requested permission profile', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {
+        token: GITHUB_STATELESS_INSTALLATION_TOKEN,
+        expires_at: '2026-06-10T12:00:00.000Z',
+      },
+    });
+    const provider = createGithubInstallationTokenProvider();
+    const permissions = {pull_requests: 'read' as const, contents: 'write' as const};
+
+    await provider.getInstallationAccessToken(1, undefined, permissions);
+    await provider.getInstallationAccessToken(1, undefined, {
+      contents: 'write',
+      pull_requests: 'read',
+    });
+
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
+      installation_id: 1,
+      permissions,
+    });
+    expect(githubInstallationTokenPermissionFingerprint(permissions)).toBe(
+      '{"contents":"write","pull_requests":"read"}',
+    );
   });
 
   it('passes through a stateful broad installation token', async () => {

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -109,6 +109,57 @@ describe('GithubInstallationTokenProvider', () => {
     );
   });
 
+  it('uses byte-stable ordering for permission fingerprints', () => {
+    expect(githubInstallationTokenPermissionFingerprint({é: 'read', z: 'read', a: 'write'})).toBe(
+      '{"a":"write","z":"read","é":"read"}',
+    );
+  });
+
+  it('rejects a permission profile whose explicit fingerprint does not match', async () => {
+    const provider = createGithubInstallationTokenProvider();
+
+    await expect(
+      provider.getInstallationAccessToken(1, 'wrong', {contents: 'read'}),
+    ).rejects.toThrow('permission fingerprint does not match permissions');
+    expect(createInstallationAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the compatibility and permissions-derived cache profiles separate', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
+    createInstallationAccessTokenMock
+      .mockResolvedValueOnce({
+        data: {
+          token: 'ghs_broad',
+          expires_at: '2026-06-10T12:00:00.000Z',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          token: 'ghs_narrow',
+          expires_at: '2026-06-10T12:00:00.000Z',
+        },
+      });
+    const provider = createGithubInstallationTokenProvider();
+    const permissions = {contents: 'read' as const};
+
+    const broad = await provider.getInstallationAccessToken(1);
+    const narrow = await provider.getInstallationAccessToken(1, undefined, permissions);
+    const narrowAgain = await provider.getInstallationAccessToken(1, undefined, permissions);
+
+    expect(broad.token).toBe('ghs_broad');
+    expect(narrow.token).toBe('ghs_narrow');
+    expect(narrowAgain.token).toBe('ghs_narrow');
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(2);
+    expect(createInstallationAccessTokenMock).toHaveBeenNthCalledWith(1, {
+      installation_id: 1,
+    });
+    expect(createInstallationAccessTokenMock).toHaveBeenNthCalledWith(2, {
+      installation_id: 1,
+      permissions,
+    });
+  });
+
   it('passes through a stateful broad installation token', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -9,8 +9,10 @@ import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
 import {githubInstallationTokenFormatPlugin} from './github-octokit.js';
 import {
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+  type GithubInstallationTokenPermissions,
   githubInstallationTokenKey,
   githubInstallationTokenNamespace,
+  githubInstallationTokenPermissionFingerprint,
   TOKEN_REFRESH_MARGIN_MS,
 } from './installation-token-envelope.js';
 import {
@@ -24,6 +26,7 @@ export interface GithubInstallationTokenProvider {
   getInstallationAccessToken(
     installationId: number,
     permissionFingerprint?: string,
+    permissions?: GithubInstallationTokenPermissions,
   ): Promise<GithubInstallationAccessToken>;
 }
 
@@ -56,11 +59,18 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
 
   async getInstallationAccessToken(
     installationId: number,
-    permissionFingerprint = GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+    permissionFingerprint?: string,
+    permissions?: GithubInstallationTokenPermissions,
   ): Promise<GithubInstallationAccessToken> {
     await this.assertInstallationIsActive(installationId);
-    return await this.cache.getOrMint(installationId, permissionFingerprint, () =>
-      this.mintInstallationAccessToken(installationId),
+    const effectivePermissionFingerprint =
+      permissionFingerprint ??
+      (permissions === undefined
+        ? GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT
+        : githubInstallationTokenPermissionFingerprint(permissions));
+    const requestedPermissions = permissions === undefined ? undefined : {...permissions};
+    return await this.cache.getOrMint(installationId, effectivePermissionFingerprint, () =>
+      this.mintInstallationAccessToken(installationId, requestedPermissions),
     );
   }
 
@@ -79,11 +89,13 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
 
   private async mintInstallationAccessToken(
     installationId: number,
+    permissions: GithubInstallationTokenPermissions | undefined,
   ): Promise<GithubInstallationAccessToken> {
     const response = await mapGithubError(
       () =>
         this.getApp().octokit.rest.apps.createInstallationAccessToken({
           installation_id: installationId,
+          ...(permissions === undefined ? {} : {permissions}),
         }),
       'installation-not-found',
     );

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -63,11 +63,23 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
     permissions?: GithubInstallationTokenPermissions,
   ): Promise<GithubInstallationAccessToken> {
     await this.assertInstallationIsActive(installationId);
+    const derivedPermissionFingerprint =
+      permissions === undefined
+        ? undefined
+        : githubInstallationTokenPermissionFingerprint(permissions);
+    if (
+      permissionFingerprint !== undefined &&
+      derivedPermissionFingerprint !== undefined &&
+      permissionFingerprint !== derivedPermissionFingerprint
+    ) {
+      throw new TypeError(
+        'GitHub installation token permission fingerprint does not match permissions',
+      );
+    }
     const effectivePermissionFingerprint =
+      derivedPermissionFingerprint ??
       permissionFingerprint ??
-      (permissions === undefined
-        ? GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT
-        : githubInstallationTokenPermissionFingerprint(permissions));
+      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT;
     const requestedPermissions = permissions === undefined ? undefined : {...permissions};
     return await this.cache.getOrMint(installationId, effectivePermissionFingerprint, () =>
       this.mintInstallationAccessToken(installationId, requestedPermissions),

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -181,16 +181,16 @@ describe('SharedInstallationTokenCache', () => {
     ).toBe(true);
   });
 
-  it('isolates backoff across permission profile keys', async () => {
+  it('isolates profile-specific backoff across permission profile keys', async () => {
     const store = createStore();
     const shared = cache({store});
     const failedMint = vi
       .fn()
-      .mockRejectedValue(new GithubIntegrationProviderError('rate-limited', 'rate limited', 42));
+      .mockRejectedValue(new GithubIntegrationProviderError('provider-rejected', 'rejected'));
     const siblingMint = vi.fn(() => Promise.resolve(token('ghs_sibling')));
 
     await expect(shared.getOrMint(installationId, 'broad', failedMint)).rejects.toMatchObject({
-      reason: 'rate-limited',
+      reason: 'provider-rejected',
     });
     await expect(shared.getOrMint(installationId, 'narrow', siblingMint)).resolves.toEqual(
       token('ghs_sibling'),
@@ -202,12 +202,48 @@ describe('SharedInstallationTokenCache', () => {
       store.values.get(
         `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('broad')}`,
       ),
-    ).toContain('rate-limited');
+    ).toContain('provider-rejected');
     expect(
       store.values.get(
         `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('narrow')}`,
       ),
     ).toBe('{}');
+  });
+
+  it('shares installation-wide backoff across permission profile keys', async () => {
+    const store = createStore();
+    const lockFingerprints: string[] = [];
+    const shared = cache({
+      store,
+      withLock: async <T>(
+        _installationId: number,
+        permissionFingerprint: string,
+        fn: () => Promise<T>,
+      ): Promise<InstallationTokenLockResult<T>> => {
+        lockFingerprints.push(permissionFingerprint);
+        return {acquired: true as const, value: await fn()};
+      },
+    });
+    const failedMint = vi
+      .fn()
+      .mockRejectedValue(new GithubIntegrationProviderError('provider-unavailable', 'unavailable'));
+    const siblingMint = vi.fn(() => Promise.resolve(token('ghs_sibling')));
+
+    await expect(shared.getOrMint(installationId, 'broad', failedMint)).rejects.toMatchObject({
+      reason: 'provider-unavailable',
+    });
+    await expect(shared.getOrMint(installationId, 'narrow', siblingMint)).rejects.toMatchObject({
+      reason: 'provider-unavailable',
+    });
+
+    expect(failedMint).toHaveBeenCalledTimes(1);
+    expect(siblingMint).not.toHaveBeenCalled();
+    expect(lockFingerprints).toContain(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT);
+    expect(
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      ),
+    ).toContain('provider-unavailable');
   });
 
   it('shares one mint between two concurrent cache replicas', async () => {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -4,6 +4,7 @@ import {
   backoffActive,
   encodeInstallationTokenEnvelope,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+  githubInstallationTokenBackoffKey,
   githubInstallationTokenKey,
   needsRefresh,
   stillValid,
@@ -180,7 +181,7 @@ describe('SharedInstallationTokenCache', () => {
     ).toBe(true);
   });
 
-  it('shares installation-wide backoff across profile keys', async () => {
+  it('isolates backoff across permission profile keys', async () => {
     const store = createStore();
     const shared = cache({store});
     const failedMint = vi
@@ -191,12 +192,22 @@ describe('SharedInstallationTokenCache', () => {
     await expect(shared.getOrMint(installationId, 'broad', failedMint)).rejects.toMatchObject({
       reason: 'rate-limited',
     });
-    await expect(shared.getOrMint(installationId, 'narrow', siblingMint)).rejects.toMatchObject({
-      reason: 'rate-limited',
-    });
+    await expect(shared.getOrMint(installationId, 'narrow', siblingMint)).resolves.toEqual(
+      token('ghs_sibling'),
+    );
 
     expect(failedMint).toHaveBeenCalledTimes(1);
-    expect(siblingMint).not.toHaveBeenCalled();
+    expect(siblingMint).toHaveBeenCalledTimes(1);
+    expect(
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('broad')}`,
+      ),
+    ).toContain('rate-limited');
+    expect(
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('narrow')}`,
+      ),
+    ).toBe('{}');
   });
 
   it('shares one mint between two concurrent cache replicas', async () => {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -89,9 +89,10 @@ function cache(
 function setEnvelope(
   store: {values: Map<string, string>},
   envelope: Parameters<typeof encodeInstallationTokenEnvelope>[0],
+  permissionFingerprint = GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
 ) {
   store.values.set(
-    `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+    `${workspaceId}:${installationId}:${githubInstallationTokenKey(permissionFingerprint)}`,
     encodeInstallationTokenEnvelope(envelope),
   );
 }
@@ -244,6 +245,38 @@ describe('SharedInstallationTokenCache', () => {
         `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
       ),
     ).toContain('provider-unavailable');
+  });
+
+  it('preserves an active terminal backoff over a later transient backoff', async () => {
+    const store = createStore();
+    setEnvelope(
+      store,
+      {
+        ...token('ghs_existing', '2026-06-10T11:04:30.000Z'),
+      },
+      'broad',
+    );
+    store.values.set(
+      `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('broad')}`,
+      encodeInstallationTokenEnvelope({
+        backoffUntil: new Date('2026-06-10T11:10:00.000Z'),
+        backoffReason: 'provider-rejected',
+      }),
+    );
+    store.values.set(
+      `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      encodeInstallationTokenEnvelope({
+        backoffUntil: new Date('2026-06-10T11:15:00.000Z'),
+        backoffReason: 'provider-unavailable',
+      }),
+    );
+    const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, 'broad', mint)).rejects.toMatchObject({
+      reason: 'provider-rejected',
+    });
+    expect(mint).not.toHaveBeenCalled();
   });
 
   it('shares one mint between two concurrent cache replicas', async () => {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -14,11 +14,14 @@ import {
   type ClassifiedMintError,
   classifyMintError,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+  GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
   GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
   GITHUB_LEGACY_INSTALLATION_TOKEN_KEY,
   githubInstallationTokenBackoffKey,
+  githubInstallationTokenBackoffKeys,
   githubInstallationTokenKey,
   type InstallationTokenEnvelope,
+  mintBackoffScopeForReason,
   mintErrorClassForReason,
   parseInstallationTokenEnvelope,
   providerErrorFromBackoff,
@@ -92,7 +95,8 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   ): Promise<GithubInstallationAccessToken> {
     const workspaceId = await this.resolveWorkspaceId(installationId);
     const profileKey = githubInstallationTokenKey(permissionFingerprint);
-    const backoffKey = githubInstallationTokenBackoffKey(permissionFingerprint);
+    const backoffKeys = githubInstallationTokenBackoffKeys(permissionFingerprint);
+    const profileBackoffKey = githubInstallationTokenBackoffKey(permissionFingerprint);
     let readFailureReported = false;
     const reportReadFailure = (error: unknown) => {
       if (readFailureReported) return;
@@ -108,7 +112,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       workspaceId,
       installationId,
       profileKey,
-      backoffKey,
+      backoffKeys,
       reportReadFailure,
     );
     if (usable(envelope, this.now())) {
@@ -123,7 +127,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
           workspaceId,
           installationId,
           profileKey,
-          backoffKey,
+          backoffKeys,
           permissionFingerprint,
           mint,
           reportReadFailure,
@@ -135,7 +139,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         workspaceId,
         installationId,
         profileKey,
-        backoffKey,
+        profileBackoffKey,
         permissionFingerprint,
         reportReadFailure,
         failure: error,
@@ -177,8 +181,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         workspaceId,
         installationId,
         profileKey,
-        backoffKey,
-        permissionFingerprint,
+        backoffKeys,
         reportReadFailure,
       });
       return result.value;
@@ -188,7 +191,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       workspaceId,
       installationId,
       profileKey,
-      backoffKey,
+      backoffKeys,
       envelope,
       reportReadFailure,
     });
@@ -198,7 +201,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
-    backoffKey: string;
+    backoffKeys: readonly string[];
     permissionFingerprint: string;
     mint: () => Promise<GithubInstallationAccessToken>;
     reportReadFailure: (error: unknown) => void;
@@ -207,7 +210,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       params.workspaceId,
       params.installationId,
       params.profileKey,
-      params.backoffKey,
+      params.backoffKeys,
       params.reportReadFailure,
     );
     const now = this.now();
@@ -280,16 +283,25 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
-    backoffKey: string;
+    profileBackoffKey: string;
     permissionFingerprint: string;
     reportReadFailure: (error: unknown) => void;
     failure: InstallationTokenMintFailure;
   }): Promise<Date> {
     const candidateUntil = new Date(this.now().getTime() + backoffMs(params.failure.failure));
+    const backoffScope = mintBackoffScopeForReason(params.failure.failure.reason);
+    const backoffKey =
+      backoffScope === 'installation'
+        ? GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY
+        : params.profileBackoffKey;
+    const lockFingerprint =
+      backoffScope === 'installation'
+        ? GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT
+        : params.permissionFingerprint;
     try {
       const result = await this.withBackoffLock(
         params.installationId,
-        params.permissionFingerprint,
+        lockFingerprint,
         async () => {
           let readFailed = false;
           const reportReadFailure = (error: unknown) => {
@@ -300,7 +312,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
             params.workspaceId,
             params.installationId,
             params.profileKey,
-            params.backoffKey,
+            [backoffKey],
             reportReadFailure,
           );
           const existingBackoff =
@@ -329,7 +341,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
             this.writeEnvelope(
               params.workspaceId,
               params.installationId,
-              params.backoffKey,
+              backoffKey,
               selectedBackoff,
             ),
           ];
@@ -379,26 +391,33 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
-    backoffKey: string;
-    permissionFingerprint: string;
+    backoffKeys: readonly string[];
     reportReadFailure: (error: unknown) => void;
   }): Promise<void> {
     try {
-      await this.withBackoffLock(params.installationId, params.permissionFingerprint, async () => {
-        let readFailed = false;
-        const envelope = await this.readEnvelope(
-          params.workspaceId,
-          params.installationId,
-          params.profileKey,
-          params.backoffKey,
-          (error) => {
-            readFailed = true;
-            params.reportReadFailure(error);
-          },
-        );
-        if (readFailed || activeBackoff(envelope, this.now())) return;
-        await this.writeEnvelope(params.workspaceId, params.installationId, params.backoffKey, {});
-      });
+      await this.withBackoffLock(
+        params.installationId,
+        GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+        async () => {
+          let readFailed = false;
+          const envelope = await this.readEnvelope(
+            params.workspaceId,
+            params.installationId,
+            params.profileKey,
+            params.backoffKeys,
+            (error) => {
+              readFailed = true;
+              params.reportReadFailure(error);
+            },
+          );
+          if (readFailed || activeBackoff(envelope, this.now())) return;
+          await Promise.all(
+            params.backoffKeys.map((backoffKey) =>
+              this.writeEnvelope(params.workspaceId, params.installationId, backoffKey, {}),
+            ),
+          );
+        },
+      );
     } catch (error) {
       logger().warn(
         {installationId: params.installationId, permissionProfile: params.profileKey, error},
@@ -430,7 +449,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
-    backoffKey: string;
+    backoffKeys: readonly string[];
     envelope: InstallationTokenEnvelope | undefined;
     reportReadFailure: (error: unknown) => void;
   }): Promise<GithubInstallationAccessToken> {
@@ -454,7 +473,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         params.workspaceId,
         params.installationId,
         params.profileKey,
-        params.backoffKey,
+        params.backoffKeys,
         params.reportReadFailure,
       );
       const now = this.now();
@@ -497,48 +516,46 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string,
     installationId: number,
     profileKey: string,
-    backoffKey: string,
+    backoffKeys: readonly string[],
     reportReadFailure: (error: unknown) => void,
   ): Promise<InstallationTokenEnvelope | undefined> {
     const isCompatibilityProfile =
       profileKey === githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT);
-    const fixedEnvelopeRead = this.options.secretStore.read(
-      workspaceId,
-      installationId,
-      GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
-    );
-    const legacyRead = this.options.secretStore.read(
-      workspaceId,
-      installationId,
-      GITHUB_LEGACY_INSTALLATION_TOKEN_KEY,
-    );
-    const [profileResult, backoffResult, fixedEnvelopeResult, legacyResult] =
-      await Promise.allSettled([
-        this.options.secretStore.read(workspaceId, installationId, profileKey),
-        this.options.secretStore.read(workspaceId, installationId, backoffKey),
-        fixedEnvelopeRead,
-        legacyRead,
-      ]);
-    if (profileResult.status === 'rejected') reportReadFailure(profileResult.reason);
-    if (backoffResult.status === 'rejected') reportReadFailure(backoffResult.reason);
-    if (fixedEnvelopeResult.status === 'rejected') {
-      reportReadFailure(fixedEnvelopeResult.reason);
+    const {profileResult, backoffResults, fixedEnvelopeResult, legacyResult} =
+      await readSecretValues(
+        this.options.secretStore,
+        workspaceId,
+        installationId,
+        profileKey,
+        backoffKeys,
+      );
+    reportSecretReadFailure(profileResult, reportReadFailure);
+    for (const backoffResult of backoffResults) {
+      reportSecretReadFailure(backoffResult, reportReadFailure);
     }
-    if (legacyResult.status === 'rejected') reportReadFailure(legacyResult.reason);
+    reportSecretReadFailure(fixedEnvelopeResult, reportReadFailure);
+    reportSecretReadFailure(legacyResult, reportReadFailure);
 
     const profileRaw = settledRaw(profileResult);
-    const backoffRaw = settledRaw(backoffResult);
+    const backoffRaws = backoffResults.map(settledRaw);
     const fixedEnvelopeRaw = settledRaw(fixedEnvelopeResult);
     const legacyRaw = settledRaw(legacyResult);
     let profile = parseRawEnvelope(profileRaw, installationId);
-    let backoff = parseRawEnvelope(backoffRaw, installationId);
+    let backoff = latestBackoff(
+      backoffRaws.map((backoffRaw) => parseRawEnvelope(backoffRaw, installationId)),
+    );
     const fixedEnvelope = parseRawEnvelope(fixedEnvelopeRaw, installationId);
     const legacy = parseRawEnvelope(legacyRaw, installationId);
     const compatibilityEnvelope = fixedEnvelope ?? legacy;
     if (isCompatibilityProfile && profile === undefined && profileRaw === null) {
       profile = compatibilityEnvelope;
     }
-    if (isCompatibilityProfile && backoff === undefined && backoffRaw === null) {
+    if (
+      isCompatibilityProfile &&
+      backoff === undefined &&
+      backoffRaws.length === 1 &&
+      backoffRaws[0] === null
+    ) {
       backoff = compatibilityEnvelope;
     }
     if (!profile && !backoff) return undefined;
@@ -573,7 +590,58 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   }
 }
 
-function settledRaw(result: PromiseSettledResult<string | null>): string | null | undefined {
+type SettledSecretRead = PromiseSettledResult<string | null>;
+
+interface InstallationTokenSecretReads {
+  profileResult: SettledSecretRead;
+  backoffResults: readonly SettledSecretRead[];
+  fixedEnvelopeResult: SettledSecretRead;
+  legacyResult: SettledSecretRead;
+}
+
+async function readSecretValues(
+  secretStore: InstallationTokenSecretStore,
+  workspaceId: string,
+  installationId: number,
+  profileKey: string,
+  backoffKeys: readonly string[],
+): Promise<InstallationTokenSecretReads> {
+  const profileRead = secretStore.read(workspaceId, installationId, profileKey);
+  const backoffReads = backoffKeys.map((backoffKey) =>
+    secretStore.read(workspaceId, installationId, backoffKey),
+  );
+  const fixedEnvelopeRead = secretStore.read(
+    workspaceId,
+    installationId,
+    GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
+  );
+  const legacyRead = secretStore.read(
+    workspaceId,
+    installationId,
+    GITHUB_LEGACY_INSTALLATION_TOKEN_KEY,
+  );
+  const [profileResult, fixedEnvelopeResult, legacyResult] = await Promise.allSettled([
+    profileRead,
+    fixedEnvelopeRead,
+    legacyRead,
+  ]);
+  const backoffResults = await Promise.allSettled(backoffReads);
+  return {
+    profileResult,
+    backoffResults,
+    fixedEnvelopeResult,
+    legacyResult,
+  };
+}
+
+function reportSecretReadFailure(
+  result: SettledSecretRead,
+  report: (error: unknown) => void,
+): void {
+  if (result.status === 'rejected') report(result.reason);
+}
+
+function settledRaw(result: SettledSecretRead): string | null | undefined {
   if (result.status === 'rejected') return undefined;
   return result.value;
 }
@@ -588,6 +656,24 @@ function parseRawEnvelope(
     logger().warn({installationId}, 'github installation token cache envelope failed to decode');
   }
   return envelope;
+}
+
+function latestBackoff(
+  envelopes: readonly (InstallationTokenEnvelope | undefined)[],
+): InstallationTokenEnvelope | undefined {
+  let latest: InstallationTokenEnvelope | undefined;
+  for (const envelope of envelopes) {
+    if (envelope?.backoffUntil === undefined || envelope.backoffReason === undefined) continue;
+    const latestBackoffUntil = latest?.backoffUntil;
+    if (
+      latest === undefined ||
+      latestBackoffUntil === undefined ||
+      envelope.backoffUntil > latestBackoffUntil
+    ) {
+      latest = envelope;
+    }
+  }
+  return latest;
 }
 
 class InstallationTokenMintFailure extends Error {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -14,9 +14,9 @@ import {
   type ClassifiedMintError,
   classifyMintError,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-  GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
   GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
   GITHUB_LEGACY_INSTALLATION_TOKEN_KEY,
+  githubInstallationTokenBackoffKey,
   githubInstallationTokenKey,
   type InstallationTokenEnvelope,
   mintErrorClassForReason,
@@ -92,6 +92,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   ): Promise<GithubInstallationAccessToken> {
     const workspaceId = await this.resolveWorkspaceId(installationId);
     const profileKey = githubInstallationTokenKey(permissionFingerprint);
+    const backoffKey = githubInstallationTokenBackoffKey(permissionFingerprint);
     let readFailureReported = false;
     const reportReadFailure = (error: unknown) => {
       if (readFailureReported) return;
@@ -107,6 +108,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       workspaceId,
       installationId,
       profileKey,
+      backoffKey,
       reportReadFailure,
     );
     if (usable(envelope, this.now())) {
@@ -121,6 +123,8 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
           workspaceId,
           installationId,
           profileKey,
+          backoffKey,
+          permissionFingerprint,
           mint,
           reportReadFailure,
         }),
@@ -131,6 +135,8 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         workspaceId,
         installationId,
         profileKey,
+        backoffKey,
+        permissionFingerprint,
         reportReadFailure,
         failure: error,
       });
@@ -143,6 +149,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
           {
             installationId,
             expiresAt: error.failureEnvelope.expiresAt?.toISOString(),
+            permissionProfile: profileKey,
             reason: error.providerError.reason,
             backoffUntil: until.toISOString(),
           },
@@ -155,6 +162,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       logger().warn(
         {
           installationId,
+          permissionProfile: profileKey,
           reason: error.providerError.reason,
           backoffUntil: until.toISOString(),
           error: error.providerError,
@@ -165,7 +173,14 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       throw error.providerError;
     }
     if (result.acquired) {
-      await this.clearBackoff({workspaceId, installationId, profileKey, reportReadFailure});
+      await this.clearBackoff({
+        workspaceId,
+        installationId,
+        profileKey,
+        backoffKey,
+        permissionFingerprint,
+        reportReadFailure,
+      });
       return result.value;
     }
 
@@ -173,6 +188,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       workspaceId,
       installationId,
       profileKey,
+      backoffKey,
       envelope,
       reportReadFailure,
     });
@@ -182,6 +198,8 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
+    backoffKey: string;
+    permissionFingerprint: string;
     mint: () => Promise<GithubInstallationAccessToken>;
     reportReadFailure: (error: unknown) => void;
   }): Promise<GithubInstallationAccessToken> {
@@ -189,6 +207,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       params.workspaceId,
       params.installationId,
       params.profileKey,
+      params.backoffKey,
       params.reportReadFailure,
     );
     const now = this.now();
@@ -216,7 +235,14 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     } catch (error) {
       const providerError = toProviderError(error);
       const failure = classifyMintError(providerError);
-      recordInstallationTokenBackoff({reason: failure.reason, class: failure.class});
+      recordInstallationTokenBackoff({
+        reason: failure.reason,
+        class: failure.class,
+        profile:
+          params.permissionFingerprint === GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT
+            ? 'compatibility'
+            : 'scoped',
+      });
       throw new InstallationTokenMintFailure(providerError, failure, envelope);
     }
 
@@ -239,7 +265,11 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     }
 
     logger().info(
-      {installationId: params.installationId, expiresAt: token.expiresAt.toISOString()},
+      {
+        installationId: params.installationId,
+        permissionProfile: params.profileKey,
+        expiresAt: token.expiresAt.toISOString(),
+      },
       'github installation token minted',
     );
     recordInstallationTokenLookup('minted');
@@ -250,74 +280,90 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
+    backoffKey: string;
+    permissionFingerprint: string;
     reportReadFailure: (error: unknown) => void;
     failure: InstallationTokenMintFailure;
   }): Promise<Date> {
     const candidateUntil = new Date(this.now().getTime() + backoffMs(params.failure.failure));
     try {
-      const result = await this.withBackoffLock(params.installationId, async () => {
-        let readFailed = false;
-        const reportReadFailure = (error: unknown) => {
-          readFailed = true;
-          params.reportReadFailure(error);
-        };
-        const envelope = await this.readEnvelope(
-          params.workspaceId,
-          params.installationId,
-          params.profileKey,
-          reportReadFailure,
-        );
-        const existingBackoff =
-          envelope?.backoffUntil !== undefined && envelope.backoffReason !== undefined
-            ? {
-                backoffUntil: envelope.backoffUntil,
-                backoffReason: envelope.backoffReason,
-                backoffError: envelope.backoffError,
-              }
-            : undefined;
-        const selectedBackoff =
-          existingBackoff && existingBackoff.backoffUntil.getTime() >= candidateUntil.getTime()
-            ? existingBackoff
-            : {
-                backoffUntil: candidateUntil,
-                backoffReason: params.failure.failure.reason,
-                backoffError: {
-                  message: params.failure.providerError.message,
-                  ...(params.failure.providerError.status === undefined
-                    ? {}
-                    : {status: params.failure.providerError.status}),
-                },
-              };
-
-        const writes = [
-          this.writeEnvelope(
+      const result = await this.withBackoffLock(
+        params.installationId,
+        params.permissionFingerprint,
+        async () => {
+          let readFailed = false;
+          const reportReadFailure = (error: unknown) => {
+            readFailed = true;
+            params.reportReadFailure(error);
+          };
+          const envelope = await this.readEnvelope(
             params.workspaceId,
             params.installationId,
-            GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
-            selectedBackoff,
-          ),
-        ];
-        if (!readFailed) {
-          writes.push(
-            this.writeEnvelope(params.workspaceId, params.installationId, params.profileKey, {
-              token: envelope?.token,
-              expiresAt: envelope?.expiresAt,
-              permissions: envelope?.permissions,
-            }),
+            params.profileKey,
+            params.backoffKey,
+            reportReadFailure,
           );
-        }
-        await Promise.all(writes);
-        return selectedBackoff.backoffUntil;
-      });
+          const existingBackoff =
+            envelope?.backoffUntil !== undefined && envelope.backoffReason !== undefined
+              ? {
+                  backoffUntil: envelope.backoffUntil,
+                  backoffReason: envelope.backoffReason,
+                  backoffError: envelope.backoffError,
+                }
+              : undefined;
+          const selectedBackoff =
+            existingBackoff && existingBackoff.backoffUntil.getTime() >= candidateUntil.getTime()
+              ? existingBackoff
+              : {
+                  backoffUntil: candidateUntil,
+                  backoffReason: params.failure.failure.reason,
+                  backoffError: {
+                    message: params.failure.providerError.message,
+                    ...(params.failure.providerError.status === undefined
+                      ? {}
+                      : {status: params.failure.providerError.status}),
+                  },
+                };
+
+          const writes = [
+            this.writeEnvelope(
+              params.workspaceId,
+              params.installationId,
+              params.backoffKey,
+              selectedBackoff,
+            ),
+          ];
+          if (!readFailed) {
+            writes.push(
+              this.writeEnvelope(params.workspaceId, params.installationId, params.profileKey, {
+                token: envelope?.token,
+                expiresAt: envelope?.expiresAt,
+                permissions: envelope?.permissions,
+              }),
+            );
+          }
+          await Promise.all(writes);
+          return selectedBackoff.backoffUntil;
+        },
+      );
 
       if (result.acquired) return result.value;
       logger().warn(
-        {installationId: params.installationId, reason: params.failure.failure.reason},
+        {
+          installationId: params.installationId,
+          permissionProfile: params.profileKey,
+          reason: params.failure.failure.reason,
+        },
         'github installation token backoff lock was contended',
       );
     } catch (error) {
       logger().warn(
-        {installationId: params.installationId, reason: params.failure.failure.reason, error},
+        {
+          installationId: params.installationId,
+          permissionProfile: params.profileKey,
+          reason: params.failure.failure.reason,
+          error,
+        },
         'github installation token backoff write failed',
       );
       reportError(error, {
@@ -333,31 +379,29 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
+    backoffKey: string;
+    permissionFingerprint: string;
     reportReadFailure: (error: unknown) => void;
   }): Promise<void> {
     try {
-      await this.withBackoffLock(params.installationId, async () => {
+      await this.withBackoffLock(params.installationId, params.permissionFingerprint, async () => {
         let readFailed = false;
         const envelope = await this.readEnvelope(
           params.workspaceId,
           params.installationId,
           params.profileKey,
+          params.backoffKey,
           (error) => {
             readFailed = true;
             params.reportReadFailure(error);
           },
         );
         if (readFailed || activeBackoff(envelope, this.now())) return;
-        await this.writeEnvelope(
-          params.workspaceId,
-          params.installationId,
-          GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
-          {},
-        );
+        await this.writeEnvelope(params.workspaceId, params.installationId, params.backoffKey, {});
       });
     } catch (error) {
       logger().warn(
-        {installationId: params.installationId, error},
+        {installationId: params.installationId, permissionProfile: params.profileKey, error},
         'github installation token backoff clear failed',
       );
       reportError(error, {
@@ -370,16 +414,13 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
 
   private async withBackoffLock<T>(
     installationId: number,
+    permissionFingerprint: string,
     operation: () => Promise<T>,
   ): Promise<InstallationTokenLockResult<T>> {
     const withLock = this.options.withBackoffLock ?? this.options.withLock;
     for (const delayMs of [0, ...this.pollDelaysMs]) {
       if (delayMs > 0) await this.sleep(delayMs);
-      const result = await withLock(
-        installationId,
-        GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-        operation,
-      );
+      const result = await withLock(installationId, permissionFingerprint, operation);
       if (result.acquired) return result;
     }
     return {acquired: false};
@@ -389,6 +430,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string;
     installationId: number;
     profileKey: string;
+    backoffKey: string;
     envelope: InstallationTokenEnvelope | undefined;
     reportReadFailure: (error: unknown) => void;
   }): Promise<GithubInstallationAccessToken> {
@@ -412,6 +454,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         params.workspaceId,
         params.installationId,
         params.profileKey,
+        params.backoffKey,
         params.reportReadFailure,
       );
       const now = this.now();
@@ -454,6 +497,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     workspaceId: string,
     installationId: number,
     profileKey: string,
+    backoffKey: string,
     reportReadFailure: (error: unknown) => void,
   ): Promise<InstallationTokenEnvelope | undefined> {
     const isCompatibilityProfile =
@@ -471,11 +515,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const [profileResult, backoffResult, fixedEnvelopeResult, legacyResult] =
       await Promise.allSettled([
         this.options.secretStore.read(workspaceId, installationId, profileKey),
-        this.options.secretStore.read(
-          workspaceId,
-          installationId,
-          GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
-        ),
+        this.options.secretStore.read(workspaceId, installationId, backoffKey),
         fixedEnvelopeRead,
         legacyRead,
       ]);
@@ -498,7 +538,9 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     if (isCompatibilityProfile && profile === undefined && profileRaw === null) {
       profile = compatibilityEnvelope;
     }
-    if (backoff === undefined && backoffRaw === null) backoff = compatibilityEnvelope;
+    if (isCompatibilityProfile && backoff === undefined && backoffRaw === null) {
+      backoff = compatibilityEnvelope;
+    }
     if (!profile && !backoff) return undefined;
     return {
       ...profile,

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -543,6 +543,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     let profile = parseRawEnvelope(profileRaw, installationId);
     let backoff = latestBackoff(
       backoffRaws.map((backoffRaw) => parseRawEnvelope(backoffRaw, installationId)),
+      this.now(),
     );
     const fixedEnvelope = parseRawEnvelope(fixedEnvelopeRaw, installationId);
     const legacy = parseRawEnvelope(legacyRaw, installationId);
@@ -660,8 +661,10 @@ function parseRawEnvelope(
 
 function latestBackoff(
   envelopes: readonly (InstallationTokenEnvelope | undefined)[],
+  now: Date,
 ): InstallationTokenEnvelope | undefined {
   let latest: InstallationTokenEnvelope | undefined;
+  let latestActiveTerminal: InstallationTokenEnvelope | undefined;
   for (const envelope of envelopes) {
     if (envelope?.backoffUntil === undefined || envelope.backoffReason === undefined) continue;
     const latestBackoffUntil = latest?.backoffUntil;
@@ -672,8 +675,16 @@ function latestBackoff(
     ) {
       latest = envelope;
     }
+    const latestActiveTerminalUntil = latestActiveTerminal?.backoffUntil;
+    if (
+      envelope.backoffUntil > now &&
+      mintErrorClassForReason(envelope.backoffReason) === 'terminal' &&
+      (latestActiveTerminalUntil === undefined || envelope.backoffUntil > latestActiveTerminalUntil)
+    ) {
+      latestActiveTerminal = envelope;
+    }
   }
-  return latest;
+  return latestActiveTerminal ?? latest;
 }
 
 class InstallationTokenMintFailure extends Error {

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -81,6 +81,7 @@ const expectedCatalogRows = [
     requiredScope: [
       {permission: 'pull_requests', access: 'read'},
       {permission: 'issues', access: 'read'},
+      {permission: 'checks', access: 'read'},
     ],
     methods: [
       'get',
@@ -929,6 +930,8 @@ describe('github agent tool catalog', () => {
     });
     const issueTool = githubAgentToolCatalog.find((entry) => entry.id === 'issue_read');
     if (!issueTool) throw new Error('Missing issue_read tool');
+    const createCommit = githubAgentToolCatalog.find((entry) => entry.id === 'create_commit');
+    if (!createCommit) throw new Error('Missing create_commit tool');
 
     const session = await provider.openSession({
       connection: connection(),
@@ -940,6 +943,14 @@ describe('github agent tool catalog', () => {
             ...method,
             requiredScope: [{permission: 'actions', access: 'write'}],
           })),
+        },
+        {
+          ...createCommit,
+          requiredScope: [{permission: 'actions', access: 'write'}],
+        },
+        {
+          ...createCommit,
+          id: 'removed_tool',
         },
       ],
       scope: {
@@ -962,6 +973,21 @@ describe('github agent tool catalog', () => {
       },
     });
 
+    await expect(session.call({toolId: 'removed_tool', arguments: {}})).resolves.toMatchObject({
+      isError: true,
+      structuredContent: {code: 'invalid-request'},
+    });
+    await expect(
+      session.call({
+        toolId: 'issue_read',
+        arguments: {method: 'removed_method', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      }),
+    ).resolves.toMatchObject({
+      isError: true,
+      structuredContent: {code: 'invalid-request'},
+    });
+    expect(getInstallationAccessToken).not.toHaveBeenCalled();
+
     await expect(
       session.call({
         toolId: 'issue_read',
@@ -969,11 +995,88 @@ describe('github agent tool catalog', () => {
       }),
     ).resolves.toMatchObject({structuredContent: {number: 1}});
 
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(
-      1,
-      '{"contents":"write","issues":"read"}',
-      {contents: 'write', issues: 'read'},
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
+      contents: 'write',
+      issues: 'read',
+    });
+  });
+
+  it('keeps the strongest permission when selected tools share a scope', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {issues: 'write' as const},
+      }),
     );
+    const issueRead = githubAgentToolCatalog.find((entry) => entry.id === 'issue_read');
+    const issueWrite = githubAgentToolCatalog.find((entry) => entry.id === 'issue_write');
+    if (!issueRead || !issueWrite) throw new Error('Missing issue catalog entries');
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [issueRead, issueWrite],
+      scope: undefined,
+    });
+
+    await expect(
+      session.call({
+        toolId: 'issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      }),
+    ).resolves.toMatchObject({structuredContent: {number: 1}});
+
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {issues: 'write'});
+  });
+
+  it('requests checks read for check-run reads', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {total_count: 1}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {checks: 'read' as const},
+      }),
+    );
+    const pullRequestRead = githubAgentToolCatalog.find(
+      (entry) => entry.id === 'pull_request_read',
+    );
+    const checkRunsMethod = pullRequestRead?.methods?.find(
+      (method) => method.id === 'get_check_runs',
+    );
+    if (!pullRequestRead || !checkRunsMethod) throw new Error('Missing check-run catalog entry');
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [{...pullRequestRead, methods: [checkRunsMethod]}],
+      scope: undefined,
+    });
+
+    await expect(
+      session.call({
+        toolId: 'pull_request_read',
+        arguments: {
+          method: 'get_check_runs',
+          owner: 'shipfox',
+          repo: 'platform',
+          pull_number: 1,
+          ref: 'abc123',
+        },
+      }),
+    ).resolves.toMatchObject({structuredContent: {total_count: 1}});
+
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {checks: 'read'});
   });
 
   it('returns artifact download metadata without buffering archive bytes', async () => {
@@ -2118,11 +2221,10 @@ describe('github agent tool catalog', () => {
       content: [{type: 'text', text: '{"message":"Branch updated"}'}],
       structuredContent: {message: 'Branch updated'},
     });
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(
-      1,
-      '{"contents":"write","pull_requests":"write"}',
-      {contents: 'write', pull_requests: 'write'},
-    );
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
+      contents: 'write',
+      pull_requests: 'write',
+    });
   });
 
   it('creates a branch from a commit oid through the provider session', async () => {
@@ -3190,6 +3292,7 @@ function createAgentToolsProvider(client: GithubToolClient) {
           expiresAt: new Date(),
           permissions: {
             actions: 'write' as const,
+            checks: 'read' as const,
             contents: 'write' as const,
             issues: 'write' as const,
             pull_requests: 'write' as const,

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -954,20 +954,16 @@ describe('github agent tool catalog', () => {
         },
       ],
       scope: {
-        repositories: ['shipfox/platform'],
         tools: [
           {
             id: 'issue_read',
             methods: [{id: 'get'}, {id: 'removed_method'}],
-            requiredScope: [{permission: 'actions', access: 'write'}],
           },
           {
             id: 'create_commit',
-            requiredScope: [{permission: 'actions', access: 'write'}],
           },
           {
             id: 'removed_tool',
-            requiredScope: [{permission: 'actions', access: 'write'}],
           },
         ],
       },
@@ -1023,6 +1019,40 @@ describe('github agent tool catalog', () => {
       connection: connection(),
       tools: [issueRead, issueWrite],
       scope: undefined,
+    });
+
+    await expect(
+      session.call({
+        toolId: 'issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      }),
+    ).resolves.toMatchObject({structuredContent: {number: 1}});
+
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {issues: 'write'});
+  });
+
+  it('uses the full integration scope for a single-tool session profile', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {issues: 'write' as const},
+      }),
+    );
+    const issueRead = githubAgentToolCatalog.find((entry) => entry.id === 'issue_read');
+    const issueWrite = githubAgentToolCatalog.find((entry) => entry.id === 'issue_write');
+    if (!issueRead || !issueWrite) throw new Error('Missing issue catalog entries');
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [issueRead],
+      scope: {tools: [{id: issueRead.id}, {id: issueWrite.id}]},
     });
 
     await expect(

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -910,6 +910,72 @@ describe('github agent tool catalog', () => {
     });
   });
 
+  it('derives the token profile from live catalog ids and method allowlists', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {
+          contents: 'write' as const,
+          issues: 'read' as const,
+        },
+      }),
+    );
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+    const issueTool = githubAgentToolCatalog.find((entry) => entry.id === 'issue_read');
+    if (!issueTool) throw new Error('Missing issue_read tool');
+
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [
+        {
+          ...issueTool,
+          requiredScope: [{permission: 'actions', access: 'write'}],
+          methods: issueTool.methods?.map((method) => ({
+            ...method,
+            requiredScope: [{permission: 'actions', access: 'write'}],
+          })),
+        },
+      ],
+      scope: {
+        repositories: ['shipfox/platform'],
+        tools: [
+          {
+            id: 'issue_read',
+            methods: [{id: 'get'}, {id: 'removed_method'}],
+            requiredScope: [{permission: 'actions', access: 'write'}],
+          },
+          {
+            id: 'create_commit',
+            requiredScope: [{permission: 'actions', access: 'write'}],
+          },
+          {
+            id: 'removed_tool',
+            requiredScope: [{permission: 'actions', access: 'write'}],
+          },
+        ],
+      },
+    });
+
+    await expect(
+      session.call({
+        toolId: 'issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      }),
+    ).resolves.toMatchObject({structuredContent: {number: 1}});
+
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(
+      1,
+      '{"contents":"write","issues":"read"}',
+      {contents: 'write', issues: 'read'},
+    );
+  });
+
   it('returns artifact download metadata without buffering archive bytes', async () => {
     const request = vi.fn(() =>
       Promise.resolve({
@@ -2006,20 +2072,19 @@ describe('github agent tool catalog', () => {
 
   it('authorizes update_pull_request_branch when the installation grants both permissions', async () => {
     const request = vi.fn(() => Promise.resolve({data: {message: 'Branch updated'}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {
+          contents: 'write' as const,
+          pull_requests: 'write' as const,
+        },
+      }),
+    );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {
-              contents: 'write' as const,
-              pull_requests: 'write' as const,
-            },
-          }),
-        ),
-      },
+      tokenProvider: {getInstallationAccessToken},
       createClient: vi.fn(() => ({request})),
     });
     const tool = githubAgentToolCatalog.find((entry) => entry.id === 'update_pull_request_branch');
@@ -2053,6 +2118,11 @@ describe('github agent tool catalog', () => {
       content: [{type: 'text', text: '{"message":"Branch updated"}'}],
       structuredContent: {message: 'Branch updated'},
     });
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(
+      1,
+      '{"contents":"write","pull_requests":"write"}',
+      {contents: 'write', pull_requests: 'write'},
+    );
   });
 
   it('creates a branch from a commit oid through the provider session', async () => {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -10,7 +10,10 @@ import type {
 import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-spi';
 import {Octokit} from 'octokit';
 import {mapGithubError} from '#api/client.js';
-import {GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT} from '#api/installation-token-envelope.js';
+import {
+  type GithubInstallationTokenPermissions,
+  githubInstallationTokenPermissionFingerprint,
+} from '#api/installation-token-envelope.js';
 import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
@@ -194,13 +197,22 @@ export class GithubAgentToolsProvider
         'GitHub installation has an invalid installation ID',
       );
     }
+    const liveCatalog = this.catalog();
+    const authorizedTools = input.tools.flatMap((tool) => {
+      const authorizedTool = intersectGithubToolWithLiveCatalog(tool, liveCatalog);
+      return authorizedTool === undefined ? [] : [authorizedTool];
+    });
+    const permissionProfile = githubToolPermissionProfile(
+      githubToolAllowlist(input.scope, input.tools),
+      liveCatalog,
+    );
     let tokenPromise:
       | ReturnType<GithubInstallationTokenProvider['getInstallationAccessToken']>
       | undefined;
 
     return {
       call: async (call) => {
-        const tool = input.tools.find((candidate) => candidate.id === call.toolId);
+        const tool = authorizedTools.find((candidate) => candidate.id === call.toolId);
         if (!tool) return githubToolError(`Unknown GitHub tool: ${call.toolId}`, 'invalid-request');
         const operation = resolveGithubOperation(tool, call);
         if (operation === undefined)
@@ -209,7 +221,8 @@ export class GithubAgentToolsProvider
         if (validationError) return githubToolError(validationError, 'invalid-request');
         tokenPromise ??= this.tokenProvider.getInstallationAccessToken(
           installationId,
-          GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+          permissionProfile.fingerprint,
+          permissionProfile.permissions,
         );
         const token = await tokenPromise;
         if (!hasGrantedPermissions(token.permissions ?? {}, tool, call)) {
@@ -258,6 +271,98 @@ export interface GithubAgentToolsProviderOptions {
     | undefined;
   tokenProvider?: GithubInstallationTokenProvider | undefined;
   createClient?: GithubToolClientFactory | undefined;
+}
+
+interface GithubToolAllowlistEntry {
+  id: string;
+  methods?: readonly {id: string}[] | undefined;
+}
+
+interface GithubToolPermissionProfile {
+  fingerprint: string;
+  permissions: GithubInstallationTokenPermissions;
+}
+
+function githubToolAllowlist(
+  scope: unknown,
+  fallback: readonly AgentToolCatalogEntry<GithubAgentToolRequiredScope>[],
+): readonly GithubToolAllowlistEntry[] {
+  const scopedTools = isRecord(scope) && Array.isArray(scope.tools) ? scope.tools : fallback;
+  return scopedTools.flatMap((tool) => {
+    const allowlistEntry = toGithubToolAllowlistEntry(tool);
+    return allowlistEntry === undefined ? [] : [allowlistEntry];
+  });
+}
+
+function toGithubToolAllowlistEntry(value: unknown): GithubToolAllowlistEntry | undefined {
+  if (!isRecord(value) || typeof value.id !== 'string') return undefined;
+  if (value.methods === undefined) return {id: value.id};
+  if (!Array.isArray(value.methods)) return {id: value.id, methods: []};
+
+  return {
+    id: value.id,
+    methods: value.methods.flatMap((method) => {
+      if (!isRecord(method) || typeof method.id !== 'string') return [];
+      return [{id: method.id}];
+    }),
+  };
+}
+
+function intersectGithubToolWithLiveCatalog(
+  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
+  liveCatalog: readonly GithubAgentToolCatalogEntry[],
+): AgentToolCatalogEntry<GithubAgentToolRequiredScope> | undefined {
+  const liveTool = liveCatalog.find((candidate) => candidate.id === tool.id);
+  if (liveTool === undefined) return undefined;
+  if (tool.methods === undefined) return liveTool;
+  if (liveTool.methods === undefined) return undefined;
+
+  const allowedMethods = new Set(tool.methods.map((method) => method.id));
+  const methods = liveTool.methods.filter((method) => allowedMethods.has(method.id));
+  return methods.length === 0 ? undefined : {...liveTool, methods};
+}
+
+function githubToolPermissionProfile(
+  allowlist: readonly GithubToolAllowlistEntry[],
+  liveCatalog: readonly GithubAgentToolCatalogEntry[],
+): GithubToolPermissionProfile {
+  const permissionsByName = new Map<string, 'read' | 'write'>();
+
+  for (const selectedTool of allowlist) {
+    const liveTool = liveCatalog.find((candidate) => candidate.id === selectedTool.id);
+    if (liveTool === undefined) continue;
+
+    if (selectedTool.methods === undefined) {
+      addGithubRequiredScope(permissionsByName, liveTool.requiredScope);
+      continue;
+    }
+    if (liveTool.methods === undefined) continue;
+
+    const selectedMethods = new Set(selectedTool.methods.map((method) => method.id));
+    for (const liveMethod of liveTool.methods) {
+      if (selectedMethods.has(liveMethod.id)) {
+        addGithubRequiredScope(permissionsByName, liveMethod.requiredScope);
+      }
+    }
+  }
+
+  const permissions = Object.fromEntries(
+    [...permissionsByName.entries()].sort(([first], [second]) => first.localeCompare(second)),
+  ) as GithubInstallationTokenPermissions;
+  return {
+    permissions,
+    fingerprint: githubInstallationTokenPermissionFingerprint(permissions),
+  };
+}
+
+function addGithubRequiredScope(
+  permissions: Map<string, 'read' | 'write'>,
+  requiredScope: GithubAgentToolRequiredScope,
+): void {
+  for (const {permission, access} of requiredScope) {
+    if (permissions.get(permission) === 'write') continue;
+    permissions.set(permission, access);
+  }
 }
 
 export interface GithubToolResponse {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -10,10 +10,7 @@ import type {
 import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-spi';
 import {Octokit} from 'octokit';
 import {mapGithubError} from '#api/client.js';
-import {
-  type GithubInstallationTokenPermissions,
-  githubInstallationTokenPermissionFingerprint,
-} from '#api/installation-token-envelope.js';
+import type {GithubInstallationTokenPermissions} from '#api/installation-token-envelope.js';
 import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
@@ -202,10 +199,7 @@ export class GithubAgentToolsProvider
       const authorizedTool = intersectGithubToolWithLiveCatalog(tool, liveCatalog);
       return authorizedTool === undefined ? [] : [authorizedTool];
     });
-    const permissionProfile = githubToolPermissionProfile(
-      githubToolAllowlist(input.scope, input.tools),
-      liveCatalog,
-    );
+    const permissionProfile = githubToolPermissionProfile(authorizedTools);
     let tokenPromise:
       | ReturnType<GithubInstallationTokenProvider['getInstallationAccessToken']>
       | undefined;
@@ -221,7 +215,7 @@ export class GithubAgentToolsProvider
         if (validationError) return githubToolError(validationError, 'invalid-request');
         tokenPromise ??= this.tokenProvider.getInstallationAccessToken(
           installationId,
-          permissionProfile.fingerprint,
+          undefined,
           permissionProfile.permissions,
         );
         const token = await tokenPromise;
@@ -273,39 +267,8 @@ export interface GithubAgentToolsProviderOptions {
   createClient?: GithubToolClientFactory | undefined;
 }
 
-interface GithubToolAllowlistEntry {
-  id: string;
-  methods?: readonly {id: string}[] | undefined;
-}
-
 interface GithubToolPermissionProfile {
-  fingerprint: string;
   permissions: GithubInstallationTokenPermissions;
-}
-
-function githubToolAllowlist(
-  scope: unknown,
-  fallback: readonly AgentToolCatalogEntry<GithubAgentToolRequiredScope>[],
-): readonly GithubToolAllowlistEntry[] {
-  const scopedTools = isRecord(scope) && Array.isArray(scope.tools) ? scope.tools : fallback;
-  return scopedTools.flatMap((tool) => {
-    const allowlistEntry = toGithubToolAllowlistEntry(tool);
-    return allowlistEntry === undefined ? [] : [allowlistEntry];
-  });
-}
-
-function toGithubToolAllowlistEntry(value: unknown): GithubToolAllowlistEntry | undefined {
-  if (!isRecord(value) || typeof value.id !== 'string') return undefined;
-  if (value.methods === undefined) return {id: value.id};
-  if (!Array.isArray(value.methods)) return {id: value.id, methods: []};
-
-  return {
-    id: value.id,
-    methods: value.methods.flatMap((method) => {
-      if (!isRecord(method) || typeof method.id !== 'string') return [];
-      return [{id: method.id}];
-    }),
-  };
 }
 
 function intersectGithubToolWithLiveCatalog(
@@ -323,35 +286,29 @@ function intersectGithubToolWithLiveCatalog(
 }
 
 function githubToolPermissionProfile(
-  allowlist: readonly GithubToolAllowlistEntry[],
-  liveCatalog: readonly GithubAgentToolCatalogEntry[],
+  authorizedTools: readonly AgentToolCatalogEntry<GithubAgentToolRequiredScope>[],
 ): GithubToolPermissionProfile {
   const permissionsByName = new Map<string, 'read' | 'write'>();
 
-  for (const selectedTool of allowlist) {
-    const liveTool = liveCatalog.find((candidate) => candidate.id === selectedTool.id);
-    if (liveTool === undefined) continue;
-
-    if (selectedTool.methods === undefined) {
-      addGithubRequiredScope(permissionsByName, liveTool.requiredScope);
+  for (const tool of authorizedTools) {
+    if (tool.methods === undefined) {
+      addGithubRequiredScope(permissionsByName, tool.requiredScope);
       continue;
     }
-    if (liveTool.methods === undefined) continue;
-
-    const selectedMethods = new Set(selectedTool.methods.map((method) => method.id));
-    for (const liveMethod of liveTool.methods) {
-      if (selectedMethods.has(liveMethod.id)) {
-        addGithubRequiredScope(permissionsByName, liveMethod.requiredScope);
-      }
+    for (const method of tool.methods) {
+      addGithubRequiredScope(permissionsByName, method.requiredScope);
     }
   }
 
   const permissions = Object.fromEntries(
-    [...permissionsByName.entries()].sort(([first], [second]) => first.localeCompare(second)),
+    [...permissionsByName.entries()].sort(([first], [second]) => {
+      if (first < second) return -1;
+      if (first > second) return 1;
+      return 0;
+    }),
   ) as GithubInstallationTokenPermissions;
   return {
     permissions,
-    fingerprint: githubInstallationTokenPermissionFingerprint(permissions),
   };
 }
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -159,7 +159,7 @@ export class GithubAgentToolsProvider
     AgentToolsProvider<
       GithubIntegrationConnection,
       GithubAgentToolRequiredScope,
-      unknown,
+      GithubAgentToolsScope | undefined,
       GithubToolCallResult
     >
 {
@@ -178,7 +178,11 @@ export class GithubAgentToolsProvider
   }
 
   async openSession(
-    input: OpenAgentToolsSessionInput<GithubIntegrationConnection, GithubAgentToolRequiredScope>,
+    input: OpenAgentToolsSessionInput<
+      GithubIntegrationConnection,
+      GithubAgentToolRequiredScope,
+      GithubAgentToolsScope | undefined
+    >,
   ): Promise<AgentToolSession<GithubToolCallResult>> {
     const installation = await this.options.getInstallationByConnectionId?.(input.connection.id);
     if (!installation) {
@@ -195,11 +199,13 @@ export class GithubAgentToolsProvider
       );
     }
     const liveCatalog = this.catalog();
-    const authorizedTools = input.tools.flatMap((tool) => {
-      const authorizedTool = intersectGithubToolWithLiveCatalog(tool, liveCatalog);
-      return authorizedTool === undefined ? [] : [authorizedTool];
-    });
-    const permissionProfile = githubToolPermissionProfile(authorizedTools);
+    const authorizedTools = intersectGithubToolsWithLiveCatalog(input.tools, liveCatalog);
+    // The core tool-call service opens one-tool sessions, while scope retains
+    // the full frozen integration selection. Aggregate the token profile from
+    // that selection so sequential calls reuse one token profile.
+    const selectedTools = input.scope?.tools ?? input.tools;
+    const profileTools = intersectGithubToolsWithLiveCatalog(selectedTools, liveCatalog);
+    const permissionProfile = githubToolPermissionProfile(profileTools);
     let tokenPromise:
       | ReturnType<GithubInstallationTokenProvider['getInstallationAccessToken']>
       | undefined;
@@ -271,8 +277,31 @@ interface GithubToolPermissionProfile {
   permissions: GithubInstallationTokenPermissions;
 }
 
+interface GithubToolSelection {
+  id: string;
+  methods?: readonly GithubToolSelectionMethod[] | undefined;
+}
+
+interface GithubToolSelectionMethod {
+  id: string;
+}
+
+interface GithubAgentToolsScope {
+  tools?: readonly GithubToolSelection[] | undefined;
+}
+
+function intersectGithubToolsWithLiveCatalog(
+  tools: readonly GithubToolSelection[],
+  liveCatalog: readonly GithubAgentToolCatalogEntry[],
+): AgentToolCatalogEntry<GithubAgentToolRequiredScope>[] {
+  return tools.flatMap((tool) => {
+    const authorizedTool = intersectGithubToolWithLiveCatalog(tool, liveCatalog);
+    return authorizedTool === undefined ? [] : [authorizedTool];
+  });
+}
+
 function intersectGithubToolWithLiveCatalog(
-  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
+  tool: GithubToolSelection,
   liveCatalog: readonly GithubAgentToolCatalogEntry[],
 ): AgentToolCatalogEntry<GithubAgentToolRequiredScope> | undefined {
   const liveTool = liveCatalog.find((candidate) => candidate.id === tool.id);

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -25,7 +25,12 @@ interface GithubCatalogEntry<RequiredScope = unknown> extends AgentToolCatalogEn
 export const DEFAULT_JOB_LOG_TAIL_LINES = 500;
 
 export type GithubAgentToolCategory = 'issues' | 'pull_requests' | 'actions' | 'repository';
-export type GithubAgentToolPermission = 'actions' | 'contents' | 'issues' | 'pull_requests';
+export type GithubAgentToolPermission =
+  | 'actions'
+  | 'checks'
+  | 'contents'
+  | 'issues'
+  | 'pull_requests';
 export type GithubAgentToolPermissionAccess = 'read' | 'write';
 export type GithubAgentToolSensitivity = 'read' | 'write';
 
@@ -65,6 +70,7 @@ const scopes = {
   pullRequestsWrite: [{permission: 'pull_requests', access: 'write'}],
   actionsRead: [{permission: 'actions', access: 'read'}],
   actionsWrite: [{permission: 'actions', access: 'write'}],
+  checksRead: [{permission: 'checks', access: 'read'}],
   contentsWrite: [{permission: 'contents', access: 'write'}],
   mergePullRequest: [
     {permission: 'pull_requests', access: 'write'},
@@ -262,7 +268,7 @@ const pullRequestReadMethods = [
     'Get check runs for the head commit of a pull request.',
     'read',
     false,
-    scopes.pullRequestsRead,
+    scopes.checksRead,
   ),
 ] as const satisfies readonly GithubAgentToolCatalogMethod[];
 

--- a/libs/api/integration/github/src/metrics/instance.ts
+++ b/libs/api/integration/github/src/metrics/instance.ts
@@ -52,8 +52,10 @@ const installationTokenLockWaitDuration = meter.createHistogram<Record<string, n
 const installationTokenBackoffCount = meter.createCounter<{
   reason: IntegrationProviderErrorReason;
   class: MintErrorClass;
+  profile: 'compatibility' | 'scoped';
 }>('github_installation_token_backoff', {
-  description: 'GitHub installation token mint backoff activations by reason and class',
+  description:
+    'GitHub installation token mint backoff activations by reason, class, and profile kind',
 });
 
 export type GithubCheckoutTokenLookupOutcome =
@@ -126,6 +128,7 @@ export function recordInstallationTokenLockWait(durationMs: number): void {
 export function recordInstallationTokenBackoff(params: {
   reason: IntegrationProviderErrorReason;
   class: MintErrorClass;
+  profile: 'compatibility' | 'scoped';
 }): void {
   recordMetric(() => installationTokenBackoffCount.add(1, params));
 }


### PR DESCRIPTION
## Summary

GitHub agent-tool installation tokens now derive their permission profile from the live catalog intersected with the frozen tool and method allowlists. The deterministic inter-module path applies the same live-catalog boundary, keeping MCP and deterministic authority aligned.

This prevents removed tools and methods from granting permissions, supports multi-scope operations such as `update_pull_request_branch`, and keeps repository targets out of token variants while preserving profile-aware caching and installation-wide backoff.

Closes ENG-1824

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows GitHub agent-tool installation tokens to only the permissions the live catalog requires, so tools and methods removed from the catalog no longer grant access. The deterministic inter-module path applies the same live-catalog boundary, keeping MCP and deterministic authority aligned.

**Details**
- Token minting accepts a permission profile derived from the live catalog intersected with frozen tool/method allowlists, merging strongest access across methods for multi-scope operations.
- The profile is aggregated from the full frozen integration selection so sequential one-tool sessions share one token profile.
- Backoff is isolated per permission profile while provider-wide failures like rate limits keep installation-wide backoff, and active terminal backoffs win over later transient ones.
- Check-run reads request `checks: read`.
- Repository targets are not included in the token permission fingerprint.
- The E2E flow test now sends the explicit `issues: write` permission profile.

Closes ENG-1824.

<sup>Written for commit 581a8e3c1735c6e4d9b7fa85d078068ceb49ebe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

