### PR TITLE
[provisioner-docker] Switch Docker registration deadline to backend authorization

### DIFF
--- a/apps/docs/content/docs/installation/runner-provisioner.mdx
+++ b/apps/docs/content/docs/installation/runner-provisioner.mdx
@@ -16,6 +16,13 @@ provisioner.
 - Access to your workspace settings in the Shipfox dashboard.
 - A Shipfox source checkout with `mise install` and `pnpm install` complete.
 
+<Callout title="Upgrade order for self-hosted deployments" type="info">
+  Upgrade the Shipfox API before upgrading the Docker provisioner. The provisioner
+  submits stale-created containers as registration-deadline candidates and removes
+  them only after the API authorizes termination. Keep the older provisioner running
+  until the API upgrade is complete.
+</Callout>
+
 ## Create a provisioner token
 
 <Steps>

--- a/apps/docs/content/docs/installation/runner-provisioner.mdx
+++ b/apps/docs/content/docs/installation/runner-provisioner.mdx
@@ -19,8 +19,11 @@ provisioner.
 <Callout title="Upgrade order for self-hosted deployments" type="info">
   Upgrade the Shipfox API before upgrading the Docker provisioner. The provisioner
   submits stale-created containers as registration-deadline candidates and removes
-  them only after the API authorizes termination. Keep the older provisioner running
-  until the API upgrade is complete.
+  them only after the API authorizes termination. Set
+  `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` on the API before
+  upgrading the provisioner; it defaults to `false`. Keep the older provisioner
+  running until the API upgrade is complete. On rollback, downgrade the Docker
+  provisioner before the API.
 </Callout>
 
 ## Create a provisioner token

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -31,7 +31,7 @@ This page is the canonical reference for configuring the Docker runner provision
 | `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | `1000` | Provider observation and reconciliation cadence. Backs off on errors up to the larger of 5000 ms and the configured cadence. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | `250` | Most reservations requested in one poll. Also bounded by free template capacity and the API's cap of 1000. |
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1 to 1000). Must not exceed the API's own batch limit. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner submits a registration-deadline candidate. The API must authorize cleanup; an unavailable API leaves the container in place for retry. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner submits a registration-deadline candidate. Enable `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` on the API to authorize cleanup; it defaults to `false`. An unavailable API leaves the container in place for retry. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | `3600000` | How long failed runner containers remain stopped for forensic inspection. Set to `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | `20` | Maximum number of failed runner containers retained per provisioner. Set to `0` to disable retention. |
 | `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` | `3600` | Legacy lifetime value retained for older runner images. Timer-free images accept it without scheduling age-based shutdown. |

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -31,7 +31,7 @@ This page is the canonical reference for configuring the Docker runner provision
 | `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | `1000` | Provider observation and reconciliation cadence. Backs off on errors up to the larger of 5000 ms and the configured cadence. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | `250` | Most reservations requested in one poll. Also bounded by free template capacity and the API's cap of 1000. |
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1 to 1000). Must not exceed the API's own batch limit. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner reaps it as stale. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner submits a registration-deadline candidate. The API must authorize cleanup; an unavailable API leaves the container in place for retry. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | `3600000` | How long failed runner containers remain stopped for forensic inspection. Set to `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | `20` | Maximum number of failed runner containers retained per provisioner. Set to `0` to disable retention. |
 | `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` | `3600` | Legacy lifetime value retained for older runner images. Timer-free images accept it without scheduling age-based shutdown. |
@@ -79,9 +79,9 @@ count bound is 20. Docker `FinishedAt` drives TTL cleanup. Missing `FinishedAt`
 uses the first observed failure time instead of creation time, so a long-running
 container is not removed immediately. Terminal inspection failures defer TTL
 cleanup but remain subject to the count bound, and unknown failure times rank as
-newly observed for count eviction. Successful exits, dead containers,
-stale-created containers, and backend termination keep their immediate cleanup
-behavior.
+newly observed for count eviction. Successful exits and backend-authorized
+termination intents keep their immediate cleanup behavior. Stale-created
+containers remain while the provisioner waits for backend authorization.
 
 Forensic output is driver-specific: use `docker inspect <runner-name>` and
 `docker logs --timestamps --tail 200 <runner-name>` for `local` or `json-file`,

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -41,6 +41,9 @@ until observation succeeds.
 For self-hosted deployments, upgrade the Shipfox API before upgrading the Docker
 provisioner. The provisioner keeps stale-created containers when the API is
 unavailable or does not authorize cleanup, so the candidate can be retried safely.
+Set `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` on the API
+before upgrading the provisioner; it defaults to `false`. On rollback, downgrade
+the Docker provisioner before the API.
 
 ## Configuration
 
@@ -57,7 +60,7 @@ unavailable or does not authorize cleanup, so the candidate can be retried safel
 | `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | N/A | JSON object of string-valued driver options; requires the driver setting. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Failed-container retention TTL in milliseconds; `0` disables retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed containers; `0` disables retention. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before the provisioner submits a registration-deadline candidate. The API authorizes cleanup. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before the provisioner submits a registration-deadline candidate. Set `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` on the API to authorize cleanup; it defaults to `false`. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Long-poll wait per demand request. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Base delay between polls; backs off on error. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Backoff ceiling. |

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -31,10 +31,16 @@ containers are re-reported every convergence cycle to keep the backend active-ru
 Exited containers are reported as `stopped` or `failed`. Successful exits are removed
 immediately; failed exits are retained for the configured forensic TTL/count bound and
 then cleaned up. Containers stuck in Docker's `created` state past the registration
-deadline are reaped as stale pre-run resources; running containers are never locally killed.
+deadline are submitted to the API as registration-deadline candidates and removed
+only after backend authorization; running containers are never killed from
+observation alone.
 
 If Docker cannot be observed, the provisioner advertises no free capacity and backs off
 until observation succeeds.
+
+For self-hosted deployments, upgrade the Shipfox API before upgrading the Docker
+provisioner. The provisioner keeps stale-created containers when the API is
+unavailable or does not authorize cleanup, so the candidate can be retried safely.
 
 ## Configuration
 
@@ -51,7 +57,7 @@ until observation succeeds.
 | `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | N/A | JSON object of string-valued driver options; requires the driver setting. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Failed-container retention TTL in milliseconds; `0` disables retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed containers; `0` disables retention. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before being reaped as stale. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before the provisioner submits a registration-deadline candidate. The API authorizes cleanup. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Long-poll wait per demand request. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Base delay between polls; backs off on error. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Backoff ceiling. |

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -506,6 +506,20 @@ export async function reportRunnerInstances(params: ReportRunnerInstancesParams)
           runnerSessionId: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN coalesce(${providerRunners.runnerSessionId}, excluded.runner_session_id) ELSE ${providerRunners.runnerSessionId} END`,
           providerKind: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN coalesce(excluded.provider_kind, ${providerRunners.providerKind}) ELSE ${providerRunners.providerKind} END`,
           reportedAt: sql`CASE WHEN ${providerRunnerProjectionUpdateCondition()} THEN excluded.reported_at ELSE ${providerRunners.reportedAt} END`,
+          terminationAuthorizedAt: sql`CASE
+            WHEN (${providerRunnerProjectionUpdateCondition()})
+              AND ${providerRunners.terminationReason} = 'registration-deadline'
+              AND excluded.state IN ('starting', 'running')
+            THEN NULL
+            ELSE ${providerRunners.terminationAuthorizedAt}
+          END`,
+          terminationReason: sql`CASE
+            WHEN (${providerRunnerProjectionUpdateCondition()})
+              AND ${providerRunners.terminationReason} = 'registration-deadline'
+              AND excluded.state IN ('starting', 'running')
+            THEN NULL
+            ELSE ${providerRunners.terminationReason}
+          END`,
           startedAt: firstObservedAt(providerRunners.startedAt, sql`excluded.started_at`),
           stoppingAt: firstObservedAt(providerRunners.stoppingAt, sql`excluded.stopping_at`),
           stoppedAt: firstObservedAt(providerRunners.stoppedAt, sql`excluded.stopped_at`),

--- a/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
@@ -118,6 +118,82 @@ describe('POST /provisioners/runner-instances/report', () => {
     expect(rows[0]?.reportedAt.toISOString()).toBe(reportedAt);
   });
 
