### PR TITLE
[runner-agent] Keep Pi tool results safe for image providers

### DIFF
--- a/libs/runner/agent/src/core/fixtures/pi-linear-three-badges.json
+++ b/libs/runner/agent/src/core/fixtures/pi-linear-three-badges.json
@@ -1,0 +1,24 @@
+{
+  "toolName": "linear__get_issue",
+  "content": [
+    {
+      "type": "text",
+      "text": "Linear returned three status badges."
+    },
+    {
+      "type": "image",
+      "data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxODAiIGhlaWdodD0iNDAiPjxyZWN0IHdpZHRoPSIxODAiIGhlaWdodD0iNDAiIHJ4PSI4IiBmaWxsPSIjZThlZWZjIi8+PHRleHQgeD0iMTIiIHk9IjI2IiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzE3MjU1NCI+Rml4IHdpdGggY3ViaWM8L3RleHQ+PC9zdmc+",
+      "mimeType": "image/svg+xml"
+    },
+    {
+      "type": "image",
+      "data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxODAiIGhlaWdodD0iNDAiPjxyZWN0IHdpZHRoPSIxODAiIGhlaWdodD0iNDAiIHJ4PSI4IiBmaWxsPSIjZThlZWZjIi8+PHRleHQgeD0iMTIiIHk9IjI2IiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzE3MjU1NCI+UmVhZHk8L3RleHQ+PC9zdmc+",
+      "mimeType": "image/svg+xml"
+    },
+    {
+      "type": "image",
+      "data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxODAiIGhlaWdodD0iNDAiPjxyZWN0IHdpZHRoPSIxODAiIGhlaWdodD0iNDAiIHJ4PSI4IiBmaWxsPSIjZThlZWZjIi8+PHRleHQgeD0iMTIiIHk9IjI2IiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzE3MjU1NCI+UmVxdWVzdCBSZXZpZXc8L3RleHQ+PC9zdmc+",
+      "mimeType": "image/svg+xml"
+    }
+  ]
+}

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -428,6 +428,13 @@ describe('piHarnessAdapter', () => {
       ['pi-web-access', 'pi-mcp-adapter'],
       sessionDir,
     );
+    expect(
+      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions.extensionFactories,
+    ).toEqual([
+      expect.objectContaining({
+        name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
+      }),
+    ]);
     expect(extensionShutdownMock).toHaveBeenCalledWith({type: 'session_shutdown', reason: 'quit'});
     expect(disposeMock).toHaveBeenCalledAfter(extensionShutdownMock);
     expect(existsSync(configPath)).toBe(false);

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -126,6 +126,7 @@ import type {HarnessInvocation} from '#core/harness.js';
 import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
 import {piExtensionDirectories} from '#core/pi-extensions.js';
+import {PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME} from '#core/pi-tool-svg-normalizer.js';
 
 function extensionDirectory(packageName: string): string {
   const [directory] = piExtensionDirectories({packageNames: [packageName]});
@@ -321,6 +322,19 @@ describe('piHarnessAdapter', () => {
     expect(createAgentSessionMock.mock.calls[0]?.[0]).not.toHaveProperty('customTools');
   });
 
+  it('binds the inline image normalizer for sessions without MCP', async () => {
+    await piHarnessAdapter.run(invocation());
+
+    const options = createAgentSessionServicesMock.mock.calls[0]?.[0];
+    expect(options.resourceLoaderOptions.extensionFactories).toEqual([
+      expect.objectContaining({
+        name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
+      }),
+    ]);
+    expect(bindExtensionsMock).toHaveBeenCalledTimes(1);
+    expect(bindExtensionsMock).toHaveBeenCalledWith(expect.objectContaining({mode: 'print'}));
+  });
+
   it('keeps Pi built-ins available when pi-web-access is unavailable', async () => {
     isPiExtensionAvailableMock.mockImplementation(
       ({packageName}: {packageName: string}) => packageName !== 'pi-web-access',
@@ -329,7 +343,9 @@ describe('piHarnessAdapter', () => {
     await piHarnessAdapter.run(invocation());
 
     expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
-      expect.objectContaining({resourceLoaderOptions: {additionalExtensionPaths: []}}),
+      expect.objectContaining({
+        resourceLoaderOptions: expect.objectContaining({additionalExtensionPaths: []}),
+      }),
     );
     expect(createAgentSessionMock).toHaveBeenCalled();
   });
@@ -895,6 +911,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages,
       },
@@ -934,6 +951,7 @@ describe('piHarnessAdapter', () => {
         session: {
           prompt: promptMock,
           abort: abortMock,
+          bindExtensions: bindExtensionsMock,
           getLastAssistantText: getLastAssistantTextMock,
           messages: [],
         },
@@ -1506,6 +1524,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
         sessionFile,
@@ -1536,6 +1555,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
         sessionFile,
@@ -1636,6 +1656,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
         sessionFile: forkedSessionFile,
@@ -1671,6 +1692,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
         sessionFile,
@@ -1708,6 +1730,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
         sessionFile: committedFile,
@@ -1744,6 +1767,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
         sessionFile,
@@ -1925,6 +1949,7 @@ describe('piHarnessAdapter', () => {
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
       },

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -43,6 +43,7 @@ import {
   isPiExtensionAvailable,
   piExtensionDirectories,
 } from '#core/pi-extensions.js';
+import {createPiToolSvgNormalizerExtension} from '#core/pi-tool-svg-normalizer.js';
 import {type SessionForwarder, startSessionForwarder} from '#core/session-forwarder.js';
 import {toolSelectionOption} from '#core/tool-selection.js';
 
@@ -213,12 +214,10 @@ async function runPiSession(params: {
 async function runActivePiSession(
   params: Parameters<typeof runPiSession>[0],
 ): Promise<HarnessResult> {
-  if (params.mcpConfig !== undefined) {
-    await params.session.bindExtensions({
-      mode: 'print',
-      onError: (error) => logger().warn({err: error}, 'Pi extension failed'),
-    });
-  }
+  await params.session.bindExtensions({
+    mode: 'print',
+    onError: (error) => logger().warn({err: error}, 'Pi extension failed'),
+  });
   if (params.signal.aborted) throw new Error('Agent step aborted during pi session creation');
 
   const forwarder = startForwarding(
@@ -411,7 +410,10 @@ async function preparePiSessionServices(params: {
       ...(mcpConfig === undefined
         ? {}
         : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
-      resourceLoaderOptions: {additionalExtensionPaths: extensionDirectories},
+      resourceLoaderOptions: {
+        additionalExtensionPaths: extensionDirectories,
+        extensionFactories: [createPiToolSvgNormalizerExtension()],
+      },
     }),
   );
   const extensionResult = services.resourceLoader?.getExtensions?.();

--- a/libs/runner/agent/src/core/pi-tool-svg-normalizer.test.ts
+++ b/libs/runner/agent/src/core/pi-tool-svg-normalizer.test.ts
@@ -1,0 +1,471 @@
+import {once} from 'node:events';
+import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {createServer, type Server as HttpServer} from 'node:http';
+import {tmpdir} from 'node:os';
+import type {ImageContent} from '@earendil-works/pi-ai';
+import type {ContextEvent, ExtensionAPI, ToolResultEvent} from '@earendil-works/pi-coding-agent';
+import {
+  createAgentSessionFromServices,
+  createAgentSessionServices,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from '@earendil-works/pi-coding-agent';
+import {Type} from 'typebox';
+import type {SvgRasterizationResult} from './pi-image-rasterizer.js';
+import {closePiSvgRasterizer} from './pi-image-rasterizer.js';
+import {
+  createPiToolSvgNormalizer,
+  createPiToolSvgNormalizerExtension,
+  PI_IMAGE_OMISSION_PLACEHOLDER,
+  type PiImageContent,
+  type PiToolSvgNormalizerOptions,
+} from './pi-tool-svg-normalizer.js';
+
+const PNG_BYTES = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const ONE_PIXEL_BMP =
+  'Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AA==';
+const ONE_PIXEL_JPEG =
+  '/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAABgj/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABykX//Z';
+const FIXTURE_PATH = new URL('./fixtures/pi-linear-three-badges.json', import.meta.url);
+const LINEAR_BADGE_FIXTURE = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as {
+  toolName: string;
+  content: PiImageContent[];
+};
+
+afterEach(async () => {
+  await closePiSvgRasterizer();
+});
+
+type Rasterizer = NonNullable<PiToolSvgNormalizerOptions['rasterize']>;
+type ExtensionHandler = (event: unknown) => unknown;
+
+describe('Pi tool SVG normalizer', () => {
+  it('converts SVG blocks after canonical MIME classification and preserves order', async () => {
+    const svg = encodedSvg('first');
+    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
+    const normalizer = createPiToolSvgNormalizer({rasterize});
+    const original: PiImageContent[] = [
+      {type: 'text', text: 'before'},
+      {type: 'image', data: svg, mimeType: ' IMAGE/SVG+XML ; charset=utf-8'},
+      {type: 'image', data: 'not base64', mimeType: 'image/bmp'},
+      {type: 'text', text: 'after'},
+    ];
+
+    const result = await normalizer.normalizeToolResult(original);
+
+    expect(result).toEqual([
+      {type: 'text', text: 'before'},
+      {type: 'image', data: Buffer.from(PNG_BYTES).toString('base64'), mimeType: 'image/png'},
+      original[2],
+      {type: 'text', text: 'after'},
+    ]);
+    expect(result).not.toBe(original);
+    expect(original[1]).toEqual({
+      type: 'image',
+      data: svg,
+      mimeType: ' IMAGE/SVG+XML ; charset=utf-8',
+    });
+    expect(rasterize).toHaveBeenCalledWith({base64: svg, deadlineMs: expect.any(Number)});
+  });
+
+  it('leaves every non-SVG tool-result image untouched without decoding it', async () => {
+    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
+    const normalizer = createPiToolSvgNormalizer({rasterize});
+    const content: PiImageContent[] = [
+      {type: 'image', data: 'not base64', mimeType: 'image/png'},
+      {type: 'image', data: 'also not base64', mimeType: 'image/jpg; quality=1'},
+      {type: 'image', data: 'still not base64', mimeType: 'IMAGE/BMP'},
+      {type: 'image', data: 'not base64 either', mimeType: 'image/tiff'},
+    ];
+
+    const result = await normalizer.normalizeToolResult(content);
+
+    expect(result).toBe(content);
+    expect(result).toEqual(content);
+    expect(rasterize).not.toHaveBeenCalled();
+  });
+
+  it('normalizes legacy context images while preserving unrelated messages', async () => {
+    const svg = encodedSvg('legacy');
+    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
+    const normalizer = createPiToolSvgNormalizer({rasterize});
+    const userMessage = {
+      role: 'user',
+      content: [
+        {type: 'text', text: 'context'},
+        {type: 'image', data: svg, mimeType: 'image/svg+xml; charset=utf-8'},
+        {type: 'image', data: 'jpg bytes', mimeType: 'IMAGE/JPG; quality=1'},
+        {type: 'image', data: 'png bytes', mimeType: 'image/png'},
+        {type: 'image', data: 'bmp bytes', mimeType: 'image/bmp'},
+      ],
+      timestamp: 1,
+    } as ContextEvent['messages'][number];
+    const assistantMessage = {
+      role: 'assistant',
+      content: [{type: 'text', text: 'assistant'}],
+      timestamp: 2,
+    } as unknown as ContextEvent['messages'][number];
+    const messages = [userMessage, assistantMessage] as ContextEvent['messages'];
+
+    const result = await normalizer.normalizeContext(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(assistantMessage);
+    expect(result[0]).toMatchObject({role: 'user', timestamp: 1});
+    if (result[0]?.role !== 'user' || !Array.isArray(result[0].content)) return;
+    expect(result[0].content).toEqual([
+      {type: 'text', text: 'context'},
+      {type: 'image', data: Buffer.from(PNG_BYTES).toString('base64'), mimeType: 'image/png'},
+      {type: 'image', data: 'jpg bytes', mimeType: 'image/jpeg'},
+      {type: 'image', data: 'png bytes', mimeType: 'image/png'},
+      {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER},
+    ]);
+    expect(rasterize).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds SVG count and aggregate normalization time for one pass', async () => {
+    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
+    const normalizer = createPiToolSvgNormalizer({rasterize});
+    const content = Array.from({length: 21}, (_, index) =>
+      image(encodedSvg(`badge-${index}`), 'image/svg+xml'),
+    );
+
+    const result = await normalizer.normalizeToolResult(content);
+
+    expect(rasterize).toHaveBeenCalledTimes(20);
+    expect(result.slice(0, 20).every((block) => block.type === 'image')).toBe(true);
+    expect(result[20]).toEqual({type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER});
+
+    let now = 0;
+    const timedRasterize = vi.fn<Rasterizer>(() => {
+      now += 1_000;
+      return Promise.resolve(convertedResult());
+    });
+    const timedNormalizer = createPiToolSvgNormalizer({rasterize: timedRasterize, now: () => now});
+    const timedResult = await timedNormalizer.normalizeToolResult(
+      Array.from({length: 6}, (_, index) => image(encodedSvg(`timed-${index}`), 'image/svg+xml')),
+    );
+
+    expect(timedRasterize).toHaveBeenCalledTimes(5);
+    expect(timedResult[5]).toEqual({type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER});
+  });
+
+  it('caches converted SVGs within the session', async () => {
+    const svg = encodedSvg('cached');
+    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
+    const normalizer = createPiToolSvgNormalizer({rasterize});
+
+    const first = await normalizer.normalizeToolResult([image(svg, 'image/svg+xml')]);
+    const second = await normalizer.normalizeToolResult([image(svg, 'image/svg+xml')]);
+
+    expect(rasterize).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it('omits malformed SVG data with the exact placeholder', async () => {
+    const normalizer = createPiToolSvgNormalizer();
+
+    await expect(
+      normalizer.normalizeToolResult([image('not valid base64', 'image/svg+xml')]),
+    ).resolves.toEqual([{type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER}]);
+  });
+
+  it('runs the exact three-badge Linear result through the typed tool-result hook', async () => {
+    const handlers = extensionHandlers({rasterize: async () => convertedResult()});
+    const handler = requiredHandler(handlers, 'tool_result');
+    const event = {
+      type: 'tool_result',
+      toolName: LINEAR_BADGE_FIXTURE.toolName,
+      toolCallId: 'linear-call-1',
+      input: {issue: 'ENG-1860'},
+      content: LINEAR_BADGE_FIXTURE.content,
+      details: {source: 'fixture'},
+      isError: false,
+      usage: undefined,
+    } as unknown as ToolResultEvent;
+
+    const result = (await handler(event)) as {
+      content: PiImageContent[];
+      details: unknown;
+      isError: boolean;
+      usage: unknown;
+    };
+
+    expect(result.details).toEqual({source: 'fixture'});
+    expect(result.isError).toBe(false);
+    expect(result.content).toHaveLength(4);
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: 'Linear returned three status badges.',
+    });
+    expect(result.content.slice(1).every(isPngImage)).toBe(true);
+    expect(result.content.some(isSvgImage)).toBe(false);
+    expect(LINEAR_BADGE_FIXTURE.content.slice(1).every(isSvgImage)).toBe(true);
+  }, 10_000);
+
+  it('keeps the three-badge result out of the OpenAI provider request', async () => {
+    const root = mkdtempSync(`${tmpdir()}/shipfox-pi-svg-session-`);
+    const requests: unknown[] = [];
+    const httpServer = createServer(async (request, response) => {
+      const body = await readJsonBody(request);
+      requests.push(body);
+      response.writeHead(200, {
+        connection: 'keep-alive',
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      });
+      const id = `chatcmpl-svg-${requests.length}`;
+      if (requests.length === 1) {
+        writeOpenAiEvent(response, {
+          id,
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'svg-normalizer-model',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'linear-call-1',
+                    type: 'function',
+                    function: {name: 'linear__get_issue', arguments: '{}'},
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        });
+        writeOpenAiEvent(response, {
+          id,
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'svg-normalizer-model',
+          choices: [{index: 0, delta: {}, finish_reason: 'tool_calls'}],
+        });
+      } else {
+        writeOpenAiEvent(response, {
+          id,
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'svg-normalizer-model',
+          choices: [{index: 0, delta: {content: 'done'}, finish_reason: null}],
+        });
+        writeOpenAiEvent(response, {
+          id,
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'svg-normalizer-model',
+          choices: [{index: 0, delta: {}, finish_reason: 'stop'}],
+        });
+      }
+      response.write('data: [DONE]\n\n');
+      response.end();
+    });
+    httpServer.listen(0, '127.0.0.1');
+    await once(httpServer, 'listening');
+    const serverAddress = httpServer.address();
+    if (typeof serverAddress !== 'object' || serverAddress === null) {
+      throw new Error('OpenAI test server did not bind a TCP address');
+    }
+    const providerBaseUrl = `http://127.0.0.1:${serverAddress.port}/v1`;
+    const modelRuntime = await ModelRuntime.create({refreshOnCreate: false});
+    modelRuntime.registerProvider('pi-svg-http-test', {
+      name: 'Pi SVG HTTP test',
+      baseUrl: providerBaseUrl,
+      api: 'openai-completions',
+      apiKey: 'test-key',
+      models: [
+        {
+          id: 'svg-normalizer-model',
+          name: 'SVG normalizer model',
+          input: ['text', 'image'],
+          reasoning: false,
+          cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0},
+          contextWindow: 128_000,
+          maxTokens: 2_048,
+        },
+      ],
+    });
+    const model = modelRuntime.getModel('pi-svg-http-test', 'svg-normalizer-model');
+    if (model === undefined) throw new Error('HTTP SVG model was not registered');
+
+    let session: Awaited<ReturnType<typeof createAgentSessionFromServices>>['session'] | undefined;
+    try {
+      const services = await createAgentSessionServices({
+        cwd: root,
+        agentDir: root,
+        modelRuntime,
+        settingsManager: SettingsManager.inMemory(),
+        resourceLoaderOptions: {
+          noContextFiles: true,
+          noExtensions: true,
+          noPromptTemplates: true,
+          noSkills: true,
+          noThemes: true,
+          extensionFactories: [createPiToolSvgNormalizerExtension()],
+        },
+      });
+      const linearTool = {
+        name: 'linear__get_issue',
+        label: 'linear__get_issue',
+        description: 'Return the fixture badges.',
+        parameters: Type.Object({}),
+        execute: () =>
+          Promise.resolve({
+            content: [
+              ...LINEAR_BADGE_FIXTURE.content,
+              image(ONE_PIXEL_BMP, 'image/bmp'),
+              image(ONE_PIXEL_JPEG, 'image/jpg'),
+            ],
+            details: {source: 'fixture'},
+          }),
+      };
+      const created = await createAgentSessionFromServices({
+        services,
+        sessionManager: SessionManager.inMemory(root),
+        model,
+        thinkingLevel: 'off',
+        tools: ['linear__get_issue'],
+        customTools: [linearTool],
+      });
+      session = created.session;
+
+      await session.bindExtensions({mode: 'print'});
+      await session.prompt('Return the Linear badges.');
+
+      const storedToolResult = session.messages.find((message) => message.role === 'toolResult');
+      expect(storedToolResult?.role).toBe('toolResult');
+      if (storedToolResult?.role !== 'toolResult') return;
+      const storedImages = storedToolResult.content.filter(isImage);
+      expect(storedImages.slice(0, 3).every(isPngImage)).toBe(true);
+      expect(storedImages[3]).toMatchObject({type: 'image', mimeType: 'image/png'});
+      expect(storedImages[3]?.data).not.toBe(ONE_PIXEL_BMP);
+      expect(storedImages).toContainEqual(image(ONE_PIXEL_JPEG, 'image/jpg'));
+      expect(storedImages.some(isSvgImage)).toBe(false);
+      expect(requests).toHaveLength(2);
+      const providerPayload = JSON.stringify(requests[1]);
+      expect(providerPayload).not.toContain('image/svg+xml');
+      for (const block of LINEAR_BADGE_FIXTURE.content) {
+        if (block.type === 'image') expect(providerPayload).not.toContain(block.data);
+      }
+    } finally {
+      session?.dispose();
+      await closeHttpServer(httpServer);
+      rmSync(root, {recursive: true, force: true});
+    }
+  }, 15_000);
+
+  it('falls back to placeholders for SVGs if the normalizer fails unexpectedly', async () => {
+    const handlers = extensionHandlers({
+      rasterize: () => Promise.reject(new Error('test failure')),
+    });
+    const handler = requiredHandler(handlers, 'tool_result');
+    const raster = image('keep this payload', 'image/bmp');
+    const event = {
+      type: 'tool_result',
+      toolName: 'linear',
+      toolCallId: 'call-1',
+      input: {},
+      content: [{type: 'text', text: 'before'}, image(encodedSvg('bad'), 'image/svg+xml'), raster],
+      details: {structured: true},
+      isError: true,
+      usage: {input: 1},
+    } as unknown as ToolResultEvent;
+
+    const result = (await handler(event)) as {
+      content: PiImageContent[];
+      details: unknown;
+      isError: boolean;
+      usage: unknown;
+    };
+
+    expect(result.content).toEqual([
+      {type: 'text', text: 'before'},
+      {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER},
+      raster,
+    ]);
+    expect(result.details).toEqual({structured: true});
+    expect(result.isError).toBe(true);
+    expect(result.usage).toEqual({input: 1});
+  });
+});
+
+function convertedResult(): Extract<SvgRasterizationResult, {outcome: 'converted'}> {
+  return {
+    outcome: 'converted',
+    png: PNG_BYTES,
+    width: 1,
+    height: 1,
+    inputBytes: 1,
+    outputBytes: PNG_BYTES.byteLength,
+    durationMs: 1,
+  };
+}
+
+function image(data: string, mimeType: string): ImageContent {
+  return {type: 'image', data, mimeType};
+}
+
+function encodedSvg(label: string): string {
+  return Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40"><text x="2" y="20">${label}</text></svg>`,
+  ).toString('base64');
+}
+
+function isImage(block: PiImageContent): block is ImageContent {
+  return block.type === 'image';
+}
+
+function isPngImage(block: PiImageContent): block is ImageContent {
+  return block.type === 'image' && block.mimeType === 'image/png';
+}
+
+function isSvgImage(block: PiImageContent): block is ImageContent {
+  return block.type === 'image' && block.mimeType === 'image/svg+xml';
+}
+
+function extensionHandlers(
+  options: PiToolSvgNormalizerOptions = {},
+): Map<string, ExtensionHandler> {
+  const handlers = new Map<string, ExtensionHandler>();
+  const api = {
+    on: (event: string, handler: ExtensionHandler) => handlers.set(event, handler),
+  } as unknown as ExtensionAPI;
+  const extension = createPiToolSvgNormalizerExtension(options);
+  if (typeof extension === 'function') throw new Error('Expected an inline extension object');
+  extension.factory(api);
+  return handlers;
+}
+
+function requiredHandler(handlers: Map<string, ExtensionHandler>, name: string): ExtensionHandler {
+  const handler = handlers.get(name);
+  if (handler === undefined) throw new Error(`Missing ${name} extension handler`);
+  return handler;
+}
+
+async function readJsonBody(request: NodeJS.ReadableStream): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text === '' ? undefined : (JSON.parse(text) as unknown);
+}
+
+function writeOpenAiEvent(response: NodeJS.WritableStream, event: unknown): void {
+  response.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+function closeHttpServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/libs/runner/agent/src/core/pi-tool-svg-normalizer.test.ts
+++ b/libs/runner/agent/src/core/pi-tool-svg-normalizer.test.ts
@@ -3,7 +3,7 @@ import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
 import {createServer, type Server as HttpServer} from 'node:http';
 import {tmpdir} from 'node:os';
 import type {ImageContent} from '@earendil-works/pi-ai';
-import type {ContextEvent, ExtensionAPI, ToolResultEvent} from '@earendil-works/pi-coding-agent';
+import type {ExtensionAPI, ToolResultEvent} from '@earendil-works/pi-coding-agent';
 import {
   createAgentSessionFromServices,
   createAgentSessionServices,
@@ -44,7 +44,9 @@ describe('Pi tool SVG normalizer', () => {
   it('converts SVG blocks after canonical MIME classification and preserves order', async () => {
     const svg = encodedSvg('first');
     const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
-    const normalizer = createPiToolSvgNormalizer({rasterize});
+    const recordNormalization = vi.fn();
+    const recordDuration = vi.fn();
+    const normalizer = createPiToolSvgNormalizer({rasterize, recordNormalization, recordDuration});
     const original: PiImageContent[] = [
       {type: 'text', text: 'before'},
       {type: 'image', data: svg, mimeType: ' IMAGE/SVG+XML ; charset=utf-8'},
@@ -67,6 +69,8 @@ describe('Pi tool SVG normalizer', () => {
       mimeType: ' IMAGE/SVG+XML ; charset=utf-8',
     });
     expect(rasterize).toHaveBeenCalledWith({base64: svg, deadlineMs: expect.any(Number)});
+    expect(recordNormalization).toHaveBeenCalledWith('converted', 'none', 'tool_result');
+    expect(recordDuration).toHaveBeenCalledWith('converted', 1);
   });
 
   it('leaves every non-SVG tool-result image untouched without decoding it', async () => {
@@ -84,44 +88,6 @@ describe('Pi tool SVG normalizer', () => {
     expect(result).toBe(content);
     expect(result).toEqual(content);
     expect(rasterize).not.toHaveBeenCalled();
-  });
-
-  it('normalizes legacy context images while preserving unrelated messages', async () => {
-    const svg = encodedSvg('legacy');
-    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
-    const normalizer = createPiToolSvgNormalizer({rasterize});
-    const userMessage = {
-      role: 'user',
-      content: [
-        {type: 'text', text: 'context'},
-        {type: 'image', data: svg, mimeType: 'image/svg+xml; charset=utf-8'},
-        {type: 'image', data: 'jpg bytes', mimeType: 'IMAGE/JPG; quality=1'},
-        {type: 'image', data: 'png bytes', mimeType: 'image/png'},
-        {type: 'image', data: 'bmp bytes', mimeType: 'image/bmp'},
-      ],
-      timestamp: 1,
-    } as ContextEvent['messages'][number];
-    const assistantMessage = {
-      role: 'assistant',
-      content: [{type: 'text', text: 'assistant'}],
-      timestamp: 2,
-    } as unknown as ContextEvent['messages'][number];
-    const messages = [userMessage, assistantMessage] as ContextEvent['messages'];
-
-    const result = await normalizer.normalizeContext(messages);
-
-    expect(result).toHaveLength(2);
-    expect(result[1]).toBe(assistantMessage);
-    expect(result[0]).toMatchObject({role: 'user', timestamp: 1});
-    if (result[0]?.role !== 'user' || !Array.isArray(result[0].content)) return;
-    expect(result[0].content).toEqual([
-      {type: 'text', text: 'context'},
-      {type: 'image', data: Buffer.from(PNG_BYTES).toString('base64'), mimeType: 'image/png'},
-      {type: 'image', data: 'jpg bytes', mimeType: 'image/jpeg'},
-      {type: 'image', data: 'png bytes', mimeType: 'image/png'},
-      {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER},
-    ]);
-    expect(rasterize).toHaveBeenCalledTimes(1);
   });
 
   it('bounds SVG count and aggregate normalization time for one pass', async () => {
@@ -151,25 +117,16 @@ describe('Pi tool SVG normalizer', () => {
     expect(timedResult[5]).toEqual({type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER});
   });
 
-  it('caches converted SVGs within the session', async () => {
-    const svg = encodedSvg('cached');
-    const rasterize = vi.fn<Rasterizer>(async () => convertedResult());
-    const normalizer = createPiToolSvgNormalizer({rasterize});
-
-    const first = await normalizer.normalizeToolResult([image(svg, 'image/svg+xml')]);
-    const second = await normalizer.normalizeToolResult([image(svg, 'image/svg+xml')]);
-
-    expect(rasterize).toHaveBeenCalledTimes(1);
-    expect(second).toEqual(first);
-    expect(second[0]).not.toBe(first[0]);
-  });
-
   it('omits malformed SVG data with the exact placeholder', async () => {
-    const normalizer = createPiToolSvgNormalizer();
+    const recordNormalization = vi.fn();
+    const recordDuration = vi.fn();
+    const normalizer = createPiToolSvgNormalizer({recordNormalization, recordDuration});
 
     await expect(
       normalizer.normalizeToolResult([image('not valid base64', 'image/svg+xml')]),
     ).resolves.toEqual([{type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER}]);
+    expect(recordNormalization).toHaveBeenCalledWith('omitted', 'invalid_base64', 'tool_result');
+    expect(recordDuration).toHaveBeenCalledWith('omitted', expect.any(Number));
   });
 
   it('runs the exact three-badge Linear result through the typed tool-result hook', async () => {

--- a/libs/runner/agent/src/core/pi-tool-svg-normalizer.ts
+++ b/libs/runner/agent/src/core/pi-tool-svg-normalizer.ts
@@ -1,12 +1,6 @@
-import {createHash} from 'node:crypto';
 import {performance} from 'node:perf_hooks';
 import type {ImageContent, TextContent} from '@earendil-works/pi-ai';
-import type {
-  ContextEvent,
-  ExtensionAPI,
-  InlineExtension,
-  ToolResultEvent,
-} from '@earendil-works/pi-coding-agent';
+import type {ExtensionAPI, InlineExtension} from '@earendil-works/pi-coding-agent';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
   PI_SVG_RASTERIZATION_LIMITS,
@@ -27,18 +21,8 @@ export const PI_IMAGE_OMISSION_PLACEHOLDER =
 export const PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME = 'shipfox-pi-tool-svg-normalizer';
 
 const CANONICAL_SVG_MIME_TYPE = 'image/svg+xml';
-const LEGACY_INLINE_IMAGE_MIME_TYPES = new Set([
-  'image/png',
-  'image/jpeg',
-  'image/webp',
-  'image/gif',
-]);
 const MAX_SVG_BLOCKS_PER_PASS = 20;
-const MAX_CACHE_ENTRIES = 32;
-const MAX_CACHE_BYTES = 32 * 1024 * 1024;
 const WARNING_INTERVAL_MS = 60_000;
-const MAX_ENCODED_BASE64_LENGTH = Math.ceil(PI_SVG_RASTERIZATION_LIMITS.maxInputBytes / 3) * 4;
-const STRICT_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 export type ImageOmissionReason = 'unsupported_format' | SvgRasterizationReason;
 export type PiImageContent = TextContent | ImageContent;
@@ -69,8 +53,6 @@ export interface PiToolSvgNormalizerOptions {
 
 export interface PiToolSvgNormalizer {
   normalizeToolResult(content: PiImageContent[]): Promise<PiImageContent[]>;
-  normalizeContext(messages: ContextEvent['messages']): Promise<ContextEvent['messages']>;
-  clear(): void;
 }
 
 type NormalizationBudget = {
@@ -78,33 +60,20 @@ type NormalizationBudget = {
   svgBlocks: number;
 };
 
-type PiToolResultExtensionAPI = {
-  on(event: 'tool_result', handler: (event: ToolResultEvent) => unknown): void;
-};
-
-type CachedSvg = {
-  block: PiImageContent;
-  outcome: PiSvgNormalizationOutcome;
-  reason: PiSvgNormalizationReason;
-  weight: number;
-};
-
 /**
- * Creates the session-local normalizer used by the inline Pi extension.
- * Non-SVG tool-result images intentionally do not enter this normalizer.
+ * Creates the normalizer used by the inline Pi extension.
+ * Non-SVG tool-result images are returned unchanged without decoding or hashing.
  */
 export function createPiToolSvgNormalizer(
   options: PiToolSvgNormalizerOptions = {},
 ): PiToolSvgNormalizer {
-  const normalizer = new SessionPiToolSvgNormalizer(options);
+  const normalizer = new PiToolSvgNormalizerImpl(options);
   return {
     normalizeToolResult: (content) => normalizer.normalizeContent(content, 'tool_result'),
-    normalizeContext: (messages) => normalizer.normalizeContextMessages(messages),
-    clear: () => normalizer.clear(),
   };
 }
 
-/** Registers typed tool-result and context hooks independently of MCP extensions. */
+/** Registers the typed tool-result hook independently of MCP extensions. */
 export function createPiToolSvgNormalizerExtension(
   options: PiToolSvgNormalizerOptions = {},
 ): InlineExtension {
@@ -114,53 +83,35 @@ export function createPiToolSvgNormalizerExtension(
     factory: (pi: ExtensionAPI) => {
       const normalizer = createPiToolSvgNormalizer(options);
 
-      const toolResultApi = pi as unknown as PiToolResultExtensionAPI;
-      toolResultApi.on('tool_result', async (event: ToolResultEvent) => {
+      pi.on('tool_result', async (event) => {
+        const {
+          type: _type,
+          toolCallId: _toolCallId,
+          input: _input,
+          toolName: _toolName,
+          ...result
+        } = event;
         try {
           const content = await normalizer.normalizeToolResult(event.content);
-          return {
-            content,
-            details: event.details,
-            isError: event.isError,
-            usage: event.usage,
-          };
+          return {...result, content};
         } catch {
-          recordUnexpectedFailure('tool_result', options.warnUnexpectedFailure);
+          recordUnexpectedFailure(options.warnUnexpectedFailure);
           return {
-            content: fallbackSvgContent(event.content, 'tool_result', options.recordNormalization),
-            details: event.details,
-            isError: event.isError,
-            usage: event.usage,
+            ...result,
+            content: fallbackSvgContent(event.content, options.recordNormalization),
           };
         }
       });
-      pi.on('context', async (event) => {
-        try {
-          return {messages: await normalizer.normalizeContext(event.messages)};
-        } catch {
-          recordUnexpectedFailure('legacy_context', options.warnUnexpectedFailure);
-          return {
-            messages: fallbackContextMessages(
-              event.messages,
-              'legacy_context',
-              options.recordNormalization,
-            ),
-          };
-        }
-      });
-      pi.on('session_shutdown', () => normalizer.clear());
     },
   };
 }
 
-class SessionPiToolSvgNormalizer {
+class PiToolSvgNormalizerImpl {
   private readonly now: NormalizationClock;
   private readonly rasterize: RasterizeSvg;
   private readonly recordNormalization: RecordNormalization;
   private readonly recordDuration: RecordDuration;
   private readonly warnUnexpectedFailure: WarnUnexpectedFailure;
-  private readonly cache = new Map<string, CachedSvg>();
-  private cacheBytes = 0;
 
   constructor(options: PiToolSvgNormalizerOptions) {
     this.now = options.now ?? (() => performance.now());
@@ -197,40 +148,6 @@ class SessionPiToolSvgNormalizer {
     return this.normalizeContentWithBudget(content, source, budget);
   }
 
-  async normalizeContextMessages(
-    messages: ContextEvent['messages'],
-  ): Promise<ContextEvent['messages']> {
-    const budget: NormalizationBudget = {
-      deadlineAt: this.now() + PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs,
-      svgBlocks: 0,
-    };
-    let changed = false;
-    const normalized: ContextEvent['messages'] = [];
-
-    for (const message of messages) {
-      const content = legacyContentOf(message);
-      if (content === undefined) {
-        normalized.push(message);
-        continue;
-      }
-
-      const nextContent = await this.normalizeContentWithBudget(content, 'legacy_context', budget);
-      if (nextContent === content) {
-        normalized.push(message);
-        continue;
-      }
-      normalized.push({...message, content: nextContent} as ContextEvent['messages'][number]);
-      changed = true;
-    }
-
-    return changed ? normalized : messages;
-  }
-
-  clear(): void {
-    this.cache.clear();
-    this.cacheBytes = 0;
-  }
-
   private async normalizeContentWithBudget(
     content: PiImageContent[],
     source: PiSvgNormalizationSource,
@@ -247,9 +164,7 @@ class SessionPiToolSvgNormalizer {
 
       const canonicalMimeType = canonicalPiMimeType(block.mimeType);
       if (canonicalMimeType !== CANONICAL_SVG_MIME_TYPE) {
-        const nonSvg = this.normalizeNonSvgBlock(block, canonicalMimeType, source);
-        normalized.push(nonSvg.block);
-        changed ||= nonSvg.changed;
+        normalized.push(block);
         continue;
       }
 
@@ -258,24 +173,6 @@ class SessionPiToolSvgNormalizer {
     }
 
     return changed ? normalized : content;
-  }
-
-  private normalizeNonSvgBlock(
-    block: ImageContent,
-    canonicalMimeType: string,
-    source: PiSvgNormalizationSource,
-  ): {block: PiImageContent; changed: boolean} {
-    if (source === 'tool_result') return {block, changed: false};
-    if (canonicalMimeType === 'image/jpg') {
-      return {block: {...block, mimeType: 'image/jpeg'}, changed: true};
-    }
-    if (LEGACY_INLINE_IMAGE_MIME_TYPES.has(canonicalMimeType)) {
-      return {block, changed: false};
-    }
-    return {
-      block: this.omittedBlock('unsupported_format', source),
-      changed: true,
-    };
   }
 
   private async normalizeSvgBlock(
@@ -294,16 +191,6 @@ class SessionPiToolSvgNormalizer {
       return this.omittedBlock('result_budget_exhausted', source);
     }
 
-    const cacheKey = svgCacheKey(block.data);
-    const cached = cacheKey === undefined ? undefined : this.getCached(cacheKey);
-    if (cached !== undefined) {
-      this.recordNormalization(cached.outcome, cached.reason, source);
-      if (cached.outcome === 'converted' && cached.block.type === 'image') {
-        return {...block, data: cached.block.data, mimeType: cached.block.mimeType};
-      }
-      return cloneContentBlock(cached.block);
-    }
-
     const result = await this.rasterize({
       base64: block.data,
       deadlineMs: Math.min(remainingMs, PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs),
@@ -320,14 +207,6 @@ class SessionPiToolSvgNormalizer {
       };
       this.recordNormalization('converted', 'none', source);
       this.recordDuration('converted', boundedDuration(result.durationMs));
-      if (cacheKey !== undefined) {
-        this.setCached(cacheKey, {
-          block: converted,
-          outcome: 'converted',
-          reason: 'none',
-          weight: Buffer.byteLength(converted.data, 'utf8'),
-        });
-      }
       return converted;
     }
 
@@ -335,48 +214,12 @@ class SessionPiToolSvgNormalizer {
     if (result.reason === 'render_error' || result.reason === 'rasterizer_unavailable') {
       this.warnUnexpectedFailure(source, result.reason);
     }
-    const omitted = this.omittedBlock(result.reason, source);
-    if (cacheKey !== undefined && isStableOmission(result.reason)) {
-      this.setCached(cacheKey, {
-        block: omitted,
-        outcome: 'omitted',
-        reason: result.reason,
-        weight: Buffer.byteLength(PI_IMAGE_OMISSION_PLACEHOLDER, 'utf8'),
-      });
-    }
-    return omitted;
+    return this.omittedBlock(result.reason, source);
   }
 
   private omittedBlock(reason: ImageOmissionReason, source: PiSvgNormalizationSource): TextContent {
     this.recordNormalization('omitted', reason, source);
     return {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER};
-  }
-
-  private getCached(key: string): CachedSvg | undefined {
-    const entry = this.cache.get(key);
-    if (entry === undefined) return undefined;
-    this.cache.delete(key);
-    this.cache.set(key, entry);
-    return entry;
-  }
-
-  private setCached(key: string, entry: CachedSvg): void {
-    if (entry.weight > MAX_CACHE_BYTES) return;
-    const previous = this.cache.get(key);
-    if (previous !== undefined) this.cacheBytes -= previous.weight;
-    this.cache.delete(key);
-    while (
-      this.cache.size >= MAX_CACHE_ENTRIES ||
-      this.cacheBytes + entry.weight > MAX_CACHE_BYTES
-    ) {
-      const oldestKey = this.cache.keys().next().value;
-      if (oldestKey === undefined) break;
-      const oldest = this.cache.get(oldestKey);
-      this.cache.delete(oldestKey);
-      if (oldest !== undefined) this.cacheBytes -= oldest.weight;
-    }
-    this.cache.set(key, entry);
-    this.cacheBytes += entry.weight;
   }
 }
 
@@ -389,19 +232,8 @@ function canonicalPiMimeType(value: string): string {
     .toLowerCase();
 }
 
-function legacyContentOf(message: ContextEvent['messages'][number]): PiImageContent[] | undefined {
-  if (
-    (message.role !== 'user' && message.role !== 'toolResult') ||
-    !Array.isArray(message.content)
-  ) {
-    return undefined;
-  }
-  return message.content as PiImageContent[];
-}
-
 function fallbackSvgContent(
   content: PiImageContent[],
-  source: PiSvgNormalizationSource,
   recordNormalization: RecordNormalization = recordPiSvgNormalization,
 ): PiImageContent[] {
   let changed = false;
@@ -410,65 +242,10 @@ function fallbackSvgContent(
       return block;
     }
     changed = true;
-    safelyRecordNormalization(recordNormalization, 'omitted', 'render_error', source);
+    safelyRecordNormalization(recordNormalization, 'omitted', 'render_error', 'tool_result');
     return {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER} satisfies TextContent;
   });
   return changed ? fallback : content;
-}
-
-function fallbackContextMessages(
-  messages: ContextEvent['messages'],
-  source: PiSvgNormalizationSource,
-  recordNormalization: RecordNormalization = recordPiSvgNormalization,
-): ContextEvent['messages'] {
-  let changed = false;
-  const fallback = messages.map((message) => {
-    const content = legacyContentOf(message);
-    if (content === undefined) return message;
-    const nextContent = fallbackSvgContent(content, source, recordNormalization);
-    if (nextContent === content) return message;
-    changed = true;
-    return {...message, content: nextContent} as ContextEvent['messages'][number];
-  });
-  return changed ? fallback : messages;
-}
-
-function cloneContentBlock(block: PiImageContent): PiImageContent {
-  return {...block};
-}
-
-function svgCacheKey(value: string): string | undefined {
-  if (
-    typeof value !== 'string' ||
-    value.length === 0 ||
-    value.length > MAX_ENCODED_BASE64_LENGTH ||
-    !STRICT_BASE64.test(value)
-  ) {
-    return undefined;
-  }
-  const decoded = Buffer.from(value, 'base64');
-  if (
-    decoded.byteLength === 0 ||
-    decoded.toString('base64') !== value ||
-    decoded.byteLength > PI_SVG_RASTERIZATION_LIMITS.maxInputBytes
-  ) {
-    return undefined;
-  }
-  return createHash('sha256')
-    .update(CANONICAL_SVG_MIME_TYPE)
-    .update('\0')
-    .update(decoded)
-    .digest('hex');
-}
-
-function isStableOmission(reason: SvgRasterizationReason): boolean {
-  return (
-    reason === 'invalid_base64' ||
-    reason === 'input_too_large' ||
-    reason === 'unsafe_svg' ||
-    reason === 'external_resource' ||
-    reason === 'output_too_large'
-  );
 }
 
 function boundedDuration(value: number): number {
@@ -493,11 +270,10 @@ function warnOnUnexpectedFailure(
 }
 
 function recordUnexpectedFailure(
-  source: PiSvgNormalizationSource,
   warnUnexpectedFailure: WarnUnexpectedFailure = warnOnUnexpectedFailure,
 ): void {
   try {
-    warnUnexpectedFailure(source, 'render_error');
+    warnUnexpectedFailure('tool_result', 'render_error');
   } catch {
     // Warnings must not affect Pi tool results.
   }

--- a/libs/runner/agent/src/core/pi-tool-svg-normalizer.ts
+++ b/libs/runner/agent/src/core/pi-tool-svg-normalizer.ts
@@ -1,0 +1,517 @@
+import {createHash} from 'node:crypto';
+import {performance} from 'node:perf_hooks';
+import type {ImageContent, TextContent} from '@earendil-works/pi-ai';
+import type {
+  ContextEvent,
+  ExtensionAPI,
+  InlineExtension,
+  ToolResultEvent,
+} from '@earendil-works/pi-coding-agent';
+import {logger} from '@shipfox/node-opentelemetry';
+import {
+  PI_SVG_RASTERIZATION_LIMITS,
+  rasterizeSvg,
+  type SvgRasterizationReason,
+  type SvgRasterizationResult,
+} from '#core/pi-image-rasterizer.js';
+import {
+  type PiSvgNormalizationOutcome,
+  type PiSvgNormalizationReason,
+  type PiSvgNormalizationSource,
+  recordPiSvgNormalization,
+  recordPiSvgRasterizationDuration,
+} from '#metrics/index.js';
+
+export const PI_IMAGE_OMISSION_PLACEHOLDER =
+  '[Image omitted: could not be converted to a supported inline image format.]';
+export const PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME = 'shipfox-pi-tool-svg-normalizer';
+
+const CANONICAL_SVG_MIME_TYPE = 'image/svg+xml';
+const LEGACY_INLINE_IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+]);
+const MAX_SVG_BLOCKS_PER_PASS = 20;
+const MAX_CACHE_ENTRIES = 32;
+const MAX_CACHE_BYTES = 32 * 1024 * 1024;
+const WARNING_INTERVAL_MS = 60_000;
+const MAX_ENCODED_BASE64_LENGTH = Math.ceil(PI_SVG_RASTERIZATION_LIMITS.maxInputBytes / 3) * 4;
+const STRICT_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export type ImageOmissionReason = 'unsupported_format' | SvgRasterizationReason;
+export type PiImageContent = TextContent | ImageContent;
+
+type NormalizationClock = () => number;
+type RasterizeSvg = (params: {
+  base64: string;
+  deadlineMs?: number;
+}) => Promise<SvgRasterizationResult>;
+type RecordNormalization = (
+  outcome: PiSvgNormalizationOutcome,
+  reason: PiSvgNormalizationReason,
+  source: PiSvgNormalizationSource,
+) => void;
+type RecordDuration = (outcome: PiSvgNormalizationOutcome, durationMs: number) => void;
+type WarnUnexpectedFailure = (
+  source: PiSvgNormalizationSource,
+  reason: 'render_error' | 'rasterizer_unavailable',
+) => void;
+
+export interface PiToolSvgNormalizerOptions {
+  now?: NormalizationClock;
+  rasterize?: RasterizeSvg;
+  recordNormalization?: RecordNormalization;
+  recordDuration?: RecordDuration;
+  warnUnexpectedFailure?: WarnUnexpectedFailure;
+}
+
+export interface PiToolSvgNormalizer {
+  normalizeToolResult(content: PiImageContent[]): Promise<PiImageContent[]>;
+  normalizeContext(messages: ContextEvent['messages']): Promise<ContextEvent['messages']>;
+  clear(): void;
+}
+
+type NormalizationBudget = {
+  deadlineAt: number;
+  svgBlocks: number;
+};
+
+type PiToolResultExtensionAPI = {
+  on(event: 'tool_result', handler: (event: ToolResultEvent) => unknown): void;
+};
+
+type CachedSvg = {
+  block: PiImageContent;
+  outcome: PiSvgNormalizationOutcome;
+  reason: PiSvgNormalizationReason;
+  weight: number;
+};
+
+/**
+ * Creates the session-local normalizer used by the inline Pi extension.
+ * Non-SVG tool-result images intentionally do not enter this normalizer.
+ */
+export function createPiToolSvgNormalizer(
+  options: PiToolSvgNormalizerOptions = {},
+): PiToolSvgNormalizer {
+  const normalizer = new SessionPiToolSvgNormalizer(options);
+  return {
+    normalizeToolResult: (content) => normalizer.normalizeContent(content, 'tool_result'),
+    normalizeContext: (messages) => normalizer.normalizeContextMessages(messages),
+    clear: () => normalizer.clear(),
+  };
+}
+
+/** Registers typed tool-result and context hooks independently of MCP extensions. */
+export function createPiToolSvgNormalizerExtension(
+  options: PiToolSvgNormalizerOptions = {},
+): InlineExtension {
+  return {
+    name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
+    hidden: true,
+    factory: (pi: ExtensionAPI) => {
+      const normalizer = createPiToolSvgNormalizer(options);
+
+      const toolResultApi = pi as unknown as PiToolResultExtensionAPI;
+      toolResultApi.on('tool_result', async (event: ToolResultEvent) => {
+        try {
+          const content = await normalizer.normalizeToolResult(event.content);
+          return {
+            content,
+            details: event.details,
+            isError: event.isError,
+            usage: event.usage,
+          };
+        } catch {
+          recordUnexpectedFailure('tool_result', options.warnUnexpectedFailure);
+          return {
+            content: fallbackSvgContent(event.content, 'tool_result', options.recordNormalization),
+            details: event.details,
+            isError: event.isError,
+            usage: event.usage,
+          };
+        }
+      });
+      pi.on('context', async (event) => {
+        try {
+          return {messages: await normalizer.normalizeContext(event.messages)};
+        } catch {
+          recordUnexpectedFailure('legacy_context', options.warnUnexpectedFailure);
+          return {
+            messages: fallbackContextMessages(
+              event.messages,
+              'legacy_context',
+              options.recordNormalization,
+            ),
+          };
+        }
+      });
+      pi.on('session_shutdown', () => normalizer.clear());
+    },
+  };
+}
+
+class SessionPiToolSvgNormalizer {
+  private readonly now: NormalizationClock;
+  private readonly rasterize: RasterizeSvg;
+  private readonly recordNormalization: RecordNormalization;
+  private readonly recordDuration: RecordDuration;
+  private readonly warnUnexpectedFailure: WarnUnexpectedFailure;
+  private readonly cache = new Map<string, CachedSvg>();
+  private cacheBytes = 0;
+
+  constructor(options: PiToolSvgNormalizerOptions) {
+    this.now = options.now ?? (() => performance.now());
+    this.rasterize = options.rasterize ?? rasterizeSvg;
+    const recordNormalization = options.recordNormalization ?? recordPiSvgNormalization;
+    this.recordNormalization = (outcome, reason, source) =>
+      safelyRecordNormalization(recordNormalization, outcome, reason, source);
+    const recordDuration = options.recordDuration ?? recordPiSvgRasterizationDuration;
+    this.recordDuration = (outcome, durationMs) => {
+      try {
+        recordDuration(outcome, durationMs);
+      } catch {
+        // Metrics must not affect Pi tool results.
+      }
+    };
+    const warnUnexpectedFailure = options.warnUnexpectedFailure ?? warnOnUnexpectedFailure;
+    this.warnUnexpectedFailure = (source, reason) => {
+      try {
+        warnUnexpectedFailure(source, reason);
+      } catch {
+        // Warnings must not affect Pi tool results.
+      }
+    };
+  }
+
+  normalizeContent(
+    content: PiImageContent[],
+    source: PiSvgNormalizationSource,
+  ): Promise<PiImageContent[]> {
+    const budget: NormalizationBudget = {
+      deadlineAt: this.now() + PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs,
+      svgBlocks: 0,
+    };
+    return this.normalizeContentWithBudget(content, source, budget);
+  }
+
+  async normalizeContextMessages(
+    messages: ContextEvent['messages'],
+  ): Promise<ContextEvent['messages']> {
+    const budget: NormalizationBudget = {
+      deadlineAt: this.now() + PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs,
+      svgBlocks: 0,
+    };
+    let changed = false;
+    const normalized: ContextEvent['messages'] = [];
+
+    for (const message of messages) {
+      const content = legacyContentOf(message);
+      if (content === undefined) {
+        normalized.push(message);
+        continue;
+      }
+
+      const nextContent = await this.normalizeContentWithBudget(content, 'legacy_context', budget);
+      if (nextContent === content) {
+        normalized.push(message);
+        continue;
+      }
+      normalized.push({...message, content: nextContent} as ContextEvent['messages'][number]);
+      changed = true;
+    }
+
+    return changed ? normalized : messages;
+  }
+
+  clear(): void {
+    this.cache.clear();
+    this.cacheBytes = 0;
+  }
+
+  private async normalizeContentWithBudget(
+    content: PiImageContent[],
+    source: PiSvgNormalizationSource,
+    budget: NormalizationBudget,
+  ): Promise<PiImageContent[]> {
+    let changed = false;
+    const normalized: PiImageContent[] = [];
+
+    for (const block of content) {
+      if (block.type !== 'image') {
+        normalized.push(block);
+        continue;
+      }
+
+      const canonicalMimeType = canonicalPiMimeType(block.mimeType);
+      if (canonicalMimeType !== CANONICAL_SVG_MIME_TYPE) {
+        const nonSvg = this.normalizeNonSvgBlock(block, canonicalMimeType, source);
+        normalized.push(nonSvg.block);
+        changed ||= nonSvg.changed;
+        continue;
+      }
+
+      normalized.push(await this.normalizeSvgBlock(block, source, budget));
+      changed = true;
+    }
+
+    return changed ? normalized : content;
+  }
+
+  private normalizeNonSvgBlock(
+    block: ImageContent,
+    canonicalMimeType: string,
+    source: PiSvgNormalizationSource,
+  ): {block: PiImageContent; changed: boolean} {
+    if (source === 'tool_result') return {block, changed: false};
+    if (canonicalMimeType === 'image/jpg') {
+      return {block: {...block, mimeType: 'image/jpeg'}, changed: true};
+    }
+    if (LEGACY_INLINE_IMAGE_MIME_TYPES.has(canonicalMimeType)) {
+      return {block, changed: false};
+    }
+    return {
+      block: this.omittedBlock('unsupported_format', source),
+      changed: true,
+    };
+  }
+
+  private async normalizeSvgBlock(
+    block: ImageContent,
+    source: PiSvgNormalizationSource,
+    budget: NormalizationBudget,
+  ): Promise<PiImageContent> {
+    const svgIndex = budget.svgBlocks;
+    budget.svgBlocks += 1;
+    if (svgIndex >= MAX_SVG_BLOCKS_PER_PASS) {
+      return this.omittedBlock('result_budget_exhausted', source);
+    }
+
+    const remainingMs = budget.deadlineAt - this.now();
+    if (remainingMs <= 0) {
+      return this.omittedBlock('result_budget_exhausted', source);
+    }
+
+    const cacheKey = svgCacheKey(block.data);
+    const cached = cacheKey === undefined ? undefined : this.getCached(cacheKey);
+    if (cached !== undefined) {
+      this.recordNormalization(cached.outcome, cached.reason, source);
+      if (cached.outcome === 'converted' && cached.block.type === 'image') {
+        return {...block, data: cached.block.data, mimeType: cached.block.mimeType};
+      }
+      return cloneContentBlock(cached.block);
+    }
+
+    const result = await this.rasterize({
+      base64: block.data,
+      deadlineMs: Math.min(remainingMs, PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs),
+    });
+    if (this.now() > budget.deadlineAt) {
+      this.recordDuration('omitted', boundedDuration(result.durationMs));
+      return this.omittedBlock('result_budget_exhausted', source);
+    }
+    if (result.outcome === 'converted') {
+      const converted: ImageContent = {
+        ...block,
+        data: Buffer.from(result.png).toString('base64'),
+        mimeType: 'image/png',
+      };
+      this.recordNormalization('converted', 'none', source);
+      this.recordDuration('converted', boundedDuration(result.durationMs));
+      if (cacheKey !== undefined) {
+        this.setCached(cacheKey, {
+          block: converted,
+          outcome: 'converted',
+          reason: 'none',
+          weight: Buffer.byteLength(converted.data, 'utf8'),
+        });
+      }
+      return converted;
+    }
+
+    this.recordDuration('omitted', boundedDuration(result.durationMs));
+    if (result.reason === 'render_error' || result.reason === 'rasterizer_unavailable') {
+      this.warnUnexpectedFailure(source, result.reason);
+    }
+    const omitted = this.omittedBlock(result.reason, source);
+    if (cacheKey !== undefined && isStableOmission(result.reason)) {
+      this.setCached(cacheKey, {
+        block: omitted,
+        outcome: 'omitted',
+        reason: result.reason,
+        weight: Buffer.byteLength(PI_IMAGE_OMISSION_PLACEHOLDER, 'utf8'),
+      });
+    }
+    return omitted;
+  }
+
+  private omittedBlock(reason: ImageOmissionReason, source: PiSvgNormalizationSource): TextContent {
+    this.recordNormalization('omitted', reason, source);
+    return {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER};
+  }
+
+  private getCached(key: string): CachedSvg | undefined {
+    const entry = this.cache.get(key);
+    if (entry === undefined) return undefined;
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    return entry;
+  }
+
+  private setCached(key: string, entry: CachedSvg): void {
+    if (entry.weight > MAX_CACHE_BYTES) return;
+    const previous = this.cache.get(key);
+    if (previous !== undefined) this.cacheBytes -= previous.weight;
+    this.cache.delete(key);
+    while (
+      this.cache.size >= MAX_CACHE_ENTRIES ||
+      this.cacheBytes + entry.weight > MAX_CACHE_BYTES
+    ) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = this.cache.get(oldestKey);
+      this.cache.delete(oldestKey);
+      if (oldest !== undefined) this.cacheBytes -= oldest.weight;
+    }
+    this.cache.set(key, entry);
+    this.cacheBytes += entry.weight;
+  }
+}
+
+function canonicalPiMimeType(value: string): string {
+  if (typeof value !== 'string') return '';
+  const parameterIndex = value.indexOf(';');
+  return value
+    .slice(0, parameterIndex < 0 ? value.length : parameterIndex)
+    .trim()
+    .toLowerCase();
+}
+
+function legacyContentOf(message: ContextEvent['messages'][number]): PiImageContent[] | undefined {
+  if (
+    (message.role !== 'user' && message.role !== 'toolResult') ||
+    !Array.isArray(message.content)
+  ) {
+    return undefined;
+  }
+  return message.content as PiImageContent[];
+}
+
+function fallbackSvgContent(
+  content: PiImageContent[],
+  source: PiSvgNormalizationSource,
+  recordNormalization: RecordNormalization = recordPiSvgNormalization,
+): PiImageContent[] {
+  let changed = false;
+  const fallback = content.map((block) => {
+    if (block.type !== 'image' || canonicalPiMimeType(block.mimeType) !== CANONICAL_SVG_MIME_TYPE) {
+      return block;
+    }
+    changed = true;
+    safelyRecordNormalization(recordNormalization, 'omitted', 'render_error', source);
+    return {type: 'text', text: PI_IMAGE_OMISSION_PLACEHOLDER} satisfies TextContent;
+  });
+  return changed ? fallback : content;
+}
+
+function fallbackContextMessages(
+  messages: ContextEvent['messages'],
+  source: PiSvgNormalizationSource,
+  recordNormalization: RecordNormalization = recordPiSvgNormalization,
+): ContextEvent['messages'] {
+  let changed = false;
+  const fallback = messages.map((message) => {
+    const content = legacyContentOf(message);
+    if (content === undefined) return message;
+    const nextContent = fallbackSvgContent(content, source, recordNormalization);
+    if (nextContent === content) return message;
+    changed = true;
+    return {...message, content: nextContent} as ContextEvent['messages'][number];
+  });
+  return changed ? fallback : messages;
+}
+
+function cloneContentBlock(block: PiImageContent): PiImageContent {
+  return {...block};
+}
+
+function svgCacheKey(value: string): string | undefined {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_ENCODED_BASE64_LENGTH ||
+    !STRICT_BASE64.test(value)
+  ) {
+    return undefined;
+  }
+  const decoded = Buffer.from(value, 'base64');
+  if (
+    decoded.byteLength === 0 ||
+    decoded.toString('base64') !== value ||
+    decoded.byteLength > PI_SVG_RASTERIZATION_LIMITS.maxInputBytes
+  ) {
+    return undefined;
+  }
+  return createHash('sha256')
+    .update(CANONICAL_SVG_MIME_TYPE)
+    .update('\0')
+    .update(decoded)
+    .digest('hex');
+}
+
+function isStableOmission(reason: SvgRasterizationReason): boolean {
+  return (
+    reason === 'invalid_base64' ||
+    reason === 'input_too_large' ||
+    reason === 'unsafe_svg' ||
+    reason === 'external_resource' ||
+    reason === 'output_too_large'
+  );
+}
+
+function boundedDuration(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs, Math.max(0, Math.round(value)));
+}
+
+let lastUnexpectedWarningAt = Number.NEGATIVE_INFINITY;
+
+function warnOnUnexpectedFailure(
+  source: PiSvgNormalizationSource,
+  reason: 'render_error' | 'rasterizer_unavailable',
+): void {
+  const now = Date.now();
+  if (now - lastUnexpectedWarningAt < WARNING_INTERVAL_MS) return;
+  lastUnexpectedWarningAt = now;
+  try {
+    logger().warn({source, reason}, 'Pi SVG image normalization encountered an unexpected failure');
+  } catch {
+    // Logging must not affect Pi tool results.
+  }
+}
+
+function recordUnexpectedFailure(
+  source: PiSvgNormalizationSource,
+  warnUnexpectedFailure: WarnUnexpectedFailure = warnOnUnexpectedFailure,
+): void {
+  try {
+    warnUnexpectedFailure(source, 'render_error');
+  } catch {
+    // Warnings must not affect Pi tool results.
+  }
+}
+
+function safelyRecordNormalization(
+  recordNormalization: RecordNormalization,
+  outcome: PiSvgNormalizationOutcome,
+  reason: PiSvgNormalizationReason,
+  source: PiSvgNormalizationSource,
+): void {
+  try {
+    recordNormalization(outcome, reason, source);
+  } catch {
+    // Metrics must not affect Pi tool results.
+  }
+}

--- a/libs/runner/agent/src/metrics/index.ts
+++ b/libs/runner/agent/src/metrics/index.ts
@@ -1,0 +1,9 @@
+export type {
+  PiSvgNormalizationOutcome,
+  PiSvgNormalizationReason,
+  PiSvgNormalizationSource,
+} from './instance.js';
+export {
+  recordPiSvgNormalization,
+  recordPiSvgRasterizationDuration,
+} from './instance.js';

--- a/libs/runner/agent/src/metrics/instance.test.ts
+++ b/libs/runner/agent/src/metrics/instance.test.ts
@@ -1,0 +1,75 @@
+const metricMocks = vi.hoisted(() => {
+  const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
+  const histograms = new Map<string, {record: ReturnType<typeof vi.fn>}>();
+  const createCounter = vi.fn((name: string) => {
+    const counter = {add: vi.fn()};
+    counters.set(name, counter);
+    return counter;
+  });
+  const createHistogram = vi.fn((name: string) => {
+    const histogram = {record: vi.fn()};
+    histograms.set(name, histogram);
+    return histogram;
+  });
+
+  return {counters, createCounter, createHistogram, histograms};
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  instanceMetrics: {
+    getMeter: () => ({
+      createCounter: metricMocks.createCounter,
+      createHistogram: metricMocks.createHistogram,
+    }),
+  },
+}));
+
+const metrics = await import('./instance.js');
+
+function counterAdd(name: string): ReturnType<typeof vi.fn> {
+  const counter = metricMocks.counters.get(name);
+  if (!counter) throw new Error(`Missing counter: ${name}`);
+  return counter.add;
+}
+
+function histogramRecord(name: string): ReturnType<typeof vi.fn> {
+  const histogram = metricMocks.histograms.get(name);
+  if (!histogram) throw new Error(`Missing histogram: ${name}`);
+  return histogram.record;
+}
+
+describe('Pi SVG normalization metrics', () => {
+  beforeEach(() => {
+    for (const counter of metricMocks.counters.values()) counter.add.mockReset();
+    for (const histogram of metricMocks.histograms.values()) histogram.record.mockReset();
+  });
+
+  it('records converted outcomes with bounded labels', () => {
+    metrics.recordPiSvgNormalization('converted', 'none', 'tool_result');
+
+    expect(counterAdd('runner_agent_pi_svg_normalization')).toHaveBeenCalledWith(1, {
+      outcome: 'converted',
+      reason: 'none',
+      source: 'tool_result',
+    });
+  });
+
+  it('records omitted outcomes with bounded labels', () => {
+    metrics.recordPiSvgNormalization('omitted', 'invalid_base64', 'tool_result');
+
+    expect(counterAdd('runner_agent_pi_svg_normalization')).toHaveBeenCalledWith(1, {
+      outcome: 'omitted',
+      reason: 'invalid_base64',
+      source: 'tool_result',
+    });
+  });
+
+  it('records bounded rasterization duration labels', () => {
+    metrics.recordPiSvgRasterizationDuration('omitted', 5_000);
+
+    expect(histogramRecord('runner_agent_pi_svg_rasterization_duration')).toHaveBeenCalledWith(
+      5_000,
+      {outcome: 'omitted'},
+    );
+  });
+});

--- a/libs/runner/agent/src/metrics/instance.ts
+++ b/libs/runner/agent/src/metrics/instance.ts
@@ -2,7 +2,7 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 import type {ImageOmissionReason} from '#core/pi-tool-svg-normalizer.js';
 
 export type PiSvgNormalizationOutcome = 'converted' | 'omitted';
-export type PiSvgNormalizationSource = 'tool_result' | 'legacy_context';
+export type PiSvgNormalizationSource = 'tool_result';
 export type PiSvgNormalizationReason = 'none' | ImageOmissionReason;
 
 const meter = instanceMetrics.getMeter('runner-agent');

--- a/libs/runner/agent/src/metrics/instance.ts
+++ b/libs/runner/agent/src/metrics/instance.ts
@@ -1,0 +1,49 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+import type {ImageOmissionReason} from '#core/pi-tool-svg-normalizer.js';
+
+export type PiSvgNormalizationOutcome = 'converted' | 'omitted';
+export type PiSvgNormalizationSource = 'tool_result' | 'legacy_context';
+export type PiSvgNormalizationReason = 'none' | ImageOmissionReason;
+
+const meter = instanceMetrics.getMeter('runner-agent');
+
+const piSvgNormalizationCount = meter.createCounter<{
+  outcome: PiSvgNormalizationOutcome;
+  reason: PiSvgNormalizationReason;
+  source: PiSvgNormalizationSource;
+}>('runner_agent_pi_svg_normalization', {
+  description: 'Pi SVG image normalization outcomes by bounded reason and source',
+});
+
+const piSvgRasterizationDuration = meter.createHistogram<{
+  outcome: PiSvgNormalizationOutcome;
+}>('runner_agent_pi_svg_rasterization_duration', {
+  description: 'Bounded duration of Pi SVG rasterization attempts',
+  unit: 'ms',
+  advice: {
+    explicitBucketBoundaries: [0, 10, 50, 100, 250, 500, 1_000, 2_000, 5_000],
+  },
+});
+
+export function recordPiSvgNormalization(
+  outcome: PiSvgNormalizationOutcome,
+  reason: PiSvgNormalizationReason,
+  source: PiSvgNormalizationSource,
+): void {
+  try {
+    piSvgNormalizationCount.add(1, {outcome, reason, source});
+  } catch {
+    // Metrics must not affect Pi tool results.
+  }
+}
+
+export function recordPiSvgRasterizationDuration(
+  outcome: PiSvgNormalizationOutcome,
+  durationMs: number,
+): void {
+  try {
+    piSvgRasterizationDuration.record(durationMs, {outcome});
+  } catch {
+    // Metrics must not affect Pi tool results.
+  }
+}


### PR DESCRIPTION
Normalize SVG images returned by Pi tools before they are persisted or sent to model providers.

The inline Pi extension uses the bounded SVG rasterizer and replaces invalid, unsafe, oversized, slow, or unavailable SVGs with the exact omission placeholder. It is registered and bound for every Pi session independently of MCP, while existing downstream handling remains responsible for non-SVG raster images. Historical session context and session caching are intentionally out of scope; ENG-1861 tracks historical coverage.

Validation: @shipfox/runner-agent check, type, test (15 files / 279 tests), and build pass. A local OpenAI-compatible streaming fixture confirms the provider payload contains no SVG image MIME or source data. `git diff --check` passes.

The broader runner graph was also attempted; unrelated runner-execution real-git tests require a missing local GPG signing key.

Closes ENG-1860