### PR TITLE
[e2e-client-workspaces] Stabilize Linear callback redirect

### DIFF
--- a/e2e/suites/client/workspaces/tests/setup-checklist.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/setup-checklist.e2e.ts
@@ -85,9 +85,11 @@ test.describe('workspace setup checklist', () => {
         displayName: 'Linear E2E',
         accessToken: `linear-e2e-token-${linearOrganizationId}`,
       });
+      const linearCallbackResponse = page.waitForResponse('**/integrations/linear/callback/api**');
       await page.goto('/integrations/linear/callback?code=e2e-code&state=e2e-state', {
         waitUntil: 'commit',
       });
+      expect((await linearCallbackResponse).ok()).toBe(true);
       await expect(page).toHaveURL(
         new RegExp(`/w/${workspace.slug}/settings/integrations/?$`, 'u'),
       );


### PR DESCRIPTION
## Summary

Wait for the mocked Linear callback response before asserting the integration-settings redirect. This keeps the existing `commit` navigation, which avoids an expected aborted load during the SPA redirect, while synchronizing the assertion with the client callback flow and removing the CI-load-sensitive five-second gap.

## Validation

- `mise run e2e -- --filter=@shipfox/e2e-client-workspaces -- -- --grep 'tracks a Linear installation' --repeat-each=10` — 10 passed with 8 workers.
- `mise exec -- turbo check type build depcruise --filter=@shipfox/e2e-client-workspaces...` — 490 tasks passed.

The target checklist scenario also passed in both full-suite runs. Those local runs ended with unrelated redirect failures in the onboarding and workspace-switcher cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Linear callback E2E test by waiting for the mocked callback response before asserting the redirect URL, so CI load no longer consumes the URL assertion timeout.

Previously the test asserted the redirect immediately after navigation, leaving a load-sensitive gap. Now it confirms the mocked callback succeeded first.

<sup>Written for commit 6030ef9e30047958db40e6f5f97c8e9c7774dfeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

