### PR TITLE
Resolve canonical workflow run selections from nested IDs

### DIFF
--- a/.changeset/clear-selection-path.md
+++ b/.changeset/clear-selection-path.md
@@ -3,4 +3,4 @@
 "@shipfox/api-workflows-dto": minor
 ---
 
-Add a bounded workflow run selection resolver for canonical ancestry lookup from incomplete nested-resource URLs.
+Allow workflow run detail URLs to resolve a single run selection from a deeply nested attempt, job, execution, or step ID without requiring the intermediate ancestry in the URL.

--- a/.changeset/clear-selection-path.md
+++ b/.changeset/clear-selection-path.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": minor
+---
+
+Add a bounded workflow run selection resolver for canonical ancestry lookup from incomplete nested-resource URLs.

--- a/e2e/suites/flow/workflows/tests/selection-resolver.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/selection-resolver.e2e.ts
@@ -1,0 +1,85 @@
+import {workflowRunSelectionResponseSchema} from '@shipfox/api-workflows-dto';
+import {createApiClient} from '@shipfox/e2e-core';
+import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import {waitForRunTerminal} from '@shipfox/e2e-observe-workflows';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
+import {fireManualAndAwaitRun} from '#triggers.js';
+import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {expect, test} from './fixtures.js';
+
+const SELECTION_RESOLVER_WORKFLOW = `
+name: Selection resolver smoke
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    steps:
+      - key: selection
+        run: echo "selection resolver smoke"
+`;
+
+test('resolves an older step identity through the public selection API', async ({suite}) => {
+  const token = suite.sessionToken;
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const repo = `selection-resolver-${uniqueId}`;
+  const runnerLabel = `e2e-selection-resolver-${uniqueId}`;
+  const client = createApiClient({token});
+  const localRunner = await startSuiteLocalRunner({
+    workspaceId: suite.workspaceId,
+    userToken: token,
+    name: `E2E selection resolver ${uniqueId}`,
+    runnerLabel,
+  });
+
+  try {
+    const {definition} = await seedAndWaitForDefinition({
+      suite,
+      token,
+      name: 'selection-resolver',
+      repo,
+      runnerLabel,
+      workflowYaml: SELECTION_RESOLVER_WORKFLOW,
+      configPath: '.shipfox/workflows/selection-resolver.yml',
+    });
+    const runId = await fireManualAndAwaitRun({
+      client,
+      definitionId: definition.id,
+      inputs: {},
+      scenario: repo,
+    });
+    const firstAttempt = await waitForRunTerminalOrFailedRunner({
+      runId,
+      token,
+      timeoutMs: 180_000,
+      runner: localRunner.runner,
+    });
+    const oldStepId = firstAttempt.jobs
+      .find((job) => job.key === 'build')
+      ?.job_executions[0]?.steps.find((step) => step.key === 'selection')?.id;
+    if (!oldStepId) throw new Error('Expected the first-attempt selection step');
+
+    await client.requestJson('post', `/workflows/runs/${encodeURIComponent(runId)}/rerun`, {
+      json: {mode: 'all'},
+    });
+    await waitForRunTerminal({runId, token, timeoutMs: 180_000});
+
+    const selectionQuery = new URLSearchParams({step_id: oldStepId});
+    const selection = workflowRunSelectionResponseSchema.parse(
+      await client.requestJson(
+        'get',
+        `/workflows/runs/${encodeURIComponent(runId)}/selection?${selectionQuery}`,
+      ),
+    );
+
+    expect(selection).toMatchObject({
+      workflow_run_id: runId,
+      workflow_run_attempt: 1,
+      step_id: oldStepId,
+    });
+  } finally {
+    await stopLocalRunner(localRunner.runner).catch(() => undefined);
+  }
+});

