### PR TITLE
[api-integration-core] Enforce persisted repository authorization

### DIFF
--- a/.changeset/repository-authorization-cache.md
+++ b/.changeset/repository-authorization-cache.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": minor
+---
+
+Enforces persisted repository access modes and manual grants during checkout and tool authorization, with a bounded positive-decision cache.

--- a/.changeset/repository-authorization-invalidation.md
+++ b/.changeset/repository-authorization-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Invalidates local repository authorization after committed GitHub repository changes.

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -3,6 +3,7 @@ import {RepositoryAuthorizerConfigurationError} from './errors.js';
 import {
   createRepositoryAuthorizationRequestContext,
   createRepositoryAuthorizer,
+  type RepositoryAuthorizationGrantStore,
   RepositoryAuthorizationTargetInvalidError,
   repositoryAuthorizationClientErrorCode,
   repositoryAuthorizationClientErrorCodes,
@@ -33,6 +34,16 @@ function createProjects(
     findProjectBySourceRepositoryName: vi.fn().mockResolvedValue({projects: []}),
     ...overrides,
   } as unknown as ProjectsModuleClient;
+}
+
+function createGrants(
+  overrides: Partial<RepositoryAuthorizationGrantStore> = {},
+): RepositoryAuthorizationGrantStore {
+  return {
+    getByExternalId: vi.fn().mockResolvedValue(undefined),
+    listByName: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
 }
 
 function selectedInput(
@@ -125,6 +136,31 @@ describe('repository authorization', () => {
     ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
   });
 
+  it('authorizes an exact external-id manual grant', async () => {
+    const grants = createGrants({
+      getByExternalId: vi.fn().mockResolvedValue({
+        externalRepositoryId: 'github:42',
+        repositoryOwner: 'Shipfox',
+        repositoryName: 'Platform',
+      }),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects: createProjects(),
+        grants,
+        ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {
+        externalRepositoryId: 'github:42',
+        owner: 'Shipfox',
+        name: 'Platform',
+      },
+    });
+  });
+
   it('passes selected external IDs through as exact project lookup keys', async () => {
     const getProjectBySource = vi.fn().mockResolvedValue({
       project: {
@@ -191,6 +227,105 @@ describe('repository authorization', () => {
     ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
   });
 
+  it('authorizes a name matched by a manual grant without a project', async () => {
+    const grants = createGrants({
+      listByName: vi.fn().mockResolvedValue([
+        {
+          externalRepositoryId: 'github:42',
+          repositoryOwner: 'Shipfox',
+          repositoryName: 'Platform',
+        },
+      ]),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects: createProjects(),
+        grants,
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {
+        externalRepositoryId: 'github:42',
+        owner: 'Shipfox',
+        name: 'Platform',
+      },
+    });
+  });
+
+  it('deduplicates project and manual-grant provenance by external repository id', async () => {
+    const projects = createProjects({
+      findProjectBySourceRepositoryName: vi.fn().mockResolvedValue({
+        projects: [
+          {
+            id: 'project-1',
+            sourceExternalRepositoryId: 'github:42',
+            sourceRepositoryOwner: 'shipfox',
+            sourceRepositoryName: 'platform',
+          },
+        ],
+      }),
+    });
+    const grants = createGrants({
+      listByName: vi.fn().mockResolvedValue([
+        {
+          externalRepositoryId: 'github:42',
+          repositoryOwner: 'Shipfox',
+          repositoryName: 'Platform',
+        },
+      ]),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        grants,
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      repository: {
+        externalRepositoryId: 'github:42',
+        owner: 'shipfox',
+        name: 'platform',
+      },
+      targetProjectId: 'project-1',
+    });
+  });
+
+  it('denies a name when project and manual-grant matches have distinct ids', async () => {
+    const projects = createProjects({
+      findProjectBySourceRepositoryName: vi.fn().mockResolvedValue({
+        projects: [
+          {
+            id: 'project-1',
+            sourceExternalRepositoryId: 'github:42',
+            sourceRepositoryOwner: 'shipfox',
+            sourceRepositoryName: 'platform',
+          },
+        ],
+      }),
+    });
+    const grants = createGrants({
+      listByName: vi.fn().mockResolvedValue([
+        {
+          externalRepositoryId: 'github:43',
+          repositoryOwner: 'shipfox',
+          repositoryName: 'platform',
+        },
+      ]),
+    });
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects,
+        grants,
+        ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'repository_ambiguous'});
+  });
+
   it('denies an ambiguous name after deduplicating rows by external repository id', async () => {
     const projects = createProjects({
       findProjectBySourceRepositoryName: vi.fn().mockResolvedValue({
@@ -247,10 +382,15 @@ describe('repository authorization', () => {
       getProjectBySource: vi.fn().mockRejectedValue(new Error('must not be called')),
       findProjectBySourceRepositoryName: vi.fn().mockRejectedValue(new Error('must not be called')),
     });
+    const grants = createGrants({
+      getByExternalId: vi.fn().mockRejectedValue(new Error('must not be called')),
+      listByName: vi.fn().mockRejectedValue(new Error('must not be called')),
+    });
 
     await expect(
       resolveRepositoryAuthorization({
         projects,
+        grants,
         ...selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'}),
         mode: 'all',
       }),
@@ -261,6 +401,7 @@ describe('repository authorization', () => {
     await expect(
       resolveRepositoryAuthorization({
         projects,
+        grants,
         ...selectedInput({kind: 'name', owner: 'shipfox', name: 'platform'}),
         mode: 'all',
       }),
@@ -270,6 +411,8 @@ describe('repository authorization', () => {
     });
     expect(projects.getProjectBySource).not.toHaveBeenCalled();
     expect(projects.findProjectBySourceRepositoryName).not.toHaveBeenCalled();
+    expect(grants.getByExternalId).not.toHaveBeenCalled();
+    expect(grants.listByName).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -348,6 +491,99 @@ describe('repository authorization', () => {
       authorized: true,
       repository: {externalRepositoryId: 'github:42'},
       targetProjectId: 'project-1',
+    });
+    expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares positive selected decisions for 30 seconds and then refreshes them', async () => {
+    let now = 0;
+    const getProjectBySource = vi.fn().mockResolvedValue({
+      project: {
+        id: 'project-1',
+        sourceExternalRepositoryId: 'github:42',
+      },
+    });
+    const authorizer = createRepositoryAuthorizer({
+      projects: createProjects({getProjectBySource}),
+      grants: createGrants(),
+      enabled: true,
+      now: () => now,
+    });
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+
+    await authorizer.resolveRepositoryAuthorization({
+      ...input,
+      request: createRepositoryAuthorizationRequestContext(),
+    });
+    await authorizer.resolveRepositoryAuthorization({
+      ...input,
+      request: createRepositoryAuthorizationRequestContext(),
+    });
+    expect(getProjectBySource).toHaveBeenCalledOnce();
+
+    now = 30_000;
+    await authorizer.resolveRepositoryAuthorization({
+      ...input,
+      request: createRepositoryAuthorizationRequestContext(),
+    });
+    expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share denials between request contexts', async () => {
+    const getProjectBySource = vi
+      .fn()
+      .mockResolvedValueOnce({project: null})
+      .mockResolvedValueOnce({
+        project: {
+          id: 'project-1',
+          sourceExternalRepositoryId: 'github:42',
+        },
+      });
+    const authorizer = createRepositoryAuthorizer({
+      projects: createProjects({getProjectBySource}),
+      grants: createGrants(),
+      enabled: true,
+    });
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+
+    await expect(
+      authorizer.resolveRepositoryAuthorization({
+        ...input,
+        request: createRepositoryAuthorizationRequestContext(),
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
+    await expect(
+      authorizer.resolveRepositoryAuthorization({
+        ...input,
+        request: createRepositoryAuthorizationRequestContext(),
+      }),
+    ).resolves.toMatchObject({authorized: true});
+    expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates positive decisions for a connection immediately', async () => {
+    const getProjectBySource = vi.fn().mockResolvedValue({
+      project: {
+        id: 'project-1',
+        sourceExternalRepositoryId: 'github:42',
+      },
+    });
+    const authorizer = createRepositoryAuthorizer({
+      projects: createProjects({getProjectBySource}),
+      grants: createGrants(),
+      enabled: true,
+    });
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+
+    await expect(authorizer.resolveRepositoryAuthorization(input)).resolves.toMatchObject({
+      authorized: true,
+    });
+    getProjectBySource.mockResolvedValue({project: null});
+    authorizer.invalidateRepositoryAuthorizationCache?.(connectionId);
+
+    await expect(authorizer.resolveRepositoryAuthorization(input)).resolves.toEqual({
+      authorized: false,
+      reason: 'repository_not_granted',
     });
     expect(getProjectBySource).toHaveBeenCalledTimes(2);
   });

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -377,6 +377,27 @@ describe('repository authorization', () => {
     ).resolves.toEqual({authorized: false, reason: 'authorization_store_unavailable'});
   });
 
+  it.each([
+    'getByExternalId',
+    'listByName',
+  ] as const)('distinguishes a %s grant-store failure from a repository denial', async (method) => {
+    const grants = createGrants({
+      [method]: vi.fn().mockRejectedValue(new Error('grant store unavailable')),
+    });
+    const repository =
+      method === 'getByExternalId'
+        ? {kind: 'external-id' as const, externalRepositoryId: 'github:42'}
+        : {kind: 'name' as const, owner: 'shipfox', name: 'platform'};
+
+    await expect(
+      resolveRepositoryAuthorization({
+        projects: createProjects(),
+        grants,
+        ...selectedInput(repository),
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'authorization_store_unavailable'});
+  });
+
   it('accepts valid all-mode declarations without consulting Projects', async () => {
     const projects = createProjects({
       getProjectBySource: vi.fn().mockRejectedValue(new Error('must not be called')),
@@ -527,6 +548,94 @@ describe('repository authorization', () => {
       request: createRepositoryAuthorizationRequestContext(),
     });
     expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not repopulate a connection cache after invalidation during an in-flight lookup', async () => {
+    let releaseProject:
+      | ((result: {project: {id: string; sourceExternalRepositoryId: string}}) => void)
+      | undefined;
+    const pendingProject = new Promise<{project: {id: string; sourceExternalRepositoryId: string}}>(
+      (resolve) => {
+        releaseProject = resolve;
+      },
+    );
+    const getProjectBySource = vi
+      .fn()
+      .mockReturnValueOnce(pendingProject)
+      .mockResolvedValueOnce({project: null});
+    const authorizer = createRepositoryAuthorizer({
+      projects: createProjects({getProjectBySource}),
+      grants: createGrants(),
+      enabled: true,
+    });
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:42'});
+
+    const inFlight = authorizer.resolveRepositoryAuthorization(input);
+    await vi.waitFor(() => expect(getProjectBySource).toHaveBeenCalledOnce());
+    authorizer.invalidateRepositoryAuthorizationCache?.(connectionId);
+    releaseProject?.({
+      project: {id: 'project-1', sourceExternalRepositoryId: 'github:42'},
+    });
+
+    await expect(inFlight).resolves.toMatchObject({authorized: true});
+    await expect(authorizer.resolveRepositoryAuthorization(input)).resolves.toEqual({
+      authorized: false,
+      reason: 'repository_not_granted',
+    });
+    expect(getProjectBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the oldest positive decision when the cache reaches its configured capacity', async () => {
+    const getProjectBySource = vi.fn(
+      async (input: Parameters<ProjectsModuleClient['getProjectBySource']>[0]) => ({
+        project: {
+          id: input.sourceExternalRepositoryId,
+          workspaceId: input.workspaceId,
+          sourceConnectionId: input.sourceConnectionId,
+          sourceExternalRepositoryId: input.sourceExternalRepositoryId,
+          name: input.sourceExternalRepositoryId,
+        },
+      }),
+    );
+    const authorizer = createRepositoryAuthorizer({
+      projects: createProjects({getProjectBySource}),
+      grants: createGrants(),
+      enabled: true,
+      maxCacheEntries: 1,
+    });
+
+    await authorizer.resolveRepositoryAuthorization(
+      selectedInput({kind: 'external-id', externalRepositoryId: 'github:1'}),
+    );
+    await authorizer.resolveRepositoryAuthorization(
+      selectedInput({kind: 'external-id', externalRepositoryId: 'github:2'}),
+    );
+    await authorizer.resolveRepositoryAuthorization(
+      selectedInput({kind: 'external-id', externalRepositoryId: 'github:1'}),
+    );
+
+    expect(getProjectBySource).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    0,
+    Number.NaN,
+  ])('falls back to a bounded cache for invalid capacity %s', async (maxCacheEntries) => {
+    const getProjectBySource = vi.fn().mockResolvedValue({
+      project: {id: 'project-1', sourceExternalRepositoryId: 'github:1'},
+    });
+    const authorizer = createRepositoryAuthorizer({
+      projects: createProjects({getProjectBySource}),
+      grants: createGrants(),
+      enabled: true,
+      maxCacheEntries,
+    });
+    const input = selectedInput({kind: 'external-id', externalRepositoryId: 'github:1'});
+
+    await authorizer.resolveRepositoryAuthorization(input);
+    await authorizer.resolveRepositoryAuthorization(input);
+
+    expect(getProjectBySource).toHaveBeenCalledOnce();
   });
 
   it('does not share denials between request contexts', async () => {

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -208,9 +208,9 @@ export function createRepositoryAuthorizer({
       const cached = cache.get(key);
       if (cached) return cloneAuthorizationResult(cached);
 
-      const generation = cache.generation(input.connectionId);
+      const generation = cache.generation();
       const result = await resolveRepositoryAuthorization({projects, grants, ...input});
-      if (result.authorized && cache.generation(input.connectionId) === generation) {
+      if (result.authorized && cache.generation() === generation) {
         cache.set(key, input.connectionId, result);
       }
       return result;
@@ -454,7 +454,7 @@ function createSharedAuthorizationCache({
 }): {
   get(key: string): AuthorizedRepositoryAuthorizationResult | undefined;
   set(key: string, connectionId: string, result: AuthorizedRepositoryAuthorizationResult): void;
-  generation(connectionId: string): number;
+  generation(): number;
   invalidate(connectionId: string): void;
 } {
   const entries = new Map<
@@ -465,7 +465,7 @@ function createSharedAuthorizationCache({
       result: AuthorizedRepositoryAuthorizationResult;
     }
   >();
-  const generations = new Map<string, number>();
+  let invalidationGeneration = 0;
   const capacity =
     Number.isSafeInteger(maxCacheEntries) && maxCacheEntries > 0
       ? maxCacheEntries
@@ -502,11 +502,11 @@ function createSharedAuthorizationCache({
         entries.delete(oldest.value);
       }
     },
-    generation(connectionId) {
-      return generations.get(connectionId) ?? 0;
+    generation() {
+      return invalidationGeneration;
     },
     invalidate(connectionId) {
-      generations.set(connectionId, (generations.get(connectionId) ?? 0) + 1);
+      invalidationGeneration += 1;
       for (const [key, entry] of entries) {
         if (entry.connectionId === connectionId) entries.delete(key);
       }

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -9,6 +9,8 @@ const REPOSITORY_PART_UNSAFE_PATTERN = /[\s/:\\]/u;
 const EXTERNAL_REPOSITORY_VALUE_UNSAFE_PATTERN = /\s/u;
 // Keep every outage retryable while bounding the Sentry volume process-wide.
 const REPOSITORY_AUTHORIZATION_REPORT_INTERVAL_MS = 60_000;
+const REPOSITORY_AUTHORIZATION_CACHE_TTL_MS = 30_000;
+const DEFAULT_REPOSITORY_AUTHORIZATION_CACHE_SIZE = 256;
 let lastRepositoryAuthorizationReportAt = Number.NEGATIVE_INFINITY;
 
 export type RepositoryAuthorizationMode = IntegrationConnectionRepositoryAccessMode;
@@ -85,11 +87,33 @@ export interface ResolveRepositoryAuthorizationInput {
 
 export interface ResolveRepositoryAuthorizationParams extends ResolveRepositoryAuthorizationInput {
   projects: ProjectsModuleClient;
+  grants?: RepositoryAuthorizationGrantStore | undefined;
+}
+
+export interface RepositoryAuthorizationGrant {
+  externalRepositoryId: string;
+  repositoryOwner: string;
+  repositoryName: string;
+}
+
+export interface RepositoryAuthorizationGrantStore {
+  getByExternalId(input: {
+    connectionId: string;
+    externalRepositoryId: string;
+  }): Promise<RepositoryAuthorizationGrant | undefined>;
+  listByName(input: {
+    connectionId: string;
+    repositoryOwner: string;
+    repositoryName: string;
+  }): Promise<readonly RepositoryAuthorizationGrant[]>;
 }
 
 export interface CreateRepositoryAuthorizerOptions {
   projects?: ProjectsModuleClient | undefined;
+  grants?: RepositoryAuthorizationGrantStore | undefined;
   enabled?: boolean | undefined;
+  now?: (() => number) | undefined;
+  maxCacheEntries?: number | undefined;
 }
 
 export interface RepositoryAuthorizer {
@@ -97,6 +121,7 @@ export interface RepositoryAuthorizer {
   resolveRepositoryAuthorization(
     input: ResolveRepositoryAuthorizationInput,
   ): Promise<RepositoryAuthorizationResult | undefined>;
+  invalidateRepositoryAuthorizationCache?: (connectionId: string) => void;
 }
 
 export class RepositoryAuthorizationTargetInvalidError extends Error {
@@ -107,12 +132,13 @@ export class RepositoryAuthorizationTargetInvalidError extends Error {
 }
 
 /**
- * Resolves a repository declaration against local project state. This function
- * accepts only the Projects contract; provider adapters are deliberately not
- * part of the authorization boundary.
+ * Resolves a repository declaration against local project and integration-owned
+ * grant state. Provider adapters are deliberately not part of the authorization
+ * boundary.
  */
 export async function resolveRepositoryAuthorization({
   projects,
+  grants,
   request,
   ...input
 }: ResolveRepositoryAuthorizationParams): Promise<RepositoryAuthorizationResult> {
@@ -122,7 +148,7 @@ export async function resolveRepositoryAuthorization({
     return authorizeAllMode(input.repository);
   }
 
-  const resolve = () => resolveSelectedMode({projects, ...input});
+  const resolve = () => resolveSelectedMode({projects, grants, ...input});
   if (!request) return await resolve();
 
   const key = authorizationMemoKey(input);
@@ -153,7 +179,10 @@ export async function resolveRepositoryAuthorization({
  */
 export function createRepositoryAuthorizer({
   projects,
+  grants,
   enabled = false,
+  now = Date.now,
+  maxCacheEntries = DEFAULT_REPOSITORY_AUTHORIZATION_CACHE_SIZE,
 }: CreateRepositoryAuthorizerOptions): RepositoryAuthorizer {
   if (!enabled) {
     return {
@@ -165,64 +194,93 @@ export function createRepositoryAuthorizer({
   }
   if (!projects) throw new RepositoryAuthorizerConfigurationError();
 
+  const cache = createSharedAuthorizationCache({now, maxCacheEntries});
+
   return {
     enabled: true,
     async resolveRepositoryAuthorization(input) {
-      return await resolveRepositoryAuthorization({projects, ...input});
+      assertValidTarget(input.repository, input.mode);
+      if (input.mode === 'all') {
+        return await resolveRepositoryAuthorization({projects, grants, ...input});
+      }
+
+      const key = authorizationSharedCacheKey(input);
+      const cached = cache.get(key);
+      if (cached) return cloneAuthorizationResult(cached);
+
+      const generation = cache.generation(input.connectionId);
+      const result = await resolveRepositoryAuthorization({projects, grants, ...input});
+      if (result.authorized && cache.generation(input.connectionId) === generation) {
+        cache.set(key, input.connectionId, result);
+      }
+      return result;
+    },
+    invalidateRepositoryAuthorizationCache(connectionId) {
+      cache.invalidate(connectionId);
     },
   };
 }
 
 async function resolveSelectedMode({
   projects,
+  grants,
   workspaceId,
   connectionId,
   repository,
 }: Pick<
   ResolveRepositoryAuthorizationParams,
-  'projects' | 'workspaceId' | 'connectionId' | 'repository'
+  'projects' | 'grants' | 'workspaceId' | 'connectionId' | 'repository'
 >): Promise<RepositoryAuthorizationResult> {
   if (repository.kind === 'external-id') {
-    let projectResult: Awaited<ReturnType<ProjectsModuleClient['getProjectBySource']>>;
     try {
-      projectResult = await projects.getProjectBySource({
-        workspaceId,
-        sourceConnectionId: connectionId,
-        sourceExternalRepositoryId: repository.externalRepositoryId,
-      });
+      const [projectResult, grant] = await Promise.all([
+        projects.getProjectBySource({
+          workspaceId,
+          sourceConnectionId: connectionId,
+          sourceExternalRepositoryId: repository.externalRepositoryId,
+        }),
+        grants?.getByExternalId({
+          connectionId,
+          externalRepositoryId: repository.externalRepositoryId,
+        }) ?? Promise.resolve(undefined),
+      ]);
+
+      const candidates = new Map<string, RepositoryAuthorizationCandidate>();
+      if (projectResult.project)
+        addCandidate(candidates, projectToCandidate(projectResult.project));
+      if (grant) addCandidate(candidates, grantToCandidate(grant));
+      return authorizeCandidates(candidates);
     } catch (error) {
       return storeUnavailable(error, repository.kind);
     }
-
-    return projectResult.project
-      ? authorizeProject(projectResult.project)
-      : deny('repository_not_granted');
   }
 
-  let projectResult: Awaited<ReturnType<ProjectsModuleClient['findProjectBySourceRepositoryName']>>;
   try {
-    projectResult = await projects.findProjectBySourceRepositoryName({
-      workspaceId,
-      sourceConnectionId: connectionId,
-      sourceRepositoryOwner: repository.owner,
-      sourceRepositoryName: repository.name,
-    });
+    const [projectResult, grantsResult] = await Promise.all([
+      projects.findProjectBySourceRepositoryName({
+        workspaceId,
+        sourceConnectionId: connectionId,
+        sourceRepositoryOwner: repository.owner,
+        sourceRepositoryName: repository.name,
+      }),
+      grants?.listByName({
+        connectionId,
+        repositoryOwner: repository.owner,
+        repositoryName: repository.name,
+      }) ?? Promise.resolve([]),
+    ]);
+
+    const candidates = new Map<string, RepositoryAuthorizationCandidate>();
+    for (const project of projectResult.projects) {
+      addCandidate(candidates, projectToCandidate(project));
+    }
+    for (const grant of grantsResult) {
+      addCandidate(candidates, grantToCandidate(grant));
+    }
+    return authorizeCandidates(candidates);
   } catch (error) {
     return storeUnavailable(error, repository.kind);
   }
-
-  const projectsByRepositoryId = new Map<string, (typeof projectResult.projects)[number]>();
-  for (const project of projectResult.projects) {
-    if (!projectsByRepositoryId.has(project.sourceExternalRepositoryId)) {
-      projectsByRepositoryId.set(project.sourceExternalRepositoryId, project);
-    }
-  }
-
-  if (projectsByRepositoryId.size === 0) return deny('repository_not_granted');
-  if (projectsByRepositoryId.size > 1) return deny('repository_ambiguous');
-
-  const project = projectsByRepositoryId.values().next().value;
-  return project ? authorizeProject(project) : deny('repository_not_granted');
 }
 
 function storeUnavailable(
@@ -267,20 +325,72 @@ function authorizeAllMode(
   };
 }
 
-function authorizeProject(project: {
+interface RepositoryAuthorizationCandidate {
+  externalRepositoryId: string;
+  owner?: string | undefined;
+  name?: string | undefined;
+  targetProjectId?: string | undefined;
+}
+
+function projectToCandidate(project: {
   id: string;
   sourceExternalRepositoryId: string;
   sourceRepositoryOwner?: string | null | undefined;
   sourceRepositoryName?: string | null | undefined;
-}): RepositoryAuthorizationResult {
+}): RepositoryAuthorizationCandidate {
+  return {
+    externalRepositoryId: project.sourceExternalRepositoryId,
+    ...(project.sourceRepositoryOwner == null ? {} : {owner: project.sourceRepositoryOwner}),
+    ...(project.sourceRepositoryName == null ? {} : {name: project.sourceRepositoryName}),
+    targetProjectId: project.id,
+  };
+}
+
+function grantToCandidate(grant: RepositoryAuthorizationGrant): RepositoryAuthorizationCandidate {
+  return {
+    externalRepositoryId: grant.externalRepositoryId,
+    owner: grant.repositoryOwner,
+    name: grant.repositoryName,
+  };
+}
+
+function addCandidate(
+  candidates: Map<string, RepositoryAuthorizationCandidate>,
+  candidate: RepositoryAuthorizationCandidate,
+): void {
+  const existing = candidates.get(candidate.externalRepositoryId);
+  if (!existing) {
+    candidates.set(candidate.externalRepositoryId, candidate);
+    return;
+  }
+
+  candidates.set(candidate.externalRepositoryId, {
+    externalRepositoryId: candidate.externalRepositoryId,
+    owner: existing.owner ?? candidate.owner,
+    name: existing.name ?? candidate.name,
+    targetProjectId: existing.targetProjectId ?? candidate.targetProjectId,
+  });
+}
+
+function authorizeCandidates(
+  candidates: Map<string, RepositoryAuthorizationCandidate>,
+): RepositoryAuthorizationResult {
+  if (candidates.size === 0) return deny('repository_not_granted');
+  if (candidates.size > 1) return deny('repository_ambiguous');
+
+  const candidate = candidates.values().next().value;
+  if (!candidate) return deny('repository_not_granted');
+
   return {
     authorized: true,
     repository: {
-      externalRepositoryId: project.sourceExternalRepositoryId,
-      ...(project.sourceRepositoryOwner == null ? {} : {owner: project.sourceRepositoryOwner}),
-      ...(project.sourceRepositoryName == null ? {} : {name: project.sourceRepositoryName}),
+      externalRepositoryId: candidate.externalRepositoryId,
+      ...(candidate.owner === undefined ? {} : {owner: candidate.owner}),
+      ...(candidate.name === undefined ? {} : {name: candidate.name}),
     },
-    targetProjectId: project.id,
+    ...(candidate.targetProjectId === undefined
+      ? {}
+      : {targetProjectId: candidate.targetProjectId}),
   };
 }
 
@@ -300,10 +410,108 @@ function authorizationMemoKey({
     connectionId,
     mode,
     capability,
-    repository.kind === 'external-id'
-      ? [repository.kind, repository.externalRepositoryId]
-      : [repository.kind, repository.owner.toLowerCase(), repository.name.toLowerCase()],
+    normalizedRepositoryTarget(repository),
   ]);
+}
+
+function authorizationSharedCacheKey({
+  connectionId,
+  mode,
+  repository,
+}: Pick<ResolveRepositoryAuthorizationInput, 'connectionId' | 'mode' | 'repository'>): string {
+  return JSON.stringify([connectionId, mode, normalizedRepositoryTarget(repository)]);
+}
+
+function normalizedRepositoryTarget(
+  repository: RepositoryAuthorizationTarget,
+): readonly [string, ...string[]] {
+  return repository.kind === 'external-id'
+    ? [repository.kind, repository.externalRepositoryId]
+    : [repository.kind, repository.owner.toLowerCase(), repository.name.toLowerCase()];
+}
+
+type AuthorizedRepositoryAuthorizationResult = Extract<
+  RepositoryAuthorizationResult,
+  {authorized: true}
+>;
+
+function cloneAuthorizationResult(
+  result: AuthorizedRepositoryAuthorizationResult,
+): AuthorizedRepositoryAuthorizationResult {
+  return {
+    authorized: true,
+    repository: {...result.repository},
+    ...(result.targetProjectId === undefined ? {} : {targetProjectId: result.targetProjectId}),
+  };
+}
+
+function createSharedAuthorizationCache({
+  now,
+  maxCacheEntries,
+}: {
+  now: () => number;
+  maxCacheEntries: number;
+}): {
+  get(key: string): AuthorizedRepositoryAuthorizationResult | undefined;
+  set(key: string, connectionId: string, result: AuthorizedRepositoryAuthorizationResult): void;
+  generation(connectionId: string): number;
+  invalidate(connectionId: string): void;
+} {
+  const entries = new Map<
+    string,
+    {
+      connectionId: string;
+      expiresAt: number;
+      result: AuthorizedRepositoryAuthorizationResult;
+    }
+  >();
+  const generations = new Map<string, number>();
+  const capacity =
+    Number.isSafeInteger(maxCacheEntries) && maxCacheEntries > 0
+      ? maxCacheEntries
+      : DEFAULT_REPOSITORY_AUTHORIZATION_CACHE_SIZE;
+
+  function removeExpired(currentTime: number): void {
+    for (const [key, entry] of entries) {
+      if (entry.expiresAt <= currentTime) entries.delete(key);
+    }
+  }
+
+  return {
+    get(key) {
+      const currentTime = now();
+      const entry = entries.get(key);
+      if (!entry) return undefined;
+      if (entry.expiresAt <= currentTime) {
+        entries.delete(key);
+        return undefined;
+      }
+      return entry.result;
+    },
+    set(key, connectionId, result) {
+      removeExpired(now());
+      entries.delete(key);
+      entries.set(key, {
+        connectionId,
+        expiresAt: now() + REPOSITORY_AUTHORIZATION_CACHE_TTL_MS,
+        result: cloneAuthorizationResult(result),
+      });
+      while (entries.size > capacity) {
+        const oldest = entries.keys().next();
+        if (oldest.done) break;
+        entries.delete(oldest.value);
+      }
+    },
+    generation(connectionId) {
+      return generations.get(connectionId) ?? 0;
+    },
+    invalidate(connectionId) {
+      generations.set(connectionId, (generations.get(connectionId) ?? 0) + 1);
+      for (const [key, entry] of entries) {
+        if (entry.connectionId === connectionId) entries.delete(key);
+      }
+    },
+  };
 }
 
 function assertValidTarget(

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -1,4 +1,5 @@
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import type {IntegrationConnection} from './entities/connection.js';
 import {
   IntegrationCheckoutUnsupportedError,
   IntegrationProviderError,
@@ -45,6 +46,7 @@ describe('integration source-control service', () => {
       omitCheckoutSpec?: boolean;
       repositoryAuthorizer?: RepositoryAuthorizer;
       getRepositoryAuthorizationMode?: () => 'selected' | 'all';
+      connection?: IntegrationConnection;
     } = {},
   ) {
     const sourceControl: SourceControlProvider = {
@@ -93,7 +95,8 @@ describe('integration source-control service', () => {
       ]),
       getIntegrationConnectionById: async (connectionId) => {
         await Promise.resolve();
-        return connectionId === connection.id ? connection : undefined;
+        const activeConnection = options.connection ?? connection;
+        return connectionId === activeConnection.id ? activeConnection : undefined;
       },
       repositoryAuthorizer: options.repositoryAuthorizer,
       getRepositoryAuthorizationMode: options.getRepositoryAuthorizationMode,
@@ -343,6 +346,42 @@ describe('integration source-control service', () => {
       capability: 'checkout',
     });
     expect(createCheckoutSpec).not.toHaveBeenCalled();
+  });
+
+  it('uses the persisted connection repository mode by default', async () => {
+    const allModeConnection = {...connection, repositoryAccessMode: 'all' as const};
+    const createCheckoutSpec = vi.fn(async () => ({
+      repositoryUrl: repository.cloneUrl,
+      ref: repository.defaultBranch,
+    }));
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: true,
+      repository: {externalRepositoryId: repository.externalRepositoryId},
+    } as const);
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        connection: allModeConnection,
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      target: {kind: 'external-id', externalRepositoryId: repository.externalRepositoryId},
+    });
+
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith({
+      workspaceId,
+      connectionId: connection.id,
+      mode: 'all',
+      repository: {kind: 'external-id', externalRepositoryId: repository.externalRepositoryId},
+      capability: 'checkout',
+    });
   });
 
   it('authorizes checkout credentials before calling the provider', async () => {

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -107,7 +107,7 @@ export interface CreateIntegrationSourceControlServiceOptions {
     connectionId: string,
   ) => Promise<IntegrationConnection | undefined>;
   repositoryAuthorizer?: RepositoryAuthorizer | undefined;
-  /** Trusted server-side seam for the future per-connection repository mode. */
+  /** Trusted server-side seam for overriding the persisted per-connection repository mode. */
   getRepositoryAuthorizationMode?:
     | ((
         connection: IntegrationConnection,
@@ -119,7 +119,7 @@ export function createSourceControlIntegrationService({
   registry,
   getIntegrationConnectionById,
   repositoryAuthorizer,
-  getRepositoryAuthorizationMode = () => 'selected',
+  getRepositoryAuthorizationMode = (connection) => connection.repositoryAccessMode,
 }: CreateIntegrationSourceControlServiceOptions): IntegrationSourceControlService {
   async function getConnection(connectionId: string): Promise<IntegrationConnection> {
     const connection = await getIntegrationConnectionById(connectionId);

--- a/libs/api/integration/core/src/core/tool-call-service.test.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.test.ts
@@ -663,6 +663,45 @@ describe('callIntegrationTool', () => {
     );
   });
 
+  it('uses the persisted connection repository mode when no override is supplied', async () => {
+    const entry = catalogWithRepositoryScope(declaredRepositoryScope);
+    const resolveRepositoryAuthorization = vi.fn(
+      async (): Promise<RepositoryAuthorizationResult> => ({
+        authorized: true,
+        repository: {owner: 'shipfox', name: 'platform'},
+      }),
+    );
+    const repositoryAuthorizer: RepositoryAuthorizer = {
+      enabled: true,
+      resolveRepositoryAuthorization,
+    };
+    const registry = registryWithAgentTools([entry], {repositoryAuthorization: 'enforced'});
+
+    const result = await callIntegrationTool(
+      createInput(
+        {},
+        {
+          registry,
+          catalogEntry: entry,
+          connection: connection({
+            id: 'connection-1',
+            workspaceId: 'workspace-1',
+            repositoryAccessMode: 'all',
+          }),
+          repositoryAuthorizer,
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      authorization: {repositoryAccess: 'all', decision: 'allowed'},
+    });
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({mode: 'all'}),
+    );
+  });
+
   it('keeps an explicit-repository connection scope available in all mode', async () => {
     const onOpenSession = vi.fn();
     const entry = catalogTool({

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -77,7 +77,7 @@ export interface IntegrationToolCallInput {
   caller: IntegrationToolCallCaller;
   /** Live catalog metadata used by the shared repository-scope boundary. */
   catalogEntry?: AgentToolCatalogEntry | undefined;
-  /** The persisted connection mode will be threaded here when the authorization boundary consumes it. */
+  /** Trusted override for the persisted connection mode, primarily for callers and tests. */
   repositoryAccessMode?: RepositoryAuthorizationMode | undefined;
   repositoryAuthorizer?: RepositoryAuthorizer | undefined;
   /** Cooperative cancellation for one call; an abort maps to `provider-timeout`. */
@@ -216,7 +216,7 @@ async function resolveIntegrationToolAuthorization(
   input: IntegrationToolCallInput,
   catalogEntry: AgentToolCatalogEntry | undefined,
 ): Promise<IntegrationToolCallAuthorization> {
-  const mode = input.repositoryAccessMode ?? 'selected';
+  const mode = input.repositoryAccessMode ?? input.connection.repositoryAccessMode;
   const provider = input.registry.get(input.integration.provider);
   const scope = classifyToolCall(
     catalogEntry,

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -1,7 +1,11 @@
 import type {StoredWebhookRequest, WebhookRequestProcessor} from '@shipfox/api-integration-spi';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {createOutboxRegistry, type ModuleService, startModuleServices} from '@shipfox/node-module';
-import {createIntegrationsContext, WebhookProcessorNotConfiguredError} from './index.js';
+import {
+  createIntegrationsContext,
+  type RepositoryAuthorizationGrantStore,
+  WebhookProcessorNotConfiguredError,
+} from './index.js';
 
 const request = {
   schema_version: 1,
@@ -154,6 +158,10 @@ describe('createIntegrationsContext', () => {
       getProjectBySource,
       findProjectBySourceRepositoryName: vi.fn(),
     } as unknown as ProjectsModuleClient;
+    const repositoryGrants: RepositoryAuthorizationGrantStore = {
+      getByExternalId: vi.fn().mockResolvedValue(undefined),
+      listByName: vi.fn().mockResolvedValue([]),
+    };
     const workspaceId = crypto.randomUUID();
     const connection = {
       id: crypto.randomUUID(),
@@ -198,6 +206,7 @@ describe('createIntegrationsContext', () => {
           },
         ],
         projects,
+        repositoryGrants,
         getIntegrationConnectionById,
       });
 

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -290,6 +290,14 @@ export async function createIntegrationsModule(
 export async function createIntegrationsContext(
   options: CreateIntegrationsModuleOptions = {},
 ): Promise<IntegrationsContext> {
+  const repositoryAuthorizer = createRepositoryAuthorizer({
+    projects: options.projects,
+    grants: options.repositoryGrants ?? {
+      getByExternalId: getIntegrationConnectionRepositoryGrant,
+      listByName: listIntegrationConnectionRepositoryGrantsByName,
+    },
+    enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
+  });
   const workspaces = options.workspaces;
   const parts: IntegrationModuleParts[] =
     options.parts ??
@@ -315,19 +323,13 @@ export async function createIntegrationsContext(
                   }),
               }
             : {}),
+          invalidateRepositoryAuthorizationCache:
+            repositoryAuthorizer.invalidateRepositoryAuthorizationCache,
         }));
 
   const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
   const resolveIntegrationConnectionById =
     options.getIntegrationConnectionById ?? getIntegrationConnectionById;
-  const repositoryAuthorizer = createRepositoryAuthorizer({
-    projects: options.projects,
-    grants: options.repositoryGrants ?? {
-      getByExternalId: getIntegrationConnectionRepositoryGrant,
-      listByName: listIntegrationConnectionRepositoryGrantsByName,
-    },
-    enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
-  });
   const sourceControl = createSourceControlIntegrationService({
     registry,
     getIntegrationConnectionById: resolveIntegrationConnectionById,

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -22,6 +22,7 @@ import {
 } from '#core/providers/registry.js';
 import {
   createRepositoryAuthorizer,
+  type RepositoryAuthorizationGrantStore,
   type RepositoryAuthorizer,
 } from '#core/repository-authorizer.js';
 import {
@@ -34,6 +35,10 @@ import {
 } from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
+import {
+  getIntegrationConnectionRepositoryGrant,
+  listIntegrationConnectionRepositoryGrantsByName,
+} from '#db/repository-grants.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
 import {createIntegrationsInterModulePresentation} from '#presentation/inter-module.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
@@ -147,6 +152,8 @@ export type {
   RepositoryAuthorizationClientErrorCode,
   RepositoryAuthorizationDenial,
   RepositoryAuthorizationExternalIdTarget,
+  RepositoryAuthorizationGrant,
+  RepositoryAuthorizationGrantStore,
   RepositoryAuthorizationMode,
   RepositoryAuthorizationNameTarget,
   RepositoryAuthorizationRequestContext,
@@ -235,6 +242,8 @@ export interface CreateIntegrationsModuleOptions {
   parts?: IntegrationModuleParts[] | undefined;
   secrets?: IntegrationProviderSecrets | undefined;
   projects?: ProjectsModuleClient | undefined;
+  /** Test seam for composing repository authorization without the grants database. */
+  repositoryGrants?: RepositoryAuthorizationGrantStore | undefined;
   /** Test seam for composing checkout authorization without a database connection. */
   getIntegrationConnectionById?: GetIntegrationConnectionByIdFn | undefined;
   workspaces?: WorkspacesInterModuleClient | undefined;
@@ -313,6 +322,10 @@ export async function createIntegrationsContext(
     options.getIntegrationConnectionById ?? getIntegrationConnectionById;
   const repositoryAuthorizer = createRepositoryAuthorizer({
     projects: options.projects,
+    grants: options.repositoryGrants ?? {
+      getByExternalId: getIntegrationConnectionRepositoryGrant,
+      listByName: listIntegrationConnectionRepositoryGrantsByName,
+    },
     enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
   });
   const sourceControl = createSourceControlIntegrationService({

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -161,6 +161,7 @@ async function loadGithubModuleParts(
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,
+    invalidateRepositoryAuthorizationCache: options.invalidateRepositoryAuthorizationCache,
     coreDb: db,
     deleteSecrets: options.secrets?.deleteSecrets,
     checkoutTokenCache,

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -40,6 +40,8 @@ export interface IntegrationProviderModule {
 
 export interface IntegrationProviderModuleLoadOptions {
   secrets?: IntegrationProviderSecrets | undefined;
+  /** Invalidates local repository authorization decisions after committed provider-owned changes. */
+  invalidateRepositoryAuthorizationCache?: ((connectionId: string) => void) | undefined;
   requireActiveWorkspaceMembership?:
     | ((input: {
         workspaceId: string;

--- a/libs/api/integration/github/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.test.ts
@@ -42,6 +42,22 @@ function signedInstallationRequest(deliveryId: string, installationId: number) {
   });
 }
 
+function signedRequest(deliveryId: string, event: string, payload: unknown) {
+  const body = Buffer.from(JSON.stringify(payload));
+  return createStoredWebhookRequest({
+    requestId: randomUUID(),
+    routeId: 'github',
+    receivedAt: new Date().toISOString(),
+    rawQueryString: '',
+    headers: {
+      'x-github-delivery': deliveryId,
+      'x-github-event': event,
+      'x-hub-signature-256': `sha256=${createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex')}`,
+    },
+    body,
+  });
+}
+
 describe('GitHub webhook processor', () => {
   beforeEach(async () => {
     await db().delete(githubInstallations);
@@ -167,5 +183,42 @@ describe('GitHub webhook processor', () => {
       workspaceId: connection.workspaceId,
       installationId,
     });
+  });
+
+  it('invalidates repository authorization after a repository mutation commits', async () => {
+    const installationId = 8413;
+    const connectionId = randomUUID();
+    const connection = fakeConnection(connectionId);
+    await githubInstallationFactory.create({
+      connectionId,
+      installationId: String(installationId),
+    });
+    const deliveryId = randomUUID();
+    const invalidateRepositoryAuthorizationCache = vi.fn();
+    const processor = createGithubWebhookProcessor({
+      coreDb: db,
+      publishIntegrationEventReceived: vi.fn(),
+      publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: true})),
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+      invalidateRepositoryAuthorizationCache,
+    });
+
+    const result = await processor.process(
+      signedRequest(deliveryId, 'repository', {
+        action: 'deleted',
+        installation: {id: installationId},
+        repository: {
+          id: 42,
+          name: 'platform',
+          owner: {login: 'acme'},
+          default_branch: 'main',
+        },
+      }),
+    );
+
+    expect(result).toEqual({outcome: 'processed', deliveryId});
+    expect(invalidateRepositoryAuthorizationCache).toHaveBeenCalledWith(connectionId);
   });
 });

--- a/libs/api/integration/github/src/core/webhook-processor.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.ts
@@ -26,6 +26,8 @@ export interface CreateGithubWebhookProcessorOptions {
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  /** Invalidates local repository authorization decisions after the delivery transaction commits. */
+  invalidateRepositoryAuthorizationCache?: ((connectionId: string) => void) | undefined;
   deleteInstallationTokenSecret?:
     | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
     | undefined;
@@ -89,6 +91,12 @@ async function processGithubWebhookRequest(
       getIntegrationConnectionById: options.getIntegrationConnectionById,
     }),
   );
+
+  if (result.repositoryAuthorizationCacheInvalidationConnectionId !== undefined) {
+    options.invalidateRepositoryAuthorizationCache?.(
+      result.repositoryAuthorizationCacheInvalidationConnectionId,
+    );
+  }
 
   if (result.installationTokenCleanup && options.deleteInstallationTokenSecret) {
     await options.deleteInstallationTokenSecret(result.installationTokenCleanup);

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -54,6 +54,7 @@ export type HandleGithubEventOutcome =
 export interface HandleGithubEventResult {
   outcome: HandleGithubEventOutcome;
   installationTokenCleanup?: {workspaceId: string; installationId: number} | undefined;
+  repositoryAuthorizationCacheInvalidationConnectionId?: string | undefined;
 }
 
 function isBranchDeletion(after: string): boolean {
@@ -158,7 +159,12 @@ async function dispatchGithubEvent(
       removedRepositories: repositoryChanges.removedRepositories,
     });
     return withInstallationTokenCleanup(
-      {outcome: result.published ? 'published' : 'duplicate'},
+      {
+        outcome: result.published ? 'published' : 'duplicate',
+        ...(result.published
+          ? {repositoryAuthorizationCacheInvalidationConnectionId: connection.id}
+          : {}),
+      },
       params.event,
       action,
       connection.workspaceId,

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -105,6 +105,8 @@ export interface CreateGithubIntegrationProviderOptions
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  /** Invalidates local repository authorization decisions after a committed webhook mutation. */
+  invalidateRepositoryAuthorizationCache?: ((connectionId: string) => void) | undefined;
   getGithubInstallationByConnectionId?: typeof getGithubInstallationByConnectionId | undefined;
   getGithubInstallationByInstallationId?: typeof getGithubInstallationByInstallationId | undefined;
   deleteSecrets?:


### PR DESCRIPTION
## Summary

Repository authorization now consumes the persisted connection access mode and evaluates selected repositories against both project associations and connection-owned manual grants. Matching project and grant provenance is deduplicated by external repository ID, while distinct IDs remain ambiguous and denied.

Positive decisions use a bounded 30-second cache keyed by connection, mode, and normalized target. Denials remain request-scoped, and integration-owned writers have a connection-scoped invalidation seam for immediate local revocation.

## Validation

- `mise exec -- turbo type --filter=@shipfox/api-integration-core...`
- `mise exec -- turbo check --filter=@shipfox/api-integration-core...`
- `mise exec -- turbo test --filter=@shipfox/api-integration-core...`
- `mise exec -- pnpm check:api-database-boundaries`
- `git diff --check origin/main...HEAD`

Closes ENG-1831

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repository authorization now enforces the persisted connection access mode instead of defaulting to `selected`, and selected repositories are authorized against the union of project associations and connection-owned manual grants. Dual provenance is deduplicated by external repository ID; multiple distinct IDs remain ambiguous and denied. Positive decisions are cached for 30 seconds per connection and mode with an immediate local invalidation seam, while denials stay request-scoped and `all` mode skips Projects and grant lookups entirely. GitHub repository webhooks invalidate the cache after committed mutations.

The optional mode override and tool-call `repositoryAccessMode` now default to the persisted connection value when not supplied.

Closes ENG-1831

<sup>Written for commit ba2af84c9c0cf73dc7f7796e6ca315262ce26528. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

