### PR TITLE
[e2e-client-workspaces] Stabilize onboarding completion snapshot

### DIFF
--- a/e2e/suites/client/workspaces/tests/onboarding.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/onboarding.e2e.ts
@@ -104,7 +104,7 @@ test.describe('workspace onboarding', () => {
     await workspaceHome.goto(workspaceSlug as string);
     const lastWorkspaceId = await workspaceHome.readLastWorkspaceId(user.user.id);
     expect(lastWorkspaceId).toMatch(UUID_RE);
-    await stableScreenshot(page, 'workspaces/onboarding-complete');
+    await stableScreenshot(page, 'workspaces/onboarding-complete', {hideToaster: true});
     await workspaceSwitcher.open();
     const workspaceOption = workspaceSwitcher.workspaceOption(workspaceName);
     await expect(workspaceOption).toBeVisible();


### PR DESCRIPTION
The onboarding completion checkpoint can capture a transient success toast, making the Argos snapshot nondeterministic. This hides the toast only during the `workspaces/onboarding-complete` capture while leaving the user-facing onboarding flow unchanged.

Validation: `mise exec -- turbo check type depcruise --filter=@shipfox/e2e-client-workspaces... --output-logs=errors-only` passed (385 tasks); `mise exec -- mise run e2e -- --filter=@shipfox/e2e-client-workspaces` passed (22 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the onboarding completion snapshot so the Argos screenshot no longer catches a transient success toast. The toast is hidden only during the `workspaces/onboarding-complete` capture; the user-facing onboarding flow is unchanged.

<sup>Written for commit d30ad3ae644f9985b00b03b889f9cada8e225b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

