### PR TITLE
[api-auth] Add agent credential management and request authentication

### DIFF
--- a/.changeset/agent-access-credentials.md
+++ b/.changeset/agent-access-credentials.md
@@ -1,0 +1,7 @@
+---
+'@shipfox/api-auth': minor
+'@shipfox/api-auth-context': minor
+'@shipfox/api-auth-dto': minor
+---
+
+Add opt-in agent credential management and unified OAuth/PAT request authentication.

--- a/docs/adr/0014-admin-user-impersonation.md
+++ b/docs/adr/0014-admin-user-impersonation.md
@@ -180,8 +180,9 @@ days. An operator could mint permanent, unattributed workspace access inside a 1
 audited window, stop impersonating, and use it later. Nothing in the audit trail would point at
 it.
 
-The deny-list covers runner registration tokens, provisioner tokens, workspace invitations, and
-OAuth consent approval, which creates an agent grant and its refresh-token family. Its guard is
+The deny-list covers runner registration tokens, provisioner tokens, workspace invitations, agent
+personal access token minting, and OAuth consent approval, which creates an agent grant and its
+refresh-token family. Its guard is
 the administration guard under a second name, exported from the same package, so a route opts in
 with one line. Adding a credential-issuing or grant-creating route later means adding it here.
 

--- a/libs/api/auth-context/src/agent-access-context.test.ts
+++ b/libs/api/auth-context/src/agent-access-context.test.ts
@@ -1,0 +1,29 @@
+import {getAgentAccessContext, requireAgentAccessContext, setAgentAccessContext} from './index.js';
+
+describe('agent access context', () => {
+  test('stores and reads the common identity for an OAuth grant', () => {
+    const request = {};
+    const context = {
+      userId: crypto.randomUUID(),
+      workspaceId: crypto.randomUUID(),
+      scopes: ['read'] as const,
+      credential: {
+        kind: 'oauth_grant' as const,
+        grantId: crypto.randomUUID(),
+        clientId: 'client-id',
+      },
+    };
+
+    setAgentAccessContext(request, context);
+
+    expect(getAgentAccessContext(request)).toEqual(context);
+    expect(requireAgentAccessContext(request)).toEqual(context);
+  });
+
+  test('returns null until an agent credential has authenticated the request', () => {
+    expect(getAgentAccessContext({})).toBeNull();
+    expect(() => requireAgentAccessContext({})).toThrow(
+      'Agent access context is not available on this request',
+    );
+  });
+});

--- a/libs/api/auth-context/src/index.ts
+++ b/libs/api/auth-context/src/index.ts
@@ -13,6 +13,7 @@ export const AUTH_RUNNER_SESSION = 'runner-session';
 export const AUTH_RUNNER_CONTROL_SESSION = 'runner-control-session';
 export const AUTH_LEASED_JOB = 'leased-job';
 export const AUTH_PROVISIONER_TOKEN = 'provisioner-token';
+export const AUTH_AGENT_ACCESS = 'agent-access';
 
 export type WorkspaceStatus = 'active' | 'suspended' | 'deleted';
 
