### PR TITLE
Add Gitea tool-step E2E coverage

### DIFF
--- a/.changeset/tool-gate-outputs.md
+++ b/.changeset/tool-gate-outputs.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-workflows': patch
+---
+
+Allows tool-step gates to evaluate provider outputs without an exit code.

--- a/.changeset/tool-gate-outputs.md
+++ b/.changeset/tool-gate-outputs.md
@@ -2,4 +2,4 @@
 '@shipfox/api-workflows': patch
 ---
 
-Allows tool-step gates to evaluate provider outputs without an exit code.
+Enforces tool-step gates against provider outputs without an exit code and keeps failed provider calls from rewinding.

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -35,7 +35,7 @@ MAILER_FROM=noreply@shipfox.local
 # Integrations
 INTEGRATIONS_ENABLE_DEBUG_PROVIDER=true
 
-# Bundled local Gitea; credentials match the read-only bot from dev/gitea/bootstrap.sh.
+# Bundled local Gitea; credentials match the scoped bot from dev/gitea/bootstrap.sh.
 INTEGRATIONS_ENABLE_GITEA_PROVIDER=true
 GITEA_BASE_URL=http://localhost:3000
 GITEA_SERVICE_USERNAME=shipfox-bot

--- a/dev/gitea/README.md
+++ b/dev/gitea/README.md
@@ -53,8 +53,15 @@ delivers a webhook to the API, verified against `GITEA_WEBHOOK_SECRET`.
 ## Re-seeding
 
 `gitea-init` skips anything that already exists, so `docker compose up` is safe to
-re-run. To start from a clean slate, remove the `gitea` volume (Compose prefixes it
-with the project name, which defaults to the repo directory name):
+re-run. If the stack was created before issue tools were enabled, rerun the bootstrap
+once so it creates the issue-comment-write team:
+
+```sh
+docker compose run --rm gitea-init
+```
+
+To start from a clean slate, remove the `gitea` volume (Compose prefixes it with the
+project name, which defaults to the repo directory name):
 
 ```sh
 docker compose down

--- a/dev/gitea/README.md
+++ b/dev/gitea/README.md
@@ -8,9 +8,9 @@ it uses in production, with no throwaway fake git server.
 
 `docker compose up -d` starts Gitea and runs `gitea-init`, which provisions it over
 the HTTP API (idempotently): a site-admin user, the low-privilege bot user the
-provider authenticates as, a demo org, a read-only team the bot belongs to, the org
-push webhook, and a few seeded repos carrying the demo workflow and code files under
-`dev/gitea/seed/`.
+provider authenticates as, a demo org, code-read and issue-comment-write teams the
+bot belongs to, the org push webhook, and a few seeded repos carrying the demo
+workflow and code files under `dev/gitea/seed/`.
 
 | Setting | Value |
 | -- | -- |
@@ -45,10 +45,10 @@ vantage point:
 
 With `INTEGRATIONS_ENABLE_GITEA_PROVIDER=true` (already set in `apps/api/.env`),
 connect the `shipfox` org through the API to persist the connection. The org
-push webhook is registered by `gitea-init` as admin (the read-only bot cannot manage
-org hooks, so the instance admin owns it). The provider then lists the seeded repos
-and reads their files; a push to Gitea delivers a webhook to the API, verified
-against `GITEA_WEBHOOK_SECRET`.
+push webhook is registered by `gitea-init` as admin (the scoped bot cannot manage org
+hooks, so the instance admin owns it). The provider then lists the seeded repos and
+reads their files; issue tools can read issues and write comments; a push to Gitea
+delivers a webhook to the API, verified against `GITEA_WEBHOOK_SECRET`.
 
 ## Re-seeding
 

--- a/dev/gitea/bootstrap.sh
+++ b/dev/gitea/bootstrap.sh
@@ -15,11 +15,13 @@ BOT_USER="${GITEA_SERVICE_USERNAME:-shipfox-bot}"
 BOT_PASSWORD="${GITEA_SERVICE_TOKEN:-shipfox-bot-dev-password}"
 BOT_EMAIL="${GITEA_BOT_EMAIL:-shipfox-bot@shipfox.local}"
 ORG="${GITEA_ORG:-shipfox}"
-# A read-only team that includes every repo, current and future. It is the bot's
-# only org membership, so a leaked bot credential is bounded to read access on the
-# demo repos rather than the whole instance.
+# Scoped teams that include every repo, current and future. Keeping code read access
+# and issue-comment write access separate means a leaked bot credential cannot push
+# code or manage the org.
 READ_TEAM="shipfox-readers"
-# Webhook setup uses admin credentials because the service account has read-only org access.
+ISSUE_WRITE_TEAM="shipfox-issue-writers"
+# Webhook setup uses admin credentials because the service account's scoped teams do not grant
+# org-hook administration.
 WEBHOOK_TARGET_URL="${GITEA_WEBHOOK_TARGET_URL:-http://host.docker.internal:16101/webhooks/integrations/gitea}"
 WEBHOOK_SECRET="${GITEA_WEBHOOK_SECRET:-shipfox-gitea-dev-webhook-secret}"
 SEED_DIR="${SEED_DIR:-/seed}"
@@ -106,6 +108,18 @@ fi
 # PUT is idempotent: re-adding an existing member is a no-op.
 admin_api PUT "/teams/$team_id/members/$BOT_USER" >/dev/null
 echo "Bot user '$BOT_USER' is a member of read team '$READ_TEAM'."
+
+# Issue tools need to read issues and write comments, but do not need repository
+# code write access. Keep that capability on its own unit-scoped team.
+issue_team_id="$(admin_api GET "/orgs/$ORG/teams" | jq -r --arg name "$ISSUE_WRITE_TEAM" '.[] | select(.name == $name) | .id' | head -n1)"
+if [ -z "$issue_team_id" ]; then
+  issue_team_id="$(admin_api POST "/orgs/$ORG/teams" "$(jq -n --arg name "$ISSUE_WRITE_TEAM" \
+    '{name: $name, permission: "write", includes_all_repositories: true, units: ["repo.issues"]}')" \
+    | jq -r '.id')"
+  echo "Created issue-write team '$ISSUE_WRITE_TEAM' (#$issue_team_id)."
+fi
+admin_api PUT "/teams/$issue_team_id/members/$BOT_USER" >/dev/null
+echo "Bot user '$BOT_USER' is a member of issue-write team '$ISSUE_WRITE_TEAM'."
 
 # Skip an existing hook with the same target so re-runs do not stack duplicate deliveries.
 existing_hook="$(admin_api GET "/orgs/$ORG/hooks" \

--- a/e2e/drivers/gitea/README.md
+++ b/e2e/drivers/gitea/README.md
@@ -1,8 +1,9 @@
 # @shipfox/e2e-driver-gitea
 
 The integration/gitea domain end to end for E2E suites. It drives the external Gitea
-instance with admin credentials (org, team, webhook, repos, commits) and links the org
-to a workspace through the product route. One import gives a scenario a connected org.
+instance with admin credentials (org, scoped teams, webhook, repos, issues, comments,
+commits) and links the org to a workspace through the product route. One import gives
+a scenario a connected org.
 
 Calling Gitea's REST API directly is on purpose: Gitea is the external system under
 integration, exactly like the browser is for client E2E. Everything else goes through
@@ -12,12 +13,16 @@ the platform's public HTTP surface.
 
 Instance side (admin-credentialed, against `E2E_GITEA_URL`):
 
-- `createOrg(params?)`: org + read-only team (`includes_all_repositories`) + bot
-  membership + org push webhook, mirroring `dev/gitea/bootstrap.sh`. Returns
-  `{org, teamId, webhookId}`. A fresh org per suite run is required because an org can
-  only ever be linked to one workspace.
+- `createOrg(params?)`: org + code-read and issue-comment-write teams
+  (`includes_all_repositories`) + bot membership + org push webhook, mirroring
+  `dev/gitea/bootstrap.sh`. Returns `{org, teamId, webhookId}`. A fresh org per suite
+  run is required because an org can only ever be linked to one workspace.
 - `createRepo({org, name, ...})`: create a repo in the org. Returns `{name, fullName,
   cloneUrl, defaultBranch}`.
+- `createIssue({org, repo, title, body?})`: seed an issue in a repo. Returns its
+  `{number, title, body}`.
+- `listIssueComments({org, repo, index})`: read the comments on an issue. Returns
+  `{id, body}` entries for external-state assertions.
 - `commitFiles({org, repo, message, files, branch?})`: one commit for the whole batch
   through Gitea's change-files contents API. Returns the commit SHA. File `content` is
   UTF-8 text; the helper base64-encodes it. `operation` defaults to `create`; `update`
@@ -59,7 +64,7 @@ with no environment set.
 | `E2E_GITEA_URL` | `http://localhost:3000` | Gitea instance, seen from the test host. |
 | `E2E_GITEA_ADMIN_USERNAME` | `gitea-admin` | Site admin the helper authenticates as. |
 | `E2E_GITEA_ADMIN_PASSWORD` | `gitea-admin-dev-password` | Site admin password (Basic auth). |
