### PR TITLE
[api-auth] Add agent access OAuth consent and token flows

### DIFF
--- a/.changeset/agent-access-oauth-flows.md
+++ b/.changeset/agent-access-oauth-flows.md
@@ -3,4 +3,4 @@
 '@shipfox/api-auth-dto': minor
 ---
 
-Add dormant OAuth authorization, consent, authorization-code, and refresh-token flows for agent access.
+Add `createOAuthAuthorizationRoutes` and the OAuth authorization, consent, authorization-code, and refresh-token contracts for agent access.

--- a/.changeset/agent-access-oauth-flows.md
+++ b/.changeset/agent-access-oauth-flows.md
@@ -1,0 +1,6 @@
+---
+'@shipfox/api-auth': minor
+'@shipfox/api-auth-dto': minor
+---
+
+Add dormant OAuth authorization, consent, authorization-code, and refresh-token flows for agent access.

--- a/.changeset/agent-access-token-key.md
+++ b/.changeset/agent-access-token-key.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/node-auth-root-key': minor
+---
+
+Add a dedicated HKDF-derived key for agent access tokens.

--- a/.changeset/agent-access-token-key.md
+++ b/.changeset/agent-access-token-key.md
@@ -2,4 +2,4 @@
 '@shipfox/node-auth-root-key': minor
 ---
 
-Add a dedicated HKDF-derived key for agent access tokens.
+Add `agentAccessTokenKey()` for signing agent access tokens.

--- a/docs/adr/0014-admin-user-impersonation.md
+++ b/docs/adr/0014-admin-user-impersonation.md
@@ -180,10 +180,10 @@ days. An operator could mint permanent, unattributed workspace access inside a 1
 audited window, stop impersonating, and use it later. Nothing in the audit trail would point at
 it.
 
-The deny-list covers runner registration tokens, provisioner tokens, and workspace
-invitations. Its guard is the administration guard under a second name, exported from the same
-package, so a route opts in with one line. Adding a credential-issuing or grant-creating route
-later means adding it here.
+The deny-list covers runner registration tokens, provisioner tokens, workspace invitations, and
+OAuth consent approval, which creates an agent grant and its refresh-token family. Its guard is
+the administration guard under a second name, exported from the same package, so a route opts in
+with one line. Adding a credential-issuing or grant-creating route later means adding it here.
 
 This narrows read-write capability in an enumerated, documented way. It is not the per-route policy
 scoping this record rejects below. The deny-list governs what a session can leave behind, not

