### PR TITLE
[client-onboarding] Keep the Get-started panel compact

### DIFF
--- a/.changeset/collapse-setup-checklist-panel.md
+++ b/.changeset/collapse-setup-checklist-panel.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/client-onboarding": minor
+---
+
+Collapses the Get-started panel to the next step so the setup guide stops
+pushing page content below the fold. A header toggle opens the full list and
+remembers the choice per device, and the nav-bar indicator still carries the
+whole checklist on every route.

--- a/.changeset/collapse-setup-checklist-panel.md
+++ b/.changeset/collapse-setup-checklist-panel.md
@@ -2,7 +2,6 @@
 "@shipfox/client-onboarding": minor
 ---
 
-Collapses the Get-started panel to the next step so the setup guide stops
-pushing page content below the fold. A header toggle opens the full list and
-remembers the choice per device, and the nav-bar indicator still carries the
-whole checklist on every route.
+Collapses the Get-started panel to the next step. A header toggle opens the
+full list and remembers the choice per device, and the nav-bar indicator still
+carries the whole checklist on every route.

--- a/libs/client/onboarding/README.md
+++ b/libs/client/onboarding/README.md
@@ -26,9 +26,9 @@ post-activation Get-started checklist, and its panel and top-bar hosts.
 - **`WorkspaceSetupChecklist`** and **`WorkspaceSetupIndicator`**: slot-ready
   hosts that load the five checklist query families, render the checklist in a
   panel or a non-modal popover, and persist per-device dismissal. The panel sits
-  above a page's own content, so it shows only the next step until a header
-  toggle opens the full list, and it remembers that choice per device. The
-  popover always carries the whole checklist.
+  above a page's own content, so it shows only the next step. A header toggle
+  opens the full list, and that choice is remembered per device. The popover
+  always carries the whole checklist.
 
 The derivations are pure functions. They test without React and decide what
 the checklist shows, while the hosts own query freshness, loading and failure

--- a/libs/client/onboarding/README.md
+++ b/libs/client/onboarding/README.md
@@ -20,9 +20,15 @@ post-activation Get-started checklist, and its panel and top-bar hosts.
   `complete`. Rows follow the spec order; the runner and model-provider rows
   exist only when the installation does not already provide the capability;
   the first-workflow and teammates rows are pointers that never count.
+- **`selectNextSetupStep`**: the one row a compact host asks for. It returns the
+  first open tracked row, falling back to the first unfinished pointer once
+  every tracked row is done.
 - **`WorkspaceSetupChecklist`** and **`WorkspaceSetupIndicator`**: slot-ready
   hosts that load the five checklist query families, render the checklist in a
-  panel or a non-modal popover, and persist per-device dismissal.
+  panel or a non-modal popover, and persist per-device dismissal. The panel sits
+  above a page's own content, so it shows only the next step until a header
+  toggle opens the full list, and it remembers that choice per device. The
+  popover always carries the whole checklist.
 
 The derivations are pure functions. They test without React and decide what
 the checklist shows, while the hosts own query freshness, loading and failure
