### PR TITLE
[@shipfox/api-server] Preserve default module dependencies during customization

### DIFF
--- a/.changeset/safe-default-module-customization.md
+++ b/.changeset/safe-default-module-customization.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-server": minor
+---
+
+Adds additive default module options that preserve composition-owned dependencies when hosts customize Agent, Auth, or Runners.

--- a/.changeset/safe-default-module-customization.md
+++ b/.changeset/safe-default-module-customization.md
@@ -1,5 +1,6 @@
 ---
+"@shipfox/api-agent": minor
 "@shipfox/api-server": minor
 ---
 
-Adds additive default module options that preserve composition-owned dependencies when hosts customize Agent, Auth, or Runners.
+Adds `CreateAgentModuleOptions` to `@shipfox/api-agent` and `agentModuleOptions`, `authModuleOptions`, and `runnersModuleOptions` to `defaultModules()` in `@shipfox/api-server`.

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -66,7 +66,7 @@ export {
   upsertModelProviderConfig,
 } from '#db/index.js';
 
-export function createAgentModule(params: {
+export interface CreateAgentModuleOptions {
   secrets: AgentSecretsClient;
   managedProvider?: ManagedModelProvider | undefined;
   /**
@@ -77,7 +77,9 @@ export function createAgentModule(params: {
    * so an external consumer can omit it and keep the module claim/release-free.
    */
   workflows?: WorkflowsModuleClient | undefined;
-}): ShipfoxModule {
+}
+
+export function createAgentModule(params: CreateAgentModuleOptions): ShipfoxModule {
   assertAgentConfig(params.managedProvider);
   warnOnUnsafeAgentSessionConfig();
 

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -76,7 +76,9 @@ factories to the matching `*ModuleOptions` field.
 The standard Agent module validates its configuration during composition. Its
 additive options cannot provide or replace the composition-owned Secrets and
 Workflows clients. The returned standard module therefore keeps the
-Workflows-backed session transcript routes mounted.
+Workflows-backed session transcript routes mounted. An options object whose
+fields are all undefined is treated as unconfigured and does not conflict with
+a full replacement factory.
 
 Load the instrumentation entry before feature modules:
 

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -5,8 +5,10 @@ Runs a Shipfox API server.
 ## What it does
 
 - **`defaultModules()`**: Returns the standard module list.
-- **`DefaultAgentModuleFactory`**: Builds the Agent module with a scoped Secrets client.
-- **`DefaultAuthModuleFactory`**: Builds the Auth module with the composed Workspaces client.
+- **`DefaultAgentModuleOptions`**: Configures the standard Agent module while `defaultModules()` supplies its Secrets and Workflows clients.
+- **`DefaultAuthModuleOptions`**: Configures the standard Auth module while `defaultModules()` supplies its Workspaces client.
+- **`DefaultRunnersModuleOptions`**: Configures the standard Runners module while `defaultModules()` supplies its Auth client.
+- **`DefaultAgentModuleFactory`**, **`DefaultAuthModuleFactory`**, and **`DefaultRunnersModuleFactory`**: Full module replacement escape hatches.
 - **`createServer()`**: Builds an API server. The caller owns process signals.
 - **`runServer()`**: Starts the server. It listens for SIGTERM and SIGINT.
 - **`createLoginMethodsRoute()`**: Builds the public login-method catalog route. `createServer` mounts it automatically.
@@ -35,36 +37,46 @@ const modules = await defaultModules({
 });
 ```
 
-To provide an Auth module with an application-specific signup policy, use the
-Auth factory. Its returned module is included in the standard composition and
-its inter-module presentations are registered with the same transport:
+To configure the standard Auth module with an application-specific signup
+policy, use `authModuleOptions`. The composition root keeps ownership of the
+Workspaces client and the module lifecycle:
 
 ```ts
-import {createAuthModule} from '@shipfox/api-auth';
-
 const modules = await defaultModules({
-  authModule: ({workspaces}) => createAuthModule({workspaces, signupPolicy}),
+  authModuleOptions: {signupPolicy},
 });
 ```
 
-To replace the Agent module, use the Agent factory. It receives the composed
-Secrets operations used by Agent, and its returned module is included in the
-standard composition before presentation registration and transport sealing:
+To configure the standard Agent module with a managed provider, use
+`agentModuleOptions`. `defaultModules()` calls `createAgentModule` with the
+managed provider and every composition-owned dependency:
 
 ```ts
-import {createAgentModule} from '@shipfox/api-agent';
-
 const modules = await defaultModules({
-  agentModule: ({secrets}) => createAgentModule({secrets, managedProvider}),
+  agentModuleOptions: {managedProvider},
 });
 ```
 
-The standard `createAgentModule` validates Agent configuration during
-composition. A custom factory that does not call it owns equivalent validation.
-Its module must declare the `agent` database namespace and present the canonical
-Agent inter-module contract. The scoped Secrets client exposes only the
-operations used by Agent. Treat a custom module as trusted code with access to
-those operations.
+To configure installation provisioning in the standard Runners module, use
+`runnersModuleOptions`:
+
+```ts
+const modules = await defaultModules({
+  runnersModuleOptions: {installationProvisioning: {policy}},
+});
+```
+
+Use `agentModuleFactory`, `authModuleFactory`, or `runnersModuleFactory` only
+when replacing a complete module. A replacement factory owns equivalent
+validation and must preserve the module contract and forward every dependency
+it needs. The legacy `agentModule`, `authModule`, and `runnersModule` factory
+options remain supported as deprecated aliases. Migrate configuration-only
+factories to the matching `*ModuleOptions` field.
+
+The standard Agent module validates its configuration during composition. Its
+additive options cannot provide or replace the composition-owned Secrets and
+Workflows clients. The returned standard module therefore keeps the
+Workflows-backed session transcript routes mounted.
 
 Load the instrumentation entry before feature modules:
 

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,9 +1,12 @@
 export {
   type DefaultAgentModuleFactory,
+  type DefaultAgentModuleOptions,
   type DefaultAuthModuleFactory,
+  type DefaultAuthModuleOptions,
   type DefaultModulesExtension,
   type DefaultModulesOptions,
   type DefaultRunnersModuleFactory,
+  type DefaultRunnersModuleOptions,
   defaultModules,
 } from './modules.js';
 export {createLoginMethodsRoute} from './routes/login-methods.js';

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -16,7 +16,7 @@ import {
   workspacesInterModuleContract,
 } from '@shipfox/api-workspaces-dto/inter-module';
 import {defineInterModuleContract, defineInterModulePresentation} from '@shipfox/inter-module';
-import type {DefaultAgentModuleFactory} from './modules.js';
+import type {DefaultAgentModuleFactory, DefaultAgentModuleOptions} from './modules.js';
 import {defaultModules} from './modules.js';
 
 const mocks = vi.hoisted(() => ({
@@ -366,14 +366,49 @@ describe('defaultModules', () => {
     expect(mocks.createAgentModule.mock.calls[0]?.[0].secrets).not.toHaveProperty('getSecret');
   });
 
-  it('composes Agent with the shared Secrets client and registers the supplied module', async () => {
+  it('composes Agent options with the default factory and keeps session routes registered', async () => {
+    const managedProvider: NonNullable<DefaultAgentModuleOptions['managedProvider']> = {
+      id: 'managed',
+      label: 'Managed',
+      models: [],
+      defaultModel: 'managed-model',
+      resolveCredentials: async () => ({
+        api: 'openai-responses',
+        baseUrl: 'https://gateway.example.test',
+        credentials: {},
+      }),
+    };
+    const sessionTranscriptRoutes = [
+      {prefix: '/runs/jobs/current/steps/:stepId/session', routes: []},
+    ];
+    const defaultAgentModule = mocks.createAgentModule();
+    mocks.createAgentModule.mockClear();
+    mocks.createAgentModule.mockImplementation(({workflows}) => ({
+      ...defaultAgentModule,
+      routes: workflows === undefined ? [] : sessionTranscriptRoutes,
+    }));
+
+    const modules = await defaultModules({agentModuleOptions: {managedProvider}});
+    const agentOptions = mocks.createAgentModule.mock.calls[0]?.[0];
+
+    expect(agentOptions).toEqual({
+      managedProvider,
+      secrets: expect.any(Object),
+      workflows: expect.objectContaining({
+        getLeasedAgentSessionContext: expect.any(Function),
+      }),
+    });
+    expect(modules.find((module) => module.name === 'agent')?.routes).toBe(sessionTranscriptRoutes);
+  });
+
+  it('supports an explicitly named full Agent module replacement', async () => {
     const customAgentModule = mocks.createAgentModule();
     mocks.createAgentModule.mockClear();
     const agentModule = vi.fn<DefaultAgentModuleFactory>((options) =>
       mocks.createAgentModule(options),
     );
 
-    const modules = await defaultModules({agentModule});
+    const modules = await defaultModules({agentModuleFactory: agentModule});
     const agentFactoryCall = agentModule.mock.calls[0];
     expect(agentFactoryCall).toBeDefined();
     if (!agentFactoryCall) throw new Error('Agent module factory was not called.');
@@ -437,7 +472,7 @@ describe('defaultModules', () => {
       },
     };
 
-    await expect(defaultModules({agentModule: () => customAgentModule})).rejects.toThrow(
+    await expect(defaultModules({agentModuleFactory: () => customAgentModule})).rejects.toThrow(
       'Custom agentModule must declare database namespace "agent"',
     );
   });
@@ -448,7 +483,7 @@ describe('defaultModules', () => {
       interModulePresentations: [],
     };
 
-    await expect(defaultModules({agentModule: () => customAgentModule})).rejects.toThrow(
+    await expect(defaultModules({agentModuleFactory: () => customAgentModule})).rejects.toThrow(
       'Custom agentModule must present the canonical "agent" inter-module contract',
     );
   });
@@ -471,8 +506,33 @@ describe('defaultModules', () => {
       interModulePresentations: [{...defaultPresentation, contract: mismatchedAgentContract}],
     };
 
-    await expect(defaultModules({agentModule: () => customAgentModule})).rejects.toThrow(
+    await expect(defaultModules({agentModuleFactory: () => customAgentModule})).rejects.toThrow(
       'Custom agentModule must present the canonical "agent" inter-module contract',
+    );
+  });
+
+  it('rejects Agent options combined with a full replacement', async () => {
+    await expect(
+      defaultModules({agentModuleOptions: {}, agentModuleFactory: () => mocks.createAgentModule()}),
+    ).rejects.toThrow('Use Agent module options or a Agent module replacement factory, not both.');
+  });
+
+  it('keeps legacy module replacement aliases working during migration', async () => {
+    const customAgentModule = mocks.createAgentModule();
+    const customAuthModule = mocks.createAuthModule();
+    const customRunnersModule = mocks.createRunnersModule();
+    mocks.createAgentModule.mockClear();
+    mocks.createAuthModule.mockClear();
+    mocks.createRunnersModule.mockClear();
+
+    const modules = await defaultModules({
+      agentModule: () => customAgentModule,
+      authModule: () => customAuthModule,
+      runnersModule: () => customRunnersModule,
+    });
+
+    expect(modules).toEqual(
+      expect.arrayContaining([customAgentModule, customAuthModule, customRunnersModule]),
     );
   });
 
@@ -501,7 +561,7 @@ describe('defaultModules', () => {
       mocks.createAuthModule({workspaces, signupPolicy}),
     );
 
-    const modules = await defaultModules({authModule, extension});
+    const modules = await defaultModules({authModuleFactory: authModule, extension});
     const authWorkspaces = authModule.mock.calls[0]?.[0].workspaces;
 
     expect(authModule).toHaveBeenCalledWith({workspaces: expect.any(Object)});
@@ -519,7 +579,18 @@ describe('defaultModules', () => {
     ).toContain(authInterModuleContract.module);
   });
 
-  it('lets a host replace only the Runners module with the composed Auth client', async () => {
+  it('composes Auth options with the shared Workspaces client', async () => {
+    const signupPolicy = {isSignupAllowed: vi.fn().mockResolvedValue({allowed: true})};
+
+    await defaultModules({authModuleOptions: {signupPolicy}});
+
+    expect(mocks.createAuthModule).toHaveBeenCalledWith({
+      signupPolicy,
+      workspaces: expect.any(Object),
+    });
+  });
+
+  it('supports an explicitly named full Runners module replacement', async () => {
     const policy = {filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set<string>())};
     const runnersModule = mocks.createRunnersModule({});
     const createHostRunnersModule = vi.fn(({auth}) =>
@@ -527,7 +598,7 @@ describe('defaultModules', () => {
     );
     mocks.createRunnersModule.mockClear();
 
-    const modules = await defaultModules({runnersModule: createHostRunnersModule});
+    const modules = await defaultModules({runnersModuleFactory: createHostRunnersModule});
 
     expect(createHostRunnersModule).toHaveBeenCalledWith({auth: expect.any(Object)});
     expect(mocks.createRunnersModule).toHaveBeenCalledWith({
@@ -551,6 +622,19 @@ describe('defaultModules', () => {
       'triggers',
       'dispatcher',
     ]);
+  });
+
+  it('composes Runners options with the shared Auth client', async () => {
+    const policy = {filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set<string>())};
+
+    await defaultModules({
+      runnersModuleOptions: {installationProvisioning: {policy}},
+    });
+
+    expect(mocks.createRunnersModule).toHaveBeenCalledWith({
+      auth: expect.any(Object),
+      installationProvisioning: {policy},
+    });
   });
 
   it('extends the default module list with the composed Workspaces client', async () => {

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -16,7 +16,11 @@ import {
   workspacesInterModuleContract,
 } from '@shipfox/api-workspaces-dto/inter-module';
 import {defineInterModuleContract, defineInterModulePresentation} from '@shipfox/inter-module';
-import type {DefaultAgentModuleFactory, DefaultAgentModuleOptions} from './modules.js';
+import type {
+  DefaultAgentModuleFactory,
+  DefaultAgentModuleOptions,
+  DefaultModulesOptions,
+} from './modules.js';
 import {defaultModules} from './modules.js';
 
 const mocks = vi.hoisted(() => ({
@@ -401,6 +405,29 @@ describe('defaultModules', () => {
     expect(modules.find((module) => module.name === 'agent')?.routes).toBe(sessionTranscriptRoutes);
   });
 
+  it('keeps composition-owned Agent dependencies ahead of runtime options', async () => {
+    const hostSecrets = {getSecret: vi.fn()};
+    const hostWorkflows = {getLeasedAgentSessionContext: vi.fn()};
+    const agentModuleOptions = {
+      secrets: hostSecrets,
+      workflows: hostWorkflows,
+    } as unknown as DefaultAgentModuleOptions;
+
+    await defaultModules({agentModuleOptions});
+
+    const agentOptions = mocks.createAgentModule.mock.calls[0]?.[0] as
+      | {secrets: object; workflows: object}
+      | undefined;
+    expect(agentOptions).toBeDefined();
+    if (!agentOptions) throw new Error('Default Agent module options were not captured.');
+    expect(agentOptions.secrets).not.toBe(hostSecrets);
+    expect(agentOptions.secrets).not.toHaveProperty('getSecret');
+    expect(agentOptions.workflows).not.toBe(hostWorkflows);
+    expect(agentOptions.workflows).toEqual(
+      expect.objectContaining({getLeasedAgentSessionContext: expect.any(Function)}),
+    );
+  });
+
   it('supports an explicitly named full Agent module replacement', async () => {
     const customAgentModule = mocks.createAgentModule();
     mocks.createAgentModule.mockClear();
@@ -511,10 +538,95 @@ describe('defaultModules', () => {
     );
   });
 
-  it('rejects Agent options combined with a full replacement', async () => {
-    await expect(
-      defaultModules({agentModuleOptions: {}, agentModuleFactory: () => mocks.createAgentModule()}),
-    ).rejects.toThrow('Use Agent module options or a Agent module replacement factory, not both.');
+  it('rejects conflicting module customization paths before creating a module', async () => {
+    const managedProvider: NonNullable<DefaultAgentModuleOptions['managedProvider']> = {
+      id: 'managed',
+      label: 'Managed',
+      models: [{id: 'managed-model', label: 'Managed model', api: 'openai-responses'}],
+      defaultModel: 'managed-model',
+      resolveCredentials: async () => ({
+        api: 'openai-responses',
+        baseUrl: 'https://gateway.example.test',
+        credentials: {},
+      }),
+    };
+    const signupPolicy = {isSignupAllowed: vi.fn().mockResolvedValue({allowed: true})};
+    const installationProvisioning = {
+      policy: {
+        filterEligibleWorkspaceIds: async (workspaceIds: readonly string[]) =>
+          new Set(workspaceIds),
+      },
+    };
+    const replacementFactory = () => ({name: 'replacement'});
+    const cases = [
+      {
+        moduleName: 'Agent',
+        article: 'an',
+        moduleMock: mocks.createAgentModule,
+        moduleOptions: {agentModuleOptions: {managedProvider}},
+        newFactory: {agentModuleFactory: replacementFactory},
+        legacyFactory: {agentModule: replacementFactory},
+      },
+      {
+        moduleName: 'Auth',
+        article: 'an',
+        moduleMock: mocks.createAuthModule,
+        moduleOptions: {authModuleOptions: {signupPolicy}},
+        newFactory: {authModuleFactory: replacementFactory},
+        legacyFactory: {authModule: replacementFactory},
+      },
+      {
+        moduleName: 'Runners',
+        article: 'a',
+        moduleMock: mocks.createRunnersModule,
+        moduleOptions: {runnersModuleOptions: {installationProvisioning}},
+        newFactory: {runnersModuleFactory: replacementFactory},
+        legacyFactory: {runnersModule: replacementFactory},
+      },
+    ] as const;
+
+    for (const {
+      moduleName,
+      article,
+      moduleMock,
+      moduleOptions,
+      newFactory,
+      legacyFactory,
+    } of cases) {
+      for (const [description, conflict] of [
+        ['options with named replacement', {...moduleOptions, ...newFactory}],
+        ['options with legacy replacement', {...moduleOptions, ...legacyFactory}],
+      ] as const) {
+        moduleMock.mockClear();
+        await expect(defaultModules(conflict as DefaultModulesOptions)).rejects.toThrow(
+          `Use ${moduleName} module options or ${article} ${moduleName} module replacement factory, not both.`,
+        );
+        expect(moduleMock, `${moduleName} ${description}`).not.toHaveBeenCalled();
+      }
+
+      moduleMock.mockClear();
+      await expect(
+        defaultModules({...newFactory, ...legacyFactory} as DefaultModulesOptions),
+      ).rejects.toThrow(`Provide only one ${moduleName} module replacement factory.`);
+      expect(moduleMock, `${moduleName} replacement conflict`).not.toHaveBeenCalled();
+    }
+  });
+
+  it('treats module options with no defined values as unconfigured', async () => {
+    const customAgentModule = mocks.createAgentModule();
+    mocks.createAgentModule.mockClear();
+    const agentModuleFactory = vi.fn(() => customAgentModule);
+
+    await defaultModules({
+      agentModuleOptions: {managedProvider: undefined},
+      agentModuleFactory,
+    });
+
+    expect(agentModuleFactory).toHaveBeenCalledWith({
+      secrets: expect.any(Object),
+      workflows: expect.any(Object),
+    });
+    expect(mocks.createAgentModule).not.toHaveBeenCalled();
   });
 
   it('keeps legacy module replacement aliases working during migration', async () => {

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -1,6 +1,6 @@
 import {annotationsModule} from '@shipfox/annotations';
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
-import {createAgentModule} from '@shipfox/api-agent';
+import {type CreateAgentModuleOptions, createAgentModule} from '@shipfox/api-agent';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {type CreateAuthModuleOptions, createAuthModule} from '@shipfox/api-auth';
 import {config as authConfig} from '@shipfox/api-auth/config';
@@ -71,10 +71,7 @@ export type DefaultAuthModuleFactory = (options: {
 }) => ShipfoxModule;
 
 /** Options for the standard Agent module. `defaultModules` supplies Secrets and Workflows. */
-export type DefaultAgentModuleOptions = Pick<
-  Parameters<typeof createAgentModule>[0],
-  'managedProvider'
->;
+export type DefaultAgentModuleOptions = Pick<CreateAgentModuleOptions, 'managedProvider'>;
 
 /**
  * Replaces the Agent module in the standard composition slot. This is a full
@@ -351,6 +348,7 @@ type AgentModuleSecretsClient = Pick<
 >;
 
 const GITHUB_SECRET_NAMESPACE_PREFIX = 'system/github/';
+const INITIAL_VOWEL_RE = /^[aeiou]/iu;
 
 function requireGithubSecretNamespace(namespace: string): string {
   if (!namespace.startsWith(GITHUB_SECRET_NAMESPACE_PREFIX)) {
@@ -380,16 +378,24 @@ function resolveModuleReplacementFactory<T>(
   return replacementFactory ?? legacyFactory;
 }
 
-function assertModuleOptionsNotCombinedWithReplacement<T>(
+function assertModuleOptionsNotCombinedWithReplacement<T extends object>(
   moduleOptions: T | undefined,
   replacementFactory: unknown,
   moduleName: string,
 ): void {
-  if (moduleOptions !== undefined && replacementFactory !== undefined) {
+  if (hasConfiguredModuleOptions(moduleOptions) && replacementFactory !== undefined) {
     throw new Error(
-      `Use ${moduleName} module options or a ${moduleName} module replacement factory, not both.`,
+      `Use ${moduleName} module options or ${indefiniteArticle(moduleName)} ${moduleName} module replacement factory, not both.`,
     );
   }
+}
+
+function hasConfiguredModuleOptions<T extends object>(moduleOptions: T | undefined): boolean {
+  return Object.values(moduleOptions ?? {}).some((value) => value !== undefined);
+}
+
+function indefiniteArticle(value: string): 'a' | 'an' {
+  return INITIAL_VOWEL_RE.test(value) ? 'an' : 'a';
 }
 
 function validateCustomAgentModule(module: ShipfoxModule): void {

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -2,7 +2,7 @@ import {annotationsModule} from '@shipfox/annotations';
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import {createAgentModule} from '@shipfox/api-agent';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
-import {createAuthModule} from '@shipfox/api-auth';
+import {type CreateAuthModuleOptions, createAuthModule} from '@shipfox/api-auth';
 import {config as authConfig} from '@shipfox/api-auth/config';
 import {
   type AuthInterModuleClient,
@@ -18,7 +18,7 @@ import {createLogsModule} from '@shipfox/api-logs';
 import {logsInterModuleContract} from '@shipfox/api-logs-dto/inter-module';
 import {createProjectsModule} from '@shipfox/api-projects';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
-import {createRunnersModule} from '@shipfox/api-runners';
+import {type CreateRunnersModuleOptions, createRunnersModule} from '@shipfox/api-runners';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {createSecretsModule} from '@shipfox/api-secrets';
 import {
@@ -47,22 +47,40 @@ import {logger} from '@shipfox/node-opentelemetry';
 
 export interface DefaultModulesOptions {
   webhookDeliverySource?: WebhookDeliverySource | undefined;
+  authModuleOptions?: DefaultAuthModuleOptions | undefined;
+  agentModuleOptions?: DefaultAgentModuleOptions | undefined;
+  runnersModuleOptions?: DefaultRunnersModuleOptions | undefined;
+  authModuleFactory?: DefaultAuthModuleFactory | undefined;
+  agentModuleFactory?: DefaultAgentModuleFactory | undefined;
+  runnersModuleFactory?: DefaultRunnersModuleFactory | undefined;
+  /** @deprecated Use `authModuleOptions` or `authModuleFactory`. */
   authModule?: DefaultAuthModuleFactory | undefined;
+  /** @deprecated Use `agentModuleOptions` or `agentModuleFactory`. */
   agentModule?: DefaultAgentModuleFactory | undefined;
+  /** @deprecated Use `runnersModuleOptions` or `runnersModuleFactory`. */
   runnersModule?: DefaultRunnersModuleFactory | undefined;
   extension?: DefaultModulesExtension | undefined;
 }
 
+/** Options for the standard Auth module. `defaultModules` supplies Workspaces. */
+export type DefaultAuthModuleOptions = Pick<CreateAuthModuleOptions, 'signupPolicy'>;
+
+/** Full replacement escape hatch for the standard Auth module. */
 export type DefaultAuthModuleFactory = (options: {
   workspaces: WorkspacesInterModuleClient;
 }) => ShipfoxModule;
 
+/** Options for the standard Agent module. `defaultModules` supplies Secrets and Workflows. */
+export type DefaultAgentModuleOptions = Pick<
+  Parameters<typeof createAgentModule>[0],
+  'managedProvider'
+>;
+
 /**
- * Builds the Agent module in the standard composition slot. The default
- * factory validates Agent configuration through `createAgentModule`; a custom
- * factory owns equivalent validation when it does not delegate to that
- * factory. Custom modules must preserve the `agent` database namespace and
- * canonical Agent presentation required by the composed clients.
+ * Replaces the Agent module in the standard composition slot. This is a full
+ * replacement escape hatch. Configuration-only changes should use
+ * `agentModuleOptions` so the composition root retains ownership of its
+ * dependencies.
  */
 export type DefaultAgentModuleFactory = (options: {
   secrets: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecretsByNamespace' | 'setSecrets'>;
@@ -75,6 +93,14 @@ export type DefaultAgentModuleFactory = (options: {
    */
   workflows?: WorkflowsModuleClient | undefined;
 }) => ShipfoxModule;
+
+/** Options for the standard Runners module. `defaultModules` supplies Auth. */
+export type DefaultRunnersModuleOptions = Pick<
+  CreateRunnersModuleOptions,
+  'installationProvisioning'
+>;
+
+/** Full replacement escape hatch for the standard Runners module. */
 export type DefaultRunnersModuleFactory = (options: {auth: AuthInterModuleClient}) => ShipfoxModule;
 export type DefaultModulesExtension = (options: {
   workspaces: WorkspacesInterModuleClient;
@@ -226,15 +252,57 @@ export async function defaultModules(
     integrations: integrationsClient,
   });
   const extensionModules = options.extension?.({workspaces: workspacesClient}) ?? [];
-  const agentModule = (options.agentModule ?? createAgentModule)({
-    secrets: createAgentSecretsClient(secretsClient),
-    workflows: workflowsClient,
-  });
-  if (options.agentModule) validateCustomAgentModule(agentModule);
+  const agentModuleFactory = resolveModuleReplacementFactory(
+    options.agentModuleFactory,
+    options.agentModule,
+    'Agent',
+  );
+  const authModuleFactory = resolveModuleReplacementFactory(
+    options.authModuleFactory,
+    options.authModule,
+    'Auth',
+  );
+  const runnersModuleFactory = resolveModuleReplacementFactory(
+    options.runnersModuleFactory,
+    options.runnersModule,
+    'Runners',
+  );
+  assertModuleOptionsNotCombinedWithReplacement(
+    options.agentModuleOptions,
+    agentModuleFactory,
+    'Agent',
+  );
+  assertModuleOptionsNotCombinedWithReplacement(
+    options.authModuleOptions,
+    authModuleFactory,
+    'Auth',
+  );
+  assertModuleOptionsNotCombinedWithReplacement(
+    options.runnersModuleOptions,
+    runnersModuleFactory,
+    'Runners',
+  );
+
+  const agentModule = agentModuleFactory
+    ? agentModuleFactory({
+        secrets: createAgentSecretsClient(secretsClient),
+        workflows: workflowsClient,
+      })
+    : createAgentModule({
+        ...options.agentModuleOptions,
+        secrets: createAgentSecretsClient(secretsClient),
+        workflows: workflowsClient,
+      });
+  if (agentModuleFactory) validateCustomAgentModule(agentModule);
 
   const modules = [
     emailChallengesModule,
-    (options.authModule ?? createAuthModule)({workspaces: workspacesClient}),
+    authModuleFactory
+      ? authModuleFactory({workspaces: workspacesClient})
+      : createAuthModule({
+          ...options.authModuleOptions,
+          workspaces: workspacesClient,
+        }),
     createWorkspacesModule({auth: authClient, projects: projectsClient, runners: runnersClient}),
     createSecretsModule(projectsClient),
     agentModule,
@@ -254,7 +322,12 @@ export async function defaultModules(
       logs: logsClient,
     }),
     annotationsModule,
-    (options.runnersModule ?? createRunnersModule)({auth: authClient}),
+    runnersModuleFactory
+      ? runnersModuleFactory({auth: authClient})
+      : createRunnersModule({
+          ...options.runnersModuleOptions,
+          auth: authClient,
+        }),
     createLogsModule({
       workflows: workflowsClient,
       jobLeaseTokenTtlSeconds: durationToSeconds(authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN),
@@ -294,6 +367,29 @@ function createAgentSecretsClient(
     getSecretsByNamespace: (input, options) => secretsClient.getSecretsByNamespace(input, options),
     setSecrets: (input, options) => secretsClient.setSecrets(input, options),
   };
+}
+
+function resolveModuleReplacementFactory<T>(
+  replacementFactory: T | undefined,
+  legacyFactory: T | undefined,
+  moduleName: string,
+): T | undefined {
+  if (replacementFactory !== undefined && legacyFactory !== undefined) {
+    throw new Error(`Provide only one ${moduleName} module replacement factory.`);
+  }
+  return replacementFactory ?? legacyFactory;
+}
+
+function assertModuleOptionsNotCombinedWithReplacement<T>(
+  moduleOptions: T | undefined,
+  replacementFactory: unknown,
+  moduleName: string,
+): void {
+  if (moduleOptions !== undefined && replacementFactory !== undefined) {
+    throw new Error(
+      `Use ${moduleName} module options or a ${moduleName} module replacement factory, not both.`,
+    );
+  }
 }
 
 function validateCustomAgentModule(module: ShipfoxModule): void {

--- a/libs/api/server/test/published/composition.ts
+++ b/libs/api/server/test/published/composition.ts
@@ -1,6 +1,16 @@
-import {createServer, defaultModules} from '@shipfox/api-server';
+import {createServer, type DefaultAgentModuleOptions, defaultModules} from '@shipfox/api-server';
 
-const managedProvider = undefined;
+const managedProvider: NonNullable<DefaultAgentModuleOptions['managedProvider']> = {
+  id: 'managed',
+  label: 'Managed',
+  models: [{id: 'managed-model', label: 'Managed model', api: 'openai-responses'}],
+  defaultModel: 'managed-model',
+  resolveCredentials: async () => ({
+    api: 'openai-responses',
+    baseUrl: 'https://gateway.example.test',
+    credentials: {},
+  }),
+};
 
 void createServer({
   modules: [

--- a/libs/api/server/test/published/composition.ts
+++ b/libs/api/server/test/published/composition.ts
@@ -1,18 +1,18 @@
-import {createRunnersModule} from '@shipfox/api-runners';
 import {createServer, defaultModules} from '@shipfox/api-server';
+
+const managedProvider = undefined;
 
 void createServer({
   modules: [
     ...(await defaultModules({
-      runnersModule: ({auth}) =>
-        createRunnersModule({
-          auth,
-          installationProvisioning: {
-            policy: {
-              filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
-            },
+      agentModuleOptions: {managedProvider},
+      runnersModuleOptions: {
+        installationProvisioning: {
+          policy: {
+            filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
           },
-        }),
+        },
+      },
     })),
     {name: 'external-dummy'},
   ],


### PR DESCRIPTION
## Summary

Additive options for the standard Agent, Auth, and Runners modules now keep composition-owned dependencies under defaultModules(). Agent customizations retain the root-provided Secrets and Workflows clients, including the Workflows-backed session transcript routes.

Complete replacements remain available through explicitly named *ModuleFactory fields, while the existing *Module factory fields remain supported as deprecated aliases. The README, module tests, and published composition fixture cover the supported customization paths, with a minor @shipfox/api-server changeset.

Validation passed:

mise exec -- turbo check type test build --filter=@shipfox/api-server
mise exec -- turbo test:external --filter=@shipfox/application-release
mise exec -- turbo test --filter=@shipfox/api-definitions

Closes ENG-1878

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds additive options for the standard Agent, Auth, and Runners modules so hosts can customize them without taking ownership of composition-provided dependencies. Previously, customizing meant replacing the whole module via a factory; now `agentModuleOptions`, `authModuleOptions`, and `runnersModuleOptions` configure the standard modules while `defaultModules()` keeps their Secrets, Workflows, Workspaces, and Auth clients.

- The standard Agent module retains its Workflows-backed session transcript routes under the new options.
- Full replacements are explicitly named `*ModuleFactory` fields; combining options with a replacement factory, or supplying both named and legacy factories, now throws.
- The legacy `*Module` factory fields remain as deprecated aliases.
- README, module tests, and the published composition fixture cover the supported customization paths, including runtime dependency ownership checks.
- Adds a minor changeset for both `@shipfox/api-server` and `@shipfox/api-agent`.

Closes ENG-1878.

<sup>Written for commit 316ce03b8d9c84881b21a293d11f3681a69a59a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

