### PR TITLE
[e2e-flow-workflows] Verify session continuation across jobs and events

### DIFF
--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -235,16 +235,34 @@ export async function stepLogText(params: {
   return logText(logs.records);
 }
 
-export async function sendBatchPairAndAwaitMaterialization(params: {
+export async function sendBatchAndAwaitMaterialization(params: {
   testCase: ListenerCase;
   runId: string;
   label: string;
   sequence: number;
   timeoutMs: number;
+  eventCount?: number | undefined;
+  expectedEventCount?: number | undefined;
 }): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
+  const eventCount = params.eventCount ?? 2;
+  const expectedEventCount = params.expectedEventCount ?? eventCount;
+  if (
+    !Number.isInteger(eventCount) ||
+    eventCount < 1 ||
+    !Number.isInteger(expectedEventCount) ||
+    expectedEventCount < 1 ||
+    expectedEventCount > eventCount
+  ) {
+    throw new Error(
+      `Invalid listener batch counts: eventCount=${eventCount}, expectedEventCount=${expectedEventCount}`,
+    );
+  }
+
   const deliveryIds = [
-    `${params.testCase.uniqueId}-${params.label}-a`,
-    `${params.testCase.uniqueId}-${params.label}-b`,
+    ...Array.from({length: eventCount}, (_, index) => {
+      const suffix = String.fromCharCode('a'.charCodeAt(0) + index);
+      return `${params.testCase.uniqueId}-${params.label}-${suffix}`;
+    }),
   ];
   for (const deliveryId of deliveryIds) {
     params.testCase.fireDiagnostics.deliveryIds.push(deliveryId);
@@ -266,10 +284,20 @@ export async function sendBatchPairAndAwaitMaterialization(params: {
         runDetail: candidate,
         jobKey: LISTENER_JOB,
         sequence: params.sequence,
-        deliveryIds,
+        deliveryIds: deliveryIds.slice(0, expectedEventCount),
       }),
   });
   return {deliveryIds, runDetail};
+}
+
+export async function sendBatchPairAndAwaitMaterialization(params: {
+  testCase: ListenerCase;
+  runId: string;
+  label: string;
+  sequence: number;
+  timeoutMs: number;
+}): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
+  return await sendBatchAndAwaitMaterialization({...params, eventCount: 2});
 }
 
 export const listenerWorkflows = {

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -384,3 +384,56 @@ jobs:
           echo "listener_done"
 `,
 };
+
+export function sessionContinuationWorkflow(params: {provider: string; model: string}): string {
+  return `
+name: Session continuation
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  plan:
+    steps:
+      - key: draft
+        harness: pi
+        provider: ${params.provider}
+        model: ${params.model}
+        thinking: off
+        session: main
+        prompt: |
+          Prepare the plan and reply with exactly: PLAN_SESSION_SEGMENT
+  implement:
+    needs: plan
+    steps:
+      - key: apply
+        harness: pi
+        provider: ${params.provider}
+        model: ${params.model}
+        thinking: off
+        session: main
+        prompt: |
+          Implement the plan and reply with exactly: IMPLEMENT_SESSION_SEGMENT
+  listen:
+    needs: implement
+    listening:
+      on:
+        - source: __FIRE_WEBHOOK_SOURCE__
+          event: received
+      until:
+        - source: __RESOLVE_WEBHOOK_SOURCE__
+          event: received
+      batch:
+        max_size: 2
+    steps:
+      - key: continue
+        harness: pi
+        provider: ${params.provider}
+        model: ${params.model}
+        thinking: off
+        session: main
+        prompt: |
+          Process this event batch and reply with the next session marker.
+`;
+}

--- a/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
@@ -14,7 +14,7 @@ import {
   fireManualRun,
   LISTENER_JOB,
   type ListenerCase,
-  sendBatchPairAndAwaitMaterialization,
+  sendBatchAndAwaitMaterialization,
   sendResolve,
   sessionContinuationWorkflow,
   setupListenerCase,
@@ -26,6 +26,7 @@ import {expect, test} from './fixtures.js';
 const SESSION_MODEL_MAX_OUTPUT_TOKENS = 64;
 const SESSION_FLOW_OBSERVATION_TIMEOUT_MS = 60_000;
 const SESSION_RUN_TERMINAL_TIMEOUT_MS = 180_000;
+const SESSION_TEST_TIMEOUT_MS = 600_000;
 
 const SESSION_RESPONSES = [
   'PLAN_SESSION_SEGMENT',
@@ -37,6 +38,7 @@ const SESSION_RESPONSES = [
 test('resumes one Pi session across jobs and listening event batches', async ({
   suite,
 }, testInfo) => {
+  test.setTimeout(SESSION_TEST_TIMEOUT_MS);
   const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
   const fakeModelProvider = await startFakeOpenAiModelProvider({
     runId: `${suite.runId}-session-continuation-${uniqueId}`,
@@ -106,12 +108,14 @@ test('resumes one Pi session across jobs and listening event batches', async ({
       timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
     });
 
-    const firstBatch = await sendBatchPairAndAwaitMaterialization({
+    const firstBatch = await sendBatchAndAwaitMaterialization({
       testCase,
       runId,
       label: 'first-batch',
       sequence: 1,
       timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+      eventCount: 4,
+      expectedEventCount: 2,
     });
     await waitForListenerExecution({
       token: testCase.token,
@@ -122,13 +126,6 @@ test('resumes one Pi session across jobs and listening event batches', async ({
       timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
     });
 
-    const secondBatch = await sendBatchPairAndAwaitMaterialization({
-      testCase,
-      runId,
-      label: 'second-batch',
-      sequence: 2,
-      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
-    });
     await waitForListenerExecution({
       token: testCase.token,
       runId,
@@ -138,7 +135,7 @@ test('resumes one Pi session across jobs and listening event batches', async ({
       timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
     });
 
-    const resolveDeliveryId = await sendResolve(testCase, 'resolve');
+    await sendResolve(testCase, 'resolve');
     const resolved = await waitForListenerResolution({
       token: testCase.token,
       runId,
@@ -156,10 +153,8 @@ test('resumes one Pi session across jobs and listening event batches', async ({
 
     assertSessionRun({
       firstBatch,
-      secondBatch,
       terminal,
       resolved,
-      resolveDeliveryId,
     });
 
     const requests = await fakeModelProvider.getRequests(script.id);
@@ -193,11 +188,9 @@ test('resumes one Pi session across jobs and listening event batches', async ({
 });
 
 function assertSessionRun(params: {
-  firstBatch: Awaited<ReturnType<typeof sendBatchPairAndAwaitMaterialization>>;
-  secondBatch: Awaited<ReturnType<typeof sendBatchPairAndAwaitMaterialization>>;
+  firstBatch: Awaited<ReturnType<typeof sendBatchAndAwaitMaterialization>>;
   terminal: WorkflowRunDetailResponseDto;
   resolved: WorkflowRunDetailResponseDto;
-  resolveDeliveryId: string;
 }): void {
   const plan = sessionStep(params.terminal, 'plan', 1, 'draft');
   const implement = sessionStep(params.terminal, 'implement', 1, 'apply');
@@ -217,16 +210,16 @@ function assertSessionRun(params: {
     'succeeded',
     'succeeded',
   ]);
+  expect(params.firstBatch.deliveryIds).toHaveLength(4);
   expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
-    params.firstBatch.deliveryIds,
+    params.firstBatch.deliveryIds.slice(0, 2),
   );
   expect(listen?.job_executions[1]?.trigger_events.map((event) => event.delivery_id)).toEqual(
-    params.secondBatch.deliveryIds,
+    params.firstBatch.deliveryIds.slice(2),
   );
   expect(params.resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
     'until',
   );
-  expect(params.resolveDeliveryId).toContain('resolve');
 
   expect(plan.response?.trim()).toBe(SESSION_RESPONSES[0]);
   expect(implement.response?.trim()).toBe(SESSION_RESPONSES[1]);

--- a/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
@@ -1,0 +1,266 @@
+import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
+import {message, startFakeOpenAiModelProvider} from '@shipfox/e2e-driver-model-provider';
+import {
+  createOpenAiCompatibleCustomProvider,
+  deleteModelProviderConfig,
+} from '@shipfox/e2e-setup-agent';
+import {
+  waitForListenerExecution,
+  waitForListenerResolution,
+  waitForListenerStatus,
+} from '#listener-helpers.js';
+import {
+  cleanupListenerCase,
+  fireManualRun,
+  LISTENER_JOB,
+  type ListenerCase,
+  sendBatchPairAndAwaitMaterialization,
+  sendResolve,
+  sessionContinuationWorkflow,
+  setupListenerCase,
+  stopRunner,
+} from '#listener-jobs.js';
+import {waitForRunTerminalOrFailedRunner} from '#runner.js';
+import {expect, test} from './fixtures.js';
+
+const SESSION_MODEL_MAX_OUTPUT_TOKENS = 64;
+const SESSION_FLOW_OBSERVATION_TIMEOUT_MS = 60_000;
+const SESSION_RUN_TERMINAL_TIMEOUT_MS = 180_000;
+
+const SESSION_RESPONSES = [
+  'PLAN_SESSION_SEGMENT',
+  'IMPLEMENT_SESSION_SEGMENT',
+  'LISTENER_BATCH_SEGMENT',
+  'LISTENER_BATCH_SEGMENT_TWO',
+] as const;
+
+test('resumes one Pi session across jobs and listening event batches', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const fakeModelProvider = await startFakeOpenAiModelProvider({
+    runId: `${suite.runId}-session-continuation-${uniqueId}`,
+  });
+
+  let providerId: string | undefined;
+  let testCase: (ListenerCase & {definitionId: string}) | undefined;
+  let runId: string | undefined;
+  try {
+    const script = await fakeModelProvider.createScript({
+      id: `${suite.runId}-session-continuation-${uniqueId}`,
+      model: `deterministic-session-${uniqueId}`,
+      responses: [
+        message('provider probe ok'),
+        ...SESSION_RESPONSES.map((content) => message(content)),
+      ],
+      assertions: [
+        {kind: 'model', equals: `deterministic-session-${uniqueId}`},
+        {
+          kind: 'message_content_includes',
+          value: SESSION_RESPONSES[0],
+          minRequestIndex: 2,
+        },
+        {
+          kind: 'message_content_includes',
+          value: SESSION_RESPONSES[1],
+          minRequestIndex: 3,
+        },
+        {
+          kind: 'message_content_includes',
+          value: SESSION_RESPONSES[2],
+          minRequestIndex: 4,
+        },
+      ],
+    });
+    const provider = await createOpenAiCompatibleCustomProvider({
+      workspaceId: suite.workspaceId,
+      sessionToken: suite.sessionToken,
+      providerId: `fake-openai-session-${uniqueId}`,
+      displayName: `Fake OpenAI Session ${uniqueId}`,
+      baseUrl: script.modelProviderBaseUrl,
+      model: script.model,
+      modelMetadata: {max_output_tokens: SESSION_MODEL_MAX_OUTPUT_TOKENS},
+    });
+    providerId = provider.provider_id;
+
+    testCase = await setupListenerCase({
+      suite,
+      testName: 'session-continuation',
+      workflowYaml: sessionContinuationWorkflow({
+        provider: provider.provider_id,
+        model: script.model,
+      }),
+      attach: (attachment) =>
+        testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        }),
+    });
+    runId = await fireManualRun(testCase);
+
+    await waitForListenerStatus({
+      token: testCase.token,
+      runId,
+      jobKey: LISTENER_JOB,
+      listenerStatus: 'listening',
+      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+    });
+
+    const firstBatch = await sendBatchPairAndAwaitMaterialization({
+      testCase,
+      runId,
+      label: 'first-batch',
+      sequence: 1,
+      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+    });
+    await waitForListenerExecution({
+      token: testCase.token,
+      runId,
+      jobKey: LISTENER_JOB,
+      sequence: 1,
+      status: 'succeeded',
+      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+    });
+
+    const secondBatch = await sendBatchPairAndAwaitMaterialization({
+      testCase,
+      runId,
+      label: 'second-batch',
+      sequence: 2,
+      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+    });
+    await waitForListenerExecution({
+      token: testCase.token,
+      runId,
+      jobKey: LISTENER_JOB,
+      sequence: 2,
+      status: 'succeeded',
+      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+    });
+
+    const resolveDeliveryId = await sendResolve(testCase, 'resolve');
+    const resolved = await waitForListenerResolution({
+      token: testCase.token,
+      runId,
+      jobKey: LISTENER_JOB,
+      status: 'succeeded',
+      reason: 'until',
+      timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+    });
+    const terminal = await waitForRunTerminalOrFailedRunner({
+      runId,
+      token: testCase.token,
+      timeoutMs: SESSION_RUN_TERMINAL_TIMEOUT_MS,
+      runner: testCase.runner,
+    });
+
+    assertSessionRun({
+      firstBatch,
+      secondBatch,
+      terminal,
+      resolved,
+      resolveDeliveryId,
+    });
+
+    const requests = await fakeModelProvider.getRequests(script.id);
+    expect(requests).toHaveLength(5);
+    expect(requests.map((request) => request.assertion_failures)).toEqual([[], [], [], [], []]);
+    expect(requests.map((request) => request.message_roles.includes('assistant'))).toEqual([
+      false,
+      false,
+      true,
+      true,
+      true,
+    ]);
+  } catch (error) {
+    await cleanupListenerCase(testCase, runId);
+    throw error;
+  } finally {
+    await stopRunner(testCase);
+    if (providerId !== undefined) {
+      await deleteModelProviderConfig({
+        workspaceId: suite.workspaceId,
+        sessionToken: suite.sessionToken,
+        providerId,
+      }).catch(() => undefined);
+    }
+    await fakeModelProvider.stop().catch((error: unknown) => {
+      process.stderr.write(
+        `session-continuation-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
+      );
+    });
+  }
+});
+
+function assertSessionRun(params: {
+  firstBatch: Awaited<ReturnType<typeof sendBatchPairAndAwaitMaterialization>>;
+  secondBatch: Awaited<ReturnType<typeof sendBatchPairAndAwaitMaterialization>>;
+  terminal: WorkflowRunDetailResponseDto;
+  resolved: WorkflowRunDetailResponseDto;
+  resolveDeliveryId: string;
+}): void {
+  const plan = sessionStep(params.terminal, 'plan', 1, 'draft');
+  const implement = sessionStep(params.terminal, 'implement', 1, 'apply');
+  const firstListener = sessionStep(params.terminal, LISTENER_JOB, 1, 'continue');
+  const secondListener = sessionStep(params.terminal, LISTENER_JOB, 2, 'continue');
+
+  expect(params.terminal.status).toBe('succeeded');
+  expect(params.terminal.jobs.find((job) => job.key === 'plan')?.status).toBe('succeeded');
+  expect(params.terminal.jobs.find((job) => job.key === 'implement')?.status).toBe('succeeded');
+
+  const listen = params.terminal.jobs.find((job) => job.key === LISTENER_JOB);
+  expect(listen?.status).toBe('succeeded');
+  expect(listen?.listener_status).toBe('resolved');
+  expect(listen?.resolution_reason).toBe('until');
+  expect(listen?.job_executions.map((execution) => execution.sequence)).toEqual([1, 2]);
+  expect(listen?.job_executions.map((execution) => execution.status)).toEqual([
+    'succeeded',
+    'succeeded',
+  ]);
+  expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+    params.firstBatch.deliveryIds,
+  );
+  expect(listen?.job_executions[1]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+    params.secondBatch.deliveryIds,
+  );
+  expect(params.resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
+    'until',
+  );
+  expect(params.resolveDeliveryId).toContain('resolve');
+
+  expect(plan.response?.trim()).toBe(SESSION_RESPONSES[0]);
+  expect(implement.response?.trim()).toBe(SESSION_RESPONSES[1]);
+  expect(firstListener.response?.trim()).toBe(SESSION_RESPONSES[2]);
+  expect(secondListener.response?.trim()).toBe(SESSION_RESPONSES[3]);
+
+  const descriptors = [plan, implement, firstListener, secondListener].map((step) => {
+    if (step.session === undefined || step.session === null) {
+      throw new Error(`Step ${step.key ?? '<unnamed>'} did not record a session descriptor`);
+    }
+    return step.session;
+  });
+  expect(descriptors.map((descriptor) => descriptor.key)).toEqual(['main', 'main', 'main', 'main']);
+  expect(descriptors.map((descriptor) => descriptor.mode)).toEqual([
+    'resume',
+    'resume',
+    'resume',
+    'resume',
+  ]);
+  expect(descriptors.map((descriptor) => descriptor.segment)).toEqual([0, 1, 2, 3]);
+  expect(new Set(descriptors.map((descriptor) => descriptor.id)).size).toBe(1);
+}
+
+function sessionStep(
+  run: WorkflowRunDetailResponseDto,
+  jobKey: string,
+  sequence: number,
+  stepKey: string,
+) {
+  const job = run.jobs.find((candidate) => candidate.key === jobKey);
+  if (!job) throw new Error(`Job ${jobKey} missing from run detail`);
+  const execution = job.job_executions.find((candidate) => candidate.sequence === sequence);
+  if (!execution) throw new Error(`Job ${jobKey} execution ${sequence} missing from run detail`);
+  const step = execution.steps.find((candidate) => candidate.key === stepKey);
+  if (!step) throw new Error(`Step ${jobKey}.${sequence}.${stepKey} missing from run detail`);
+  return step;
+}