-| `E2E_GITEA_BOT_USERNAME` | `shipfox-bot` | Read-only bot added to each run org's team. |
+| `E2E_GITEA_BOT_USERNAME` | `shipfox-bot` | Scoped bot added to each run org's code-read and issue-comment-write teams. |
 | `E2E_GITEA_WEBHOOK_SECRET` | `shipfox-gitea-dev-webhook-secret` | Secret on the org push webhook; must match the API's `GITEA_WEBHOOK_SECRET`. |
 | `E2E_API_HOST_FROM_CONTAINER` | `host.docker.internal` | Host the Gitea container uses to reach the API when delivering webhooks. |
 

--- a/e2e/drivers/gitea/src/config.ts
+++ b/e2e/drivers/gitea/src/config.ts
@@ -15,7 +15,7 @@ export const config = createConfig({
     default: 'gitea-admin-dev-password',
   }),
   E2E_GITEA_BOT_USERNAME: str({
-    desc: "Username of the read-only bot added to each run org's team, so the platform service account can read the org's repositories. Matches the value dev/gitea/bootstrap.sh creates.",
+    desc: "Username of the scoped bot added to each run org's code-read and issue-comment-write teams. Matches the value dev/gitea/bootstrap.sh creates.",
     default: 'shipfox-bot',
   }),
   E2E_GITEA_WEBHOOK_SECRET: str({

--- a/e2e/drivers/gitea/src/index.test.ts
+++ b/e2e/drivers/gitea/src/index.test.ts
@@ -12,10 +12,12 @@ describe('createConnectedOrg', () => {
     vi.doMock('./instance.js', () => ({
       bestEffortDeleteOrg,
       commitFiles: vi.fn(),
+      createIssue: vi.fn(),
       createOrg,
       createRepo: vi.fn(),
       deleteOrg: vi.fn(),
       deleteRepo: vi.fn(),
+      listIssueComments: vi.fn(),
     }));
     vi.doMock('./connect.js', () => ({connectGiteaOrg}));
     const {createConnectedOrg} = await import('./index.js');
@@ -44,10 +46,12 @@ describe('createConnectedOrg', () => {
     vi.doMock('./instance.js', () => ({
       bestEffortDeleteOrg,
       commitFiles: vi.fn(),
+      createIssue: vi.fn(),
       createOrg,
       createRepo: vi.fn(),
       deleteOrg: vi.fn(),
       deleteRepo: vi.fn(),
+      listIssueComments: vi.fn(),
     }));
     vi.doMock('./connect.js', () => ({connectGiteaOrg}));
     const {createConnectedOrg} = await import('./index.js');

--- a/e2e/drivers/gitea/src/index.ts
+++ b/e2e/drivers/gitea/src/index.ts
@@ -4,10 +4,12 @@ import {
   bestEffortDeleteOrg,
   type CreatedOrg,
   commitFiles,
+  createIssue,
   createOrg,
   createRepo,
   deleteOrg,
   deleteRepo,
+  listIssueComments,
 } from './instance.js';
 
 export type {CreateGiteaConnectionResponseDto} from '@shipfox/api-integration-gitea-dto';
@@ -17,16 +19,21 @@ export {
   type CommitFile,
   type CommitFileOperation,
   type CommitFilesParams,
+  type CreatedIssue,
   type CreatedOrg,
   type CreatedRepo,
+  type CreateIssueParams,
   type CreateOrgParams,
   type CreateRepoParams,
   commitFiles,
+  createIssue,
   createOrg,
   createRepo,
   deleteOrg,
   deleteRepo,
   generateOrgName,
+  type IssueComment,
+  listIssueComments,
 } from './instance.js';
 
 export interface CreateConnectedOrgParams {
@@ -64,6 +71,8 @@ export function createGiteaHelper() {
   return {
     createOrg,
     createRepo,
+    createIssue,
+    listIssueComments,
     commitFiles,
     deleteRepo,
     deleteOrg,

--- a/e2e/drivers/gitea/src/instance.test.ts
+++ b/e2e/drivers/gitea/src/instance.test.ts
@@ -129,6 +129,48 @@ describe('gitea instance driver', () => {
       method: 'POST',
       json: {title: 'Fixture', body: 'Read me'},
     });
-    expect(giteaFetchJson).toHaveBeenNthCalledWith(2, 'repos/e2e-org/fixture/issues/1/comments');
+    expect(giteaFetchJson).toHaveBeenNthCalledWith(
+      2,
+      'repos/e2e-org/fixture/issues/1/comments?page=1&limit=50',
+    );
+  });
+
+  test('lists issue comments across pages', async () => {
+    const giteaFetch = vi.fn().mockResolvedValue(undefined);
+    const firstPage = Array.from({length: 50}, (_, index) => ({
+      id: index + 1,
+      body: `Comment ${index + 1}`,
+    }));
+    const giteaFetchJson = vi
+      .fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([{id: 51, body: 'Comment 51'}]);
+    vi.doMock('./config.js', () => ({
+      config: {
+        E2E_GITEA_BOT_USERNAME: 'shipfox-bot',
+        E2E_GITEA_WEBHOOK_SECRET: 'webhook-secret',
+      },
+      defaultWebhookTargetUrl: () => 'https://api.example.test/webhook',
+    }));
+    vi.doMock('./gitea-client.js', () => ({
+      encodeSegment: encodeURIComponent,
+      GiteaInstanceError: class GiteaInstanceError extends Error {},
+      giteaFetch,
+      giteaFetchJson,
+    }));
+    const {listIssueComments} = await import('./instance.js');
+
+    await expect(
+      listIssueComments({org: 'e2e-org', repo: 'fixture', index: 1}),
+    ).resolves.toHaveLength(51);
+
+    expect(giteaFetchJson).toHaveBeenNthCalledWith(
+      1,
+      'repos/e2e-org/fixture/issues/1/comments?page=1&limit=50',
+    );
+    expect(giteaFetchJson).toHaveBeenNthCalledWith(
+      2,
+      'repos/e2e-org/fixture/issues/1/comments?page=2&limit=50',
+    );
   });
 });

--- a/e2e/drivers/gitea/src/instance.test.ts
+++ b/e2e/drivers/gitea/src/instance.test.ts
@@ -8,9 +8,13 @@ describe('gitea instance driver', () => {
     vi.unstubAllGlobals();
   });
 
-  test('creates org infrastructure with a read-only bot membership and push webhook', async () => {
+  test('creates org infrastructure with scoped bot memberships and push webhook', async () => {
     const giteaFetch = vi.fn().mockResolvedValue(undefined);
-    const giteaFetchJson = vi.fn().mockResolvedValueOnce({id: 17}).mockResolvedValueOnce({id: 23});
+    const giteaFetchJson = vi
+      .fn()
+      .mockResolvedValueOnce({id: 17})
+      .mockResolvedValueOnce({id: 19})
+      .mockResolvedValueOnce({id: 23});
     vi.doMock('./config.js', () => ({
       config: {
         E2E_GITEA_BOT_USERNAME: 'shipfox-bot',
@@ -42,6 +46,16 @@ describe('gitea instance driver', () => {
       },
     });
     expect(giteaFetch).toHaveBeenCalledWith('teams/17/members/shipfox-bot', {method: 'PUT'});
+    expect(giteaFetchJson).toHaveBeenCalledWith('orgs/e2e-org/teams', {
+      method: 'POST',
+      json: {
+        name: 'shipfox-issue-writers',
+        permission: 'write',
+        includes_all_repositories: true,
+        units: ['repo.issues'],
+      },
+    });
+    expect(giteaFetch).toHaveBeenCalledWith('teams/19/members/shipfox-bot', {method: 'PUT'});
     expect(giteaFetchJson).toHaveBeenCalledWith('orgs/e2e-org/hooks', {
       method: 'POST',
       json: {
@@ -81,5 +95,40 @@ describe('gitea instance driver', () => {
 
     await expect(result).rejects.toBe(error);
     expect(giteaFetch).toHaveBeenCalledWith('orgs/e2e-org', {method: 'DELETE'});
+  });
+
+  test('creates an issue and lists its comments', async () => {
+    const giteaFetch = vi.fn().mockResolvedValue(undefined);
+    const giteaFetchJson = vi
+      .fn()
+      .mockResolvedValueOnce({number: 1, title: 'Fixture', body: 'Read me'})
+      .mockResolvedValueOnce([{id: 23, body: 'Comment landed'}]);
+    vi.doMock('./config.js', () => ({
+      config: {
+        E2E_GITEA_BOT_USERNAME: 'shipfox-bot',
+        E2E_GITEA_WEBHOOK_SECRET: 'webhook-secret',
+      },
+      defaultWebhookTargetUrl: () => 'https://api.example.test/webhook',
+    }));
+    vi.doMock('./gitea-client.js', () => ({
+      encodeSegment: encodeURIComponent,
+      GiteaInstanceError: class GiteaInstanceError extends Error {},
+      giteaFetch,
+      giteaFetchJson,
+    }));
+    const {createIssue, listIssueComments} = await import('./instance.js');
+
+    await expect(
+      createIssue({org: 'e2e-org', repo: 'fixture', title: 'Fixture', body: 'Read me'}),
+    ).resolves.toEqual({number: 1, title: 'Fixture', body: 'Read me'});
+    await expect(listIssueComments({org: 'e2e-org', repo: 'fixture', index: 1})).resolves.toEqual([
+      {id: 23, body: 'Comment landed'},
+    ]);
+
+    expect(giteaFetchJson).toHaveBeenNthCalledWith(1, 'repos/e2e-org/fixture/issues', {
+      method: 'POST',
+      json: {title: 'Fixture', body: 'Read me'},
+    });
+    expect(giteaFetchJson).toHaveBeenNthCalledWith(2, 'repos/e2e-org/fixture/issues/1/comments');
   });
 });

--- a/e2e/drivers/gitea/src/instance.ts
+++ b/e2e/drivers/gitea/src/instance.ts
@@ -2,10 +2,11 @@ import {Buffer} from 'node:buffer';
 import {config, defaultWebhookTargetUrl} from './config.js';
 import {encodeSegment, GiteaInstanceError, giteaFetch, giteaFetchJson} from './gitea-client.js';
 
-// A read-only team that includes every repo, current and future, mirroring
-// dev/gitea/bootstrap.sh: it is the bot's only membership, so a leaked bot
-// credential is bounded to read access on the run's repos.
+// Scoped teams that include every repo, current and future, mirroring
+// dev/gitea/bootstrap.sh. Keeping code read access and issue-comment write access
+// separate means a leaked bot credential cannot push code or manage the org.
 const READ_TEAM_NAME = 'shipfox-readers';
+const ISSUE_WRITE_TEAM_NAME = 'shipfox-issue-writers';
 
 export interface CreateOrgParams {
   name?: string;
@@ -36,6 +37,24 @@ export interface CreatedRepo {
   defaultBranch: string;
 }
 
+export interface CreateIssueParams {
+  org: string;
+  repo: string;
+  title: string;
+  body?: string;
+}
+
+export interface CreatedIssue {
+  number: number;
+  title: string;
+  body: string;
+}
+
+export interface IssueComment {
+  id: number;
+  body: string;
+}
+
 export type CommitFileOperation = 'create' | 'update' | 'delete';
 
 export interface CommitFile {
@@ -57,11 +76,12 @@ export function generateOrgName(): string {
   return `e2e-${crypto.randomUUID().replaceAll('-', '').slice(0, 20)}`;
 }
 
-// Org + read-only team + bot membership + push webhook, mirroring
+// Org + scoped bot memberships + push webhook, mirroring
 // dev/gitea/bootstrap.sh. A fresh org per suite run is required because an org
 // can only ever be linked to one workspace (GiteaOrgAlreadyLinkedError). The org
 // is public so the platform service account can see it exists while its repos
-// stay private, exercising the checkout path's Basic auth.
+// stay private, exercising the checkout path's Basic auth. The bot can read repo
+// code and write issue comments, but cannot push code or manage org hooks.
 export async function createOrg(params: CreateOrgParams = {}): Promise<CreatedOrg> {
   const org = params.name ?? generateOrgName();
 
@@ -86,6 +106,19 @@ export async function createOrg(params: CreateOrgParams = {}): Promise<CreatedOr
 
     const botUsername = params.botUsername ?? config.E2E_GITEA_BOT_USERNAME;
     await giteaFetch(`teams/${team.id}/members/${encodeSegment(botUsername)}`, {method: 'PUT'});
+
+    const issueTeam = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/teams`, {
+      method: 'POST',
+      json: {
+        name: ISSUE_WRITE_TEAM_NAME,
+        permission: 'write',
+        includes_all_repositories: true,
+        units: ['repo.issues'],
+      },
+    });
+    await giteaFetch(`teams/${issueTeam.id}/members/${encodeSegment(botUsername)}`, {
+      method: 'PUT',
+    });
 
     const hook = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/hooks`, {
       method: 'POST',
@@ -130,6 +163,38 @@ export async function createRepo(params: CreateRepoParams): Promise<CreatedRepo>
     cloneUrl: repo.clone_url,
     defaultBranch: repo.default_branch,
   };
+}
+
+export async function createIssue(params: CreateIssueParams): Promise<CreatedIssue> {
+  const issue = await giteaFetchJson<{
+    number: number;
+    title: string;
+    body?: string | null;
+  }>(`repos/${encodeSegment(params.org)}/${encodeSegment(params.repo)}/issues`, {
+    method: 'POST',
+    json: {title: params.title, body: params.body ?? ''},
+  });
+
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? '',
+  };
+}
+
+export async function listIssueComments(params: {
+  org: string;
+  repo: string;
+  index: number;
+}): Promise<IssueComment[]> {
+  const comments = await giteaFetchJson<Array<{id: number; body?: string | null}>>(
+    `repos/${encodeSegment(params.org)}/${encodeSegment(params.repo)}/issues/${params.index}/comments`,
+  );
+
+  return comments.map((comment) => ({
+    id: comment.id,
+    body: comment.body ?? '',
+  }));
 }
 
 // One commit for the whole batch through Gitea's change-files contents API,

--- a/e2e/drivers/gitea/src/instance.ts
+++ b/e2e/drivers/gitea/src/instance.ts
@@ -55,6 +55,8 @@ export interface IssueComment {
   body: string;
 }
 
+const ISSUE_COMMENTS_PAGE_SIZE = 50;
+
 export type CommitFileOperation = 'create' | 'update' | 'delete';
 
 export interface CommitFile {
@@ -187,9 +189,14 @@ export async function listIssueComments(params: {
   repo: string;
   index: number;
 }): Promise<IssueComment[]> {
-  const comments = await giteaFetchJson<Array<{id: number; body?: string | null}>>(
-    `repos/${encodeSegment(params.org)}/${encodeSegment(params.repo)}/issues/${params.index}/comments`,
-  );
+  const comments: Array<{id: number; body?: string | null}> = [];
+  for (let page = 1; ; page++) {
+    const pageComments = await giteaFetchJson<Array<{id: number; body?: string | null}>>(
+      `repos/${encodeSegment(params.org)}/${encodeSegment(params.repo)}/issues/${params.index}/comments?page=${page}&limit=${ISSUE_COMMENTS_PAGE_SIZE}`,
+    );
+    comments.push(...pageComments);
+    if (pageComments.length < ISSUE_COMMENTS_PAGE_SIZE) break;
+  }
 
   return comments.map((comment) => ({
     id: comment.id,

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -7,8 +7,9 @@ file is the deep runbook for the workflow flow suite.
 End-to-end tests where each case is a real workflow YAML run through the whole
 platform: a gitea push, the org webhook, definition sync, trigger dispatch, Temporal
 orchestration, a local source runner, step execution, and log capture. The suite
-asserts only on the public observation APIs (`/workflows/runs`, `/workflows/runs/:id`,
-and the step logs route).
+asserts on the public observation APIs (`/workflows/runs`, `/workflows/runs/:id`, and
+the step logs route). Scenarios with a `gitea` fixture also verify the external Gitea
+state through the driver.
 
 ## How a scenario works
 
@@ -17,7 +18,7 @@ A scenario is a directory under `scenarios/`:
 ```
 scenarios/hello-world/
   workflow.yml    pushed verbatim to .shipfox/workflows/hello-world.yml
-  expect.yaml     declarative expectations (run/job/step status, job status reason, step error, exit code, logs)
+  expect.yaml     declarative expectations (run/job/step status and type, errors, gates, exit code, logs)
   reject.yaml     alternative to expect.yaml for authoring-time rejection scenarios
   model-provider.yaml optional fake model-provider script metadata
   secrets.yaml    optional E2E setup secrets to seed before the run
@@ -60,6 +61,7 @@ jobs:                    # optional, keyed by job key
     status_reason: step_failed   # optional: why the job ended (step_failed, condition_false, ...)
     steps:               # optional, keyed by step key or name
       greet:
+        type: run         # optional: setup | run | agent | checkout | tool
         status: succeeded
         exit_code: 0     # optional
         gate_result:     # optional: assert the latest attempt's gate evaluation
@@ -73,11 +75,17 @@ jobs:                    # optional, keyed by job key
         logs:
           include: ["hello world"]   # substring, or /regex/
           exclude: ["SECRET_VALUE"]
+gitea:                    # optional external fixture and post-run assertion
+  issue:
+    title: Tool step fixture
+    body: Read this issue from the workflow.
+  comment: Tool step comment
 ```
 
 Assertions that are only observable inside the runner (checkout contents, env
-propagation) are written as self-asserting `run` steps in the workflow itself; the
-manifest then only asserts the run succeeded.
+propagation, or output propagation) are written as self-asserting `run` steps in the
+workflow itself. A `gitea` block creates the declared issue before the workflow is
+synced and checks for the exact comment after the run completes.
 
 ### model-provider.yaml
 

--- a/e2e/suites/flow/workflows/scenarios/tool-step-gitea/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/tool-step-gitea/expect.yaml
@@ -1,0 +1,27 @@
+trigger: push
+run:
+  status: succeeded
+gitea:
+  issue:
+    title: Gitea tool step fixture
+    body: Read this issue through a workflow tool step.
+  comment: Tool step comment landed
+jobs:
+  tools:
+    status: succeeded
+    steps:
+      read_issue:
+        type: tool
+        status: succeeded
+        gate_result:
+          kind: passed
+          exit_code: null
+      consume_result:
+        type: run
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["tool output consumed: Gitea tool step fixture"]
+      comment_issue:
+        type: tool
+        status: succeeded

--- a/e2e/suites/flow/workflows/scenarios/tool-step-gitea/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/tool-step-gitea/workflow.yml
@@ -1,0 +1,45 @@
+name: Gitea tool step
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  tools:
+    steps:
+      - key: read_issue
+        name: Read Gitea issue
+        tool: get_issue
+        connection: __GITEA_SOURCE__
+        with:
+          repo: __GITEA_REPOSITORY_NAME__
+          index: __GITEA_ISSUE_NUMBER__
+        outputs:
+          title: ${{ result.title }}
+          body: ${{ result.body }}
+        gate:
+          success: step.outputs.result.number == __GITEA_ISSUE_NUMBER__
+      - key: consume_result
+        name: Consume issue output
+        env:
+          ISSUE_TITLE: '${{ steps.read_issue.outputs.result.title }}'
+          ISSUE_BODY: '${{ steps.read_issue.outputs.result.body }}'
+          MAPPED_TITLE: '${{ steps.read_issue.outputs.title }}'
+          EXPECTED_TITLE: __GITEA_ISSUE_TITLE__
+          EXPECTED_BODY: __GITEA_ISSUE_BODY__
+        run: |
+          test "$ISSUE_TITLE" = "$EXPECTED_TITLE"
+          test "$ISSUE_BODY" = "$EXPECTED_BODY"
+          test "$MAPPED_TITLE" = "$EXPECTED_TITLE"
+          echo "tool output consumed: $ISSUE_TITLE"
+      - key: comment_issue
+        name: Comment on Gitea issue
+        tool: comment_on_issue
+        connection: __GITEA_SOURCE__
+        with:
+          repo: __GITEA_REPOSITORY_NAME__
+          index: __GITEA_ISSUE_NUMBER__
+          body: __GITEA_COMMENT_BODY__
+        outputs:
+          body: ${{ result.body }}

--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -237,6 +237,28 @@ describe('evaluateExpectations', () => {
     expect(result.mismatches).toEqual([]);
   });
 
+  test('flags an unexpected step type', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          job_executions: [makeJobExecution({steps: [makeStep({type: 'run'})]})],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {type: 'tool'}}}},
+      }),
+    );
+
+    expect(result.mismatches).toEqual([
+      {path: 'jobs.build.steps.greet.type', expected: 'tool', actual: 'run'},
+    ]);
+  });
+
   test('parses an external Gitea fixture expectation', () => {
     const expectation = parseExpectation({
       run: {status: 'succeeded'},

--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -217,6 +217,41 @@ describe('evaluateExpectations', () => {
     expect(result.mismatches).toEqual([]);
   });
 
+  test('matches an expected step type', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          job_executions: [makeJobExecution({steps: [makeStep({type: 'tool'})]})],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {type: 'tool'}}}},
+      }),
+    );
+
+    expect(result.mismatches).toEqual([]);
+  });
+
+  test('parses an external Gitea fixture expectation', () => {
+    const expectation = parseExpectation({
+      run: {status: 'succeeded'},
+      gitea: {
+        issue: {title: 'Fixture', body: 'Read me'},
+        comment: 'Comment landed',
+      },
+    });
+
+    expect(expectation.gitea).toEqual({
+      issue: {title: 'Fixture', body: 'Read me'},
+      comment: 'Comment landed',
+    });
+  });
+
   test('flags job status, step status, and exit code mismatches together', () => {
     const detail = makeDetail({
       status: 'failed',

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -46,6 +46,7 @@ const stepStatusSchema = z.enum([
   'skipped',
   'cancelled',
 ]);
+const stepTypeSchema = z.enum(['setup', 'run', 'agent', 'checkout', 'tool']);
 const stepErrorReasonSchema = z.enum([
   'checkout_failed',
   'checkout_auth_failed',
@@ -132,8 +133,21 @@ const stepGateResultExpectationSchema = z
   })
   .strict();
 
+const giteaExpectationSchema = z
+  .object({
+    issue: z
+      .object({
+        title: z.string().min(1),
+        body: z.string().min(1),
+      })
+      .strict(),
+    comment: z.string().min(1),
+  })
+  .strict();
+
 const stepExpectationSchema = z
   .object({
+    type: stepTypeSchema.optional(),
     status: stepStatusSchema.optional(),
     exit_code: z.number().int().optional(),
     error: stepErrorExpectationSchema.optional(),
@@ -160,6 +174,7 @@ export const expectationSchema = z
     run: z.object({status: runStatusSchema}).strict(),
     jobs: z.record(z.string(), jobExpectationSchema).optional(),
     runner_log: logsExpectationSchema.optional(),
+    gitea: giteaExpectationSchema.optional(),
   })
   .strict();
 
@@ -353,6 +368,14 @@ function evaluateStepExpectation(
     });
   }
 
+  if (expectation.type !== undefined && step.type !== expectation.type) {
+    result.mismatches.push({
+      path: `${path}.type`,
+      expected: expectation.type,
+      actual: step.type,
+    });
+  }
+
   if (expectation.exit_code !== undefined) {
     const exitCode = latestExitCode(step);
     if (exitCode !== expectation.exit_code) {
@@ -416,8 +439,9 @@ function evaluateJobExpectation(
 
 /**
  * Compares a run detail against an expectation, returning every structural mismatch
- * (run/job/step status and step exit code) plus the log requirements the harness still
- * needs to fetch. Pure and synchronous, so it is unit-tested against canned run detail.
+ * (run/job/step status, step type, and step exit code) plus the log requirements the
+ * harness still needs to fetch. Pure and synchronous, so it is unit-tested against canned
+ * run detail.
  */
 export function evaluateExpectations(
   runDetail: WorkflowRunDetailResponseDto,

--- a/e2e/suites/flow/workflows/src/run-scenario.test.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.test.ts
@@ -1,0 +1,80 @@
+import type {CreatedIssue, listIssueComments} from '@shipfox/e2e-driver-gitea';
+import {parseExpectation} from './expect.js';
+import {evaluateGiteaScenario} from './run-scenario.js';
+
+const issue: CreatedIssue = {
+  number: 1,
+  title: 'Fixture',
+  body: 'Read me',
+};
+
+function giteaExpectation() {
+  const expectation = parseExpectation({
+    run: {status: 'succeeded'},
+    gitea: {
+      issue: {title: issue.title, body: issue.body},
+      comment: 'Comment landed',
+    },
+  }).gitea;
+  if (expectation === undefined) throw new Error('Expected a Gitea expectation');
+  return expectation;
+}
+
+function scenarioParams(
+  listComments?: typeof listIssueComments,
+  scenarioIssue: CreatedIssue | undefined = issue,
+) {
+  return {
+    expectation: giteaExpectation(),
+    issue: scenarioIssue,
+    org: 'e2e-org',
+    repo: 'fixture',
+    ...(listComments === undefined ? {} : {listComments}),
+  };
+}
+
+describe('evaluateGiteaScenario', () => {
+  test('reports a missing fixture issue', async () => {
+    const listComments = vi.fn();
+    const result = await evaluateGiteaScenario({...scenarioParams(listComments), issue: undefined});
+
+    expect(result).toEqual([{path: 'gitea.issue', expected: 'created', actual: 'missing'}]);
+    expect(listComments).not.toHaveBeenCalled();
+  });
+
+  test('reports an issue comment lookup failure', async () => {
+    const listComments = vi.fn().mockRejectedValue(new Error('Gitea unavailable'));
+
+    const result = await evaluateGiteaScenario(scenarioParams(listComments));
+
+    expect(result).toEqual([
+      {
+        path: 'gitea.issue.comments',
+        expected: 'readable',
+        actual: 'Gitea unavailable',
+      },
+    ]);
+  });
+
+  test('reports when the expected comment is absent', async () => {
+    const listComments = vi.fn().mockResolvedValue([{id: 1, body: 'Different comment'}]);
+
+    const result = await evaluateGiteaScenario(scenarioParams(listComments));
+
+    expect(result).toEqual([
+      {
+        path: 'gitea.issue.comments',
+        expected: 'exact Comment landed',
+        actual: 'Different comment',
+      },
+    ]);
+  });
+
+  test('matches the expected comment exactly', async () => {
+    const listComments = vi.fn().mockResolvedValue([{id: 1, body: 'Comment landed'}]);
+
+    const result = await evaluateGiteaScenario(scenarioParams(listComments));
+
+    expect(result).toEqual([]);
+  });
+});

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -1,5 +1,6 @@
 import {readFile} from 'node:fs/promises';
 import {createApiClient} from '@shipfox/e2e-core';
+import {type CreatedIssue, listIssueComments} from '@shipfox/e2e-driver-gitea';
 import {readFakeOpenAiModelProviderState} from '@shipfox/e2e-driver-model-provider';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
@@ -34,6 +35,10 @@ import {seedAndWaitForDefinition, seedWorkflowProject} from './workflow-project.
 const REJECTION_NO_RUN_TIMEOUT_MS = 15_000;
 const E2E_SECRET_ACTOR_ID = '11111111-1111-4111-8111-111111111111';
 const FAKE_MODEL_PROVIDER_REQUEST_TIMEOUT_MS = 5_000;
+
+type GiteaScenarioExpectation = NonNullable<
+  Extract<Scenario, {kind: 'expect'}>['expectation']['gitea']
+>;
 
 export interface RunScenarioParams {
   scenario: Scenario;
@@ -101,6 +106,47 @@ async function evaluateScenarioResult(params: {
   }
 
   return {allMismatches, fetchedLogs};
+}
+
+async function evaluateGiteaScenario(params: {
+  expectation: GiteaScenarioExpectation | undefined;
+  issue: CreatedIssue | undefined;
+  org: string;
+  repo: string;
+}): Promise<Mismatch[]> {
+  if (params.expectation === undefined) return [];
+  if (params.issue === undefined) {
+    return [{path: 'gitea.issue', expected: 'created', actual: 'missing'}];
+  }
+  const expectedComment = params.expectation.comment;
+
+  let comments: Awaited<ReturnType<typeof listIssueComments>>;
+  try {
+    comments = await listIssueComments({
+      org: params.org,
+      repo: params.repo,
+      index: params.issue.number,
+    });
+  } catch (error) {
+    return [
+      {
+        path: 'gitea.issue.comments',
+        expected: 'readable',
+        actual: error instanceof Error ? error.message : String(error),
+      },
+    ];
+  }
+
+  if (comments.some((comment) => comment.body === expectedComment)) return [];
+
+  return [
+    {
+      path: 'gitea.issue.comments',
+      expected: `include ${expectedComment}`,
+      actual:
+        comments.length === 0 ? 'none' : comments.map((comment) => comment.body).join('\n---\n'),
+    },
+  ];
 }
 
 async function attachScenarioMismatches(params: {
@@ -201,6 +247,7 @@ async function seedScenarioProject(params: {
   token: string;
   webhookSlug: string;
 }) {
+  const gitea = params.scenario.kind === 'expect' ? params.scenario.expectation.gitea : undefined;
   const seedParams = {
     suite: params.suite,
     token: params.token,
@@ -211,13 +258,27 @@ async function seedScenarioProject(params: {
     configPath: params.scenario.configPath,
     webhookSlug: params.webhookSlug,
     extraFiles: params.scenario.extraFiles,
+    ...(gitea === undefined
+      ? {}
+      : {
+          giteaIssue: gitea.issue,
+          replacements: {
+            __GITEA_ISSUE_TITLE__: JSON.stringify(gitea.issue.title),
+            __GITEA_ISSUE_BODY__: JSON.stringify(gitea.issue.body),
+            __GITEA_COMMENT_BODY__: JSON.stringify(gitea.comment),
+          },
+        }),
   };
   if (params.scenario.kind === 'reject') {
     const seeded = await seedWorkflowProject(seedParams);
-    return {definition: undefined, project: seeded.project};
+    return {definition: undefined, project: seeded.project, giteaIssue: seeded.giteaIssue};
   }
   const seeded = await seedAndWaitForDefinition(seedParams);
-  return {definition: seeded.definition, project: seeded.project};
+  return {
+    definition: seeded.definition,
+    project: seeded.project,
+    giteaIssue: seeded.giteaIssue,
+  };
 }
 
 async function seedScenarioValues(params: {
@@ -370,7 +431,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       uniqueId,
       webhookSlug,
     });
-    const {definition, project} = await seedScenarioProject({
+    const {definition, project, giteaIssue} = await seedScenarioProject({
       repo,
       runnerLabel,
       scenario,
@@ -424,10 +485,16 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
     });
 
     const {mismatches, logRequirements} = evaluateExpectations(runDetail, scenario.expectation);
+    const giteaMismatches = await evaluateGiteaScenario({
+      expectation: scenario.expectation.gitea,
+      issue: giteaIssue,
+      org: suite.org,
+      repo,
+    });
     const {allMismatches, fetchedLogs} = await evaluateScenarioResult({
       expectation: scenario.expectation,
       logRequirements,
-      mismatches,
+      mismatches: [...mismatches, ...giteaMismatches],
       runnerLogFile,
       token,
     });

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -108,9 +108,10 @@ async function evaluateScenarioResult(params: {
   return {allMismatches, fetchedLogs};
 }
 
-async function evaluateGiteaScenario(params: {
+export async function evaluateGiteaScenario(params: {
   expectation: GiteaScenarioExpectation | undefined;
   issue: CreatedIssue | undefined;
+  listComments?: typeof listIssueComments;
   org: string;
   repo: string;
 }): Promise<Mismatch[]> {
@@ -119,10 +120,11 @@ async function evaluateGiteaScenario(params: {
     return [{path: 'gitea.issue', expected: 'created', actual: 'missing'}];
   }
   const expectedComment = params.expectation.comment;
+  const listComments = params.listComments ?? listIssueComments;
 
   let comments: Awaited<ReturnType<typeof listIssueComments>>;
   try {
-    comments = await listIssueComments({
+    comments = await listComments({
       org: params.org,
       repo: params.repo,
       index: params.issue.number,
@@ -142,7 +144,7 @@ async function evaluateGiteaScenario(params: {
   return [
     {
       path: 'gitea.issue.comments',
-      expected: `include ${expectedComment}`,
+      expected: `exact ${expectedComment}`,
       actual:
         comments.length === 0 ? 'none' : comments.map((comment) => comment.body).join('\n---\n'),
     },

--- a/e2e/suites/flow/workflows/src/workflow-project.ts
+++ b/e2e/suites/flow/workflows/src/workflow-project.ts
@@ -1,12 +1,13 @@
 import type {DefinitionResponseDto} from '@shipfox/api-definitions-dto';
 import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
-import {commitFiles, createRepo} from '@shipfox/e2e-driver-gitea';
+import {type CreatedIssue, commitFiles, createIssue, createRepo} from '@shipfox/e2e-driver-gitea';
 import {waitForDefinition} from '@shipfox/e2e-observe-definitions';
 import {createProject, giteaExternalRepositoryId} from './create-project.js';
 import type {SuiteContext} from './suite-context.js';
 
 const GITEA_SOURCE_PLACEHOLDER = '__GITEA_SOURCE__';
 const GITEA_REPOSITORY_PLACEHOLDER = '__GITEA_REPOSITORY__';
+const GITEA_REPOSITORY_NAME_PLACEHOLDER = '__GITEA_REPOSITORY_NAME__';
 const WEBHOOK_SOURCE_PLACEHOLDER = '__WEBHOOK_SOURCE__';
 const RUNNER_LABEL_PLACEHOLDER = '__RUNNER_LABEL__';
 const MODEL_PROVIDER_PLACEHOLDER = '__MODEL_PROVIDER__';
@@ -21,6 +22,7 @@ export interface SeededWorkflowProject {
   project: ProjectResponseDto;
   repo: string;
   renderedWorkflowYaml: string;
+  giteaIssue?: CreatedIssue;
 }
 
 export interface ReadyWorkflowProject extends SeededWorkflowProject {
@@ -38,6 +40,7 @@ export function renderWorkflowYaml(params: {
   let rendered = params.workflowYaml
     .replaceAll(GITEA_SOURCE_PLACEHOLDER, params.suite.connectionSlug)
     .replaceAll(GITEA_REPOSITORY_PLACEHOLDER, `${params.suite.org}/${params.repo}`)
+    .replaceAll(GITEA_REPOSITORY_NAME_PLACEHOLDER, params.repo)
     .replaceAll(RUNNER_LABEL_PLACEHOLDER, params.runnerLabel)
     .replaceAll(MODEL_PROVIDER_PLACEHOLDER, params.suite.modelProviderId)
     .replaceAll(AGENT_MODEL_PLACEHOLDER, params.suite.agentModel);
@@ -61,10 +64,25 @@ export async function seedWorkflowProject(params: {
   webhookSlug?: string | undefined;
   replacements?: Record<string, string> | undefined;
   extraFiles?: WorkflowProjectFile[] | undefined;
+  giteaIssue?: {title: string; body: string} | undefined;
 }): Promise<SeededWorkflowProject> {
-  const renderedWorkflowYaml = renderWorkflowYaml(params);
-
   await createRepo({org: params.suite.org, name: params.repo});
+  const giteaIssue =
+    params.giteaIssue === undefined
+      ? undefined
+      : await createIssue({
+          org: params.suite.org,
+          repo: params.repo,
+          title: params.giteaIssue.title,
+          body: params.giteaIssue.body,
+        });
+  const renderedWorkflowYaml = renderWorkflowYaml({
+    ...params,
+    replacements: {
+      ...(params.replacements ?? {}),
+      ...(giteaIssue === undefined ? {} : {__GITEA_ISSUE_NUMBER__: String(giteaIssue.number)}),
+    },
+  });
   await commitFiles({
     org: params.suite.org,
     repo: params.repo,
@@ -83,7 +101,12 @@ export async function seedWorkflowProject(params: {
     externalRepositoryId: giteaExternalRepositoryId(params.suite.org, params.repo),
   });
 
-  return {project, repo: params.repo, renderedWorkflowYaml};
+  return {
+    project,
+    repo: params.repo,
+    renderedWorkflowYaml,
+    ...(giteaIssue === undefined ? {} : {giteaIssue}),
+  };
 }
 
 export async function seedAndWaitForDefinition(params: Parameters<typeof seedWorkflowProject>[0]) {

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1060,12 +1060,7 @@ async function decideReportedStepTransition(params: {
       ? undefined
       : ((await getWorkflowContextForJob(params.jobId, params.tx)).vars ?? undefined);
   const gateOutcome = params.gateEvaluationAllowed
-    ? evaluateGate(
-        gate,
-        params.result,
-        vars,
-        params.target.type === 'tool' ? {stepType: 'tool'} : undefined,
-      )
+    ? evaluateGate(gate, params.result, vars, {stepType: params.target.type})
     : {kind: 'no-gate' as const};
   // The restart cap is bounded on the gating step's OWN attempts, not its
   // current_attempt (which a rewind inflates for downstream steps).

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1060,7 +1060,12 @@ async function decideReportedStepTransition(params: {
       ? undefined
       : ((await getWorkflowContextForJob(params.jobId, params.tx)).vars ?? undefined);
   const gateOutcome = params.gateEvaluationAllowed
-    ? evaluateGate(gate, params.result, vars)
+    ? evaluateGate(
+        gate,
+        params.result,
+        vars,
+        params.target.type === 'tool' ? {stepType: 'tool'} : undefined,
+      )
     : {kind: 'no-gate' as const};
   // The restart cap is bounded on the gating step's OWN attempts, not its
   // current_attempt (which a rewind inflates for downstream steps).

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -144,6 +144,31 @@ describe('decideStepTransition', () => {
     });
   });
 
+  test('a failing tool-step gate never rewinds a provider call', () => {
+    const restartTarget = step({id: 's0', key: 'producer', position: 0, status: 'succeeded'});
+    const target = step({id: 's1', position: 1, status: 'running', type: 'tool'});
+
+    const decision = decideStepTransition({
+      steps: [restartTarget, target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'succeeded', exitCode: null},
+      gateOutcome: {kind: 'failed', source: 'step.outputs.result.ok == true'},
+      gateOnFailure: {restartFrom: 'producer'},
+    });
+
+    expect(decision).toEqual({
+      kind: 'fail-job',
+      failedStepId: 's1',
+      attempt: 1,
+      failureError: {
+        kind: 'gate_failed',
+        message: 'gate condition not met',
+        source: 'step.outputs.result.ok == true',
+      },
+    });
+  });
+
   test('restart_from never resolves to the synthetic setup step (no workspace re-delete)', () => {
     // A user step legitimately keyed "Set up job" shares its label with the synthetic
     // setup step at position 0. Restart must resolve to the user step, not position 0.

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -27,7 +27,8 @@ export interface StepReport {
 // Precomputed gate evaluation (the CEL engine runs in evaluate-gate.ts, never
 // here). `passed`/`failed` are clean evaluations; `uncheckable` means the gate
 // could not be evaluated (a required exit code is missing, or an evaluation
-// error) and is treated as a plain command failure. It is never a restart.
+// error) and is treated as a plain command failure. Tool-step failures are also
+// plain failures because provider calls may have side effects. Neither restarts.
 export type GateOutcome =
   | {kind: 'no-gate'}
   | {kind: 'passed'; source: string; trace?: readonly PersistedEvaluationTraceEntry[]}
@@ -124,10 +125,10 @@ function fail(
 
 // Pure: maps a step report (and its precomputed gate outcome) to a transition
 // decision. No DB, no expression engine. A passing gate succeeds; a checkable
-// failure with a resolvable `restart_from` rewinds (until the per-step attempt cap
-// is hit); everything else fails the job. An `uncheckable` failure (a required
-// exit code is missing or evaluation errors) is always a plain failure, never a
-// restart.
+// runner-step failure with a resolvable `restart_from` rewinds (until the per-step
+// attempt cap is hit); everything else fails the job. An `uncheckable` failure (a
+// required exit code is missing or evaluation errors) and every tool-step failure
+// are always plain failures, never restarts.
 export function decideStepTransition(input: DecideStepTransitionInput): StepTransitionDecision {
   const {steps, target, reportedAttempt, result, gateOnFailure} = input;
   const gate = input.gateOutcome ?? {kind: 'no-gate'};
@@ -140,13 +141,12 @@ export function decideStepTransition(input: DecideStepTransitionInput): StepTran
   }
 
   // 2. It failed. Classify the failure error and whether it is restartable.
-  //    `uncheckable` (a required exit code is missing or evaluation errors) is a
-  //    plain command failure that never restarts.
-  const uncheckable = gate.kind === 'uncheckable';
+  //    Tool provider calls can have side effects, so a tool step never rewinds.
+  const restartAllowed = target.type !== 'tool' && gate.kind !== 'uncheckable';
   const failureError = stepFailureError(gate, result);
 
   // 3. Restart when a policy is configured and the failure is checkable.
-  if (gateOnFailure?.restartFrom && !uncheckable) {
+  if (gateOnFailure?.restartFrom && restartAllowed) {
     return restartStepTransition(input, gateOnFailure, failureError, maxAttempts);
   }
 

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -26,8 +26,8 @@ export interface StepReport {
 
 // Precomputed gate evaluation (the CEL engine runs in evaluate-gate.ts, never
 // here). `passed`/`failed` are clean evaluations; `uncheckable` means the gate
-// could not be evaluated (no exit code, or an evaluation error) and is treated
-// as a plain command failure. It is never a restart.
+// could not be evaluated (a required exit code is missing, or an evaluation
+// error) and is treated as a plain command failure. It is never a restart.
 export type GateOutcome =
   | {kind: 'no-gate'}
   | {kind: 'passed'; source: string; trace?: readonly PersistedEvaluationTraceEntry[]}
@@ -125,8 +125,9 @@ function fail(
 // Pure: maps a step report (and its precomputed gate outcome) to a transition
 // decision. No DB, no expression engine. A passing gate succeeds; a checkable
 // failure with a resolvable `restart_from` rewinds (until the per-step attempt cap
-// is hit); everything else fails the job. An `uncheckable` failure (no exit code /
-// eval error) is always a plain failure, never a restart.
+// is hit); everything else fails the job. An `uncheckable` failure (a required
+// exit code is missing or evaluation errors) is always a plain failure, never a
+// restart.
 export function decideStepTransition(input: DecideStepTransitionInput): StepTransitionDecision {
   const {steps, target, reportedAttempt, result, gateOnFailure} = input;
   const gate = input.gateOutcome ?? {kind: 'no-gate'};
@@ -139,8 +140,8 @@ export function decideStepTransition(input: DecideStepTransitionInput): StepTran
   }
 
   // 2. It failed. Classify the failure error and whether it is restartable.
-  //    `uncheckable` (no exit code / eval error) is a plain command failure that
-  //    never restarts.
+  //    `uncheckable` (a required exit code is missing or evaluation errors) is a
+  //    plain command failure that never restarts.
   const uncheckable = gate.kind === 'uncheckable';
   const failureError = stepFailureError(gate, result);
 

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -196,6 +196,24 @@ describe('evaluateGate', () => {
     });
   });
 
+  test('a failing tool-step output gate remains checkable without an exit code', () => {
+    const source = 'step.outputs.result.number == 1';
+    const gate = readStepGate(gateConfig(source));
+
+    expect(
+      evaluateGate(
+        gate,
+        {status: 'succeeded', exitCode: null, output: {result: {number: 2}}},
+        undefined,
+        {stepType: 'tool'},
+      ),
+    ).toEqual({
+      kind: 'failed',
+      source,
+      trace: gateTrace(source, false),
+    });
+  });
+
   test('unguarded missing step output keys fail closed as uncheckable', () => {
     const gate = readStepGate(gateConfig('step.outputs.pass == true'));
 

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -178,6 +178,24 @@ describe('evaluateGate', () => {
     });
   });
 
+  test('tool-step output gates do not require an exit code', () => {
+    const source = 'step.outputs.result.number == 1';
+    const gate = readStepGate(gateConfig(source));
+
+    expect(
+      evaluateGate(
+        gate,
+        {status: 'succeeded', exitCode: null, output: {result: {number: 1}}},
+        undefined,
+        {stepType: 'tool'},
+      ),
+    ).toEqual({
+      kind: 'passed',
+      source,
+      trace: gateTrace(source, true),
+    });
+  });
+
   test('unguarded missing step output keys fail closed as uncheckable', () => {
     const gate = readStepGate(gateConfig('step.outputs.pass == true'));
 

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -5,6 +5,7 @@ import {
   type ResolvedField,
   type WorkflowExpression,
 } from '@shipfox/expression';
+import type {StepType} from '../entities/step.js';
 import {assembleGateContext} from '../step-config/assemble-run-context.js';
 import {completeStepField} from '../step-config/fields.js';
 import type {GateOutcome, StepReport} from './decide-step-transition.js';
@@ -69,7 +70,8 @@ function readGateFeedbackTemplate(value: unknown): ResolvedField | undefined {
  * Gate evaluation fails closed: a missing exit code on a runner step or a CEL
  * evaluation error is `uncheckable` (a plain command failure), never a gate
  * failure that can restart. Tool steps intentionally have no exit code, so
- * their gates evaluate against the step status and outputs instead.
+ * their gates evaluate against the step status and outputs instead. Tool-step
+ * failures remain non-restartable because provider calls may have side effects.
  *
  * Callers hold step-row locks while this runs. Keep the CEL context bounded
  * unless evaluation gets a budget outside the lock. The materializer only
@@ -79,7 +81,7 @@ export function evaluateGate(
   gate: StepGate | undefined,
   result: StepReport,
   vars?: Record<string, string> | undefined,
-  options?: {readonly stepType?: 'tool'},
+  options?: {readonly stepType?: StepType},
 ): GateOutcome {
   if (!gate?.success) return {kind: 'no-gate'};
   const source = gate.success.source;

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -66,8 +66,10 @@ function readGateFeedbackTemplate(value: unknown): ResolvedField | undefined {
 }
 
 /**
- * Gate evaluation fails closed: a missing exit code or CEL evaluation error is
- * `uncheckable` (a plain command failure), never a gate failure that can restart.
+ * Gate evaluation fails closed: a missing exit code on a runner step or a CEL
+ * evaluation error is `uncheckable` (a plain command failure), never a gate
+ * failure that can restart. Tool steps intentionally have no exit code, so
+ * their gates evaluate against the step status and outputs instead.
  *
  * Callers hold step-row locks while this runs. Keep the CEL context bounded
  * unless evaluation gets a budget outside the lock. The materializer only
@@ -77,17 +79,18 @@ export function evaluateGate(
   gate: StepGate | undefined,
   result: StepReport,
   vars?: Record<string, string> | undefined,
+  options?: {readonly stepType?: 'tool'},
 ): GateOutcome {
   if (!gate?.success) return {kind: 'no-gate'};
   const source = gate.success.source;
 
-  if (result.exitCode === null || result.exitCode === undefined) {
+  if (options?.stepType !== 'tool' && (result.exitCode === null || result.exitCode === undefined)) {
     return {kind: 'uncheckable', reason: 'step produced no exit code'};
   }
 
   const context = assembleGateContext({
     status: result.status,
-    exitCode: result.exitCode,
+    exitCode: result.exitCode ?? null,
     output: result.output,
     vars,
   });


### PR DESCRIPTION
Adds an end-to-end workflow scenario for the Gitea-backed tool-step path. The scenario reads an issue, consumes `steps.read_issue.outputs.result`, gates on provider output, and writes a comment back to Gitea.

The E2E harness now seeds and verifies external issue state, and run expectations can assert tool-step types. Gitea bootstrap keeps issue-comment write access separate from code-read access. Tool-step gates evaluate status and outputs without requiring runner exit codes, while runner-step behavior remains unchanged.

Validation:
- Targeted E2E scenario passed: 1 test.
- Flow tests passed: 52 tests.
- Gitea driver tests passed: 7 tests.
- API workflow tests passed: 996 tests.
- Package checks, staged diff checks, shell syntax, and prose validation passed with zero prose errors.

The affected flow type graph still reports pre-existing implicit-any errors in `e2e/suites/flow/workflows/tests/fixtures.ts`, which is unchanged by this PR.

Closes ENG-1685

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end Gitea tool-step scenario that reads an issue, consumes `steps.read_issue.outputs.result`, gates on the output, and writes a comment back. Tool-step gates now evaluate on step status and outputs instead of requiring a runner exit code, and failed tool steps fail the job without rewinding; runner-step gating and rewinds are unchanged.

- The E2E harness seeds the fixture issue before the run and verifies the expected comment landed afterwards, paginating issue comments.
- Expect files can assert step types, so the scenario marks tool steps as `type: tool`.
- Gitea bootstrap now separates bot access into a code-read team and an issue-comment-write team, so a leaked credential cannot push code or manage the org.

Closes ENG-1685.

<sup>Written for commit 3519c7affb6316619e4fb80edd858bb9cb661c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

