### PR TITLE
Build server-owned GitHub search scope

### DIFF
--- a/.changeset/github-search-scope.md
+++ b/.changeset/github-search-scope.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-integration-spi": minor
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github": patch
+---
+
+Build GitHub issue and pull request search queries from server-owned repository scope.

--- a/.changeset/github-search-scope.md
+++ b/.changeset/github-search-scope.md
@@ -1,7 +1,8 @@
 ---
 "@shipfox/api-integration-spi": minor
+"@shipfox/api-integration-core-dto": patch
 "@shipfox/api-integration-core": patch
 "@shipfox/api-integration-github": patch
 ---
 
-Build GitHub issue and pull request search queries from server-owned repository scope.
+Build GitHub issue and pull request search queries from server-owned repository scope, driven by a new repository-scope classifier on agent tool catalog entries.

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -6,6 +6,7 @@ import {
 describe('integrationsInterModuleContract', () => {
   test('owns the repository authorization error codes', () => {
     expect(repositoryAuthorizationErrorCodes).toEqual({
+      required: 'repository-required',
       notGranted: 'repository-not-granted',
       ambiguous: 'repository-ambiguous',
       storeUnavailable: 'repository-authorization-unavailable',
@@ -190,6 +191,7 @@ describe('integrationsInterModuleContract', () => {
   });
 
   test.each([
+    'repository-required',
     'repository-not-granted',
     'repository-ambiguous',
     'repository-authorization-unavailable',
@@ -374,6 +376,7 @@ describe('integrationsInterModuleContract', () => {
   });
 
   test.each([
+    'repository-required',
     'repository-not-granted',
     'repository-ambiguous',
     'repository-authorization-unavailable',

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -116,6 +116,7 @@ const toolCallOutcome = z.discriminatedUnion('outcome', [
   }),
 ]);
 export const repositoryAuthorizationErrorCodes = {
+  required: 'repository-required',
   notGranted: 'repository-not-granted',
   ambiguous: 'repository-ambiguous',
   storeUnavailable: 'repository-authorization-unavailable',
@@ -127,6 +128,7 @@ const repositoryAuthorizationDetails = z.object({
   target: checkoutTarget.optional(),
 });
 const repositoryAuthorizationErrors = {
+  [repositoryAuthorizationErrorCodes.required]: repositoryAuthorizationDetails,
   [repositoryAuthorizationErrorCodes.notGranted]: repositoryAuthorizationDetails,
   [repositoryAuthorizationErrorCodes.ambiguous]: repositoryAuthorizationDetails,
   [repositoryAuthorizationErrorCodes.storeUnavailable]: repositoryAuthorizationDetails,

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -431,6 +431,7 @@ describe('repository authorization', () => {
 
   it('publishes closed client error codes for each denial reason', () => {
     expect(repositoryAuthorizationClientErrorCodes).toEqual({
+      repository_required: 'repository-required',
       repository_not_granted: 'repository-not-granted',
       repository_ambiguous: 'repository-ambiguous',
       authorization_store_unavailable: 'repository-authorization-unavailable',

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -29,11 +29,13 @@ export type RepositoryAuthorizationTarget =
   | RepositoryAuthorizationNameTarget;
 
 export type RepositoryAuthorizationDenial =
+  | 'repository_required'
   | 'repository_not_granted'
   | 'repository_ambiguous'
   | 'authorization_store_unavailable';
 
 export const repositoryAuthorizationClientErrorCodes = {
+  repository_required: repositoryAuthorizationErrorCodes.required,
   repository_not_granted: repositoryAuthorizationErrorCodes.notGranted,
   repository_ambiguous: repositoryAuthorizationErrorCodes.ambiguous,
   authorization_store_unavailable: repositoryAuthorizationErrorCodes.storeUnavailable,

--- a/libs/api/integration/core/src/core/tool-call-audit.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-audit.test.ts
@@ -140,6 +140,29 @@ describe('integration tool call audit', () => {
     expect(JSON.stringify(logInfo.mock.calls)).not.toContain('must-not-appear');
   });
 
+  it('records search qualifier conflicts as a bounded metric error label', () => {
+    const recordMetric = vi.fn();
+    const logInfo = vi.fn();
+    const recorder = createIntegrationToolCallRecorder(agentCaller, {recordMetric, logInfo});
+
+    recorder({
+      authorizedTool: auditTarget(),
+      arguments: {query: 'org:other-org'},
+      method: 'none',
+      outcome: 'tool-error',
+      errorCode: 'search-qualifier-conflict',
+    });
+
+    expect(recordMetric).toHaveBeenCalledWith({
+      caller: 'agent',
+      provider: 'github',
+      tool: 'issue_read',
+      method: 'none',
+      outcome: 'tool-error',
+      error_code: 'search-qualifier-conflict',
+    });
+  });
+
   it('records repository authorization fields and bounded authorization labels', () => {
     const recordMetric = vi.fn();
     const recordAuthorizationMetric = vi.fn();

--- a/libs/api/integration/core/src/core/tool-call-service.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.test.ts
@@ -474,20 +474,90 @@ describe('callIntegrationTool', () => {
     expect(result).toMatchObject({
       outcome: 'error',
       error: {
-        code: 'repository-not-granted',
-        message: 'Repository is not authorized for this integration connection',
+        code: 'repository-required',
+        message: 'Selected repository access requires owner and repo parameters',
       },
       authorization: {
         repositories: [],
         classification: 'connection',
         repositoryAccess: 'selected',
         decision: 'denied',
-        denialReason: 'repository_not_granted',
+        denialReason: 'repository_required',
         targetProjectIds: [],
       },
     });
     expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
     expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps explicit-repository calls available for an unclassified provider', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({kind: 'connection', requiresExplicitRepository: true}),
+    });
+    const resolveRepositoryAuthorization = vi.fn();
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'unclassified',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        repositories: [],
+        classification: 'unclassified',
+        repositoryAccess: 'selected',
+        decision: 'not-applicable',
+        denialReason: 'none',
+        targetProjectIds: [],
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).toHaveBeenCalledOnce();
+  });
+
+  it('keeps explicit-repository calls available when the authorizer is disabled', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({kind: 'connection', requiresExplicitRepository: true}),
+    });
+    const resolveRepositoryAuthorization = vi.fn();
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: false,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        repositories: [],
+        classification: 'connection',
+        repositoryAccess: 'selected',
+        decision: 'not-enforced',
+        denialReason: 'none',
+        targetProjectIds: [],
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).toHaveBeenCalledOnce();
   });
 
   it('keeps provider-unclassified calls available while recording declared targets', async () => {

--- a/libs/api/integration/core/src/core/tool-call-service.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.test.ts
@@ -451,6 +451,45 @@ describe('callIntegrationTool', () => {
     expect(onOpenSession).toHaveBeenCalledTimes(1);
   });
 
+  it('denies selected calls that require an explicit repository without an authorization lookup', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({kind: 'connection', requiresExplicitRepository: true}),
+    });
+    const resolveRepositoryAuthorization = vi.fn();
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput({onOpenSession}, {registry, catalogEntry: entry, repositoryAuthorizer}),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'error',
+      error: {
+        code: 'repository-not-granted',
+        message: 'Repository is not authorized for this integration connection',
+      },
+      authorization: {
+        repositories: [],
+        classification: 'connection',
+        repositoryAccess: 'selected',
+        decision: 'denied',
+        denialReason: 'repository_not_granted',
+        targetProjectIds: [],
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).not.toHaveBeenCalled();
+  });
+
   it('keeps provider-unclassified calls available while recording declared targets', async () => {
     const onOpenSession = vi.fn();
     const entry = catalogWithRepositoryScope(declaredRepositoryScope);
@@ -552,6 +591,49 @@ describe('callIntegrationTool', () => {
     expect(resolveRepositoryAuthorization).toHaveBeenCalledWith(
       expect.objectContaining({mode: 'all'}),
     );
+  });
+
+  it('keeps an explicit-repository connection scope available in all mode', async () => {
+    const onOpenSession = vi.fn();
+    const entry = catalogTool({
+      methods: undefined,
+      repositoryScope: () => ({kind: 'connection', requiresExplicitRepository: true}),
+    });
+    const resolveRepositoryAuthorization = vi.fn();
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {
+      repositoryAuthorization: 'enforced',
+      onOpenSession,
+    });
+
+    const result = await callIntegrationTool(
+      createInput(
+        {onOpenSession},
+        {
+          registry,
+          catalogEntry: entry,
+          repositoryAccessMode: 'all',
+          repositoryAuthorizer,
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {
+        repositories: [],
+        classification: 'connection',
+        repositoryAccess: 'all',
+        decision: 'not-applicable',
+        denialReason: 'none',
+        targetProjectIds: [],
+      },
+    });
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(onOpenSession).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -952,6 +1034,30 @@ describe('callIntegrationTool', () => {
         message: 'Rate limited',
         retryAfterSeconds: 30,
         status: 429,
+      },
+    });
+    expect(serviceMocks.loggerError).not.toHaveBeenCalled();
+    expect(serviceMocks.reportError).not.toHaveBeenCalled();
+  });
+
+  it('preserves the search qualifier conflict code from a provider tool error', async () => {
+    const result = await callIntegrationTool(
+      createInput({
+        result: {
+          isError: true,
+          content: [
+            {type: 'text', text: 'Search query cannot contain repo:, org:, or user: qualifiers'},
+          ],
+          structuredContent: {code: 'search-qualifier-conflict'},
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: {
+        code: 'search-qualifier-conflict',
+        message: 'Search query cannot contain repo:, org:, or user: qualifiers',
       },
     });
     expect(serviceMocks.loggerError).not.toHaveBeenCalled();

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -232,17 +232,11 @@ async function resolveIntegrationToolAuthorization(
     scope,
   );
 
-  if (
-    input.repositoryAuthorizer?.enabled === true &&
-    provider.repositoryAuthorization === 'enforced' &&
-    mode === 'selected' &&
-    scope.kind === 'connection' &&
-    scope.requiresExplicitRepository === true
-  ) {
+  if (requiresExplicitRepositoryDenial(input, provider.repositoryAuthorization, mode, scope)) {
     return {
       ...authorization,
       decision: 'denied',
-      denialReason: 'repository_not_granted',
+      denialReason: 'repository_required',
     };
   }
 
@@ -250,6 +244,21 @@ async function resolveIntegrationToolAuthorization(
     return authorization;
   }
   return await authorizeDeclaredTargets(input, mode, scope, authorization);
+}
+
+function requiresExplicitRepositoryDenial(
+  input: IntegrationToolCallInput,
+  providerAuthorization: 'enforced' | 'unclassified' | undefined,
+  mode: RepositoryAuthorizationMode,
+  scope: ClassifiedToolCallScope,
+): boolean {
+  return (
+    input.repositoryAuthorizer?.enabled === true &&
+    providerAuthorization === 'enforced' &&
+    mode === 'selected' &&
+    scope.kind === 'connection' &&
+    scope.requiresExplicitRepository === true
+  );
 }
 
 function createBaseAuthorization(
@@ -423,6 +432,8 @@ function runProjectId(caller: IntegrationToolCallCaller): string | undefined {
 
 function repositoryAuthorizationErrorMessage(reason: RepositoryAuthorizationDenial): string {
   switch (reason) {
+    case 'repository_required':
+      return 'Selected repository access requires owner and repo parameters';
     case 'repository_not_granted':
       return 'Repository is not authorized for this integration connection';
     case 'repository_ambiguous':

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -232,6 +232,20 @@ async function resolveIntegrationToolAuthorization(
     scope,
   );
 
+  if (
+    input.repositoryAuthorizer?.enabled === true &&
+    provider.repositoryAuthorization === 'enforced' &&
+    mode === 'selected' &&
+    scope.kind === 'connection' &&
+    scope.requiresExplicitRepository === true
+  ) {
+    return {
+      ...authorization,
+      decision: 'denied',
+      denialReason: 'repository_not_granted',
+    };
+  }
+
   if (!shouldAuthorizeDeclaredTargets(input, provider.repositoryAuthorization, scope)) {
     return authorization;
   }

--- a/libs/api/integration/core/src/metrics/instance.ts
+++ b/libs/api/integration/core/src/metrics/instance.ts
@@ -23,17 +23,18 @@ export type IntegrationToolRepositoryDecision =
   | 'not-enforced';
 export type IntegrationToolRepositoryDenialReason =
   | 'none'
+  | 'repository_required'
   | 'repository_not_granted'
   | 'repository_ambiguous'
   | 'authorization_store_unavailable';
 
 export type IntegrationAgentToolCallErrorCode =
   | 'invalid-request'
-  | 'search-qualifier-conflict'
   | 'unknown'
   | 'provider-timeout'
   | 'cancelled'
   | 'credentials-unavailable'
+  | 'repository-required'
   | 'repository-not-granted'
   | 'repository-ambiguous'
   | 'repository-authorization-unavailable'
@@ -61,6 +62,7 @@ const integrationAgentToolCallErrorCodes = new Set<string>([
   'malformed-provider-response',
   'content-too-large',
   'too-many-files',
+  'repository-required',
   'repository-not-granted',
   'repository-ambiguous',
   'repository-authorization-unavailable',

--- a/libs/api/integration/core/src/metrics/instance.ts
+++ b/libs/api/integration/core/src/metrics/instance.ts
@@ -29,6 +29,7 @@ export type IntegrationToolRepositoryDenialReason =
 
 export type IntegrationAgentToolCallErrorCode =
   | 'invalid-request'
+  | 'search-qualifier-conflict'
   | 'unknown'
   | 'provider-timeout'
   | 'cancelled'
@@ -42,6 +43,7 @@ export type IntegrationAgentToolCallErrorLabel = IntegrationAgentToolCallErrorCo
 
 const integrationAgentToolCallErrorCodes = new Set<string>([
   'invalid-request',
+  'search-qualifier-conflict',
   'unknown',
   'provider-timeout',
   'cancelled',

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -165,6 +165,7 @@ describe('integrations inter-module presentation', () => {
   });
 
   it.each([
+    ['repository_required', 'repository-required'],
     ['repository_not_granted', 'repository-not-granted'],
     ['repository_ambiguous', 'repository-ambiguous'],
     ['authorization_store_unavailable', 'repository-authorization-unavailable'],

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -33,8 +33,11 @@ import {buildFixedEventProviders, buildProviderEventCatalogs} from '#core/event-
 import type {AgentToolCatalogEntry} from '#core/providers/agent-tools.js';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {CheckoutSpec, CheckoutTarget} from '#core/providers/source-control.js';
-import type {RepositoryAuthorizer} from '#core/repository-authorizer.js';
-import {RepositoryAuthorizationTargetInvalidError} from '#core/repository-authorizer.js';
+import {
+  RepositoryAuthorizationTargetInvalidError,
+  type RepositoryAuthorizer,
+  repositoryAuthorizationClientErrorCodes,
+} from '#core/repository-authorizer.js';
 import type {
   AuthorizedCheckoutSpec,
   IntegrationSourceControlService,
@@ -542,24 +545,9 @@ function mapRepositoryAuthorizationError(
   }
   if (!(error instanceof IntegrationRepositoryAuthorizationError)) return undefined;
 
-  switch (error.reason) {
-    case 'repository_not_granted':
-      if ('repository-not-granted' in method.errors) {
-        return createInterModuleKnownError(method, 'repository-not-granted', details);
-      }
-      break;
-    case 'repository_ambiguous':
-      if ('repository-ambiguous' in method.errors) {
-        return createInterModuleKnownError(method, 'repository-ambiguous', details);
-      }
-      break;
-    case 'authorization_store_unavailable':
-      if ('repository-authorization-unavailable' in method.errors) {
-        return createInterModuleKnownError(method, 'repository-authorization-unavailable', details);
-      }
-      break;
-  }
-  return undefined;
+  const code = repositoryAuthorizationClientErrorCodes[error.reason];
+  if (!(code in method.errors)) return undefined;
+  return createInterModuleKnownError(method, code as keyof typeof method.errors & string, details);
 }
 
 function repositoryAuthorizationDetails(input: ErrorMappingInput) {

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -45,7 +45,10 @@ const terminalMintErrorReasons = new Set<IntegrationProviderErrorReason>([
 // observes; keep them out of the envelope schema and acknowledge them here.
 type MissingProviderErrorReason = Exclude<
   IntegrationProviderErrorReason,
-  (typeof providerErrorReasons)[number] | 'ref-not-found' | 'ref-invalid'
+  | (typeof providerErrorReasons)[number]
+  | 'ref-not-found'
+  | 'ref-invalid'
+  | 'search-qualifier-conflict'
 >;
 const providerErrorReasonSchemaCoversUnion: Record<MissingProviderErrorReason, never> = {};
 void providerErrorReasonSchemaCoversUnion;

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -634,6 +634,8 @@ describe('github agent tool catalog', () => {
     expect(searchIssues?.repositoryScope({query: 'is:open'})).toEqual({
       kind: 'connection',
       requiresExplicitRepository: true,
+      indirectTargetNote:
+        'The free-form query may match results in repositories other than the declared target.',
     });
     expect(
       searchPullRequests?.repositoryScope({
@@ -987,6 +989,37 @@ describe('github agent tool catalog', () => {
   });
 
   it.each([
+    {toolId: 'search_issues', query: ''},
+    {toolId: 'search_issues', query: '   '},
+    {toolId: 'search_pull_requests', query: ''},
+    {toolId: 'search_pull_requests', query: '   '},
+  ] as const)('rejects an empty query for $toolId', async ({toolId, query}) => {
+    const request = vi.fn();
+    const result = await callGithubToolWithRequest(toolId, {query}, request);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Parameter query must be a non-empty string'}],
+      structuredContent: {code: 'invalid-request'},
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'search_issues',
+    'search_pull_requests',
+  ] as const)('allows scope-like text inside quoted $0 searches', async (toolId) => {
+    const request = vi.fn(() => Promise.resolve({data: {items: []}}));
+    const query = 'label:"org:planning" "repo:managers"';
+
+    await callGithubToolWithRequest(toolId, {query, owner: 'shipfox', repo: 'platform'}, request);
+
+    expect(request).toHaveBeenCalledWith('GET /search/issues', {
+      q: [query, 'repo:shipfox/platform'].join(' '),
+    });
+  });
+
+  it.each([
     {toolId: 'search_issues', qualifier: 'repo:other/repository'},
     {toolId: 'search_issues', qualifier: 'org:other-org'},
     {toolId: 'search_issues', qualifier: 'user:other-user'},
@@ -1012,6 +1045,41 @@ describe('github agent tool catalog', () => {
   });
 
   it.each([
+    {
+      toolId: 'search_issues',
+      query: 'is:open ORG:other-org',
+      arguments_: {owner: 'shipfox', repo: 'platform'},
+    },
+    {
+      toolId: 'search_pull_requests',
+      query: 'is:open REPO:other/repository',
+      arguments_: {owner: 'shipfox', repo: 'platform'},
+    },
+    {
+      toolId: 'search_issues',
+      query: 'is:open org:other-org',
+      arguments_: {},
+    },
+    {
+      toolId: 'search_pull_requests',
+      query: 'is:open USER:other-user',
+      arguments_: {},
+    },
+  ] as const)('rejects an untrusted qualifier for $toolId', async ({toolId, query, arguments_}) => {
+    const request = vi.fn();
+    const result = await callGithubToolWithRequest(toolId, {query, ...arguments_}, request);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {type: 'text', text: 'Search query cannot contain repo:, org:, or user: qualifiers'},
+      ],
+      structuredContent: {code: 'search-qualifier-conflict'},
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each([
     'search_issues',
     'search_pull_requests',
   ] as const)('rejects an unpaired repository for $0', async (toolId) => {
@@ -1025,6 +1093,38 @@ describe('github agent tool catalog', () => {
     expect(result).toEqual({
       isError: true,
       content: [{type: 'text', text: 'Parameters owner and repo must be provided together'}],
+      structuredContent: {code: 'invalid-request'},
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {toolId: 'search_issues', field: 'owner', value: 'ship fox'},
+    {toolId: 'search_issues', field: 'repo', value: 'platform/repository'},
+    {toolId: 'search_issues', field: 'repo', value: 'platform:repository'},
+    {toolId: 'search_pull_requests', field: 'owner', value: 'ship fox'},
+    {toolId: 'search_pull_requests', field: 'repo', value: 'platform/repository'},
+    {toolId: 'search_pull_requests', field: 'repo', value: 'platform:repository'},
+  ] as const)('rejects invalid repository name parts for $toolId', async ({
+    toolId,
+    field,
+    value,
+  }) => {
+    const request = vi.fn();
+    const arguments_: Record<string, unknown> = {
+      query: 'is:open',
+      owner: 'shipfox',
+      repo: 'platform',
+    };
+    arguments_[field] = value;
+
+    const result = await callGithubToolWithRequest(toolId, arguments_, request);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {type: 'text', text: 'Parameters owner and repo must be valid repository name parts'},
+      ],
       structuredContent: {code: 'invalid-request'},
     });
     expect(request).not.toHaveBeenCalled();

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -610,6 +610,10 @@ describe('github agent tool catalog', () => {
   it('classifies every catalog entry with a pure repository scope classifier', () => {
     const issueRead = githubAgentToolCatalog.find((entry) => entry.id === 'issue_read');
     const issueTypes = githubAgentToolCatalog.find((entry) => entry.id === 'list_issue_types');
+    const searchIssues = githubAgentToolCatalog.find((entry) => entry.id === 'search_issues');
+    const searchPullRequests = githubAgentToolCatalog.find(
+      (entry) => entry.id === 'search_pull_requests',
+    );
     const reviewThread = githubAgentToolCatalog.find(
       (entry) => entry.id === 'pull_request_review_thread_write',
     );
@@ -624,6 +628,20 @@ describe('github agent tool catalog', () => {
     });
     expect(issueTypes?.repositoryScope({owner: 'shipfox'})).toEqual({kind: 'connection'});
     expect(issueTypes?.repositoryScope({owner: 'shipfox', repo: 'platform'})).toEqual({
+      kind: 'declared-targets',
+      repositories: [{owner: 'shipfox', name: 'platform'}],
+    });
+    expect(searchIssues?.repositoryScope({query: 'is:open'})).toEqual({
+      kind: 'connection',
+      requiresExplicitRepository: true,
+    });
+    expect(
+      searchPullRequests?.repositoryScope({
+        query: 'is:open',
+        owner: 'shipfox',
+        repo: 'platform',
+      }),
+    ).toEqual({
       kind: 'declared-targets',
       repositories: [{owner: 'shipfox', name: 'platform'}],
     });
@@ -778,8 +796,16 @@ describe('github agent tool catalog', () => {
     const actionsRunTriggerSchema = inputSchemaFor('actions_run_trigger');
     const getJobLogsSchema = inputSchemaFor('get_job_logs');
     const createCommitSchema = inputSchemaFor('create_commit');
+    const searchIssuesSchema = inputSchemaFor('search_issues');
+    const searchPullRequestsSchema = inputSchemaFor('search_pull_requests');
 
     expect(listIssueTypesSchema.required).toEqual(['owner']);
+    const searchRepositoryPairSchema = [
+      {required: ['owner', 'repo']},
+      {not: {anyOf: [{required: ['owner']}, {required: ['repo']}]}},
+    ];
+    expect(searchIssuesSchema.oneOf).toEqual(searchRepositoryPairSchema);
+    expect(searchPullRequestsSchema.oneOf).toEqual(searchRepositoryPairSchema);
     expect(updatePullRequestSchema.properties).not.toHaveProperty('draft');
     expect(addIssueCommentSchema.anyOf).toEqual([
       {required: ['issue_number', 'body']},
@@ -909,6 +935,99 @@ describe('github agent tool catalog', () => {
       content: [{type: 'text', text: '{"number":1}'}],
       structuredContent: {number: 1},
     });
+  });
+
+  it.each([
+    {toolId: 'search_issues', outputKey: 'issues'},
+    {toolId: 'search_pull_requests', outputKey: 'pull_requests'},
+  ] as const)('builds a server-owned repository-scoped $toolId query', async ({
+    toolId,
+    outputKey,
+  }) => {
+    const request = vi.fn(() => Promise.resolve({data: {items: []}}));
+
+    const result = await callGithubToolWithRequest(
+      toolId,
+      {
+        query: 'is:open',
+        owner: 'shipfox',
+        repo: 'platform',
+        sort: 'updated',
+        order: 'desc',
+        page: 2,
+        per_page: 20,
+      },
+      request,
+    );
+
+    expect(result).toMatchObject({structuredContent: {[outputKey]: []}});
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith('GET /search/issues', {
+      q: 'is:open repo:shipfox/platform',
+      sort: 'updated',
+      order: 'desc',
+      page: 2,
+      per_page: 20,
+    });
+  });
+
+  it.each([
+    'search_issues',
+    'search_pull_requests',
+  ] as const)('projects an unpaired $0 search without repository parameters', async (toolId) => {
+    const request = vi.fn(() => Promise.resolve({data: {items: []}}));
+
+    await callGithubToolWithRequest(toolId, {query: 'is:open', page: 2, per_page: 20}, request);
+
+    expect(request).toHaveBeenCalledWith('GET /search/issues', {
+      q: 'is:open',
+      page: 2,
+      per_page: 20,
+    });
+  });
+
+  it.each([
+    {toolId: 'search_issues', qualifier: 'repo:other/repository'},
+    {toolId: 'search_issues', qualifier: 'org:other-org'},
+    {toolId: 'search_issues', qualifier: 'user:other-user'},
+    {toolId: 'search_pull_requests', qualifier: 'repo:other/repository'},
+    {toolId: 'search_pull_requests', qualifier: 'org:other-org'},
+    {toolId: 'search_pull_requests', qualifier: 'user:other-user'},
+  ] as const)('rejects a conflicting qualifier for $toolId', async ({toolId, qualifier}) => {
+    const request = vi.fn();
+    const result = await callGithubToolWithRequest(
+      toolId,
+      {query: `is:open ${qualifier}`, owner: 'shipfox', repo: 'platform'},
+      request,
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {type: 'text', text: 'Search query cannot contain repo:, org:, or user: qualifiers'},
+      ],
+      structuredContent: {code: 'search-qualifier-conflict'},
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'search_issues',
+    'search_pull_requests',
+  ] as const)('rejects an unpaired repository for $0', async (toolId) => {
+    const request = vi.fn();
+    const result = await callGithubToolWithRequest(
+      toolId,
+      {query: 'is:open', owner: 'shipfox'},
+      request,
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Parameters owner and repo must be provided together'}],
+      structuredContent: {code: 'invalid-request'},
+    });
+    expect(request).not.toHaveBeenCalled();
   });
 
   it('derives the token profile from live catalog ids and method allowlists', async () => {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -5,6 +5,7 @@ import type {
   AgentToolSession,
   AgentToolsProvider,
   IntegrationConnection,
+  IntegrationProviderErrorReason,
   OpenAgentToolsSessionInput,
 } from '@shipfox/api-integration-spi';
 import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-spi';
@@ -58,12 +59,7 @@ type GithubToolCallResult = {
   structuredContent?: Record<string, unknown> | undefined;
 };
 
-type GithubToolErrorCode =
-  | 'invalid-request'
-  | 'search-qualifier-conflict'
-  | 'access-denied'
-  | 'provider-rejected'
-  | 'malformed-provider-response';
+type GithubToolErrorCode = 'invalid-request' | IntegrationProviderErrorReason;
 
 const GITHUB_GRAPHQL_ROUTE = 'POST /graphql';
 const GITHUB_ARTIFACT_ARCHIVE_FORMAT = 'zip';
@@ -810,7 +806,9 @@ function projectGithubSearchOperationParameters(
   return {
     ...parameters,
     q:
-      typeof query === 'string' && query.length > 0 ? `${query} ${scopeQualifier}` : scopeQualifier,
+      typeof query === 'string' && query.trim().length > 0
+        ? [query, scopeQualifier].join(' ')
+        : scopeQualifier,
   };
 }
 
@@ -1392,8 +1390,8 @@ interface GithubToolValidationError {
 function validateGithubSearchArguments(
   arguments_: Record<string, unknown>,
 ): GithubToolValidationError | undefined {
-  if (typeof arguments_.query !== 'string') {
-    return {message: 'Parameter query must be a string', code: 'invalid-request'};
+  if (typeof arguments_.query !== 'string' || arguments_.query.trim().length === 0) {
+    return {message: 'Parameter query must be a non-empty string', code: 'invalid-request'};
   }
 
   const hasOwner = arguments_.owner !== undefined;
@@ -1416,7 +1414,17 @@ function validateGithubSearchArguments(
       code: 'invalid-request',
     };
   }
-  if (GITHUB_SEARCH_SCOPE_QUALIFIER_PATTERN.test(arguments_.query)) {
+  if (
+    hasOwner &&
+    (GITHUB_REPOSITORY_PART_UNSAFE_PATTERN.test(arguments_.owner as string) ||
+      GITHUB_REPOSITORY_PART_UNSAFE_PATTERN.test(arguments_.repo as string))
+  ) {
+    return {
+      message: 'Parameters owner and repo must be valid repository name parts',
+      code: 'invalid-request',
+    };
+  }
+  if (hasUnquotedGithubSearchScopeQualifier(arguments_.query)) {
     return {
       message: 'Search query cannot contain repo:, org:, or user: qualifiers',
       code: 'search-qualifier-conflict',
@@ -1434,7 +1442,34 @@ function validateGithubArgument(name: string, value: unknown, schema: unknown): 
   return undefined;
 }
 
-const GITHUB_SEARCH_SCOPE_QUALIFIER_PATTERN = /\b(?:repo|org|user):/iu;
+const GITHUB_REPOSITORY_PART_UNSAFE_PATTERN = /[\s/:\\]/u;
+const GITHUB_SEARCH_SCOPE_QUALIFIER_PATTERN = /(?:^|\s)-?(?:repo|org|user):/iu;
+
+function hasUnquotedGithubSearchScopeQualifier(query: string): boolean {
+  let quoted = false;
+  let escaped = false;
+  let unquotedQuery = '';
+
+  for (const character of query) {
+    if (escaped) {
+      if (!quoted) unquotedQuery += character;
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      if (!quoted) unquotedQuery += character;
+      escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted) unquotedQuery += character;
+  }
+
+  return GITHUB_SEARCH_SCOPE_QUALIFIER_PATTERN.test(unquotedQuery);
+}
 
 function validateCreateCommitArguments(arguments_: Record<string, unknown>): string | undefined {
   const metadataError = validateCreateCommitMetadata(arguments_);

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -60,6 +60,7 @@ type GithubToolCallResult = {
 
 type GithubToolErrorCode =
   | 'invalid-request'
+  | 'search-qualifier-conflict'
   | 'access-denied'
   | 'provider-rejected'
   | 'malformed-provider-response';
@@ -218,7 +219,11 @@ export class GithubAgentToolsProvider
         if (operation === undefined)
           return githubToolError('Unknown GitHub tool operation', 'invalid-request');
         const validationError = validateGithubToolArguments(tool, call.arguments);
-        if (validationError) return githubToolError(validationError, 'invalid-request');
+        if (validationError) {
+          return typeof validationError === 'string'
+            ? githubToolError(validationError, 'invalid-request')
+            : githubToolError(validationError.message, validationError.code);
+        }
         tokenPromise ??= this.tokenProvider.getInstallationAccessToken(
           installationId,
           undefined,
@@ -778,6 +783,9 @@ export function projectGithubOperationParameters(
   method: string | undefined,
   args: Record<string, unknown>,
 ): Record<string, unknown> {
+  if (toolId === 'search_issues' || toolId === 'search_pull_requests') {
+    return projectGithubSearchOperationParameters(args);
+  }
   const parameters = {...args};
   if (toolId === 'add_issue_comment' && parameters.reaction !== undefined) {
     parameters.content = parameters.reaction;
@@ -788,6 +796,22 @@ export function projectGithubOperationParameters(
     parameters.headers = {accept: 'application/vnd.github.diff'};
   }
   return parameters;
+}
+
+function projectGithubSearchOperationParameters(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const {query, owner, repo, ...parameters} = args;
+  if (typeof owner !== 'string' || typeof repo !== 'string') {
+    return {...parameters, q: query};
+  }
+
+  const scopeQualifier = `repo:${owner}/${repo}`;
+  return {
+    ...parameters,
+    q:
+      typeof query === 'string' && query.length > 0 ? `${query} ${scopeQualifier}` : scopeQualifier,
+  };
 }
 
 async function resolveGithubOperationParameters(
@@ -1303,20 +1327,52 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function validateGithubToolArguments(
   tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
   arguments_: Record<string, unknown>,
+): string | GithubToolValidationError | undefined {
+  const missingParameter = validateMissingGithubToolArgument(tool.inputSchema, arguments_);
+  if (missingParameter !== undefined) return missingParameter;
+
+  const searchValidationError = validateGithubSearchArgumentsForTool(tool.id, arguments_);
+  if (searchValidationError !== undefined) return searchValidationError;
+
+  const argumentValidationError = validateGithubArgumentProperties(tool.inputSchema, arguments_);
+  if (argumentValidationError !== undefined) return argumentValidationError;
+
+  return tool.id === 'create_commit' ? validateCreateCommitArguments(arguments_) : undefined;
+}
+
+function validateMissingGithubToolArgument(
+  inputSchema: AgentToolCatalogEntry<GithubAgentToolRequiredScope>['inputSchema'],
+  arguments_: Record<string, unknown>,
 ): string | undefined {
-  const required = Array.isArray(tool.inputSchema.required) ? tool.inputSchema.required : [];
+  const required = Array.isArray(inputSchema.required) ? inputSchema.required : [];
   for (const name of required) {
     if (typeof name === 'string' && arguments_[name] === undefined) {
       return `Missing required parameter: ${name}`;
     }
   }
 
-  const methodRequired = methodRequiredParameters(tool.inputSchema, arguments_);
+  const methodRequired = methodRequiredParameters(inputSchema, arguments_);
   for (const name of methodRequired) {
     if (arguments_[name] === undefined) return `Missing required parameter: ${name}`;
   }
 
-  const properties = tool.inputSchema.properties;
+  return undefined;
+}
+
+function validateGithubSearchArgumentsForTool(
+  toolId: string,
+  arguments_: Record<string, unknown>,
+): GithubToolValidationError | undefined {
+  return toolId === 'search_issues' || toolId === 'search_pull_requests'
+    ? validateGithubSearchArguments(arguments_)
+    : undefined;
+}
+
+function validateGithubArgumentProperties(
+  inputSchema: AgentToolCatalogEntry<GithubAgentToolRequiredScope>['inputSchema'],
+  arguments_: Record<string, unknown>,
+): string | undefined {
+  const properties = inputSchema.properties;
   if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
     return undefined;
   }
@@ -1325,7 +1381,47 @@ function validateGithubToolArguments(
     const invalid = validateGithubArgument(name, value, propertySchemas[name]);
     if (invalid !== undefined) return invalid;
   }
-  if (tool.id === 'create_commit') return validateCreateCommitArguments(arguments_);
+  return undefined;
+}
+
+interface GithubToolValidationError {
+  message: string;
+  code: GithubToolErrorCode;
+}
+
+function validateGithubSearchArguments(
+  arguments_: Record<string, unknown>,
+): GithubToolValidationError | undefined {
+  if (typeof arguments_.query !== 'string') {
+    return {message: 'Parameter query must be a string', code: 'invalid-request'};
+  }
+
+  const hasOwner = arguments_.owner !== undefined;
+  const hasRepo = arguments_.repo !== undefined;
+  if (hasOwner !== hasRepo) {
+    return {
+      message: 'Parameters owner and repo must be provided together',
+      code: 'invalid-request',
+    };
+  }
+  if (hasOwner && (typeof arguments_.owner !== 'string' || typeof arguments_.repo !== 'string')) {
+    return {
+      message: 'Parameters owner and repo must be strings',
+      code: 'invalid-request',
+    };
+  }
+  if (hasOwner && (arguments_.owner === '' || arguments_.repo === '')) {
+    return {
+      message: 'Parameters owner and repo must be non-empty strings',
+      code: 'invalid-request',
+    };
+  }
+  if (GITHUB_SEARCH_SCOPE_QUALIFIER_PATTERN.test(arguments_.query)) {
+    return {
+      message: 'Search query cannot contain repo:, org:, or user: qualifiers',
+      code: 'search-qualifier-conflict',
+    };
+  }
   return undefined;
 }
 
@@ -1337,6 +1433,8 @@ function validateGithubArgument(name: string, value: unknown, schema: unknown): 
   if (schema.type === 'array' && !Array.isArray(value)) return `Parameter ${name} must be an array`;
   return undefined;
 }
+
+const GITHUB_SEARCH_SCOPE_QUALIFIER_PATTERN = /\b(?:repo|org|user):/iu;
 
 function validateCreateCommitArguments(arguments_: Record<string, unknown>): string | undefined {
   const metadataError = validateCreateCommitMetadata(arguments_);

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -85,6 +85,20 @@ const repositoryProperties = {
 
 const connectionRepositoryScope: GithubRepositoryScopeClassifier = () => ({kind: 'connection'});
 
+const searchRepositoryScope: GithubRepositoryScopeClassifier = (arguments_) => {
+  const owner = arguments_.owner;
+  const repo = arguments_.repo;
+  if (
+    typeof owner === 'string' &&
+    owner.length > 0 &&
+    typeof repo === 'string' &&
+    repo.length > 0
+  ) {
+    return {kind: 'declared-targets', repositories: [{owner, name: repo}]};
+  }
+  return {kind: 'connection', requiresExplicitRepository: true};
+};
+
 /** Classifies explicit repository coordinates without resolving them remotely. */
 export const githubRepositoryScope: GithubRepositoryScopeClassifier = (arguments_) => {
   const repositories: AgentToolRepositoryTarget[] = [];
@@ -162,9 +176,6 @@ const issueWriteMethods = [
   method('create', 'Create a new issue.', 'write', false, scopes.issuesWrite),
   method('update', 'Update an existing issue.', 'write', false, scopes.issuesWrite),
 ] as const satisfies readonly GithubAgentToolCatalogMethod[];
-
-const indirectSearchTargetNote =
-  'The free-form query may match results in repositories other than the declared target.';
 
 const subIssueIndirectTargetNote =
   'The opaque child and ordering IDs may refer to another repository in the GitHub installation.';
@@ -435,7 +446,7 @@ export const githubAgentToolCatalog = [
     sensitivity: 'read',
     sensitive: false,
     requiredScope: scopes.issuesRead,
-    indirectTargetNote: indirectSearchTargetNote,
+    repositoryScope: searchRepositoryScope,
     inputSchema: objectSchema(
       {
         query: stringSchema('Search query using GitHub issues search syntax'),
@@ -461,6 +472,12 @@ export const githubAgentToolCatalog = [
         ...pageProperties,
       },
       ['query'],
+      {
+        oneOf: [
+          {required: ['owner', 'repo']},
+          {not: {anyOf: [{required: ['owner']}, {required: ['repo']}]}},
+        ],
+      },
     ),
     outputSchema: objectSchema({issues: arraySchema(openObjectSchema('GitHub issue'))}, ['issues']),
   }),
@@ -605,7 +622,7 @@ export const githubAgentToolCatalog = [
     sensitivity: 'read',
     sensitive: false,
     requiredScope: scopes.pullRequestsRead,
-    indirectTargetNote: indirectSearchTargetNote,
+    repositoryScope: searchRepositoryScope,
     inputSchema: objectSchema(
       {
         query: stringSchema('Search query using GitHub pull request search syntax'),
@@ -631,6 +648,12 @@ export const githubAgentToolCatalog = [
         ...pageProperties,
       },
       ['query'],
+      {
+        oneOf: [
+          {required: ['owner', 'repo']},
+          {not: {anyOf: [{required: ['owner']}, {required: ['repo']}]}},
+        ],
+      },
     ),
     outputSchema: objectSchema(
       {pull_requests: arraySchema(openObjectSchema('GitHub pull request'))},

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -83,6 +83,9 @@ const repositoryProperties = {
   repo: stringSchema('Repository name'),
 };
 
+const indirectSearchTargetNote =
+  'The free-form query may match results in repositories other than the declared target.';
+
 const connectionRepositoryScope: GithubRepositoryScopeClassifier = () => ({kind: 'connection'});
 
 const searchRepositoryScope: GithubRepositoryScopeClassifier = (arguments_) => {
@@ -96,7 +99,11 @@ const searchRepositoryScope: GithubRepositoryScopeClassifier = (arguments_) => {
   ) {
     return {kind: 'declared-targets', repositories: [{owner, name: repo}]};
   }
-  return {kind: 'connection', requiresExplicitRepository: true};
+  return {
+    kind: 'connection',
+    requiresExplicitRepository: true,
+    indirectTargetNote: indirectSearchTargetNote,
+  };
 };
 
 /** Classifies explicit repository coordinates without resolving them remotely. */
@@ -442,16 +449,22 @@ export const githubAgentToolCatalog = [
     id: 'search_issues',
     category: 'issues',
     description:
-      'Search for issues in GitHub repositories using issues search syntax already scoped to is:issue',
+      'Search for issues in GitHub repositories using issues search syntax already scoped to is:issue. Provide owner and repo together for a repository-scoped search; omit both for a connection-scoped search. Do not include unquoted repo:, org:, or user: qualifiers; quoted occurrences are treated as literal text.',
     sensitivity: 'read',
     sensitive: false,
     requiredScope: scopes.issuesRead,
     repositoryScope: searchRepositoryScope,
     inputSchema: objectSchema(
       {
-        query: stringSchema('Search query using GitHub issues search syntax'),
-        owner: stringSchema('Optional repository owner'),
-        repo: stringSchema('Optional repository name'),
+        query: stringSchema(
+          'Search query using GitHub issues search syntax. Do not include unquoted repo:, org:, or user: qualifiers; quoted occurrences are treated as literal text.',
+        ),
+        owner: stringSchema(
+          'Optional repository owner. Provide together with repo, or omit both for a connection-scoped search.',
+        ),
+        repo: stringSchema(
+          'Optional repository name. Provide together with owner, or omit both for a connection-scoped search.',
+        ),
         sort: enumSchema(
           [
             'comments',
@@ -618,16 +631,22 @@ export const githubAgentToolCatalog = [
     id: 'search_pull_requests',
     category: 'pull_requests',
     description:
-      'Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr',
+      'Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr. Provide owner and repo together for a repository-scoped search; omit both for a connection-scoped search. Do not include unquoted repo:, org:, or user: qualifiers; quoted occurrences are treated as literal text.',
     sensitivity: 'read',
     sensitive: false,
     requiredScope: scopes.pullRequestsRead,
     repositoryScope: searchRepositoryScope,
     inputSchema: objectSchema(
       {
-        query: stringSchema('Search query using GitHub pull request search syntax'),
-        owner: stringSchema('Optional repository owner'),
-        repo: stringSchema('Optional repository name'),
+        query: stringSchema(
+          'Search query using GitHub pull request search syntax. Do not include unquoted repo:, org:, or user: qualifiers; quoted occurrences are treated as literal text.',
+        ),
+        owner: stringSchema(
+          'Optional repository owner. Provide together with repo, or omit both for a connection-scoped search.',
+        ),
+        repo: stringSchema(
+          'Optional repository name. Provide together with owner, or omit both for a connection-scoped search.',
+        ),
         sort: enumSchema(
           [
             'comments',

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -226,6 +226,8 @@ export type AgentToolRepositoryScope =
        * All-mode calls remain connection-scoped without those targets.
        */
       requiresExplicitRepository?: boolean;
+      /** Explains why a connection-scoped read may reach outside a target. */
+      indirectTargetNote?: string | undefined;
     };
 
 /** A pure classifier over already validated tool arguments. */
@@ -390,7 +392,8 @@ export type IntegrationProviderErrorReason =
   | 'provider-rejected'
   | 'malformed-provider-response'
   | 'content-too-large'
-  | 'too-many-files';
+  | 'too-many-files'
+  | 'search-qualifier-conflict';
 
 export class IntegrationProviderError extends Error {
   constructor(

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -219,7 +219,14 @@ export interface AgentToolRepositoryTarget {
 
 export type AgentToolRepositoryScope =
   | {kind: 'declared-targets'; repositories: readonly AgentToolRepositoryTarget[]}
-  | {kind: 'connection'};
+  | {
+      kind: 'connection';
+      /**
+       * Selected-mode calls must declare repository targets when this is true.
+       * All-mode calls remain connection-scoped without those targets.
+       */
+      requiresExplicitRepository?: boolean;
+    };
 
 /** A pure classifier over already validated tool arguments. */
 export type AgentToolRepositoryScopeClassifier = (


### PR DESCRIPTION
## Summary

Builds GitHub issue and pull-request searches from a server-owned repository scope. Repository coordinates are schema-paired; selected-mode calls require an explicit authorized target, while all-mode searches remain connection-scoped without a pair. The provider appends `repo:owner/name` to `q`, removes loose scope parameters, and rejects model-authored `repo:`, `org:`, and `user:` qualifiers.

This completes ENG-1822 while leaving the provider's staged authorization cutover unchanged.

Validation: GitHub and core test suites passed (23 files / 422 tests; 30 files / 310 tests), affected check and type dependency graphs passed, Changesets status passed, and `git diff --check` passed.

Closes ENG-1822

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds GitHub issue and pull-request searches from a server-owned repository scope so search results stay within authorized repositories.

- Search calls accept an optional `owner`/`repo` pair; when both are provided, the provider appends `repo:owner/name` to `q` and classifies the connection scope as declared-targets.
- Search calls without a pair are denied in selected mode with a new `repository-required` error code unless an explicit repository is granted.
- Unquoted `repo:`, `org:`, or `user:` qualifiers are rejected with a new `search-qualifier-conflict` error code; quoted occurrences are treated as literal text.
- Adds a changeset marking `@shipfox/api-integration-spi` minor and `@shipfox/api-integration-core-dto`, `@shipfox/api-integration-core`, and `@shipfox/api-integration-github` patches.

Closes ENG-1822.

<sup>Written for commit 243c69c07e30f1111041ffc1f6d51cf61907da6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