### PR DESCRIPTION
## Summary

Add end-to-end coverage for a workflow that resumes one Pi session from a planning job into an implementation job and two listening executions. The scenario verifies transcript continuity, shared session identity, sequential event-batch claims, and terminal resolution.

This closes the ENG-1700 coverage gap by exercising the complete two-job resume path and listening continuation behavior through the public workflow APIs.

## Validation

- `mise exec -- turbo check --filter=@shipfox/e2e-flow-workflows`
- `mise exec -- turbo type --filter=@shipfox/e2e-flow-workflows`
- `mise exec -- turbo depcruise --filter=@shipfox/e2e-flow-workflows`
- `mise exec -- turbo test --filter=@shipfox/e2e-flow-workflows`
- `mise exec -- mise run e2e -- --filter=@shipfox/e2e-flow-workflows` (43 passed)

Closes ENG-1700

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds E2E coverage for resuming one Pi session across two jobs and two listening event batches, closing the ENG-1700 coverage gap.

- New test drives a plan job, an implement job, and two listening executions that continue the same session.
- Asserts transcript continuity, shared session ID, sequential event-batch claims, and terminal resolution.
- The listening step sends four events with a batch size of two and asserts each execution claims exactly its two events.
- Adds a `sessionContinuationWorkflow` helper to `listener-jobs.ts` that builds the workflow YAML.

<sup>Written for commit 1e4b02d86fef292118fa053001a5a9e9b4ab4f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

