### PR TITLE
[provisioner-ec2] Gate registration-deadline termination through backend

### DIFF
--- a/.changeset/ec2-backend-authorization.md
+++ b/.changeset/ec2-backend-authorization.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-runners': patch
+---
+
+Authorizes installation-scoped EC2 termination candidates through the durable backend termination gate.

--- a/.changeset/ec2-backend-authorization.md
+++ b/.changeset/ec2-backend-authorization.md
@@ -1,5 +1,6 @@
 ---
 '@shipfox/api-runners': patch
+'@shipfox/api-runners-dto': patch
 ---
 
-Authorizes installation-scoped EC2 termination candidates through the durable backend termination gate.
+Authorizes registration-deadline EC2 runner instances for termination through the backend.

--- a/.changeset/ec2-backend-authorization.md
+++ b/.changeset/ec2-backend-authorization.md
@@ -1,6 +1,6 @@
 ---
 '@shipfox/api-runners': patch
-'@shipfox/api-runners-dto': patch
+'@shipfox/api-runners-dto': minor
 ---
 
 Authorizes registration-deadline EC2 runner instances for termination through the backend.

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -21,6 +21,11 @@ reads IMDSv2 user data and writes `/etc/shipfox/runner.env`. It formats and moun
 workspace volume at `/var/lib/shipfox/workspaces` before the runner starts. The AMI reads that
 file and shuts down when its watchdog exits.
 
+Before deploying registration-deadline cleanup, enable
+`RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED` in the runners API. The flag defaults
+to false; an EC2 provider safely keeps overdue instances out of capacity and retries the backend
+authorization while it remains disabled.
+
 ### AMI migration
 
 The split-volume launch contract requires AMIs to be rebuilt before using the 30 GB boot

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -21,11 +21,6 @@ reads IMDSv2 user data and writes `/etc/shipfox/runner.env`. It formats and moun
 workspace volume at `/var/lib/shipfox/workspaces` before the runner starts. The AMI reads that
 file and shuts down when its watchdog exits.
 
-Before deploying registration-deadline cleanup, enable
-`RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED` in the runners API. The flag defaults
-to false; an EC2 provider safely keeps overdue instances out of capacity and retries the backend
-authorization while it remains disabled.
-
 ### AMI migration
 
 The split-volume launch contract requires AMIs to be rebuilt before using the 30 GB boot
@@ -82,6 +77,11 @@ remain continuous.
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per control-plane request. |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Idle polling lifetime injected into each runner. |
 | `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` | no | `3600` | Hard lifetime injected into each runner watchdog. |
+
+Before deploying registration-deadline cleanup, enable
+`RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` in the runners API. The flag
+defaults to false; an EC2 provider safely keeps overdue instances out of capacity and retries
+backend authorization while it remains disabled.
 
 ## Development
 

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -6,7 +6,8 @@ Runs one-job Shipfox runners on Amazon EC2 from a prebaked AMI.
 
 - **Starts runners**: Creates a runner instance and one-use bootstrap token before launch.
 - **Uses EC2 tags**: Finds and adopts its instances after a restart.
-- **Keeps state in sync**: Reports state, reaps missed enrollment, and applies terminate requests.
+- **Keeps state in sync**: Reports state, requests backend authorization for missed enrollment,
+  and applies authorized termination requests.
 - **Protects credentials**: Sends bootstrap data to the AMI. It never sends workspace registration credentials.
 
 ## Setup