--- a/libs/api/auth-dto/src/schemas/agent-access-token.ts
+++ b/libs/api/auth-dto/src/schemas/agent-access-token.ts
@@ -1,0 +1,17 @@
+import {z} from 'zod';
+
+/** Audience binding an OAuth access token to agent-access request auth. */
+export const AGENT_ACCESS_TOKEN_AUDIENCE = 'agent-access';
+
+export const agentAccessTokenClaimsSchema = z.object({
+  sub: z.string().uuid(),
+  workspaceId: z.string().uuid(),
+  grantId: z.string().uuid(),
+  clientId: z.string().min(1).max(2048),
+  scopes: z.array(z.literal('read')).min(1),
+  aud: z.literal(AGENT_ACCESS_TOKEN_AUDIENCE),
+  iat: z.number().int(),
+  exp: z.number().int(),
+});
+
+export type AgentAccessTokenClaims = z.infer<typeof agentAccessTokenClaimsSchema>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -125,6 +125,7 @@ export {
   jobLeaseTokenClaimsSchema,
 } from './job-lease-token.js';
 export {
+  OAUTH_MCP_RESOURCE_PATH,
   OAUTH_READ_SCOPE,
   type OAuthAuthorizationServerMetadataDto,
   type OAuthAuthorizeQueryDto,

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -58,6 +58,11 @@ export {
   suspendAdministratorUserBodySchema,
 } from './admin.js';
 export {
+  AGENT_ACCESS_TOKEN_AUDIENCE,
+  type AgentAccessTokenClaims,
+  agentAccessTokenClaimsSchema,
+} from './agent-access-token.js';
+export {
   type ChangePasswordBodyDto,
   changePasswordBodySchema,
   emailSchema,
@@ -122,15 +127,29 @@ export {
 export {
   OAUTH_READ_SCOPE,
   type OAuthAuthorizationServerMetadataDto,
+  type OAuthAuthorizeQueryDto,
   type OAuthClientMetadataDocumentDto,
+  type OAuthConsentApprovalBodyDto,
+  type OAuthConsentDecisionResponseDto,
+  type OAuthConsentParamsDto,
+  type OAuthConsentResponseDto,
   type OAuthDynamicClientRegistrationRequestDto,
   type OAuthDynamicClientRegistrationResponseDto,
   type OAuthProtectedResourceMetadataDto,
+  type OAuthTokenRequestDto,
+  type OAuthTokenResponseDto,
   oauthAuthorizationServerMetadataSchema,
+  oauthAuthorizeQuerySchema,
   oauthClientMetadataDocumentSchema,
+  oauthConsentApprovalBodySchema,
+  oauthConsentDecisionResponseSchema,
+  oauthConsentParamsSchema,
+  oauthConsentResponseSchema,
   oauthDynamicClientRegistrationRequestSchema,
   oauthDynamicClientRegistrationResponseSchema,
   oauthProtectedResourceMetadataSchema,
+  oauthTokenRequestSchema,
+  oauthTokenResponseSchema,
 } from './oauth.js';
 export {
   RUNNER_SESSION_TOKEN_AUDIENCE,

--- a/libs/api/auth-dto/src/schemas/oauth.test.ts
+++ b/libs/api/auth-dto/src/schemas/oauth.test.ts
@@ -1,12 +1,27 @@
 import {describe, expect, it} from '@shipfox/vitest/vi';
 import {
   oauthAuthorizationServerMetadataSchema,
+  oauthAuthorizeQuerySchema,
   oauthClientMetadataDocumentSchema,
   oauthDynamicClientRegistrationRequestSchema,
   oauthProtectedResourceMetadataSchema,
 } from './oauth.js';
 
 describe('OAuth metadata schemas', () => {
+  it('requires a non-empty authorization state when it is supplied', () => {
+    expect(
+      oauthAuthorizeQuerySchema.safeParse({
+        client_id: 'client-id',
+        response_type: 'code',
+        redirect_uri: 'https://client.example/callback',
+        code_challenge: 'a'.repeat(43),
+        code_challenge_method: 'S256',
+        resource: 'https://api.example.test/mcp',
+        state: '',
+      }).success,
+    ).toBe(false);
+  });
+
   it('accepts the MCP read-only discovery profile', () => {
     expect(
       oauthProtectedResourceMetadataSchema.safeParse({

--- a/libs/api/auth-dto/src/schemas/oauth.ts
+++ b/libs/api/auth-dto/src/schemas/oauth.ts
@@ -102,3 +102,112 @@ export const oauthClientMetadataDocumentSchema = z
   .passthrough();
 
 export type OAuthClientMetadataDocumentDto = z.infer<typeof oauthClientMetadataDocumentSchema>;
+
+const utf8Encoder = new TextEncoder();
+const utf8ByteLengthAtMost = (value: string, maxBytes: number): boolean =>
+  utf8Encoder.encode(value).byteLength <= maxBytes;
+const oauthClientIdSchema = z
+  .string()
+  .min(1)
+  .max(2048)
+  .refine((value) => utf8ByteLengthAtMost(value, 2048));
+const oauthStateSchema = z
+  .string()
+  .max(2048)
+  .refine((value) => utf8ByteLengthAtMost(value, 2048));
+const oauthCodeChallengeSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/u);
+const oauthCodeVerifierSchema = z
+  .string()
+  .min(43)
+  .max(128)
+  .regex(/^[A-Za-z0-9._~-]+$/u);
+const oauthPresentedTokenSchema = z
+  .string()
+  .min(1)
+  .max(1024)
+  .refine((value) => utf8ByteLengthAtMost(value, 1024));
+const oauthRedirectResponseUrlSchema = z.string().url().max(16_384);
+
+/** The validated public request accepted by the OAuth authorization endpoint. */
+export const oauthAuthorizeQuerySchema = z
+  .object({
+    client_id: oauthClientIdSchema,
+    response_type: oauthResponseTypeSchema,
+    redirect_uri: oauthRedirectUriSchema,
+    code_challenge: oauthCodeChallengeSchema,
+    code_challenge_method: z.literal('S256'),
+    resource: oauthUrlSchema,
+    scope: oauthScopeSchema.optional(),
+    state: oauthStateSchema.optional(),
+  })
+  .strict();
+
+export type OAuthAuthorizeQueryDto = z.infer<typeof oauthAuthorizeQuerySchema>;
+
+/** Opaque request id parameters used by the dashboard consent routes. */
+export const oauthConsentParamsSchema = z.object({requestId: z.string().min(1).max(128)}).strict();
+
+export type OAuthConsentParamsDto = z.infer<typeof oauthConsentParamsSchema>;
+
+const oauthConsentWorkspaceSchema = z
+  .object({
+    workspace_id: z.string().uuid(),
+    role: z.string().min(1).max(64),
+  })
+  .strict();
+
+/** Detail returned to the authenticated dashboard before a consent decision. */
+export const oauthConsentResponseSchema = z
+  .object({
+    request_id: z.string().uuid(),
+    client_name: oauthClientNameSchema,
+    scope: z.literal(OAUTH_READ_SCOPE),
+    expires_at: z.string().datetime(),
+    redirect_uri_hostname: z.string().min(1).max(253),
+    client_identity_origin: z.string().min(1).max(2048),
+    is_loopback_redirect: z.boolean(),
+    workspaces: z.array(oauthConsentWorkspaceSchema),
+  })
+  .strict();
+
+export type OAuthConsentResponseDto = z.infer<typeof oauthConsentResponseSchema>;
+
+/** Explicit workspace selection required to approve a consent request. */
+export const oauthConsentApprovalBodySchema = z.object({workspace_id: z.string().uuid()}).strict();
+
+export type OAuthConsentApprovalBodyDto = z.infer<typeof oauthConsentApprovalBodySchema>;
+
+/** The redirect produced after an approval or denial decision. */
+export const oauthConsentDecisionResponseSchema = z
+  .object({redirect_url: oauthRedirectResponseUrlSchema})
+  .strict();
+
+export type OAuthConsentDecisionResponseDto = z.infer<typeof oauthConsentDecisionResponseSchema>;
+
+/** Public OAuth token request supporting authorization-code and refresh grants. */
+export const oauthTokenRequestSchema = z
+  .object({
+    grant_type: oauthGrantTypeSchema,
+    client_id: oauthClientIdSchema,
+    code: oauthPresentedTokenSchema.optional(),
+    redirect_uri: oauthRedirectUriSchema.optional(),
+    code_verifier: oauthCodeVerifierSchema.optional(),
+    refresh_token: oauthPresentedTokenSchema.optional(),
+    resource: oauthUrlSchema.optional(),
+  })
+  .strict();
+
+export type OAuthTokenRequestDto = z.infer<typeof oauthTokenRequestSchema>;
+
+/** RFC 6749 token response for an agent access grant. */
+export const oauthTokenResponseSchema = z
+  .object({
+    access_token: z.string().min(1),
+    token_type: z.literal('Bearer'),
+    expires_in: z.number().int().positive(),
+    refresh_token: z.string().min(1).optional(),
+    scope: z.literal(OAUTH_READ_SCOPE),
+  })
+  .strict();
+
+export type OAuthTokenResponseDto = z.infer<typeof oauthTokenResponseSchema>;

--- a/libs/api/auth-dto/src/schemas/oauth.ts
+++ b/libs/api/auth-dto/src/schemas/oauth.ts
@@ -113,6 +113,7 @@ const oauthClientIdSchema = z
   .refine((value) => utf8ByteLengthAtMost(value, 2048));
 const oauthStateSchema = z
   .string()
+  .min(1)
   .max(2048)
   .refine((value) => utf8ByteLengthAtMost(value, 2048));
 const oauthCodeChallengeSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/u);

--- a/libs/api/auth-dto/src/schemas/oauth.ts
+++ b/libs/api/auth-dto/src/schemas/oauth.ts
@@ -10,6 +10,9 @@ const oauthResponseTypeSchema = z.literal('code');
 /** The only scope exposed by the MCP read-only profile. */
 export const OAUTH_READ_SCOPE = 'read' as const;
 
+/** The canonical resource path exposed by the MCP read-only profile. */
+export const OAUTH_MCP_RESOURCE_PATH = '/mcp' as const;
+
 /** RFC 9728 metadata advertised for the protected MCP resource. */
 export const oauthProtectedResourceMetadataSchema = z
   .object({
@@ -190,6 +193,7 @@ export const oauthTokenRequestSchema = z
   .object({
     grant_type: oauthGrantTypeSchema,
     client_id: oauthClientIdSchema,
+    scope: oauthScopeSchema.optional(),
     code: oauthPresentedTokenSchema.optional(),
     redirect_uri: oauthRedirectUriSchema.optional(),
     code_verifier: oauthCodeVerifierSchema.optional(),

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -351,6 +351,10 @@ All routes are mounted under `/admin/auth/users` and require an authenticated be
 
 `POST /:userId/impersonate` requires an `Idempotency-Key` and a bounded reason, and is rate limited under the `impersonate` bucket by source IP and by actor. It returns `{token, expires_at, server_time, impersonator_id, user}` and sets no cookie. The target must be active with a verified email and hold no active administrator grant; the actor must not be the target. The mint, a same-key in-window replay, and a renewal each re-run the full authorization and eligibility ladder and publish their own `administration.action.performed` event. A replay re-signs for the same target with the original `expires_at` and never extends the window; after the window passes, the key is consumed for good: every further replay returns `410 impersonation-expired`, and a fresh `Idempotency-Key` is required for a new mint. The stored command result holds only SHA-256 fingerprints of the issued tokens. Failures are audited from their own committed transaction when the actor holds an identifiable administrator role (the strict event schema carries the actor role); role-less denials (a revoked grant, a suspended actor, or a non-admin probing the route) fail closed without an event, and client-contract errors (`404 not-found` for an unknown target, `409 idempotency-key-reused`) are reported to the caller and never enter the failure stream.
 
+Each command requires an `Idempotency-Key`. Suspension requires a bounded reason; reactivation and session revocation accept an optional bounded reason. Repeating a successful command returns its committed result. Reusing a key for a different command or request returns `409 idempotency-key-reused`.
+
+Suspension preserves the user record and rejects the final active administrator owner. State, the command result, and one redacted `administration.action.performed` outbox event commit atomically. The event stores only the idempotency-key fingerprint, never the raw key or session material.
+
 ### Agent access OAuth
 
 `createOAuthAuthorizationRoutes` is an explicit opt-in factory for the OAuth authorization,
@@ -365,10 +369,6 @@ Authorization-code replay returns `invalid_grant` and
 does not revoke a grant that was already issued, because a lost token response is indistinguishable
 from a replay. Refresh-token reuse outside the grace window revokes the grant family, and a lost
 rotation response therefore requires a new consent flow.
-
-Each command requires an `Idempotency-Key`. Suspension requires a bounded reason; reactivation and session revocation accept an optional bounded reason. Repeating a successful command returns its committed result. Reusing a key for a different command or request returns `409 idempotency-key-reused`.
-
-Suspension preserves the user record and rejects the final active administrator owner. State, the command result, and one redacted `administration.action.performed` outbox event commit atomically. The event stores only the idempotency-key fingerprint, never the raw key or session material.
 
 ## API
 

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -357,9 +357,11 @@ All routes are mounted under `/admin/auth/users` and require an authenticated be
 consent, authorization-code, and refresh-token routes. `createAuthModule().routes` does not
 compose these routes until an application provides its consent UI and agent-resource boundary.
 
-Consent approval creates a durable agent grant. The current package does not expose agent-grant
-listing or revocation routes; composition should add that lifecycle surface before treating a
-grant as an operator-managed credential. Authorization-code replay returns `invalid_grant` and
+Consent approval creates a durable agent grant from a pre-commit workspace-membership snapshot;
+every authorization-code and refresh exchange revalidates membership before issuing tokens. The
+current package does not expose agent-grant listing or revocation routes; composition should add
+that lifecycle surface before treating a grant as an operator-managed credential.
+Authorization-code replay returns `invalid_grant` and
 does not revoke a grant that was already issued, because a lost token response is indistinguishable
 from a replay. Refresh-token reuse outside the grace window revokes the grant family, and a lost
 rotation response therefore requires a new consent flow.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -351,6 +351,19 @@ All routes are mounted under `/admin/auth/users` and require an authenticated be
 
 `POST /:userId/impersonate` requires an `Idempotency-Key` and a bounded reason, and is rate limited under the `impersonate` bucket by source IP and by actor. It returns `{token, expires_at, server_time, impersonator_id, user}` and sets no cookie. The target must be active with a verified email and hold no active administrator grant; the actor must not be the target. The mint, a same-key in-window replay, and a renewal each re-run the full authorization and eligibility ladder and publish their own `administration.action.performed` event. A replay re-signs for the same target with the original `expires_at` and never extends the window; after the window passes, the key is consumed for good: every further replay returns `410 impersonation-expired`, and a fresh `Idempotency-Key` is required for a new mint. The stored command result holds only SHA-256 fingerprints of the issued tokens. Failures are audited from their own committed transaction when the actor holds an identifiable administrator role (the strict event schema carries the actor role); role-less denials (a revoked grant, a suspended actor, or a non-admin probing the route) fail closed without an event, and client-contract errors (`404 not-found` for an unknown target, `409 idempotency-key-reused`) are reported to the caller and never enter the failure stream.
 
+### Agent access OAuth
+
+`createOAuthAuthorizationRoutes` is an explicit opt-in factory for the OAuth authorization,
+consent, authorization-code, and refresh-token routes. `createAuthModule().routes` does not
+compose these routes until an application provides its consent UI and agent-resource boundary.
+
+Consent approval creates a durable agent grant. The current package does not expose agent-grant
+listing or revocation routes; composition should add that lifecycle surface before treating a
+grant as an operator-managed credential. Authorization-code replay returns `invalid_grant` and
+does not revoke a grant that was already issued, because a lost token response is indistinguishable
+from a replay. Refresh-token reuse outside the grace window revokes the grant family, and a lost
+rotation response therefore requires a new consent flow.
+
 Each command requires an `Idempotency-Key`. Suspension requires a bounded reason; reactivation and session revocation accept an optional bounded reason. Repeating a successful command returns its committed result. Reusing a key for a different command or request returns `409 idempotency-key-reused`.
 
 Suspension preserves the user record and rejects the final active administrator owner. State, the command result, and one redacted `administration.action.performed` outbox event commit atomically. The event stores only the idempotency-key fingerprint, never the raw key or session material.
@@ -380,6 +393,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `createEnvironmentSignupPolicy()`: creates the environment-backed signup policy used by default. Pass `signupPolicy` to `createAuthModule` to replace it. A denied custom policy can opt into sanitized Markdown with `format: 'markdown'`; without a format, its message stays plain text.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
 - `createImpersonatedSessionToken({targetUserId, impersonatorId, workspaces})`: mints an access-token-only impersonated session (capped TTL, `impersonatorId` claim, no refresh material). The `impersonateUser` administration command owns the authorization ladder, idempotency, and audit flow.
+- `createOAuthAuthorizationRoutes(options)`: explicitly composes the OAuth authorization, consent, authorization-code, and refresh-token routes for an agent-resource integration.
 - `getAuthenticatedSessionContext(request)`: reads the user ID and required refresh-session ID from verified access-token claims. It does not check whether the refresh session is still active.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
 - `listAdministratorUsers({actorId, limit, cursor?, search?, status?, eligible?})`: returns `{users, rows, nextCursor}` after requiring an active observer role. `rows` remains as a compatibility alias. Search accepts at most 10 whitespace-separated terms. Each term can contain at most 100 characters.

--- a/libs/api/auth/drizzle/0005_nifty_the_twelve.sql
+++ b/libs/api/auth/drizzle/0005_nifty_the_twelve.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "auth_agent_authorization_requests" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+ALTER TABLE "auth_agent_authorization_requests" ADD CONSTRAINT "auth_agent_authorization_requests_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "auth_agent_authorization_requests_user_id_idx" ON "auth_agent_authorization_requests" USING btree ("user_id");

--- a/libs/api/auth/drizzle/meta/0005_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1781 @@
+{
+  "id": "d1d9db15-fbe2-4478-a44d-fa83e104b959",
+  "prevId": "c22b8dbd-5550-4d0f-b131-5e42a13e8cdc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_admin_command_results": {
+      "name": "auth_admin_command_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key_fingerprint": {
+          "name": "idempotency_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_admin_command_results_actor_key_unique": {
+          "name": "auth_admin_command_results_actor_key_unique",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_admin_command_results_actor_id_auth_users_id_fk": {
+          "name": "auth_admin_command_results_actor_id_auth_users_id_fk",
+          "tableFrom": "auth_admin_command_results",
+          "tableTo": "auth_users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_admin_grants": {
+      "name": "auth_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "auth_admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_admin_grants_user_id_idx": {
+          "name": "auth_admin_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_admin_grants_active_owners_idx": {
+          "name": "auth_admin_grants_active_owners_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_admin_grants\".\"role\" = 'admin-owner' AND \"auth_admin_grants\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_admin_grants_active_user_role_unique": {
+          "name": "auth_admin_grants_active_user_role_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_admin_grants\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_admin_grants_user_id_auth_users_id_fk": {
+          "name": "auth_admin_grants_user_id_auth_users_id_fk",
+          "tableFrom": "auth_admin_grants",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_agent_authorization_codes": {
+      "name": "auth_agent_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_code": {
+          "name": "hashed_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_agent_authorization_codes_hashed_code_unique": {
+          "name": "auth_agent_authorization_codes_hashed_code_unique",
+          "columns": [
+            {
+              "expression": "hashed_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_authorization_codes_grant_id_idx": {
+          "name": "auth_agent_authorization_codes_grant_id_idx",
+          "columns": [
+            {
+              "expression": "grant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_authorization_codes_expires_at_idx": {
+          "name": "auth_agent_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_agent_authorization_codes_grant_id_auth_agent_grants_id_fk": {
+          "name": "auth_agent_authorization_codes_grant_id_auth_agent_grants_id_fk",
+          "tableFrom": "auth_agent_authorization_codes",
+          "tableTo": "auth_agent_grants",
+          "columnsFrom": ["grant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_agent_authorization_requests": {
+      "name": "auth_agent_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_agent_authorization_requests_client_id_idx": {
+          "name": "auth_agent_authorization_requests_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_authorization_requests_user_id_idx": {
+          "name": "auth_agent_authorization_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_authorization_requests_expires_at_idx": {
+          "name": "auth_agent_authorization_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_agent_authorization_requests_client_id_auth_agent_clients_id_fk": {
+          "name": "auth_agent_authorization_requests_client_id_auth_agent_clients_id_fk",
+          "tableFrom": "auth_agent_authorization_requests",
+          "tableTo": "auth_agent_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_agent_authorization_requests_user_id_auth_users_id_fk": {
+          "name": "auth_agent_authorization_requests_user_id_auth_users_id_fk",
+          "tableFrom": "auth_agent_authorization_requests",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_agent_clients": {
+      "name": "auth_agent_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "auth_agent_client_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreferenced_at": {
+          "name": "unreferenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_agent_clients_client_id_unique": {
+          "name": "auth_agent_clients_client_id_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_clients_unreferenced_at_idx": {
+          "name": "auth_agent_clients_unreferenced_at_idx",
+          "columns": [
+            {
+              "expression": "unreferenced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_clients_created_at_idx": {
+          "name": "auth_agent_clients_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_agent_grants": {
+      "name": "auth_agent_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_agent_grants_user_id_idx": {
+          "name": "auth_agent_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_grants_workspace_id_idx": {
+          "name": "auth_agent_grants_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_grants_client_id_idx": {
+          "name": "auth_agent_grants_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_grants_terminal_at_idx": {
+          "name": "auth_agent_grants_terminal_at_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_grants_active_user_workspace_client_unique": {
+          "name": "auth_agent_grants_active_user_workspace_client_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_agent_grants\".\"revoked_at\" IS NULL AND \"auth_agent_grants\".\"terminal_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_agent_grants_user_id_auth_users_id_fk": {
+          "name": "auth_agent_grants_user_id_auth_users_id_fk",
+          "tableFrom": "auth_agent_grants",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_agent_grants_client_id_auth_agent_clients_id_fk": {
+          "name": "auth_agent_grants_client_id_auth_agent_clients_id_fk",
+          "tableFrom": "auth_agent_grants",
+          "tableTo": "auth_agent_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_agent_pats": {
+      "name": "auth_agent_pats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_agent_pats_hashed_token_unique": {
+          "name": "auth_agent_pats_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_pats_user_id_idx": {
+          "name": "auth_agent_pats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_pats_workspace_id_idx": {
+          "name": "auth_agent_pats_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_pats_expires_at_idx": {
+          "name": "auth_agent_pats_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_pats_revoked_at_idx": {
+          "name": "auth_agent_pats_revoked_at_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_agent_pats_user_id_auth_users_id_fk": {
+          "name": "auth_agent_pats_user_id_auth_users_id_fk",
+          "tableFrom": "auth_agent_pats",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_agent_refresh_tokens": {
+      "name": "auth_agent_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_agent_refresh_tokens_hashed_token_unique": {
+          "name": "auth_agent_refresh_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_refresh_tokens_live_grant_unique": {
+          "name": "auth_agent_refresh_tokens_live_grant_unique",
+          "columns": [
+            {
+              "expression": "grant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_agent_refresh_tokens\".\"rotated_at\" IS NULL AND \"auth_agent_refresh_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_refresh_tokens_grant_id_idx": {
+          "name": "auth_agent_refresh_tokens_grant_id_idx",
+          "columns": [
+            {
+              "expression": "grant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_refresh_tokens_expires_at_idx": {
+          "name": "auth_agent_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_refresh_tokens_rotated_at_idx": {
+          "name": "auth_agent_refresh_tokens_rotated_at_idx",
+          "columns": [
+            {
+              "expression": "rotated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_agent_refresh_tokens_revoked_at_idx": {
+          "name": "auth_agent_refresh_tokens_revoked_at_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_agent_refresh_tokens_grant_id_auth_agent_grants_id_fk": {
+          "name": "auth_agent_refresh_tokens_grant_id_auth_agent_grants_id_fk",
+          "tableFrom": "auth_agent_refresh_tokens",
+          "tableTo": "auth_agent_grants",
+          "columnsFrom": ["grant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_outbox": {
+      "name": "auth_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_outbox_pending_idx": {
+          "name": "auth_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_outbox_dispatched_retention_idx": {
+          "name": "auth_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_password_resets": {
+      "name": "auth_password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_password_resets_hashed_token_unique": {
+          "name": "auth_password_resets_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_password_resets_user_id_idx": {
+          "name": "auth_password_resets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_password_resets_user_id_auth_users_id_fk": {
+          "name": "auth_password_resets_user_id_auth_users_id_fk",
+          "tableFrom": "auth_password_resets",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_rate_limits_window_unique": {
+          "name": "auth_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_rate_limits_expires_at_idx": {
+          "name": "auth_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_refresh_tokens": {
+      "name": "auth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_refresh_tokens_hashed_token_unique": {
+          "name": "auth_refresh_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_active_session_unique": {
+          "name": "auth_refresh_tokens_active_session_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_refresh_tokens\".\"revoked_at\" IS NULL AND \"auth_refresh_tokens\".\"rotated_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_user_id_idx": {
+          "name": "auth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_refresh_tokens_user_id_auth_users_id_fk": {
+          "name": "auth_refresh_tokens_user_id_auth_users_id_fk",
+          "tableFrom": "auth_refresh_tokens",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "auth_user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_users_created_at_id_index": {
+          "name": "auth_users_created_at_id_index",
+          "columns": [
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_users_name_trgm_index": {
+          "name": "auth_users_name_trgm_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "auth_users_email_trgm_index": {
+          "name": "auth_users_email_trgm_index",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_admin_role": {
+      "name": "auth_admin_role",
+      "schema": "public",
+      "values": ["admin-observer", "admin-operator", "admin-owner"]
+    },
+    "public.auth_agent_client_kind": {
+      "name": "auth_agent_client_kind",
+      "schema": "public",
+      "values": ["registered", "cimd"]
+    },
+    "public.auth_user_status": {
+      "name": "auth_user_status",
+      "schema": "public",
+      "values": ["active", "suspended", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/auth/drizzle/meta/_journal.json
+++ b/libs/api/auth/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1788195662870,
       "tag": "0004_yummy_runaways",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1788279929383,
+      "tag": "0005_nifty_the_twelve",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -76,6 +76,7 @@
     "@temporalio/activity": "catalog:",
     "@temporalio/workflow": "catalog:",
     "drizzle-orm": "catalog:",
+    "fastify-plugin": "^6.0.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/libs/api/auth/src/core/agent-access-token.test.ts
+++ b/libs/api/auth/src/core/agent-access-token.test.ts
@@ -1,0 +1,44 @@
+import {agentAccessTokenKey, userAccessTokenKey} from '@shipfox/node-auth-root-key';
+import {issueAgentAccessToken, verifyAgentAccessToken} from './agent-access-token.js';
+import {signUserToken, verifyUserToken} from './jwt.js';
+
+function claims() {
+  return {
+    sub: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    grantId: crypto.randomUUID(),
+    clientId: 'client_123',
+    scopes: ['read' as const],
+  };
+}
+
+describe('agent-access-token', () => {
+  test('issues and verifies a token with its dedicated signing key', async () => {
+    const input = claims();
+
+    const token = await issueAgentAccessToken(input);
+    const verified = await verifyAgentAccessToken(token);
+
+    expect(verified).toMatchObject(input);
+  });
+
+  test('does not cross-verify agent and session tokens', async () => {
+    const input = claims();
+    const agentToken = await issueAgentAccessToken(input);
+
+    await expect(
+      verifyUserToken({token: agentToken, secret: userAccessTokenKey()}),
+    ).rejects.toThrow();
+
+    const sessionToken = await signUserToken({
+      userId: input.sub,
+      email: 'agent@example.test',
+      memberships: [],
+      secret: userAccessTokenKey(),
+      expiresIn: '15m',
+    });
+
+    expect(await verifyAgentAccessToken(sessionToken)).toBeNull();
+    expect(agentAccessTokenKey()).not.toEqual(userAccessTokenKey());
+  });
+});

--- a/libs/api/auth/src/core/agent-access-token.ts
+++ b/libs/api/auth/src/core/agent-access-token.ts
@@ -3,8 +3,9 @@ import {
   type AgentAccessTokenClaims,
   agentAccessTokenClaimsSchema,
 } from '@shipfox/api-auth-dto';
-import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
+import {agentAccessTokenKey} from '@shipfox/node-auth-root-key';
 import {signHs256, verifyHs256} from '@shipfox/node-jwt';
+import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
 
 /** OAuth access tokens are deliberately shorter-lived than refresh tokens. */
 export const AGENT_ACCESS_TOKEN_EXPIRES_IN = '15m';
@@ -15,18 +16,20 @@ export const AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS = 15 * 60;
 export type IssueAgentAccessTokenParams = Omit<AgentAccessTokenClaims, 'aud' | 'iat' | 'exp'>;
 
 export async function issueAgentAccessToken(claims: IssueAgentAccessTokenParams): Promise<string> {
-  return await signHs256({
+  const token = await signHs256({
     payload: {
       workspaceId: claims.workspaceId,
       grantId: claims.grantId,
       clientId: claims.clientId,
       scopes: claims.scopes,
     },
-    secret: userAccessTokenKey(),
+    secret: agentAccessTokenKey(),
     expiresIn: AGENT_ACCESS_TOKEN_EXPIRES_IN,
     subject: claims.sub,
     audience: AGENT_ACCESS_TOKEN_AUDIENCE,
   });
+  recordTokenIssued('agent_access');
+  return token;
 }
 
 /** Returns claims on success, or null for any invalid or expired token. */
@@ -34,13 +37,16 @@ export async function verifyAgentAccessToken(
   token: string,
 ): Promise<AgentAccessTokenClaims | null> {
   try {
-    return await verifyHs256({
+    const claims = await verifyHs256({
       token,
-      secret: userAccessTokenKey(),
+      secret: agentAccessTokenKey(),
       schema: agentAccessTokenClaimsSchema,
       audience: AGENT_ACCESS_TOKEN_AUDIENCE,
     });
+    recordTokenVerified('agent_access', 'ok');
+    return claims;
   } catch {
+    recordTokenVerified('agent_access', 'rejected');
     return null;
   }
 }

--- a/libs/api/auth/src/core/agent-access-token.ts
+++ b/libs/api/auth/src/core/agent-access-token.ts
@@ -36,10 +36,13 @@ export async function issueAgentAccessToken(claims: IssueAgentAccessTokenParams)
 export async function verifyAgentAccessToken(
   token: string,
 ): Promise<AgentAccessTokenClaims | null> {
+  // Resolve configuration outside the invalid-token catch. A runtime key
+  // failure must remain distinguishable from a malformed or expired token.
+  const secret = agentAccessTokenKey();
   try {
     const claims = await verifyHs256({
       token,
-      secret: agentAccessTokenKey(),
+      secret,
       schema: agentAccessTokenClaimsSchema,
       audience: AGENT_ACCESS_TOKEN_AUDIENCE,
     });

--- a/libs/api/auth/src/core/agent-access-token.ts
+++ b/libs/api/auth/src/core/agent-access-token.ts
@@ -1,0 +1,46 @@
+import {
+  AGENT_ACCESS_TOKEN_AUDIENCE,
+  type AgentAccessTokenClaims,
+  agentAccessTokenClaimsSchema,
+} from '@shipfox/api-auth-dto';
+import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
+import {signHs256, verifyHs256} from '@shipfox/node-jwt';
+
+/** OAuth access tokens are deliberately shorter-lived than refresh tokens. */
+export const AGENT_ACCESS_TOKEN_EXPIRES_IN = '15m';
+export const AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS = 15 * 60;
+
+// `aud`, `iat`, and `exp` are set by the codec; callers provide the grant
+// identity and the workspace-scoped capability.
+export type IssueAgentAccessTokenParams = Omit<AgentAccessTokenClaims, 'aud' | 'iat' | 'exp'>;
+
+export async function issueAgentAccessToken(claims: IssueAgentAccessTokenParams): Promise<string> {
+  return await signHs256({
+    payload: {
+      workspaceId: claims.workspaceId,
+      grantId: claims.grantId,
+      clientId: claims.clientId,
+      scopes: claims.scopes,
+    },
+    secret: userAccessTokenKey(),
+    expiresIn: AGENT_ACCESS_TOKEN_EXPIRES_IN,
+    subject: claims.sub,
+    audience: AGENT_ACCESS_TOKEN_AUDIENCE,
+  });
+}
+
+/** Returns claims on success, or null for any invalid or expired token. */
+export async function verifyAgentAccessToken(
+  token: string,
+): Promise<AgentAccessTokenClaims | null> {
+  try {
+    return await verifyHs256({
+      token,
+      secret: userAccessTokenKey(),
+      schema: agentAccessTokenClaimsSchema,
+      audience: AGENT_ACCESS_TOKEN_AUDIENCE,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/libs/api/auth/src/core/entities/agent-access.ts
+++ b/libs/api/auth/src/core/entities/agent-access.ts
@@ -15,6 +15,7 @@ export interface AgentClient {
 export interface AgentAuthorizationRequest {
   id: string;
   clientId: string;
+  userId: string | null;
   redirectUri: string;
   resource: string;
   scopes: string[];

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -268,3 +268,56 @@ export class InvalidOAuthConfigurationError extends Error {
     this.name = 'InvalidOAuthConfigurationError';
   }
 }
+
+export type OAuthProtocolErrorCode =
+  | 'invalid_request'
+  | 'invalid_grant'
+  | 'invalid_client'
+  | 'invalid_scope'
+  | 'invalid_target'
+  | 'access_denied';
+
+export interface OAuthProtocolErrorParams {
+  status?: number;
+  description?: string;
+  redirectUri?: string;
+  state?: string | null;
+}
+
+/** A safe OAuth error that can be rendered as a protocol response. */
+export class OAuthProtocolError extends Error {
+  readonly code: OAuthProtocolErrorCode;
+  readonly status: number;
+  readonly description: string | undefined;
+  readonly redirectUri: string | undefined;
+  readonly state: string | null | undefined;
+
+  constructor(
+    code: OAuthProtocolErrorCode,
+    message: string,
+    params: OAuthProtocolErrorParams = {},
+  ) {
+    super(message);
+    this.name = 'OAuthProtocolError';
+    this.code = code;
+    this.status = params.status ?? 400;
+    this.description = params.description;
+    this.redirectUri = params.redirectUri;
+    this.state = params.state;
+  }
+}
+
+export class OAuthConsentNotFoundError extends Error {
+  constructor() {
+    super('OAuth consent request was not found');
+    this.name = 'OAuthConsentNotFoundError';
+  }
+}
+
+/** Keeps workspace ownership failures indistinguishable from a missing row. */
+export class OAuthOwnershipNotFoundError extends Error {
+  constructor() {
+    super('OAuth workspace access was not found');
+    this.name = 'OAuthOwnershipNotFoundError';
+  }
+}

--- a/libs/api/auth/src/core/oauth-client.test.ts
+++ b/libs/api/auth/src/core/oauth-client.test.ts
@@ -58,6 +58,12 @@ describe('OAuth client validation', () => {
     }
   });
 
+  it('rejects redirect hostnames longer than the DNS hostname limit', () => {
+    expect(() => validateOAuthRedirectUri(`https://${'a'.repeat(254)}/callback`)).toThrow(
+      InvalidOAuthClientMetadataError,
+    );
+  });
+
   it('requires CIMD client IDs to be HTTPS URLs with a path', () => {
     expect(validateOAuthClientId('https://client.example/.well-known/oauth-client').pathname).toBe(
       '/.well-known/oauth-client',

--- a/libs/api/auth/src/core/oauth-client.ts
+++ b/libs/api/auth/src/core/oauth-client.ts
@@ -15,6 +15,7 @@ import {
 const URI_SUFFIX_PATTERN = /[/?#]/u;
 const PORT_PATTERN = /^\d+$/u;
 const BRACKETED_PORT_PATTERN = /^:\d+$/u;
+const OAUTH_HOSTNAME_MAX_LENGTH = 253;
 
 function hasControlCharacter(value: string): boolean {
   return [...value].some((character) => {
@@ -72,6 +73,7 @@ function validateUrlShape(url: URL): void {
     url.password ||
     url.hash ||
     url.hostname.length === 0 ||
+    url.hostname.length > OAUTH_HOSTNAME_MAX_LENGTH ||
     hasControlCharacter(url.href)
   ) {
     rejectInvalidMetadata();

--- a/libs/api/auth/src/core/oauth-flow.ts
+++ b/libs/api/auth/src/core/oauth-flow.ts
@@ -18,6 +18,7 @@ import {
   claimAgentAuthorizationRequest,
   createAgentAuthorizationRequest,
   denyAgentAuthorizationRequest,
+  evaluateAgentGrantBinding,
   exchangeAgentAuthorizationCode,
   exchangeAgentRefreshToken,
   findAgentAuthorizationCodeByHash,
@@ -336,13 +337,21 @@ async function grantBinding(params: {
   expectedResource: string;
 }): Promise<{grant: AgentGrant; client: AgentClient}> {
   const grant = await findAgentGrant({id: params.grantId});
-  if (!grant || grant.revokedAt || grant.terminalAt) throw invalidGrant();
-  const client = await findAgentClientById({id: grant.clientId});
-  if (!client || client.clientId !== params.clientId) throw invalidGrant();
-  if (params.resource !== undefined && params.resource !== params.expectedResource) {
-    throw new OAuthProtocolError('invalid_target', 'The OAuth resource is not supported');
+  const client = grant ? await findAgentClientById({id: grant.clientId}) : undefined;
+  const binding = evaluateAgentGrantBinding({
+    grant,
+    client,
+    clientId: params.clientId,
+    resource: params.resource,
+    expectedResource: params.expectedResource,
+  });
+  if (binding.kind === 'invalid') {
+    if (binding.reason === 'resource') {
+      throw new OAuthProtocolError('invalid_target', 'The OAuth resource is not supported');
+    }
+    throw invalidGrant();
   }
-  return {grant, client};
+  return {grant: binding.grant, client: binding.client};
 }
 
 function accessTokenFor(grant: AgentGrant, client: AgentClient): Promise<string> {
@@ -408,19 +417,24 @@ export async function exchangeOAuthRefreshToken(params: {
   const existing = await findAgentRefreshTokenByHash({hashedToken});
   if (!existing) throw invalidGrant();
   const grant = await findAgentGrant({id: existing.grantId});
-  if (!grant || grant.revokedAt || grant.terminalAt) throw invalidGrant();
-  const client = await findAgentClientById({id: grant.clientId});
-  if (!client || client.clientId !== params.request.client_id) throw invalidGrant();
-  if (
-    params.request.resource !== undefined &&
-    params.request.resource !== expectedResource(params.options)
-  ) {
-    throw new OAuthProtocolError('invalid_target', 'The OAuth resource is not supported');
+  const client = grant ? await findAgentClientById({id: grant.clientId}) : undefined;
+  const binding = evaluateAgentGrantBinding({
+    grant,
+    client,
+    clientId: params.request.client_id,
+    resource: params.request.resource,
+    expectedResource: expectedResource(params.options),
+  });
+  if (binding.kind === 'invalid') {
+    if (binding.reason === 'resource') {
+      throw new OAuthProtocolError('invalid_target', 'The OAuth resource is not supported');
+    }
+    throw invalidGrant();
   }
 
   await requireCurrentMembership({
-    userId: grant.userId,
-    workspaceId: grant.workspaceId,
+    userId: binding.grant.userId,
+    workspaceId: binding.grant.workspaceId,
     options: params.options,
     ownershipShape: false,
   });
@@ -435,7 +449,7 @@ export async function exchangeOAuthRefreshToken(params: {
     clientId: params.request.client_id,
     resource: params.request.resource,
     expectedResource: expectedResource(params.options),
-    rawReplacement,
+    replacementHashedToken: hashOpaqueToken(rawReplacement),
     replacementExpiresAt: agentRefreshTokenExpiresAt(now),
     now,
   });
@@ -450,8 +464,8 @@ export async function exchangeOAuthRefreshToken(params: {
   recordTokenRefreshed(outcome.kind);
 
   return {
-    accessToken: await accessTokenFor(outcome.grant, client),
-    ...(outcome.kind === 'rotated' ? {refreshToken: outcome.refreshToken} : {}),
+    accessToken: await accessTokenFor(outcome.grant, binding.client),
+    ...(outcome.kind === 'rotated' ? {refreshToken: rawReplacement} : {}),
     scope: 'read',
   };
 }

--- a/libs/api/auth/src/core/oauth-flow.ts
+++ b/libs/api/auth/src/core/oauth-flow.ts
@@ -1,0 +1,589 @@
+import {createHash, randomBytes, timingSafeEqual} from 'node:crypto';
+import type {
+  OAuthAuthorizeQueryDto,
+  OAuthConsentResponseDto,
+  OAuthTokenRequestDto,
+} from '@shipfox/api-auth-dto';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {hashOpaqueToken} from '@shipfox/node-tokens';
+import {config} from '#config.js';
+import {
+  type AgentAccessTx,
+  agentRefreshTokenExpiresAt,
+  consumeAgentAuthorizationCodeTx,
+  consumeAgentAuthorizationRequestTx,
+  createAgentAuthorizationCodeTx,
+  createAgentAuthorizationRequest,
+  createAgentGrantTx,
+  createAgentRefreshTokenTx,
+  findAgentAuthorizationCodeByHash,
+  findAgentClientById,
+  findAgentGrant,
+  findAgentRefreshTokenByHash,
+  findPendingAgentAuthorizationRequest,
+  isActiveAgentUserTx,
+  resolveAgentRefreshTokenReplayTx,
+  rotateAgentRefreshTokenTx,
+} from '#db/agent-access.js';
+import {db} from '#db/db.js';
+import {
+  AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+  issueAgentAccessToken,
+} from './agent-access-token.js';
+import type {AgentAuthorizationRequest, AgentClient, AgentGrant} from './entities/agent-access.js';
+import {
+  AuthDependencyUnavailableError,
+  InvalidOAuthClientMetadataError,
+  OAuthConsentNotFoundError,
+  OAuthOwnershipNotFoundError,
+  OAuthProtocolError,
+  OAuthRedirectUriNotRegisteredError,
+} from './errors.js';
+import {isOAuthLoopbackRedirectUri} from './oauth-client.js';
+import type {OAuthClientResolver} from './oauth-client-resolver.js';
+import {createOAuthClientResolver} from './oauth-client-resolver.js';
+
+export const OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS = 5 * 60;
+export const OAUTH_AUTHORIZATION_CODE_TTL_SECONDS = 60;
+
+export interface OAuthFlowOptions {
+  /** The normalized API origin, validated by the route factory. */
+  apiPublicOrigin: string;
+  /** Dashboard base URL used only for the opaque consent redirect. */
+  clientBaseUrl?: string;
+  workspaces: WorkspacesInterModuleClient;
+  clientResolver?: OAuthClientResolver;
+  now?: () => Date;
+}
+
+export interface BeginOAuthAuthorizationResult {
+  request: AgentAuthorizationRequest;
+  consentUrl: string;
+}
+
+export interface OAuthConsentWorkspace {
+  workspaceId: string;
+  role: string;
+}
+
+export interface OAuthConsentDetail {
+  request: AgentAuthorizationRequest;
+  client: AgentClient;
+  workspaces: OAuthConsentWorkspace[];
+}
+
+export interface OAuthTokenExchangeResult {
+  accessToken: string;
+  refreshToken?: string;
+  scope: 'read';
+}
+
+interface RefreshExchangeOutcome {
+  kind: 'rotated' | 'grace' | 'rejected' | 'reused';
+  grant?: AgentGrant;
+  refreshToken?: string;
+}
+
+function nowFor(options: OAuthFlowOptions): Date {
+  return options.now?.() ?? new Date();
+}
+
+function expectedResource(options: OAuthFlowOptions): string {
+  return `${options.apiPublicOrigin}/mcp`;
+}
+
+function invalidRequest(message: string, params: {redirectUri?: string; state?: string} = {}) {
+  return new OAuthProtocolError('invalid_request', message, params);
+}
+
+function invalidGrant(message = 'The OAuth grant is invalid'): OAuthProtocolError {
+  return new OAuthProtocolError('invalid_grant', message);
+}
+
+function invalidClient(message = 'The OAuth client is invalid'): OAuthProtocolError {
+  return new OAuthProtocolError('invalid_client', message);
+}
+
+function redirectableError(
+  code: 'invalid_request' | 'invalid_scope' | 'invalid_target' | 'access_denied',
+  message: string,
+  request: Pick<OAuthAuthorizeQueryDto, 'redirect_uri' | 'state'>,
+): OAuthProtocolError {
+  return new OAuthProtocolError(code, message, {
+    redirectUri: request.redirect_uri,
+    ...(request.state !== undefined ? {state: request.state} : {}),
+  });
+}
+
+function newOpaqueValue(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function consentUrl(options: OAuthFlowOptions, requestId: string): string {
+  const baseUrl = options.clientBaseUrl ?? config.CLIENT_BASE_URL;
+  try {
+    const url = new URL('/oauth/consent', baseUrl);
+    url.searchParams.set('request_id', requestId);
+    return url.toString();
+  } catch (error) {
+    throw new OAuthProtocolError('invalid_request', 'The OAuth consent URL is not configured', {
+      status: 500,
+      ...(error instanceof Error ? {description: error.message} : {}),
+    });
+  }
+}
+
+function authorizationRedirect(
+  redirectUri: string,
+  params: {code?: string; error?: string; state?: string | null},
+): string {
+  const url = new URL(redirectUri);
+  if (params.code !== undefined) url.searchParams.set('code', params.code);
+  if (params.error !== undefined) url.searchParams.set('error', params.error);
+  if (params.state !== undefined && params.state !== null) {
+    url.searchParams.set('state', params.state);
+  }
+  return url.toString();
+}
+
+function isActiveWorkspaceStatus(status: string): boolean {
+  return status === 'active';
+}
+
+async function currentMemberships(
+  userId: string,
+  options: OAuthFlowOptions,
+): Promise<OAuthConsentWorkspace[]> {
+  let result: Awaited<ReturnType<WorkspacesInterModuleClient['listMembershipsForTokenClaims']>>;
+  try {
+    result = await options.workspaces.listMembershipsForTokenClaims({userId});
+  } catch (error) {
+    throw new AuthDependencyUnavailableError('workspaces', error);
+  }
+  return result.memberships
+    .filter((membership) => isActiveWorkspaceStatus(membership.workspaceStatus))
+    .map((membership) => ({workspaceId: membership.workspaceId, role: membership.role}));
+}
+
+async function requireCurrentMembership(params: {
+  userId: string;
+  workspaceId: string;
+  options: OAuthFlowOptions;
+  ownershipShape: boolean;
+}): Promise<void> {
+  let result: Awaited<ReturnType<WorkspacesInterModuleClient['listMembershipsForTokenClaims']>>;
+  try {
+    result = await params.options.workspaces.listMembershipsForTokenClaims({
+      userId: params.userId,
+    });
+    await params.options.workspaces.requireActiveMembership({
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      memberships: result.memberships,
+    });
+  } catch (error) {
+    if (
+      isInterModuleKnownError(workspacesInterModuleContract.methods.requireActiveMembership, error)
+    ) {
+      if (params.ownershipShape) throw new OAuthOwnershipNotFoundError();
+      throw invalidGrant('The workspace grant is no longer active');
+    }
+    if (error instanceof AuthDependencyUnavailableError) throw error;
+    throw new AuthDependencyUnavailableError('workspaces', error);
+  }
+}
+
+function identityOrigin(client: AgentClient): string {
+  if (client.kind === 'registered') return 'registered client';
+  try {
+    return new URL(client.clientId).origin;
+  } catch {
+    // A CIMD client was validated before it was stored. Keep an invalid row
+    // from becoming a request-time crash if old data predates that check.
+    return client.clientId;
+  }
+}
+
+function consentDetailDto(detail: OAuthConsentDetail): OAuthConsentResponseDto {
+  const redirectUrl = new URL(detail.request.redirectUri);
+  return {
+    request_id: detail.request.id,
+    client_name: detail.client.name,
+    scope: 'read',
+    expires_at: detail.request.expiresAt.toISOString(),
+    redirect_uri_hostname: redirectUrl.hostname,
+    client_identity_origin: identityOrigin(detail.client),
+    is_loopback_redirect: isOAuthLoopbackRedirectUri(detail.request.redirectUri),
+    workspaces: detail.workspaces.map(({workspaceId, role}) => ({
+      workspace_id: workspaceId,
+      role,
+    })),
+  };
+}
+
+export async function beginOAuthAuthorization(params: {
+  request: OAuthAuthorizeQueryDto;
+  requestIp: string;
+  options: OAuthFlowOptions;
+}): Promise<BeginOAuthAuthorizationResult> {
+  const resolver = params.options.clientResolver ?? createOAuthClientResolver();
+  let resolved: Awaited<ReturnType<OAuthClientResolver['resolve']>>;
+  try {
+    resolved = await resolver.resolve({
+      clientId: params.request.client_id,
+      requestIp: params.requestIp,
+      redirectUri: params.request.redirect_uri,
+    });
+  } catch (error) {
+    if (error instanceof OAuthRedirectUriNotRegisteredError) {
+      throw invalidRequest('The OAuth redirect URI is not registered');
+    }
+    if (error instanceof InvalidOAuthClientMetadataError) throw invalidClient();
+    throw error;
+  }
+
+  if (params.request.resource !== expectedResource(params.options)) {
+    throw redirectableError(
+      'invalid_target',
+      'The OAuth resource is not supported',
+      params.request,
+    );
+  }
+  if (params.request.scope !== undefined && params.request.scope !== 'read') {
+    throw redirectableError(
+      'invalid_scope',
+      'The requested OAuth scope is not supported',
+      params.request,
+    );
+  }
+
+  const now = nowFor(params.options);
+  const request = await createAgentAuthorizationRequest({
+    clientId: resolved.client.id,
+    redirectUri: params.request.redirect_uri,
+    resource: params.request.resource,
+    scopes: ['read'],
+    codeChallenge: params.request.code_challenge,
+    state: params.request.state ?? null,
+    expiresAt: new Date(now.getTime() + OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS * 1000),
+  });
+
+  return {request, consentUrl: consentUrl(params.options, request.id)};
+}
+
+export async function getOAuthConsentDetail(params: {
+  requestId: string;
+  userId: string;
+  options: OAuthFlowOptions;
+}): Promise<OAuthConsentDetail> {
+  const request = await findPendingRequestOrThrow(params.requestId);
+  const client = await findAgentClientById({id: request.clientId});
+  if (!client) throw new OAuthConsentNotFoundError();
+  const workspaces = await currentMemberships(params.userId, params.options);
+  return {request, client, workspaces};
+}
+
+export function toOAuthConsentResponse(detail: OAuthConsentDetail): OAuthConsentResponseDto {
+  return consentDetailDto(detail);
+}
+
+async function findPendingRequestOrThrow(requestId: string): Promise<AgentAuthorizationRequest> {
+  const request = await findPendingAgentAuthorizationRequest({id: requestId});
+  if (!request) throw new OAuthConsentNotFoundError();
+  return request;
+}
+
+export async function approveOAuthConsent(params: {
+  requestId: string;
+  userId: string;
+  workspaceId: string;
+  options: OAuthFlowOptions;
+}): Promise<{redirectUrl: string}> {
+  await requireCurrentMembership({
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    options: params.options,
+    ownershipShape: true,
+  });
+
+  const rawCode = newOpaqueValue();
+  const now = nowFor(params.options);
+  const result = await db().transaction(async (tx) => {
+    if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) {
+      throw new OAuthProtocolError('access_denied', 'The user is not active');
+    }
+
+    const request = await consumeAgentAuthorizationRequestTx(tx, {id: params.requestId});
+    if (!request) throw new OAuthConsentNotFoundError();
+
+    const grant = await createAgentGrantTx(tx, {
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      clientId: request.clientId,
+      scopes: request.scopes,
+    });
+    await createAgentAuthorizationCodeTx(tx, {
+      grantId: grant.id,
+      hashedCode: hashOpaqueToken(rawCode),
+      codeChallenge: request.codeChallenge,
+      redirectUri: request.redirectUri,
+      resource: request.resource,
+      expiresAt: new Date(now.getTime() + OAUTH_AUTHORIZATION_CODE_TTL_SECONDS * 1000),
+    });
+    return {request};
+  });
+
+  return {
+    redirectUrl: authorizationRedirect(result.request.redirectUri, {
+      code: rawCode,
+      state: result.request.state,
+    }),
+  };
+}
+
+export async function denyOAuthConsent(params: {
+  requestId: string;
+}): Promise<{redirectUrl: string}> {
+  const result = await db().transaction(async (tx) => {
+    const request = await consumeAgentAuthorizationRequestTx(tx, {id: params.requestId});
+    if (!request) throw new OAuthConsentNotFoundError();
+    return {request};
+  });
+
+  return {
+    redirectUrl: authorizationRedirect(result.request.redirectUri, {
+      error: 'access_denied',
+      state: result.request.state,
+    }),
+  };
+}
+
+function pkceMatches(verifier: string, challenge: string): boolean {
+  const candidate = createHash('sha256').update(verifier).digest('base64url');
+  const candidateBytes = Buffer.from(candidate, 'utf8');
+  const challengeBytes = Buffer.from(challenge, 'utf8');
+  return (
+    candidateBytes.length === challengeBytes.length &&
+    timingSafeEqual(candidateBytes, challengeBytes)
+  );
+}
+
+async function grantBinding(params: {
+  clientId: string;
+  grantId: string;
+  resource: string | undefined;
+  expectedResource: string;
+}): Promise<{grant: AgentGrant; client: AgentClient}> {
+  const grant = await findAgentGrant({id: params.grantId});
+  if (!grant || grant.revokedAt || grant.terminalAt) throw invalidGrant();
+  const client = await findAgentClientById({id: grant.clientId});
+  if (!client || client.clientId !== params.clientId) throw invalidGrant();
+  if (params.resource !== undefined && params.resource !== params.expectedResource) {
+    throw new OAuthProtocolError('invalid_target', 'The OAuth resource is not supported');
+  }
+  return {grant, client};
+}
+
+function accessTokenFor(grant: AgentGrant, client: AgentClient): Promise<string> {
+  return issueAgentAccessToken({
+    sub: grant.userId,
+    workspaceId: grant.workspaceId,
+    grantId: grant.id,
+    clientId: client.clientId,
+    scopes: ['read'],
+  });
+}
+
+export async function exchangeOAuthAuthorizationCode(params: {
+  request: OAuthTokenRequestDto;
+  options: OAuthFlowOptions;
+}): Promise<OAuthTokenExchangeResult> {
+  if (!params.request.code || !params.request.code_verifier || !params.request.redirect_uri) {
+    throw invalidRequest('The authorization-code request is incomplete');
+  }
+
+  const hashedCode = hashOpaqueToken(params.request.code);
+  const existing = await findAgentAuthorizationCodeByHash({hashedCode});
+  if (!existing) throw invalidGrant();
+  const binding = await grantBinding({
+    clientId: params.request.client_id,
+    grantId: existing.grantId,
+    resource: params.request.resource,
+    expectedResource: expectedResource(params.options),
+  });
+  if (params.request.redirect_uri !== existing.redirectUri) throw invalidGrant();
+  if (!pkceMatches(params.request.code_verifier, existing.codeChallenge)) throw invalidGrant();
+
+  await requireCurrentMembership({
+    userId: binding.grant.userId,
+    workspaceId: binding.grant.workspaceId,
+    options: params.options,
+    ownershipShape: false,
+  });
+
+  const rawRefreshToken = newOpaqueValue();
+  const exchange = await db().transaction(async (tx) => {
+    const code = await consumeAgentAuthorizationCodeTx(tx, {hashedCode});
+    if (!code) return undefined;
+    const refreshToken = await createAgentRefreshTokenTx(tx, {
+      grantId: code.grantId,
+      hashedToken: hashOpaqueToken(rawRefreshToken),
+      expiresAt: agentRefreshTokenExpiresAt(nowFor(params.options)),
+    });
+    return {code, refreshToken};
+  });
+  if (!exchange) throw invalidGrant();
+
+  return {
+    accessToken: await accessTokenFor(binding.grant, binding.client),
+    refreshToken: rawRefreshToken,
+    scope: 'read',
+  };
+}
+
+async function refreshReplayOutcome(
+  tx: AgentAccessTx,
+  params: {hashedToken: string; options: OAuthFlowOptions},
+): Promise<RefreshExchangeOutcome> {
+  const replay = await resolveAgentRefreshTokenReplayTx(tx, {
+    hashedToken: params.hashedToken,
+    now: nowFor(params.options),
+  });
+  if (!replay) return {kind: 'rejected'};
+  if (replay.kind === 'reused') return {kind: 'reused', grant: replay.grant};
+  return {kind: 'grace', grant: replay.grant};
+}
+
+async function rotateRefreshInTransaction(
+  tx: AgentAccessTx,
+  params: {
+    hashedToken: string;
+    rawReplacement: string;
+    grant: AgentGrant;
+    options: OAuthFlowOptions;
+  },
+): Promise<RefreshExchangeOutcome> {
+  const successor = await rotateAgentRefreshTokenTx(tx, {
+    hashedToken: params.hashedToken,
+    replacementHashedToken: hashOpaqueToken(params.rawReplacement),
+    replacementExpiresAt: agentRefreshTokenExpiresAt(nowFor(params.options)),
+  });
+  if (successor) {
+    return {kind: 'rotated', grant: params.grant, refreshToken: params.rawReplacement};
+  }
+
+  // Another transaction may have rotated the token while this transaction
+  // waited on the grant row. Resolve the now-rotated predecessor under the
+  // same lock so a grace response and replay revocation remain serialized.
+  return await refreshReplayOutcome(tx, {
+    hashedToken: params.hashedToken,
+    options: params.options,
+  });
+}
+
+async function refreshExchange(params: {
+  hashedToken: string;
+  clientId: string;
+  resource: string | undefined;
+  options: OAuthFlowOptions;
+}): Promise<RefreshExchangeOutcome> {
+  const rawReplacement = newOpaqueValue();
+  return await db().transaction(async (tx) => {
+    const existing = await findAgentRefreshTokenByHash({
+      hashedToken: params.hashedToken,
+      executor: tx,
+    });
+    if (!existing) return {kind: 'rejected'};
+
+    const grant = await findAgentGrant({id: existing.grantId, executor: tx});
+    if (!grant || grant.revokedAt || grant.terminalAt) return {kind: 'rejected'};
+    const client = await findAgentClientById({id: grant.clientId, executor: tx});
+    if (!client || client.clientId !== params.clientId) return {kind: 'rejected'};
+    if (params.resource !== undefined && params.resource !== expectedResource(params.options)) {
+      return {kind: 'rejected'};
+    }
+
+    if (existing.rotatedAt) {
+      return await refreshReplayOutcome(tx, {
+        hashedToken: params.hashedToken,
+        options: params.options,
+      });
+    }
+
+    return await rotateRefreshInTransaction(tx, {
+      hashedToken: params.hashedToken,
+      rawReplacement,
+      grant,
+      options: params.options,
+    });
+  });
+}
+
+export async function exchangeOAuthRefreshToken(params: {
+  request: OAuthTokenRequestDto;
+  options: OAuthFlowOptions;
+}): Promise<OAuthTokenExchangeResult> {
+  if (!params.request.refresh_token)
+    throw invalidRequest('The refresh-token request is incomplete');
+
+  const hashedToken = hashOpaqueToken(params.request.refresh_token);
+  const existing = await findAgentRefreshTokenByHash({hashedToken});
+  if (!existing) throw invalidGrant();
+  const grant = await findAgentGrant({id: existing.grantId});
+  if (!grant || grant.revokedAt || grant.terminalAt) throw invalidGrant();
+  const client = await findAgentClientById({id: grant.clientId});
+  if (!client || client.clientId !== params.request.client_id) throw invalidGrant();
+  if (
+    params.request.resource !== undefined &&
+    params.request.resource !== expectedResource(params.options)
+  ) {
+    throw new OAuthProtocolError('invalid_target', 'The OAuth resource is not supported');
+  }
+
+  await requireCurrentMembership({
+    userId: grant.userId,
+    workspaceId: grant.workspaceId,
+    options: params.options,
+    ownershipShape: false,
+  });
+
+  const outcome = await refreshExchange({
+    hashedToken,
+    clientId: params.request.client_id,
+    resource: params.request.resource,
+    options: params.options,
+  });
+  if (outcome.kind === 'reused' || outcome.kind === 'rejected' || !outcome.grant) {
+    throw invalidGrant();
+  }
+
+  return {
+    accessToken: await accessTokenFor(outcome.grant, client),
+    ...(outcome.refreshToken ? {refreshToken: outcome.refreshToken} : {}),
+    scope: 'read',
+  };
+}
+
+export async function exchangeOAuthToken(params: {
+  request: OAuthTokenRequestDto;
+  options: OAuthFlowOptions;
+}): Promise<OAuthTokenExchangeResult> {
+  if (params.request.grant_type === 'authorization_code') {
+    return await exchangeOAuthAuthorizationCode(params);
+  }
+  return await exchangeOAuthRefreshToken(params);
+}
+
+export function oauthTokenResponse(result: OAuthTokenExchangeResult) {
+  return {
+    access_token: result.accessToken,
+    token_type: 'Bearer' as const,
+    expires_in: AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+    ...(result.refreshToken ? {refresh_token: result.refreshToken} : {}),
+    scope: result.scope,
+  };
+}

--- a/libs/api/auth/src/core/oauth-flow.ts
+++ b/libs/api/auth/src/core/oauth-flow.ts
@@ -1,8 +1,9 @@
 import {createHash, randomBytes, timingSafeEqual} from 'node:crypto';
-import type {
-  OAuthAuthorizeQueryDto,
-  OAuthConsentResponseDto,
-  OAuthTokenRequestDto,
+import {
+  OAUTH_MCP_RESOURCE_PATH,
+  OAUTH_READ_SCOPE,
+  type OAuthAuthorizeQueryDto,
+  type OAuthTokenRequestDto,
 } from '@shipfox/api-auth-dto';
 import {
   type WorkspacesInterModuleClient,
@@ -12,29 +13,21 @@ import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {config} from '#config.js';
 import {
-  type AgentAccessTx,
   agentRefreshTokenExpiresAt,
-  consumeAgentAuthorizationCodeTx,
-  consumeAgentAuthorizationRequestTx,
-  createAgentAuthorizationCodeTx,
+  approveAgentAuthorizationRequest,
+  claimAgentAuthorizationRequest,
   createAgentAuthorizationRequest,
-  createAgentGrantTx,
-  createAgentRefreshTokenTx,
+  denyAgentAuthorizationRequest,
+  exchangeAgentAuthorizationCode,
+  exchangeAgentRefreshToken,
   findAgentAuthorizationCodeByHash,
   findAgentClientById,
   findAgentGrant,
   findAgentRefreshTokenByHash,
-  findPendingAgentAuthorizationRequest,
   isActiveAgentUser,
-  isActiveAgentUserTx,
-  resolveAgentRefreshTokenReplayTx,
-  rotateAgentRefreshTokenTx,
 } from '#db/agent-access.js';
-import {db} from '#db/db.js';
-import {
-  AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
-  issueAgentAccessToken,
-} from './agent-access-token.js';
+import {recordTokenRefreshed} from '#metrics/index.js';
+import {issueAgentAccessToken} from './agent-access-token.js';
 import type {AgentAuthorizationRequest, AgentClient, AgentGrant} from './entities/agent-access.js';
 import {
   AuthDependencyUnavailableError,
@@ -44,7 +37,6 @@ import {
   OAuthProtocolError,
   OAuthRedirectUriNotRegisteredError,
 } from './errors.js';
-import {isOAuthLoopbackRedirectUri} from './oauth-client.js';
 import type {OAuthClientResolver} from './oauth-client-resolver.js';
 import {createOAuthClientResolver} from './oauth-client-resolver.js';
 
@@ -84,18 +76,12 @@ export interface OAuthTokenExchangeResult {
   scope: 'read';
 }
 
-interface RefreshExchangeOutcome {
-  kind: 'rotated' | 'grace' | 'rejected' | 'reused';
-  grant?: AgentGrant;
-  refreshToken?: string;
-}
-
 function nowFor(options: OAuthFlowOptions): Date {
   return options.now?.() ?? new Date();
 }
 
 function expectedResource(options: OAuthFlowOptions): string {
-  return `${options.apiPublicOrigin}/mcp`;
+  return `${options.apiPublicOrigin}${OAUTH_MCP_RESOURCE_PATH}`;
 }
 
 function invalidRequest(message: string, params: {redirectUri?: string; state?: string} = {}) {
@@ -133,18 +119,21 @@ function newOpaqueValue(): string {
   return randomBytes(32).toString('base64url');
 }
 
-function consentUrl(options: OAuthFlowOptions, requestId: string): string {
+function consentBaseUrl(options: OAuthFlowOptions): URL {
   const baseUrl = options.clientBaseUrl ?? config.CLIENT_BASE_URL;
   try {
-    const url = new URL('/oauth/consent', baseUrl);
-    url.searchParams.set('request_id', requestId);
-    return url.toString();
-  } catch (error) {
+    return new URL(baseUrl);
+  } catch {
     throw new OAuthProtocolError('invalid_request', 'The OAuth consent URL is not configured', {
       status: 500,
-      ...(error instanceof Error ? {description: error.message} : {}),
     });
   }
+}
+
+function consentUrl(baseUrl: URL, requestId: string): string {
+  const url = new URL('/oauth/consent', baseUrl);
+  url.searchParams.set('request_id', requestId);
+  return url.toString();
 }
 
 function authorizationRedirect(
@@ -207,39 +196,12 @@ async function requireCurrentMembership(params: {
   }
 }
 
-function identityOrigin(client: AgentClient): string {
-  if (client.kind === 'registered') return 'registered client';
-  try {
-    return new URL(client.clientId).origin;
-  } catch {
-    // A CIMD client was validated before it was stored. Keep an invalid row
-    // from becoming a request-time crash if old data predates that check.
-    return client.clientId;
-  }
-}
-
-function consentDetailDto(detail: OAuthConsentDetail): OAuthConsentResponseDto {
-  const redirectUrl = new URL(detail.request.redirectUri);
-  return {
-    request_id: detail.request.id,
-    client_name: detail.client.name,
-    scope: 'read',
-    expires_at: detail.request.expiresAt.toISOString(),
-    redirect_uri_hostname: redirectUrl.hostname,
-    client_identity_origin: identityOrigin(detail.client),
-    is_loopback_redirect: isOAuthLoopbackRedirectUri(detail.request.redirectUri),
-    workspaces: detail.workspaces.map(({workspaceId, role}) => ({
-      workspace_id: workspaceId,
-      role,
-    })),
-  };
-}
-
 export async function beginOAuthAuthorization(params: {
   request: OAuthAuthorizeQueryDto;
   requestIp: string;
   options: OAuthFlowOptions;
 }): Promise<BeginOAuthAuthorizationResult> {
+  const consentBase = consentBaseUrl(params.options);
   const resolver = params.options.clientResolver ?? createOAuthClientResolver();
   let resolved: Awaited<ReturnType<OAuthClientResolver['resolve']>>;
   try {
@@ -282,7 +244,7 @@ export async function beginOAuthAuthorization(params: {
     expiresAt: new Date(now.getTime() + OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS * 1000),
   });
 
-  return {request, consentUrl: consentUrl(params.options, request.id)};
+  return {request, consentUrl: consentUrl(consentBase, request.id)};
 }
 
 export async function getOAuthConsentDetail(params: {
@@ -292,21 +254,15 @@ export async function getOAuthConsentDetail(params: {
 }): Promise<OAuthConsentDetail> {
   assertConsentRequestId(params.requestId);
   if (!(await isActiveAgentUser({userId: params.userId}))) throw inactiveUserError();
-  const request = await findPendingRequestOrThrow(params.requestId);
+  const request = await claimAgentAuthorizationRequest({
+    id: params.requestId,
+    userId: params.userId,
+  });
+  if (!request) throw new OAuthConsentNotFoundError();
   const client = await findAgentClientById({id: request.clientId});
   if (!client) throw new OAuthConsentNotFoundError();
   const workspaces = await currentMemberships(params.userId, params.options);
   return {request, client, workspaces};
-}
-
-export function toOAuthConsentResponse(detail: OAuthConsentDetail): OAuthConsentResponseDto {
-  return consentDetailDto(detail);
-}
-
-async function findPendingRequestOrThrow(requestId: string): Promise<AgentAuthorizationRequest> {
-  const request = await findPendingAgentAuthorizationRequest({id: requestId});
-  if (!request) throw new OAuthConsentNotFoundError();
-  return request;
 }
 
 export async function approveOAuthConsent(params: {
@@ -325,30 +281,15 @@ export async function approveOAuthConsent(params: {
 
   const rawCode = newOpaqueValue();
   const now = nowFor(params.options);
-  const result = await db().transaction(async (tx) => {
-    if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) {
-      throw inactiveUserError();
-    }
-
-    const request = await consumeAgentAuthorizationRequestTx(tx, {id: params.requestId});
-    if (!request) throw new OAuthConsentNotFoundError();
-
-    const grant = await createAgentGrantTx(tx, {
-      userId: params.userId,
-      workspaceId: params.workspaceId,
-      clientId: request.clientId,
-      scopes: request.scopes,
-    });
-    await createAgentAuthorizationCodeTx(tx, {
-      grantId: grant.id,
-      hashedCode: hashOpaqueToken(rawCode),
-      codeChallenge: request.codeChallenge,
-      redirectUri: request.redirectUri,
-      resource: request.resource,
-      expiresAt: new Date(now.getTime() + OAUTH_AUTHORIZATION_CODE_TTL_SECONDS * 1000),
-    });
-    return {request};
+  const result = await approveAgentAuthorizationRequest({
+    id: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    hashedCode: hashOpaqueToken(rawCode),
+    codeExpiresAt: new Date(now.getTime() + OAUTH_AUTHORIZATION_CODE_TTL_SECONDS * 1000),
   });
+  if (result.kind === 'inactive') throw inactiveUserError();
+  if (result.kind === 'not-found') throw new OAuthConsentNotFoundError();
 
   return {
     redirectUrl: authorizationRedirect(result.request.redirectUri, {
@@ -363,14 +304,12 @@ export async function denyOAuthConsent(params: {
   userId: string;
 }): Promise<{redirectUrl: string}> {
   assertConsentRequestId(params.requestId);
-  const result = await db().transaction(async (tx) => {
-    if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) {
-      throw inactiveUserError();
-    }
-    const request = await consumeAgentAuthorizationRequestTx(tx, {id: params.requestId});
-    if (!request) throw new OAuthConsentNotFoundError();
-    return {request};
+  const result = await denyAgentAuthorizationRequest({
+    id: params.requestId,
+    userId: params.userId,
   });
+  if (result.kind === 'inactive') throw inactiveUserError();
+  if (result.kind === 'not-found') throw new OAuthConsentNotFoundError();
 
   return {
     redirectUrl: authorizationRedirect(result.request.redirectUri, {
@@ -444,15 +383,10 @@ export async function exchangeOAuthAuthorizationCode(params: {
   });
 
   const rawRefreshToken = newOpaqueValue();
-  const exchange = await db().transaction(async (tx) => {
-    const code = await consumeAgentAuthorizationCodeTx(tx, {hashedCode});
-    if (!code) return undefined;
-    const refreshToken = await createAgentRefreshTokenTx(tx, {
-      grantId: code.grantId,
-      hashedToken: hashOpaqueToken(rawRefreshToken),
-      expiresAt: agentRefreshTokenExpiresAt(nowFor(params.options)),
-    });
-    return {code, refreshToken};
+  const exchange = await exchangeAgentAuthorizationCode({
+    hashedCode,
+    hashedRefreshToken: hashOpaqueToken(rawRefreshToken),
+    refreshTokenExpiresAt: agentRefreshTokenExpiresAt(nowFor(params.options)),
   });
   if (!exchange) throw invalidGrant();
 
@@ -461,84 +395,6 @@ export async function exchangeOAuthAuthorizationCode(params: {
     refreshToken: rawRefreshToken,
     scope: 'read',
   };
-}
-
-async function refreshReplayOutcome(
-  tx: AgentAccessTx,
-  params: {hashedToken: string; options: OAuthFlowOptions},
-): Promise<RefreshExchangeOutcome> {
-  const replay = await resolveAgentRefreshTokenReplayTx(tx, {
-    hashedToken: params.hashedToken,
-    now: nowFor(params.options),
-  });
-  if (!replay) return {kind: 'rejected'};
-  if (replay.kind === 'reused') return {kind: 'reused', grant: replay.grant};
-  return {kind: 'grace', grant: replay.grant};
-}
-
-async function rotateRefreshInTransaction(
-  tx: AgentAccessTx,
-  params: {
-    hashedToken: string;
-    rawReplacement: string;
-    grant: AgentGrant;
-    options: OAuthFlowOptions;
-  },
-): Promise<RefreshExchangeOutcome> {
-  const successor = await rotateAgentRefreshTokenTx(tx, {
-    hashedToken: params.hashedToken,
-    replacementHashedToken: hashOpaqueToken(params.rawReplacement),
-    replacementExpiresAt: agentRefreshTokenExpiresAt(nowFor(params.options)),
-  });
-  if (successor) {
-    return {kind: 'rotated', grant: params.grant, refreshToken: params.rawReplacement};
-  }
-
-  // Another transaction may have rotated the token while this transaction
-  // waited on the grant row. Resolve the now-rotated predecessor under the
-  // same lock so a grace response and replay revocation remain serialized.
-  return await refreshReplayOutcome(tx, {
-    hashedToken: params.hashedToken,
-    options: params.options,
-  });
-}
-
-async function refreshExchange(params: {
-  hashedToken: string;
-  clientId: string;
-  resource: string | undefined;
-  options: OAuthFlowOptions;
-}): Promise<RefreshExchangeOutcome> {
-  const rawReplacement = newOpaqueValue();
-  return await db().transaction(async (tx) => {
-    const existing = await findAgentRefreshTokenByHash({
-      hashedToken: params.hashedToken,
-      executor: tx,
-    });
-    if (!existing) return {kind: 'rejected'};
-
-    const grant = await findAgentGrant({id: existing.grantId, executor: tx});
-    if (!grant || grant.revokedAt || grant.terminalAt) return {kind: 'rejected'};
-    const client = await findAgentClientById({id: grant.clientId, executor: tx});
-    if (!client || client.clientId !== params.clientId) return {kind: 'rejected'};
-    if (params.resource !== undefined && params.resource !== expectedResource(params.options)) {
-      return {kind: 'rejected'};
-    }
-
-    if (existing.rotatedAt) {
-      return await refreshReplayOutcome(tx, {
-        hashedToken: params.hashedToken,
-        options: params.options,
-      });
-    }
-
-    return await rotateRefreshInTransaction(tx, {
-      hashedToken: params.hashedToken,
-      rawReplacement,
-      grant,
-      options: params.options,
-    });
-  });
 }
 
 export async function exchangeOAuthRefreshToken(params: {
@@ -569,19 +425,33 @@ export async function exchangeOAuthRefreshToken(params: {
     ownershipShape: false,
   });
 
-  const outcome = await refreshExchange({
+  // Keep the inter-module membership check outside the database transaction.
+  // The DB helper re-reads and revalidates the binding under its transaction so
+  // rotation remains safe if the grant or client changes while this check runs.
+  const now = nowFor(params.options);
+  const rawReplacement = newOpaqueValue();
+  const outcome = await exchangeAgentRefreshToken({
     hashedToken,
     clientId: params.request.client_id,
     resource: params.request.resource,
-    options: params.options,
+    expectedResource: expectedResource(params.options),
+    rawReplacement,
+    replacementExpiresAt: agentRefreshTokenExpiresAt(now),
+    now,
   });
-  if (outcome.kind === 'reused' || outcome.kind === 'rejected' || !outcome.grant) {
+  if (outcome.kind === 'reused') {
+    recordTokenRefreshed('reused');
     throw invalidGrant();
   }
+  if (outcome.kind === 'rejected' || !outcome.grant) {
+    recordTokenRefreshed('rejected');
+    throw invalidGrant();
+  }
+  recordTokenRefreshed(outcome.kind);
 
   return {
     accessToken: await accessTokenFor(outcome.grant, client),
-    ...(outcome.refreshToken ? {refreshToken: outcome.refreshToken} : {}),
+    ...(outcome.kind === 'rotated' ? {refreshToken: outcome.refreshToken} : {}),
     scope: 'read',
   };
 }
@@ -590,18 +460,11 @@ export async function exchangeOAuthToken(params: {
   request: OAuthTokenRequestDto;
   options: OAuthFlowOptions;
 }): Promise<OAuthTokenExchangeResult> {
+  if (params.request.scope !== undefined && params.request.scope !== OAUTH_READ_SCOPE) {
+    throw new OAuthProtocolError('invalid_scope', 'The requested OAuth scope is not supported');
+  }
   if (params.request.grant_type === 'authorization_code') {
     return await exchangeOAuthAuthorizationCode(params);
   }
   return await exchangeOAuthRefreshToken(params);
-}
-
-export function oauthTokenResponse(result: OAuthTokenExchangeResult) {
-  return {
-    access_token: result.accessToken,
-    token_type: 'Bearer' as const,
-    expires_in: AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
-    ...(result.refreshToken ? {refresh_token: result.refreshToken} : {}),
-    scope: result.scope,
-  };
 }

--- a/libs/api/auth/src/core/oauth-flow.ts
+++ b/libs/api/auth/src/core/oauth-flow.ts
@@ -25,6 +25,7 @@ import {
   findAgentGrant,
   findAgentRefreshTokenByHash,
   findPendingAgentAuthorizationRequest,
+  isActiveAgentUser,
   isActiveAgentUserTx,
   resolveAgentRefreshTokenReplayTx,
   rotateAgentRefreshTokenTx,
@@ -49,6 +50,7 @@ import {createOAuthClientResolver} from './oauth-client-resolver.js';
 
 export const OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS = 5 * 60;
 export const OAUTH_AUTHORIZATION_CODE_TTL_SECONDS = 60;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 export interface OAuthFlowOptions {
   /** The normalized API origin, validated by the route factory. */
@@ -106,6 +108,14 @@ function invalidGrant(message = 'The OAuth grant is invalid'): OAuthProtocolErro
 
 function invalidClient(message = 'The OAuth client is invalid'): OAuthProtocolError {
   return new OAuthProtocolError('invalid_client', message);
+}
+
+function inactiveUserError(): OAuthProtocolError {
+  return new OAuthProtocolError('access_denied', 'The user is not active');
+}
+
+function assertConsentRequestId(requestId: string): void {
+  if (!UUID_PATTERN.test(requestId)) throw new OAuthConsentNotFoundError();
 }
 
 function redirectableError(
@@ -280,6 +290,8 @@ export async function getOAuthConsentDetail(params: {
   userId: string;
   options: OAuthFlowOptions;
 }): Promise<OAuthConsentDetail> {
+  assertConsentRequestId(params.requestId);
+  if (!(await isActiveAgentUser({userId: params.userId}))) throw inactiveUserError();
   const request = await findPendingRequestOrThrow(params.requestId);
   const client = await findAgentClientById({id: request.clientId});
   if (!client) throw new OAuthConsentNotFoundError();
@@ -303,6 +315,7 @@ export async function approveOAuthConsent(params: {
   workspaceId: string;
   options: OAuthFlowOptions;
 }): Promise<{redirectUrl: string}> {
+  assertConsentRequestId(params.requestId);
   await requireCurrentMembership({
     userId: params.userId,
     workspaceId: params.workspaceId,
@@ -314,7 +327,7 @@ export async function approveOAuthConsent(params: {
   const now = nowFor(params.options);
   const result = await db().transaction(async (tx) => {
     if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) {
-      throw new OAuthProtocolError('access_denied', 'The user is not active');
+      throw inactiveUserError();
     }
 
     const request = await consumeAgentAuthorizationRequestTx(tx, {id: params.requestId});
@@ -347,8 +360,13 @@ export async function approveOAuthConsent(params: {
 
 export async function denyOAuthConsent(params: {
   requestId: string;
+  userId: string;
 }): Promise<{redirectUrl: string}> {
+  assertConsentRequestId(params.requestId);
   const result = await db().transaction(async (tx) => {
+    if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) {
+      throw inactiveUserError();
+    }
     const request = await consumeAgentAuthorizationRequestTx(tx, {id: params.requestId});
     if (!request) throw new OAuthConsentNotFoundError();
     return {request};

--- a/libs/api/auth/src/core/oauth-flow.ts
+++ b/libs/api/auth/src/core/oauth-flow.ts
@@ -123,7 +123,10 @@ function newOpaqueValue(): string {
 function consentBaseUrl(options: OAuthFlowOptions): URL {
   const baseUrl = options.clientBaseUrl ?? config.CLIENT_BASE_URL;
   try {
-    return new URL(baseUrl);
+    const url = new URL(baseUrl);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:')
+      throw new Error('Unsupported URL scheme');
+    return url;
   } catch {
     throw new OAuthProtocolError('invalid_request', 'The OAuth consent URL is not configured', {
       status: 500,
@@ -444,15 +447,16 @@ export async function exchangeOAuthRefreshToken(params: {
   // rotation remains safe if the grant or client changes while this check runs.
   const now = nowFor(params.options);
   const rawReplacement = newOpaqueValue();
-  const outcome = await exchangeAgentRefreshToken({
+  const exchangeParams = {
     hashedToken,
     clientId: params.request.client_id,
     resource: params.request.resource,
     expectedResource: expectedResource(params.options),
     replacementHashedToken: hashOpaqueToken(rawReplacement),
     replacementExpiresAt: agentRefreshTokenExpiresAt(now),
-    now,
-  });
+    ...(params.options.now ? {now} : {}),
+  };
+  const outcome = await exchangeAgentRefreshToken(exchangeParams);
   if (outcome.kind === 'reused') {
     recordTokenRefreshed('reused');
     throw invalidGrant();

--- a/libs/api/auth/src/db/agent-access.test.ts
+++ b/libs/api/auth/src/db/agent-access.test.ts
@@ -401,6 +401,53 @@ describe('agent-access db', () => {
     ).toBeUndefined();
   });
 
+  test('revokes a grant when a predecessor expires during the rotation grace window', async () => {
+    const user = await userFactory.create();
+    const client = await createAgentClient({
+      clientId: `https://client.example/${crypto.randomUUID()}`,
+      name: 'Expired predecessor client',
+      redirectUris: ['https://client.example/callback'],
+      kind: 'registered',
+    });
+    const grant = await createAgentGrant({
+      userId: user.id,
+      workspaceId: crypto.randomUUID(),
+      clientId: client.id,
+      scopes: ['read'],
+    });
+    const predecessor = await createAgentRefreshToken({
+      grantId: grant.id,
+      hashedToken: hashOpaqueToken(`expired-predecessor-${crypto.randomUUID()}`),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const successor = await rotateAgentRefreshToken({
+      hashedToken: predecessor.hashedToken,
+      replacementHashedToken: hashOpaqueToken(`expired-successor-${crypto.randomUUID()}`),
+    });
+    if (!successor) throw new Error('Expected refresh rotation to create a successor');
+
+    const rotated = await findAgentRefreshTokenByHash({hashedToken: predecessor.hashedToken});
+    if (!rotated?.rotatedAt) throw new Error('Expected the predecessor to be marked rotated');
+    const replayNow = new Date(rotated.rotatedAt.getTime() + 1_000);
+    await db()
+      .update(agentRefreshTokens)
+      .set({expiresAt: new Date(replayNow.getTime() - 1)})
+      .where(eq(agentRefreshTokens.id, predecessor.id));
+
+    const replay = await resolveAgentRefreshTokenReplay({
+      hashedToken: predecessor.hashedToken,
+      now: replayNow,
+    });
+    expect(replay).toMatchObject({
+      kind: 'reused',
+      grant: {
+        id: grant.id,
+        revokedAt: expect.any(Date),
+        terminalAt: expect.any(Date),
+      },
+    });
+  });
+
   test('rejects code exchange and refresh rotation for suspended users', async () => {
     const user = await userFactory.create();
     const client = await createAgentClient({

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -134,6 +134,20 @@ async function isActiveUser(tx: AgentAccessTx, userId: string): Promise<boolean>
   return rows.length > 0;
 }
 
+/** Locks the user before the grant so approval and token issuance share one order. */
+async function lockActiveAgentGrant(
+  tx: AgentAccessTx,
+  grantId: string,
+): Promise<AgentGrant | undefined> {
+  const candidate = await findAgentGrant({id: grantId, executor: tx});
+  if (!candidate || candidate.revokedAt || candidate.terminalAt) return undefined;
+  if (!(await isActiveUser(tx, candidate.userId))) return undefined;
+
+  const grant = await lockAgentGrant(tx, {grantId});
+  if (!grant || grant.revokedAt || grant.terminalAt) return undefined;
+  return grant;
+}
+
 async function databaseClock(tx: AgentAccessTx): Promise<Date> {
   const result = await tx.execute<{now: Date | string}>(sql`select clock_timestamp() as now`);
   const raw = result.rows[0]?.now;
@@ -688,9 +702,8 @@ export async function consumeAgentAuthorizationCodeTx(
   const existing = existingRows[0];
   if (!existing) return undefined;
 
-  const grant = await lockAgentGrant(tx, {grantId: existing.grantId});
-  if (!grant || grant.revokedAt || grant.terminalAt) return undefined;
-  if (!(await isActiveUser(tx, grant.userId))) return undefined;
+  const grant = await lockActiveAgentGrant(tx, existing.grantId);
+  if (!grant) return undefined;
 
   const rows = await tx
     .update(agentAuthorizationCodes)
@@ -862,9 +875,8 @@ export async function resolveAgentRefreshTokenReplayTx(
   const existing = rows[0];
   if (!existing) return undefined;
 
-  const grant = await lockAgentGrant(tx, {grantId: existing.grantId});
-  if (!grant || grant.revokedAt || grant.terminalAt) return undefined;
-  if (!(await isActiveUser(tx, grant.userId))) return undefined;
+  const grant = await lockActiveAgentGrant(tx, existing.grantId);
+  if (!grant) return undefined;
 
   const currentRows = await tx
     .select()
@@ -946,9 +958,8 @@ export async function rotateAgentRefreshTokenTx(
   const existing = existingRows[0];
   if (!existing) return undefined;
 
-  const grant = await lockAgentGrant(tx, {grantId: existing.grantId});
-  if (!grant || grant.revokedAt || grant.terminalAt) return undefined;
-  if (!(await isActiveUser(tx, grant.userId))) return undefined;
+  const grant = await lockActiveAgentGrant(tx, existing.grantId);
+  if (!grant) return undefined;
 
   const rows = await tx
     .update(agentRefreshTokens)

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -129,8 +129,18 @@ async function isActiveUser(tx: AgentAccessTx, userId: string): Promise<boolean>
     .select({id: users.id})
     .from(users)
     .where(and(eq(users.id, userId), eq(users.status, 'active')))
+    .for('update')
     .limit(1);
   return rows.length > 0;
+}
+
+async function databaseClock(tx: AgentAccessTx): Promise<Date> {
+  const result = await tx.execute<{now: Date | string}>(sql`select clock_timestamp() as now`);
+  const raw = result.rows[0]?.now;
+  if (raw === undefined) throw new Error('Database clock returned no timestamp');
+  const now = raw instanceof Date ? raw : new Date(raw);
+  if (Number.isNaN(now.getTime())) throw new Error('Database clock returned an invalid timestamp');
+  return now;
 }
 
 /** Checks the authority-creating user state inside the caller's transaction. */
@@ -864,8 +874,9 @@ export async function resolveAgentRefreshTokenReplayTx(
   const current = currentRows[0];
   if (!current?.rotatedAt) return undefined;
 
-  const now = params.now ?? new Date();
+  const now = params.now ?? (await databaseClock(tx));
   if (
+    current.expiresAt.getTime() > now.getTime() &&
     isWithinAgentRefreshRotationGrace({
       rotatedAt: current.rotatedAt,
       now,
@@ -981,11 +992,11 @@ export type AgentRefreshExchangeOutcome =
 
 async function refreshReplayOutcome(
   tx: AgentAccessTx,
-  params: {hashedToken: string; now: Date},
+  params: {hashedToken: string; now?: Date},
 ): Promise<AgentRefreshExchangeOutcome> {
   const replay = await resolveAgentRefreshTokenReplayTx(tx, {
     hashedToken: params.hashedToken,
-    now: params.now,
+    ...(params.now === undefined ? {} : {now: params.now}),
   });
   if (!replay) return {kind: 'rejected'};
   if (replay.kind === 'reused') return {kind: 'reused', grant: replay.grant};
@@ -999,7 +1010,7 @@ async function rotateRefreshInTransaction(
     replacementHashedToken: string;
     grant: AgentGrant;
     replacementExpiresAt: Date;
-    now: Date;
+    now?: Date;
   },
 ): Promise<AgentRefreshExchangeOutcome> {
   const successor = await rotateAgentRefreshTokenTx(tx, {
@@ -1013,7 +1024,7 @@ async function rotateRefreshInTransaction(
 
   return await refreshReplayOutcome(tx, {
     hashedToken: params.hashedToken,
-    now: params.now,
+    ...(params.now === undefined ? {} : {now: params.now}),
   });
 }
 
@@ -1024,7 +1035,7 @@ export async function exchangeAgentRefreshToken(params: {
   expectedResource: string;
   replacementHashedToken: string;
   replacementExpiresAt: Date;
-  now: Date;
+  now?: Date;
 }): Promise<AgentRefreshExchangeOutcome> {
   return await db().transaction(async (tx) => {
     const existing = await findAgentRefreshTokenByHash({
@@ -1049,7 +1060,7 @@ export async function exchangeAgentRefreshToken(params: {
     if (existing.rotatedAt) {
       return await refreshReplayOutcome(tx, {
         hashedToken: params.hashedToken,
-        now: params.now,
+        ...(params.now === undefined ? {} : {now: params.now}),
       });
     }
 

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -1,4 +1,3 @@
-import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {and, asc, eq, gt, inArray, isNotNull, isNull, lte, notExists, or, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import type {
@@ -44,6 +43,30 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 function isUuid(value: string): boolean {
   return UUID_PATTERN.test(value);
+}
+
+export type AgentGrantBindingEvaluation =
+  | {kind: 'valid'; grant: AgentGrant; client: AgentClient}
+  | {kind: 'invalid'; reason: 'grant' | 'client' | 'resource'};
+
+/** Applies the shared OAuth grant, client, and resource binding policy. */
+export function evaluateAgentGrantBinding(params: {
+  grant: AgentGrant | undefined;
+  client: AgentClient | undefined;
+  clientId: string;
+  resource: string | undefined;
+  expectedResource: string;
+}): AgentGrantBindingEvaluation {
+  if (!params.grant || params.grant.revokedAt || params.grant.terminalAt) {
+    return {kind: 'invalid', reason: 'grant'};
+  }
+  if (!params.client || params.client.clientId !== params.clientId) {
+    return {kind: 'invalid', reason: 'client'};
+  }
+  if (params.resource !== undefined && params.resource !== params.expectedResource) {
+    return {kind: 'invalid', reason: 'resource'};
+  }
+  return {kind: 'valid', grant: params.grant, client: params.client};
 }
 
 function retentionCutoff(now: Date, days: number): Date {
@@ -951,7 +974,7 @@ export async function rotateAgentRefreshTokenTx(
 }
 
 export type AgentRefreshExchangeOutcome =
-  | {kind: 'rotated'; grant: AgentGrant; refreshToken: string}
+  | {kind: 'rotated'; grant: AgentGrant}
   | {kind: 'grace'; grant: AgentGrant}
   | {kind: 'rejected'}
   | {kind: 'reused'; grant: AgentGrant};
@@ -973,7 +996,7 @@ async function rotateRefreshInTransaction(
   tx: AgentAccessTx,
   params: {
     hashedToken: string;
-    rawReplacement: string;
+    replacementHashedToken: string;
     grant: AgentGrant;
     replacementExpiresAt: Date;
     now: Date;
@@ -981,11 +1004,11 @@ async function rotateRefreshInTransaction(
 ): Promise<AgentRefreshExchangeOutcome> {
   const successor = await rotateAgentRefreshTokenTx(tx, {
     hashedToken: params.hashedToken,
-    replacementHashedToken: hashOpaqueToken(params.rawReplacement),
+    replacementHashedToken: params.replacementHashedToken,
     replacementExpiresAt: params.replacementExpiresAt,
   });
   if (successor) {
-    return {kind: 'rotated', grant: params.grant, refreshToken: params.rawReplacement};
+    return {kind: 'rotated', grant: params.grant};
   }
 
   return await refreshReplayOutcome(tx, {
@@ -999,7 +1022,7 @@ export async function exchangeAgentRefreshToken(params: {
   clientId: string;
   resource: string | undefined;
   expectedResource: string;
-  rawReplacement: string;
+  replacementHashedToken: string;
   replacementExpiresAt: Date;
   now: Date;
 }): Promise<AgentRefreshExchangeOutcome> {
@@ -1011,12 +1034,17 @@ export async function exchangeAgentRefreshToken(params: {
     if (!existing) return {kind: 'rejected'};
 
     const grant = await findAgentGrant({id: existing.grantId, executor: tx});
-    if (!grant || grant.revokedAt || grant.terminalAt) return {kind: 'rejected'};
-    const client = await findAgentClientById({id: grant.clientId, executor: tx});
-    if (!client || client.clientId !== params.clientId) return {kind: 'rejected'};
-    if (params.resource !== undefined && params.resource !== params.expectedResource) {
-      return {kind: 'rejected'};
-    }
+    const client = grant
+      ? await findAgentClientById({id: grant.clientId, executor: tx})
+      : undefined;
+    const binding = evaluateAgentGrantBinding({
+      grant,
+      client,
+      clientId: params.clientId,
+      resource: params.resource,
+      expectedResource: params.expectedResource,
+    });
+    if (binding.kind === 'invalid') return {kind: 'rejected'};
 
     if (existing.rotatedAt) {
       return await refreshReplayOutcome(tx, {
@@ -1025,7 +1053,7 @@ export async function exchangeAgentRefreshToken(params: {
       });
     }
 
-    return await rotateRefreshInTransaction(tx, {...params, grant});
+    return await rotateRefreshInTransaction(tx, {...params, grant: binding.grant});
   });
 }
 

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -39,6 +39,11 @@ type AgentAccessExecutor = ReturnType<typeof db> | AgentAccessTx;
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 const MILLISECONDS_PER_SECOND = 1000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
 
 function retentionCutoff(now: Date, days: number): Date {
   if (!Number.isFinite(days) || days < 0) {
@@ -100,6 +105,20 @@ async function isActiveUser(tx: AgentAccessTx, userId: string): Promise<boolean>
     .select({id: users.id})
     .from(users)
     .where(and(eq(users.id, userId), eq(users.status, 'active')))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/** Checks the authority-creating user state inside the caller's transaction. */
+export async function isActiveAgentUserTx(
+  tx: AgentAccessTx,
+  params: {userId: string},
+): Promise<boolean> {
+  const rows = await tx
+    .select({id: users.id})
+    .from(users)
+    .where(and(eq(users.id, params.userId), eq(users.status, 'active')))
+    .for('update')
     .limit(1);
   return rows.length > 0;
 }
@@ -231,6 +250,21 @@ export async function findAgentClientByClientId(params: {
   return row ? toAgentClient(row) : undefined;
 }
 
+/** Resolves a client by its private database id for stored OAuth artifacts. */
+export async function findAgentClientById(params: {
+  id: string;
+  executor?: AgentAccessExecutor;
+}): Promise<AgentClient | undefined> {
+  const executor = params.executor ?? db();
+  const rows = await executor
+    .select()
+    .from(agentClients)
+    .where(eq(agentClients.id, params.id))
+    .limit(1);
+  const row = rows[0];
+  return row ? toAgentClient(row) : undefined;
+}
+
 export async function markAgentClientReferenced(
   tx: AgentAccessTx,
   params: {clientUuid: string},
@@ -295,6 +329,7 @@ export async function findPendingAgentAuthorizationRequest(params: {
   id: string;
   executor?: AgentAccessExecutor;
 }): Promise<AgentAuthorizationRequest | undefined> {
+  if (!isUuid(params.id)) return undefined;
   const executor = params.executor ?? db();
   const rows = await executor
     .select()
@@ -326,6 +361,7 @@ export async function consumeAgentAuthorizationRequestTx(
   tx: AgentAccessTx,
   params: {id: string},
 ): Promise<AgentAuthorizationRequest | undefined> {
+  if (!isUuid(params.id)) return undefined;
   const rows = await tx
     .update(agentAuthorizationRequests)
     .set({consumedAt: sql`now()`, updatedAt: sql`now()`})

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -1,3 +1,4 @@
+import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {and, asc, eq, gt, inArray, isNotNull, isNull, lte, notExists, or, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import type {
@@ -329,6 +330,58 @@ export async function createAgentAuthorizationRequestTx(
   return toAgentAuthorizationRequest(row);
 }
 
+export type AgentAuthorizationRequestDecision =
+  | {kind: 'inactive'}
+  | {kind: 'not-found'}
+  | {kind: 'consumed'; request: AgentAuthorizationRequest};
+
+async function consumeAgentAuthorizationRequestForActiveUserTx(
+  tx: AgentAccessTx,
+  params: {id: string; userId: string},
+): Promise<AgentAuthorizationRequestDecision> {
+  if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) return {kind: 'inactive'};
+  const request = await consumeAgentAuthorizationRequestTx(tx, params);
+  return request ? {kind: 'consumed', request} : {kind: 'not-found'};
+}
+
+export async function approveAgentAuthorizationRequest(params: {
+  id: string;
+  userId: string;
+  workspaceId: string;
+  hashedCode: string;
+  codeExpiresAt: Date;
+}): Promise<AgentAuthorizationRequestDecision> {
+  return await db().transaction(async (tx) => {
+    const decision = await consumeAgentAuthorizationRequestForActiveUserTx(tx, params);
+    if (decision.kind !== 'consumed') return decision;
+
+    const grant = await createAgentGrantTx(tx, {
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      clientId: decision.request.clientId,
+      scopes: decision.request.scopes,
+    });
+    await createAgentAuthorizationCodeTx(tx, {
+      grantId: grant.id,
+      hashedCode: params.hashedCode,
+      codeChallenge: decision.request.codeChallenge,
+      redirectUri: decision.request.redirectUri,
+      resource: decision.request.resource,
+      expiresAt: params.codeExpiresAt,
+    });
+    return decision;
+  });
+}
+
+export async function denyAgentAuthorizationRequest(params: {
+  id: string;
+  userId: string;
+}): Promise<AgentAuthorizationRequestDecision> {
+  return await db().transaction((tx) =>
+    consumeAgentAuthorizationRequestForActiveUserTx(tx, params),
+  );
+}
+
 export async function findPendingAgentAuthorizationRequest(params: {
   id: string;
   executor?: AgentAccessExecutor;
@@ -350,6 +403,38 @@ export async function findPendingAgentAuthorizationRequest(params: {
   return row ? toAgentAuthorizationRequest(row) : undefined;
 }
 
+/** Binds an unclaimed pending request to the first authenticated consent user. */
+export async function claimAgentAuthorizationRequest(params: {
+  id: string;
+  userId: string;
+}): Promise<AgentAuthorizationRequest | undefined> {
+  return await db().transaction((tx) => claimAgentAuthorizationRequestTx(tx, params));
+}
+
+export async function claimAgentAuthorizationRequestTx(
+  tx: AgentAccessTx,
+  params: {id: string; userId: string},
+): Promise<AgentAuthorizationRequest | undefined> {
+  if (!isUuid(params.id)) return undefined;
+  const rows = await tx
+    .update(agentAuthorizationRequests)
+    .set({userId: params.userId, updatedAt: sql`now()`})
+    .where(
+      and(
+        eq(agentAuthorizationRequests.id, params.id),
+        isNull(agentAuthorizationRequests.consumedAt),
+        gt(agentAuthorizationRequests.expiresAt, sql`now()`),
+        or(
+          isNull(agentAuthorizationRequests.userId),
+          eq(agentAuthorizationRequests.userId, params.userId),
+        ),
+      ),
+    )
+    .returning();
+  const row = rows[0];
+  return row ? toAgentAuthorizationRequest(row) : undefined;
+}
+
 export async function consumeAgentAuthorizationRequest(params: {
   id: string;
 }): Promise<AgentAuthorizationRequest | undefined> {
@@ -363,19 +448,35 @@ export async function consumeAgentAuthorizationRequest(params: {
  */
 export async function consumeAgentAuthorizationRequestTx(
   tx: AgentAccessTx,
-  params: {id: string},
+  params: {id: string; userId?: string},
 ): Promise<AgentAuthorizationRequest | undefined> {
   if (!isUuid(params.id)) return undefined;
-  const rows = await tx
-    .update(agentAuthorizationRequests)
-    .set({consumedAt: sql`now()`, updatedAt: sql`now()`})
-    .where(
-      and(
+  const userBinding = params.userId
+    ? or(
+        isNull(agentAuthorizationRequests.userId),
+        eq(agentAuthorizationRequests.userId, params.userId),
+      )
+    : undefined;
+  const predicate = userBinding
+    ? and(
         eq(agentAuthorizationRequests.id, params.id),
         isNull(agentAuthorizationRequests.consumedAt),
         gt(agentAuthorizationRequests.expiresAt, sql`now()`),
-      ),
-    )
+        userBinding,
+      )
+    : and(
+        eq(agentAuthorizationRequests.id, params.id),
+        isNull(agentAuthorizationRequests.consumedAt),
+        gt(agentAuthorizationRequests.expiresAt, sql`now()`),
+      );
+  const rows = await tx
+    .update(agentAuthorizationRequests)
+    .set({
+      ...(params.userId ? {userId: params.userId} : {}),
+      consumedAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .where(predicate)
     .returning();
   const row = rows[0];
   return row ? toAgentAuthorizationRequest(row) : undefined;
@@ -572,6 +673,23 @@ export async function consumeAgentAuthorizationCodeTx(
     .returning();
   const row = rows[0];
   return row ? toAgentAuthorizationCode(row) : undefined;
+}
+
+export async function exchangeAgentAuthorizationCode(params: {
+  hashedCode: string;
+  hashedRefreshToken: string;
+  refreshTokenExpiresAt: Date;
+}): Promise<{code: AgentAuthorizationCode; refreshToken: AgentRefreshToken} | undefined> {
+  return await db().transaction(async (tx) => {
+    const code = await consumeAgentAuthorizationCodeTx(tx, {hashedCode: params.hashedCode});
+    if (!code) return undefined;
+    const refreshToken = await createAgentRefreshTokenTx(tx, {
+      grantId: code.grantId,
+      hashedToken: params.hashedRefreshToken,
+      expiresAt: params.refreshTokenExpiresAt,
+    });
+    return {code, refreshToken};
+  });
 }
 
 export interface CreateAgentRefreshTokenParams {
@@ -830,6 +948,85 @@ export async function rotateAgentRefreshTokenTx(
   const successor = successorRows[0];
   if (!successor) throw new Error('Insert returned no rows');
   return toAgentRefreshToken(successor);
+}
+
+export type AgentRefreshExchangeOutcome =
+  | {kind: 'rotated'; grant: AgentGrant; refreshToken: string}
+  | {kind: 'grace'; grant: AgentGrant}
+  | {kind: 'rejected'}
+  | {kind: 'reused'; grant: AgentGrant};
+
+async function refreshReplayOutcome(
+  tx: AgentAccessTx,
+  params: {hashedToken: string; now: Date},
+): Promise<AgentRefreshExchangeOutcome> {
+  const replay = await resolveAgentRefreshTokenReplayTx(tx, {
+    hashedToken: params.hashedToken,
+    now: params.now,
+  });
+  if (!replay) return {kind: 'rejected'};
+  if (replay.kind === 'reused') return {kind: 'reused', grant: replay.grant};
+  return {kind: 'grace', grant: replay.grant};
+}
+
+async function rotateRefreshInTransaction(
+  tx: AgentAccessTx,
+  params: {
+    hashedToken: string;
+    rawReplacement: string;
+    grant: AgentGrant;
+    replacementExpiresAt: Date;
+    now: Date;
+  },
+): Promise<AgentRefreshExchangeOutcome> {
+  const successor = await rotateAgentRefreshTokenTx(tx, {
+    hashedToken: params.hashedToken,
+    replacementHashedToken: hashOpaqueToken(params.rawReplacement),
+    replacementExpiresAt: params.replacementExpiresAt,
+  });
+  if (successor) {
+    return {kind: 'rotated', grant: params.grant, refreshToken: params.rawReplacement};
+  }
+
+  return await refreshReplayOutcome(tx, {
+    hashedToken: params.hashedToken,
+    now: params.now,
+  });
+}
+
+export async function exchangeAgentRefreshToken(params: {
+  hashedToken: string;
+  clientId: string;
+  resource: string | undefined;
+  expectedResource: string;
+  rawReplacement: string;
+  replacementExpiresAt: Date;
+  now: Date;
+}): Promise<AgentRefreshExchangeOutcome> {
+  return await db().transaction(async (tx) => {
+    const existing = await findAgentRefreshTokenByHash({
+      hashedToken: params.hashedToken,
+      executor: tx,
+    });
+    if (!existing) return {kind: 'rejected'};
+
+    const grant = await findAgentGrant({id: existing.grantId, executor: tx});
+    if (!grant || grant.revokedAt || grant.terminalAt) return {kind: 'rejected'};
+    const client = await findAgentClientById({id: grant.clientId, executor: tx});
+    if (!client || client.clientId !== params.clientId) return {kind: 'rejected'};
+    if (params.resource !== undefined && params.resource !== params.expectedResource) {
+      return {kind: 'rejected'};
+    }
+
+    if (existing.rotatedAt) {
+      return await refreshReplayOutcome(tx, {
+        hashedToken: params.hashedToken,
+        now: params.now,
+      });
+    }
+
+    return await rotateRefreshInTransaction(tx, {...params, grant});
+  });
 }
 
 export async function revokeAgentRefreshToken(params: {

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -123,6 +123,10 @@ export async function isActiveAgentUserTx(
   return rows.length > 0;
 }
 
+export async function isActiveAgentUser(params: {userId: string}): Promise<boolean> {
+  return await db().transaction((tx) => isActiveAgentUserTx(tx, params));
+}
+
 async function lockAgentClient(
   tx: AgentAccessTx,
   clientId: string,

--- a/libs/api/auth/src/db/schema/agent-access.ts
+++ b/libs/api/auth/src/db/schema/agent-access.ts
@@ -42,6 +42,7 @@ export const agentAuthorizationRequests = pgTable(
     clientId: uuid('client_id')
       .notNull()
       .references(() => agentClients.id, {onDelete: 'cascade'}),
+    userId: uuid('user_id').references(() => users.id, {onDelete: 'cascade'}),
     redirectUri: text('redirect_uri').notNull(),
     resource: text('resource').notNull(),
     scopes: text('scopes').array().notNull(),
@@ -54,6 +55,7 @@ export const agentAuthorizationRequests = pgTable(
   },
   (table) => [
     index('auth_agent_authorization_requests_client_id_idx').on(table.clientId),
+    index('auth_agent_authorization_requests_user_id_idx').on(table.userId),
     index('auth_agent_authorization_requests_expires_at_idx').on(table.expiresAt),
   ],
 );
@@ -197,6 +199,7 @@ export function toAgentAuthorizationRequest(
   return {
     id: row.id,
     clientId: row.clientId,
+    userId: row.userId,
     redirectUri: row.redirectUri,
     resource: row.resource,
     scopes: row.scopes,

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -34,7 +34,12 @@ const authPublisherEventSchemas = {...authEventSchemas, ...administrationActionE
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
-export type {AdminRole, JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
+export type {
+  AdminRole,
+  AgentAccessTokenClaims,
+  JobLeaseTokenClaims,
+  RunnerSessionTokenClaims,
+} from '@shipfox/api-auth-dto';
 export {
   ADMIN_ROLES,
   getCurrentAdminRole,
@@ -57,6 +62,13 @@ export {
   revokeAdministratorUserSessions,
   suspendAdministratorUser,
 } from '#core/administration.js';
+export type {IssueAgentAccessTokenParams} from '#core/agent-access-token.js';
+export {
+  AGENT_ACCESS_TOKEN_EXPIRES_IN,
+  AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+  issueAgentAccessToken,
+  verifyAgentAccessToken,
+} from '#core/agent-access-token.js';
 export type {
   CreateImpersonatedSessionTokenParams,
   CreateImpersonatedSessionTokenResult,
@@ -103,7 +115,12 @@ export {
   InvalidOAuthClientMetadataError,
   InvalidOAuthConfigurationError,
   LastAdminOwnerError,
+  OAuthConsentNotFoundError,
   OAuthMetadataFetchError,
+  OAuthOwnershipNotFoundError,
+  OAuthProtocolError,
+  type OAuthProtocolErrorCode,
+  type OAuthProtocolErrorParams,
   OAuthRedirectUriNotRegisteredError,
   SignupNotAllowedError,
   UserNotFoundError,
@@ -145,6 +162,26 @@ export {
   registerOAuthClient,
   resolveOAuthClient,
 } from '#core/oauth-client-resolver.js';
+export type {
+  BeginOAuthAuthorizationResult,
+  OAuthConsentDetail,
+  OAuthConsentWorkspace,
+  OAuthFlowOptions,
+  OAuthTokenExchangeResult,
+} from '#core/oauth-flow.js';
+export {
+  approveOAuthConsent,
+  beginOAuthAuthorization,
+  denyOAuthConsent,
+  exchangeOAuthAuthorizationCode,
+  exchangeOAuthRefreshToken,
+  exchangeOAuthToken,
+  getOAuthConsentDetail,
+  OAUTH_AUTHORIZATION_CODE_TTL_SECONDS,
+  OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS,
+  oauthTokenResponse,
+  toOAuthConsentResponse,
+} from '#core/oauth-flow.js';
 export type {SignupDenialMessageFormat, SignupPolicy} from '#core/ports.js';
 export {
   issueRunnerSessionToken,
@@ -172,6 +209,7 @@ export {
 export {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
 export type {CreateOAuthRoutesOptions} from '#presentation/routes/oauth.js';
 export {
+  createOAuthAuthorizationRoutes,
   createOAuthClientIdentificationRoutes,
   createOAuthMetadataRoutes,
   createOAuthRoutes,

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -207,7 +207,10 @@ export {
   setRefreshTokenCookie,
 } from '#presentation/auth/refresh-cookie.js';
 export {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
-export type {CreateOAuthRoutesOptions} from '#presentation/routes/oauth.js';
+export type {
+  CreateOAuthAuthorizationRoutesOptions,
+  CreateOAuthRoutesOptions,
+} from '#presentation/routes/oauth.js';
 export {
   createOAuthAuthorizationRoutes,
   createOAuthClientIdentificationRoutes,

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -179,8 +179,6 @@ export {
   getOAuthConsentDetail,
   OAUTH_AUTHORIZATION_CODE_TTL_SECONDS,
   OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS,
-  oauthTokenResponse,
-  toOAuthConsentResponse,
 } from '#core/oauth-flow.js';
 export type {SignupDenialMessageFormat, SignupPolicy} from '#core/ports.js';
 export {
@@ -207,6 +205,7 @@ export {
   setRefreshTokenCookie,
 } from '#presentation/auth/refresh-cookie.js';
 export {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
+export {oauthTokenResponse, toOAuthConsentResponse} from '#presentation/dto/oauth.js';
 export type {
   CreateOAuthAuthorizationRoutesOptions,
   CreateOAuthRoutesOptions,

--- a/libs/api/auth/src/metrics/instance.test.ts
+++ b/libs/api/auth/src/metrics/instance.test.ts
@@ -52,6 +52,19 @@ describe('auth metrics', () => {
     expect(counterAdd('auth_rate_limit_prune_failures')).toHaveBeenCalledWith(1);
   });
 
+  it('records token issuance and verification outcomes by token type', () => {
+    metrics.recordTokenIssued('agent_access');
+    metrics.recordTokenVerified('agent_access', 'rejected');
+
+    expect(counterAdd('auth_token_issued')).toHaveBeenCalledWith(1, {
+      token_type: 'agent_access',
+    });
+    expect(counterAdd('auth_token_verified')).toHaveBeenCalledWith(1, {
+      token_type: 'agent_access',
+      outcome: 'rejected',
+    });
+  });
+
   it('does not let metric failures affect callers', () => {
     counterAdd('auth_rate_limit_checks').mockImplementationOnce(() => {
       throw new Error('metrics unavailable');

--- a/libs/api/auth/src/metrics/instance.test.ts
+++ b/libs/api/auth/src/metrics/instance.test.ts
@@ -65,6 +65,14 @@ describe('auth metrics', () => {
     });
   });
 
+  it('records refresh-token reuse as a security outcome', () => {
+    metrics.recordTokenRefreshed('reused');
+
+    expect(counterAdd('auth_token_refreshed')).toHaveBeenCalledWith(1, {
+      outcome: 'reused',
+    });
+  });
+
   it('does not let metric failures affect callers', () => {
     counterAdd('auth_rate_limit_checks').mockImplementationOnce(() => {
       throw new Error('metrics unavailable');

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -2,7 +2,7 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
 export type AuthTokenType = 'session' | 'agent_access' | 'job_lease' | 'runner_session';
 export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
-export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
+export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected' | 'reused';
 export type AuthRateLimitAction =
   | 'login'
   | 'email-send'

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -1,6 +1,6 @@
 import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
-export type AuthTokenType = 'session' | 'job_lease' | 'runner_session';
+export type AuthTokenType = 'session' | 'agent_access' | 'job_lease' | 'runner_session';
 export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
 export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
 export type AuthRateLimitAction =

--- a/libs/api/auth/src/presentation/dto/oauth.ts
+++ b/libs/api/auth/src/presentation/dto/oauth.ts
@@ -1,0 +1,44 @@
+import type {OAuthConsentResponseDto} from '@shipfox/api-auth-dto';
+import {OAUTH_READ_SCOPE} from '@shipfox/api-auth-dto';
+import {AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS} from '#core/agent-access-token.js';
+import type {AgentClient} from '#core/entities/agent-access.js';
+import {isOAuthLoopbackRedirectUri} from '#core/oauth-client.js';
+import type {OAuthConsentDetail, OAuthTokenExchangeResult} from '#core/oauth-flow.js';
+
+function identityOrigin(client: AgentClient): string {
+  if (client.kind === 'registered') return 'registered client';
+  try {
+    return new URL(client.clientId).origin;
+  } catch {
+    // A CIMD client was validated before it was stored. Keep an invalid row
+    // from becoming a request-time crash if old data predates that check.
+    return client.clientId;
+  }
+}
+
+export function toOAuthConsentResponse(detail: OAuthConsentDetail): OAuthConsentResponseDto {
+  const redirectUrl = new URL(detail.request.redirectUri);
+  return {
+    request_id: detail.request.id,
+    client_name: detail.client.name,
+    scope: OAUTH_READ_SCOPE,
+    expires_at: detail.request.expiresAt.toISOString(),
+    redirect_uri_hostname: redirectUrl.hostname,
+    client_identity_origin: identityOrigin(detail.client),
+    is_loopback_redirect: isOAuthLoopbackRedirectUri(detail.request.redirectUri),
+    workspaces: detail.workspaces.map(({workspaceId, role}) => ({
+      workspace_id: workspaceId,
+      role,
+    })),
+  };
+}
+
+export function oauthTokenResponse(result: OAuthTokenExchangeResult) {
+  return {
+    access_token: result.accessToken,
+    token_type: 'Bearer' as const,
+    expires_in: AGENT_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+    ...(result.refreshToken ? {refresh_token: result.refreshToken} : {}),
+    scope: result.scope,
+  };
+}

--- a/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
@@ -5,13 +5,17 @@ import {
 } from '@shipfox/api-workspaces-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {describe, expect, it, vi} from '@shipfox/vitest/vi';
 import {eq} from 'drizzle-orm';
+import {config} from '#config.js';
 import {verifyAgentAccessToken} from '#core/agent-access-token.js';
 import {signUserToken} from '#core/jwt.js';
 import {createOAuthClientResolver} from '#core/oauth-client-resolver.js';
+import {OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS} from '#core/oauth-flow.js';
 import {createAgentClient, findAgentClientByClientId} from '#db/agent-access.js';
 import {db} from '#db/db.js';
+import {agentAuthorizationCodes, agentRefreshTokens} from '#db/schema/agent-access.js';
 import {users} from '#db/schema/users.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {createVerifiedSession, ROUTE_TEST_SECRET} from '#test/routes.js';
@@ -28,8 +32,14 @@ function pkce() {
   return {verifier, challenge};
 }
 
-function workspaceClient(workspaceId: string) {
-  const memberships = [{workspaceId, role: 'admin' as const, workspaceStatus: 'active' as const}];
+function workspaceClient(
+  workspaceId: string,
+  memberships: Array<{
+    workspaceId: string;
+    role: 'admin' | 'member';
+    workspaceStatus: 'active' | 'archived';
+  }> = [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
+) {
   return {
     listMembershipsForTokenClaims: vi.fn(async () => ({memberships})),
     requireActiveMembership: vi.fn(async () => ({})),
@@ -45,7 +55,10 @@ async function createTestClient() {
   });
 }
 
-async function createTestApp(workspaces: WorkspacesInterModuleClient): Promise<FastifyInstance> {
+async function createTestApp(
+  workspaces: WorkspacesInterModuleClient,
+  options: {clientBaseUrl?: string; now?: () => Date} = {},
+): Promise<FastifyInstance> {
   const resolver = createOAuthClientResolver({
     findClient: async ({clientId}) => await findAgentClientByClientId({clientId}),
   });
@@ -54,9 +67,10 @@ async function createTestApp(workspaces: WorkspacesInterModuleClient): Promise<F
     routes: [
       createOAuthAuthorizationRoutes({
         apiPublicUrl: `${API_ORIGIN}/`,
-        clientBaseUrl: 'https://app.example.test',
+        clientBaseUrl: options.clientBaseUrl ?? 'https://app.example.test',
         clientResolver: resolver,
         workspaces,
+        ...(options.now ? {now: options.now} : {}),
       }),
     ],
     swagger: false,
@@ -159,6 +173,7 @@ describe('dormant OAuth authorization and token routes', () => {
           redirect_uri: REDIRECT_URI,
           code_verifier: verifier,
           resource: RESOURCE,
+          scope: 'read',
         },
         '198.51.100.240',
       ),
@@ -302,6 +317,87 @@ describe('dormant OAuth authorization and token routes', () => {
     );
   });
 
+  it('revokes the grant family when a refresh-token replay arrives after the grace window', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-refresh-reuse');
+    const client = await createTestClient();
+    let currentNow = new Date();
+    app = await createTestApp(workspaces, {now: () => currentNow});
+    const firstPkce = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, firstPkce.challenge),
+      headers: {'x-forwarded-for': '198.51.100.254'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+    const approval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    const code = new URL(approval.json().redirect_url).searchParams.get('code') ?? '';
+    const token = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: firstPkce.verifier,
+        },
+        '198.51.100.255',
+      ),
+    );
+    const predecessor = token.json().refresh_token;
+    expect(token.statusCode).toBe(200);
+    expect(predecessor).toEqual(expect.any(String));
+
+    const rotated = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'refresh_token',
+          client_id: client.clientId,
+          refresh_token: predecessor,
+        },
+        '198.51.100.1',
+      ),
+    );
+    const successor = rotated.json().refresh_token;
+    expect(rotated.statusCode).toBe(200);
+    expect(successor).toEqual(expect.any(String));
+
+    currentNow = new Date(
+      currentNow.getTime() + (config.AUTH_REFRESH_ROTATION_GRACE_SECONDS + 1) * 1000,
+    );
+    const reused = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'refresh_token',
+          client_id: client.clientId,
+          refresh_token: predecessor,
+        },
+        '198.51.100.2',
+      ),
+    );
+    expect(reused.statusCode).toBe(400);
+    expect(reused.json()).toMatchObject({error: 'invalid_grant'});
+
+    const revokedSuccessor = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'refresh_token',
+          client_id: client.clientId,
+          refresh_token: successor,
+        },
+        '198.51.100.3',
+      ),
+    );
+    expect(revokedSuccessor.statusCode).toBe(400);
+    expect(revokedSuccessor.json()).toMatchObject({error: 'invalid_grant'});
+  });
+
   it('rejects impersonated approval and preserves 404-shaped workspace ownership failures', async () => {
     const workspaceId = crypto.randomUUID();
     const account = await createVerifiedSession('oauth-impersonation');
@@ -340,6 +436,14 @@ describe('dormant OAuth authorization and token routes', () => {
     });
     expect(rejected.statusCode).toBe(403);
     expect(rejected.json()).toEqual({code: 'impersonation-not-permitted'});
+
+    const denialRejected = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(impersonated),
+    });
+    expect(denialRejected.statusCode).toBe(403);
+    expect(denialRejected.json()).toEqual({code: 'impersonation-not-permitted'});
 
     const ownership = await app.inject({
       method: 'POST',
@@ -398,6 +502,44 @@ describe('dormant OAuth authorization and token routes', () => {
     });
     expect(emptyState.statusCode).toBe(400);
     expect(emptyState.json()).toEqual({error: 'invalid_request'});
+
+    const unsupportedTokenScope = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code: 'not-a-real-code',
+          redirect_uri: REDIRECT_URI,
+          code_verifier: 'a'.repeat(43),
+          scope: 'write',
+        },
+        '198.51.100.251',
+      ),
+    );
+    expect(unsupportedTokenScope.statusCode).toBe(400);
+    expect(unsupportedTokenScope.json()).toEqual({
+      error: 'invalid_scope',
+      error_description: 'The requested OAuth scope is not supported',
+    });
+  });
+
+  it('rejects an invalid consent base URL before persisting an authorization request', async () => {
+    const workspaces = workspaceClient(crypto.randomUUID());
+    const client = await createTestClient();
+    app = await createTestApp(workspaces, {clientBaseUrl: 'not-a-url'});
+    const {challenge} = pkce();
+
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': '198.51.100.252'},
+    });
+
+    expect(authorization.statusCode).toBe(500);
+    expect(authorization.json()).toEqual({
+      error: 'invalid_request',
+      error_description: 'The OAuth consent URL is not configured',
+    });
   });
 
   it('rejects consent detail and denial for a suspended account without consuming the request', async () => {
@@ -439,6 +581,311 @@ describe('dormant OAuth authorization and token routes', () => {
       headers: bearer(account.token),
     });
     expect(allowedDenial.statusCode).toBe(200);
+  });
+
+  it('binds consent detail and denial to the first authenticated user', async () => {
+    const workspaces = workspaceClient(crypto.randomUUID());
+    const consentingAccount = await createVerifiedSession('oauth-bound-consent');
+    const otherAccount = await createVerifiedSession('oauth-other-consent');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': '198.51.100.15'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/oauth/consents/${requestId}`,
+      headers: bearer(consentingAccount.token),
+    });
+    expect(detail.statusCode).toBe(200);
+
+    const otherDetail = await app.inject({
+      method: 'GET',
+      url: `/oauth/consents/${requestId}`,
+      headers: bearer(otherAccount.token),
+    });
+    expect(otherDetail.statusCode).toBe(404);
+    expect(otherDetail.json()).toEqual({code: 'not-found'});
+
+    const otherDenial = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(otherAccount.token),
+    });
+    expect(otherDenial.statusCode).toBe(404);
+    expect(otherDenial.json()).toEqual({code: 'not-found'});
+
+    const denial = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(consentingAccount.token),
+    });
+    expect(denial.statusCode).toBe(200);
+  });
+
+  it('enforces the authorization-request and authorization-code TTLs', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-request-expired');
+    const client = await createTestClient();
+    let currentNow = new Date(Date.now() - (OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS * 1000 + 1));
+    app = await createTestApp(workspaces, {now: () => currentNow});
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': '198.51.100.4'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/oauth/consents/${requestId}`,
+      headers: bearer(account.token),
+    });
+    expect(detail.statusCode).toBe(404);
+    expect(detail.json()).toEqual({code: 'not-found'});
+
+    const approval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    expect(approval.statusCode).toBe(404);
+    expect(approval.json()).toEqual({code: 'not-found'});
+
+    const denial = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(account.token),
+    });
+    expect(denial.statusCode).toBe(404);
+    expect(denial.json()).toEqual({code: 'not-found'});
+
+    currentNow = new Date();
+    const firstPkce = pkce();
+    const validAuthorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, firstPkce.challenge),
+      headers: {'x-forwarded-for': '198.51.100.5'},
+    });
+    const validRequestId = new URL(validAuthorization.headers.location ?? '').searchParams.get(
+      'request_id',
+    );
+    const validApproval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${validRequestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    const code = new URL(validApproval.json().redirect_url).searchParams.get('code') ?? '';
+    await db()
+      .update(agentAuthorizationCodes)
+      .set({expiresAt: new Date(Date.now() - 1_000)})
+      .where(eq(agentAuthorizationCodes.hashedCode, hashOpaqueToken(code)));
+
+    const expiredCode = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: firstPkce.verifier,
+        },
+        '198.51.100.6',
+      ),
+    );
+    expect(expiredCode.statusCode).toBe(400);
+    expect(expiredCode.json()).toMatchObject({error: 'invalid_grant'});
+  });
+
+  it('rejects authorization-code binding mismatches before consuming the code', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-binding');
+    const client = await createTestClient();
+    const otherClient = await createTestClient();
+    app = await createTestApp(workspaces);
+
+    const issueCode = async () => {
+      const firstPkce = pkce();
+      const authorization = await app.inject({
+        method: 'GET',
+        url: authorizationUrl(client.clientId, firstPkce.challenge),
+        headers: {'x-forwarded-for': `198.51.100.${Math.floor(Math.random() * 200) + 7}`},
+      });
+      const requestId = new URL(authorization.headers.location ?? '').searchParams.get(
+        'request_id',
+      );
+      const approval = await app.inject({
+        method: 'POST',
+        url: `/oauth/consents/${requestId}/approve`,
+        headers: bearer(account.token),
+        payload: {workspace_id: workspaceId},
+      });
+      return {
+        code: new URL(approval.json().redirect_url).searchParams.get('code') ?? '',
+        verifier: firstPkce.verifier,
+      };
+    };
+
+    const redirectCode = await issueCode();
+    const redirectMismatch = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code: redirectCode.code,
+          redirect_uri: 'https://other.example/callback',
+          code_verifier: redirectCode.verifier,
+        },
+        '198.51.100.8',
+      ),
+    );
+    expect(redirectMismatch.statusCode).toBe(400);
+    expect(redirectMismatch.json()).toMatchObject({error: 'invalid_grant'});
+
+    const redirectRetry = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code: redirectCode.code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: redirectCode.verifier,
+        },
+        '198.51.100.9',
+      ),
+    );
+    expect(redirectRetry.statusCode).toBe(200);
+
+    const clientCode = await issueCode();
+    const clientMismatch = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: otherClient.clientId,
+          code: clientCode.code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: clientCode.verifier,
+        },
+        '198.51.100.10',
+      ),
+    );
+    expect(clientMismatch.statusCode).toBe(400);
+    expect(clientMismatch.json()).toMatchObject({error: 'invalid_grant'});
+
+    const clientRetry = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code: clientCode.code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: clientCode.verifier,
+        },
+        '198.51.100.11',
+      ),
+    );
+    expect(clientRetry.statusCode).toBe(200);
+  });
+
+  it('does not persist a refresh token when membership is lost at exchange time', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-membership-loss');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const firstPkce = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, firstPkce.challenge),
+      headers: {'x-forwarded-for': '198.51.100.12'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+    const approval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    const code = new URL(approval.json().redirect_url).searchParams.get('code') ?? '';
+    const refreshCountBefore = (await db().select().from(agentRefreshTokens)).length;
+    workspaces.requireActiveMembership = vi.fn(() => {
+      throw createInterModuleKnownError(
+        workspacesInterModuleContract.methods.requireActiveMembership,
+        'membership-required',
+        {workspaceId},
+      );
+    }) as unknown as WorkspacesInterModuleClient['requireActiveMembership'];
+
+    const rejected = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: firstPkce.verifier,
+        },
+        '198.51.100.13',
+      ),
+    );
+    expect(rejected.statusCode).toBe(400);
+    expect(rejected.json()).toMatchObject({error: 'invalid_grant'});
+    expect((await db().select().from(agentRefreshTokens)).length).toBe(refreshCountBefore);
+
+    workspaces.requireActiveMembership = vi.fn(
+      async () => ({}),
+    ) as unknown as WorkspacesInterModuleClient['requireActiveMembership'];
+    const retry = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: firstPkce.verifier,
+        },
+        '198.51.100.14',
+      ),
+    );
+    expect(retry.statusCode).toBe(200);
+  });
+
+  it('shows only active workspaces in the consent detail', async () => {
+    const activeWorkspaceId = crypto.randomUUID();
+    const inactiveWorkspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(activeWorkspaceId, [
+      {workspaceId: activeWorkspaceId, role: 'admin', workspaceStatus: 'active'},
+      {workspaceId: inactiveWorkspaceId, role: 'member', workspaceStatus: 'archived'},
+    ]);
+    const account = await createVerifiedSession('oauth-active-workspace');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': '198.51.100.253'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/oauth/consents/${requestId}`,
+      headers: bearer(account.token),
+    });
+
+    expect(detail.statusCode).toBe(200);
+    expect(detail.json().workspaces).toEqual([{workspace_id: activeWorkspaceId, role: 'admin'}]);
   });
 
   it('rejects approval after the account is suspended and treats malformed ids as not found', async () => {

--- a/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
@@ -636,7 +636,9 @@ describe('dormant OAuth authorization and token routes', () => {
     const workspaces = workspaceClient(workspaceId);
     const account = await createVerifiedSession('oauth-request-expired');
     const client = await createTestClient();
-    let currentNow = new Date(Date.now() - (OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS * 1000 + 1));
+    let currentNow = new Date(
+      Date.now() - (OAUTH_AUTHORIZATION_REQUEST_TTL_SECONDS * 1000 + 1_000),
+    );
     app = await createTestApp(workspaces, {now: () => currentNow});
     const {challenge} = pkce();
     const authorization = await app.inject({

--- a/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
@@ -1,0 +1,456 @@
+import {createHash, randomBytes} from 'node:crypto';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {describe, expect, it, vi} from '@shipfox/vitest/vi';
+import {eq} from 'drizzle-orm';
+import {verifyAgentAccessToken} from '#core/agent-access-token.js';
+import {signUserToken} from '#core/jwt.js';
+import {createOAuthClientResolver} from '#core/oauth-client-resolver.js';
+import {createAgentClient, findAgentClientByClientId} from '#db/agent-access.js';
+import {db} from '#db/db.js';
+import {users} from '#db/schema/users.js';
+import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
+import {createVerifiedSession, ROUTE_TEST_SECRET} from '#test/routes.js';
+import {createOAuthAuthorizationRoutes} from './oauth.js';
+
+const API_ORIGIN = 'https://api.example.test';
+const RESOURCE = `${API_ORIGIN}/mcp`;
+const REDIRECT_URI = 'https://client.example/callback';
+const UUID_PATTERN = /^[0-9a-f-]{36}$/u;
+
+function pkce() {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return {verifier, challenge};
+}
+
+function workspaceClient(workspaceId: string) {
+  const memberships = [{workspaceId, role: 'admin' as const, workspaceStatus: 'active' as const}];
+  return {
+    listMembershipsForTokenClaims: vi.fn(async () => ({memberships})),
+    requireActiveMembership: vi.fn(async () => ({})),
+  } as unknown as WorkspacesInterModuleClient;
+}
+
+async function createTestClient() {
+  return await createAgentClient({
+    clientId: `client_${crypto.randomUUID()}`,
+    name: 'Desktop agent',
+    redirectUris: [REDIRECT_URI],
+    kind: 'registered',
+  });
+}
+
+async function createTestApp(workspaces: WorkspacesInterModuleClient): Promise<FastifyInstance> {
+  const resolver = createOAuthClientResolver({
+    findClient: async ({clientId}) => await findAgentClientByClientId({clientId}),
+  });
+  return await createApp({
+    auth: [createJwtAuthMethod()],
+    routes: [
+      createOAuthAuthorizationRoutes({
+        apiPublicUrl: `${API_ORIGIN}/`,
+        clientBaseUrl: 'https://app.example.test',
+        clientResolver: resolver,
+        workspaces,
+      }),
+    ],
+    swagger: false,
+  });
+}
+
+function authorizationUrl(clientId: string, challenge: string, state = 'client-state'): string {
+  const url = new URL('/oauth/authorize', API_ORIGIN);
+  url.search = new URLSearchParams({
+    client_id: clientId,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    resource: RESOURCE,
+    scope: 'read',
+    state,
+  }).toString();
+  return url.pathname + url.search;
+}
+
+function bearer(token: string) {
+  return {authorization: `Bearer ${token}`};
+}
+
+describe('dormant OAuth authorization and token routes', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('keeps validated parameters server-side through approval and exchanges a PKCE code', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-flow');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {verifier, challenge} = pkce();
+
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': `198.51.100.${Math.floor(Math.random() * 200) + 1}`},
+    });
+    expect(authorization.statusCode).toBe(302);
+    const consentLocation = authorization.headers.location;
+    expect(consentLocation).toBeDefined();
+    const consentUrl = new URL(consentLocation ?? 'https://invalid.example');
+    const requestId = consentUrl.searchParams.get('request_id');
+    expect(requestId).toMatch(UUID_PATTERN);
+    expect([...consentUrl.searchParams.keys()]).toEqual(['request_id']);
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/oauth/consents/${requestId}`,
+      headers: bearer(account.token),
+    });
+    expect(detail.statusCode).toBe(200);
+    expect(detail.json()).toMatchObject({
+      request_id: requestId,
+      client_name: 'Desktop agent',
+      scope: 'read',
+      redirect_uri_hostname: 'client.example',
+      client_identity_origin: 'registered client',
+      is_loopback_redirect: false,
+      workspaces: [{workspace_id: workspaceId, role: 'admin'}],
+    });
+
+    const approval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    expect(approval.statusCode).toBe(200);
+    const callback = new URL(approval.json().redirect_url);
+    expect(callback.searchParams.get('state')).toBe('client-state');
+    const code = callback.searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    const token = await app.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-forwarded-for': '198.51.100.240',
+      },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.clientId,
+        code: code ?? '',
+        redirect_uri: REDIRECT_URI,
+        code_verifier: verifier,
+        resource: RESOURCE,
+      }).toString(),
+    });
+    expect(token.statusCode).toBe(200);
+    expect(token.json()).toMatchObject({
+      token_type: 'Bearer',
+      expires_in: 900,
+      scope: 'read',
+      access_token: expect.any(String),
+      refresh_token: expect.any(String),
+    });
+
+    const accessClaims = await verifyAgentAccessToken(token.json().access_token);
+    expect(accessClaims).toMatchObject({
+      sub: account.userId,
+      workspaceId,
+      clientId: client.clientId,
+      scopes: ['read'],
+    });
+
+    const replay = await app.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: {'x-forwarded-for': '198.51.100.246'},
+      payload: {
+        grant_type: 'authorization_code',
+        client_id: client.clientId,
+        code,
+        redirect_uri: REDIRECT_URI,
+        code_verifier: verifier,
+      },
+    });
+    expect(replay.statusCode).toBe(400);
+    expect(replay.json()).toMatchObject({error: 'invalid_grant'});
+  });
+
+  it('returns denial through the stored redirect and makes the request single-use', async () => {
+    const workspaces = workspaceClient(crypto.randomUUID());
+    const account = await createVerifiedSession('oauth-deny');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge, 'deny-state'),
+      headers: {'x-forwarded-for': `198.51.100.${Math.floor(Math.random() * 200) + 1}`},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+    expect(requestId).toBeTruthy();
+
+    const denial = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(account.token),
+    });
+    expect(denial.statusCode).toBe(200);
+    const callback = new URL(denial.json().redirect_url);
+    expect(callback.searchParams.get('error')).toBe('access_denied');
+    expect(callback.searchParams.get('state')).toBe('deny-state');
+
+    const replay = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(account.token),
+    });
+    expect(replay.statusCode).toBe(404);
+    expect(replay.json()).toEqual({code: 'not-found'});
+  });
+
+  it('serializes refresh rotation, allows a grace replay, and rejects a bad PKCE exchange', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-refresh');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const firstPkce = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, firstPkce.challenge),
+      headers: {'x-forwarded-for': `198.51.100.${Math.floor(Math.random() * 200) + 1}`},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+    const approval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    const code = new URL(approval.json().redirect_url).searchParams.get('code') ?? '';
+
+    const badCode = await app.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: {'x-forwarded-for': '198.51.100.241'},
+      payload: {
+        grant_type: 'authorization_code',
+        client_id: client.clientId,
+        code,
+        redirect_uri: REDIRECT_URI,
+        code_verifier: 'a'.repeat(43),
+      },
+    });
+    expect(badCode.statusCode).toBe(400);
+    expect(badCode.json()).toMatchObject({error: 'invalid_grant'});
+
+    const token = await app.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: {'x-forwarded-for': '198.51.100.242'},
+      payload: {
+        grant_type: 'authorization_code',
+        client_id: client.clientId,
+        code,
+        redirect_uri: REDIRECT_URI,
+        code_verifier: firstPkce.verifier,
+      },
+    });
+    const refreshToken = token.json().refresh_token;
+    expect(token.statusCode).toBe(200);
+    expect(refreshToken).toEqual(expect.any(String));
+
+    const refresh = () =>
+      app.inject({
+        method: 'POST',
+        url: '/oauth/token',
+        headers: {'x-forwarded-for': '198.51.100.243'},
+        payload: {
+          grant_type: 'refresh_token',
+          client_id: client.clientId,
+          refresh_token: refreshToken,
+        },
+      });
+    const [first, second] = await Promise.all([refresh(), refresh()]);
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(first.json().access_token).toEqual(expect.any(String));
+    expect(second.json().access_token).toEqual(expect.any(String));
+    expect([first.json().refresh_token, second.json().refresh_token].filter(Boolean)).toHaveLength(
+      1,
+    );
+  });
+
+  it('rejects impersonated approval and preserves 404-shaped workspace ownership failures', async () => {
+    const workspaceId = crypto.randomUUID();
+    const account = await createVerifiedSession('oauth-impersonation');
+    const client = await createTestClient();
+    const workspaces = workspaceClient(workspaceId);
+    workspaces.requireActiveMembership = vi.fn(() => {
+      throw createInterModuleKnownError(
+        workspacesInterModuleContract.methods.requireActiveMembership,
+        'membership-required',
+        {workspaceId},
+      );
+    }) as unknown as WorkspacesInterModuleClient['requireActiveMembership'];
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': `198.51.100.${Math.floor(Math.random() * 200) + 1}`},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+    const impersonated = await signUserToken({
+      userId: account.userId,
+      email: account.email,
+      name: 'Impersonated User',
+      memberships: [],
+      impersonatorId: crypto.randomUUID(),
+      secret: ROUTE_TEST_SECRET,
+      expiresIn: '15m',
+    });
+
+    const rejected = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(impersonated),
+      payload: {workspace_id: workspaceId},
+    });
+    expect(rejected.statusCode).toBe(403);
+    expect(rejected.json()).toEqual({code: 'impersonation-not-permitted'});
+
+    const ownership = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    expect(ownership.statusCode).toBe(404);
+    expect(ownership.json()).toEqual({code: 'not-found'});
+  });
+
+  it('uses standard authorization errors without redirecting an untrusted client', async () => {
+    const workspaces = workspaceClient(crypto.randomUUID());
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+
+    const invalidTarget = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge).replace(
+        encodeURIComponent(RESOURCE),
+        encodeURIComponent(`${API_ORIGIN}/other`),
+      ),
+      headers: {'x-forwarded-for': '198.51.100.247'},
+    });
+    expect(invalidTarget.statusCode).toBe(302);
+    const targetCallback = new URL(invalidTarget.headers.location ?? '');
+    expect(targetCallback.searchParams.get('error')).toBe('invalid_target');
+    expect(targetCallback.searchParams.get('state')).toBe('client-state');
+
+    const invalidScope = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge).replace('scope=read', 'scope=write'),
+      headers: {'x-forwarded-for': '198.51.100.248'},
+    });
+    expect(invalidScope.statusCode).toBe(302);
+    const scopeCallback = new URL(invalidScope.headers.location ?? '');
+    expect(scopeCallback.searchParams.get('error')).toBe('invalid_scope');
+    expect(scopeCallback.searchParams.get('state')).toBe('client-state');
+
+    const invalidRedirect = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge).replace(
+        encodeURIComponent(REDIRECT_URI),
+        encodeURIComponent('https://other.example/callback'),
+      ),
+      headers: {'x-forwarded-for': '198.51.100.249'},
+    });
+    expect(invalidRedirect.statusCode).toBe(400);
+    expect(invalidRedirect.json()).toMatchObject({error: 'invalid_request'});
+  });
+
+  it('rejects approval after the account is suspended and treats malformed ids as not found', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-suspended-approval');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': '198.51.100.250'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, account.userId));
+    const rejected = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    expect(rejected.statusCode).toBe(403);
+    expect(rejected.json()).toEqual({code: 'access-denied'});
+
+    const malformed = await app.inject({
+      method: 'GET',
+      url: '/oauth/consents/not-a-uuid',
+      headers: bearer(account.token),
+    });
+    expect(malformed.statusCode).toBe(404);
+    expect(malformed.json()).toEqual({code: 'not-found'});
+  });
+
+  it('rejects an OAuth code when the user is suspended after approval', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-suspended');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {verifier, challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': `198.51.100.${Math.floor(Math.random() * 200) + 1}`},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+    const approval = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/approve`,
+      headers: bearer(account.token),
+      payload: {workspace_id: workspaceId},
+    });
+    const code = new URL(approval.json().redirect_url).searchParams.get('code') ?? '';
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, account.userId));
+
+    const token = await app.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: {'x-forwarded-for': '198.51.100.245'},
+      payload: {
+        grant_type: 'authorization_code',
+        client_id: client.clientId,
+        code,
+        redirect_uri: REDIRECT_URI,
+        code_verifier: verifier,
+      },
+    });
+    expect(token.statusCode).toBe(400);
+    expect(token.json()).toMatchObject({error: 'invalid_grant'});
+  });
+});

--- a/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
@@ -523,10 +523,13 @@ describe('dormant OAuth authorization and token routes', () => {
     });
   });
 
-  it('rejects an invalid consent base URL before persisting an authorization request', async () => {
+  it.each([
+    'not-a-url',
+    'mailto:consent',
+  ])('rejects an invalid consent base URL before persisting an authorization request (%s)', async (clientBaseUrl) => {
     const workspaces = workspaceClient(crypto.randomUUID());
     const client = await createTestClient();
-    app = await createTestApp(workspaces, {clientBaseUrl: 'not-a-url'});
+    app = await createTestApp(workspaces, {clientBaseUrl});
     const {challenge} = pkce();
 
     const authorization = await app.inject({

--- a/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth-flow.test.ts
@@ -82,6 +82,18 @@ function bearer(token: string) {
   return {authorization: `Bearer ${token}`};
 }
 
+function tokenForm(payload: Record<string, string>, ip: string) {
+  return {
+    method: 'POST' as const,
+    url: '/oauth/token',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-forwarded-for': ip,
+    },
+    payload: new URLSearchParams(payload).toString(),
+  };
+}
+
 describe('dormant OAuth authorization and token routes', () => {
   let app: FastifyInstance;
 
@@ -138,22 +150,19 @@ describe('dormant OAuth authorization and token routes', () => {
     const code = callback.searchParams.get('code');
     expect(code).toBeTruthy();
 
-    const token = await app.inject({
-      method: 'POST',
-      url: '/oauth/token',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded',
-        'x-forwarded-for': '198.51.100.240',
-      },
-      payload: new URLSearchParams({
-        grant_type: 'authorization_code',
-        client_id: client.clientId,
-        code: code ?? '',
-        redirect_uri: REDIRECT_URI,
-        code_verifier: verifier,
-        resource: RESOURCE,
-      }).toString(),
-    });
+    const token = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code: code ?? '',
+          redirect_uri: REDIRECT_URI,
+          code_verifier: verifier,
+          resource: RESOURCE,
+        },
+        '198.51.100.240',
+      ),
+    );
     expect(token.statusCode).toBe(200);
     expect(token.json()).toMatchObject({
       token_type: 'Bearer',
@@ -171,18 +180,18 @@ describe('dormant OAuth authorization and token routes', () => {
       scopes: ['read'],
     });
 
-    const replay = await app.inject({
-      method: 'POST',
-      url: '/oauth/token',
-      headers: {'x-forwarded-for': '198.51.100.246'},
-      payload: {
-        grant_type: 'authorization_code',
-        client_id: client.clientId,
-        code,
-        redirect_uri: REDIRECT_URI,
-        code_verifier: verifier,
-      },
-    });
+    const replay = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code: code ?? '',
+          redirect_uri: REDIRECT_URI,
+          code_verifier: verifier,
+        },
+        '198.51.100.246',
+      ),
+    );
     expect(replay.statusCode).toBe(400);
     expect(replay.json()).toMatchObject({error: 'invalid_grant'});
   });
@@ -241,48 +250,48 @@ describe('dormant OAuth authorization and token routes', () => {
     });
     const code = new URL(approval.json().redirect_url).searchParams.get('code') ?? '';
 
-    const badCode = await app.inject({
-      method: 'POST',
-      url: '/oauth/token',
-      headers: {'x-forwarded-for': '198.51.100.241'},
-      payload: {
-        grant_type: 'authorization_code',
-        client_id: client.clientId,
-        code,
-        redirect_uri: REDIRECT_URI,
-        code_verifier: 'a'.repeat(43),
-      },
-    });
+    const badCode = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: 'a'.repeat(43),
+        },
+        '198.51.100.241',
+      ),
+    );
     expect(badCode.statusCode).toBe(400);
     expect(badCode.json()).toMatchObject({error: 'invalid_grant'});
 
-    const token = await app.inject({
-      method: 'POST',
-      url: '/oauth/token',
-      headers: {'x-forwarded-for': '198.51.100.242'},
-      payload: {
-        grant_type: 'authorization_code',
-        client_id: client.clientId,
-        code,
-        redirect_uri: REDIRECT_URI,
-        code_verifier: firstPkce.verifier,
-      },
-    });
+    const token = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: firstPkce.verifier,
+        },
+        '198.51.100.242',
+      ),
+    );
     const refreshToken = token.json().refresh_token;
     expect(token.statusCode).toBe(200);
     expect(refreshToken).toEqual(expect.any(String));
 
     const refresh = () =>
-      app.inject({
-        method: 'POST',
-        url: '/oauth/token',
-        headers: {'x-forwarded-for': '198.51.100.243'},
-        payload: {
-          grant_type: 'refresh_token',
-          client_id: client.clientId,
-          refresh_token: refreshToken,
-        },
-      });
+      app.inject(
+        tokenForm(
+          {
+            grant_type: 'refresh_token',
+            client_id: client.clientId,
+            refresh_token: refreshToken,
+          },
+          '198.51.100.243',
+        ),
+      );
     const [first, second] = await Promise.all([refresh(), refresh()]);
     expect(first.statusCode).toBe(200);
     expect(second.statusCode).toBe(200);
@@ -381,6 +390,55 @@ describe('dormant OAuth authorization and token routes', () => {
     });
     expect(invalidRedirect.statusCode).toBe(400);
     expect(invalidRedirect.json()).toMatchObject({error: 'invalid_request'});
+
+    const emptyState = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge, ''),
+      headers: {'x-forwarded-for': '198.51.100.250'},
+    });
+    expect(emptyState.statusCode).toBe(400);
+    expect(emptyState.json()).toEqual({error: 'invalid_request'});
+  });
+
+  it('rejects consent detail and denial for a suspended account without consuming the request', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const account = await createVerifiedSession('oauth-suspended-consent');
+    const client = await createTestClient();
+    app = await createTestApp(workspaces);
+    const {challenge} = pkce();
+    const authorization = await app.inject({
+      method: 'GET',
+      url: authorizationUrl(client.clientId, challenge),
+      headers: {'x-forwarded-for': '198.51.100.252'},
+    });
+    const requestId = new URL(authorization.headers.location ?? '').searchParams.get('request_id');
+
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, account.userId));
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/oauth/consents/${requestId}`,
+      headers: bearer(account.token),
+    });
+    expect(detail.statusCode).toBe(403);
+    expect(detail.json()).toEqual({code: 'access-denied'});
+
+    const denial = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(account.token),
+    });
+    expect(denial.statusCode).toBe(403);
+    expect(denial.json()).toEqual({code: 'access-denied'});
+
+    await db().update(users).set({status: 'active'}).where(eq(users.id, account.userId));
+    const allowedDenial = await app.inject({
+      method: 'POST',
+      url: `/oauth/consents/${requestId}/deny`,
+      headers: bearer(account.token),
+    });
+    expect(allowedDenial.statusCode).toBe(200);
   });
 
   it('rejects approval after the account is suspended and treats malformed ids as not found', async () => {
@@ -438,18 +496,18 @@ describe('dormant OAuth authorization and token routes', () => {
     const code = new URL(approval.json().redirect_url).searchParams.get('code') ?? '';
     await db().update(users).set({status: 'suspended'}).where(eq(users.id, account.userId));
 
-    const token = await app.inject({
-      method: 'POST',
-      url: '/oauth/token',
-      headers: {'x-forwarded-for': '198.51.100.245'},
-      payload: {
-        grant_type: 'authorization_code',
-        client_id: client.clientId,
-        code,
-        redirect_uri: REDIRECT_URI,
-        code_verifier: verifier,
-      },
-    });
+    const token = await app.inject(
+      tokenForm(
+        {
+          grant_type: 'authorization_code',
+          client_id: client.clientId,
+          code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: verifier,
+        },
+        '198.51.100.245',
+      ),
+    );
     expect(token.statusCode).toBe(400);
     expect(token.json()).toMatchObject({error: 'invalid_grant'});
   });

--- a/libs/api/auth/src/presentation/routes/oauth.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth.test.ts
@@ -59,8 +59,10 @@ describe('OAuth route factories', () => {
 
   it('keeps authorization and token routes behind the explicit flow factory', async () => {
     const result = await app.inject({method: 'GET', url: '/oauth/authorize'});
+    const token = await app.inject({method: 'POST', url: '/oauth/token'});
 
     expect(result.statusCode).toBe(404);
+    expect(token.statusCode).toBe(404);
   });
 
   it('creates a public registration with no client secret', async () => {

--- a/libs/api/auth/src/presentation/routes/oauth.test.ts
+++ b/libs/api/auth/src/presentation/routes/oauth.test.ts
@@ -57,6 +57,12 @@ describe('OAuth route factories', () => {
     });
   });
 
+  it('keeps authorization and token routes behind the explicit flow factory', async () => {
+    const result = await app.inject({method: 'GET', url: '/oauth/authorize'});
+
+    expect(result.statusCode).toBe(404);
+  });
+
   it('creates a public registration with no client secret', async () => {
     const result = await app.inject({
       method: 'POST',

--- a/libs/api/auth/src/presentation/routes/oauth.ts
+++ b/libs/api/auth/src/presentation/routes/oauth.ts
@@ -54,12 +54,14 @@ import {createAuthIpRateLimitPreHandler} from './rate-limit.js';
 export interface CreateOAuthRoutesOptions {
   /** Validated here and deliberately injected until production composition. */
   apiPublicUrl: string;
-  /** Required only when the dormant authorization and consent routes are requested. */
-  workspaces?: WorkspacesInterModuleClient;
   /** Optional dashboard base URL override for isolated route tests. */
   clientBaseUrl?: string;
   /** Optional resolver override for isolated CIMD/client tests. */
   clientResolver?: OAuthClientResolver;
+}
+
+export interface CreateOAuthAuthorizationRoutesOptions extends CreateOAuthRoutesOptions {
+  workspaces: WorkspacesInterModuleClient;
 }
 
 function apiPublicOrigin(options: CreateOAuthRoutesOptions): string {
@@ -264,7 +266,7 @@ function createDynamicRegistrationRoute() {
 }
 
 function flowOptions(
-  options: CreateOAuthRoutesOptions & {workspaces: WorkspacesInterModuleClient},
+  options: CreateOAuthAuthorizationRoutesOptions,
   origin: string,
 ): OAuthFlowOptions {
   return {
@@ -389,7 +391,12 @@ function createOAuthConsentDenyRoute() {
     },
     errorHandler: translateOAuthConsentError,
     handler: async (request) => {
-      const result = await denyOAuthConsent({requestId: request.params.requestId});
+      const context = getUserContext(request);
+      if (!context) throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+      const result = await denyOAuthConsent({
+        requestId: request.params.requestId,
+        userId: context.userId,
+      });
       return {redirect_url: result.redirectUrl};
     },
   });
@@ -412,7 +419,7 @@ export function createOAuthClientIdentificationRoutes(): RouteGroup {
 
 /** Dormant OAuth authorization, consent, and token routes for isolated composition. */
 export function createOAuthAuthorizationRoutes(
-  options: CreateOAuthRoutesOptions & {workspaces: WorkspacesInterModuleClient},
+  options: CreateOAuthAuthorizationRoutesOptions,
 ): RouteGroup {
   const origin = apiPublicOrigin(options);
   const flow = flowOptions(options, origin);
@@ -432,16 +439,8 @@ export function createOAuthAuthorizationRoutes(
 export function createOAuthRoutes(options: CreateOAuthRoutesOptions): RouteGroup {
   const metadataRoutes = createOAuthMetadataRoutes(options);
   const clientIdentificationRoutes = createOAuthClientIdentificationRoutes();
-  const authorizationRoutes = options.workspaces
-    ? createOAuthAuthorizationRoutes({...options, workspaces: options.workspaces})
-    : undefined;
   return {
     prefix: '',
-    routes: [
-      ...metadataRoutes.routes,
-      ...clientIdentificationRoutes.routes,
-      ...(authorizationRoutes ? authorizationRoutes.routes : []),
-    ],
-    ...(authorizationRoutes?.plugins ? {plugins: authorizationRoutes.plugins} : {}),
+    routes: [...metadataRoutes.routes, ...clientIdentificationRoutes.routes],
   };
 }

--- a/libs/api/auth/src/presentation/routes/oauth.ts
+++ b/libs/api/auth/src/presentation/routes/oauth.ts
@@ -1,31 +1,72 @@
+import {AUTH_USER, getUserContext, rejectImpersonatedSession} from '@shipfox/api-auth-context';
 import {
   type OAuthDynamicClientRegistrationResponseDto,
   oauthAuthorizationServerMetadataSchema,
+  oauthAuthorizeQuerySchema,
+  oauthConsentApprovalBodySchema,
+  oauthConsentDecisionResponseSchema,
+  oauthConsentParamsSchema,
+  oauthConsentResponseSchema,
   oauthDynamicClientRegistrationRequestSchema,
   oauthDynamicClientRegistrationResponseSchema,
   oauthProtectedResourceMetadataSchema,
+  oauthTokenRequestSchema,
+  oauthTokenResponseSchema,
 } from '@shipfox/api-auth-dto';
-import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import {
+  ClientError,
+  defineRoute,
+  type FastifyReply,
+  type FastifyRequest,
+  type RouteGroup,
+} from '@shipfox/node-fastify';
+import type {FastifyPluginAsync} from 'fastify';
+import fp from 'fastify-plugin';
+import {
+  AuthDependencyUnavailableError,
   InvalidOAuthClientMetadataError,
   InvalidOAuthConfigurationError,
+  OAuthConsentNotFoundError,
   OAuthMetadataFetchError,
+  OAuthOwnershipNotFoundError,
+  OAuthProtocolError,
   OAuthRedirectUriNotRegisteredError,
 } from '#core/errors.js';
 import {validateOAuthPublicOrigin} from '#core/oauth-client.js';
-import {registerOAuthClient} from '#core/oauth-client-resolver.js';
+import {
+  createOAuthClientResolver,
+  type OAuthClientResolver,
+  registerOAuthClient,
+} from '#core/oauth-client-resolver.js';
+import {
+  approveOAuthConsent,
+  beginOAuthAuthorization,
+  denyOAuthConsent,
+  exchangeOAuthToken,
+  getOAuthConsentDetail,
+  type OAuthFlowOptions,
+  oauthTokenResponse,
+  toOAuthConsentResponse,
+} from '#core/oauth-flow.js';
 import {createAuthIpRateLimitPreHandler} from './rate-limit.js';
 
 export interface CreateOAuthRoutesOptions {
   /** Validated here and deliberately injected until production composition. */
   apiPublicUrl: string;
+  /** Required only when the dormant authorization and consent routes are requested. */
+  workspaces?: WorkspacesInterModuleClient;
+  /** Optional dashboard base URL override for isolated route tests. */
+  clientBaseUrl?: string;
+  /** Optional resolver override for isolated CIMD/client tests. */
+  clientResolver?: OAuthClientResolver;
 }
 
 function apiPublicOrigin(options: CreateOAuthRoutesOptions): string {
   return validateOAuthPublicOrigin(options.apiPublicUrl);
 }
 
-function translateOAuthError(error: unknown): never {
+function translateOAuthRegistrationError(error: unknown): never {
   if (
     error instanceof InvalidOAuthClientMetadataError ||
     error instanceof OAuthMetadataFetchError ||
@@ -38,6 +79,109 @@ function translateOAuthError(error: unknown): never {
   if (error instanceof InvalidOAuthConfigurationError) {
     throw new ClientError('OAuth configuration is invalid', 'oauth-configuration-invalid', {
       status: 500,
+    });
+  }
+  throw error;
+}
+
+function isFastifyValidationError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as {code?: unknown}).code === 'FST_ERR_VALIDATION'
+  );
+}
+
+function oauthErrorPayload(error: OAuthProtocolError): {
+  error: OAuthProtocolError['code'];
+  error_description?: string;
+} {
+  return {
+    error: error.code,
+    ...((error.description ?? error.message)
+      ? {error_description: error.description ?? error.message}
+      : {}),
+  };
+}
+
+function sendOAuthProtocolError(error: OAuthProtocolError, reply: FastifyReply) {
+  return reply.code(error.status).send(oauthErrorPayload(error));
+}
+
+function oauthAuthorizationErrorRedirect(error: OAuthProtocolError): string {
+  if (!error.redirectUri) throw new Error('OAuth authorization error has no redirect URI');
+  const url = new URL(error.redirectUri);
+  url.searchParams.set('error', error.code);
+  if (error.description ?? error.message) {
+    url.searchParams.set('error_description', error.description ?? error.message);
+  }
+  if (error.state !== undefined && error.state !== null) {
+    url.searchParams.set('state', error.state);
+  }
+  return url.toString();
+}
+
+function translateOAuthAuthorizationError(
+  error: unknown,
+  _request: FastifyRequest,
+  reply: FastifyReply,
+): unknown {
+  if (error instanceof OAuthProtocolError) {
+    if (error.redirectUri) return reply.redirect(oauthAuthorizationErrorRedirect(error));
+    return sendOAuthProtocolError(error, reply);
+  }
+  if (isFastifyValidationError(error)) {
+    return reply.code(400).send({error: 'invalid_request'});
+  }
+  if (error instanceof OAuthRedirectUriNotRegisteredError) {
+    return reply
+      .code(400)
+      .send({error: 'invalid_request', error_description: 'The OAuth redirect URI is invalid'});
+  }
+  if (
+    error instanceof InvalidOAuthClientMetadataError ||
+    error instanceof OAuthMetadataFetchError
+  ) {
+    return reply.code(400).send({error: 'invalid_client'});
+  }
+  if (error instanceof InvalidOAuthConfigurationError) {
+    throw new ClientError('OAuth configuration is invalid', 'oauth-configuration-invalid', {
+      status: 500,
+    });
+  }
+  throw error;
+}
+
+function translateOAuthTokenError(
+  error: unknown,
+  _request: FastifyRequest,
+  reply: FastifyReply,
+): unknown {
+  if (error instanceof OAuthProtocolError) return sendOAuthProtocolError(error, reply);
+  if (isFastifyValidationError(error)) return reply.code(400).send({error: 'invalid_request'});
+  if (error instanceof AuthDependencyUnavailableError) {
+    throw new ClientError('Authentication dependency unavailable', 'auth-dependency-unavailable', {
+      status: 503,
+      cause: error,
+    });
+  }
+  throw error;
+}
+
+function translateOAuthConsentError(error: unknown): never {
+  if (error instanceof OAuthProtocolError && error.code === 'access_denied') {
+    throw new ClientError('OAuth consent approval was denied', 'access-denied', {
+      status: 403,
+      cause: error,
+    });
+  }
+  if (error instanceof OAuthConsentNotFoundError || error instanceof OAuthOwnershipNotFoundError) {
+    throw new ClientError('OAuth consent request not found', 'not-found', {status: 404});
+  }
+  if (error instanceof AuthDependencyUnavailableError) {
+    throw new ClientError('Authentication dependency unavailable', 'auth-dependency-unavailable', {
+      status: 503,
+      cause: error,
     });
   }
   throw error;
@@ -103,7 +247,7 @@ function createDynamicRegistrationRoute() {
       response: {201: oauthDynamicClientRegistrationResponseSchema},
     },
     preHandler: createAuthIpRateLimitPreHandler('oauth-register'),
-    errorHandler: translateOAuthError,
+    errorHandler: translateOAuthRegistrationError,
     handler: async (request, reply) => {
       const result = await registerOAuthClient({
         clientName: request.body.client_name,
@@ -115,6 +259,138 @@ function createDynamicRegistrationRoute() {
       });
       reply.code(201);
       return registrationResponse(result);
+    },
+  });
+}
+
+function flowOptions(
+  options: CreateOAuthRoutesOptions & {workspaces: WorkspacesInterModuleClient},
+  origin: string,
+): OAuthFlowOptions {
+  return {
+    apiPublicOrigin: origin,
+    ...(options.clientBaseUrl !== undefined ? {clientBaseUrl: options.clientBaseUrl} : {}),
+    workspaces: options.workspaces,
+    clientResolver: options.clientResolver ?? createOAuthClientResolver(),
+  };
+}
+
+const oauthFormBodyPlugin: FastifyPluginAsync = fp((scope) => {
+  scope.addContentTypeParser(
+    'application/x-www-form-urlencoded',
+    {parseAs: 'string', bodyLimit: 32 * 1024},
+    (_request, body: string, done: (error: Error | null, value?: unknown) => void) => {
+      try {
+        done(null, Object.fromEntries(new URLSearchParams(body)));
+      } catch (error) {
+        done(error instanceof Error ? error : new Error('Invalid form body'));
+      }
+    },
+  );
+  return Promise.resolve();
+});
+
+function createOAuthAuthorizeRoute(options: OAuthFlowOptions) {
+  return defineRoute({
+    method: 'GET',
+    path: '/oauth/authorize',
+    description: 'Validate an OAuth request and begin the browser consent flow.',
+    schema: {querystring: oauthAuthorizeQuerySchema},
+    preHandler: createAuthIpRateLimitPreHandler('oauth-authorize'),
+    errorHandler: translateOAuthAuthorizationError,
+    handler: async (request, reply) => {
+      const result = await beginOAuthAuthorization({
+        request: request.query,
+        requestIp: request.ip,
+        options,
+      });
+      return reply.redirect(result.consentUrl);
+    },
+  });
+}
+
+function createOAuthTokenRoute(options: OAuthFlowOptions) {
+  return defineRoute({
+    method: 'POST',
+    path: '/oauth/token',
+    description: 'Exchange an OAuth authorization code or refresh token.',
+    options: {bodyLimit: 32 * 1024},
+    schema: {
+      body: oauthTokenRequestSchema,
+      response: {200: oauthTokenResponseSchema},
+    },
+    preHandler: createAuthIpRateLimitPreHandler('oauth-token'),
+    errorHandler: translateOAuthTokenError,
+    handler: async (request) =>
+      oauthTokenResponse(await exchangeOAuthToken({request: request.body, options})),
+  });
+}
+
+function createOAuthConsentDetailRoute(options: OAuthFlowOptions) {
+  return defineRoute({
+    method: 'GET',
+    path: '/oauth/consents/:requestId',
+    description: 'Load an authenticated OAuth consent request.',
+    auth: AUTH_USER,
+    schema: {
+      params: oauthConsentParamsSchema,
+      response: {200: oauthConsentResponseSchema},
+    },
+    errorHandler: translateOAuthConsentError,
+    handler: async (request) => {
+      const context = getUserContext(request);
+      if (!context) throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+      const detail = await getOAuthConsentDetail({
+        requestId: request.params.requestId,
+        userId: context.userId,
+        options,
+      });
+      return toOAuthConsentResponse(detail);
+    },
+  });
+}
+
+function createOAuthConsentApproveRoute(options: OAuthFlowOptions) {
+  return defineRoute({
+    method: 'POST',
+    path: '/oauth/consents/:requestId/approve',
+    description: 'Approve an authenticated OAuth consent request for one workspace.',
+    auth: AUTH_USER,
+    schema: {
+      params: oauthConsentParamsSchema,
+      body: oauthConsentApprovalBodySchema,
+      response: {200: oauthConsentDecisionResponseSchema},
+    },
+    errorHandler: translateOAuthConsentError,
+    handler: async (request) => {
+      const context = getUserContext(request);
+      if (!context) throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+      rejectImpersonatedSession(request);
+      const result = await approveOAuthConsent({
+        requestId: request.params.requestId,
+        userId: context.userId,
+        workspaceId: request.body.workspace_id,
+        options,
+      });
+      return {redirect_url: result.redirectUrl};
+    },
+  });
+}
+
+function createOAuthConsentDenyRoute() {
+  return defineRoute({
+    method: 'POST',
+    path: '/oauth/consents/:requestId/deny',
+    description: 'Deny an authenticated OAuth consent request.',
+    auth: AUTH_USER,
+    schema: {
+      params: oauthConsentParamsSchema,
+      response: {200: oauthConsentDecisionResponseSchema},
+    },
+    errorHandler: translateOAuthConsentError,
+    handler: async (request) => {
+      const result = await denyOAuthConsent({requestId: request.params.requestId});
+      return {redirect_url: result.redirectUrl};
     },
   });
 }
@@ -134,11 +410,38 @@ export function createOAuthClientIdentificationRoutes(): RouteGroup {
   return {prefix: '', routes: [createDynamicRegistrationRoute()]};
 }
 
+/** Dormant OAuth authorization, consent, and token routes for isolated composition. */
+export function createOAuthAuthorizationRoutes(
+  options: CreateOAuthRoutesOptions & {workspaces: WorkspacesInterModuleClient},
+): RouteGroup {
+  const origin = apiPublicOrigin(options);
+  const flow = flowOptions(options, origin);
+  return {
+    prefix: '',
+    plugins: [oauthFormBodyPlugin],
+    routes: [
+      createOAuthAuthorizeRoute(flow),
+      createOAuthTokenRoute(flow),
+      createOAuthConsentDetailRoute(flow),
+      createOAuthConsentApproveRoute(flow),
+      createOAuthConsentDenyRoute(),
+    ],
+  };
+}
+
 export function createOAuthRoutes(options: CreateOAuthRoutesOptions): RouteGroup {
   const metadataRoutes = createOAuthMetadataRoutes(options);
   const clientIdentificationRoutes = createOAuthClientIdentificationRoutes();
+  const authorizationRoutes = options.workspaces
+    ? createOAuthAuthorizationRoutes({...options, workspaces: options.workspaces})
+    : undefined;
   return {
     prefix: '',
-    routes: [...metadataRoutes.routes, ...clientIdentificationRoutes.routes],
+    routes: [
+      ...metadataRoutes.routes,
+      ...clientIdentificationRoutes.routes,
+      ...(authorizationRoutes ? authorizationRoutes.routes : []),
+    ],
+    ...(authorizationRoutes?.plugins ? {plugins: authorizationRoutes.plugins} : {}),
   };
 }

--- a/libs/api/auth/src/presentation/routes/oauth.ts
+++ b/libs/api/auth/src/presentation/routes/oauth.ts
@@ -1,5 +1,6 @@
 import {AUTH_USER, getUserContext, rejectImpersonatedSession} from '@shipfox/api-auth-context';
 import {
+  OAUTH_MCP_RESOURCE_PATH,
   type OAuthDynamicClientRegistrationResponseDto,
   oauthAuthorizationServerMetadataSchema,
   oauthAuthorizeQuerySchema,
@@ -46,9 +47,8 @@ import {
   exchangeOAuthToken,
   getOAuthConsentDetail,
   type OAuthFlowOptions,
-  oauthTokenResponse,
-  toOAuthConsentResponse,
 } from '#core/oauth-flow.js';
+import {oauthTokenResponse, toOAuthConsentResponse} from '../dto/oauth.js';
 import {createAuthIpRateLimitPreHandler} from './rate-limit.js';
 
 export interface CreateOAuthRoutesOptions {
@@ -62,6 +62,8 @@ export interface CreateOAuthRoutesOptions {
 
 export interface CreateOAuthAuthorizationRoutesOptions extends CreateOAuthRoutesOptions {
   workspaces: WorkspacesInterModuleClient;
+  /** Optional clock override for deterministic flow tests. */
+  now?: () => Date;
 }
 
 function apiPublicOrigin(options: CreateOAuthRoutesOptions): string {
@@ -210,7 +212,7 @@ function createProtectedResourceMetadataRoute(origin: string) {
     description: 'Describe the protected MCP resource and its authorization server.',
     schema: {response: {200: oauthProtectedResourceMetadataSchema}},
     handler: () => ({
-      resource: `${origin}/mcp`,
+      resource: `${origin}${OAUTH_MCP_RESOURCE_PATH}`,
       authorization_servers: [origin],
       scopes_supported: ['read'],
     }),
@@ -274,6 +276,7 @@ function flowOptions(
     ...(options.clientBaseUrl !== undefined ? {clientBaseUrl: options.clientBaseUrl} : {}),
     workspaces: options.workspaces,
     clientResolver: options.clientResolver ?? createOAuthClientResolver(),
+    ...(options.now ? {now: options.now} : {}),
   };
 }
 
@@ -393,6 +396,7 @@ function createOAuthConsentDenyRoute() {
     handler: async (request) => {
       const context = getUserContext(request);
       if (!context) throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+      rejectImpersonatedSession(request);
       const result = await denyOAuthConsent({
         requestId: request.params.requestId,
         userId: context.userId,

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -856,7 +856,7 @@ describe('tool step executor', () => {
   });
 
   test('stops a log group when its first append fails', async () => {
-    const {jobId} = await arrangeToolStep();
+    const {jobId, stepId} = await arrangeToolStep();
     const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
       outcome: 'success' as const,
       result: {identifier: 'ENG-1680'},
@@ -881,7 +881,9 @@ describe('tool step executor', () => {
       callTimeoutMs: 30_000,
     });
 
-    expect(appendServerRecords).toHaveBeenCalledTimes(1);
+    expect(
+      appendServerRecords.mock.calls.filter(([input]) => input.stepId === stepId),
+    ).toHaveLength(1);
     const [step] = await getStepsByJobId(jobId);
     expect(step).toMatchObject({status: 'succeeded'});
   });

--- a/libs/shared/node/auth-root-key/README.md
+++ b/libs/shared/node/auth-root-key/README.md
@@ -5,7 +5,7 @@ Named HKDF-SHA256 keys for Shipfox API authentication and email challenges.
 ## What it does
 
 - **Root-key loading**: Reads and checks `AUTH_ROOT_KEY` before application startup.
-- **Named keys**: Exports one key function for user tokens, job leases, runner sessions, rate-limit identifiers, and email challenges.
+- **Named keys**: Exports one key function for user tokens, agent access tokens, job leases, runner sessions, rate-limit identifiers, and email challenges.
 - **Fixed domains**: Uses versioned labels and a fixed salt so callers cannot select an arbitrary HMAC or signing domain.
 
 ## Installation

--- a/libs/shared/node/auth-root-key/src/index.test.ts
+++ b/libs/shared/node/auth-root-key/src/index.test.ts
@@ -21,13 +21,14 @@ describe('auth root key derivation', () => {
       new Set(
         [
           first,
+          keys.agentAccessTokenKey(),
           keys.jobLeaseTokenKey(),
           keys.runnerSessionTokenKey(),
           keys.rateLimitIdentifierKey(),
           keys.emailChallengeKey(),
         ].map((key) => Buffer.from(key).toString('hex')),
       ),
-    ).toHaveLength(5);
+    ).toHaveLength(6);
     expect(Buffer.from(first).toString('hex')).toBe(
       'fab85cafc21c6a9580b7f93ec5cdd880cb3abf9ab22fcf9652029f8cf44c1c5a',
     );

--- a/libs/shared/node/auth-root-key/src/index.ts
+++ b/libs/shared/node/auth-root-key/src/index.ts
@@ -14,6 +14,7 @@ const config = createConfig({
 const rootKey = decodeAuthRootKey(config.AUTH_ROOT_KEY);
 
 const userAccessKey = deriveKey('shipfox/user-access-token/v1');
+const agentAccessTokenDerivedKey = deriveKey('shipfox/agent-access-token/v1');
 const jobLeaseKey = deriveKey('shipfox/job-lease-token/v1');
 const runnerSessionKey = deriveKey('shipfox/runner-session-token/v1');
 const rateLimitKey = deriveKey('shipfox/rate-limit-identifier/v1');
@@ -21,6 +22,10 @@ const emailChallengeDerivedKey = deriveKey('shipfox/email-challenge/v1');
 
 export function userAccessTokenKey(): Uint8Array {
   return userAccessKey;
+}
+
+export function agentAccessTokenKey(): Uint8Array {
+  return agentAccessTokenDerivedKey;
 }
 
 export function jobLeaseTokenKey(): Uint8Array {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2319,6 +2319,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      fastify-plugin:
+        specifier: ^6.0.0
+        version: 6.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
Implement the Agent Access OAuth browser and token state machine required by ENG-1828.

Validated authorization requests keep client, redirect, resource, PKCE, and original state server-side behind an opaque, short-lived, single-use pending request. Authenticated consent approval/denial and authorization-code exchange enforce active users, workspace membership, grant/client binding, redirect/resource checks, and PKCE. Refresh rotation covers grace-period replay detection and family revocation.

The new routes are exposed only through the opt-in `createOAuthAuthorizationRoutes` factory. `createAuthModule().routes` remains unchanged so production composition stays out of scope.

Validation: `mise exec -- pnpm turbo check --filter=@shipfox/api-auth...`, `type`, `test`, and `build`; real Postgres OAuth flow tests; API database-boundary checks; dependency-cruiser; and `git diff --check` all pass. The auth suite passes 350 tests and the auth DTO suite passes 25 tests.

Closes ENG-1828

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the dormant OAuth authorization, consent, and token flows for agent access, implementing the state machine from ENG-1828. Previously, agent access had no OAuth routes; now the full browser and token flows exist but are only exposed through the opt-in `createOAuthAuthorizationRoutes` factory, leaving `createAuthModule().routes` unchanged.

**New Features**

- Stores validated authorization requests bound to the approving user as opaque, short-lived, single-use pending requests; the new `user_id` migration is required before deployment.
- Adds session-authenticated consent routes that enforce active users, workspace membership, shared grant/client/resource binding, and single-use approval or denial.
- Implements authorization-code exchange with PKCE, redirect/resource checks, and terminal grant checks, with input bounds that reject empty `state`, invalid consent URL schemes, and redirect hostnames beyond the DNS limit.
- Adds refresh-token rotation with grace-period replay detection and family revocation, using the post-lock database clock for replay decisions.
- Serializes token issuance with user suspension and locks the user row before the grant so suspension cannot race exchange or deadlock concurrent reauthorization.
- Signs agent access tokens with a dedicated `agentAccessTokenKey()` so they cannot cross-verify with user session tokens; its missing root-key configuration fails distinctly from other key derivations.
- Returns the client's original `state` unchanged without using it as Shipfox continuation state.
- Rejects impersonated approval and preserves 404-shaped ownership denials.
- Adds DTO schemas for the new OAuth request, consent, and token payloads.

**Dependencies**

- Adds `fastify-plugin` to `@shipfox/api-auth` for OAuth form body parsing.

<sup>Written for commit 3ff33bd5fff713e0fdec08fb05846ef4099ff452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

