### PR TITLE
Stabilize workspace setup checklist E2E coverage

### DIFF
--- a/e2e/screens/workspaces/src/index.ts
+++ b/e2e/screens/workspaces/src/index.ts
@@ -9,6 +9,10 @@ const SETUP_STATUS_NAME_RE = /^(?:\d+ of \d+ done|You're set up)$/u;
 const SETUP_DIALOG_NAME_RE = /Get started/u;
 const SETTINGS_ROOT_URL_RE = /\/settings(?:\/members)?\/?$/u;
 const SHOW_ALL_STEPS_NAME_RE = /^Show all \d+ steps$/u;
+// Bounds one in-app route change. A client-side click is fast when it lands, so
+// this only has to be long enough to absorb CI scheduling noise before the
+// caller recovers with a document load.
+const IN_APP_NAVIGATION_TIMEOUT_MS = 5_000;
 
 function lastWorkspaceStorageKey(principalId: string): string {
   return `${LAST_WORKSPACE_KEY}.principal.${encodeURIComponent(principalId)}`;
@@ -52,23 +56,16 @@ export class WorkspaceHomeScreen {
 
   async goto(workspaceSlug: string): Promise<void> {
     const workspacePath = `/w/${workspaceSlug}`;
-    if (new URL(this.page.url()).pathname === workspacePath) return;
-    if (this.page.url() === 'about:blank') {
-      await this.page.goto(workspacePath);
-      return;
+    const workspaceUrlRe = new RegExp(`/w/${workspaceSlug}/?$`, 'u');
+    if (!this.isBlank() && new URL(this.page.url()).pathname === workspacePath) return;
+    const followed = await this.followMountedLink(workspaceUrlRe, [
+      `a[role="tab"][href="${workspacePath}"]`,
+      `a[aria-current="page"][href="${workspacePath}"]`,
+    ]);
+    if (!followed) {
+      await this.page.goto(workspacePath, {waitUntil: 'commit'});
+      await this.page.waitForURL(workspaceUrlRe);
     }
-    const projectsTab = this.page.locator(`a[role="tab"][href="${workspacePath}"]`);
-    if ((await projectsTab.count()) === 1) {
-      await projectsTab.click({noWaitAfter: true});
-    } else {
-      const workspaceCrumb = this.page.locator(`a[aria-current="page"][href="${workspacePath}"]`);
-      if ((await workspaceCrumb.count()) === 1) {
-        await workspaceCrumb.click({noWaitAfter: true});
-      } else {
-        await this.page.goto(workspacePath, {waitUntil: 'commit'});
-      }
-    }
-    await this.page.waitForURL(new RegExp(`/w/${workspaceSlug}/?$`, 'u'));
     await this.page
       .locator(`a[role="tab"][href="${workspacePath}"][aria-selected="true"]`)
       .waitFor({state: 'visible'});
@@ -94,13 +91,60 @@ export class WorkspaceHomeScreen {
   }
 
   private async gotoSettingsSection(section: 'General' | 'Integrations'): Promise<void> {
-    await this.settingsTab().click({noWaitAfter: true});
-    await this.page.waitForURL(SETTINGS_ROOT_URL_RE);
-    await this.page
-      .getByRole('navigation', {name: 'Workspace settings'})
-      .getByRole('link', {name: section, exact: true})
-      .click({noWaitAfter: true});
-    await this.page.waitForURL(new RegExp(`/settings/${section.toLowerCase()}/?$`, 'u'));
+    const sectionPath = `/settings/${section.toLowerCase()}`;
+    const sectionUrlRe = new RegExp(`${sectionPath}/?$`, 'u');
+    if (await this.followSettingsNavigation(section, sectionUrlRe)) return;
+    const [, workspaceSegment, workspaceSlug] = new URL(this.page.url()).pathname.split('/');
+    if (workspaceSegment !== 'w' || !workspaceSlug) {
+      throw new Error(`Cannot reach ${sectionPath} from ${this.page.url()}`);
+    }
+    await this.page.goto(`/w/${workspaceSlug}${sectionPath}`, {waitUntil: 'commit'});
+    await this.page.waitForURL(sectionUrlRe);
+  }
+
+  private async followSettingsNavigation(
+    section: 'General' | 'Integrations',
+    sectionUrlRe: RegExp,
+  ): Promise<boolean> {
+    try {
+      await this.settingsTab().click({noWaitAfter: true, timeout: IN_APP_NAVIGATION_TIMEOUT_MS});
+      await this.page.waitForURL(SETTINGS_ROOT_URL_RE, {timeout: IN_APP_NAVIGATION_TIMEOUT_MS});
+      await this.page
+        .getByRole('navigation', {name: 'Workspace settings'})
+        .getByRole('link', {name: section, exact: true})
+        .click({noWaitAfter: true, timeout: IN_APP_NAVIGATION_TIMEOUT_MS});
+      await this.page.waitForURL(sectionUrlRe, {timeout: IN_APP_NAVIGATION_TIMEOUT_MS});
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Clicks the first mounted link whose selector matches exactly once, so an
+   * in-app route change replaces a dev-server document load. Reports whether
+   * the route settled: a client-side click that loses to a re-render or to a
+   * competing navigation raises nothing, it just leaves a URL that never
+   * changes, which would otherwise hold `waitForURL` until the test times out.
+   */
+  private async followMountedLink(targetUrlRe: RegExp, selectors: string[]): Promise<boolean> {
+    if (this.isBlank()) return false;
+    for (const selector of selectors) {
+      const link = this.page.locator(selector);
+      if ((await link.count()) !== 1) continue;
+      try {
+        await link.click({noWaitAfter: true, timeout: IN_APP_NAVIGATION_TIMEOUT_MS});
+        await this.page.waitForURL(targetUrlRe, {timeout: IN_APP_NAVIGATION_TIMEOUT_MS});
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private isBlank(): boolean {
+    return this.page.url() === 'about:blank';
   }
 
   settingsTab(): Locator {

--- a/e2e/suites/client/workspaces/playwright.config.ts
+++ b/e2e/suites/client/workspaces/playwright.config.ts
@@ -1,3 +1,7 @@
 import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineClientE2eConfig({buildName: 'e2e-client-workspaces'});
+// The onboarding journey walks workspace creation, a Gitea install, harness
+// selection, the first project, and the setup checklist in one test. Its own
+// step budgets (SETUP_NAVIGATION_TIMEOUT_MS) already reach 15s each, so the
+// 30s default leaves no room for CI scheduling noise.
+export default defineClientE2eConfig({buildName: 'e2e-client-workspaces', timeout: 90_000});

--- a/e2e/suites/client/workspaces/tests/setup-checklist-fixtures.ts
+++ b/e2e/suites/client/workspaces/tests/setup-checklist-fixtures.ts
@@ -1,10 +1,18 @@
+import type {WorkspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 import type {Page} from '@shipfox/playwright';
 
 export const INITIAL_CHECKLIST_COUNT_RE = /2 of 4 done/u;
 export const LINEAR_CHECKLIST_COUNT_RE = /3 of 4 done/u;
 export const CLOUD_CHECKLIST_COUNT_RE = /2 of 3 done/u;
+export const LINEAR_AUTHORIZE_ORIGIN = 'https://linear.app';
+export const LINEAR_AUTHORIZE_URL_RE = /^https:\/\/linear\.app\//u;
 
 type InstallationRunners = 'managed' | 'none';
+
+export interface ChecklistWorkspace {
+  id: string;
+  slug: string;
+}
 
 async function stubModelProviderDependencies(page: Page, workspaceId: string) {
   await page.route('**/agent/model-provider-catalog', async (route) => {
@@ -40,4 +48,63 @@ export async function stubChecklistDependencies(
     });
   });
   await stubModelProviderDependencies(page, workspaceId);
+}
+
+/**
+ * Arranges the workspace the checklist reads: an owner, a project so the
+ * workspace is past onboarding, a browser session, and the stubbed runner and
+ * model-provider families that pin the checklist to a known count.
+ */
+export async function createChecklistWorkspace({
+  auth,
+  page,
+  projects,
+  workspaces,
+  name,
+  installationRunners = 'none',
+}: Pick<WorkspaceFixtures, 'auth' | 'projects' | 'workspaces'> & {
+  page: Page;
+  name: string;
+  installationRunners?: InstallationRunners;
+}): Promise<ChecklistWorkspace> {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({userId: user.user.id, name});
+  await projects.createProject({workspaceId: workspace.id});
+  await auth.loginAs(page, user);
+  await stubChecklistDependencies(page, workspace.id, installationRunners);
+  return {id: workspace.id, slug: workspace.slug};
+}
+
+/** Serves Linear's authorize page so the install redirect stays inside the browser. */
+export async function stubLinearAuthorizePage(page: Page) {
+  await page.route(`${LINEAR_AUTHORIZE_ORIGIN}/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><title>Linear OAuth</title>',
+    });
+  });
+}
+
+/** Answers the callback exchange the client makes on its way back from Linear. */
+export async function stubLinearCallback(page: Page, workspaceId: string) {
+  await page.route('**/integrations/linear/callback/api**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '00000000-0000-4000-8000-0000000000ad',
+        workspace_id: workspaceId,
+        provider: 'linear',
+        external_account_id: 'linear-e2e-org',
+        slug: 'linear_e2e',
+        display_name: 'Linear E2E',
+        lifecycle_status: 'active',
+        capabilities: ['agent_tools'],
+        external_url: 'https://linear.app/e2e',
+        created_at: '2026-01-15T12:00:00.000Z',
+        updated_at: '2026-01-15T12:00:00.000Z',
+      }),
+    });
+  });
 }

--- a/e2e/suites/client/workspaces/tests/setup-checklist.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/setup-checklist.e2e.ts
@@ -2,14 +2,22 @@ import {randomUUID} from 'node:crypto';
 import {createLinearConnection} from '@shipfox/e2e-setup-integrations';
 import {
   CLOUD_CHECKLIST_COUNT_RE,
+  createChecklistWorkspace,
   INITIAL_CHECKLIST_COUNT_RE,
+  LINEAR_AUTHORIZE_ORIGIN,
+  LINEAR_AUTHORIZE_URL_RE,
   LINEAR_CHECKLIST_COUNT_RE,
-  stubChecklistDependencies,
+  stubLinearAuthorizePage,
+  stubLinearCallback,
 } from './setup-checklist-fixtures.js';
 import {expect, test} from './test.js';
 
+function integrationsSettingsUrlRe(workspaceSlug: string): RegExp {
+  return new RegExp(`/w/${workspaceSlug}/settings/integrations/?$`, 'u');
+}
+
 test.describe('workspace setup checklist', () => {
-  test('tracks a Linear installation, dismissal, and settings re-entry', async ({
+  test('tracks a Linear installation through the checklist', async ({
     auth,
     integrationsCatalogue,
     page,
@@ -18,34 +26,15 @@ test.describe('workspace setup checklist', () => {
     workspaceSetupChecklist,
     workspaces,
   }) => {
-    const user = await auth.createUser();
-    const workspace = await workspaces.create({
-      userId: user.user.id,
+    const workspace = await createChecklistWorkspace({
+      auth,
+      page,
+      projects,
+      workspaces,
       name: 'Setup Guide Workspace',
     });
-    await projects.createProject({workspaceId: workspace.id});
-    await auth.loginAs(page, user);
-    await stubChecklistDependencies(page, workspace.id);
-
-    await page.route('**/integrations/linear/callback/api**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          id: '00000000-0000-4000-8000-0000000000ad',
-          workspace_id: workspace.id,
-          provider: 'linear',
-          external_account_id: 'linear-e2e-org',
-          slug: 'linear_e2e',
-          display_name: 'Linear E2E',
-          lifecycle_status: 'active',
-          capabilities: ['agent_tools'],
-          external_url: 'https://linear.app/e2e',
-          created_at: '2026-01-15T12:00:00.000Z',
-          updated_at: '2026-01-15T12:00:00.000Z',
-        }),
-      });
-    });
+    await stubLinearAuthorizePage(page);
+    await stubLinearCallback(page, workspace.id);
 
     await workspaceHome.goto(workspace.slug);
     await expect(workspaceSetupChecklist.panel()).toBeVisible();
@@ -53,30 +42,24 @@ test.describe('workspace setup checklist', () => {
       'aria-label',
       INITIAL_CHECKLIST_COUNT_RE,
     );
-    const linearOrganizationId = `linear-e2e-org-${randomUUID()}`;
-    await test.step('install Linear and verify checklist progress', async () => {
+
+    await test.step('leave for Linear from the checklist action', async () => {
       await workspaceSetupChecklist.connectLink().click();
-      await expect(page).toHaveURL(
-        new RegExp(`/w/${workspace.slug}/settings/integrations/?$`, 'u'),
-      );
-      let resolveLinearNavigation!: (url: string) => void;
-      const linearNavigation = new Promise<string>((resolve) => {
-        resolveLinearNavigation = resolve;
-      });
-      await page.route('https://linear.app/**', async (route) => {
-        resolveLinearNavigation(route.request().url());
-        await route.fulfill({
-          status: 200,
-          contentType: 'text/html',
-          body: '<!doctype html><title>Linear OAuth</title>',
-        });
-      });
+      await expect(page).toHaveURL(integrationsSettingsUrlRe(workspace.slug));
       await integrationsCatalogue.installLink('Linear').click();
-      const navigatedUrl = await linearNavigation;
-      const linearInstallUrl = new URL(navigatedUrl);
-      expect(linearInstallUrl.origin + linearInstallUrl.pathname).toBe(
-        'https://linear.app/oauth/authorize',
+      // The install page leaves the app through window.location.assign, so wait
+      // for the stubbed authorize document to commit. Reading the URL from the
+      // route handler instead leaves that navigation in flight, and it then
+      // lands on top of the callback navigation the next step starts.
+      await page.waitForURL(LINEAR_AUTHORIZE_URL_RE);
+      const authorizeUrl = new URL(page.url());
+      expect(authorizeUrl.origin + authorizeUrl.pathname).toBe(
+        `${LINEAR_AUTHORIZE_ORIGIN}/oauth/authorize`,
       );
+    });
+
+    await test.step('return through the Linear callback', async () => {
+      const linearOrganizationId = `linear-e2e-org-${randomUUID()}`;
       await createLinearConnection({
         workspaceId: workspace.id,
         organizationId: linearOrganizationId,
@@ -90,41 +73,76 @@ test.describe('workspace setup checklist', () => {
         waitUntil: 'commit',
       });
       expect((await linearCallbackResponse).ok()).toBe(true);
-      await expect(page).toHaveURL(
-        new RegExp(`/w/${workspace.slug}/settings/integrations/?$`, 'u'),
-      );
-      await workspaceHome.goto(workspace.slug);
-      await expect(workspaceSetupChecklist.indicator()).toHaveAttribute(
-        'aria-label',
-        LINEAR_CHECKLIST_COUNT_RE,
-      );
-      await expect(workspaceSetupChecklist.status()).toHaveAttribute('aria-live', 'polite');
-      await expect(workspaceSetupChecklist.status()).toHaveText(LINEAR_CHECKLIST_COUNT_RE);
-      await expect(workspaceSetupChecklist.text('Set up runner capacity')).toBeVisible();
+      await expect(page).toHaveURL(integrationsSettingsUrlRe(workspace.slug));
     });
 
-    await test.step('dismiss and re-enter the setup guide', async () => {
-      await workspaceSetupChecklist.indicator().click();
-      await expect(workspaceSetupChecklist.text('Set up runner capacity')).toBeVisible();
-      await workspaceSetupChecklist.hideButton().click();
-      await expect(workspaceSetupChecklist.panel()).toHaveCount(0);
-      await expect(workspaceSetupChecklist.indicator()).toHaveCount(0);
-      await workspaceHome.gotoSettingsGeneral();
-      await expect(workspaceHome.showSetupGuideButton()).toBeVisible();
-      await workspaceHome.showSetupGuideButton().click();
-      await expect(workspaceHome.showSetupGuideButton()).toHaveCount(0);
-      await workspaceHome.goto(workspace.slug);
-      await expect(workspaceSetupChecklist.panel()).toBeVisible();
+    await workspaceHome.goto(workspace.slug);
+    await expect(workspaceSetupChecklist.indicator()).toHaveAttribute(
+      'aria-label',
+      LINEAR_CHECKLIST_COUNT_RE,
+    );
+    await expect(workspaceSetupChecklist.status()).toHaveAttribute('aria-live', 'polite');
+    await expect(workspaceSetupChecklist.status()).toHaveText(LINEAR_CHECKLIST_COUNT_RE);
+    await expect(workspaceSetupChecklist.text('Set up runner capacity')).toBeVisible();
+  });
+
+  test('restores the setup guide after a dismissal', async ({
+    auth,
+    page,
+    projects,
+    workspaceHome,
+    workspaceSetupChecklist,
+    workspaces,
+  }) => {
+    const workspace = await createChecklistWorkspace({
+      auth,
+      page,
+      projects,
+      workspaces,
+      name: 'Dismissed Guide Workspace',
     });
 
-    await test.step('open and close the setup guide with the keyboard', async () => {
-      await workspaceSetupChecklist.indicator().focus();
-      await page.keyboard.press('Enter');
-      await expect(workspaceSetupChecklist.dialog()).toBeVisible();
-      await page.keyboard.press('Escape');
-      await expect(workspaceSetupChecklist.dialog()).toHaveCount(0);
-      await expect(workspaceSetupChecklist.indicator()).toBeFocused();
+    await workspaceHome.goto(workspace.slug);
+    await expect(workspaceSetupChecklist.panel()).toBeVisible();
+
+    await workspaceSetupChecklist.hideButton().click();
+    await expect(workspaceSetupChecklist.panel()).toHaveCount(0);
+    await expect(workspaceSetupChecklist.indicator()).toHaveCount(0);
+
+    await workspaceHome.gotoSettingsGeneral();
+    await expect(workspaceHome.showSetupGuideButton()).toBeVisible();
+    await workspaceHome.showSetupGuideButton().click();
+    await expect(workspaceHome.showSetupGuideButton()).toHaveCount(0);
+
+    await workspaceHome.goto(workspace.slug);
+    await expect(workspaceSetupChecklist.panel()).toBeVisible();
+  });
+
+  test('opens and closes the setup guide with the keyboard', async ({
+    auth,
+    page,
+    projects,
+    workspaceHome,
+    workspaceSetupChecklist,
+    workspaces,
+  }) => {
+    const workspace = await createChecklistWorkspace({
+      auth,
+      page,
+      projects,
+      workspaces,
+      name: 'Keyboard Guide Workspace',
     });
+
+    await workspaceHome.goto(workspace.slug);
+    await expect(workspaceSetupChecklist.indicator()).toBeVisible();
+
+    await workspaceSetupChecklist.indicator().focus();
+    await page.keyboard.press('Enter');
+    await expect(workspaceSetupChecklist.dialog()).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(workspaceSetupChecklist.dialog()).toHaveCount(0);
+    await expect(workspaceSetupChecklist.indicator()).toBeFocused();
   });
 
   test('completes the checklist when the installation provides runners and inference', async ({
@@ -136,14 +154,14 @@ test.describe('workspace setup checklist', () => {
     workspaceSetupChecklist,
     workspaces,
   }) => {
-    const user = await auth.createUser();
-    const workspace = await workspaces.create({
-      userId: user.user.id,
+    const workspace = await createChecklistWorkspace({
+      auth,
+      page,
+      projects,
+      workspaces,
       name: 'Cloud Setup Guide Workspace',
+      installationRunners: 'managed',
     });
-    await projects.createProject({workspaceId: workspace.id});
-    await auth.loginAs(page, user);
-    await stubChecklistDependencies(page, workspace.id, 'managed');
 
     await workspaceHome.goto(workspace.slug);
     await expect(workspaceSetupChecklist.countLabel(CLOUD_CHECKLIST_COUNT_RE)).toBeVisible();
@@ -159,9 +177,7 @@ test.describe('workspace setup checklist', () => {
     });
     await test.step('refresh the mounted checklist from the integration settings', async () => {
       await workspaceHome.gotoSettingsIntegrations();
-      await expect(page).toHaveURL(
-        new RegExp(`/w/${workspace.slug}/settings/integrations/?$`, 'u'),
-      );
+      await expect(page).toHaveURL(integrationsSettingsUrlRe(workspace.slug));
       await expect(integrationsCatalogue.installedProviderName('Linear Cloud E2E')).toBeVisible();
       await expect(workspaceSetupChecklist.status()).toHaveText("You're set up");
     });


### PR DESCRIPTION
Stabilizes the workspace setup checklist E2E coverage around client-side navigation and the Linear OAuth callback.

The workspace screen now waits for mounted in-app route transitions and falls back to a document navigation when a transition does not settle. Checklist tests share deterministic workspace setup and cover the Linear flow, dismissal and re-entry, keyboard interaction, and completed installation independently. The workspace suite timeout accommodates the longer onboarding journey.

Local validation: `mise exec -- turbo check type build depcruise --filter=@shipfox/e2e-client-workspaces...` passed with 490 successful tasks. The isolated checklist run passed all 4 tests. The broader workspace suite passed 20 tests but reported 2 unchanged workspace-creation test failures that remained on `/setup/workspaces/new` (`onboarding.e2e.ts` and `workspace-switcher.e2e.ts`). No Changeset is included because the affected packages are private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the workspace setup checklist E2E tests so they no longer flake on client-side navigation and competing route changes.

- Workspace screen navigation now waits for in-app route transitions to settle before falling back to a document load when a transition doesn't resolve.
- Checklist tests share a deterministic workspace setup fixture, and each journey (Linear flow, dismissal, keyboard interaction, completed installation) runs independently.
- Workspace suite timeout is raised to 90s to accommodate the longer onboarding journey.

<sup>Written for commit 423fd263904612698a7a251b35c38f0d95eb8432. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

