### PR TITLE
[client-workflows] Filter runs by workflow

### DIFF
--- a/.changeset/filter-runs-by-workflow.md
+++ b/.changeset/filter-runs-by-workflow.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-workflows": minor
+"@shipfox/react-ui": patch
+---
+
+Adds a searchable, URL-backed workflow filter to the run list and improves the Sheet close button's accessible focus treatment.

--- a/libs/client/workflows/package.json
+++ b/libs/client/workflows/package.json
@@ -74,6 +74,7 @@
     "@shipfox/client-triggers": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
+    "@shipfox/regex": "workspace:*",
     "@swc/helpers": "catalog:",
     "date-fns": "catalog:"
   },

--- a/libs/client/workflows/src/components/workflow-run-list/run-display.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/run-display.test.ts
@@ -257,6 +257,20 @@ describe('workflowRunFacets', () => {
 
     expect(facets.workflow).toContainEqual(workflow);
   });
+
+  test('ignores optimistic runs that do not have a definition yet', () => {
+    const run = workflowRunListItem({definition_id: '', workflow_name: 'Optimistic run'});
+
+    expect(workflowRunFacets([run]).workflow).toEqual([]);
+  });
+
+  test('names an unresolved selected workflow without exposing its id', () => {
+    const selected = '44444444-4444-4444-8444-000000000009';
+
+    expect(workflowRunFacets([], {workflow: selected}).workflow).toEqual([
+      {value: selected, label: 'Unknown workflow'},
+    ]);
+  });
 });
 
 function shiftDay(date: string, days: number): string {

--- a/libs/client/workflows/src/components/workflow-run-list/run-display.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/run-display.test.ts
@@ -108,7 +108,9 @@ describe('runMatchesStatusFilter', () => {
 });
 
 describe('runMatchesFilters', () => {
+  const definitionId = '33333333-3333-4333-8333-333333333333';
   const run = workflowRunListItem({
+    definition_id: definitionId,
     name: 'deploy-web',
     status: 'failed',
     trigger_event: 'push',
@@ -125,6 +127,7 @@ describe('runMatchesFilters', () => {
     expect(
       runMatchesFilters(run, {
         search: 'deploy',
+        workflow: definitionId,
         status: ['failed'],
         branch: ['main'],
         actor: ['octocat'],
@@ -134,6 +137,7 @@ describe('runMatchesFilters', () => {
   });
 
   test.each([
+    ['workflow', {workflow: '44444444-4444-4444-8444-444444444444'}],
     ['status', {status: ['succeeded' as const]}],
     ['branch', {branch: ['release']}],
     ['actor', {actor: ['someone-else']}],
@@ -203,6 +207,8 @@ describe('workflowRunFacets', () => {
     const runs = [
       workflowRunListItem({
         id: '11111111-1111-4111-8111-000000000001',
+        definition_id: '33333333-3333-4333-8333-000000000001',
+        workflow_name: 'Deploy production',
         trigger_event: 'push',
         trigger_reference: {
           repository: 'acme/api',
@@ -213,6 +219,8 @@ describe('workflowRunFacets', () => {
       }),
       workflowRunListItem({
         id: '11111111-1111-4111-8111-000000000002',
+        definition_id: '33333333-3333-4333-8333-000000000002',
+        workflow_name: 'CI',
         trigger_event: 'pull_request',
         trigger_reference: {
           repository: 'acme/api',
@@ -224,6 +232,10 @@ describe('workflowRunFacets', () => {
     ];
 
     expect(workflowRunFacets(runs)).toEqual({
+      workflow: [
+        {value: '33333333-3333-4333-8333-000000000002', label: 'CI'},
+        {value: '33333333-3333-4333-8333-000000000001', label: 'Deploy production'},
+      ],
       branch: ['main'],
       actor: ['hubot', 'octocat'],
       event: ['pull_request', 'push'],
@@ -236,6 +248,14 @@ describe('workflowRunFacets', () => {
     });
 
     expect(facets.branch).toEqual(['release/v2']);
+  });
+
+  test('includes project workflows whose runs are outside the loaded history', () => {
+    const workflow = {value: '44444444-4444-4444-8444-444444444444', label: 'Nightly'};
+
+    const facets = workflowRunFacets([workflowRunListItem()], {}, [workflow]);
+
+    expect(facets.workflow).toContainEqual(workflow);
   });
 });
 

--- a/libs/client/workflows/src/components/workflow-run-list/run-display.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/run-display.ts
@@ -24,6 +24,8 @@ export type WorkflowRunFacets = Record<WorkflowRunFacetName, string[]> & {
   workflow: WorkflowRunWorkflowFacet[];
 };
 
+const UNKNOWN_WORKFLOW_LABEL = 'Unknown workflow';
+
 export function runMatchesSearch(run: WorkflowRunListItem, query: string): boolean {
   const needle = query.trim().toLowerCase();
   if (needle === '') return true;
@@ -113,12 +115,12 @@ function workflowFacetValues(
 ): WorkflowRunWorkflowFacet[] {
   const options = new Map(workflows.map((workflow) => [workflow.value, workflow]));
   for (const run of runs) {
-    if (!options.has(run.definitionId)) {
+    if (run.definitionId && !options.has(run.definitionId)) {
       options.set(run.definitionId, {value: run.definitionId, label: run.workflowName});
     }
   }
   if (selected && !options.has(selected)) {
-    options.set(selected, {value: selected, label: selected});
+    options.set(selected, {value: selected, label: UNKNOWN_WORKFLOW_LABEL});
   }
   return [...options.values()].sort((left, right) => left.label.localeCompare(right.label));
 }

--- a/libs/client/workflows/src/components/workflow-run-list/run-display.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/run-display.ts
@@ -9,13 +9,20 @@ import type {WorkflowRunListStatus, WorkflowRunsSearch} from '#routes/inputs.js'
 
 export type WorkflowRunFilterCriteria = Pick<
   WorkflowRunsSearch,
-  'search' | 'status' | 'origin' | 'branch' | 'actor' | 'event' | 'after' | 'before'
+  'search' | 'workflow' | 'status' | 'origin' | 'branch' | 'actor' | 'event' | 'after' | 'before'
 >;
 
 /** The dimensions whose options are read off the loaded runs rather than a fixed enum. */
 export type WorkflowRunFacetName = 'branch' | 'actor' | 'event';
 
-export type WorkflowRunFacets = Record<WorkflowRunFacetName, string[]>;
+export interface WorkflowRunWorkflowFacet {
+  value: string;
+  label: string;
+}
+
+export type WorkflowRunFacets = Record<WorkflowRunFacetName, string[]> & {
+  workflow: WorkflowRunWorkflowFacet[];
+};
 
 export function runMatchesSearch(run: WorkflowRunListItem, query: string): boolean {
   const needle = query.trim().toLowerCase();
@@ -66,8 +73,9 @@ export function runMatchesFilters(
   criteria: WorkflowRunFilterCriteria,
 ): boolean {
   if (!runMatchesStatusFilter(run.status, criteria.status)) return false;
-  // The origin facet is also sent to the API, so this predicate only ever sees matching runs
-  // on the live page; it keeps the standalone view honest (stories, isolated tests).
+  // Workflow and origin are also sent to the API. These predicates keep the standalone view
+  // honest and prevent placeholder data from briefly showing stale rows between queries.
+  if (criteria.workflow && run.definitionId !== criteria.workflow) return false;
   if (criteria.origin && run.origin !== criteria.origin) return false;
   if (!matchesFacet(criteria.branch, workflowRunBranchLabel(run))) return false;
   if (!matchesFacet(criteria.actor, workflowRunActor(run))) return false;
@@ -85,8 +93,10 @@ export function runMatchesFilters(
 export function workflowRunFacets(
   runs: readonly WorkflowRunListItem[],
   criteria: WorkflowRunFilterCriteria = {},
+  workflows: readonly WorkflowRunWorkflowFacet[] = [],
 ): WorkflowRunFacets {
   return {
+    workflow: workflowFacetValues(runs, workflows, criteria.workflow),
     branch: facetValues(runs.map(workflowRunBranchLabel), criteria.branch),
     actor: facetValues(runs.map(workflowRunActor), criteria.actor),
     event: facetValues(
@@ -94,6 +104,23 @@ export function workflowRunFacets(
       criteria.event,
     ),
   };
+}
+
+function workflowFacetValues(
+  runs: readonly WorkflowRunListItem[],
+  workflows: readonly WorkflowRunWorkflowFacet[],
+  selected: string | undefined,
+): WorkflowRunWorkflowFacet[] {
+  const options = new Map(workflows.map((workflow) => [workflow.value, workflow]));
+  for (const run of runs) {
+    if (!options.has(run.definitionId)) {
+      options.set(run.definitionId, {value: run.definitionId, label: run.workflowName});
+    }
+  }
+  if (selected && !options.has(selected)) {
+    options.set(selected, {value: selected, label: selected});
+  }
+  return [...options.values()].sort((left, right) => left.label.localeCompare(right.label));
 }
 
 /**

--- a/libs/client/workflows/src/components/workflow-run-list/types.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/types.ts
@@ -1,13 +1,19 @@
 import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
 import type {WorkflowRunListItem} from '#core/workflow-run.js';
 import type {WorkflowRunFilterPatch, WorkflowRunsSearch} from '#routes/inputs.js';
+import type {WorkflowRunWorkflowFacet} from './run-display.js';
 
 export type WorkflowRunListQuery = QueryLoadErrorQuery & {isPending: boolean};
+export type WorkflowOptionsStatus = 'loading' | 'ready' | 'error';
 
 interface WorkflowRunListCommonProps {
   workspaceSlug?: string | undefined;
   projectSlug?: string | undefined;
   className?: string | undefined;
+  /** Project workflows available even when their runs are outside the loaded history. */
+  workflowOptions?: WorkflowRunWorkflowFacet[];
+  workflowOptionsStatus?: WorkflowOptionsStatus;
+  onRetryWorkflowOptions?: () => void;
   /**
    * The parsed URL search. Pair with `onFiltersChange` to keep it in the URL; omit the
    * handler and the view holds filter state itself, which is what stories and isolated tests

--- a/libs/client/workflows/src/components/workflow-run-list/types.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/types.ts
@@ -13,6 +13,7 @@ interface WorkflowRunListCommonProps {
   /** Project workflows available even when their runs are outside the loaded history. */
   workflowOptions?: WorkflowRunWorkflowFacet[];
   workflowOptionsStatus?: WorkflowOptionsStatus;
+  onOpenWorkflowOptions?: () => void;
   onRetryWorkflowOptions?: () => void;
   /**
    * The parsed URL search. Pair with `onFiltersChange` to keep it in the URL; omit the

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
@@ -1,4 +1,11 @@
 import {Button} from '@shipfox/react-ui/button';
+import {
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxRoot,
+  ComboboxTrigger,
+} from '@shipfox/react-ui/combobox';
 import {DateRangePicker} from '@shipfox/react-ui/date-range-picker';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Input} from '@shipfox/react-ui/input';
@@ -21,6 +28,7 @@ import {
   type WorkflowRunsSearch,
 } from '#routes/inputs.js';
 import type {WorkflowRunFacets} from './run-display.js';
+import type {WorkflowOptionsStatus} from './types.js';
 import {WorkflowRunFilterMenu, type WorkflowRunFilterOption} from './workflow-run-filter-menu.js';
 
 const STATUS_OPTIONS: WorkflowRunFilterOption[] = WORKFLOW_RUN_LIST_STATUSES.map((status) => ({
@@ -34,6 +42,8 @@ export interface WorkflowRunFiltersProps {
   onChange: (patch: WorkflowRunFilterPatch) => void;
   onClear: () => void;
   hasActiveFilters: boolean;
+  workflowOptionsStatus: WorkflowOptionsStatus;
+  onRetryWorkflowOptions?: () => void;
 }
 
 /**
@@ -49,8 +59,11 @@ export function WorkflowRunFilters({
   onChange,
   onClear,
   hasActiveFilters,
+  workflowOptionsStatus,
+  onRetryWorkflowOptions,
 }: WorkflowRunFiltersProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
+  const activeSheetFilterCount = sheetFilterCount(search);
 
   return (
     <div className="flex w-full flex-wrap items-center gap-inline">
@@ -65,7 +78,13 @@ export function WorkflowRunFilters({
       />
 
       <div className="hidden flex-wrap items-center gap-inline md:flex">
-        <WorkflowRunFilterControls search={search} facets={facets} onChange={onChange} />
+        <WorkflowRunFilterControls
+          search={search}
+          facets={facets}
+          onChange={onChange}
+          workflowOptionsStatus={workflowOptionsStatus}
+          {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
+        />
         {hasActiveFilters ? <ClearFiltersButton onClear={onClear} /> : null}
       </div>
 
@@ -78,7 +97,7 @@ export function WorkflowRunFilters({
             iconLeft="filterLine"
             className="md:hidden"
           >
-            Filters
+            {activeSheetFilterCount > 0 ? `Filters (${activeSheetFilterCount})` : 'Filters'}
           </Button>
         </SheetTrigger>
         <SheetContent side="bottom" aria-describedby={undefined}>
@@ -90,6 +109,8 @@ export function WorkflowRunFilters({
               search={search}
               facets={facets}
               onChange={onChange}
+              workflowOptionsStatus={workflowOptionsStatus}
+              {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
               stacked
             />
           </SheetBody>
@@ -113,21 +134,45 @@ export function WorkflowRunFilters({
   );
 }
 
+function sheetFilterCount(search: WorkflowRunsSearch): number {
+  return [
+    search.workflow,
+    search.status?.length,
+    search.origin,
+    search.branch?.length,
+    search.actor?.length,
+    search.event?.length,
+    search.after || search.before,
+  ].filter(Boolean).length;
+}
+
 function WorkflowRunFilterControls({
   search,
   facets,
   onChange,
+  workflowOptionsStatus,
+  onRetryWorkflowOptions,
   stacked = false,
 }: {
   search: WorkflowRunsSearch;
   facets: WorkflowRunFacets;
   onChange: (patch: WorkflowRunFilterPatch) => void;
+  workflowOptionsStatus: WorkflowOptionsStatus;
+  onRetryWorkflowOptions?: () => void;
   stacked?: boolean;
 }) {
   const controlClassName = stacked ? 'w-full max-w-none' : undefined;
 
   return (
     <>
+      <WorkflowFilter
+        search={search}
+        facets={facets}
+        onChange={onChange}
+        workflowOptionsStatus={workflowOptionsStatus}
+        {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
+        stacked={stacked}
+      />
       <WorkflowRunFilterMenu
         label="Status"
         options={STATUS_OPTIONS}
@@ -169,6 +214,76 @@ function WorkflowRunFilterControls({
         <RunDateRangeFilter search={search} onChange={onChange} />
       )}
     </>
+  );
+}
+
+function WorkflowFilter({
+  search,
+  facets,
+  onChange,
+  workflowOptionsStatus,
+  onRetryWorkflowOptions,
+  stacked,
+}: {
+  search: WorkflowRunsSearch;
+  facets: WorkflowRunFacets;
+  onChange: (patch: WorkflowRunFilterPatch) => void;
+  workflowOptionsStatus: WorkflowOptionsStatus;
+  onRetryWorkflowOptions?: () => void;
+  stacked: boolean;
+}) {
+  const selected = facets.workflow.find((option) => option.value === search.workflow);
+  const triggerText = selected ? `Workflow: ${selected.label}` : 'Workflow';
+
+  return (
+    <ComboboxRoot
+      options={facets.workflow}
+      value={search.workflow ?? ''}
+      onValueChange={(workflow) => onChange({workflow: workflow || undefined})}
+      isLoading={workflowOptionsStatus === 'loading'}
+    >
+      <ComboboxTrigger
+        size="small"
+        aria-label={`${triggerText} filter`}
+        className={stacked ? 'w-full max-w-none' : 'max-w-[200px]'}
+      >
+        {triggerText}
+      </ComboboxTrigger>
+      <ComboboxContent className="w-[280px]">
+        <ComboboxInput placeholder="Search workflows..." />
+        <WorkflowOptionsFeedback
+          status={workflowOptionsStatus}
+          {...(onRetryWorkflowOptions ? {onRetry: onRetryWorkflowOptions} : {})}
+        />
+        {facets.workflow.length > 0 || workflowOptionsStatus === 'ready' ? (
+          <ComboboxList emptyState="No workflows found." />
+        ) : null}
+      </ComboboxContent>
+    </ComboboxRoot>
+  );
+}
+
+function WorkflowOptionsFeedback({
+  status,
+  onRetry,
+}: {
+  status: WorkflowOptionsStatus;
+  onRetry?: () => void;
+}) {
+  if (status === 'ready') return null;
+
+  return (
+    <div
+      role={status === 'error' ? 'alert' : 'status'}
+      className="flex min-h-32 items-center justify-between gap-inline border-b border-border-neutral-strong px-row py-row text-xs text-foreground-neutral-muted"
+    >
+      <span>{status === 'error' ? 'Could not load all workflows.' : 'Loading workflows...'}</span>
+      {status === 'error' && onRetry ? (
+        <Button type="button" variant="transparent" size="2xs" onClick={onRetry}>
+          Retry
+        </Button>
+      ) : null}
+    </div>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-filters.tsx
@@ -22,6 +22,7 @@ import {
 import {useState} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {
+  countWorkflowRunFilters,
   WORKFLOW_RUN_LIST_STATUSES,
   type WorkflowRunFilterPatch,
   type WorkflowRunListStatus,
@@ -43,6 +44,7 @@ export interface WorkflowRunFiltersProps {
   onClear: () => void;
   hasActiveFilters: boolean;
   workflowOptionsStatus: WorkflowOptionsStatus;
+  onOpenWorkflowOptions?: () => void;
   onRetryWorkflowOptions?: () => void;
 }
 
@@ -60,10 +62,11 @@ export function WorkflowRunFilters({
   onClear,
   hasActiveFilters,
   workflowOptionsStatus,
+  onOpenWorkflowOptions,
   onRetryWorkflowOptions,
 }: WorkflowRunFiltersProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
-  const activeSheetFilterCount = sheetFilterCount(search);
+  const activeSheetFilterCount = countWorkflowRunFilters(search, {includeSearch: false});
 
   return (
     <div className="flex w-full flex-wrap items-center gap-inline">
@@ -83,6 +86,7 @@ export function WorkflowRunFilters({
           facets={facets}
           onChange={onChange}
           workflowOptionsStatus={workflowOptionsStatus}
+          {...(onOpenWorkflowOptions ? {onOpenWorkflowOptions} : {})}
           {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
         />
         {hasActiveFilters ? <ClearFiltersButton onClear={onClear} /> : null}
@@ -110,6 +114,7 @@ export function WorkflowRunFilters({
               facets={facets}
               onChange={onChange}
               workflowOptionsStatus={workflowOptionsStatus}
+              {...(onOpenWorkflowOptions ? {onOpenWorkflowOptions} : {})}
               {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
               stacked
             />
@@ -134,23 +139,12 @@ export function WorkflowRunFilters({
   );
 }
 
-function sheetFilterCount(search: WorkflowRunsSearch): number {
-  return [
-    search.workflow,
-    search.status?.length,
-    search.origin,
-    search.branch?.length,
-    search.actor?.length,
-    search.event?.length,
-    search.after || search.before,
-  ].filter(Boolean).length;
-}
-
 function WorkflowRunFilterControls({
   search,
   facets,
   onChange,
   workflowOptionsStatus,
+  onOpenWorkflowOptions,
   onRetryWorkflowOptions,
   stacked = false,
 }: {
@@ -158,6 +152,7 @@ function WorkflowRunFilterControls({
   facets: WorkflowRunFacets;
   onChange: (patch: WorkflowRunFilterPatch) => void;
   workflowOptionsStatus: WorkflowOptionsStatus;
+  onOpenWorkflowOptions?: () => void;
   onRetryWorkflowOptions?: () => void;
   stacked?: boolean;
 }) {
@@ -170,6 +165,7 @@ function WorkflowRunFilterControls({
         facets={facets}
         onChange={onChange}
         workflowOptionsStatus={workflowOptionsStatus}
+        {...(onOpenWorkflowOptions ? {onOpenWorkflowOptions} : {})}
         {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
         stacked={stacked}
       />
@@ -222,6 +218,7 @@ function WorkflowFilter({
   facets,
   onChange,
   workflowOptionsStatus,
+  onOpenWorkflowOptions,
   onRetryWorkflowOptions,
   stacked,
 }: {
@@ -229,6 +226,7 @@ function WorkflowFilter({
   facets: WorkflowRunFacets;
   onChange: (patch: WorkflowRunFilterPatch) => void;
   workflowOptionsStatus: WorkflowOptionsStatus;
+  onOpenWorkflowOptions?: () => void;
   onRetryWorkflowOptions?: () => void;
   stacked: boolean;
 }) {
@@ -245,12 +243,13 @@ function WorkflowFilter({
       <ComboboxTrigger
         size="small"
         aria-label={`${triggerText} filter`}
+        onClick={onOpenWorkflowOptions}
         className={stacked ? 'w-full max-w-none' : 'max-w-[200px]'}
       >
         {triggerText}
       </ComboboxTrigger>
       <ComboboxContent className="w-[280px]">
-        <ComboboxInput placeholder="Search workflows..." />
+        <ComboboxInput aria-label="Search workflows" placeholder="Search workflows..." />
         <WorkflowOptionsFeedback
           status={workflowOptionsStatus}
           {...(onRetryWorkflowOptions ? {onRetry: onRetryWorkflowOptions} : {})}
@@ -272,14 +271,27 @@ function WorkflowOptionsFeedback({
 }) {
   if (status === 'ready') return null;
 
+  if (status === 'loading') {
+    return (
+      <div
+        key="workflow-options-loading"
+        role="status"
+        className="flex min-h-32 items-center border-b border-border-neutral-strong px-row py-row text-xs text-foreground-neutral-muted"
+      >
+        Loading workflows...
+      </div>
+    );
+  }
+
   return (
     <div
-      role={status === 'error' ? 'alert' : 'status'}
+      key="workflow-options-error"
+      role="alert"
       className="flex min-h-32 items-center justify-between gap-inline border-b border-border-neutral-strong px-row py-row text-xs text-foreground-neutral-muted"
     >
-      <span>{status === 'error' ? 'Could not load all workflows.' : 'Loading workflows...'}</span>
-      {status === 'error' && onRetry ? (
-        <Button type="button" variant="transparent" size="2xs" onClick={onRetry}>
+      <span>Could not load all workflows.</span>
+      {onRetry ? (
+        <Button type="button" variant="transparent" size="xs" onClick={onRetry}>
           Retry
         </Button>
       ) : null}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -101,18 +101,55 @@ describe('WorkflowRunListView', () => {
       expect(screen.getByRole('button', {name: 'Filters (1)'})).toBeInTheDocument();
     });
 
+    test('clears the workflow filter when its selected option is chosen again', async () => {
+      const user = userEvent.setup();
+      renderListView([
+        run('succeeded', 'deploy-run', 'run-1', {
+          definition_id: '55555555-5555-4555-8555-000000000001',
+          workflow_name: 'Deploy production',
+        }),
+        run('failed', 'ci-run', 'run-2', {
+          definition_id: '55555555-5555-4555-8555-000000000002',
+          workflow_name: 'CI',
+        }),
+      ]);
+
+      await selectWorkflowFilter(user, 'Deploy production');
+      await selectWorkflowFilter(user, 'Deploy production');
+
+      expect(screen.getByText('deploy-run')).toBeInTheDocument();
+      expect(screen.getByText('ci-run')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: filterTrigger('Workflow')})).toHaveTextContent(
+        'Workflow',
+      );
+    });
+
     test('offers project workflows outside the loaded run history', async () => {
       const user = userEvent.setup();
+      const onOpenWorkflowOptions = vi.fn();
       renderListView([run('succeeded', 'deploy-run')], {
         workflowOptions: [
           {value: '55555555-5555-4555-8555-000000000001', label: 'Deploy production'},
           {value: '55555555-5555-4555-8555-000000000002', label: 'Nightly'},
         ],
+        onOpenWorkflowOptions,
       });
 
       await user.click(await screen.findByRole('button', {name: filterTrigger('Workflow')}));
 
+      expect(onOpenWorkflowOptions).toHaveBeenCalledOnce();
+      expect(await screen.findByLabelText('Search workflows')).toBeInTheDocument();
       expect(await screen.findByRole('option', {name: 'Nightly'})).toBeInTheDocument();
+    });
+
+    test('uses a human fallback for a selected workflow that has not loaded', async () => {
+      renderListView([], {
+        search: {workflow: '55555555-5555-4555-8555-000000000009'},
+      });
+
+      expect(
+        await screen.findByRole('button', {name: filterTrigger('Workflow')}),
+      ).toHaveTextContent('Workflow: Unknown workflow');
     });
 
     test('reports workflow option loading in the chooser', async () => {
@@ -240,21 +277,26 @@ describe('WorkflowRunListView', () => {
       expect(trigger).toHaveAccessibleName('Status: Failed filter');
     });
 
-    test('includes origin when a controlled consumer uses the default clear path', async () => {
+    test('includes workflow and origin when a controlled consumer uses the default clear path', async () => {
       const user = userEvent.setup();
       const onFiltersChange = vi.fn();
       renderWithRouter(
         <WorkflowRunListView
           runs={[run('succeeded', 'triage-sentry', 'run-2', devRunOverrides())]}
           query={loadedQuery()}
-          search={{origin: 'dev'}}
+          search={{
+            workflow: '55555555-5555-4555-8555-555555555555',
+            origin: 'dev',
+          }}
           onFiltersChange={onFiltersChange}
         />,
       );
 
       await user.click(await screen.findByRole('button', {name: 'Clear filters'}));
 
-      expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({origin: undefined}));
+      expect(onFiltersChange).toHaveBeenCalledWith(
+        expect.objectContaining({workflow: undefined, origin: undefined}),
+      );
     });
 
     test('restores every row after the filters are cleared', async () => {
@@ -281,6 +323,16 @@ describe('WorkflowRunListView', () => {
 
       expect(await screen.findByText('build-image')).toBeInTheDocument();
       expect(screen.queryByRole('button', {name: 'Clear filters'})).not.toBeInTheDocument();
+    });
+
+    test('does not count text search in the compact filter badge', async () => {
+      const user = userEvent.setup();
+      renderListView([run('succeeded', 'build-image')]);
+
+      await user.type(await screen.findByLabelText('Search runs'), 'build');
+
+      expect(screen.getByRole('button', {name: 'Filters'})).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Filters (1)'})).not.toBeInTheDocument();
     });
   });
 
@@ -609,7 +661,10 @@ describe('WorkflowRunListView', () => {
 
     test('renders optimistic temp runs without a navigable link', async () => {
       const optimisticRun = {
-        ...run('pending', 'queued-build', 'temp-1234', {workflow_name: 'CI'}),
+        ...run('pending', 'queued-build', 'temp-1234', {
+          definition_id: '',
+          workflow_name: 'CI',
+        }),
         number: null,
       };
       renderListView([optimisticRun, run('running', 'deploy-web')]);
@@ -738,8 +793,10 @@ function renderListView(
       | 'hasNextPage'
       | 'onLoadMore'
       | 'query'
+      | 'search'
       | 'workflowOptions'
       | 'workflowOptionsStatus'
+      | 'onOpenWorkflowOptions'
       | 'onRetryWorkflowOptions'
     >
   > = {},

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -53,6 +53,9 @@ describe('WorkflowRunListView', () => {
       expect(body).not.toBeNull();
       expect(within(header as HTMLElement).getByLabelText('Search runs')).toBeInTheDocument();
       expect(
+        within(header as HTMLElement).getByRole('button', {name: filterTrigger('Workflow')}),
+      ).toBeInTheDocument();
+      expect(
         within(header as HTMLElement).getByRole('button', {name: filterTrigger('Status')}),
       ).toBeInTheDocument();
       expect(
@@ -75,6 +78,67 @@ describe('WorkflowRunListView', () => {
   });
 
   describe('filtering', () => {
+    test('narrows the list to the selected workflow', async () => {
+      const user = userEvent.setup();
+      renderListView([
+        run('succeeded', 'deploy-run', 'run-1', {
+          definition_id: '55555555-5555-4555-8555-000000000001',
+          workflow_name: 'Deploy production',
+        }),
+        run('failed', 'ci-run', 'run-2', {
+          definition_id: '55555555-5555-4555-8555-000000000002',
+          workflow_name: 'CI',
+        }),
+      ]);
+
+      await selectWorkflowFilter(user, 'Deploy production');
+
+      expect(screen.getByText('deploy-run')).toBeInTheDocument();
+      expect(screen.queryByText('ci-run')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: filterTrigger('Workflow')})).toHaveTextContent(
+        'Workflow: Deploy production',
+      );
+      expect(screen.getByRole('button', {name: 'Filters (1)'})).toBeInTheDocument();
+    });
+
+    test('offers project workflows outside the loaded run history', async () => {
+      const user = userEvent.setup();
+      renderListView([run('succeeded', 'deploy-run')], {
+        workflowOptions: [
+          {value: '55555555-5555-4555-8555-000000000001', label: 'Deploy production'},
+          {value: '55555555-5555-4555-8555-000000000002', label: 'Nightly'},
+        ],
+      });
+
+      await user.click(await screen.findByRole('button', {name: filterTrigger('Workflow')}));
+
+      expect(await screen.findByRole('option', {name: 'Nightly'})).toBeInTheDocument();
+    });
+
+    test('reports workflow option loading in the chooser', async () => {
+      const user = userEvent.setup();
+      renderListView([], {workflowOptionsStatus: 'loading'});
+
+      await user.click(await screen.findByRole('button', {name: filterTrigger('Workflow')}));
+
+      expect(await screen.findByRole('status')).toHaveTextContent('Loading workflows...');
+      expect(screen.queryByText('No workflows found.')).not.toBeInTheDocument();
+    });
+
+    test('reports workflow option failures and retries them', async () => {
+      const user = userEvent.setup();
+      const onRetryWorkflowOptions = vi.fn();
+      renderListView([], {workflowOptionsStatus: 'error', onRetryWorkflowOptions});
+
+      await user.click(await screen.findByRole('button', {name: filterTrigger('Workflow')}));
+      expect(await screen.findByRole('alert')).toHaveTextContent('Could not load all workflows.');
+      expect(screen.queryByText('No workflows found.')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: 'Retry'}));
+
+      expect(onRetryWorkflowOptions).toHaveBeenCalledOnce();
+    });
+
     test('narrows the list to the selected status', async () => {
       const user = userEvent.setup();
       renderListView([
@@ -668,7 +732,17 @@ function renderListView(
   {
     query = loadedQuery(),
     ...options
-  }: Partial<Pick<WorkflowRunListViewProps, 'hasNextPage' | 'onLoadMore' | 'query'>> = {},
+  }: Partial<
+    Pick<
+      WorkflowRunListViewProps,
+      | 'hasNextPage'
+      | 'onLoadMore'
+      | 'query'
+      | 'workflowOptions'
+      | 'workflowOptionsStatus'
+      | 'onRetryWorkflowOptions'
+    >
+  > = {},
 ) {
   // Row links need router context; the query and data stay injected by props.
   renderWithRouter(
@@ -680,6 +754,11 @@ function renderListView(
       {...options}
     />,
   );
+}
+
+async function selectWorkflowFilter(user: ReturnType<typeof userEvent.setup>, workflow: string) {
+  await user.click(await screen.findByRole('button', {name: filterTrigger('Workflow')}));
+  await user.click(await screen.findByRole('option', {name: workflow}));
 }
 
 /** Matches a filter trigger by its label, whatever value it currently reports. */

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
@@ -25,6 +25,7 @@ export function WorkflowRunListView({
   className,
   workflowOptions = [],
   workflowOptionsStatus = 'ready',
+  onOpenWorkflowOptions,
   onRetryWorkflowOptions,
   search = EMPTY_SEARCH,
   onFiltersChange,
@@ -82,6 +83,7 @@ export function WorkflowRunListView({
               onClear={handleClearFilters}
               hasActiveFilters={hasActiveFilters}
               workflowOptionsStatus={workflowOptionsStatus}
+              {...(onOpenWorkflowOptions ? {onOpenWorkflowOptions} : {})}
               {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
             />
           </PanelHeader>

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
@@ -23,6 +23,9 @@ export function WorkflowRunListView({
   workspaceSlug,
   projectSlug,
   className,
+  workflowOptions = [],
+  workflowOptionsStatus = 'ready',
+  onRetryWorkflowOptions,
   search = EMPTY_SEARCH,
   onFiltersChange,
   onClearFilters,
@@ -39,7 +42,10 @@ export function WorkflowRunListView({
     () => runs.filter((run) => runMatchesFilters(run, currentSearch)),
     [runs, currentSearch],
   );
-  const facets = useMemo(() => workflowRunFacets(runs, currentSearch), [runs, currentSearch]);
+  const facets = useMemo(
+    () => workflowRunFacets(runs, currentSearch, workflowOptions),
+    [runs, currentSearch, workflowOptions],
+  );
   const hasActiveFilters = hasWorkflowRunFilters(currentSearch);
 
   function handleFiltersChange(patch: WorkflowRunFilterPatch) {
@@ -75,6 +81,8 @@ export function WorkflowRunListView({
               onChange={handleFiltersChange}
               onClear={handleClearFilters}
               hasActiveFilters={hasActiveFilters}
+              workflowOptionsStatus={workflowOptionsStatus}
+              {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
             />
           </PanelHeader>
           <PanelBody className="min-h-0 flex-1 overflow-y-auto">
@@ -100,6 +108,7 @@ export function WorkflowRunListView({
 
 const CLEAR_ALL_FILTERS: WorkflowRunFilterPatch = {
   search: undefined,
+  workflow: undefined,
   status: undefined,
   origin: undefined,
   branch: undefined,

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.stories.tsx
@@ -24,6 +24,7 @@ function makeQuery(overrides: Partial<WorkflowRunListQuery> = {}): WorkflowRunLi
 
 const JOB_STRIP_NAME = /jobs:/u;
 const STATUS_FILTER = /^Status\b.*filter$/u;
+const WORKFLOW_FILTER = /^Workflow\b.*filter$/u;
 
 let commitSequence = 0;
 
@@ -45,6 +46,7 @@ function makeRun(
   }: {ref?: string; actor?: string; jobs?: JobStatusDto[]} = {},
 ): WorkflowRunListItem {
   return sequencedWorkflowRunListItem(status, name, minutesAgo, {
+    definition_id: `def-${name}`,
     workflow_name: name,
     trigger_reference: {repository: 'acme/checkout-api', ref, commit: nextCommit(), actor},
     ...workflowRunJobsFixture(jobs),
@@ -70,6 +72,7 @@ function makeDevRun(
   },
 ): WorkflowRunListItem {
   return sequencedWorkflowRunListItem(status, name, minutesAgo, {
+    definition_id: `def-${name}`,
     workflow_name: name,
     origin: 'dev',
     trigger_reference: triggerReference,
@@ -271,6 +274,30 @@ export const TestMultiSelectFilter: Story = {
     );
     await expect(canvas.getByText('integration-tests')).toBeInTheDocument();
     await expect(canvas.queryByText('build-image')).not.toBeInTheDocument();
+  },
+};
+
+export const TestWorkflowFilter: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    let sheet: HTMLElement | null = null;
+    let workflowTrigger = canvas.queryByRole('button', {name: WORKFLOW_FILTER});
+    if (!workflowTrigger) {
+      await userEvent.click(canvas.getByRole('button', {name: 'Filters'}));
+      sheet = await within(document.body).findByRole('dialog');
+      workflowTrigger = within(sheet).getByRole('button', {name: WORKFLOW_FILTER});
+    }
+
+    await userEvent.click(workflowTrigger);
+    const listbox = await within(document.body).findByRole('listbox');
+    await userEvent.click(within(listbox).getByRole('option', {name: 'integration-tests'}));
+
+    await expect(workflowTrigger).toHaveTextContent('Workflow: integration-tests');
+    if (sheet) {
+      await userEvent.click(within(sheet).getByRole('button', {name: 'Show runs'}));
+    }
+    await expect(canvas.getByText('integration-tests')).toBeInTheDocument();
+    await expect(canvas.queryByText('deploy-web')).not.toBeInTheDocument();
   },
 };
 

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.tsx
@@ -17,6 +17,9 @@ export function WorkflowRunList({
   workspaceSlug,
   projectSlug,
   className,
+  workflowOptions,
+  workflowOptionsStatus,
+  onRetryWorkflowOptions,
   search,
   onFiltersChange,
   onClearFilters,
@@ -30,10 +33,12 @@ export function WorkflowRunList({
   const handleFiltersChange = onFiltersChange ?? handleLocalFiltersChange;
   const handleClearFilters = onFiltersChange ? onClearFilters : handleLocalClearFilters;
 
-  // The origin facet is the one filter the API honors (it is a column with an index, and the
-  // aggregates follow it); the rest stay client-side over the loaded pages. Passing it here
-  // keeps the facet working across full history instead of only the fetched window.
-  const query = useWorkflowRunsInfiniteQuery(projectId, {origin: effectiveSearch?.origin});
+  // Origin and workflow are server-backed so those filters cover the full run history. The
+  // remaining dimensions stay client-side over the pages the user has loaded.
+  const query = useWorkflowRunsInfiniteQuery(projectId, {
+    origin: effectiveSearch?.origin,
+    definitionId: effectiveSearch?.workflow,
+  });
   const handleLoadMore = useCallback(() => {
     void query.fetchNextPage();
   }, [query.fetchNextPage]);
@@ -49,6 +54,9 @@ export function WorkflowRunList({
       workspaceSlug={workspaceSlug}
       projectSlug={projectSlug}
       className={className}
+      {...(workflowOptions ? {workflowOptions} : {})}
+      {...(workflowOptionsStatus ? {workflowOptionsStatus} : {})}
+      {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
       {...(effectiveSearch ? {search: effectiveSearch} : {})}
       onFiltersChange={handleFiltersChange}
       {...(handleClearFilters ? {onClearFilters: handleClearFilters} : {})}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list.tsx
@@ -19,6 +19,7 @@ export function WorkflowRunList({
   className,
   workflowOptions,
   workflowOptionsStatus,
+  onOpenWorkflowOptions,
   onRetryWorkflowOptions,
   search,
   onFiltersChange,
@@ -56,6 +57,7 @@ export function WorkflowRunList({
       className={className}
       {...(workflowOptions ? {workflowOptions} : {})}
       {...(workflowOptionsStatus ? {workflowOptionsStatus} : {})}
+      {...(onOpenWorkflowOptions ? {onOpenWorkflowOptions} : {})}
       {...(onRetryWorkflowOptions ? {onRetryWorkflowOptions} : {})}
       {...(effectiveSearch ? {search: effectiveSearch} : {})}
       onFiltersChange={handleFiltersChange}

--- a/libs/client/workflows/src/hooks/api/workflow-filter-options.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-filter-options.test.tsx
@@ -51,8 +51,9 @@ describe('useWorkflowFilterOptions', () => {
       {projectId: PROJECT_ID},
     );
 
-    await waitFor(() => expect(result.current.workflowOptions).toHaveLength(1));
-    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.current.workflowOptions).toEqual([]);
+    expect(result.current.workflowOptionsStatus).toBe('ready');
+    expect(fetchImpl).not.toHaveBeenCalled();
 
     act(() => result.current.onOpenWorkflowOptions());
 
@@ -81,6 +82,7 @@ describe('useWorkflowFilterOptions', () => {
       {projectId: PROJECT_ID},
     );
 
+    act(() => result.current.onOpenWorkflowOptions());
     await waitFor(() =>
       expect(result.current.workflowOptions).toEqual([
         {value: DEFINITION_ID, label: 'First project workflow'},
@@ -88,6 +90,11 @@ describe('useWorkflowFilterOptions', () => {
     );
 
     rerender({projectId: SECOND_PROJECT_ID});
+
+    expect(result.current.workflowOptions).toEqual([]);
+    expect(result.current.workflowOptionsStatus).toBe('ready');
+
+    act(() => result.current.onOpenWorkflowOptions());
 
     expect(result.current.workflowOptions).toEqual([]);
     expect(result.current.workflowOptionsStatus).toBe('loading');

--- a/libs/client/workflows/src/hooks/api/workflow-filter-options.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-filter-options.test.tsx
@@ -1,0 +1,118 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {act, cleanup, renderHook, waitFor} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {useWorkflowFilterOptions} from './workflow-filter-options.js';
+
+const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
+const SECOND_PROJECT_ID = '44444444-4444-4444-8444-000000000002';
+const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+function renderWithQueryClient<TProps>(
+  callback: (props: TProps) => ReturnType<typeof useWorkflowFilterOptions>,
+  initialProps: TProps,
+) {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(callback, {wrapper, initialProps});
+}
+
+describe('useWorkflowFilterOptions', () => {
+  afterEach(() => {
+    cleanup();
+    configureApiClient({baseUrl: '', fetchImpl: undefined});
+  });
+
+  test('stops with an error when the API repeats a pagination cursor', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(requestInputUrl(input));
+      const secondPage = url.searchParams.get('cursor') === 'repeat-cursor';
+      return Promise.resolve(
+        jsonResponse({
+          definitions: [definitionDto(secondPage ? 'Second' : 'First')],
+          next_cursor: 'repeat-cursor',
+          sync: null,
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    const {result} = renderWithQueryClient(
+      ({projectId}: {projectId: string}) => useWorkflowFilterOptions(projectId),
+      {projectId: PROJECT_ID},
+    );
+
+    await waitFor(() => expect(result.current.workflowOptions).toHaveLength(1));
+    expect(fetchImpl).toHaveBeenCalledOnce();
+
+    act(() => result.current.onOpenWorkflowOptions());
+
+    await waitFor(() => expect(result.current.workflowOptionsStatus).toBe('error'));
+    expect(result.current.workflowOptions).toHaveLength(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not expose the previous project while the next project loads', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(requestInputUrl(input));
+      if (url.searchParams.get('project_id') === SECOND_PROJECT_ID) {
+        return new Promise<Response>(() => undefined);
+      }
+      return Promise.resolve(
+        jsonResponse({
+          definitions: [definitionDto('First project workflow')],
+          next_cursor: null,
+          sync: null,
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    const {result, rerender} = renderWithQueryClient(
+      ({projectId}: {projectId: string}) => useWorkflowFilterOptions(projectId),
+      {projectId: PROJECT_ID},
+    );
+
+    await waitFor(() =>
+      expect(result.current.workflowOptions).toEqual([
+        {value: DEFINITION_ID, label: 'First project workflow'},
+      ]),
+    );
+
+    rerender({projectId: SECOND_PROJECT_ID});
+
+    expect(result.current.workflowOptions).toEqual([]);
+    expect(result.current.workflowOptionsStatus).toBe('loading');
+  });
+});
+
+function definitionDto(name: string) {
+  return {
+    id: DEFINITION_ID,
+    project_id: PROJECT_ID,
+    config_path: `.shipfox/workflows/${name.toLowerCase().replaceAll(' ', '-')}.yml`,
+    source: 'vcs',
+    sha: 'abc123',
+    ref: 'main',
+    name,
+    workflow_document: {name, jobs: {}},
+    workflow_model: {kind: 'workflow', name},
+    manual_trigger: null,
+    fetched_at: '2026-05-07T01:00:00.000Z',
+    created_at: '2026-05-07T01:00:00.000Z',
+    updated_at: '2026-05-07T01:00:00.000Z',
+  };
+}
+
+function requestInputUrl(input: RequestInfo | URL): string {
+  if (input instanceof Request) return input.url;
+  return String(input);
+}

--- a/libs/client/workflows/src/hooks/api/workflow-filter-options.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-filter-options.ts
@@ -16,8 +16,9 @@ export function useWorkflowFilterOptions(projectId: string): {
   const [requestedProjectId, setRequestedProjectId] = useState<string>();
   const loadAllRequested = requestedProjectId === projectId;
   // A previous project's definitions must never appear in this project's chooser.
-  const {placeholderData: _placeholderData, ...configuredOptions} =
-    definitionsInfiniteQueryOptions(projectId);
+  const {placeholderData: _placeholderData, ...configuredOptions} = definitionsInfiniteQueryOptions(
+    loadAllRequested ? projectId : undefined,
+  );
   const definitionsQuery = useInfiniteQuery({
     ...configuredOptions,
     staleTime: WORKFLOW_OPTIONS_STALE_TIME_MS,
@@ -62,8 +63,10 @@ export function useWorkflowFilterOptions(projectId: string): {
   if (definitionsQuery.isError || definitionsQuery.isFetchNextPageError || repeatedCursor) {
     workflowOptionsStatus = 'error';
   } else if (
-    definitionsQuery.isPending ||
-    (loadAllRequested && (definitionsQuery.isFetchingNextPage || definitionsQuery.hasNextPage))
+    loadAllRequested &&
+    (definitionsQuery.isPending ||
+      definitionsQuery.isFetchingNextPage ||
+      definitionsQuery.hasNextPage)
   ) {
     workflowOptionsStatus = 'loading';
   }

--- a/libs/client/workflows/src/hooks/api/workflow-filter-options.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-filter-options.ts
@@ -1,0 +1,101 @@
+import {definitionsInfiniteQueryOptions} from '@shipfox/client-projects';
+import {useInfiniteQuery} from '@tanstack/react-query';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import type {WorkflowRunWorkflowFacet} from '#components/workflow-run-list/run-display.js';
+import type {WorkflowOptionsStatus} from '#components/workflow-run-list/types.js';
+
+const WORKFLOW_OPTIONS_STALE_TIME_MS = 5 * 60_000;
+
+/** Loads the project-wide workflow options only when the workflow chooser needs them. */
+export function useWorkflowFilterOptions(projectId: string): {
+  workflowOptions: WorkflowRunWorkflowFacet[];
+  workflowOptionsStatus: WorkflowOptionsStatus;
+  onOpenWorkflowOptions: () => void;
+  onRetryWorkflowOptions: () => void;
+} {
+  const [requestedProjectId, setRequestedProjectId] = useState<string>();
+  const loadAllRequested = requestedProjectId === projectId;
+  // A previous project's definitions must never appear in this project's chooser.
+  const {placeholderData: _placeholderData, ...configuredOptions} =
+    definitionsInfiniteQueryOptions(projectId);
+  const definitionsQuery = useInfiniteQuery({
+    ...configuredOptions,
+    staleTime: WORKFLOW_OPTIONS_STALE_TIME_MS,
+  });
+  const repeatedCursor = hasRepeatedCursor(
+    definitionsQuery.data?.pages.at(-1)?.nextCursor,
+    definitionsQuery.data?.pageParams,
+  );
+
+  useEffect(() => {
+    if (
+      !loadAllRequested ||
+      !definitionsQuery.hasNextPage ||
+      definitionsQuery.isFetchingNextPage ||
+      definitionsQuery.isFetchNextPageError ||
+      repeatedCursor
+    ) {
+      return;
+    }
+    void definitionsQuery.fetchNextPage();
+  }, [
+    definitionsQuery.fetchNextPage,
+    definitionsQuery.hasNextPage,
+    definitionsQuery.isFetchNextPageError,
+    definitionsQuery.isFetchingNextPage,
+    loadAllRequested,
+    repeatedCursor,
+  ]);
+
+  const workflowOptions = useMemo(
+    () =>
+      definitionsQuery.data?.pages.flatMap((page) =>
+        page.definitions.map((definition) => ({
+          value: definition.id,
+          label: definition.name,
+        })),
+      ) ?? [],
+    [definitionsQuery.data],
+  );
+
+  let workflowOptionsStatus: WorkflowOptionsStatus = 'ready';
+  if (definitionsQuery.isError || definitionsQuery.isFetchNextPageError || repeatedCursor) {
+    workflowOptionsStatus = 'error';
+  } else if (
+    definitionsQuery.isPending ||
+    (loadAllRequested && (definitionsQuery.isFetchingNextPage || definitionsQuery.hasNextPage))
+  ) {
+    workflowOptionsStatus = 'loading';
+  }
+
+  const onOpenWorkflowOptions = useCallback(() => {
+    setRequestedProjectId(projectId);
+  }, [projectId]);
+  const onRetryWorkflowOptions = useCallback(() => {
+    setRequestedProjectId(projectId);
+    if (definitionsQuery.isFetchNextPageError) {
+      void definitionsQuery.fetchNextPage();
+      return;
+    }
+    void definitionsQuery.refetch();
+  }, [
+    definitionsQuery.fetchNextPage,
+    definitionsQuery.isFetchNextPageError,
+    definitionsQuery.refetch,
+    projectId,
+  ]);
+
+  return {
+    workflowOptions,
+    workflowOptionsStatus,
+    onOpenWorkflowOptions,
+    onRetryWorkflowOptions,
+  };
+}
+
+function hasRepeatedCursor(
+  nextCursor: string | null | undefined,
+  pageParams: readonly (string | undefined)[] | undefined,
+): boolean {
+  return Boolean(nextCursor && pageParams?.includes(nextCursor));
+}

--- a/libs/client/workflows/src/pages/workflow-run-list-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-list-page.tsx
@@ -1,5 +1,6 @@
+import {useDefinitionsInfiniteQuery} from '@shipfox/client-projects';
 import {useNavigate} from '@tanstack/react-router';
-import {useCallback} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {WorkflowRunList} from '#components/workflow-run-list/workflow-run-list.js';
 import {
   applyWorkflowRunFilterPatch,
@@ -25,6 +26,62 @@ export function WorkflowRunsPage({
   search = EMPTY_SEARCH,
 }: WorkflowRunsPageProps) {
   const navigate = useNavigate();
+  const definitionsQuery = useDefinitionsInfiniteQuery(projectId);
+  const {
+    fetchNextPage: fetchNextDefinitionsPage,
+    hasNextPage: hasNextDefinitionsPage,
+    isFetchingNextPage: isFetchingNextDefinitionsPage,
+    isFetchNextPageError: isFetchNextDefinitionsPageError,
+  } = definitionsQuery;
+
+  // The selector represents the project, not merely the first API page. Fetch successive
+  // definition pages in the background so workflows without recent runs remain selectable.
+  useEffect(() => {
+    if (
+      hasNextDefinitionsPage &&
+      !isFetchingNextDefinitionsPage &&
+      !isFetchNextDefinitionsPageError
+    ) {
+      void fetchNextDefinitionsPage();
+    }
+  }, [
+    fetchNextDefinitionsPage,
+    hasNextDefinitionsPage,
+    isFetchingNextDefinitionsPage,
+    isFetchNextDefinitionsPageError,
+  ]);
+
+  const workflowOptions = useMemo(
+    () =>
+      definitionsQuery.data?.pages.flatMap((page) =>
+        page.definitions.map((definition) => ({
+          value: definition.id,
+          label: definition.name,
+        })),
+      ) ?? [],
+    [definitionsQuery.data],
+  );
+  let workflowOptionsStatus: 'loading' | 'ready' | 'error' = 'ready';
+  if (definitionsQuery.isError || definitionsQuery.isFetchNextPageError) {
+    workflowOptionsStatus = 'error';
+  } else if (
+    definitionsQuery.isPending ||
+    definitionsQuery.isFetchingNextPage ||
+    definitionsQuery.hasNextPage
+  ) {
+    workflowOptionsStatus = 'loading';
+  }
+  const retryWorkflowOptions = useCallback(() => {
+    if (definitionsQuery.isFetchNextPageError) {
+      void definitionsQuery.fetchNextPage();
+      return;
+    }
+    void definitionsQuery.refetch();
+  }, [
+    definitionsQuery.fetchNextPage,
+    definitionsQuery.isFetchNextPageError,
+    definitionsQuery.refetch,
+  ]);
 
   // Filter changes replace history instead of pushing it, so Back leaves the list rather than
   // walking every keystroke of a search box.
@@ -54,6 +111,9 @@ export function WorkflowRunsPage({
         projectId={projectId}
         workspaceSlug={workspaceSlug}
         projectSlug={projectSlug}
+        workflowOptions={workflowOptions}
+        workflowOptionsStatus={workflowOptionsStatus}
+        onRetryWorkflowOptions={retryWorkflowOptions}
         search={search}
         onFiltersChange={onFiltersChange}
         onClearFilters={onClearFilters}

--- a/libs/client/workflows/src/pages/workflow-run-list-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-list-page.tsx
@@ -1,7 +1,7 @@
-import {useDefinitionsInfiniteQuery} from '@shipfox/client-projects';
 import {useNavigate} from '@tanstack/react-router';
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback} from 'react';
 import {WorkflowRunList} from '#components/workflow-run-list/workflow-run-list.js';
+import {useWorkflowFilterOptions} from '#hooks/api/workflow-filter-options.js';
 import {
   applyWorkflowRunFilterPatch,
   clearWorkflowRunFilters,
@@ -26,62 +26,7 @@ export function WorkflowRunsPage({
   search = EMPTY_SEARCH,
 }: WorkflowRunsPageProps) {
   const navigate = useNavigate();
-  const definitionsQuery = useDefinitionsInfiniteQuery(projectId);
-  const {
-    fetchNextPage: fetchNextDefinitionsPage,
-    hasNextPage: hasNextDefinitionsPage,
-    isFetchingNextPage: isFetchingNextDefinitionsPage,
-    isFetchNextPageError: isFetchNextDefinitionsPageError,
-  } = definitionsQuery;
-
-  // The selector represents the project, not merely the first API page. Fetch successive
-  // definition pages in the background so workflows without recent runs remain selectable.
-  useEffect(() => {
-    if (
-      hasNextDefinitionsPage &&
-      !isFetchingNextDefinitionsPage &&
-      !isFetchNextDefinitionsPageError
-    ) {
-      void fetchNextDefinitionsPage();
-    }
-  }, [
-    fetchNextDefinitionsPage,
-    hasNextDefinitionsPage,
-    isFetchingNextDefinitionsPage,
-    isFetchNextDefinitionsPageError,
-  ]);
-
-  const workflowOptions = useMemo(
-    () =>
-      definitionsQuery.data?.pages.flatMap((page) =>
-        page.definitions.map((definition) => ({
-          value: definition.id,
-          label: definition.name,
-        })),
-      ) ?? [],
-    [definitionsQuery.data],
-  );
-  let workflowOptionsStatus: 'loading' | 'ready' | 'error' = 'ready';
-  if (definitionsQuery.isError || definitionsQuery.isFetchNextPageError) {
-    workflowOptionsStatus = 'error';
-  } else if (
-    definitionsQuery.isPending ||
-    definitionsQuery.isFetchingNextPage ||
-    definitionsQuery.hasNextPage
-  ) {
-    workflowOptionsStatus = 'loading';
-  }
-  const retryWorkflowOptions = useCallback(() => {
-    if (definitionsQuery.isFetchNextPageError) {
-      void definitionsQuery.fetchNextPage();
-      return;
-    }
-    void definitionsQuery.refetch();
-  }, [
-    definitionsQuery.fetchNextPage,
-    definitionsQuery.isFetchNextPageError,
-    definitionsQuery.refetch,
-  ]);
+  const workflowFilterOptions = useWorkflowFilterOptions(projectId);
 
   // Filter changes replace history instead of pushing it, so Back leaves the list rather than
   // walking every keystroke of a search box.
@@ -111,9 +56,7 @@ export function WorkflowRunsPage({
         projectId={projectId}
         workspaceSlug={workspaceSlug}
         projectSlug={projectSlug}
-        workflowOptions={workflowOptions}
-        workflowOptionsStatus={workflowOptionsStatus}
-        onRetryWorkflowOptions={retryWorkflowOptions}
+        {...workflowFilterOptions}
         search={search}
         onFiltersChange={onFiltersChange}
         onClearFilters={onClearFilters}

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -206,6 +206,21 @@ describe('WorkflowRunPages', () => {
 
     renderRunsPath();
 
+    await waitFor(() => {
+      expect(
+        fetchImpl.mock.calls.some((call) => {
+          const url = new URL(requestInputUrl(call[0]));
+          return url.pathname === '/definitions' && !url.searchParams.has('cursor');
+        }),
+      ).toBe(true);
+    });
+    expect(
+      fetchImpl.mock.calls.some((call) => {
+        const url = new URL(requestInputUrl(call[0]));
+        return url.pathname === '/definitions' && url.searchParams.has('cursor');
+      }),
+    ).toBe(false);
+
     await user.click(await screen.findByRole('button', {name: WORKFLOW_FILTER_RE}));
 
     expect(await screen.findByRole('option', {name: 'Nightly'})).toBeInTheDocument();
@@ -215,6 +230,28 @@ describe('WorkflowRunPages', () => {
         return url.pathname === '/definitions' && url.searchParams.get('cursor') === 'workflow-2';
       }),
     ).toBe(true);
+  });
+
+  test('reports a workflow definition failure and recovers when retried', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = createRecoveringWorkflowDefinitionsFetch();
+    configureApiClient({fetchImpl});
+
+    renderRunsPath();
+
+    await user.click(await screen.findByRole('button', {name: WORKFLOW_FILTER_RE}));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load all workflows.');
+
+    await user.click(screen.getByRole('button', {name: 'Retry'}));
+
+    expect(await screen.findByRole('option', {name: 'Deploy production'})).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      fetchImpl.mock.calls.filter((call) => {
+        const url = new URL(requestInputUrl(call[0]));
+        return url.pathname === '/definitions';
+      }),
+    ).toHaveLength(2);
   });
 
   test('replaces history on a filter change so back leaves the list', async () => {
@@ -569,6 +606,19 @@ function createMixedWorkflowRunsFetch() {
       );
     }
 
+    if (url.pathname === '/definitions') {
+      return Promise.resolve(
+        jsonResponse({
+          definitions: [
+            definitionDto(DEFINITION_ID, 'Deploy production'),
+            definitionDto(SECOND_DEFINITION_ID, 'CI'),
+          ],
+          next_cursor: null,
+          sync: null,
+        }),
+      );
+    }
+
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
   });
 }
@@ -588,6 +638,34 @@ function createPaginatedWorkflowDefinitionsFetch() {
             ),
           ],
           next_cursor: isSecondPage ? null : 'workflow-2',
+          sync: null,
+        }),
+      );
+    }
+
+    if (url.pathname === '/workflows/runs') {
+      return Promise.resolve(jsonResponse({runs: [], next_cursor: null, filtered_total_count: 0}));
+    }
+
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function createRecoveringWorkflowDefinitionsFetch() {
+  let definitionAttempts = 0;
+
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+
+    if (url.pathname === '/definitions') {
+      definitionAttempts += 1;
+      if (definitionAttempts === 1) {
+        return Promise.resolve(jsonResponse({code: 'unexpected'}, {status: 500}));
+      }
+      return Promise.resolve(
+        jsonResponse({
+          definitions: [definitionDto(DEFINITION_ID, 'Deploy production')],
+          next_cursor: null,
           sync: null,
         }),
       );

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -21,6 +21,7 @@ import {WorkflowRunsPage} from './workflow-run-list-page.js';
 
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+const SECOND_DEFINITION_ID = '55555555-5555-4555-8555-000000000002';
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const SECOND_RUN_ID = '66666666-6666-4666-8666-000000000002';
 const OLDER_RUN_ID = '66666666-6666-4666-8666-000000000003';
@@ -34,11 +35,14 @@ const DEPLOY_ATTEMPT_ONE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001';
 const DEPLOY_ATTEMPT_TWO_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002';
 const SMOKE_WEB_RE = /smoke-web/u;
 const DEPLOY_WEB_RE = /deploy-web/u;
+const DEPLOY_PRODUCTION_RE = /deploy-production/u;
+const CI_RUN_RE = /ci-run/u;
 const OLDER_RUN_RE = /older-run/u;
 const TRIAGE_SENTRY_RE = /triage-sentry/u;
 const INTEGRATION_TESTS_RE = /integration-tests/u;
 const BUILD_IMAGE_RE = /build-image/u;
 const STATUS_FILTER_RE = /^Status\b.*filter$/u;
+const WORKFLOW_FILTER_RE = /^Workflow\b.*filter$/u;
 const ORIGIN_FILTER_RE = /^Origin\b.*filter$/u;
 const JOBS_TAB_NAME = /^Jobs/u;
 const BUILD_JOB_BUTTON_NAME = 'build, Succeeded';
@@ -166,6 +170,51 @@ describe('WorkflowRunPages', () => {
     expect(router.state.location.searchStr).toBe('');
     expect(await screen.findByRole('link', {name: DEPLOY_WEB_RE})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: TRIAGE_SENTRY_RE})).toBeInTheDocument();
+  });
+
+  test('writes the selected workflow to the URL and filters the full history through the API', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = createMixedWorkflowRunsFetch();
+    configureApiClient({fetchImpl});
+
+    const {router} = renderRunsPath();
+
+    await user.click(await screen.findByRole('button', {name: WORKFLOW_FILTER_RE}));
+    await user.click(await screen.findByRole('option', {name: 'Deploy production'}));
+
+    await waitFor(() => {
+      expect(currentSearch(router).workflow).toBe(DEFINITION_ID);
+    });
+    expect(router.state.location.searchStr).toBe(`?workflow=${DEFINITION_ID}`);
+    expect(
+      fetchImpl.mock.calls.some((call) => {
+        const url = new URL(requestInputUrl(call[0]));
+        return (
+          url.pathname === '/workflows/runs' &&
+          url.searchParams.get('definition_id') === DEFINITION_ID
+        );
+      }),
+    ).toBe(true);
+    expect(await screen.findByRole('link', {name: DEPLOY_PRODUCTION_RE})).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: CI_RUN_RE})).not.toBeInTheDocument();
+  });
+
+  test('loads every workflow definition page into the chooser', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = createPaginatedWorkflowDefinitionsFetch();
+    configureApiClient({fetchImpl});
+
+    renderRunsPath();
+
+    await user.click(await screen.findByRole('button', {name: WORKFLOW_FILTER_RE}));
+
+    expect(await screen.findByRole('option', {name: 'Nightly'})).toBeInTheDocument();
+    expect(
+      fetchImpl.mock.calls.some((call) => {
+        const url = new URL(requestInputUrl(call[0]));
+        return url.pathname === '/definitions' && url.searchParams.get('cursor') === 'workflow-2';
+      }),
+    ).toBe(true);
   });
 
   test('replaces history on a filter change so back leaves the list', async () => {
@@ -489,6 +538,85 @@ function createMixedOriginRunsFetch() {
 
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
   });
+}
+
+function createMixedWorkflowRunsFetch() {
+  const runs = [
+    workflowRunDto({
+      ...RUN_OVERRIDES,
+      name: 'deploy-production',
+      workflow_name: 'Deploy production',
+    }),
+    workflowRunDto({
+      ...RUN_OVERRIDES,
+      id: SECOND_RUN_ID,
+      definition_id: SECOND_DEFINITION_ID,
+      name: 'ci-run',
+      workflow_name: 'CI',
+    }),
+  ];
+
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+
+    if (url.pathname === '/workflows/runs') {
+      const definitionId = url.searchParams.get('definition_id');
+      const filtered = definitionId
+        ? runs.filter((run) => run.definition_id === definitionId)
+        : runs;
+      return Promise.resolve(
+        jsonResponse({runs: filtered, next_cursor: null, filtered_total_count: filtered.length}),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function createPaginatedWorkflowDefinitionsFetch() {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+
+    if (url.pathname === '/definitions') {
+      const isSecondPage = url.searchParams.get('cursor') === 'workflow-2';
+      return Promise.resolve(
+        jsonResponse({
+          definitions: [
+            definitionDto(
+              isSecondPage ? SECOND_DEFINITION_ID : DEFINITION_ID,
+              isSecondPage ? 'Nightly' : 'Deploy production',
+            ),
+          ],
+          next_cursor: isSecondPage ? null : 'workflow-2',
+          sync: null,
+        }),
+      );
+    }
+
+    if (url.pathname === '/workflows/runs') {
+      return Promise.resolve(jsonResponse({runs: [], next_cursor: null, filtered_total_count: 0}));
+    }
+
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function definitionDto(id: string, name: string) {
+  return {
+    id,
+    project_id: PROJECT_ID,
+    config_path: `.shipfox/workflows/${name.toLowerCase().replaceAll(' ', '-')}.yml`,
+    source: 'vcs',
+    sha: 'abc123',
+    ref: 'main',
+    name,
+    workflow_document: {name, jobs: {}},
+    workflow_model: {kind: 'workflow', name},
+    manual_trigger: null,
+    fetched_at: '2026-05-07T01:00:00.000Z',
+    created_at: '2026-05-07T01:00:00.000Z',
+    updated_at: '2026-05-07T01:00:00.000Z',
+  };
 }
 
 function createMixedStatusRunsFetch() {

--- a/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-pages.test.tsx
@@ -206,22 +206,15 @@ describe('WorkflowRunPages', () => {
 
     renderRunsPath();
 
-    await waitFor(() => {
-      expect(
-        fetchImpl.mock.calls.some((call) => {
-          const url = new URL(requestInputUrl(call[0]));
-          return url.pathname === '/definitions' && !url.searchParams.has('cursor');
-        }),
-      ).toBe(true);
-    });
+    const workflowFilter = await screen.findByRole('button', {name: WORKFLOW_FILTER_RE});
     expect(
       fetchImpl.mock.calls.some((call) => {
         const url = new URL(requestInputUrl(call[0]));
-        return url.pathname === '/definitions' && url.searchParams.has('cursor');
+        return url.pathname === '/definitions';
       }),
     ).toBe(false);
 
-    await user.click(await screen.findByRole('button', {name: WORKFLOW_FILTER_RE}));
+    await user.click(workflowFilter);
 
     expect(await screen.findByRole('option', {name: 'Nightly'})).toBeInTheDocument();
     expect(

--- a/libs/client/workflows/src/routes/inputs.test.ts
+++ b/libs/client/workflows/src/routes/inputs.test.ts
@@ -15,6 +15,8 @@ import {
   workflowRunTab,
 } from './inputs.js';
 
+const WORKFLOW_ID = '55555555-5555-4555-8555-555555555555';
+
 /** Everything a filter change writes, then reads back, exactly as the router would. */
 function roundTrip(search: WorkflowRunsSearch): WorkflowRunsSearch {
   const query = stringifyAppSearch(workflowRunSearchParams(search, {}));
@@ -26,6 +28,7 @@ describe('validateWorkflowRunsSearch', () => {
     expect(
       validateWorkflowRunsSearch({
         search: ['unexpected'],
+        workflow: 'not-a-workflow-id',
         status: 'unknown',
         tab: 'unknown',
         severity: 'critical',
@@ -147,6 +150,7 @@ describe('the job detail URL contract', () => {
 describe('the run list URL contract', () => {
   test.each([
     ['search', {search: 'deploy-web'}],
+    ['workflow', {workflow: WORKFLOW_ID}],
     ['status', {status: ['failed' as const, 'running' as const]}],
     ['origin', {origin: 'dev' as const}],
     ['origin synced', {origin: 'synced' as const}],
@@ -161,6 +165,7 @@ describe('the run list URL contract', () => {
   test('round-trips every parameter at once', () => {
     const search: WorkflowRunsSearch = {
       search: 'deploy',
+      workflow: WORKFLOW_ID,
       status: ['failed', 'cancelled'],
       origin: 'dev',
       branch: ['main'],
@@ -214,12 +219,13 @@ describe('the run list URL contract', () => {
     expect(
       workflowRunListSearchParams({
         search: 'deploy',
+        workflow: WORKFLOW_ID,
         status: ['running'],
         tab: 'jobs',
         severity: 'error',
         jobId: 'job-1',
       }),
-    ).toEqual({search: 'deploy', status: ['running']});
+    ).toEqual({search: 'deploy', workflow: WORKFLOW_ID, status: ['running']});
   });
 
   test('has no page or cursor parameter to carry', () => {
@@ -245,6 +251,7 @@ describe('applyWorkflowRunFilterPatch', () => {
   test('deletes a dimension set to undefined, an empty string, or an empty list', () => {
     const search: WorkflowRunsSearch = {
       search: 'deploy',
+      workflow: WORKFLOW_ID,
       status: ['failed'],
       origin: 'dev',
       after: '2026-05-01',
@@ -253,6 +260,7 @@ describe('applyWorkflowRunFilterPatch', () => {
     expect(
       applyWorkflowRunFilterPatch(search, {
         search: '',
+        workflow: undefined,
         status: [],
         origin: undefined,
         after: undefined,
@@ -271,6 +279,7 @@ describe('clearWorkflowRunFilters', () => {
   test('drops every filter and keeps the selection parameters', () => {
     const cleared = clearWorkflowRunFilters({
       search: 'deploy',
+      workflow: WORKFLOW_ID,
       status: ['failed'],
       origin: 'dev',
       branch: ['main'],
@@ -288,6 +297,7 @@ describe('clearWorkflowRunFilters', () => {
 describe('hasWorkflowRunFilters', () => {
   test.each([
     ['search', {search: 'deploy'}],
+    ['workflow', {workflow: WORKFLOW_ID}],
     ['status', {status: ['failed' as const]}],
     ['origin', {origin: 'dev' as const}],
     ['branch', {branch: ['main']}],

--- a/libs/client/workflows/src/routes/inputs.test.ts
+++ b/libs/client/workflows/src/routes/inputs.test.ts
@@ -2,6 +2,7 @@ import {parseAppSearch, stringifyAppSearch} from '@shipfox/client-shell/runtime'
 import {
   applyWorkflowRunFilterPatch,
   clearWorkflowRunFilters,
+  countWorkflowRunFilters,
   hasWorkflowRunFilters,
   validateWorkflowJobSearch,
   validateWorkflowRunsSearch,
@@ -311,6 +312,19 @@ describe('hasWorkflowRunFilters', () => {
 
   test('does not count a run selection parameter as a filter', () => {
     expect(hasWorkflowRunFilters({runAttempt: 2})).toBe(false);
+  });
+
+  test('can exclude text search from a compact filter count', () => {
+    const search: WorkflowRunsSearch = {
+      search: 'deploy',
+      workflow: WORKFLOW_ID,
+      status: ['failed', 'running'],
+      after: '2026-05-01',
+      before: '2026-05-31',
+    };
+
+    expect(countWorkflowRunFilters(search)).toBe(4);
+    expect(countWorkflowRunFilters(search, {includeSearch: false})).toBe(3);
   });
 });
 

--- a/libs/client/workflows/src/routes/inputs.ts
+++ b/libs/client/workflows/src/routes/inputs.ts
@@ -32,6 +32,8 @@ export type WorkflowRunAnnotationSeverity = RunAnnotationSeverity;
 
 export interface WorkflowRunsSearch extends WorkflowRunSelectionInput {
   search?: string;
+  /** Workflow definition id. Absent means runs from every workflow. */
+  workflow?: string;
   status?: WorkflowRunListStatus[];
   origin?: WorkflowRunListOrigin;
   branch?: string[];
@@ -52,6 +54,7 @@ const ORIGIN_VALUES = new Set<string>(WORKFLOW_RUN_LIST_ORIGINS);
 const TAB_VALUES = new Set<string>(WORKFLOW_RUN_TABS);
 const ANNOTATION_SEVERITY_VALUES = new Set<string>(WORKFLOW_RUN_ANNOTATION_SEVERITIES);
 const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 /**
  * Reads the run list and run detail query string.
@@ -62,6 +65,7 @@ const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
  */
 export function validateWorkflowRunsSearch(input: Record<string, unknown>): WorkflowRunsSearch {
   const search = string(input.search);
+  const workflow = uuid(input.workflow);
   const status = repeatable(input.status).filter(isWorkflowRunListStatus);
   const origin = enumSearchValue<WorkflowRunListOrigin>(input.origin, ORIGIN_VALUES);
   const branch = repeatable(input.branch);
@@ -77,6 +81,7 @@ export function validateWorkflowRunsSearch(input: Record<string, unknown>): Work
 
   return {
     ...(search ? {search} : {}),
+    ...(workflow ? {workflow} : {}),
     ...(status.length > 0 ? {status} : {}),
     ...(origin ? {origin} : {}),
     ...(branch.length > 0 ? {branch} : {}),
@@ -117,6 +122,7 @@ export function workflowRunSearchParams(
 ) {
   return {
     ...(search.search ? {search: search.search} : {}),
+    ...(search.workflow ? {workflow: search.workflow} : {}),
     ...(search.status?.length ? {status: search.status} : {}),
     ...(search.origin ? {origin: search.origin} : {}),
     ...(search.branch?.length ? {branch: search.branch} : {}),
@@ -155,6 +161,7 @@ export function workflowRunListSearchParams(search: WorkflowRunsSearch) {
  */
 export interface WorkflowRunFilterPatch {
   search?: string | undefined;
+  workflow?: string | undefined;
   status?: WorkflowRunListStatus[] | undefined;
   origin?: WorkflowRunListOrigin | undefined;
   branch?: string[] | undefined;
@@ -177,6 +184,7 @@ export function applyWorkflowRunFilterPatch(
 ): WorkflowRunsSearch {
   const next: WorkflowRunsSearch = {...search};
   if ('search' in patch) setOrDelete(next, 'search', patch.search || undefined);
+  if ('workflow' in patch) setOrDelete(next, 'workflow', patch.workflow || undefined);
   if ('status' in patch) setOrDelete(next, 'status', nonEmptyList(patch.status));
   if ('origin' in patch) setOrDelete(next, 'origin', patch.origin || undefined);
   if ('branch' in patch) setOrDelete(next, 'branch', nonEmptyList(patch.branch));
@@ -191,6 +199,7 @@ export function applyWorkflowRunFilterPatch(
 export function clearWorkflowRunFilters(search: WorkflowRunsSearch): WorkflowRunsSearch {
   return applyWorkflowRunFilterPatch(search, {
     search: undefined,
+    workflow: undefined,
     status: undefined,
     origin: undefined,
     branch: undefined,
@@ -205,6 +214,7 @@ export function clearWorkflowRunFilters(search: WorkflowRunsSearch): WorkflowRun
 export function hasWorkflowRunFilters(search: WorkflowRunsSearch): boolean {
   return Boolean(
     search.search ||
+      search.workflow ||
       search.status?.length ||
       search.origin ||
       search.branch?.length ||
@@ -327,6 +337,11 @@ function calendarDate(value: unknown): string | undefined {
 
 function string(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function uuid(value: unknown): string | undefined {
+  const candidate = string(value);
+  return candidate && UUID_PATTERN.test(candidate) ? candidate : undefined;
 }
 
 function positiveInteger(value: unknown): number | undefined {

--- a/libs/client/workflows/src/routes/inputs.ts
+++ b/libs/client/workflows/src/routes/inputs.ts
@@ -1,3 +1,4 @@
+import {isUuid} from '@shipfox/regex';
 import {RUN_ANNOTATION_SEVERITIES, type RunAnnotationSeverity} from '#core/run-annotation.js';
 import {WORKFLOW_RUN_ORIGINS, type WorkflowRunOrigin} from '#core/workflow-run.js';
 import type {WorkflowRunSelectionInput} from '#core/workflow-run-url-state.js';
@@ -54,7 +55,6 @@ const ORIGIN_VALUES = new Set<string>(WORKFLOW_RUN_LIST_ORIGINS);
 const TAB_VALUES = new Set<string>(WORKFLOW_RUN_TABS);
 const ANNOTATION_SEVERITY_VALUES = new Set<string>(WORKFLOW_RUN_ANNOTATION_SEVERITIES);
 const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 /**
  * Reads the run list and run detail query string.
@@ -212,17 +212,24 @@ export function clearWorkflowRunFilters(search: WorkflowRunsSearch): WorkflowRun
 
 /** True when any list filter is active, which separates "no matches" from "no runs". */
 export function hasWorkflowRunFilters(search: WorkflowRunsSearch): boolean {
-  return Boolean(
-    search.search ||
-      search.workflow ||
-      search.status?.length ||
-      search.origin ||
-      search.branch?.length ||
-      search.actor?.length ||
-      search.event?.length ||
-      search.after ||
-      search.before,
-  );
+  return countWorkflowRunFilters(search) > 0;
+}
+
+/** Counts active filter dimensions, optionally excluding the always-visible text search. */
+export function countWorkflowRunFilters(
+  search: WorkflowRunsSearch,
+  {includeSearch = true}: {includeSearch?: boolean} = {},
+): number {
+  return [
+    includeSearch && search.search,
+    search.workflow,
+    search.status?.length,
+    search.origin,
+    search.branch?.length,
+    search.actor?.length,
+    search.event?.length,
+    search.after || search.before,
+  ].filter(Boolean).length;
 }
 
 export function workflowRouteParams(input: Record<string, unknown>): {
@@ -341,7 +348,7 @@ function string(value: unknown): string | undefined {
 
 function uuid(value: unknown): string | undefined {
   const candidate = string(value);
-  return candidate && UUID_PATTERN.test(candidate) ? candidate : undefined;
+  return candidate && isUuid(candidate) ? candidate : undefined;
 }
 
 function positiveInteger(value: unknown): number | undefined {

--- a/libs/shared/react/ui/src/components/sheet/sheet.test.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.test.tsx
@@ -1,0 +1,33 @@
+import {render, screen} from '@testing-library/react';
+import {Sheet, SheetContent, SheetHeader, SheetTitle} from './sheet.js';
+
+describe('Sheet', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('names the close control and uses the canonical neutral focus treatment', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }) as unknown as typeof window.matchMedia;
+
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Filters</SheetTitle>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    const close = screen.getByRole('button', {name: 'Close'});
+
+    expect(close.classList.contains('focus-visible:shadow-button-neutral-focus')).toBe(true);
+    expect(close.classList.contains('focus-visible:ring-background-accent-blue-base')).toBe(false);
+  });
+});

--- a/libs/shared/react/ui/src/components/sheet/sheet.test.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.test.tsx
@@ -28,6 +28,5 @@ describe('Sheet', () => {
     const close = screen.getByRole('button', {name: 'Close'});
 
     expect(close.classList.contains('focus-visible:shadow-button-neutral-focus')).toBe(true);
-    expect(close.classList.contains('focus-visible:ring-background-accent-blue-base')).toBe(false);
   });
 });

--- a/libs/shared/react/ui/src/components/sheet/sheet.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.tsx
@@ -157,7 +157,8 @@ function SheetHeader({
               <Button
                 variant="transparent"
                 size="xs"
-                className="rounded-4 p-2 cursor-pointer bg-transparent border-none text-foreground-neutral-muted hover:text-foreground-neutral-base hover:bg-background-components-hover transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-background-accent-blue-base focus-visible:ring-offset-2 w-24 h-24"
+                aria-label="Close"
+                className="rounded-4 p-2 cursor-pointer bg-transparent border-none text-foreground-neutral-muted hover:text-foreground-neutral-base hover:bg-background-components-hover transition-colors duration-150 outline-none focus-visible:shadow-button-neutral-focus w-24 h-24"
               >
                 <Icon name="close" />
               </Button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6326,6 +6326,9 @@ importers:
       '@shipfox/react-ui':
         specifier: workspace:*
         version: link:../../shared/react/ui
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../shared/common/regex
       '@swc/helpers':
         specifier: 'catalog:'
         version: 0.5.23


### PR DESCRIPTION
## Why

The run list currently mixes executions from every workflow, which makes it difficult to investigate one workflow's history.

## What changed

This adds a searchable Workflow filter to the run-list toolbar. The selected definition is stored in the URL and sent to the runs API, so the filter covers the full run history and can be shared or restored.

The selector loads the complete paginated workflow inventory, preserves historical run labels, and reports loading and retryable error states. The mobile filter sheet exposes the same control and reports its active-filter count. The shared Sheet close control also receives an accessible name and the canonical focus treatment.

## Validation

- `mise exec -- turbo test check type --filter=@shipfox/client-workflows... --filter=@shipfox/react-ui...` (228 tasks passed; 691 workflow tests and 470 React UI tests)
- `mise exec -- pnpm check:client-architecture`
- `mise exec -- pnpm exec changeset status`
- Desktop and mobile Storybook review; Impeccable finish verdict: `ship — PASS`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a searchable Workflow filter to the run list so you can investigate a single workflow's history instead of sifting through runs from every workflow. The selected workflow lives in the URL and is sent to the runs API, so the filter spans full history and can be shared or restored.

- Loads the full paginated workflow inventory lazily, only when the workflow chooser opens.
- Halts loading with an error when the API repeats a pagination cursor and never shows the previous project's workflows; the error state offers a retry.
- Reports loading and error states in the selector; the mobile filter sheet now shows the active-filter count without the text search.
- The shared Sheet close button gets an accessible name and the canonical focus treatment.

<sup>Written for commit 3bb28db56e15ed3f16579694bd27ab727ac5fd84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

