### PR TITLE
[workflow-document] Enable authorable workflow tool steps

### DIFF
--- a/.changeset/enable-tool-steps.md
+++ b/.changeset/enable-tool-steps.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/workflow-document': minor
+---
+
+Enables authoring integration tool steps with literal tool references, JSON inputs, and result output mappings.

--- a/.changeset/enable-tool-steps.md
+++ b/.changeset/enable-tool-steps.md
@@ -3,4 +3,4 @@
 '@shipfox/workflow-document': minor
 ---
 
-Enables authoring integration tool steps with literal tool references, JSON inputs, and result output mappings. Deploy the validation API and editor schema together: older API builds reject tool-step fields, and rolling back after tool-step definitions are saved will make those definitions fail validation until this release is restored.
+Enables authoring integration tool steps with literal tool references, JSON inputs, and result output mappings.

--- a/.changeset/enable-tool-steps.md
+++ b/.changeset/enable-tool-steps.md
@@ -1,5 +1,6 @@
 ---
+'@shipfox/api-definitions': minor
 '@shipfox/workflow-document': minor
 ---
 
-Enables authoring integration tool steps with literal tool references, JSON inputs, and result output mappings.
+Enables authoring integration tool steps with literal tool references, JSON inputs, and result output mappings. Deploy the validation API and editor schema together: older API builds reject tool-step fields, and rolling back after tool-step definitions are saved will make those definitions fail validation until this release is restored.

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -19,6 +19,8 @@ import {
   ListeningFields,
   RunStepFields,
   StepOutputs,
+  ToolStepFields,
+  ToolStepOutputs,
   TopLevelFields,
   TriggerFields,
 } from '../../generated/reference/workflow-schema.mdx';
@@ -171,8 +173,8 @@ These permissions apply to both job-level checkout and explicit checkout steps.
 
 ## Step fields
 
-Each step is either a run step, an agent step, or a checkout step. The schema
-rejects unknown fields and invalid field combinations.
+Each step is either a run step, an agent step, a checkout step, or a tool step.
+The schema rejects unknown fields and invalid field combinations.
 
 ### Run step fields
 
@@ -191,6 +193,23 @@ shell reads it as text and not as part of the command.
   `deploy "$TARGET"` rather than `eval "deploy $TARGET"`. A workflow sync warns
   when it finds one of these positions.
 </Callout>
+
+### Tool step fields
+
+<ToolStepFields />
+
+The `tool` value is a literal integration tool id. A tool id can name a
+standalone tool or one method in a tool family with `family.method`. The
+optional `connection` value is the slug of an integration connection. Omit it
+to use the project's source connection.
+
+The `with` block contains JSON-compatible tool inputs. String values can use
+workflow expressions. Tool outputs use a mapping from output names to one
+expression over `result` or `vars`.
+
+### Tool step outputs
+
+<ToolStepOutputs />
 
 ### Checkout step fields
 
@@ -218,8 +237,12 @@ A gate must define `success`, `on_failure`, or both.
 
 <StepOutputs />
 
-Each output declaration can be its type directly (for example, `sha: string`) or
-an object with required `type`. Only `json` declarations can include `schema`.
+Run, agent, and checkout steps use output declarations. A declaration can be its
+type directly (for example, `sha: string`) or an object with required `type`.
+Only `json` declarations can include `schema`.
+
+Tool steps use output mappings instead. Each mapping value must be exactly one
+`${{ }}` expression over the tool `result` or workflow `vars`.
 
 ## Listening fields
 

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -207,6 +207,11 @@ The `with` block contains JSON-compatible tool inputs. String values can use
 workflow expressions. Tool outputs use a mapping from output names to one
 expression over `result` or `vars`.
 
+Tool-step authoring requires a validation API deployment that supports these
+fields. Deploy the editor schema and validation API together; rolling back the
+validation API after tool-step definitions are saved makes those definitions
+fail validation until tool-step support is restored.
+
 ### Tool step outputs
 
 <ToolStepOutputs />

--- a/apps/docs/scripts/check-workflow-schema.mjs
+++ b/apps/docs/scripts/check-workflow-schema.mjs
@@ -15,6 +15,8 @@ const requiredAnchors = new Set([
   'listening-fields',
   'gate-fields',
   'run-step-fields',
+  'tool-step-fields',
+  'tool-step-outputs',
   'environment-variables',
   'checkout-fields',
 ]);

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -441,6 +441,18 @@ function renderWorkflowSchemaReference() {
         outputs: recordType('Output'),
       },
     }),