--- a/e2e/suites/flow/workflows/tests/selection-resolver.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/selection-resolver.e2e.ts
@@ -64,7 +64,12 @@ test('resolves an older step identity through the public selection API', async (
     await client.requestJson('post', `/workflows/runs/${encodeURIComponent(runId)}/rerun`, {
       json: {mode: 'all'},
     });
-    await waitForRunTerminal({runId, token, timeoutMs: 180_000});
+    const rerun = await waitForRunTerminal({runId, token, timeoutMs: 180_000});
+    expect(rerun).toMatchObject({
+      current_attempt: 2,
+      latest_attempt: 2,
+      run_attempt: {attempt: 2},
+    });
 
     const selectionQuery = new URLSearchParams({step_id: oldStepId});
     const selection = workflowRunSelectionResponseSchema.parse(

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -151,6 +151,14 @@ export {
   workflowRunAncestrySchema,
 } from '#schemas/workflow-run-ancestry.js';
 export {
+  type WorkflowRunSelectionDto,
+  type WorkflowRunSelectionQueryDto,
+  type WorkflowRunSelectionResponseDto,
+  workflowRunSelectionQuerySchema,
+  workflowRunSelectionResponseSchema,
+  workflowRunSelectionSchema,
+} from '#schemas/workflow-run-selection.js';
+export {
   jobTerminalStatusSchema,
   type ListenerFilterExpressionType,
   type ListenerFilterOutputTypes,

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -151,6 +151,8 @@ export {
   workflowRunAncestrySchema,
 } from '#schemas/workflow-run-ancestry.js';
 export {
+  getWorkflowRunSelectionDepth,
+  type WorkflowRunSelectionDepth,
   type WorkflowRunSelectionDto,
   type WorkflowRunSelectionQueryDto,
   type WorkflowRunSelectionResponseDto,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -159,6 +159,8 @@ export {
   workflowRunStepDetailDtoSchema,
 } from './workflow-run-detail.js';
 export {
+  getWorkflowRunSelectionDepth,
+  type WorkflowRunSelectionDepth,
   type WorkflowRunSelectionDto,
   type WorkflowRunSelectionQueryDto,
   type WorkflowRunSelectionResponseDto,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -158,3 +158,11 @@ export {
   workflowRunJobExecutionDetailDtoSchema,
   workflowRunStepDetailDtoSchema,
 } from './workflow-run-detail.js';
+export {
+  type WorkflowRunSelectionDto,
+  type WorkflowRunSelectionQueryDto,
+  type WorkflowRunSelectionResponseDto,
+  workflowRunSelectionQuerySchema,
+  workflowRunSelectionResponseSchema,
+  workflowRunSelectionSchema,
+} from './workflow-run-selection.js';

--- a/libs/api/workflows-dto/src/schemas/workflow-run-selection.test.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run-selection.test.ts
@@ -1,0 +1,55 @@
+import {
+  workflowRunSelectionQuerySchema,
+  workflowRunSelectionResponseSchema,
+} from './workflow-run-selection.js';
+
+const ids = {
+  run: '11111111-1111-4111-8111-111111111111',
+  job: '22222222-2222-4222-8222-222222222222',
+  execution: '33333333-3333-4333-8333-333333333333',
+  step: '44444444-4444-4444-8444-444444444444',
+  stepAttempt: '55555555-5555-4555-8555-555555555555',
+};
+
+describe('workflow run selection schemas', () => {
+  test.each([
+    ['job_id', ids.job],
+    ['job_execution_id', ids.execution],
+    ['step_id', ids.step],
+    ['step_attempt_id', ids.stepAttempt],
+  ])('accepts a %s-only selection query', (key, value) => {
+    const result = workflowRunSelectionQuerySchema.parse({[key]: value});
+
+    expect(result).toEqual({[key]: value});
+  });
+
+  test('coerces and accepts an optional attempt', () => {
+    expect(workflowRunSelectionQuerySchema.parse({step_id: ids.step, attempt: '2'})).toEqual({
+      step_id: ids.step,
+      attempt: 2,
+    });
+  });
+
+  test.each([
+    {},
+    {attempt: '2'},
+    {job_id: 'not-a-uuid'},
+  ])('rejects an incomplete or invalid query: %j', (query) => {
+    expect(workflowRunSelectionQuerySchema.safeParse(query).success).toBe(false);
+  });
+
+  test('parses ancestry and the selected step source location', () => {
+    const result = workflowRunSelectionResponseSchema.parse({
+      workflow_run_id: ids.run,
+      workflow_run_attempt: 2,
+      job_id: ids.job,
+      job_execution_id: ids.execution,
+      step_id: ids.step,
+      step_attempt_id: ids.stepAttempt,
+      step_attempt: 1,
+      source_location: {start_line: 5, end_line: 8},
+    });
+
+    expect(result.source_location).toEqual({start_line: 5, end_line: 8});
+  });
+});

--- a/libs/api/workflows-dto/src/schemas/workflow-run-selection.test.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run-selection.test.ts
@@ -1,4 +1,5 @@
 import {
+  getWorkflowRunSelectionDepth,
   workflowRunSelectionQuerySchema,
   workflowRunSelectionResponseSchema,
 } from './workflow-run-selection.js';
@@ -12,6 +13,17 @@ const ids = {
 };
 
 describe('workflow run selection schemas', () => {
+  test('derives the deepest supplied identity depth', () => {
+    expect(
+      getWorkflowRunSelectionDepth({
+        job_id: ids.job,
+        job_execution_id: ids.execution,
+        step_id: ids.step,
+        step_attempt_id: ids.stepAttempt,
+      }),
+    ).toBe('step_attempt');
+  });
+
   test.each([
     ['job_id', ids.job],
     ['job_execution_id', ids.execution],

--- a/libs/api/workflows-dto/src/schemas/workflow-run-selection.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run-selection.ts
@@ -1,0 +1,33 @@
+import {z} from 'zod';
+import {stepSourceLocationSchema} from './step.js';
+import {workflowRunAncestrySchema} from './workflow-run-ancestry.js';
+
+const nestedIdentityKeys = ['job_id', 'job_execution_id', 'step_id', 'step_attempt_id'] as const;
+
+export const workflowRunSelectionQuerySchema = z
+  .object({
+    attempt: z.coerce.number().int().positive().optional(),
+    job_id: z.string().uuid().optional(),
+    job_execution_id: z.string().uuid().optional(),
+    step_id: z.string().uuid().optional(),
+    step_attempt_id: z.string().uuid().optional(),
+  })
+  .superRefine((value, context) => {
+    if (nestedIdentityKeys.every((key) => value[key] === undefined)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one nested identity is required',
+      });
+    }
+  });
+
+export type WorkflowRunSelectionQueryDto = z.infer<typeof workflowRunSelectionQuerySchema>;
+
+export const workflowRunSelectionSchema = workflowRunAncestrySchema.extend({
+  source_location: stepSourceLocationSchema.nullable(),
+});
+
+export const workflowRunSelectionResponseSchema = workflowRunSelectionSchema;
+
+export type WorkflowRunSelectionDto = z.infer<typeof workflowRunSelectionSchema>;
+export type WorkflowRunSelectionResponseDto = z.infer<typeof workflowRunSelectionResponseSchema>;

--- a/libs/api/workflows-dto/src/schemas/workflow-run-selection.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run-selection.ts
@@ -2,7 +2,20 @@ import {z} from 'zod';
 import {stepSourceLocationSchema} from './step.js';
 import {workflowRunAncestrySchema} from './workflow-run-ancestry.js';
 
-const nestedIdentityKeys = ['job_id', 'job_execution_id', 'step_id', 'step_attempt_id'] as const;
+const nestedIdentityDefinitions = [
+  {key: 'step_attempt_id', depth: 'step_attempt'},
+  {key: 'step_id', depth: 'step'},
+  {key: 'job_execution_id', depth: 'execution'},
+  {key: 'job_id', depth: 'job'},
+] as const;
+
+export type WorkflowRunSelectionDepth = (typeof nestedIdentityDefinitions)[number]['depth'];
+
+export function getWorkflowRunSelectionDepth(
+  query: Pick<WorkflowRunSelectionQueryDto, (typeof nestedIdentityDefinitions)[number]['key']>,
+): WorkflowRunSelectionDepth {
+  return nestedIdentityDefinitions.find(({key}) => query[key] !== undefined)?.depth ?? 'job';
+}
 
 export const workflowRunSelectionQuerySchema = z
   .object({
@@ -13,7 +26,7 @@ export const workflowRunSelectionQuerySchema = z
     step_attempt_id: z.string().uuid().optional(),
   })
   .superRefine((value, context) => {
-    if (nestedIdentityKeys.every((key) => value[key] === undefined)) {
+    if (nestedIdentityDefinitions.every(({key}) => value[key] === undefined)) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'At least one nested identity is required',

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -73,6 +73,8 @@ export type {
   WorkflowRunJobsSummary,
   WorkflowRunLineageHead,
   WorkflowRunReadPlanEvidence,
+  WorkflowRunSelection,
+  WorkflowRunSelectionParams,
   WorkflowRunStorageAudit,
   WorkflowRunStorageAuditOptions,
 } from './workflow-runs.js';
@@ -118,6 +120,7 @@ export {
   getWorkflowRunById,
   getWorkflowRunDetail,
   getWorkflowRunLineageHead,
+  getWorkflowRunSelection,
   listRunAttempts,
   listRunAttemptsPage,
   listStepAttemptIdsByJobId,

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -75,6 +75,8 @@ export type {
   WorkflowRunJobSummaryTarget,
   WorkflowRunJobsSummary,
   WorkflowRunLineageHead,
+  WorkflowRunSelection,
+  WorkflowRunSelectionParams,
 } from './workflow-runs/queries.js';
 export {
   buildWorkflowRunListConditions,
@@ -88,6 +90,7 @@ export {
   getWorkflowRunById,
   getWorkflowRunDetail,
   getWorkflowRunLineageHead,
+  getWorkflowRunSelection,
   listRunAttempts,
   listRunAttemptsPage,
   listWorkflowRunJobSummaries,

--- a/libs/api/workflows/src/db/workflow-runs/queries.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/queries.test.ts
@@ -14,6 +14,7 @@ import {
   getWorkflowRunById,
   getWorkflowRunDetail,
   getWorkflowRunLineageHead,
+  getWorkflowRunSelection,
   listRunAttempts,
   listRunAttemptsPage,
   listWorkflowRunJobSummaries,
@@ -117,6 +118,57 @@ describe('workflow run queries', () => {
 
       await expect(
         getWorkflowRunDetail(crypto.randomUUID(), 1, undefined, {onRead}),
+      ).resolves.toBeUndefined();
+      expect(onRead).toHaveBeenCalledTimes(1);
+      expect(onRead).toHaveBeenCalledWith(
+        expect.objectContaining({
+          databaseDurationMilliseconds: expect.any(Number),
+          returnedRows: 0,
+        }),
+      );
+    });
+  });
+
+  describe('getWorkflowRunSelection measurement observer', () => {
+    test('does not let a throwing observer change a successful read', async () => {
+      const created = await createTestRun({workspaceId, projectId, definitionId});
+      const [job] = await getJobsByWorkflowRunId(created.id);
+      if (!job) throw new Error('Expected workflow job');
+      const onRead = vi.fn(() => {
+        throw new Error('observer unavailable');
+      });
+
+      await expect(
+        getWorkflowRunSelection(
+          {
+            workflowRunId: created.id,
+            projectId,
+            query: {job_id: job.id},
+          },
+          {onRead},
+        ),
+      ).resolves.toMatchObject({workflowRunId: created.id, jobId: job.id});
+      expect(onRead).toHaveBeenCalledTimes(1);
+      expect(onRead).toHaveBeenCalledWith(
+        expect.objectContaining({
+          databaseDurationMilliseconds: expect.any(Number),
+          returnedRows: expect.any(Number),
+        }),
+      );
+    });
+
+    test('notifies the observer for a missing identity with zero returned rows', async () => {
+      const onRead = vi.fn();
+
+      await expect(
+        getWorkflowRunSelection(
+          {
+            workflowRunId: crypto.randomUUID(),
+            projectId,
+            query: {job_id: crypto.randomUUID()},
+          },
+          {onRead},
+        ),
       ).resolves.toBeUndefined();
       expect(onRead).toHaveBeenCalledTimes(1);
       expect(onRead).toHaveBeenCalledWith(

--- a/libs/api/workflows/src/db/workflow-runs/queries.ts
+++ b/libs/api/workflows/src/db/workflow-runs/queries.ts
@@ -8,6 +8,7 @@ import {
 import {and, asc, count, desc, eq, gte, lt, lte, or, type SQL, sql} from 'drizzle-orm';
 import type {JobMode, JobStatus, ListenerStatus} from '#core/entities/job.js';
 import type {JobExecutionStatus} from '#core/entities/job-execution.js';
+import type {StepSourceLocation} from '#core/entities/step.js';
 import type {
   JobExecutionDetail,
   StepDetail,
@@ -64,6 +65,27 @@ export interface WorkflowRunLineageHead {
   latestAttempt: number;
   currentStatus: WorkflowRunStatus;
   updatedAt: Date;
+}
+
+export interface WorkflowRunSelection {
+  workflowRunId: string;
+  workflowRunAttempt: number;
+  jobId: string;
+  jobExecutionId: string | null;
+  stepId: string | null;
+  stepAttemptId: string | null;
+  stepAttempt: number | null;
+  sourceLocation: StepSourceLocation | null;
+}
+
+export interface WorkflowRunSelectionParams {
+  workflowRunId: string;
+  projectId: string;
+  attempt?: number | undefined;
+  jobId?: string | undefined;
+  jobExecutionId?: string | undefined;
+  stepId?: string | undefined;
+  stepAttemptId?: string | undefined;
 }
 
 export interface WorkflowRunBoundedReadMeasurement {
@@ -265,6 +287,228 @@ export async function getWorkflowRunLineageHead(
           updatedAt: row.updatedAt,
         }
       : undefined;
+  } finally {
+    try {
+      options.onRead?.({
+        databaseDurationMilliseconds: performance.now() - startedAt,
+        returnedRows,
+      });
+    } catch {
+      // Measurement observers must not change the bounded read outcome.
+    }
+  }
+}
+
+type WorkflowRunSelectionRow = {
+  workflowRunId: string;
+  workflowRunAttempt: number;
+  jobId: string;
+  jobExecutionId: string | null;
+  stepId: string | null;
+  stepAttemptId: string | null;
+  stepAttempt: number | null;
+  sourceLocation: StepSourceLocation | null;
+};
+
+/**
+ * Resolve only the supplied identity's ancestry. Each branch starts at the deepest supplied
+ * identity so the resolver never scans unrelated executions, steps, or step-attempt history.
+ */
+export function getWorkflowRunSelection(
+  params: WorkflowRunSelectionParams,
+  options: WorkflowRunBoundedReadOptions = {},
+): Promise<WorkflowRunSelection | undefined> {
+  if (params.stepAttemptId) {
+    return getStepAttemptSelection(params, options);
+  }
+
+  if (params.stepId) {
+    return getStepSelection(params, options);
+  }
+
+  if (params.jobExecutionId) {
+    return getJobExecutionSelection(params, options);
+  }
+
+  if (params.jobId) {
+    return getJobSelection(params, options);
+  }
+
+  return Promise.resolve(undefined);
+}
+
+function getStepAttemptSelection(
+  params: WorkflowRunSelectionParams,
+  options: WorkflowRunBoundedReadOptions,
+): Promise<WorkflowRunSelection | undefined> {
+  const stepAttemptId = params.stepAttemptId;
+  if (!stepAttemptId) return Promise.resolve(undefined);
+
+  const identityConditions: SQL[] = [eq(stepAttempts.id, stepAttemptId)];
+  if (params.stepId) identityConditions.push(eq(steps.id, params.stepId));
+  if (params.jobExecutionId) identityConditions.push(eq(jobExecutions.id, params.jobExecutionId));
+  if (params.jobId) identityConditions.push(eq(jobs.id, params.jobId));
+
+  return readWorkflowRunSelection(
+    () =>
+      db()
+        .select({
+          workflowRunId: workflowRuns.id,
+          workflowRunAttempt: workflowRunAttempts.attempt,
+          jobId: jobs.id,
+          jobExecutionId: jobExecutions.id,
+          stepId: steps.id,
+          stepAttemptId: stepAttempts.id,
+          stepAttempt: stepAttempts.attempt,
+          sourceLocation: steps.sourceLocation,
+        })
+        .from(stepAttempts)
+        .innerJoin(
+          steps,
+          and(
+            eq(stepAttempts.stepId, steps.id),
+            eq(stepAttempts.jobExecutionId, steps.jobExecutionId),
+          ),
+        )
+        .innerJoin(jobExecutions, eq(steps.jobExecutionId, jobExecutions.id))
+        .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
+        .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
+        .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
+        .where(and(...workflowRunSelectionConditions(params, ...identityConditions)))
+        .limit(1),
+    (row) => row,
+    options,
+  );
+}
+
+function getStepSelection(
+  params: WorkflowRunSelectionParams,
+  options: WorkflowRunBoundedReadOptions,
+): Promise<WorkflowRunSelection | undefined> {
+  const stepId = params.stepId;
+  if (!stepId) return Promise.resolve(undefined);
+
+  const identityConditions: SQL[] = [eq(steps.id, stepId)];
+  if (params.jobExecutionId) identityConditions.push(eq(jobExecutions.id, params.jobExecutionId));
+  if (params.jobId) identityConditions.push(eq(jobs.id, params.jobId));
+
+  return readWorkflowRunSelection(
+    () =>
+      db()
+        .select({
+          workflowRunId: workflowRuns.id,
+          workflowRunAttempt: workflowRunAttempts.attempt,
+          jobId: jobs.id,
+          jobExecutionId: jobExecutions.id,
+          stepId: steps.id,
+          stepAttemptId: sql<string | null>`null`,
+          stepAttempt: sql<number | null>`null`,
+          sourceLocation: steps.sourceLocation,
+        })
+        .from(steps)
+        .innerJoin(jobExecutions, eq(steps.jobExecutionId, jobExecutions.id))
+        .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
+        .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
+        .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
+        .where(and(...workflowRunSelectionConditions(params, ...identityConditions)))
+        .limit(1),
+    (row) => row,
+    options,
+  );
+}
+
+function getJobExecutionSelection(
+  params: WorkflowRunSelectionParams,
+  options: WorkflowRunBoundedReadOptions,
+): Promise<WorkflowRunSelection | undefined> {
+  const jobExecutionId = params.jobExecutionId;
+  if (!jobExecutionId) return Promise.resolve(undefined);
+
+  const identityConditions: SQL[] = [eq(jobExecutions.id, jobExecutionId)];
+  if (params.jobId) identityConditions.push(eq(jobs.id, params.jobId));
+
+  return readWorkflowRunSelection(
+    () =>
+      db()
+        .select({
+          workflowRunId: workflowRuns.id,
+          workflowRunAttempt: workflowRunAttempts.attempt,
+          jobId: jobs.id,
+          jobExecutionId: jobExecutions.id,
+          stepId: sql<string | null>`null`,
+          stepAttemptId: sql<string | null>`null`,
+          stepAttempt: sql<number | null>`null`,
+          sourceLocation: sql<StepSourceLocation | null>`null`,
+        })
+        .from(jobExecutions)
+        .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
+        .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
+        .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
+        .where(and(...workflowRunSelectionConditions(params, ...identityConditions)))
+        .limit(1),
+    (row) => row,
+    options,
+  );
+}
+
+function getJobSelection(
+  params: WorkflowRunSelectionParams,
+  options: WorkflowRunBoundedReadOptions,
+): Promise<WorkflowRunSelection | undefined> {
+  const jobId = params.jobId;
+  if (!jobId) return Promise.resolve(undefined);
+
+  return readWorkflowRunSelection(
+    () =>
+      db()
+        .select({
+          workflowRunId: workflowRuns.id,
+          workflowRunAttempt: workflowRunAttempts.attempt,
+          jobId: jobs.id,
+          jobExecutionId: sql<string | null>`null`,
+          stepId: sql<string | null>`null`,
+          stepAttemptId: sql<string | null>`null`,
+          stepAttempt: sql<number | null>`null`,
+          sourceLocation: sql<StepSourceLocation | null>`null`,
+        })
+        .from(jobs)
+        .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
+        .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
+        .where(and(...workflowRunSelectionConditions(params, eq(jobs.id, jobId))))
+        .limit(1),
+    (row) => row,
+    options,
+  );
+}
+
+function workflowRunSelectionConditions(
+  params: WorkflowRunSelectionParams,
+  ...identityConditions: SQL[]
+): SQL[] {
+  const conditions: SQL[] = [
+    eq(workflowRuns.id, params.workflowRunId),
+    eq(workflowRuns.projectId, params.projectId),
+    ...identityConditions,
+  ];
+  if (params.attempt !== undefined) {
+    conditions.push(eq(workflowRunAttempts.attempt, params.attempt));
+  }
+  return conditions;
+}
+
+async function readWorkflowRunSelection<T extends WorkflowRunSelectionRow>(
+  read: () => Promise<T[]>,
+  map: (row: T) => WorkflowRunSelection,
+  options: WorkflowRunBoundedReadOptions,
+): Promise<WorkflowRunSelection | undefined> {
+  const startedAt = performance.now();
+  let returnedRows = 0;
+
+  try {
+    const rows = await read();
+    returnedRows = rows.length;
+    const row = rows[0];
+    return row ? map(row) : undefined;
   } finally {
     try {
       options.onRead?.({

--- a/libs/api/workflows/src/db/workflow-runs/queries.ts
+++ b/libs/api/workflows/src/db/workflow-runs/queries.ts
@@ -1,4 +1,8 @@
-import {WORKFLOW_RUN_JOB_PREVIEW_LIMIT} from '@shipfox/api-workflows-dto';
+import {
+  getWorkflowRunSelectionDepth,
+  WORKFLOW_RUN_JOB_PREVIEW_LIMIT,
+  type WorkflowRunSelectionQueryDto,
+} from '@shipfox/api-workflows-dto';
 import {
   type NumberIdCursor,
   paginateTimestampIdRows,
@@ -81,11 +85,7 @@ export interface WorkflowRunSelection {
 export interface WorkflowRunSelectionParams {
   workflowRunId: string;
   projectId: string;
-  attempt?: number | undefined;
-  jobId?: string | undefined;
-  jobExecutionId?: string | undefined;
-  stepId?: string | undefined;
-  stepAttemptId?: string | undefined;
+  query: WorkflowRunSelectionQueryDto;
 }
 
 export interface WorkflowRunBoundedReadMeasurement {
@@ -318,36 +318,31 @@ export function getWorkflowRunSelection(
   params: WorkflowRunSelectionParams,
   options: WorkflowRunBoundedReadOptions = {},
 ): Promise<WorkflowRunSelection | undefined> {
-  if (params.stepAttemptId) {
-    return getStepAttemptSelection(params, options);
+  switch (getWorkflowRunSelectionDepth(params.query)) {
+    case 'step_attempt':
+      return getStepAttemptSelection(params, options);
+    case 'step':
+      return getStepSelection(params, options);
+    case 'execution':
+      return getJobExecutionSelection(params, options);
+    case 'job':
+      return getJobSelection(params, options);
   }
-
-  if (params.stepId) {
-    return getStepSelection(params, options);
-  }
-
-  if (params.jobExecutionId) {
-    return getJobExecutionSelection(params, options);
-  }
-
-  if (params.jobId) {
-    return getJobSelection(params, options);
-  }
-
-  return Promise.resolve(undefined);
 }
 
 function getStepAttemptSelection(
   params: WorkflowRunSelectionParams,
   options: WorkflowRunBoundedReadOptions,
 ): Promise<WorkflowRunSelection | undefined> {
-  const stepAttemptId = params.stepAttemptId;
+  const stepAttemptId = params.query.step_attempt_id;
   if (!stepAttemptId) return Promise.resolve(undefined);
 
   const identityConditions: SQL[] = [eq(stepAttempts.id, stepAttemptId)];
-  if (params.stepId) identityConditions.push(eq(steps.id, params.stepId));
-  if (params.jobExecutionId) identityConditions.push(eq(jobExecutions.id, params.jobExecutionId));
-  if (params.jobId) identityConditions.push(eq(jobs.id, params.jobId));
+  if (params.query.step_id) identityConditions.push(eq(steps.id, params.query.step_id));
+  if (params.query.job_execution_id) {
+    identityConditions.push(eq(jobExecutions.id, params.query.job_execution_id));
+  }
+  if (params.query.job_id) identityConditions.push(eq(jobs.id, params.query.job_id));
 
   return readWorkflowRunSelection(
     () =>
@@ -385,12 +380,14 @@ function getStepSelection(
   params: WorkflowRunSelectionParams,
   options: WorkflowRunBoundedReadOptions,
 ): Promise<WorkflowRunSelection | undefined> {
-  const stepId = params.stepId;
+  const stepId = params.query.step_id;
   if (!stepId) return Promise.resolve(undefined);
 
   const identityConditions: SQL[] = [eq(steps.id, stepId)];
-  if (params.jobExecutionId) identityConditions.push(eq(jobExecutions.id, params.jobExecutionId));
-  if (params.jobId) identityConditions.push(eq(jobs.id, params.jobId));
+  if (params.query.job_execution_id) {
+    identityConditions.push(eq(jobExecutions.id, params.query.job_execution_id));
+  }
+  if (params.query.job_id) identityConditions.push(eq(jobs.id, params.query.job_id));
 
   return readWorkflowRunSelection(
     () =>
@@ -421,11 +418,11 @@ function getJobExecutionSelection(
   params: WorkflowRunSelectionParams,
   options: WorkflowRunBoundedReadOptions,
 ): Promise<WorkflowRunSelection | undefined> {
-  const jobExecutionId = params.jobExecutionId;
+  const jobExecutionId = params.query.job_execution_id;
   if (!jobExecutionId) return Promise.resolve(undefined);
 
   const identityConditions: SQL[] = [eq(jobExecutions.id, jobExecutionId)];
-  if (params.jobId) identityConditions.push(eq(jobs.id, params.jobId));
+  if (params.query.job_id) identityConditions.push(eq(jobs.id, params.query.job_id));
 
   return readWorkflowRunSelection(
     () =>
@@ -455,7 +452,7 @@ function getJobSelection(
   params: WorkflowRunSelectionParams,
   options: WorkflowRunBoundedReadOptions,
 ): Promise<WorkflowRunSelection | undefined> {
-  const jobId = params.jobId;
+  const jobId = params.query.job_id;
   if (!jobId) return Promise.resolve(undefined);
 
   return readWorkflowRunSelection(
@@ -490,8 +487,8 @@ function workflowRunSelectionConditions(
     eq(workflowRuns.projectId, params.projectId),
     ...identityConditions,
   ];
-  if (params.attempt !== undefined) {
-    conditions.push(eq(workflowRunAttempts.attempt, params.attempt));
+  if (params.query.attempt !== undefined) {
+    conditions.push(eq(workflowRunAttempts.attempt, params.query.attempt));
   }
   return conditions;
 }

--- a/libs/api/workflows/src/presentation/dto/index.ts
+++ b/libs/api/workflows/src/presentation/dto/index.ts
@@ -7,4 +7,5 @@ export {
   toRunDto,
   toRunLineageHeadDto,
   toRunListItemDto,
+  toRunSelectionDto,
 } from './workflow-run.js';

--- a/libs/api/workflows/src/presentation/dto/workflow-run.ts
+++ b/libs/api/workflows/src/presentation/dto/workflow-run.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowRunDto,
   WorkflowRunLineageHeadDto,
   WorkflowRunListItemDto,
+  WorkflowRunSelectionDto,
   WorkflowRunTriggerReferenceDto,
 } from '@shipfox/api-workflows-dto';
 import type {
@@ -14,7 +15,11 @@ import type {
   WorkflowRunTriggerReference,
 } from '#core/entities/workflow-run.js';
 import type {WorkflowRunAttempt} from '#core/entities/workflow-run-attempt.js';
-import type {WorkflowRunJobsSummary, WorkflowRunLineageHead} from '#db/index.js';
+import type {
+  WorkflowRunJobsSummary,
+  WorkflowRunLineageHead,
+  WorkflowRunSelection,
+} from '#db/index.js';
 import {toJobDto, toJobExecutionDto} from './job.js';
 import {toStepAttemptDto, toStepDto} from './step.js';
 
@@ -150,5 +155,24 @@ export function toRunLineageHeadDto(head: WorkflowRunLineageHead): WorkflowRunLi
     latest_attempt: head.latestAttempt,
     current_status: head.currentStatus,
     updated_at: head.updatedAt.toISOString(),
+  };
+}
+
+export function toRunSelectionDto(selection: WorkflowRunSelection): WorkflowRunSelectionDto {
+  return {
+    workflow_run_id: selection.workflowRunId,
+    workflow_run_attempt: selection.workflowRunAttempt,
+    job_id: selection.jobId,
+    job_execution_id: selection.jobExecutionId,
+    step_id: selection.stepId,
+    step_attempt_id: selection.stepAttemptId,
+    step_attempt: selection.stepAttempt,
+    source_location:
+      selection.sourceLocation === null
+        ? null
+        : {
+            start_line: selection.sourceLocation.startLine,
+            end_line: selection.sourceLocation.endLine,
+          },
   };
 }

--- a/libs/api/workflows/src/presentation/routes/get-run-selection.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-selection.test.ts
@@ -97,6 +97,41 @@ describe('GET /api/workflows/runs/:id/selection', () => {
     });
   });
 
+  test('resolves a step identity pinned to the requested attempt', async () => {
+    const fixture = await createLineage();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: selectionUrl(fixture.run.id, {step_id: fixture.rerunStep.id, attempt: 2}),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      workflow_run_id: fixture.run.id,
+      workflow_run_attempt: 2,
+      step_id: fixture.rerunStep.id,
+    });
+  });
+
+  test('resolves a step-attempt identity pinned to the requested attempt', async () => {
+    const fixture = await createLineage();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: selectionUrl(fixture.run.id, {
+        step_attempt_id: fixture.stepAttemptId,
+        attempt: 1,
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      workflow_run_id: fixture.run.id,
+      workflow_run_attempt: 1,
+      step_attempt_id: fixture.stepAttemptId,
+    });
+  });
+
   test('returns the stable not-found response for a mismatched attempt', async () => {
     const fixture = await createLineage();
 
@@ -126,6 +161,8 @@ describe('GET /api/workflows/runs/:id/selection', () => {
       {step_id: fixture.sourceStep.id, job_id: otherJob.id},
       {step_id: fixture.sourceStep.id, job_execution_id: otherExecution.id},
       {step_attempt_id: fixture.stepAttemptId, step_id: otherStep.id},
+      {step_attempt_id: fixture.stepAttemptId, job_id: otherJob.id},
+      {step_attempt_id: fixture.stepAttemptId, job_execution_id: otherExecution.id},
     ];
 
     for (const query of mismatchedSelections) {

--- a/libs/api/workflows/src/presentation/routes/get-run-selection.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-selection.test.ts
@@ -1,0 +1,276 @@
+import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {ClientError} from '@shipfox/node-fastify';
+import type {FastifyInstance} from 'fastify';
+import Fastify from 'fastify';
+import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
+import {db} from '#db/db.js';
+import {
+  createRerunWorkflowRun,
+  createWorkflowRun,
+  getJobExecutionsByJobId,
+  getJobsByWorkflowRunId,
+  getStepsByJobExecutionId,
+  insertRunningStepAttempt,
+  updateWorkflowRunStatus,
+} from '#db/workflow-runs.js';
+import {workflowModel} from '#test/index.js';
+import {getRunSelectionRoute} from './get-run-selection.js';
+
+const getProjectById = vi.fn();
+const projects = {
+  getProjectById,
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
+
+describe('GET /api/workflows/runs/:id/selection', () => {
+  let app: FastifyInstance;
+  let workspaceId: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.addHook('onRequest', (request, _reply, done) => {
+      setUserContext(
+        request,
+        buildUserContext({
+          userId: crypto.randomUUID(),
+          email: 'user@example.com',
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
+        }),
+      );
+      done();
+    });
+    app.get('/api/workflows/runs/:id/selection', getRunSelectionRoute(projects));
+    await app.ready();
+  });
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+    projectId = crypto.randomUUID();
+    getProjectById.mockReset();
+    getProjectById.mockImplementation(({projectId: requestedProjectId}) =>
+      Promise.resolve({
+        project: {
+          id: requestedProjectId,
+          workspaceId,
+          sourceConnectionId: crypto.randomUUID(),
+          sourceExternalRepositoryId: `repo:${crypto.randomUUID()}`,
+          name: 'Project',
+        },
+      }),
+    );
+  });
+
+  test.each([
+    ['job', (fixture: SelectionFixture) => ({job_id: fixture.sourceJob.id})],
+    ['execution', (fixture: SelectionFixture) => ({job_execution_id: fixture.sourceExecution.id})],
+    ['step', (fixture: SelectionFixture) => ({step_id: fixture.sourceStep.id})],
+    ['step attempt', (fixture: SelectionFixture) => ({step_attempt_id: fixture.stepAttemptId})],
+  ])('resolves ancestry from a %s identity', async (_depth, queryFor) => {
+    const fixture = await createLineage();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: selectionUrl(fixture.run.id, queryFor(fixture)),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual(expectedSelection(fixture, _depth));
+  });
+
+  test('derives an older attempt from a step-only identity', async () => {
+    const fixture = await createLineage();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: selectionUrl(fixture.run.id, {step_id: fixture.sourceStep.id}),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      workflow_run_id: fixture.run.id,
+      workflow_run_attempt: 1,
+      step_id: fixture.sourceStep.id,
+    });
+  });
+
+  test('returns the stable not-found response for a mismatched attempt', async () => {
+    const fixture = await createLineage();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: selectionUrl(fixture.run.id, {step_id: fixture.sourceStep.id, attempt: 2}),
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({code: 'not-found'});
+  });
+
+  test('rejects identities that cross run, attempt, job, execution, or step ancestry', async () => {
+    const fixture = await createLineage();
+    const otherRun = await createRun();
+    const [otherJob] = await getJobsByWorkflowRunId(otherRun.id);
+    if (!otherJob) throw new Error('Missing other job');
+    const [otherExecution] = await getJobExecutionsByJobId(otherJob.id);
+    if (!otherExecution) throw new Error('Missing other execution');
+    const otherSteps = await getStepsByJobExecutionId(otherExecution.id);
+    const otherStep = otherSteps.find((step) => step.sourceLocation !== null);
+    if (!otherStep) throw new Error('Missing other step');
+
+    const mismatchedSelections = [
+      {job_id: fixture.sourceJob.id, job_execution_id: fixture.rerunExecution.id},
+      {job_execution_id: fixture.sourceExecution.id, step_id: fixture.rerunStep.id},
+      {step_id: fixture.sourceStep.id, job_id: otherJob.id},
+      {step_id: fixture.sourceStep.id, job_execution_id: otherExecution.id},
+      {step_attempt_id: fixture.stepAttemptId, step_id: otherStep.id},
+    ];
+
+    for (const query of mismatchedSelections) {
+      const response = await app.inject({
+        method: 'GET',
+        url: selectionUrl(fixture.run.id, query),
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toMatchObject({code: 'not-found'});
+    }
+  });
+
+  test('returns the stable not-found response for missing or inaccessible runs', async () => {
+    const missing = await app.inject({
+      method: 'GET',
+      url: selectionUrl(crypto.randomUUID(), {job_id: crypto.randomUUID()}),
+    });
+    const fixture = await createLineage();
+    getProjectById.mockRejectedValueOnce(new ClientError('Forbidden', 'forbidden', {status: 403}));
+
+    const inaccessible = await app.inject({
+      method: 'GET',
+      url: selectionUrl(fixture.run.id, {job_id: fixture.sourceJob.id}),
+    });
+
+    expect(missing.statusCode).toBe(404);
+    expect(inaccessible.statusCode).toBe(404);
+  });
+
+  test('rejects a query without a nested identity', async () => {
+    const fixture = await createLineage();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${fixture.run.id}/selection?attempt=2`,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  async function createLineage(): Promise<SelectionFixture> {
+    const sourceRun = await createRun();
+    const [sourceJob] = await getJobsByWorkflowRunId(sourceRun.id);
+    if (!sourceJob) throw new Error('Missing source job');
+    const [sourceExecution] = await getJobExecutionsByJobId(sourceJob.id);
+    if (!sourceExecution) throw new Error('Missing source execution');
+    const sourceSteps = await getStepsByJobExecutionId(sourceExecution.id);
+    const sourceStep = sourceSteps.find((step) => step.sourceLocation !== null);
+    if (!sourceStep) throw new Error('Missing source step');
+    const stepAttemptId = await db().transaction((tx) =>
+      insertRunningStepAttempt(
+        {
+          jobExecutionId: sourceExecution.id,
+          stepId: sourceStep.id,
+          attempt: 1,
+        },
+        tx,
+      ),
+    );
+    if (!stepAttemptId) throw new Error('Missing source step attempt');
+
+    await updateWorkflowRunStatus({
+      workflowRunId: sourceRun.id,
+      status: 'failed',
+      expectedVersion: 1,
+    });
+    const run = await createRerunWorkflowRun({
+      workflowRunId: sourceRun.id,
+      mode: 'all',
+      actorUserId: crypto.randomUUID(),
+    });
+    const [rerunJob] = await getJobsByWorkflowRunId(run.id);
+    if (!rerunJob) throw new Error('Missing rerun job');
+    const [rerunExecution] = await getJobExecutionsByJobId(rerunJob.id);
+    if (!rerunExecution) throw new Error('Missing rerun execution');
+    const rerunSteps = await getStepsByJobExecutionId(rerunExecution.id);
+    const rerunStep = rerunSteps.find((step) => step.sourceLocation !== null);
+    if (!rerunStep) throw new Error('Missing rerun step');
+
+    return {
+      run,
+      sourceJob,
+      sourceExecution,
+      sourceStep,
+      stepAttemptId,
+      rerunExecution,
+      rerunStep,
+    };
+  }
+
+  function createRun() {
+    return createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId: crypto.randomUUID(),
+      model: workflowModel({
+        name: 'Selection',
+        jobs: {
+          build: {
+            steps: [
+              {name: 'Install', run: 'npm install', sourceLocation: {startLine: 5, endLine: 6}},
+            ],
+          },
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+  }
+});
+
+interface SelectionFixture {
+  run: Awaited<ReturnType<typeof createWorkflowRun>>;
+  sourceJob: Awaited<ReturnType<typeof getJobsByWorkflowRunId>>[number];
+  sourceExecution: Awaited<ReturnType<typeof getJobExecutionsByJobId>>[number];
+  sourceStep: Awaited<ReturnType<typeof getStepsByJobExecutionId>>[number];
+  stepAttemptId: string;
+  rerunExecution: Awaited<ReturnType<typeof getJobExecutionsByJobId>>[number];
+  rerunStep: Awaited<ReturnType<typeof getStepsByJobExecutionId>>[number];
+}
+
+function selectionUrl(runId: string, query: Record<string, string | number>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) search.set(key, String(value));
+  return `/api/workflows/runs/${runId}/selection?${search.toString()}`;
+}
+
+function expectedSelection(fixture: SelectionFixture, depth: string) {
+  const includesExecution = depth !== 'job';
+  const includesStep = depth === 'step' || depth === 'step attempt';
+  const includesStepAttempt = depth === 'step attempt';
+
+  return {
+    workflow_run_id: fixture.run.id,
+    workflow_run_attempt: 1,
+    job_id: fixture.sourceJob.id,
+    job_execution_id: includesExecution ? fixture.sourceExecution.id : null,
+    step_id: includesStep ? fixture.sourceStep.id : null,
+    step_attempt_id: includesStepAttempt ? fixture.stepAttemptId : null,
+    step_attempt: includesStepAttempt ? 1 : null,
+    source_location: includesStep ? {start_line: 5, end_line: 6} : null,
+  };
+}

--- a/libs/api/workflows/src/presentation/routes/get-run-selection.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-selection.ts
@@ -1,6 +1,6 @@
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
-  type WorkflowRunSelectionQueryDto,
+  getWorkflowRunSelectionDepth,
   workflowRunSelectionQuerySchema,
   workflowRunSelectionResponseSchema,
 } from '@shipfox/api-workflows-dto';
@@ -11,8 +11,6 @@ import {getWorkflowRunSelection} from '#db/index.js';
 import {toRunSelectionDto} from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 import {serializedResponseByteLength} from './serialized-response-byte-length.js';
-
-type SelectionDepth = 'job' | 'execution' | 'step' | 'step_attempt';
 
 export function getRunSelectionRoute(projects: ProjectsModuleClient) {
   return defineRoute({
@@ -31,7 +29,7 @@ export function getRunSelectionRoute(projects: ProjectsModuleClient) {
     handler: async (request, reply) => {
       const {id} = request.params;
       const query = request.query;
-      const selectionDepth = getSelectionDepth(query);
+      const selectionDepth = getWorkflowRunSelectionDepth(query);
       const startedAt = performance.now();
       let dbDurationMilliseconds = 0;
       let responseBytes = 0;
@@ -46,11 +44,7 @@ export function getRunSelectionRoute(projects: ProjectsModuleClient) {
           {
             workflowRunId: run.id,
             projectId: run.projectId,
-            attempt: query.attempt,
-            jobId: query.job_id,
-            jobExecutionId: query.job_execution_id,
-            stepId: query.step_id,
-            stepAttemptId: query.step_attempt_id,
+            query,
           },
           {
             onRead: (measurement) => {
@@ -95,11 +89,4 @@ export function getRunSelectionRoute(projects: ProjectsModuleClient) {
       }
     },
   });
-}
-
-function getSelectionDepth(query: WorkflowRunSelectionQueryDto): SelectionDepth {
-  if (query.step_attempt_id !== undefined) return 'step_attempt';
-  if (query.step_id !== undefined) return 'step';
-  if (query.job_execution_id !== undefined) return 'execution';
-  return 'job';
 }

--- a/libs/api/workflows/src/presentation/routes/get-run-selection.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-selection.ts
@@ -1,0 +1,105 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {
+  type WorkflowRunSelectionQueryDto,
+  workflowRunSelectionQuerySchema,
+  workflowRunSelectionResponseSchema,
+} from '@shipfox/api-workflows-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import {z} from 'zod';
+import {getWorkflowRunSelection} from '#db/index.js';
+import {toRunSelectionDto} from '#presentation/dto/index.js';
+import {requireAccessibleRun} from './require-accessible-run.js';
+import {serializedResponseByteLength} from './serialized-response-byte-length.js';
+
+type SelectionDepth = 'job' | 'execution' | 'step' | 'step_attempt';
+
+export function getRunSelectionRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/:id/selection',
+    description: 'Resolve a workflow run selection',
+    schema: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      querystring: workflowRunSelectionQuerySchema,
+      response: {
+        200: workflowRunSelectionResponseSchema,
+      },
+    },
+    handler: async (request, reply) => {
+      const {id} = request.params;
+      const query = request.query;
+      const selectionDepth = getSelectionDepth(query);
+      const startedAt = performance.now();
+      let dbDurationMilliseconds = 0;
+      let responseBytes = 0;
+      let resultCount = 0;
+      let resolvedAttempt: number | null = null;
+      let responseStatus = 200;
+      let outcome: 'success' | 'not_found' | 'error' = 'success';
+
+      try {
+        const run = await requireAccessibleRun({request, id, projects});
+        const selection = await getWorkflowRunSelection(
+          {
+            workflowRunId: run.id,
+            projectId: run.projectId,
+            attempt: query.attempt,
+            jobId: query.job_id,
+            jobExecutionId: query.job_execution_id,
+            stepId: query.step_id,
+            stepAttemptId: query.step_attempt_id,
+          },
+          {
+            onRead: (measurement) => {
+              dbDurationMilliseconds = measurement.databaseDurationMilliseconds;
+            },
+          },
+        );
+        if (!selection) {
+          throw new ClientError('Workflow run selection not found', 'not-found', {status: 404});
+        }
+
+        resultCount = 1;
+        resolvedAttempt = selection.workflowRunAttempt;
+        const response = toRunSelectionDto(selection);
+        const serializedResponse = reply.serialize(response);
+        responseBytes = serializedResponseByteLength(serializedResponse);
+        return reply.type('application/json').send(serializedResponse);
+      } catch (error) {
+        responseStatus =
+          error instanceof ClientError && typeof error.status === 'number' ? error.status : 500;
+        outcome = responseStatus === 404 ? 'not_found' : 'error';
+        throw error;
+      } finally {
+        logger().info(
+          {
+            route: 'workflow-runs/:id/selection',
+            status: responseStatus,
+            outcome,
+            runId: id,
+            selectionDepth,
+            selectionMode: query.attempt === undefined ? 'derive_attempt' : 'pinned_attempt',
+            attemptProvided: query.attempt !== undefined,
+            resolvedAttempt,
+            resultCount,
+            cursorRemaining: false,
+            responseBytes,
+            databaseDurationMs: Math.round(dbDurationMilliseconds),
+            durationMs: Math.round(performance.now() - startedAt),
+          },
+          'Resolved workflow run selection',
+        );
+      }
+    },
+  });
+}
+
+function getSelectionDepth(query: WorkflowRunSelectionQueryDto): SelectionDepth {
+  if (query.step_attempt_id !== undefined) return 'step_attempt';
+  if (query.step_id !== undefined) return 'step';
+  if (query.job_execution_id !== undefined) return 'execution';
+  return 'job';
+}

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -14,6 +14,7 @@ import {createCheckoutTokenRoute} from './checkout-token.js';
 import {getRunRoute} from './get-run.js';
 import {getRunAggregatesRoute} from './get-run-aggregates.js';
 import {getRunLineageHeadRoute} from './get-run-lineage-head.js';
+import {getRunSelectionRoute} from './get-run-selection.js';
 import {getStepAttemptDetailRoute} from './get-step-attempt-detail.js';
 import {createGetStepSecretsRoute} from './get-step-secrets.js';
 import {listRunAttemptsRoute} from './list-run-attempts.js';
@@ -64,6 +65,7 @@ export function createWorkflowRoutes(params: WorkflowRouteClients): RouteGroup[]
         listRunsRoute(params.projects),
         getRunAggregatesRoute(params.projects),
         getRunLineageHeadRoute(params.projects),
+        getRunSelectionRoute(params.projects),
         listRunAttemptsRoute(params.projects),
         getRunRoute(params.projects),
         getStepAttemptDetailRoute(params.projects),


### PR DESCRIPTION
Legacy or incomplete workflow URLs can now resolve one canonical workflow-run selection without loading the workflow tree. The bounded resolver accepts the deepest available job, execution, step, or step-attempt identity, derives its owning attempt when needed, validates all supplied ancestry, and returns a stable not-found response for missing, inaccessible, or mismatched resources.

Shared DTOs, route telemetry, and ancestry coverage are included. Validation passed with the scoped DTO and workflows check/type/test/build/depcruise gates and the API database-boundary validator.

Closes ENG-1870

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow run selection resolver that resolves one canonical run attempt and ancestry from a legacy or incomplete nested-resource URL without loading the workflow tree. Missing, inaccessible, or mismatched resources now return a stable not-found response.

- Accepts the deepest available job, execution, step, or step-attempt identity and derives the owning attempt when none is supplied.
- Validates all supplied identities agree with the run, the supplied attempt, and each other.
- Scans only the branch the supplied identity lives on, so unrelated execution, step, and attempt history is never read.
- Adds shared selection DTOs, route telemetry, ancestry contract tests for all four identity depths, and an e2e smoke test that derives an older attempt from a step ID after a rerun.

Closes ENG-1870.

<sup>Written for commit d3453bb05ba742dac7572656e0c320aab9123cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