+  it('clears registration-deadline authorization when a runner reports an active state', async () => {
+    const registrationDeadlineRunner = await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisionerTokenId,
+      providerRunnerId: 'registration-deadline-runner',
+      state: 'starting',
+      terminationAuthorizedAt: new Date('2025-01-01T00:01:00.000Z'),
+      terminationReason: 'registration-deadline',
+    });
+    const otherAuthorizedRunner = await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisionerTokenId,
+      providerRunnerId: 'other-authorized-runner',
+      state: 'starting',
+      terminationAuthorizedAt: new Date('2025-01-01T00:01:00.000Z'),
+      terminationReason: 'job-cancelled',
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/report',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        events: [
+          {
+            provider_runner_id: registrationDeadlineRunner.providerRunnerId,
+            labels: ['linux'],
+            state: 'running',
+            reported_at: new Date('2025-01-01T00:02:00.000Z').toISOString(),
+          },
+          {
+            provider_runner_id: otherAuthorizedRunner.providerRunnerId,
+            labels: ['linux'],
+            state: 'running',
+            reported_at: new Date('2025-01-01T00:02:00.000Z').toISOString(),
+          },
+        ],
+      },
+    });
+
+    const rows = await db()
+      .select({
+        providerRunnerId: providerRunners.providerRunnerId,
+        terminationAuthorizedAt: providerRunners.terminationAuthorizedAt,
+        terminationReason: providerRunners.terminationReason,
+      })
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.provisionerId, provisionerTokenId),
+          eq(providerRunners.providerRunnerId, registrationDeadlineRunner.providerRunnerId),
+        ),
+      );
+    const [otherRow] = await db()
+      .select({
+        terminationAuthorizedAt: providerRunners.terminationAuthorizedAt,
+        terminationReason: providerRunners.terminationReason,
+      })
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.provisionerId, provisionerTokenId),
+          eq(providerRunners.providerRunnerId, otherAuthorizedRunner.providerRunnerId),
+        ),
+      );
+
+    expect(res.statusCode).toBe(200);
+    expect(rows[0]).toEqual({
+      providerRunnerId: registrationDeadlineRunner.providerRunnerId,
+      terminationAuthorizedAt: null,
+      terminationReason: null,
+    });
+    expect(otherRow?.terminationAuthorizedAt).toEqual(new Date('2025-01-01T00:01:00.000Z'));
+    expect(otherRow?.terminationReason).toBe('job-cancelled');
+  });
+
   it('strips reserved labels from workspace runner reports', async () => {
     const res = await app.inject({
       method: 'POST',

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -86,13 +86,19 @@ provisioner control loop, and starts one Docker container per reserved runner. E
 container is named by its `provider_runner_id` and carries `shipfox.*` labels so a
 restarted provisioner can rebuild local capacity from Docker state.
 
+For self-hosted deployments, upgrade the Shipfox API before upgrading the Docker
+provisioner. The provisioner submits stale-created containers as
+registration-deadline candidates and keeps them when the API is unavailable or
+does not authorize cleanup.
+
 The provider reports lifecycle through the API:
 
 - `starting` before container creation.
 - `running` on every observation cycle for running containers.
 - `stopped` after successful exits, which are removed immediately; failed exits
   are retained for forensic inspection when retention is enabled.
-- `terminated` for dead/removing containers and stale pre-run `created` containers.
+- `terminated` for dead/removing containers and containers covered by a backend
+  termination authorization, including registration-deadline candidates.
 
 At startup and at the top of every control-loop iteration, the provider lists local
 containers owned by the provisioner token and refreshes tracker capacity before demand
@@ -114,7 +120,7 @@ variables:
 | `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | - | JSON object of string-valued driver options. Requires `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER`; option values are never logged. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Retention time for failed runner containers, in milliseconds. Set `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed runner containers. Set `0` to disable retention. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before being reaped as stale. Also the reservation lifetime the provisioner requests on each demand poll, rounded up to whole seconds; the control plane clamps it to its own `RESERVATION_TTL_MAX_SECONDS`. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before the provisioner submits a registration-deadline candidate. The API authorizes cleanup. Also the reservation lifetime the provisioner requests on each demand poll, rounded up to whole seconds; the control plane clamps it to its own `RESERVATION_TTL_MAX_SECONDS`. |
 
 The core `SHIPFOX_RUNNER_API_URL` variable is injected into runner containers as
 `SHIPFOX_API_URL` and defaults to `SHIPFOX_API_URL`. Set it when containers reach the
@@ -174,10 +180,11 @@ long-running container is not removed immediately. When terminal inspection is
 unavailable, TTL cleanup is deferred while the container remains count-bounded.
 Unknown failure times are ranked as newly observed for count eviction. Expired
 containers and the oldest containers over the count bound are removed on
-observation. Successful, dead, stale-created, and backend-terminated containers
-keep their immediate cleanup behavior. A retained failed container releases
-capacity immediately, and its failure record is emitted once per provisioner
-process. Inspect a failure using the command for its logging driver: use
+observation. Successful, dead, and backend-authorized containers keep their
+immediate cleanup behavior. Stale-created containers remain while the provisioner
+waits for backend authorization. A retained failed container releases capacity
+immediately, and its failure record is emitted once per provisioner process. Inspect
+a failure using the command for its logging driver: use
 `docker logs --timestamps --tail 200 <runner-name>` for `local` or `json-file`,
 `journalctl CONTAINER_NAME=<runner-name>` for `journald`, and the configured
 durable backend for remote drivers. The `none` driver has no container output.

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -89,7 +89,10 @@ restarted provisioner can rebuild local capacity from Docker state.
 For self-hosted deployments, upgrade the Shipfox API before upgrading the Docker
 provisioner. The provisioner submits stale-created containers as
 registration-deadline candidates and keeps them when the API is unavailable or
-does not authorize cleanup.
+does not authorize cleanup. Set
+`RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` on the API before
+upgrading the provisioner; it defaults to `false`. On rollback, downgrade the
+Docker provisioner before the API.
 
 The provider reports lifecycle through the API:
 
@@ -120,7 +123,7 @@ variables:
 | `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | - | JSON object of string-valued driver options. Requires `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER`; option values are never logged. |
 | `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Retention time for failed runner containers, in milliseconds. Set `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed runner containers. Set `0` to disable retention. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before the provisioner submits a registration-deadline candidate. The API authorizes cleanup. Also the reservation lifetime the provisioner requests on each demand poll, rounded up to whole seconds; the control plane clamps it to its own `RESERVATION_TTL_MAX_SECONDS`. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before the provisioner submits a registration-deadline candidate. Set `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` on the API to authorize cleanup; it defaults to `false`. Also the reservation lifetime the provisioner requests on each demand poll, rounded up to whole seconds; the control plane clamps it to its own `RESERVATION_TTL_MAX_SECONDS`. |
 
 The core `SHIPFOX_RUNNER_API_URL` variable is injected into runner containers as
 `SHIPFOX_API_URL` and defaults to `SHIPFOX_API_URL`. Set it when containers reach the

--- a/libs/provisioner/docker/src/config.ts
+++ b/libs/provisioner/docker/src/config.ts
@@ -33,7 +33,7 @@ export const config = createConfig({
     default: 20,
   }),
   SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS: num({
-    desc: 'How long a created runner container may remain unstarted before the provisioner submits a registration-deadline candidate, in milliseconds. The API authorizes cleanup, and an unavailable API leaves the container in place for retry.',
+    desc: 'How long a created runner container may remain unstarted before the provisioner submits a registration-deadline candidate, in milliseconds. Enable RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true on the API to authorize cleanup; it defaults to false. An unavailable API leaves the container in place for retry.',
     default: 120_000,
   }),
 });

--- a/libs/provisioner/docker/src/config.ts
+++ b/libs/provisioner/docker/src/config.ts
@@ -33,7 +33,7 @@ export const config = createConfig({
     default: 20,
   }),
   SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS: num({
-    desc: 'How long a created runner container may remain unstarted before the provisioner reaps it as a stale pre-run resource, in milliseconds.',
+    desc: 'How long a created runner container may remain unstarted before the provisioner submits a registration-deadline candidate, in milliseconds. The API authorizes cleanup, and an unavailable API leaves the container in place for retry.',
     default: 120_000,
   }),
 });

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -934,11 +934,20 @@ describe('createDockerLifecycle', () => {
   });
 
   it('revalidates registration-deadline actions with one Docker listing per batch', async () => {
+    const labels = {
+      'shipfox.runner_instance_id': '00000000-0000-4000-8000-000000000004',
+      'shipfox.provider_runner_id': 'runner-1',
+      'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+      'shipfox.reservation_id': RESERVATION_ID,
+      'shipfox.template_key': 'small',
+      'shipfox.labels': 'ubuntu22',
+    };
     const containers = [
       container({
         name: 'runner-1',
         state: 'created',
         createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        labels,
       }),
       container({
         name: 'runner-2',
@@ -949,7 +958,7 @@ describe('createDockerLifecycle', () => {
     const engine = fakeEngine({
       containers,
       onList: (call) => {
-        if (call === 2) containers[0] = container({name: 'runner-1', state: 'running'});
+        if (call === 2) containers[0] = container({name: 'runner-1', state: 'running', labels});
       },
     });
     const client = fakeClient({
@@ -967,6 +976,12 @@ describe('createDockerLifecycle', () => {
 
     expect(engine.listManagedCalls).toBe(2);
     expect(engine.killedAndRemoved).toEqual(['runner-2']);
+    expect(client.assignmentBodies).toEqual([
+      {
+        reservationId: RESERVATION_ID,
+        runnerInstanceIds: ['00000000-0000-4000-8000-000000000004'],
+      },
+    ]);
     expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
       'running',
       'terminated',

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -922,6 +922,7 @@ describe('createDockerLifecycle', () => {
     expect(engine.killedAndRemoved).toEqual([]);
     expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
       'running',
+      'running',
     ]);
     expect(observability.logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -930,6 +931,46 @@ describe('createDockerLifecycle', () => {
       }),
       'Skipped backend registration-deadline termination after the container state changed',
     );
+  });
+
+  it('revalidates registration-deadline actions with one Docker listing per batch', async () => {
+    const containers = [
+      container({
+        name: 'runner-1',
+        state: 'created',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+      container({
+        name: 'runner-2',
+        state: 'created',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ];
+    const engine = fakeEngine({
+      containers,
+      onList: (call) => {
+        if (call === 2) containers[0] = container({name: 'runner-1', state: 'running'});
+      },
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [
+          reconciledRunner('runner-1', 'terminate', 'registration-deadline'),
+          reconciledRunner('runner-2', 'terminate', 'registration-deadline'),
+        ],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.reconcile();
+
+    expect(engine.listManagedCalls).toBe(2);
+    expect(engine.killedAndRemoved).toEqual(['runner-2']);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'running',
+      'terminated',
+    ]);
   });
 
   it('does not report termination when backend-authorized registration cleanup fails', async () => {

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -4,6 +4,7 @@ import type {
   ReportRunnerInstancesBodyDto,
   ReportRunnerInstancesResponseDto,
 } from '@shipfox/api-runners-dto';
+import {MAX_TERMINATION_CANDIDATES} from '@shipfox/api-runners-dto';
 import type {
   ProviderRunnerLaunch,
   ProviderRunnerTracker,
@@ -357,24 +358,38 @@ describe('createDockerLifecycle', () => {
 
   it('keeps stale-created containers when backend reconciliation is unavailable', async () => {
     const error = new Error('api unavailable');
+    let currentTime = NOW;
     const containers = [
       container({
         state: 'created',
         createdAt: new Date('2026-01-01T00:00:00.000Z'),
       }),
+      container({name: 'running-1', state: 'running'}),
     ];
     const engine = fakeEngine({
       containers,
     });
     const client = fakeClient({reconcileErrors: [error, error]});
-    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      now: () => currentTime,
+      registrationDeadlineMs: 60_000,
+    });
 
     await expect(lifecycle.observe()).rejects.toThrow(error);
+    currentTime = new Date(NOW.getTime() + 1_000);
     await expect(lifecycle.observe()).rejects.toThrow(error);
 
     expect(engine.killedAndRemoved).toEqual([]);
     expect(engine.removed).toEqual([]);
     expect(client.reconcileBodies).toHaveLength(2);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'starting',
+      'running',
+      'starting',
+      'running',
+    ]);
   });
 
   it('marks OOM exits as failed with an oom reason', async () => {
@@ -773,6 +788,82 @@ describe('createDockerLifecycle', () => {
     );
   });
 
+  it('backs off unchanged registration-deadline candidate retries', async () => {
+    let currentTime = NOW;
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'created',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, now: () => currentTime});
+
+    await lifecycle.observe();
+    currentTime = new Date(NOW.getTime() + 500);
+    await lifecycle.observe();
+    currentTime = new Date(NOW.getTime() + 1_000);
+    await lifecycle.observe();
+
+    expect(client.reconcileBodies).toHaveLength(2);
+    expect(
+      observability.logger.info.mock.calls.filter(
+        ([fields]) =>
+          fields?.event === 'provisioner.docker.registration_deadline_candidates_submitted',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('caps and rotates registration-deadline candidate submissions', async () => {
+    const orderedIds = Array.from(
+      {length: MAX_TERMINATION_CANDIDATES + 2},
+      (_, index) => `runner-${index.toString().padStart(3, '0')}`,
+    );
+    const containers = orderedIds.map((name) =>
+      container({
+        name,
+        state: 'created',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    );
+    const engine = fakeEngine({containers});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.reconcile();
+    await lifecycle.reconcile();
+
+    expect(
+      client.reconcileBodies[0]?.termination_candidates?.map(
+        (candidate) => candidate.provider_runner_id,
+      ),
+    ).toEqual(orderedIds.slice(0, MAX_TERMINATION_CANDIDATES));
+    expect(
+      client.reconcileBodies[1]?.termination_candidates?.map(
+        (candidate) => candidate.provider_runner_id,
+      ),
+    ).toEqual([
+      ...orderedIds.slice(MAX_TERMINATION_CANDIDATES),
+      ...orderedIds.slice(0, MAX_TERMINATION_CANDIDATES - 2),
+    ]);
+    expect(
+      observability.logger.warn.mock.calls.filter(
+        ([fields]) => fields?.event === 'provisioner.docker.registration_deadline_candidate_limit',
+      ),
+    ).toHaveLength(2);
+
+    containers.splice(2);
+    await lifecycle.reconcile();
+
+    expect(
+      client.reconcileBodies[2]?.termination_candidates?.map(
+        (candidate) => candidate.provider_runner_id,
+      ),
+    ).toEqual(orderedIds.slice(0, 2));
+  });
+
   it('terminates a stale-created container only after backend authorization', async () => {
     const engine = fakeEngine({
       containers: [
@@ -802,6 +893,75 @@ describe('createDockerLifecycle', () => {
       state: 'terminated',
       reason: 'registration-deadline',
     });
+  });
+
+  it('revalidates a registration-deadline authorization before killing a container', async () => {
+    const containers = [
+      container({
+        state: 'created',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ];
+    const engine = fakeEngine({
+      containers,
+      onList: (call) => {
+        if (call === 2) containers[0] = container({state: 'running'});
+      },
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate', 'registration-deadline')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.reconcile();
+    await lifecycle.reconcile();
+
+    expect(engine.killedAndRemoved).toEqual([]);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'running',
+    ]);
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'runner.container_registration_deadline_termination_skipped',
+        currentState: 'running',
+      }),
+      'Skipped backend registration-deadline termination after the container state changed',
+    );
+  });
+
+  it('does not report termination when backend-authorized registration cleanup fails', async () => {
+    const error = new DockerEngineError('unknown', 'kill failed');
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'created',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+      killAndRemoveErrors: [error],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate', 'registration-deadline')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await expect(lifecycle.reconcile()).rejects.toThrow(error);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual(
+      [],
+    );
+
+    await lifecycle.reconcile();
+
+    expect(engine.killedAndRemoved).toEqual(['runner-1', 'runner-1']);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'terminated',
+    ]);
   });
 
   it('reconciles a stale-created container discovered after the first successful tick', async () => {
@@ -864,13 +1024,14 @@ describe('createDockerLifecycle', () => {
 
     await expect(lifecycle.tick()).rejects.toThrow('api down');
     expect(client.reconcileBodies).toHaveLength(1);
-    expect(client.reportBodies).toHaveLength(0);
+    expect(client.reportBodies.map((body) => body.events[0]?.state)).toEqual(['running']);
 
     await lifecycle.tick();
     await lifecycle.tick();
 
     expect(client.reconcileBodies).toHaveLength(2);
     expect(client.reportBodies.map((body) => body.events[0]?.state)).toEqual([
+      'running',
       'running',
       'running',
     ]);
@@ -1095,9 +1256,16 @@ describe('createDockerLifecycle', () => {
 
   it('reports oversized reconciliation as an incomplete provider operation', async () => {
     const engine = fakeEngine({
-      containers: Array.from({length: 5001}, (_, index) =>
-        container({name: `runner-${index}`, state: 'running'}),
-      ),
+      containers: [
+        container({
+          name: 'stale-runner',
+          state: 'created',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        ...Array.from({length: 5000}, (_, index) =>
+          container({name: `runner-${index}`, state: 'running'}),
+        ),
+      ],
     });
     const client = fakeClient();
     const lifecycle = makeLifecycle({engine, client});
@@ -1108,6 +1276,15 @@ describe('createDockerLifecycle', () => {
     expect(client.reportBodies.map((body) => body.events.length)).toEqual([
       1000, 1000, 1000, 1000, 1000, 1,
     ]);
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.docker.registration_deadline_candidates_skipped',
+        candidate_count: 1,
+        observed_count: 5001,
+        max_observed: 5000,
+      }),
+      'Skipped Docker registration-deadline candidates because the observed runner set exceeds the API limit',
+    );
   });
 
   it('tick retries backend reconcile after an oversized observed set later fits the API limit', async () => {
@@ -1357,6 +1534,7 @@ function makeLifecycle(
     engine?: ReturnType<typeof fakeEngine>;
     client?: ReturnType<typeof fakeClient>;
     tracker?: ProviderRunnerTracker;
+    now?: () => Date;
     registrationDeadlineMs?: number;
     failedContainerRetentionMs?: number;
     maxRetainedFailedContainers?: number;
@@ -1371,7 +1549,7 @@ function makeLifecycle(
     },
     tracker: args.tracker ?? testTracker(),
     templates: [template],
-    now: () => NOW,
+    now: args.now ?? (() => NOW),
     registrationDeadlineMs: args.registrationDeadlineMs ?? 120_000,
     providerKind: 'docker',
     ...(args.failedContainerRetentionMs !== undefined
@@ -1469,6 +1647,8 @@ function fakeEngine(
     removeError?: Error;
     removeErrors?: Array<Error | undefined>;
     killAndRemoveError?: Error;
+    killAndRemoveErrors?: Array<Error | undefined>;
+    onList?: (call: number) => void;
     onRemove?: () => void;
     events?: string[];
   } = {},
@@ -1482,6 +1662,7 @@ function fakeEngine(
   const removed: string[] = [];
   const killedAndRemoved: string[] = [];
   const removeErrors = [...(options.removeErrors ?? [])];
+  const killAndRemoveErrors = [...(options.killAndRemoveErrors ?? [])];
   let listManagedCalls = 0;
 
   return {
@@ -1504,6 +1685,7 @@ function fakeEngine(
     },
     listManaged: () => {
       listManagedCalls += 1;
+      options.onList?.(listManagedCalls);
       if (options.listError) return Promise.reject(options.listError);
       return Promise.resolve(options.containers ?? []);
     },
@@ -1516,7 +1698,8 @@ function fakeEngine(
     },
     killAndRemove: (name) => {
       killedAndRemoved.push(name);
-      if (options.killAndRemoveError) return Promise.reject(options.killAndRemoveError);
+      const error = killAndRemoveErrors.shift() ?? options.killAndRemoveError;
+      if (error) return Promise.reject(error);
       return Promise.resolve();
     },
   };

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -852,7 +852,7 @@ describe('createDockerLifecycle', () => {
       observability.logger.warn.mock.calls.filter(
         ([fields]) => fields?.event === 'provisioner.docker.registration_deadline_candidate_limit',
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(1);
 
     containers.splice(2);
     await lifecycle.reconcile();

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -334,7 +334,7 @@ describe('createDockerLifecycle', () => {
     expect(client.reportBodies).toEqual([]);
   });
 
-  it('buffers stale-created terminal reports and still kills containers when reporting transiently fails', async () => {
+  it('keeps stale-created containers when lifecycle report delivery is unavailable', async () => {
     const engine = fakeEngine({
       containers: [
         container({
@@ -348,11 +348,15 @@ describe('createDockerLifecycle', () => {
 
     await lifecycle.observe();
 
-    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+    expect(engine.killedAndRemoved).toEqual([]);
+    expect(client.reconcileBodies[0]).toEqual({
+      observed_provider_runner_ids: ['runner-1'],
+      termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+    });
   });
 
-  it('logs stale cleanup as requested when kill-and-remove fails', async () => {
-    const error = new DockerEngineError('unknown', 'daemon unavailable');
+  it('keeps stale-created containers when backend reconciliation is unavailable', async () => {
+    const error = new Error('api unavailable');
     const containers = [
       container({
         state: 'created',
@@ -361,33 +365,16 @@ describe('createDockerLifecycle', () => {
     ];
     const engine = fakeEngine({
       containers,
-      killAndRemoveError: error,
     });
-    const lifecycle = makeLifecycle({engine, registrationDeadlineMs: 60_000});
+    const client = fakeClient({reconcileErrors: [error, error]});
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
     await expect(lifecycle.observe()).rejects.toThrow(error);
     await expect(lifecycle.observe()).rejects.toThrow(error);
-    containers[0] = container({state: 'running'});
-    await lifecycle.observe();
-    containers[0] = container({
-      state: 'created',
-      createdAt: new Date('2026-01-01T00:00:00.000Z'),
-    });
-    await expect(lifecycle.observe()).rejects.toThrow(error);
 
-    expect(observability.logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({event: 'runner.container_stale_reap_requested'}),
-      'Stale runner container reap requested before registration',
-    );
-    expect(
-      observability.logger.info.mock.calls.filter(
-        ([fields]) => fields?.event === 'runner.container_stale_reap_requested',
-      ),
-    ).toHaveLength(2);
-    expect(observability.logger.info).not.toHaveBeenCalledWith(
-      expect.objectContaining({event: 'runner.container_stale_reaped'}),
-      expect.any(String),
-    );
+    expect(engine.killedAndRemoved).toEqual([]);
+    expect(engine.removed).toEqual([]);
+    expect(client.reconcileBodies).toHaveLength(2);
   });
 
   it('marks OOM exits as failed with an oom reason', async () => {
@@ -739,7 +726,7 @@ describe('createDockerLifecycle', () => {
     ).toHaveLength(2);
   });
 
-  it('reaps only created containers past the registration deadline', async () => {
+  it('submits only created containers past the registration deadline as candidates', async () => {
     const engine = fakeEngine({
       containers: [
         container({
@@ -754,17 +741,88 @@ describe('createDockerLifecycle', () => {
         }),
       ],
     });
-    const client = fakeClient();
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('created-old', 'keep'), reconciledRunner('running-old', 'keep')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
     const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
     await lifecycle.observe();
 
-    expect(engine.killedAndRemoved).toEqual(['created-old']);
+    expect(engine.killedAndRemoved).toEqual([]);
     expect(engine.removed).toEqual([]);
     expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'starting',
       'running',
-      'terminated',
     ]);
+    expect(client.reconcileBodies[0]).toEqual({
+      observed_provider_runner_ids: ['created-old', 'running-old'],
+      termination_candidates: [
+        {provider_runner_id: 'created-old', reason: 'registration-deadline'},
+      ],
+    });
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.docker.registration_deadline_candidates_submitted',
+        requested_count: 1,
+        termination_authorization: 'backend-gated',
+      }),
+      'Sent Docker registration-deadline termination candidates for backend authorization',
+    );
+  });
+
+  it('terminates a stale-created container only after backend authorization', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'created',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate', 'registration-deadline')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.observe();
+
+    expect(client.reconcileBodies[0]).toEqual({
+      observed_provider_runner_ids: ['runner-1'],
+      termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+    });
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      provider_runner_id: 'runner-1',
+      state: 'terminated',
+      reason: 'registration-deadline',
+    });
+  });
+
+  it('reconciles a stale-created container discovered after the first successful tick', async () => {
+    const containers = [container({state: 'running'})];
+    const engine = fakeEngine({containers});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.tick();
+    containers[0] = container({
+      state: 'created',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await lifecycle.tick();
+
+    expect(client.reconcileBodies).toHaveLength(2);
+    expect(client.reconcileBodies[1]).toEqual({
+      observed_provider_runner_ids: ['runner-1'],
+      termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+    });
+    expect(engine.killedAndRemoved).toEqual([]);
   });
 
   it('reconcile rebuilds tracker counts from listed containers', async () => {
@@ -1538,6 +1596,7 @@ function container(args: {
 function reconciledRunner(
   providerRunnerId: string,
   desiredIntent: 'keep' | 'terminate',
+  terminationReason?: ReconcileRunnerInstancesResponseDto['runners'][number]['termination_reason'],
 ): ReconcileRunnerInstancesResponseDto['runners'][number] {
   return {
     provider_runner_id: providerRunnerId,
@@ -1547,6 +1606,7 @@ function reconciledRunner(
     runner_session_id: null,
     bound_job: null,
     desired_intent: desiredIntent,
+    ...(terminationReason !== undefined ? {termination_reason: terminationReason} : {}),
   };
 }
 

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -1,6 +1,9 @@
 import {
   MAX_RECONCILE_OBSERVED_RUNNERS,
+  MAX_TERMINATION_CANDIDATES,
+  type ProviderTerminationCandidateDto,
   type RunnerInstanceReportEventDto,
+  type TerminationReasonDto,
 } from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {
@@ -21,6 +24,7 @@ import type {DockerTemplateSpec} from '#templates.js';
 const MAX_REPORT_BATCH = 1000;
 const MAX_PENDING_REPORTS = 5000;
 const MAX_REASON_LENGTH = 500;
+const MAX_REGISTRATION_CANDIDATE_IDS_IN_LOG = 20;
 const EMPTY_TERMINATE_INTENT_IDS = new Set<string>();
 
 class DockerReconciliationLimitError extends Error {
@@ -92,6 +96,7 @@ interface DockerLifecycleContext {
   readonly maxRetainedFailedContainers: number;
   loggingDriver?: string;
   readonly loggingDriverSource: 'daemon' | 'provisioner';
+  registrationCandidateCursor: number;
   backendReconcileSucceeded: boolean;
   reportDeliveryDelivered: number;
   reportQueueDropped: number;
@@ -145,6 +150,7 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     maxRetainedFailedContainers: args.maxRetainedFailedContainers ?? 0,
     ...(args.loggingDriver ? {loggingDriver: args.loggingDriver} : {}),
     loggingDriverSource: args.loggingDriverSource ?? 'daemon',
+    registrationCandidateCursor: 0,
     backendReconcileSucceeded: false,
     reportDeliveryDelivered: 0,
     reportQueueDropped: 0,
@@ -271,6 +277,10 @@ async function reportContainerCreationFailure(
 async function observe(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
   const listedContainers = await context.engine.listManaged(context.identity.id);
+  if (hasStaleRegistrationCandidate(context, listedContainers)) {
+    await reconcileListedContainers(context, listedContainers);
+    return;
+  }
   await applyObservedContainers(context, listedContainers, EMPTY_TERMINATE_INTENT_IDS);
   await cleanupRetainedFailedContainers(context, listedContainers);
 }
@@ -278,6 +288,13 @@ async function observe(context: DockerLifecycleContext): Promise<void> {
 async function reconcile(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
   const listedContainers = await context.engine.listManaged(context.identity.id);
+  await reconcileListedContainers(context, listedContainers);
+}
+
+async function reconcileListedContainers(
+  context: DockerLifecycleContext,
+  listedContainers: readonly DockerContainerView[],
+): Promise<void> {
   const observedProviderRunnerIds = observedRunnerIds(listedContainers);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
     await applyObservedContainers(context, listedContainers, EMPTY_TERMINATE_INTENT_IDS);
@@ -285,14 +302,35 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
     throw new DockerReconciliationLimitError(observedProviderRunnerIds.length);
   }
 
+  const registrationDeadlineCandidates = observeRegistrationDeadlineCandidates(
+    context,
+    listedContainers,
+  );
   const response = await context.client.reconcileRunnerInstances({
     observed_provider_runner_ids: observedProviderRunnerIds,
+    ...(registrationDeadlineCandidates.length > 0
+      ? {termination_candidates: registrationDeadlineCandidates}
+      : {}),
   });
-  const terminateIntentIds = new Set(
-    response.runners
-      .filter((runner) => runner.desired_intent === 'terminate')
-      .map((runner) => runner.provider_runner_id),
-  );
+  if (registrationDeadlineCandidates.length > 0) {
+    logger().info(
+      {
+        event: 'provisioner.docker.registration_deadline_candidates_submitted',
+        requested_count: registrationDeadlineCandidates.length,
+        termination_authorization: 'backend-gated',
+        provider_runner_ids: registrationDeadlineCandidates
+          .slice(0, MAX_REGISTRATION_CANDIDATE_IDS_IN_LOG)
+          .map((candidate) => candidate.provider_runner_id),
+      },
+      'Sent Docker registration-deadline termination candidates for backend authorization',
+    );
+  }
+  const terminateIntentReasons = new Map<string, TerminationReasonDto | undefined>();
+  for (const runner of response.runners) {
+    if (runner.desired_intent !== 'terminate') continue;
+    terminateIntentReasons.set(runner.provider_runner_id, runner.termination_reason ?? undefined);
+  }
+  const terminateIntentIds = new Set(terminateIntentReasons.keys());
   context.backendTerminationRequestedIds.clear();
   for (const providerRunnerId of terminateIntentIds) {
     context.backendTerminationRequestedIds.add(providerRunnerId);
@@ -310,7 +348,12 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
     );
   }
 
-  await applyObservedContainers(context, listedContainers, terminateIntentIds);
+  await applyObservedContainers(
+    context,
+    listedContainers,
+    terminateIntentIds,
+    terminateIntentReasons,
+  );
   await cleanupRetainedFailedContainers(
     context,
     listedContainers.filter(
@@ -318,6 +361,65 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
     ),
   );
   context.backendReconcileSucceeded = true;
+}
+
+function hasStaleRegistrationCandidate(
+  context: DockerLifecycleContext,
+  containers: readonly DockerContainerView[],
+): boolean {
+  return containers.some(
+    (container) =>
+      container.state === 'created' &&
+      isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs),
+  );
+}
+
+function observeRegistrationDeadlineCandidates(
+  context: DockerLifecycleContext,
+  containers: readonly DockerContainerView[],
+): ProviderTerminationCandidateDto[] {
+  const candidates = new Map<string, ProviderTerminationCandidateDto>();
+  for (const container of containers) {
+    if (
+      container.state !== 'created' ||
+      !isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs)
+    )
+      continue;
+    const providerRunnerId = parseContainerIdentity(container).providerRunnerId;
+    candidates.set(providerRunnerId, {
+      provider_runner_id: providerRunnerId,
+      reason: 'registration-deadline',
+    });
+  }
+
+  const orderedCandidates = [...candidates.values()].sort((left, right) =>
+    left.provider_runner_id.localeCompare(right.provider_runner_id),
+  );
+  if (orderedCandidates.length <= MAX_TERMINATION_CANDIDATES) {
+    context.registrationCandidateCursor = 0;
+    return orderedCandidates;
+  }
+
+  const start = context.registrationCandidateCursor % orderedCandidates.length;
+  const rotatedCandidates = [
+    ...orderedCandidates.slice(start),
+    ...orderedCandidates.slice(0, start),
+  ];
+  const selectedCandidates = rotatedCandidates.slice(0, MAX_TERMINATION_CANDIDATES);
+  context.registrationCandidateCursor =
+    (start + selectedCandidates.length) % orderedCandidates.length;
+  logger().warn(
+    {
+      event: 'provisioner.docker.registration_deadline_candidate_limit',
+      candidate_count: orderedCandidates.length,
+      submitted_count: selectedCandidates.length,
+      dropped_count: orderedCandidates.length - selectedCandidates.length,
+      start_index: start,
+      next_start_index: context.registrationCandidateCursor,
+    },
+    'Capped Docker registration-deadline termination candidates at the API limit',
+  );
+  return selectedCandidates;
 }
 
 async function tick(context: DockerLifecycleContext): Promise<void> {
@@ -358,6 +460,7 @@ function buildObservationPlan(
   context: DockerLifecycleContext,
   containers: readonly DockerContainerView[],
   terminateIntentIds: ReadonlySet<string>,
+  terminateIntentReasons: ReadonlyMap<string, TerminationReasonDto | undefined>,
 ): ObservationPlan {
   const listedIds = new Set<string>();
   const plan: ObservationPlan = {
@@ -368,7 +471,14 @@ function buildObservationPlan(
   };
 
   for (const container of containers) {
-    recordContainerObservation(context, plan, listedIds, container, terminateIntentIds);
+    recordContainerObservation(
+      context,
+      plan,
+      listedIds,
+      container,
+      terminateIntentIds,
+      terminateIntentReasons,
+    );
   }
   pruneFailedObservationState(context, containers, listedIds);
   pruneRequestState(context, listedIds);
@@ -383,6 +493,7 @@ function recordContainerObservation(
   listedIds: Set<string>,
   container: DockerContainerView,
   terminateIntentIds: ReadonlySet<string>,
+  terminateIntentReasons: ReadonlyMap<string, TerminationReasonDto | undefined>,
 ): void {
   const parsed = parseContainerIdentity(container);
   listedIds.add(parsed.providerRunnerId);
@@ -394,7 +505,12 @@ function recordContainerObservation(
   if (terminateIntentIds.has(parsed.providerRunnerId)) {
     closeEpisode(context.episodes, staleEpisodeKey);
     plan.terminalActions.push(
-      terminalActionFor(context, container, 'backend-terminate', 'backend'),
+      terminalActionFor(
+        context,
+        container,
+        terminateIntentReasons.get(parsed.providerRunnerId) ?? 'backend-terminate',
+        'backend',
+      ),
     );
     return;
   }
@@ -405,8 +521,7 @@ function recordContainerObservation(
     return;
   }
   logMissingLabelsRecovery(context, parsed.providerRunnerId);
-  if (recordStaleContainer(context, plan, container, parsed, staleRegistration, staleEpisodeKey))
-    return;
+  recordStaleContainer(context, container, parsed, staleRegistration, staleEpisodeKey);
   recordMappedContainer(context, plan, container, parsed, labels);
 }
 
@@ -432,13 +547,12 @@ function logMissingLabelsRecovery(context: DockerLifecycleContext, providerRunne
 
 function recordStaleContainer(
   context: DockerLifecycleContext,
-  plan: ObservationPlan,
   container: DockerContainerView,
   parsed: ParsedContainerIdentity,
   staleRegistration: boolean,
   staleEpisodeKey: string,
-): boolean {
-  if (!staleRegistration) return false;
+): void {
+  if (!staleRegistration) return;
   const update = recordEpisode(
     context.episodes,
     staleEpisodeKey,
@@ -448,8 +562,8 @@ function recordStaleContainer(
   if (shouldLogEpisode(update)) {
     logger().info(
       {
-        event: 'runner.container_stale_reap_requested',
-        operation: 'kill_and_remove',
+        event: 'runner.container_registration_deadline_observed',
+        operation: 'backend_authorization',
         providerRunnerId: parsed.providerRunnerId,
         containerId: container.id,
         containerName: container.name,
@@ -459,11 +573,9 @@ function recordStaleContainer(
         suppressed: update.state.suppressed,
         ...(update.transition === 'changed' ? {changed: true} : {}),
       },
-      'Stale runner container reap requested before registration',
+      'Stale runner container awaiting backend authorization',
     );
   }
-  plan.terminalActions.push(terminalActionFor(context, container, 'registration-deadline'));
-  return true;
 }
 
 function recordMappedContainer(
@@ -705,9 +817,15 @@ async function applyObservedContainers(
   context: DockerLifecycleContext,
   containers: readonly DockerContainerView[],
   terminateIntentIds: ReadonlySet<string>,
+  terminateIntentReasons: ReadonlyMap<string, TerminationReasonDto | undefined> = new Map(),
 ): Promise<void> {
   context.pendingMissingLabelEpisodes.length = 0;
-  const plan = buildObservationPlan(context, containers, terminateIntentIds);
+  const plan = buildObservationPlan(
+    context,
+    containers,
+    terminateIntentIds,
+    terminateIntentReasons,
+  );
   flushMissingLabelEpisodes(context);
   await applyObservationPlan(context, plan);
 }
@@ -725,7 +843,7 @@ function logRequestedTerminalActions(
   actions: readonly TerminalAction[],
 ): void {
   const requestedIds = actions
-    .filter((action) => action.reason === 'backend-terminate')
+    .filter((action) => action.requestSource === 'backend' || action.reason === 'backend-terminate')
     .filter((action) => {
       const update = recordEpisode(
         context.episodes,
@@ -793,7 +911,7 @@ function clearTerminalActionState(context: DockerLifecycleContext, action: Termi
   if (action.reason === 'registration-deadline') {
     closeEpisode(context.episodes, episodeKey('stale-reap', action.providerRunnerId));
   }
-  if (action.reason === 'backend-terminate') {
+  if (action.requestSource || action.reason === 'backend-terminate') {
     const requestedIds =
       action.requestSource === 'poll'
         ? context.pollTerminationRequestedIds

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -2,6 +2,7 @@ import {
   MAX_RECONCILE_OBSERVED_RUNNERS,
   MAX_TERMINATION_CANDIDATES,
   type ProviderTerminationCandidateDto,
+  type ReconcileRunnerInstancesResponseDto,
   type RunnerInstanceReportEventDto,
   type TerminationReasonDto,
 } from '@shipfox/api-runners-dto';
@@ -25,6 +26,10 @@ const MAX_REPORT_BATCH = 1000;
 const MAX_PENDING_REPORTS = 5000;
 const MAX_REASON_LENGTH = 500;
 const MAX_REGISTRATION_CANDIDATE_IDS_IN_LOG = 20;
+const REGISTRATION_CANDIDATE_RETRY_INITIAL_DELAY_MS = 1_000;
+const REGISTRATION_CANDIDATE_RETRY_MAX_DELAY_MS = 60_000;
+const REGISTRATION_CANDIDATE_SUBMISSION_EPISODE = 'registration-deadline-candidates';
+const REGISTRATION_CANDIDATE_LIMIT_EPISODE = 'registration-deadline-candidate-limit';
 const EMPTY_TERMINATE_INTENT_IDS = new Set<string>();
 
 class DockerReconciliationLimitError extends Error {
@@ -97,6 +102,9 @@ interface DockerLifecycleContext {
   loggingDriver?: string;
   readonly loggingDriverSource: 'daemon' | 'provisioner';
   registrationCandidateCursor: number;
+  registrationCandidateFingerprint?: string;
+  registrationCandidateRetryAt?: number;
+  registrationCandidateRetryDelayMs: number;
   backendReconcileSucceeded: boolean;
   reportDeliveryDelivered: number;
   reportQueueDropped: number;
@@ -111,6 +119,7 @@ interface ObservationPlan {
 
 interface TerminalAction {
   readonly providerRunnerId: string;
+  readonly containerId?: string;
   readonly event?: RunnerInstanceReportEventDto;
   readonly remove?: string;
   readonly killAndRemove?: string;
@@ -151,6 +160,7 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     ...(args.loggingDriver ? {loggingDriver: args.loggingDriver} : {}),
     loggingDriverSource: args.loggingDriverSource ?? 'daemon',
     registrationCandidateCursor: 0,
+    registrationCandidateRetryDelayMs: REGISTRATION_CANDIDATE_RETRY_INITIAL_DELAY_MS,
     backendReconcileSucceeded: false,
     reportDeliveryDelivered: 0,
     reportQueueDropped: 0,
@@ -277,10 +287,20 @@ async function reportContainerCreationFailure(
 async function observe(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
   const listedContainers = await context.engine.listManaged(context.identity.id);
-  if (hasStaleRegistrationCandidate(context, listedContainers)) {
-    await reconcileListedContainers(context, listedContainers);
+  const registrationDeadlineCandidates = collectRegistrationDeadlineCandidates(
+    context,
+    listedContainers,
+  );
+  if (registrationDeadlineCandidates.length > 0) {
+    await reconcileListedContainers(
+      context,
+      listedContainers,
+      registrationDeadlineCandidates,
+      false,
+    );
     return;
   }
+  resetRegistrationCandidateState(context);
   await applyObservedContainers(context, listedContainers, EMPTY_TERMINATE_INTENT_IDS);
   await cleanupRetainedFailedContainers(context, listedContainers);
 }
@@ -288,49 +308,75 @@ async function observe(context: DockerLifecycleContext): Promise<void> {
 async function reconcile(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
   const listedContainers = await context.engine.listManaged(context.identity.id);
-  await reconcileListedContainers(context, listedContainers);
+  await reconcileListedContainers(
+    context,
+    listedContainers,
+    collectRegistrationDeadlineCandidates(context, listedContainers),
+    true,
+  );
 }
 
 async function reconcileListedContainers(
   context: DockerLifecycleContext,
   listedContainers: readonly DockerContainerView[],
+  registrationDeadlineCandidates: readonly ProviderTerminationCandidateDto[],
+  forceReconcile: boolean,
 ): Promise<void> {
   const observedProviderRunnerIds = observedRunnerIds(listedContainers);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
-    await applyObservedContainers(context, listedContainers, EMPTY_TERMINATE_INTENT_IDS);
-    await cleanupRetainedFailedContainers(context, listedContainers);
+    logSkippedRegistrationDeadlineCandidates(
+      context,
+      registrationDeadlineCandidates.length,
+      observedProviderRunnerIds.length,
+    );
+    await applyLocalObservationAndCleanup(context, listedContainers);
     throw new DockerReconciliationLimitError(observedProviderRunnerIds.length);
   }
 
-  const registrationDeadlineCandidates = observeRegistrationDeadlineCandidates(
+  closeEpisode(context.episodes, REGISTRATION_CANDIDATE_LIMIT_EPISODE, context.now());
+  const candidatesToSubmit = selectRegistrationDeadlineCandidateWindow(
     context,
-    listedContainers,
+    registrationDeadlineCandidates,
+    forceReconcile,
   );
-  const response = await context.client.reconcileRunnerInstances({
-    observed_provider_runner_ids: observedProviderRunnerIds,
-    ...(registrationDeadlineCandidates.length > 0
-      ? {termination_candidates: registrationDeadlineCandidates}
-      : {}),
-  });
-  if (registrationDeadlineCandidates.length > 0) {
-    logger().info(
-      {
-        event: 'provisioner.docker.registration_deadline_candidates_submitted',
-        requested_count: registrationDeadlineCandidates.length,
-        termination_authorization: 'backend-gated',
-        provider_runner_ids: registrationDeadlineCandidates
-          .slice(0, MAX_REGISTRATION_CANDIDATE_IDS_IN_LOG)
-          .map((candidate) => candidate.provider_runner_id),
-      },
-      'Sent Docker registration-deadline termination candidates for backend authorization',
-    );
+  if (candidatesToSubmit === undefined) {
+    await applyLocalObservationAndCleanup(context, listedContainers);
+    return;
+  }
+
+  let response: ReconcileRunnerInstancesResponseDto;
+  try {
+    response = await context.client.reconcileRunnerInstances({
+      observed_provider_runner_ids: observedProviderRunnerIds,
+      ...(candidatesToSubmit.length > 0 ? {termination_candidates: candidatesToSubmit} : {}),
+    });
+  } catch (error) {
+    if (candidatesToSubmit.length > 0) scheduleRegistrationCandidateRetry(context);
+    await applyLocalObservationAndCleanup(context, listedContainers);
+    throw error;
+  }
+  if (candidatesToSubmit.length > 0) {
+    scheduleRegistrationCandidateRetry(context);
+    logSubmittedRegistrationDeadlineCandidates(context, candidatesToSubmit);
   }
   const terminateIntentReasons = new Map<string, TerminationReasonDto | undefined>();
   for (const runner of response.runners) {
     if (runner.desired_intent !== 'terminate') continue;
     terminateIntentReasons.set(runner.provider_runner_id, runner.termination_reason ?? undefined);
   }
-  const terminateIntentIds = new Set(terminateIntentReasons.keys());
+  const containersByProviderRunnerId = new Map(
+    listedContainers.map((container) => [
+      parseContainerIdentity(container).providerRunnerId,
+      container,
+    ]),
+  );
+  const terminateIntentIds = new Set(
+    [...terminateIntentReasons.keys()].filter((providerRunnerId) => {
+      const reason = terminateIntentReasons.get(providerRunnerId);
+      const container = containersByProviderRunnerId.get(providerRunnerId);
+      return reason !== 'registration-deadline' || container?.state === 'created';
+    }),
+  );
   context.backendTerminationRequestedIds.clear();
   for (const providerRunnerId of terminateIntentIds) {
     context.backendTerminationRequestedIds.add(providerRunnerId);
@@ -363,28 +409,21 @@ async function reconcileListedContainers(
   context.backendReconcileSucceeded = true;
 }
 
-function hasStaleRegistrationCandidate(
+async function applyLocalObservationAndCleanup(
   context: DockerLifecycleContext,
   containers: readonly DockerContainerView[],
-): boolean {
-  return containers.some(
-    (container) =>
-      container.state === 'created' &&
-      isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs),
-  );
+): Promise<void> {
+  await applyObservedContainers(context, containers, EMPTY_TERMINATE_INTENT_IDS);
+  await cleanupRetainedFailedContainers(context, containers);
 }
 
-function observeRegistrationDeadlineCandidates(
+function collectRegistrationDeadlineCandidates(
   context: DockerLifecycleContext,
   containers: readonly DockerContainerView[],
 ): ProviderTerminationCandidateDto[] {
   const candidates = new Map<string, ProviderTerminationCandidateDto>();
   for (const container of containers) {
-    if (
-      container.state !== 'created' ||
-      !isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs)
-    )
-      continue;
+    if (!isStaleRegistrationContainer(context, container)) continue;
     const providerRunnerId = parseContainerIdentity(container).providerRunnerId;
     candidates.set(providerRunnerId, {
       provider_runner_id: providerRunnerId,
@@ -395,9 +434,49 @@ function observeRegistrationDeadlineCandidates(
   const orderedCandidates = [...candidates.values()].sort((left, right) =>
     left.provider_runner_id.localeCompare(right.provider_runner_id),
   );
+  return orderedCandidates;
+}
+
+function isStaleRegistrationContainer(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+): boolean {
+  return (
+    container.state === 'created' &&
+    isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs)
+  );
+}
+
+function selectRegistrationDeadlineCandidateWindow(
+  context: DockerLifecycleContext,
+  orderedCandidates: readonly ProviderTerminationCandidateDto[],
+  forceReconcile: boolean,
+): ProviderTerminationCandidateDto[] | undefined {
+  if (orderedCandidates.length === 0) {
+    resetRegistrationCandidateState(context);
+    return [];
+  }
+
+  const fingerprint = orderedCandidates
+    .map((candidate) => candidate.provider_runner_id)
+    .join('\u0000');
+  if (context.registrationCandidateFingerprint !== fingerprint) {
+    context.registrationCandidateFingerprint = fingerprint;
+    delete context.registrationCandidateRetryAt;
+    context.registrationCandidateRetryDelayMs = REGISTRATION_CANDIDATE_RETRY_INITIAL_DELAY_MS;
+    context.registrationCandidateCursor = 0;
+  }
+  if (
+    !forceReconcile &&
+    context.registrationCandidateRetryAt !== undefined &&
+    context.now().getTime() < context.registrationCandidateRetryAt
+  ) {
+    return undefined;
+  }
+
   if (orderedCandidates.length <= MAX_TERMINATION_CANDIDATES) {
     context.registrationCandidateCursor = 0;
-    return orderedCandidates;
+    return [...orderedCandidates];
   }
 
   const start = context.registrationCandidateCursor % orderedCandidates.length;
@@ -420,6 +499,74 @@ function observeRegistrationDeadlineCandidates(
     'Capped Docker registration-deadline termination candidates at the API limit',
   );
   return selectedCandidates;
+}
+
+function scheduleRegistrationCandidateRetry(context: DockerLifecycleContext): void {
+  const delay = context.registrationCandidateRetryDelayMs;
+  context.registrationCandidateRetryAt = context.now().getTime() + delay;
+  context.registrationCandidateRetryDelayMs = Math.min(
+    REGISTRATION_CANDIDATE_RETRY_MAX_DELAY_MS,
+    delay * 2,
+  );
+}
+
+function resetRegistrationCandidateState(context: DockerLifecycleContext): void {
+  delete context.registrationCandidateFingerprint;
+  delete context.registrationCandidateRetryAt;
+  context.registrationCandidateRetryDelayMs = REGISTRATION_CANDIDATE_RETRY_INITIAL_DELAY_MS;
+  context.registrationCandidateCursor = 0;
+  closeEpisode(context.episodes, REGISTRATION_CANDIDATE_SUBMISSION_EPISODE, context.now());
+}
+
+function logSubmittedRegistrationDeadlineCandidates(
+  context: DockerLifecycleContext,
+  candidates: readonly ProviderTerminationCandidateDto[],
+): void {
+  const update = recordEpisode(
+    context.episodes,
+    REGISTRATION_CANDIDATE_SUBMISSION_EPISODE,
+    context.registrationCandidateFingerprint ?? '',
+    context.now(),
+  );
+  if (!shouldLogEpisode(update)) return;
+  logger().info(
+    {
+      event: 'provisioner.docker.registration_deadline_candidates_submitted',
+      requested_count: candidates.length,
+      termination_authorization: 'backend-gated',
+      provider_runner_ids: candidates
+        .slice(0, MAX_REGISTRATION_CANDIDATE_IDS_IN_LOG)
+        .map((candidate) => candidate.provider_runner_id),
+      ...(update.transition === 'changed' ? {changed: true} : {}),
+    },
+    'Sent Docker registration-deadline termination candidates for backend authorization',
+  );
+}
+
+function logSkippedRegistrationDeadlineCandidates(
+  context: DockerLifecycleContext,
+  candidateCount: number,
+  observedCount: number,
+): void {
+  if (candidateCount === 0) return;
+  const update = recordEpisode(
+    context.episodes,
+    REGISTRATION_CANDIDATE_LIMIT_EPISODE,
+    `${candidateCount}:${observedCount}`,
+    context.now(),
+  );
+  if (!shouldLogEpisode(update)) return;
+  logger().warn(
+    {
+      event: 'provisioner.docker.registration_deadline_candidates_skipped',
+      candidate_count: candidateCount,
+      observed_count: observedCount,
+      max_observed: MAX_RECONCILE_OBSERVED_RUNNERS,
+      attempts: update.state.attempts,
+      suppressed: update.state.suppressed,
+    },
+    'Skipped Docker registration-deadline candidates because the observed runner set exceeds the API limit',
+  );
 }
 
 async function tick(context: DockerLifecycleContext): Promise<void> {
@@ -497,9 +644,7 @@ function recordContainerObservation(
 ): void {
   const parsed = parseContainerIdentity(container);
   listedIds.add(parsed.providerRunnerId);
-  const staleRegistration =
-    container.state === 'created' &&
-    isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs);
+  const staleRegistration = isStaleRegistrationContainer(context, container);
   const staleEpisodeKey = episodeKey('stale-reap', parsed.providerRunnerId);
   if (!staleRegistration) closeEpisode(context.episodes, staleEpisodeKey);
   if (terminateIntentIds.has(parsed.providerRunnerId)) {
@@ -871,6 +1016,7 @@ async function applyTerminalAction(
   context: DockerLifecycleContext,
   action: TerminalAction,
 ): Promise<void> {
+  if (!(await revalidateRegistrationDeadlineTermination(context, action))) return;
   const reportBeforeRemove = action.event?.state === 'failed' && action.remove;
   let reportError: unknown;
   if (reportBeforeRemove && action.event) {
@@ -905,6 +1051,39 @@ function logTerminalAction(action: TerminalAction): void {
       'Runner container removed',
     );
   }
+}
+
+async function revalidateRegistrationDeadlineTermination(
+  context: DockerLifecycleContext,
+  action: TerminalAction,
+): Promise<boolean> {
+  if (
+    action.reason !== 'registration-deadline' ||
+    action.requestSource !== 'backend' ||
+    !action.containerId
+  )
+    return true;
+
+  const currentContainers = await context.engine.listManaged(context.identity.id);
+  const currentContainer = currentContainers.find(
+    (container) => container.id === action.containerId,
+  );
+  if (currentContainer?.state === 'created') return true;
+
+  context.backendTerminationRequestedIds.delete(action.providerRunnerId);
+  syncTerminationEpisodes(context);
+  logger().info(
+    {
+      event: 'runner.container_registration_deadline_termination_skipped',
+      operation: 'kill_and_remove',
+      providerRunnerId: action.providerRunnerId,
+      containerId: action.containerId,
+      currentState: currentContainer?.state ?? 'absent',
+      reason: 'state-changed',
+    },
+    'Skipped backend registration-deadline termination after the container state changed',
+  );
+  return false;
 }
 
 function clearTerminalActionState(context: DockerLifecycleContext, action: TerminalAction): void {
@@ -1003,6 +1182,7 @@ function terminalActionFor(
     logMissingLabels(context, parsed.providerRunnerId, parsed.templateKey);
     return {
       providerRunnerId: parsed.providerRunnerId,
+      containerId: container.id,
       killAndRemove: container.name,
       reason,
       ...(requestSource ? {requestSource} : {}),
@@ -1010,6 +1190,7 @@ function terminalActionFor(
   }
 
   return {
+    containerId: container.id,
     ...(parsed.runnerInstanceId ? {runner_instance_id: parsed.runnerInstanceId} : {}),
     providerRunnerId: parsed.providerRunnerId,
     event: eventFor(container, 'terminated', labels, context.providerKind, context.now(), reason),

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -29,6 +29,7 @@ const MAX_REGISTRATION_CANDIDATE_IDS_IN_LOG = 20;
 const REGISTRATION_CANDIDATE_RETRY_INITIAL_DELAY_MS = 1_000;
 const REGISTRATION_CANDIDATE_RETRY_MAX_DELAY_MS = 60_000;
 const REGISTRATION_CANDIDATE_SUBMISSION_EPISODE = 'registration-deadline-candidates';
+const REGISTRATION_CANDIDATE_WINDOW_LIMIT_EPISODE = 'registration-deadline-candidate-window-limit';
 const REGISTRATION_CANDIDATE_LIMIT_EPISODE = 'registration-deadline-candidate-limit';
 const EMPTY_TERMINATE_INTENT_IDS = new Set<string>();
 
@@ -476,6 +477,7 @@ function selectRegistrationDeadlineCandidateWindow(
 
   if (orderedCandidates.length <= MAX_TERMINATION_CANDIDATES) {
     context.registrationCandidateCursor = 0;
+    closeEpisode(context.episodes, REGISTRATION_CANDIDATE_WINDOW_LIMIT_EPISODE, context.now());
     return [...orderedCandidates];
   }
 
@@ -487,18 +489,36 @@ function selectRegistrationDeadlineCandidateWindow(
   const selectedCandidates = rotatedCandidates.slice(0, MAX_TERMINATION_CANDIDATES);
   context.registrationCandidateCursor =
     (start + selectedCandidates.length) % orderedCandidates.length;
+  logRegistrationCandidateWindowLimit(context, orderedCandidates, selectedCandidates.length, start);
+  return selectedCandidates;
+}
+
+function logRegistrationCandidateWindowLimit(
+  context: DockerLifecycleContext,
+  orderedCandidates: readonly ProviderTerminationCandidateDto[],
+  submittedCount: number,
+  start: number,
+): void {
+  const update = recordEpisode(
+    context.episodes,
+    REGISTRATION_CANDIDATE_WINDOW_LIMIT_EPISODE,
+    context.registrationCandidateFingerprint ?? '',
+    context.now(),
+  );
+  if (!shouldLogEpisode(update)) return;
   logger().warn(
     {
       event: 'provisioner.docker.registration_deadline_candidate_limit',
       candidate_count: orderedCandidates.length,
-      submitted_count: selectedCandidates.length,
-      dropped_count: orderedCandidates.length - selectedCandidates.length,
+      submitted_count: submittedCount,
+      dropped_count: orderedCandidates.length - submittedCount,
       start_index: start,
       next_start_index: context.registrationCandidateCursor,
+      attempts: update.state.attempts,
+      suppressed: update.state.suppressed,
     },
     'Capped Docker registration-deadline termination candidates at the API limit',
   );
-  return selectedCandidates;
 }
 
 function scheduleRegistrationCandidateRetry(context: DockerLifecycleContext): void {
@@ -516,6 +536,7 @@ function resetRegistrationCandidateState(context: DockerLifecycleContext): void 
   context.registrationCandidateRetryDelayMs = REGISTRATION_CANDIDATE_RETRY_INITIAL_DELAY_MS;
   context.registrationCandidateCursor = 0;
   closeEpisode(context.episodes, REGISTRATION_CANDIDATE_SUBMISSION_EPISODE, context.now());
+  closeEpisode(context.episodes, REGISTRATION_CANDIDATE_WINDOW_LIMIT_EPISODE, context.now());
 }
 
 function logSubmittedRegistrationDeadlineCandidates(

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -1001,7 +1001,35 @@ async function applyTerminalActions(
   actions: readonly TerminalAction[],
 ): Promise<void> {
   logRequestedTerminalActions(context, actions);
-  for (const action of actions) await applyTerminalAction(context, action);
+  const currentContainers = await revalidateRegistrationDeadlineTerminations(context, actions);
+  const skippedActions = new Set<TerminalAction>();
+  const stateTransitionEvents: RunnerInstanceReportEventDto[] = [];
+  for (const action of actions) {
+    const currentContainer = currentContainers.get(action.containerId ?? '');
+    if (!shouldSkipRegistrationDeadlineTermination(action, currentContainer)) continue;
+
+    skippedActions.add(action);
+    context.backendTerminationRequestedIds.delete(action.providerRunnerId);
+    syncTerminationEpisodes(context);
+    const event = recordRevalidatedLiveContainer(context, currentContainer);
+    if (event) stateTransitionEvents.push(event);
+    logger().info(
+      {
+        event: 'runner.container_registration_deadline_termination_skipped',
+        operation: 'kill_and_remove',
+        providerRunnerId: action.providerRunnerId,
+        containerId: action.containerId,
+        currentState: currentContainer?.state ?? 'absent',
+        reason: 'state-changed',
+      },
+      'Skipped backend registration-deadline termination after the container state changed',
+    );
+  }
+  if (stateTransitionEvents.length > 0) await reportEvents(context, stateTransitionEvents);
+  for (const action of actions) {
+    if (skippedActions.has(action)) continue;
+    await applyTerminalAction(context, action);
+  }
 }
 
 function logRequestedTerminalActions(
@@ -1037,7 +1065,6 @@ async function applyTerminalAction(
   context: DockerLifecycleContext,
   action: TerminalAction,
 ): Promise<void> {
-  if (!(await revalidateRegistrationDeadlineTermination(context, action))) return;
   const reportBeforeRemove = action.event?.state === 'failed' && action.remove;
   let reportError: unknown;
   if (reportBeforeRemove && action.event) {
@@ -1074,37 +1101,67 @@ function logTerminalAction(action: TerminalAction): void {
   }
 }
 
-async function revalidateRegistrationDeadlineTermination(
+async function revalidateRegistrationDeadlineTerminations(
   context: DockerLifecycleContext,
-  action: TerminalAction,
-): Promise<boolean> {
+  actions: readonly TerminalAction[],
+): Promise<ReadonlyMap<string, DockerContainerView>> {
   if (
-    action.reason !== 'registration-deadline' ||
-    action.requestSource !== 'backend' ||
-    !action.containerId
+    !actions.some(
+      (action) =>
+        action.reason === 'registration-deadline' &&
+        action.requestSource === 'backend' &&
+        action.containerId,
+    )
   )
-    return true;
+    return new Map();
 
   const currentContainers = await context.engine.listManaged(context.identity.id);
-  const currentContainer = currentContainers.find(
-    (container) => container.id === action.containerId,
-  );
-  if (currentContainer?.state === 'created') return true;
+  return new Map(currentContainers.map((container) => [container.id, container]));
+}
 
-  context.backendTerminationRequestedIds.delete(action.providerRunnerId);
-  syncTerminationEpisodes(context);
-  logger().info(
-    {
-      event: 'runner.container_registration_deadline_termination_skipped',
-      operation: 'kill_and_remove',
-      providerRunnerId: action.providerRunnerId,
-      containerId: action.containerId,
-      currentState: currentContainer?.state ?? 'absent',
-      reason: 'state-changed',
-    },
-    'Skipped backend registration-deadline termination after the container state changed',
+function shouldSkipRegistrationDeadlineTermination(
+  action: TerminalAction,
+  currentContainer: DockerContainerView | undefined,
+): boolean {
+  if (action.reason !== 'registration-deadline' || action.requestSource !== 'backend') return false;
+  if (!currentContainer) return true;
+  return mapContainerState(currentContainer).state === 'running';
+}
+
+function recordRevalidatedLiveContainer(
+  context: DockerLifecycleContext,
+  container: DockerContainerView | undefined,
+): RunnerInstanceReportEventDto | undefined {
+  if (!container) return undefined;
+  const mapped = mapContainerState(container);
+  if (mapped.state !== 'starting' && mapped.state !== 'running') return undefined;
+
+  const parsed = parseContainerIdentity(container);
+  const labels = labelsFor(context, parsed.templateKey, parsed.labels);
+  if (labels.length === 0) {
+    logMissingLabels(context, parsed.providerRunnerId, parsed.templateKey);
+    return undefined;
+  }
+  context.knownLiveIds.add(parsed.providerRunnerId);
+  context.reportedFailedIds.delete(parsed.providerRunnerId);
+  context.reportedFailedContainerIds.delete(parsed.providerRunnerId);
+  context.firstObservedFailedAt.delete(container.id);
+  if (parsed.templateKey) {
+    context.knownTemplateKeys.set(parsed.providerRunnerId, parsed.templateKey);
+    context.tracker.recordStarting({
+      providerRunnerId: parsed.providerRunnerId,
+      templateKey: parsed.templateKey,
+    });
+    if (mapped.state === 'running') context.tracker.markRunning(parsed.providerRunnerId);
+  }
+  return eventFor(
+    container,
+    mapped.state,
+    labels,
+    context.providerKind,
+    context.now(),
+    mapped.reason,
   );
-  return false;
 }
 
 function clearTerminalActionState(context: DockerLifecycleContext, action: TerminalAction): void {

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -955,17 +955,17 @@ async function applyObservationPlan(
   plan: ObservationPlan,
 ): Promise<void> {
   context.tracker.replaceAll(plan.trackerRunners);
-  await assignEnrolledReservations(context, plan);
+  await assignEnrolledReservations(context, plan.assignmentCandidates);
   if (plan.liveEvents.length > 0) await reportEvents(context, plan.liveEvents);
   await applyTerminalActions(context, plan.terminalActions);
 }
 
 async function assignEnrolledReservations(
   context: DockerLifecycleContext,
-  plan: ObservationPlan,
+  assignmentCandidates: readonly {reservationId: string; runnerInstanceId: string}[],
 ): Promise<void> {
   const assignments = new Map<string, string[]>();
-  for (const {reservationId, runnerInstanceId} of plan.assignmentCandidates) {
+  for (const {reservationId, runnerInstanceId} of assignmentCandidates) {
     const runnerInstanceIds = assignments.get(reservationId) ?? [];
     runnerInstanceIds.push(runnerInstanceId);
     assignments.set(reservationId, runnerInstanceIds);
@@ -1003,6 +1003,7 @@ async function applyTerminalActions(
   logRequestedTerminalActions(context, actions);
   const currentContainers = await revalidateRegistrationDeadlineTerminations(context, actions);
   const skippedActions = new Set<TerminalAction>();
+  const assignmentCandidates: Array<{reservationId: string; runnerInstanceId: string}> = [];
   const stateTransitionEvents: RunnerInstanceReportEventDto[] = [];
   for (const action of actions) {
     const currentContainer = currentContainers.get(action.containerId ?? '');
@@ -1011,8 +1012,13 @@ async function applyTerminalActions(
     skippedActions.add(action);
     context.backendTerminationRequestedIds.delete(action.providerRunnerId);
     syncTerminationEpisodes(context);
-    const event = recordRevalidatedLiveContainer(context, currentContainer);
-    if (event) stateTransitionEvents.push(event);
+    const revalidatedLive = recordRevalidatedLiveContainer(context, currentContainer);
+    if (revalidatedLive) {
+      stateTransitionEvents.push(revalidatedLive.event);
+      if (revalidatedLive.assignmentCandidate) {
+        assignmentCandidates.push(revalidatedLive.assignmentCandidate);
+      }
+    }
     logger().info(
       {
         event: 'runner.container_registration_deadline_termination_skipped',
@@ -1025,6 +1031,8 @@ async function applyTerminalActions(
       'Skipped backend registration-deadline termination after the container state changed',
     );
   }
+  if (assignmentCandidates.length > 0)
+    await assignEnrolledReservations(context, assignmentCandidates);
   if (stateTransitionEvents.length > 0) await reportEvents(context, stateTransitionEvents);
   for (const action of actions) {
     if (skippedActions.has(action)) continue;
@@ -1131,7 +1139,12 @@ function shouldSkipRegistrationDeadlineTermination(
 function recordRevalidatedLiveContainer(
   context: DockerLifecycleContext,
   container: DockerContainerView | undefined,
-): RunnerInstanceReportEventDto | undefined {
+):
+  | {
+      event: RunnerInstanceReportEventDto;
+      assignmentCandidate?: {reservationId: string; runnerInstanceId: string};
+    }
+  | undefined {
   if (!container) return undefined;
   const mapped = mapContainerState(container);
   if (mapped.state !== 'starting' && mapped.state !== 'running') return undefined;
@@ -1154,14 +1167,24 @@ function recordRevalidatedLiveContainer(
     });
     if (mapped.state === 'running') context.tracker.markRunning(parsed.providerRunnerId);
   }
-  return eventFor(
-    container,
-    mapped.state,
-    labels,
-    context.providerKind,
-    context.now(),
-    mapped.reason,
-  );
+  return {
+    event: eventFor(
+      container,
+      mapped.state,
+      labels,
+      context.providerKind,
+      context.now(),
+      mapped.reason,
+    ),
+    ...(parsed.runnerInstanceId && parsed.reservationId
+      ? {
+          assignmentCandidate: {
+            runnerInstanceId: parsed.runnerInstanceId,
+            reservationId: parsed.reservationId,
+          },
+        }
+      : {}),
+  };
 }
 
 function clearTerminalActionState(context: DockerLifecycleContext, action: TerminalAction): void {


### PR DESCRIPTION
## Summary

Docker registration-deadline cleanup is now backend-authorized. The provisioner submits bounded stale-created containers as termination candidates, retains them when reconciliation is unavailable or authorization is absent, and applies backend termination reasons only after authorization. Observation alone no longer removes a created container.

The runtime descriptions and self-hosted documentation explain the API-first upgrade order required for this protocol.

## Validation

- `mise exec -- turbo check --filter=@shipfox/provisioner-docker-provider...`
- `mise exec -- turbo type --filter=@shipfox/provisioner-docker-provider...`
- `mise exec -- turbo test --filter=@shipfox/provisioner-docker-provider...`
- `mise exec -- pnpm --filter @shipfox/provisioner-docker-provider test:integration`
- `mise exec -- pnpm --filter @shipfox/docs test`
- `mise exec -- git diff --check`

Closes ENG-1775

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docker registration-deadline cleanup is now backend-authorized. The provisioner submits stale-created containers as termination candidates and removes them only after the API authorizes termination; observation alone no longer reaps a created container. Reporting a container in `starting` or `running` state also clears a pending registration-deadline authorization so it cannot linger after the container comes alive.

- Backs off resubmitting the same candidates and rotates submissions when they exceed the API cap.
- Revalidates against a fresh Docker listing before honoring a registration-deadline kill; a container that has since started is reported as active and keeps its reservation assignment.
- Continues reporting observed running state while backend reconciliation is unavailable.

**Migration**
- Upgrade the Shipfox API before the Docker provisioner in self-hosted deployments, setting `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` (defaults to `false`) before upgrading.
- Stale-created containers remain in place for retry when the API is unavailable or withholds authorization.

Closes ENG-1775.

<sup>Written for commit 861a1000623ee54826b8a6c42b03cf559e4096af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

