### PR TITLE
Enforce repository authorization at checkout boundaries

### DIFF
--- a/.changeset/eng-1819-checkout-authorization.md
+++ b/.changeset/eng-1819-checkout-authorization.md
@@ -1,8 +1,12 @@
 ---
 "@shipfox/api-integration-core": minor
-"@shipfox/api-projects": minor
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-gitea": minor
+"@shipfox/api-integration-github": minor
+"@shipfox/api-integration-spi": minor
+"@shipfox/api-projects": patch
 "@shipfox/api-projects-dto": major
 "@shipfox/api-workflows": patch
 ---
 
-Enforces repository authorization at both checkout credential boundaries and preserves provider-free name targets for unassociated repositories.
+Projects checkout resolution now requires a project ID and no longer accepts repository names. Checkout requests authorize the repository target before issuing credentials. Repository declarations remain valid without a project association.

--- a/.changeset/eng-1819-checkout-authorization.md
+++ b/.changeset/eng-1819-checkout-authorization.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-core": minor
+"@shipfox/api-projects": minor
+"@shipfox/api-projects-dto": major
+"@shipfox/api-workflows": patch
+---
+
+Enforces repository authorization at both checkout credential boundaries and preserves provider-free name targets for unassociated repositories.

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -9,6 +9,7 @@ describe('integrationsInterModuleContract', () => {
       notGranted: 'repository-not-granted',
       ambiguous: 'repository-ambiguous',
       storeUnavailable: 'repository-authorization-unavailable',
+      targetInvalid: 'repository-authorization-target-invalid',
     });
   });
 