--- a/libs/api/runners-dto/src/schemas/reconcile-runner-instances.test.ts
+++ b/libs/api/runners-dto/src/schemas/reconcile-runner-instances.test.ts
@@ -20,6 +20,30 @@ describe('reconcileRunnerInstancesBodySchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts candidate-only reconciliation with termination candidates', () => {
+    const result = reconcileRunnerInstancesBodySchema.safeParse({
+      observed_provider_runner_ids: [],
+      termination_candidates: [
+        {
+          provider_runner_id: 'provider-runner-1',
+          reason: 'registration-deadline',
+        },
+      ],
+      candidate_only_reconcile: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects candidate-only reconciliation without termination candidates', () => {
+    const result = reconcileRunnerInstancesBodySchema.safeParse({
+      observed_provider_runner_ids: [],
+      candidate_only_reconcile: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('rejects duplicate provider termination candidates', () => {
     const result = reconcileRunnerInstancesBodySchema.safeParse({
       observed_provider_runner_ids: [],

--- a/libs/api/runners-dto/src/schemas/reconcile-runner-instances.ts
+++ b/libs/api/runners-dto/src/schemas/reconcile-runner-instances.ts
@@ -30,6 +30,8 @@ export const reconcileRunnerInstancesBodySchema = z
       .array(providerTerminationCandidateSchema)
       .max(MAX_TERMINATION_CANDIDATES)
       .optional(),
+    // Candidate-only requests carry a bounded subset and must not trigger absence reconciliation.
+    candidate_only_reconcile: z.boolean().optional(),
   })
   .strict()
   .refine(
@@ -47,6 +49,13 @@ export const reconcileRunnerInstancesBodySchema = z
     {
       message: 'termination_candidates provider_runner_id values must be unique',
       path: ['termination_candidates'],
+    },
+  )
+  .refine(
+    (body) => !body.candidate_only_reconcile || (body.termination_candidates?.length ?? 0) > 0,
+    {
+      message: 'candidate_only_reconcile requires termination_candidates',
+      path: ['candidate_only_reconcile'],
     },
   );
 

--- a/libs/api/runners/src/core/runner-instances.ts
+++ b/libs/api/runners/src/core/runner-instances.ts
@@ -68,6 +68,7 @@ export interface ReconcileRunnerInstancesParams {
   workspaceId: string | null;
   provisionerId: string;
   observedRunnerInstanceIds: string[];
+  candidateOnlyReconcile?: boolean;
   terminationCandidates?: ProviderTerminationCandidate[];
 }
 

--- a/libs/api/runners/src/core/runner-instances.ts
+++ b/libs/api/runners/src/core/runner-instances.ts
@@ -169,13 +169,11 @@ export async function reconcileRunnerInstances(
   params: ReconcileRunnerInstancesParams,
 ): Promise<ReconcileRunnerInstancesResult> {
   const terminationCandidates = (params.terminationCandidates ?? []).filter((candidate) => {
-    const resolution = params.workspaceId
-      ? resolveRunnerTerminationReason({
-          provisionerId: params.provisionerId,
-          providerRunnerId: candidate.providerRunnerId,
-          reason: candidate.reason,
-        })
-      : {reason: null, rejectionReason: 'unknown-runner' as const};
+    const resolution = resolveRunnerTerminationReason({
+      provisionerId: params.provisionerId,
+      providerRunnerId: candidate.providerRunnerId,
+      reason: candidate.reason,
+    });
     if (!resolution.reason)
       recordRunnerTerminationAuthorizationTelemetry(
         {

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -1,6 +1,6 @@
 import {pgClient} from '@shipfox/node-postgres';
 import {beforeEach, vi} from '@shipfox/vitest/vi';
-import {and, desc, eq, inArray, or, sql} from 'drizzle-orm';
+import {and, desc, eq, inArray, isNull, or, sql} from 'drizzle-orm';
 import {reconcileRunnerInstances as reconcileRunnerInstancesCore} from '#core/runner-instances.js';
 import {
   authorizeRunnerTermination,
@@ -540,7 +540,7 @@ describe('reportRunnerInstances', () => {
     expect(row).toMatchObject({workspaceId: null, provisionerId, reportedAt});
   });
 
-  it('returns installation candidates rejected by scope as keep observations', async () => {
+  it('authorizes an unassigned installation termination candidate', async () => {
     const reportedAt = new Date();
     await reportRunnerInstances({
       scope: 'installation',
@@ -561,10 +561,26 @@ describe('reportRunnerInstances', () => {
     expect(result.runners).toMatchObject([
       {
         providerRunnerId: 'installation-candidate',
-        desiredIntent: 'keep',
-        desiredIntentReason: null,
+        desiredIntent: 'terminate',
+        desiredIntentReason: 'registration-deadline',
+        terminationReason: 'registration-deadline',
       },
     ]);
+    const [runner] = await db()
+      .select({
+        terminationAuthorizedAt: providerRunners.terminationAuthorizedAt,
+        terminationReason: providerRunners.terminationReason,
+      })
+      .from(providerRunners)
+      .where(
+        and(
+          isNull(providerRunners.workspaceId),
+          eq(providerRunners.provisionerId, provisionerId),
+          eq(providerRunners.providerRunnerId, 'installation-candidate'),
+        ),
+      );
+    expect(runner?.terminationAuthorizedAt).toBeInstanceOf(Date);
+    expect(runner?.terminationReason).toBe('registration-deadline');
   });
 
   it('dedupes duplicate provisioned runner ids in one batch', async () => {

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -1349,7 +1349,7 @@ async function authorizeProviderTerminationCandidatesTx(
   tx: Tx,
   params: ReconcileRunnerInstancesParams,
 ): Promise<TerminationAuthorizationTelemetryRecord[]> {
-  if (!params.workspaceId || !params.terminationReasonResolver) return [];
+  if (!params.terminationReasonResolver) return [];
 
   const telemetry: TerminationAuthorizationTelemetryRecord[] = [];
   const candidates = [...(params.terminationCandidates ?? [])].sort((a, b) =>
@@ -1359,7 +1359,7 @@ async function authorizeProviderTerminationCandidatesTx(
     const runner = await identifyProviderTerminationCandidateTx(tx, params, candidate);
     if (!runner || (await hasRunnerEnrollmentSessionTx(tx, params, runner))) continue;
     if (await hasOpenRunnerControlSessionTx(tx, params, runner.id)) continue;
-    if (await hasLiveRunnerJobTx(tx, params, runner.providerRunnerId)) continue;
+    if (await hasLiveRunnerJobTx(tx, params, runner)) continue;
 
     let revocationCounts: RunnerEnrollmentRevocationCounts | null = null;
     const authorization = await persistRunnerTerminationAuthorizationTx(
@@ -1394,15 +1394,17 @@ async function identifyProviderTerminationCandidateTx(
   tx: Tx,
   params: ReconcileRunnerInstancesParams,
   candidate: ProviderTerminationCandidate,
-): Promise<{id: string; providerRunnerId: string} | null> {
+): Promise<{id: string; providerRunnerId: string; workspaceId: string | null} | null> {
   const workspaceId = params.workspaceId;
-  if (!workspaceId) return null;
+  const workspaceCondition = workspaceId
+    ? eq(providerRunners.workspaceId, workspaceId)
+    : isNull(providerRunners.workspaceId);
   const [identifiedRunner] = await tx
     .select({id: providerRunners.id})
     .from(providerRunners)
     .where(
       and(
-        eq(providerRunners.workspaceId, workspaceId),
+        workspaceCondition,
         eq(providerRunners.provisionerId, params.provisionerId),
         eq(providerRunners.providerRunnerId, candidate.providerRunnerId),
         inArray(providerRunners.state, ['starting', 'running']),
@@ -1416,12 +1418,16 @@ async function identifyProviderTerminationCandidateTx(
     runnerInstanceId: identifiedRunner.id,
   });
   const [runner] = await tx
-    .select({id: providerRunners.id, providerRunnerId: providerRunners.providerRunnerId})
+    .select({
+      id: providerRunners.id,
+      providerRunnerId: providerRunners.providerRunnerId,
+      workspaceId: providerRunners.workspaceId,
+    })
     .from(providerRunners)
     .where(
       and(
         eq(providerRunners.id, identifiedRunner.id),
-        eq(providerRunners.workspaceId, workspaceId),
+        workspaceCondition,
         eq(providerRunners.provisionerId, params.provisionerId),
         eq(providerRunners.providerRunnerId, candidate.providerRunnerId),
         inArray(providerRunners.state, ['starting', 'running']),
@@ -1430,27 +1436,28 @@ async function identifyProviderTerminationCandidateTx(
     .limit(1)
     .for('update');
   if (!runner?.providerRunnerId) return null;
-  return {id: runner.id, providerRunnerId: runner.providerRunnerId};
+  return {
+    id: runner.id,
+    providerRunnerId: runner.providerRunnerId,
+    workspaceId: runner.workspaceId,
+  };
 }
 
 async function hasRunnerEnrollmentSessionTx(
   tx: Tx,
   params: ReconcileRunnerInstancesParams,
-  runner: {providerRunnerId: string},
+  runner: {providerRunnerId: string; workspaceId: string | null},
 ): Promise<boolean> {
-  const workspaceId = params.workspaceId;
-  if (!workspaceId) return false;
+  const conditions = [
+    eq(runnerSessions.provisionerId, params.provisionerId),
+    eq(runnerSessions.providerRunnerId, runner.providerRunnerId),
+    isNull(runnerSessions.revokedAt),
+  ] as SQL[];
+  if (runner.workspaceId) conditions.push(eq(runnerSessions.workspaceId, runner.workspaceId));
   const [session] = await tx
     .select({id: runnerSessions.id})
     .from(runnerSessions)
-    .where(
-      and(
-        eq(runnerSessions.workspaceId, workspaceId),
-        eq(runnerSessions.provisionerId, params.provisionerId),
-        eq(runnerSessions.providerRunnerId, runner.providerRunnerId),
-        isNull(runnerSessions.revokedAt),
-      ),
-    )
+    .where(and(...conditions))
     .limit(1);
   return Boolean(session);
 }
@@ -1478,20 +1485,17 @@ async function hasOpenRunnerControlSessionTx(
 async function hasLiveRunnerJobTx(
   tx: Tx,
   params: ReconcileRunnerInstancesParams,
-  providerRunnerId: string,
+  runner: {providerRunnerId: string; workspaceId: string | null},
 ): Promise<boolean> {
-  const workspaceId = params.workspaceId;
-  if (!workspaceId) return false;
+  const conditions = [
+    eq(runningJobExecutions.provisionerId, params.provisionerId),
+    eq(runningJobExecutions.providerRunnerId, runner.providerRunnerId),
+  ] as SQL[];
+  if (runner.workspaceId) conditions.push(eq(runningJobExecutions.workspaceId, runner.workspaceId));
   const [job] = await tx
     .select({id: runningJobExecutions.id})
     .from(runningJobExecutions)
-    .where(
-      and(
-        eq(runningJobExecutions.workspaceId, workspaceId),
-        eq(runningJobExecutions.provisionerId, params.provisionerId),
-        eq(runningJobExecutions.providerRunnerId, providerRunnerId),
-      ),
-    )
+    .where(and(...conditions))
     .limit(1);
   return Boolean(job);
 }

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -374,6 +374,7 @@ export interface ReconcileRunnerInstancesParams {
   workspaceId: string | null;
   provisionerId: string;
   observedRunnerInstanceIds: string[];
+  candidateOnlyReconcile?: boolean;
   terminationCandidates?: ProviderTerminationCandidate[];
   terminateGraceSeconds: number;
   postJobExitGraceSeconds?: number;
@@ -1287,8 +1288,11 @@ export async function reconcileRunnerInstances(
       sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId ?? params.provisionerId}))`,
     );
 
+    // Candidate-only requests carry a bounded subset, so their IDs are not a complete snapshot.
     const {absentIds, reservationsReleased: absentReservationsReleased} =
-      await reconcileAbsentRunnerInstancesTx(tx, params, observedRunnerInstanceIds);
+      params.candidateOnlyReconcile
+        ? {absentIds: [], reservationsReleased: 0}
+        : await reconcileAbsentRunnerInstancesTx(tx, params, observedRunnerInstanceIds);
     let reservationsReleased = absentReservationsReleased;
     const terminationAuthorizationTelemetry: TerminationAuthorizationTelemetryRecord[] = [];
     terminationAuthorizationTelemetry.push(

--- a/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
@@ -323,6 +323,47 @@ describe('POST /provisioners/runner-instances/reconcile', () => {
     expect(runner?.terminationReason).toBe('registration-deadline');
   });
 
+  it('does not reconcile absent runners for candidate-only requests', async () => {
+    await createRunnerInstance({
+      providerRunnerId: 'stale-runner',
+      reportedAt: new Date(Date.now() - 300_000),
+    });
+    await createRunnerInstance({providerRunnerId: 'candidate-runner'});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/reconcile',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        observed_provider_runner_ids: [],
+        termination_candidates: [
+          {provider_runner_id: 'candidate-runner', reason: 'registration-deadline'},
+        ],
+        candidate_only_reconcile: true,
+      },
+    });
+
+    const [staleRunner] = await db()
+      .select({state: providerRunners.state})
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.workspaceId, workspaceId),
+          eq(providerRunners.provisionerId, provisionerTokenId),
+          eq(providerRunners.providerRunnerId, 'stale-runner'),
+        ),
+      );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().runners[0]).toMatchObject({
+      provider_runner_id: 'candidate-runner',
+      desired_intent: 'terminate',
+      termination_reason: 'registration-deadline',
+    });
+    expect(res.json().terminated_absent_provider_runner_ids).toEqual([]);
+    expect(staleRunner?.state).toBe('running');
+  });
+
   it('keeps a provider termination candidate when a live job exists', async () => {
     await createRunnerInstance({providerRunnerId: 'busy-candidate'});
     await insertRunningJob({

--- a/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
@@ -335,7 +335,7 @@ describe('POST /provisioners/runner-instances/reconcile', () => {
       url: '/provisioners/runner-instances/reconcile',
       headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
       payload: {
-        observed_provider_runner_ids: [],
+        observed_provider_runner_ids: ['candidate-runner'],
         termination_candidates: [
           {provider_runner_id: 'candidate-runner', reason: 'registration-deadline'},
         ],

--- a/libs/api/runners/src/presentation/routes/reconcile-runner-instances.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-runner-instances.ts
@@ -25,6 +25,9 @@ export const reconcileRunnerInstancesRoute = defineRoute({
       workspaceId: context.scope === 'workspace' ? context.workspaceId : null,
       provisionerId: context.provisionerTokenId,
       observedRunnerInstanceIds: request.body.observed_provider_runner_ids,
+      ...(request.body.candidate_only_reconcile !== undefined
+        ? {candidateOnlyReconcile: request.body.candidate_only_reconcile}
+        : {}),
       ...(request.body.termination_candidates
         ? {
             terminationCandidates: request.body.termination_candidates.map((candidate) => ({

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -25,10 +25,13 @@ events with `ec2:DescribeInstanceStatus`. The provisioner role must grant that a
 runner region. An authorization or other permanent status-read failure fails the reconciliation
 closed; a transient or stale-instance status-read failure keeps the ordinary `DescribeInstances`
 snapshot and submits no health candidate.
-Candidates require an impairment that is at least one reconciliation interval old or two
+Health candidates require an impairment that is at least one reconciliation interval old or two
 consecutive close observations. Candidates are requests to the existing backend authorization
 gate, not direct termination calls. Regular observation, termination lookup, and service metrics
 omit status checks so they do not poll the status API unnecessarily.
+A pending instance past its registration deadline is submitted to the same authorization gate
+during reconciliation. The provider keeps it out of usable capacity and does not terminate it
+until the backend authorizes the request.
 
 ## Template config
 
@@ -189,8 +192,8 @@ Search for `Observed EC2 runner instance termination` to find one terminal log p
 instance ID. The provider keeps the marker while AWS lists the instance, and for one
 hour after a listing gap.
 The provider reports non-terminal states on every observation.
-When the provider terminates an instance, it reports `terminated` with either
-`backend-terminate` or `registration-deadline`.
+When the provider terminates an instance, it reports `terminated` with the backend authorization
+reason when one is present. Direct provider termination requests use `backend-terminate`.
 An authorized instance that remains in `stopping` past its configured timeout receives one forced termination retry.
 The retry reuses the API's first-observed `stopping_at` timestamp and does not create authorization.
 A live bound job fences the retry; a bound job with cancellation requested does not, because the API has already authorized cleanup.

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -199,10 +199,11 @@ hour after a listing gap.
 The provider reports non-terminal states on every observation.
 When the provider terminates an instance, it reports `terminated` with the backend authorization
 reason when one is present. Direct provider termination requests use `backend-terminate`.
-If `provisioner.ec2.registration_deadline_candidate_unidentifiable` appears, verify the logged
-`aws_instance_id` and `shipfox.provisioner_id` ownership, then follow the operator-approved AWS
-cleanup procedure. The provider cannot terminate an instance without a provider runner ID and
-does not bypass backend authorization.
+If `provisioner.ec2.registration_deadline_candidate_unidentifiable` appears, use
+`aws ec2 describe-instances --instance-ids <aws_instance_id>` to compare its
+`shipfox.provisioner_id` tag with the logged `provisioner_id`, then follow the operator-approved
+AWS cleanup procedure. The provider cannot terminate an instance without a provider runner ID
+and does not bypass backend authorization.
 An authorized instance that remains in `stopping` past its configured timeout receives one forced termination retry.
 The retry reuses the API's first-observed `stopping_at` timestamp and does not create authorization.
 A live bound job fences the retry; a bound job with cancellation requested does not, because the API has already authorized cleanup.

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -32,6 +32,9 @@ omit status checks so they do not poll the status API unnecessarily.
 A pending instance past its registration deadline is submitted to the same authorization gate
 during reconciliation. The provider keeps it out of usable capacity and does not terminate it
 until the backend authorizes the request.
+Enable `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED` in the runners API before
+deploying this behavior. The API flag defaults to false; while it is disabled, the provider
+keeps overdue candidates out of capacity and retries authorization without terminating them.
 
 ## Template config
 

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -32,9 +32,6 @@ omit status checks so they do not poll the status API unnecessarily.
 A pending instance past its registration deadline is submitted to the same authorization gate
 during reconciliation. The provider keeps it out of usable capacity and does not terminate it
 until the backend authorizes the request.
-Enable `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED` in the runners API before
-deploying this behavior. The API flag defaults to false; while it is disabled, the provider
-keeps overdue candidates out of capacity and retries authorization without terminating them.
 
 ## Template config
 
@@ -155,6 +152,11 @@ The provider reads the shared provisioner variables plus these EC2-specific vari
 | `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval for a full backend reconcile using EC2 instance tags. |
 | `SHIPFOX_PROVISIONER_EC2_STOPPING_TIMEOUT_MS` | no | `300000` | Time an authorized instance may remain in `stopping` before one forced termination retry. |
 
+The runners API must have `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED=true` before
+deploying registration-deadline cleanup. The API flag defaults to false; while it is disabled,
+the provider keeps overdue candidates out of capacity and retries authorization without
+terminating them.
+
 The reservation clock starts when the API grants demand. The EC2 registration clock starts
 when EC2 records the instance launch time. The provider requests
 `ceil((registration deadline + launch headroom) / 1000)` seconds, so the reservation covers
@@ -197,6 +199,10 @@ hour after a listing gap.
 The provider reports non-terminal states on every observation.
 When the provider terminates an instance, it reports `terminated` with the backend authorization
 reason when one is present. Direct provider termination requests use `backend-terminate`.
+If `provisioner.ec2.registration_deadline_candidate_unidentifiable` appears, verify the logged
+`aws_instance_id` and `shipfox.provisioner_id` ownership, then follow the operator-approved AWS
+cleanup procedure. The provider cannot terminate an instance without a provider runner ID and
+does not bypass backend authorization.
 An authorized instance that remains in `stopping` past its configured timeout receives one forced termination retry.
 The retry reuses the API's first-observed `stopping_at` timestamp and does not create authorization.
 A live bound job fences the retry; a bound job with cancellation requested does not, because the API has already authorized cleanup.

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -952,10 +952,43 @@ describe('createEc2Lifecycle', () => {
         candidate_count: 101,
         submitted_count: 100,
         dropped_count: 1,
+        candidate_counts: {'registration-deadline': 0, 'provider-health-failed': 101},
+        submitted_candidate_counts: {'registration-deadline': 0, 'provider-health-failed': 100},
+        dropped_candidate_counts: {'registration-deadline': 0, 'provider-health-failed': 1},
       }),
       'Capped EC2 provider health termination candidates at the API limit',
     );
     expect(engine.terminationCalls).toEqual([]);
+  });
+
+  it('preserves registration-deadline precedence when candidate sources collide', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'pending',
+          instanceId: 'i-pending',
+          providerRunnerId: 'duplicate-runner',
+          launchTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        instance({
+          state: 'running',
+          instanceId: 'i-running',
+          providerRunnerId: 'duplicate-runner',
+          systemStatus: {
+            status: 'impaired',
+            impairedSince: new Date(NOW.getTime() - RECONCILE_INTERVAL_MS),
+          },
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies[0]?.termination_candidates).toEqual([
+      {provider_runner_id: 'duplicate-runner', reason: 'registration-deadline'},
+    ]);
   });
 
   it('fails closed when the health candidate reconcile request is unauthorized', async () => {
@@ -1058,6 +1091,98 @@ describe('createEc2Lifecycle', () => {
     expect(engine.terminationCalls).toEqual([]);
     expect(client.reportBodies).toEqual([]);
     expect(tracker.countsByTemplate()).toEqual(new Map());
+  });
+
+  it('submits only pending instances as registration deadline candidates', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'pending',
+          instanceId: 'i-pending',
+          providerRunnerId: 'pending-runner',
+          launchTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        instance({
+          state: 'running',
+          instanceId: 'i-running',
+          providerRunnerId: 'running-runner',
+          launchTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const tracker = testTracker();
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      registrationDeadlineMs: 60_000,
+      tracker,
+    });
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([
+      {
+        observed_provider_runner_ids: ['pending-runner', 'running-runner'],
+        termination_candidates: [
+          {provider_runner_id: 'pending-runner', reason: 'registration-deadline'},
+        ],
+      },
+    ]);
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
+      expect.objectContaining({provider_runner_id: 'running-runner', state: 'running'}),
+    ]);
+    expect(tracker.countsByTemplate()).toEqual(
+      new Map([['spot-small', {starting: 0, running: 1}]]),
+    );
+  });
+
+  it('warns when a deadline candidate remains without backend authorization', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
+    });
+    const lifecycle = makeLifecycle({engine, registrationDeadlineMs: 60_000});
+
+    for (let attempt = 0; attempt < 5; attempt++) await lifecycle.reconcile();
+
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.registration_deadline_authorization_waiting',
+        provider_runner_id: 'runner-1',
+        attempt_count: 5,
+        first_attempt_at: NOW.toISOString(),
+        age_ms: 0,
+        termination_authorization: 'backend-gated',
+      }),
+      'EC2 registration deadline candidate is still waiting for backend authorization',
+    );
+  });
+
+  it('warns when an overdue instance has no provider runner identity', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'pending',
+          instanceId: 'i-unidentifiable',
+          providerRunnerId: null,
+          launchTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: []}]);
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.registration_deadline_candidate_unidentifiable',
+        aws_instance_id: 'i-unidentifiable',
+        termination_authorization: 'backend-gated',
+      }),
+      'Cannot submit an EC2 registration deadline candidate without provider runner identity',
+    );
   });
 
   it('keeps an overdue instance when backend candidate authorization fails', async () => {
@@ -1217,6 +1342,53 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies.map((body) => body.events.length)).toEqual([
       1000, 1000, 1000, 1000, 1000, 1,
     ]);
+  });
+
+  it('reconciles deadline candidates separately when the observed id count exceeds the API limit', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'pending',
+          instanceId: 'i-pending',
+          providerRunnerId: 'pending-runner',
+          launchTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        ...Array.from({length: 5000}, (_, index) =>
+          instance({
+            state: 'running',
+            instanceId: `i-running-${index}`,
+            providerRunnerId: `running-runner-${index}`,
+          }),
+        ),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([
+      {
+        observed_provider_runner_ids: [],
+        termination_candidates: [
+          {provider_runner_id: 'pending-runner', reason: 'registration-deadline'},
+        ],
+      },
+    ]);
+    expect(observability.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.ec2.reconcile_observed_runner_limit',
+        observedCount: 5001,
+        termination_candidate_count: 1,
+        termination_candidate_counts: {
+          'registration-deadline': 1,
+          'provider-health-failed': 0,
+        },
+        termination_candidates_submitted: 1,
+        candidate_only_reconcile: true,
+      }),
+      'EC2 observed runner count exceeds the API limit; reconciling termination candidates separately',
+    );
   });
 
   it('terminates and reports instances with backend terminate intent', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -1038,21 +1038,29 @@ describe('createEc2Lifecycle', () => {
     await expect(lifecycle.launch(launch())).rejects.toThrow(ProvisionerAuthenticationError);
   });
 
-  it('terminates an overdue instance before authentication failures can block reporting', async () => {
+  it('does not terminate or advertise an overdue instance during observation', async () => {
     const engine = fakeEngine({
       instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
     });
     const client = fakeClient({
       reportErrors: [new ProvisionerAuthenticationError(401)],
     });
-    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+    const tracker = testTracker();
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      registrationDeadlineMs: 60_000,
+      tracker,
+    });
 
-    await expect(lifecycle.observe()).rejects.toThrow(ProvisionerAuthenticationError);
+    await lifecycle.observe();
 
-    expect(engine.terminated).toEqual(['i-123']);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(client.reportBodies).toEqual([]);
+    expect(tracker.countsByTemplate()).toEqual(new Map());
   });
 
-  it('reaps an overdue instance before a failed reconcile request from tick', async () => {
+  it('keeps an overdue instance when backend candidate authorization fails', async () => {
     const engine = fakeEngine({
       instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
     });
@@ -1063,8 +1071,17 @@ describe('createEc2Lifecycle', () => {
     await expect(lifecycle.tick()).rejects.toThrow(ProvisionerAuthenticationError);
     await expect(lifecycle.tick()).rejects.toThrow(ProvisionerAuthenticationError);
 
-    expect(engine.terminated).toEqual(['i-123']);
-    expect(client.reconcileBodies).toHaveLength(2);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(client.reconcileBodies).toEqual([
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+      },
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+      },
+    ]);
   });
 
   it('reports a failed launch and does not launch when provider identity attachment is rejected', async () => {
@@ -1754,7 +1771,7 @@ describe('createEc2Lifecycle', () => {
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });
 
-  it('reaps a pending instance past its registration deadline even when its labels are unresolvable', async () => {
+  it('submits an overdue candidate even when its labels are unresolvable', async () => {
     const engine = fakeEngine({
       instances: [
         instance({
@@ -1768,15 +1785,40 @@ describe('createEc2Lifecycle', () => {
     const client = fakeClient();
     const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
-    await lifecycle.observe();
-    await lifecycle.observe();
+    await lifecycle.reconcile();
 
-    expect(engine.terminated).toEqual(['i-123']);
-    expect(observability.recordEc2Termination).toHaveBeenCalledWith(
-      'registration-deadline',
-      UNKNOWN_TEMPLATE_KEY,
-    );
-    expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
+    expect(engine.terminationCalls).toEqual([]);
+    expect(client.reconcileBodies).toEqual([
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+      },
+    ]);
+    expect(observability.recordEc2Termination).not.toHaveBeenCalled();
+  });
+
+  it('does not report or assign an overdue instance until backend authorization arrives', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
+    });
+    const client = fakeClient();
+    const tracker = testTracker();
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      registrationDeadlineMs: 60_000,
+      tracker,
+    });
+
+    await lifecycle.reconcile();
+
+    expect(engine.terminationCalls).toEqual([]);
+    expect(client.reconcileBodies[0]?.termination_candidates).toEqual([
+      {provider_runner_id: 'runner-1', reason: 'registration-deadline'},
+    ]);
+    expect(client.assignmentBodies).toEqual([]);
+    expect(client.reportBodies).toEqual([]);
+    expect(tracker.countsByTemplate()).toEqual(new Map());
   });
 
   it('attributes an observed tagless termination to the reserved fallback key', async () => {
@@ -1804,27 +1846,52 @@ describe('createEc2Lifecycle', () => {
     );
   });
 
-  it('reaps a pending instance past its registration deadline', async () => {
-    const instances = [
-      instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')}),
-    ];
+  it('honors an authorized registration deadline termination idempotently', async () => {
     const engine = fakeEngine({
-      instances,
+      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
     });
-    const client = fakeClient();
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [
+          reconciledRunner(
+            'runner-1',
+            'terminate',
+            null,
+            null,
+            true,
+            'starting',
+            'registration-deadline',
+          ),
+        ],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
     const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
-    await lifecycle.observe();
-    instances[0] = instance({state: 'terminated'});
-    await lifecycle.observe();
+    await lifecycle.reconcile();
+    await lifecycle.reconcile();
 
-    expect(engine.terminated).toEqual(['i-123']);
+    expect(engine.terminationCalls).toEqual([{instanceIds: ['i-123'], options: undefined}]);
+    expect(client.reconcileBodies).toEqual([
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+      },
+      {
+        observed_provider_runner_ids: ['runner-1'],
+        termination_candidates: [{provider_runner_id: 'runner-1', reason: 'registration-deadline'}],
+      },
+    ]);
     expect(client.reportBodies.flatMap((body) => body.events)).toEqual([
       expect.objectContaining({state: 'terminated', reason: 'registration-deadline'}),
     ]);
     expect(observability.recordEc2Termination).toHaveBeenCalledWith(
       'registration-deadline',
       'spot-small',
+    );
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({reason: 'registration-deadline'}),
+      'Terminated EC2 runner instance',
     );
     expect(observability.recordEc2Termination).toHaveBeenCalledTimes(1);
   });

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -1138,12 +1138,16 @@ describe('createEc2Lifecycle', () => {
   });
 
   it('warns when a deadline candidate remains without backend authorization', async () => {
+    const now = new Date(NOW);
     const engine = fakeEngine({
       instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
     });
-    const lifecycle = makeLifecycle({engine, registrationDeadlineMs: 60_000});
+    const lifecycle = makeLifecycle({engine, registrationDeadlineMs: 60_000, now: () => now});
 
-    for (let attempt = 0; attempt < 5; attempt++) await lifecycle.reconcile();
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await lifecycle.reconcile();
+      if (attempt < 4) now.setTime(now.getTime() + 1_000);
+    }
 
     expect(observability.logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1151,7 +1155,7 @@ describe('createEc2Lifecycle', () => {
         provider_runner_id: 'runner-1',
         attempt_count: 5,
         first_attempt_at: NOW.toISOString(),
-        age_ms: 0,
+        age_ms: 4_000,
         termination_authorization: 'backend-gated',
       }),
       'EC2 registration deadline candidate is still waiting for backend authorization',
@@ -1179,6 +1183,7 @@ describe('createEc2Lifecycle', () => {
       expect.objectContaining({
         event: 'provisioner.ec2.registration_deadline_candidate_unidentifiable',
         aws_instance_id: 'i-unidentifiable',
+        provisioner_id: '00000000-0000-4000-8000-000000000001',
         termination_authorization: 'backend-gated',
       }),
       'Cannot submit an EC2 registration deadline candidate without provider runner identity',
@@ -1373,6 +1378,7 @@ describe('createEc2Lifecycle', () => {
         termination_candidates: [
           {provider_runner_id: 'pending-runner', reason: 'registration-deadline'},
         ],
+        candidate_only_reconcile: true,
       },
     ]);
     expect(observability.logger.error).toHaveBeenCalledWith(

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -47,7 +47,7 @@ const TERMINAL_REPORT_ABSENCE_GRACE_MS = 60 * 60 * 1000;
 const SPOT_INTERRUPTION_REASON =
   /spot|instance-terminated-by-price|instance-terminated-no-capacity/i;
 const MAX_SCHEDULED_EVENT_CODES_IN_LOG = 20;
-const MAX_HEALTH_CANDIDATE_IDS_IN_LOG = 20;
+const MAX_TERMINATION_CANDIDATE_IDS_IN_LOG = 20;
 
 type Ec2HealthObservation = {
   checkType: Ec2HealthCheckType;
@@ -148,7 +148,7 @@ interface Ec2LifecycleContext {
   readonly suppressedReservationRunnerIds: Map<string, Set<string>>;
   readonly canonicalReservationIdsByRunner: Map<string, string | null>;
   readonly healthImpairmentObservations: Map<string, HealthImpairmentObservation>;
-  healthCandidateCursor: number;
+  terminationCandidateCursor: number;
   lastReconciledAt?: Date;
 }
 
@@ -180,7 +180,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     suppressedReservationRunnerIds: new Map(),
     canonicalReservationIdsByRunner: new Map(),
     healthImpairmentObservations: new Map(),
-    healthCandidateCursor: 0,
+    terminationCandidateCursor: 0,
   };
 
   return {
@@ -256,8 +256,8 @@ async function observe(context: Ec2LifecycleContext): Promise<void> {
 
 async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   const instances = await context.engine.listManaged(context.identity.id, {includeStatus: true});
+  const registrationDeadlineCandidates = observeRegistrationDeadlineCandidates(context, instances);
   const healthCandidates = observeEc2Health(context, instances);
-  await reapRegistrationDeadlineInstances(context, instances);
   const observedProviderRunnerIds = observedRunnerIds(instances);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
     logger().error(
@@ -273,21 +273,44 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
     return;
   }
 
+  const terminationCandidates = selectTerminationCandidateWindow(context, [
+    ...registrationDeadlineCandidates,
+    ...healthCandidates,
+  ]);
   const response = await context.client.reconcileRunnerInstances({
     observed_provider_runner_ids: observedProviderRunnerIds,
-    ...(healthCandidates.length > 0 ? {termination_candidates: healthCandidates} : {}),
+    ...(terminationCandidates.length > 0 ? {termination_candidates: terminationCandidates} : {}),
   });
-  if (healthCandidates.length > 0) {
+  const submittedHealthCandidates = terminationCandidates.filter(
+    (candidate) => candidate.reason === 'provider-health-failed',
+  );
+  if (submittedHealthCandidates.length > 0) {
     logger().info(
       {
         event: 'provisioner.ec2.provider_health_candidates_submitted',
-        requested_count: healthCandidates.length,
+        requested_count: submittedHealthCandidates.length,
         termination_authorization: 'backend-gated',
-        provider_runner_ids: healthCandidates
-          .slice(0, MAX_HEALTH_CANDIDATE_IDS_IN_LOG)
+        provider_runner_ids: submittedHealthCandidates
+          .slice(0, MAX_TERMINATION_CANDIDATE_IDS_IN_LOG)
           .map((candidate) => candidate.provider_runner_id),
       },
       'Sent EC2 provider health termination candidates for backend authorization',
+    );
+  }
+  const submittedRegistrationDeadlineCandidates = terminationCandidates.filter(
+    (candidate) => candidate.reason === 'registration-deadline',
+  );
+  if (submittedRegistrationDeadlineCandidates.length > 0) {
+    logger().info(
+      {
+        event: 'provisioner.ec2.registration_deadline_candidates_submitted',
+        requested_count: submittedRegistrationDeadlineCandidates.length,
+        termination_authorization: 'backend-gated',
+        provider_runner_ids: submittedRegistrationDeadlineCandidates
+          .slice(0, MAX_TERMINATION_CANDIDATE_IDS_IN_LOG)
+          .map((candidate) => candidate.provider_runner_id),
+      },
+      'Sent EC2 registration deadline candidates for backend authorization',
     );
   }
   syncCanonicalReservationIds(context, response.runners);
@@ -333,7 +356,7 @@ function observeEc2Health(
   const orderedCandidates = [...candidates.values()].sort((left, right) =>
     left.provider_runner_id.localeCompare(right.provider_runner_id),
   );
-  return selectHealthCandidateWindow(context, orderedCandidates);
+  return orderedCandidates;
 }
 
 function observeEc2InstanceHealth(
@@ -492,34 +515,72 @@ function hasPersistentImpairment(
   });
 }
 
-function selectHealthCandidateWindow(
+function observeRegistrationDeadlineCandidates(
+  context: Ec2LifecycleContext,
+  instances: readonly Ec2InstanceView[],
+): ProviderTerminationCandidateDto[] {
+  const candidates = new Map<string, ProviderTerminationCandidateDto>();
+  for (const instance of instances) {
+    if (!isPastRegistrationDeadline(instance, context) || !canTerminateInstance(instance)) continue;
+    const providerRunnerId = parseInstanceIdentity(instance).providerRunnerId;
+    if (!providerRunnerId) continue;
+    candidates.set(providerRunnerId, {
+      provider_runner_id: providerRunnerId,
+      reason: 'registration-deadline',
+    });
+  }
+  return [...candidates.values()].sort((left, right) =>
+    left.provider_runner_id.localeCompare(right.provider_runner_id),
+  );
+}
+
+function selectTerminationCandidateWindow(
   context: Ec2LifecycleContext,
   orderedCandidates: readonly ProviderTerminationCandidateDto[],
 ): ProviderTerminationCandidateDto[] {
-  if (orderedCandidates.length <= MAX_TERMINATION_CANDIDATES) {
-    context.healthCandidateCursor = 0;
-    return [...orderedCandidates];
+  const deduplicatedCandidates = deduplicateTerminationCandidates(orderedCandidates).sort(
+    (left, right) => left.provider_runner_id.localeCompare(right.provider_runner_id),
+  );
+  if (deduplicatedCandidates.length <= MAX_TERMINATION_CANDIDATES) {
+    context.terminationCandidateCursor = 0;
+    return deduplicatedCandidates;
   }
 
-  const start = context.healthCandidateCursor % orderedCandidates.length;
+  const start = context.terminationCandidateCursor % deduplicatedCandidates.length;
   const rotatedCandidates = [
-    ...orderedCandidates.slice(start),
-    ...orderedCandidates.slice(0, start),
+    ...deduplicatedCandidates.slice(start),
+    ...deduplicatedCandidates.slice(0, start),
   ];
   const selectedCandidates = rotatedCandidates.slice(0, MAX_TERMINATION_CANDIDATES);
-  context.healthCandidateCursor = (start + selectedCandidates.length) % orderedCandidates.length;
+  context.terminationCandidateCursor =
+    (start + selectedCandidates.length) % deduplicatedCandidates.length;
+  const allHealthCandidates = deduplicatedCandidates.every(
+    (candidate) => candidate.reason === 'provider-health-failed',
+  );
   logger().warn(
     {
-      event: 'provisioner.ec2.provider_health_candidate_limit',
-      candidate_count: orderedCandidates.length,
+      event: allHealthCandidates
+        ? 'provisioner.ec2.provider_health_candidate_limit'
+        : 'provisioner.ec2.termination_candidate_limit',
+      candidate_count: deduplicatedCandidates.length,
       submitted_count: selectedCandidates.length,
-      dropped_count: orderedCandidates.length - selectedCandidates.length,
+      dropped_count: deduplicatedCandidates.length - selectedCandidates.length,
       start_index: start,
-      next_start_index: context.healthCandidateCursor,
+      next_start_index: context.terminationCandidateCursor,
     },
-    'Capped EC2 provider health termination candidates at the API limit',
+    allHealthCandidates
+      ? 'Capped EC2 provider health termination candidates at the API limit'
+      : 'Capped EC2 termination candidates at the API limit',
   );
   return selectedCandidates;
+}
+
+function deduplicateTerminationCandidates(
+  candidates: readonly ProviderTerminationCandidateDto[],
+): ProviderTerminationCandidateDto[] {
+  return [
+    ...new Map(candidates.map((candidate) => [candidate.provider_runner_id, candidate])).values(),
+  ];
 }
 
 function healthObservations(instance: Ec2InstanceView): Ec2HealthObservation[] {
@@ -546,16 +607,6 @@ function healthObservations(instance: Ec2InstanceView): Ec2HealthObservation[] {
         : {}),
     },
   ];
-}
-
-async function reapRegistrationDeadlineInstances(
-  context: Ec2LifecycleContext,
-  instances: readonly Ec2InstanceView[],
-): Promise<void> {
-  const instancesToReap = instances.filter(
-    (instance) => isPastRegistrationDeadline(instance, context) && canTerminateInstance(instance),
-  );
-  await terminateInstances(context, instancesToReap, 'registration-deadline');
 }
 
 function tick(context: Ec2LifecycleContext): Promise<void> {
@@ -607,7 +658,6 @@ async function applyObservedInstances(
     plan.terminationDeadlines,
     plan.missingStoppingTimestampIntentIds,
   );
-  await terminateInstances(context, plan.reapInstances, 'registration-deadline');
   if (plan.events.length > 0)
     await reportEvents(context, plan.events, plan.terminalReportInstanceIds);
 }
@@ -620,7 +670,6 @@ interface Ec2ObservationPlan {
   observedIds: Set<string>;
   observedInstanceIds: Set<string>;
   observedRunnerInstanceIds: Set<string>;
-  reapInstances: Ec2InstanceView[];
   terminateIntentInstances: Ec2InstanceView[];
   forcedTerminateIntentIds: Set<string>;
   terminationAuthorizationReasons: Map<string, TerminationReasonDto | undefined>;
@@ -637,7 +686,6 @@ function createEc2ObservationPlan(): Ec2ObservationPlan {
     observedIds: new Set(),
     observedInstanceIds: new Set(),
     observedRunnerInstanceIds: new Set(),
-    reapInstances: [],
     terminateIntentInstances: [],
     forcedTerminateIntentIds: new Set(),
     terminationAuthorizationReasons: new Map(),
@@ -851,7 +899,7 @@ function recordTerminationCandidate(
   terminateIntents: ReadonlyMap<string, TerminationIntent>,
 ): {requested: boolean; skipObservation: boolean} {
   const terminationIntent = terminateIntents.get(providerRunnerId);
-  const pastRegistrationDeadline = isPastRegistrationDeadline(instance, context);
+  const registrationDeadlineReached = isPastRegistrationDeadline(instance, context);
   const retry = shouldRetryTermination(context, instance, terminationIntent);
   const stoppingTimestampMissing = isStoppingTimestampMissing(instance, terminationIntent);
   const terminationRequested = shouldRequestTermination(
@@ -860,12 +908,9 @@ function recordTerminationCandidate(
     retry,
     stoppingTimestampMissing,
   );
-  const requested = pastRegistrationDeadline || terminationRequested;
+  const requested = terminationRequested;
   if (!canTerminateInstance(instance)) return {requested, skipObservation: false};
-  if (!terminationIntent) {
-    if (pastRegistrationDeadline) plan.reapInstances.push(instance);
-    return {requested, skipObservation: requested};
-  }
+  if (!terminationIntent) return {requested, skipObservation: registrationDeadlineReached};
   if (stoppingTimestampMissing) reportMissingStoppingTimestamp(context, instance);
   if (terminationRequested) {
     plan.terminateIntentInstances.push(instance);
@@ -877,8 +922,6 @@ function recordTerminationCandidate(
         new Date(terminationIntent.stoppingAt.getTime() + context.stoppingTimeoutMs),
       );
     if (stoppingTimestampMissing) plan.missingStoppingTimestampIntentIds.add(instance.instanceId);
-  } else if (pastRegistrationDeadline) {
-    plan.reapInstances.push(instance);
   }
   return {requested, skipObservation: requested};
 }
@@ -1209,7 +1252,13 @@ async function terminateInstances(
     );
 
   const terminalReportInstanceIds = new Map<RunnerInstanceReportEventDto, string>();
-  const events = terminationEvents(context, terminableInstances, reason, terminalReportInstanceIds);
+  const events = terminationEvents(
+    context,
+    terminableInstances,
+    reason,
+    terminalReportInstanceIds,
+    authorizationReasons,
+  );
   if (events.length > 0) await reportEvents(context, events, terminalReportInstanceIds);
   clearTerminatedInstances(context, instances);
 }
@@ -1254,6 +1303,7 @@ async function terminateInstance(
     ? new Date(stoppingDeadline.getTime() - context.stoppingTimeoutMs)
     : undefined;
   const authorizationReason = authorizationReasons.get(instance.instanceId);
+  const effectiveReason = authorizationReason ?? reason;
   context.terminationActionedInstanceIds.set(instance.instanceId, {
     actionedAt: context.now().getTime(),
     force,
@@ -1263,7 +1313,7 @@ async function terminateInstance(
       ? {stoppingTimestampMissingReported: true}
       : {}),
   });
-  recordEc2Termination(reason, templateKey);
+  recordEc2Termination(effectiveReason, templateKey);
   const terminationLogOptions = force
     ? {
         force: true,
@@ -1277,7 +1327,7 @@ async function terminateInstance(
       identity,
       templateKey,
       template,
-      reason,
+      effectiveReason,
       locallyLaunched?.ami,
       terminationLogOptions,
     ),
@@ -1290,6 +1340,7 @@ function terminationEvents(
   instances: readonly Ec2InstanceView[],
   reason: Ec2TerminationReason,
   terminalReportInstanceIds: Map<RunnerInstanceReportEventDto, string>,
+  authorizationReasons: ReadonlyMap<string, TerminationReasonDto | undefined>,
 ): RunnerInstanceReportEventDto[] {
   return instances.flatMap((instance) => {
     const identity = parseInstanceIdentity(instance);
@@ -1299,7 +1350,13 @@ function terminationEvents(
     const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
     if (!identity.providerRunnerId || labels.length === 0) return [];
     if (hasTerminalReport(context, instance.instanceId)) return [];
-    const event = eventForInstance(context, instance, 'terminated', labels, reason);
+    const event = eventForInstance(
+      context,
+      instance,
+      'terminated',
+      labels,
+      authorizationReasons.get(instance.instanceId) ?? reason,
+    );
     terminalReportInstanceIds.set(event, instance.instanceId);
     return [event];
   });

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -295,43 +295,16 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   )
     return;
 
-  const submittedHealthCandidates = terminationCandidates.filter(
-    (candidate) => candidate.reason === 'provider-health-failed',
-  );
   const submittedRegistrationDeadlineCandidates = terminationCandidates.filter(
     (candidate) => candidate.reason === 'registration-deadline',
   );
-  recordRegistrationDeadlineAuthorizationAttempts(context, submittedRegistrationDeadlineCandidates);
-  const response = await context.client.reconcileRunnerInstances({
-    observed_provider_runner_ids: observedRunnerLimitExceeded ? [] : observedProviderRunnerIds,
-    ...(terminationCandidates.length > 0 ? {termination_candidates: terminationCandidates} : {}),
-  });
-  if (submittedHealthCandidates.length > 0) {
-    logger().info(
-      {
-        event: 'provisioner.ec2.provider_health_candidates_submitted',
-        requested_count: submittedHealthCandidates.length,
-        termination_authorization: 'backend-gated',
-        provider_runner_ids: submittedHealthCandidates
-          .slice(0, MAX_TERMINATION_CANDIDATE_IDS_IN_LOG)
-          .map((candidate) => candidate.provider_runner_id),
-      },
-      'Sent EC2 provider health termination candidates for backend authorization',
-    );
-  }
-  if (submittedRegistrationDeadlineCandidates.length > 0) {
-    logger().info(
-      {
-        event: 'provisioner.ec2.registration_deadline_candidates_submitted',
-        requested_count: submittedRegistrationDeadlineCandidates.length,
-        termination_authorization: 'backend-gated',
-        provider_runner_ids: submittedRegistrationDeadlineCandidates
-          .slice(0, MAX_TERMINATION_CANDIDATE_IDS_IN_LOG)
-          .map((candidate) => candidate.provider_runner_id),
-      },
-      'Sent EC2 registration deadline candidates for backend authorization',
-    );
-  }
+  const response = await reconcileWithBackend(
+    context,
+    observedProviderRunnerIds,
+    terminationCandidates,
+    observedRunnerLimitExceeded,
+    submittedRegistrationDeadlineCandidates,
+  );
   syncCanonicalReservationIds(context, response.runners);
   const terminateIntents = new Map<string, TerminationIntent>();
   for (const runner of response.runners) {
@@ -359,6 +332,52 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   await applyObservedInstances(context, instances, terminateIntents);
   await reportEvents(context, []);
   if (!observedRunnerLimitExceeded) context.lastReconciledAt = new Date(context.now());
+}
+
+async function reconcileWithBackend(
+  context: Ec2LifecycleContext,
+  observedProviderRunnerIds: string[],
+  terminationCandidates: ProviderTerminationCandidateDto[],
+  observedRunnerLimitExceeded: boolean,
+  submittedRegistrationDeadlineCandidates: ProviderTerminationCandidateDto[],
+): Promise<ReconcileRunnerInstancesResponseDto> {
+  const submittedHealthCandidates = terminationCandidates.filter(
+    (candidate) => candidate.reason === 'provider-health-failed',
+  );
+  const candidateOnlyReconcile = observedRunnerLimitExceeded && terminationCandidates.length > 0;
+  recordRegistrationDeadlineAuthorizationAttempts(context, submittedRegistrationDeadlineCandidates);
+  const response = await context.client.reconcileRunnerInstances({
+    observed_provider_runner_ids: observedRunnerLimitExceeded ? [] : observedProviderRunnerIds,
+    ...(terminationCandidates.length > 0 ? {termination_candidates: terminationCandidates} : {}),
+    ...(candidateOnlyReconcile ? {candidate_only_reconcile: true} : {}),
+  });
+  if (submittedHealthCandidates.length > 0) {
+    logger().info(
+      {
+        event: 'provisioner.ec2.provider_health_candidates_submitted',
+        requested_count: submittedHealthCandidates.length,
+        termination_authorization: 'backend-gated',
+        provider_runner_ids: submittedHealthCandidates
+          .slice(0, MAX_TERMINATION_CANDIDATE_IDS_IN_LOG)
+          .map((candidate) => candidate.provider_runner_id),
+      },
+      'Sent EC2 provider health termination candidates for backend authorization',
+    );
+  }
+  if (submittedRegistrationDeadlineCandidates.length > 0) {
+    logger().info(
+      {
+        event: 'provisioner.ec2.registration_deadline_candidates_submitted',
+        requested_count: submittedRegistrationDeadlineCandidates.length,
+        termination_authorization: 'backend-gated',
+        provider_runner_ids: submittedRegistrationDeadlineCandidates
+          .slice(0, MAX_TERMINATION_CANDIDATE_IDS_IN_LOG)
+          .map((candidate) => candidate.provider_runner_id),
+      },
+      'Sent EC2 registration deadline candidates for backend authorization',
+    );
+  }
+  return response;
 }
 
 async function handleObservedRunnerLimit(
@@ -585,6 +604,7 @@ function observeRegistrationDeadlineCandidates(
           event: 'provisioner.ec2.registration_deadline_candidate_unidentifiable',
           ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
           aws_instance_id: instance.instanceId,
+          provisioner_id: context.identity.id,
           termination_authorization: 'backend-gated',
         },
         'Cannot submit an EC2 registration deadline candidate without provider runner identity',

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -48,6 +48,7 @@ const SPOT_INTERRUPTION_REASON =
   /spot|instance-terminated-by-price|instance-terminated-no-capacity/i;
 const MAX_SCHEDULED_EVENT_CODES_IN_LOG = 20;
 const MAX_TERMINATION_CANDIDATE_IDS_IN_LOG = 20;
+const REGISTRATION_DEADLINE_AUTHORIZATION_WARNING_ATTEMPTS = 5;
 
 type Ec2HealthObservation = {
   checkType: Ec2HealthCheckType;
@@ -71,6 +72,16 @@ type LocallyLaunchedRunner = {
 type HealthImpairmentObservation = {
   lastObservedAt: number;
   consecutiveObservations: number;
+};
+
+type RegistrationDeadlineAuthorizationAttempt = {
+  firstAttemptAt: number;
+  attemptCount: number;
+};
+
+type TerminationCandidateReasonCounts = {
+  'registration-deadline': number;
+  'provider-health-failed': number;
 };
 
 type AssignmentCandidate = {
@@ -148,6 +159,10 @@ interface Ec2LifecycleContext {
   readonly suppressedReservationRunnerIds: Map<string, Set<string>>;
   readonly canonicalReservationIdsByRunner: Map<string, string | null>;
   readonly healthImpairmentObservations: Map<string, HealthImpairmentObservation>;
+  readonly registrationDeadlineAuthorizationAttempts: Map<
+    string,
+    RegistrationDeadlineAuthorizationAttempt
+  >;
   terminationCandidateCursor: number;
   lastReconciledAt?: Date;
 }
@@ -180,6 +195,7 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     suppressedReservationRunnerIds: new Map(),
     canonicalReservationIdsByRunner: new Map(),
     healthImpairmentObservations: new Map(),
+    registrationDeadlineAuthorizationAttempts: new Map(),
     terminationCandidateCursor: 0,
   };
 
@@ -258,32 +274,38 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
   const instances = await context.engine.listManaged(context.identity.id, {includeStatus: true});
   const registrationDeadlineCandidates = observeRegistrationDeadlineCandidates(context, instances);
   const healthCandidates = observeEc2Health(context, instances);
-  const observedProviderRunnerIds = observedRunnerIds(instances);
-  if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
-    logger().error(
-      {
-        observedCount: observedProviderRunnerIds.length,
-        maxObserved: MAX_RECONCILE_OBSERVED_RUNNERS,
-      },
-      'Skipping backend reconcile because observed EC2 runner count exceeds the API limit',
-    );
-    context.canonicalReservationIdsByRunner.clear();
-    await applyObservedInstances(context, instances, new Map());
-    await reportEvents(context, []);
-    return;
-  }
-
-  const terminationCandidates = selectTerminationCandidateWindow(context, [
+  const allTerminationCandidates = deduplicateTerminationCandidates([
     ...registrationDeadlineCandidates,
     ...healthCandidates,
   ]);
-  const response = await context.client.reconcileRunnerInstances({
-    observed_provider_runner_ids: observedProviderRunnerIds,
-    ...(terminationCandidates.length > 0 ? {termination_candidates: terminationCandidates} : {}),
-  });
+  pruneRegistrationDeadlineAuthorizationAttempts(context, registrationDeadlineCandidates);
+  const observedProviderRunnerIds = observedRunnerIds(instances);
+  const observedRunnerLimitExceeded =
+    observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS;
+  const terminationCandidates = selectTerminationCandidateWindow(context, allTerminationCandidates);
+  if (
+    await handleObservedRunnerLimit(
+      context,
+      instances,
+      observedProviderRunnerIds,
+      allTerminationCandidates,
+      terminationCandidates,
+      observedRunnerLimitExceeded,
+    )
+  )
+    return;
+
   const submittedHealthCandidates = terminationCandidates.filter(
     (candidate) => candidate.reason === 'provider-health-failed',
   );
+  const submittedRegistrationDeadlineCandidates = terminationCandidates.filter(
+    (candidate) => candidate.reason === 'registration-deadline',
+  );
+  recordRegistrationDeadlineAuthorizationAttempts(context, submittedRegistrationDeadlineCandidates);
+  const response = await context.client.reconcileRunnerInstances({
+    observed_provider_runner_ids: observedRunnerLimitExceeded ? [] : observedProviderRunnerIds,
+    ...(terminationCandidates.length > 0 ? {termination_candidates: terminationCandidates} : {}),
+  });
   if (submittedHealthCandidates.length > 0) {
     logger().info(
       {
@@ -297,9 +319,6 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
       'Sent EC2 provider health termination candidates for backend authorization',
     );
   }
-  const submittedRegistrationDeadlineCandidates = terminationCandidates.filter(
-    (candidate) => candidate.reason === 'registration-deadline',
-  );
   if (submittedRegistrationDeadlineCandidates.length > 0) {
     logger().info(
       {
@@ -324,6 +343,11 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
         runner.bound_job === null || runner.bound_job.cancellation_requested_at !== null,
     });
   }
+  clearAuthorizedRegistrationDeadlineAttempts(
+    context,
+    submittedRegistrationDeadlineCandidates,
+    response.runners,
+  );
   if (response.terminated_absent_provider_runner_ids.length > 0) {
     recordEc2ReconcileAbsent(response.terminated_absent_provider_runner_ids.length);
     logger().info(
@@ -334,7 +358,38 @@ async function reconcile(context: Ec2LifecycleContext): Promise<void> {
 
   await applyObservedInstances(context, instances, terminateIntents);
   await reportEvents(context, []);
-  context.lastReconciledAt = new Date(context.now());
+  if (!observedRunnerLimitExceeded) context.lastReconciledAt = new Date(context.now());
+}
+
+async function handleObservedRunnerLimit(
+  context: Ec2LifecycleContext,
+  instances: readonly Ec2InstanceView[],
+  observedProviderRunnerIds: readonly string[],
+  allTerminationCandidates: readonly ProviderTerminationCandidateDto[],
+  terminationCandidates: readonly ProviderTerminationCandidateDto[],
+  observedRunnerLimitExceeded: boolean,
+): Promise<boolean> {
+  if (!observedRunnerLimitExceeded) return false;
+
+  logger().error(
+    {
+      event: 'provisioner.ec2.reconcile_observed_runner_limit',
+      observedCount: observedProviderRunnerIds.length,
+      maxObserved: MAX_RECONCILE_OBSERVED_RUNNERS,
+      termination_candidate_count: allTerminationCandidates.length,
+      termination_candidate_counts: terminationCandidateReasonCounts(allTerminationCandidates),
+      termination_candidates_submitted: terminationCandidates.length,
+      candidate_only_reconcile: terminationCandidates.length > 0,
+    },
+    terminationCandidates.length > 0
+      ? 'EC2 observed runner count exceeds the API limit; reconciling termination candidates separately'
+      : 'Skipping backend reconcile because observed EC2 runner count exceeds the API limit',
+  );
+  context.canonicalReservationIdsByRunner.clear();
+  if (terminationCandidates.length > 0) return false;
+  await applyObservedInstances(context, instances, new Map());
+  await reportEvents(context, []);
+  return true;
 }
 
 function observeEc2Health(
@@ -522,8 +577,20 @@ function observeRegistrationDeadlineCandidates(
   const candidates = new Map<string, ProviderTerminationCandidateDto>();
   for (const instance of instances) {
     if (!isPastRegistrationDeadline(instance, context) || !canTerminateInstance(instance)) continue;
-    const providerRunnerId = parseInstanceIdentity(instance).providerRunnerId;
-    if (!providerRunnerId) continue;
+    const identity = parseInstanceIdentity(instance);
+    const providerRunnerId = identity.providerRunnerId;
+    if (!providerRunnerId) {
+      logger().warn(
+        {
+          event: 'provisioner.ec2.registration_deadline_candidate_unidentifiable',
+          ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+          aws_instance_id: instance.instanceId,
+          termination_authorization: 'backend-gated',
+        },
+        'Cannot submit an EC2 registration deadline candidate without provider runner identity',
+      );
+      continue;
+    }
     candidates.set(providerRunnerId, {
       provider_runner_id: providerRunnerId,
       reason: 'registration-deadline',
@@ -557,6 +624,8 @@ function selectTerminationCandidateWindow(
   const allHealthCandidates = deduplicatedCandidates.every(
     (candidate) => candidate.reason === 'provider-health-failed',
   );
+  const submittedCandidateCounts = terminationCandidateReasonCounts(selectedCandidates);
+  const candidateCounts = terminationCandidateReasonCounts(deduplicatedCandidates);
   logger().warn(
     {
       event: allHealthCandidates
@@ -565,6 +634,16 @@ function selectTerminationCandidateWindow(
       candidate_count: deduplicatedCandidates.length,
       submitted_count: selectedCandidates.length,
       dropped_count: deduplicatedCandidates.length - selectedCandidates.length,
+      candidate_counts: candidateCounts,
+      submitted_candidate_counts: submittedCandidateCounts,
+      dropped_candidate_counts: {
+        'registration-deadline':
+          candidateCounts['registration-deadline'] -
+          submittedCandidateCounts['registration-deadline'],
+        'provider-health-failed':
+          candidateCounts['provider-health-failed'] -
+          submittedCandidateCounts['provider-health-failed'],
+      },
       start_index: start,
       next_start_index: context.terminationCandidateCursor,
     },
@@ -578,9 +657,75 @@ function selectTerminationCandidateWindow(
 function deduplicateTerminationCandidates(
   candidates: readonly ProviderTerminationCandidateDto[],
 ): ProviderTerminationCandidateDto[] {
-  return [
-    ...new Map(candidates.map((candidate) => [candidate.provider_runner_id, candidate])).values(),
-  ];
+  const candidatesByRunnerId = new Map<string, ProviderTerminationCandidateDto>();
+  for (const candidate of candidates) {
+    const existing = candidatesByRunnerId.get(candidate.provider_runner_id);
+    if (!existing || candidate.reason === 'registration-deadline')
+      candidatesByRunnerId.set(candidate.provider_runner_id, candidate);
+  }
+  return [...candidatesByRunnerId.values()];
+}
+
+function terminationCandidateReasonCounts(
+  candidates: readonly ProviderTerminationCandidateDto[],
+): TerminationCandidateReasonCounts {
+  const counts: TerminationCandidateReasonCounts = {
+    'registration-deadline': 0,
+    'provider-health-failed': 0,
+  };
+  for (const candidate of candidates) counts[candidate.reason] += 1;
+  return counts;
+}
+
+function pruneRegistrationDeadlineAuthorizationAttempts(
+  context: Ec2LifecycleContext,
+  candidates: readonly ProviderTerminationCandidateDto[],
+): void {
+  const candidateIds = new Set(candidates.map((candidate) => candidate.provider_runner_id));
+  for (const providerRunnerId of context.registrationDeadlineAuthorizationAttempts.keys()) {
+    if (!candidateIds.has(providerRunnerId))
+      context.registrationDeadlineAuthorizationAttempts.delete(providerRunnerId);
+  }
+}
+
+function recordRegistrationDeadlineAuthorizationAttempts(
+  context: Ec2LifecycleContext,
+  candidates: readonly ProviderTerminationCandidateDto[],
+): void {
+  const attemptedAt = context.now().getTime();
+  for (const candidate of candidates) {
+    const previous = context.registrationDeadlineAuthorizationAttempts.get(
+      candidate.provider_runner_id,
+    );
+    const attempt = previous
+      ? {firstAttemptAt: previous.firstAttemptAt, attemptCount: previous.attemptCount + 1}
+      : {firstAttemptAt: attemptedAt, attemptCount: 1};
+    context.registrationDeadlineAuthorizationAttempts.set(candidate.provider_runner_id, attempt);
+    if (attempt.attemptCount % REGISTRATION_DEADLINE_AUTHORIZATION_WARNING_ATTEMPTS !== 0) continue;
+    logger().warn(
+      {
+        event: 'provisioner.ec2.registration_deadline_authorization_waiting',
+        provider_runner_id: candidate.provider_runner_id,
+        attempt_count: attempt.attemptCount,
+        first_attempt_at: new Date(attempt.firstAttemptAt).toISOString(),
+        age_ms: Math.max(0, attemptedAt - attempt.firstAttemptAt),
+        termination_authorization: 'backend-gated',
+      },
+      'EC2 registration deadline candidate is still waiting for backend authorization',
+    );
+  }
+}
+
+function clearAuthorizedRegistrationDeadlineAttempts(
+  context: Ec2LifecycleContext,
+  candidates: readonly ProviderTerminationCandidateDto[],
+  runners: readonly ReconcileRunnerInstancesResponseDto['runners'][number][],
+): void {
+  const submittedIds = new Set(candidates.map((candidate) => candidate.provider_runner_id));
+  for (const runner of runners) {
+    if (runner.desired_intent === 'terminate' && submittedIds.has(runner.provider_runner_id))
+      context.registrationDeadlineAuthorizationAttempts.delete(runner.provider_runner_id);
+  }
 }
 
 function healthObservations(instance: Ec2InstanceView): Ec2HealthObservation[] {

--- a/libs/provisioner/ec2/src/metrics/instance.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.ts
@@ -1,3 +1,4 @@
+import type {TerminationReasonDto} from '@shipfox/api-runners-dto';
 import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
 const meter = instanceMetrics.getMeter('provisioner-ec2');
@@ -33,11 +34,7 @@ const launchCount = meter.createCounter<{
 
 const terminateCount = meter.createCounter<{
   template_key: string;
-  reason:
-    | 'backend-terminate'
-    | 'registration-deadline'
-    | 'spot-interruption'
-    | 'observed-terminated';
+  reason: Ec2TerminationReason;
 }>('ec2_provisioner_terminate', {
   description: 'EC2 runner instance terminations by template and reason',
 });
@@ -93,6 +90,7 @@ const pendingDuration = meter.createHistogram<{
 
 export type Ec2LaunchOutcome = 'launched' | 'capacity' | 'throttled' | 'error';
 export type Ec2TerminationReason =
+  | TerminationReasonDto
   | 'backend-terminate'
   | 'registration-deadline'
   | 'spot-interruption'


### PR DESCRIPTION
Registration-deadline EC2 instances now submit a bounded termination candidate during reconciliation and remain outside usable capacity until the backend issues durable authorization. This removes the provider's direct termination fallback when the API is unavailable and preserves the authorization reason in terminal reporting and telemetry.

The change reuses the existing backend candidate/reconciliation contract and adds coverage for observation, failed authorization, and idempotent authorized termination.

Closes ENG-1774

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registration-deadline EC2 instances now terminate only after backend authorization. The provider submits them as termination candidates during reconciliation and keeps them out of usable capacity until approved, replacing the direct termination fallback used when the API was unavailable.

- The runners API authorizes deadline candidates without a workspace assignment and accepts candidate-only requests that skip absence reconciliation; when the observed runner count exceeds the API limit, the provider still submits candidates through this path.
- Enable `RUNNER_TERMINATION_REASON_REGISTRATION_DEADLINE_ENABLED` in the runners API before deploying; it defaults to false, so overdue instances stay out of capacity without terminating.
- Terminal reports and telemetry preserve the backend's authorization reason when present.
- Documents operator cleanup steps for overdue instances without a provider runner ID; the provider never bypasses backend authorization.
- Adds coverage for observation, failed authorization, and idempotent authorized termination.

Closes ENG-1774.

<sup>Written for commit 2faa11f75ce21bacd27a4b3d5ff95b1d47fd75e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

