### PR TITLE
[client-integrations] Add connection repository access settings

### DIFF
--- a/.changeset/connection-access-settings.md
+++ b/.changeset/connection-access-settings.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-integrations": minor
+---
+
+Add a connection-detail page for managing repository access modes.

--- a/apps/client/src/shipfox-app.gen.ts
+++ b/apps/client/src/shipfox-app.gen.ts
@@ -23,25 +23,26 @@ import * as route16Module from "@shipfox/client-integrations/routes/jira";
 import * as route17Module from "@shipfox/client-integrations/routes/sentry";
 import * as route18Module from "@shipfox/client-integrations/routes/slack";
 import * as route19Module from "@shipfox/client-integrations/routes/integrations-settings";
-import * as route20Module from "@shipfox/client-projects/routes/home";
-import * as route21Module from "@shipfox/client-projects/routes/create-project";
-import * as route22Module from "@shipfox/client-projects/routes/project-index";
-import * as route23Module from "@shipfox/client-projects/routes/project-settings-index";
-import * as route24Module from "@shipfox/client-projects/routes/project-settings";
-import * as route25Module from "@shipfox/client-workflows/routes/workflows";
-import * as route26Module from "@shipfox/client-workflows/routes/runs";
-import * as route27Module from "@shipfox/client-workflows/routes/run-detail";
-import * as route28Module from "@shipfox/client-workflows/routes/job-detail";
-import * as route29Module from "@shipfox/client-agent/routes/model-provider";
-import * as route30Module from "@shipfox/client-agent/routes/agents-settings";
-import * as route31Module from "@shipfox/client-runners/routes/runners-settings";
-import * as route32Module from "@shipfox/client-runners/routes/provisioners-settings";
-import * as route33Module from "@shipfox/client-secrets/routes/secrets-settings";
-import * as route34Module from "@shipfox/client-secrets/routes/variables-settings";
-import * as route35Module from "@shipfox/client-triggers/routes/events-settings";
-import * as route36Module from "@shipfox/client-workspace-settings/routes/index";
-import * as route37Module from "@shipfox/client-workspace-settings/routes/members";
-import * as route38Module from "@shipfox/client-workspace-settings/routes/general";
+import * as route20Module from "@shipfox/client-integrations/routes/connection-details";
+import * as route21Module from "@shipfox/client-projects/routes/home";
+import * as route22Module from "@shipfox/client-projects/routes/create-project";
+import * as route23Module from "@shipfox/client-projects/routes/project-index";
+import * as route24Module from "@shipfox/client-projects/routes/project-settings-index";
+import * as route25Module from "@shipfox/client-projects/routes/project-settings";
+import * as route26Module from "@shipfox/client-workflows/routes/workflows";
+import * as route27Module from "@shipfox/client-workflows/routes/runs";
+import * as route28Module from "@shipfox/client-workflows/routes/run-detail";
+import * as route29Module from "@shipfox/client-workflows/routes/job-detail";
+import * as route30Module from "@shipfox/client-agent/routes/model-provider";
+import * as route31Module from "@shipfox/client-agent/routes/agents-settings";
+import * as route32Module from "@shipfox/client-runners/routes/runners-settings";
+import * as route33Module from "@shipfox/client-runners/routes/provisioners-settings";
+import * as route34Module from "@shipfox/client-secrets/routes/secrets-settings";
+import * as route35Module from "@shipfox/client-secrets/routes/variables-settings";
+import * as route36Module from "@shipfox/client-triggers/routes/events-settings";
+import * as route37Module from "@shipfox/client-workspace-settings/routes/index";
+import * as route38Module from "@shipfox/client-workspace-settings/routes/members";
+import * as route39Module from "@shipfox/client-workspace-settings/routes/general";
 
 function routeOptions<T extends RouteImpl>(routeImpl: T, impl: string, path: string): T['options'] {
   assertRouteImplFrame(routeImpl, impl, path);
@@ -285,125 +286,131 @@ const route19 = createRoute({
 });
 
 const route20 = createRoute({
-  getParentRoute: () => skeleton.workspaceLayout,
-  path: "/",
-  ...routeOptions(route20Module.default, "@shipfox/client-projects/routes/home", "/w/$workspaceSlug"),
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: "/integrations/$connectionSlug",
+  ...routeOptions(route20Module.default, "@shipfox/client-integrations/routes/connection-details", "/w/$workspaceSlug/settings/integrations/$connectionSlug"),
 });
 
 const route21 = createRoute({
   getParentRoute: () => skeleton.workspaceLayout,
-  path: "/projects/new",
-  ...routeOptions(route21Module.default, "@shipfox/client-projects/routes/create-project", "/w/$workspaceSlug/projects/new"),
+  path: "/",
+  ...routeOptions(route21Module.default, "@shipfox/client-projects/routes/home", "/w/$workspaceSlug"),
 });
 
 const route22 = createRoute({
-  getParentRoute: () => skeleton.projectLayout,
-  path: "/",
-  ...routeOptions(route22Module.default, "@shipfox/client-projects/routes/project-index", "/w/$workspaceSlug/p/$projectSlug"),
+  getParentRoute: () => skeleton.workspaceLayout,
+  path: "/projects/new",
+  ...routeOptions(route22Module.default, "@shipfox/client-projects/routes/create-project", "/w/$workspaceSlug/projects/new"),
 });
 
 const route23 = createRoute({
-  getParentRoute: () => skeleton.projectSettings,
+  getParentRoute: () => skeleton.projectLayout,
   path: "/",
-  ...routeOptions(route23Module.default, "@shipfox/client-projects/routes/project-settings-index", "/w/$workspaceSlug/p/$projectSlug/settings"),
+  ...routeOptions(route23Module.default, "@shipfox/client-projects/routes/project-index", "/w/$workspaceSlug/p/$projectSlug"),
 });
 
 const route24 = createRoute({
   getParentRoute: () => skeleton.projectSettings,
-  path: "/general",
-  ...routeOptions(route24Module.default, "@shipfox/client-projects/routes/project-settings", "/w/$workspaceSlug/p/$projectSlug/settings/general"),
+  path: "/",
+  ...routeOptions(route24Module.default, "@shipfox/client-projects/routes/project-settings-index", "/w/$workspaceSlug/p/$projectSlug/settings"),
 });
 
 const route25 = createRoute({
-  getParentRoute: () => skeleton.projectLayout,
-  path: "/workflows",
-  ...routeOptions(route25Module.default, "@shipfox/client-workflows/routes/workflows", "/w/$workspaceSlug/p/$projectSlug/workflows"),
+  getParentRoute: () => skeleton.projectSettings,
+  path: "/general",
+  ...routeOptions(route25Module.default, "@shipfox/client-projects/routes/project-settings", "/w/$workspaceSlug/p/$projectSlug/settings/general"),
 });
 
 const route26 = createRoute({
   getParentRoute: () => skeleton.projectLayout,
-  path: "/runs",
-  ...routeOptions(route26Module.default, "@shipfox/client-workflows/routes/runs", "/w/$workspaceSlug/p/$projectSlug/runs"),
+  path: "/workflows",
+  ...routeOptions(route26Module.default, "@shipfox/client-workflows/routes/workflows", "/w/$workspaceSlug/p/$projectSlug/workflows"),
 });
 
 const route27 = createRoute({
   getParentRoute: () => skeleton.projectLayout,
-  path: "/runs/$workflowRunId",
-  ...routeOptions(route27Module.default, "@shipfox/client-workflows/routes/run-detail", "/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"),
+  path: "/runs",
+  ...routeOptions(route27Module.default, "@shipfox/client-workflows/routes/runs", "/w/$workspaceSlug/p/$projectSlug/runs"),
 });
 
 const route28 = createRoute({
   getParentRoute: () => skeleton.projectLayout,
-  path: "/runs/$workflowRunId/jobs/$jobId",
-  ...routeOptions(route28Module.default, "@shipfox/client-workflows/routes/job-detail", "/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId/jobs/$jobId"),
+  path: "/runs/$workflowRunId",
+  ...routeOptions(route28Module.default, "@shipfox/client-workflows/routes/run-detail", "/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"),
 });
 
 const route29 = createRoute({
-  getParentRoute: () => skeleton.workspaceLayout,
-  path: "/model-provider",
-  ...routeOptions(route29Module.default, "@shipfox/client-agent/routes/model-provider", "/w/$workspaceSlug/model-provider"),
+  getParentRoute: () => skeleton.projectLayout,
+  path: "/runs/$workflowRunId/jobs/$jobId",
+  ...routeOptions(route29Module.default, "@shipfox/client-workflows/routes/job-detail", "/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId/jobs/$jobId"),
 });
 
 const route30 = createRoute({
-  getParentRoute: () => skeleton.workspaceSettings,
-  path: "/agents",
-  ...routeOptions(route30Module.default, "@shipfox/client-agent/routes/agents-settings", "/w/$workspaceSlug/settings/agents"),
+  getParentRoute: () => skeleton.workspaceLayout,
+  path: "/model-provider",
+  ...routeOptions(route30Module.default, "@shipfox/client-agent/routes/model-provider", "/w/$workspaceSlug/model-provider"),
 });
 
 const route31 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/runners",
-  ...routeOptions(route31Module.default, "@shipfox/client-runners/routes/runners-settings", "/w/$workspaceSlug/settings/runners"),
+  path: "/agents",
+  ...routeOptions(route31Module.default, "@shipfox/client-agent/routes/agents-settings", "/w/$workspaceSlug/settings/agents"),
 });
 
 const route32 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/provisioners",
-  ...routeOptions(route32Module.default, "@shipfox/client-runners/routes/provisioners-settings", "/w/$workspaceSlug/settings/provisioners"),
+  path: "/runners",
+  ...routeOptions(route32Module.default, "@shipfox/client-runners/routes/runners-settings", "/w/$workspaceSlug/settings/runners"),
 });
 
 const route33 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/secrets",
-  ...routeOptions(route33Module.default, "@shipfox/client-secrets/routes/secrets-settings", "/w/$workspaceSlug/settings/secrets"),
+  path: "/provisioners",
+  ...routeOptions(route33Module.default, "@shipfox/client-runners/routes/provisioners-settings", "/w/$workspaceSlug/settings/provisioners"),
 });
 
 const route34 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/variables",
-  ...routeOptions(route34Module.default, "@shipfox/client-secrets/routes/variables-settings", "/w/$workspaceSlug/settings/variables"),
+  path: "/secrets",
+  ...routeOptions(route34Module.default, "@shipfox/client-secrets/routes/secrets-settings", "/w/$workspaceSlug/settings/secrets"),
 });
 
 const route35 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/events",
-  ...routeOptions(route35Module.default, "@shipfox/client-triggers/routes/events-settings", "/w/$workspaceSlug/settings/events"),
+  path: "/variables",
+  ...routeOptions(route35Module.default, "@shipfox/client-secrets/routes/variables-settings", "/w/$workspaceSlug/settings/variables"),
 });
 
 const route36 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/",
-  ...routeOptions(route36Module.default, "@shipfox/client-workspace-settings/routes/index", "/w/$workspaceSlug/settings"),
+  path: "/events",
+  ...routeOptions(route36Module.default, "@shipfox/client-triggers/routes/events-settings", "/w/$workspaceSlug/settings/events"),
 });
 
 const route37 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/members",
-  ...routeOptions(route37Module.default, "@shipfox/client-workspace-settings/routes/members", "/w/$workspaceSlug/settings/members"),
+  path: "/",
+  ...routeOptions(route37Module.default, "@shipfox/client-workspace-settings/routes/index", "/w/$workspaceSlug/settings"),
 });
 
 const route38 = createRoute({
   getParentRoute: () => skeleton.workspaceSettings,
-  path: "/general",
-  ...routeOptions(route38Module.default, "@shipfox/client-workspace-settings/routes/general", "/w/$workspaceSlug/settings/general"),
+  path: "/members",
+  ...routeOptions(route38Module.default, "@shipfox/client-workspace-settings/routes/members", "/w/$workspaceSlug/settings/members"),
 });
 
-const projectSettings = skeleton.projectSettings.addChildren([route23, route24]);
-const projectLayout = skeleton.projectLayout.addChildren([route22, route25, route26, route27, route28,
+const route39 = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: "/general",
+  ...routeOptions(route39Module.default, "@shipfox/client-workspace-settings/routes/general", "/w/$workspaceSlug/settings/general"),
+});
+
+const projectSettings = skeleton.projectSettings.addChildren([route24, route25]);
+const projectLayout = skeleton.projectLayout.addChildren([route23, route26, route27, route28, route29,
   projectSettings]);