@@ -192,10 +193,21 @@ describe('integrationsInterModuleContract', () => {
     'repository-not-granted',
     'repository-ambiguous',
     'repository-authorization-unavailable',
+    'repository-authorization-target-invalid',
   ] as const)('defines the %s checkout failure', (code) => {
     const schema = integrationsInterModuleContract.methods.createCheckoutSpec.errors[code];
 
     expect(schema.parse({})).toEqual({});
+  });
+
+  test('requires the provider-resolved checkout target in a checkout spec', () => {
+    const output = integrationsInterModuleContract.methods.createCheckoutSpec.output.parse({
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      target: {kind: 'external-id', externalRepositoryId: 'github:42'},
+    });
+
+    expect(output.target).toEqual({kind: 'external-id', externalRepositoryId: 'github:42'});
   });
 
   test.each([

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -119,11 +119,18 @@ export const repositoryAuthorizationErrorCodes = {
   notGranted: 'repository-not-granted',
   ambiguous: 'repository-ambiguous',
   storeUnavailable: 'repository-authorization-unavailable',
+  targetInvalid: 'repository-authorization-target-invalid',
 } as const;
+const repositoryAuthorizationDetails = z.object({
+  workspaceId: id.optional(),
+  connectionId: id.optional(),
+  target: checkoutTarget.optional(),
+});
 const repositoryAuthorizationErrors = {
-  [repositoryAuthorizationErrorCodes.notGranted]: z.object({}),
-  [repositoryAuthorizationErrorCodes.ambiguous]: z.object({}),
-  [repositoryAuthorizationErrorCodes.storeUnavailable]: z.object({}),
+  [repositoryAuthorizationErrorCodes.notGranted]: repositoryAuthorizationDetails,
+  [repositoryAuthorizationErrorCodes.ambiguous]: repositoryAuthorizationDetails,
+  [repositoryAuthorizationErrorCodes.storeUnavailable]: repositoryAuthorizationDetails,
+  [repositoryAuthorizationErrorCodes.targetInvalid]: repositoryAuthorizationDetails,
 };
 const toolCallErrors = {
   'connection-not-found': z.object({connectionId: id}),
@@ -211,6 +218,7 @@ export const integrationsInterModuleContract = defineInterModuleContract({
       output: z.object({
         repositoryUrl: z.string(),
         ref: z.string(),
+        target: checkoutTarget,
         credentials: checkoutCredentials.optional(),
         gitAuthor: z.object({name: z.string(), email: z.string()}).optional(),
       }),

--- a/libs/api/integration/core/src/core/errors.ts
+++ b/libs/api/integration/core/src/core/errors.ts
@@ -4,6 +4,7 @@ import {
   type IntegrationProviderErrorReason,
 } from '@shipfox/api-integration-spi';
 import type {IntegrationCapability, IntegrationProviderKind} from '#core/entities/provider.js';
+import type {RepositoryAuthorizationDenial} from '#core/repository-authorizer.js';
 
 export class IntegrationConnectionNotFoundError extends Error {
   constructor(connectionId: string) {
@@ -65,6 +66,13 @@ export class RepositoryAuthorizerConfigurationError extends Error {
   constructor() {
     super('Repository authorization is enabled but the Projects client is not configured');
     this.name = 'RepositoryAuthorizerConfigurationError';
+  }
+}
+
+export class IntegrationRepositoryAuthorizationError extends Error {
+  constructor(public readonly reason: RepositoryAuthorizationDenial) {
+    super(`Repository authorization denied: ${reason}`);
+    this.name = 'IntegrationRepositoryAuthorizationError';
   }
 }
 

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -6,8 +6,11 @@ import {
 } from './errors.js';
 import {createIntegrationProviderRegistry} from './providers/registry.js';
 import type {RepositorySnapshot, SourceControlProvider} from './providers/source-control.js';
-import type {RepositoryAuthorizer} from './repository-authorizer.js';
-import {createRepositoryAuthorizer} from './repository-authorizer.js';
+import {
+  createRepositoryAuthorizer,
+  RepositoryAuthorizationTargetInvalidError,
+  type RepositoryAuthorizer,
+} from './repository-authorizer.js';
 import {createSourceControlIntegrationService} from './source-control-service.js';
 
 const repository: RepositorySnapshot = {
@@ -267,6 +270,7 @@ describe('integration source-control service', () => {
     expect(result).toEqual({
       repositoryUrl: 'https://gitea.local/gitea-owner/platform.git',
       ref: 'feature/x',
+      target: {kind: 'external-id', externalRepositoryId: 'gitea:gitea-owner/platform'},
     });
     expect(createCheckoutSpec).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -384,6 +388,10 @@ describe('integration source-control service', () => {
       async (input: Parameters<NonNullable<SourceControlProvider['createCheckoutSpec']>>[0]) => ({
         repositoryUrl: repository.cloneUrl,
         ref: input.ref ?? repository.defaultBranch,
+        target: {
+          kind: 'external-id' as const,
+          externalRepositoryId: repository.externalRepositoryId,
+        },
       }),
     );
     const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
@@ -415,6 +423,32 @@ describe('integration source-control service', () => {
     });
   });
 
+  it('rejects an invalid authorized target before calling the provider', async () => {
+    const createCheckoutSpec = vi.fn();
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: true,
+      repository: {},
+    } as const);
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await expect(
+      service.createCheckoutSpec({
+        workspaceId,
+        connectionId: connection.id,
+        target: {kind: 'name', owner: 'acme', name: 'platform'},
+      }),
+    ).rejects.toBeInstanceOf(RepositoryAuthorizationTargetInvalidError);
+    expect(createCheckoutSpec).not.toHaveBeenCalled();
+  });
+
   it('does not query Projects for an all-mode name target', async () => {
     const getProjectBySource = vi.fn();
     const findProjectBySourceRepositoryName = vi.fn();
@@ -429,6 +463,10 @@ describe('integration source-control service', () => {
       async (input: Parameters<NonNullable<SourceControlProvider['createCheckoutSpec']>>[0]) => ({
         repositoryUrl: repository.cloneUrl,
         ref: input.ref ?? repository.defaultBranch,
+        target: {
+          kind: 'external-id' as const,
+          externalRepositoryId: repository.externalRepositoryId,
+        },
       }),
     );
     const service = createService(
@@ -439,10 +477,15 @@ describe('integration source-control service', () => {
       },
     );
 
-    await service.createCheckoutSpec({
+    const result = await service.createCheckoutSpec({
       workspaceId,
       connectionId: connection.id,
       target: {kind: 'name', owner: 'acme', name: 'unassociated'},
+    });
+
+    expect(result.target).toEqual({
+      kind: 'external-id',
+      externalRepositoryId: repository.externalRepositoryId,
     });
 
     expect(createCheckoutSpec).toHaveBeenCalledWith({

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -1,6 +1,13 @@
-import {IntegrationCheckoutUnsupportedError, IntegrationProviderError} from './errors.js';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {
+  IntegrationCheckoutUnsupportedError,
+  IntegrationProviderError,
+  IntegrationRepositoryAuthorizationError,
+} from './errors.js';
 import {createIntegrationProviderRegistry} from './providers/registry.js';
 import type {RepositorySnapshot, SourceControlProvider} from './providers/source-control.js';
+import type {RepositoryAuthorizer} from './repository-authorizer.js';
+import {createRepositoryAuthorizer} from './repository-authorizer.js';
 import {createSourceControlIntegrationService} from './source-control-service.js';
 
 const repository: RepositorySnapshot = {
@@ -30,7 +37,11 @@ describe('integration source-control service', () => {
 
   function createService(
     overrides: Partial<SourceControlProvider> = {},
-    options: {omitCheckoutSpec?: boolean} = {},
+    options: {
+      omitCheckoutSpec?: boolean;
+      repositoryAuthorizer?: RepositoryAuthorizer;
+      getRepositoryAuthorizationMode?: () => 'selected' | 'all';
+    } = {},
   ) {
     const sourceControl: SourceControlProvider = {
       listRepositories: async () => {
@@ -80,6 +91,8 @@ describe('integration source-control service', () => {
         await Promise.resolve();
         return connectionId === connection.id ? connection : undefined;
       },
+      repositoryAuthorizer: options.repositoryAuthorizer,
+      getRepositoryAuthorizationMode: options.getRepositoryAuthorizationMode,
     });
   }
 
@@ -288,6 +301,198 @@ describe('integration source-control service', () => {
       ref: 'feature/x',
       permissions: undefined,
     });
+  });
+
+  it('authorizes a checkout spec before calling the provider', async () => {
+    const createCheckoutSpec = vi.fn(async () => ({
+      repositoryUrl: repository.cloneUrl,
+      ref: repository.defaultBranch,
+    }));
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: false,
+      reason: 'repository_not_granted',
+    } as const);
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await expect(
+      service.createCheckoutSpec({
+        workspaceId,
+        connectionId: connection.id,
+        target: {kind: 'external-id', externalRepositoryId: repository.externalRepositoryId},
+      }),
+    ).rejects.toBeInstanceOf(IntegrationRepositoryAuthorizationError);
+
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith({
+      workspaceId,
+      connectionId: connection.id,
+      mode: 'selected',
+      repository: {kind: 'external-id', externalRepositoryId: repository.externalRepositoryId},
+      capability: 'checkout',
+    });
+    expect(createCheckoutSpec).not.toHaveBeenCalled();
+  });
+
+  it('authorizes checkout credentials before calling the provider', async () => {
+    const createCheckoutCredentials = vi.fn(async () => ({
+      username: 'x-access-token',
+      token: 'secret',
+      expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+    }));
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: false,
+      reason: 'repository_ambiguous',
+    } as const);
+    const service = createService(
+      {createCheckoutCredentials},
+      {
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await expect(
+      service.createCheckoutCredentials({
+        workspaceId,
+        connectionId: connection.id,
+        target: {kind: 'name', owner: 'acme', name: 'platform'},
+        permissions: {contents: 'read'},
+      }),
+    ).rejects.toBeInstanceOf(IntegrationRepositoryAuthorizationError);
+
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith({
+      workspaceId,
+      connectionId: connection.id,
+      mode: 'selected',
+      repository: {kind: 'name', owner: 'acme', name: 'platform'},
+      capability: 'checkout',
+    });
+    expect(createCheckoutCredentials).not.toHaveBeenCalled();
+  });
+
+  it('forwards the canonical authorized target returned by the authorizer', async () => {
+    const createCheckoutSpec = vi.fn(
+      async (input: Parameters<NonNullable<SourceControlProvider['createCheckoutSpec']>>[0]) => ({
+        repositoryUrl: repository.cloneUrl,
+        ref: input.ref ?? repository.defaultBranch,
+      }),
+    );
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: true,
+      repository: {externalRepositoryId: repository.externalRepositoryId},
+      targetProjectId: crypto.randomUUID(),
+    } as const);
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      target: {kind: 'name', owner: repository.owner, name: repository.name},
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      connection,
+      target: {kind: 'external-id', externalRepositoryId: repository.externalRepositoryId},
+      ref: undefined,
+      permissions: undefined,
+    });
+  });
+
+  it('does not query Projects for an all-mode name target', async () => {
+    const getProjectBySource = vi.fn();
+    const findProjectBySourceRepositoryName = vi.fn();
+    const authorizer = createRepositoryAuthorizer({
+      enabled: true,
+      projects: {
+        getProjectBySource,
+        findProjectBySourceRepositoryName,
+      } as unknown as ProjectsModuleClient,
+    });
+    const createCheckoutSpec = vi.fn(
+      async (input: Parameters<NonNullable<SourceControlProvider['createCheckoutSpec']>>[0]) => ({
+        repositoryUrl: repository.cloneUrl,
+        ref: input.ref ?? repository.defaultBranch,
+      }),
+    );
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        repositoryAuthorizer: authorizer,
+        getRepositoryAuthorizationMode: () => 'all',
+      },
+    );
+
+    await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      target: {kind: 'name', owner: 'acme', name: 'unassociated'},
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      connection,
+      target: {kind: 'name', owner: 'acme', name: 'unassociated'},
+      ref: undefined,
+      permissions: undefined,
+    });
+    expect(getProjectBySource).not.toHaveBeenCalled();
+    expect(findProjectBySourceRepositoryName).not.toHaveBeenCalled();
+  });
+
+  it('does not query Projects for an all-mode name credential target', async () => {
+    const getProjectBySource = vi.fn();
+    const findProjectBySourceRepositoryName = vi.fn();
+    const authorizer = createRepositoryAuthorizer({
+      enabled: true,
+      projects: {
+        getProjectBySource,
+        findProjectBySourceRepositoryName,
+      } as unknown as ProjectsModuleClient,
+    });
+    const createCheckoutCredentials = vi.fn(async () => ({
+      username: 'x-access-token',
+      token: 'secret',
+      expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+    }));
+    const service = createService(
+      {createCheckoutCredentials},
+      {
+        repositoryAuthorizer: authorizer,
+        getRepositoryAuthorizationMode: () => 'all',
+      },
+    );
+
+    await service.createCheckoutCredentials({
+      workspaceId,
+      connectionId: connection.id,
+      target: {kind: 'name', owner: 'acme', name: 'unassociated'},
+      permissions: {contents: 'read'},
+    });
+
+    expect(createCheckoutCredentials).toHaveBeenCalledWith({
+      connection,
+      target: {kind: 'name', owner: 'acme', name: 'unassociated'},
+      permissions: {contents: 'read'},
+      rejectedGeneration: undefined,
+    });
+    expect(getProjectBySource).not.toHaveBeenCalled();
+    expect(findProjectBySourceRepositoryName).not.toHaveBeenCalled();
   });
 
   it('preserves distinct errors for missing and ambiguous checkout targets', async () => {

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -27,6 +27,9 @@ import type {
   RepositoryAuthorizationResult,
   RepositoryAuthorizer,
 } from './repository-authorizer.js';
+import {RepositoryAuthorizationTargetInvalidError} from './repository-authorizer.js';
+
+export type AuthorizedCheckoutSpec = CheckoutSpec & {target: CheckoutTarget};
 
 export interface IntegrationSourceControlService {
   getConnection(connectionId: string): Promise<IntegrationConnection>;
@@ -36,7 +39,7 @@ export interface IntegrationSourceControlService {
   resolveSourceRef(input: ResolveSourceRefInput): Promise<ResolvedRef>;
   listFiles(input: ListSourceFilesInput): Promise<FilePage>;
   fetchFile(input: FetchSourceFileInput): Promise<FileSnapshot>;
-  createCheckoutSpec(input: CreateSourceCheckoutSpecInput): Promise<CheckoutSpec>;
+  createCheckoutSpec(input: CreateSourceCheckoutSpecInput): Promise<AuthorizedCheckoutSpec>;
   createCheckoutCredentials(
     input: CreateSourceCheckoutCredentialsInput,
   ): Promise<CheckoutCredentials>;
@@ -228,13 +231,17 @@ export function createSourceControlIntegrationService({
         getRepositoryAuthorizationMode,
       });
 
-      return await sourceControl.createCheckoutSpec({
+      const spec = await sourceControl.createCheckoutSpec({
         connection,
         target,
         ...(projectId === undefined ? {} : {projectId}),
         ref,
         permissions,
       });
+      return {
+        ...spec,
+        target: checkoutSpecTarget(target, spec.target),
+      };
     },
 
     async createCheckoutCredentials(input) {
@@ -316,10 +323,17 @@ function checkoutTargetFromAuthorization(
       name: authorization.repository.name,
     };
   }
-  throw new IntegrationProviderError(
-    'malformed-provider-response',
-    'Repository authorizer returned an empty authorized target',
-  );
+  throw new RepositoryAuthorizationTargetInvalidError();
+}
+
+function checkoutSpecTarget(
+  target: CheckoutTarget,
+  providerTarget: CheckoutSpec['target'],
+): CheckoutTarget {
+  // Name targets are the only form whose provider response can add a stable
+  // identity for credential renewal. An authorizer's external-id decision is
+  // already canonical and must remain authoritative for every other input.
+  return target.kind === 'name' && providerTarget?.kind === 'external-id' ? providerTarget : target;
 }
 
 function checkoutTarget(input: CheckoutTargetInput): CheckoutTarget {

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -6,6 +6,7 @@ import {
   IntegrationConnectionNotFoundError,
   IntegrationConnectionWorkspaceMismatchError,
   IntegrationProviderError,
+  IntegrationRepositoryAuthorizationError,
 } from './errors.js';
 import type {IntegrationProviderRegistry} from './providers/registry.js';
 import type {
@@ -21,6 +22,11 @@ import type {
   ResolvedRef,
   TriggerReference,
 } from './providers/source-control.js';
+import type {
+  RepositoryAuthorizationMode,
+  RepositoryAuthorizationResult,
+  RepositoryAuthorizer,
+} from './repository-authorizer.js';
 
 export interface IntegrationSourceControlService {
   getConnection(connectionId: string): Promise<IntegrationConnection>;
@@ -97,11 +103,20 @@ export interface CreateIntegrationSourceControlServiceOptions {
   getIntegrationConnectionById: (
     connectionId: string,
   ) => Promise<IntegrationConnection | undefined>;
+  repositoryAuthorizer?: RepositoryAuthorizer | undefined;
+  /** Trusted server-side seam for the future per-connection repository mode. */
+  getRepositoryAuthorizationMode?:
+    | ((
+        connection: IntegrationConnection,
+      ) => RepositoryAuthorizationMode | Promise<RepositoryAuthorizationMode>)
+    | undefined;
 }
 
 export function createSourceControlIntegrationService({
   registry,
   getIntegrationConnectionById,
+  repositoryAuthorizer,
+  getRepositoryAuthorizationMode = () => 'selected',
 }: CreateIntegrationSourceControlServiceOptions): IntegrationSourceControlService {
   async function getConnection(connectionId: string): Promise<IntegrationConnection> {
     const connection = await getIntegrationConnectionById(connectionId);
@@ -206,10 +221,16 @@ export function createSourceControlIntegrationService({
       if (!sourceControl.createCheckoutSpec) {
         throw new IntegrationCheckoutUnsupportedError(connection.provider);
       }
+      const target = await authorizeCheckoutTarget({
+        connection,
+        input,
+        repositoryAuthorizer,
+        getRepositoryAuthorizationMode,
+      });
 
       return await sourceControl.createCheckoutSpec({
         connection,
-        target: checkoutTarget(input),
+        target,
         ...(projectId === undefined ? {} : {projectId}),
         ref,
         permissions,
@@ -226,10 +247,16 @@ export function createSourceControlIntegrationService({
       if (!sourceControl?.createCheckoutCredentials) {
         throw new IntegrationCheckoutUnsupportedError(connection.provider);
       }
+      const target = await authorizeCheckoutTarget({
+        connection,
+        input,
+        repositoryAuthorizer,
+        getRepositoryAuthorizationMode,
+      });
 
       const credentials = await sourceControl.createCheckoutCredentials({
         connection,
-        target: checkoutTarget(input),
+        target,
         ...(projectId === undefined ? {} : {projectId}),
         permissions,
         rejectedGeneration,
@@ -246,6 +273,53 @@ export function createSourceControlIntegrationService({
       return credentials;
     },
   };
+}
+
+async function authorizeCheckoutTarget(params: {
+  connection: IntegrationConnection;
+  input: CheckoutTargetInput & {workspaceId: string};
+  repositoryAuthorizer: RepositoryAuthorizer | undefined;
+  getRepositoryAuthorizationMode: (
+    connection: IntegrationConnection,
+  ) => RepositoryAuthorizationMode | Promise<RepositoryAuthorizationMode>;
+}): Promise<CheckoutTarget> {
+  const target = checkoutTarget(params.input);
+  if (params.repositoryAuthorizer === undefined) return target;
+
+  const authorization = await params.repositoryAuthorizer.resolveRepositoryAuthorization({
+    workspaceId: params.input.workspaceId,
+    connectionId: params.connection.id,
+    mode: await params.getRepositoryAuthorizationMode(params.connection),
+    repository: target,
+    capability: 'checkout',
+  });
+  if (authorization === undefined) return target;
+  if (!authorization.authorized) {
+    throw new IntegrationRepositoryAuthorizationError(authorization.reason);
+  }
+  return checkoutTargetFromAuthorization(authorization);
+}
+
+function checkoutTargetFromAuthorization(
+  authorization: Extract<RepositoryAuthorizationResult, {authorized: true}>,
+): CheckoutTarget {
+  if (authorization.repository.externalRepositoryId !== undefined) {
+    return {
+      kind: 'external-id',
+      externalRepositoryId: authorization.repository.externalRepositoryId,
+    };
+  }
+  if (authorization.repository.owner !== undefined && authorization.repository.name !== undefined) {
+    return {
+      kind: 'name',
+      owner: authorization.repository.owner,
+      name: authorization.repository.name,
+    };
+  }
+  throw new IntegrationProviderError(
+    'malformed-provider-response',
+    'Repository authorizer returned an empty authorized target',
+  );
 }
 
 function checkoutTarget(input: CheckoutTargetInput): CheckoutTarget {

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -154,12 +154,50 @@ describe('createIntegrationsContext', () => {
       getProjectBySource,
       findProjectBySourceRepositoryName: vi.fn(),
     } as unknown as ProjectsModuleClient;
+    const workspaceId = crypto.randomUUID();
+    const connection = {
+      id: crypto.randomUUID(),
+      workspaceId,
+      provider: 'github',
+      externalAccountId: 'github-test-account',
+      slug: 'github_test',
+      displayName: 'GitHub Test',
+      lifecycleStatus: 'active' as const,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const getIntegrationConnectionById = vi.fn(async (id: string) =>
+      id === connection.id ? connection : undefined,
+    );
+    const createCheckoutSpec = vi.fn().mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/platform.git',
+      ref: 'main',
+    });
 
     try {
       const {createIntegrationsContext: createContext} = await import('./index.js');
       const context = await createContext({
-        parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+        parts: [
+          {
+            provider: {
+              provider: 'github',
+              displayName: 'GitHub',
+              adapters: {
+                source_control: {
+                  listRepositories: vi.fn(),
+                  resolveRepository: vi.fn(),
+                  listFiles: vi.fn(),
+                  fetchFile: vi.fn(),
+                  resolveTriggerReference: vi.fn().mockReturnValue(null),
+                  resolveRef: vi.fn(),
+                  createCheckoutSpec,
+                },
+              },
+            },
+          },
+        ],
         projects,
+        getIntegrationConnectionById,
       });
 
       expect(context.repositoryAuthorizer.enabled).toBe(true);
@@ -175,6 +213,20 @@ describe('createIntegrationsContext', () => {
       expect(getProjectBySource).toHaveBeenCalledWith({
         workspaceId: 'workspace-1',
         sourceConnectionId: 'connection-1',
+        sourceExternalRepositoryId: 'github:42',
+      });
+
+      await expect(
+        context.sourceControl.createCheckoutSpec({
+          workspaceId,
+          connectionId: connection.id,
+          target: {kind: 'external-id', externalRepositoryId: 'github:42'},
+        }),
+      ).rejects.toMatchObject({reason: 'repository_not_granted'});
+      expect(createCheckoutSpec).not.toHaveBeenCalled();
+      expect(getProjectBySource).toHaveBeenLastCalledWith({
+        workspaceId,
+        sourceConnectionId: connection.id,
         sourceExternalRepositoryId: 'github:42',
       });
     } finally {

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -28,7 +28,10 @@ import {
   createSourceControlIntegrationService,
   type IntegrationSourceControlService,
 } from '#core/source-control-service.js';
-import {getIntegrationConnectionById} from '#db/connections.js';
+import {
+  type GetIntegrationConnectionByIdFn,
+  getIntegrationConnectionById,
+} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
@@ -160,6 +163,7 @@ export {
   resolveRepositoryAuthorization,
 } from '#core/repository-authorizer.js';
 export type {
+  AuthorizedCheckoutSpec,
   CreateSourceCheckoutCredentialsInput,
   IntegrationSourceControlService,
 } from '#core/source-control-service.js';
@@ -226,6 +230,8 @@ export interface CreateIntegrationsModuleOptions {
   parts?: IntegrationModuleParts[] | undefined;
   secrets?: IntegrationProviderSecrets | undefined;
   projects?: ProjectsModuleClient | undefined;
+  /** Test seam for composing checkout authorization without a database connection. */
+  getIntegrationConnectionById?: GetIntegrationConnectionByIdFn | undefined;
   workspaces?: WorkspacesInterModuleClient | undefined;
   agentTools?:
     | {
@@ -298,13 +304,15 @@ export async function createIntegrationsContext(
         }));
 
   const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
+  const resolveIntegrationConnectionById =
+    options.getIntegrationConnectionById ?? getIntegrationConnectionById;
   const repositoryAuthorizer = createRepositoryAuthorizer({
     projects: options.projects,
     enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
   });
   const sourceControl = createSourceControlIntegrationService({
     registry,
-    getIntegrationConnectionById,
+    getIntegrationConnectionById: resolveIntegrationConnectionById,
     repositoryAuthorizer,
   });
   const webhookProcessor = createComposedWebhookProcessor(

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -91,6 +91,7 @@ export {
   IntegrationConnectionWorkspaceMismatchError,
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
+  IntegrationRepositoryAuthorizationError,
   RepositoryAuthorizerConfigurationError,
   WebhookProcessorNotConfiguredError,
 } from '#core/errors.js';
@@ -297,13 +298,14 @@ export async function createIntegrationsContext(
         }));
 
   const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
-  const sourceControl = createSourceControlIntegrationService({
-    registry,
-    getIntegrationConnectionById,
-  });
   const repositoryAuthorizer = createRepositoryAuthorizer({
     projects: options.projects,
     enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
+  });
+  const sourceControl = createSourceControlIntegrationService({
+    registry,
+    getIntegrationConnectionById,
+    repositoryAuthorizer,
   });
   const webhookProcessor = createComposedWebhookProcessor(
     parts.flatMap((part) => part.webhookProcessors ?? []),

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -3,10 +3,13 @@ import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-module';
 import type {z} from 'zod';
 import type {IntegrationConnection} from '#core/entities/connection.js';
-import {IntegrationProviderError} from '#core/errors.js';
+import {IntegrationProviderError, RepositoryAuthorizerConfigurationError} from '#core/errors.js';
 import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {SourceControlProvider} from '#core/providers/source-control.js';
-import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
+import {
+  RepositoryAuthorizationTargetInvalidError,
+  type RepositoryAuthorizer,
+} from '#core/repository-authorizer.js';
 import {createSourceControlIntegrationService} from '#core/source-control-service.js';
 import type {
   IntegrationToolCallCaller,
@@ -35,6 +38,10 @@ function createClient(
     expiresAt: new Date('2026-01-01T00:00:00.000Z'),
   }),
   repositoryAuthorizer?: RepositoryAuthorizer,
+  createCheckoutSpec: NonNullable<SourceControlProvider['createCheckoutSpec']> = async (input) => ({
+    repositoryUrl: 'https://gitea.local/gitea-owner/platform.git',
+    ref: input.ref ?? 'main',
+  }),
 ) {
   const transport = createInMemoryInterModuleTransport();
   const client = transport.createClient(integrationsInterModuleContract);
@@ -52,6 +59,7 @@ function createClient(
             fetchFile: vi.fn(),
             resolveTriggerReference: () => null,
             resolveRef: async (input) => await resolveRef(input),
+            createCheckoutSpec,
             createCheckoutCredentials,
           },
         },
@@ -156,44 +164,97 @@ describe('integrations inter-module presentation', () => {
     }
   });
 
-  it('maps checkout authorization denials to the transport error contract', async () => {
+  it.each([
+    ['repository_not_granted', 'repository-not-granted'],
+    ['repository_ambiguous', 'repository-ambiguous'],
+    ['authorization_store_unavailable', 'repository-authorization-unavailable'],
+  ] as const)('maps %s for both checkout methods', async (reason, code) => {
     const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
       authorized: false,
-      reason: 'repository_not_granted',
-    } as const);
+      reason,
+    });
     const client = createClient(
       async () => ({ref: 'main', commit: 'a'.repeat(40)}),
       undefined,
       undefined,
       {enabled: true, resolveRepositoryAuthorization},
     );
+    const details = {
+      workspaceId,
+      connectionId,
+      target: {kind: 'external-id' as const, externalRepositoryId: input.externalRepositoryId},
+    };
 
-    const error = await client
+    const specError = await client.createCheckoutSpec(input).catch((caught: unknown) => caught);
+    expect(
+      isInterModuleKnownError(
+        integrationsInterModuleContract.methods.createCheckoutSpec,
+        specError,
+      ),
+    ).toBe(true);
+    if (
+      isInterModuleKnownError(integrationsInterModuleContract.methods.createCheckoutSpec, specError)
+    ) {
+      expect(specError.code).toBe(code);
+      expect(specError.details).toEqual(details);
+    }
+
+    const credentialsError = await client
       .createCheckoutCredentials({...input, permissions: {contents: 'read'}})
       .catch((caught: unknown) => caught);
-
     expect(
       isInterModuleKnownError(
         integrationsInterModuleContract.methods.createCheckoutCredentials,
-        error,
+        credentialsError,
       ),
     ).toBe(true);
     if (
       isInterModuleKnownError(
         integrationsInterModuleContract.methods.createCheckoutCredentials,
-        error,
+        credentialsError,
       )
     ) {
-      expect(error.code).toBe('repository-not-granted');
-      expect(error.details).toEqual({});
+      expect(credentialsError.code).toBe(code);
+      expect(credentialsError.details).toEqual(details);
     }
-    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith({
+    expect(resolveRepositoryAuthorization).toHaveBeenNthCalledWith(1, {
       workspaceId,
       connectionId,
       mode: 'selected',
       repository: {kind: 'external-id', externalRepositoryId: input.externalRepositoryId},
       capability: 'checkout',
     });
+  });
+
+  it.each([
+    [RepositoryAuthorizationTargetInvalidError, 'repository-authorization-target-invalid'],
+    [RepositoryAuthorizerConfigurationError, 'repository-authorization-unavailable'],
+  ] as const)('maps %s to a checkout contract error', async (ErrorType, code) => {
+    const client = createClient(
+      async () => ({ref: 'main', commit: 'a'.repeat(40)}),
+      undefined,
+      undefined,
+      {
+        enabled: true,
+        resolveRepositoryAuthorization: vi.fn().mockRejectedValue(new ErrorType()),
+      },
+    );
+
+    const error = await client.createCheckoutSpec(input).catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(integrationsInterModuleContract.methods.createCheckoutSpec, error),
+    ).toBe(true);
+    if (
+      isInterModuleKnownError(integrationsInterModuleContract.methods.createCheckoutSpec, error)
+    ) {
+      expect(error.code).toBe(code);
+      expect(error.details).toEqual({
+        workspaceId,
+        connectionId,
+        target: {kind: 'external-id', externalRepositoryId: input.externalRepositoryId},
+      });
+    }
   });
 
   it('round-trips on-rejection renewal without a refresh timestamp', async () => {

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -34,6 +34,7 @@ function createClient(
     token: 'token',
     expiresAt: new Date('2026-01-01T00:00:00.000Z'),
   }),
+  repositoryAuthorizer?: RepositoryAuthorizer,
 ) {
   const transport = createInMemoryInterModuleTransport();
   const client = transport.createClient(integrationsInterModuleContract);
@@ -72,6 +73,7 @@ function createClient(
           }
         : undefined;
     },
+    repositoryAuthorizer,
   });
 
   transport.register(
@@ -152,6 +154,46 @@ describe('integrations inter-module presentation', () => {
     } else {
       throw error;
     }
+  });
+
+  it('maps checkout authorization denials to the transport error contract', async () => {
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: false,
+      reason: 'repository_not_granted',
+    } as const);
+    const client = createClient(
+      async () => ({ref: 'main', commit: 'a'.repeat(40)}),
+      undefined,
+      undefined,
+      {enabled: true, resolveRepositoryAuthorization},
+    );
+
+    const error = await client
+      .createCheckoutCredentials({...input, permissions: {contents: 'read'}})
+      .catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(
+        integrationsInterModuleContract.methods.createCheckoutCredentials,
+        error,
+      ),
+    ).toBe(true);
+    if (
+      isInterModuleKnownError(
+        integrationsInterModuleContract.methods.createCheckoutCredentials,
+        error,
+      )
+    ) {
+      expect(error.code).toBe('repository-not-granted');
+      expect(error.details).toEqual({});
+    }
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith({
+      workspaceId,
+      connectionId,
+      mode: 'selected',
+      repository: {kind: 'external-id', externalRepositoryId: input.externalRepositoryId},
+      capability: 'checkout',
+    });
   });
 
   it('round-trips on-rejection renewal without a refresh timestamp', async () => {

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -26,6 +26,7 @@ import {
   IntegrationConnectionWorkspaceMismatchError,
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
+  IntegrationRepositoryAuthorizationError,
 } from '#core/errors.js';
 import {buildFixedEventProviders, buildProviderEventCatalogs} from '#core/event-catalogs.js';
 import type {AgentToolCatalogEntry} from '#core/providers/agent-tools.js';
@@ -495,7 +496,35 @@ function mapError(
 ): unknown {
   const connectionError = mapConnectionError(method, input, error);
   if (connectionError !== undefined) return connectionError;
+  const repositoryAuthorizationError = mapRepositoryAuthorizationError(method, error);
+  if (repositoryAuthorizationError !== undefined) return repositoryAuthorizationError;
   return mapProviderError(method, input, error);
+}
+
+function mapRepositoryAuthorizationError(
+  method: InterModuleMethodContract,
+  error: unknown,
+): unknown | undefined {
+  if (!(error instanceof IntegrationRepositoryAuthorizationError)) return undefined;
+
+  switch (error.reason) {
+    case 'repository_not_granted':
+      if ('repository-not-granted' in method.errors) {
+        return createInterModuleKnownError(method, 'repository-not-granted', {});
+      }
+      break;
+    case 'repository_ambiguous':
+      if ('repository-ambiguous' in method.errors) {
+        return createInterModuleKnownError(method, 'repository-ambiguous', {});
+      }
+      break;
+    case 'authorization_store_unavailable':
+      if ('repository-authorization-unavailable' in method.errors) {
+        return createInterModuleKnownError(method, 'repository-authorization-unavailable', {});
+      }
+      break;
+  }
+  return undefined;
 }
 
 function mapConnectionError(

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -27,13 +27,18 @@ import {
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
   IntegrationRepositoryAuthorizationError,
+  RepositoryAuthorizerConfigurationError,
 } from '#core/errors.js';
 import {buildFixedEventProviders, buildProviderEventCatalogs} from '#core/event-catalogs.js';
 import type {AgentToolCatalogEntry} from '#core/providers/agent-tools.js';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
-import type {CheckoutSpec} from '#core/providers/source-control.js';
+import type {CheckoutSpec, CheckoutTarget} from '#core/providers/source-control.js';
 import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
-import type {IntegrationSourceControlService} from '#core/source-control-service.js';
+import {RepositoryAuthorizationTargetInvalidError} from '#core/repository-authorizer.js';
+import type {
+  AuthorizedCheckoutSpec,
+  IntegrationSourceControlService,
+} from '#core/source-control-service.js';
 import {
   createIntegrationToolCallRecorder,
   INVALID_METHOD_LABEL,
@@ -66,6 +71,7 @@ type CheckoutCredentialsDto = {
 type CheckoutSpecDto = {
   repositoryUrl: string;
   ref: string;
+  target: NonNullable<CheckoutSpec['target']>;
   credentials?: CheckoutCredentialsDto;
   gitAuthor?: {name: string; email: string};
 };
@@ -92,10 +98,11 @@ function toCheckoutCredentialsDto(
   return result;
 }
 
-function toCheckoutSpecDto(spec: CheckoutSpec): CheckoutSpecDto {
+function toCheckoutSpecDto(spec: AuthorizedCheckoutSpec): CheckoutSpecDto {
   const result: CheckoutSpecDto = {
     repositoryUrl: spec.repositoryUrl,
     ref: spec.ref,
+    target: spec.target,
   };
   if (spec.credentials !== undefined) {
     result.credentials = toCheckoutCredentialsDto(spec.credentials);
@@ -480,7 +487,7 @@ function toCallToolOutput(outcome: IntegrationToolCallOutcome): CallToolOutput {
 
 async function known<Output>(
   method: InterModuleMethodContract,
-  input: {connectionId?: string; defaultConnectionId?: string; ref?: string | undefined},
+  input: ErrorMappingInput,
   operation: () => Promise<Output>,
 ): Promise<Output> {
   try {
@@ -491,45 +498,86 @@ async function known<Output>(
 }
 function mapError(
   method: InterModuleMethodContract,
-  input: {connectionId?: string; defaultConnectionId?: string; ref?: string | undefined},
+  input: ErrorMappingInput,
   error: unknown,
 ): unknown {
   const connectionError = mapConnectionError(method, input, error);
   if (connectionError !== undefined) return connectionError;
-  const repositoryAuthorizationError = mapRepositoryAuthorizationError(method, error);
+  const repositoryAuthorizationError = mapRepositoryAuthorizationError(method, input, error);
   if (repositoryAuthorizationError !== undefined) return repositoryAuthorizationError;
   return mapProviderError(method, input, error);
 }
 
+type ErrorMappingInput = {
+  workspaceId?: string | undefined;
+  connectionId?: string | undefined;
+  defaultConnectionId?: string | undefined;
+  target?: CheckoutTarget | undefined;
+  externalRepositoryId?: string | undefined;
+  ref?: string | undefined;
+};
+
 function mapRepositoryAuthorizationError(
   method: InterModuleMethodContract,
+  input: ErrorMappingInput,
   error: unknown,
 ): unknown | undefined {
+  const details = repositoryAuthorizationDetails(input);
+
+  if (error instanceof RepositoryAuthorizerConfigurationError) {
+    if ('repository-authorization-unavailable' in method.errors) {
+      return createInterModuleKnownError(method, 'repository-authorization-unavailable', details);
+    }
+    return undefined;
+  }
+  if (error instanceof RepositoryAuthorizationTargetInvalidError) {
+    if ('repository-authorization-target-invalid' in method.errors) {
+      return createInterModuleKnownError(
+        method,
+        'repository-authorization-target-invalid',
+        details,
+      );
+    }
+    return undefined;
+  }
   if (!(error instanceof IntegrationRepositoryAuthorizationError)) return undefined;
 
   switch (error.reason) {
     case 'repository_not_granted':
       if ('repository-not-granted' in method.errors) {
-        return createInterModuleKnownError(method, 'repository-not-granted', {});
+        return createInterModuleKnownError(method, 'repository-not-granted', details);
       }
       break;
     case 'repository_ambiguous':
       if ('repository-ambiguous' in method.errors) {
-        return createInterModuleKnownError(method, 'repository-ambiguous', {});
+        return createInterModuleKnownError(method, 'repository-ambiguous', details);
       }
       break;
     case 'authorization_store_unavailable':
       if ('repository-authorization-unavailable' in method.errors) {
-        return createInterModuleKnownError(method, 'repository-authorization-unavailable', {});
+        return createInterModuleKnownError(method, 'repository-authorization-unavailable', details);
       }
       break;
   }
   return undefined;
 }
 
+function repositoryAuthorizationDetails(input: ErrorMappingInput) {
+  const target =
+    input.target ??
+    (input.externalRepositoryId === undefined
+      ? undefined
+      : {kind: 'external-id' as const, externalRepositoryId: input.externalRepositoryId});
+  return {
+    ...(input.workspaceId === undefined ? {} : {workspaceId: input.workspaceId}),
+    ...(input.connectionId === undefined ? {} : {connectionId: input.connectionId}),
+    ...(target === undefined ? {} : {target}),
+  };
+}
+
 function mapConnectionError(
   method: InterModuleMethodContract,
-  input: {connectionId?: string; defaultConnectionId?: string},
+  input: ErrorMappingInput,
   error: unknown,
 ): unknown | undefined {
   if (error instanceof IntegrationConnectionNotFoundError)

--- a/libs/api/integration/gitea/src/core/source-control.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control.test.ts
@@ -578,6 +578,7 @@ describe('GiteaSourceControlProvider', () => {
       expect(result).toEqual({
         repositoryUrl: 'https://gitea.example.com/shipfox/platform.git',
         ref: 'feature/x',
+        target: {kind: 'external-id', externalRepositoryId: 'gitea:shipfox/platform'},
         credentials: {
           username: 'shipfox-bot',
           token: 'test-service-token',

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -262,6 +262,13 @@ export class GiteaSourceControlProvider
     return {
       repositoryUrl: createCheckoutRepositoryUrl(repository.cloneUrl),
       ref,
+      target: {
+        kind: 'external-id',
+        externalRepositoryId: buildProviderRepositoryId(
+          giteaProviderKind,
+          `${repository.ownerLogin}/${repository.name}`,
+        ),
+      },
       credentials,
     };
   }

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -466,6 +466,7 @@ describe('GithubSourceControlProvider', () => {
     expect(result).toEqual({
       repositoryUrl: 'https://github.com/shipfox/platform.git',
       ref: 'feature/x',
+      target: {kind: 'external-id', externalRepositoryId: 'github:42'},
       credentials: {
         username: 'x-access-token',
         token: 'ghs_installationtoken',

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -274,6 +274,10 @@ export class GithubSourceControlProvider
     return {
       repositoryUrl: repository.cloneUrl,
       ref,
+      target: {
+        kind: 'external-id',
+        externalRepositoryId: buildProviderRepositoryId(GITHUB_PROVIDER, String(repository.id)),
+      },
       credentials,
       ...(gitAuthor ? {gitAuthor} : {}),
     };

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -119,6 +119,8 @@ export interface CheckoutPermissions {
 export interface CheckoutSpec {
   repositoryUrl: string;
   ref: string;
+  /** Provider-resolved identity for renewing a checkout addressed by name. */
+  target?: CheckoutTarget | undefined;
   credentials?: CheckoutCredentials | undefined;
   gitAuthor?: CheckoutGitAuthor | undefined;
 }

--- a/libs/api/projects-dto/src/inter-module.test.ts
+++ b/libs/api/projects-dto/src/inter-module.test.ts
@@ -35,24 +35,16 @@ describe('projectsInterModuleContract', () => {
     ).toEqual(input);
   });
 
-  test('accepts checkout targets addressed by project or repository', () => {
+  test('accepts checkout targets addressed by project', () => {
     const workspaceId = '00000000-0000-4000-8000-000000000001';
-    const connectionId = '00000000-0000-4000-8000-000000000002';
+    const projectId = '00000000-0000-4000-8000-000000000003';
 
     expect(
       projectsInterModuleContract.methods.resolveCheckoutTarget.input.parse({
         workspaceId,
-        defaults: {connectionId, owner: 'acme'},
-        target: {project: '00000000-0000-4000-8000-000000000003'},
+        target: {project: projectId},
       }).target,
-    ).toEqual({project: '00000000-0000-4000-8000-000000000003'});
-    expect(
-      projectsInterModuleContract.methods.resolveCheckoutTarget.input.parse({
-        workspaceId,
-        defaults: {connectionId, owner: 'acme'},
-        target: {connection: connectionId, repository: 'acme/api'},
-      }).target,
-    ).toEqual({connection: connectionId, repository: 'acme/api'});
+    ).toEqual({project: projectId});
   });
 
   test('accepts paginated workspace project source listings', () => {

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -26,19 +26,13 @@ const projectCursorSchema = z.object({
   createdAt: z.string().datetime(),
   id: idSchema,
 });
-const checkoutTargetSchema = z.union([
-  z.strictObject({project: idSchema}),
-  z.strictObject({
-    connection: idSchema.optional(),
-    repository: z.string().min(1),
-  }),
-]);
-const resolvedCheckoutTargetValue = z.discriminatedUnion('kind', [
-  z.strictObject({kind: z.literal('external-id'), externalRepositoryId: z.string()}),
-  z.strictObject({kind: z.literal('name'), owner: z.string().min(1), name: z.string().min(1)}),
-]);
+const checkoutTargetSchema = z.strictObject({project: idSchema});
+const resolvedCheckoutTargetValue = z.strictObject({
+  kind: z.literal('external-id'),
+  externalRepositoryId: z.string(),
+});
 const resolvedCheckoutTargetSchema = z.object({
-  projectId: idSchema.optional(),
+  projectId: idSchema,
   connectionId: idSchema,
   target: resolvedCheckoutTargetValue,
 });
@@ -105,7 +99,6 @@ export const projectsInterModuleContract = defineInterModuleContract({
     resolveCheckoutTarget: {
       input: z.object({
         workspaceId: idSchema,
-        defaults: z.object({connectionId: idSchema, owner: z.string().min(1)}),
         target: checkoutTargetSchema,
       }),
       output: resolvedCheckoutTargetSchema,

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -33,10 +33,14 @@ const checkoutTargetSchema = z.union([
     repository: z.string().min(1),
   }),
 ]);
+const resolvedCheckoutTargetValue = z.discriminatedUnion('kind', [
+  z.strictObject({kind: z.literal('external-id'), externalRepositoryId: z.string()}),
+  z.strictObject({kind: z.literal('name'), owner: z.string().min(1), name: z.string().min(1)}),
+]);
 const resolvedCheckoutTargetSchema = z.object({
-  projectId: idSchema,
+  projectId: idSchema.optional(),
   connectionId: idSchema,
-  externalRepositoryId: z.string(),
+  target: resolvedCheckoutTargetValue,
 });
 
 /** Producer-owned project lookup and workspace ownership operations. */

--- a/libs/api/projects/README.md
+++ b/libs/api/projects/README.md
@@ -68,6 +68,12 @@ The create form derives an editable default slug from the project name. The API
 requires an explicit slug and never adds a suffix when the value is taken. A
 rename frees the old slug immediately and emits a project-updated outbox event.
 
+Checkout authorization in selected mode reads the persisted source repository
+owner and name. The `integrations.source_control.repository_updated` event
+refreshes this metadata after provider-side changes. If a provider misses a
+webhook, use the project and source identifiers to locate the stale row.
+Reprocess the provider event before enabling authorization or retrying checkout.
+
 ## Development
 
 ```sh

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -296,69 +296,36 @@ export async function requireProjectForWorkspace(params: {
 
 export interface ResolveCheckoutTargetParams {
   workspaceId: string;
-  defaults: {
-    connectionId: string;
-    owner: string;
-  };
-  target: {project: string} | {connection?: string | undefined; repository: string};
+  target: {project: string};
 }
 
 export interface ResolvedCheckoutTarget {
-  projectId?: string | undefined;
+  projectId: string;
   connectionId: string;
-  target:
-    | {kind: 'external-id'; externalRepositoryId: string}
-    | {kind: 'name'; owner: string; name: string};
+  target: {kind: 'external-id'; externalRepositoryId: string};
 }
 
 export async function resolveCheckoutTarget(
   params: ResolveCheckoutTargetParams,
 ): Promise<ResolvedCheckoutTarget | undefined> {
-  const selection = {
-    projectId: projects.id,
-    connectionId: projects.sourceConnectionId,
-    externalRepositoryId: projects.sourceExternalRepositoryId,
-  };
-
-  if ('project' in params.target) {
-    const [project] = await db()
-      .select(selection)
-      .from(projects)
-      .where(
-        and(eq(projects.workspaceId, params.workspaceId), eq(projects.id, params.target.project)),
-      )
-      .limit(1);
-    return project === undefined
-      ? undefined
-      : {
-          projectId: project.projectId,
-          connectionId: project.connectionId,
-          target: {kind: 'external-id', externalRepositoryId: project.externalRepositoryId},
-        };
-  }
-
-  const separator = params.target.repository.indexOf('/');
-  if (separator === 0 || separator === params.target.repository.length - 1) return undefined;
-
-  let repository: {connectionId: string; owner: string; name: string} | undefined;
-  if (separator === -1) {
-    repository = {
-      connectionId: params.target.connection ?? params.defaults.connectionId,
-      owner: params.defaults.owner,
-      name: params.target.repository,
-    };
-  } else if (params.target.repository.indexOf('/', separator + 1) === -1) {
-    repository = {
-      connectionId: params.target.connection ?? params.defaults.connectionId,
-      owner: params.target.repository.slice(0, separator),
-      name: params.target.repository.slice(separator + 1),
-    };
-  }
-  if (repository === undefined) return undefined;
-  return {
-    connectionId: repository.connectionId,
-    target: {kind: 'name', owner: repository.owner, name: repository.name},
-  };
+  const [project] = await db()
+    .select({
+      projectId: projects.id,
+      connectionId: projects.sourceConnectionId,
+      externalRepositoryId: projects.sourceExternalRepositoryId,
+    })
+    .from(projects)
+    .where(
+      and(eq(projects.workspaceId, params.workspaceId), eq(projects.id, params.target.project)),
+    )
+    .limit(1);
+  return project === undefined
+    ? undefined
+    : {
+        projectId: project.projectId,
+        connectionId: project.connectionId,
+        target: {kind: 'external-id', externalRepositoryId: project.externalRepositoryId},
+      };
 }
 
 export async function listProjects(params: ListProjectsParams): Promise<ListProjectsResult> {

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -304,35 +304,11 @@ export interface ResolveCheckoutTargetParams {
 }
 
 export interface ResolvedCheckoutTarget {
-  projectId: string;
+  projectId?: string | undefined;
   connectionId: string;
-  externalRepositoryId: string;
-}
-
-export interface UpdateProjectSourceMetadataParams {
-  workspaceId: string;
-  projectId: string;
-  sourceConnectionId: string;
-  sourceExternalRepositoryId: string;
-  sourceRepositoryOwner: string;
-  sourceRepositoryName: string;
-  sourceDefaultBranch: string;
-}
-
-export async function updateProjectSourceMetadata(
-  params: UpdateProjectSourceMetadataParams,
-): Promise<void> {
-  await db()
-    .update(projects)
-    .set({
-      sourceConnectionId: params.sourceConnectionId,
-      sourceExternalRepositoryId: params.sourceExternalRepositoryId,
-      sourceRepositoryOwner: params.sourceRepositoryOwner,
-      sourceRepositoryName: params.sourceRepositoryName,
-      sourceDefaultBranch: params.sourceDefaultBranch,
-      updatedAt: new Date(),
-    })
-    .where(and(eq(projects.workspaceId, params.workspaceId), eq(projects.id, params.projectId)));
+  target:
+    | {kind: 'external-id'; externalRepositoryId: string}
+    | {kind: 'name'; owner: string; name: string};
 }
 
 export async function resolveCheckoutTarget(
@@ -352,7 +328,13 @@ export async function resolveCheckoutTarget(
         and(eq(projects.workspaceId, params.workspaceId), eq(projects.id, params.target.project)),
       )
       .limit(1);
-    return project;
+    return project === undefined
+      ? undefined
+      : {
+          projectId: project.projectId,
+          connectionId: project.connectionId,
+          target: {kind: 'external-id', externalRepositoryId: project.externalRepositoryId},
+        };
   }
 
   const separator = params.target.repository.indexOf('/');
@@ -373,23 +355,10 @@ export async function resolveCheckoutTarget(
     };
   }
   if (repository === undefined) return undefined;
-
-  const matches = await db()
-    .select(selection)
-    .from(projects)
-    .where(
-      whereSourceRepositoryMatches({
-        workspaceId: params.workspaceId,
-        sourceConnectionId: repository.connectionId,
-        sourceRepositoryOwner: repository.owner,
-        sourceRepositoryName: repository.name,
-      }),
-    )
-    .limit(2);
-
-  // Owner/name isn't a unique key: renamed or reconnected repositories can leave
-  // more than one project row matching. Fail closed instead of picking arbitrarily.
-  return matches.length === 1 ? matches[0] : undefined;
+  return {
+    connectionId: repository.connectionId,
+    target: {kind: 'name', owner: repository.owner, name: repository.name},
+  };
 }
 
 export async function listProjects(params: ListProjectsParams): Promise<ListProjectsResult> {

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -66,7 +66,7 @@ export function createProjectsModule({
     e2eRoutes: [projectsE2eRoutes],
     metrics: registerProjectsServiceMetrics,
     publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
-    interModulePresentations: [createProjectsInterModulePresentation({integrations})],
+    interModulePresentations: [createProjectsInterModulePresentation()],
     subscribers: [
       subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed),
       subscriber(INTEGRATION_SOURCE_REPOSITORY_UPDATED, onSourceRepositoryUpdated),

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -1,4 +1,3 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-module';
@@ -6,26 +5,10 @@ import {db} from '#db/index.js';
 import {projects} from '#db/schema/projects.js';
 import {createProjectsInterModulePresentation} from './inter-module.js';
 
-function createClient(
-  integrations: Pick<IntegrationsModuleClient, 'resolveSourceRepository'> = {
-    resolveSourceRepository: vi.fn(async ({connectionId, externalRepositoryId}) => ({
-      connection: {id: connectionId, provider: 'github', slug: 'github'},
-      repository: {
-        externalRepositoryId,
-        owner: 'acme',
-        name: 'api',
-        fullName: 'acme/api',
-        defaultBranch: 'main',
-        visibility: 'private' as const,
-        cloneUrl: 'https://github.com/acme/api.git',
-        htmlUrl: 'https://github.com/acme/api',
-      },
-    })),
-  },
-) {
+function createClient() {
   const transport = createInMemoryInterModuleTransport();
   const client = transport.createClient(projectsInterModuleContract);
-  transport.register(createProjectsInterModulePresentation({integrations}));
+  transport.register(createProjectsInterModulePresentation());
   transport.seal();
   return client;
 }
@@ -168,8 +151,7 @@ describe('Projects checkout target inter-module presentation', () => {
   });
 
   test('finds zero, one, and multiple source repository name matches', async () => {
-    const resolveSourceRepository = vi.fn();
-    const client = createClient({resolveSourceRepository});
+    const client = createClient();
     const workspaceId = crypto.randomUUID();
     const connectionId = crypto.randomUUID();
 
@@ -240,7 +222,6 @@ describe('Projects checkout target inter-module presentation', () => {
 
     expect(multipleMatches.projects).toHaveLength(2);
     expect(multipleMatches.projects.map(({id}) => id)).toEqual([first.projectId, second.projectId]);
-    expect(resolveSourceRepository).not.toHaveBeenCalled();
   });
 
   test('resolves a project target in its workspace', async () => {
@@ -259,14 +240,21 @@ describe('Projects checkout target inter-module presentation', () => {
         defaults: {connectionId: crypto.randomUUID(), owner: 'other'},
         target: {project: project.projectId},
       }),
-    ).resolves.toEqual(project);
+    ).resolves.toEqual({
+      projectId: project.projectId,
+      connectionId: project.connectionId,
+      target: {
+        kind: 'external-id',
+        externalRepositoryId: project.externalRepositoryId,
+      },
+    });
   });
 
   test('resolves a bare repository name against the default owner', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();
     const connectionId = crypto.randomUUID();
-    const project = await insertProject({
+    await insertProject({
       workspaceId,
       connectionId,
       owner: 'AcMe',
@@ -279,14 +267,17 @@ describe('Projects checkout target inter-module presentation', () => {
         defaults: {connectionId, owner: 'acme'},
         target: {repository: 'api'},
       }),
-    ).resolves.toEqual(project);
+    ).resolves.toEqual({
+      connectionId,
+      target: {kind: 'name', owner: 'acme', name: 'api'},
+    });
   });
 
   test('resolves an owner/name repository case-insensitively', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();
     const connectionId = crypto.randomUUID();
-    const project = await insertProject({
+    await insertProject({
       workspaceId,
       connectionId,
       owner: 'AcMe',
@@ -299,7 +290,10 @@ describe('Projects checkout target inter-module presentation', () => {
         defaults: {connectionId, owner: 'other'},
         target: {repository: 'aCmE/aPI'},
       }),
-    ).resolves.toEqual(project);
+    ).resolves.toEqual({
+      connectionId,
+      target: {kind: 'name', owner: 'aCmE', name: 'aPI'},
+    });
   });
 
   test('uses an explicit connection to select between identical repositories', async () => {
@@ -313,7 +307,7 @@ describe('Projects checkout target inter-module presentation', () => {
       owner: 'acme',
       name: 'api',
     });
-    const explicitProject = await insertProject({
+    await insertProject({
       workspaceId,
       connectionId: explicitConnectionId,
       owner: 'acme',
@@ -326,70 +320,32 @@ describe('Projects checkout target inter-module presentation', () => {
         defaults: {connectionId: defaultConnectionId, owner: 'acme'},
         target: {connection: explicitConnectionId, repository: 'acme/api'},
       }),
-    ).resolves.toEqual(explicitProject);
+    ).resolves.toEqual({
+      connectionId: explicitConnectionId,
+      target: {kind: 'name', owner: 'acme', name: 'api'},
+    });
   });
 
-  test('rejects an ambiguous owner/name match instead of picking arbitrarily', async () => {
+  test('preserves an owner/name target without deciding authorization', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();
     const connectionId = crypto.randomUUID();
     await insertProject({workspaceId, connectionId, owner: 'acme', name: 'api'});
     await insertProject({workspaceId, connectionId, owner: 'acme', name: 'api'});
 
-    await expectUnauthorized(client, {
-      workspaceId,
-      defaults: {connectionId, owner: 'acme'},
-      target: {repository: 'acme/api'},
-    });
-  });
-
-  test('refreshes provider metadata before resolving a repository name', async () => {
-    const workspaceId = crypto.randomUUID();
-    const connectionId = crypto.randomUUID();
-    const externalRepositoryId = `github:${crypto.randomUUID()}`;
-    const resolveSourceRepository = vi.fn(async () => ({
-      connection: {id: connectionId, provider: 'github', slug: 'github'},
-      repository: {
-        externalRepositoryId,
-        owner: 'acme',
-        name: 'new-name',
-        fullName: 'acme/new-name',
-        defaultBranch: 'main',
-        visibility: 'private' as const,
-        cloneUrl: 'https://github.com/acme/new-name.git',
-        htmlUrl: 'https://github.com/acme/new-name',
-      },
-    }));
-    const client = createClient({resolveSourceRepository});
-    const project = await insertProject({
-      workspaceId,
-      connectionId,
-      owner: 'acme',
-      name: 'old-name',
-      externalRepositoryId,
-    });
-
-    await expectUnauthorized(client, {
-      workspaceId,
-      defaults: {connectionId, owner: 'acme'},
-      target: {repository: 'acme/old-name'},
-    });
-
     await expect(
       client.resolveCheckoutTarget({
         workspaceId,
         defaults: {connectionId, owner: 'acme'},
-        target: {repository: 'acme/new-name'},
+        target: {repository: 'acme/api'},
       }),
-    ).resolves.toEqual(project);
-    expect(resolveSourceRepository).toHaveBeenCalledWith({
-      workspaceId,
+    ).resolves.toEqual({
       connectionId,
-      externalRepositoryId: project.externalRepositoryId,
+      target: {kind: 'name', owner: 'acme', name: 'api'},
     });
   });
 
-  test('does not let a bare name escape the default owner', async () => {
+  test('does not decide authorization for a bare repository name', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();
     const connectionId = crypto.randomUUID();
@@ -400,10 +356,15 @@ describe('Projects checkout target inter-module presentation', () => {
       name: 'api',
     });
 
-    await expectUnauthorized(client, {
-      workspaceId,
-      defaults: {connectionId, owner: 'acme'},
-      target: {repository: 'api'},
+    await expect(
+      client.resolveCheckoutTarget({
+        workspaceId,
+        defaults: {connectionId, owner: 'acme'},
+        target: {repository: 'api'},
+      }),
+    ).resolves.toEqual({
+      connectionId,
+      target: {kind: 'name', owner: 'acme', name: 'api'},
     });
   });
 
@@ -424,7 +385,6 @@ describe('Projects checkout target inter-module presentation', () => {
   });
 
   test.each([
-    ['an unknown target', {repository: 'acme/missing'}],
     ['a leading slash', {repository: '/api'}],
     ['a trailing slash', {repository: 'acme/'}],
     ['more than one slash', {repository: 'acme/api/extra'}],

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -237,7 +237,6 @@ describe('Projects checkout target inter-module presentation', () => {
     await expect(
       client.resolveCheckoutTarget({
         workspaceId,
-        defaults: {connectionId: crypto.randomUUID(), owner: 'other'},
         target: {project: project.projectId},
       }),
     ).resolves.toEqual({
@@ -247,124 +246,6 @@ describe('Projects checkout target inter-module presentation', () => {
         kind: 'external-id',
         externalRepositoryId: project.externalRepositoryId,
       },
-    });
-  });
-
-  test('resolves a bare repository name against the default owner', async () => {
-    const client = createClient();
-    const workspaceId = crypto.randomUUID();
-    const connectionId = crypto.randomUUID();
-    await insertProject({
-      workspaceId,
-      connectionId,
-      owner: 'AcMe',
-      name: 'Api',
-    });
-
-    await expect(
-      client.resolveCheckoutTarget({
-        workspaceId,
-        defaults: {connectionId, owner: 'acme'},
-        target: {repository: 'api'},
-      }),
-    ).resolves.toEqual({
-      connectionId,
-      target: {kind: 'name', owner: 'acme', name: 'api'},
-    });
-  });
-
-  test('resolves an owner/name repository case-insensitively', async () => {
-    const client = createClient();
-    const workspaceId = crypto.randomUUID();
-    const connectionId = crypto.randomUUID();
-    await insertProject({
-      workspaceId,
-      connectionId,
-      owner: 'AcMe',
-      name: 'Api',
-    });
-
-    await expect(
-      client.resolveCheckoutTarget({
-        workspaceId,
-        defaults: {connectionId, owner: 'other'},
-        target: {repository: 'aCmE/aPI'},
-      }),
-    ).resolves.toEqual({
-      connectionId,
-      target: {kind: 'name', owner: 'aCmE', name: 'aPI'},
-    });
-  });
-
-  test('uses an explicit connection to select between identical repositories', async () => {
-    const client = createClient();
-    const workspaceId = crypto.randomUUID();
-    const defaultConnectionId = crypto.randomUUID();
-    const explicitConnectionId = crypto.randomUUID();
-    await insertProject({
-      workspaceId,
-      connectionId: defaultConnectionId,
-      owner: 'acme',
-      name: 'api',
-    });
-    await insertProject({
-      workspaceId,
-      connectionId: explicitConnectionId,
-      owner: 'acme',
-      name: 'api',
-    });
-
-    await expect(
-      client.resolveCheckoutTarget({
-        workspaceId,
-        defaults: {connectionId: defaultConnectionId, owner: 'acme'},
-        target: {connection: explicitConnectionId, repository: 'acme/api'},
-      }),
-    ).resolves.toEqual({
-      connectionId: explicitConnectionId,
-      target: {kind: 'name', owner: 'acme', name: 'api'},
-    });
-  });
-
-  test('preserves an owner/name target without deciding authorization', async () => {
-    const client = createClient();
-    const workspaceId = crypto.randomUUID();
-    const connectionId = crypto.randomUUID();
-    await insertProject({workspaceId, connectionId, owner: 'acme', name: 'api'});
-    await insertProject({workspaceId, connectionId, owner: 'acme', name: 'api'});
-
-    await expect(
-      client.resolveCheckoutTarget({
-        workspaceId,
-        defaults: {connectionId, owner: 'acme'},
-        target: {repository: 'acme/api'},
-      }),
-    ).resolves.toEqual({
-      connectionId,
-      target: {kind: 'name', owner: 'acme', name: 'api'},
-    });
-  });
-
-  test('does not decide authorization for a bare repository name', async () => {
-    const client = createClient();
-    const workspaceId = crypto.randomUUID();
-    const connectionId = crypto.randomUUID();
-    await insertProject({
-      workspaceId,
-      connectionId,
-      owner: 'other',
-      name: 'api',
-    });
-
-    await expect(
-      client.resolveCheckoutTarget({
-        workspaceId,
-        defaults: {connectionId, owner: 'acme'},
-        target: {repository: 'api'},
-      }),
-    ).resolves.toEqual({
-      connectionId,
-      target: {kind: 'name', owner: 'acme', name: 'api'},
     });
   });
 
@@ -379,30 +260,7 @@ describe('Projects checkout target inter-module presentation', () => {
 
     await expectUnauthorized(client, {
       workspaceId: crypto.randomUUID(),
-      defaults: {connectionId: project.connectionId, owner: 'acme'},
       target: {project: project.projectId},
-    });
-  });
-
-  test.each([
-    ['a leading slash', {repository: '/api'}],
-    ['a trailing slash', {repository: 'acme/'}],
-    ['more than one slash', {repository: 'acme/api/extra'}],
-  ])('rejects %s', async (_label, target) => {
-    const client = createClient();
-    const workspaceId = crypto.randomUUID();
-    const connectionId = crypto.randomUUID();
-    await insertProject({
-      workspaceId,
-      connectionId,
-      owner: 'acme',
-      name: 'new-name',
-    });
-
-    await expectUnauthorized(client, {
-      workspaceId,
-      defaults: {connectionId, owner: 'acme'},
-      target,
     });
   });
 });

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -1,4 +1,3 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {
   createInterModuleKnownError,
@@ -13,12 +12,11 @@ import {
   getWorkspaceProjectCounts,
   listProjects,
   resolveCheckoutTarget,
-  updateProjectSourceMetadata,
 } from '#db/projects.js';
 
-export function createProjectsInterModulePresentation(params: {
-  integrations: Pick<IntegrationsModuleClient, 'resolveSourceRepository'>;
-}): InterModulePresentation<typeof projectsInterModuleContract> {
+export function createProjectsInterModulePresentation(): InterModulePresentation<
+  typeof projectsInterModuleContract
+> {
   return defineInterModulePresentation(projectsInterModuleContract, {
     getProjectById: async ({projectId}) => ({project: (await getProjectById(projectId)) ?? null}),
     getProjectBySource: async (input) => ({
@@ -72,55 +70,6 @@ export function createProjectsInterModulePresentation(params: {
         );
       }
 
-      if ('repository' in input.target) {
-        const source = await params.integrations
-          .resolveSourceRepository({
-            workspaceId: input.workspaceId,
-            connectionId: target.connectionId,
-            externalRepositoryId: target.externalRepositoryId,
-          })
-          .catch(() => undefined);
-        if (source === undefined) {
-          throw createInterModuleKnownError(
-            projectsInterModuleContract.methods.resolveCheckoutTarget,
-            'checkout-repository-not-authorized',
-            {},
-          );
-        }
-
-        const {owner: requestedOwner, name: requestedName} = requestedRepository(
-          input.target.repository,
-          input.defaults.owner,
-        );
-        const repositoryMatches =
-          source.repository.owner.toLowerCase() === requestedOwner.toLowerCase() &&
-          source.repository.name.toLowerCase() === requestedName.toLowerCase();
-
-        await updateProjectSourceMetadata({
-          workspaceId: input.workspaceId,
-          projectId: target.projectId,
-          sourceConnectionId: source.connection.id,
-          sourceExternalRepositoryId: source.repository.externalRepositoryId,
-          sourceRepositoryOwner: source.repository.owner,
-          sourceRepositoryName: source.repository.name,
-          sourceDefaultBranch: source.repository.defaultBranch,
-        });
-
-        if (!repositoryMatches) {
-          throw createInterModuleKnownError(
-            projectsInterModuleContract.methods.resolveCheckoutTarget,
-            'checkout-repository-not-authorized',
-            {},
-          );
-        }
-
-        return {
-          ...target,
-          connectionId: source.connection.id,
-          externalRepositoryId: source.repository.externalRepositoryId,
-        };
-      }
-
       return target;
     },
   });
@@ -164,13 +113,4 @@ function toProjectInterModule(project: Project) {
     sourceDefaultBranch: project.sourceDefaultBranch,
     name: project.name,
   };
-}
-
-function requestedRepository(
-  repository: string,
-  defaultOwner: string,
-): {owner: string; name: string} {
-  const separator = repository.indexOf('/');
-  if (separator === -1) return {owner: defaultOwner, name: repository};
-  return {owner: repository.slice(0, separator), name: repository.slice(separator + 1)};
 }

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -34,7 +34,7 @@ const projects = createFakeInterModuleClients({
     resolveCheckoutTarget: () => ({
       projectId: crypto.randomUUID(),
       connectionId: crypto.randomUUID(),
-      externalRepositoryId: 'repo',
+      target: {kind: 'external-id' as const, externalRepositoryId: 'repo'},
     }),
   }),
 }).projects;

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -186,7 +186,7 @@ describe('defaultModules', () => {
           resolveCheckoutTarget: () => ({
             projectId: crypto.randomUUID(),
             connectionId: crypto.randomUUID(),
-            externalRepositoryId: 'repo',
+            target: {kind: 'external-id' as const, externalRepositoryId: 'repo'},
           }),
         }),
       ],

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -97,7 +97,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -129,7 +129,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       permissions: {contents: 'read'},
     });
   });
@@ -148,7 +149,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: targetProjectId,
       connectionId: crypto.randomUUID(),
-      externalRepositoryId: 'github:412',
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -173,7 +174,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: expect.any(String),
-      externalRepositoryId: 'github:412',
+      projectId: targetProjectId,
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
       ref: 'refs/pull/412/head',
       permissions: {contents: 'write'},
     });
@@ -187,7 +189,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -207,7 +209,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: triggerReference.commit,
       permissions: {contents: 'read'},
     });
@@ -221,7 +224,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -241,7 +244,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: explicitRef,
       permissions: {contents: 'read'},
     });
@@ -255,7 +259,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -275,7 +279,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       permissions: {contents: 'read'},
     });
   });
@@ -289,7 +294,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -309,7 +314,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: devCommit,
       permissions: {contents: 'read'},
     });
@@ -323,7 +329,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: targetProjectId,
       connectionId: crypto.randomUUID(),
-      externalRepositoryId: 'github:412',
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/target.git',
@@ -343,7 +349,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: expect.any(String),
-      externalRepositoryId: 'github:412',
+      projectId: targetProjectId,
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
       permissions: {contents: 'read'},
     });
   });
@@ -356,7 +363,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -375,7 +382,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: devCommit,
       permissions: {contents: 'read'},
     });
@@ -390,7 +398,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -410,7 +418,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: eventCommit,
       permissions: {contents: 'read'},
     });
@@ -424,7 +433,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
@@ -444,7 +453,8 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: explicitRef,
       permissions: {contents: 'read'},
     });
@@ -458,7 +468,7 @@ describe('createStepCheckoutSpec', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: targetProjectId,
       connectionId: crypto.randomUUID(),
-      externalRepositoryId: 'github:412',
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/target.git',
@@ -478,20 +488,16 @@ describe('createStepCheckoutSpec', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: expect.any(String),
-      externalRepositoryId: 'github:412',
+      projectId: targetProjectId,
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
       permissions: {contents: 'read'},
     });
   });
 
-  it('resolves a repository target using the frozen project owner as the default', async () => {
+  it('passes a repository target using the frozen project owner as the default', async () => {
     const project = projectFactory.build();
     const step = checkoutStep({repository: 'repo', persist_credentials: true});
     getProjectById.mockResolvedValue({project});
-    resolveCheckoutTarget.mockResolvedValue({
-      projectId: project.id,
-      connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
-    });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
       ref: 'main',
@@ -506,24 +512,21 @@ describe('createStepCheckoutSpec', () => {
       projects: projects as ProjectsModuleClient,
     });
 
-    expect(resolveCheckoutTarget).toHaveBeenCalledWith({
+    expect(resolveCheckoutTarget).not.toHaveBeenCalled();
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
-      defaults: {connectionId: project.sourceConnectionId, owner: 'acme'},
-      target: {repository: 'repo'},
+      connectionId: project.sourceConnectionId,
+      target: {kind: 'name', owner: 'acme', name: 'repo'},
+      permissions: {contents: 'read'},
     });
   });
 
-  it('resolves an explicit connection slug before resolving a repository target', async () => {
+  it('resolves an explicit connection slug before passing a repository target', async () => {
     const project = projectFactory.build();
     const connectionId = crypto.randomUUID();
     const step = checkoutStep({connection: 'github', repository: 'acme/repo'});
     getProjectById.mockResolvedValue({project});
     resolveConnection.mockResolvedValue({id: connectionId, provider: 'github', slug: 'github'});
-    resolveCheckoutTarget.mockResolvedValue({
-      projectId: project.id,
-      connectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
-    });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
       ref: 'main',
@@ -542,10 +545,12 @@ describe('createStepCheckoutSpec', () => {
       workspaceId: project.workspaceId,
       slug: 'github',
     });
-    expect(resolveCheckoutTarget).toHaveBeenCalledWith({
+    expect(resolveCheckoutTarget).not.toHaveBeenCalled();
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
-      defaults: {connectionId: project.sourceConnectionId, owner: 'acme'},
-      target: {connection: connectionId, repository: 'acme/repo'},
+      connectionId,
+      target: {kind: 'name', owner: 'acme', name: 'repo'},
+      permissions: {contents: 'read'},
     });
   });
 
@@ -556,11 +561,6 @@ describe('createStepCheckoutSpec', () => {
     const project = projectFactory.build({sourceRepositoryOwner: null});
     const step = checkoutStep({repository});
     getProjectById.mockResolvedValue({project});
-    resolveCheckoutTarget.mockResolvedValue({
-      projectId: project.id,
-      connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
-    });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://github.com/acme/repo.git',
       ref: 'main',
@@ -575,10 +575,40 @@ describe('createStepCheckoutSpec', () => {
       projects: projects as ProjectsModuleClient,
     });
 
-    expect(resolveCheckoutTarget).toHaveBeenCalledWith({
+    expect(resolveCheckoutTarget).not.toHaveBeenCalled();
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
-      defaults: {connectionId: project.sourceConnectionId, owner},
-      target: {repository},
+      connectionId: project.sourceConnectionId,
+      target: {kind: 'name', owner, name: repository.includes('/') ? 'repo' : repository},
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('does not use another project trigger or dev commit for a repository target', async () => {
+    const project = projectFactory.build();
+    const step = checkoutStep({repository: 'acme/other'});
+    getProjectById.mockResolvedValue({project});
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/other.git',
+      ref: 'main',
+    });
+
+    await createStepCheckoutSpec({
+      run: devRun('b'.repeat(40)),
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      triggerReference: triggerReferenceFor(project.id),
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(resolveCheckoutTarget).not.toHaveBeenCalled();
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      target: {kind: 'name', owner: 'acme', name: 'other'},
+      permissions: {contents: 'read'},
     });
   });
 

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -123,7 +123,6 @@ describe('createStepCheckoutSpec', () => {
     });
     expect(resolveCheckoutTarget).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
-      defaults: {connectionId: project.sourceConnectionId, owner: 'acme'},
       target: {project: project.id},
     });
     expect(createCheckoutSpec).toHaveBeenCalledWith({
@@ -584,6 +583,71 @@ describe('createStepCheckoutSpec', () => {
     });
   });
 
+  it('preserves the same-project trigger commit for a repository-name target', async () => {
+    const project = projectFactory.build({
+      sourceExternalRepositoryId: 'github:42',
+      sourceRepositoryName: 'repo',
+    });
+    const triggerCommit = 'c'.repeat(40);
+    const step = checkoutStep({repository: 'ACME/REPO'});
+    getProjectById.mockResolvedValue({project});
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      ref: triggerCommit,
+    });
+
+    await createStepCheckoutSpec({
+      run: syncedRun,
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      triggerReference: {...triggerReferenceFor(project.id), commit: triggerCommit},
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: 'github:42'},
+      ref: triggerCommit,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('preserves the same-project dev commit for a repository-name target', async () => {
+    const project = projectFactory.build({
+      sourceExternalRepositoryId: 'github:42',
+      sourceRepositoryName: 'repo',
+    });
+    const devCommit = 'd'.repeat(40);
+    const step = checkoutStep({repository: 'acme/repo'});
+    getProjectById.mockResolvedValue({project});
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      ref: devCommit,
+    });
+
+    await createStepCheckoutSpec({
+      run: devRun(devCommit),
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: 'github:42'},
+      ref: devCommit,
+      permissions: {contents: 'read'},
+    });
+  });
+
   it('does not use another project trigger or dev commit for a repository target', async () => {
     const project = projectFactory.build();
     const step = checkoutStep({repository: 'acme/other'});
@@ -610,6 +674,61 @@ describe('createStepCheckoutSpec', () => {
       target: {kind: 'name', owner: 'acme', name: 'other'},
       permissions: {contents: 'read'},
     });
+  });
+
+  it('uses the provider-resolved target for name-target credential renewal', async () => {
+    const project = projectFactory.build();
+    const step = checkoutStep({repository: 'acme/other', persist_credentials: true});
+    getProjectById.mockResolvedValue({project});
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/other.git',
+      ref: 'main',
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
+      credentials: {
+        username: 'x-access-token',
+        token: 'secret',
+        expiresAt: '2027-01-01T00:00:00.000Z',
+        generation: 'generation-1',
+        renewal: {mode: 'on-rejection'},
+      },
+    });
+
+    const result = await createStepCheckoutSpec({
+      run: syncedRun,
+      step,
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    expect(result.renewalSubject).toEqual({
+      repositoryUrl: 'https://github.com/acme/other',
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: 'github:412',
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it.each([
+    '/repo',
+    'owner/',
+    'owner/repo/extra',
+  ])('rejects malformed repository syntax: %s', async (repository) => {
+    const project = projectFactory.build();
+    getProjectById.mockResolvedValue({project});
+
+    const act = createStepCheckoutSpec({
+      run: syncedRun,
+      step: checkoutStep({repository}),
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    await expect(act).rejects.toBeInstanceOf(CheckoutConfigInvalidError);
+    expect(createCheckoutSpec).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -647,6 +766,27 @@ describe('createStepCheckoutSpec', () => {
 
     await expect(act).rejects.toBeInstanceOf(CheckoutIntentUnresolvedError);
     expect(resolveCheckoutTarget).not.toHaveBeenCalled();
+    expect(createCheckoutSpec).not.toHaveBeenCalled();
+  });
+
+  it('identifies a missing explicit project in the unresolved error', async () => {
+    const project = projectFactory.build();
+    const targetProjectId = crypto.randomUUID();
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue(undefined);
+
+    const act = createStepCheckoutSpec({
+      run: syncedRun,
+      step: checkoutStep({project: targetProjectId}),
+      workspaceId: project.workspaceId,
+      projectId: project.id,
+      integrations: integrations as IntegrationsModuleClient,
+      projects: projects as ProjectsModuleClient,
+    });
+
+    await expect(act).rejects.toThrow(
+      `Checkout intent unresolved: project ${targetProjectId} not found`,
+    );
     expect(createCheckoutSpec).not.toHaveBeenCalled();
   });
 

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -109,22 +109,22 @@ export async function createStepCheckoutSpec({
     'project' in target
       ? await projects.resolveCheckoutTarget({
           workspaceId,
-          defaults: {
-            connectionId: defaultProject.sourceConnectionId,
-            owner: defaultOwner(defaultProject.sourceRepositoryOwner, checkout.repository),
-          },
           target,
         })
-      : {
+      : repositoryCheckoutTarget({
           connectionId: target.connection ?? defaultProject.sourceConnectionId,
-          target: repositoryTarget(
+          defaultProject,
+          repository: repositoryTarget(
             target.repository,
             defaultOwner(defaultProject.sourceRepositoryOwner, target.repository),
             step.id,
           ),
-        };
+        });
   if (resolvedTarget === undefined) {
-    throw new CheckoutIntentUnresolvedError({kind: 'project', value: projectId});
+    throw new CheckoutIntentUnresolvedError({
+      kind: 'project',
+      value: 'project' in target ? target.project : projectId,
+    });
   }
   const ref = resolveCheckoutRef({checkout, triggerReference, run, resolvedTarget, projectId});
   const permissions = checkout.permissions ?? {contents: 'read'};
@@ -208,13 +208,14 @@ function checkoutResult(
 ) {
   const credentials = checkoutCredentials(response.credentials);
   const persistCredentials = checkout.persist_credentials ?? true;
+  const renewalTarget = response.target ?? target.target;
   const renewalSubject =
-    credentials === undefined || !persistCredentials || target.target.kind !== 'external-id'
+    credentials === undefined || !persistCredentials || renewalTarget.kind !== 'external-id'
       ? undefined
       : {
           repositoryUrl: normalizeRepositoryUrl(response.repositoryUrl),
           connectionId: target.connectionId,
-          externalRepositoryId: target.target.externalRepositoryId,
+          externalRepositoryId: renewalTarget.externalRepositoryId,
           permissions: target.permissions,
         };
   return {
@@ -260,13 +261,17 @@ function parseCheckoutConfig(step: Step): CheckoutConfig {
   return result.data;
 }
 
+type CheckoutTargetSelection =
+  | {project: string}
+  | {connection?: string | undefined; repository: string};
+
 async function checkoutTarget(params: {
   checkout: CheckoutConfig;
   defaultProjectId: string;
   defaultConnectionId: string;
   integrations: IntegrationsModuleClient;
   workspaceId: string;
-}) {
+}): Promise<CheckoutTargetSelection> {
   const {checkout} = params;
   if (checkout.project !== undefined) return {project: checkout.project};
   if (checkout.repository !== undefined) {
@@ -279,10 +284,9 @@ async function checkoutTarget(params: {
             defaultConnectionId: params.defaultConnectionId,
             slug: checkout.connection,
           });
-    return {
-      ...(connection === undefined ? {} : {connection}),
-      repository: checkout.repository,
-    };
+    return connection === undefined
+      ? {repository: checkout.repository}
+      : {connection, repository: checkout.repository};
   }
   return {project: params.defaultProjectId};
 }
@@ -307,6 +311,42 @@ function repositoryTarget(
         owner: repository.slice(0, separator),
         name: repository.slice(separator + 1),
       };
+}
+
+function repositoryCheckoutTarget(params: {
+  connectionId: string;
+  defaultProject: {
+    id: string;
+    sourceConnectionId: string;
+    sourceExternalRepositoryId: string;
+    sourceRepositoryOwner?: string | null | undefined;
+    sourceRepositoryName?: string | null | undefined;
+  };
+  repository: {kind: 'name'; owner: string; name: string};
+}) {
+  const isSameProjectRepository =
+    params.connectionId === params.defaultProject.sourceConnectionId &&
+    params.defaultProject.sourceRepositoryOwner !== null &&
+    params.defaultProject.sourceRepositoryOwner !== undefined &&
+    params.defaultProject.sourceRepositoryName !== null &&
+    params.defaultProject.sourceRepositoryName !== undefined &&
+    params.repository.owner.toLowerCase() ===
+      params.defaultProject.sourceRepositoryOwner.toLowerCase() &&
+    params.repository.name.toLowerCase() ===
+      params.defaultProject.sourceRepositoryName.toLowerCase();
+
+  if (isSameProjectRepository) {
+    return {
+      projectId: params.defaultProject.id,
+      connectionId: params.connectionId,
+      target: {
+        kind: 'external-id' as const,
+        externalRepositoryId: params.defaultProject.sourceExternalRepositoryId,
+      },
+    };
+  }
+
+  return {connectionId: params.connectionId, target: params.repository};
 }
 
 async function resolveConnectionId(params: {

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -105,27 +105,41 @@ export async function createStepCheckoutSpec({
     integrations,
     workspaceId,
   });
-  const resolvedTarget = await projects.resolveCheckoutTarget({
-    workspaceId,
-    defaults: {
-      connectionId: defaultProject.sourceConnectionId,
-      owner: defaultOwner(defaultProject.sourceRepositoryOwner, checkout.repository),
-    },
-    target,
-  });
+  const resolvedTarget =
+    'project' in target
+      ? await projects.resolveCheckoutTarget({
+          workspaceId,
+          defaults: {
+            connectionId: defaultProject.sourceConnectionId,
+            owner: defaultOwner(defaultProject.sourceRepositoryOwner, checkout.repository),
+          },
+          target,
+        })
+      : {
+          connectionId: target.connection ?? defaultProject.sourceConnectionId,
+          target: repositoryTarget(
+            target.repository,
+            defaultOwner(defaultProject.sourceRepositoryOwner, target.repository),
+            step.id,
+          ),
+        };
+  if (resolvedTarget === undefined) {
+    throw new CheckoutIntentUnresolvedError({kind: 'project', value: projectId});
+  }
   const ref = resolveCheckoutRef({checkout, triggerReference, run, resolvedTarget, projectId});
   const permissions = checkout.permissions ?? {contents: 'read'};
   const response = await integrations.createCheckoutSpec({
     workspaceId,
     connectionId: resolvedTarget.connectionId,
-    externalRepositoryId: resolvedTarget.externalRepositoryId,
+    ...(resolvedTarget.projectId === undefined ? {} : {projectId: resolvedTarget.projectId}),
+    target: resolvedTarget.target,
     ...(ref === undefined ? {} : {ref}),
     permissions,
   });
 
   return checkoutResult(checkout, response, {
     connectionId: resolvedTarget.connectionId,
-    externalRepositoryId: resolvedTarget.externalRepositoryId,
+    target: resolvedTarget.target,
     permissions,
   });
 }
@@ -163,6 +177,7 @@ function resolveCheckoutRef(params: {
   let triggerCommitRef: string | undefined;
   const {triggerReference} = params;
   if (
+    params.resolvedTarget.projectId !== undefined &&
     triggerReference !== null &&
     triggerReference !== undefined &&
     triggerReference.project?.id === params.resolvedTarget.projectId
@@ -170,7 +185,11 @@ function resolveCheckoutRef(params: {
     triggerCommitRef = triggerReference.commit ?? undefined;
   }
   let devCommitRef: string | undefined;
-  if (params.run.origin === 'dev' && params.resolvedTarget.projectId === params.projectId) {
+  if (
+    params.run.origin === 'dev' &&
+    params.resolvedTarget.projectId !== undefined &&
+    params.resolvedTarget.projectId === params.projectId
+  ) {
     devCommitRef = params.run.devSource.commit;
   }
   return params.checkout.ref ?? triggerCommitRef ?? devCommitRef;
@@ -181,10 +200,23 @@ type CheckoutSpecResponse = Awaited<ReturnType<IntegrationsModuleClient['createC
 function checkoutResult(
   checkout: CheckoutConfig,
   response: CheckoutSpecResponse,
-  target: Pick<CheckoutRenewalSubject, 'connectionId' | 'externalRepositoryId' | 'permissions'>,
+  target: Pick<CheckoutRenewalSubject, 'connectionId' | 'permissions'> & {
+    target:
+      | {kind: 'external-id'; externalRepositoryId: string}
+      | {kind: 'name'; owner: string; name: string};
+  },
 ) {
   const credentials = checkoutCredentials(response.credentials);
   const persistCredentials = checkout.persist_credentials ?? true;
+  const renewalSubject =
+    credentials === undefined || !persistCredentials || target.target.kind !== 'external-id'
+      ? undefined
+      : {
+          repositoryUrl: normalizeRepositoryUrl(response.repositoryUrl),
+          connectionId: target.connectionId,
+          externalRepositoryId: target.target.externalRepositoryId,
+          permissions: target.permissions,
+        };
   return {
     spec: {
       repositoryUrl: response.repositoryUrl,
@@ -194,16 +226,7 @@ function checkoutResult(
     },
     fetchDepth: checkout.fetch_depth ?? 1,
     persistCredentials,
-    ...(credentials === undefined || !persistCredentials
-      ? {}
-      : {
-          renewalSubject: {
-            repositoryUrl: normalizeRepositoryUrl(response.repositoryUrl),
-            connectionId: target.connectionId,
-            externalRepositoryId: target.externalRepositoryId,
-            permissions: target.permissions,
-          },
-        }),
+    ...(renewalSubject === undefined ? {} : {renewalSubject}),
   };
 }
 
@@ -262,6 +285,28 @@ async function checkoutTarget(params: {
     };
   }
   return {project: params.defaultProjectId};
+}
+
+function repositoryTarget(
+  repository: string,
+  defaultOwnerValue: string,
+  stepId: string,
+): {kind: 'name'; owner: string; name: string} {
+  const separator = repository.indexOf('/');
+  if (
+    separator === 0 ||
+    separator === repository.length - 1 ||
+    repository.indexOf('/', separator + 1) !== -1
+  ) {
+    throw new CheckoutConfigInvalidError(stepId);
+  }
+  return separator === -1
+    ? {kind: 'name', owner: defaultOwnerValue, name: repository}
+    : {
+        kind: 'name',
+        owner: repository.slice(0, separator),
+        name: repository.slice(separator + 1),
+      };
 }
 
 async function resolveConnectionId(params: {

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -172,7 +172,6 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     expect(storedSubject).not.toHaveProperty('token');
     expect(resolveCheckoutTarget).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
-      defaults: {connectionId: project.sourceConnectionId, owner: 'acme'},
       target: {project: project.id},
     });
     expect(createCheckoutSpec).toHaveBeenCalledWith({
@@ -210,7 +209,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     const token = await mintActiveLeaseToken({jobId: job.id});
     vi.spyOn(runnersTestClient, 'getLeaseState')
@@ -240,7 +239,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('ghs-expired-after-mint-token'));
     const token = await mintActiveLeaseToken({jobId: job.id});
@@ -271,7 +270,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('ghs-initial-token'));
     const token = await mintActiveLeaseToken({jobId: job.id});
@@ -810,6 +809,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     ['repository-not-granted', 404],
     ['repository-ambiguous', 409],
     ['repository-authorization-unavailable', 503],
+    ['repository-authorization-target-invalid', 409],
   ] as const)('maps the %s integration checkout failure', async (code, status) => {
     const {project, job, step} = await createRunningCheckoutStep();
     getProjectById.mockResolvedValue({project});
@@ -1025,7 +1025,7 @@ async function createPromotedCheckout(app: FastifyInstance) {
   resolveCheckoutTarget.mockResolvedValue({
     projectId: project.id,
     connectionId: project.sourceConnectionId,
-    externalRepositoryId: project.sourceExternalRepositoryId,
+    target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
   });
   createCheckoutSpec.mockResolvedValue(githubSpec('ghs-initial-token'));
   const token = await mintActiveLeaseToken({jobId: job.id});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -128,7 +128,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('ghs-secret-token'));
     const token = await mintActiveLeaseToken({jobId: job.id});
@@ -178,7 +178,8 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       permissions: {contents: 'read'},
     });
   });
@@ -447,7 +448,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('ghs-untracked-token'));
     savePendingCheckoutRenewalSubjectMock.mockResolvedValueOnce(false);
@@ -470,7 +471,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('ghs-save-failure-token'));
     savePendingCheckoutRenewalSubjectMock.mockRejectedValueOnce(new Error('database unavailable'));
@@ -502,7 +503,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('ghs-trigger-token'));
     const token = await mintActiveLeaseToken({jobId: job.id});
@@ -517,7 +518,8 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: triggerReference.commit,
       permissions: {contents: 'read'},
     });
@@ -530,7 +532,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({...githubSpec('ghs-dev-token'), ref: devCommit});
     const token = await mintActiveLeaseToken({jobId: job.id});
@@ -546,7 +548,8 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      projectId: project.id,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       ref: devCommit,
       permissions: {contents: 'read'},
     });
@@ -595,7 +598,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue({
       repositoryUrl: 'https://example.com/acme/repo.git',
@@ -638,7 +641,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: targetProjectId,
       connectionId: crypto.randomUUID(),
-      externalRepositoryId: 'github:412',
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
     });
     createCheckoutSpec.mockResolvedValue({
       ...githubSpec('ghs-target-token'),
@@ -661,7 +664,8 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     expect(createCheckoutSpec).toHaveBeenCalledWith({
       workspaceId: project.workspaceId,
       connectionId: expect.any(String),
-      externalRepositoryId: 'github:412',
+      projectId: targetProjectId,
+      target: {kind: 'external-id', externalRepositoryId: 'github:412'},
       ref: 'refs/pull/412/head',
       permissions: {contents: 'write'},
     });
@@ -673,7 +677,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockResolvedValue(githubSpec('token'));
     const token = await mintActiveLeaseToken({
@@ -812,7 +816,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockRejectedValue(
       createInterModuleKnownError(
@@ -839,7 +843,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     createCheckoutSpec.mockRejectedValue(
       createInterModuleKnownError(
@@ -867,7 +871,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockResolvedValue({
       projectId: project.id,
       connectionId: project.sourceConnectionId,
-      externalRepositoryId: project.sourceExternalRepositoryId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
     });
     const secret = 'ghs-super-secret-token-value';
     createCheckoutSpec.mockResolvedValue(githubSpec(secret));

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -292,6 +292,12 @@ function throwIntegrationCheckoutError(
         repositoryAuthorizationErrorCodes.storeUnavailable,
         {status: 503},
       );
+    case repositoryAuthorizationErrorCodes.targetInvalid:
+      throw new ClientError(
+        'Checkout repository target is invalid',
+        repositoryAuthorizationErrorCodes.targetInvalid,
+        {status: 409},
+      );
     default:
       throw error;
   }

--- a/libs/api/workflows/test/factories/project.ts
+++ b/libs/api/workflows/test/factories/project.ts
@@ -6,6 +6,7 @@ interface Project {
   sourceConnectionId: string;
   sourceExternalRepositoryId: string;
   sourceRepositoryOwner: string | null;
+  sourceRepositoryName: string | null;
   name: string;
   createdAt: Date;
   updatedAt: Date;
@@ -17,6 +18,7 @@ export const projectFactory = Factory.define<Project>(({sequence}) => ({
   sourceConnectionId: crypto.randomUUID(),
   sourceExternalRepositoryId: `acme/repo-${sequence}`,
   sourceRepositoryOwner: 'acme',
+  sourceRepositoryName: `repo-${sequence}`,
   name: `Project ${sequence}`,
   createdAt: new Date(),
   updatedAt: new Date(),


### PR DESCRIPTION
Checkout credential minting now enforces repository authorization at the integration boundary, including direct callers that bypass Workflows. Workflow and Projects target handling remains provider-free so project targets carry stable repository IDs and name targets can flow through the dark all-mode path.

Ref selection remains scoped to the associated project, preventing unrelated trigger or development commits from being applied to non-project checkout targets. Authorization mode selection remains a trusted server-side seam; persistence and activation stay in their follow-up issues.

Closes ENG-1819

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checkout credential minting now enforces repository authorization at the integration boundary, so direct callers that bypass Workflows are covered too. Project targets resolve through Projects with stable repository IDs, while repository-name targets go straight to Integrations without a Projects lookup, and checkout specs carry the provider-resolved target so credential renewal uses the canonical identity.

- `resolveCheckoutTarget` accepts project targets only and returns a `target` shape instead of a bare `externalRepositoryId`.
- Repository-name targets matching the default project keep same-project trigger and dev commits; other name targets skip them.
- The Projects presentation no longer refreshes source metadata or calls `resolveSourceRepository`.
- Authorization denials surface as `IntegrationRepositoryAuthorizationError` with a new target-invalid code mapped to HTTP 409.

**Migration**
- Callers of `resolveCheckoutTarget` must pass a project target and handle the new `target` shape in `@shipfox/api-projects-dto`.

<sup>Written for commit 266f784dd60639d39e7b97e60ce54895a400ff05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