+    component('ToolStepFields', object(steps.properties), {
+      fields: ['key', 'if', 'name', 'tool', 'connection', 'with', 'gate', 'outputs'],
+      required: ['tool'],
+      nested: {
+        gate: '#gate-fields',
+      },
+      types: {
+        with: codeType('Record<string, value>'),
+        gate: namedType('Gate'),
+        outputs: recordType('string'),
+      },
+    }),
     component('CheckoutStepFields', object(steps.properties), {
       fields: ['key', 'if', 'name', 'checkout', 'gate', 'outputs'],
       required: ['checkout'],
@@ -490,6 +502,7 @@ function renderWorkflowSchemaReference() {
     }),
     component('GateFailureFields', object(gateFailure.properties), {required: ['restart_from']}),
     component('StepOutputs', outputFields()),
+    component('ToolStepOutputs', toolOutputFields()),
     component('ListeningFields', object(listening.properties), {
       required: ['on'],
       nested: {
@@ -605,6 +618,16 @@ function outputFields() {
       type: 'string | number | boolean | json | {type: string | number | boolean} | {type: json; schema?: value}',
       description:
         'Output declaration. Use a type directly (for example, `sha: string`) or an object with required `type`. Only `json` declarations can include `schema`.',
+    },
+  };
+}
+
+function toolOutputFields() {
+  return {
+    OUTPUT_NAME: {
+      type: 'string',
+      description:
+        'Output mapping. Use exactly one $' + '{{ }} expression over `result` or `vars`.',
     },
   };
 }

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -446,6 +446,7 @@ function renderWorkflowSchemaReference() {
       required: ['tool'],
       nested: {
         gate: '#gate-fields',
+        outputs: '#tool-step-outputs',
       },
       types: {
         with: codeType('Record<string, value>'),

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -420,7 +420,8 @@ function previousStepOverlays(
     if (step.key === undefined) return [];
     const toolOverlay = toolOverlayByKey.get(step.key);
     if (toolOverlay !== undefined) return [toolOverlay];
-    return [{key: step.key, ...(step.outputs === undefined ? {} : {outputs: step.outputs})}];
+    const outputs = step.tool === undefined ? step.outputs : undefined;
+    return [{key: step.key, ...(outputs === undefined ? {} : {outputs})}];
   });
 }
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-step-outputs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-step-outputs.ts
@@ -9,6 +9,7 @@ export function normalizeStepOutputs(params: {
   stepIndex: number;
   issues: WorkflowModelValidationIssue[];
 }): OutputDeclarations | undefined {
+  if (params.step.tool !== undefined) return undefined;
   const outputs = params.step.outputs;
   if (outputs === undefined) return undefined;
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-tool-step.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-tool-step.test.ts
@@ -35,10 +35,8 @@ function toolStep(step: WorkflowDocumentStep): WorkflowDocumentStep {
   return step;
 }
 
-function mappingOutputs(
-  outputs: Record<string, string>,
-): NonNullable<WorkflowDocumentStep['outputs']> {
-  return outputs as unknown as NonNullable<WorkflowDocumentStep['outputs']>;
+function mappingOutputs(outputs: Record<string, string>): Record<string, string> {
+  return outputs;
 }
 
 function toolDocument(step: WorkflowDocumentStep): WorkflowDocument {
@@ -392,7 +390,7 @@ describe('normalizeToolStep', () => {
           with: {id: 'ENG-1'},
           // The declaration form is not valid on a tool step: every value must
           // be a single interpolation expression string.
-          outputs: {ts: {type: 'string'}},
+          outputs: {ts: {type: 'string'}} as unknown as Record<string, string>,
         }),
       ),
       {integrationValidationContext},

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1,8 +1,9 @@
 import type {AgentValidationCatalogV2} from '@shipfox/api-agent-dto/inter-module';
 import type {WorkflowDocument} from '@shipfox/workflow-document';
+import {parseWorkflowDocument} from '@shipfox/workflow-document';
 import {agentValidationCatalog} from '#test/agent-validation-catalog.js';
 import type {IntegrationValidationContext} from '../entities/integration-context.js';
-import type {WorkflowModel} from '../entities/workflow-model.js';
+import type {WorkflowModel, WorkflowModelToolStep} from '../entities/workflow-model.js';
 import {
   InvalidWorkflowModelError,
   type WorkflowModelValidationIssue,
@@ -356,6 +357,40 @@ describe('normalizeWorkflowDocument', () => {
       {kind: 'literal', value: 'Deploy '},
       {kind: 'deferred', roots: ['event'], fillTarget: 'execution-creation'},
     ]);
+  });
+
+  it('parses and normalizes a tool step with inputs and output mappings', () => {
+    const document = parseWorkflowDocument({
+      name: 'Read an issue',
+      jobs: {
+        inspect: {
+          steps: [
+            {
+              key: 'issue',
+              tool: 'issue_read.get',
+              connection: 'github-main',
+              with: {owner: 'acme', repo: 'platform', number: 7},
+              outputs: {title: interpolation('result.title')},
+            },
+          ],
+        },
+      },
+    });
+
+    const model = normalizeWorkflowDocument(document, {integrationValidationContext});
+    const step = model.jobs[0]?.steps[0] as WorkflowModelToolStep;
+
+    expect(step).toMatchObject({
+      kind: 'tool',
+      key: 'issue',
+      tool: {id: 'issue_read', method: 'get'},
+      connection: 'github-main',
+      with: {owner: 'acme', repo: 'platform', number: 7},
+      outputs: {title: {type: 'json'}},
+      outputMappings: {
+        title: {language: 'cel', source: 'result.title'},
+      },
+    });
   });
 
   it('preserves literal workflow run and job execution names', () => {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -369,8 +369,13 @@ describe('normalizeWorkflowDocument', () => {
               key: 'issue',
               tool: 'issue_read.get',
               connection: 'github-main',
-              with: {owner: 'acme', repo: 'platform', number: 7},
+              with: {
+                owner: 'acme',
+                repo: 'platform',
+                number: interpolation('inputs.issue_number'),
+              },
               outputs: {title: interpolation('result.title')},
+              gate: {success: 'step.outputs.result.title != ""'},
             },
           ],
         },
@@ -385,10 +390,20 @@ describe('normalizeWorkflowDocument', () => {
       key: 'issue',
       tool: {id: 'issue_read', method: 'get'},
       connection: 'github-main',
-      with: {owner: 'acme', repo: 'platform', number: 7},
+      with: {
+        owner: 'acme',
+        repo: 'platform',
+        number: interpolation('inputs.issue_number'),
+      },
       outputs: {title: {type: 'json'}},
       outputMappings: {
         title: {language: 'cel', source: 'result.title'},
+      },
+      templates: {
+        with: {number: [{kind: 'deferred', roots: ['inputs']}]},
+      },
+      gate: {
+        success: expect.objectContaining({source: 'step.outputs.result.title != ""'}),
       },
     });
   });

--- a/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
@@ -1,4 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
@@ -10,8 +11,10 @@ describe('POST /definitions/validate', () => {
   let app: FastifyInstance;
   let projectId = crypto.randomUUID();
   let workspaceId = crypto.randomUUID();
+  let sourceConnectionId = crypto.randomUUID();
   const getProjectById = vi.fn();
   const getValidationCatalogV2 = vi.fn(() => agentValidationCatalog);
+  const getAgentToolsContext = vi.fn();
 
   beforeAll(async () => {
     app = Fastify();
@@ -33,6 +36,9 @@ describe('POST /definitions/validate', () => {
       buildValidateDefinitionRoute({
         agent: {getValidationCatalogV2} as never,
         projects: {getProjectById} as Pick<ProjectsModuleClient, 'getProjectById'> as never,
+        integrations: {
+          getAgentToolsContext,
+        } as Pick<IntegrationsModuleClient, 'getAgentToolsContext'> as IntegrationsModuleClient,
       }),
     );
     await app.ready();
@@ -41,7 +47,28 @@ describe('POST /definitions/validate', () => {
   beforeEach(() => {
     projectId = crypto.randomUUID();
     workspaceId = crypto.randomUUID();
-    getProjectById.mockResolvedValue({project: {id: projectId, workspaceId}});
+    sourceConnectionId = crypto.randomUUID();
+    getProjectById.mockResolvedValue({project: {id: projectId, workspaceId, sourceConnectionId}});
+    getAgentToolsContext.mockClear();
+    getAgentToolsContext.mockResolvedValue({
+      selectionCatalogs: [],
+      catalogs: [{provider: 'github', tools: []}],
+      workspaceConnections: [
+        {
+          id: sourceConnectionId,
+          slug: 'github-main',
+          provider: 'github',
+          capabilities: ['agent_tools'],
+        },
+      ],
+      eventCatalogs: [],
+      fixedEventProviders: [],
+      defaultConnection: {
+        id: sourceConnectionId,
+        slug: 'github-main',
+        provider: 'github',
+      },
+    });
   });
 
   test('valid YAML returns 200 with { valid: true }', async () => {
@@ -103,6 +130,69 @@ jobs:
     expect(body.valid).toBe(false);
     expect(body.errors).toBeDefined();
     expect(body.errors.length).toBeGreaterThan(0);
+  });
+
+  test('loads integration context when validating a tool step', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/definitions/validate',
+      payload: {
+        project_id: projectId,
+        yaml: `
+name: Tool workflow
+runner: ubuntu-latest
+jobs:
+  inspect:
+    steps:
+      - tool: missing_tool
+`,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(getAgentToolsContext).toHaveBeenCalledWith({
+      workspaceId,
+      defaultConnectionId: sourceConnectionId,
+    });
+    expect(res.json()).toEqual({
+      valid: false,
+      errors: [
+        {
+          path: 'jobs.inspect.steps.0.tool',
+          message: 'Unknown integration tool: missing_tool.',
+        },
+      ],
+    });
+  });
+
+  test('requires project context when validating a tool step', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/definitions/validate',
+      payload: {
+        yaml: `
+name: Tool workflow
+runner: ubuntu-latest
+jobs:
+  inspect:
+    steps:
+      - tool: missing_tool
+`,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(getAgentToolsContext).not.toHaveBeenCalled();
+    expect(res.json()).toEqual({
+      valid: false,
+      errors: [
+        {
+          path: 'project_id',
+          message:
+            '`project_id` is required to validate integration triggers, listeners, agent integrations, and tool steps.',
+        },
+      ],
+    });
   });
 
   test('missing body returns 400', async () => {

--- a/libs/api/definitions/src/presentation/routes/validate-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.ts
@@ -4,9 +4,12 @@ import {
   definitionValidationDiagnosticSchema,
   definitionValidationErrorSchema,
 } from '@shipfox/api-definitions-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
+import {loadIntegrationValidationContext} from '#core/integrations.js';
+import {needsIntegrationValidationContext} from '#core/needs-integration-validation-context.js';
 import {validateDefinition} from '#core/validate-definition.js';
 import {requireProjectAccess} from './project-access.js';
 
@@ -31,6 +34,7 @@ const validationResultSchema = z.union([
 export function buildValidateDefinitionRoute(options: {
   agent: AgentInterModuleClient;
   projects: ProjectsModuleClient;
+  integrations: IntegrationsModuleClient;
 }) {
   return defineRoute({
     method: 'POST',
@@ -44,13 +48,39 @@ export function buildValidateDefinitionRoute(options: {
     },
     handler: async (request) => {
       const {yaml, project_id: projectId} = request.body;
-      const workspaceId =
+      const project =
         projectId === undefined
           ? null
-          : (await requireProjectAccess(request, projectId, options.projects)).workspaceId;
-      const result = validateDefinition(yaml, {
-        agentValidationCatalog: await options.agent.getValidationCatalogV2({workspaceId}),
+          : await requireProjectAccess(request, projectId, options.projects);
+      const workspaceId = project?.workspaceId ?? null;
+      const agentValidationCatalog = await options.agent.getValidationCatalogV2({workspaceId});
+      let result = validateDefinition(yaml, {
+        agentValidationCatalog,
       });
+
+      if (result.valid && needsIntegrationValidationContext(result.definition.document)) {
+        if (project === null) {
+          return {
+            valid: false as const,
+            errors: [
+              {
+                path: 'project_id',
+                message:
+                  '`project_id` is required to validate integration triggers, listeners, agent integrations, and tool steps.',
+              },
+            ],
+          };
+        }
+
+        result = validateDefinition(yaml, {
+          agentValidationCatalog,
+          integrationValidationContext: await loadIntegrationValidationContext(
+            options.integrations,
+            project.workspaceId,
+            project.sourceConnectionId,
+          ),
+        });
+      }
 
       if (result.valid) {
         return {

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -9,10 +9,9 @@ Input shape for Shipfox workflow authoring.
 - `InvalidWorkflowDocumentError` reports invalid input with the original Zod error as `cause`.
 - `WorkflowDocumentRunStepGate` describes the step `gate` block with `success`
   and `on_failure`.
-- A job step is either a **run step** (`run: <shell command>`) or an inline
-  **agent step** (`prompt`, with optional `model`, `harness`, `thinking`, and
-  `provider`).
-  A step carries one or the other, never both.
+- A job step is a **run step** (`run: <shell command>`), an inline **agent
+  step** (`prompt`), a **checkout step** (`checkout`), or a **tool step**
+  (`tool`). A step carries one kind, never multiple kinds.
 
 Use this package where Shipfox accepts a workflow object from a file, tool, or
 API call. It checks the shape only. It does not add defaults, pick runners,
@@ -119,6 +118,28 @@ parseWorkflowDocument({
 });
 ```
 
+A tool step invokes an integration tool by literal id. Use `family.method` for
+a method in a tool family. Tool input strings can use workflow expressions, and
+tool output values map names to one expression over `result` or `vars`:
+
+```ts
+parseWorkflowDocument({
+  name: 'issue summary',
+  jobs: {
+    inspect: {
+      steps: [
+        {
+          tool: 'issue_read.get',
+          connection: 'github-main',
+          with: {owner: 'acme', repo: 'platform', number: 42},
+          outputs: {title: '${{ result.title }}'},
+        },
+      ],
+    },
+  },
+});
+```
+
 Jobs may also declare checkout intent. `permissions.contents` accepts `read` or
 `write`; `persist-credentials` accepts a boolean. Both fields are optional in
 the document shape. Later layers resolve omitted values to read-only checkout
@@ -153,20 +174,20 @@ parseWorkflowDocument({
   target checks belong to definitions-owned model code.
 - A step is discriminated by which keys it carries: `run` marks a run step;
   `prompt`, `model`, `harness`, `thinking`, `provider`, `tools`, or
-  `integrations` mark an agent step, and an agent step must include `prompt`.
-  Declaring run and agent fields together, or neither kind, is rejected.
-  `model`, `harness`, `thinking`, `provider`, `tools`, and `integrations` are
-  valid only on an agent step; using them on a run step is rejected. `thinking`
-  is validated against a fixed set (`off`, `minimal`, `low`, `medium`, `high`,
-  `xhigh`, `max`). Provider, model, tool, integration connection, and integration
-  catalog checks belong to the model layer, not this parser. The `agent` key is
-  reserved for a future step kind and is rejected today. The `tool`,
-  `connection`, and `with` fields and the expression `outputs` mapping form are
-  reserved for the upcoming tool step kind; any step carrying one of these
-  fields is rejected with "Tool steps are not available yet." Their shape still parses:
-  `with` is a JSON tree of tool inputs limited to 32768 serialized bytes and 16
-  nesting levels, and its `method` key is rejected. `tool` and `connection` must
-  be literal names; interpolated values such as `${{ ... }}` are rejected at parse.
+  `integrations` mark an agent step; `checkout` marks a checkout step; and
+  `tool` marks a tool step. An agent step must include `prompt`. Declaring
+  fields from multiple kinds, or neither kind, is rejected. `model`, `harness`,
+  `thinking`, `provider`, `tools`, and `integrations` are valid only on an agent
+  step. `thinking` is validated against a fixed set (`off`, `minimal`, `low`,
+  `medium`, `high`, `xhigh`, `max`). Provider, model, tool, integration
+  connection, and integration catalog checks belong to the model layer, not
+  this parser. The `agent` key is reserved for a future step kind and is
+  rejected today. Tool steps accept literal `tool` and `connection` names,
+  JSON-tree `with` inputs, and output mappings. `connection` defaults to the
+  project source when omitted. Tool input maps are limited to 32768 serialized
+  bytes and 16 nesting levels, and their `method` key is rejected. Tool output
+  mappings must use one `${{ ... }}` expression over `result` or `vars`; exact
+  expression and catalog checks belong to the model layer.
 - `env` can be declared on the workflow, a job, or a run step. Values may be
   strings, numbers, or booleans; the model layer stringifies numbers and
   booleans before a run is saved. Values are literal. Expression interpolation

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -100,12 +100,13 @@ describe('workflowDocumentSchema', () => {
     expect(checkout).toBe(false);
   });
 
-  it('accepts working_directory on run and agent steps', () => {
+  it('accepts working_directory on run, agent, and checkout steps', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'multi-directory build',
       jobs: {
         build: {steps: [{run: 'make test', working_directory: 'api'}]},
         review: {steps: [{prompt: 'Review the API changes.', working_directory: 'api'}]},
+        checkout: {steps: [{checkout: {}, working_directory: 'api'}]},
       },
     });
 
@@ -1417,14 +1418,22 @@ describe('workflowDocumentSchema', () => {
       jobs: {build: {steps: [step]}},
     });
 
-    const issue = result.success
-      ? undefined
-      : result.error.issues.find(
-          (candidate) => candidate.path.join('.') === `jobs.build.steps.0.${field}`,
-        );
-    let stepKind = 'run';
-    if (_label.startsWith('agent')) stepKind = 'agent';
-    if (_label.startsWith('checkout')) stepKind = 'checkout';
+    const issues = result.success ? [] : result.error.issues;
+    if (_label.startsWith('agent')) {
+      expect(issues).toContainEqual(
+        expect.objectContaining({
+          path: ['jobs', 'build', 'steps', 0, 'tool'],
+          message:
+            'A tool step requires `tool`; `connection` and `with` are only valid alongside it.',
+        }),
+      );
+      return;
+    }
+
+    const issue = issues.find(
+      (candidate) => candidate.path.join('.') === `jobs.build.steps.0.${field}`,
+    );
+    const stepKind = _label.startsWith('checkout') ? 'checkout' : 'run';
     expect(issue?.message).toBe(`"${field}" is not valid on a ${stepKind} step.`);
   });
 
@@ -1583,6 +1592,42 @@ describe('workflowDocumentSchema', () => {
           (candidate) => candidate.path.join('.') === 'jobs.build.steps.0.outputs',
         );
     expect(issue?.message).toBe('The `outputs` declaration form is required on a run step.');
+  });
+
+  it.each([
+    ['run', {run: 'npm run build'}, 'a run'],
+    ['agent', {prompt: 'Review the build.'}, 'an agent'],
+    ['checkout', {checkout: {}}, 'a checkout'],
+  ] as const)('rejects expression-mapped outputs on %s steps', (_kind, step, articleAndKind) => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'typed outputs',
+      jobs: {
+        build: {
+          steps: [{...step, outputs: {value: interpolation('result.value')}}],
+        },
+      },
+    });
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find(
+          (candidate) => candidate.path.join('.') === 'jobs.build.steps.0.outputs',
+        );
+    expect(issue?.message).toBe(
+      `The \`outputs\` declaration form is required on ${articleAndKind} step.`,
+    );
+  });
+
+  it('explains the available kind when a step has no kind', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'missing kind',
+      jobs: {build: {steps: [{name: 'noop'}]}},
+    });
+
+    const issue = result.success ? undefined : result.error.issues[0];
+    expect(issue?.message).toBe(
+      'A step must define either "run", an agent "prompt", a "checkout", or a "tool".',
+    );
   });
 
   it('reports a non-expression output string at its value path', () => {

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -223,6 +223,66 @@ describe('workflowDocumentSchema', () => {
     });
   });
 
+  it('accepts tool output mappings without transforming their expressions', () => {
+    const result = workflowDocumentSchema.parse({
+      name: 'tool outputs',
+      jobs: {
+        notify: {
+          steps: [
+            {
+              tool: 'send_message',
+              outputs: {message_id: interpolation('result.id')},
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.jobs.notify?.steps[0]?.outputs).toEqual({
+      message_id: interpolation('result.id'),
+    });
+  });
+
+  it('rejects declaration outputs on tool steps with the expected form', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'tool outputs',
+      jobs: {notify: {steps: [{tool: 'send_message', outputs: {message_id: 'string'}}]}},
+    });
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find(
+          (candidate) => candidate.path.join('.') === 'jobs.notify.steps.0.outputs',
+        );
+    expect(issue?.message).toBe('The `outputs` mapping form is required on a tool step.');
+  });
+
+  it('rejects mixed output forms on tool steps with the expected form', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'tool outputs',
+      jobs: {
+        notify: {
+          steps: [
+            {
+              tool: 'send_message',
+              outputs: {
+                message_id: interpolation('result.id'),
+                timestamp: 'string',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find(
+          (candidate) => candidate.path.join('.') === 'jobs.notify.steps.0.outputs',
+        );
+    expect(issue?.message).toBe('The `outputs` mapping form is required on a tool step.');
+  });
+
   it('accepts boolean JSON Schemas in step output declarations', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'typed outputs',
@@ -1197,6 +1257,15 @@ describe('workflowDocumentSchema', () => {
       {model: 'claude-opus-4-8', prompt: 'Fix it.', gate: {success: 'step.exit_code == 0'}},
     ],
     ['custom-model-provider model string', {model: 'openrouter/anthropic/claude', prompt: 'Hi.'}],
+    ['tool step', {tool: 'send_message'}],
+    [
+      'tool step with connection and inputs',
+      {tool: 'send_message', connection: 'slack_acme', with: {channel_id: 'C0ABC12345'}},
+    ],
+    [
+      'tool step with output mappings',
+      {tool: 'get_issue', outputs: {id: interpolation('result.id')}},
+    ],
   ])('accepts %s', (_label, step) => {
     const result = workflowDocumentSchema.safeParse({
       name: 'agent build',
@@ -1212,14 +1281,12 @@ describe('workflowDocumentSchema', () => {
     ['model on a run step', {run: 'npm test', model: 'claude-opus-4-8'}],
     ['neither run nor agent', {name: 'noop'}],
     ['reserved agent keyword', {agent: 'producer', model: 'claude-opus-4-8', prompt: 'Fix.'}],
-    ['reserved tool step', {tool: 'send_message'}],
-    ['reserved tool step with connection', {tool: 'send_message', connection: 'slack_acme'}],
-    ['reserved tool step with with', {tool: 'send_message', with: {channel_id: 'C0ABC12345'}}],
-    [
-      'reserved tool step with outputs mapping',
-      {tool: 'get_issue', outputs: {id: interpolation('result.id')}},
-    ],
     ['tool step on a run step', {run: 'npm test', tool: 'send_message'}],
+    ['tool step on an agent step', {tool: 'send_message', prompt: 'Notify the team.'}],
+    ['tool step with checkout', {tool: 'send_message', checkout: {}}],
+    ['tool step with env', {tool: 'send_message', env: {CI: true}}],
+    ['tool step with working directory', {tool: 'send_message', working_directory: 'api'}],
+    ['tool step with declaration outputs', {tool: 'send_message', outputs: {id: 'string'}}],
     ['thinking on a run step', {run: 'npm test', thinking: 'high'}],
     ['session on a run step', {run: 'npm test', session: 'main'}],
     ['session on a checkout step', {checkout: {}, session: {key: 'main', mode: 'fork'}}],
@@ -1281,7 +1348,7 @@ describe('workflowDocumentSchema', () => {
     expect(messages.some((message) => message.includes('reserved'))).toBe(true);
   });
 
-  it('reports a clear message for reserved tool step fields', () => {
+  it('accepts tool step fields and preserves the mapping output form', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'tool build',
       jobs: {
@@ -1298,8 +1365,15 @@ describe('workflowDocumentSchema', () => {
       },
     });
 
-    const messages = result.success ? [] : result.error.issues.map((issue) => issue.message);
-    expect(messages.some((message) => message.includes('not available yet'))).toBe(true);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.jobs.fix?.steps[0]).toMatchObject({
+        tool: 'send_message',
+        connection: 'slack_acme',
+        with: {channel_id: 'C0ABC12345'},
+        outputs: {ts: interpolation('result.ts')},
+      });
+    }
   });
 
   it.each([
@@ -1320,19 +1394,13 @@ describe('workflowDocumentSchema', () => {
     });
   });
 
-  it('accepts a literal dotted tool id and connection with a single reserved-field issue', () => {
+  it('accepts a literal dotted tool id and connection', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'tool build',
       jobs: {fix: {steps: [{tool: 'issue_read.get', connection: 'github-main'}]}},
     });
 
-    const issues = result.success ? [] : result.error.issues;
-    expect(result.success).toBe(false);
-    expect(issues).toHaveLength(1);
-    expect(issues[0]).toMatchObject({
-      path: ['jobs', 'fix', 'steps', 0, 'tool'],
-      message: 'Tool steps are not available yet.',
-    });
+    expect(result.success).toBe(true);
   });
 
   it.each([
@@ -1343,9 +1411,9 @@ describe('workflowDocumentSchema', () => {
       {checkout: {repository: 'shipfox/platform'}, connection: 'slack_acme'},
       'connection',
     ],
-  ] as const)('rejects reserved %s without a tool field', (_label, step, field) => {
+  ] as const)('rejects tool-only field %s without a tool field', (_label, step, field) => {
     const result = workflowDocumentSchema.safeParse({
-      name: 'reserved tool field',
+      name: 'tool-only field',
       jobs: {build: {steps: [step]}},
     });
 
@@ -1354,10 +1422,13 @@ describe('workflowDocumentSchema', () => {
       : result.error.issues.find(
           (candidate) => candidate.path.join('.') === `jobs.build.steps.0.${field}`,
         );
-    expect(issue?.message).toBe('Tool steps are not available yet.');
+    let stepKind = 'run';
+    if (_label.startsWith('agent')) stepKind = 'agent';
+    if (_label.startsWith('checkout')) stepKind = 'checkout';
+    expect(issue?.message).toBe(`"${field}" is not valid on a ${stepKind} step.`);
   });
 
-  it('rejects a method key in a reserved tool step `with` map', () => {
+  it('rejects a method key in a tool step `with` map', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'tool build',
       jobs: {fix: {steps: [{tool: 'issue_write.update', with: {method: 'update'}}]}},
@@ -1373,7 +1444,7 @@ describe('workflowDocumentSchema', () => {
     );
   });
 
-  it('rejects reserved tool step `with` maps that exceed the byte cap', () => {
+  it('rejects tool step `with` maps that exceed the byte cap', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'tool build',
       jobs: {
@@ -1398,7 +1469,7 @@ describe('workflowDocumentSchema', () => {
     );
   });
 
-  it('rejects reserved tool step `with` maps nested deeper than the depth cap', () => {
+  it('rejects tool step `with` maps nested deeper than the depth cap', () => {
     let withValue: unknown = {leaf: 'value'};
     for (let index = 0; index < WORKFLOW_DOCUMENT_TOOL_WITH_MAX_DEPTH; index += 1) {
       withValue = {nested: withValue};
@@ -1485,7 +1556,7 @@ describe('workflowDocumentSchema', () => {
       : result.error.issues.find(
           (candidate) => candidate.path.join('.') === 'jobs.build.steps.0.outputs',
         );
-    expect(issue?.message).toBe('The `outputs` mapping form is reserved for tool steps.');
+    expect(issue?.message).toBe('The `outputs` declaration form is required on a run step.');
   });
 
   it('rejects mixed declaration and expression-mapped outputs on non-tool steps', () => {
@@ -1511,7 +1582,7 @@ describe('workflowDocumentSchema', () => {
       : result.error.issues.find(
           (candidate) => candidate.path.join('.') === 'jobs.build.steps.0.outputs',
         );
-    expect(issue?.message).toBe('The `outputs` mapping form is reserved for tool steps.');
+    expect(issue?.message).toBe('The `outputs` declaration form is required on a run step.');
   });
 
   it('reports a non-expression output string at its value path', () => {
@@ -1531,7 +1602,7 @@ describe('workflowDocumentSchema', () => {
       );
       expect(result.error.issues).not.toContainEqual(
         expect.objectContaining({
-          message: 'The `outputs` mapping form is reserved for tool steps.',
+          message: 'The `outputs` declaration form is required on a run step.',
         }),
       );
     }
@@ -1547,9 +1618,15 @@ describe('workflowDocumentSchema', () => {
       },
     });
     const step: WorkflowDocumentStep = workflowDocumentStepSchema.parse({run: 'npm run build'});
+    const toolStep: WorkflowDocumentStep = workflowDocumentStepSchema.parse({
+      tool: 'send_message',
+      outputs: {message_id: interpolation('result.id')},
+    });
 
     expect(document.jobs.build?.steps[0]?.outputs).toEqual({status: {type: 'string'}});
     expect(step.run).toBe('npm run build');
+    expect(toolStep.tool).toBe('send_message');
+    expect(toolStep.outputs).toEqual({message_id: interpolation('result.id')});
   });
 
   it('reports a missing-prompt message on the prompt path', () => {

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -126,7 +126,7 @@ export const workflowDocumentToolStepWithSchema = z
       WORKFLOW_DOCUMENT_TOOL_WITH_MAX_SERIALIZED_BYTES +
       ' serialized bytes and ' +
       WORKFLOW_DOCUMENT_TOOL_WITH_MAX_DEPTH +
-      ' nesting levels. Tool steps are not available yet.',
+      ' nesting levels for a tool step.',
   });
 
 type WorkflowDocumentToolWithValidationTask =
@@ -384,7 +384,17 @@ export const workflowDocumentStepOutputDeclarationSchema = z
 function stepOutputsAreMappingForm(outputs: Readonly<Record<string, unknown>>): boolean {
   const interpolationOpen = '$' + '{{';
   const values = Object.values(outputs);
-  return values.some((value) => typeof value === 'string' && value.includes(interpolationOpen));
+  return (
+    values.length > 0 &&
+    values.every((value) => typeof value === 'string' && value.includes(interpolationOpen))
+  );
+}
+
+function stepOutputsContainMappingForm(outputs: Readonly<Record<string, unknown>>): boolean {
+  const interpolationOpen = '$' + '{{';
+  return Object.values(outputs).some(
+    (value) => typeof value === 'string' && value.includes(interpolationOpen),
+  );
 }
 
 function stepOutputsRecordChecks(outputs: Readonly<Record<string, unknown>>, ctx: z.RefinementCtx) {
@@ -414,22 +424,20 @@ export const workflowDocumentStepOutputsSchema = z
   });
 
 // The tool-step `outputs` form maps output keys to a single `${{ }}` expression
-// over `result`. The expression layer validates the interpolation; the mapping
-// form is rejected with the reserved tool step fields until tool steps exist.
+// over `result`. The expression layer validates the interpolation and its exact
+// shape at normalization time.
 export const workflowDocumentToolStepOutputsSchema = z
   .record(z.string(), workflowDocumentToolStepOutputMappingValueSchema)
   .superRefine((outputs, ctx) => stepOutputsRecordChecks(outputs, ctx))
   .meta({
     description:
-      'Tool-step output mappings over `result`. Each value is exactly one $' +
-      '{{ }} expression. Tool steps are not available yet.',
+      'Tool-step output mappings over `result`. Each value is exactly one $' + '{{ }} expression.',
   });
 
 // `outputs` carries the declaration form on run, agent, and checkout steps and
-// the expression mapping form on tool steps. One value union accepts both so a
-// reserved tool step parses and is rejected by the step `superRefine`; zod
-// reports the declaration branch's own issues for malformed declarations, and
-// the step `superRefine` rejects the mapping form on every other step kind.
+// the expression mapping form on tool steps. One value union accepts both so
+// the step `superRefine` can report the form expected by the selected kind;
+// zod reports the declaration branch's own issues for malformed declarations.
 const workflowDocumentStepOutputValueSchema = z.union([
   workflowDocumentStepOutputDeclarationSchema,
   workflowDocumentToolStepOutputMappingValueSchema,
@@ -855,16 +863,13 @@ export const workflowDocumentAgentStepFields = [
   'session',
 ] as const;
 
-// A step is a run step (`run`), an inline agent step (`prompt`), or a checkout
-// step (`checkout`), never two kinds at once. They share one strict object so
-// an unknown key is still rejected; the `superRefine` discriminates by which
-// payload keys are present and emits one targeted issue per failure mode (a
-// plain union would surface every branch's errors at once). The `agent`
-// keyword is declared only so the reserved-keyword case produces a clear
-// message instead of a generic "unrecognized key". The `tool`, `connection`,
-// `with`, and tool-step `outputs` mapping form are declared the same way: they
-// parse so their shape is checked, then any step carrying a reserved tool field
-// is rejected until the tool step kind exists.
+// A step is a run step (`run`), an inline agent step (`prompt`), a checkout step
+// (`checkout`), or a tool step (`tool`), never two kinds at once. They share one
+// strict object so an unknown key is still rejected; the `superRefine`
+// discriminates by which payload keys are present and emits one targeted issue
+// per offending field (a plain union would surface every branch's errors at
+// once). The `agent` keyword is declared only so the reserved-keyword case
+// produces a clear message instead of a generic "unrecognized key".
 const workflowDocumentStepBaseSchema = z.strictObject({
   key: z
     .string()
@@ -918,14 +923,12 @@ const workflowDocumentStepBaseSchema = z.strictObject({
     description: 'Reserved keyword. It is rejected; use `prompt` to define an agent step.',
   }),
   tool: literalNameSchema('Tool id must be literal. Interpolation is rejected.').optional().meta({
-    description:
-      'Literal integration tool id for a tool step. It is rejected; tool steps are not available yet.',
+    description: 'Literal integration tool id for a tool step.',
   }),
   connection: literalNameSchema('Connection slug must be literal. Interpolation is rejected.')
     .optional()
     .meta({
-      description:
-        'Literal integration connection slug for a tool step. It is rejected; tool steps are not available yet.',
+      description: 'Literal integration connection slug for a tool step.',
     }),
   with: workflowDocumentToolStepWithSchema.optional(),
   gate: workflowDocumentStepGateSchema.optional().meta({
@@ -937,116 +940,164 @@ const workflowDocumentStepBaseSchema = z.strictObject({
   outputs: workflowDocumentStepOutputsFieldSchema.optional().meta({
     description:
       'Named output declarations produced by this step, or on a tool step a mapping of output keys to exactly one $' +
-      '{{ }} expression over `result`. Tool steps are not available yet.',
+      '{{ }} expression over `result`.',
   }),
 });
 
-type WorkflowDocumentStepSchemaOutput = Omit<
+type WorkflowDocumentStepSchemaFields = Omit<
   z.infer<typeof workflowDocumentStepBaseSchema>,
-  'outputs'
-> & {
-  outputs?: WorkflowDocumentStepOutputs;
-};
+  'outputs' | 'tool'
+>;
+type WorkflowDocumentStepSchemaOutput =
+  | (WorkflowDocumentStepSchemaFields & {
+      tool: string;
+      outputs?: WorkflowDocumentToolStepOutputs;
+    })
+  | (WorkflowDocumentStepSchemaFields & {
+      tool?: undefined;
+      outputs?: WorkflowDocumentStepOutputs;
+    });
 type WorkflowDocumentStepInput = z.infer<typeof workflowDocumentStepBaseSchema>;
 
 export const workflowDocumentStepSchema = workflowDocumentStepBaseSchema
   .superRefine(validateWorkflowDocumentStep)
-  .transform<WorkflowDocumentStepSchemaOutput>(({outputs, ...step}) =>
-    outputs === undefined ? step : {...step, outputs: outputs as WorkflowDocumentStepOutputs},
+  .transform<WorkflowDocumentStepSchemaOutput>(
+    ({outputs, ...step}) =>
+      ({
+        ...step,
+        ...(outputs === undefined
+          ? {}
+          : {
+              outputs:
+                step.tool === undefined
+                  ? (outputs as WorkflowDocumentStepOutputs)
+                  : (outputs as WorkflowDocumentToolStepOutputs),
+            }),
+      }) as WorkflowDocumentStepSchemaOutput,
   );
 
 function validateWorkflowDocumentStep(step: WorkflowDocumentStepInput, ctx: z.RefinementCtx): void {
-  if (validateReservedWorkflowDocumentStepFields(step, ctx)) return;
-  validateWorkflowDocumentStepOutputs(step, ctx);
-  if (step.checkout !== undefined) {
-    validateWorkflowDocumentCheckoutStep(step, ctx);
-    return;
-  }
-  if (step.run !== undefined) {
-    addWorkflowDocumentInvalidAgentFields(step, ctx, 'run');
-    return;
-  }
-  validateWorkflowDocumentAgentStep(step, ctx);
-}
-
-function validateReservedWorkflowDocumentStepFields(
-  step: WorkflowDocumentStepInput,
-  ctx: z.RefinementCtx,
-): boolean {
   if (step.agent !== undefined) {
     ctx.addIssue({
       code: 'custom',
       path: ['agent'],
       message: 'The "agent" keyword is reserved for a future step kind and is not supported yet.',
     });
-    return true;
+    return;
   }
-  const reservedTool = reservedWorkflowDocumentToolField(step);
-  if (
-    reservedTool?.value !== undefined &&
-    !WORKFLOW_LITERAL_NAME_PATTERN.test(reservedTool.value)
-  ) {
-    // The field-level literal-name check already rejected the interpolated
-    // value; skip the reserved-field issue so one defect does not report twice.
-    return true;
+  if (step.checkout !== undefined) {
+    validateWorkflowDocumentStepOutputs(step, ctx, 'checkout');
+    validateWorkflowDocumentCheckoutStep(step, ctx);
+    return;
   }
-  if (reservedTool === undefined && step.with === undefined) return false;
-  ctx.addIssue({
-    code: 'custom',
-    path: [reservedTool?.field ?? 'with'],
-    message: 'Tool steps are not available yet.',
-  });
-  return true;
-}
-
-function reservedWorkflowDocumentToolField(
-  step: WorkflowDocumentStepInput,
-): {readonly field: 'tool' | 'connection'; readonly value: string} | undefined {
-  if (step.tool !== undefined) return {field: 'tool', value: step.tool};
-  if (step.connection !== undefined) return {field: 'connection', value: step.connection};
-  return undefined;
+  if (step.tool !== undefined) {
+    validateWorkflowDocumentStepOutputs(step, ctx, 'tool');
+    validateWorkflowDocumentToolStep(step, ctx);
+    return;
+  }
+  if (step.run !== undefined) {
+    validateWorkflowDocumentStepOutputs(step, ctx, 'run');
+    validateWorkflowDocumentRunStep(step, ctx);
+    return;
+  }
+  validateWorkflowDocumentStepOutputs(step, ctx, 'agent');
+  validateWorkflowDocumentAgentStep(step, ctx);
 }
 
 function validateWorkflowDocumentStepOutputs(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
+  stepKind: 'agent' | 'checkout' | 'run' | 'tool',
 ): void {
-  if (step.outputs === undefined || !stepOutputsAreMappingForm(step.outputs)) return;
+  if (step.outputs === undefined) return;
+  if (Object.keys(step.outputs).length === 0) return;
+  const isMapping = stepOutputsAreMappingForm(step.outputs);
+  if (stepKind === 'tool') {
+    if (isMapping) return;
+    ctx.addIssue({
+      code: 'custom',
+      path: ['outputs'],
+      message: 'The `outputs` mapping form is required on a tool step.',
+    });
+    return;
+  }
+  if (!stepOutputsContainMappingForm(step.outputs)) return;
   ctx.addIssue({
     code: 'custom',
     path: ['outputs'],
-    message: 'The `outputs` mapping form is reserved for tool steps.',
+    message: `The \`outputs\` declaration form is required on a ${stepKind} step.`,
   });
+}
+
+function validateWorkflowDocumentRunStep(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+): void {
+  addWorkflowDocumentInvalidAgentFields(step, ctx, 'run');
+  addWorkflowDocumentInvalidToolFields(step, ctx, 'run');
+}
+
+function validateWorkflowDocumentToolStep(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+): void {
+  addWorkflowDocumentInvalidStepFields(step, ctx, 'tool', [
+    'run',
+    ...workflowDocumentAgentStepFields,
+    'checkout',
+    'env',
+    'working_directory',
+  ]);
 }
 
 function validateWorkflowDocumentCheckoutStep(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
 ): void {
-  if (step.run !== undefined) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['run'],
-      message: '"run" is not valid on a checkout step.',
-    });
-  }
-  addWorkflowDocumentInvalidAgentFields(step, ctx, 'checkout');
-  if (step.env !== undefined) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['env'],
-      message: '"env" is not valid on a checkout step.',
-    });
-  }
+  addWorkflowDocumentInvalidStepFields(step, ctx, 'checkout', [
+    'run',
+    ...workflowDocumentAgentStepFields,
+    'tool',
+    'connection',
+    'with',
+    'env',
+    'working_directory',
+  ]);
 }
 
 function addWorkflowDocumentInvalidAgentFields(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
-  stepKind: 'checkout' | 'run',
+  stepKind: 'checkout' | 'run' | 'tool',
 ): void {
-  for (const key of workflowDocumentAgentStepFields) {
+  addWorkflowDocumentInvalidStepFields(step, ctx, stepKind, workflowDocumentAgentStepFields);
+}
+
+function addWorkflowDocumentInvalidToolFields(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+  stepKind: 'agent' | 'checkout' | 'run',
+): void {
+  addWorkflowDocumentInvalidStepFields(step, ctx, stepKind, ['tool', 'connection', 'with']);
+}
+
+function addWorkflowDocumentInvalidStepFields(
+  step: WorkflowDocumentStepInput,
+  ctx: z.RefinementCtx,
+  stepKind: 'agent' | 'checkout' | 'run' | 'tool',
+  fields: readonly (keyof WorkflowDocumentStepInput)[],
+): void {
+  for (const key of fields) {
     if (step[key] === undefined) continue;
+    if (
+      (key === 'tool' || key === 'connection') &&
+      typeof step[key] === 'string' &&
+      !WORKFLOW_LITERAL_NAME_PATTERN.test(step[key])
+    ) {
+      // The field-level literal-name check already rejected the interpolated
+      // value; skip the exclusivity issue so one defect does not report twice.
+      continue;
+    }
     ctx.addIssue({
       code: 'custom',
       path: [key],
@@ -1061,6 +1112,8 @@ function validateWorkflowDocumentAgentStep(
 ): void {
   const isAgent = workflowDocumentAgentStepFields.some((field) => step[field] !== undefined);
   if (!isAgent) {
+    addWorkflowDocumentInvalidToolFields(step, ctx, 'agent');
+    if (hasToolOnlyField(step)) return;
     ctx.addIssue({
       code: 'custom',
       message: 'A step must define either "run", an agent "prompt", or "checkout".',
@@ -1070,9 +1123,14 @@ function validateWorkflowDocumentAgentStep(
   if (step.env !== undefined) {
     ctx.addIssue({code: 'custom', path: ['env'], message: '"env" is supported only on run steps.'});
   }
+  addWorkflowDocumentInvalidToolFields(step, ctx, 'agent');
   if (step.prompt === undefined) {
     ctx.addIssue({code: 'custom', path: ['prompt'], message: 'An agent step requires "prompt".'});
   }
+}
+
+function hasToolOnlyField(step: WorkflowDocumentStepInput): boolean {
+  return step.tool !== undefined || step.connection !== undefined || step.with !== undefined;
 }
 
 const workflowDocumentJobOutputsSchema = nonEmptyRecordSchema(z.string().min(1)).superRefine(
@@ -1128,7 +1186,7 @@ export const workflowDocumentJobSchema = z.strictObject({
       'Environment variables for run steps in this job. They do not apply to agent steps. See [secrets and variables](/reference/secrets-variables).',
   }),
   steps: z.array(workflowDocumentStepSchema).min(1).meta({
-    description: 'Ordered run or agent steps. Each job needs at least one step.',
+    description: 'Ordered run, agent, checkout, or tool steps. Each job needs at least one step.',
   }),
 });
 

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -12,6 +12,7 @@ export const WORKFLOW_LITERAL_NAME_PATTERN = /^(?:[^$]|\$\$\{\{|\$(?!\{\{))*$/;
 // The inverse of a literal name: a literal prefix followed by an unescaped
 // `${{`. An enum field that also accepts a template matches one or the other.
 export const WORKFLOW_INTERPOLATED_VALUE_PATTERN = /^(?:[^$]|\$\$\{\{|\$(?!\{\{))*\$\{\{/;
+export const WORKFLOW_INTERPOLATION_MARKER_PATTERN = /\$\{\{/;
 export const WORKFLOW_SESSION_KEY_MAX_LENGTH = 128;
 export const WORKFLOW_SESSION_KEY_PATTERN_SOURCE = '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$';
 export const WORKFLOW_SESSION_KEY_PATTERN = new RegExp(WORKFLOW_SESSION_KEY_PATTERN_SOURCE);
@@ -89,7 +90,7 @@ export const workflowDocumentEnvSchema = z
     description: `Environment variables as string, number, or boolean values. Each map allows up to ${WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES} entries and ${WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES} serialized bytes.`,
   });
 
-const workflowDocumentStepOutputKeyPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+export const WORKFLOW_DOCUMENT_STEP_OUTPUT_KEY_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 // Tool inputs are a JSON tree: scalars, nested mappings, and sequences. String
 // leaves accept `${{ }}` interpolation; the expression layer validates them.
@@ -309,7 +310,7 @@ const workflowDocumentStepOutputTypeSchema = z.enum(workflowDocumentStepOutputTy
 const workflowDocumentToolStepOutputMappingValueSchema = z
   .string()
   .min(1)
-  .refine((value) => value.includes('$' + '{{'), {
+  .refine((value) => WORKFLOW_INTERPOLATION_MARKER_PATTERN.test(value), {
     message: 'Tool-step output mappings must use a $' + '{{ }} expression.',
   });
 
@@ -382,18 +383,18 @@ export const workflowDocumentStepOutputDeclarationSchema = z
   });
 
 function stepOutputsAreMappingForm(outputs: Readonly<Record<string, unknown>>): boolean {
-  const interpolationOpen = '$' + '{{';
   const values = Object.values(outputs);
   return (
     values.length > 0 &&
-    values.every((value) => typeof value === 'string' && value.includes(interpolationOpen))
+    values.every(
+      (value) => typeof value === 'string' && WORKFLOW_INTERPOLATION_MARKER_PATTERN.test(value),
+    )
   );
 }
 
 function stepOutputsContainMappingForm(outputs: Readonly<Record<string, unknown>>): boolean {
-  const interpolationOpen = '$' + '{{';
   return Object.values(outputs).some(
-    (value) => typeof value === 'string' && value.includes(interpolationOpen),
+    (value) => typeof value === 'string' && WORKFLOW_INTERPOLATION_MARKER_PATTERN.test(value),
   );
 }
 
@@ -407,7 +408,7 @@ function stepOutputsRecordChecks(outputs: Readonly<Record<string, unknown>>, ctx
   }
 
   for (const key of Object.keys(outputs)) {
-    if (workflowDocumentStepOutputKeyPattern.test(key)) continue;
+    if (WORKFLOW_DOCUMENT_STEP_OUTPUT_KEY_PATTERN.test(key)) continue;
     ctx.addIssue({
       code: 'custom',
       path: [key],
@@ -959,6 +960,13 @@ type WorkflowDocumentStepSchemaOutput =
     });
 type WorkflowDocumentStepInput = z.infer<typeof workflowDocumentStepBaseSchema>;
 
+export const workflowDocumentStepKindInvalidFields = {
+  run: [...workflowDocumentAgentStepFields, 'checkout', 'tool', 'connection', 'with'],
+  agent: ['run', 'checkout', 'tool', 'connection', 'with'],
+  checkout: ['run', ...workflowDocumentAgentStepFields, 'env', 'tool', 'connection', 'with'],
+  tool: ['run', ...workflowDocumentAgentStepFields, 'checkout', 'env', 'working_directory'],
+} as const;
+
 export const workflowDocumentStepSchema = workflowDocumentStepBaseSchema
   .superRefine(validateWorkflowDocumentStep)
   .transform<WorkflowDocumentStepSchemaOutput>(
@@ -1025,7 +1033,7 @@ function validateWorkflowDocumentStepOutputs(
   ctx.addIssue({
     code: 'custom',
     path: ['outputs'],
-    message: `The \`outputs\` declaration form is required on a ${stepKind} step.`,
+    message: `The \`outputs\` declaration form is required on ${articleForStepKind(stepKind)} ${stepKind} step.`,
   });
 }
 
@@ -1033,52 +1041,31 @@ function validateWorkflowDocumentRunStep(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
 ): void {
-  addWorkflowDocumentInvalidAgentFields(step, ctx, 'run');
-  addWorkflowDocumentInvalidToolFields(step, ctx, 'run');
+  addWorkflowDocumentInvalidStepFields(step, ctx, 'run', workflowDocumentStepKindInvalidFields.run);
 }
 
 function validateWorkflowDocumentToolStep(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
 ): void {
-  addWorkflowDocumentInvalidStepFields(step, ctx, 'tool', [
-    'run',
-    ...workflowDocumentAgentStepFields,
-    'checkout',
-    'env',
-    'working_directory',
-  ]);
+  addWorkflowDocumentInvalidStepFields(
+    step,
+    ctx,
+    'tool',
+    workflowDocumentStepKindInvalidFields.tool,
+  );
 }
 
 function validateWorkflowDocumentCheckoutStep(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
 ): void {
-  addWorkflowDocumentInvalidStepFields(step, ctx, 'checkout', [
-    'run',
-    ...workflowDocumentAgentStepFields,
-    'tool',
-    'connection',
-    'with',
-    'env',
-    'working_directory',
-  ]);
-}
-
-function addWorkflowDocumentInvalidAgentFields(
-  step: WorkflowDocumentStepInput,
-  ctx: z.RefinementCtx,
-  stepKind: 'checkout' | 'run' | 'tool',
-): void {
-  addWorkflowDocumentInvalidStepFields(step, ctx, stepKind, workflowDocumentAgentStepFields);
-}
-
-function addWorkflowDocumentInvalidToolFields(
-  step: WorkflowDocumentStepInput,
-  ctx: z.RefinementCtx,
-  stepKind: 'agent' | 'checkout' | 'run',
-): void {
-  addWorkflowDocumentInvalidStepFields(step, ctx, stepKind, ['tool', 'connection', 'with']);
+  addWorkflowDocumentInvalidStepFields(
+    step,
+    ctx,
+    'checkout',
+    workflowDocumentStepKindInvalidFields.checkout,
+  );
 }
 
 function addWorkflowDocumentInvalidStepFields(
@@ -1101,7 +1088,7 @@ function addWorkflowDocumentInvalidStepFields(
     ctx.addIssue({
       code: 'custom',
       path: [key],
-      message: `"${key}" is not valid on a ${stepKind} step.`,
+      message: `"${key}" is not valid on ${articleForStepKind(stepKind)} ${stepKind} step.`,
     });
   }
 }
@@ -1110,27 +1097,51 @@ function validateWorkflowDocumentAgentStep(
   step: WorkflowDocumentStepInput,
   ctx: z.RefinementCtx,
 ): void {
-  const isAgent = workflowDocumentAgentStepFields.some((field) => step[field] !== undefined);
-  if (!isAgent) {
-    addWorkflowDocumentInvalidToolFields(step, ctx, 'agent');
-    if (hasToolOnlyField(step)) return;
+  if (hasToolOnlyField(step)) {
+    if (hasInvalidToolOnlyField(step)) return;
     ctx.addIssue({
       code: 'custom',
-      message: 'A step must define either "run", an agent "prompt", or "checkout".',
+      path: ['tool'],
+      message: 'A tool step requires `tool`; `connection` and `with` are only valid alongside it.',
+    });
+    return;
+  }
+  const isAgent = workflowDocumentAgentStepFields.some((field) => step[field] !== undefined);
+  if (!isAgent) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'A step must define either "run", an agent "prompt", a "checkout", or a "tool".',
     });
     return;
   }
   if (step.env !== undefined) {
     ctx.addIssue({code: 'custom', path: ['env'], message: '"env" is supported only on run steps.'});
   }
-  addWorkflowDocumentInvalidToolFields(step, ctx, 'agent');
+  addWorkflowDocumentInvalidStepFields(
+    step,
+    ctx,
+    'agent',
+    workflowDocumentStepKindInvalidFields.agent,
+  );
   if (step.prompt === undefined) {
     ctx.addIssue({code: 'custom', path: ['prompt'], message: 'An agent step requires "prompt".'});
   }
 }
 
 function hasToolOnlyField(step: WorkflowDocumentStepInput): boolean {
-  return step.tool !== undefined || step.connection !== undefined || step.with !== undefined;
+  return step.tool === undefined && (step.connection !== undefined || step.with !== undefined);
+}
+
+function hasInvalidToolOnlyField(step: WorkflowDocumentStepInput): boolean {
+  return (
+    step.tool === undefined &&
+    step.connection !== undefined &&
+    (step.connection.length === 0 || !WORKFLOW_LITERAL_NAME_PATTERN.test(step.connection))
+  );
+}
+
+function articleForStepKind(stepKind: 'agent' | 'checkout' | 'run' | 'tool'): 'a' | 'an' {
+  return stepKind === 'agent' ? 'an' : 'a';
 }
 
 const workflowDocumentJobOutputsSchema = nonEmptyRecordSchema(z.string().min(1)).superRefine(

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
@@ -8,7 +8,7 @@ import {buildWorkflowJsonSchema} from './workflow-json-schema.js';
 type JsonSchema = Record<string, unknown>;
 
 describe('buildWorkflowJsonSchema', () => {
-  it('publishes input declarations without the reserved keys', () => {
+  it('publishes input declarations and authorable tool fields', () => {
     const schema = buildWorkflowJsonSchema();
     const step = stepSchemaFor(schema);
     const output = object(object(object(step.properties).outputs).additionalProperties);
@@ -20,17 +20,56 @@ describe('buildWorkflowJsonSchema', () => {
     });
     const stepProperties = object(step.properties);
     expect(stepProperties).not.toHaveProperty('agent');
-    expect(stepProperties).not.toHaveProperty('tool');
-    expect(stepProperties).not.toHaveProperty('connection');
-    expect(stepProperties).not.toHaveProperty('with');
+    expect(stepProperties).toEqual(
+      expect.objectContaining({
+        tool: expect.any(Object),
+        connection: expect.any(Object),
+        with: expect.any(Object),
+      }),
+    );
     expect(output.anyOf).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({enum: ['string', 'number', 'boolean', 'json']}),
+        expect.objectContaining({
+          anyOf: expect.arrayContaining([
+            expect.objectContaining({enum: ['string', 'number', 'boolean', 'json']}),
+          ]),
+        }),
+        expect.objectContaining({type: 'string', minLength: 1}),
       ]),
     );
-    expect(objects(output.anyOf)).not.toContainEqual(
-      expect.objectContaining({type: 'string', minLength: 1}),
+  });
+
+  it('switches step output values to mappings when a tool is present', () => {
+    const schema = buildWorkflowJsonSchema();
+    const step = stepSchemaFor(schema);
+    const condition = objects(step.allOf).find(
+      (candidate) => JSON.stringify(candidate.if) === JSON.stringify({required: ['tool']}),
     );
+    const defaultOutput = object(object(object(step.properties).outputs).additionalProperties);
+    const toolOutput = object(
+      object(object(condition?.then).properties).outputs,
+    ).additionalProperties;
+
+    expect(condition).toBeDefined();
+    expect(defaultOutput.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          anyOf: expect.arrayContaining([
+            expect.objectContaining({enum: ['string', 'number', 'boolean', 'json']}),
+          ]),
+        }),
+      ]),
+    );
+    expect(object(toolOutput)).toMatchObject({
+      type: 'string',
+      minLength: 1,
+      pattern: '\\$\\{\\{',
+    });
+
+    const declarationCondition = objects(step.allOf).find(
+      (candidate) => JSON.stringify(candidate.if) === JSON.stringify({not: {required: ['tool']}}),
+    );
+    expect(declarationCondition).toBeDefined();
   });
 
   it('describes static and dynamic workflow and job name fields', () => {
@@ -94,7 +133,12 @@ describe('buildWorkflowJsonSchema', () => {
     expect(triggers.minProperties).toBe(1);
     expect(jobOutputs.minProperties).toBe(1);
     expect(discriminator).toMatchObject({
-      oneOf: [{required: ['run']}, {required: ['prompt']}, {required: ['checkout']}],
+      oneOf: [
+        {required: ['run']},
+        {required: ['prompt']},
+        {required: ['checkout']},
+        {required: ['tool']},
+      ],
     });
     expect(requiredAlternatives(gate)).toEqual(['success', 'on_failure']);
     expect(requiredAlternatives(batch)).toEqual(['debounce', 'max_size', 'max_wait']);

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
@@ -1,4 +1,7 @@
 import {
+  WORKFLOW_DOCUMENT_STEP_OUTPUT_KEY_PATTERN,
+  WORKFLOW_DOCUMENT_STEP_OUTPUTS_MAX_ENTRIES,
+  WORKFLOW_INTERPOLATION_MARKER_PATTERN,
   WORKFLOW_LITERAL_NAME_PATTERN,
   WORKFLOW_SESSION_KEY_MAX_LENGTH,
   WORKFLOW_SESSION_KEY_PATTERN_SOURCE,
@@ -63,13 +66,30 @@ describe('buildWorkflowJsonSchema', () => {
     expect(object(toolOutput)).toMatchObject({
       type: 'string',
       minLength: 1,
-      pattern: '\\$\\{\\{',
+      pattern: WORKFLOW_INTERPOLATION_MARKER_PATTERN.source,
+    });
+    expect(object(object(condition?.then).properties).outputs).toMatchObject({
+      maxProperties: WORKFLOW_DOCUMENT_STEP_OUTPUTS_MAX_ENTRIES,
+      propertyNames: {pattern: WORKFLOW_DOCUMENT_STEP_OUTPUT_KEY_PATTERN.source},
     });
 
     const declarationCondition = objects(step.allOf).find(
       (candidate) => JSON.stringify(candidate.if) === JSON.stringify({not: {required: ['tool']}}),
     );
     expect(declarationCondition).toBeDefined();
+    const declarationOutput = object(
+      object(object(declarationCondition?.then).properties).outputs,
+    ).additionalProperties;
+    expect(declarationOutput).toEqual(
+      expect.objectContaining({
+        anyOf: expect.arrayContaining([
+          expect.objectContaining({enum: ['string', 'number', 'boolean', 'json']}),
+        ]),
+      }),
+    );
+    expect(objects(object(declarationOutput).anyOf)).not.toContainEqual(
+      expect.objectContaining({pattern: WORKFLOW_INTERPOLATION_MARKER_PATTERN.source}),
+    );
   });
 
   it('describes static and dynamic workflow and job name fields', () => {
@@ -179,6 +199,9 @@ describe('buildWorkflowJsonSchema', () => {
     );
     expect(object(checkoutBranch?.not).anyOf).toEqual(
       expect.arrayContaining([expect.objectContaining({required: ['session']})]),
+    );
+    expect(object(checkoutBranch?.not).anyOf).not.toContainEqual(
+      expect.objectContaining({required: ['working_directory']}),
     );
   });
 

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.ts
@@ -1,9 +1,12 @@
 import {z} from 'zod';
 import {thinkingLevelsForHarness} from './step-enums.js';
 import {
+  WORKFLOW_DOCUMENT_STEP_OUTPUT_KEY_PATTERN,
+  WORKFLOW_DOCUMENT_STEP_OUTPUTS_MAX_ENTRIES,
+  WORKFLOW_INTERPOLATION_MARKER_PATTERN,
   WORKFLOW_LITERAL_NAME_PATTERN,
-  workflowDocumentAgentStepFields,
   workflowDocumentSchema,
+  workflowDocumentStepKindInvalidFields,
   workflowDocumentStepOutputDeclarationSchema,
   workflowDocumentToolStepOutputsSchema,
 } from './workflow-document.js';
@@ -85,52 +88,36 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
         {
           required: ['run'],
           not: {
-            anyOf: [
-              ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
-              {required: ['checkout']},
-              {required: ['tool']},
-              {required: ['connection']},
-              {required: ['with']},
-            ],
+            anyOf: workflowDocumentStepKindInvalidFields.run.map((field) => ({
+              required: [field],
+            })),
           },
         },
         {
           required: ['prompt'],
           not: {
             anyOf: [
-              {required: ['run']},
-              {required: ['checkout']},
+              ...workflowDocumentStepKindInvalidFields.agent.map((field) => ({
+                required: [field],
+              })),
               {required: ['env']},
-              {required: ['tool']},
-              {required: ['connection']},
-              {required: ['with']},
             ],
           },
         },
         {
           required: ['checkout'],
           not: {
-            anyOf: [
-              {required: ['run']},
-              ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
-              {required: ['env']},
-              {required: ['working_directory']},
-              {required: ['tool']},
-              {required: ['connection']},
-              {required: ['with']},
-            ],
+            anyOf: workflowDocumentStepKindInvalidFields.checkout.map((field) => ({
+              required: [field],
+            })),
           },
         },
         {
           required: ['tool'],
           not: {
-            anyOf: [
-              {required: ['run']},
-              ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
-              {required: ['checkout']},
-              {required: ['env']},
-              {required: ['working_directory']},
-            ],
+            anyOf: workflowDocumentStepKindInvalidFields.tool.map((field) => ({
+              required: [field],
+            })),
           },
         },
       ],
@@ -167,7 +154,9 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
   // Zod refinements are not representable in its JSON Schema projection. Keep
   // the mapping marker in the editor schema; exact expression validation stays
   // in the model layer.
-  toolOutputValue.pattern = '\\$\\{\\{';
+  toolOutputValue.pattern = WORKFLOW_INTERPOLATION_MARKER_PATTERN.source;
+  outputs.maxProperties = WORKFLOW_DOCUMENT_STEP_OUTPUTS_MAX_ENTRIES;
+  outputs.propertyNames = {pattern: WORKFLOW_DOCUMENT_STEP_OUTPUT_KEY_PATTERN.source};
   outputs.additionalProperties = {
     anyOf: [declarationOutputValue, toolOutputValue],
   };

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.ts
@@ -5,6 +5,7 @@ import {
   workflowDocumentAgentStepFields,
   workflowDocumentSchema,
   workflowDocumentStepOutputDeclarationSchema,
+  workflowDocumentToolStepOutputsSchema,
 } from './workflow-document.js';
 
 type JsonSchema = Record<string, unknown>;
@@ -29,12 +30,9 @@ export function buildWorkflowJsonSchema({
   const thinkingEnumBranch = thinkingBranches.find((branch) => Array.isArray(branch.enum)) ?? {};
   const thinkingTemplateBranches = thinkingBranches.filter((branch) => !Array.isArray(branch.enum));
 
-  // The reserved step fields (`agent` and the tool step fields) stay out of
-  // the editor schema until they are authorable.
+  // `agent` remains reserved. Tool-step fields are now part of the authoring
+  // schema and are constrained below by the projected discriminator.
   delete stepProperties.agent;
-  delete stepProperties.tool;
-  delete stepProperties.connection;
-  delete stepProperties.with;
   projectWorkflowValidation(schema, stepSchema);
   const thinkingConditionals = (['pi', 'claude'] as const).map((harness) => {
     const conditional: JsonSchema = {
@@ -90,12 +88,24 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
             anyOf: [
               ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
               {required: ['checkout']},
+              {required: ['tool']},
+              {required: ['connection']},
+              {required: ['with']},
             ],
           },
         },
         {
           required: ['prompt'],
-          not: {anyOf: [{required: ['run']}, {required: ['checkout']}, {required: ['env']}]},
+          not: {
+            anyOf: [
+              {required: ['run']},
+              {required: ['checkout']},
+              {required: ['env']},
+              {required: ['tool']},
+              {required: ['connection']},
+              {required: ['with']},
+            ],
+          },
         },
         {
           required: ['checkout'],
@@ -104,6 +114,22 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
               {required: ['run']},
               ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
               {required: ['env']},
+              {required: ['working_directory']},
+              {required: ['tool']},
+              {required: ['connection']},
+              {required: ['with']},
+            ],
+          },
+        },
+        {
+          required: ['tool'],
+          not: {
+            anyOf: [
+              {required: ['run']},
+              ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
+              {required: ['checkout']},
+              {required: ['env']},
+              {required: ['working_directory']},
             ],
           },
         },
@@ -123,16 +149,57 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
   const gate = object(propertiesOf(stepSchema).gate);
   addAtLeastOneConstraint(gate, ['success', 'on_failure']);
 
-  // The step `outputs` field also accepts the reserved tool-step mapping form;
-  // the editor schema keeps describing the declaration form until tool steps
-  // are enabled.
+  // The raw document schema accepts both output forms so the conditional
+  // branches below can select the form that belongs to the step kind.
   const outputs = object(propertiesOf(stepSchema).outputs);
-  outputs.additionalProperties = z.toJSONSchema(workflowDocumentStepOutputDeclarationSchema, {
+  const declarationOutputValue = z.toJSONSchema(workflowDocumentStepOutputDeclarationSchema, {
     io: 'input',
     unrepresentable: 'any',
-  });
-  const additionalProperties = outputs.additionalProperties as JsonSchema;
-  delete additionalProperties.$schema;
+  }) as JsonSchema;
+  delete declarationOutputValue.$schema;
+
+  const toolOutputs = z.toJSONSchema(workflowDocumentToolStepOutputsSchema, {
+    io: 'input',
+    unrepresentable: 'any',
+  }) as JsonSchema;
+  const toolOutputValue = object(toolOutputs.additionalProperties);
+  delete toolOutputValue.$schema;
+  // Zod refinements are not representable in its JSON Schema projection. Keep
+  // the mapping marker in the editor schema; exact expression validation stays
+  // in the model layer.
+  toolOutputValue.pattern = '\\$\\{\\{';
+  outputs.additionalProperties = {
+    anyOf: [declarationOutputValue, toolOutputValue],
+  };
+
+  const toolOutputsCondition: JsonSchema = {if: {required: ['tool']}};
+  // biome-ignore lint/suspicious/noThenProperty: JSON Schema uses "then" for a conditional branch.
+  toolOutputsCondition.then = {
+    properties: {
+      outputs: {
+        ...outputs,
+        ...(typeof toolOutputs.description === 'string'
+          ? {description: toolOutputs.description}
+          : {}),
+        additionalProperties: toolOutputValue,
+      },
+    },
+  };
+  const declarationOutputsCondition: JsonSchema = {if: {not: {required: ['tool']}}};
+  // biome-ignore lint/suspicious/noThenProperty: JSON Schema uses "then" for a conditional branch.
+  declarationOutputsCondition.then = {
+    properties: {
+      outputs: {
+        ...outputs,
+        additionalProperties: declarationOutputValue,
+      },
+    },
+  };
+  stepSchema.allOf = [
+    ...objects(stepSchema.allOf),
+    toolOutputsCondition,
+    declarationOutputsCondition,
+  ];
 }
 
 function addLiteralNamePattern(schema: JsonSchema | undefined) {


### PR DESCRIPTION
## Summary

Workflow documents can now author integration tool steps with literal tool references, JSON inputs, and result output mappings. The parser enforces step-kind exclusivity and output-form rules while the model layer preserves catalog and expression validation.

The editor JSON Schema, workflow-schema reference, package README, and parse-to-normalize coverage now expose and verify the enabled contract.

Deployment note: deploy the validation API and editor schema together. Older API builds reject tool-step fields, and rolling back the validation API after tool-step definitions are saved makes those definitions fail validation until tool-step support is restored.

Closes ENG-1682