### PR TITLE
[api-integration-core] Enforce repository scope for integration tools

### DIFF
--- a/.changeset/enforce-tool-repo-scope.md
+++ b/.changeset/enforce-tool-repo-scope.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-core-dto": minor
+---
+
+Enforces declared repository scope for integration tool calls and records equivalent authorization decisions across MCP and deterministic dispatch.

--- a/.changeset/enforce-tool-repo-scope.md
+++ b/.changeset/enforce-tool-repo-scope.md
@@ -1,6 +1,6 @@
 ---
-"@shipfox/api-integration-core": minor
-"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": major
+"@shipfox/api-integration-core-dto": major
 ---
 
-Enforces declared repository scope for integration tool calls and records equivalent authorization decisions across MCP and deterministic dispatch.
+Enforces the declared repository scope for integration tool calls so denied or partially unauthorized multi-target calls never open a provider session.

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -267,6 +267,7 @@ describe('integrationsInterModuleContract', () => {
     arguments: {owner: 'shipfox', repo: 'platform', issue_number: 1},
     caller: {
       kind: 'tool_step',
+      projectId: 'project-1',
       runId: 'run-1',
       jobExecutionId: 'execution-1',
       stepId: 'step-1',

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -336,6 +336,15 @@ describe('integrationsInterModuleContract', () => {
     ).toThrow();
   });
 
+  test.each([undefined, ''])('rejects a tool step caller with projectId %j', (projectId) => {
+    expect(() =>
+      integrationsInterModuleContract.methods.callTool.input.parse({
+        ...toolCallInput,
+        caller: {...toolCallInput.caller, projectId},
+      }),
+    ).toThrow();
+  });
+
   test.each([
     ['connection-not-found', {connectionId: '00000000-0000-4000-8000-000000000001'}],
     ['connection-inactive', {connectionId: '00000000-0000-4000-8000-000000000001'}],

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -93,6 +93,7 @@ const toolCallCaller = z.discriminatedUnion('kind', [
   z.object({kind: z.literal('agent')}),
   z.object({
     kind: z.literal('tool_step'),
+    projectId: z.string().min(1),
     runId: z.string().min(1),
     jobExecutionId: z.string().min(1),
     stepId: z.string().min(1),

--- a/libs/api/integration/core/src/core/tool-call-audit.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-audit.test.ts
@@ -188,6 +188,38 @@ describe('integration tool call audit', () => {
     );
   });
 
+  it('records non-denied authorization decisions and skips records without authorization fields', () => {
+    const recordMetric = vi.fn();
+    const recordAuthorizationMetric = vi.fn();
+    const logInfo = vi.fn();
+    const recorder = createIntegrationToolCallRecorder(agentCaller, {
+      recordMetric,
+      recordAuthorizationMetric,
+      logInfo,
+    });
+
+    recorder({
+      authorizedTool: auditTarget(),
+      arguments: {},
+      method: 'get',
+      outcome: 'success',
+      errorCode: 'none',
+      classification: 'connection',
+      repositoryAccess: 'selected',
+      decision: 'not-applicable',
+    });
+    recorder({arguments: {}, method: 'get', outcome: 'success', errorCode: 'none'});
+
+    expect(recordAuthorizationMetric).toHaveBeenCalledOnce();
+    expect(recordAuthorizationMetric).toHaveBeenCalledWith({
+      provider: 'github',
+      mode: 'selected',
+      classification: 'connection',
+      decision: 'not-applicable',
+      denial_reason: 'none',
+    });
+  });
+
   it('falls back to unknown labels and omits the lease context for a leaseless agent caller', () => {
     const recordMetric = vi.fn();
     const logInfo = vi.fn();

--- a/libs/api/integration/core/src/core/tool-call-audit.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-audit.test.ts
@@ -26,6 +26,7 @@ const agentCaller: IntegrationToolCallCaller = {
 const toolStepCaller: IntegrationToolCallCaller = {
   caller: 'tool_step',
   workspaceId: 'workspace-1',
+  projectId: 'project-1',
   runId: 'run-1',
   jobExecutionId: 'execution-1',
   stepId: 'step-1',
@@ -137,6 +138,54 @@ describe('integration tool call audit', () => {
     );
     expect(JSON.stringify(logInfo.mock.calls)).not.toContain('private-repository');
     expect(JSON.stringify(logInfo.mock.calls)).not.toContain('must-not-appear');
+  });
+
+  it('records repository authorization fields and bounded authorization labels', () => {
+    const recordMetric = vi.fn();
+    const recordAuthorizationMetric = vi.fn();
+    const logInfo = vi.fn();
+    const recorder = createIntegrationToolCallRecorder(agentCaller, {
+      recordMetric,
+      recordAuthorizationMetric,
+      logInfo,
+    });
+
+    recorder({
+      authorizedTool: auditTarget(),
+      arguments: {owner: 'shipfox', repo: 'platform'},
+      method: 'get',
+      outcome: 'tool-error',
+      errorCode: 'repository-not-granted',
+      repositories: [{owner: 'shipfox', name: 'platform'}],
+      classification: 'declared-targets',
+      repositoryAccess: 'selected',
+      decision: 'denied',
+      denialReason: 'repository_not_granted',
+      targetProjectIds: ['project-platform'],
+      runProjectId: 'project-run',
+      indirectTargetNote: 'The provider resolved a parent resource.',
+    });
+
+    expect(recordAuthorizationMetric).toHaveBeenCalledWith({
+      provider: 'github',
+      mode: 'selected',
+      classification: 'declared-targets',
+      decision: 'denied',
+      denial_reason: 'repository_not_granted',
+    });
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+        classification: 'declared-targets',
+        repositoryAccess: 'selected',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        targetProjectIds: ['project-platform'],
+        runProjectId: 'project-run',
+        indirectTargetNote: 'The provider resolved a parent resource.',
+      }),
+      'integration tool call audited',
+    );
   });
 
   it('falls back to unknown labels and omits the lease context for a leaseless agent caller', () => {

--- a/libs/api/integration/core/src/core/tool-call-audit.ts
+++ b/libs/api/integration/core/src/core/tool-call-audit.ts
@@ -7,9 +7,15 @@ import {logger} from '@shipfox/node-opentelemetry';
 import {
   type IntegrationAgentToolCallErrorLabel,
   type IntegrationAgentToolCallOutcome,
+  type IntegrationToolRepositoryAccessMode,
+  type IntegrationToolRepositoryClassification,
+  type IntegrationToolRepositoryDecision,
+  type IntegrationToolRepositoryDenialReason,
   recordIntegrationAgentToolCall,
+  recordIntegrationAgentToolRepositoryAuthorization,
 } from '#metrics/index.js';
 import type {IntegrationConnection} from './entities/connection.js';
+import type {RepositoryAuthorizationDenial} from './repository-authorizer.js';
 
 /**
  * Who asked for an integration tool call. The agent caller is the MCP gateway
@@ -22,6 +28,7 @@ export type IntegrationToolCallCaller =
   | {
       caller: 'tool_step';
       workspaceId: string;
+      projectId: string;
       runId: string;
       jobExecutionId: string;
       stepId: string;
@@ -45,6 +52,7 @@ export function callerLogContext(caller: IntegrationToolCallCaller): Record<stri
               jobExecutionId: caller.lease.jobExecutionId,
               workflowRunId: caller.lease.workflowRunId,
               workflowRunAttemptId: caller.lease.workflowRunAttemptId,
+              projectId: caller.lease.projectId,
               workspaceId: caller.lease.workspaceId,
               currentStepId: caller.lease.currentStepId,
               currentStepAttempt: caller.lease.currentStepAttempt,
@@ -53,6 +61,7 @@ export function callerLogContext(caller: IntegrationToolCallCaller): Record<stri
     : {
         caller: 'tool_step',
         workspaceId: caller.workspaceId,
+        projectId: caller.projectId,
         runId: caller.runId,
         jobExecutionId: caller.jobExecutionId,
         stepId: caller.stepId,
@@ -72,6 +81,17 @@ export interface IntegrationToolCallAuditTarget {
   tool: MaterializedAgentIntegrationToolConfigDto;
 }
 
+export interface IntegrationToolCallAuthorization {
+  repositories: readonly {owner: string; name: string}[];
+  classification: IntegrationToolRepositoryClassification;
+  repositoryAccess: IntegrationToolRepositoryAccessMode;
+  decision: IntegrationToolRepositoryDecision;
+  denialReason: IntegrationToolRepositoryDenialReason;
+  targetProjectIds: readonly string[];
+  runProjectId?: string | undefined;
+  indirectTargetNote?: string | undefined;
+}
+
 export interface IntegrationToolCallAuditRecord {
   authorizedTool?: IntegrationToolCallAuditTarget | undefined;
   arguments: unknown;
@@ -79,12 +99,42 @@ export interface IntegrationToolCallAuditRecord {
   outcome: IntegrationAgentToolCallOutcome;
   errorCode: IntegrationAgentToolCallErrorLabel;
   providerStatus?: number | undefined;
+  repositories?: readonly {owner: string; name: string}[] | undefined;
+  classification?: IntegrationToolRepositoryClassification | undefined;
+  repositoryAccess?: IntegrationToolRepositoryAccessMode | undefined;
+  decision?: IntegrationToolRepositoryDecision | undefined;
+  denialReason?: RepositoryAuthorizationDenial | 'none' | undefined;
+  targetProjectIds?: readonly string[] | undefined;
+  runProjectId?: string | undefined;
+  indirectTargetNote?: string | undefined;
+}
+
+export function integrationToolCallAuthorizationAuditFields(
+  authorization: IntegrationToolCallAuthorization | undefined,
+): Partial<IntegrationToolCallAuditRecord> {
+  return authorization === undefined
+    ? {}
+    : {
+        repositories: authorization.repositories,
+        classification: authorization.classification,
+        repositoryAccess: authorization.repositoryAccess,
+        decision: authorization.decision,
+        denialReason: authorization.denialReason,
+        targetProjectIds: authorization.targetProjectIds,
+        ...(authorization.runProjectId === undefined
+          ? {}
+          : {runProjectId: authorization.runProjectId}),
+        ...(authorization.indirectTargetNote === undefined
+          ? {}
+          : {indirectTargetNote: authorization.indirectTargetNote}),
+      };
 }
 
 export type IntegrationToolCallRecorder = (record: IntegrationToolCallAuditRecord) => void;
 
 export interface CreateIntegrationToolCallRecorderOptions {
   recordMetric?: typeof recordIntegrationAgentToolCall | undefined;
+  recordAuthorizationMetric?: typeof recordIntegrationAgentToolRepositoryAuthorization | undefined;
   logInfo?:
     | ((context: Record<string, unknown>, message: 'integration tool call audited') => void)
     | undefined;
@@ -95,12 +145,13 @@ export function createIntegrationToolCallRecorder(
   options: CreateIntegrationToolCallRecorderOptions = {},
 ): IntegrationToolCallRecorder {
   const recordMetric = options.recordMetric ?? recordIntegrationAgentToolCall;
+  const recordAuthorizationMetric =
+    options.recordAuthorizationMetric ?? recordIntegrationAgentToolRepositoryAuthorization;
   const logInfo = options.logInfo ?? ((context, message) => logger().info(context, message));
 
   return (record) => {
     const provider = record.authorizedTool?.integration.provider ?? UNKNOWN_TOOL_LABEL;
     const toolId = record.authorizedTool?.tool.id ?? UNKNOWN_TOOL_LABEL;
-
     recordMetric({
       caller: caller.caller,
       provider,
@@ -109,22 +160,61 @@ export function createIntegrationToolCallRecorder(
       outcome: record.outcome,
       error_code: record.errorCode,
     });
-
-    logInfo(
-      {
-        ...callerLogContext(caller),
-        connectionId: record.authorizedTool?.connection.id,
-        provider,
-        toolId,
-        method: record.method,
-        outcome: record.outcome,
-        errorCode: record.errorCode,
-        ...(record.providerStatus === undefined ? {} : {providerStatus: record.providerStatus}),
-        argumentSummary: summarizeIntegrationToolArguments(record.arguments),
-      },
-      'integration tool call audited',
-    );
+    recordAuthorizationMetricIfPresent(recordAuthorizationMetric, provider, record);
+    logInfo(auditLogContext(caller, record, provider, toolId), 'integration tool call audited');
   };
+}
+
+function recordAuthorizationMetricIfPresent(
+  recordMetric: typeof recordIntegrationAgentToolRepositoryAuthorization,
+  provider: string,
+  record: IntegrationToolCallAuditRecord,
+): void {
+  if (
+    record.repositoryAccess === undefined ||
+    record.classification === undefined ||
+    record.decision === undefined
+  ) {
+    return;
+  }
+  recordMetric({
+    provider,
+    mode: record.repositoryAccess,
+    classification: record.classification,
+    decision: record.decision,
+    denial_reason: record.denialReason ?? 'none',
+  });
+}
+
+function auditLogContext(
+  caller: IntegrationToolCallCaller,
+  record: IntegrationToolCallAuditRecord,
+  provider: string,
+  toolId: string,
+): Record<string, unknown> {
+  return {
+    ...callerLogContext(caller),
+    ...optionalLogField('connectionId', record.authorizedTool?.connection.id),
+    provider,
+    toolId,
+    method: record.method,
+    outcome: record.outcome,
+    errorCode: record.errorCode,
+    ...optionalLogField('repositories', record.repositories),
+    ...optionalLogField('classification', record.classification),
+    ...optionalLogField('repositoryAccess', record.repositoryAccess),
+    ...optionalLogField('decision', record.decision),
+    ...optionalLogField('denialReason', record.denialReason),
+    ...optionalLogField('targetProjectIds', record.targetProjectIds),
+    ...optionalLogField('runProjectId', record.runProjectId),
+    ...optionalLogField('indirectTargetNote', record.indirectTargetNote),
+    ...optionalLogField('providerStatus', record.providerStatus),
+    argumentSummary: summarizeIntegrationToolArguments(record.arguments),
+  };
+}
+
+function optionalLogField(key: string, value: unknown): Record<string, unknown> {
+  return value === undefined ? {} : {[key]: value};
 }
 
 export interface IntegrationToolArgumentSummary {

--- a/libs/api/integration/core/src/core/tool-call-service.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.test.ts
@@ -3,6 +3,7 @@ import type {logger as loggerFactoryType} from '@shipfox/node-opentelemetry';
 import {
   type AgentToolsProviderOptions,
   catalogTool,
+  catalogWithRepositoryScope,
   connection,
   leaseContext,
   materializedIntegration,
@@ -12,10 +13,11 @@ import {
 import {IntegrationProviderError} from './errors.js';
 import type {AgentToolRepositoryScopeClassifier} from './providers/agent-tools.js';
 import {createIntegrationProviderRegistry} from './providers/registry.js';
-import type {
-  RepositoryAuthorizationResult,
-  RepositoryAuthorizer,
-  ResolveRepositoryAuthorizationInput,
+import {
+  type RepositoryAuthorizationResult,
+  RepositoryAuthorizationTargetInvalidError,
+  type RepositoryAuthorizer,
+  type ResolveRepositoryAuthorizationInput,
 } from './repository-authorizer.js';
 import {
   callIntegrationTool,
@@ -126,17 +128,93 @@ describe('callIntegrationTool', () => {
     expect(onOpenSession).not.toHaveBeenCalled();
   });
 
+  it('re-reads the current catalog before classifying an authorized call', async () => {
+    const staleEntry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({kind: 'connection'}),
+    });
+    const liveEntry = catalogTool({
+      methods: undefined,
+      repositoryScope: declaredRepositoryScope,
+    });
+    const onOpenSession = vi.fn();
+    const resolveRepositoryAuthorization = vi.fn(
+      async (): Promise<RepositoryAuthorizationResult> => ({
+        authorized: false,
+        reason: 'repository_not_granted',
+      }),
+    );
+    const registry = registryWithAgentTools([liveEntry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+    const catalog = vi.spyOn(registry.getAdapter('github', 'agent_tools'), 'catalog');
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: staleEntry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {code: 'repository-not-granted'},
+      authorization: {
+        classification: 'declared-targets',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+      },
+    });
+    expect(catalog).toHaveBeenCalledOnce();
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledOnce();
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('does not inherit an entry classifier for a method without its own classifier', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({repositoryScope: declaredRepositoryScope});
+    const resolveRepositoryAuthorization = vi.fn();
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {
+        code: 'provider-rejected',
+        message: 'Enforced integration tool is missing a repository scope classifier',
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
   it('authorizes every declared target and denies the whole multi-target call', async () => {
     const onOpenSession = vi.fn();
-    const entry = catalogTool({
-      repositoryScope: () => ({
-        kind: 'declared-targets',
-        repositories: [
-          {owner: 'shipfox', name: 'platform'},
-          {owner: 'shipfox', name: 'private'},
-        ],
-      }),
-    });
+    const entry = catalogWithRepositoryScope(() => ({
+      kind: 'declared-targets',
+      repositories: [
+        {owner: 'shipfox', name: 'platform'},
+        {owner: 'shipfox', name: 'private'},
+      ],
+    }));
     const resolveRepositoryAuthorization = vi.fn(
       async ({
         repository,
@@ -176,6 +254,159 @@ describe('callIntegrationTool', () => {
       {kind: 'name', owner: 'shipfox', name: 'platform'},
       {kind: 'name', owner: 'shipfox', name: 'private'},
     ]);
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('maps an invalid declared target to a bounded repository denial', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({
+        kind: 'declared-targets',
+        repositories: [{owner: 'octo/hello', name: 'platform'}],
+      }),
+    });
+    const resolveRepositoryAuthorization = vi.fn(() =>
+      Promise.reject(new RepositoryAuthorizationTargetInvalidError()),
+    );
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {
+        code: 'repository-not-granted',
+        message: 'Repository is not authorized for this integration connection',
+      },
+      authorization: {
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        repositories: [{owner: 'octo/hello', name: 'platform'}],
+      },
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledOnce();
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('denies an enforced empty declared-targets scope without opening a session', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({kind: 'declared-targets', repositories: []}),
+    });
+    const resolveRepositoryAuthorization = vi.fn();
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {code: 'repository-not-granted'},
+      authorization: {
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        repositories: [],
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('maps an unavailable authorization store to a bounded denial', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const resolveRepositoryAuthorization = vi.fn(async (): Promise<undefined> => undefined);
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {
+        code: 'repository-authorization-unavailable',
+        message: 'Repository authorization is temporarily unavailable',
+      },
+      authorization: {
+        decision: 'denied',
+        denialReason: 'authorization_store_unavailable',
+      },
+    });
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('maps an ambiguous authorization result to a bounded denial', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const resolveRepositoryAuthorization = vi.fn(
+      async (): Promise<RepositoryAuthorizationResult> => ({
+        authorized: false,
+        reason: 'repository_ambiguous',
+      }),
+    );
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {
+        code: 'repository-ambiguous',
+        message: 'Repository authorization is ambiguous for this integration connection',
+      },
+      authorization: {
+        decision: 'denied',
+        denialReason: 'repository_ambiguous',
+      },
+    });
     expect(onOpenSession).not.toHaveBeenCalled();
   });
 
@@ -249,6 +480,38 @@ describe('callIntegrationTool', () => {
     });
     expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
     expect(onOpenSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch the catalog when repository authorization is disabled', async () => {
+    const onOpenSession = vi.fn();
+    const registry = registryWithAgentTools([catalogTool()], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+    const catalog = vi.spyOn(registry.getAdapter('github', 'agent_tools'), 'catalog');
+    const resolveRepositoryAuthorization = vi.fn();
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          repositoryAuthorizer: {enabled: false, resolveRepositoryAuthorization},
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        classification: 'connection',
+        decision: 'not-enforced',
+        denialReason: 'none',
+      },
+    });
+    expect(catalog).not.toHaveBeenCalled();
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).toHaveBeenCalledOnce();
   });
 
   it('passes the explicit all repository mode to each authorization target', async () => {
@@ -522,6 +785,79 @@ describe('callIntegrationTool', () => {
     expect(serviceMocks.loggerError).not.toHaveBeenCalled();
   });
 
+  it('does not load the catalog or authorization store after an early abort', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const onOpenSession = vi.fn();
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+    const catalog = vi.spyOn(registry.getAdapter('github', 'agent_tools'), 'catalog');
+    const resolveRepositoryAuthorization = vi.fn();
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+          signal: controller.signal,
+        },
+      ),
+    );
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: {code: 'cancelled', message: 'Integration tool call cancelled'},
+    });
+    expect(catalog).not.toHaveBeenCalled();
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('stops waiting for authorization when the call signal aborts', async () => {
+    const controller = new AbortController();
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const onOpenSession = vi.fn();
+    let releaseAuthorization: ((result: RepositoryAuthorizationResult) => void) | undefined;
+    const authorization = new Promise<RepositoryAuthorizationResult>((resolve) => {
+      releaseAuthorization = resolve;
+    });
+    const resolveRepositoryAuthorization = vi.fn(() => authorization);
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const call = callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAuthorizer: {enabled: true, resolveRepositoryAuthorization},
+          signal: controller.signal,
+        },
+      ),
+    );
+    await vi.waitFor(() => expect(resolveRepositoryAuthorization).toHaveBeenCalledOnce());
+
+    controller.abort();
+
+    await expect(call).resolves.toEqual({
+      outcome: 'error',
+      error: {code: 'cancelled', message: 'Integration tool call cancelled'},
+    });
+    expect(onOpenSession).not.toHaveBeenCalled();
+    releaseAuthorization?.({
+      authorized: true,
+      repository: {owner: 'shipfox', name: 'platform'},
+    });
+  });
+
   it('closes a session that resolves after an abort during session opening', async () => {
     const onClose = vi.fn();
     const controller = new AbortController();
@@ -717,12 +1053,6 @@ const declaredRepositoryScope: AgentToolRepositoryScopeClassifier = (arguments_)
     },
   ],
 });
-
-function catalogWithRepositoryScope(
-  repositoryScope: AgentToolRepositoryScopeClassifier,
-): ReturnType<typeof catalogTool> {
-  return catalogTool({repositoryScope});
-}
 
 describe('loadAuthorizedToolConnection', () => {
   const params = {

--- a/libs/api/integration/core/src/core/tool-call-service.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.test.ts
@@ -10,7 +10,13 @@ import {
   registryWithAgentTools,
 } from '#test/agent-tools-gateway-helpers.js';
 import {IntegrationProviderError} from './errors.js';
+import type {AgentToolRepositoryScopeClassifier} from './providers/agent-tools.js';
 import {createIntegrationProviderRegistry} from './providers/registry.js';
+import type {
+  RepositoryAuthorizationResult,
+  RepositoryAuthorizer,
+  ResolveRepositoryAuthorizationInput,
+} from './repository-authorizer.js';
 import {
   callIntegrationTool,
   type IntegrationToolCallInput,
@@ -68,6 +74,221 @@ describe('callIntegrationTool', () => {
       ],
     });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies a declared repository before opening a provider session', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const resolveRepositoryAuthorization = vi.fn(
+      async (): Promise<RepositoryAuthorizationResult> => ({
+        authorized: false,
+        reason: 'repository_not_granted',
+      }),
+    );
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {
+        code: 'repository-not-granted',
+        message: 'Repository is not authorized for this integration connection',
+      },
+      authorization: {
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+        classification: 'declared-targets',
+        repositoryAccess: 'selected',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        targetProjectIds: [],
+      },
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-1',
+        connectionId: 'connection-1',
+        mode: 'selected',
+        repository: {kind: 'name', owner: 'shipfox', name: 'platform'},
+        capability: 'tools',
+        request: expect.any(Object),
+      }),
+    );
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('authorizes every declared target and denies the whole multi-target call', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      repositoryScope: () => ({
+        kind: 'declared-targets',
+        repositories: [
+          {owner: 'shipfox', name: 'platform'},
+          {owner: 'shipfox', name: 'private'},
+        ],
+      }),
+    });
+    const resolveRepositoryAuthorization = vi.fn(
+      async ({
+        repository,
+      }: ResolveRepositoryAuthorizationInput): Promise<RepositoryAuthorizationResult> =>
+        repository.kind === 'name' && repository.name === 'private'
+          ? {authorized: false, reason: 'repository_not_granted'}
+          : {
+              authorized: true,
+              repository: {owner: 'shipfox', name: 'platform'},
+              targetProjectId: 'project-platform',
+            },
+    );
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {code: 'repository-not-granted'},
+      authorization: {
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        targetProjectIds: ['project-platform'],
+      },
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledTimes(2);
+    expect(resolveRepositoryAuthorization.mock.calls.map(([input]) => input.repository)).toEqual([
+      {kind: 'name', owner: 'shipfox', name: 'platform'},
+      {kind: 'name', owner: 'shipfox', name: 'private'},
+    ]);
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps connection-scoped calls available and records their classification', async () => {
+    const onOpenSession = vi.fn();
+    const baseEntry = catalogTool();
+    const entry = catalogTool({
+      repositoryScope: declaredRepositoryScope,
+      methods: baseEntry.methods?.map((method) => ({
+        ...method,
+        repositoryScope: () => ({kind: 'connection'}),
+      })),
+      indirectTargetNote: 'Provider resolves the destination from the connection.',
+    });
+    const resolveRepositoryAuthorization = vi.fn();
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        repositories: [],
+        classification: 'connection',
+        repositoryAccess: 'selected',
+        decision: 'not-applicable',
+        denialReason: 'none',
+        targetProjectIds: [],
+        indirectTargetNote: 'Provider resolves the destination from the connection.',
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps provider-unclassified calls available while recording declared targets', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const resolveRepositoryAuthorization = vi.fn();
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'unclassified',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+        classification: 'unclassified',
+        repositoryAccess: 'selected',
+        decision: 'not-applicable',
+        denialReason: 'none',
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the explicit all repository mode to each authorization target', async () => {
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const resolveRepositoryAuthorization = vi.fn(
+      async (): Promise<RepositoryAuthorizationResult> => ({
+        authorized: true,
+        repository: {owner: 'shipfox', name: 'platform'},
+        targetProjectId: 'project-platform',
+      }),
+    );
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {repositoryAuthorization: 'enforced'});
+
+    const result = await callIntegrationTool(
+      createInput(
+        {},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAccessMode: 'all',
+          repositoryAuthorizer,
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        repositoryAccess: 'all',
+        decision: 'allowed',
+        targetProjectIds: ['project-platform'],
+      },
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({mode: 'all'}),
+    );
   });
 
   it.each([
@@ -204,6 +425,7 @@ describe('callIntegrationTool', () => {
         caller: {
           caller: 'tool_step',
           workspaceId: 'workspace-1',
+          projectId: 'project-1',
           runId: 'run-1',
           jobExecutionId: 'execution-1',
           stepId: 'step-1',
@@ -219,6 +441,7 @@ describe('callIntegrationTool', () => {
     expect(serviceMocks.loggerError.mock.calls[0]?.[0]).toEqual({
       caller: 'tool_step',
       workspaceId: 'workspace-1',
+      projectId: 'project-1',
       runId: 'run-1',
       jobExecutionId: 'execution-1',
       stepId: 'step-1',
@@ -483,6 +706,22 @@ function createInput(
     reportError,
     ...overrides,
   };
+}
+
+const declaredRepositoryScope: AgentToolRepositoryScopeClassifier = (arguments_) => ({
+  kind: 'declared-targets',
+  repositories: [
+    {
+      owner: String(arguments_.owner),
+      name: String(arguments_.repo),
+    },
+  ],
+});
+
+function catalogWithRepositoryScope(
+  repositoryScope: AgentToolRepositoryScopeClassifier,
+): ReturnType<typeof catalogTool> {
+  return catalogTool({repositoryScope});
 }
 
 describe('loadAuthorizedToolConnection', () => {

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -22,12 +22,21 @@ import type {
   AgentToolCatalogEntry,
   AgentToolCatalogMethod,
   AgentToolJsonSchema,
+  AgentToolRepositoryScope,
   AgentToolSession,
   AgentToolsProvider,
 } from './providers/agent-tools.js';
 import type {IntegrationProviderRegistry} from './providers/registry.js';
 import {
+  createRepositoryAuthorizationRequestContext,
+  type RepositoryAuthorizationDenial,
+  type RepositoryAuthorizationMode,
+  type RepositoryAuthorizer,
+  repositoryAuthorizationClientErrorCode,
+} from './repository-authorizer.js';
+import {
   callerLogContext,
+  type IntegrationToolCallAuthorization,
   type IntegrationToolCallCaller,
   NO_METHOD_LABEL,
 } from './tool-call-audit.js';
@@ -42,8 +51,16 @@ export interface IntegrationToolCallError {
 }
 
 export type IntegrationToolCallOutcome =
-  | {outcome: 'success'; result: CallToolResult}
-  | {outcome: 'error'; error: IntegrationToolCallError};
+  | {
+      outcome: 'success';
+      result: CallToolResult;
+      authorization?: IntegrationToolCallAuthorization | undefined;
+    }
+  | {
+      outcome: 'error';
+      error: IntegrationToolCallError;
+      authorization?: IntegrationToolCallAuthorization | undefined;
+    };
 
 export interface IntegrationToolCallInput {
   registry: IntegrationProviderRegistry;
@@ -56,6 +73,11 @@ export interface IntegrationToolCallInput {
   arguments: Record<string, unknown>;
   method?: string | undefined;
   caller: IntegrationToolCallCaller;
+  /** Live catalog metadata used by the shared repository-scope boundary. */
+  catalogEntry?: AgentToolCatalogEntry | undefined;
+  /** The persisted connection mode will be threaded here when that schema lands. */
+  repositoryAccessMode?: RepositoryAuthorizationMode | undefined;
+  repositoryAuthorizer?: RepositoryAuthorizer | undefined;
   /** Cooperative cancellation for one call; an abort maps to `provider-timeout`. */
   signal?: AbortSignal | undefined;
   logger?: typeof logger;
@@ -128,6 +150,7 @@ function handleIntegrationToolError(
   state: ToolSessionState,
   log: typeof logger,
   report: typeof reportError,
+  authorization?: IntegrationToolCallAuthorization | undefined,
 ): IntegrationToolCallOutcome {
   if (input.signal?.aborted) {
     if (state.openingSession !== undefined && state.session === undefined) {
@@ -136,11 +159,11 @@ function handleIntegrationToolError(
         () => undefined,
       );
     }
-    return {outcome: 'error', error: abortOutcome(input.signal)};
+    return withAuthorization({outcome: 'error', error: abortOutcome(input.signal)}, authorization);
   }
   const errorRecord = errorResult(error);
   logIntegrationToolError(input, error, errorRecord, log, report);
-  return {outcome: 'error', error: errorRecord};
+  return withAuthorization({outcome: 'error', error: errorRecord}, authorization);
 }
 
 export async function callIntegrationTool(
@@ -149,14 +172,201 @@ export async function callIntegrationTool(
   const log = input.logger ?? logger;
   const report = input.reportError ?? reportError;
   const state: ToolSessionState = {session: undefined, openingSession: undefined};
+  let authorization: IntegrationToolCallAuthorization | undefined;
 
   try {
-    return await executeIntegrationTool(input, state);
+    if (input.repositoryAuthorizer !== undefined) {
+      const catalogEntry = await liveCatalogEntry(input);
+      authorization = await resolveIntegrationToolAuthorization(input, catalogEntry);
+      if (authorization.decision === 'denied' && authorization.denialReason !== 'none') {
+        return withAuthorization(
+          {
+            outcome: 'error',
+            error: {
+              code: repositoryAuthorizationClientErrorCode(authorization.denialReason),
+              message: repositoryAuthorizationErrorMessage(authorization.denialReason),
+            },
+          },
+          authorization,
+        );
+      }
+    }
+
+    return withAuthorization(await executeIntegrationTool(input, state), authorization);
   } catch (error) {
-    return handleIntegrationToolError(input, error, state, log, report);
+    return handleIntegrationToolError(input, error, state, log, report, authorization);
   } finally {
     await closeSession(state.session, log, report);
   }
+}
+
+/**
+ * Evaluates the live tool classifier and the local authorizer immediately
+ * before a provider session is opened. This is deliberately shared by the MCP
+ * and deterministic callers through `callIntegrationTool`.
+ */
+export async function resolveIntegrationToolAuthorization(
+  input: IntegrationToolCallInput,
+  catalogEntry: AgentToolCatalogEntry | undefined,
+): Promise<IntegrationToolCallAuthorization> {
+  const mode = input.repositoryAccessMode ?? 'selected';
+  const provider = input.registry.get(input.integration.provider);
+  const scope = classifyToolCall(
+    catalogEntry,
+    input.method,
+    input.arguments,
+    provider.repositoryAuthorization,
+  );
+  const authorization = createBaseAuthorization(
+    input,
+    mode,
+    provider.repositoryAuthorization,
+    scope,
+  );
+
+  if (!shouldAuthorizeDeclaredTargets(input, provider.repositoryAuthorization, scope)) {
+    return authorization;
+  }
+  return await authorizeDeclaredTargets(input, mode, scope, authorization);
+}
+
+function createBaseAuthorization(
+  input: IntegrationToolCallInput,
+  mode: RepositoryAuthorizationMode,
+  providerAuthorization: 'enforced' | 'unclassified' | undefined,
+  scope: ClassifiedToolCallScope,
+): IntegrationToolCallAuthorization {
+  const runProject = runProjectId(input.caller);
+  return {
+    repositories: scope.kind === 'declared-targets' ? scope.repositories : [],
+    classification: providerAuthorization === 'enforced' ? scope.kind : 'unclassified',
+    repositoryAccess: mode,
+    decision: input.repositoryAuthorizer?.enabled ? 'not-applicable' : 'not-enforced',
+    denialReason: 'none',
+    targetProjectIds: [],
+    ...(runProject === undefined ? {} : {runProjectId: runProject}),
+    ...(scope.indirectTargetNote === undefined
+      ? {}
+      : {indirectTargetNote: scope.indirectTargetNote}),
+  };
+}
+
+function shouldAuthorizeDeclaredTargets(
+  input: IntegrationToolCallInput,
+  providerAuthorization: 'enforced' | 'unclassified' | undefined,
+  scope: ClassifiedToolCallScope,
+): scope is ClassifiedToolCallScope & {kind: 'declared-targets'} {
+  return (
+    input.repositoryAuthorizer?.enabled === true &&
+    providerAuthorization === 'enforced' &&
+    scope.kind === 'declared-targets'
+  );
+}
+
+async function authorizeDeclaredTargets(
+  input: IntegrationToolCallInput,
+  mode: RepositoryAuthorizationMode,
+  scope: ClassifiedToolCallScope & {kind: 'declared-targets'},
+  authorization: IntegrationToolCallAuthorization,
+): Promise<IntegrationToolCallAuthorization> {
+  const authorizer = input.repositoryAuthorizer;
+  if (authorizer === undefined) return authorization;
+
+  const request = createRepositoryAuthorizationRequestContext();
+  const targetProjectIds: string[] = [];
+  let denialReason: RepositoryAuthorizationDenial | undefined;
+  for (const repository of scope.repositories) {
+    const result = await authorizer.resolveRepositoryAuthorization({
+      workspaceId: input.connection.workspaceId,
+      connectionId: input.connection.id,
+      mode,
+      repository: {kind: 'name', owner: repository.owner, name: repository.name},
+      capability: 'tools',
+      request,
+    });
+    if (result === undefined) {
+      denialReason ??= 'authorization_store_unavailable';
+      continue;
+    }
+    if (!result.authorized) {
+      denialReason ??= result.reason;
+      continue;
+    }
+    if (
+      result.targetProjectId !== undefined &&
+      !targetProjectIds.includes(result.targetProjectId)
+    ) {
+      targetProjectIds.push(result.targetProjectId);
+    }
+  }
+
+  return denialReason === undefined
+    ? {...authorization, decision: 'allowed', targetProjectIds}
+    : {...authorization, decision: 'denied', denialReason, targetProjectIds};
+}
+
+type ClassifiedToolCallScope = AgentToolRepositoryScope & {
+  indirectTargetNote?: string | undefined;
+};
+
+async function liveCatalogEntry(
+  input: IntegrationToolCallInput,
+): Promise<AgentToolCatalogEntry | undefined> {
+  if (input.catalogEntry?.id === input.tool.id) return input.catalogEntry;
+  const catalog = await input.registry
+    .getAdapter(input.integration.provider, 'agent_tools')
+    .catalog();
+  return catalog.find((entry) => entry.id === input.tool.id);
+}
+
+function classifyToolCall(
+  entry: AgentToolCatalogEntry | undefined,
+  method: string | undefined,
+  arguments_: Record<string, unknown>,
+  providerAuthorization: 'enforced' | 'unclassified' | undefined,
+): ClassifiedToolCallScope {
+  const catalogMethod = entry?.methods?.find((candidate) => candidate.id === method);
+  const classifier = catalogMethod?.repositoryScope ?? entry?.repositoryScope;
+  if (classifier === undefined) {
+    if (providerAuthorization === 'enforced') {
+      throw new IntegrationProviderError(
+        'provider-rejected',
+        'Enforced integration tool is missing a repository scope classifier',
+      );
+    }
+    return {kind: 'connection'};
+  }
+
+  return {
+    ...classifier(arguments_),
+    ...((catalogMethod?.indirectTargetNote ?? entry?.indirectTargetNote) === undefined
+      ? {}
+      : {
+          indirectTargetNote: catalogMethod?.indirectTargetNote ?? entry?.indirectTargetNote,
+        }),
+  };
+}
+
+function runProjectId(caller: IntegrationToolCallCaller): string | undefined {
+  return caller.caller === 'agent' ? caller.lease?.projectId : caller.projectId;
+}
+
+function repositoryAuthorizationErrorMessage(reason: RepositoryAuthorizationDenial): string {
+  switch (reason) {
+    case 'repository_not_granted':
+      return 'Repository is not authorized for this integration connection';
+    case 'repository_ambiguous':
+      return 'Repository authorization is ambiguous for this integration connection';
+    case 'authorization_store_unavailable':
+      return 'Repository authorization is temporarily unavailable';
+  }
+}
+
+function withAuthorization(
+  outcome: IntegrationToolCallOutcome,
+  authorization: IntegrationToolCallAuthorization | undefined,
+): IntegrationToolCallOutcome {
+  return authorization === undefined ? outcome : {...outcome, authorization};
 }
 
 export interface LoadAuthorizedToolConnectionParams {

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -31,6 +31,8 @@ import {
   createRepositoryAuthorizationRequestContext,
   type RepositoryAuthorizationDenial,
   type RepositoryAuthorizationMode,
+  type RepositoryAuthorizationResult,
+  RepositoryAuthorizationTargetInvalidError,
   type RepositoryAuthorizer,
   repositoryAuthorizationClientErrorCode,
 } from './repository-authorizer.js';
@@ -175,8 +177,13 @@ export async function callIntegrationTool(
   let authorization: IntegrationToolCallAuthorization | undefined;
 
   try {
+    if (input.signal?.aborted) {
+      return {outcome: 'error', error: abortOutcome(input.signal)};
+    }
     if (input.repositoryAuthorizer !== undefined) {
-      const catalogEntry = await liveCatalogEntry(input);
+      const catalogEntry = input.repositoryAuthorizer.enabled
+        ? await liveCatalogEntry(input)
+        : input.catalogEntry;
       authorization = await resolveIntegrationToolAuthorization(input, catalogEntry);
       if (authorization.decision === 'denied' && authorization.denialReason !== 'none') {
         return withAuthorization(
@@ -205,7 +212,7 @@ export async function callIntegrationTool(
  * before a provider session is opened. This is deliberately shared by the MCP
  * and deterministic callers through `callIntegrationTool`.
  */
-export async function resolveIntegrationToolAuthorization(
+async function resolveIntegrationToolAuthorization(
   input: IntegrationToolCallInput,
   catalogEntry: AgentToolCatalogEntry | undefined,
 ): Promise<IntegrationToolCallAuthorization> {
@@ -216,6 +223,7 @@ export async function resolveIntegrationToolAuthorization(
     input.method,
     input.arguments,
     provider.repositoryAuthorization,
+    input.repositoryAuthorizer?.enabled === true,
   );
   const authorization = createBaseAuthorization(
     input,
@@ -272,18 +280,25 @@ async function authorizeDeclaredTargets(
   const authorizer = input.repositoryAuthorizer;
   if (authorizer === undefined) return authorization;
 
+  if (scope.repositories.length === 0) {
+    return {
+      ...authorization,
+      decision: 'denied',
+      denialReason: 'repository_not_granted',
+    };
+  }
+
   const request = createRepositoryAuthorizationRequestContext();
   const targetProjectIds: string[] = [];
   let denialReason: RepositoryAuthorizationDenial | undefined;
   for (const repository of scope.repositories) {
-    const result = await authorizer.resolveRepositoryAuthorization({
-      workspaceId: input.connection.workspaceId,
-      connectionId: input.connection.id,
+    const result = await resolveDeclaredTargetAuthorization(
+      input,
+      authorizer,
       mode,
-      repository: {kind: 'name', owner: repository.owner, name: repository.name},
-      capability: 'tools',
+      repository,
       request,
-    });
+    );
     if (result === undefined) {
       denialReason ??= 'authorization_store_unavailable';
       continue;
@@ -305,6 +320,37 @@ async function authorizeDeclaredTargets(
     : {...authorization, decision: 'denied', denialReason, targetProjectIds};
 }
 
+async function resolveDeclaredTargetAuthorization(
+  input: IntegrationToolCallInput,
+  authorizer: RepositoryAuthorizer,
+  mode: RepositoryAuthorizationMode,
+  repository: {owner: string; name: string},
+  request: ReturnType<typeof createRepositoryAuthorizationRequestContext>,
+): Promise<RepositoryAuthorizationResult | undefined> {
+  if (input.signal?.aborted) throw abortReason(input.signal);
+  try {
+    return await raceWithSignal(
+      Promise.resolve().then(() => {
+        if (input.signal?.aborted) throw abortReason(input.signal);
+        return authorizer.resolveRepositoryAuthorization({
+          workspaceId: input.connection.workspaceId,
+          connectionId: input.connection.id,
+          mode,
+          repository: {kind: 'name', owner: repository.owner, name: repository.name},
+          capability: 'tools',
+          request,
+        });
+      }),
+      input.signal,
+    );
+  } catch (error) {
+    if (error instanceof RepositoryAuthorizationTargetInvalidError) {
+      return {authorized: false, reason: 'repository_not_granted'};
+    }
+    throw error;
+  }
+}
+
 type ClassifiedToolCallScope = AgentToolRepositoryScope & {
   indirectTargetNote?: string | undefined;
 };
@@ -312,10 +358,13 @@ type ClassifiedToolCallScope = AgentToolRepositoryScope & {
 async function liveCatalogEntry(
   input: IntegrationToolCallInput,
 ): Promise<AgentToolCatalogEntry | undefined> {
-  if (input.catalogEntry?.id === input.tool.id) return input.catalogEntry;
-  const catalog = await input.registry
-    .getAdapter(input.integration.provider, 'agent_tools')
-    .catalog();
+  const catalog = await raceWithSignal(
+    Promise.resolve().then(() => {
+      if (input.signal?.aborted) throw abortReason(input.signal);
+      return input.registry.getAdapter(input.integration.provider, 'agent_tools').catalog();
+    }),
+    input.signal,
+  );
   return catalog.find((entry) => entry.id === input.tool.id);
 }
 
@@ -324,11 +373,18 @@ function classifyToolCall(
   method: string | undefined,
   arguments_: Record<string, unknown>,
   providerAuthorization: 'enforced' | 'unclassified' | undefined,
+  enforceRepositoryAuthorization: boolean,
 ): ClassifiedToolCallScope {
   const catalogMethod = entry?.methods?.find((candidate) => candidate.id === method);
-  const classifier = catalogMethod?.repositoryScope ?? entry?.repositoryScope;
+  const classifier =
+    entry?.methods === undefined
+      ? entry?.repositoryScope
+      : (catalogMethod?.repositoryScope ??
+        (enforceRepositoryAuthorization && providerAuthorization === 'enforced'
+          ? undefined
+          : entry?.repositoryScope));
   if (classifier === undefined) {
-    if (providerAuthorization === 'enforced') {
+    if (enforceRepositoryAuthorization && providerAuthorization === 'enforced') {
       throw new IntegrationProviderError(
         'provider-rejected',
         'Enforced integration tool is missing a repository scope classifier',

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -168,6 +168,7 @@ export type {
   IntegrationToolArgumentSummary,
   IntegrationToolCallAuditRecord,
   IntegrationToolCallAuditTarget,
+  IntegrationToolCallAuthorization,
   IntegrationToolCallCaller,
   IntegrationToolCallRecorder,
 } from '#core/tool-call-audit.js';
@@ -175,6 +176,7 @@ export {
   callerLogContext,
   createIntegrationToolCallRecorder,
   INVALID_METHOD_LABEL,
+  integrationToolCallAuthorizationAuditFields,
   NO_METHOD_LABEL,
   summarizeIntegrationToolArguments,
   UNKNOWN_TOOL_LABEL,
@@ -188,6 +190,7 @@ export type {
 export {
   callIntegrationTool,
   loadAuthorizedToolConnection,
+  resolveIntegrationToolAuthorization,
 } from '#core/tool-call-service.js';
 export type {
   GetIntegrationConnectionByIdFn,
@@ -322,7 +325,7 @@ export async function createIntegrationsContext(
   const module: ShipfoxModule = {
     name: 'integrations',
     interModulePresentations: [
-      createIntegrationsInterModulePresentation({registry, sourceControl}),
+      createIntegrationsInterModulePresentation({registry, sourceControl, repositoryAuthorizer}),
     ],
     startupTasks: runStartupTasks,
     database: [
@@ -334,6 +337,7 @@ export async function createIntegrationsContext(
         ? {
             workflows: options.agentTools.workflows,
             getIntegrationConnectionById,
+            repositoryAuthorizer,
           }
         : undefined,
     }),

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -190,7 +190,6 @@ export type {
 export {
   callIntegrationTool,
   loadAuthorizedToolConnection,
-  resolveIntegrationToolAuthorization,
 } from '#core/tool-call-service.js';
 export type {
   GetIntegrationConnectionByIdFn,

--- a/libs/api/integration/core/src/metrics/instance.ts
+++ b/libs/api/integration/core/src/metrics/instance.ts
@@ -11,12 +11,31 @@ export type IntegrationAgentToolCallOutcome =
 
 export type IntegrationToolCallCallerLabel = 'agent' | 'tool_step';
 
+export type IntegrationToolRepositoryAccessMode = 'selected' | 'all';
+export type IntegrationToolRepositoryClassification =
+  | 'declared-targets'
+  | 'connection'
+  | 'unclassified';
+export type IntegrationToolRepositoryDecision =
+  | 'allowed'
+  | 'denied'
+  | 'not-applicable'
+  | 'not-enforced';
+export type IntegrationToolRepositoryDenialReason =
+  | 'none'
+  | 'repository_not_granted'
+  | 'repository_ambiguous'
+  | 'authorization_store_unavailable';
+
 export type IntegrationAgentToolCallErrorCode =
   | 'invalid-request'
   | 'unknown'
   | 'provider-timeout'
   | 'cancelled'
   | 'credentials-unavailable'
+  | 'repository-not-granted'
+  | 'repository-ambiguous'
+  | 'repository-authorization-unavailable'
   | IntegrationProviderErrorReason;
 
 export type IntegrationAgentToolCallErrorLabel = IntegrationAgentToolCallErrorCode | 'none';
@@ -40,6 +59,9 @@ const integrationAgentToolCallErrorCodes = new Set<string>([
   'malformed-provider-response',
   'content-too-large',
   'too-many-files',
+  'repository-not-granted',
+  'repository-ambiguous',
+  'repository-authorization-unavailable',
 ]);
 
 const agentToolCallCount = meter.createCounter<{
@@ -71,6 +93,27 @@ export function recordIntegrationAgentToolCall(params: {
   error_code: IntegrationAgentToolCallErrorLabel;
 }): void {
   recordMetric(() => agentToolCallCount.add(1, params));
+}
+
+const agentToolRepositoryAuthorizationCount = meter.createCounter<{
+  provider: string;
+  mode: IntegrationToolRepositoryAccessMode;
+  classification: IntegrationToolRepositoryClassification;
+  decision: IntegrationToolRepositoryDecision;
+  denial_reason: IntegrationToolRepositoryDenialReason;
+}>('integrations_agent_tool_repository_authorization', {
+  description:
+    'Integration agent tool repository authorization decisions by provider, mode, classification, decision, and bounded denial reason',
+});
+
+export function recordIntegrationAgentToolRepositoryAuthorization(params: {
+  provider: string;
+  mode: IntegrationToolRepositoryAccessMode;
+  classification: IntegrationToolRepositoryClassification;
+  decision: IntegrationToolRepositoryDecision;
+  denial_reason: IntegrationToolRepositoryDenialReason;
+}): void {
+  recordMetric(() => agentToolRepositoryAuthorizationCount.add(1, params));
 }
 
 export function normalizeIntegrationAgentToolCallErrorCode(

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -6,6 +6,7 @@ import type {IntegrationConnection} from '#core/entities/connection.js';
 import {IntegrationProviderError} from '#core/errors.js';
 import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {SourceControlProvider} from '#core/providers/source-control.js';
+import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
 import {createSourceControlIntegrationService} from '#core/source-control-service.js';
 import type {
   IntegrationToolCallCaller,
@@ -386,6 +387,7 @@ describe('integrations inter-module callTool', () => {
     arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
     caller: {
       kind: 'tool_step',
+      projectId: 'project-1',
       runId: 'run-1',
       jobExecutionId: 'execution-1',
       stepId: 'step-1',
@@ -402,6 +404,9 @@ describe('integrations inter-module callTool', () => {
       | ((caller: IntegrationToolCallCaller) => IntegrationToolCallRecorder)
       | undefined = undefined,
     catalog = [catalogTool()],
+    options: {
+      repositoryAuthorizer?: RepositoryAuthorizer | undefined;
+    } = {},
   ) {
     const transport = createInMemoryInterModuleTransport();
     const client = transport.createClient(integrationsInterModuleContract);
@@ -413,6 +418,7 @@ describe('integrations inter-module callTool', () => {
           getIntegrationConnectionById: async () => undefined,
         }),
         getIntegrationConnectionById: resolveConnection,
+        repositoryAuthorizer: options.repositoryAuthorizer,
         ...(createRecorder === undefined
           ? {}
           : {createIntegrationToolCallRecorder: createRecorder}),
@@ -443,6 +449,56 @@ describe('integrations inter-module callTool', () => {
       toolId: 'issue_read',
       arguments: toolCallInput.arguments,
     });
+  });
+
+  it('denies a repository before deterministic dispatch and audits the run project', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      repositoryScope: () => ({
+        kind: 'declared-targets',
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+      }),
+    });
+    const resolveRepositoryAuthorization = vi.fn(async () => ({
+      authorized: false as const,
+      reason: 'repository_not_granted' as const,
+    }));
+    const recorder = vi.fn();
+    const client = createToolCallClient(
+      {repositoryAuthorization: 'enforced', onOpenSession},
+      undefined,
+      () => recorder,
+      [entry],
+      {
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    const result = await client.callTool(toolCallInput);
+
+    expect(result).toEqual({
+      outcome: 'error',
+      code: 'repository-not-granted',
+      message: 'Repository is not authorized for this integration connection',
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledTimes(1);
+    expect(onOpenSession).not.toHaveBeenCalled();
+    expect(recorder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        outcome: 'tool-error',
+        errorCode: 'repository-not-granted',
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+        classification: 'declared-targets',
+        repositoryAccess: 'selected',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        runProjectId: 'project-1',
+      }),
+    );
   });
 
   it('accepts the agent caller without tool-step identity fields', async () => {

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   type AgentToolsProviderOptions,
   catalogTool,
+  catalogWithRepositoryScope,
   connection,
   registryWithAgentTools,
 } from '#test/agent-tools-gateway-helpers.js';
@@ -453,12 +454,10 @@ describe('integrations inter-module callTool', () => {
 
   it('denies a repository before deterministic dispatch and audits the run project', async () => {
     const onOpenSession = vi.fn();
-    const entry = catalogTool({
-      repositoryScope: () => ({
-        kind: 'declared-targets',
-        repositories: [{owner: 'shipfox', name: 'platform'}],
-      }),
-    });
+    const entry = catalogWithRepositoryScope(() => ({
+      kind: 'declared-targets',
+      repositories: [{owner: 'shipfox', name: 'platform'}],
+    }));
     const resolveRepositoryAuthorization = vi.fn(async () => ({
       authorized: false as const,
       reason: 'repository_not_granted' as const,

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -31,6 +31,7 @@ import {buildFixedEventProviders, buildProviderEventCatalogs} from '#core/event-
 import type {AgentToolCatalogEntry} from '#core/providers/agent-tools.js';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {CheckoutSpec} from '#core/providers/source-control.js';
+import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
 import type {IntegrationSourceControlService} from '#core/source-control-service.js';
 import {
   createIntegrationToolCallRecorder,
@@ -39,6 +40,7 @@ import {
   type IntegrationToolCallAuditTarget,
   type IntegrationToolCallCaller,
   type IntegrationToolCallRecorder,
+  integrationToolCallAuthorizationAuditFields,
   NO_METHOD_LABEL,
 } from '#core/tool-call-audit.js';
 import {
@@ -111,6 +113,7 @@ export function createIntegrationsInterModulePresentation(params: {
   createIntegrationToolCallRecorder?: (
     caller: IntegrationToolCallCaller,
   ) => IntegrationToolCallRecorder;
+  repositoryAuthorizer?: RepositoryAuthorizer | undefined;
 }): InterModulePresentation<typeof integrationsInterModuleContract> {
   const contract = integrationsInterModuleContract;
   const getConnectionById = params.getIntegrationConnectionById ?? getIntegrationConnectionById;
@@ -294,6 +297,8 @@ export function createIntegrationsInterModulePresentation(params: {
           arguments: input.arguments,
           method: executedMethod,
           caller,
+          catalogEntry,
+          repositoryAuthorizer: params.repositoryAuthorizer,
           signal: context.signal,
         });
 
@@ -323,6 +328,7 @@ function toToolCallCaller(caller: CallToolCaller, workspaceId: string): Integrat
     : {
         caller: 'tool_step',
         workspaceId,
+        projectId: caller.projectId,
         runId: caller.runId,
         jobExecutionId: caller.jobExecutionId,
         stepId: caller.stepId,
@@ -432,6 +438,7 @@ function recordCallOutcome(
     method,
     outcome: outcome.outcome === 'success' ? 'success' : 'tool-error',
     errorCode: outcome.outcome === 'success' ? 'none' : outcome.error.code,
+    ...integrationToolCallAuthorizationAuditFields(outcome.authorization),
     ...(outcome.outcome === 'success' || outcome.error.status === undefined
       ? {}
       : {providerStatus: outcome.error.status}),

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.test.ts
@@ -3,6 +3,7 @@ import type {logger as loggerFactoryType} from '@shipfox/node-opentelemetry';
 import {IntegrationProviderError} from '#core/errors.js';
 import {
   catalogTool,
+  catalogWithRepositoryScope,
   connection,
   leaseContext,
   materializedIntegration,
@@ -131,12 +132,10 @@ describe('createIntegrationToolDispatcher', () => {
 
   it('returns a repository denial without opening the provider session', async () => {
     const onOpenSession = vi.fn();
-    const entry = catalogTool({
-      repositoryScope: () => ({
-        kind: 'declared-targets',
-        repositories: [{owner: 'shipfox', name: 'platform'}],
-      }),
-    });
+    const entry = catalogWithRepositoryScope(() => ({
+      kind: 'declared-targets',
+      repositories: [{owner: 'shipfox', name: 'platform'}],
+    }));
     const resolveRepositoryAuthorization = vi.fn(async () => ({
       authorized: false as const,
       reason: 'repository_not_granted' as const,

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.test.ts
@@ -128,6 +128,60 @@ describe('createIntegrationToolDispatcher', () => {
       boundary: 'integration.agent-tool',
     });
   });
+
+  it('returns a repository denial without opening the provider session', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      repositoryScope: () => ({
+        kind: 'declared-targets',
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+      }),
+    });
+    const resolveRepositoryAuthorization = vi.fn(async () => ({
+      authorized: false as const,
+      reason: 'repository_not_granted' as const,
+    }));
+    const dispatch = createIntegrationToolDispatcher(
+      {
+        registry: registryWithAgentTools([entry], {
+          repositoryAuthorization: 'enforced',
+          onOpenSession,
+        }),
+        lease: leaseContext({
+          workspaceId: 'workspace-1',
+          projectId: 'project-run',
+        }),
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+      {logger: loggerFactory, reportError},
+    );
+
+    const result = await dispatch({
+      authorizedTool: {...authorizedTool(), catalogEntry: entry},
+      arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      method: 'get',
+    });
+
+    expect(result).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {code: 'repository-not-granted'},
+      },
+      authorization: {
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+        classification: 'declared-targets',
+        repositoryAccess: 'selected',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        runProjectId: 'project-run',
+      },
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledTimes(1);
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
 });
 
 function createDispatcher(callError: unknown) {

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
@@ -3,12 +3,18 @@ import type {LeasedJobContext} from '@shipfox/api-auth-context';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
+import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
 import {callIntegrationTool, type IntegrationToolCallError} from '#core/tool-call-service.js';
-import type {IntegrationToolDispatcher, IntegrationToolDispatchInput} from './mcp-server.js';
+import type {
+  IntegrationToolDispatcher,
+  IntegrationToolDispatchInput,
+  IntegrationToolDispatchResult,
+} from './mcp-server.js';
 
 export interface CreateIntegrationToolDispatcherParams {
   registry: IntegrationProviderRegistry;
   lease: LeasedJobContext;
+  repositoryAuthorizer?: RepositoryAuthorizer | undefined;
 }
 
 export interface IntegrationToolDispatcherDependencies {
@@ -25,6 +31,7 @@ export function createIntegrationToolDispatcher(
       ...input,
       registry: params.registry,
       caller: {caller: 'agent', lease: params.lease},
+      repositoryAuthorizer: params.repositoryAuthorizer,
       logger: dependencies.logger ?? logger,
       reportError: dependencies.reportError ?? reportError,
     });
@@ -34,10 +41,11 @@ async function dispatchIntegrationToolCall(
   input: IntegrationToolDispatchInput & {
     registry: IntegrationProviderRegistry;
     caller: {caller: 'agent'; lease: LeasedJobContext};
+    repositoryAuthorizer?: RepositoryAuthorizer | undefined;
     logger: typeof logger;
     reportError: typeof reportError;
   },
-): Promise<CallToolResult> {
+): Promise<CallToolResult | IntegrationToolDispatchResult> {
   const outcome = await callIntegrationTool({
     registry: input.registry,
     connection: input.authorizedTool.connection,
@@ -49,11 +57,16 @@ async function dispatchIntegrationToolCall(
     arguments: input.arguments,
     method: input.method,
     caller: input.caller,
+    catalogEntry: input.authorizedTool.catalogEntry,
+    repositoryAuthorizer: input.repositoryAuthorizer,
     logger: input.logger,
     reportError: input.reportError,
   });
 
-  return outcome.outcome === 'success' ? outcome.result : toolError(outcome.error);
+  const result = outcome.outcome === 'success' ? outcome.result : toolError(outcome.error);
+  return outcome.authorization === undefined
+    ? result
+    : {result, authorization: outcome.authorization};
 }
 
 function toolError(error: IntegrationToolCallError): CallToolResult {

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
@@ -5,6 +5,7 @@ import {reportError} from '@shipfox/node-error-monitoring';
 import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
+import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
 import {createIntegrationToolCallRecorder} from '#core/tool-call-audit.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
 import {createIntegrationToolDispatcher} from './dispatch.js';
@@ -21,6 +22,7 @@ export interface CreateAgentToolsGatewayRoutesParams {
   loadLeasedAgentStep: LeasedAgentStepLoader;
   registry: IntegrationProviderRegistry;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  repositoryAuthorizer?: RepositoryAuthorizer | undefined;
 }
 
 export function createAgentToolsGatewayRoutes(
@@ -44,7 +46,11 @@ export function createAgentToolsGatewayRoutes(
           });
           const server = buildAgentToolsMcpServer({
             authorizedTools,
-            dispatch: createIntegrationToolDispatcher({registry: params.registry, lease}),
+            dispatch: createIntegrationToolDispatcher({
+              registry: params.registry,
+              lease,
+              repositoryAuthorizer: params.repositoryAuthorizer,
+            }),
             recordCall: createIntegrationToolCallRecorder({caller: 'agent', lease}),
           });
           const transport = new StreamableHTTPServerTransport();

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -4,6 +4,7 @@ import {CallToolResultSchema} from '@modelcontextprotocol/sdk/types.js';
 import {INVALID_METHOD_LABEL, NO_METHOD_LABEL} from '#core/tool-call-audit.js';
 import {
   catalogTool,
+  catalogWithRepositoryScope,
   connection,
   leaseContext,
   materializedIntegration,
@@ -63,12 +64,10 @@ describe('buildAgentToolsMcpServer', () => {
   });
 
   it('records the shared repository denial returned by the MCP dispatcher', async () => {
-    const entry = catalogTool({
-      repositoryScope: () => ({
-        kind: 'declared-targets',
-        repositories: [{owner: 'shipfox', name: 'platform'}],
-      }),
-    });
+    const entry = catalogWithRepositoryScope(() => ({
+      kind: 'declared-targets',
+      repositories: [{owner: 'shipfox', name: 'platform'}],
+    }));
     const onOpenSession = vi.fn();
     const resolveRepositoryAuthorization = vi.fn(async () => ({
       authorized: false as const,

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -5,9 +5,12 @@ import {INVALID_METHOD_LABEL, NO_METHOD_LABEL} from '#core/tool-call-audit.js';
 import {
   catalogTool,
   connection,
+  leaseContext,
   materializedIntegration,
   materializedTool,
+  registryWithAgentTools,
 } from '#test/agent-tools-gateway-helpers.js';
+import {createIntegrationToolDispatcher} from './dispatch.js';
 import {buildAgentToolsMcpServer, type IntegrationToolDispatchInput} from './mcp-server.js';
 import type {AuthorizedIntegrationToolMap} from './resolve-authorized-tools.js';
 
@@ -55,6 +58,70 @@ describe('buildAgentToolsMcpServer', () => {
         method: 'get',
         outcome: 'success',
         errorCode: 'none',
+      },
+    ]);
+  });
+
+  it('records the shared repository denial returned by the MCP dispatcher', async () => {
+    const entry = catalogTool({
+      repositoryScope: () => ({
+        kind: 'declared-targets',
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+      }),
+    });
+    const onOpenSession = vi.fn();
+    const resolveRepositoryAuthorization = vi.fn(async () => ({
+      authorized: false as const,
+      reason: 'repository_not_granted' as const,
+    }));
+    const authorizedTools = defaultAuthorizedTools();
+    const authorizedTool = authorizedTools.get('github_main__issue_read');
+    if (!authorizedTool) throw new Error('Expected default authorized tool');
+    authorizedTools.set('github_main__issue_read', {...authorizedTool, catalogEntry: entry});
+    const dispatch = createIntegrationToolDispatcher({
+      registry: registryWithAgentTools([entry], {
+        repositoryAuthorization: 'enforced',
+        onOpenSession,
+      }),
+      lease: leaseContext({
+        workspaceId: 'workspace-1',
+        projectId: 'project-run',
+      }),
+      repositoryAuthorizer: {
+        enabled: true,
+        resolveRepositoryAuthorization,
+      },
+    });
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, authorizedTools, (record) =>
+      records.push(record),
+    );
+
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      },
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(result.isError).toBe(true);
+    expect(onOpenSession).not.toHaveBeenCalled();
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledTimes(1);
+    expect(records).toMatchObject([
+      {
+        method: 'get',
+        outcome: 'tool-error',
+        errorCode: 'repository-not-granted',
+        repositories: [{owner: 'shipfox', name: 'platform'}],
+        classification: 'declared-targets',
+        repositoryAccess: 'selected',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        runProjectId: 'project-run',
       },
     ]);
   });

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -8,7 +8,9 @@ import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
   INVALID_METHOD_LABEL,
+  type IntegrationToolCallAuthorization,
   type IntegrationToolCallRecorder,
+  integrationToolCallAuthorizationAuditFields,
   NO_METHOD_LABEL,
 } from '#core/tool-call-audit.js';
 import {
@@ -28,7 +30,12 @@ export interface IntegrationToolDispatchInput {
 
 export type IntegrationToolDispatcher = (
   input: IntegrationToolDispatchInput,
-) => Promise<CallToolResult>;
+) => Promise<CallToolResult | IntegrationToolDispatchResult>;
+
+export interface IntegrationToolDispatchResult {
+  result: CallToolResult;
+  authorization?: IntegrationToolCallAuthorization | undefined;
+}
 
 export interface BuildAgentToolsMcpServerParams {
   authorizedTools: AuthorizedIntegrationToolMap;
@@ -100,17 +107,19 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
     const method = methodValidation.method ?? NO_METHOD_LABEL;
 
     try {
-      const result = await params.dispatch({
+      const dispatched = await params.dispatch({
         authorizedTool,
         arguments: args,
         method: methodValidation.method,
       });
+      const {result, authorization} = unpackDispatchResult(dispatched);
       recordToolCall(params.recordCall, {
         authorizedTool,
         arguments: args,
         method,
         outcome: result.isError === true ? 'tool-error' : 'success',
         ...toolCallErrorDetails(result),
+        ...integrationToolCallAuthorizationAuditFields(authorization),
       });
       return result;
     } catch (error) {
@@ -126,6 +135,21 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
   });
 
   return server;
+}
+
+function unpackDispatchResult(dispatched: CallToolResult | IntegrationToolDispatchResult): {
+  result: CallToolResult;
+  authorization?: IntegrationToolCallAuthorization | undefined;
+} {
+  if (isRecord(dispatched) && isRecord(dispatched.result) && 'content' in dispatched.result) {
+    return {
+      result: dispatched.result as CallToolResult,
+      authorization: isRecord(dispatched.authorization)
+        ? (dispatched.authorization as unknown as IntegrationToolCallAuthorization)
+        : undefined,
+    };
+  }
+  return {result: dispatched as CallToolResult};
 }
 
 function toolCallErrorDetails(result: CallToolResult): {

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
@@ -18,7 +18,7 @@ import {
   IntegrationConnectionProviderChangedError,
   IntegrationConnectionWorkspaceMismatchError,
 } from '#core/errors.js';
-import type {AgentToolJsonSchema} from '#core/providers/agent-tools.js';
+import type {AgentToolCatalogEntry, AgentToolJsonSchema} from '#core/providers/agent-tools.js';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import {loadAuthorizedToolConnection} from '#core/tool-call-service.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
@@ -79,6 +79,8 @@ export interface AuthorizedIntegrationTool {
   description: string;
   inputSchema: AgentToolJsonSchema;
   outputSchema?: AgentToolJsonSchema | undefined;
+  /** Live catalog entry used for repository classification at dispatch time. */
+  catalogEntry?: AgentToolCatalogEntry | undefined;
 }
 
 export type AuthorizedIntegrationToolMap = Map<string, AuthorizedIntegrationTool>;
@@ -120,32 +122,46 @@ export async function resolveAuthorizedIntegrationTools(
     const catalogByToolId = new Map(catalog.map((entry) => [entry.id, entry]));
 
     for (const tool of integration.tools) {
-      const catalogTool = catalogByToolId.get(tool.id);
-      const mcpName = mcpToolName(integration.connectionSlug, tool.id);
-      if (authorizedTools.has(mcpName)) {
-        throw new ClientError(
-          'Integration tool names collide after MCP namespacing',
-          'integration-tool-name-collision',
-          {
-            status: 409,
-          },
-        );
-      }
-
-      authorizedTools.set(mcpName, {
-        mcpName,
+      addAuthorizedTool(
+        authorizedTools,
         integration,
         tool,
         connection,
-        // The live catalog enriches display metadata only. Frozen step config remains the allowlist.
-        description: catalogTool?.description ?? tool.id,
-        inputSchema: tool.methods ? toolInputSchema(tool) : tool.inputSchema,
-        outputSchema: tool.outputSchema ?? catalogTool?.outputSchema,
-      });
+        catalogByToolId.get(tool.id),
+      );
     }
   }
 
   return authorizedTools;
+}
+
+function addAuthorizedTool(
+  authorizedTools: AuthorizedIntegrationToolMap,
+  integration: MaterializedAgentIntegrationConfigDto,
+  tool: MaterializedAgentIntegrationToolConfigDto,
+  connection: IntegrationConnection,
+  catalogTool: AgentToolCatalogEntry | undefined,
+): void {
+  const mcpName = mcpToolName(integration.connectionSlug, tool.id);
+  if (authorizedTools.has(mcpName)) {
+    throw new ClientError(
+      'Integration tool names collide after MCP namespacing',
+      'integration-tool-name-collision',
+      {status: 409},
+    );
+  }
+
+  authorizedTools.set(mcpName, {
+    mcpName,
+    integration,
+    tool,
+    connection,
+    // Live catalog metadata supplies dispatch classification; frozen step config remains the allowlist.
+    description: catalogTool?.description ?? tool.id,
+    inputSchema: tool.methods ? toolInputSchema(tool) : tool.inputSchema,
+    outputSchema: tool.outputSchema ?? catalogTool?.outputSchema,
+    ...(catalogTool === undefined ? {} : {catalogEntry: catalogTool}),
+  });
 }
 
 function legacyIntegrations(step: {type: string; config: Record<string, unknown>} | undefined) {

--- a/libs/api/integration/core/src/presentation/routes/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/index.ts
@@ -1,6 +1,7 @@
 import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import type {RouteExport} from '@shipfox/node-fastify';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
+import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
 import type {IntegrationSourceControlService} from '#core/source-control-service.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
 import {
@@ -20,6 +21,7 @@ export interface CreateIntegrationRoutesOptions {
     | {
         workflows: WorkflowsModuleClient;
         getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+        repositoryAuthorizer?: RepositoryAuthorizer | undefined;
       }
     | undefined;
 }
@@ -36,6 +38,7 @@ export function createIntegrationRoutes(
           registry,
           loadLeasedAgentStep: createWorkflowsLeasedAgentStepLoader(options.agentTools.workflows),
           getIntegrationConnectionById: options.agentTools.getIntegrationConnectionById,
+          repositoryAuthorizer: options.agentTools.repositoryAuthorizer,
         }),
       ]
     : [];

--- a/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
+++ b/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
@@ -8,6 +8,7 @@ import type {IntegrationConnection} from '#core/entities/connection.js';
 import type {
   AgentToolCatalogEntry,
   AgentToolRepositoryAuthorizationState,
+  AgentToolRepositoryScopeClassifier,
   AgentToolsProvider,
 } from '#core/providers/agent-tools.js';
 import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
@@ -147,6 +148,16 @@ export function catalogTool(overrides: Partial<AgentToolCatalogEntry> = {}): Age
       },
     ],
     ...overrides,
+  };
+}
+
+export function catalogWithRepositoryScope(
+  repositoryScope: AgentToolRepositoryScopeClassifier,
+): AgentToolCatalogEntry {
+  const entry = catalogTool({repositoryScope});
+  return {
+    ...entry,
+    methods: entry.methods?.map((method) => ({...method, repositoryScope})),
   };
 }
 

--- a/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
+++ b/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
@@ -5,7 +5,11 @@ import type {
 } from '@shipfox/api-agent-dto';
 import type {LeasedJobContext} from '@shipfox/api-auth-context';
 import type {IntegrationConnection} from '#core/entities/connection.js';
-import type {AgentToolCatalogEntry, AgentToolsProvider} from '#core/providers/agent-tools.js';
+import type {
+  AgentToolCatalogEntry,
+  AgentToolRepositoryAuthorizationState,
+  AgentToolsProvider,
+} from '#core/providers/agent-tools.js';
 import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
 
 export function leaseContext(overrides: Partial<LeasedJobContext> = {}): LeasedJobContext {
@@ -147,6 +151,7 @@ export function catalogTool(overrides: Partial<AgentToolCatalogEntry> = {}): Age
 }
 
 export interface AgentToolsProviderOptions {
+  repositoryAuthorization?: AgentToolRepositoryAuthorizationState | undefined;
   result?: CallToolResult | undefined;
   openSessionError?: unknown;
   callError?: unknown;
@@ -204,6 +209,9 @@ export function registryWithAgentTools(
     {
       provider: 'github',
       displayName: 'GitHub',
+      ...(options.repositoryAuthorization === undefined
+        ? {}
+        : {repositoryAuthorization: options.repositoryAuthorization}),
       adapters: {
         agent_tools: agentToolsProvider(catalog, options),
       },


### PR DESCRIPTION
## Summary

Integration tool calls now apply the live repository-scope classifier and shared project authorizer immediately before provider dispatch. MCP and deterministic inter-module calls use the same boundary, so denied and partially unauthorized multi-target calls never open a provider session. Connection-scoped and provider-unclassified calls remain available while being explicitly audited for rollout visibility.

The gate remains off by default. Audit records include repository targets and project attribution, while authorization metrics use bounded labels without repository names.

## Validation

- Core checks and tests passed: 30 test files, 281 tests.
- Core DTO checks, type validation, and tests passed: 3 test files, 64 tests.
- Dependent Turbo type, check, and build tasks passed.
- Dependency-cruise and diff checks passed.

The package-local core type command still reports pre-existing Vitest declaration errors; dependent Turbo type validation passes.

Closes ENG-1821

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integration tool calls now enforce the declared repository scope through the live classifier and shared repository authorizer before any provider session opens. MCP and deterministic dispatch share the same boundary, so denied and partially unauthorized multi-target calls never reach the provider; the gate is off by default and connection-scoped or provider-unclassified calls continue to work while being explicitly audited. The classifier is re-read from the live catalog at dispatch time, and authorization honors the call's abort signal.

**Migration**
- `tool_step` inter-module callers must now include `projectId` in the caller payload.
- Enable enforcement by wiring a `RepositoryAuthorizer` through the inter-module presentation and agent-tools gateway.

**Audit and metrics**
- Audit logs now include repository targets, classification, decision, denial reason, and project attribution.
- A new bounded authorization metric records decisions without repository names.
- New error codes `repository-not-granted`, `repository-ambiguous`, and `repository-authorization-unavailable` are surfaced to callers.

Closes ENG-1821.

<sup>Written for commit a0e21e69c7206ae619d6a68dc33200a836a45fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