@@ -44,6 +50,7 @@ are `client-agent`, `client-integrations`, `client-projects`, `client-runners`,
 import {
   deriveIntegrationReadiness,
   deriveSetupChecklist,
+  selectNextSetupStep,
 } from '@shipfox/client-onboarding';
 
 const readiness = deriveIntegrationReadiness({
@@ -67,6 +74,8 @@ checklist.items; // 7 rows: source control, project, tools, runner,
 checklist.trackedCount; // 5
 checklist.openCount; // 3
 checklist.complete; // false
+
+selectNextSetupStep(checklist)?.id; // 'tools'
 ```
 
 The rendered hosts can be exported through the package feature entry point for

--- a/libs/client/onboarding/src/components/setup-checklist-completion.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-completion.tsx
@@ -1,6 +1,7 @@
 import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Text} from '@shipfox/react-ui/typography';
+import {cn} from '@shipfox/react-ui/utils';
 import {useEffect, useRef} from 'react';
 import {createConfettiParticles} from './setup-checklist-confetti.js';
 
@@ -12,13 +13,21 @@ export function SetupChecklistCompletion({
   showBurst,
   onBurstComplete,
   onDone,
+  standalone = false,
 }: {
   showBurst: boolean;
   onBurstComplete?: (() => void) | undefined;
   onDone?: (() => void) | undefined;
+  /** The whole panel body, so the divider would double the panel's own edge. */
+  standalone?: boolean;
 }) {
   return (
-    <div className="relative overflow-hidden border-b border-tag-success-border bg-tag-success-bg p-panel">
+    <div
+      className={cn(
+        'relative overflow-hidden bg-tag-success-bg p-panel',
+        !standalone && 'border-b border-tag-success-border',
+      )}
+    >
       <ConfettiBurst active={showBurst} onComplete={onBurstComplete} />
       <div className="relative flex items-center gap-group">
         <Icon

--- a/libs/client/onboarding/src/components/setup-checklist-host-primitives.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-host-primitives.tsx
@@ -53,12 +53,7 @@ export function ChecklistHeader({
             iconRight={expansion.expanded ? 'arrowUpSLine' : 'arrowDownSLine'}
             onClick={expansion.onToggle}
           >
-            {/* Below the narrow breakpoint the label would wrap the header onto a
-                second row, so the chevron carries the control and the name stays
-                readable to assistive technology. */}
-            <span className="max-[480px]:sr-only">
-              {expansion.expanded ? 'Show less' : `Show all ${expansion.stepCount} steps`}
-            </span>
+            {expansion.expanded ? 'Show less' : `Show all ${expansion.stepCount} steps`}
           </Button>
         ) : null}
         <IconButton

--- a/libs/client/onboarding/src/components/setup-checklist-host-primitives.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-host-primitives.tsx
@@ -4,6 +4,15 @@ import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
 import type {SetupChecklist} from '#core/setup-checklist.js';
 
+export interface ChecklistExpansionControl {
+  expanded: boolean;
+  /** Rows behind the toggle, so the collapsed label can name what it opens. */
+  stepCount: number;
+  /** The panel body the toggle controls. */
+  bodyId: string;
+  onToggle: () => void;
+}
+
 export function ChecklistDismissAction({onDismiss}: {onDismiss: () => void}) {
   return (
     <div className="flex justify-end border-t border-border-neutral-base px-row py-row">
@@ -16,13 +25,15 @@ export function ChecklistDismissAction({onDismiss}: {onDismiss: () => void}) {
 
 export function ChecklistHeader({
   count,
+  expansion,
   onDismiss,
 }: {
   count?: string | undefined;
+  expansion?: ChecklistExpansionControl | undefined;
   onDismiss: () => void;
 }) {
   return (
-    <PanelHeader>
+    <PanelHeader className="flex-wrap">
       <div className="flex min-w-0 items-center gap-group">
         <PanelTitle>Get started</PanelTitle>
         {count ? (
@@ -32,6 +43,24 @@ export function ChecklistHeader({
         ) : null}
       </div>
       <PanelActions>
+        {expansion ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="transparentMuted"
+            aria-expanded={expansion.expanded}
+            aria-controls={expansion.bodyId}
+            iconRight={expansion.expanded ? 'arrowUpSLine' : 'arrowDownSLine'}
+            onClick={expansion.onToggle}
+          >
+            {/* Below the narrow breakpoint the label would wrap the header onto a
+                second row, so the chevron carries the control and the name stays
+                readable to assistive technology. */}
+            <span className="max-[480px]:sr-only">
+              {expansion.expanded ? 'Show less' : `Show all ${expansion.stepCount} steps`}
+            </span>
+          </Button>
+        ) : null}
         <IconButton
           type="button"
           variant="transparent"

--- a/libs/client/onboarding/src/components/setup-checklist-item-primitives.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-item-primitives.tsx
@@ -41,7 +41,9 @@ export function ChecklistStatus({item}: {item: SetupChecklistItem}) {
 /**
  * The anchor for a checklist action, ready to be slotted into a `Button` or a
  * `ButtonLink`. Each route is written out because the router types `params`
- * against a literal `to`, so a computed path loses its inference.
+ * against a literal `to`, so a computed path loses its inference. The switch is
+ * exhaustive over `SetupChecklistActionHref`, so a new destination fails to
+ * compile rather than silently routing to the last branch.
  */
 export function checklistActionTarget({
   action,
@@ -52,41 +54,40 @@ export function checklistActionTarget({
   workspaceSlug: string;
   onClick: () => void;
 }): ReactElement {
-  if (action.href === '/docs/getting-started') {
-    return (
-      <a href={GETTING_STARTED_URL} onClick={onClick}>
-        {action.label}
-      </a>
-    );
+  switch (action.href) {
+    case '/docs/getting-started':
+      return (
+        <a href={GETTING_STARTED_URL} onClick={onClick}>
+          {action.label}
+        </a>
+      );
+    case '/settings/integrations':
+      return (
+        <Link
+          to="/w/$workspaceSlug/settings/integrations"
+          params={{workspaceSlug}}
+          onClick={onClick}
+        >
+          {action.label}
+        </Link>
+      );
+    case '/settings/runners':
+      return (
+        <Link to="/w/$workspaceSlug/settings/runners" params={{workspaceSlug}} onClick={onClick}>
+          {action.label}
+        </Link>
+      );
+    case '/settings/agents':
+      return (
+        <Link to="/w/$workspaceSlug/settings/agents" params={{workspaceSlug}} onClick={onClick}>
+          {action.label}
+        </Link>
+      );
+    case '/settings/members':
+      return (
+        <Link to="/w/$workspaceSlug/settings/members" params={{workspaceSlug}} onClick={onClick}>
+          {action.label}
+        </Link>
+      );
   }
-
-  if (action.href === '/settings/integrations') {
-    return (
-      <Link to="/w/$workspaceSlug/settings/integrations" params={{workspaceSlug}} onClick={onClick}>
-        {action.label}
-      </Link>
-    );
-  }
-
-  if (action.href === '/settings/runners') {
-    return (
-      <Link to="/w/$workspaceSlug/settings/runners" params={{workspaceSlug}} onClick={onClick}>
-        {action.label}
-      </Link>
-    );
-  }
-
-  if (action.href === '/settings/agents') {
-    return (
-      <Link to="/w/$workspaceSlug/settings/agents" params={{workspaceSlug}} onClick={onClick}>
-        {action.label}
-      </Link>
-    );
-  }
-
-  return (
-    <Link to="/w/$workspaceSlug/settings/members" params={{workspaceSlug}} onClick={onClick}>
-      {action.label}
-    </Link>
-  );
 }

--- a/libs/client/onboarding/src/components/setup-checklist-item-primitives.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-item-primitives.tsx
@@ -1,0 +1,92 @@
+import {Icon} from '@shipfox/react-ui/icon';
+import {cn} from '@shipfox/react-ui/utils';
+import {Link} from '@tanstack/react-router';
+import type {ReactElement} from 'react';
+import type {SetupChecklistAction, SetupChecklistItem} from '#core/setup-checklist.js';
+
+const GETTING_STARTED_URL = 'https://www.shipfox.io/docs/getting-started';
+
+export function checklistStatusLabel(item: SetupChecklistItem): string {
+  if (item.status === 'done') return 'done';
+  if (!item.tracked) return 'next step';
+  return item.attention ? 'needs attention' : 'to do';
+}
+
+export function ChecklistStatus({item}: {item: SetupChecklistItem}) {
+  const done = item.status === 'done';
+  const pointer = !item.tracked;
+
+  return (
+    <span className="mt-1 shrink-0">
+      {done || pointer ? (
+        <Icon
+          name={done ? 'checkCircleSolid' : 'circleDottedLine'}
+          className={cn(
+            'size-16',
+            done ? 'text-foreground-highlight-interactive' : 'text-foreground-neutral-subtle',
+          )}
+          aria-hidden="true"
+        />
+      ) : (
+        <span
+          aria-hidden="true"
+          className="block size-16 rounded-full border-2 border-foreground-neutral-subtle"
+        />
+      )}
+      <span className="sr-only">{checklistStatusLabel(item)}</span>
+    </span>
+  );
+}
+
+/**
+ * The anchor for a checklist action, ready to be slotted into a `Button` or a
+ * `ButtonLink`. Each route is written out because the router types `params`
+ * against a literal `to`, so a computed path loses its inference.
+ */
+export function checklistActionTarget({
+  action,
+  workspaceSlug,
+  onClick,
+}: {
+  action: SetupChecklistAction;
+  workspaceSlug: string;
+  onClick: () => void;
+}): ReactElement {
+  if (action.href === '/docs/getting-started') {
+    return (
+      <a href={GETTING_STARTED_URL} onClick={onClick}>
+        {action.label}
+      </a>
+    );
+  }
+
+  if (action.href === '/settings/integrations') {
+    return (
+      <Link to="/w/$workspaceSlug/settings/integrations" params={{workspaceSlug}} onClick={onClick}>
+        {action.label}
+      </Link>
+    );
+  }
+
+  if (action.href === '/settings/runners') {
+    return (
+      <Link to="/w/$workspaceSlug/settings/runners" params={{workspaceSlug}} onClick={onClick}>
+        {action.label}
+      </Link>
+    );
+  }
+
+  if (action.href === '/settings/agents') {
+    return (
+      <Link to="/w/$workspaceSlug/settings/agents" params={{workspaceSlug}} onClick={onClick}>
+        {action.label}
+      </Link>
+    );
+  }
+
+  return (
+    <Link to="/w/$workspaceSlug/settings/members" params={{workspaceSlug}} onClick={onClick}>
+      {action.label}
+    </Link>
+  );
+}

--- a/libs/client/onboarding/src/components/setup-checklist-next-step.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-next-step.tsx
@@ -1,0 +1,49 @@
+import {Button} from '@shipfox/react-ui/button';
+import {Text} from '@shipfox/react-ui/typography';
+import type {SetupChecklistItem} from '#core/setup-checklist.js';
+import {ChecklistStatus, checklistActionTarget} from './setup-checklist-item-primitives.js';
+
+/**
+ * The collapsed panel body: one step at full weight. A pointer keeps the
+ * secondary fill, because reading the quickstart is an offer rather than the
+ * workspace's next unfinished ask.
+ */
+export function SetupChecklistNextStep({
+  item,
+  workspaceSlug,
+  onAction,
+}: {
+  item: SetupChecklistItem;
+  workspaceSlug: string;
+  onAction?: ((item: SetupChecklistItem) => void) | undefined;
+}) {
+  return (
+    <div className="flex min-w-0 items-start gap-group px-row py-row">
+      <ChecklistStatus item={item} />
+      <div className="min-w-0 flex-1">
+        <Text as="span" size="sm" className="block text-foreground-neutral-base">
+          {item.title}
+        </Text>
+        {item.purpose ? (
+          <Text as="span" size="xs" className="mt-tight block text-foreground-neutral-muted">
+            {item.purpose}
+          </Text>
+        ) : null}
+      </div>
+      {item.action ? (
+        <Button
+          asChild
+          size="sm"
+          variant={item.tracked ? 'primary' : 'secondary'}
+          className="self-center"
+        >
+          {checklistActionTarget({
+            action: item.action,
+            workspaceSlug,
+            onClick: () => onAction?.(item),
+          })}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/libs/client/onboarding/src/components/setup-checklist-row.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist-row.tsx
@@ -1,11 +1,8 @@
 import {ButtonLink} from '@shipfox/react-ui/button';
-import {Icon} from '@shipfox/react-ui/icon';
 import {Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
-import {Link} from '@tanstack/react-router';
 import type {SetupChecklistItem} from '#core/setup-checklist.js';
-
-const GETTING_STARTED_URL = 'https://www.shipfox.io/docs/getting-started';
+import {ChecklistStatus, checklistActionTarget} from './setup-checklist-item-primitives.js';
 
 export function ChecklistRow({
   item,
@@ -18,14 +15,10 @@ export function ChecklistRow({
 }) {
   const pointer = !item.tracked;
   const showDetails = pointer || item.status === 'open';
-  let statusLabel = 'to do';
-  if (item.status === 'done') statusLabel = 'done';
-  else if (pointer) statusLabel = 'next step';
-  else if (item.attention) statusLabel = 'needs attention';
 
   return (
     <li className="flex min-w-0 items-start gap-group border-b border-border-neutral-base px-row py-row last:border-b-0">
-      <ChecklistStatus item={item} pointer={pointer} label={statusLabel} />
+      <ChecklistStatus item={item} />
       <div className="min-w-0 flex-1">
         <Text
           as="span"
@@ -46,140 +39,21 @@ export function ChecklistRow({
         ) : null}
         {showDetails && item.action ? (
           <div className="mt-inline">
-            <ChecklistActionLink
-              item={item}
-              action={item.action}
-              pointer={pointer}
-              workspaceSlug={workspaceSlug}
-              onAction={onAction}
-            />
+            <ButtonLink
+              asChild
+              variant={pointer ? 'muted' : 'interactive'}
+              underline
+              iconRight="chevronRight"
+            >
+              {checklistActionTarget({
+                action: item.action,
+                workspaceSlug,
+                onClick: () => onAction?.(item),
+              })}
+            </ButtonLink>
           </div>
         ) : null}
       </div>
     </li>
-  );
-}
-
-function ChecklistStatus({
-  item,
-  pointer,
-  label,
-}: {
-  item: SetupChecklistItem;
-  pointer: boolean;
-  label: string;
-}) {
-  if (pointer) {
-    return (
-      <span className="mt-1 shrink-0">
-        <Icon
-          name={item.status === 'done' ? 'checkCircleSolid' : 'circleDottedLine'}
-          className={cn(
-            'size-16',
-            item.status === 'done'
-              ? 'text-foreground-highlight-interactive'
-              : 'text-foreground-neutral-subtle',
-          )}
-          aria-hidden="true"
-        />
-        <span className="sr-only">{label}</span>
-      </span>
-    );
-  }
-
-  if (item.status === 'done') {
-    return (
-      <span className="mt-1 shrink-0">
-        <Icon
-          name="checkCircleSolid"
-          className="size-16 text-foreground-highlight-interactive"
-          aria-hidden="true"
-        />
-        <span className="sr-only">{label}</span>
-      </span>
-    );
-  }
-
-  return (
-    <span className="mt-1 shrink-0">
-      <span
-        aria-hidden="true"
-        className="block size-16 rounded-full border-2 border-foreground-neutral-subtle"
-      />
-      <span className="sr-only">{label}</span>
-    </span>
-  );
-}
-
-function ChecklistActionLink({
-  item,
-  action,
-  pointer,
-  workspaceSlug,
-  onAction,
-}: {
-  item: SetupChecklistItem;
-  action: NonNullable<SetupChecklistItem['action']>;
-  pointer: boolean;
-  workspaceSlug: string;
-  onAction?: ((item: SetupChecklistItem) => void) | undefined;
-}) {
-  const handleClick = () => onAction?.(item);
-  const variant = pointer ? 'muted' : 'interactive';
-
-  if (action.href === '/docs/getting-started') {
-    return (
-      <ButtonLink asChild variant={variant} underline iconRight="chevronRight">
-        <a href={GETTING_STARTED_URL} onClick={handleClick}>
-          {action.label}
-        </a>
-      </ButtonLink>
-    );
-  }
-
-  if (action.href === '/settings/integrations') {
-    return (
-      <ButtonLink asChild variant={variant} underline iconRight="chevronRight">
-        <Link
-          to="/w/$workspaceSlug/settings/integrations"
-          params={{workspaceSlug}}
-          onClick={handleClick}
-        >
-          {action.label}
-        </Link>
-      </ButtonLink>
-    );
-  }
-
-  if (action.href === '/settings/runners') {
-    return (
-      <ButtonLink asChild variant={variant} underline iconRight="chevronRight">
-        <Link
-          to="/w/$workspaceSlug/settings/runners"
-          params={{workspaceSlug}}
-          onClick={handleClick}
-        >
-          {action.label}
-        </Link>
-      </ButtonLink>
-    );
-  }
-
-  if (action.href === '/settings/agents') {
-    return (
-      <ButtonLink asChild variant={variant} underline iconRight="chevronRight">
-        <Link to="/w/$workspaceSlug/settings/agents" params={{workspaceSlug}} onClick={handleClick}>
-          {action.label}
-        </Link>
-      </ButtonLink>
-    );
-  }
-
-  return (
-    <ButtonLink asChild variant={variant} underline iconRight="chevronRight">
-      <Link to="/w/$workspaceSlug/settings/members" params={{workspaceSlug}} onClick={handleClick}>
-        {action.label}
-      </Link>
-    </ButtonLink>
   );
 }

--- a/libs/client/onboarding/src/components/setup-checklist.stories.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist.stories.tsx
@@ -11,6 +11,7 @@ import {
   dismissWorkspaceSetupChecklist,
 } from '@shipfox/client-shell/runtime';
 import {listInvitationsQueryKey, listMembersQueryKey} from '@shipfox/client-workspace-settings';
+import {Panel, PanelBody} from '@shipfox/react-ui/panel';
 import type {Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {
@@ -24,8 +25,10 @@ import {
 import type {ReactNode} from 'react';
 import {useEffect, useMemo, useState} from 'react';
 import {deriveSetupChecklist} from '#core/setup-checklist.js';
+import {setWorkspaceSetupChecklistExpanded} from '#hooks/use-checklist-expansion.js';
 import {
   SetupChecklistBody,
+  SetupChecklistCompletion,
   type WorkspaceReference,
   WorkspaceSetupChecklist,
   WorkspaceSetupIndicator,
@@ -34,6 +37,10 @@ import {
 const WORKSPACE: WorkspaceReference = {id: 'story-workspace', slug: 'acme'};
 const DISMISSED_WORKSPACE: WorkspaceReference = {
   id: 'dismissed-story-workspace',
+  slug: WORKSPACE.slug,
+};
+const EXPANDED_WORKSPACE: WorkspaceReference = {
+  id: 'expanded-story-workspace',
   slug: WORKSPACE.slug,
 };
 const now = new Date().toISOString();
@@ -135,8 +142,26 @@ export const NeedsAttentionIndicator: Story = {
   render: () => <HostStory scenario="attention" host="indicator" />,
 };
 
+export const SelfHostedPanelExpanded: Story = {
+  render: () => <ExpandedPanelStory />,
+};
+
 export const Dismissed: Story = {
   render: () => <DismissedStory />,
+};
+
+export const PanelCompletion: Story = {
+  render: () => (
+    <div className="min-h-[240px] bg-background-subtle-base p-frame">
+      <div className="mx-auto w-full max-w-[480px]">
+        <Panel>
+          <PanelBody>
+            <SetupChecklistCompletion standalone showBurst={false} />
+          </PanelBody>
+        </Panel>
+      </div>
+    </div>
+  ),
 };
 
 export const CompletedWithBurst: Story = {
@@ -149,7 +174,7 @@ export const CompletedWithoutBurst: Story = {
 
 function HostStory({scenario, host}: {scenario: Scenario; host: 'panel' | 'indicator'}) {
   return (
-    <StoryProviders scenario={scenario}>
+    <StoryProviders scenario={scenario} workspace={WORKSPACE}>
       <div className="min-h-[240px] bg-background-subtle-base p-frame">
         <div className="mx-auto flex w-full max-w-[480px] flex-col gap-group">
           {host === 'panel' ? (
@@ -165,9 +190,33 @@ function HostStory({scenario, host}: {scenario: Scenario; host: 'panel' | 'indic
   );
 }
 
+/**
+ * The panel opens collapsed, so the expanded list needs its own workspace: a
+ * shared one would leak the persisted expansion into the collapsed stories.
+ */
+function ExpandedPanelStory() {
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    setWorkspaceSetupChecklistExpanded(EXPANDED_WORKSPACE.id, true);
+    setInitialized(true);
+    return () => setWorkspaceSetupChecklistExpanded(EXPANDED_WORKSPACE.id, false);
+  }, []);
+
+  return (
+    <StoryProviders scenario="self-hosted" workspace={EXPANDED_WORKSPACE}>
+      <div className="min-h-[240px] bg-background-subtle-base p-frame">
+        <div className="mx-auto w-full max-w-[480px]">
+          {initialized ? <WorkspaceSetupChecklist workspace={EXPANDED_WORKSPACE} /> : null}
+        </div>
+      </div>
+    </StoryProviders>
+  );
+}
+
 function CompletedStory({showBurst = false}: {showBurst?: boolean}) {
   return (
-    <StoryProviders scenario="complete">
+    <StoryProviders scenario="complete" workspace={WORKSPACE}>
       <div className="min-h-[240px] bg-background-subtle-base p-frame">
         <div className="mx-auto w-full max-w-[480px]">
           <div className="overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
@@ -194,7 +243,7 @@ function DismissedStory() {
   }, []);
 
   return (
-    <StoryProviders scenario="cloud">
+    <StoryProviders scenario="cloud" workspace={DISMISSED_WORKSPACE}>
       <div className="min-h-[240px] bg-background-subtle-base p-frame">
         {initialized ? <WorkspaceSetupChecklist workspace={DISMISSED_WORKSPACE} /> : null}
       </div>
@@ -204,8 +253,19 @@ function DismissedStory() {
 
 type Scenario = 'attention' | 'cloud' | 'complete' | 'self-hosted';
 
-function StoryProviders({scenario, children}: {scenario: Scenario; children: ReactNode}) {
-  const queryClient = useMemo(() => createScenarioQueryClient(scenario), [scenario]);
+function StoryProviders({
+  scenario,
+  workspace,
+  children,
+}: {
+  scenario: Scenario;
+  workspace: WorkspaceReference;
+  children: ReactNode;
+}) {
+  const queryClient = useMemo(
+    () => createScenarioQueryClient(scenario, workspace),
+    [scenario, workspace],
+  );
   const router = useMemo(() => createStoryRouter(children), [children]);
 
   return (
@@ -215,7 +275,7 @@ function StoryProviders({scenario, children}: {scenario: Scenario; children: Rea
   );
 }
 
-function createScenarioQueryClient(scenario: Scenario) {
+function createScenarioQueryClient(scenario: Scenario, workspace: WorkspaceReference) {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
   const cloud = scenario === 'cloud' || scenario === 'complete';
   const attention = scenario === 'attention';
@@ -233,19 +293,19 @@ function createScenarioQueryClient(scenario: Scenario) {
   };
 
   queryClient.setQueryData(integrationProvidersQueryOptions().queryKey, providers);
-  queryClient.setQueryData(integrationConnectionsQueryOptions(WORKSPACE.id).queryKey, connections);
-  queryClient.setQueryData(provisionerTokenQueryKeys.active(WORKSPACE.id), runnerResponse);
+  queryClient.setQueryData(integrationConnectionsQueryOptions(workspace.id).queryKey, connections);
+  queryClient.setQueryData(provisionerTokenQueryKeys.active(workspace.id), runnerResponse);
   queryClient.setQueryData(modelProviderQueryKeys.catalog(), catalog);
-  queryClient.setQueryData(modelProviderQueryKeys.configs(WORKSPACE.id), {
+  queryClient.setQueryData(modelProviderQueryKeys.configs(workspace.id), {
     configs: [],
     defaultHarnessId: null,
     defaultProviderId: null,
   });
-  queryClient.setQueryData(listMembersQueryKey(WORKSPACE.id), [
+  queryClient.setQueryData(listMembersQueryKey(workspace.id), [
     {
       id: 'member-1',
       userId: 'user-1',
-      workspaceId: WORKSPACE.id,
+      workspaceId: workspace.id,
       email: 'you@example.com',
       name: 'You',
       role: 'admin' as const,
@@ -253,7 +313,7 @@ function createScenarioQueryClient(scenario: Scenario) {
       updatedAt: now,
     },
   ]);
-  queryClient.setQueryData(listInvitationsQueryKey(WORKSPACE.id), []);
+  queryClient.setQueryData(listInvitationsQueryKey(workspace.id), []);
 
   return queryClient;
 }

--- a/libs/client/onboarding/src/components/setup-checklist.test.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist.test.tsx
@@ -710,6 +710,44 @@ describe('workspace checklist hosts', () => {
     expect(screen.queryByText(DONE_COUNT_RE)).not.toBeInTheDocument();
   });
 
+  test('does not wait on the teammates family, which cannot change the count', async () => {
+    const queryClient = createQueryClient();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(() => pendingResponse()),
+    });
+    queryClient.setQueryData(integrationProvidersQueryOptions().queryKey, [
+      githubProvider,
+      linearProvider,
+    ]);
+    queryClient.setQueryData(integrationConnectionsQueryOptions(WORKSPACE.id).queryKey, [
+      connection('github', 'active'),
+    ]);
+    queryClient.setQueryData(provisionerTokenQueryKeys.active(WORKSPACE.id), {
+      provisioners: [],
+      installationRunners: 'managed' as const,
+    });
+    queryClient.setQueryData(modelProviderQueryKeys.catalog(), {
+      providers: [],
+      workspaceProviders: 'enabled' as const,
+      managedProviderId: 'managed-default',
+      instanceDefaultProviderId: null,
+    });
+    queryClient.setQueryData(modelProviderQueryKeys.configs(WORKSPACE.id), {
+      configs: [],
+      defaultHarnessId: null,
+      defaultProviderId: null,
+    });
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+
+    // Members and invitations are still in flight, and the count is already final.
+    expect(await screen.findByText('2 of 3 done')).toBeInTheDocument();
+    expect(await screen.findByText('Connect your tools')).toBeInTheDocument();
+  });
+
   test('does not render an initially complete checklist without a transition', async () => {
     const queryClient = createQueryClient();
     seedQueries(queryClient, true);

--- a/libs/client/onboarding/src/components/setup-checklist.test.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist.test.tsx
@@ -40,6 +40,7 @@ const WORKSPACE: WorkspaceReference = {id: 'test-workspace', slug: 'acme'};
 const OTHER_WORKSPACE: WorkspaceReference = {id: 'other-test-workspace', slug: 'acme'};
 const GET_STARTED_BUTTON_RE = /Get started/u;
 const SHOW_ALL_STEPS_RE = /Show all/u;
+const DONE_COUNT_RE = /\d+ of \d+ done/u;
 const now = new Date().toISOString();
 const githubProvider: IntegrationProvider = {
   provider: 'github',
@@ -705,6 +706,8 @@ describe('workspace checklist hosts', () => {
 
     expect(await screen.findByRole('status', {name: 'Loading setup guide'})).toBeInTheDocument();
     expect(screen.queryByText('Push your first workflow')).not.toBeInTheDocument();
+    // The tracked rows are still hidden, so no count may claim they are done.
+    expect(screen.queryByText(DONE_COUNT_RE)).not.toBeInTheDocument();
   });
 
   test('does not render an initially complete checklist without a transition', async () => {

--- a/libs/client/onboarding/src/components/setup-checklist.test.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist.test.tsx
@@ -37,6 +37,7 @@ import {
 } from './setup-checklist.js';
 
 const WORKSPACE: WorkspaceReference = {id: 'test-workspace', slug: 'acme'};
+const OTHER_WORKSPACE: WorkspaceReference = {id: 'other-test-workspace', slug: 'acme'};
 const GET_STARTED_BUTTON_RE = /Get started/u;
 const SHOW_ALL_STEPS_RE = /Show all/u;
 const now = new Date().toISOString();
@@ -79,16 +80,20 @@ function pendingResponse(): Promise<Response> {
   });
 }
 
-function seedQueries(queryClient: QueryClient, toolsConnected = false) {
+function seedQueries(
+  queryClient: QueryClient,
+  toolsConnected = false,
+  workspace: WorkspaceReference = WORKSPACE,
+) {
   queryClient.setQueryData(integrationProvidersQueryOptions().queryKey, [
     githubProvider,
     linearProvider,
   ]);
-  queryClient.setQueryData(integrationConnectionsQueryOptions(WORKSPACE.id).queryKey, [
+  queryClient.setQueryData(integrationConnectionsQueryOptions(workspace.id).queryKey, [
     connection('github', 'active'),
     ...(toolsConnected ? [connection('linear', 'active')] : []),
   ]);
-  queryClient.setQueryData(provisionerTokenQueryKeys.active(WORKSPACE.id), {
+  queryClient.setQueryData(provisionerTokenQueryKeys.active(workspace.id), {
     provisioners: [],
     installationRunners: 'managed' as const,
   });
@@ -98,16 +103,16 @@ function seedQueries(queryClient: QueryClient, toolsConnected = false) {
     managedProviderId: 'managed-default',
     instanceDefaultProviderId: null,
   });
-  queryClient.setQueryData(modelProviderQueryKeys.configs(WORKSPACE.id), {
+  queryClient.setQueryData(modelProviderQueryKeys.configs(workspace.id), {
     configs: [],
     defaultHarnessId: null,
     defaultProviderId: null,
   });
-  queryClient.setQueryData(listMembersQueryKey(WORKSPACE.id), [
+  queryClient.setQueryData(listMembersQueryKey(workspace.id), [
     {
       id: 'member-1',
       userId: 'user-1',
-      workspaceId: WORKSPACE.id,
+      workspaceId: workspace.id,
       email: 'you@example.com',
       name: 'You',
       role: 'admin' as const,
@@ -115,7 +120,7 @@ function seedQueries(queryClient: QueryClient, toolsConnected = false) {
       updatedAt: now,
     },
   ]);
-  queryClient.setQueryData(listInvitationsQueryKey(WORKSPACE.id), []);
+  queryClient.setQueryData(listInvitationsQueryKey(workspace.id), []);
 }
 
 function renderWithProviders(
@@ -607,6 +612,99 @@ describe('workspace checklist hosts', () => {
     expect(await screen.findByText("You're set up")).toBeInTheDocument();
     expect(screen.queryByRole('list', {name: 'Setup steps'})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: SHOW_ALL_STEPS_RE})).not.toBeInTheDocument();
+  });
+
+  test('replaces an expanded list with the completion state, not just a collapsed one', async () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient);
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+    fireEvent.click(await screen.findByRole('button', {name: 'Show all 5 steps'}));
+    expect(await screen.findByRole('list', {name: 'Setup steps'})).toBeInTheDocument();
+
+    act(() => {
+      queryClient.setQueryData(integrationConnectionsQueryOptions(WORKSPACE.id).queryKey, [
+        connection('github', 'active'),
+        connection('linear', 'active'),
+      ]);
+    });
+
+    expect(await screen.findByText("You're set up")).toBeInTheDocument();
+    expect(screen.queryByRole('list', {name: 'Setup steps'})).not.toBeInTheDocument();
+  });
+
+  test('scopes the remembered expansion to the workspace that was expanded', async () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient);
+    seedQueries(queryClient, false, OTHER_WORKSPACE);
+
+    const expandedHost = renderWithProviders(
+      <WorkspaceSetupChecklist workspace={WORKSPACE} />,
+      queryClient,
+      {capture: vi.fn()},
+    );
+    fireEvent.click(await screen.findByRole('button', {name: 'Show all 5 steps'}));
+    expect(await screen.findByRole('list', {name: 'Setup steps'})).toBeInTheDocument();
+    expandedHost.unmount();
+
+    const otherHost = renderWithProviders(
+      <WorkspaceSetupChecklist workspace={OTHER_WORKSPACE} />,
+      queryClient,
+      {capture: vi.fn()},
+    );
+    expect(await screen.findByRole('button', {name: 'Show all 5 steps'})).toBeInTheDocument();
+    expect(screen.queryByRole('list', {name: 'Setup steps'})).not.toBeInTheDocument();
+    otherHost.unmount();
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+    expect(await screen.findByRole('button', {name: 'Show less'})).toBeInTheDocument();
+  });
+
+  test('captures the expansion toggle so adoption of the collapsed panel is measurable', async () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient);
+    const capture = vi.fn();
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {capture});
+
+    fireEvent.click(await screen.findByRole('button', {name: 'Show all 5 steps'}));
+    expect(capture).toHaveBeenCalledWith('onboarding_checklist_expansion_toggled', {
+      host: 'panel',
+      expanded: true,
+    });
+
+    fireEvent.click(await screen.findByRole('button', {name: 'Show less'}));
+    expect(capture).toHaveBeenCalledWith('onboarding_checklist_expansion_toggled', {
+      host: 'panel',
+      expanded: false,
+    });
+  });
+
+  test('keeps the skeleton rather than promoting a pointer while optional families load', async () => {
+    const queryClient = createQueryClient();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(() => pendingResponse()),
+    });
+    queryClient.setQueryData(integrationProvidersQueryOptions().queryKey, [
+      githubProvider,
+      linearProvider,
+    ]);
+    queryClient.setQueryData(integrationConnectionsQueryOptions(WORKSPACE.id).queryKey, [
+      connection('github', 'active'),
+      connection('linear', 'active'),
+    ]);
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+
+    expect(await screen.findByRole('status', {name: 'Loading setup guide'})).toBeInTheDocument();
+    expect(screen.queryByText('Push your first workflow')).not.toBeInTheDocument();
   });
 
   test('does not render an initially complete checklist without a transition', async () => {

--- a/libs/client/onboarding/src/components/setup-checklist.test.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist.test.tsx
@@ -38,6 +38,7 @@ import {
 
 const WORKSPACE: WorkspaceReference = {id: 'test-workspace', slug: 'acme'};
 const GET_STARTED_BUTTON_RE = /Get started/u;
+const SHOW_ALL_STEPS_RE = /Show all/u;
 const now = new Date().toISOString();
 const githubProvider: IntegrationProvider = {
   provider: 'github',
@@ -534,6 +535,78 @@ describe('workspace checklist hosts', () => {
       expect(screen.queryByRole('button', {name: GET_STARTED_BUTTON_RE})).not.toBeInTheDocument();
     });
     expect(capture).not.toHaveBeenCalledWith('onboarding_checklist_shown', {host: 'popover'});
+  });
+
+  test('shows only the next step until the reader opens the full list', async () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient);
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+
+    expect(await screen.findByText('Connect your tools')).toBeInTheDocument();
+    expect(screen.queryByRole('list', {name: 'Setup steps'})).not.toBeInTheDocument();
+    expect(screen.queryByText('Create a project')).not.toBeInTheDocument();
+    expect(screen.queryByText('Push your first workflow')).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', {name: 'Show all 5 steps'});
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggle);
+
+    expect(await screen.findByRole('list', {name: 'Setup steps'})).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(5);
+    expect(screen.getByText('Push your first workflow')).toBeInTheDocument();
+
+    const collapse = screen.getByRole('button', {name: 'Show less'});
+    expect(collapse).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(collapse);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('list', {name: 'Setup steps'})).not.toBeInTheDocument(),
+    );
+  });
+
+  test('reopens the full list on a later visit once the reader expanded it', async () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient);
+
+    const first = renderWithProviders(
+      <WorkspaceSetupChecklist workspace={WORKSPACE} />,
+      queryClient,
+      {capture: vi.fn()},
+    );
+    fireEvent.click(await screen.findByRole('button', {name: 'Show all 5 steps'}));
+    expect(await screen.findByRole('list', {name: 'Setup steps'})).toBeInTheDocument();
+    first.unmount();
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+
+    expect(await screen.findByRole('list', {name: 'Setup steps'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Show less'})).toBeInTheDocument();
+  });
+
+  test('replaces the panel body with the completion state rather than the finished list', async () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient);
+
+    renderWithProviders(<WorkspaceSetupChecklist workspace={WORKSPACE} />, queryClient, {
+      capture: vi.fn(),
+    });
+    expect(await screen.findByText('Connect your tools')).toBeInTheDocument();
+
+    act(() => {
+      queryClient.setQueryData(integrationConnectionsQueryOptions(WORKSPACE.id).queryKey, [
+        connection('github', 'active'),
+        connection('linear', 'active'),
+      ]);
+    });
+
+    expect(await screen.findByText("You're set up")).toBeInTheDocument();
+    expect(screen.queryByRole('list', {name: 'Setup steps'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: SHOW_ALL_STEPS_RE})).not.toBeInTheDocument();
   });
 
   test('does not render an initially complete checklist without a transition', async () => {

--- a/libs/client/onboarding/src/components/setup-checklist.tsx
+++ b/libs/client/onboarding/src/components/setup-checklist.tsx
@@ -1,4 +1,6 @@
 export {SetupChecklistBody} from './setup-checklist-body.js';
+export {SetupChecklistCompletion} from './setup-checklist-completion.js';
+export {SetupChecklistNextStep} from './setup-checklist-next-step.js';
 export type {
   SetupChecklistBodyProps,
   WorkspaceReference,

--- a/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
+++ b/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
@@ -36,7 +36,7 @@ function WorkspaceSetupChecklistFromShell() {
 
 function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceReference}) {
   const dismissal = useChecklistDismissal(workspace.id);
-  const expansion = useChecklistExpansion(workspace.id);
+  const {expanded, toggle: toggleExpansion} = useChecklistExpansion(workspace.id);
   const queryState = useSetupChecklistQueryState(workspace.id, !dismissal.dismissed);
   const bodyId = useId();
   const [burstPending, setBurstPending] = useState(false);
@@ -57,6 +57,13 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
     },
     [analytics],
   );
+  const handleToggleExpansion = useCallback(() => {
+    toggleExpansion();
+    analytics.capture('onboarding_checklist_expansion_toggled', {
+      host: 'panel',
+      expanded: !expanded,
+    });
+  }, [analytics, expanded, toggleExpansion]);
   const isVisible =
     !dismissal.dismissed &&
     queryState.baseSettled &&
@@ -72,10 +79,10 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
 
   const expansionControl: ChecklistExpansionControl | undefined = expandable
     ? {
-        expanded: expansion.expanded,
+        expanded,
         stepCount: queryState.checklist.items.length,
         bodyId,
-        onToggle: expansion.toggle,
+        onToggle: handleToggleExpansion,
       }
     : undefined;
 
@@ -91,7 +98,7 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
           <ChecklistPanelBody
             queryState={queryState}
             workspaceSlug={workspace.slug}
-            expanded={expansion.expanded}
+            expanded={expanded}
             completion={showCompletion}
             showBurst={burstPending}
             onBurstComplete={consumeBurst}
@@ -153,6 +160,11 @@ function ChecklistPanelBody({
 
   const nextStep = selectNextSetupStep(queryState.checklist);
   if (!nextStep) return null;
+
+  // A pointer only leads once nothing is left to ask for. The runner,
+  // model-provider, and teammate rows stay hidden while their families load, so
+  // promoting the pointer then would call setup finished a moment too early.
+  if (!nextStep.tracked && !queryState.optionalSettled) return <ChecklistSkeleton />;
 
   return (
     <SetupChecklistNextStep item={nextStep} workspaceSlug={workspaceSlug} onAction={onAction} />

--- a/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
+++ b/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
@@ -1,16 +1,20 @@
 import {useClientAnalytics, useMaybeActiveWorkspace} from '@shipfox/client-shell/runtime';
 import {Panel, PanelBody} from '@shipfox/react-ui/panel';
-import {useCallback, useState} from 'react';
-import type {SetupChecklistItem} from '#core/setup-checklist.js';
-import {useSetupChecklistQueryState} from '#hooks/api/setup-checklist.js';
+import {useCallback, useId, useState} from 'react';
+import {type SetupChecklistItem, selectNextSetupStep} from '#core/setup-checklist.js';
+import {type ChecklistQueryState, useSetupChecklistQueryState} from '#hooks/api/setup-checklist.js';
 import {useCompletionTransition, useShownAnalytics} from '#hooks/use-checklist-analytics.js';
 import {useChecklistDismissal} from '#hooks/use-checklist-dismissal.js';
+import {useChecklistExpansion} from '#hooks/use-checklist-expansion.js';
 import {SetupChecklistBody} from './setup-checklist-body.js';
+import {SetupChecklistCompletion} from './setup-checklist-completion.js';
 import {
+  type ChecklistExpansionControl,
   ChecklistHeader,
   ChecklistSkeleton,
   checklistCountLabel,
 } from './setup-checklist-host-primitives.js';
+import {SetupChecklistNextStep} from './setup-checklist-next-step.js';
 import type {WorkspaceReference, WorkspaceSetupHostProps} from './setup-checklist-types.js';
 
 export function WorkspaceSetupChecklist(props: WorkspaceSetupHostProps = {}) {
@@ -32,7 +36,9 @@ function WorkspaceSetupChecklistFromShell() {
 
 function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceReference}) {
   const dismissal = useChecklistDismissal(workspace.id);
+  const expansion = useChecklistExpansion(workspace.id);
   const queryState = useSetupChecklistQueryState(workspace.id, !dismissal.dismissed);
+  const bodyId = useId();
   const [burstPending, setBurstPending] = useState(false);
   const handleCompleted = useCallback((completed: boolean) => {
     if (completed) setBurstPending(true);
@@ -61,30 +67,94 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
 
   if (queryState.baseSettled && queryState.checklist.complete && !showCompletion) return null;
 
-  let checklistBody = <ChecklistSkeleton />;
-  if (queryState.baseSettled) {
-    checklistBody = (
-      <SetupChecklistBody
-        checklist={queryState.checklist}
-        workspaceSlug={workspace.slug}
-        completion={showCompletion}
-        showBurst={burstPending}
-        onBurstComplete={consumeBurst}
-        onAction={handleAction}
-        onDone={dismiss}
-      />
-    );
-  }
+  const expandable =
+    queryState.baseSettled && !showCompletion && queryState.checklist.items.length > 1;
+
+  const expansionControl: ChecklistExpansionControl | undefined = expandable
+    ? {
+        expanded: expansion.expanded,
+        stepCount: queryState.checklist.items.length,
+        bodyId,
+        onToggle: expansion.toggle,
+      }
+    : undefined;
 
   return (
     <Panel asChild className="w-full">
       <section aria-label="Get started">
         <ChecklistHeader
           count={queryState.baseSettled ? checklistCountLabel(queryState.checklist) : undefined}
+          expansion={expansionControl}
           onDismiss={dismiss}
         />
-        <PanelBody>{checklistBody}</PanelBody>
+        <PanelBody id={bodyId}>
+          <ChecklistPanelBody
+            queryState={queryState}
+            workspaceSlug={workspace.slug}
+            expanded={expansion.expanded}
+            completion={showCompletion}
+            showBurst={burstPending}
+            onBurstComplete={consumeBurst}
+            onAction={handleAction}
+            onDone={dismiss}
+          />
+        </PanelBody>
       </section>
     </Panel>
+  );
+}
+
+/**
+ * The panel stays at one step until the reader asks for the list, because it
+ * sits above the page's own content. The nav-bar indicator carries the full
+ * checklist on every route.
+ */
+function ChecklistPanelBody({
+  queryState,
+  workspaceSlug,
+  expanded,
+  completion,
+  showBurst,
+  onBurstComplete,
+  onAction,
+  onDone,
+}: {
+  queryState: ChecklistQueryState;
+  workspaceSlug: string;
+  expanded: boolean;
+  completion: boolean;
+  showBurst: boolean;
+  onBurstComplete: () => void;
+  onAction: (item: SetupChecklistItem) => void;
+  onDone: () => void;
+}) {
+  if (!queryState.baseSettled) return <ChecklistSkeleton />;
+
+  if (completion) {
+    return (
+      <SetupChecklistCompletion
+        standalone
+        showBurst={showBurst}
+        onBurstComplete={onBurstComplete}
+        onDone={onDone}
+      />
+    );
+  }
+
+  if (expanded) {
+    return (
+      <SetupChecklistBody
+        checklist={queryState.checklist}
+        workspaceSlug={workspaceSlug}
+        onAction={onAction}
+      />
+    );
+  }
+
+  const nextStep = selectNextSetupStep(queryState.checklist);
+  if (!nextStep) return null;
+
+  return (
+    <SetupChecklistNextStep item={nextStep} workspaceSlug={workspaceSlug} onAction={onAction} />
   );
 }

--- a/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
+++ b/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
@@ -77,6 +77,13 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
   const expandable =
     queryState.baseSettled && !showCompletion && queryState.checklist.items.length > 1;
 
+  // `trackedCount` only stops moving once every family has reported, so a count
+  // shown before then can read "3 of 3 done" over rows that have yet to arrive.
+  const countLabel =
+    queryState.baseSettled && queryState.optionalSettled
+      ? checklistCountLabel(queryState.checklist)
+      : undefined;
+
   const expansionControl: ChecklistExpansionControl | undefined = expandable
     ? {
         expanded,
@@ -89,11 +96,7 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
   return (
     <Panel asChild className="w-full">
       <section aria-label="Get started">
-        <ChecklistHeader
-          count={queryState.baseSettled ? checklistCountLabel(queryState.checklist) : undefined}
-          expansion={expansionControl}
-          onDismiss={dismiss}
-        />
+        <ChecklistHeader count={countLabel} expansion={expansionControl} onDismiss={dismiss} />
         <PanelBody id={bodyId}>
           <ChecklistPanelBody
             queryState={queryState}

--- a/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
+++ b/libs/client/onboarding/src/components/workspace-setup-checklist.tsx
@@ -77,10 +77,11 @@ function WorkspaceSetupChecklistForWorkspace({workspace}: {workspace: WorkspaceR
   const expandable =
     queryState.baseSettled && !showCompletion && queryState.checklist.items.length > 1;
 
-  // `trackedCount` only stops moving once every family has reported, so a count
-  // shown before then can read "3 of 3 done" over rows that have yet to arrive.
+  // `trackedCount` only stops moving once the runner and model-provider families
+  // report, so a count shown before then can read "3 of 3 done" over rows that
+  // have yet to arrive.
   const countLabel =
-    queryState.baseSettled && queryState.optionalSettled
+    queryState.baseSettled && queryState.trackedRowsSettled
       ? checklistCountLabel(queryState.checklist)
       : undefined;
 
@@ -164,10 +165,10 @@ function ChecklistPanelBody({
   const nextStep = selectNextSetupStep(queryState.checklist);
   if (!nextStep) return null;
 
-  // A pointer only leads once nothing is left to ask for. The runner,
-  // model-provider, and teammate rows stay hidden while their families load, so
-  // promoting the pointer then would call setup finished a moment too early.
-  if (!nextStep.tracked && !queryState.optionalSettled) return <ChecklistSkeleton />;
+  // A pointer only leads once nothing is left to ask for. The runner and
+  // model-provider rows stay hidden while their families load, so promoting the
+  // pointer then would call setup finished a moment too early.
+  if (!nextStep.tracked && !queryState.trackedRowsSettled) return <ChecklistSkeleton />;
 
   return (
     <SetupChecklistNextStep item={nextStep} workspaceSlug={workspaceSlug} onAction={onAction} />

--- a/libs/client/onboarding/src/core/setup-checklist.test.ts
+++ b/libs/client/onboarding/src/core/setup-checklist.test.ts
@@ -4,6 +4,7 @@ import {
   deriveSetupChecklist,
   type SetupChecklistInput,
   type SetupChecklistItem,
+  selectNextSetupStep,
 } from './setup-checklist.js';
 
 function readiness(overrides: Partial<ReturnType<typeof deriveIntegrationReadiness>> = {}) {
@@ -338,5 +339,45 @@ describe('deriveSetupChecklist', () => {
     expect(checklist.trackedCount).toBe(5);
     expect(checklist.openCount).toBe(3);
     expect(checklist.items.filter((item) => !item.tracked)).toHaveLength(2);
+  });
+});
+
+describe('selectNextSetupStep', () => {
+  test('picks the first open tracked row ahead of every pointer', () => {
+    const checklist = deriveSetupChecklist(
+      input({
+        installationRunners: 'none',
+        modelProvider: {installationProvided: false, configured: false},
+      }),
+    );
+
+    expect(selectNextSetupStep(checklist)?.id).toBe('tools');
+  });
+
+  test('follows the spec order once an earlier ask is done', () => {
+    const checklist = deriveSetupChecklist(
+      input({
+        readiness: readiness({hasToolIntegration: true}),
+        installationRunners: 'none',
+        modelProvider: {installationProvided: false, configured: false},
+      }),
+    );
+
+    expect(selectNextSetupStep(checklist)?.id).toBe('runner');
+  });
+
+  test('falls back to the first unfinished pointer when every tracked row is done', () => {
+    const checklist = deriveSetupChecklist(
+      input({readiness: readiness({hasToolIntegration: true})}),
+    );
+
+    expect(checklist.openCount).toBe(0);
+    expect(selectNextSetupStep(checklist)?.id).toBe('first-workflow');
+  });
+
+  test('returns nothing when the checklist has no rows left to show', () => {
+    expect(
+      selectNextSetupStep({items: [], openCount: 0, trackedCount: 0, complete: true}),
+    ).toBeUndefined();
   });
 });

--- a/libs/client/onboarding/src/core/setup-checklist.ts
+++ b/libs/client/onboarding/src/core/setup-checklist.ts
@@ -11,9 +11,17 @@ export type SetupChecklistItemId =
   | 'first-workflow'
   | 'teammates';
 
+/** Every destination the checklist routes to. Keeps action routing total. */
+export type SetupChecklistActionHref =
+  | '/docs/getting-started'
+  | '/settings/agents'
+  | '/settings/integrations'
+  | '/settings/members'
+  | '/settings/runners';
+
 export interface SetupChecklistAction {
   label: string;
-  href: string;
+  href: SetupChecklistActionHref;
 }
 
 export interface SetupChecklistItem {

--- a/libs/client/onboarding/src/core/setup-checklist.ts
+++ b/libs/client/onboarding/src/core/setup-checklist.ts
@@ -163,3 +163,15 @@ function attentionToolProviders(readiness: WorkspaceIntegrationReadiness) {
       (provider) => provider !== undefined && !provider.capabilities.includes('source_control'),
     );
 }
+
+/**
+ * The single step a compact host asks for: the first open tracked row, or the
+ * first unfinished pointer once every tracked row is done but the checklist has
+ * not settled as complete.
+ */
+export function selectNextSetupStep(checklist: SetupChecklist): SetupChecklistItem | undefined {
+  return (
+    checklist.items.find((item) => item.tracked && item.status === 'open') ??
+    checklist.items.find((item) => item.status !== 'done')
+  );
+}

--- a/libs/client/onboarding/src/hooks/api/setup-checklist.ts
+++ b/libs/client/onboarding/src/hooks/api/setup-checklist.ts
@@ -27,8 +27,12 @@ const CHECKLIST_STALE_TIME_MS = 5 * 60 * 1000;
 export interface ChecklistQueryState {
   checklist: SetupChecklist;
   baseSettled: boolean;
-  /** Every non-base family has reported, by success or by failure. */
-  optionalSettled: boolean;
+  /**
+   * Every family that can still add a tracked row has reported, by success or
+   * by failure. The teammates family is excluded: its row is a pointer, so it
+   * never moves `trackedCount`.
+   */
+  trackedRowsSettled: boolean;
   completionReady: boolean;
 }
 
@@ -122,7 +126,7 @@ export function useSetupChecklistQueryState(
 
   return {
     baseSettled: families.baseSettled,
-    optionalSettled: families.optionalSettled,
+    trackedRowsSettled: families.trackedRowsSettled,
     completionReady: families.completionReady,
     checklist: {
       items,
@@ -156,7 +160,7 @@ function checklistFamilyState(queries: {
   const membersSettled = isSettled(queries.membersQuery) && isSettled(queries.invitationsQuery);
   const providersReady = queries.providersQuery.isSuccess;
   const connectionsReady = queries.connectionsQuery.isSuccess;
-  const optionalSettled = runnerSettled && modelSettled && membersSettled;
+  const everyFamilySettled = runnerSettled && modelSettled && membersSettled;
 
   return {
     providersReady,
@@ -165,8 +169,8 @@ function checklistFamilyState(queries: {
     modelReady: queries.catalogQuery.isSuccess && queries.configsQuery.isSuccess,
     membersReady: queries.membersQuery.isSuccess && queries.invitationsQuery.isSuccess,
     baseSettled: isSettled(queries.providersQuery) && isSettled(queries.connectionsQuery),
-    optionalSettled,
-    completionReady: providersReady && connectionsReady && optionalSettled,
+    trackedRowsSettled: runnerSettled && modelSettled,
+    completionReady: providersReady && connectionsReady && everyFamilySettled,
   };
 }
 

--- a/libs/client/onboarding/src/hooks/api/setup-checklist.ts
+++ b/libs/client/onboarding/src/hooks/api/setup-checklist.ts
@@ -27,6 +27,8 @@ const CHECKLIST_STALE_TIME_MS = 5 * 60 * 1000;
 export interface ChecklistQueryState {
   checklist: SetupChecklist;
   baseSettled: boolean;
+  /** Every non-base family has reported, by success or by failure. */
+  optionalSettled: boolean;
   completionReady: boolean;
 }
 
@@ -82,20 +84,15 @@ export function useSetupChecklistQueryState(
     ...queryPolicy,
   });
 
-  const baseSettled = isSettled(providersQuery) && isSettled(connectionsQuery);
-  const runnerSettled = isSettled(activeProvisionersQuery) && isSettled(runnersStatusQuery);
-  const runnerReady = activeProvisionersQuery.isSuccess && runnersStatusQuery.isSuccess;
-  const catalogInstallationProvided = hasInstallationProvider(catalogQuery.data);
-  const modelReady = catalogQuery.isSuccess && configsQuery.isSuccess;
-  const membersReady = membersQuery.isSuccess && invitationsQuery.isSuccess;
-  const modelSettled = isSettled(catalogQuery) && isSettled(configsQuery);
-  const membersSettled = isSettled(membersQuery) && isSettled(invitationsQuery);
-  const completionReady = allChecklistQueriesReady({
-    providersReady: providersQuery.isSuccess,
-    connectionsReady: connectionsQuery.isSuccess,
-    runnerSettled,
-    modelSettled,
-    membersSettled,
+  const families = checklistFamilyState({
+    providersQuery,
+    connectionsQuery,
+    activeProvisionersQuery,
+    runnersStatusQuery,
+    catalogQuery,
+    configsQuery,
+    membersQuery,
+    invitationsQuery,
   });
 
   const rawChecklist = deriveSetupChecklist({
@@ -108,7 +105,7 @@ export function useSetupChecklistQueryState(
     modelProvider: {
       installationProvided: installationProviderReadiness(
         catalogQuery.isSuccess,
-        catalogInstallationProvided,
+        hasInstallationProvider(catalogQuery.data),
       ),
       configured: (configsQuery.data?.configs.length ?? 0) > 0,
     },
@@ -118,27 +115,58 @@ export function useSetupChecklistQueryState(
     },
   });
 
-  const hiddenRows = hiddenChecklistRows({
-    providersReady: providersQuery.isSuccess,
-    connectionsReady: connectionsQuery.isSuccess,
-    runnerReady,
-    modelReady,
-    membersReady,
-  });
-
+  const hiddenRows = hiddenChecklistRows(families);
   const items = rawChecklist.items.filter((item) => !hiddenRows.has(item.id));
   const trackedItems = items.filter((item) => item.tracked);
   const openCount = trackedItems.filter((item) => item.status === 'open').length;
 
   return {
-    baseSettled,
-    completionReady,
+    baseSettled: families.baseSettled,
+    optionalSettled: families.optionalSettled,
+    completionReady: families.completionReady,
     checklist: {
       items,
       openCount,
       trackedCount: trackedItems.length,
-      complete: completionReady && openCount === 0,
+      complete: families.completionReady && openCount === 0,
     },
+  };
+}
+
+type SettleableQuery = {isError: boolean; isSuccess: boolean};
+
+/**
+ * Per-family readiness. A row is hidden while its family is merely loading, so
+ * `ready` tracks success while `settled` also accepts a failure: a family that
+ * gave up must not hold the whole checklist back.
+ */
+function checklistFamilyState(queries: {
+  providersQuery: SettleableQuery;
+  connectionsQuery: SettleableQuery;
+  activeProvisionersQuery: SettleableQuery;
+  runnersStatusQuery: SettleableQuery;
+  catalogQuery: SettleableQuery;
+  configsQuery: SettleableQuery;
+  membersQuery: SettleableQuery;
+  invitationsQuery: SettleableQuery;
+}) {
+  const runnerSettled =
+    isSettled(queries.activeProvisionersQuery) && isSettled(queries.runnersStatusQuery);
+  const modelSettled = isSettled(queries.catalogQuery) && isSettled(queries.configsQuery);
+  const membersSettled = isSettled(queries.membersQuery) && isSettled(queries.invitationsQuery);
+  const providersReady = queries.providersQuery.isSuccess;
+  const connectionsReady = queries.connectionsQuery.isSuccess;
+  const optionalSettled = runnerSettled && modelSettled && membersSettled;
+
+  return {
+    providersReady,
+    connectionsReady,
+    runnerReady: queries.activeProvisionersQuery.isSuccess && queries.runnersStatusQuery.isSuccess,
+    modelReady: queries.catalogQuery.isSuccess && queries.configsQuery.isSuccess,
+    membersReady: queries.membersQuery.isSuccess && queries.invitationsQuery.isSuccess,
+    baseSettled: isSettled(queries.providersQuery) && isSettled(queries.connectionsQuery),
+    optionalSettled,
+    completionReady: providersReady && connectionsReady && optionalSettled,
   };
 }
 
@@ -164,22 +192,6 @@ function hasInstallationProvider(
   return catalog.managedProviderId !== null || catalog.instanceDefaultProviderId !== null;
 }
 
-function allChecklistQueriesReady(readiness: {
-  providersReady: boolean;
-  connectionsReady: boolean;
-  runnerSettled: boolean;
-  modelSettled: boolean;
-  membersSettled: boolean;
-}): boolean {
-  return (
-    readiness.providersReady &&
-    readiness.connectionsReady &&
-    readiness.runnerSettled &&
-    readiness.modelSettled &&
-    readiness.membersSettled
-  );
-}
-
 function installationProviderReadiness(
   catalogReady: boolean,
   installationProvided: boolean,
@@ -188,7 +200,7 @@ function installationProviderReadiness(
   return installationProvided;
 }
 
-function isSettled(query: {isError: boolean; isSuccess: boolean}) {
+function isSettled(query: SettleableQuery) {
   return query.isSuccess || query.isError;
 }
 

--- a/libs/client/onboarding/src/hooks/use-checklist-expansion.ts
+++ b/libs/client/onboarding/src/hooks/use-checklist-expansion.ts
@@ -32,13 +32,13 @@ export function useChecklistExpansion(workspaceId: string) {
     () => checklistExpansionStorage(workspaceId).read() === true,
   );
 
+  // The write stays out of the state updater: React may replay or discard an
+  // updater, so persistence belongs to the event rather than to the render.
   const toggle = useCallback(() => {
-    setExpanded((current) => {
-      const next = !current;
-      setWorkspaceSetupChecklistExpanded(workspaceId, next);
-      return next;
-    });
-  }, [workspaceId]);
+    const next = !expanded;
+    setExpanded(next);
+    setWorkspaceSetupChecklistExpanded(workspaceId, next);
+  }, [expanded, workspaceId]);
 
   return {expanded, toggle};
 }

--- a/libs/client/onboarding/src/hooks/use-checklist-expansion.ts
+++ b/libs/client/onboarding/src/hooks/use-checklist-expansion.ts
@@ -1,0 +1,48 @@
+import type {BrowserStorageKey} from '@shipfox/react-ui/utils';
+import {createTypedBrowserStorage, localStorageOrUndefined} from '@shipfox/react-ui/utils';
+import {useCallback, useState} from 'react';
+
+const checklistExpansionKey = {
+  key: 'shipfox.workspaceSetupChecklist.expanded',
+  lifetime: 'persistent',
+  principalScope: 'workspace',
+  serialize: (expanded: boolean) => JSON.stringify(expanded),
+  parse: (raw: string) => {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return typeof parsed === 'boolean' ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+} satisfies BrowserStorageKey<boolean>;
+
+export function setWorkspaceSetupChecklistExpanded(workspaceId: string, expanded: boolean): void {
+  checklistExpansionStorage(workspaceId).write(expanded);
+}
+
+/**
+ * Per-device panel expansion. The panel opens collapsed so the setup guide
+ * never displaces the page below it, and a reader who opens the full list keeps
+ * it open on their next visit. The hosts remount per workspace, so the initial
+ * read never has to follow a workspace switch.
+ */
+export function useChecklistExpansion(workspaceId: string) {
+  const [expanded, setExpanded] = useState(
+    () => checklistExpansionStorage(workspaceId).read() === true,
+  );
+
+  const toggle = useCallback(() => {
+    setExpanded((current) => {
+      const next = !current;
+      setWorkspaceSetupChecklistExpanded(workspaceId, next);
+      return next;
+    });
+  }, [workspaceId]);
+
+  return {expanded, toggle};
+}
+
+function checklistExpansionStorage(workspaceId: string) {
+  return createTypedBrowserStorage(localStorageOrUndefined, checklistExpansionKey, {workspaceId});
+}

--- a/libs/client/onboarding/src/index.ts
+++ b/libs/client/onboarding/src/index.ts
@@ -12,6 +12,7 @@ export {
   type SetupChecklistItem,
   type SetupChecklistItemId,
   type SetupChecklistItemStatus,
+  selectNextSetupStep,
 } from '#core/setup-checklist.js';
 export {
   SetupChecklistBody,


### PR DESCRIPTION
Keep the workspace Get-started panel compact by showing the next setup step by default. Users can expand the full checklist from the header, with the per-workspace preference retained on the device; the navigation indicator continues to expose all steps.

This prevents the panel from pushing page content below the fold while keeping the complete setup guide accessible.

Validation:
- `mise exec -- turbo check --filter=@shipfox/client-onboarding...`
- `mise exec -- turbo type --filter=@shipfox/client-onboarding...`
- `mise exec -- turbo test --filter=@shipfox/client-onboarding...` (101 tests passed)
- `mise exec -- turbo build --filter=@shipfox/client-onboarding...`
- `mise exec -- git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the workspace Get-started panel compact by showing the next setup step by default, with a header toggle to expand the full checklist. The expansion preference is remembered per device, and the navigation indicator still lists all steps.

**Details**
- The panel renders only the next incomplete step until the reader clicks "Show all N steps"; the toggle becomes "Show less" when expanded, and the choice persists per workspace on the same device.
- Toggling the expansion is captured as `onboarding_checklist_expansion_toggled` so adoption of the collapsed panel is measurable.
- While the runner and model-provider families are still loading, the panel keeps the skeleton instead of promoting the quickstart pointer, and the header count is held so it can't read "N of N done" early.
- A fully completed checklist shows the completion state even when the full list was open.
- The navigation indicator continues to display the complete checklist on all routes.

<sup>Written for commit 1e6cbb59abd62849ed60ed5f67abc7d3ad55811e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