@@ -30,6 +31,20 @@ export interface UserContext {
   impersonatorId?: string | undefined;
   canAccess(workspaceId: string): boolean;
   hasRole(workspaceId: string, role: WorkspaceRole): boolean;
+}
+
+export type AgentAccessScope = 'read';
+
+export type AgentAccessCredential =
+  | {kind: 'oauth_grant'; grantId: string; clientId: string}
+  | {kind: 'pat'; patId: string};
+
+/** The shared identity and authority resolved from an agent credential. */
+export interface AgentAccessContext {
+  userId: string;
+  workspaceId: string;
+  scopes: ReadonlyArray<AgentAccessScope>;
+  credential: AgentAccessCredential;
 }
 
 export interface BuildUserContextParams {
@@ -78,6 +93,7 @@ const RUNNER_SESSION_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/runner-
 const RUNNER_CONTROL_SESSION_CONTEXT_KEY = Symbol.for(
   '@shipfox/api-auth-context/runner-control-session',
 );
+const AGENT_ACCESS_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/agent-access');
 
 export function setUserContext(request: RequestWithContext, context: UserContext): void {
   (request as Record<symbol, unknown>)[USER_CONTEXT_KEY] = context;
@@ -93,6 +109,29 @@ export function requireUserContext(request: RequestWithContext): UserContext {
   const context = getUserContext(request);
   if (!context) {
     throw new Error('User context is not available on this request');
+  }
+  return context;
+}
+
+export function setAgentAccessContext(
+  request: RequestWithContext,
+  context: AgentAccessContext,
+): void {
+  (request as Record<symbol, unknown>)[AGENT_ACCESS_CONTEXT_KEY] = context;
+}
+
+export function getAgentAccessContext(request: RequestWithContext): AgentAccessContext | null {
+  return (
+    ((request as Record<symbol, unknown>)[AGENT_ACCESS_CONTEXT_KEY] as
+      | AgentAccessContext
+      | undefined) ?? null
+  );
+}
+
+export function requireAgentAccessContext(request: RequestWithContext): AgentAccessContext {
+  const context = getAgentAccessContext(request);
+  if (!context) {
+    throw new Error('Agent access context is not available on this request');
   }
   return context;
 }

--- a/libs/api/auth-dto/src/schemas/agent-access.test.ts
+++ b/libs/api/auth-dto/src/schemas/agent-access.test.ts
@@ -1,0 +1,57 @@
+import {describe, expect, it} from '@shipfox/vitest/vi';
+import {
+  agentAccessNameSchema,
+  agentGrantSummarySchema,
+  createAgentPersonalAccessTokenBodySchema,
+} from './agent-access.js';
+import {oauthDynamicClientRegistrationRequestSchema} from './oauth.js';
+
+describe('agent access name schemas', () => {
+  it('rejects names that exceed the UTF-8 byte bound', () => {
+    const value = '😀'.repeat(65);
+
+    expect([...value]).toHaveLength(65);
+    expect(new TextEncoder().encode(value)).toHaveLength(260);
+    expect(agentAccessNameSchema.safeParse(value).success).toBe(false);
+  });
+
+  it.each([
+    ['NUL', 'Agent\0name'],
+    ['right-to-left override', 'Agent\u202ename'],
+    ['zero-width joiner', 'Agent\u200dname'],
+  ])('rejects %s characters in PAT and OAuth client names', (_name, value) => {
+    expect(agentAccessNameSchema.safeParse(value).success).toBe(false);
+    expect(
+      agentGrantSummarySchema.safeParse({
+        id: crypto.randomUUID(),
+        client_name: value,
+        workspace_id: crypto.randomUUID(),
+        scopes: ['read'],
+        created_at: new Date().toISOString(),
+        last_refreshed_at: null,
+      }).success,
+    ).toBe(false);
+    expect(
+      createAgentPersonalAccessTokenBodySchema.safeParse({
+        workspace_id: crypto.randomUUID(),
+        name: value,
+      }).success,
+    ).toBe(false);
+    expect(
+      oauthDynamicClientRegistrationRequestSchema.safeParse({
+        client_name: value,
+        redirect_uris: ['https://client.example/callback'],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('accepts an ASCII name at the 256-byte boundary and defaults PAT expiry to 90 days', () => {
+    expect(agentAccessNameSchema.safeParse('a'.repeat(256)).success).toBe(true);
+
+    const parsed = createAgentPersonalAccessTokenBodySchema.parse({
+      workspace_id: crypto.randomUUID(),
+      name: 'CI access',
+    });
+    expect(parsed.expires_in_days).toBe(90);
+  });
+});

--- a/libs/api/auth-dto/src/schemas/agent-access.ts
+++ b/libs/api/auth-dto/src/schemas/agent-access.ts
@@ -5,7 +5,8 @@ const scopeSchema = z.literal('read');
 const textEncoder = new TextEncoder();
 const CONTROL_OR_FORMAT_CHARACTER_RE = /[\p{Cc}\p{Cf}]/u;
 
-const agentPersonalAccessTokenNameSchema = z
+/** Names displayed in the agent-access UI reject invisible control characters. */
+export const agentAccessNameSchema = z
   .string()
   .min(1)
   .max(256)
@@ -16,11 +17,13 @@ const agentPersonalAccessTokenNameSchema = z
     message: 'must not contain control or format characters',
   });
 
+const agentPersonalAccessTokenNameSchema = agentAccessNameSchema;
+
 /** The dashboard-safe representation of an OAuth agent grant. */
 export const agentGrantSummarySchema = z
   .object({
     id: z.string().uuid(),
-    client_name: z.string().min(1).max(256),
+    client_name: agentAccessNameSchema,
     workspace_id: z.string().uuid(),
     scopes: z.array(scopeSchema).min(1),
     created_at: timestampSchema,

--- a/libs/api/auth-dto/src/schemas/agent-access.ts
+++ b/libs/api/auth-dto/src/schemas/agent-access.ts
@@ -1,0 +1,95 @@
+import {z} from 'zod';
+
+const timestampSchema = z.string().datetime();
+const scopeSchema = z.literal('read');
+const textEncoder = new TextEncoder();
+const CONTROL_OR_FORMAT_CHARACTER_RE = /[\p{Cc}\p{Cf}]/u;
+
+const agentPersonalAccessTokenNameSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((value) => textEncoder.encode(value).byteLength <= 256, {
+    message: 'must be at most 256 UTF-8 bytes',
+  })
+  .refine((value) => !CONTROL_OR_FORMAT_CHARACTER_RE.test(value), {
+    message: 'must not contain control or format characters',
+  });
+
+/** The dashboard-safe representation of an OAuth agent grant. */
+export const agentGrantSummarySchema = z
+  .object({
+    id: z.string().uuid(),
+    client_name: z.string().min(1).max(256),
+    workspace_id: z.string().uuid(),
+    scopes: z.array(scopeSchema).min(1),
+    created_at: timestampSchema,
+    last_refreshed_at: timestampSchema.nullable(),
+  })
+  .strict();
+
+export type AgentGrantSummaryDto = z.infer<typeof agentGrantSummarySchema>;
+
+export const listAgentGrantsResponseSchema = z
+  .object({grants: z.array(agentGrantSummarySchema)})
+  .strict();
+
+export type ListAgentGrantsResponseDto = z.infer<typeof listAgentGrantsResponseSchema>;
+
+/** The dashboard-safe representation of a PAT; the raw value is never included. */
+export const agentPersonalAccessTokenSummarySchema = z
+  .object({
+    id: z.string().uuid(),
+    workspace_id: z.string().uuid(),
+    prefix: z.string().min(1).max(64),
+    name: agentPersonalAccessTokenNameSchema,
+    expires_at: timestampSchema,
+    last_used_at: timestampSchema.nullable(),
+    created_at: timestampSchema,
+  })
+  .strict();
+
+export type AgentPersonalAccessTokenSummaryDto = z.infer<
+  typeof agentPersonalAccessTokenSummarySchema
+>;
+
+export const listAgentPersonalAccessTokensResponseSchema = z
+  .object({pats: z.array(agentPersonalAccessTokenSummarySchema)})
+  .strict();
+
+export type ListAgentPersonalAccessTokensResponseDto = z.infer<
+  typeof listAgentPersonalAccessTokensResponseSchema
+>;
+
+export const createAgentPersonalAccessTokenBodySchema = z
+  .object({
+    workspace_id: z.string().uuid(),
+    name: agentPersonalAccessTokenNameSchema,
+    expires_in_days: z.union([z.literal(30), z.literal(90), z.literal(365)]).default(90),
+  })
+  .strict();
+
+export type CreateAgentPersonalAccessTokenBodyDto = z.infer<
+  typeof createAgentPersonalAccessTokenBodySchema
+>;
+
+export const createAgentPersonalAccessTokenResponseSchema = z
+  .object({
+    raw_token: z.string().min(1),
+    id: z.string().uuid(),
+    workspace_id: z.string().uuid(),
+    prefix: z.string().min(1).max(64),
+    name: agentPersonalAccessTokenNameSchema,
+    expires_at: timestampSchema,
+    last_used_at: timestampSchema.nullable(),
+    created_at: timestampSchema,
+  })
+  .strict();
+
+export type CreateAgentPersonalAccessTokenResponseDto = z.infer<
+  typeof createAgentPersonalAccessTokenResponseSchema
+>;
+
+export const agentAccessCredentialParamsSchema = z.object({id: z.string().uuid()}).strict();
+
+export type AgentAccessCredentialParamsDto = z.infer<typeof agentAccessCredentialParamsSchema>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -62,6 +62,7 @@ export {
   type AgentGrantSummaryDto,
   type AgentPersonalAccessTokenSummaryDto,
   agentAccessCredentialParamsSchema,
+  agentAccessNameSchema,
   agentGrantSummarySchema,
   agentPersonalAccessTokenSummarySchema,
   type CreateAgentPersonalAccessTokenBodyDto,

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -58,6 +58,22 @@ export {
   suspendAdministratorUserBodySchema,
 } from './admin.js';
 export {
+  type AgentAccessCredentialParamsDto,
+  type AgentGrantSummaryDto,
+  type AgentPersonalAccessTokenSummaryDto,
+  agentAccessCredentialParamsSchema,
+  agentGrantSummarySchema,
+  agentPersonalAccessTokenSummarySchema,
+  type CreateAgentPersonalAccessTokenBodyDto,
+  type CreateAgentPersonalAccessTokenResponseDto,
+  createAgentPersonalAccessTokenBodySchema,
+  createAgentPersonalAccessTokenResponseSchema,
+  type ListAgentGrantsResponseDto,
+  type ListAgentPersonalAccessTokensResponseDto,
+  listAgentGrantsResponseSchema,
+  listAgentPersonalAccessTokensResponseSchema,
+} from './agent-access.js';
+export {
   AGENT_ACCESS_TOKEN_AUDIENCE,
   type AgentAccessTokenClaims,
   agentAccessTokenClaimsSchema,

--- a/libs/api/auth-dto/src/schemas/oauth.ts
+++ b/libs/api/auth-dto/src/schemas/oauth.ts
@@ -1,7 +1,8 @@
 import {z} from 'zod';
+import {agentAccessNameSchema} from './agent-access.js';
 
 const oauthUrlSchema = z.string().url().max(2048);
-const oauthClientNameSchema = z.string().min(1).max(256);
+const oauthClientNameSchema = agentAccessNameSchema;
 const oauthRedirectUriSchema = z.string().min(1).max(2048);
 const oauthScopeSchema = z.string().min(1).max(256);
 const oauthGrantTypeSchema = z.enum(['authorization_code', 'refresh_token']);

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -108,18 +108,21 @@ When `AUTH_PASSWORD_ENABLED=false`, the module does not register signup, login, 
 
 ## Security model
 
-The module issues three kinds of bearer token, all presented as
-`Authorization: Bearer <token>`. All are **stateless**: each is signed with
-HMAC-SHA256 and verified by checking its signature and expiry alone, with no
-database read on the request path. They differ in who they authenticate and what
-they grant, and the stateless tradeoff is accepted for a different reason in each
-case. Each token class uses a separate key derived from `AUTH_ROOT_KEY` and a
+The module issues several bearer token types, all presented as
+`Authorization: Bearer <token>`. User session, runner session, job lease, and
+OAuth access tokens are **stateless**: each is signed with HMAC-SHA256 and
+verified by checking its signature and expiry alone. Personal access tokens
+are opaque, database-backed credentials because their long-lived lifetime needs
+per-request revocation.
+
+Each signed token class uses a separate key derived from `AUTH_ROOT_KEY` and a
 fixed audience, so one token type cannot be used in place of another.
 
 Changing `AUTH_ROOT_KEY` invalidates every user session token, runner session
-token, job lease token, email challenge, and rate-limit identifier created with
-the previous root. The module does not support rotating one derived key by
-itself.
+token, job lease token, OAuth access token, email challenge, and rate-limit
+identifier created with the previous root. Personal access tokens remain
+database-backed and are revoked through their management route. The module does
+not support rotating one derived key by itself.
 
 ### User session token
 
@@ -269,9 +272,29 @@ progress and drives that job to completion.
   proves too wide, the right fix is to bind the lease to live runner or job state,
   not to broaden what the token itself can authorize.
 
+### Agent access credentials
+
+Agent access supports OAuth grants and personal access tokens. Both credentials
+use the `AUTH_AGENT_ACCESS` method and resolve to one `AgentAccessContext` with a
+user, workspace, read scopes, and credential identity.
+
+- **OAuth access token:** a stateless HMAC token with a distinct audience and a
+  15-minute lifetime. Request authentication performs no database read. Grant
+  revocation blocks refresh immediately; an issued access token remains valid
+  until it expires.
+- **Personal access token:** an opaque `sf_pat_` token bound to one user and
+  workspace. The raw value is returned once, and only its prefix and metadata
+  are listed afterward. Each request checks the active user, membership,
+  workspace status, expiry, and revocation state. Last-used writes are limited
+  to once per 60 seconds, and revocation applies to the next request.
+
+The management route factories are opt-in. `createAuthModule` does not register
+them or the `AUTH_AGENT_ACCESS` method until the application activates the full
+agent-access surface.
+
 ## Routes
 
-All routes are mounted under `/auth`.
+The core auth routes are mounted under `/auth`.
 
 | Method | Path | Auth | Result |
 | --- | --- | --- | --- |
@@ -363,8 +386,19 @@ compose these routes until an application provides its consent UI and agent-reso
 
 Consent approval creates a durable agent grant from a pre-commit workspace-membership snapshot;
 every authorization-code and refresh exchange revalidates membership before issuing tokens. The
-current package does not expose agent-grant listing or revocation routes; composition should add
-that lifecycle surface before treating a grant as an operator-managed credential.
+package also exports opt-in management factories for grant and PAT lifecycle operations. These
+factories use `AUTH_USER` and remain unregistered by `createAuthModule().routes`.
+
+| Method | Path | Auth | Result |
+| --- | --- | --- | --- |
+| `GET` | `/agent-access/grants` | session bearer | Lists the caller's active grants. |
+| `DELETE` | `/agent-access/grants/:id` | session bearer | Idempotently revokes a caller-owned grant. |
+| `POST` | `/agent-access/pats` | session bearer | Creates a PAT and returns its raw value once. |
+| `GET` | `/agent-access/pats` | session bearer | Lists caller-owned PAT metadata without raw values. |
+| `DELETE` | `/agent-access/pats/:id` | session bearer | Idempotently revokes a caller-owned PAT. |
+
+Management identifiers are caller-owned. Another user's identifier and an unknown identifier
+both return `404`.
 Authorization-code replay returns `invalid_grant` and
 does not revoke a grant that was already issued, because a lost token response is indistinguishable
 from a replay. Refresh-token reuse outside the grace window revokes the grant family, and a lost
@@ -396,6 +430,10 @@ It also exports lower-level pieces for tests and advanced integration:
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
 - `createImpersonatedSessionToken({targetUserId, impersonatorId, workspaces})`: mints an access-token-only impersonated session (capped TTL, `impersonatorId` claim, no refresh material). The `impersonateUser` administration command owns the authorization ladder, idempotency, and audit flow.
 - `createOAuthAuthorizationRoutes(options)`: explicitly composes the OAuth authorization, consent, authorization-code, and refresh-token routes for an agent-resource integration.
+- `createAgentAccessAuthMethod(workspaces)`: authenticates stateless OAuth access tokens and database-checked PATs into the shared agent-access context.
+- `createAgentAccessManagementRoutes({workspaces})`: composes the grant and PAT management routes under `/agent-access`.
+- `createAgentGrantRoutes()` / `createAgentPersonalAccessTokenRoutes(workspaces)`: compose the management route groups separately when the application needs independent registration.
+- `listAgentGrants({userId})`, `listAgentPersonalAccessTokens({userId})`, `revokeAgentGrant(...)`, and `revokeAgentPersonalAccessToken(...)`: implement the caller-scoped management use cases.
 - `getAuthenticatedSessionContext(request)`: reads the user ID and required refresh-session ID from verified access-token claims. It does not check whether the refresh session is still active.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
 - `listAdministratorUsers({actorId, limit, cursor?, search?, status?, eligible?})`: returns `{users, rows, nextCursor}` after requiring an active observer role. `rows` remains as a compatibility alias. Search accepts at most 10 whitespace-separated terms. Each term can contain at most 100 characters.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -167,10 +167,10 @@ be removed or forged by a client.
   at most 15 minutes after issuance; and every `/admin` route rejects a request
   whose context carries `impersonatorId` with `admin-role-required`, before
   roles are consulted. The durable-artefact deny-list (runner registration
-  tokens, provisioner tokens, and workspace invitations) rejects impersonated
-  sessions with `impersonation-not-permitted`; the list is enumerated and
-  documented in ADR 0014, and adding a credential-issuing or grant-creating
-  route means adding it there.
+  tokens, provisioner tokens, workspace invitations, and agent personal access
+  token minting) rejects impersonated sessions with `impersonation-not-permitted`; the
+  list is enumerated and documented in ADR 0014, and adding a
+  credential-issuing or grant-creating route means adding it there.
 - **No token at rest:** the idempotent command result stores only the target
   user ID, the expiry, and a list of SHA-256 fingerprints of the tokens issued
   under the key. The raw token is never logged or persisted, and a token
@@ -399,6 +399,8 @@ factories use `AUTH_USER` and remain unregistered by `createAuthModule().routes`
 
 Management identifiers are caller-owned. Another user's identifier and an unknown identifier
 both return `404`.
+Impersonated sessions may list and revoke the target user's credentials; only PAT creation is
+blocked because it would create a durable credential outside the impersonation window.
 Authorization-code replay returns `invalid_grant` and
 does not revoke a grant that was already issued, because a lost token response is indistinguishable
 from a replay. Refresh-token reuse outside the grace window revokes the grant family, and a lost

--- a/libs/api/auth/src/core/agent-access.ts
+++ b/libs/api/auth/src/core/agent-access.ts
@@ -1,0 +1,186 @@
+import {OAUTH_READ_SCOPE} from '@shipfox/api-auth-dto';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {
+  type AgentGrantSummaryRecord,
+  type AgentPersonalAccessTokenSummaryRecord,
+  createAgentPersonalAccessTokenForActiveUser,
+  listAgentGrantSummaries,
+  listAgentPersonalAccessTokenSummaries,
+  revokeAgentGrantForUser,
+  revokeAgentPersonalAccessTokenForUser,
+} from '#db/agent-access.js';
+import type {AgentGrant, AgentPersonalAccessToken} from './entities/agent-access.js';
+import {
+  AgentAccessUserInactiveError,
+  AgentAccessWorkspaceError,
+  AgentGrantNotFoundError,
+  AgentPersonalAccessTokenNotFoundError,
+  AuthDependencyUnavailableError,
+} from './errors.js';
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const AGENT_PAT_EXPIRY_DAYS = [30, 90, 365] as const;
+export type AgentPatExpiryDays = (typeof AGENT_PAT_EXPIRY_DAYS)[number];
+
+export type AgentGrantSummary = AgentGrantSummaryRecord;
+export type AgentPersonalAccessTokenSummary = AgentPersonalAccessTokenSummaryRecord;
+
+export interface CreateAgentPersonalAccessTokenParams {
+  userId: string;
+  workspaceId: string;
+  name: string;
+  expiresInDays?: AgentPatExpiryDays;
+  now?: Date;
+}
+
+export interface CreateAgentPersonalAccessTokenResult {
+  token: string;
+  pat: AgentPersonalAccessToken;
+}
+
+function isAgentPatExpiryDays(value: number): value is AgentPatExpiryDays {
+  return (AGENT_PAT_EXPIRY_DAYS as readonly number[]).includes(value);
+}
+
+function workspaceErrorForStatus(status: string): AgentAccessWorkspaceError {
+  return new AgentAccessWorkspaceError(
+    status === 'suspended' ? 'workspace-suspended' : 'workspace-inactive',
+  );
+}
+
+async function currentAgentMemberships(params: {
+  userId: string;
+  workspaces: WorkspacesInterModuleClient;
+}): Promise<Awaited<ReturnType<WorkspacesInterModuleClient['listMembershipsForTokenClaims']>>> {
+  try {
+    return await params.workspaces.listMembershipsForTokenClaims({userId: params.userId});
+  } catch (error) {
+    if (error instanceof AuthDependencyUnavailableError) throw error;
+    throw new AuthDependencyUnavailableError('workspaces', error);
+  }
+}
+
+function assertActiveAgentMembershipSnapshot(params: {
+  workspaceId: string;
+  memberships: Awaited<
+    ReturnType<WorkspacesInterModuleClient['listMembershipsForTokenClaims']>
+  >['memberships'];
+}): void {
+  const membership = params.memberships.find(
+    (candidate) => candidate.workspaceId === params.workspaceId,
+  );
+  if (!membership) throw new AgentAccessWorkspaceError('membership-required');
+  if (membership.workspaceStatus !== 'active') {
+    throw workspaceErrorForStatus(membership.workspaceStatus);
+  }
+}
+
+async function assertActiveAgentMembership(params: {
+  userId: string;
+  workspaceId: string;
+  memberships: Awaited<
+    ReturnType<WorkspacesInterModuleClient['listMembershipsForTokenClaims']>
+  >['memberships'];
+  workspaces: WorkspacesInterModuleClient;
+}): Promise<void> {
+  try {
+    await params.workspaces.requireActiveMembership({
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      memberships: params.memberships,
+    });
+  } catch (error) {
+    if (
+      isInterModuleKnownError(workspacesInterModuleContract.methods.requireActiveMembership, error)
+    ) {
+      if (error.code === 'membership-required') {
+        throw new AgentAccessWorkspaceError('membership-required');
+      }
+      if (error.code === 'workspace-inactive' || error.code === 'workspace-not-found') {
+        throw new AgentAccessWorkspaceError('workspace-inactive');
+      }
+      throw new AgentAccessWorkspaceError('workspace-suspended');
+    }
+    if (error instanceof AuthDependencyUnavailableError) throw error;
+    throw new AuthDependencyUnavailableError('workspaces', error);
+  }
+}
+
+/** Re-checks live membership and workspace lifecycle through the owning module. */
+export async function requireActiveAgentWorkspaceMembership(params: {
+  userId: string;
+  workspaceId: string;
+  workspaces: WorkspacesInterModuleClient;
+}): Promise<void> {
+  const result = await currentAgentMemberships(params);
+  assertActiveAgentMembershipSnapshot({
+    workspaceId: params.workspaceId,
+    memberships: result.memberships,
+  });
+  await assertActiveAgentMembership({...params, memberships: result.memberships});
+}
+
+export async function listAgentGrants(params: {userId: string}): Promise<AgentGrantSummary[]> {
+  return await listAgentGrantSummaries(params);
+}
+
+export async function revokeAgentGrant(params: {
+  userId: string;
+  grantId: string;
+}): Promise<AgentGrant> {
+  const grant = await revokeAgentGrantForUser(params);
+  if (!grant) throw new AgentGrantNotFoundError();
+  return grant;
+}
+
+export async function createAgentPersonalAccessToken(
+  params: CreateAgentPersonalAccessTokenParams & {workspaces: WorkspacesInterModuleClient},
+): Promise<CreateAgentPersonalAccessTokenResult> {
+  const expiresInDays = params.expiresInDays ?? 90;
+  if (!isAgentPatExpiryDays(expiresInDays)) {
+    throw new Error('Agent personal access token expiry must be 30, 90, or 365 days');
+  }
+
+  await requireActiveAgentWorkspaceMembership({
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    workspaces: params.workspaces,
+  });
+
+  const token = generateOpaqueToken('personalAccessToken');
+  const pat = await createAgentPersonalAccessTokenForActiveUser({
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    hashedToken: hashOpaqueToken(token),
+    prefix: extractDisplayPrefix(token),
+    name: params.name,
+    scopes: [OAUTH_READ_SCOPE],
+    expiresAt: new Date(
+      (params.now ?? new Date()).getTime() + expiresInDays * MILLISECONDS_PER_DAY,
+    ),
+  });
+  if (!pat) throw new AgentAccessUserInactiveError();
+
+  return {token, pat};
+}
+
+export async function listAgentPersonalAccessTokens(params: {
+  userId: string;
+}): Promise<AgentPersonalAccessTokenSummary[]> {
+  return await listAgentPersonalAccessTokenSummaries(params);
+}
+
+export async function revokeAgentPersonalAccessToken(params: {
+  userId: string;
+  id: string;
+}): Promise<AgentPersonalAccessToken> {
+  const pat = await revokeAgentPersonalAccessTokenForUser(params);
+  if (!pat) throw new AgentPersonalAccessTokenNotFoundError();
+  return pat;
+}

--- a/libs/api/auth/src/core/agent-access.ts
+++ b/libs/api/auth/src/core/agent-access.ts
@@ -105,7 +105,7 @@ async function assertActiveAgentMembership(params: {
       if (error.code === 'workspace-inactive' || error.code === 'workspace-not-found') {
         throw new AgentAccessWorkspaceError('workspace-inactive');
       }
-      throw new AgentAccessWorkspaceError('workspace-suspended');
+      throw new AuthDependencyUnavailableError('workspaces', error);
     }
     if (error instanceof AuthDependencyUnavailableError) throw error;
     throw new AuthDependencyUnavailableError('workspaces', error);

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -121,6 +121,13 @@ export class AgentPersonalAccessTokenNotFoundError extends Error {
   }
 }
 
+export class InvalidAgentAccessScopeError extends Error {
+  constructor() {
+    super('Agent access contains an unsupported scope');
+    this.name = 'InvalidAgentAccessScopeError';
+  }
+}
+
 export class AdminRoleRequiredError extends Error {
   readonly minimumRole: import('@shipfox/api-auth-dto').AdminRole;
 

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -85,6 +85,42 @@ export class AuthDependencyUnavailableError extends Error {
   }
 }
 
+export type AgentAccessWorkspaceErrorCode =
+  | 'membership-required'
+  | 'workspace-inactive'
+  | 'workspace-suspended';
+
+export class AgentAccessWorkspaceError extends Error {
+  readonly code: AgentAccessWorkspaceErrorCode;
+
+  constructor(code: AgentAccessWorkspaceErrorCode) {
+    super(`Agent access workspace check failed: ${code}`);
+    this.name = 'AgentAccessWorkspaceError';
+    this.code = code;
+  }
+}
+
+export class AgentAccessUserInactiveError extends Error {
+  constructor() {
+    super('The user is not active');
+    this.name = 'AgentAccessUserInactiveError';
+  }
+}
+
+export class AgentGrantNotFoundError extends Error {
+  constructor() {
+    super('Agent grant not found');
+    this.name = 'AgentGrantNotFoundError';
+  }
+}
+
+export class AgentPersonalAccessTokenNotFoundError extends Error {
+  constructor() {
+    super('Personal access token not found');
+    this.name = 'AgentPersonalAccessTokenNotFoundError';
+  }
+}
+
 export class AdminRoleRequiredError extends Error {
   readonly minimumRole: import('@shipfox/api-auth-dto').AdminRole;
 

--- a/libs/api/auth/src/db/agent-access.test.ts
+++ b/libs/api/auth/src/db/agent-access.test.ts
@@ -275,6 +275,43 @@ describe('agent-access db', () => {
     ).toBeUndefined();
   });
 
+  test(
+    'uses the current database clock after waiting for a PAT row lock',
+    async () => {
+      const user = await userFactory.create();
+      const pat = await createAgentPersonalAccessToken({
+        userId: user.id,
+        workspaceId: crypto.randomUUID(),
+        hashedToken: hashOpaqueToken(`clock-pat-${crypto.randomUUID()}`),
+        prefix: 'sf_pat_clock',
+        name: 'Clock PAT',
+        scopes: ['read'],
+        expiresAt: new Date(Date.now() + 200),
+      });
+      const holderReady = deferred<void>();
+      const holder = db().transaction(async (tx) => {
+        await tx
+          .update(agentPersonalAccessTokens)
+          .set({updatedAt: sql`now()`})
+          .where(eq(agentPersonalAccessTokens.id, pat.id));
+        holderReady.resolve();
+        await tx.execute(sql`select pg_sleep(0.75)`);
+      });
+      holder.catch(holderReady.reject);
+
+      try {
+        await holderReady.promise;
+        const used = markAgentPersonalAccessTokenUsed({id: pat.id});
+        const [, result] = await Promise.all([holder, used]);
+
+        expect(result).toBeUndefined();
+      } finally {
+        await holder.catch(() => undefined);
+      }
+    },
+    GRANT_LOCK_TEST_TIMEOUT_MS,
+  );
+
   test('serializes concurrent refresh rotation and revokes the complete grant family', async () => {
     const user = await userFactory.create();
     const client = await createAgentClient({

--- a/libs/api/auth/src/db/agent-access.test.ts
+++ b/libs/api/auth/src/db/agent-access.test.ts
@@ -312,6 +312,49 @@ describe('agent-access db', () => {
     GRANT_LOCK_TEST_TIMEOUT_MS,
   );
 
+  test(
+    'rejects PAT use after a concurrent user suspension commits',
+    async () => {
+      const user = await userFactory.create();
+      const pat = await createAgentPersonalAccessToken({
+        userId: user.id,
+        workspaceId: crypto.randomUUID(),
+        hashedToken: hashOpaqueToken(`suspension-pat-${crypto.randomUUID()}`),
+        prefix: 'sf_pat_suspend',
+        name: 'Suspension PAT',
+        scopes: ['read'],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const holderReady = deferred<void>();
+      const holder = db().transaction(async (tx) => {
+        await tx
+          .select({id: users.id})
+          .from(users)
+          .where(eq(users.id, user.id))
+          .for('update')
+          .limit(1);
+        holderReady.resolve();
+        await tx.execute(sql`select pg_sleep(0.75)`);
+        await tx
+          .update(users)
+          .set({status: 'suspended', updatedAt: sql`now()`})
+          .where(eq(users.id, user.id));
+      });
+      holder.catch(holderReady.reject);
+
+      try {
+        await holderReady.promise;
+        const used = markAgentPersonalAccessTokenUsed({id: pat.id});
+        const [, result] = await Promise.all([holder, used]);
+
+        expect(result).toBeUndefined();
+      } finally {
+        await holder.catch(() => undefined);
+      }
+    },
+    GRANT_LOCK_TEST_TIMEOUT_MS,
+  );
+
   test('serializes concurrent refresh rotation and revokes the complete grant family', async () => {
     const user = await userFactory.create();
     const client = await createAgentClient({

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -3,7 +3,6 @@ import {
   asc,
   desc,
   eq,
-  exists,
   gt,
   inArray,
   isNotNull,
@@ -1431,52 +1430,56 @@ export async function markAgentPersonalAccessTokenUsed(params: {
     throw new Error('PAT last-used throttle must be a non-negative finite number of seconds');
   }
 
-  const currentDatabaseTime = sql`clock_timestamp()`;
-  const activeUser = exists(
-    db()
-      .select({id: users.id})
-      .from(users)
-      .where(and(eq(users.id, agentPersonalAccessTokens.userId), eq(users.status, 'active'))),
-  );
-  const throttleCutoff = sql`clock_timestamp() - (${throttleSeconds} || ' seconds')::interval`;
+  return await db().transaction(async (tx) => {
+    const candidateRows = await tx
+      .select({userId: agentPersonalAccessTokens.userId})
+      .from(agentPersonalAccessTokens)
+      .where(eq(agentPersonalAccessTokens.id, params.id))
+      .limit(1);
+    const candidate = candidateRows[0];
+    if (!candidate) return undefined;
 
-  const rows = await db()
-    .update(agentPersonalAccessTokens)
-    .set({lastUsedAt: currentDatabaseTime, updatedAt: currentDatabaseTime})
-    .where(
-      and(
-        eq(agentPersonalAccessTokens.id, params.id),
-        activeUser,
-        isNull(agentPersonalAccessTokens.revokedAt),
-        gt(agentPersonalAccessTokens.expiresAt, currentDatabaseTime),
-        or(
-          isNull(agentPersonalAccessTokens.lastUsedAt),
-          lte(agentPersonalAccessTokens.lastUsedAt, throttleCutoff),
+    // Serialize PAT use with suspension. A plain EXISTS can read a
+    // pre-suspension snapshot and return a credential after suspension commits.
+    if (!(await isActiveAgentUserTx(tx, {userId: candidate.userId}))) return undefined;
+
+    const currentDatabaseTime = sql`clock_timestamp()`;
+    const throttleCutoff = sql`clock_timestamp() - (${throttleSeconds} || ' seconds')::interval`;
+    const rows = await tx
+      .update(agentPersonalAccessTokens)
+      .set({lastUsedAt: currentDatabaseTime, updatedAt: currentDatabaseTime})
+      .where(
+        and(
+          eq(agentPersonalAccessTokens.id, params.id),
+          isNull(agentPersonalAccessTokens.revokedAt),
+          gt(agentPersonalAccessTokens.expiresAt, currentDatabaseTime),
+          or(
+            isNull(agentPersonalAccessTokens.lastUsedAt),
+            lte(agentPersonalAccessTokens.lastUsedAt, throttleCutoff),
+          ),
         ),
-      ),
-    )
-    .returning();
-  const row = rows[0];
-  if (row) return toAgentPersonalAccessToken(row);
+      )
+      .returning();
+    const row = rows[0];
+    if (row) return toAgentPersonalAccessToken(row);
 
-  // A valid token can intentionally skip the write inside the throttle
-  // window. Return its current row so callers can distinguish that from an
-  // invalid, expired, revoked, or inactive-user token.
-  const existingRows = await db()
-    .select({token: agentPersonalAccessTokens})
-    .from(agentPersonalAccessTokens)
-    .innerJoin(users, eq(agentPersonalAccessTokens.userId, users.id))
-    .where(
-      and(
-        eq(agentPersonalAccessTokens.id, params.id),
-        eq(users.status, 'active'),
-        isNull(agentPersonalAccessTokens.revokedAt),
-        gt(agentPersonalAccessTokens.expiresAt, currentDatabaseTime),
-      ),
-    )
-    .limit(1);
-  const existing = existingRows[0]?.token;
-  return existing ? toAgentPersonalAccessToken(existing) : undefined;
+    // A valid token can intentionally skip the write inside the throttle
+    // window. Return its current row so callers can distinguish that from an
+    // invalid, expired, revoked, or inactive-user token.
+    const existingRows = await tx
+      .select()
+      .from(agentPersonalAccessTokens)
+      .where(
+        and(
+          eq(agentPersonalAccessTokens.id, params.id),
+          isNull(agentPersonalAccessTokens.revokedAt),
+          gt(agentPersonalAccessTokens.expiresAt, currentDatabaseTime),
+        ),
+      )
+      .limit(1);
+    const existing = existingRows[0];
+    return existing ? toAgentPersonalAccessToken(existing) : undefined;
+  });
 }
 
 export async function revokeAgentPersonalAccessToken(params: {

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -3,6 +3,7 @@ import {
   asc,
   desc,
   eq,
+  exists,
   gt,
   inArray,
   isNotNull,
@@ -1430,54 +1431,52 @@ export async function markAgentPersonalAccessTokenUsed(params: {
     throw new Error('PAT last-used throttle must be a non-negative finite number of seconds');
   }
 
-  return await db().transaction(async (tx) => {
-    const candidateRows = await tx
-      .select({userId: agentPersonalAccessTokens.userId})
-      .from(agentPersonalAccessTokens)
-      .where(eq(agentPersonalAccessTokens.id, params.id))
-      .limit(1);
-    const candidate = candidateRows[0];
-    if (!candidate) return undefined;
-    if (!(await isActiveAgentUserTx(tx, {userId: candidate.userId}))) return undefined;
+  const currentDatabaseTime = sql`clock_timestamp()`;
+  const activeUser = exists(
+    db()
+      .select({id: users.id})
+      .from(users)
+      .where(and(eq(users.id, agentPersonalAccessTokens.userId), eq(users.status, 'active'))),
+  );
+  const throttleCutoff = sql`clock_timestamp() - (${throttleSeconds} || ' seconds')::interval`;
 
-    const rows = await tx
-      .update(agentPersonalAccessTokens)
-      .set({lastUsedAt: sql`now()`, updatedAt: sql`now()`})
-      .where(
-        and(
-          eq(agentPersonalAccessTokens.id, params.id),
-          isNull(agentPersonalAccessTokens.revokedAt),
-          gt(agentPersonalAccessTokens.expiresAt, sql`now()`),
-          or(
-            isNull(agentPersonalAccessTokens.lastUsedAt),
-            lte(
-              agentPersonalAccessTokens.lastUsedAt,
-              sql`now() - (${throttleSeconds} || ' seconds')::interval`,
-            ),
-          ),
+  const rows = await db()
+    .update(agentPersonalAccessTokens)
+    .set({lastUsedAt: currentDatabaseTime, updatedAt: currentDatabaseTime})
+    .where(
+      and(
+        eq(agentPersonalAccessTokens.id, params.id),
+        activeUser,
+        isNull(agentPersonalAccessTokens.revokedAt),
+        gt(agentPersonalAccessTokens.expiresAt, currentDatabaseTime),
+        or(
+          isNull(agentPersonalAccessTokens.lastUsedAt),
+          lte(agentPersonalAccessTokens.lastUsedAt, throttleCutoff),
         ),
-      )
-      .returning();
-    const row = rows[0];
-    if (row) return toAgentPersonalAccessToken(row);
+      ),
+    )
+    .returning();
+  const row = rows[0];
+  if (row) return toAgentPersonalAccessToken(row);
 
-    // A valid token can intentionally skip the write inside the throttle
-    // window. Return its current row so callers can distinguish that from an
-    // invalid, expired, revoked, or inactive-user token.
-    const existingRows = await tx
-      .select()
-      .from(agentPersonalAccessTokens)
-      .where(
-        and(
-          eq(agentPersonalAccessTokens.id, params.id),
-          isNull(agentPersonalAccessTokens.revokedAt),
-          gt(agentPersonalAccessTokens.expiresAt, sql`now()`),
-        ),
-      )
-      .limit(1);
-    const existing = existingRows[0];
-    return existing ? toAgentPersonalAccessToken(existing) : undefined;
-  });
+  // A valid token can intentionally skip the write inside the throttle
+  // window. Return its current row so callers can distinguish that from an
+  // invalid, expired, revoked, or inactive-user token.
+  const existingRows = await db()
+    .select({token: agentPersonalAccessTokens})
+    .from(agentPersonalAccessTokens)
+    .innerJoin(users, eq(agentPersonalAccessTokens.userId, users.id))
+    .where(
+      and(
+        eq(agentPersonalAccessTokens.id, params.id),
+        eq(users.status, 'active'),
+        isNull(agentPersonalAccessTokens.revokedAt),
+        gt(agentPersonalAccessTokens.expiresAt, currentDatabaseTime),
+      ),
+    )
+    .limit(1);
+  const existing = existingRows[0]?.token;
+  return existing ? toAgentPersonalAccessToken(existing) : undefined;
 }
 
 export async function revokeAgentPersonalAccessToken(params: {

--- a/libs/api/auth/src/db/agent-access.ts
+++ b/libs/api/auth/src/db/agent-access.ts
@@ -1,4 +1,17 @@
-import {and, asc, eq, gt, inArray, isNotNull, isNull, lte, notExists, or, sql} from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  notExists,
+  or,
+  sql,
+} from 'drizzle-orm';
 import {config} from '#config.js';
 import type {
   AgentAuthorizationCode,
@@ -600,6 +613,42 @@ export async function findAgentGrant(params: {
   return row ? toAgentGrant(row) : undefined;
 }
 
+export interface AgentGrantSummaryRecord {
+  id: string;
+  clientName: string;
+  workspaceId: string;
+  scopes: string[];
+  createdAt: Date;
+  lastRefreshedAt: Date | null;
+}
+
+/** Lists only the caller's active grants, with client identity resolved in auth-owned tables. */
+export async function listAgentGrantSummaries(params: {
+  userId: string;
+}): Promise<AgentGrantSummaryRecord[]> {
+  const rows = await db()
+    .select({
+      id: agentGrants.id,
+      clientName: agentClients.name,
+      workspaceId: agentGrants.workspaceId,
+      scopes: agentGrants.scopes,
+      createdAt: agentGrants.createdAt,
+      lastRefreshedAt: agentGrants.lastUsedAt,
+    })
+    .from(agentGrants)
+    .innerJoin(agentClients, eq(agentGrants.clientId, agentClients.id))
+    .where(
+      and(
+        eq(agentGrants.userId, params.userId),
+        isNull(agentGrants.revokedAt),
+        isNull(agentGrants.terminalAt),
+      ),
+    )
+    .orderBy(desc(agentGrants.createdAt), desc(agentGrants.id));
+
+  return rows;
+}
+
 /**
  * Locks one grant row until the surrounding transaction ends. Code exchange
  * and lifecycle transitions must use this same primitive before inspecting or
@@ -1108,6 +1157,25 @@ export async function revokeAgentGrant(params: {grantId: string}): Promise<Agent
   return await db().transaction((tx) => revokeAgentGrantTx(tx, params));
 }
 
+/** Revokes a grant only when it belongs to the caller; repeated revocation is a success. */
+export async function revokeAgentGrantForUser(params: {
+  userId: string;
+  grantId: string;
+}): Promise<AgentGrant | undefined> {
+  return await db().transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(agentGrants)
+      .where(and(eq(agentGrants.id, params.grantId), eq(agentGrants.userId, params.userId)))
+      .for('update')
+      .limit(1);
+    const grant = rows[0];
+    if (!grant) return undefined;
+    if (grant.revokedAt) return toAgentGrant(grant);
+    return await revokeAgentGrantTx(tx, {grantId: grant.id});
+  });
+}
+
 export async function revokeAgentGrantTx(
   tx: AgentAccessTx,
   params: {grantId: string},
@@ -1261,6 +1329,16 @@ export async function createAgentPersonalAccessToken(
   return await db().transaction((tx) => createAgentPersonalAccessTokenTx(tx, params));
 }
 
+/** Creates a PAT while holding the owning user row lock and requiring an active account. */
+export async function createAgentPersonalAccessTokenForActiveUser(
+  params: CreateAgentPersonalAccessTokenParams,
+): Promise<AgentPersonalAccessToken | undefined> {
+  return await db().transaction(async (tx) => {
+    if (!(await isActiveAgentUserTx(tx, {userId: params.userId}))) return undefined;
+    return await createAgentPersonalAccessTokenTx(tx, params);
+  });
+}
+
 export async function createAgentPersonalAccessTokenTx(
   tx: AgentAccessTx,
   params: CreateAgentPersonalAccessTokenParams,
@@ -1307,6 +1385,42 @@ export async function findActiveAgentPersonalAccessTokenByHash(params: {
   return row ? toAgentPersonalAccessToken(row) : undefined;
 }
 
+export interface AgentPersonalAccessTokenSummaryRecord {
+  id: string;
+  workspaceId: string;
+  prefix: string;
+  name: string;
+  expiresAt: Date;
+  lastUsedAt: Date | null;
+  createdAt: Date;
+}
+
+/** Lists the caller's non-revoked PAT metadata without exposing token hashes. */
+export async function listAgentPersonalAccessTokenSummaries(params: {
+  userId: string;
+}): Promise<AgentPersonalAccessTokenSummaryRecord[]> {
+  const rows = await db()
+    .select({
+      id: agentPersonalAccessTokens.id,
+      workspaceId: agentPersonalAccessTokens.workspaceId,
+      prefix: agentPersonalAccessTokens.prefix,
+      name: agentPersonalAccessTokens.name,
+      expiresAt: agentPersonalAccessTokens.expiresAt,
+      lastUsedAt: agentPersonalAccessTokens.lastUsedAt,
+      createdAt: agentPersonalAccessTokens.createdAt,
+    })
+    .from(agentPersonalAccessTokens)
+    .where(
+      and(
+        eq(agentPersonalAccessTokens.userId, params.userId),
+        isNull(agentPersonalAccessTokens.revokedAt),
+      ),
+    )
+    .orderBy(desc(agentPersonalAccessTokens.createdAt), desc(agentPersonalAccessTokens.id));
+
+  return rows;
+}
+
 export async function markAgentPersonalAccessTokenUsed(params: {
   id: string;
   throttleSeconds?: number;
@@ -1316,43 +1430,54 @@ export async function markAgentPersonalAccessTokenUsed(params: {
     throw new Error('PAT last-used throttle must be a non-negative finite number of seconds');
   }
 
-  const rows = await db()
-    .update(agentPersonalAccessTokens)
-    .set({lastUsedAt: sql`now()`, updatedAt: sql`now()`})
-    .where(
-      and(
-        eq(agentPersonalAccessTokens.id, params.id),
-        isNull(agentPersonalAccessTokens.revokedAt),
-        gt(agentPersonalAccessTokens.expiresAt, sql`now()`),
-        or(
-          isNull(agentPersonalAccessTokens.lastUsedAt),
-          lte(
-            agentPersonalAccessTokens.lastUsedAt,
-            sql`now() - (${throttleSeconds} || ' seconds')::interval`,
+  return await db().transaction(async (tx) => {
+    const candidateRows = await tx
+      .select({userId: agentPersonalAccessTokens.userId})
+      .from(agentPersonalAccessTokens)
+      .where(eq(agentPersonalAccessTokens.id, params.id))
+      .limit(1);
+    const candidate = candidateRows[0];
+    if (!candidate) return undefined;
+    if (!(await isActiveAgentUserTx(tx, {userId: candidate.userId}))) return undefined;
+
+    const rows = await tx
+      .update(agentPersonalAccessTokens)
+      .set({lastUsedAt: sql`now()`, updatedAt: sql`now()`})
+      .where(
+        and(
+          eq(agentPersonalAccessTokens.id, params.id),
+          isNull(agentPersonalAccessTokens.revokedAt),
+          gt(agentPersonalAccessTokens.expiresAt, sql`now()`),
+          or(
+            isNull(agentPersonalAccessTokens.lastUsedAt),
+            lte(
+              agentPersonalAccessTokens.lastUsedAt,
+              sql`now() - (${throttleSeconds} || ' seconds')::interval`,
+            ),
           ),
         ),
-      ),
-    )
-    .returning();
-  const row = rows[0];
-  if (row) return toAgentPersonalAccessToken(row);
+      )
+      .returning();
+    const row = rows[0];
+    if (row) return toAgentPersonalAccessToken(row);
 
-  // A valid token can intentionally skip the write inside the throttle
-  // window. Return its current row so callers can distinguish that from an
-  // invalid, expired, or revoked token.
-  const existingRows = await db()
-    .select()
-    .from(agentPersonalAccessTokens)
-    .where(
-      and(
-        eq(agentPersonalAccessTokens.id, params.id),
-        isNull(agentPersonalAccessTokens.revokedAt),
-        gt(agentPersonalAccessTokens.expiresAt, sql`now()`),
-      ),
-    )
-    .limit(1);
-  const existing = existingRows[0];
-  return existing ? toAgentPersonalAccessToken(existing) : undefined;
+    // A valid token can intentionally skip the write inside the throttle
+    // window. Return its current row so callers can distinguish that from an
+    // invalid, expired, revoked, or inactive-user token.
+    const existingRows = await tx
+      .select()
+      .from(agentPersonalAccessTokens)
+      .where(
+        and(
+          eq(agentPersonalAccessTokens.id, params.id),
+          isNull(agentPersonalAccessTokens.revokedAt),
+          gt(agentPersonalAccessTokens.expiresAt, sql`now()`),
+        ),
+      )
+      .limit(1);
+    const existing = existingRows[0];
+    return existing ? toAgentPersonalAccessToken(existing) : undefined;
+  });
 }
 
 export async function revokeAgentPersonalAccessToken(params: {
@@ -1367,6 +1492,42 @@ export async function revokeAgentPersonalAccessToken(params: {
     .returning();
   const row = rows[0];
   return row ? toAgentPersonalAccessToken(row) : undefined;
+}
+
+/** Revokes a PAT only when it belongs to the caller; repeated revocation is a success. */
+export async function revokeAgentPersonalAccessTokenForUser(params: {
+  userId: string;
+  id: string;
+}): Promise<AgentPersonalAccessToken | undefined> {
+  return await db().transaction(async (tx) => {
+    const existingRows = await tx
+      .select()
+      .from(agentPersonalAccessTokens)
+      .where(
+        and(
+          eq(agentPersonalAccessTokens.id, params.id),
+          eq(agentPersonalAccessTokens.userId, params.userId),
+        ),
+      )
+      .for('update')
+      .limit(1);
+    const existing = existingRows[0];
+    if (!existing) return undefined;
+    if (existing.revokedAt) return toAgentPersonalAccessToken(existing);
+
+    const rows = await tx
+      .update(agentPersonalAccessTokens)
+      .set({revokedAt: sql`now()`, updatedAt: sql`now()`})
+      .where(
+        and(
+          eq(agentPersonalAccessTokens.id, params.id),
+          isNull(agentPersonalAccessTokens.revokedAt),
+        ),
+      )
+      .returning();
+    const row = rows[0];
+    return row ? toAgentPersonalAccessToken(row) : toAgentPersonalAccessToken(existing);
+  });
 }
 
 export interface PruneAgentAccessParams {

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -137,4 +137,11 @@ describe('authModule', () => {
     );
     expect(worker?.activities).toBe(createAuthMaintenanceActivities);
   });
+
+  test('keeps agent access routes and authentication opt-in', () => {
+    expect(authModule.auth?.map(({name}) => name)).not.toContain('agent-access');
+    expect(authModule.routes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({prefix: '/agent-access'})]),
+    );
+  });
 });

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -62,6 +62,22 @@ export {
   revokeAdministratorUserSessions,
   suspendAdministratorUser,
 } from '#core/administration.js';
+export type {
+  AgentGrantSummary,
+  AgentPatExpiryDays,
+  AgentPersonalAccessTokenSummary,
+  CreateAgentPersonalAccessTokenParams,
+  CreateAgentPersonalAccessTokenResult,
+} from '#core/agent-access.js';
+export {
+  AGENT_PAT_EXPIRY_DAYS,
+  createAgentPersonalAccessToken,
+  listAgentGrants,
+  listAgentPersonalAccessTokens,
+  requireActiveAgentWorkspaceMembership,
+  revokeAgentGrant,
+  revokeAgentPersonalAccessToken,
+} from '#core/agent-access.js';
 export type {IssueAgentAccessTokenParams} from '#core/agent-access-token.js';
 export {
   AGENT_ACCESS_TOKEN_EXPIRES_IN,
@@ -96,12 +112,17 @@ export type {EmailOwner, FindUserByEmailParams} from '#core/email-owner.js';
 export {findUserByEmail} from '#core/email-owner.js';
 export type {AdminGrant} from '#core/entities/admin-grant.js';
 export type {User, UserStatus} from '#core/entities/user.js';
+export type {AgentAccessWorkspaceErrorCode} from '#core/errors.js';
 export {
   AdminBootstrapClosedError,
   AdminGrantAlreadyExistsError,
   AdminGrantNotFoundError,
   AdminIdempotencyKeyReuseError,
   AdminRoleRequiredError,
+  AgentAccessUserInactiveError,
+  AgentAccessWorkspaceError,
+  AgentGrantNotFoundError,
+  AgentPersonalAccessTokenNotFoundError,
   AuthDependencyUnavailableError,
   CannotImpersonateAdministratorError,
   CannotImpersonateSelfError,
@@ -190,6 +211,7 @@ export {
   DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
 } from '#core/signup-policy.js';
 export type {ImpersonationResult} from '#db/impersonation.js';
+export {createAgentAccessAuthMethod} from '#presentation/auth/agent-access-auth.js';
 export {
   type AuthenticatedSessionContext,
   createJwtAuthMethod,
@@ -206,6 +228,13 @@ export {
 } from '#presentation/auth/refresh-cookie.js';
 export {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
 export {oauthTokenResponse, toOAuthConsentResponse} from '#presentation/dto/oauth.js';
+export type {CreateAgentAccessManagementRoutesOptions} from '#presentation/routes/agent-access.js';
+export {
+  createAgentAccessManagementRoutes,
+  createAgentAccessRoutes,
+  createAgentGrantRoutes,
+  createAgentPersonalAccessTokenRoutes,
+} from '#presentation/routes/agent-access.js';
 export type {
   CreateOAuthAuthorizationRoutesOptions,
   CreateOAuthRoutesOptions,

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -132,6 +132,7 @@ export {
   ImpersonationTargetNotActiveError,
   InvalidAdminBootstrapTokenError,
   InvalidAdministratorUserDirectoryFilterError,
+  InvalidAgentAccessScopeError,
   InvalidCredentialsError,
   InvalidOAuthClientMetadataError,
   InvalidOAuthConfigurationError,

--- a/libs/api/auth/src/presentation/auth/agent-access-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/agent-access-auth.test.ts
@@ -1,0 +1,179 @@
+import {AUTH_AGENT_ACCESS, getAgentAccessContext} from '@shipfox/api-auth-context';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
+import {createApp, defineRoute, type FastifyInstance} from '@shipfox/node-fastify';
+import {generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {vi} from '@shipfox/vitest/vi';
+import {eq} from 'drizzle-orm';
+import {issueAgentAccessToken} from '#core/agent-access-token.js';
+import {
+  createAgentPersonalAccessToken as createAgentPersonalAccessTokenInDb,
+  revokeAgentPersonalAccessToken as revokeAgentPersonalAccessTokenInDb,
+} from '#db/agent-access.js';
+import {db} from '#db/db.js';
+import {agentPersonalAccessTokens} from '#db/schema/agent-access.js';
+import {users} from '#db/schema/users.js';
+import {userFactory} from '#test/index.js';
+import {createAgentAccessAuthMethod} from './agent-access-auth.js';
+
+function workspaceClient(workspaceId: string, status: 'active' | 'suspended' = 'active') {
+  return {
+    listMembershipsForTokenClaims: vi.fn(async () => ({
+      memberships: [{workspaceId, role: 'admin' as const, workspaceStatus: status}],
+    })),
+    requireActiveMembership: vi.fn(async () => ({})),
+    getWorkspaceCreator: vi.fn(),
+    getWorkspaceOperatingState: vi.fn(),
+    preflightInvitationAcceptance: vi.fn(),
+    acceptInvitation: vi.fn(),
+  } as unknown as WorkspacesInterModuleClient;
+}
+
+const protectedRoute = defineRoute({
+  method: 'GET',
+  path: '/protected',
+  description: 'Test agent access boundary.',
+  auth: AUTH_AGENT_ACCESS,
+  handler: (request) => getAgentAccessContext(request),
+});
+
+async function openApp(workspaces: WorkspacesInterModuleClient): Promise<FastifyInstance> {
+  return await createApp({
+    auth: [createAgentAccessAuthMethod(workspaces)],
+    routes: [protectedRoute],
+    swagger: false,
+  });
+}
+
+describe('agent access auth method', () => {
+  test('maps a stateless OAuth access token to the common context without a workspace lookup', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const claims = {
+      sub: crypto.randomUUID(),
+      workspaceId,
+      grantId: crypto.randomUUID(),
+      clientId: 'client-id',
+      scopes: ['read'] as Array<'read'>,
+    };
+    const token = await issueAgentAccessToken(claims);
+    const app = await openApp(workspaces);
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${token}`},
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        userId: claims.sub,
+        workspaceId,
+        scopes: ['read'],
+        credential: {kind: 'oauth_grant', grantId: claims.grantId, clientId: claims.clientId},
+      });
+      expect(workspaces.listMembershipsForTokenClaims).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('checks a PAT against its user and live workspace membership and records use', async () => {
+    const user = await userFactory.create();
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const rawToken = generateOpaqueToken('personalAccessToken');
+    const pat = await createAgentPersonalAccessTokenInDb({
+      userId: user.id,
+      workspaceId,
+      hashedToken: hashOpaqueToken(rawToken),
+      prefix: rawToken.slice(0, 12),
+      name: 'Test PAT',
+      scopes: ['read'],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const app = await openApp(workspaces);
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${rawToken}`},
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        userId: user.id,
+        workspaceId,
+        scopes: ['read'],
+        credential: {kind: 'pat', patId: pat.id},
+      });
+      expect(workspaces.listMembershipsForTokenClaims).toHaveBeenCalledWith({userId: user.id});
+      expect(workspaces.requireActiveMembership).toHaveBeenCalledWith({
+        userId: user.id,
+        workspaceId,
+        memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
+      });
+      const stored = await db()
+        .select({lastUsedAt: agentPersonalAccessTokens.lastUsedAt})
+        .from(agentPersonalAccessTokens)
+        .where(eq(agentPersonalAccessTokens.id, pat.id));
+      expect(stored).toHaveLength(1);
+      expect(stored[0]?.lastUsedAt).toEqual(expect.any(Date));
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('rejects a PAT after revocation, user suspension, or workspace suspension', async () => {
+    const user = await userFactory.create();
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const rawToken = generateOpaqueToken('personalAccessToken');
+    const pat = await createAgentPersonalAccessTokenInDb({
+      userId: user.id,
+      workspaceId,
+      hashedToken: hashOpaqueToken(rawToken),
+      prefix: rawToken.slice(0, 12),
+      name: 'Revocation PAT',
+      scopes: ['read'],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const app = await openApp(workspaces);
+
+    try {
+      await db().update(users).set({status: 'suspended'}).where(eq(users.id, user.id));
+      const suspended = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${rawToken}`},
+      });
+      expect(suspended.statusCode).toBe(401);
+
+      await db().update(users).set({status: 'active'}).where(eq(users.id, user.id));
+      workspaces.listMembershipsForTokenClaims = vi.fn(async () => ({
+        memberships: [{workspaceId, role: 'admin' as const, workspaceStatus: 'suspended' as const}],
+      })) as unknown as WorkspacesInterModuleClient['listMembershipsForTokenClaims'];
+      const workspaceSuspended = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${rawToken}`},
+      });
+      expect(workspaceSuspended.statusCode).toBe(401);
+
+      await db().update(users).set({status: 'active'}).where(eq(users.id, user.id));
+      await revokeAgentPersonalAccessTokenInDb({id: pat.id});
+      workspaces.listMembershipsForTokenClaims = vi.fn(async () => ({
+        memberships: [{workspaceId, role: 'admin' as const, workspaceStatus: 'active' as const}],
+      })) as unknown as WorkspacesInterModuleClient['listMembershipsForTokenClaims'];
+      const revoked = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${rawToken}`},
+      });
+      expect(revoked.statusCode).toBe(401);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/libs/api/auth/src/presentation/auth/agent-access-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/agent-access-auth.test.ts
@@ -78,6 +78,36 @@ describe('agent access auth method', () => {
     }
   });
 
+  test('accepts an OAuth access token with a maximum-length client ID', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    const clientIdPrefix = 'https://client.example/';
+    const clientId = clientIdPrefix + 'x'.repeat(2048 - clientIdPrefix.length);
+    const token = await issueAgentAccessToken({
+      sub: crypto.randomUUID(),
+      workspaceId,
+      grantId: crypto.randomUUID(),
+      clientId,
+      scopes: ['read'],
+    });
+    expect(Buffer.byteLength(token, 'utf8')).toBeGreaterThan(1024);
+    const app = await openApp(workspaces);
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${token}`},
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({credential: {kind: 'oauth_grant', clientId}});
+      expect(workspaces.listMembershipsForTokenClaims).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
   test('checks a PAT against its user and live workspace membership and records use', async () => {
     const user = await userFactory.create();
     const workspaceId = crypto.randomUUID();
@@ -172,6 +202,39 @@ describe('agent access auth method', () => {
         headers: {authorization: `Bearer ${rawToken}`},
       });
       expect(revoked.statusCode).toBe(401);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('returns 503 when workspace membership resolution is unavailable', async () => {
+    const user = await userFactory.create();
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspaceClient(workspaceId);
+    workspaces.listMembershipsForTokenClaims = vi.fn(() => {
+      throw new Error('workspaces unavailable');
+    }) as unknown as WorkspacesInterModuleClient['listMembershipsForTokenClaims'];
+    const rawToken = generateOpaqueToken('personalAccessToken');
+    await createAgentPersonalAccessTokenInDb({
+      userId: user.id,
+      workspaceId,
+      hashedToken: hashOpaqueToken(rawToken),
+      prefix: rawToken.slice(0, 12),
+      name: 'Dependency test PAT',
+      scopes: ['read'],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const app = await openApp(workspaces);
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {authorization: `Bearer ${rawToken}`},
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toEqual({code: 'auth-dependency-unavailable'});
     } finally {
       await app.close();
     }

--- a/libs/api/auth/src/presentation/auth/agent-access-auth.ts
+++ b/libs/api/auth/src/presentation/auth/agent-access-auth.ts
@@ -18,7 +18,9 @@ import {
 } from '#db/agent-access.js';
 import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
-const MAX_PRESENTED_TOKEN_BYTES = 1024;
+// The OAuth claims contract permits a 2 KiB client ID. Keep enough room for
+// its base64url-encoded JWT payload, header, and signature.
+const MAX_PRESENTED_TOKEN_BYTES = 8 * 1024;
 
 type VerifiedAgentAccessCredential =
   | {kind: 'oauth'; claims: AgentAccessTokenClaims}

--- a/libs/api/auth/src/presentation/auth/agent-access-auth.ts
+++ b/libs/api/auth/src/presentation/auth/agent-access-auth.ts
@@ -1,0 +1,139 @@
+import {
+  type AgentAccessContext,
+  type AgentAccessScope,
+  AUTH_AGENT_ACCESS,
+  setAgentAccessContext,
+} from '@shipfox/api-auth-context';
+import type {AgentAccessTokenClaims} from '@shipfox/api-auth-dto';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
+import {type AuthMethod, ClientError, type FastifyRequest} from '@shipfox/node-fastify';
+import {getTokenType, hashOpaqueToken} from '@shipfox/node-tokens';
+import {requireActiveAgentWorkspaceMembership} from '#core/agent-access.js';
+import {verifyAgentAccessToken} from '#core/agent-access-token.js';
+import type {AgentPersonalAccessToken} from '#core/entities/agent-access.js';
+import {AgentAccessWorkspaceError, AuthDependencyUnavailableError} from '#core/errors.js';
+import {
+  findActiveAgentPersonalAccessTokenByHash,
+  markAgentPersonalAccessTokenUsed,
+} from '#db/agent-access.js';
+import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
+
+const MAX_PRESENTED_TOKEN_BYTES = 1024;
+
+type VerifiedAgentAccessCredential =
+  | {kind: 'oauth'; claims: AgentAccessTokenClaims}
+  | {kind: 'pat'; pat: AgentPersonalAccessToken};
+
+class InvalidAgentAccessCredentialError extends Error {
+  constructor() {
+    super('Invalid agent access credential');
+    this.name = 'InvalidAgentAccessCredentialError';
+  }
+}
+
+function invalidCredential(): never {
+  throw new InvalidAgentAccessCredentialError();
+}
+
+function dependencyUnavailable(error: unknown): ClientError {
+  return new ClientError('Authentication dependency unavailable', 'auth-dependency-unavailable', {
+    status: 503,
+    cause: error,
+  });
+}
+
+function agentScopes(scopes: string[]): ReadonlyArray<AgentAccessScope> {
+  if (scopes.length === 0 || scopes.some((scope) => scope !== 'read')) invalidCredential();
+  return scopes as ReadonlyArray<AgentAccessScope>;
+}
+
+async function findActiveAgentPersonalAccessToken(
+  token: string,
+): Promise<AgentPersonalAccessToken | undefined> {
+  try {
+    return await findActiveAgentPersonalAccessTokenByHash({hashedToken: hashOpaqueToken(token)});
+  } catch (error) {
+    throw dependencyUnavailable(error);
+  }
+}
+
+async function verifyAgentPersonalAccessToken(
+  token: string,
+  workspaces: WorkspacesInterModuleClient,
+): Promise<VerifiedAgentAccessCredential> {
+  const pat = await findActiveAgentPersonalAccessToken(token);
+  if (!pat) return invalidCredential();
+  // Reject malformed persisted authority before touching its last-used timestamp.
+  agentScopes(pat.scopes);
+
+  try {
+    await requireActiveAgentWorkspaceMembership({
+      userId: pat.userId,
+      workspaceId: pat.workspaceId,
+      workspaces,
+    });
+  } catch (error) {
+    if (error instanceof AgentAccessWorkspaceError) return invalidCredential();
+    if (error instanceof AuthDependencyUnavailableError) throw dependencyUnavailable(error);
+    throw error;
+  }
+
+  let used: AgentPersonalAccessToken | undefined;
+  try {
+    used = await markAgentPersonalAccessTokenUsed({id: pat.id});
+  } catch (error) {
+    throw dependencyUnavailable(error);
+  }
+  if (!used) return invalidCredential();
+  return {kind: 'pat', pat: used};
+}
+
+async function verifyAgentAccessCredential(
+  token: string,
+  workspaces: WorkspacesInterModuleClient,
+): Promise<VerifiedAgentAccessCredential | null> {
+  if (Buffer.byteLength(token, 'utf8') > MAX_PRESENTED_TOKEN_BYTES) return invalidCredential();
+
+  if (getTokenType(token) === 'personalAccessToken') {
+    return await verifyAgentPersonalAccessToken(token, workspaces);
+  }
+
+  const claims = await verifyAgentAccessToken(token);
+  if (!claims) return invalidCredential();
+  return {kind: 'oauth', claims};
+}
+
+function contextForCredential(credential: VerifiedAgentAccessCredential): AgentAccessContext {
+  if (credential.kind === 'oauth') {
+    return {
+      userId: credential.claims.sub,
+      workspaceId: credential.claims.workspaceId,
+      scopes: credential.claims.scopes,
+      credential: {
+        kind: 'oauth_grant',
+        grantId: credential.claims.grantId,
+        clientId: credential.claims.clientId,
+      },
+    };
+  }
+
+  return {
+    userId: credential.pat.userId,
+    workspaceId: credential.pat.workspaceId,
+    scopes: agentScopes(credential.pat.scopes),
+    credential: {kind: 'pat', patId: credential.pat.id},
+  };
+}
+
+/** Authenticates stateless OAuth access tokens and database-checked PATs. */
+export function createAgentAccessAuthMethod(workspaces: WorkspacesInterModuleClient): AuthMethod {
+  return createBearerTokenAuthMethod({
+    name: AUTH_AGENT_ACCESS,
+    verifyToken: (token) => verifyAgentAccessCredential(token, workspaces),
+    isInvalidTokenError: (error) => error instanceof InvalidAgentAccessCredentialError,
+    invalidTokenError: {message: 'Invalid or expired agent access token', code: 'unauthorized'},
+    setContext: (request: FastifyRequest, credential) => {
+      setAgentAccessContext(request, contextForCredential(credential));
+    },
+  });
+}

--- a/libs/api/auth/src/presentation/routes/agent-access.test.ts
+++ b/libs/api/auth/src/presentation/routes/agent-access.test.ts
@@ -18,6 +18,7 @@ import {
   findAgentGrant,
 } from '#db/agent-access.js';
 import {db} from '#db/db.js';
+import {agentGrants} from '#db/schema/agent-access.js';
 import {users} from '#db/schema/users.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {userFactory} from '#test/index.js';
@@ -144,6 +145,25 @@ describe('agent access management routes', () => {
       });
       expect(relisted.statusCode).toBe(200);
       expect(relisted.json()).toEqual({grants: []});
+
+      const terminalGrant = await createAgentGrant({
+        userId: owner.id,
+        workspaceId: crypto.randomUUID(),
+        clientId: ownerClient.id,
+        scopes: ['read'],
+      });
+      await db()
+        .update(agentGrants)
+        .set({terminalAt: new Date(), updatedAt: new Date()})
+        .where(eq(agentGrants.id, terminalGrant.id));
+
+      const terminalRelisted = await app.inject({
+        method: 'GET',
+        url: '/agent-access/grants',
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(terminalRelisted.statusCode).toBe(200);
+      expect(terminalRelisted.json()).toEqual({grants: []});
     } finally {
       await app.close();
     }

--- a/libs/api/auth/src/presentation/routes/agent-access.test.ts
+++ b/libs/api/auth/src/presentation/routes/agent-access.test.ts
@@ -1,4 +1,8 @@
-import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
 import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {generateOpaqueToken, hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
@@ -132,6 +136,14 @@ describe('agent access management routes', () => {
       expect(
         await findActiveAgentRefreshTokenByHash({hashedToken: refreshToken.hashedToken}),
       ).toBeUndefined();
+
+      const relisted = await app.inject({
+        method: 'GET',
+        url: '/agent-access/grants',
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(relisted.statusCode).toBe(200);
+      expect(relisted.json()).toEqual({grants: []});
     } finally {
       await app.close();
     }
@@ -163,7 +175,10 @@ describe('agent access management routes', () => {
       expect(body.name).toBe('CI access');
       expect(body.workspace_id).toBe(workspaceId);
       expect(body.last_used_at).toBeNull();
-      expect(body.expires_at).toBeDefined();
+      const dayInMilliseconds = 24 * 60 * 60 * 1000;
+      const firstExpiryDelta = Date.parse(body.expires_at) - Date.parse(body.created_at);
+      expect(firstExpiryDelta).toBeGreaterThan(30 * dayInMilliseconds - 60_000);
+      expect(firstExpiryDelta).toBeLessThan(30 * dayInMilliseconds + 60_000);
 
       const listed = await app.inject({
         method: 'GET',
@@ -183,6 +198,19 @@ describe('agent access management routes', () => {
         ],
       });
       expect(JSON.stringify(listed.json())).not.toContain(body.raw_token);
+
+      const defaultExpiry = await app.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'Default expiry access'},
+      });
+      expect(defaultExpiry.statusCode).toBe(201);
+      const defaultExpiryBody = defaultExpiry.json();
+      const defaultExpiryDelta =
+        Date.parse(defaultExpiryBody.expires_at) - Date.parse(defaultExpiryBody.created_at);
+      expect(defaultExpiryDelta).toBeGreaterThan(90 * dayInMilliseconds - 60_000);
+      expect(defaultExpiryDelta).toBeLessThan(90 * dayInMilliseconds + 60_000);
 
       const invalidExpiry = await app.inject({
         method: 'POST',
@@ -222,6 +250,21 @@ describe('agent access management routes', () => {
       expect(firstDelete.statusCode).toBe(204);
       expect(secondDelete.statusCode).toBe(204);
 
+      const defaultDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/pats/${defaultExpiryBody.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(defaultDelete.statusCode).toBe(204);
+
+      const relisted = await app.inject({
+        method: 'GET',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(relisted.statusCode).toBe(200);
+      expect(relisted.json()).toEqual({pats: []});
+
       await db().update(users).set({status: 'suspended'}).where(eq(users.id, owner.id));
       const suspendedMint = await app.inject({
         method: 'POST',
@@ -230,6 +273,107 @@ describe('agent access management routes', () => {
         payload: {workspace_id: workspaceId, name: 'Suspended', expires_in_days: 90},
       });
       expect(suspendedMint.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('translates workspace membership failures and dependency outages', async () => {
+    const owner = await userFactory.create();
+    const workspaceId = crypto.randomUUID();
+    const token = await sessionToken(owner);
+    const method = workspacesInterModuleContract.methods.requireActiveMembership;
+    const knownFailures = [
+      ['membership-required', 'forbidden'],
+      ['workspace-not-found', 'workspace-inactive'],
+      ['workspace-inactive', 'workspace-inactive'],
+    ] as const;
+
+    for (const [failureCode, responseCode] of knownFailures) {
+      const workspaces = workspacesFor(workspaceId);
+      workspaces.requireActiveMembership = vi.fn(() => {
+        throw createInterModuleKnownError(method, failureCode, {workspaceId});
+      }) as unknown as WorkspacesInterModuleClient['requireActiveMembership'];
+      const app = await openApp(workspaces);
+
+      try {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/agent-access/pats',
+          headers: {authorization: `Bearer ${token}`},
+          payload: {workspace_id: workspaceId, name: `Failure ${failureCode}`},
+        });
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({code: responseCode});
+      } finally {
+        await app.close();
+      }
+    }
+
+    const suspendedWorkspaces = workspacesFor(workspaceId, 'suspended');
+    const suspendedApp = await openApp(suspendedWorkspaces);
+    try {
+      const response = await suspendedApp.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'Suspended workspace'},
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toEqual({code: 'workspace-suspended'});
+    } finally {
+      await suspendedApp.close();
+    }
+
+    const unavailableWorkspaces = workspacesFor(workspaceId);
+    unavailableWorkspaces.requireActiveMembership = vi.fn(() => {
+      throw new Error('workspaces unavailable');
+    }) as unknown as WorkspacesInterModuleClient['requireActiveMembership'];
+    const unavailableApp = await openApp(unavailableWorkspaces);
+    try {
+      const response = await unavailableApp.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'Unavailable workspace'},
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toEqual({code: 'auth-dependency-unavailable'});
+    } finally {
+      await unavailableApp.close();
+    }
+  });
+
+  test('returns a controlled server error for invalid persisted grant scopes', async () => {
+    const owner = await userFactory.create();
+    const client = await createAgentClient({
+      clientId: `https://client.example/${crypto.randomUUID()}`,
+      name: 'Invalid scope client',
+      redirectUris: ['https://client.example/callback'],
+      kind: 'registered',
+    });
+    await createAgentGrant({
+      userId: owner.id,
+      workspaceId: crypto.randomUUID(),
+      clientId: client.id,
+      scopes: ['write'],
+    });
+    const workspaces = workspacesFor(crypto.randomUUID());
+    const app = await openApp(workspaces);
+    const token = await sessionToken(owner);
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/agent-access/grants',
+        headers: {authorization: `Bearer ${token}`},
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toEqual({code: 'server-error'});
     } finally {
       await app.close();
     }

--- a/libs/api/auth/src/presentation/routes/agent-access.test.ts
+++ b/libs/api/auth/src/presentation/routes/agent-access.test.ts
@@ -1,0 +1,258 @@
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
+import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
+import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {generateOpaqueToken, hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
+import {vi} from '@shipfox/vitest/vi';
+import {eq} from 'drizzle-orm';
+import {signUserToken} from '#core/jwt.js';
+import {
+  createAgentClient,
+  createAgentGrant,
+  createAgentPersonalAccessToken,
+  createAgentRefreshToken,
+  findActiveAgentRefreshTokenByHash,
+  findAgentGrant,
+} from '#db/agent-access.js';
+import {db} from '#db/db.js';
+import {users} from '#db/schema/users.js';
+import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
+import {userFactory} from '#test/index.js';
+import {createAgentAccessManagementRoutes} from './agent-access.js';
+
+function workspacesFor(workspaceId: string, workspaceStatus: 'active' | 'suspended' = 'active') {
+  return {
+    listMembershipsForTokenClaims: vi.fn(async () => ({
+      memberships: [{workspaceId, role: 'admin' as const, workspaceStatus}],
+    })),
+    requireActiveMembership: vi.fn(async () => ({})),
+    getWorkspaceCreator: vi.fn(),
+    getWorkspaceOperatingState: vi.fn(),
+    preflightInvitationAcceptance: vi.fn(),
+    acceptInvitation: vi.fn(),
+  } as unknown as WorkspacesInterModuleClient;
+}
+
+async function sessionToken(user: {id: string; email: string}, impersonatorId?: string) {
+  return await signUserToken({
+    userId: user.id,
+    email: user.email,
+    memberships: [],
+    ...(impersonatorId ? {impersonatorId} : {}),
+    secret: userAccessTokenKey(),
+    expiresIn: '15m',
+  });
+}
+
+async function openApp(workspaces: WorkspacesInterModuleClient): Promise<FastifyInstance> {
+  return await createApp({
+    auth: [createJwtAuthMethod()],
+    routes: [createAgentAccessManagementRoutes({workspaces})],
+    swagger: false,
+  });
+}
+
+describe('agent access management routes', () => {
+  test('lists only caller-owned grants and makes revocation idempotent', async () => {
+    const owner = await userFactory.create();
+    const other = await userFactory.create();
+    const ownerWorkspaceId = crypto.randomUUID();
+    const otherWorkspaceId = crypto.randomUUID();
+    const ownerClient = await createAgentClient({
+      clientId: `https://client.example/${crypto.randomUUID()}`,
+      name: 'Owner client',
+      redirectUris: ['https://client.example/callback'],
+      kind: 'registered',
+    });
+    const otherClient = await createAgentClient({
+      clientId: `https://client.example/${crypto.randomUUID()}`,
+      name: 'Other client',
+      redirectUris: ['https://client.example/callback'],
+      kind: 'registered',
+    });
+    const ownerGrant = await createAgentGrant({
+      userId: owner.id,
+      workspaceId: ownerWorkspaceId,
+      clientId: ownerClient.id,
+      scopes: ['read'],
+    });
+    const otherGrant = await createAgentGrant({
+      userId: other.id,
+      workspaceId: otherWorkspaceId,
+      clientId: otherClient.id,
+      scopes: ['read'],
+    });
+    const refreshToken = await createAgentRefreshToken({
+      grantId: ownerGrant.id,
+      hashedToken: hashOpaqueToken(`refresh-${crypto.randomUUID()}`),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const workspaces = workspacesFor(ownerWorkspaceId);
+    const app = await openApp(workspaces);
+    const token = await sessionToken(owner);
+
+    try {
+      const listed = await app.inject({
+        method: 'GET',
+        url: '/agent-access/grants',
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(listed.statusCode).toBe(200);
+      expect(listed.json()).toEqual({
+        grants: [
+          expect.objectContaining({
+            id: ownerGrant.id,
+            client_name: 'Owner client',
+            workspace_id: ownerWorkspaceId,
+            scopes: ['read'],
+            last_refreshed_at: null,
+          }),
+        ],
+      });
+
+      const otherDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/grants/${otherGrant.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(otherDelete.statusCode).toBe(404);
+      expect((await findAgentGrant({id: otherGrant.id}))?.revokedAt).toBeNull();
+
+      const firstDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/grants/${ownerGrant.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      const secondDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/grants/${ownerGrant.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(firstDelete.statusCode).toBe(204);
+      expect(secondDelete.statusCode).toBe(204);
+      expect(
+        await findActiveAgentRefreshTokenByHash({hashedToken: refreshToken.hashedToken}),
+      ).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('mints a one-time raw PAT, lists metadata, and protects ownership and expiry rules', async () => {
+    const owner = await userFactory.create();
+    const other = await userFactory.create();
+    const workspaceId = crypto.randomUUID();
+    const otherWorkspaceId = crypto.randomUUID();
+    const workspaces = workspacesFor(workspaceId);
+    const app = await openApp(workspaces);
+    const token = await sessionToken(owner);
+
+    try {
+      const created = await app.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'CI access', expires_in_days: 30},
+      });
+
+      expect(created.statusCode).toBe(201);
+      const body = created.json();
+      expect(body.raw_token).toEqual(
+        expect.stringContaining(`sf_${tokenTypeParts.personalAccessToken}_`),
+      );
+      expect(body.prefix).toBe(body.raw_token.slice(0, 12));
+      expect(body.name).toBe('CI access');
+      expect(body.workspace_id).toBe(workspaceId);
+      expect(body.last_used_at).toBeNull();
+      expect(body.expires_at).toBeDefined();
+
+      const listed = await app.inject({
+        method: 'GET',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(listed.statusCode).toBe(200);
+      expect(listed.json()).toEqual({
+        pats: [
+          expect.objectContaining({
+            id: body.id,
+            workspace_id: workspaceId,
+            prefix: body.prefix,
+            name: 'CI access',
+            last_used_at: null,
+          }),
+        ],
+      });
+      expect(JSON.stringify(listed.json())).not.toContain(body.raw_token);
+
+      const invalidExpiry = await app.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'Invalid', expires_in_days: 7},
+      });
+      expect(invalidExpiry.statusCode).toBe(400);
+
+      const otherPatToken = generateOpaqueToken('personalAccessToken');
+      const otherPat = await createAgentPersonalAccessToken({
+        userId: other.id,
+        workspaceId: otherWorkspaceId,
+        hashedToken: hashOpaqueToken(otherPatToken),
+        prefix: otherPatToken.slice(0, 12),
+        name: 'Other PAT',
+        scopes: ['read'],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const otherDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/pats/${otherPat.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(otherDelete.statusCode).toBe(404);
+
+      const firstDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/pats/${body.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      const secondDelete = await app.inject({
+        method: 'DELETE',
+        url: `/agent-access/pats/${body.id}`,
+        headers: {authorization: `Bearer ${token}`},
+      });
+      expect(firstDelete.statusCode).toBe(204);
+      expect(secondDelete.statusCode).toBe(204);
+
+      await db().update(users).set({status: 'suspended'}).where(eq(users.id, owner.id));
+      const suspendedMint = await app.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'Suspended', expires_in_days: 90},
+      });
+      expect(suspendedMint.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('does not let an impersonated session mint a PAT', async () => {
+    const owner = await userFactory.create();
+    const workspaceId = crypto.randomUUID();
+    const workspaces = workspacesFor(workspaceId);
+    const app = await openApp(workspaces);
+    const token = await sessionToken(owner, crypto.randomUUID());
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/agent-access/pats',
+        headers: {authorization: `Bearer ${token}`},
+        payload: {workspace_id: workspaceId, name: 'Impersonated', expires_in_days: 90},
+      });
+      expect(response.statusCode).toBe(403);
+      expect(response.json().code).toBe('impersonation-not-permitted');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/libs/api/auth/src/presentation/routes/agent-access.ts
+++ b/libs/api/auth/src/presentation/routes/agent-access.ts
@@ -28,6 +28,7 @@ import {
   AgentGrantNotFoundError,
   AgentPersonalAccessTokenNotFoundError,
   AuthDependencyUnavailableError,
+  InvalidAgentAccessScopeError,
 } from '#core/errors.js';
 
 export interface CreateAgentAccessManagementRoutesOptions {
@@ -43,8 +44,8 @@ function requireActorId(request: FastifyRequest): string {
 }
 
 function toReadScopes(scopes: string[]): 'read'[] {
-  if (scopes.some((scope) => scope !== 'read')) {
-    throw new Error('Agent access contains an unsupported scope');
+  if (scopes.length === 0 || scopes.some((scope) => scope !== 'read')) {
+    throw new InvalidAgentAccessScopeError();
   }
   return scopes as 'read'[];
 }
@@ -90,6 +91,12 @@ function translateAgentAccessError(error: unknown): never {
   }
   if (error instanceof AgentPersonalAccessTokenNotFoundError) {
     throw new ClientError('Personal access token not found', 'not-found', {status: 404});
+  }
+  if (error instanceof InvalidAgentAccessScopeError) {
+    throw new ClientError('Agent access data is invalid', 'server-error', {
+      status: 500,
+      cause: error,
+    });
   }
   if (error instanceof AgentAccessUserInactiveError) {
     throw new ClientError('User is not active', 'forbidden', {status: 403});

--- a/libs/api/auth/src/presentation/routes/agent-access.ts
+++ b/libs/api/auth/src/presentation/routes/agent-access.ts
@@ -1,0 +1,244 @@
+import {AUTH_USER, getUserContext, rejectImpersonatedSession} from '@shipfox/api-auth-context';
+import {
+  agentAccessCredentialParamsSchema,
+  createAgentPersonalAccessTokenBodySchema,
+  createAgentPersonalAccessTokenResponseSchema,
+  listAgentGrantsResponseSchema,
+  listAgentPersonalAccessTokensResponseSchema,
+} from '@shipfox/api-auth-dto';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
+import {
+  ClientError,
+  defineRoute,
+  type FastifyRequest,
+  type RouteGroup,
+} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {
+  createAgentPersonalAccessToken,
+  listAgentGrants,
+  listAgentPersonalAccessTokens,
+  revokeAgentGrant,
+  revokeAgentPersonalAccessToken,
+} from '#core/agent-access.js';
+import type {AgentPersonalAccessToken} from '#core/entities/agent-access.js';
+import {
+  AgentAccessUserInactiveError,
+  AgentAccessWorkspaceError,
+  AgentGrantNotFoundError,
+  AgentPersonalAccessTokenNotFoundError,
+  AuthDependencyUnavailableError,
+} from '#core/errors.js';
+
+export interface CreateAgentAccessManagementRoutesOptions {
+  workspaces: WorkspacesInterModuleClient;
+}
+
+function requireActorId(request: FastifyRequest): string {
+  const context = getUserContext(request);
+  if (!context) {
+    throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+  }
+  return context.userId;
+}
+
+function toReadScopes(scopes: string[]): 'read'[] {
+  if (scopes.some((scope) => scope !== 'read')) {
+    throw new Error('Agent access contains an unsupported scope');
+  }
+  return scopes as 'read'[];
+}
+
+function toAgentGrantSummaryDto(grant: {
+  id: string;
+  clientName: string;
+  workspaceId: string;
+  scopes: string[];
+  createdAt: Date;
+  lastRefreshedAt: Date | null;
+}) {
+  return {
+    id: grant.id,
+    client_name: grant.clientName,
+    workspace_id: grant.workspaceId,
+    scopes: toReadScopes(grant.scopes),
+    created_at: grant.createdAt.toISOString(),
+    last_refreshed_at: grant.lastRefreshedAt?.toISOString() ?? null,
+  };
+}
+
+function toAgentPersonalAccessTokenSummaryDto(
+  pat: Pick<
+    AgentPersonalAccessToken,
+    'id' | 'workspaceId' | 'prefix' | 'name' | 'expiresAt' | 'lastUsedAt' | 'createdAt'
+  >,
+) {
+  return {
+    id: pat.id,
+    workspace_id: pat.workspaceId,
+    prefix: pat.prefix,
+    name: pat.name,
+    expires_at: pat.expiresAt.toISOString(),
+    last_used_at: pat.lastUsedAt?.toISOString() ?? null,
+    created_at: pat.createdAt.toISOString(),
+  };
+}
+
+function translateAgentAccessError(error: unknown): never {
+  if (error instanceof AgentGrantNotFoundError) {
+    throw new ClientError('Agent grant not found', 'not-found', {status: 404});
+  }
+  if (error instanceof AgentPersonalAccessTokenNotFoundError) {
+    throw new ClientError('Personal access token not found', 'not-found', {status: 404});
+  }
+  if (error instanceof AgentAccessUserInactiveError) {
+    throw new ClientError('User is not active', 'forbidden', {status: 403});
+  }
+  if (error instanceof AgentAccessWorkspaceError) {
+    if (error.code === 'workspace-suspended') {
+      throw new ClientError('Workspace is suspended', 'workspace-suspended', {status: 409});
+    }
+    if (error.code === 'workspace-inactive') {
+      throw new ClientError('Workspace is not active', 'workspace-inactive', {status: 403});
+    }
+    throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
+  }
+  if (error instanceof AuthDependencyUnavailableError) {
+    throw new ClientError('Authentication dependency unavailable', 'auth-dependency-unavailable', {
+      status: 503,
+      cause: error,
+    });
+  }
+  throw error;
+}
+
+const listGrantsRoute = defineRoute({
+  method: 'GET',
+  path: '/grants',
+  description: "List the signed-in user's active agent access grants.",
+  schema: {response: {200: listAgentGrantsResponseSchema}},
+  errorHandler: translateAgentAccessError,
+  handler: async (request) => ({
+    grants: (await listAgentGrants({userId: requireActorId(request)})).map(toAgentGrantSummaryDto),
+  }),
+});
+
+const revokeGrantRoute = defineRoute({
+  method: 'DELETE',
+  path: '/grants/:id',
+  description: "Revoke one of the signed-in user's agent access grants.",
+  schema: {
+    params: agentAccessCredentialParamsSchema,
+    response: {204: z.void()},
+  },
+  errorHandler: translateAgentAccessError,
+  handler: async (request, reply) => {
+    await revokeAgentGrant({userId: requireActorId(request), grantId: request.params.id});
+    reply.code(204);
+  },
+});
+
+function createMintPersonalAccessTokenRoute(workspaces: WorkspacesInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/pats',
+    description: 'Create a workspace-bound personal access token.',
+    options: {bodyLimit: 8 * 1024},
+    schema: {
+      body: createAgentPersonalAccessTokenBodySchema,
+      response: {201: createAgentPersonalAccessTokenResponseSchema},
+    },
+    errorHandler: translateAgentAccessError,
+    handler: async (request, reply) => {
+      const context = getUserContext(request);
+      if (!context) {
+        throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+      }
+      rejectImpersonatedSession(request);
+
+      const result = await createAgentPersonalAccessToken({
+        userId: context.userId,
+        workspaceId: request.body.workspace_id,
+        name: request.body.name,
+        expiresInDays: request.body.expires_in_days,
+        workspaces,
+      });
+      reply.code(201);
+      return {
+        raw_token: result.token,
+        ...toAgentPersonalAccessTokenSummaryDto(result.pat),
+      };
+    },
+  });
+}
+
+const listPersonalAccessTokensRoute = defineRoute({
+  method: 'GET',
+  path: '/pats',
+  description: "List the signed-in user's personal access token metadata.",
+  schema: {response: {200: listAgentPersonalAccessTokensResponseSchema}},
+  errorHandler: translateAgentAccessError,
+  handler: async (request) => ({
+    pats: (await listAgentPersonalAccessTokens({userId: requireActorId(request)})).map(
+      toAgentPersonalAccessTokenSummaryDto,
+    ),
+  }),
+});
+
+const revokePersonalAccessTokenRoute = defineRoute({
+  method: 'DELETE',
+  path: '/pats/:id',
+  description: "Revoke one of the signed-in user's personal access tokens.",
+  schema: {
+    params: agentAccessCredentialParamsSchema,
+    response: {204: z.void()},
+  },
+  errorHandler: translateAgentAccessError,
+  handler: async (request, reply) => {
+    await revokeAgentPersonalAccessToken({userId: requireActorId(request), id: request.params.id});
+    reply.code(204);
+  },
+});
+
+/** Route group for grant listing and revocation. */
+export function createAgentGrantRoutes(): RouteGroup {
+  return {
+    prefix: '/agent-access',
+    auth: AUTH_USER,
+    routes: [listGrantsRoute, revokeGrantRoute],
+  };
+}
+
+/** Route group for PAT creation, listing, and revocation. */
+export function createAgentPersonalAccessTokenRoutes(
+  workspaces: WorkspacesInterModuleClient,
+): RouteGroup {
+  return {
+    prefix: '/agent-access',
+    auth: AUTH_USER,
+    routes: [
+      createMintPersonalAccessTokenRoute(workspaces),
+      listPersonalAccessTokensRoute,
+      revokePersonalAccessTokenRoute,
+    ],
+  };
+}
+
+/** Explicitly composes the dashboard-facing agent credential-management routes. */
+export function createAgentAccessManagementRoutes(
+  options: CreateAgentAccessManagementRoutesOptions,
+): RouteGroup {
+  return {
+    prefix: '/agent-access',
+    auth: AUTH_USER,
+    routes: [
+      listGrantsRoute,
+      revokeGrantRoute,
+      createMintPersonalAccessTokenRoute(options.workspaces),
+      listPersonalAccessTokensRoute,
+      revokePersonalAccessTokenRoute,
+    ],
+  };
+}
+
+export const createAgentAccessRoutes = createAgentAccessManagementRoutes;


### PR DESCRIPTION
Agent credentials now have a shared management and request-authentication seam for the upcoming MCP gateway and settings UI. This adds caller-scoped OAuth grant and PAT lifecycle operations, one-time raw PAT issuance with bounded expiry choices, and a unified `AUTH_AGENT_ACCESS` request context for OAuth and PAT callers.

The production auth method and `/agent-access` routes remain intentionally unregistered by `createAuthModule`; consuming applications must explicitly compose the opt-in surface. PAT requests revalidate user activity, workspace membership, workspace status, expiry, and revocation, while OAuth access tokens retain their stateless 15-minute lifetime.

Validation passed for the affected check, type, test, build, and dependency-cruise targets, the API database-boundary policy, and the auth suite (46 files, 373 tests).

Closes ENG-1830

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in agent credential management for the upcoming MCP gateway and settings UI, unifying OAuth grant and PAT request authentication under `AUTH_AGENT_ACCESS`. The production auth method and `/agent-access` routes stay unregistered by `createAuthModule`; consuming applications must compose them explicitly.

- Grants and PATs get caller-scoped list and idempotent revoke routes; active listings exclude terminal grants, and unknown or another user's identifiers return 404.
- PAT creation returns the raw token once and accepts 30, 90, or 365 day expiry; impersonated sessions cannot mint PATs. Client and PAT names share a schema that rejects control and format characters at a 256-byte UTF-8 bound.
- PAT requests revalidate user activity, workspace membership, workspace status, expiry, and revocation against the current database clock, with the owning-user row locked so a concurrent suspension cannot race the check; OAuth access tokens keep their stateless 15-minute lifetime and presented tokens are capped at 8 KiB.

Closes ENG-1830.

<sup>Written for commit dc4af00f70225668ba0ce110b13904eebfc5aefd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

