### PR TITLE
[api-workflows] Add tool step executor metrics

### DIFF
--- a/.changeset/tool-invocation-metrics.md
+++ b/.changeset/tool-invocation-metrics.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Adds bounded metrics for server-executed workflow tool invocations.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -48,8 +48,10 @@ src/metrics/
 
 Use snake_case names prefixed with the module, such as
 `runners_job_claimed` or `workflows_pending_runs`. Do not append `_total` to a
-counter. Do not append a unit suffix to a histogram name. The exporter derives
-those suffixes. Set `unit: 'ms'` and explicit histogram buckets where they help.
+counter. Histogram names normally omit a unit suffix when the exporter derives
+one. The API Prometheus exporter emits histogram names verbatim, so keep an
+explicit suffix when the owning metric contract requires one. Set `unit: 'ms'`
+and explicit histogram buckets where they help.
 
 Metric labels must be bounded and low-cardinality. Use an outcome, reason, type,
 conclusion, provider, or operating system. Never use an identifier, raw URL, or

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -91,6 +91,19 @@ URLs continue to use the run UUID. A run number is useful in workflow
 expressions as `run.number` and should appear beside the workflow name when it is
 shown in a list.
 
+### Observability
+
+The executor records instance metrics on each API pod and service metrics from
+shared invocation state. Labels stay bounded, and workflow or tool identifiers
+remain in logs and traces.
+
+| Metric | Plane | Labels | Meaning |
+| --- | --- | --- | --- |
+| `workflows_tool_invocation_duration_ms` | Instance | `provider`, `outcome` | Elapsed time for a claimed tool invocation through its durable result. The histogram uses millisecond units and explicit buckets through 120 seconds. |
+| `workflows_tool_invocation_reclaims` | Instance | `action` | Expired or non-retryable claims handled by the executor. `requeued` means the call advances for another read attempt. `failed` means the invocation is settled as interrupted. |
+| `workflows_tool_invocations_queued` | Service | none | Current count of queued tool invocations across the shared database. |
+| `workflows_tool_invocations_in_flight` | Service | none | Current count of tool invocations claimed by an executor. |
+
 ## Development
 
 ```sh

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -25,7 +25,22 @@ import {
   toolRetryDelayMs,
 } from './tool-step-executor.js';
 
+const metricMocks = vi.hoisted(() => ({
+  recordWorkflowToolInvocationDuration: vi.fn(),
+  recordWorkflowToolInvocationLogAppendFailure: vi.fn(),
+  recordWorkflowToolInvocationReclaims: vi.fn(),
+}));
+
+vi.mock('#metrics/instance.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('#metrics/instance.js')>()),
+  recordWorkflowToolInvocationReclaims: metricMocks.recordWorkflowToolInvocationReclaims,
+}));
+
 describe('tool step executor', () => {
+  beforeEach(() => {
+    metricMocks.recordWorkflowToolInvocationReclaims.mockClear();
+  });
+
   test('claims a queued tool, calls the integration, logs it, and settles the step', async () => {
     const {jobId, stepId, connectionId} = await arrangeToolStep();
     const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
@@ -48,6 +63,7 @@ describe('tool step executor', () => {
     });
 
     expect(didWork).toBe(true);
+    expect(metricMocks.recordWorkflowToolInvocationReclaims).not.toHaveBeenCalled();
     expect(callTool).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: expect.any(String),
@@ -269,6 +285,48 @@ describe('tool step executor', () => {
     ]);
   });
 
+  test('records a requeued reclaim when an expired read invocation is found by the executor', async () => {
+    const {jobId} = await arrangeToolStep('read');
+    await nextStepForJob(jobId);
+    const [queued] = await getToolInvocationsByJobExecutionIdForJob(jobId);
+    if (!queued) throw new Error('Expected a queued invocation');
+
+    const firstNow = new Date();
+    const [claimed] = (
+      await claimToolInvocations({
+        limit: 1,
+        now: firstNow,
+        claimOwner: 'executor-one',
+        claimExpiresAt: new Date(firstNow.getTime() + 1_000),
+      })
+    ).claims;
+    if (!claimed) throw new Error('Expected a claimed invocation');
+    await db()
+      .update(toolInvocationsTable)
+      .set({claimExpiresAt: new Date(Date.now() - 1)})
+      .where(eq(toolInvocationsTable.id, claimed.invocation.id));
+
+    const didReclaim = await runToolStepExecutorCycle({
+      integrations: {} as unknown as IntegrationsModuleClient,
+      logs: {} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-two',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    expect(didReclaim).toBe(true);
+    await db()
+      .update(toolInvocationsTable)
+      .set({dueAt: new Date(Date.now() + 60_000)})
+      .where(eq(toolInvocationsTable.id, claimed.invocation.id));
+    expect(metricMocks.recordWorkflowToolInvocationReclaims).toHaveBeenCalledWith('requeued', 1);
+    expect(metricMocks.recordWorkflowToolInvocationReclaims).not.toHaveBeenCalledWith(
+      'failed',
+      expect.any(Number),
+    );
+  });
+
   test('retries a rate-limited read and settles the next call', async () => {
     const {jobId} = await arrangeToolStep('read');
     const callTool = vi
@@ -362,6 +420,11 @@ describe('tool step executor', () => {
     });
 
     expect(callTool).not.toHaveBeenCalled();
+    expect(metricMocks.recordWorkflowToolInvocationReclaims).toHaveBeenCalledWith('failed', 1);
+    expect(metricMocks.recordWorkflowToolInvocationReclaims).not.toHaveBeenCalledWith(
+      'requeued',
+      expect.any(Number),
+    );
     const [step] = await getStepsByJobId(jobId);
     expect(step).toMatchObject({status: 'failed', error: {code: 'invocation_interrupted'}});
     const [invocation] = await getToolInvocationsByJobExecutionIdForJob(jobId);

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -157,8 +157,10 @@ export async function runToolStepExecutorCycle(params: {
     claimOwner: params.claimOwner,
     claimExpiresAt: new Date(now.getTime() + params.callTimeoutMs + CLAIM_HEADROOM_MS),
   });
+  recordWorkflowToolInvocationReclaims('requeued', claimed.requeued);
   recordWorkflowToolInvocationReclaims(
-    claimed.requeued + claimed.claims.filter((claim) => claim.interrupted).length,
+    'failed',
+    claimed.claims.filter((claim) => claim.interrupted).length,
   );
 
   await Promise.all(

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -157,11 +157,13 @@ export async function runToolStepExecutorCycle(params: {
     claimOwner: params.claimOwner,
     claimExpiresAt: new Date(now.getTime() + params.callTimeoutMs + CLAIM_HEADROOM_MS),
   });
-  recordWorkflowToolInvocationReclaims('requeued', claimed.requeued);
-  recordWorkflowToolInvocationReclaims(
-    'failed',
-    claimed.claims.filter((claim) => claim.interrupted).length,
-  );
+  if (claimed.requeued > 0) {
+    recordWorkflowToolInvocationReclaims('requeued', claimed.requeued);
+  }
+  const failedReclaims = claimed.claims.filter((claim) => claim.interrupted).length;
+  if (failedReclaims > 0) {
+    recordWorkflowToolInvocationReclaims('failed', failedReclaims);
+  }
 
   await Promise.all(
     claimed.claims.map((claim) =>

--- a/libs/api/workflows/src/metrics/instance.test.ts
+++ b/libs/api/workflows/src/metrics/instance.test.ts
@@ -1,0 +1,103 @@
+const metricMocks = vi.hoisted(() => {
+  const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
+  const histograms = new Map<string, {record: ReturnType<typeof vi.fn>}>();
+  const createCounter = vi.fn((name: string) => {
+    const counter = {add: vi.fn()};
+    counters.set(name, counter);
+    return counter;
+  });
+  const createHistogram = vi.fn((name: string) => {
+    const histogram = {record: vi.fn()};
+    histograms.set(name, histogram);
+    return histogram;
+  });
+
+  return {counters, createCounter, createHistogram, histograms};
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  instanceMetrics: {
+    getMeter: () => ({
+      createCounter: metricMocks.createCounter,
+      createHistogram: metricMocks.createHistogram,
+    }),
+  },
+}));
+
+let metrics: typeof import('./instance.js');
+
+beforeEach(async () => {
+  vi.resetModules();
+  metricMocks.counters.clear();
+  metricMocks.histograms.clear();
+  metrics = await import('./instance.js');
+});
+
+function counterAdd(name: string): ReturnType<typeof vi.fn> {
+  const counter = metricMocks.counters.get(name);
+  if (!counter) throw new Error(`Missing counter: ${name}`);
+  return counter.add;
+}
+
+function histogramRecord(name: string): ReturnType<typeof vi.fn> {
+  const histogram = metricMocks.histograms.get(name);
+  if (!histogram) throw new Error(`Missing histogram: ${name}`);
+  return histogram.record;
+}
+
+describe('workflow tool invocation metrics', () => {
+  test('defines the duration histogram and reclaim counter with bounded labels', () => {
+    const histogramCall = (
+      metricMocks.createHistogram.mock.calls as unknown as Array<
+        [string, {unit?: string; advice?: {explicitBucketBoundaries?: number[]}}]
+      >
+    ).find(([name]) => name === 'workflows_tool_invocation_duration_ms');
+    expect(histogramCall).toEqual([
+      'workflows_tool_invocation_duration_ms',
+      expect.objectContaining({
+        unit: 'ms',
+        advice: {
+          explicitBucketBoundaries: [10, 50, 100, 500, 1_000, 5_000, 30_000, 120_000],
+        },
+      }),
+    ]);
+
+    const counterCall = (
+      metricMocks.createCounter.mock.calls as unknown as Array<[string, {description?: string}]>
+    ).find(([name]) => name === 'workflows_tool_invocation_reclaims');
+    expect(counterCall).toEqual([
+      'workflows_tool_invocation_reclaims',
+      expect.objectContaining({description: expect.any(String)}),
+    ]);
+  });
+
+  test('records duration with provider and outcome labels', () => {
+    metrics.recordWorkflowToolInvocationDuration('github', 'success', 1_234);
+    metrics.recordWorkflowToolInvocationDuration('linear', 'error', 5_678);
+
+    expect(histogramRecord('workflows_tool_invocation_duration_ms')).toHaveBeenNthCalledWith(
+      1,
+      1_234,
+      {provider: 'github', outcome: 'success'},
+    );
+    expect(histogramRecord('workflows_tool_invocation_duration_ms')).toHaveBeenNthCalledWith(
+      2,
+      5_678,
+      {provider: 'linear', outcome: 'error'},
+    );
+  });
+
+  test('records reclaims with their action and ignores empty batches', () => {
+    metrics.recordWorkflowToolInvocationReclaims('requeued', 2);
+    metrics.recordWorkflowToolInvocationReclaims('failed', 1);
+    metrics.recordWorkflowToolInvocationReclaims('failed', 0);
+
+    expect(counterAdd('workflows_tool_invocation_reclaims')).toHaveBeenNthCalledWith(1, 2, {
+      action: 'requeued',
+    });
+    expect(counterAdd('workflows_tool_invocation_reclaims')).toHaveBeenNthCalledWith(2, 1, {
+      action: 'failed',
+    });
+    expect(counterAdd('workflows_tool_invocation_reclaims')).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -116,16 +116,17 @@ const listenerEventsCoalesced = meter.createHistogram<Record<string, never>>(
 const toolInvocationDuration = meter.createHistogram<{
   provider: string;
   outcome: 'success' | 'error';
-}>('workflows_tool_invocation_duration', {
+}>('workflows_tool_invocation_duration_ms', {
   description: 'Server-executed workflow tool invocation duration by provider and outcome',
   unit: 'ms',
   advice: {explicitBucketBoundaries: [10, 50, 100, 500, 1_000, 5_000, 30_000, 120_000]},
 });
 
-const toolInvocationReclaimsCount = meter.createCounter<Record<string, never>>(
-  'workflows_tool_invocation_reclaims',
-  {description: 'Expired server-executed workflow tool invocations reclaimed by the executor'},
-);
+const toolInvocationReclaimsCount = meter.createCounter<{
+  action: 'requeued' | 'failed';
+}>('workflows_tool_invocation_reclaims', {
+  description: 'Expired server-executed workflow tool invocations reclaimed by the executor',
+});
 
 const toolInvocationLogAppendFailuresCount = meter.createCounter<{
   reason: 'known' | 'unexpected';
@@ -217,8 +218,11 @@ export function recordWorkflowToolInvocationDuration(
   toolInvocationDuration.record(durationMs, {provider, outcome});
 }
 
-export function recordWorkflowToolInvocationReclaims(count: number): void {
-  if (count > 0) toolInvocationReclaimsCount.add(count);
+export function recordWorkflowToolInvocationReclaims(
+  action: 'requeued' | 'failed',
+  count: number,
+): void {
+  if (count > 0) toolInvocationReclaimsCount.add(count, {action});
 }
 
 export function recordWorkflowToolInvocationLogAppendFailure(reason: 'known' | 'unexpected'): void {


### PR DESCRIPTION
Aligns workflow tool-step telemetry with the two-plane metrics contract. Duration uses the required millisecond histogram name, and reclaim actions expose bounded `requeued` and `failed` labels. Adds focused coverage and release metadata.

Closes ENG-1681

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns workflow tool-step metrics with the two-plane contract: the duration histogram is renamed to `workflows_tool_invocation_duration_ms`, and the reclaim counter gains bounded `action` labels (`requeued`, `failed`). The explicit millisecond suffix is required because the API Prometheus exporter emits histogram names verbatim. Adds unit tests, updates the observability docs and README, and adds a patch changeset.

Closes ENG-1681.

<sup>Written for commit 176872627c79694b8e1a25cafb8b59ff0a46979e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