-const workspaceSettings = skeleton.workspaceSettings.addChildren([route19, route30, route31, route32, route33, route34, route35, route36, route37, route38]);
+const workspaceSettings = skeleton.workspaceSettings.addChildren([route19, route20, route31, route32, route33, route34, route35, route36, route37, route38, route39]);
 const workspaceLayout = skeleton.workspaceLayout.addChildren([
-  route12, route13, route14, route15, route16, route17, route18, route20, route21, route29,
+  route12, route13, route14, route15, route16, route17, route18, route21, route22, route30,
   projectLayout,
   workspaceSettings,
 ]);

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -174,7 +174,7 @@ function InstalledRow({
                       to="/w/$workspaceSlug/settings/integrations/$connectionSlug"
                       params={{workspaceSlug, connectionSlug: connection.slug}}
                     >
-                      Manage repository access
+                      Repository access settings
                     </Link>
                   </DropdownMenuItem>
                 ) : null}

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -174,7 +174,7 @@ function InstalledRow({
                       to="/w/$workspaceSlug/settings/integrations/$connectionSlug"
                       params={{workspaceSlug, connectionSlug: connection.slug}}
                     >
-                      Repository access settings
+                      Manage repository access
                     </Link>
                   </DropdownMenuItem>
                 ) : null}

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -167,15 +167,27 @@ function InstalledRow({
               Use this integration
             </DropdownMenuItem>
             {workspaceSlug ? (
-              <DropdownMenuItem asChild>
-                <Link
-                  to="/w/$workspaceSlug/settings/events"
-                  params={{workspaceSlug}}
-                  search={{source: [connection.slug], event: [recentEventsEvent]}}
-                >
-                  View recent events
-                </Link>
-              </DropdownMenuItem>
+              <>
+                {connection.capabilities.includes('source_control') ? (
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/w/$workspaceSlug/settings/integrations/$connectionSlug"
+                      params={{workspaceSlug, connectionSlug: connection.slug}}
+                    >
+                      Repository access settings
+                    </Link>
+                  </DropdownMenuItem>
+                ) : null}
+                <DropdownMenuItem asChild>
+                  <Link
+                    to="/w/$workspaceSlug/settings/events"
+                    params={{workspaceSlug}}
+                    search={{source: [connection.slug], event: [recentEventsEvent]}}
+                  >
+                    View recent events
+                  </Link>
+                </DropdownMenuItem>
+              </>
             ) : null}
             <DropdownMenuSeparator />
             <DropdownMenuItem disabled={isMutating} onSelect={() => onSetActive(!active)}>

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -398,7 +398,7 @@ describe('IntegrationGallery — installed section', () => {
 
     await openActions('Open acme-corp integration actions');
 
-    expect(screen.getByRole('menuitem', {name: 'Manage repository access'})).toHaveAttribute(
+    expect(screen.getByRole('menuitem', {name: 'Repository access settings'})).toHaveAttribute(
       'href',
       '/w/acme/settings/integrations/github_acme_corp',
     );

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -398,7 +398,7 @@ describe('IntegrationGallery — installed section', () => {
 
     await openActions('Open acme-corp integration actions');
 
-    expect(screen.getByRole('menuitem', {name: 'Repository access settings'})).toHaveAttribute(
+    expect(screen.getByRole('menuitem', {name: 'Manage repository access'})).toHaveAttribute(
       'href',
       '/w/acme/settings/integrations/github_acme_corp',
     );

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -398,6 +398,10 @@ describe('IntegrationGallery — installed section', () => {
 
     await openActions('Open acme-corp integration actions');
 
+    expect(screen.getByRole('menuitem', {name: 'Repository access settings'})).toHaveAttribute(
+      'href',
+      '/w/acme/settings/integrations/github_acme_corp',
+    );
     const externalAction = screen.getByRole('menuitem', {name: 'Open in GitHub'});
     expect(externalAction).toHaveAttribute('href', githubConnection.external_url);
     expect(externalAction).toHaveAttribute('target', '_blank');

--- a/libs/client/integrations/src/core/models.ts
+++ b/libs/client/integrations/src/core/models.ts
@@ -45,6 +45,25 @@ export interface RepositoryPage {
   nextCursor?: string;
 }
 
+export type RepositoryAccessMode = 'selected' | 'all';
+
+export type RepositoryAccessOrigin =
+  | {type: 'project'; projectId: string; projectName: string}
+  | {type: 'manual'; grantId: string};
+
+export interface RepositoryAccessRepository {
+  externalRepositoryId: string;
+  owner: string;
+  name: string;
+  origins: RepositoryAccessOrigin[];
+}
+
+export interface RepositoryAccess {
+  mode: RepositoryAccessMode;
+  repositories: RepositoryAccessRepository[];
+  nextCursor?: string;
+}
+
 export interface WebhookConnection {
   id: string;
   workspaceId: string;

--- a/libs/client/integrations/src/feature.ts
+++ b/libs/client/integrations/src/feature.ts
@@ -78,6 +78,11 @@ export const integrationsFeature = defineClientFeature({
       parent: 'workspaceSettings',
       impl: '@shipfox/client-integrations/routes/integrations-settings',
     },
+    {
+      path: '/w/$workspaceSlug/settings/integrations/$connectionSlug',
+      parent: 'workspaceSettings',
+      impl: '@shipfox/client-integrations/routes/connection-details',
+    },
   ],
   settingsSections: integrationsSettingsSections,
 });

--- a/libs/client/integrations/src/hooks/api/integration-mapper.ts
+++ b/libs/client/integrations/src/hooks/api/integration-mapper.ts
@@ -1,5 +1,8 @@
 import type {
   IntegrationConnectionDto,
+  IntegrationConnectionRepositoryAccessOriginDto,
+  IntegrationConnectionRepositoryAccessRepositoryDto,
+  IntegrationConnectionRepositoryAccessResponseDto,
   IntegrationProviderDto,
   RepositoryDto,
 } from '@shipfox/api-integration-core-dto';
@@ -11,6 +14,9 @@ import type {
   IntegrationProvider,
   JiraSite,
   Repository,
+  RepositoryAccess,
+  RepositoryAccessOrigin,
+  RepositoryAccessRepository,
   WebhookConnection,
 } from '#core/models.js';
 
@@ -53,6 +59,35 @@ export function toRepository(dto: RepositoryDto): Repository {
     visibility: dto.visibility,
     cloneUrl: dto.clone_url,
     htmlUrl: dto.html_url,
+  };
+}
+
+function toRepositoryAccessOrigin(
+  dto: IntegrationConnectionRepositoryAccessOriginDto,
+): RepositoryAccessOrigin {
+  return dto.type === 'project'
+    ? {type: 'project', projectId: dto.project_id, projectName: dto.project_name}
+    : {type: 'manual', grantId: dto.grant_id};
+}
+
+function toRepositoryAccessRepository(
+  dto: IntegrationConnectionRepositoryAccessRepositoryDto,
+): RepositoryAccessRepository {
+  return {
+    externalRepositoryId: dto.external_repository_id,
+    owner: dto.owner,
+    name: dto.name,
+    origins: dto.origins.map(toRepositoryAccessOrigin),
+  };
+}
+
+export function toRepositoryAccess(
+  dto: IntegrationConnectionRepositoryAccessResponseDto,
+): RepositoryAccess {
+  return {
+    mode: dto.mode,
+    repositories: dto.repositories.map(toRepositoryAccessRepository),
+    ...(dto.next_cursor == null ? {} : {nextCursor: dto.next_cursor}),
   };
 }
 

--- a/libs/client/integrations/src/hooks/api/integrations.test.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.test.ts
@@ -8,7 +8,9 @@ import {
   createJiraInstall,
   createLinearInstall,
   createSlackInstall,
+  listIntegrationConnectionRepositoryAccess,
   listSourceConnections,
+  updateIntegrationConnectionRepositoryAccess,
 } from './integrations.js';
 
 function connection(overrides: Partial<IntegrationConnectionDto> = {}): IntegrationConnectionDto {
@@ -61,6 +63,86 @@ describe('listSourceConnections', () => {
     expect(result.map((connection) => connection.id)).toEqual([
       '33333333-3333-4333-8333-333333333333',
     ]);
+  });
+});
+
+describe('repository access transport', () => {
+  test('loads and maps the composed repository access read model', async () => {
+    let requestedUrl = '';
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      requestedUrl = input instanceof Request ? input.url : String(input);
+      return Promise.resolve(
+        jsonResponse({
+          mode: 'selected',
+          repositories: [
+            {
+              external_repository_id: 'acme/platform',
+              owner: 'acme',
+              name: 'platform',
+              origins: [
+                {
+                  type: 'project',
+                  project_id: '33333333-3333-4333-8333-333333333333',
+                  project_name: 'Platform',
+                },
+                {type: 'manual', grant_id: '44444444-4444-4444-8444-444444444444'},
+              ],
+            },
+          ],
+          next_cursor: null,
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const result = await listIntegrationConnectionRepositoryAccess({
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      cursor: 'next-page',
+    });
+
+    expect(requestedUrl).toBe(
+      'https://api.example.test/integration-connections/11111111-1111-4111-8111-111111111111/repository-access?cursor=next-page',
+    );
+    expect(result).toEqual({
+      mode: 'selected',
+      repositories: [
+        {
+          externalRepositoryId: 'acme/platform',
+          owner: 'acme',
+          name: 'platform',
+          origins: [
+            {
+              type: 'project',
+              projectId: '33333333-3333-4333-8333-333333333333',
+              projectName: 'Platform',
+            },
+            {type: 'manual', grantId: '44444444-4444-4444-8444-444444444444'},
+          ],
+        },
+      ],
+    });
+  });
+
+  test('updates repository access mode through the idempotent route', async () => {
+    const requests: Request[] = [];
+    const fetchImpl = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      return Promise.resolve(jsonResponse({mode: 'all'}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const mode = await updateIntegrationConnectionRepositoryAccess({
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      mode: 'all',
+    });
+
+    expect(mode).toBe('all');
+    expect(requests[0]?.method).toBe('PUT');
+    expect(requests[0]?.url).toBe(
+      'https://api.example.test/integration-connections/11111111-1111-4111-8111-111111111111/repository-access',
+    );
+    expect(await requests[0]?.json()).toEqual({mode: 'all'});
   });
 });
 

--- a/libs/client/integrations/src/hooks/api/integrations.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.ts
@@ -1,12 +1,15 @@
 import type {
   IntegrationCapabilityDto,
+  IntegrationConnectionRepositoryAccessModeDto,
   UpdateIntegrationConnectionBodyDto,
 } from '@shipfox/api-integration-core-dto';
 import {
   integrationConnectionDtoSchema,
+  integrationConnectionRepositoryAccessResponseSchema,
   listIntegrationConnectionsResponseSchema,
   listIntegrationProvidersResponseSchema,
   listRepositoriesResponseSchema,
+  updateIntegrationConnectionRepositoryAccessResponseSchema,
 } from '@shipfox/api-integration-core-dto';
 import type {CreateGiteaConnectionBodyDto} from '@shipfox/api-integration-gitea-dto';
 import {createGiteaConnectionResponseSchema} from '@shipfox/api-integration-gitea-dto';
@@ -66,6 +69,8 @@ import {
   type IntegrationProvider,
   isUsableConnection,
   type JiraSite,
+  type RepositoryAccess,
+  type RepositoryAccessMode,
   type RepositoryPage,
 } from '#core/models.js';
 import {serializeJiraCallbackQuery} from '#jira-callback.js';
@@ -77,6 +82,7 @@ import {
   toIntegrationProvider,
   toJiraSite,
   toRepository,
+  toRepositoryAccess,
 } from './integration-mapper.js';
 
 export const integrationsQueryKeys = {
@@ -94,6 +100,8 @@ export const integrationsQueryKeys = {
     integrationsQueryKeys.connections(workspaceId, 'source_control'),
   repositories: (connectionId: string, search: string) =>
     [...integrationsQueryKeys.all, 'repositories', connectionId, search] as const,
+  repositoryAccess: (connectionId: string) =>
+    [...integrationsQueryKeys.all, 'repository-access', connectionId] as const,
 };
 
 type SourceConnectionsQueryKey =
@@ -136,6 +144,18 @@ type RepositoriesInfiniteQueryOptions = UseInfiniteQueryOptions<
   Error,
   InfiniteData<RepositoryPage, string | undefined>,
   RepositoriesQueryKey,
+  string | undefined
+>;
+
+type RepositoryAccessQueryKey =
+  | ReturnType<typeof integrationsQueryKeys.repositoryAccess>
+  | readonly ['integrations', 'repository-access'];
+
+type RepositoryAccessQueryOptions = UseInfiniteQueryOptions<
+  RepositoryAccess,
+  Error,
+  InfiniteData<RepositoryAccess, string | undefined>,
+  RepositoryAccessQueryKey,
   string | undefined
 >;
 
@@ -401,6 +421,44 @@ export async function listRepositories({
   };
 }
 
+export async function listIntegrationConnectionRepositoryAccess({
+  connectionId,
+  cursor,
+  signal,
+}: {
+  connectionId: string;
+  cursor?: string;
+  signal?: AbortSignal;
+}): Promise<RepositoryAccess> {
+  const search = new URLSearchParams();
+  if (cursor) search.set('cursor', cursor);
+  const query = search.toString();
+  const path = query
+    ? `/integration-connections/${encodeURIComponent(connectionId)}/repository-access?${query}`
+    : `/integration-connections/${encodeURIComponent(connectionId)}/repository-access`;
+  const response = await checkedApiRequest(
+    integrationConnectionRepositoryAccessResponseSchema,
+    path,
+    {signal},
+  );
+  return toRepositoryAccess(response);
+}
+
+export async function updateIntegrationConnectionRepositoryAccess({
+  connectionId,
+  mode,
+}: {
+  connectionId: string;
+  mode: RepositoryAccessMode;
+}): Promise<IntegrationConnectionRepositoryAccessModeDto> {
+  const response = await checkedApiRequest(
+    updateIntegrationConnectionRepositoryAccessResponseSchema,
+    `/integration-connections/${encodeURIComponent(connectionId)}/repository-access`,
+    {method: 'PUT', body: {mode}},
+  );
+  return response.mode;
+}
+
 export async function updateIntegrationConnection({
   connectionId,
   body,
@@ -445,6 +503,31 @@ export function useSourceConnectionsQuery(workspaceId: string | undefined) {
 
 export function useIntegrationConnectionsQuery(workspaceId: string | undefined) {
   return useQuery(integrationConnectionsQueryOptions(workspaceId));
+}
+
+export function useIntegrationConnectionRepositoryAccessQuery(connectionId: string | undefined) {
+  return useInfiniteQuery(repositoryAccessQueryOptions(connectionId));
+}
+
+export function repositoryAccessQueryOptions(
+  connectionId: string | undefined,
+): RepositoryAccessQueryOptions {
+  return infiniteQueryOptions({
+    queryKey: connectionId
+      ? integrationsQueryKeys.repositoryAccess(connectionId)
+      : ([...integrationsQueryKeys.all, 'repository-access'] as const),
+    enabled: Boolean(connectionId),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({pageParam, signal}) => {
+      const args: {connectionId: string; cursor?: string; signal: AbortSignal} = {
+        connectionId: connectionId ?? '',
+        signal,
+      };
+      if (pageParam) args.cursor = pageParam;
+      return listIntegrationConnectionRepositoryAccess(args);
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
 }
 
 export function integrationConnectionsQueryOptions(
@@ -538,6 +621,19 @@ export function useUpdateIntegrationConnectionMutation() {
     onSuccess: async (connection) => {
       await queryClient.invalidateQueries({
         queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspaceId),
+      });
+    },
+  });
+}
+
+export function useUpdateIntegrationConnectionRepositoryAccessMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateIntegrationConnectionRepositoryAccess,
+    onSuccess: async (_mode, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: integrationsQueryKeys.repositoryAccess(variables.connectionId),
+        refetchType: 'all',
       });
     },
   });

--- a/libs/client/integrations/src/pages/connection-details-page.stories.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.stories.tsx
@@ -1,0 +1,216 @@
+import type {
+  IntegrationConnectionDto,
+  IntegrationConnectionRepositoryAccessResponseDto,
+} from '@shipfox/api-integration-core-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {type AuthState, authStateAtom} from '@shipfox/client-auth';
+import {Toaster} from '@shipfox/react-ui/toast';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {createStore, Provider as JotaiProvider} from 'jotai';
+import {useMemo} from 'react';
+import {expect, within} from 'storybook/test';
+import {ConnectionDetailsPage} from './connection-details-page.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const CONNECTION_ID = '44444444-4444-4444-8444-444444444444';
+const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
+const GRANT_ID = '66666666-6666-4666-8666-666666666666';
+const WORKSPACE_PATH = '/w/acme/settings/integrations/github_acme_corp';
+const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
+const SELECTED_MODE_RE = /Selected direct targets/u;
+const ALL_MODE_RE = /All installation repositories/u;
+
+type Scenario = 'selected' | 'all' | 'empty-selected';
+
+interface ConnectionDetailsPageStoryProps {
+  scenario: Scenario;
+}
+
+const authState: AuthState = {
+  status: 'authenticated',
+  token: 'token',
+  user: {
+    id: '22222222-2222-4222-8222-222222222222',
+    email: 'platform@example.com',
+    name: 'Platform Engineer',
+    emailVerifiedAt: '2026-01-01T00:00:00.000Z',
+  },
+  workspaces: [{id: WORKSPACE_ID, name: 'Acme', slug: 'acme', membershipId: 'membership-1'}],
+};
+
+const connection = {
+  id: CONNECTION_ID,
+  workspace_id: WORKSPACE_ID,
+  provider: 'github',
+  external_account_id: 'acme-corp',
+  slug: 'github_acme_corp',
+  display_name: 'Acme Corp GitHub',
+  lifecycle_status: 'active',
+  capabilities: ['source_control'],
+  external_url: 'https://github.com/organizations/acme-corp/settings/installations/1',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+} satisfies IntegrationConnectionDto;
+
+const selectedRepositories: IntegrationConnectionRepositoryAccessResponseDto['repositories'] = [
+  {
+    external_repository_id: 'platform',
+    owner: 'acme-corp',
+    name: 'platform',
+    origins: [
+      {type: 'project', project_id: PROJECT_ID, project_name: 'Platform'},
+      {type: 'manual', grant_id: GRANT_ID},
+    ],
+  },
+  {
+    external_repository_id: 'agent-tools',
+    owner: 'acme-corp',
+    name: 'agent-tools',
+    origins: [{type: 'project', project_id: PROJECT_ID, project_name: 'Platform'}],
+  },
+  {
+    external_repository_id: 'workflow-runners',
+    owner: 'acme-corp',
+    name: 'workflow-runners',
+    origins: [{type: 'manual', grant_id: GRANT_ID}],
+  },
+];
+
+function ConnectionDetailsPageStory({scenario}: ConnectionDetailsPageStoryProps) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+  const store = useMemo(() => {
+    const nextStore = createStore();
+    nextStore.set(authStateAtom, authState);
+    return nextStore;
+  }, []);
+  const router = useMemo(() => createStoryRouter(), []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider store={store}>
+        <div className="min-h-screen bg-background-subtle-base px-24 py-32">
+          <div className="mx-auto w-full max-w-[760px]">
+            <RouterProvider router={router} />
+          </div>
+        </div>
+        <Toaster />
+      </JotaiProvider>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Integrations/ConnectionDetailsPage',
+  component: ConnectionDetailsPageStory,
+  parameters: {layout: 'fullscreen'},
+  args: {scenario: 'selected'},
+} satisfies Meta<typeof ConnectionDetailsPageStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByRole('radio', {name: SELECTED_MODE_RE})).toBeChecked();
+  },
+};
+
+export const AllInstallationRepositories: Story = {
+  args: {scenario: 'all'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
+  },
+};
+
+export const EmptySelectedRepositories: Story = {
+  args: {scenario: 'empty-selected'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('No selected repositories');
+  },
+};
+
+function createStoryRouter() {
+  const rootRoute = createRootRoute({component: Outlet});
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/w/$workspaceSlug',
+    component: Outlet,
+  });
+  const connectionDetailsRoute = createRoute({
+    getParentRoute: () => workspaceRoute,
+    path: 'settings/integrations/$connectionSlug',
+    component: () => (
+      <ConnectionDetailsPage workspaceSlug="acme" connectionSlug="github_acme_corp" />
+    ),
+  });
+  const integrationsRoute = createRoute({
+    getParentRoute: () => workspaceRoute,
+    path: 'settings/integrations',
+    component: () => <div />,
+  });
+
+  return createRouter({
+    history: createMemoryHistory({initialEntries: [WORKSPACE_PATH]}),
+    routeTree: rootRoute.addChildren([
+      workspaceRoute.addChildren([connectionDetailsRoute, integrationsRoute]),
+    ]),
+  });
+}
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+
+    if (url.pathname === '/integration-connections') {
+      return jsonResponse({connections: [connection]});
+    }
+    if (url.pathname === REPOSITORY_ACCESS_PATH) {
+      if (request.method === 'PUT') {
+        const body = (await request.json()) as {mode: 'selected' | 'all'};
+        return jsonResponse({mode: body.mode});
+      }
+      return jsonResponse(repositoryAccessForScenario(scenario));
+    }
+
+    return jsonResponse({}, {status: 404});
+  };
+}
+
+function repositoryAccessForScenario(
+  scenario: Scenario,
+): IntegrationConnectionRepositoryAccessResponseDto {
+  return {
+    mode: scenario === 'all' ? 'all' : 'selected',
+    repositories: scenario === 'empty-selected' ? [] : selectedRepositories,
+    next_cursor: null,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}

--- a/libs/client/integrations/src/pages/connection-details-page.stories.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.stories.tsx
@@ -26,10 +26,12 @@ const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
 const GRANT_ID = '66666666-6666-4666-8666-666666666666';
 const WORKSPACE_PATH = '/w/acme/settings/integrations/github_acme_corp';
 const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
-const SELECTED_MODE_RE = /Selected direct targets/u;
-const ALL_MODE_RE = /All installation repositories/u;
+const SELECTED_MODE_RE = /Only your projects' repositories/u;
+const ALL_MODE_RE = /Every repository this integration can access/u;
+const GITEA_INTRO_RE = /it was given on Gitea/u;
+const GITHUB_LINK_RE = /on GitHub/u;
 
-type Scenario = 'selected' | 'all' | 'empty-selected';
+type Scenario = 'selected' | 'all' | 'empty-selected' | 'gitea';
 
 interface ConnectionDetailsPageStoryProps {
   scenario: Scenario;
@@ -59,6 +61,14 @@ const connection = {
   external_url: 'https://github.com/organizations/acme-corp/settings/installations/1',
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z',
+} satisfies IntegrationConnectionDto;
+
+const giteaConnection = {
+  ...connection,
+  provider: 'gitea',
+  external_account_id: 'acme-corp',
+  display_name: 'Acme Corp Gitea',
+  external_url: undefined,
 } satisfies IntegrationConnectionDto;
 
 const selectedRepositories: IntegrationConnectionRepositoryAccessResponseDto['repositories'] = [
@@ -141,11 +151,21 @@ export const AllInstallationRepositories: Story = {
   },
 };
 
+export const GiteaConnection: Story = {
+  args: {scenario: 'gitea'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByRole('radio', {name: ALL_MODE_RE})).toBeInTheDocument();
+    expect(canvas.getByText(GITEA_INTRO_RE)).toBeVisible();
+    expect(canvas.queryByRole('link', {name: GITHUB_LINK_RE})).not.toBeInTheDocument();
+  },
+};
+
 export const EmptySelectedRepositories: Story = {
   args: {scenario: 'empty-selected'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await canvas.findByText('No selected repositories');
+    await canvas.findByText('No project repositories yet');
   },
 };
 
@@ -183,7 +203,7 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     const url = new URL(request.url);
 
     if (url.pathname === '/integration-connections') {
-      return jsonResponse({connections: [connection]});
+      return jsonResponse({connections: [scenario === 'gitea' ? giteaConnection : connection]});
     }
     if (url.pathname === REPOSITORY_ACCESS_PATH) {
       if (request.method === 'PUT') {

--- a/libs/client/integrations/src/pages/connection-details-page.stories.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.stories.tsx
@@ -26,12 +26,10 @@ const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
 const GRANT_ID = '66666666-6666-4666-8666-666666666666';
 const WORKSPACE_PATH = '/w/acme/settings/integrations/github_acme_corp';
 const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
-const SELECTED_MODE_RE = /Only your projects' repositories/u;
-const ALL_MODE_RE = /Every repository this integration can access/u;
-const GITEA_INTRO_RE = /it was given on Gitea/u;
-const GITHUB_LINK_RE = /on GitHub/u;
+const SELECTED_MODE_RE = /Selected direct targets/u;
+const ALL_MODE_RE = /All installation repositories/u;
 
-type Scenario = 'selected' | 'all' | 'empty-selected' | 'gitea';
+type Scenario = 'selected' | 'all' | 'empty-selected';
 
 interface ConnectionDetailsPageStoryProps {
   scenario: Scenario;
@@ -61,14 +59,6 @@ const connection = {
   external_url: 'https://github.com/organizations/acme-corp/settings/installations/1',
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z',
-} satisfies IntegrationConnectionDto;
-
-const giteaConnection = {
-  ...connection,
-  provider: 'gitea',
-  external_account_id: 'acme-corp',
-  display_name: 'Acme Corp Gitea',
-  external_url: undefined,
 } satisfies IntegrationConnectionDto;
 
 const selectedRepositories: IntegrationConnectionRepositoryAccessResponseDto['repositories'] = [
@@ -151,21 +141,11 @@ export const AllInstallationRepositories: Story = {
   },
 };
 
-export const GiteaConnection: Story = {
-  args: {scenario: 'gitea'},
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    expect(await canvas.findByRole('radio', {name: ALL_MODE_RE})).toBeInTheDocument();
-    expect(canvas.getByText(GITEA_INTRO_RE)).toBeVisible();
-    expect(canvas.queryByRole('link', {name: GITHUB_LINK_RE})).not.toBeInTheDocument();
-  },
-};
-
 export const EmptySelectedRepositories: Story = {
   args: {scenario: 'empty-selected'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await canvas.findByText('No project repositories yet');
+    await canvas.findByText('No selected repositories');
   },
 };
 
@@ -203,7 +183,7 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     const url = new URL(request.url);
 
     if (url.pathname === '/integration-connections') {
-      return jsonResponse({connections: [scenario === 'gitea' ? giteaConnection : connection]});
+      return jsonResponse({connections: [connection]});
     }
     if (url.pathname === REPOSITORY_ACCESS_PATH) {
       if (request.method === 'PUT') {

--- a/libs/client/integrations/src/pages/connection-details-page.test.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.test.tsx
@@ -14,10 +14,11 @@ const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
 const GRANT_ID = '66666666-6666-4666-8666-666666666666';
 const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
 const SECOND_REPOSITORY_ACCESS_PATH = `/integration-connections/${SECOND_CONNECTION_ID}/repository-access`;
-const SELECTED_MODE_RE = /Selected direct targets/u;
-const ALL_MODE_RE = /All installation repositories/u;
-const GITHUB_EFFECTS_RE = /Some ID-based, organization-scoped, and indirect GitHub effects remain/u;
-const ALL_MODE_COPY_RE = /Shipfox performs no repository allowlist check/u;
+const SELECTED_MODE_RE = /Only your projects' repositories/u;
+const ALL_MODE_RE = /Every repository this integration can access/u;
+const SELECTED_NOTICE_RE = /such as replying to a review thread/u;
+const ALL_NOTICE_RE = /add or remove repositories the GitHub App can access/u;
+const ALL_MODE_COPY_RE = /was given access to on GitHub/u;
 
 const githubConnection = {
   id: CONNECTION_ID,
@@ -184,8 +185,8 @@ describe('ConnectionDetailsPage', () => {
     expect(screen.getAllByText('acme/platform')).toHaveLength(2);
     expect(screen.getByText('Project: Platform')).toBeVisible();
     expect(screen.getByText('Manual grant')).toBeVisible();
-    expect(screen.getByText(GITHUB_EFFECTS_RE)).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Manage GitHub installation'})).toHaveAttribute(
+    expect(screen.getByText(SELECTED_NOTICE_RE)).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Change repositories on GitHub'})).toHaveAttribute(
       'href',
       githubConnection.external_url,
     );
@@ -196,8 +197,10 @@ describe('ConnectionDetailsPage', () => {
 
     expect(await screen.findByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
     expect(screen.getByText(ALL_MODE_COPY_RE)).toBeVisible();
+    expect(screen.getByText(ALL_NOTICE_RE)).toBeVisible();
+    expect(screen.queryByText(SELECTED_NOTICE_RE)).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', {name: 'Selected direct targets'}),
+      screen.queryByRole('heading', {name: "Your projects' repositories"}),
     ).not.toBeInTheDocument();
   });
 
@@ -208,12 +211,14 @@ describe('ConnectionDetailsPage', () => {
       }),
     );
 
-    expect(await screen.findByText('No selected repositories')).toBeVisible();
+    expect(await screen.findByText('No project repositories yet')).toBeVisible();
     expect(
-      screen.getByText(
-        'Repositories connected through projects or manual grants will appear here.',
-      ),
+      screen.getByText('Create a project from a repository on this connection to add it here.'),
     ).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Create project'})).toHaveAttribute(
+      'href',
+      '/w/acme/projects/new',
+    );
   });
 
   test('loads additional composed targets from the paginated read model', async () => {
@@ -288,12 +293,12 @@ describe('ConnectionDetailsPage', () => {
     fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
 
-    expect(await screen.findByText('Saving repository access settings…')).toBeVisible();
+    expect(await screen.findByText('Saving access mode…')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Save changes'})).toHaveAttribute('aria-busy', 'true');
     expect(screen.getByRole('radio', {name: ALL_MODE_RE})).toBeDisabled();
 
     resolveMutation?.(jsonResponse({mode: 'all'}));
-    await screen.findByText('Repository access settings saved.');
+    await screen.findByText('Access mode saved.');
     expect(updatedModes).toEqual(['all']);
   });
 
@@ -304,7 +309,7 @@ describe('ConnectionDetailsPage', () => {
     fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
 
-    expect(await screen.findByText('Repository access settings saved.')).toBeVisible();
+    expect(await screen.findByText('Access mode saved.')).toBeVisible();
     expect(screen.getByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
     expect(screen.getByRole('button', {name: 'Save changes'})).toBeDisabled();
   });
@@ -341,7 +346,7 @@ describe('ConnectionDetailsPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Try again. The current repository access mode is unchanged.',
+      'The previous mode still applies. Try again.',
     );
     expect(screen.getByRole('button', {name: 'Save changes'})).toBeEnabled();
   });

--- a/libs/client/integrations/src/pages/connection-details-page.test.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.test.tsx
@@ -1,0 +1,275 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {fireEvent, screen} from '@testing-library/react';
+import {INTEGRATIONS_TEST_WID, jsonResponse, renderIntegrationsPage} from '#test/render.js';
+import {ConnectionDetailsPage} from './connection-details-page.js';
+
+const CONNECTION_ID = '44444444-4444-4444-8444-444444444444';
+const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
+const GRANT_ID = '66666666-6666-4666-8666-666666666666';
+const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
+const SELECTED_MODE_RE = /Selected direct targets/u;
+const ALL_MODE_RE = /All installation repositories/u;
+const GITHUB_EFFECTS_RE = /Some ID-based, organization-scoped, and indirect GitHub effects remain/u;
+const ALL_MODE_COPY_RE = /Shipfox performs no repository allowlist check/u;
+
+const githubConnection = {
+  id: CONNECTION_ID,
+  workspace_id: INTEGRATIONS_TEST_WID,
+  provider: 'github',
+  external_account_id: 'installation-1',
+  slug: 'github_acme_corp',
+  display_name: 'acme-corp',
+  lifecycle_status: 'active',
+  capabilities: ['source_control'],
+  external_url: 'https://github.com/organizations/acme-corp/settings/installations/1',
+  created_at: '2026-03-12T00:00:00.000Z',
+  updated_at: '2026-03-12T00:00:00.000Z',
+} satisfies IntegrationConnectionDto;
+
+type RepositoryAccessResponse = {
+  mode: 'selected' | 'all';
+  repositories: Array<{
+    external_repository_id: string;
+    owner: string;
+    name: string;
+    origins: Array<
+      | {type: 'project'; project_id: string; project_name: string}
+      | {type: 'manual'; grant_id: string}
+    >;
+  }>;
+  next_cursor: string | null;
+};
+
+const selectedAccess: RepositoryAccessResponse = {
+  mode: 'selected',
+  repositories: [
+    {
+      external_repository_id: 'acme/platform',
+      owner: 'acme',
+      name: 'platform',
+      origins: [
+        {type: 'project', project_id: PROJECT_ID, project_name: 'Platform'},
+        {type: 'manual', grant_id: GRANT_ID},
+      ],
+    },
+  ],
+  next_cursor: null,
+};
+
+const allAccess: RepositoryAccessResponse = {
+  mode: 'all',
+  repositories: [],
+  next_cursor: null,
+};
+
+interface DetailsFetchOptions {
+  access?: RepositoryAccessResponse;
+  nextPageAccess?: RepositoryAccessResponse;
+  accessError?: {status: number; code: string};
+  mutationResponse?: () => Response | Promise<Response>;
+  onUpdateMode?: (mode: 'selected' | 'all') => void;
+}
+
+function detailsFetch({
+  access = selectedAccess,
+  nextPageAccess,
+  accessError,
+  mutationResponse,
+  onUpdateMode,
+}: DetailsFetchOptions = {}) {
+  let currentAccess = access;
+  let accessAttempts = 0;
+
+  function repositoryAccessGetResponse(request: Request): Response {
+    if (accessError && accessAttempts++ === 0) {
+      return jsonResponse(
+        {code: accessError.code, message: 'Repository access unavailable'},
+        {
+          status: accessError.status,
+        },
+      );
+    }
+    const cursor = new URL(request.url).searchParams.get('cursor');
+    return jsonResponse(cursor && nextPageAccess ? nextPageAccess : currentAccess);
+  }
+
+  async function repositoryAccessPutResponse(request: Request): Promise<Response> {
+    const body = (await request.json()) as {mode: 'selected' | 'all'};
+    currentAccess = body.mode === 'all' ? allAccess : selectedAccess;
+    onUpdateMode?.(body.mode);
+    if (mutationResponse) return mutationResponse();
+    return jsonResponse({mode: body.mode});
+  }
+
+  function repositoryAccessResponse(request: Request): Promise<Response> {
+    if (request.method === 'GET') return Promise.resolve(repositoryAccessGetResponse(request));
+    if (request.method === 'PUT') return repositoryAccessPutResponse(request);
+    throw new Error(`Unexpected repository access request: ${request.method} ${request.url}`);
+  }
+
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+
+    if (url.pathname === '/integration-connections')
+      return Promise.resolve(jsonResponse({connections: [githubConnection]}));
+    if (url.pathname === REPOSITORY_ACCESS_PATH) return repositoryAccessResponse(request);
+
+    throw new Error(`Unexpected integrations request: ${request.method} ${request.url}`);
+  });
+}
+
+function renderDetails(fetchImpl: typeof fetch) {
+  configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+  return renderIntegrationsPage({
+    path: '/w/acme/settings/integrations/github_acme_corp',
+    routePath: '/w/$workspaceSlug/settings/integrations/$connectionSlug',
+    element: <ConnectionDetailsPage workspaceSlug="acme" connectionSlug="github_acme_corp" />,
+    extraRoutes: ['/w/$workspaceSlug/settings/integrations'],
+  });
+}
+
+describe('ConnectionDetailsPage', () => {
+  test('renders selected targets, origins, mode copy, and the GitHub installation link', async () => {
+    renderDetails(detailsFetch());
+
+    expect(await screen.findByRole('heading', {name: 'Repository access'})).toBeVisible();
+    expect(await screen.findByRole('radio', {name: SELECTED_MODE_RE})).toBeChecked();
+    expect(screen.getByRole('radio', {name: ALL_MODE_RE})).not.toBeChecked();
+    expect(screen.getAllByText('acme/platform')).toHaveLength(2);
+    expect(screen.getByText('Project: Platform')).toBeVisible();
+    expect(screen.getByText('Manual grant')).toBeVisible();
+    expect(screen.getByText(GITHUB_EFFECTS_RE)).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Manage GitHub installation'})).toHaveAttribute(
+      'href',
+      githubConnection.external_url,
+    );
+  });
+
+  test('renders all-installation mode without a selected-target list', async () => {
+    renderDetails(detailsFetch({access: allAccess}));
+
+    expect(await screen.findByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
+    expect(screen.getByText(ALL_MODE_COPY_RE)).toBeVisible();
+    expect(
+      screen.queryByRole('heading', {name: 'Selected direct targets'}),
+    ).not.toBeInTheDocument();
+  });
+
+  test('keeps an empty selected-repository list useful', async () => {
+    renderDetails(
+      detailsFetch({
+        access: {...selectedAccess, repositories: []},
+      }),
+    );
+
+    expect(await screen.findByText('No selected repositories')).toBeVisible();
+    expect(
+      screen.getByText(
+        'Repositories connected through projects or manual grants will appear here.',
+      ),
+    ).toBeVisible();
+  });
+
+  test('loads additional composed targets from the paginated read model', async () => {
+    const firstPage: RepositoryAccessResponse = {
+      ...selectedAccess,
+      next_cursor: 'page-2',
+    };
+    const secondPage: RepositoryAccessResponse = {
+      mode: 'selected',
+      repositories: [
+        {
+          external_repository_id: 'acme/docs',
+          owner: 'acme',
+          name: 'docs',
+          origins: [{type: 'project', project_id: PROJECT_ID, project_name: 'Docs'}],
+        },
+      ],
+      next_cursor: null,
+    };
+    const fetchImpl = detailsFetch({access: firstPage, nextPageAccess: secondPage});
+    renderDetails(fetchImpl);
+
+    expect(await screen.findByRole('button', {name: 'Load more'})).toBeVisible();
+    fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
+
+    expect(await screen.findAllByText('acme/docs')).toHaveLength(2);
+    expect(
+      fetchImpl.mock.calls.some(([input]) =>
+        (input instanceof Request ? input.url : String(input)).includes('cursor=page-2'),
+      ),
+    ).toBe(true);
+  });
+
+  test.each([
+    ['access denied', {status: 403, code: 'forbidden'}, 'Access denied'],
+    [
+      'unsupported providers',
+      {status: 422, code: 'integration-repository-access-unsupported'},
+      'Repository access controls unavailable',
+    ],
+  ] as const)('renders the %s state without controls', async (_name, error, title) => {
+    renderDetails(detailsFetch({accessError: error}));
+
+    expect(await screen.findByText(title)).toBeVisible();
+    expect(screen.queryByRole('radio', {name: SELECTED_MODE_RE})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Save changes'})).not.toBeInTheDocument();
+  });
+
+  test('recovers from a read-model server error', async () => {
+    renderDetails(detailsFetch({accessError: {status: 503, code: 'server-error'}}));
+
+    expect(await screen.findByText("Couldn't load repository access settings")).toBeVisible();
+    fireEvent.click(screen.getByRole('button', {name: 'Retry loading repository access settings'}));
+
+    expect(await screen.findByRole('radio', {name: SELECTED_MODE_RE})).toBeChecked();
+  });
+
+  test('saves a changed mode through PUT and reports the pending and success states', async () => {
+    let resolveMutation: ((response: Response) => void) | undefined;
+    const mutation = new Promise<Response>((resolve) => {
+      resolveMutation = resolve;
+    });
+    const updatedModes: Array<'selected' | 'all'> = [];
+    renderDetails(
+      detailsFetch({
+        mutationResponse: () => mutation,
+        onUpdateMode: (mode) => updatedModes.push(mode),
+      }),
+    );
+
+    await screen.findByRole('radio', {name: SELECTED_MODE_RE});
+    fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    expect(await screen.findByText('Saving repository access settings…')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Save changes'})).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('radio', {name: ALL_MODE_RE})).toBeDisabled();
+
+    resolveMutation?.(jsonResponse({mode: 'all'}));
+    await screen.findByText('Repository access settings saved.');
+    expect(updatedModes).toEqual(['all']);
+  });
+
+  test('keeps the form recoverable when saving fails', async () => {
+    renderDetails(
+      detailsFetch({
+        mutationResponse: () =>
+          jsonResponse({code: 'server-error', message: 'save failed'}, {status: 500}),
+      }),
+    );
+
+    await screen.findByRole('radio', {name: SELECTED_MODE_RE});
+    fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Try again. The current repository access mode is unchanged.',
+    );
+    expect(screen.getByRole('button', {name: 'Save changes'})).toBeEnabled();
+  });
+});

--- a/libs/client/integrations/src/pages/connection-details-page.test.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.test.tsx
@@ -3,13 +3,17 @@ import '@testing-library/jest-dom/vitest';
 import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {fireEvent, screen} from '@testing-library/react';
+import type {ReactElement} from 'react';
+import {useState} from 'react';
 import {INTEGRATIONS_TEST_WID, jsonResponse, renderIntegrationsPage} from '#test/render.js';
 import {ConnectionDetailsPage} from './connection-details-page.js';
 
 const CONNECTION_ID = '44444444-4444-4444-8444-444444444444';
+const SECOND_CONNECTION_ID = '77777777-7777-4777-8777-777777777777';
 const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
 const GRANT_ID = '66666666-6666-4666-8666-666666666666';
 const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
+const SECOND_REPOSITORY_ACCESS_PATH = `/integration-connections/${SECOND_CONNECTION_ID}/repository-access`;
 const SELECTED_MODE_RE = /Selected direct targets/u;
 const ALL_MODE_RE = /All installation repositories/u;
 const GITHUB_EFFECTS_RE = /Some ID-based, organization-scoped, and indirect GitHub effects remain/u;
@@ -27,6 +31,15 @@ const githubConnection = {
   external_url: 'https://github.com/organizations/acme-corp/settings/installations/1',
   created_at: '2026-03-12T00:00:00.000Z',
   updated_at: '2026-03-12T00:00:00.000Z',
+} satisfies IntegrationConnectionDto;
+
+const secondGithubConnection = {
+  ...githubConnection,
+  id: SECOND_CONNECTION_ID,
+  external_account_id: 'installation-2',
+  slug: 'github_beta_inc',
+  display_name: 'beta-inc',
+  external_url: 'https://github.com/organizations/beta-inc/settings/installations/2',
 } satisfies IntegrationConnectionDto;
 
 type RepositoryAccessResponse = {
@@ -66,17 +79,21 @@ const allAccess: RepositoryAccessResponse = {
 };
 
 interface DetailsFetchOptions {
+  additionalConnection?: {connection: IntegrationConnectionDto; access: RepositoryAccessResponse};
   access?: RepositoryAccessResponse;
   nextPageAccess?: RepositoryAccessResponse;
   accessError?: {status: number; code: string};
+  updateAccessAfterMutation?: boolean;
   mutationResponse?: () => Response | Promise<Response>;
   onUpdateMode?: (mode: 'selected' | 'all') => void;
 }
 
 function detailsFetch({
+  additionalConnection,
   access = selectedAccess,
   nextPageAccess,
   accessError,
+  updateAccessAfterMutation = true,
   mutationResponse,
   onUpdateMode,
 }: DetailsFetchOptions = {}) {
@@ -98,7 +115,7 @@ function detailsFetch({
 
   async function repositoryAccessPutResponse(request: Request): Promise<Response> {
     const body = (await request.json()) as {mode: 'selected' | 'all'};
-    currentAccess = body.mode === 'all' ? allAccess : selectedAccess;
+    if (updateAccessAfterMutation) currentAccess = body.mode === 'all' ? allAccess : selectedAccess;
     onUpdateMode?.(body.mode);
     if (mutationResponse) return mutationResponse();
     return jsonResponse({mode: body.mode});
@@ -114,22 +131,47 @@ function detailsFetch({
     const request = new Request(input, init);
     const url = new URL(request.url);
 
-    if (url.pathname === '/integration-connections')
-      return Promise.resolve(jsonResponse({connections: [githubConnection]}));
+    if (url.pathname === '/integration-connections') {
+      return Promise.resolve(
+        jsonResponse({
+          connections: [
+            githubConnection,
+            ...(additionalConnection ? [additionalConnection.connection] : []),
+          ],
+        }),
+      );
+    }
     if (url.pathname === REPOSITORY_ACCESS_PATH) return repositoryAccessResponse(request);
+    if (url.pathname === SECOND_REPOSITORY_ACCESS_PATH && additionalConnection) {
+      return Promise.resolve(jsonResponse(additionalConnection.access));
+    }
 
     throw new Error(`Unexpected integrations request: ${request.method} ${request.url}`);
   });
 }
 
-function renderDetails(fetchImpl: typeof fetch) {
+function renderDetails(fetchImpl: typeof fetch, element?: ReactElement) {
   configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
   return renderIntegrationsPage({
     path: '/w/acme/settings/integrations/github_acme_corp',
     routePath: '/w/$workspaceSlug/settings/integrations/$connectionSlug',
-    element: <ConnectionDetailsPage workspaceSlug="acme" connectionSlug="github_acme_corp" />,
+    element: element ?? (
+      <ConnectionDetailsPage workspaceSlug="acme" connectionSlug="github_acme_corp" />
+    ),
     extraRoutes: ['/w/$workspaceSlug/settings/integrations'],
   });
+}
+
+function ConnectionSwitcher() {
+  const [connectionSlug, setConnectionSlug] = useState('github_acme_corp');
+  return (
+    <>
+      <button type="button" onClick={() => setConnectionSlug('github_beta_inc')}>
+        Switch connection
+      </button>
+      <ConnectionDetailsPage workspaceSlug="acme" connectionSlug={connectionSlug} />
+    </>
+  );
 }
 
 describe('ConnectionDetailsPage', () => {
@@ -253,6 +295,37 @@ describe('ConnectionDetailsPage', () => {
     resolveMutation?.(jsonResponse({mode: 'all'}));
     await screen.findByText('Repository access settings saved.');
     expect(updatedModes).toEqual(['all']);
+  });
+
+  test('keeps the saved mode selected while the access query still has stale data', async () => {
+    renderDetails(detailsFetch({updateAccessAfterMutation: false}));
+
+    await screen.findByRole('radio', {name: SELECTED_MODE_RE});
+    fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
+
+    expect(await screen.findByText('Repository access settings saved.')).toBeVisible();
+    expect(screen.getByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
+    expect(screen.getByRole('button', {name: 'Save changes'})).toBeDisabled();
+  });
+
+  test('resets unsaved mode changes when navigating to another connection', async () => {
+    renderDetails(
+      detailsFetch({
+        additionalConnection: {connection: secondGithubConnection, access: selectedAccess},
+      }),
+      <ConnectionSwitcher />,
+    );
+
+    await screen.findByRole('radio', {name: SELECTED_MODE_RE});
+    fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
+    expect(screen.getByRole('button', {name: 'Save changes'})).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Switch connection'}));
+
+    expect(await screen.findByRole('radio', {name: SELECTED_MODE_RE})).toBeChecked();
+    expect(screen.getByRole('radio', {name: ALL_MODE_RE})).not.toBeChecked();
+    expect(screen.getByRole('button', {name: 'Save changes'})).toBeDisabled();
   });
 
   test('keeps the form recoverable when saving fails', async () => {

--- a/libs/client/integrations/src/pages/connection-details-page.test.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.test.tsx
@@ -14,11 +14,10 @@ const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
 const GRANT_ID = '66666666-6666-4666-8666-666666666666';
 const REPOSITORY_ACCESS_PATH = `/integration-connections/${CONNECTION_ID}/repository-access`;
 const SECOND_REPOSITORY_ACCESS_PATH = `/integration-connections/${SECOND_CONNECTION_ID}/repository-access`;
-const SELECTED_MODE_RE = /Only your projects' repositories/u;
-const ALL_MODE_RE = /Every repository this integration can access/u;
-const SELECTED_NOTICE_RE = /such as replying to a review thread/u;
-const ALL_NOTICE_RE = /add or remove repositories the GitHub App can access/u;
-const ALL_MODE_COPY_RE = /was given access to on GitHub/u;
+const SELECTED_MODE_RE = /Selected direct targets/u;
+const ALL_MODE_RE = /All installation repositories/u;
+const GITHUB_EFFECTS_RE = /Some ID-based, organization-scoped, and indirect GitHub effects remain/u;
+const ALL_MODE_COPY_RE = /Shipfox performs no repository allowlist check/u;
 
 const githubConnection = {
   id: CONNECTION_ID,
@@ -185,8 +184,8 @@ describe('ConnectionDetailsPage', () => {
     expect(screen.getAllByText('acme/platform')).toHaveLength(2);
     expect(screen.getByText('Project: Platform')).toBeVisible();
     expect(screen.getByText('Manual grant')).toBeVisible();
-    expect(screen.getByText(SELECTED_NOTICE_RE)).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Change repositories on GitHub'})).toHaveAttribute(
+    expect(screen.getByText(GITHUB_EFFECTS_RE)).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Manage GitHub installation'})).toHaveAttribute(
       'href',
       githubConnection.external_url,
     );
@@ -197,10 +196,8 @@ describe('ConnectionDetailsPage', () => {
 
     expect(await screen.findByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
     expect(screen.getByText(ALL_MODE_COPY_RE)).toBeVisible();
-    expect(screen.getByText(ALL_NOTICE_RE)).toBeVisible();
-    expect(screen.queryByText(SELECTED_NOTICE_RE)).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', {name: "Your projects' repositories"}),
+      screen.queryByRole('heading', {name: 'Selected direct targets'}),
     ).not.toBeInTheDocument();
   });
 
@@ -211,14 +208,12 @@ describe('ConnectionDetailsPage', () => {
       }),
     );
 
-    expect(await screen.findByText('No project repositories yet')).toBeVisible();
+    expect(await screen.findByText('No selected repositories')).toBeVisible();
     expect(
-      screen.getByText('Create a project from a repository on this connection to add it here.'),
+      screen.getByText(
+        'Repositories connected through projects or manual grants will appear here.',
+      ),
     ).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Create project'})).toHaveAttribute(
-      'href',
-      '/w/acme/projects/new',
-    );
   });
 
   test('loads additional composed targets from the paginated read model', async () => {
@@ -293,12 +288,12 @@ describe('ConnectionDetailsPage', () => {
     fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
 
-    expect(await screen.findByText('Saving access mode…')).toBeVisible();
+    expect(await screen.findByText('Saving repository access settings…')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Save changes'})).toHaveAttribute('aria-busy', 'true');
     expect(screen.getByRole('radio', {name: ALL_MODE_RE})).toBeDisabled();
 
     resolveMutation?.(jsonResponse({mode: 'all'}));
-    await screen.findByText('Access mode saved.');
+    await screen.findByText('Repository access settings saved.');
     expect(updatedModes).toEqual(['all']);
   });
 
@@ -309,7 +304,7 @@ describe('ConnectionDetailsPage', () => {
     fireEvent.click(screen.getByRole('radio', {name: ALL_MODE_RE}));
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
 
-    expect(await screen.findByText('Access mode saved.')).toBeVisible();
+    expect(await screen.findByText('Repository access settings saved.')).toBeVisible();
     expect(screen.getByRole('radio', {name: ALL_MODE_RE})).toBeChecked();
     expect(screen.getByRole('button', {name: 'Save changes'})).toBeDisabled();
   });
@@ -346,7 +341,7 @@ describe('ConnectionDetailsPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Save changes'}));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'The previous mode still applies. Try again.',
+      'Try again. The current repository access mode is unchanged.',
     );
     expect(screen.getByRole('button', {name: 'Save changes'})).toBeEnabled();
   });

--- a/libs/client/integrations/src/pages/connection-details-page.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.tsx
@@ -60,7 +60,7 @@ export function ConnectionDetailsPage({
 
   return (
     <ConnectionDetailsShell workspaceSlug={workspaceSlug} connectionName={connection.displayName}>
-      <RepositoryAccessSettings connection={connection} />
+      <RepositoryAccessSettings key={connection.id} connection={connection} />
     </ConnectionDetailsShell>
   );
 }
@@ -157,21 +157,27 @@ function RepositoryAccessForm({
 }) {
   const updateAccess = useUpdateIntegrationConnectionRepositoryAccessMutation();
   const [selectedMode, setSelectedMode] = useState<RepositoryAccessMode>(access.mode);
+  const [persistedMode, setPersistedMode] = useState<RepositoryAccessMode>(access.mode);
 
   useEffect(() => {
-    if (!updateAccess.isPending) setSelectedMode(access.mode);
-  }, [access.mode, updateAccess.isPending]);
+    setSelectedMode(access.mode);
+    setPersistedMode(access.mode);
+  }, [access.mode]);
 
   const mutationError = updateAccess.error;
   if (isForbiddenError(mutationError)) return <AccessDeniedState />;
   if (isUnsupportedError(mutationError)) return <UnsupportedState />;
 
-  const isDirty = selectedMode !== access.mode;
+  const isDirty = selectedMode !== persistedMode;
 
   async function saveMode() {
     if (!isDirty) return;
     try {
-      await updateAccess.mutateAsync({connectionId: connection.id, mode: selectedMode});
+      const savedMode = await updateAccess.mutateAsync({
+        connectionId: connection.id,
+        mode: selectedMode,
+      });
+      setPersistedMode(savedMode);
       toast.success('Repository access settings saved.');
     } catch {
       // The recoverable error is rendered from the mutation state below.

--- a/libs/client/integrations/src/pages/connection-details-page.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.tsx
@@ -1,0 +1,415 @@
+import {ApiError} from '@shipfox/client-api';
+import {useActiveWorkspace} from '@shipfox/client-auth';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {Button} from '@shipfox/react-ui/button';
+import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
+import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {FullPageLoader} from '@shipfox/react-ui/loader';
+import {Panel, PanelBody, PanelHeader, PanelRow, PanelTitle} from '@shipfox/react-ui/panel';
+import {RadioGroup, RadioGroupItem} from '@shipfox/react-ui/radio-group';
+import {Skeleton} from '@shipfox/react-ui/skeleton';
+import {toast} from '@shipfox/react-ui/toast';
+import {Header, Text} from '@shipfox/react-ui/typography';
+import {Link} from '@tanstack/react-router';
+import {type ReactNode, useEffect, useState} from 'react';
+import type {
+  IntegrationConnection,
+  RepositoryAccess,
+  RepositoryAccessMode,
+  RepositoryAccessOrigin,
+} from '#core/models.js';
+import {
+  useIntegrationConnectionRepositoryAccessQuery,
+  useIntegrationConnectionsQuery,
+  useUpdateIntegrationConnectionRepositoryAccessMutation,
+} from '#hooks/api/integrations.js';
+
+export function ConnectionDetailsPage({
+  workspaceSlug,
+  connectionSlug,
+}: {
+  workspaceSlug: string;
+  connectionSlug: string;
+}) {
+  const workspace = useActiveWorkspace();
+  const connectionsQuery = useIntegrationConnectionsQuery(workspace.id);
+
+  if (connectionsQuery.isPending) return <FullPageLoader aria-label="Loading connection details" />;
+
+  if (connectionsQuery.isError && connectionsQuery.data === undefined) {
+    return (
+      <ConnectionDetailsShell workspaceSlug={workspaceSlug}>
+        <QueryLoadError query={connectionsQuery} subject="integrations" />
+      </ConnectionDetailsShell>
+    );
+  }
+
+  const connection = connectionsQuery.data?.find(({slug}) => slug === connectionSlug);
+  if (!connection) {
+    return (
+      <ConnectionDetailsShell workspaceSlug={workspaceSlug}>
+        <EmptyState
+          icon="errorWarningLine"
+          tone="error"
+          title="Integration connection not found"
+          description="This integration does not exist, or you don't have access to it."
+        />
+      </ConnectionDetailsShell>
+    );
+  }
+
+  return (
+    <ConnectionDetailsShell workspaceSlug={workspaceSlug} connectionName={connection.displayName}>
+      <RepositoryAccessSettings connection={connection} />
+    </ConnectionDetailsShell>
+  );
+}
+
+function ConnectionDetailsShell({
+  workspaceSlug,
+  connectionName,
+  children,
+}: {
+  workspaceSlug: string;
+  connectionName?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-section">
+      <Link
+        to="/w/$workspaceSlug/settings/integrations"
+        params={{workspaceSlug}}
+        className="self-start text-sm text-foreground-neutral-muted hover:text-foreground-neutral-base"
+      >
+        Back to integrations
+      </Link>
+      <div className="flex min-w-0 flex-col gap-tight">
+        <Header variant="h1">Repository access</Header>
+        {connectionName ? (
+          <Text size="sm" className="text-foreground-neutral-muted">
+            {connectionName}
+          </Text>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function RepositoryAccessSettings({connection}: {connection: IntegrationConnection}) {
+  const accessQuery = useIntegrationConnectionRepositoryAccessQuery(connection.id);
+
+  if (accessQuery.isPending) {
+    return (
+      <Panel>
+        <PanelBody className="gap-group p-panel">
+          <div role="status" className="sr-only">
+            Loading repository access settings.
+          </div>
+          <Skeleton className="h-20 w-240" />
+          <Skeleton className="h-48 w-full" />
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  if (accessQuery.isError && accessQuery.data === undefined) {
+    if (isForbiddenError(accessQuery.error)) return <AccessDeniedState />;
+    if (isUnsupportedError(accessQuery.error)) return <UnsupportedState />;
+    return (
+      <Panel>
+        <QueryLoadError query={accessQuery} subject="repository access settings" variant="panel" />
+      </Panel>
+    );
+  }
+
+  const access = accessQuery.data
+    ? combineRepositoryAccessPages(accessQuery.data.pages)
+    : undefined;
+  if (!access) return <UnsupportedState />;
+
+  return (
+    <RepositoryAccessForm
+      connection={connection}
+      access={access}
+      hasNextPage={accessQuery.hasNextPage}
+      isFetchingNextPage={accessQuery.isFetchingNextPage}
+      loadMoreError={accessQuery.isFetchNextPageError}
+      onLoadMore={() => void accessQuery.fetchNextPage()}
+    />
+  );
+}
+
+function RepositoryAccessForm({
+  connection,
+  access,
+  hasNextPage,
+  isFetchingNextPage,
+  loadMoreError,
+  onLoadMore,
+}: {
+  connection: IntegrationConnection;
+  access: RepositoryAccess;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  loadMoreError: boolean;
+  onLoadMore: () => void;
+}) {
+  const updateAccess = useUpdateIntegrationConnectionRepositoryAccessMutation();
+  const [selectedMode, setSelectedMode] = useState<RepositoryAccessMode>(access.mode);
+
+  useEffect(() => {
+    if (!updateAccess.isPending) setSelectedMode(access.mode);
+  }, [access.mode, updateAccess.isPending]);
+
+  const mutationError = updateAccess.error;
+  if (isForbiddenError(mutationError)) return <AccessDeniedState />;
+  if (isUnsupportedError(mutationError)) return <UnsupportedState />;
+
+  const isDirty = selectedMode !== access.mode;
+
+  async function saveMode() {
+    if (!isDirty) return;
+    try {
+      await updateAccess.mutateAsync({connectionId: connection.id, mode: selectedMode});
+      toast.success('Repository access settings saved.');
+    } catch {
+      // The recoverable error is rendered from the mutation state below.
+    }
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-group">
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>Repository access mode</PanelTitle>
+        </PanelHeader>
+        <PanelBody className="gap-group p-panel">
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Choose how Shipfox checks repository targets for this connection.
+          </Text>
+          <RadioGroup
+            aria-label="Repository access mode"
+            value={selectedMode}
+            variant="cell"
+            onValueChange={(value) => {
+              if (isRepositoryAccessMode(value)) setSelectedMode(value);
+            }}
+            disabled={updateAccess.isPending}
+          >
+            <RadioGroupItem value="selected">
+              <Text as="span" size="sm" bold>
+                Selected direct targets
+              </Text>
+              <Text as="span" size="xs" className="text-foreground-neutral-muted">
+                Shipfox checks repositories named directly by a checkout or tool against projects
+                and manual grants. Some ID-based, organization-scoped, and indirect GitHub effects
+                remain installation-scoped.
+              </Text>
+            </RadioGroupItem>
+            <RadioGroupItem value="all">
+              <Text as="span" size="sm" bold>
+                All installation repositories
+              </Text>
+              <Text as="span" size="xs" className="text-foreground-neutral-muted">
+                Shipfox performs no repository allowlist check; GitHub installation access is the
+                boundary.
+              </Text>
+            </RadioGroupItem>
+          </RadioGroup>
+
+          {mutationError ? (
+            <Callout role="alert" type="error">
+              <CalloutContent>
+                <CalloutTitle>Repository access settings were not saved</CalloutTitle>
+                <CalloutDescription>
+                  Try again. The current repository access mode is unchanged.
+                </CalloutDescription>
+              </CalloutContent>
+            </Callout>
+          ) : null}
+
+          <div className="flex items-center gap-group">
+            <Button
+              type="button"
+              isLoading={updateAccess.isPending}
+              disabled={!isDirty}
+              onClick={() => void saveMode()}
+            >
+              Save changes
+            </Button>
+            {updateAccess.isPending ? (
+              <Text size="xs" role="status" className="text-foreground-neutral-muted">
+                Saving repository access settings…
+              </Text>
+            ) : null}
+          </div>
+        </PanelBody>
+      </Panel>
+
+      {access.mode === 'selected' ? (
+        <SelectedRepositories
+          access={access}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          loadMoreError={loadMoreError}
+          onLoadMore={onLoadMore}
+        />
+      ) : null}
+      {connection.provider === 'github' ? (
+        <GithubInstallationNotice connection={connection} />
+      ) : null}
+    </div>
+  );
+}
+
+function SelectedRepositories({
+  access,
+  hasNextPage,
+  isFetchingNextPage,
+  loadMoreError,
+  onLoadMore,
+}: {
+  access: RepositoryAccess;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  loadMoreError: boolean;
+  onLoadMore: () => void;
+}) {
+  return (
+    <Panel>
+      <PanelHeader>
+        <PanelTitle>Selected direct targets</PanelTitle>
+      </PanelHeader>
+      <PanelBody>
+        {access.repositories.length === 0 ? (
+          <EmptyState
+            icon="folderOpenLine"
+            title="No selected repositories"
+            description="Repositories connected through projects or manual grants will appear here."
+            variant="panel"
+          />
+        ) : (
+          <ul>
+            {access.repositories.map((repository) => (
+              <PanelRow asChild key={repository.externalRepositoryId}>
+                <li>
+                  <div className="flex min-w-0 flex-col gap-tight">
+                    <Text size="sm" bold>
+                      {repository.owner}/{repository.name}
+                    </Text>
+                    <Text size="xs" className="truncate text-foreground-neutral-muted">
+                      {repository.externalRepositoryId}
+                    </Text>
+                  </div>
+                  <div className="flex shrink-0 flex-col items-end gap-tight">
+                    {repository.origins.map((origin) => (
+                      <OriginLabel key={originKey(origin)} origin={origin} />
+                    ))}
+                  </div>
+                </li>
+              </PanelRow>
+            ))}
+          </ul>
+        )}
+        {loadMoreError ? (
+          <Callout role="alert" type="error" className="m-panel-compact">
+            <CalloutContent>
+              <CalloutDescription>
+                Could not load more selected repositories. Existing targets are still shown.
+              </CalloutDescription>
+            </CalloutContent>
+          </Callout>
+        ) : null}
+        {hasNextPage ? (
+          <div className="flex justify-center border-t border-border-neutral-base p-panel-compact">
+            <Button
+              type="button"
+              variant="secondary"
+              isLoading={isFetchingNextPage}
+              onClick={onLoadMore}
+            >
+              Load more
+            </Button>
+          </div>
+        ) : null}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function combineRepositoryAccessPages(pages: RepositoryAccess[]): RepositoryAccess | undefined {
+  const firstPage = pages[0];
+  if (!firstPage) return undefined;
+  const nextCursor = pages.at(-1)?.nextCursor;
+  return {
+    mode: firstPage.mode,
+    repositories: pages.flatMap((page) => page.repositories),
+    ...(nextCursor === undefined ? {} : {nextCursor}),
+  };
+}
+
+function OriginLabel({origin}: {origin: RepositoryAccessOrigin}) {
+  return (
+    <Text size="xs" className="text-foreground-neutral-muted">
+      {origin.type === 'project' ? `Project: ${origin.projectName}` : 'Manual grant'}
+    </Text>
+  );
+}
+
+function GithubInstallationNotice({connection}: {connection: IntegrationConnection}) {
+  const installationUrl = connection.externalUrl ?? 'https://github.com/settings/installations';
+  return (
+    <Callout type="info">
+      <CalloutContent>
+        <CalloutTitle>GitHub installation access still applies</CalloutTitle>
+        <CalloutDescription>
+          Selected mode limits repositories named directly by a checkout or tool. It does not limit
+          every indirect or organization-scoped GitHub effect. For strict repository isolation,
+          update the GitHub App installation&apos;s repository selection.{' '}
+          <a href={installationUrl} target="_blank" rel="noreferrer noopener">
+            Manage GitHub installation
+          </a>
+        </CalloutDescription>
+      </CalloutContent>
+    </Callout>
+  );
+}
+
+function AccessDeniedState() {
+  return (
+    <EmptyState
+      icon="errorWarningLine"
+      tone="error"
+      title="Access denied"
+      description="Only workspace administrators can view or change repository access settings."
+    />
+  );
+}
+
+function UnsupportedState() {
+  return (
+    <EmptyState
+      icon="errorWarningLine"
+      tone="neutral"
+      title="Repository access controls unavailable"
+      description="This integration provider does not support repository access controls."
+    />
+  );
+}
+
+function isForbiddenError(error: unknown): boolean {
+  return error instanceof ApiError && (error.status === 403 || error.code === 'forbidden');
+}
+
+function isUnsupportedError(error: unknown): boolean {
+  return error instanceof ApiError && error.code === 'integration-repository-access-unsupported';
+}
+
+function isRepositoryAccessMode(value: string): value is RepositoryAccessMode {
+  return value === 'selected' || value === 'all';
+}
+
+function originKey(origin: RepositoryAccessOrigin): string {
+  return origin.type === 'project' ? `project:${origin.projectId}` : `manual:${origin.grantId}`;
+}

--- a/libs/client/integrations/src/pages/connection-details-page.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.tsx
@@ -23,7 +23,6 @@ import {
   useIntegrationConnectionsQuery,
   useUpdateIntegrationConnectionRepositoryAccessMutation,
 } from '#hooks/api/integrations.js';
-import {PROVIDER_CATALOG} from '#provider-catalog.js';
 
 export function ConnectionDetailsPage({
   workspaceSlug,
@@ -61,11 +60,7 @@ export function ConnectionDetailsPage({
 
   return (
     <ConnectionDetailsShell workspaceSlug={workspaceSlug} connectionName={connection.displayName}>
-      <RepositoryAccessSettings
-        key={connection.id}
-        connection={connection}
-        workspaceSlug={workspaceSlug}
-      />
+      <RepositoryAccessSettings key={connection.id} connection={connection} />
     </ConnectionDetailsShell>
   );
 }
@@ -101,13 +96,7 @@ function ConnectionDetailsShell({
   );
 }
 
-function RepositoryAccessSettings({
-  connection,
-  workspaceSlug,
-}: {
-  connection: IntegrationConnection;
-  workspaceSlug: string;
-}) {
+function RepositoryAccessSettings({connection}: {connection: IntegrationConnection}) {
   const accessQuery = useIntegrationConnectionRepositoryAccessQuery(connection.id);
 
   if (accessQuery.isPending) {
@@ -142,7 +131,6 @@ function RepositoryAccessSettings({
   return (
     <RepositoryAccessForm
       connection={connection}
-      workspaceSlug={workspaceSlug}
       access={access}
       hasNextPage={accessQuery.hasNextPage}
       isFetchingNextPage={accessQuery.isFetchingNextPage}
@@ -154,7 +142,6 @@ function RepositoryAccessSettings({
 
 function RepositoryAccessForm({
   connection,
-  workspaceSlug,
   access,
   hasNextPage,
   isFetchingNextPage,
@@ -162,7 +149,6 @@ function RepositoryAccessForm({
   onLoadMore,
 }: {
   connection: IntegrationConnection;
-  workspaceSlug: string;
   access: RepositoryAccess;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
@@ -183,7 +169,6 @@ function RepositoryAccessForm({
   if (isUnsupportedError(mutationError)) return <UnsupportedState />;
 
   const isDirty = selectedMode !== persistedMode;
-  const providerName = PROVIDER_CATALOG[connection.provider]?.displayName;
 
   async function saveMode() {
     if (!isDirty) return;
@@ -193,7 +178,7 @@ function RepositoryAccessForm({
         mode: selectedMode,
       });
       setPersistedMode(savedMode);
-      toast.success('Access mode saved.');
+      toast.success('Repository access settings saved.');
     } catch {
       // The recoverable error is rendered from the mutation state below.
     }
@@ -203,17 +188,14 @@ function RepositoryAccessForm({
     <div className="flex min-w-0 flex-col gap-group">
       <Panel>
         <PanelHeader>
-          <PanelTitle>Which repositories workflows can use</PanelTitle>
+          <PanelTitle>Repository access mode</PanelTitle>
         </PanelHeader>
         <PanelBody className="gap-group p-panel">
           <Text size="sm" className="text-foreground-neutral-muted">
-            {providerName
-              ? `This integration can only access the repositories it was given on ${providerName}.`
-              : 'This integration can only access the repositories it was given.'}{' '}
-            This setting decides which of those workflows may use.
+            Choose how Shipfox checks repository targets for this connection.
           </Text>
           <RadioGroup
-            aria-label="Which repositories workflows can use"
+            aria-label="Repository access mode"
             value={selectedMode}
             variant="cell"
             onValueChange={(value) => {
@@ -223,21 +205,21 @@ function RepositoryAccessForm({
           >
             <RadioGroupItem value="selected">
               <Text as="span" size="sm" bold>
-                Only your projects&apos; repositories
+                Selected direct targets
               </Text>
               <Text as="span" size="xs" className="text-foreground-neutral-muted">
-                Workflows can check out and act on the repositories your projects use, and nothing
-                else.
+                Shipfox checks repositories named directly by a checkout or tool against projects
+                and manual grants. Some ID-based, organization-scoped, and indirect GitHub effects
+                remain installation-scoped.
               </Text>
             </RadioGroupItem>
             <RadioGroupItem value="all">
               <Text as="span" size="sm" bold>
-                Every repository this integration can access
+                All installation repositories
               </Text>
               <Text as="span" size="xs" className="text-foreground-neutral-muted">
-                {providerName
-                  ? `Workflows can use any repository this integration was given access to on ${providerName}.`
-                  : 'Workflows can use any repository this integration was given access to.'}
+                Shipfox performs no repository allowlist check; GitHub installation access is the
+                boundary.
               </Text>
             </RadioGroupItem>
           </RadioGroup>
@@ -245,8 +227,10 @@ function RepositoryAccessForm({
           {mutationError ? (
             <Callout role="alert" type="error">
               <CalloutContent>
-                <CalloutTitle>Couldn&apos;t save the access mode</CalloutTitle>
-                <CalloutDescription>The previous mode still applies. Try again.</CalloutDescription>
+                <CalloutTitle>Repository access settings were not saved</CalloutTitle>
+                <CalloutDescription>
+                  Try again. The current repository access mode is unchanged.
+                </CalloutDescription>
               </CalloutContent>
             </Callout>
           ) : null}
@@ -262,7 +246,7 @@ function RepositoryAccessForm({
             </Button>
             {updateAccess.isPending ? (
               <Text size="xs" role="status" className="text-foreground-neutral-muted">
-                Saving access mode…
+                Saving repository access settings…
               </Text>
             ) : null}
           </div>
@@ -272,28 +256,27 @@ function RepositoryAccessForm({
       {access.mode === 'selected' ? (
         <SelectedRepositories
           access={access}
-          workspaceSlug={workspaceSlug}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           loadMoreError={loadMoreError}
           onLoadMore={onLoadMore}
         />
       ) : null}
-      <ProviderAccessNotice connection={connection} mode={access.mode} />
+      {connection.provider === 'github' ? (
+        <GithubInstallationNotice connection={connection} />
+      ) : null}
     </div>
   );
 }
 
 function SelectedRepositories({
   access,
-  workspaceSlug,
   hasNextPage,
   isFetchingNextPage,
   loadMoreError,
   onLoadMore,
 }: {
   access: RepositoryAccess;
-  workspaceSlug: string;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   loadMoreError: boolean;
@@ -302,22 +285,15 @@ function SelectedRepositories({
   return (
     <Panel>
       <PanelHeader>
-        <PanelTitle>Your projects&apos; repositories</PanelTitle>
+        <PanelTitle>Selected direct targets</PanelTitle>
       </PanelHeader>
       <PanelBody>
         {access.repositories.length === 0 ? (
           <EmptyState
             icon="folderOpenLine"
-            title="No project repositories yet"
-            description="Create a project from a repository on this connection to add it here."
+            title="No selected repositories"
+            description="Repositories connected through projects or manual grants will appear here."
             variant="panel"
-            action={
-              <Button asChild variant="secondary" size="sm">
-                <Link to="/w/$workspaceSlug/projects/new" params={{workspaceSlug}}>
-                  Create project
-                </Link>
-              </Button>
-            }
           />
         ) : (
           <ul>
@@ -346,7 +322,7 @@ function SelectedRepositories({
           <Callout role="alert" type="error" className="m-panel-compact">
             <CalloutContent>
               <CalloutDescription>
-                Couldn&apos;t load more repositories. Those already listed are unaffected.
+                Could not load more selected repositories. Existing targets are still shown.
               </CalloutDescription>
             </CalloutContent>
           </Callout>
@@ -387,51 +363,18 @@ function OriginLabel({origin}: {origin: RepositoryAccessOrigin}) {
   );
 }
 
-interface ProviderAccessNoticeCopy {
-  title: string;
-  description: string;
-  /** Shown only in projects mode: tools the provider exposes that Shipfox cannot scope by repository. */
-  projectsModeCaveat?: string;
-  linkLabel: string;
-  fallbackUrl: string;
-}
-
-// Where the outer repository list is managed is provider-specific. Providers without an entry
-// get no notice; the panel copy above stays provider-neutral.
-const PROVIDER_ACCESS_NOTICES: Record<string, ProviderAccessNoticeCopy> = {
-  github: {
-    title: 'Repository access is set on GitHub',
-    description: 'To add or remove repositories the GitHub App can access, change it on GitHub.',
-    projectsModeCaveat:
-      "A few tools, such as replying to a review thread, don't name a repository, so Shipfox can't limit them to your projects.",
-    linkLabel: 'Change repositories on GitHub',
-    fallbackUrl: 'https://github.com/settings/installations',
-  },
-};
-
-function ProviderAccessNotice({
-  connection,
-  mode,
-}: {
-  connection: IntegrationConnection;
-  mode: RepositoryAccessMode;
-}) {
-  const copy = PROVIDER_ACCESS_NOTICES[connection.provider];
-  if (!copy) return null;
-  const caveat = mode === 'selected' ? copy.projectsModeCaveat : undefined;
+function GithubInstallationNotice({connection}: {connection: IntegrationConnection}) {
+  const installationUrl = connection.externalUrl ?? 'https://github.com/settings/installations';
   return (
     <Callout type="info">
       <CalloutContent>
-        <CalloutTitle>{copy.title}</CalloutTitle>
+        <CalloutTitle>GitHub installation access still applies</CalloutTitle>
         <CalloutDescription>
-          {copy.description}
-          {caveat ? ` ${caveat}` : null}{' '}
-          <a
-            href={connection.externalUrl ?? copy.fallbackUrl}
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            {copy.linkLabel}
+          Selected mode limits repositories named directly by a checkout or tool. It does not limit
+          every indirect or organization-scoped GitHub effect. For strict repository isolation,
+          update the GitHub App installation&apos;s repository selection.{' '}
+          <a href={installationUrl} target="_blank" rel="noreferrer noopener">
+            Manage GitHub installation
           </a>
         </CalloutDescription>
       </CalloutContent>

--- a/libs/client/integrations/src/pages/connection-details-page.tsx
+++ b/libs/client/integrations/src/pages/connection-details-page.tsx
@@ -23,6 +23,7 @@ import {
   useIntegrationConnectionsQuery,
   useUpdateIntegrationConnectionRepositoryAccessMutation,
 } from '#hooks/api/integrations.js';
+import {PROVIDER_CATALOG} from '#provider-catalog.js';
 
 export function ConnectionDetailsPage({
   workspaceSlug,
@@ -60,7 +61,11 @@ export function ConnectionDetailsPage({
 
   return (
     <ConnectionDetailsShell workspaceSlug={workspaceSlug} connectionName={connection.displayName}>
-      <RepositoryAccessSettings key={connection.id} connection={connection} />
+      <RepositoryAccessSettings
+        key={connection.id}
+        connection={connection}
+        workspaceSlug={workspaceSlug}
+      />
     </ConnectionDetailsShell>
   );
 }
@@ -96,7 +101,13 @@ function ConnectionDetailsShell({
   );
 }
 
-function RepositoryAccessSettings({connection}: {connection: IntegrationConnection}) {
+function RepositoryAccessSettings({
+  connection,
+  workspaceSlug,
+}: {
+  connection: IntegrationConnection;
+  workspaceSlug: string;
+}) {
   const accessQuery = useIntegrationConnectionRepositoryAccessQuery(connection.id);
 
   if (accessQuery.isPending) {
@@ -131,6 +142,7 @@ function RepositoryAccessSettings({connection}: {connection: IntegrationConnecti
   return (
     <RepositoryAccessForm
       connection={connection}
+      workspaceSlug={workspaceSlug}
       access={access}
       hasNextPage={accessQuery.hasNextPage}
       isFetchingNextPage={accessQuery.isFetchingNextPage}
@@ -142,6 +154,7 @@ function RepositoryAccessSettings({connection}: {connection: IntegrationConnecti
 
 function RepositoryAccessForm({
   connection,
+  workspaceSlug,
   access,
   hasNextPage,
   isFetchingNextPage,
@@ -149,6 +162,7 @@ function RepositoryAccessForm({
   onLoadMore,
 }: {
   connection: IntegrationConnection;
+  workspaceSlug: string;
   access: RepositoryAccess;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
@@ -169,6 +183,7 @@ function RepositoryAccessForm({
   if (isUnsupportedError(mutationError)) return <UnsupportedState />;
 
   const isDirty = selectedMode !== persistedMode;
+  const providerName = PROVIDER_CATALOG[connection.provider]?.displayName;
 
   async function saveMode() {
     if (!isDirty) return;
@@ -178,7 +193,7 @@ function RepositoryAccessForm({
         mode: selectedMode,
       });
       setPersistedMode(savedMode);
-      toast.success('Repository access settings saved.');
+      toast.success('Access mode saved.');
     } catch {
       // The recoverable error is rendered from the mutation state below.
     }
@@ -188,14 +203,17 @@ function RepositoryAccessForm({
     <div className="flex min-w-0 flex-col gap-group">
       <Panel>
         <PanelHeader>
-          <PanelTitle>Repository access mode</PanelTitle>
+          <PanelTitle>Which repositories workflows can use</PanelTitle>
         </PanelHeader>
         <PanelBody className="gap-group p-panel">
           <Text size="sm" className="text-foreground-neutral-muted">
-            Choose how Shipfox checks repository targets for this connection.
+            {providerName
+              ? `This integration can only access the repositories it was given on ${providerName}.`
+              : 'This integration can only access the repositories it was given.'}{' '}
+            This setting decides which of those workflows may use.
           </Text>
           <RadioGroup
-            aria-label="Repository access mode"
+            aria-label="Which repositories workflows can use"
             value={selectedMode}
             variant="cell"
             onValueChange={(value) => {
@@ -205,21 +223,21 @@ function RepositoryAccessForm({
           >
             <RadioGroupItem value="selected">
               <Text as="span" size="sm" bold>
-                Selected direct targets
+                Only your projects&apos; repositories
               </Text>
               <Text as="span" size="xs" className="text-foreground-neutral-muted">
-                Shipfox checks repositories named directly by a checkout or tool against projects
-                and manual grants. Some ID-based, organization-scoped, and indirect GitHub effects
-                remain installation-scoped.
+                Workflows can check out and act on the repositories your projects use, and nothing
+                else.
               </Text>
             </RadioGroupItem>
             <RadioGroupItem value="all">
               <Text as="span" size="sm" bold>
-                All installation repositories
+                Every repository this integration can access
               </Text>
               <Text as="span" size="xs" className="text-foreground-neutral-muted">
-                Shipfox performs no repository allowlist check; GitHub installation access is the
-                boundary.
+                {providerName
+                  ? `Workflows can use any repository this integration was given access to on ${providerName}.`
+                  : 'Workflows can use any repository this integration was given access to.'}
               </Text>
             </RadioGroupItem>
           </RadioGroup>
@@ -227,10 +245,8 @@ function RepositoryAccessForm({
           {mutationError ? (
             <Callout role="alert" type="error">
               <CalloutContent>
-                <CalloutTitle>Repository access settings were not saved</CalloutTitle>
-                <CalloutDescription>
-                  Try again. The current repository access mode is unchanged.
-                </CalloutDescription>
+                <CalloutTitle>Couldn&apos;t save the access mode</CalloutTitle>
+                <CalloutDescription>The previous mode still applies. Try again.</CalloutDescription>
               </CalloutContent>
             </Callout>
           ) : null}
@@ -246,7 +262,7 @@ function RepositoryAccessForm({
             </Button>
             {updateAccess.isPending ? (
               <Text size="xs" role="status" className="text-foreground-neutral-muted">
-                Saving repository access settings…
+                Saving access mode…
               </Text>
             ) : null}
           </div>
@@ -256,27 +272,28 @@ function RepositoryAccessForm({
       {access.mode === 'selected' ? (
         <SelectedRepositories
           access={access}
+          workspaceSlug={workspaceSlug}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           loadMoreError={loadMoreError}
           onLoadMore={onLoadMore}
         />
       ) : null}
-      {connection.provider === 'github' ? (
-        <GithubInstallationNotice connection={connection} />
-      ) : null}
+      <ProviderAccessNotice connection={connection} mode={access.mode} />
     </div>
   );
 }
 
 function SelectedRepositories({
   access,
+  workspaceSlug,
   hasNextPage,
   isFetchingNextPage,
   loadMoreError,
   onLoadMore,
 }: {
   access: RepositoryAccess;
+  workspaceSlug: string;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   loadMoreError: boolean;
@@ -285,15 +302,22 @@ function SelectedRepositories({
   return (
     <Panel>
       <PanelHeader>
-        <PanelTitle>Selected direct targets</PanelTitle>
+        <PanelTitle>Your projects&apos; repositories</PanelTitle>
       </PanelHeader>
       <PanelBody>
         {access.repositories.length === 0 ? (
           <EmptyState
             icon="folderOpenLine"
-            title="No selected repositories"
-            description="Repositories connected through projects or manual grants will appear here."
+            title="No project repositories yet"
+            description="Create a project from a repository on this connection to add it here."
             variant="panel"
+            action={
+              <Button asChild variant="secondary" size="sm">
+                <Link to="/w/$workspaceSlug/projects/new" params={{workspaceSlug}}>
+                  Create project
+                </Link>
+              </Button>
+            }
           />
         ) : (
           <ul>
@@ -322,7 +346,7 @@ function SelectedRepositories({
           <Callout role="alert" type="error" className="m-panel-compact">
             <CalloutContent>
               <CalloutDescription>
-                Could not load more selected repositories. Existing targets are still shown.
+                Couldn&apos;t load more repositories. Those already listed are unaffected.
               </CalloutDescription>
             </CalloutContent>
           </Callout>
@@ -363,18 +387,51 @@ function OriginLabel({origin}: {origin: RepositoryAccessOrigin}) {
   );
 }
 
-function GithubInstallationNotice({connection}: {connection: IntegrationConnection}) {
-  const installationUrl = connection.externalUrl ?? 'https://github.com/settings/installations';
+interface ProviderAccessNoticeCopy {
+  title: string;
+  description: string;
+  /** Shown only in projects mode: tools the provider exposes that Shipfox cannot scope by repository. */
+  projectsModeCaveat?: string;
+  linkLabel: string;
+  fallbackUrl: string;
+}
+
+// Where the outer repository list is managed is provider-specific. Providers without an entry
+// get no notice; the panel copy above stays provider-neutral.
+const PROVIDER_ACCESS_NOTICES: Record<string, ProviderAccessNoticeCopy> = {
+  github: {
+    title: 'Repository access is set on GitHub',
+    description: 'To add or remove repositories the GitHub App can access, change it on GitHub.',
+    projectsModeCaveat:
+      "A few tools, such as replying to a review thread, don't name a repository, so Shipfox can't limit them to your projects.",
+    linkLabel: 'Change repositories on GitHub',
+    fallbackUrl: 'https://github.com/settings/installations',
+  },
+};
+
+function ProviderAccessNotice({
+  connection,
+  mode,
+}: {
+  connection: IntegrationConnection;
+  mode: RepositoryAccessMode;
+}) {
+  const copy = PROVIDER_ACCESS_NOTICES[connection.provider];
+  if (!copy) return null;
+  const caveat = mode === 'selected' ? copy.projectsModeCaveat : undefined;
   return (
     <Callout type="info">
       <CalloutContent>
-        <CalloutTitle>GitHub installation access still applies</CalloutTitle>
+        <CalloutTitle>{copy.title}</CalloutTitle>
         <CalloutDescription>
-          Selected mode limits repositories named directly by a checkout or tool. It does not limit
-          every indirect or organization-scoped GitHub effect. For strict repository isolation,
-          update the GitHub App installation&apos;s repository selection.{' '}
-          <a href={installationUrl} target="_blank" rel="noreferrer noopener">
-            Manage GitHub installation
+          {copy.description}
+          {caveat ? ` ${caveat}` : null}{' '}
+          <a
+            href={connection.externalUrl ?? copy.fallbackUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {copy.linkLabel}
           </a>
         </CalloutDescription>
       </CalloutContent>

--- a/libs/client/integrations/src/routes/connection-details.tsx
+++ b/libs/client/integrations/src/routes/connection-details.tsx
@@ -1,0 +1,11 @@
+import {defineRoute, useRouteParams} from '@shipfox/client-shell/runtime';
+import {ConnectionDetailsPage} from '#pages/connection-details-page.js';
+import {connectionDetailsRouteParams} from './inputs.js';
+
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: () => {
+    const {workspaceSlug, connectionSlug} = useRouteParams(connectionDetailsRouteParams);
+    return <ConnectionDetailsPage workspaceSlug={workspaceSlug} connectionSlug={connectionSlug} />;
+  },
+});

--- a/libs/client/integrations/src/routes/inputs.test.ts
+++ b/libs/client/integrations/src/routes/inputs.test.ts
@@ -1,0 +1,15 @@
+import {connectionDetailsRouteParams} from './inputs.js';
+
+describe('connectionDetailsRouteParams', () => {
+  test('returns the validated workspace and connection slugs', () => {
+    expect(
+      connectionDetailsRouteParams({workspaceSlug: 'acme', connectionSlug: 'github_acme'}),
+    ).toEqual({workspaceSlug: 'acme', connectionSlug: 'github_acme'});
+  });
+
+  test('rejects a route with a missing slug', () => {
+    expect(() => connectionDetailsRouteParams({workspaceSlug: 'acme'})).toThrow(
+      'Connection details route is missing required path parameters.',
+    );
+  });
+});

--- a/libs/client/integrations/src/routes/inputs.ts
+++ b/libs/client/integrations/src/routes/inputs.ts
@@ -1,0 +1,15 @@
+export function connectionDetailsRouteParams(input: Record<string, unknown>): {
+  workspaceSlug: string;
+  connectionSlug: string;
+} {
+  const workspaceSlug = stringParam(input.workspaceSlug);
+  const connectionSlug = stringParam(input.connectionSlug);
+  if (!workspaceSlug || !connectionSlug) {
+    throw new Error('Connection details route is missing required path parameters.');
+  }
+  return {workspaceSlug, connectionSlug};
+}
+
+function stringParam(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}


### PR DESCRIPTION
Adds a dedicated workspace settings page for integration connection repository access. Workspace admins can review the composed selected target list, understand project and manual origins, and switch between selected direct targets and all installation repositories.

The page uses the existing repository-access read and mutation routes. Manual grant picker controls remain out of scope. The UI handles unsupported providers, access denial, loading, pagination, save pending and success, and recoverable errors.

Validation:
- `mise exec -- pnpm --filter @shipfox/client-integrations check`
- `mise exec -- pnpm --filter @shipfox/client-integrations test` (199 tests)
- `mise exec -- turbo type --filter=@shipfox/client-integrations...`
- `mise exec -- turbo check --filter=@shipfox/client-integrations...`
- `mise exec -- turbo build --filter=@shipfox/client...`
- `git diff --check`

The repository-wide client architecture audit still reports the pre-existing `libs/client/workflows/src/hooks/api/workflow-filter-options.ts: inline-query-policy` violation.

Closes ENG-1846

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workspace settings page for source-control connection repository access, closing ENG-1846. Repository access was previously configurable only through API routes; workspace admins can now review composed targets and switch between selected direct targets and all repositories available to the provider installation. In selected mode, indirect and organization-scoped GitHub effects remain installation-scoped.

**Details**
- Shows paginated project and manual origins with loading, empty, denied, unsupported, retry, save, and recoverable error states.
- Keeps unsaved mode changes scoped to the active connection and preserves the saved mode until the read model refreshes; manual grant selection remains out of scope.

<sup>Written for commit 5e677c8f685bed3c916ea65c365d8a21d226bc9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

