### PR TITLE
[E2E] Prove renewable Git credentials end to end

### DIFF
--- a/.changeset/renewable-credentials-e2e.md
+++ b/.changeset/renewable-credentials-e2e.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/api-integration-core": patch
+"@shipfox/api-integration-spi": patch
 ---
 
-Adds an opt-in Test VCS provider (`test-vcs`), enabled via `INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER`.
+Adds an opt-in Test VCS provider (`test-vcs`), enabled via `INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER`, and keeps Git branch validation aligned with Git's ref rules.

--- a/.changeset/renewable-credentials-e2e.md
+++ b/.changeset/renewable-credentials-e2e.md
@@ -2,4 +2,4 @@
 "@shipfox/api-integration-core": patch
 ---
 
-Adds an opt-in Test VCS provider for renewable credential E2E coverage.
+Adds an opt-in Test VCS provider (`test-vcs`), enabled via `INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER`.

--- a/.changeset/renewable-credentials-e2e.md
+++ b/.changeset/renewable-credentials-e2e.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Adds an opt-in Test VCS provider for renewable credential E2E coverage.

--- a/e2e/drivers/runner-process/src/local-runner-process.ts
+++ b/e2e/drivers/runner-process/src/local-runner-process.ts
@@ -9,7 +9,7 @@ import {
   symlinkSync,
 } from 'node:fs';
 import {createRequire} from 'node:module';
-import {delimiter, dirname, join} from 'node:path';
+import {delimiter, dirname, join, resolve} from 'node:path';
 import {config} from '@shipfox/e2e-core';
 
 const DEFAULT_SIGTERM_TIMEOUT_MS = 15_000;
@@ -116,9 +116,14 @@ function createCredentialHelperBin(
     );
   }
 
-  const helperBinDir = mkdtempSync(join(dirname(params.logFile), '.credential-helper-'));
-  symlinkSync(helperTarget, join(helperBinDir, 'git-credential-shipfox'));
-  return helperBinDir;
+  const helperBinDir = mkdtempSync(join(resolve(dirname(params.logFile)), '.credential-helper-'));
+  try {
+    symlinkSync(helperTarget, join(helperBinDir, 'git-credential-shipfox'));
+    return helperBinDir;
+  } catch (error) {
+    removeCredentialHelperBin(helperBinDir);
+    throw error;
+  }
 }
 
 function removeCredentialHelperBin(helperBinDir: string | undefined): void {
@@ -143,19 +148,21 @@ export function startLocalRunner(params: StartLocalRunnerParams): LocalRunnerHan
   const {cwd, entry} = runnerModule;
   const credentialHelperBinDir = createCredentialHelperBin(runnerModule, params);
 
-  const logFd = openSync(params.logFile, 'a');
   let child: ChildProcess;
   try {
-    child = spawn(process.execPath, ['--import', 'tsx', '--conditions=workspace-source', entry], {
-      cwd,
-      stdio: ['ignore', logFd, logFd],
-      env: buildRunnerEnv(params, credentialHelperBinDir),
-    });
+    const logFd = openSync(params.logFile, 'a');
+    try {
+      child = spawn(process.execPath, ['--import', 'tsx', '--conditions=workspace-source', entry], {
+        cwd,
+        stdio: ['ignore', logFd, logFd],
+        env: buildRunnerEnv(params, credentialHelperBinDir),
+      });
+    } finally {
+      closeSync(logFd);
+    }
   } catch (error) {
     removeCredentialHelperBin(credentialHelperBinDir);
     throw error;
-  } finally {
-    closeSync(logFd);
   }
 
   const {pid} = child;

--- a/e2e/drivers/runner-process/src/local-runner-process.ts
+++ b/e2e/drivers/runner-process/src/local-runner-process.ts
@@ -1,7 +1,15 @@
 import {type ChildProcess, spawn} from 'node:child_process';
-import {closeSync, openSync, readFileSync} from 'node:fs';
+import {
+  closeSync,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
 import {createRequire} from 'node:module';
-import {dirname, join} from 'node:path';
+import {delimiter, dirname, join} from 'node:path';
 import {config} from '@shipfox/e2e-core';
 
 const DEFAULT_SIGTERM_TIMEOUT_MS = 15_000;
@@ -33,6 +41,7 @@ export interface LocalRunnerHandle {
   logFile: string;
   workspaceId: string;
   labels: readonly string[];
+  credentialHelperBinDir?: string | undefined;
 }
 
 export interface StopLocalRunnerOptions {
@@ -67,9 +76,14 @@ function inheritedProcessEnv(): Record<string, string> {
   return env;
 }
 
-function buildRunnerEnv(params: StartLocalRunnerParams): Record<string, string> {
+function buildRunnerEnv(
+  params: StartLocalRunnerParams,
+  credentialHelperBinDir: string | undefined,
+): Record<string, string> {
+  const inherited = inheritedProcessEnv();
+  const renewableGitEnabled = params.extraEnv?.SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT === 'true';
   return {
-    ...inheritedProcessEnv(),
+    ...inherited,
     SHIPFOX_API_URL: params.apiUrl ?? config.API_URL,
     SHIPFOX_RUNNER_REGISTRATION_TOKEN: params.registrationToken,
     SHIPFOX_RUNNER_LABELS: params.labels.join(','),
@@ -79,8 +93,37 @@ function buildRunnerEnv(params: StartLocalRunnerParams): Record<string, string> 
     ...(params.workspaceRoot !== undefined
       ? {SHIPFOX_RUNNER_WORKSPACE_ROOT: params.workspaceRoot}
       : {}),
+    ...(credentialHelperBinDir
+      ? {
+          PATH: [credentialHelperBinDir, inherited.PATH].filter(Boolean).join(delimiter),
+        }
+      : {}),
+    ...(renewableGitEnabled ? {GIT_CONFIG_NOSYSTEM: '1'} : {}),
     ...(params.extraEnv ?? {}),
   };
+}
+
+function createCredentialHelperBin(
+  runnerModule: RunnerModule,
+  params: StartLocalRunnerParams,
+): string | undefined {
+  if (params.extraEnv?.SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT !== 'true') return undefined;
+
+  const helperTarget = join(runnerModule.cwd, 'dist', 'git-credential-helper.js');
+  if (!existsSync(helperTarget)) {
+    throw new Error(
+      `The local runner credential helper is missing at ${helperTarget}; build @shipfox/runner before starting a renewable Git E2E runner.`,
+    );
+  }
+
+  const helperBinDir = mkdtempSync(join(dirname(params.logFile), '.credential-helper-'));
+  symlinkSync(helperTarget, join(helperBinDir, 'git-credential-shipfox'));
+  return helperBinDir;
+}
+
+function removeCredentialHelperBin(helperBinDir: string | undefined): void {
+  if (helperBinDir === undefined) return;
+  rmSync(helperBinDir, {force: true, recursive: true});
 }
 
 export function localRunnerLogTail(path: string): string {
@@ -94,9 +137,11 @@ export function localRunnerLogTail(path: string): string {
 }
 
 export function startLocalRunner(params: StartLocalRunnerParams): LocalRunnerHandle {
-  const {cwd, entry} = params.entryPath
+  const runnerModule = params.entryPath
     ? {cwd: dirname(params.entryPath), entry: params.entryPath}
     : resolveRunnerModule();
+  const {cwd, entry} = runnerModule;
+  const credentialHelperBinDir = createCredentialHelperBin(runnerModule, params);
 
   const logFd = openSync(params.logFile, 'a');
   let child: ChildProcess;
@@ -104,8 +149,11 @@ export function startLocalRunner(params: StartLocalRunnerParams): LocalRunnerHan
     child = spawn(process.execPath, ['--import', 'tsx', '--conditions=workspace-source', entry], {
       cwd,
       stdio: ['ignore', logFd, logFd],
-      env: buildRunnerEnv(params),
+      env: buildRunnerEnv(params, credentialHelperBinDir),
     });
+  } catch (error) {
+    removeCredentialHelperBin(credentialHelperBinDir);
+    throw error;
   } finally {
     closeSync(logFd);
   }
@@ -113,8 +161,11 @@ export function startLocalRunner(params: StartLocalRunnerParams): LocalRunnerHan
   const {pid} = child;
   if (pid === undefined) {
     child.kill('SIGKILL');
+    removeCredentialHelperBin(credentialHelperBinDir);
     throw new Error('Local runner child process failed to start (no pid)');
   }
+
+  child.once('exit', () => removeCredentialHelperBin(credentialHelperBinDir));
 
   return {
     process: child,
@@ -122,6 +173,7 @@ export function startLocalRunner(params: StartLocalRunnerParams): LocalRunnerHan
     logFile: params.logFile,
     workspaceId: params.workspaceId,
     labels: params.labels,
+    ...(credentialHelperBinDir ? {credentialHelperBinDir} : {}),
   };
 }
 
@@ -175,5 +227,9 @@ export async function stopLocalRunner(
   handle: LocalRunnerHandle,
   options: StopLocalRunnerOptions = {},
 ): Promise<void> {
-  await terminate(handle.process, options.sigtermTimeoutMs ?? DEFAULT_SIGTERM_TIMEOUT_MS);
+  try {
+    await terminate(handle.process, options.sigtermTimeoutMs ?? DEFAULT_SIGTERM_TIMEOUT_MS);
+  } finally {
+    removeCredentialHelperBin(handle.credentialHelperBinDir);
+  }
 }

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -395,11 +395,21 @@ export function turboCommandArgs(options, env) {
   if (hasTurboConcurrency(args)) return args;
 
   const concurrency = env.SHIPFOX_TURBO_CONCURRENCY;
-  return concurrency ? [...args, `--concurrency=${concurrency}`] : args;
+  if (!concurrency) return args;
+
+  const separatorIndex = args.indexOf('--');
+  if (separatorIndex < 0) return [...args, `--concurrency=${concurrency}`];
+  return [
+    ...args.slice(0, separatorIndex),
+    `--concurrency=${concurrency}`,
+    ...args.slice(separatorIndex),
+  ];
 }
 
 function hasTurboConcurrency(args) {
-  return args.some((arg) => arg === '--concurrency' || arg.startsWith('--concurrency='));
+  const separatorIndex = args.indexOf('--');
+  const turboArgs = separatorIndex < 0 ? args : args.slice(0, separatorIndex);
+  return turboArgs.some((arg) => arg === '--concurrency' || arg.startsWith('--concurrency='));
 }
 
 export function defaultLogDir(env) {

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -124,7 +124,10 @@ export function parseArgs(argv) {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--') {
-      options.turboArgs.push(...args.slice(index + 1));
+      const passthroughArgs = args.slice(index + 1);
+      options.turboArgs.push(
+        ...(options.turboArgs.length === 0 ? passthroughArgs : ['--', ...passthroughArgs]),
+      );
       break;
     }
     if (applyBooleanOption(arg, options)) continue;
@@ -210,6 +213,7 @@ export function e2eEnv(sourceEnv) {
     e2eGithubApiBaseUrl(apiUrl),
   );
   const slackApiBaseUrl = valueOr(sourceEnv.SLACK_API_BASE_URL, () => e2eSlackApiBaseUrl(apiUrl));
+  const testVcsPort = valueOr(sourceEnv.INTEGRATIONS_TEST_VCS_PORT, () => e2eTestVcsPort(apiUrl));
   return {
     ...sourceEnv,
     API_URL: apiUrl,
@@ -275,6 +279,15 @@ export function e2eEnv(sourceEnv) {
       sourceEnv.INTEGRATIONS_ENABLE_SLACK_PROVIDER,
       'true',
     ),
+    INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER: valueOr(
+      sourceEnv.INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER,
+      'true',
+    ),
+    INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS: valueOr(
+      sourceEnv.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS,
+      '3',
+    ),
+    INTEGRATIONS_TEST_VCS_PORT: String(testVcsPort),
     LINEAR_MCP_ENDPOINT: linearMcpEndpoint,
     LINEAR_OAUTH_CLIENT_ID: valueOr(sourceEnv.LINEAR_OAUTH_CLIENT_ID, 'e2e-linear-client-id'),
     LINEAR_OAUTH_CLIENT_SECRET: valueOr(
@@ -319,6 +332,18 @@ export function e2eGithubApiBaseUrl(apiUrl) {
   endpoint.search = '';
   endpoint.hash = '';
   return endpoint.toString();
+}
+
+export function e2eTestVcsPort(apiUrl) {
+  const endpoint = new URL(apiUrl);
+  const apiPort = Number(endpoint.port || (endpoint.protocol === 'https:' ? 443 : 80));
+  // Worktree services reserve the API block through the temporal metrics port
+  // at API + 12. Keep the fixture in the unused tail of that block.
+  const testVcsPort = apiPort + 14;
+  if (testVcsPort > 65_535) {
+    throw new Error(`Cannot derive a test VCS port from API port ${apiPort}.`);
+  }
+  return testVcsPort;
 }
 
 export function e2eSlackApiBaseUrl(apiUrl) {

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -233,6 +233,24 @@ describe('turboCommandArgs', () => {
 
     assert.deepEqual(args, ['test:e2e', '--concurrency', '4']);
   });
+
+  test('places the environment concurrency before test-runner arguments', () => {
+    const args = turboCommandArgs(
+      {
+        turboArgs: ['--filter=@shipfox/e2e-client-agent', '--', '--grep=renewable'],
+        turboTask: 'test:e2e',
+      },
+      {SHIPFOX_TURBO_CONCURRENCY: '2'},
+    );
+
+    assert.deepEqual(args, [
+      'test:e2e',
+      '--filter=@shipfox/e2e-client-agent',
+      '--concurrency=2',
+      '--',
+      '--grep=renewable',
+    ]);
+  });
 });
 
 describe('defaultLogDir', () => {

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -7,6 +7,7 @@ import {
   copyPlaywrightTestResults,
   copySharedOllamaLog,
   defaultLogDir,
+  e2eTestVcsPort,
   e2eEnv,
   parseArgs,
   turboCommandArgs,
@@ -46,6 +47,21 @@ describe('parseArgs', () => {
     assert.deepEqual(options.turboArgs, ['--filter=@shipfox/e2e-client-auth']);
   });
 
+  test('preserves a turbo task separator for nested test arguments', () => {
+    const options = parseArgs([
+      'run',
+      '--filter=@shipfox/e2e-flow-workflows',
+      '--',
+      '--grep=renewable credentials',
+    ]);
+
+    assert.deepEqual(options.turboArgs, [
+      '--filter=@shipfox/e2e-flow-workflows',
+      '--',
+      '--grep=renewable credentials',
+    ]);
+  });
+
   test('rejects unknown commands', () => {
     assert.throws(() => parseArgs(['down']), unknownCommandPattern);
   });
@@ -67,6 +83,9 @@ describe('e2eEnv', () => {
     assert.equal(env.INTEGRATIONS_ENABLE_LINEAR_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_GITHUB_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_SLACK_PROVIDER, 'true');
+    assert.equal(env.INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER, 'true');
+    assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '3');
+    assert.equal(env.INTEGRATIONS_TEST_VCS_PORT, '55365');
     assert.equal(env.AUTH_ROOT_KEY, 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=');
     assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'true');
     assert.equal(env.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS, 'allowed.example.test');
@@ -111,6 +130,8 @@ describe('e2eEnv', () => {
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
     assert.equal(env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE, 'disabled');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:16122');
+    assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '3');
+    assert.equal(env.INTEGRATIONS_TEST_VCS_PORT, '16115');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
     assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'false');
     assert.equal(env.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS, 'override.example.test');
@@ -144,6 +165,19 @@ describe('e2eEnv', () => {
       () => e2eEnv({API_URL: 'http://localhost:65525'}),
       /Cannot derive a Slack API port/u,
     );
+  });
+
+  test('rejects an API port that cannot reserve the Test VCS offset', () => {
+    assert.throws(
+      () => e2eEnv({API_URL: 'http://localhost:65522'}),
+      /Cannot derive a test VCS port/u,
+    );
+  });
+});
+
+describe('e2eTestVcsPort', () => {
+  test('reserves the Test VCS port after the API port', () => {
+    assert.equal(e2eTestVcsPort('http://localhost:16101'), 16115);
   });
 });
 

--- a/e2e/setup/integrations/package.json
+++ b/e2e/setup/integrations/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-github-dto": "workspace:*",
     "@shipfox/api-integration-linear-dto": "workspace:*",
     "@shipfox/api-integration-slack-dto": "workspace:*",

--- a/e2e/setup/integrations/src/index.test.ts
+++ b/e2e/setup/integrations/src/index.test.ts
@@ -1,12 +1,14 @@
 import {beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
 
 const requestJson = vi.fn();
+const request = vi.fn();
 
 describe('integrations E2E setup helper', () => {
   beforeEach(() => {
     vi.resetModules();
     requestJson.mockReset();
-    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+    request.mockReset();
+    vi.doMock('@shipfox/e2e-core', () => ({request, requestJson}));
   });
 
   it('creates Linear connections through the protected setup route', async () => {
@@ -57,5 +59,78 @@ describe('integrations E2E setup helper', () => {
         installer_user_id: '00000000-0000-4000-8000-000000000002',
       },
     });
+  });
+
+  it('creates Test VCS connections and repositories through the protected setup routes', async () => {
+    requestJson.mockResolvedValueOnce({id: 'connection-id'}).mockResolvedValueOnce({
+      external_repository_id: 'test-vcs:e2e-owner/repository',
+    });
+    const {createTestVcsConnection, createTestVcsRepository, testVcsExternalRepositoryId} =
+      await import('./index.js');
+
+    await createTestVcsConnection({
+      workspaceId: '00000000-0000-4000-8000-000000000001',
+      accountId: 'e2e-owner',
+      renewalMode: 'on-rejection',
+    });
+    await createTestVcsRepository({
+      connectionId: 'connection-id',
+      name: 'repository',
+      files: [{path: 'README.md', content: '# E2E'}],
+    });
+
+    expect(requestJson).toHaveBeenNthCalledWith(
+      1,
+      'post',
+      '/__e2e/integrations/test-vcs/connections',
+      {
+        json: {
+          workspace_id: '00000000-0000-4000-8000-000000000001',
+          account_id: 'e2e-owner',
+          renewal_mode: 'on-rejection',
+        },
+      },
+    );
+    expect(requestJson).toHaveBeenNthCalledWith(
+      2,
+      'post',
+      '/__e2e/integrations/test-vcs/repositories',
+      {
+        json: {
+          connection_id: 'connection-id',
+          name: 'repository',
+          files: [{path: 'README.md', content: '# E2E'}],
+        },
+      },
+    );
+    expect(testVcsExternalRepositoryId('e2e-owner', 'repository')).toBe(
+      'test-vcs:e2e-owner/repository',
+    );
+  });
+
+  it('records Test VCS fixture observations and can fail credential mints', async () => {
+    request.mockResolvedValueOnce(new Response(null, {status: 204}));
+    requestJson.mockResolvedValueOnce({
+      mint_count: 2,
+      request_count: 3,
+      accepted_request_count: 2,
+      rejected_request_count: 1,
+      generations: ['generation-a', 'generation-b'],
+      requests: [],
+    });
+    const {failNextTestVcsMints, getTestVcsStats} = await import('./index.js');
+
+    await failNextTestVcsMints(2);
+    const stats = await getTestVcsStats({connectionId: '00000000-0000-4000-8000-000000000003'});
+
+    expect(request).toHaveBeenCalledWith('post', '/__e2e/integrations/test-vcs/fail-next-mints', {
+      json: {count: 2},
+    });
+    expect(requestJson).toHaveBeenCalledWith(
+      'get',
+      '/__e2e/integrations/test-vcs/stats?connection_id=00000000-0000-4000-8000-000000000003',
+      {},
+    );
+    expect(stats.generations).toEqual(['generation-a', 'generation-b']);
   });
 });

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -1,3 +1,4 @@
+import type {IntegrationConnectionDto, RepositoryDto} from '@shipfox/api-integration-core-dto';
 import type {
   CreateE2eGithubConnectionBodyDto,
   CreateE2eGithubConnectionResponseDto,
@@ -10,8 +11,9 @@ import type {
   CreateE2eSlackConnectionBodyDto,
   CreateE2eSlackConnectionResponseDto,
 } from '@shipfox/api-integration-slack-dto';
-import {requestJson} from '@shipfox/e2e-core';
+import {request, requestJson} from '@shipfox/e2e-core';
 
+export type {IntegrationConnectionDto, RepositoryDto} from '@shipfox/api-integration-core-dto';
 export type {
   CreateE2eGithubConnectionBodyDto,
   CreateE2eGithubConnectionResponseDto,
@@ -24,6 +26,48 @@ export type {
   CreateE2eSlackConnectionBodyDto,
   CreateE2eSlackConnectionResponseDto,
 } from '@shipfox/api-integration-slack-dto';
+
+export type TestVcsRenewalMode = 'refresh-at' | 'on-rejection';
+
+export interface TestVcsFile {
+  path: string;
+  content: string;
+}
+
+export interface TestVcsStats {
+  mint_count: number;
+  request_count: number;
+  accepted_request_count: number;
+  rejected_request_count: number;
+  generations: string[];
+  requests: Array<{
+    method: string;
+    path: string;
+    status: 'accepted' | 'rejected';
+    generation?: string | undefined;
+  }>;
+}
+
+export interface CreateTestVcsConnectionParams {
+  workspaceId: string;
+  accountId: string;
+  displayName?: string | undefined;
+  renewalMode?: TestVcsRenewalMode | undefined;
+}
+
+export interface CreateTestVcsRepositoryParams {
+  connectionId: string;
+  name: string;
+  defaultBranch?: string | undefined;
+  files: TestVcsFile[];
+}
+
+export interface CommitTestVcsFilesParams {
+  connectionId: string;
+  externalRepositoryId: string;
+  message: string;
+  files: TestVcsFile[];
+}
 
 export interface CreateGithubConnectionParams {
   workspaceId: string;
@@ -119,4 +163,66 @@ export async function createSlackConnection(
     '/__e2e/integrations/slack-connections',
     {json: slackConnectionBody(params)},
   );
+}
+
+export async function createTestVcsConnection(
+  params: CreateTestVcsConnectionParams,
+): Promise<IntegrationConnectionDto> {
+  return await requestJson<IntegrationConnectionDto>(
+    'post',
+    '/__e2e/integrations/test-vcs/connections',
+    {
+      json: {
+        workspace_id: params.workspaceId,
+        account_id: params.accountId,
+        ...(params.displayName === undefined ? {} : {display_name: params.displayName}),
+        ...(params.renewalMode === undefined ? {} : {renewal_mode: params.renewalMode}),
+      },
+    },
+  );
+}
+
+export async function createTestVcsRepository(
+  params: CreateTestVcsRepositoryParams,
+): Promise<RepositoryDto> {
+  return await requestJson<RepositoryDto>('post', '/__e2e/integrations/test-vcs/repositories', {
+    json: {
+      connection_id: params.connectionId,
+      name: params.name,
+      ...(params.defaultBranch === undefined ? {} : {default_branch: params.defaultBranch}),
+      files: params.files,
+    },
+  });
+}
+
+export async function commitTestVcsFiles(
+  params: CommitTestVcsFilesParams,
+): Promise<{commit: string}> {
+  return await requestJson<{commit: string}>('post', '/__e2e/integrations/test-vcs/commits', {
+    json: {
+      connection_id: params.connectionId,
+      external_repository_id: params.externalRepositoryId,
+      message: params.message,
+      files: params.files,
+    },
+  });
+}
+
+export async function getTestVcsStats(
+  params: {connectionId?: string | undefined} = {},
+): Promise<TestVcsStats> {
+  const query = params.connectionId
+    ? `?connection_id=${encodeURIComponent(params.connectionId)}`
+    : '';
+  return await requestJson<TestVcsStats>('get', `/__e2e/integrations/test-vcs/stats${query}`, {});
+}
+
+export async function failNextTestVcsMints(count: number): Promise<void> {
+  await request('post', '/__e2e/integrations/test-vcs/fail-next-mints', {
+    json: {count},
+  });
+}
+
+export function testVcsExternalRepositoryId(owner: string, name: string): string {
+  return `test-vcs:${owner}/${name}`;
 }

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -62,13 +62,6 @@ export interface CreateTestVcsRepositoryParams {
   files: TestVcsFile[];
 }
 
-export interface CommitTestVcsFilesParams {
-  connectionId: string;
-  externalRepositoryId: string;
-  message: string;
-  files: TestVcsFile[];
-}
-
 export interface CreateGithubConnectionParams {
   workspaceId: string;
   installationId: number;
@@ -190,19 +183,6 @@ export async function createTestVcsRepository(
       connection_id: params.connectionId,
       name: params.name,
       ...(params.defaultBranch === undefined ? {} : {default_branch: params.defaultBranch}),
-      files: params.files,
-    },
-  });
-}
-
-export async function commitTestVcsFiles(
-  params: CommitTestVcsFilesParams,
-): Promise<{commit: string}> {
-  return await requestJson<{commit: string}>('post', '/__e2e/integrations/test-vcs/commits', {
-    json: {
-      connection_id: params.connectionId,
-      external_repository_id: params.externalRepositoryId,
-      message: params.message,
       files: params.files,
     },
   });

--- a/e2e/suites/flow/workflows/src/runner.ts
+++ b/e2e/suites/flow/workflows/src/runner.ts
@@ -20,7 +20,9 @@ export async function startSuiteLocalRunner(params: {
   userToken: string;
   name: string;
   runnerLabel: string;
+  runnerInstanceId?: string | undefined;
   extraEnv?: Record<string, string> | undefined;
+  renewableGit?: boolean | undefined;
 }): Promise<{runner: LocalRunnerHandle; logFile: string}> {
   const registrationToken = await mintManualRegistrationToken({
     workspaceId: params.workspaceId,
@@ -30,7 +32,10 @@ export async function startSuiteLocalRunner(params: {
   });
   const runDir = suiteRunDir();
   const runnerLogDir = join(runDir, 'runners');
-  const logFile = join(runnerLogDir, `${params.runnerLabel}.log`);
+  const logFile = join(
+    runnerLogDir,
+    `${params.runnerLabel}${params.runnerInstanceId === undefined ? '' : `-${params.runnerInstanceId}`}.log`,
+  );
   await mkdir(runnerLogDir, {recursive: true});
   return {
     runner: startLocalRunner({
@@ -39,7 +44,10 @@ export async function startSuiteLocalRunner(params: {
       labels: [params.runnerLabel],
       logFile,
       workspaceRoot: join(runDir, 'runner-workspaces', params.runnerLabel),
-      extraEnv: params.extraEnv,
+      extraEnv: {
+        ...(params.extraEnv ?? {}),
+        ...(params.renewableGit === true ? {SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT: 'true'} : {}),
+      },
     }),
     logFile,
   };

--- a/e2e/suites/flow/workflows/src/suite-context.ts
+++ b/e2e/suites/flow/workflows/src/suite-context.ts
@@ -14,6 +14,9 @@ export interface SuiteContext {
   connectionId: string;
   // Push workflow YAML must use this as `source`; dispatch matches webhook sources exactly.
   connectionSlug: string;
+  testVcsConnectionId: string;
+  testVcsAccountId: string;
+  testVcsConnectionSlug: string;
   modelProviderId: string;
   agentModel: string;
   fakeModelProviderRunId: string;

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -6,6 +6,7 @@ import {
   deleteModelProviderConfig,
 } from '@shipfox/e2e-setup-agent';
 import {createSession, createUser} from '@shipfox/e2e-setup-auth';
+import {createTestVcsConnection} from '@shipfox/e2e-setup-integrations';
 import {createWorkspace} from '@shipfox/e2e-setup-workspaces';
 import {resetSuiteRunDir, writeSuiteContext} from '#suite-context.js';
 
@@ -33,6 +34,13 @@ export default async function globalSetup(): Promise<void> {
       sessionToken: session.token,
     });
     cleanups.push(() => deleteOrg({org: org.org}).catch(() => undefined));
+    const testVcsAccountId = `test-vcs-${runId}`;
+    const testVcsConnection = await createTestVcsConnection({
+      workspaceId: workspace.id,
+      accountId: testVcsAccountId,
+      displayName: 'Test VCS Renewable Credentials E2E',
+      renewalMode: 'on-rejection',
+    });
 
     const fakeModelProvider = await startFakeOpenAiModelProvider({runId});
     cleanups.push(() => fakeModelProvider.stop().catch(() => undefined));
@@ -101,6 +109,9 @@ export default async function globalSetup(): Promise<void> {
       org: org.org,
       connectionId: org.connection.id,
       connectionSlug: org.connection.slug,
+      testVcsConnectionId: testVcsConnection.id,
+      testVcsAccountId,
+      testVcsConnectionSlug: testVcsConnection.slug,
       modelProviderId: modelProvider.provider_id,
       agentModel: modelProviderScript.model,
       fakeModelProviderRunId: runId,

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -41,6 +41,13 @@ export default async function globalSetup(): Promise<void> {
       displayName: 'Test VCS Renewable Credentials E2E',
       renewalMode: 'on-rejection',
     });
+    const testVcsClient = createApiClient({token: session.token});
+    cleanups.push(() =>
+      testVcsClient
+        .request('delete', `/integration-connections/${testVcsConnection.id}`)
+        .then(() => undefined)
+        .catch(() => undefined),
+    );
 
     const fakeModelProvider = await startFakeOpenAiModelProvider({runId});
     cleanups.push(() => fakeModelProvider.stop().catch(() => undefined));

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -1,0 +1,532 @@
+import {readFile} from 'node:fs/promises';
+import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
+import {createApiClient} from '@shipfox/e2e-core';
+import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import {waitForDefinition} from '@shipfox/e2e-observe-definitions';
+import {
+  createTestVcsConnection,
+  createTestVcsRepository,
+  failNextTestVcsMints,
+  getTestVcsStats,
+  type TestVcsStats,
+  testVcsExternalRepositoryId,
+} from '@shipfox/e2e-setup-integrations';
+import {attachLocalRunnerLog} from '#attachments.js';
+import {createProject} from '#create-project.js';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
+import type {SuiteContext} from '#suite-context.js';
+import {fireManualAndAwaitRun} from '#triggers.js';
+import {expect, test} from './fixtures.js';
+
+const RUNNER_TERMINAL_TIMEOUT_MS = 180_000;
+const TEST_TIMEOUT_MS = 300_000;
+const TEST_VCS_TOKEN_PATTERN = /test-vcs-[0-9a-f-]{20,}/u;
+
+const ON_REJECTION_WORKFLOW = `
+name: Renewable Git on rejection
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    checkout:
+      permissions:
+        contents: write
+      persist-credentials: true
+    steps:
+      - key: verify-primary-checkout
+        run: |
+          test -d .git
+          command -v git-credential-shipfox
+          test -n "$GIT_CONFIG_GLOBAL"
+          test -f "$GIT_CONFIG_GLOBAL"
+          git config --global --list --show-origin
+          git config --global --get-urlmatch credential.helper "$(git remote get-url origin)" || true
+      - key: secondary-checkout
+        checkout:
+          connection: __TEST_VCS_CONNECTION__
+          repository: __TEST_VCS_SECONDARY_REPOSITORY__
+          ref: main
+          path: secondary
+          permissions:
+            contents: read
+          persist-credentials: true
+      - key: use-renewed-credentials
+        run: |
+          sleep 4
+          if git ls-remote origin main; then
+            echo 'expected the expired primary credential to be rejected' >&2
+            exit 1
+          fi
+          git ls-remote origin main
+          if git -C secondary ls-remote origin main; then
+            echo 'expected the expired secondary credential to be rejected' >&2
+            exit 1
+          fi
+          git -C secondary ls-remote origin main
+          git config --local commit.gpgsign false
+          printf '\\nrenewed\\n' >> README.md
+          git add README.md
+          git commit -m "renewed credentials"
+          git push origin HEAD:main
+          test "$(git log -1 --format=%ae)" = "test-vcs@shipfox.test"
+`;
+
+const REFRESH_AT_WORKFLOW = `
+name: Renewable Git refresh at
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    checkout:
+      permissions:
+        contents: read
+      persist-credentials: true
+    steps:
+      - key: use-refreshed-credentials
+        run: |
+          sleep 2
+          git ls-remote origin main
+`;
+
+const NON_PERSISTED_WORKFLOW = `
+name: Renewable Git without persistence
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    checkout:
+      permissions:
+        contents: write
+      persist-credentials: false
+    steps:
+      - key: inspect-authorship-only-config
+        run: |
+          test -n "$GIT_CONFIG_GLOBAL"
+          test "$(git config --global user.name)" = "Shipfox Test VCS"
+          test "$(git config --global user.email)" = "test-vcs@shipfox.test"
+          remote_url="$(git remote get-url origin)"
+          test -z "$(git config --global --get-urlmatch credential.helper "$remote_url" || true)"
+          test -z "$(git config --global --get-urlmatch http.extraHeader "$remote_url" || true)"
+          sleep 4
+`;
+
+const CONCURRENT_WORKFLOW = `
+name: Concurrent renewable Git checkouts
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  first:
+    checkout:
+      permissions:
+        contents: read
+      persist-credentials: true
+    steps:
+      - key: first-checkout
+        run: |
+          sleep 1
+          git ls-remote origin main
+  second:
+    checkout:
+      permissions:
+        contents: read
+      persist-credentials: true
+    steps:
+      - key: second-checkout
+        run: |
+          sleep 1
+          git ls-remote origin main
+`;
+
+const PROVIDER_FAILURE_WORKFLOW = `
+name: Renewable Git provider failure
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    checkout:
+      permissions:
+        contents: read
+      persist-credentials: true
+    steps:
+      - key: should-not-run
+        run: exit 1
+`;
+
+test.describe.configure({mode: 'serial'});
+
+test('renews on Git rejection across a long step and multiple checkouts', async ({
+  suite,
+}, testInfo) => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+  const uniqueId = shortId();
+  const runnerLabel = `e2e-renewable-rejection-${uniqueId}`;
+  const repositoryName = `renewal-${uniqueId}`;
+  const secondaryRepositoryName = `renewal-secondary-${uniqueId}`;
+  const configPath = `.shipfox/workflows/${repositoryName}.yml`;
+  const before = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+
+  const secondary = await createTestVcsRepository({
+    connectionId: suite.testVcsConnectionId,
+    name: secondaryRepositoryName,
+    files: [{path: 'README.md', content: '# Secondary test VCS repository\n'}],
+  });
+  const workflow = await seedTestVcsWorkflow({
+    suite,
+    token: suite.sessionToken,
+    connectionId: suite.testVcsConnectionId,
+    connectionSlug: suite.testVcsConnectionSlug,
+    owner: suite.testVcsAccountId,
+    repositoryName,
+    runnerLabel,
+    configPath,
+    workflowYaml: ON_REJECTION_WORKFLOW,
+    secondaryRepositoryName,
+  });
+  expect(secondary.external_repository_id).toBe(
+    testVcsExternalRepositoryId(suite.testVcsAccountId, secondaryRepositoryName),
+  );
+
+  const {terminal, logFiles} = await runWorkflow({
+    suite,
+    testInfo,
+    definitionId: workflow.definition.id,
+    scenario: 'renewable-credentials-on-rejection',
+    runnerLabel,
+    renewableGit: true,
+  });
+  const after = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+
+  expect(terminal.status).toBe('succeeded');
+  expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('succeeded');
+  expect(after.mint_count - before.mint_count).toBe(4);
+  expect(after.generations.length - before.generations.length).toBe(4);
+  expect(rejectedCredentialRequestCount(before, after)).toBeGreaterThanOrEqual(2);
+  expect(after.accepted_request_count - before.accepted_request_count).toBeGreaterThan(0);
+  await assertNoCredentialLeak(after, logFiles);
+});
+
+test('refreshes before Git needs an expired credential', async ({suite}, testInfo) => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+  const uniqueId = shortId();
+  const accountId = `test-vcs-refresh-${uniqueId}`;
+  const connection = await createTestVcsConnection({
+    workspaceId: suite.workspaceId,
+    accountId,
+    displayName: `Test VCS refresh-at ${uniqueId}`,
+    renewalMode: 'refresh-at',
+  });
+  const runnerLabel = `e2e-renewable-refresh-${uniqueId}`;
+  const repositoryName = `refresh-${uniqueId}`;
+  const configPath = `.shipfox/workflows/${repositoryName}.yml`;
+  const before = await getTestVcsStats({connectionId: connection.id});
+  const workflow = await seedTestVcsWorkflow({
+    suite,
+    token: suite.sessionToken,
+    connectionId: connection.id,
+    connectionSlug: connection.slug,
+    owner: connection.external_account_id,
+    repositoryName,
+    runnerLabel,
+    configPath,
+    workflowYaml: REFRESH_AT_WORKFLOW,
+  });
+
+  const {terminal, logFiles} = await runWorkflow({
+    suite,
+    testInfo,
+    definitionId: workflow.definition.id,
+    scenario: 'renewable-credentials-refresh-at',
+    runnerLabel,
+    renewableGit: true,
+  });
+  const after = await getTestVcsStats({connectionId: connection.id});
+
+  expect(terminal.status).toBe('succeeded');
+  expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('succeeded');
+  expect(after.mint_count - before.mint_count).toBe(2);
+  expect(after.generations.length - before.generations.length).toBe(2);
+  expect(rejectedCredentialRequestCount(before, after)).toBe(0);
+  expect(after.accepted_request_count - before.accepted_request_count).toBeGreaterThan(0);
+  await assertNoCredentialLeak(after, logFiles);
+});
+
+test('keeps author identity without persisting credentials when disabled', async ({
+  suite,
+}, testInfo) => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+  const uniqueId = shortId();
+  const runnerLabel = `e2e-renewable-no-persistence-${uniqueId}`;
+  const repositoryName = `no-persistence-${uniqueId}`;
+  const configPath = `.shipfox/workflows/${repositoryName}.yml`;
+  const before = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+  const workflow = await seedTestVcsWorkflow({
+    suite,
+    token: suite.sessionToken,
+    connectionId: suite.testVcsConnectionId,
+    connectionSlug: suite.testVcsConnectionSlug,
+    owner: suite.testVcsAccountId,
+    repositoryName,
+    runnerLabel,
+    configPath,
+    workflowYaml: NON_PERSISTED_WORKFLOW,
+  });
+
+  const {terminal, logFiles} = await runWorkflow({
+    suite,
+    testInfo,
+    definitionId: workflow.definition.id,
+    scenario: 'renewable-credentials-no-persistence',
+    runnerLabel,
+    renewableGit: true,
+  });
+  const after = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+
+  expect(terminal.status).toBe('succeeded');
+  expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('succeeded');
+  expect(after.mint_count - before.mint_count).toBe(1);
+  expect(after.generations.length - before.generations.length).toBe(1);
+  expect(after.rejected_request_count - before.rejected_request_count).toBe(0);
+  await assertNoCredentialLeak(after, logFiles);
+});
+
+test('shares one provider mint across concurrent jobs with the same scope', async ({
+  suite,
+}, testInfo) => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+  const uniqueId = shortId();
+  const runnerLabel = `e2e-renewable-concurrent-${uniqueId}`;
+  const repositoryName = `concurrent-${uniqueId}`;
+  const configPath = `.shipfox/workflows/${repositoryName}.yml`;
+  const before = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+  const workflow = await seedTestVcsWorkflow({
+    suite,
+    token: suite.sessionToken,
+    connectionId: suite.testVcsConnectionId,
+    connectionSlug: suite.testVcsConnectionSlug,
+    owner: suite.testVcsAccountId,
+    repositoryName,
+    runnerLabel,
+    configPath,
+    workflowYaml: CONCURRENT_WORKFLOW,
+  });
+
+  const {terminal, logFiles} = await runWorkflow({
+    suite,
+    testInfo,
+    definitionId: workflow.definition.id,
+    scenario: 'renewable-credentials-concurrent',
+    runnerLabel,
+    runnerCount: 2,
+    renewableGit: true,
+  });
+  const after = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+
+  expect(terminal.status).toBe('succeeded');
+  expect(terminal.jobs.find((job) => job.key === 'first')?.status).toBe('succeeded');
+  expect(terminal.jobs.find((job) => job.key === 'second')?.status).toBe('succeeded');
+  expect(after.mint_count - before.mint_count).toBe(1);
+  expect(after.generations.length - before.generations.length).toBe(1);
+  expect(rejectedCredentialRequestCount(before, after)).toBe(0);
+  expect(after.accepted_request_count - before.accepted_request_count).toBeGreaterThan(0);
+  await assertNoCredentialLeak(after, logFiles);
+});
+
+test('fails the workflow promptly when the provider cannot mint credentials', async ({
+  suite,
+}, testInfo) => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+  const uniqueId = shortId();
+  const runnerLabel = `e2e-renewable-provider-failure-${uniqueId}`;
+  const repositoryName = `provider-failure-${uniqueId}`;
+  const configPath = `.shipfox/workflows/${repositoryName}.yml`;
+  const before = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+  const workflow = await seedTestVcsWorkflow({
+    suite,
+    token: suite.sessionToken,
+    connectionId: suite.testVcsConnectionId,
+    connectionSlug: suite.testVcsConnectionSlug,
+    owner: suite.testVcsAccountId,
+    repositoryName,
+    runnerLabel,
+    configPath,
+    workflowYaml: PROVIDER_FAILURE_WORKFLOW,
+  });
+  // The lease client retries transient 503 responses twice before surfacing the failure.
+  await failNextTestVcsMints(3);
+
+  const {terminal, logFiles} = await runWorkflow({
+    suite,
+    testInfo,
+    definitionId: workflow.definition.id,
+    scenario: 'renewable-credentials-provider-failure',
+    runnerLabel,
+    renewableGit: true,
+  });
+  const after = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+
+  expect(terminal.status).toBe('failed');
+  expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('failed');
+  expect(after.mint_count - before.mint_count).toBe(0);
+  expect(after.generations.length - before.generations.length).toBe(0);
+  expect(after.rejected_request_count - before.rejected_request_count).toBe(0);
+  await assertNoCredentialLeak(after, logFiles);
+});
+
+async function seedTestVcsWorkflow(params: {
+  suite: SuiteContext;
+  token: string;
+  connectionId: string;
+  connectionSlug: string;
+  owner: string;
+  repositoryName: string;
+  runnerLabel: string;
+  configPath: string;
+  workflowYaml: string;
+  secondaryRepositoryName?: string | undefined;
+}): Promise<{definition: Awaited<ReturnType<typeof waitForDefinition>>}> {
+  const renderedWorkflowYaml = renderTestVcsWorkflow(params);
+  const repository = await createTestVcsRepository({
+    connectionId: params.connectionId,
+    name: params.repositoryName,
+    files: [
+      {path: params.configPath, content: renderedWorkflowYaml},
+      {path: 'README.md', content: '# Renewable credentials test VCS repository\n'},
+    ],
+  });
+  const project = await createProject({
+    workspaceId: params.suite.workspaceId,
+    sessionToken: params.token,
+    name: `Test VCS ${params.repositoryName}`,
+    connectionId: params.connectionId,
+    externalRepositoryId: repository.external_repository_id,
+  });
+  const definition = await waitForDefinition({
+    projectId: project.id,
+    configPath: params.configPath,
+    token: params.token,
+  });
+  return {definition};
+}
+
+function renderTestVcsWorkflow(params: {
+  connectionSlug: string;
+  owner: string;
+  repositoryName: string;
+  runnerLabel: string;
+  secondaryRepositoryName?: string | undefined;
+  workflowYaml: string;
+}): string {
+  let rendered = params.workflowYaml
+    .replaceAll('__RUNNER_LABEL__', params.runnerLabel)
+    .replaceAll('__TEST_VCS_CONNECTION__', params.connectionSlug)
+    .replaceAll('__TEST_VCS_REPOSITORY__', `${params.owner}/${params.repositoryName}`);
+  if (params.secondaryRepositoryName !== undefined) {
+    rendered = rendered.replaceAll(
+      '__TEST_VCS_SECONDARY_REPOSITORY__',
+      `${params.owner}/${params.secondaryRepositoryName}`,
+    );
+  }
+  return rendered;
+}
+
+async function runWorkflow(params: {
+  suite: SuiteContext;
+  testInfo: {
+    attach(name: string, options: {body: Buffer | string; contentType: string}): Promise<void>;
+  };
+  definitionId: string;
+  scenario: string;
+  runnerLabel: string;
+  runnerCount?: number | undefined;
+  renewableGit: boolean;
+}): Promise<{terminal: WorkflowRunDetailResponseDto; logFiles: string[]}> {
+  const token = params.suite.sessionToken;
+  const client = createApiClient({token});
+  const localRunners: Array<Awaited<ReturnType<typeof startSuiteLocalRunner>>> = [];
+
+  try {
+    for (let index = 0; index < (params.runnerCount ?? 1); index += 1) {
+      localRunners.push(
+        await startSuiteLocalRunner({
+          workspaceId: params.suite.workspaceId,
+          userToken: token,
+          name: `E2E ${params.scenario} ${params.runnerCount === undefined ? '' : index + 1}`,
+          runnerLabel: params.runnerLabel,
+          runnerInstanceId:
+            params.runnerCount === undefined || params.runnerCount === 1
+              ? undefined
+              : String(index + 1),
+          extraEnv: {
+            GIT_SSL_NO_VERIFY: 'true',
+            SHIPFOX_POLL_MAX_DURATION_MS: String(RUNNER_TERMINAL_TIMEOUT_MS),
+          },
+          renewableGit: params.renewableGit,
+        }),
+      );
+    }
+
+    const runId = await fireManualAndAwaitRun({
+      client,
+      definitionId: params.definitionId,
+      inputs: {},
+      scenario: params.scenario,
+    });
+    const firstRunner = localRunners[0];
+    if (firstRunner === undefined) {
+      throw new Error('No local runner started');
+    }
+    const terminal = await waitForRunTerminalOrFailedRunner({
+      runId,
+      token,
+      timeoutMs: RUNNER_TERMINAL_TIMEOUT_MS,
+      runner: firstRunner.runner,
+    });
+    return {terminal, logFiles: localRunners.map((localRunner) => localRunner.logFile)};
+  } finally {
+    for (const localRunner of localRunners) {
+      await attachLocalRunnerLog(
+        (attachment) =>
+          params.testInfo.attach(attachment.name, {
+            body: attachment.body,
+            contentType: attachment.contentType,
+          }),
+        localRunner.logFile,
+      );
+      await stopLocalRunner(localRunner.runner).catch((error: unknown) => {
+        process.stderr.write(`${params.scenario}-e2e: stopLocalRunner failed: ${String(error)}\n`);
+      });
+    }
+  }
+}
+
+async function assertNoCredentialLeak(stats: TestVcsStats, logFiles: string[]): Promise<void> {
+  const logs = await Promise.all(logFiles.map((logFile) => readFile(logFile, 'utf8')));
+  expect(JSON.stringify(stats.requests)).not.toMatch(TEST_VCS_TOKEN_PATTERN);
+  expect(logs.join('\n')).not.toMatch(TEST_VCS_TOKEN_PATTERN);
+  expect(stats.requests.every((request) => !request.path.includes('Authorization:'))).toBe(true);
+}
+
+function shortId(): string {
+  return crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+}
+
+function rejectedCredentialRequestCount(before: TestVcsStats, after: TestVcsStats): number {
+  return after.requests.slice(before.request_count).filter((request) => {
+    return request.status === 'rejected' && request.generation !== undefined;
+  }).length;
+}

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -133,6 +133,7 @@ triggers:
     event: fire
 jobs:
   first:
+    runner: __FIRST_RUNNER_LABEL__
     checkout:
       permissions:
         contents: read
@@ -143,6 +144,7 @@ jobs:
           sleep 1
           git ls-remote origin main
   second:
+    runner: __SECOND_RUNNER_LABEL__
     checkout:
       permissions:
         contents: read
@@ -315,6 +317,7 @@ test('shares one provider mint across concurrent jobs with the same scope', asyn
   test.setTimeout(TEST_TIMEOUT_MS);
   const uniqueId = shortId();
   const runnerLabel = `e2e-renewable-concurrent-${uniqueId}`;
+  const runnerLabels = [`${runnerLabel}-first`, `${runnerLabel}-second`] as const;
   const repositoryName = `concurrent-${uniqueId}`;
   const configPath = `.shipfox/workflows/${repositoryName}.yml`;
   const before = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
@@ -326,6 +329,7 @@ test('shares one provider mint across concurrent jobs with the same scope', asyn
     owner: suite.testVcsAccountId,
     repositoryName,
     runnerLabel,
+    runnerLabels,
     configPath,
     workflowYaml: CONCURRENT_WORKFLOW,
   });
@@ -337,6 +341,7 @@ test('shares one provider mint across concurrent jobs with the same scope', asyn
     scenario: 'renewable-credentials-concurrent',
     runnerLabel,
     runnerCount: 2,
+    runnerLabels,
     renewableGit: true,
   });
   const after = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
@@ -400,6 +405,7 @@ async function seedTestVcsWorkflow(params: {
   owner: string;
   repositoryName: string;
   runnerLabel: string;
+  runnerLabels?: readonly [string, string] | undefined;
   configPath: string;
   workflowYaml: string;
   secondaryRepositoryName?: string | undefined;
@@ -433,11 +439,14 @@ function renderTestVcsWorkflow(params: {
   owner: string;
   repositoryName: string;
   runnerLabel: string;
+  runnerLabels?: readonly [string, string] | undefined;
   secondaryRepositoryName?: string | undefined;
   workflowYaml: string;
 }): string {
   let rendered = params.workflowYaml
     .replaceAll('__RUNNER_LABEL__', params.runnerLabel)
+    .replaceAll('__FIRST_RUNNER_LABEL__', params.runnerLabels?.[0] ?? params.runnerLabel)
+    .replaceAll('__SECOND_RUNNER_LABEL__', params.runnerLabels?.[1] ?? params.runnerLabel)
     .replaceAll('__TEST_VCS_CONNECTION__', params.connectionSlug)
     .replaceAll('__TEST_VCS_REPOSITORY__', `${params.owner}/${params.repositoryName}`);
   if (params.secondaryRepositoryName !== undefined) {
@@ -458,24 +467,27 @@ async function runWorkflow(params: {
   scenario: string;
   runnerLabel: string;
   runnerCount?: number | undefined;
+  runnerLabels?: readonly string[] | undefined;
   renewableGit: boolean;
 }): Promise<{terminal: WorkflowRunDetailResponseDto; logFiles: string[]}> {
   const token = params.suite.sessionToken;
   const client = createApiClient({token});
   const localRunners: Array<Awaited<ReturnType<typeof startSuiteLocalRunner>>> = [];
+  const runnerCount = params.runnerCount ?? 1;
+  if (params.runnerLabels !== undefined && params.runnerLabels.length !== runnerCount) {
+    throw new Error(`Expected ${runnerCount} runner labels, got ${params.runnerLabels.length}`);
+  }
 
   try {
-    for (let index = 0; index < (params.runnerCount ?? 1); index += 1) {
+    for (let index = 0; index < runnerCount; index += 1) {
+      const runnerLabel = params.runnerLabels?.[index] ?? params.runnerLabel;
       localRunners.push(
         await startSuiteLocalRunner({
           workspaceId: params.suite.workspaceId,
           userToken: token,
           name: `E2E ${params.scenario} ${params.runnerCount === undefined ? '' : index + 1}`,
-          runnerLabel: params.runnerLabel,
-          runnerInstanceId:
-            params.runnerCount === undefined || params.runnerCount === 1
-              ? undefined
-              : String(index + 1),
+          runnerLabel,
+          runnerInstanceId: runnerCount === 1 ? undefined : String(index + 1),
           extraEnv: {
             GIT_SSL_NO_VERIFY: 'true',
             SHIPFOX_POLL_MAX_DURATION_MS: String(RUNNER_TERMINAL_TIMEOUT_MS),

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -70,6 +70,11 @@ jobs:
           printf '\\nrenewed\\n' >> README.md
           git add README.md
           git commit -m "renewed credentials"
+          sleep 4
+          if git push origin HEAD:main; then
+            echo 'expected the expired primary credential to be rejected' >&2
+            exit 1
+          fi
           git push origin HEAD:main
           test "$(git log -1 --format=%ae)" = "test-vcs@shipfox.test"
 `;
@@ -213,9 +218,9 @@ test('renews on Git rejection across a long step and multiple checkouts', async 
 
   expect(terminal.status).toBe('succeeded');
   expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('succeeded');
-  expect(after.mint_count - before.mint_count).toBe(4);
-  expect(after.generations.length - before.generations.length).toBe(4);
-  expect(rejectedCredentialRequestCount(before, after)).toBeGreaterThanOrEqual(2);
+  expect(after.mint_count - before.mint_count).toBe(5);
+  expect(after.generations.length - before.generations.length).toBe(5);
+  expect(rejectedCredentialRequestCount(before, after)).toBeGreaterThanOrEqual(3);
   expect(after.accepted_request_count - before.accepted_request_count).toBeGreaterThan(0);
   await assertNoCredentialLeak(after, logFiles);
 });

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -1,4 +1,4 @@
-import {bool, createConfig} from '@shipfox/config';
+import {bool, createConfig, num, port} from '@shipfox/config';
 
 export const config = createConfig({
   INTEGRATIONS_ENABLE_CRON_PROVIDER: bool({
@@ -32,6 +32,18 @@ export const config = createConfig({
   INTEGRATIONS_ENABLE_SLACK_PROVIDER: bool({
     desc: 'Enables the Slack integration provider so users can connect Slack workspaces.',
     default: false,
+  }),
+  INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER: bool({
+    desc: 'Enables the private test source-control provider and its local smart-HTTP fixture. Keep this disabled outside E2E runs.',
+    default: false,
+  }),
+  INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS: num({
+    desc: 'Lifetime of credentials minted by the private E2E source-control provider, in seconds.',
+    default: 3,
+  }),
+  INTEGRATIONS_TEST_VCS_PORT: port({
+    desc: 'Loopback port used by the private E2E source-control smart-HTTP fixture.',
+    default: 16113,
   }),
   INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER: bool({
     desc: 'Enables the generic webhook integration provider so users can create inbound webhook URLs. It is enabled by default because it does not require provider setup.',

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -65,6 +65,33 @@ describe('createIntegrationsContext', () => {
     expect(context.module.services).toBeUndefined();
   });
 
+  it('registers provider-owned services without a delivery source', async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const service: ModuleService = {
+      name: 'test-vcs-fixture',
+      shutdownTimeoutMs: 1_000,
+      start: vi.fn().mockResolvedValue({finished: Promise.resolve(), stop}),
+    };
+
+    const context = await createIntegrationsContext({
+      parts: [
+        {
+          provider: {provider: 'test-vcs', displayName: 'Test VCS', adapters: {}},
+          services: [service],
+        },
+      ],
+    });
+
+    expect(context.module.services).toEqual([service]);
+    const services = await startModuleServices({
+      services: context.module.services ?? [],
+      context: {outboxRegistry: createOutboxRegistry()},
+    });
+    await services.stop();
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it('rejects a queued request with no registered processor', async () => {
     const context = await createIntegrationsContext({
       parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -351,6 +351,11 @@ export async function createIntegrationsContext(
     }
   }
 
+  const services = parts.flatMap((part) => part.services ?? []);
+  if (options.webhookDeliverySource !== undefined) {
+    services.push(options.webhookDeliverySource.createService(webhookProcessor));
+  }
+
   const module: ShipfoxModule = {
     name: 'integrations',
     interModulePresentations: [
@@ -394,9 +399,7 @@ export async function createIntegrationsContext(
       },
       ...parts.flatMap((part) => part.workers ?? []),
     ],
-    ...(options.webhookDeliverySource
-      ? {services: [options.webhookDeliverySource.createService(webhookProcessor)]}
-      : {}),
+    ...(services.length === 0 ? {} : {services}),
   };
 
   return {

--- a/libs/api/integration/core/src/providers/modules.test.ts
+++ b/libs/api/integration/core/src/providers/modules.test.ts
@@ -72,6 +72,19 @@ describe('loadEnabledProviderModules', () => {
     expect(parts[0]?.provider).toMatchObject({provider: 'jira', displayName: 'Jira'});
   });
 
+  it('loads the private Test VCS provider and its fixture service only when enabled', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER', 'true');
+    vi.resetModules();
+
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules();
+    const testVcsPart = parts.find((part) => part.provider.provider === 'test-vcs');
+
+    expect(parts.map((part) => part.provider.provider)).toEqual(['test-vcs', 'cron', 'webhook']);
+    expect(testVcsPart?.provider.adapters?.source_control).toBeDefined();
+    expect(testVcsPart?.services).toHaveLength(1);
+  });
+
   it('publishes registry-derived capabilities for a GitHub connect flow', async () => {
     vi.stubEnv('INTEGRATIONS_ENABLE_GITHUB_PROVIDER', 'true');
     vi.resetModules();

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -5,6 +5,7 @@ import {jiraProviderModule} from '#providers/jira.js';
 import {linearProviderModule} from '#providers/linear.js';
 import {sentryProviderModule} from '#providers/sentry.js';
 import {slackProviderModule} from '#providers/slack.js';
+import {testVcsProviderModule} from '#providers/test-vcs-module.js';
 import type {
   IntegrationModuleParts,
   IntegrationProviderModuleLoadOptions,
@@ -20,6 +21,7 @@ const providerModules = [
   jiraProviderModule,
   sentryProviderModule,
   giteaProviderModule,
+  testVcsProviderModule,
   cronProviderModule,
   webhookProviderModule,
 ];

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
@@ -1,0 +1,101 @@
+import {execFile} from 'node:child_process';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {promisify} from 'node:util';
+import type {CheckoutCredentials} from '@shipfox/api-integration-spi';
+import {createTestVcsFixture} from '#providers/test-vcs-fixture.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(
+  args: string[],
+  cwd: string,
+  repositoryUrl: string,
+  credentials: CheckoutCredentials,
+): Promise<string> {
+  const authorization = Buffer.from(`${credentials.username}:${credentials.token}`).toString(
+    'base64',
+  );
+  const result = await execFileAsync('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: `http.${repositoryUrl}.extraHeader`,
+      GIT_CONFIG_VALUE_0: `Authorization: Basic ${authorization}`,
+      GIT_CONFIG_KEY_1: 'http.sslVerify',
+      GIT_CONFIG_VALUE_1: 'false',
+      GIT_TERMINAL_PROMPT: '0',
+    },
+  });
+  return result.stdout;
+}
+
+function credentials(
+  fixture: ReturnType<typeof createTestVcsFixture>,
+  repository: {owner: string; name: string},
+  generation = 'generation-a',
+): CheckoutCredentials {
+  return fixture.issueCredential({
+    ...repository,
+    permissions: {contents: 'write'},
+    renewalMode: 'on-rejection',
+    ttlSeconds: 1,
+    rejectedGeneration: generation === 'generation-a' ? undefined : 'generation-a',
+  });
+}
+
+describe('Test VCS smart HTTP fixture', () => {
+  it('requires a credential and accepts a fresh credential after expiry', async () => {
+    const fixture = createTestVcsFixture({port: 0, credentialTtlSeconds: 1});
+    const workingDirectory = await mkdtemp(join(tmpdir(), 'shipfox-test-vcs-git-'));
+    try {
+      await fixture.start();
+      const repository = await fixture.createRepository({
+        owner: 'e2e-owner',
+        name: 'repository',
+        files: [{path: 'README.md', content: '# Test VCS\n'}],
+      });
+      const first = credentials(fixture, {owner: 'e2e-owner', name: 'repository'});
+
+      await expect(
+        git(
+          ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
+          workingDirectory,
+          repository.cloneUrl,
+          first,
+        ),
+      ).resolves.toContain('refs/heads/main');
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      await expect(
+        git(
+          ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
+          workingDirectory,
+          repository.cloneUrl,
+          first,
+        ),
+      ).rejects.toThrow();
+
+      const second = credentials(fixture, {owner: 'e2e-owner', name: 'repository'}, 'generation-b');
+      await expect(
+        git(
+          ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
+          workingDirectory,
+          repository.cloneUrl,
+          second,
+        ),
+      ).resolves.toContain('refs/heads/main');
+
+      const stats = fixture.stats('e2e-owner');
+      expect(stats.rejectedRequestCount).toBeGreaterThan(0);
+      expect(stats.acceptedRequestCount).toBeGreaterThan(0);
+      expect(stats.generations).toContain(first.generation);
+      expect(stats.generations).toContain(second.generation);
+      expect(stats.requests.every((request) => !request.path.includes(first.token))).toBe(true);
+    } finally {
+      await fixture.close();
+      await rm(workingDirectory, {recursive: true, force: true});
+    }
+  });
+});

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
@@ -48,7 +48,7 @@ function credentials(
 
 describe('Test VCS smart HTTP fixture', () => {
   it('requires a credential and accepts a fresh credential after expiry', async () => {
-    const fixture = createTestVcsFixture({port: 0, credentialTtlSeconds: 1});
+    const fixture = createTestVcsFixture({port: 0});
     const workingDirectory = await mkdtemp(join(tmpdir(), 'shipfox-test-vcs-git-'));
     try {
       await fixture.start();
@@ -96,6 +96,25 @@ describe('Test VCS smart HTTP fixture', () => {
     } finally {
       await fixture.close();
       await rm(workingDirectory, {recursive: true, force: true});
+    }
+  });
+
+  it('rejects Git-invalid default branch names before creating a repository', async () => {
+    const fixture = createTestVcsFixture({port: 0});
+    try {
+      await fixture.start();
+
+      await expect(
+        fixture.createRepository({
+          owner: 'e2e-owner',
+          name: 'invalid-branch',
+          defaultBranch: 'feature.lock',
+          files: [{path: 'README.md', content: '# Test VCS\n'}],
+        }),
+      ).rejects.toThrow('Invalid test VCS branch name');
+      expect(fixture.getRepository('e2e-owner', 'invalid-branch')).toBeUndefined();
+    } finally {
+      await fixture.close();
     }
   });
 });

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
@@ -4,7 +4,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {promisify} from 'node:util';
 import type {CheckoutCredentials} from '@shipfox/api-integration-spi';
-import {createTestVcsFixture} from '#providers/test-vcs-fixture.js';
+import {createTestVcsFixture, isValidTestVcsBranchName} from '#providers/test-vcs-fixture.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -47,6 +47,11 @@ function credentials(
 }
 
 describe('Test VCS smart HTTP fixture', () => {
+  it('uses Git-compatible branch validation for the API schema', () => {
+    expect(isValidTestVcsBranchName('feature]')).toBe(true);
+    expect(isValidTestVcsBranchName('feature[')).toBe(false);
+  });
+
   it('requires a credential and accepts a fresh credential after expiry', async () => {
     const fixture = createTestVcsFixture({port: 0});
     const workingDirectory = await mkdtemp(join(tmpdir(), 'shipfox-test-vcs-git-'));

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.ts
@@ -18,6 +18,7 @@ import type {
   RepositorySnapshot,
   ResolvedRef,
 } from '@shipfox/api-integration-spi';
+import {isValidGitRefName, MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-spi';
 import type {ModuleService} from '@shipfox/node-module';
 
 const execFileAsync = promisify(execFile);
@@ -25,6 +26,7 @@ const TEST_VCS_USERNAME = 'x-access-token';
 const TEST_VCS_REALM = 'shipfox-test-vcs';
 const GIT_BACKEND_TIMEOUT_MS = 60_000;
 const MAX_GIT_OUTPUT_BYTES = 8 * 1024 * 1024;
+const MAX_TEST_VCS_FILE_BYTES = MAX_REPOSITORY_FILE_BYTES * 2;
 const REPOSITORY_PART_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
 const GIT_TREE_FIELD_PATTERN = /\s+/u;
 const GIT_REPOSITORY_PATH_PATTERN = /^\/([^/]+)\/([^/]+)\.git(?:\/|$)/u;
@@ -118,10 +120,7 @@ interface GitHttpRequest {
   owner?: string | undefined;
 }
 
-export function createTestVcsFixture(options: {
-  port: number;
-  credentialTtlSeconds: number;
-}): TestVcsFixture {
+export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
   const repositories = new Map<string, RepositoryRecord>();
   const credentials = new Map<string, CredentialRecord>();
   const requests: GitHttpRequest[] = [];
@@ -179,11 +178,11 @@ export function createTestVcsFixture(options: {
       assertRepositoryPart(input.owner, 'owner');
       assertRepositoryPart(input.name, 'repository');
       const defaultBranch = input.defaultBranch ?? 'main';
-      assertBranchName(defaultBranch);
+      const root = requireRoot();
+      await assertBranchName(defaultBranch, root);
       if (input.files.length === 0) throw new Error('Test VCS repositories need at least one file');
       const key = repositoryKey(input.owner, input.name);
       if (repositories.has(key)) throw new Error(`Test VCS repository already exists: ${key}`);
-      const root = requireRoot();
       const barePath = join(root, input.owner, `${input.name}.git`);
       const seedPath = join(root, 'seeds', input.owner, input.name);
       await mkdir(dirname(barePath), {recursive: true});
@@ -264,7 +263,7 @@ export function createTestVcsFixture(options: {
       const repository = requireRepository(input.owner, input.name);
       assertRelativePath(input.path);
       const content = await git(['show', `${input.ref}:${input.path}`], repository.seedPath);
-      if (Buffer.byteLength(content, 'utf8') > 1_000_000) {
+      if (Buffer.byteLength(content, 'utf8') > MAX_TEST_VCS_FILE_BYTES) {
         throw new Error('Test VCS file is too large');
       }
       return {path: input.path, ref: input.ref, content};
@@ -522,8 +521,14 @@ function assertRepositoryPart(value: string, label: string): void {
   if (!REPOSITORY_PART_PATTERN.test(value)) throw new Error(`Invalid test VCS ${label}`);
 }
 
-function assertBranchName(value: string): void {
-  if (!value || value.startsWith('-') || value.includes('..') || value.includes(' ')) {
+export function isValidTestVcsBranchName(value: string): boolean {
+  return !value.startsWith('-') && isValidGitRefName(`refs/heads/${value}`);
+}
+
+async function assertBranchName(value: string, cwd: string): Promise<void> {
+  try {
+    await git(['check-ref-format', '--branch', value], cwd);
+  } catch {
     throw new Error('Invalid test VCS branch name');
   }
 }
@@ -592,12 +597,18 @@ async function proxyToGitHttpBackend(
   childExitPromises.set(child, exitPromise);
   child.stdin.on('error', () => request.unpipe(child.stdin));
   request.pipe(child.stdin);
-  const [body, errorOutput, exitCode] = await Promise.all([output, error, exitPromise]).finally(
-    () => {
-      children.delete(child);
-      childExitPromises.delete(child);
-    },
-  );
+  let body: Buffer;
+  let errorOutput: Buffer;
+  let exitCode: number;
+  try {
+    [body, errorOutput, exitCode] = await Promise.all([output, error, exitPromise]);
+  } catch (error) {
+    await terminateChild(child);
+    throw error;
+  } finally {
+    children.delete(child);
+    childExitPromises.delete(child);
+  }
   if (exitCode !== 0) throw new Error(`git-http-backend failed (${errorOutput.byteLength} bytes)`);
   const separator = body.indexOf(Buffer.from('\r\n\r\n'));
   if (separator < 0) throw new Error('git-http-backend returned malformed CGI headers');
@@ -620,17 +631,38 @@ function collect(stream: NodeJS.ReadableStream): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let size = 0;
+    let settled = false;
     stream.on('data', (chunk: Buffer) => {
+      if (settled) return;
       size += chunk.byteLength;
       if (size > MAX_GIT_OUTPUT_BYTES) {
+        settled = true;
         reject(new Error('git-http-backend output exceeded the fixture limit'));
         return;
       }
       chunks.push(Buffer.from(chunk));
     });
-    stream.once('error', reject);
-    stream.once('end', () => resolve(Buffer.concat(chunks)));
+    stream.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+    stream.once('end', () => {
+      if (settled) return;
+      settled = true;
+      resolve(Buffer.concat(chunks));
+    });
   });
+}
+
+async function terminateChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => {
+    child.once('close', () => resolve());
+    child.once('error', () => resolve());
+  });
+  child.kill();
+  await exited;
 }
 
 function waitForExit(child: ChildProcess, timeoutMs: number): Promise<number> {

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.ts
@@ -1,0 +1,677 @@
+import {type ChildProcess, execFile, spawn} from 'node:child_process';
+import {randomUUID} from 'node:crypto';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import {createServer as createHttpsServer, type Server} from 'node:https';
+import type {AddressInfo} from 'node:net';
+import {tmpdir} from 'node:os';
+import {basename, dirname, join} from 'node:path';
+import {promisify} from 'node:util';
+import type {
+  CheckoutCredentialRenewal,
+  CheckoutCredentials,
+  CheckoutPermissions,
+  FileEntry,
+  FilePage,
+  FileSnapshot,
+  RepositoryPage,
+  RepositorySnapshot,
+  ResolvedRef,
+} from '@shipfox/api-integration-spi';
+import type {ModuleService} from '@shipfox/node-module';
+
+const execFileAsync = promisify(execFile);
+const TEST_VCS_USERNAME = 'x-access-token';
+const TEST_VCS_REALM = 'shipfox-test-vcs';
+const GIT_BACKEND_TIMEOUT_MS = 60_000;
+const MAX_GIT_OUTPUT_BYTES = 8 * 1024 * 1024;
+const REPOSITORY_PART_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
+const GIT_TREE_FIELD_PATTERN = /\s+/u;
+const GIT_REPOSITORY_PATH_PATTERN = /^\/([^/]+)\/([^/]+)\.git(?:\/|$)/u;
+
+export type TestVcsRenewalMode = 'refresh-at' | 'on-rejection';
+
+export interface TestVcsFileInput {
+  path: string;
+  content: string;
+}
+
+export interface TestVcsCreateRepositoryInput {
+  owner: string;
+  name: string;
+  defaultBranch?: string | undefined;
+  files: readonly TestVcsFileInput[];
+}
+
+export interface TestVcsCommitFilesInput {
+  owner: string;
+  name: string;
+  message: string;
+  files: readonly TestVcsFileInput[];
+}
+
+export interface TestVcsCredentialInput {
+  owner: string;
+  name: string;
+  permissions: CheckoutPermissions;
+  renewalMode: TestVcsRenewalMode;
+  ttlSeconds: number;
+  rejectedGeneration?: string | undefined;
+}
+
+export interface TestVcsStats {
+  mintCount: number;
+  requestCount: number;
+  acceptedRequestCount: number;
+  rejectedRequestCount: number;
+  generations: string[];
+  requests: Array<{
+    method: string;
+    path: string;
+    status: 'accepted' | 'rejected';
+    generation?: string | undefined;
+  }>;
+}
+
+export interface TestVcsFixture {
+  start(): Promise<void>;
+  close(): Promise<void>;
+  createRepository(input: TestVcsCreateRepositoryInput): Promise<RepositorySnapshot>;
+  commitFiles(input: TestVcsCommitFilesInput): Promise<string>;
+  getRepository(owner: string, name: string): RepositorySnapshot | undefined;
+  listRepositories(owner: string): RepositoryPage;
+  listFiles(input: {
+    owner: string;
+    name: string;
+    ref: string;
+    prefix: string;
+    limit: number;
+    cursor?: string | undefined;
+  }): Promise<FilePage>;
+  fetchFile(input: {owner: string; name: string; ref: string; path: string}): Promise<FileSnapshot>;
+  resolveRef(input: {owner: string; name: string; ref: string}): Promise<ResolvedRef>;
+  issueCredential(input: TestVcsCredentialInput): CheckoutCredentials;
+  stats(owner?: string): TestVcsStats;
+}
+
+interface RepositoryRecord {
+  snapshot: RepositorySnapshot;
+  barePath: string;
+  seedPath: string;
+}
+
+interface CredentialRecord {
+  owner: string;
+  name: string;
+  username: string;
+  generation: string;
+  token: string;
+  permissions: CheckoutPermissions;
+  expiresAt: number;
+}
+
+interface GitHttpRequest {
+  method: string;
+  path: string;
+  status: 'accepted' | 'rejected';
+  generation?: string | undefined;
+  owner?: string | undefined;
+}
+
+export function createTestVcsFixture(options: {
+  port: number;
+  credentialTtlSeconds: number;
+}): TestVcsFixture {
+  const repositories = new Map<string, RepositoryRecord>();
+  const credentials = new Map<string, CredentialRecord>();
+  const requests: GitHttpRequest[] = [];
+  const children = new Set<ChildProcess>();
+  const childExitPromises = new Map<ChildProcess, Promise<number>>();
+  let rootPath: string | undefined;
+  let server: Server | undefined;
+
+  const fixture: TestVcsFixture = {
+    async start() {
+      if (server !== undefined) return;
+
+      const root = await mkdtemp(join(tmpdir(), 'shipfox-test-vcs-'));
+      const keyPath = join(root, 'key.pem');
+      const certificatePath = join(root, 'certificate.pem');
+      try {
+        await createCertificate(keyPath, certificatePath);
+        const nextServer = createHttpsServer(
+          {
+            key: await readFile(keyPath),
+            cert: await readFile(certificatePath),
+          },
+          (request, response) => {
+            void handleGitRequest(request, response).catch(() => {
+              if (!response.headersSent) response.writeHead(500);
+              response.end();
+            });
+          },
+        );
+        await listen(nextServer, options.port);
+        rootPath = root;
+        server = nextServer;
+      } catch (error) {
+        await rm(root, {recursive: true, force: true});
+        throw error;
+      }
+    },
+
+    async close() {
+      const currentServer = server;
+      server = undefined;
+      currentServer?.closeAllConnections();
+      for (const child of children) child.kill();
+      await Promise.allSettled(childExitPromises.values());
+      if (currentServer !== undefined) await closeServer(currentServer);
+      const currentRoot = rootPath;
+      rootPath = undefined;
+      if (currentRoot !== undefined) await rm(currentRoot, {recursive: true, force: true});
+      repositories.clear();
+      credentials.clear();
+      requests.length = 0;
+    },
+
+    async createRepository(input) {
+      assertRepositoryPart(input.owner, 'owner');
+      assertRepositoryPart(input.name, 'repository');
+      const defaultBranch = input.defaultBranch ?? 'main';
+      assertBranchName(defaultBranch);
+      if (input.files.length === 0) throw new Error('Test VCS repositories need at least one file');
+      const key = repositoryKey(input.owner, input.name);
+      if (repositories.has(key)) throw new Error(`Test VCS repository already exists: ${key}`);
+      const root = requireRoot();
+      const barePath = join(root, input.owner, `${input.name}.git`);
+      const seedPath = join(root, 'seeds', input.owner, input.name);
+      await mkdir(dirname(barePath), {recursive: true});
+      await mkdir(seedPath, {recursive: true});
+      await git(['init', '--bare', barePath], root);
+      await git(['symbolic-ref', 'HEAD', `refs/heads/${defaultBranch}`], barePath);
+      await git(['config', 'http.receivepack', 'true'], barePath);
+      await git(['config', 'http.uploadpack', 'true'], barePath);
+      await git(['init', '-b', defaultBranch, seedPath], seedPath);
+      await configureSeedRepository(seedPath);
+      await writeFiles(seedPath, input.files);
+      await git(['add', '--all'], seedPath);
+      await git(['commit', '-m', 'initial test VCS commit'], seedPath);
+      await git(['remote', 'add', 'origin', barePath], seedPath);
+      await git(['push', 'origin', `HEAD:${defaultBranch}`], seedPath);
+
+      const snapshot = repositorySnapshot({
+        owner: input.owner,
+        name: input.name,
+        defaultBranch,
+        port: listeningPort(),
+      });
+      repositories.set(key, {snapshot, barePath, seedPath});
+      return snapshot;
+    },
+
+    async commitFiles(input) {
+      const repository = requireRepository(input.owner, input.name);
+      if (input.files.length === 0) throw new Error('Test VCS commits need at least one file');
+      await writeFiles(repository.seedPath, input.files);
+      const status = await git(['status', '--porcelain'], repository.seedPath);
+      if (status.trim() !== '') {
+        await git(['add', '--all'], repository.seedPath);
+        await git(['commit', '-m', input.message], repository.seedPath);
+        await git(
+          ['push', 'origin', `HEAD:${repository.snapshot.defaultBranch}`],
+          repository.seedPath,
+        );
+      }
+      return await currentCommit(repository.seedPath);
+    },
+
+    getRepository(owner, name) {
+      return repositories.get(repositoryKey(owner, name))?.snapshot;
+    },
+
+    listRepositories(owner) {
+      const values = [...repositories.values()]
+        .filter((repository) => repository.snapshot.owner === owner)
+        .map((repository) => repository.snapshot)
+        .sort((left, right) => left.fullName.localeCompare(right.fullName));
+      return {repositories: values, nextCursor: null};
+    },
+
+    async listFiles(input) {
+      const repository = requireRepository(input.owner, input.name);
+      const output = await git(['ls-tree', '-r', '-l', input.ref], repository.seedPath);
+      const prefix = input.prefix.replace(/^\/+|\/+$/gu, '');
+      const files = output
+        .trimEnd()
+        .split('\n')
+        .filter(Boolean)
+        .flatMap((line): FileEntry[] => {
+          const [metadata, path] = line.split('\t', 2);
+          const fields = metadata?.split(GIT_TREE_FIELD_PATTERN) ?? [];
+          if (fields[1] !== 'blob' || !path || !matchesPrefix(path, prefix)) return [];
+          const size = fields[3] === '-' ? null : Number(fields[3]);
+          return [{path, type: 'file', size: Number.isFinite(size) ? size : null}];
+        })
+        .sort((left, right) => left.path.localeCompare(right.path));
+      const offset = parseCursor(input.cursor);
+      const page = files.slice(offset, offset + input.limit);
+      const consumed = offset + page.length;
+      return {files: page, nextCursor: consumed < files.length ? String(consumed) : null};
+    },
+
+    async fetchFile(input) {
+      const repository = requireRepository(input.owner, input.name);
+      assertRelativePath(input.path);
+      const content = await git(['show', `${input.ref}:${input.path}`], repository.seedPath);
+      if (Buffer.byteLength(content, 'utf8') > 1_000_000) {
+        throw new Error('Test VCS file is too large');
+      }
+      return {path: input.path, ref: input.ref, content};
+    },
+
+    async resolveRef(input) {
+      const repository = requireRepository(input.owner, input.name);
+      const commit = await git(
+        ['rev-parse', '--verify', `${input.ref}^{commit}`],
+        repository.seedPath,
+      );
+      return {ref: input.ref, commit: commit.trim()};
+    },
+
+    issueCredential(input) {
+      requireRepository(input.owner, input.name);
+      if (!Number.isFinite(input.ttlSeconds) || input.ttlSeconds <= 0) {
+        throw new Error('Test VCS credential TTL must be greater than zero');
+      }
+      let generation = randomUUID();
+      while (generation === input.rejectedGeneration) generation = randomUUID();
+      const token = `test-vcs-${randomUUID()}`;
+      const now = Date.now();
+      const expiresAt = now + input.ttlSeconds * 1000;
+      credentials.set(token, {
+        owner: input.owner,
+        name: input.name,
+        username: TEST_VCS_USERNAME,
+        generation,
+        token,
+        permissions: input.permissions,
+        expiresAt,
+      });
+      const renewal: CheckoutCredentialRenewal =
+        input.renewalMode === 'refresh-at'
+          ? {
+              mode: 'refresh-at',
+              refreshAt: new Date(now + Math.max(50, Math.floor(input.ttlSeconds * 500))),
+            }
+          : {mode: 'on-rejection'};
+      return {
+        username: TEST_VCS_USERNAME,
+        token,
+        expiresAt: new Date(expiresAt),
+        generation,
+        renewal,
+      };
+    },
+
+    stats(owner) {
+      const selected =
+        owner === undefined ? requests : requests.filter((request) => request.owner === owner);
+      const generations = [...credentials.values()]
+        .filter((credential) => owner === undefined || credential.owner === owner)
+        .map((credential) => credential.generation);
+      return {
+        mintCount: [...credentials.values()].filter(
+          (credential) => owner === undefined || credential.owner === owner,
+        ).length,
+        requestCount: selected.length,
+        acceptedRequestCount: selected.filter((request) => request.status === 'accepted').length,
+        rejectedRequestCount: selected.filter((request) => request.status === 'rejected').length,
+        generations,
+        requests: selected.map(({method, path, status, generation}) => ({
+          method,
+          path,
+          status,
+          ...(generation === undefined ? {} : {generation}),
+        })),
+      };
+    },
+  };
+
+  async function handleGitRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const requestUrl = new URL(request.url ?? '/', 'https://test-vcs.invalid');
+    const location = parseGitRepositoryPath(requestUrl.pathname);
+    if (location === undefined) {
+      request.resume();
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+    const repository = repositories.get(repositoryKey(location.owner, location.name));
+    if (!repository) {
+      request.resume();
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+
+    const credential = findCredential(request.headers.authorization);
+    const needsWrite =
+      requestUrl.pathname.endsWith('/git-receive-pack') ||
+      requestUrl.searchParams.get('service') === 'git-receive-pack';
+    const credentialUsable =
+      credential !== undefined &&
+      credential.owner === location.owner &&
+      credential.name === location.name &&
+      credential.expiresAt > Date.now() &&
+      (credential.permissions.contents === 'write' || !needsWrite);
+    const requestRecord = {
+      method: request.method ?? 'GET',
+      path: request.url ?? '/',
+      owner: location.owner,
+    };
+    if (!credentialUsable) {
+      requests.push({
+        ...requestRecord,
+        status: 'rejected',
+        ...(credential?.generation === undefined ? {} : {generation: credential.generation}),
+      });
+      request.resume();
+      response.writeHead(401, {'www-authenticate': `Basic realm="${TEST_VCS_REALM}"`});
+      response.end();
+      return;
+    }
+
+    requests.push({
+      ...requestRecord,
+      status: 'accepted',
+      generation: credential.generation,
+    });
+    await proxyToGitHttpBackend(
+      request,
+      response,
+      repository.barePath,
+      children,
+      childExitPromises,
+    );
+  }
+
+  function findCredential(authorization: string | undefined): CredentialRecord | undefined {
+    if (!authorization?.startsWith('Basic ')) return undefined;
+    const decoded = Buffer.from(authorization.slice('Basic '.length), 'base64').toString('utf8');
+    const separator = decoded.indexOf(':');
+    if (separator < 0) return undefined;
+    const username = decoded.slice(0, separator);
+    const token = decoded.slice(separator + 1);
+    return [...credentials.values()].find(
+      (candidate) => candidate.username === username && candidate.token === token,
+    );
+  }
+
+  function requireRoot(): string {
+    if (rootPath === undefined || server === undefined) {
+      throw new Error('Test VCS fixture is not started');
+    }
+    return rootPath;
+  }
+
+  function listeningPort(): number {
+    if (server === undefined) throw new Error('Test VCS fixture is not started');
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('Test VCS fixture did not expose a TCP address');
+    }
+    return (address as AddressInfo).port;
+  }
+
+  function requireRepository(owner: string, name: string): RepositoryRecord {
+    const repository = repositories.get(repositoryKey(owner, name));
+    if (!repository) throw new Error(`Test VCS repository not found: ${owner}/${name}`);
+    return repository;
+  }
+
+  return fixture;
+}
+
+export function createTestVcsFixtureService(fixture: TestVcsFixture): ModuleService {
+  return {
+    name: 'test-vcs-smart-http-fixture',
+    shutdownTimeoutMs: 10_000,
+    async start() {
+      await fixture.start();
+      let resolveFinished!: () => void;
+      const finished = new Promise<void>((resolve) => {
+        resolveFinished = resolve;
+      });
+      return {
+        finished,
+        async stop() {
+          await fixture.close();
+          resolveFinished();
+        },
+      };
+    },
+  };
+}
+
+async function createCertificate(keyPath: string, certificatePath: string): Promise<void> {
+  await execFileAsync('openssl', [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-keyout',
+    keyPath,
+    '-out',
+    certificatePath,
+    '-days',
+    '1',
+    '-subj',
+    '/CN=127.0.0.1',
+  ]);
+}
+
+async function configureSeedRepository(seedPath: string): Promise<void> {
+  await git(['config', 'user.name', 'Shipfox Test VCS'], seedPath);
+  await git(['config', 'user.email', 'test-vcs@shipfox.test'], seedPath);
+  await git(['config', 'commit.gpgsign', 'false'], seedPath);
+  await git(['config', 'tag.gpgSign', 'false'], seedPath);
+}
+
+async function writeFiles(directory: string, files: readonly TestVcsFileInput[]): Promise<void> {
+  for (const file of files) {
+    assertRelativePath(file.path);
+    const path = join(directory, file.path);
+    await mkdir(dirname(path), {recursive: true});
+    await writeFile(path, file.content, {mode: 0o600});
+  }
+}
+
+async function currentCommit(seedPath: string): Promise<string> {
+  return (await git(['rev-parse', 'HEAD'], seedPath)).trim();
+}
+
+function repositorySnapshot(input: {
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  port: number;
+}): RepositorySnapshot {
+  const path = `/${input.owner}/${input.name}`;
+  return {
+    externalRepositoryId: `test-vcs:${input.owner}/${input.name}`,
+    owner: input.owner,
+    name: input.name,
+    fullName: `${input.owner}/${input.name}`,
+    defaultBranch: input.defaultBranch,
+    visibility: 'private',
+    cloneUrl: `https://127.0.0.1:${input.port}/${input.owner}/${input.name}.git`,
+    htmlUrl: `https://test-vcs.invalid${path}`,
+  };
+}
+
+function repositoryKey(owner: string, name: string): string {
+  return `${owner}/${name}`;
+}
+
+function assertRepositoryPart(value: string, label: string): void {
+  if (!REPOSITORY_PART_PATTERN.test(value)) throw new Error(`Invalid test VCS ${label}`);
+}
+
+function assertBranchName(value: string): void {
+  if (!value || value.startsWith('-') || value.includes('..') || value.includes(' ')) {
+    throw new Error('Invalid test VCS branch name');
+  }
+}
+
+function assertRelativePath(value: string): void {
+  if (
+    !value ||
+    value.startsWith('/') ||
+    value.includes('\u0000') ||
+    value.split('/').some((part) => part === '' || part === '.' || part === '..')
+  ) {
+    throw new Error(`Invalid test VCS file path: ${value}`);
+  }
+}
+
+function matchesPrefix(path: string, prefix: string): boolean {
+  return prefix === '' || path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function parseCursor(cursor: string | undefined): number {
+  if (cursor === undefined) return 0;
+  const value = Number.parseInt(cursor, 10);
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function parseGitRepositoryPath(path: string): {owner: string; name: string} | undefined {
+  const match = GIT_REPOSITORY_PATH_PATTERN.exec(path);
+  if (!match?.[1] || !match[2]) return undefined;
+  try {
+    const owner = decodeURIComponent(match[1]);
+    const name = decodeURIComponent(match[2]);
+    if (!REPOSITORY_PART_PATTERN.test(owner) || !REPOSITORY_PART_PATTERN.test(name)) {
+      return undefined;
+    }
+    return {owner, name};
+  } catch {
+    return undefined;
+  }
+}
+
+async function proxyToGitHttpBackend(
+  request: IncomingMessage,
+  response: ServerResponse,
+  repositoryPath: string,
+  children: Set<ChildProcess>,
+  childExitPromises: Map<ChildProcess, Promise<number>>,
+): Promise<void> {
+  const requestUrl = new URL(request.url ?? '/', 'https://test-vcs.invalid');
+  const child = spawn('git', ['http-backend'], {
+    env: {
+      ...process.env,
+      GIT_PROJECT_ROOT: dirname(dirname(repositoryPath)),
+      GIT_HTTP_EXPORT_ALL: '1',
+      PATH_INFO: requestUrl.pathname,
+      QUERY_STRING: requestUrl.search.slice(1),
+      REQUEST_METHOD: request.method ?? 'GET',
+      CONTENT_TYPE: String(request.headers['content-type'] ?? ''),
+      CONTENT_LENGTH: String(request.headers['content-length'] ?? ''),
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  children.add(child);
+  const output = collect(child.stdout);
+  const error = collect(child.stderr);
+  const exitPromise = waitForExit(child, GIT_BACKEND_TIMEOUT_MS);
+  childExitPromises.set(child, exitPromise);
+  child.stdin.on('error', () => request.unpipe(child.stdin));
+  request.pipe(child.stdin);
+  const [body, errorOutput, exitCode] = await Promise.all([output, error, exitPromise]).finally(
+    () => {
+      children.delete(child);
+      childExitPromises.delete(child);
+    },
+  );
+  if (exitCode !== 0) throw new Error(`git-http-backend failed (${errorOutput.byteLength} bytes)`);
+  const separator = body.indexOf(Buffer.from('\r\n\r\n'));
+  if (separator < 0) throw new Error('git-http-backend returned malformed CGI headers');
+  const headerText = body.subarray(0, separator).toString('utf8');
+  const headers = new Map<string, string>();
+  let status = 200;
+  for (const line of headerText.split('\r\n')) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const name = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    if (name.toLowerCase() === 'status') status = Number.parseInt(value, 10);
+    else headers.set(name, value);
+  }
+  response.writeHead(status, Object.fromEntries(headers));
+  response.end(body.subarray(separator + 4));
+}
+
+function collect(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    stream.on('data', (chunk: Buffer) => {
+      size += chunk.byteLength;
+      if (size > MAX_GIT_OUTPUT_BYTES) {
+        reject(new Error('git-http-backend output exceeded the fixture limit'));
+        return;
+      }
+      chunks.push(Buffer.from(chunk));
+    });
+    stream.once('error', reject);
+    stream.once('end', () => resolve(Buffer.concat(chunks)));
+  });
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`git-http-backend timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      clearTimeout(timer);
+      resolve(code ?? 1);
+    });
+  });
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  try {
+    const result = await execFileAsync('git', args, {
+      cwd,
+      maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      env: {...process.env, GIT_TERMINAL_PROMPT: '0'},
+    });
+    return result.stdout;
+  } catch (error) {
+    throw new Error(`Test VCS git operation failed in ${basename(cwd)}`, {cause: error});
+  }
+}
+
+async function listen(server: Server, port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', resolve);
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/libs/api/integration/core/src/providers/test-vcs-module.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-module.ts
@@ -1,0 +1,9 @@
+import {config} from '#config.js';
+import type {IntegrationProviderModule} from '#providers/types.js';
+
+export const testVcsProviderModule: IntegrationProviderModule = {
+  id: 'test-vcs',
+  enabled: config.INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER,
+  load: async () =>
+    await import('#providers/test-vcs-runtime.js').then((runtime) => runtime.load()),
+};

--- a/libs/api/integration/core/src/providers/test-vcs-runtime.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-runtime.ts
@@ -23,6 +23,7 @@ import {
 import {
   createTestVcsFixture,
   createTestVcsFixtureService,
+  isValidTestVcsBranchName,
   type TestVcsFileInput,
   type TestVcsRenewalMode,
 } from '#providers/test-vcs-fixture.js';
@@ -33,6 +34,11 @@ const repositoryPartSchema = z
   .min(1)
   .max(64)
   .regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u);
+const branchNameSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .refine(isValidTestVcsBranchName, {message: 'must be a valid Git branch name'});
 const fileSchema = z.object({path: z.string().min(1).max(512), content: z.string()}).strict();
 const renewalModeSchema = z.enum(['refresh-at', 'on-rejection']);
 const createConnectionBodySchema = z
@@ -47,7 +53,7 @@ const createRepositoryBodySchema = z
   .object({
     connection_id: z.string().uuid(),
     name: repositoryPartSchema,
-    default_branch: z.string().min(1).max(200).default('main'),
+    default_branch: branchNameSchema.default('main'),
     files: z.array(fileSchema).min(1).max(128),
   })
   .strict();
@@ -86,7 +92,6 @@ type TestVcsConnection = SpiIntegrationConnection<typeof TEST_VCS_PROVIDER>;
 export function load(): Promise<IntegrationModuleParts> {
   const fixture = createTestVcsFixture({
     port: config.INTEGRATIONS_TEST_VCS_PORT,
-    credentialTtlSeconds: config.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS,
   });
   const {provider, sourceControl} = createTestVcsIntegrationProvider({
     fixture,

--- a/libs/api/integration/core/src/providers/test-vcs-runtime.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-runtime.ts
@@ -1,0 +1,263 @@
+import {
+  integrationConnectionDtoSchema,
+  repositoryDtoSchema,
+} from '@shipfox/api-integration-core-dto';
+import type {IntegrationConnection as SpiIntegrationConnection} from '@shipfox/api-integration-spi';
+import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {config} from '#config.js';
+import {getIntegrationProviderCapabilities} from '#core/providers/registry.js';
+import {
+  getIntegrationConnectionById,
+  resolveUniqueConnectionSlug,
+  upsertIntegrationConnection,
+} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {toIntegrationConnectionDto, toRepositoryDto} from '#presentation/dto/integrations.js';
+import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
+import {
+  createTestVcsIntegrationProvider,
+  TEST_VCS_PROVIDER,
+  type TestVcsSourceControlProvider,
+} from '#providers/test-vcs.js';
+import {
+  createTestVcsFixture,
+  createTestVcsFixtureService,
+  type TestVcsFileInput,
+  type TestVcsRenewalMode,
+} from '#providers/test-vcs-fixture.js';
+import type {IntegrationModuleParts} from '#providers/types.js';
+
+const repositoryPartSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u);
+const fileSchema = z.object({path: z.string().min(1).max(512), content: z.string()}).strict();
+const renewalModeSchema = z.enum(['refresh-at', 'on-rejection']);
+const createConnectionBodySchema = z
+  .object({
+    workspace_id: z.string().uuid(),
+    account_id: repositoryPartSchema,
+    display_name: z.string().min(1).max(200).optional(),
+    renewal_mode: renewalModeSchema.default('on-rejection'),
+  })
+  .strict();
+const createRepositoryBodySchema = z
+  .object({
+    connection_id: z.string().uuid(),
+    name: repositoryPartSchema,
+    default_branch: z.string().min(1).max(200).default('main'),
+    files: z.array(fileSchema).min(1).max(128),
+  })
+  .strict();
+const commitFilesBodySchema = z
+  .object({
+    connection_id: z.string().uuid(),
+    external_repository_id: z.string().min(1),
+    message: z.string().min(1).max(200),
+    files: z.array(fileSchema).min(1).max(128),
+  })
+  .strict();
+const statsQuerySchema = z.object({connection_id: z.string().uuid().optional()}).strict();
+const statsResponseSchema = z
+  .object({
+    mint_count: z.number().int().nonnegative(),
+    request_count: z.number().int().nonnegative(),
+    accepted_request_count: z.number().int().nonnegative(),
+    rejected_request_count: z.number().int().nonnegative(),
+    generations: z.array(z.string().min(1)),
+    requests: z.array(
+      z
+        .object({
+          method: z.string(),
+          path: z.string(),
+          status: z.enum(['accepted', 'rejected']),
+          generation: z.string().min(1).optional(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+const failMintsBodySchema = z.object({count: z.number().int().min(1).max(10)}).strict();
+
+type TestVcsConnection = SpiIntegrationConnection<typeof TEST_VCS_PROVIDER>;
+
+export function load(): Promise<IntegrationModuleParts> {
+  const fixture = createTestVcsFixture({
+    port: config.INTEGRATIONS_TEST_VCS_PORT,
+    credentialTtlSeconds: config.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS,
+  });
+  const {provider, sourceControl} = createTestVcsIntegrationProvider({
+    fixture,
+    credentialTtlSeconds: config.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS,
+  });
+  const capabilities = getIntegrationProviderCapabilities(provider.adapters);
+
+  return Promise.resolve({
+    provider,
+    services: [createTestVcsFixtureService(fixture)],
+    e2eRoutes: [
+      createTestVcsRoutes({
+        fixture,
+        sourceControl,
+        connectionCapabilities: capabilities,
+      }),
+    ],
+  });
+}
+
+function createTestVcsRoutes(options: {
+  fixture: ReturnType<typeof createTestVcsFixture>;
+  sourceControl: TestVcsSourceControlProvider;
+  connectionCapabilities: ReturnType<typeof getIntegrationProviderCapabilities>;
+}): RouteGroup {
+  return {
+    prefix: '/integrations/test-vcs',
+    routes: [
+      defineRoute({
+        method: 'POST',
+        path: '/connections',
+        description: 'Create a private Test VCS connection for E2E tests.',
+        schema: {
+          body: createConnectionBodySchema,
+          response: {201: integrationConnectionDtoSchema},
+        },
+        handler: async (request, reply) => {
+          const connection = await connectTestVcsConnection({
+            workspaceId: request.body.workspace_id,
+            accountId: request.body.account_id,
+            displayName: request.body.display_name ?? `Test VCS ${request.body.account_id}`,
+            capabilities: options.connectionCapabilities,
+          });
+          options.sourceControl.configureConnection(connection.id, request.body.renewal_mode);
+          reply.code(201);
+          return toIntegrationConnectionDto(connection, {
+            capabilities: options.connectionCapabilities,
+          });
+        },
+      }),
+      defineRoute({
+        method: 'POST',
+        path: '/repositories',
+        description: 'Create a real bare repository in the private Test VCS fixture.',
+        schema: {
+          body: createRepositoryBodySchema,
+          response: {201: repositoryDtoSchema},
+        },
+        handler: async (request, reply) => {
+          const connection = await requireTestVcsConnection(request.body.connection_id);
+          const repository = await options.sourceControl.createRepository({
+            connection,
+            name: request.body.name,
+            defaultBranch: request.body.default_branch,
+            files: request.body.files,
+          });
+          reply.code(201);
+          return toRepositoryDto(connection.id, repository);
+        },
+      }),
+      defineRoute({
+        method: 'POST',
+        path: '/commits',
+        description: 'Commit files to a private Test VCS fixture repository for E2E tests.',
+        schema: {
+          body: commitFilesBodySchema,
+          response: {200: z.object({commit: z.string().min(1)}).strict()},
+        },
+        handler: async (request) => {
+          const connection = await requireTestVcsConnection(request.body.connection_id);
+          const commit = await options.sourceControl.commitFiles({
+            connection,
+            externalRepositoryId: request.body.external_repository_id,
+            message: request.body.message,
+            files: request.body.files,
+          });
+          return {commit};
+        },
+      }),
+      defineRoute({
+        method: 'GET',
+        path: '/stats',
+        description: 'Read redacted Test VCS fixture observations for E2E assertions.',
+        schema: {
+          querystring: statsQuerySchema,
+          response: {200: statsResponseSchema},
+        },
+        handler: async (request) => {
+          const owner =
+            request.query.connection_id === undefined
+              ? undefined
+              : (await requireTestVcsConnection(request.query.connection_id)).externalAccountId;
+          const stats = options.fixture.stats(owner);
+          return {
+            mint_count: stats.mintCount,
+            request_count: stats.requestCount,
+            accepted_request_count: stats.acceptedRequestCount,
+            rejected_request_count: stats.rejectedRequestCount,
+            generations: stats.generations,
+            requests: stats.requests,
+          };
+        },
+      }),
+      defineRoute({
+        method: 'POST',
+        path: '/fail-next-mints',
+        description: 'Make the next Test VCS credential mints fail for E2E failure assertions.',
+        schema: {
+          body: failMintsBodySchema,
+          response: {204: z.void()},
+        },
+        handler: (request, reply) => {
+          options.sourceControl.failNextCredentialMints(request.body.count);
+          reply.code(204).send();
+        },
+      }),
+    ],
+  };
+}
+
+async function connectTestVcsConnection(input: {
+  workspaceId: string;
+  accountId: string;
+  displayName: string;
+  capabilities: ReturnType<typeof getIntegrationProviderCapabilities>;
+}): Promise<TestVcsConnection> {
+  return (await retryConnectionSlugCollision(() =>
+    db().transaction(async (tx) => {
+      const slug = await resolveUniqueConnectionSlug(
+        {
+          workspaceId: input.workspaceId,
+          provider: TEST_VCS_PROVIDER,
+          externalAccountId: input.accountId,
+          baseSlug: slugifyConnectionSlug(`test_vcs_${input.accountId}`, {fallback: 'test_vcs'}),
+        },
+        {tx},
+      );
+      return await upsertIntegrationConnection(
+        {
+          workspaceId: input.workspaceId,
+          provider: TEST_VCS_PROVIDER,
+          externalAccountId: input.accountId,
+          slug,
+          displayName: input.displayName,
+          lifecycleStatus: 'active',
+          capabilities: input.capabilities,
+        },
+        {tx},
+      );
+    }),
+  )) as TestVcsConnection;
+}
+
+async function requireTestVcsConnection(connectionId: string): Promise<TestVcsConnection> {
+  const connection = await getIntegrationConnectionById(connectionId);
+  if (!connection || connection.provider !== TEST_VCS_PROVIDER) {
+    throw new ClientError('Test VCS connection not found', 'test-vcs-connection-not-found', {
+      status: 404,
+    });
+  }
+  return connection as TestVcsConnection;
+}
+
+export type {TestVcsFileInput, TestVcsRenewalMode};

--- a/libs/api/integration/core/src/providers/test-vcs.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.test.ts
@@ -1,0 +1,132 @@
+import type {
+  CheckoutCredentials,
+  IntegrationConnection,
+  RepositorySnapshot,
+} from '@shipfox/api-integration-spi';
+import {
+  TestVcsSourceControlProvider,
+  type TestVcsSourceControlProviderOptions,
+} from '#providers/test-vcs.js';
+
+const repository: RepositorySnapshot = {
+  externalRepositoryId: 'test-vcs:e2e-owner/repository',
+  owner: 'e2e-owner',
+  name: 'repository',
+  fullName: 'e2e-owner/repository',
+  defaultBranch: 'main',
+  visibility: 'private',
+  cloneUrl: 'https://127.0.0.1:16113/e2e-owner/repository.git',
+  htmlUrl: 'https://test-vcs.invalid/e2e-owner/repository',
+};
+
+const connection: IntegrationConnection<'test-vcs'> = {
+  id: '00000000-0000-4000-8000-000000000001',
+  workspaceId: '00000000-0000-4000-8000-000000000002',
+  provider: 'test-vcs',
+  externalAccountId: 'e2e-owner',
+  slug: 'test_vcs_e2e_owner',
+  displayName: 'Test VCS',
+  lifecycleStatus: 'active',
+  repositoryAccessMode: 'all',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+function credential(generation: string): CheckoutCredentials {
+  return {
+    username: 'x-access-token',
+    token: `token-${generation}`,
+    expiresAt: new Date(Date.now() + 60_000),
+    generation,
+    renewal: {mode: 'on-rejection'},
+  };
+}
+
+function providerFixture(options: {
+  issueCredential: TestVcsSourceControlProviderOptions['fixture']['issueCredential'];
+}): TestVcsSourceControlProvider {
+  const fixture = {
+    getRepository: () => repository,
+    issueCredential: options.issueCredential,
+  } as unknown as TestVcsSourceControlProviderOptions['fixture'];
+  return new TestVcsSourceControlProvider({fixture, credentialTtlSeconds: 3});
+}
+
+function checkoutInput(
+  options: {permissions?: 'read' | 'write'; rejectedGeneration?: string} = {},
+) {
+  return {
+    connection,
+    externalRepositoryId: repository.externalRepositoryId,
+    permissions: {contents: options.permissions ?? ('read' as const)},
+    ...(options.rejectedGeneration === undefined
+      ? {}
+      : {rejectedGeneration: options.rejectedGeneration}),
+  };
+}
+
+describe('Test VCS source-control provider', () => {
+  it('shares one exact-scope credential mint across concurrent requests', async () => {
+    const minted = credential('generation-a');
+    const issueCredential = vi.fn().mockReturnValue(minted);
+    const provider = providerFixture({issueCredential});
+
+    const results = await Promise.all([
+      provider.createCheckoutCredentials(checkoutInput()),
+      provider.createCheckoutCredentials(checkoutInput()),
+    ]);
+
+    expect(results).toEqual([minted, minted]);
+    expect(issueCredential).toHaveBeenCalledOnce();
+  });
+
+  it('keeps repository and permission scopes isolated', async () => {
+    const issueCredential = vi
+      .fn()
+      .mockReturnValueOnce(credential('read'))
+      .mockReturnValueOnce(credential('write'))
+      .mockReturnValueOnce(credential('other-repository'));
+    const provider = providerFixture({issueCredential});
+
+    await provider.createCheckoutCredentials(checkoutInput({permissions: 'read'}));
+    await provider.createCheckoutCredentials(checkoutInput({permissions: 'write'}));
+    await provider.createCheckoutCredentials({
+      ...checkoutInput({permissions: 'read'}),
+      externalRepositoryId: 'test-vcs:e2e-owner/other-repository',
+    });
+
+    expect(issueCredential).toHaveBeenCalledTimes(3);
+  });
+
+  it('mints a fresh generation for the rejected credential without evicting a newer one', async () => {
+    const issueCredential = vi
+      .fn()
+      .mockReturnValueOnce(credential('generation-a'))
+      .mockReturnValueOnce(credential('generation-b'));
+    const provider = providerFixture({issueCredential});
+
+    await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toMatchObject({
+      generation: 'generation-a',
+    });
+    await expect(
+      provider.createCheckoutCredentials(checkoutInput({rejectedGeneration: 'generation-a'})),
+    ).resolves.toMatchObject({generation: 'generation-b'});
+    await expect(
+      provider.createCheckoutCredentials(checkoutInput({rejectedGeneration: 'generation-a'})),
+    ).resolves.toMatchObject({generation: 'generation-b'});
+
+    expect(issueCredential).toHaveBeenCalledTimes(2);
+  });
+
+  it('supplies the provider author for write checkouts', async () => {
+    const provider = providerFixture({
+      issueCredential: vi.fn().mockReturnValue(credential('write')),
+    });
+
+    await expect(
+      provider.createCheckoutSpec(checkoutInput({permissions: 'write'})),
+    ).resolves.toMatchObject({
+      gitAuthor: {name: 'Shipfox Test VCS', email: 'test-vcs@shipfox.test'},
+    });
+  });
+});

--- a/libs/api/integration/core/src/providers/test-vcs.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.test.ts
@@ -3,6 +3,7 @@ import type {
   IntegrationConnection,
   RepositorySnapshot,
 } from '@shipfox/api-integration-spi';
+import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-spi';
 import {
   TestVcsSourceControlProvider,
   type TestVcsSourceControlProviderOptions,
@@ -44,10 +45,12 @@ function credential(generation: string): CheckoutCredentials {
 
 function providerFixture(options: {
   issueCredential: TestVcsSourceControlProviderOptions['fixture']['issueCredential'];
+  fetchFile?: TestVcsSourceControlProviderOptions['fixture']['fetchFile'];
 }): TestVcsSourceControlProvider {
   const fixture = {
     getRepository: () => repository,
     issueCredential: options.issueCredential,
+    ...(options.fetchFile === undefined ? {} : {fetchFile: options.fetchFile}),
   } as unknown as TestVcsSourceControlProviderOptions['fixture'];
   return new TestVcsSourceControlProvider({fixture, credentialTtlSeconds: 3});
 }
@@ -128,5 +131,20 @@ describe('Test VCS source-control provider', () => {
     ).resolves.toMatchObject({
       gitAuthor: {name: 'Shipfox Test VCS', email: 'test-vcs@shipfox.test'},
     });
+  });
+
+  it('reports oversized files before mapping them to file-not-found', async () => {
+    const provider = providerFixture({
+      issueCredential: vi.fn(),
+      fetchFile: vi.fn().mockResolvedValue({
+        path: 'large.txt',
+        ref: 'main',
+        content: 'x'.repeat(MAX_REPOSITORY_FILE_BYTES + 1),
+      }),
+    });
+
+    await expect(
+      provider.fetchFile({...checkoutInput(), path: 'large.txt', ref: 'main'}),
+    ).rejects.toMatchObject({reason: 'content-too-large'});
   });
 });

--- a/libs/api/integration/core/src/providers/test-vcs.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.ts
@@ -1,0 +1,351 @@
+import {
+  buildProviderRepositoryId,
+  type CheckoutCredentials,
+  type CheckoutPermissions,
+  type CheckoutSpec,
+  type CheckoutTarget,
+  type CreateCheckoutCredentialsInput,
+  type CreateCheckoutSpecInput,
+  type FetchFileInput,
+  type FilePage,
+  type FileSnapshot,
+  type IntegrationConnection,
+  IntegrationProviderError,
+  isValidResolvableRef,
+  type ListFilesInput,
+  type ListRepositoriesInput,
+  MAX_REPOSITORY_FILE_BYTES,
+  normalizeCheckoutTarget,
+  parseProviderRepositoryId,
+  type RepositoryPage,
+  type RepositorySnapshot,
+  type ResolveRefInput,
+  type ResolveRepositoryInput,
+  type SourceControlProvider,
+} from '@shipfox/api-integration-spi';
+import type {IntegrationProvider} from '#core/entities/provider.js';
+import {
+  createTestVcsFixture,
+  type TestVcsFixture,
+  type TestVcsRenewalMode,
+} from './test-vcs-fixture.js';
+
+export const TEST_VCS_PROVIDER = 'test-vcs';
+type TestVcsConnection = IntegrationConnection<typeof TEST_VCS_PROVIDER>;
+
+const REPOSITORY_PAGE_SIZE = 100;
+const MISSING_REF_ERROR_PATTERN = /ambiguous argument|bad revision|unknown revision/u;
+
+export interface TestVcsSourceControlProviderOptions {
+  fixture: TestVcsFixture;
+  credentialTtlSeconds: number;
+}
+
+export class TestVcsSourceControlProvider implements SourceControlProvider<TestVcsConnection> {
+  private readonly renewalModes = new Map<string, TestVcsRenewalMode>();
+  private readonly cachedCredentials = new Map<string, CheckoutCredentials>();
+  private readonly mintFlights = new Map<string, Promise<CheckoutCredentials>>();
+  private failNextMintCount = 0;
+
+  constructor(private readonly options: TestVcsSourceControlProviderOptions) {}
+
+  configureConnection(connectionId: string, renewalMode: TestVcsRenewalMode): void {
+    this.renewalModes.set(connectionId, renewalMode);
+  }
+
+  failNextCredentialMints(count: number): void {
+    this.failNextMintCount = count;
+  }
+
+  listRepositories(input: ListRepositoriesInput<TestVcsConnection>): Promise<RepositoryPage> {
+    const repositories = this.options.fixture.listRepositories(
+      input.connection.externalAccountId,
+    ).repositories;
+    const needle = input.search?.trim().toLowerCase();
+    const filtered = needle
+      ? repositories.filter((repository) => repository.fullName.toLowerCase().includes(needle))
+      : repositories;
+    const offset = parseCursor(input.cursor);
+    const page = filtered.slice(offset, offset + Math.min(input.limit, REPOSITORY_PAGE_SIZE));
+    const consumed = offset + page.length;
+    return Promise.resolve({
+      repositories: page,
+      nextCursor: consumed < filtered.length ? String(consumed) : null,
+    });
+  }
+
+  resolveRepository(input: ResolveRepositoryInput<TestVcsConnection>): Promise<RepositorySnapshot> {
+    const locator = this.repositoryLocator(input.connection, input.externalRepositoryId);
+    const repository = this.options.fixture.getRepository(locator.owner, locator.name);
+    if (!repository) throw repositoryNotFound(input.externalRepositoryId);
+    return Promise.resolve(repository);
+  }
+
+  async listFiles(input: ListFilesInput<TestVcsConnection>): Promise<FilePage> {
+    const locator = this.repositoryLocator(input.connection, input.externalRepositoryId);
+    this.requireRepository(locator);
+    try {
+      return await this.options.fixture.listFiles({...locator, ...input});
+    } catch (error) {
+      throw new IntegrationProviderError(
+        isMissingRefError(error) ? 'ref-not-found' : 'provider-unavailable',
+        `Test VCS could not list files for ${input.externalRepositoryId}`,
+      );
+    }
+  }
+
+  async fetchFile(input: FetchFileInput<TestVcsConnection>): Promise<FileSnapshot> {
+    const locator = this.repositoryLocator(input.connection, input.externalRepositoryId);
+    this.requireRepository(locator);
+    try {
+      const file = await this.options.fixture.fetchFile({...locator, ...input});
+      if (Buffer.byteLength(file.content, 'utf8') > MAX_REPOSITORY_FILE_BYTES) {
+        throw new IntegrationProviderError(
+          'content-too-large',
+          `Test VCS file ${input.path} is larger than the supported limit`,
+        );
+      }
+      return file;
+    } catch (error) {
+      if (error instanceof IntegrationProviderError) throw error;
+      throw new IntegrationProviderError(
+        'file-not-found',
+        `Test VCS file ${input.path} was not found in ${input.externalRepositoryId}`,
+      );
+    }
+  }
+
+  resolveTriggerReference(): null {
+    return null;
+  }
+
+  async resolveRef(input: ResolveRefInput<TestVcsConnection>) {
+    const locator = this.repositoryLocator(input.connection, input.externalRepositoryId);
+    this.requireRepository(locator);
+    if (!isValidResolvableRef(input.ref)) {
+      throw new IntegrationProviderError(
+        'ref-invalid',
+        `Test VCS ref ${JSON.stringify(input.ref)} is not a resolvable branch or tag name`,
+      );
+    }
+    try {
+      return await this.options.fixture.resolveRef({...locator, ref: input.ref});
+    } catch {
+      throw new IntegrationProviderError(
+        'ref-not-found',
+        `Test VCS ref ${JSON.stringify(input.ref)} was not found in ${input.externalRepositoryId}`,
+      );
+    }
+  }
+
+  async createCheckoutSpec(
+    input: CreateCheckoutSpecInput<TestVcsConnection>,
+  ): Promise<CheckoutSpec> {
+    const target = normalizeTarget(input);
+    const locator = this.repositoryLocator(input.connection, target);
+    const repository = this.requireRepository(locator);
+    const permissions = input.permissions ?? {contents: 'read'};
+    const credentials = await this.createCheckoutCredentials({
+      connection: input.connection,
+      target,
+      permissions,
+    });
+    return {
+      repositoryUrl: repository.cloneUrl,
+      ref: input.ref?.trim() || repository.defaultBranch,
+      target: {
+        kind: 'external-id',
+        externalRepositoryId: repository.externalRepositoryId,
+      },
+      credentials,
+      ...(permissions.contents === 'write'
+        ? {gitAuthor: {name: 'Shipfox Test VCS', email: 'test-vcs@shipfox.test'}}
+        : {}),
+    };
+  }
+
+  async createCheckoutCredentials(
+    input: CreateCheckoutCredentialsInput<TestVcsConnection>,
+  ): Promise<CheckoutCredentials> {
+    const target = normalizeTarget(input);
+    const locator = this.repositoryLocator(input.connection, target);
+    this.requireRepository(locator);
+    const cacheKey = credentialCacheKey(input.connection, locator, input.permissions);
+    for (;;) {
+      const cached = this.cachedCredentials.get(cacheKey);
+      if (
+        cached !== undefined &&
+        isReusableCredential(cached, this.options.credentialTtlSeconds) &&
+        cached.generation !== input.rejectedGeneration
+      ) {
+        return cached;
+      }
+
+      const pending = this.mintFlights.get(cacheKey);
+      if (pending !== undefined) {
+        const credential = await pending;
+        if (credential.generation !== input.rejectedGeneration) return credential;
+        continue;
+      }
+
+      const operation = Promise.resolve()
+        .then(() => this.mintCredential(input, locator, cacheKey))
+        .finally(() => {
+          if (this.mintFlights.get(cacheKey) === operation) this.mintFlights.delete(cacheKey);
+        });
+      this.mintFlights.set(cacheKey, operation);
+      return await operation;
+    }
+  }
+
+  async createRepository(input: {
+    connection: TestVcsConnection;
+    name: string;
+    defaultBranch?: string | undefined;
+    files: readonly {path: string; content: string}[];
+  }): Promise<RepositorySnapshot> {
+    return await this.options.fixture.createRepository({
+      owner: input.connection.externalAccountId,
+      name: input.name,
+      defaultBranch: input.defaultBranch,
+      files: input.files,
+    });
+  }
+
+  async commitFiles(input: {
+    connection: TestVcsConnection;
+    externalRepositoryId: string;
+    message: string;
+    files: readonly {path: string; content: string}[];
+  }): Promise<string> {
+    const locator = this.repositoryLocator(input.connection, input.externalRepositoryId);
+    this.requireRepository(locator);
+    return await this.options.fixture.commitFiles({...locator, ...input});
+  }
+
+  stats(owner?: string) {
+    return this.options.fixture.stats(owner);
+  }
+
+  private mintCredential(
+    input: CreateCheckoutCredentialsInput<TestVcsConnection>,
+    locator: {owner: string; name: string},
+    cacheKey: string,
+  ): Promise<CheckoutCredentials> {
+    if (this.failNextMintCount > 0) {
+      this.failNextMintCount -= 1;
+      throw new IntegrationProviderError(
+        'provider-unavailable',
+        'Test VCS credential minting is unavailable',
+      );
+    }
+    const credential = this.options.fixture.issueCredential({
+      ...locator,
+      permissions: input.permissions,
+      renewalMode: this.renewalModes.get(input.connection.id) ?? 'on-rejection',
+      ttlSeconds: this.options.credentialTtlSeconds,
+      rejectedGeneration: input.rejectedGeneration,
+    });
+    this.cachedCredentials.set(cacheKey, credential);
+    return Promise.resolve(credential);
+  }
+
+  private repositoryLocator(
+    connection: TestVcsConnection,
+    target: string | CheckoutTarget,
+  ): {owner: string; name: string} {
+    const externalRepositoryId =
+      typeof target === 'string' ? target : checkoutTargetRepositoryId(target);
+    const value = parseProviderRepositoryId(externalRepositoryId, TEST_VCS_PROVIDER);
+    const separator = value.indexOf('/');
+    const owner = separator > 0 ? value.slice(0, separator) : '';
+    const name = separator > 0 ? value.slice(separator + 1) : '';
+    if (!owner || !name || name.includes('/') || owner !== connection.externalAccountId) {
+      throw repositoryNotFound(externalRepositoryId);
+    }
+    return {owner, name};
+  }
+
+  private requireRepository(locator: {owner: string; name: string}): RepositorySnapshot {
+    const repository = this.options.fixture.getRepository(locator.owner, locator.name);
+    if (!repository)
+      throw repositoryNotFound(`${TEST_VCS_PROVIDER}:${locator.owner}/${locator.name}`);
+    return repository;
+  }
+}
+
+export function createTestVcsIntegrationProvider(options: TestVcsSourceControlProviderOptions): {
+  provider: IntegrationProvider;
+  sourceControl: TestVcsSourceControlProvider;
+} {
+  const sourceControl = new TestVcsSourceControlProvider(options);
+  return {
+    sourceControl,
+    provider: {
+      provider: TEST_VCS_PROVIDER,
+      displayName: 'Test VCS',
+      adapters: {source_control: sourceControl},
+    },
+  };
+}
+
+export type {TestVcsFixture};
+export {createTestVcsFixture};
+
+function normalizeTarget(input: {
+  target?: CheckoutTarget | undefined;
+  externalRepositoryId?: string | undefined;
+}): CheckoutTarget {
+  const result = normalizeCheckoutTarget(input);
+  if (result.status === 'valid') return result.target;
+  if (result.status === 'ambiguous') {
+    throw new IntegrationProviderError(
+      'provider-rejected',
+      'Test VCS checkout input cannot include both a target and an external repository id',
+    );
+  }
+  throw new IntegrationProviderError(
+    'repository-not-found',
+    'Test VCS checkout input must include a target or external repository id',
+  );
+}
+
+function checkoutTargetRepositoryId(target: CheckoutTarget): string {
+  if (target.kind === 'external-id') return target.externalRepositoryId;
+  return buildProviderRepositoryId(TEST_VCS_PROVIDER, `${target.owner}/${target.name}`);
+}
+
+function repositoryNotFound(externalRepositoryId: string): IntegrationProviderError {
+  return new IntegrationProviderError(
+    'repository-not-found',
+    `Test VCS repository ${externalRepositoryId} was not found`,
+  );
+}
+
+function parseCursor(cursor: string | undefined): number {
+  if (cursor === undefined) return 0;
+  const value = Number.parseInt(cursor, 10);
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function isMissingRefError(error: unknown): boolean {
+  return error instanceof Error && MISSING_REF_ERROR_PATTERN.test(error.message);
+}
+
+function credentialCacheKey(
+  connection: TestVcsConnection,
+  locator: {owner: string; name: string},
+  permissions: CheckoutPermissions,
+): string {
+  return JSON.stringify({
+    workspaceId: connection.workspaceId,
+    provider: connection.provider,
+    accountId: connection.externalAccountId,
+    repository: `${locator.owner}/${locator.name}`,
+    permissions,
+  });
+}
+
+function isReusableCredential(credential: CheckoutCredentials, ttlSeconds: number): boolean {
+  return credential.expiresAt.getTime() > Date.now() + Math.max(50, ttlSeconds * 500);
+}

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -1,7 +1,7 @@
 import type {UserContextMembership} from '@shipfox/api-auth-context';
 import type {WebhookRequestProcessor, WebhookRouteId} from '@shipfox/api-integration-spi';
 import type {RouteExport} from '@shipfox/node-fastify';
-import type {ModuleDatabase, ModuleWorker} from '@shipfox/node-module';
+import type {ModuleDatabase, ModuleService, ModuleWorker} from '@shipfox/node-module';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 
 /**
@@ -16,6 +16,7 @@ import type {IntegrationProvider} from '#core/entities/provider.js';
 export interface IntegrationModuleParts {
   provider: IntegrationProvider;
   database?: ModuleDatabase | undefined;
+  services?: ModuleService[] | undefined;
   e2eRoutes?: RouteExport[] | undefined;
   workers?: ModuleWorker[] | undefined;
   startupTasks?: Array<() => Promise<void>> | undefined;

--- a/libs/api/integration/spi/src/contracts.test.ts
+++ b/libs/api/integration/spi/src/contracts.test.ts
@@ -15,6 +15,7 @@ describe('git ref names', () => {
     'refs/heads/feature/review',
     'refs/heads/foo./bar',
     'refs/heads/foo/-bar',
+    'refs/heads/feature]',
     'refs/pull/17/head',
   ])('accepts %s', (ref) => {
     expect(isValidGitRefName(ref)).toBe(true);
@@ -31,6 +32,7 @@ describe('git ref names', () => {
     'refs/heads/.foo',
     'refs/heads/foo.',
     'refs/heads/foo@{bar',
+    'refs/heads/feature[',
     'a'.repeat(40),
     'b'.repeat(64),
     '0'.repeat(40),

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -470,7 +470,7 @@ export function isValidGitRefName(ref: string): boolean {
   if (
     [...ref].some((character) => {
       const code = character.codePointAt(0) ?? 0;
-      return code <= 0x20 || code === 0x7f || '~^:?*[]\\'.includes(character);
+      return code <= 0x20 || code === 0x7f || '~^:?*[\\'.includes(character);
     })
   ) {
     return false;

--- a/libs/runner/agent/src/config.ts
+++ b/libs/runner/agent/src/config.ts
@@ -22,6 +22,10 @@ export const config = createConfig({
     desc: 'Comma-separated hosts and IP ranges that custom model providers may not call. Accepts exact hosts, suffix patterns such as .internal.example or *.internal.example, IP literals, and CIDR blocks such as 10.0.0.0/8.',
     default: '',
   }),
+  SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT: bool({
+    desc: 'Enables the runner-local renewable Git credential broker. Keep this disabled until the runner deployment is ready for renewable checkout credentials.',
+    default: false,
+  }),
 });
 
 export function runnerEgressPolicy(): EgressPolicy {

--- a/libs/runner/agent/src/core/tool-capabilities.test.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.test.ts
@@ -12,6 +12,10 @@ beforeEach(() => {
   isPiExtensionAvailableMock.mockReturnValue(true);
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe('runnerToolCapabilities', () => {
   it('reports web access tools when pi-web-access is available', () => {
     expect(runnerToolCapabilities().harnesses.pi?.tools).toEqual([
@@ -41,6 +45,17 @@ describe('runnerToolCapabilities', () => {
       'find',
       'ls',
     ]);
+  });
+
+  it('does not advertise renewable Git when it is not enabled', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT', undefined);
+    vi.resetModules();
+
+    const {runnerToolCapabilities: disabledCapabilities} = await import(
+      '#core/tool-capabilities.js'
+    );
+
+    expect(disabledCapabilities().features).toBeUndefined();
   });
 
   it('advertises renewable Git only when explicitly enabled', async () => {

--- a/libs/runner/agent/src/core/tool-capabilities.test.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.test.ts
@@ -42,4 +42,15 @@ describe('runnerToolCapabilities', () => {
       'ls',
     ]);
   });
+
+  it('advertises renewable Git only when explicitly enabled', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT', 'true');
+    vi.resetModules();
+
+    const {runnerToolCapabilities: enabledCapabilities} = await import(
+      '#core/tool-capabilities.js'
+    );
+
+    expect(enabledCapabilities().features).toEqual({renewable_git: true});
+  });
 });

--- a/libs/runner/agent/src/core/tool-capabilities.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.ts
@@ -1,4 +1,5 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+import {config} from '#config.js';
 import {isPiExtensionAvailable} from '#core/pi-extensions.js';
 
 const PI_BUILTIN_TOOLS = ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'] as const;
@@ -22,6 +23,9 @@ export function runnerToolCapabilities(): RunnerToolCapabilitiesDto {
     : [...PI_BUILTIN_TOOLS];
 
   return {
+    ...(config.SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT
+      ? {features: {renewable_git: true as const}}
+      : {}),
     harnesses: {
       pi: {tools: piTools},
       claude: {tools: [...CLAUDE_TOOLS]},

--- a/libs/runner/workspace/package.json
+++ b/libs/runner/workspace/package.json
@@ -13,7 +13,10 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "workspace-source": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -655,7 +655,7 @@ describe('writeAmbientGitCredential', () => {
 
     const content = await readFile(configPath, 'utf8');
     expect(content).toContain('[credential]\n\tuseHttpPath = true');
-    expect(content).toContain('[credential "https://github.com/acme/repo/"]');
+    expect(content).toContain('[credential "https://github.com/acme/repo.git"]');
     expect(content).toContain(
       '\thelper = "!node /opt/runner/dist/git-credential-helper.js --socket',
     );

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -664,6 +664,40 @@ describe('writeAmbientGitCredential', () => {
     expect(content).not.toContain('token');
   });
 
+  it('keeps a repository URL without a .git suffix in the credential subsection', async () => {
+    const configPath = join(root, 'git-cred.config');
+
+    await writeGitCredentialHelperConfig({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/repo',
+      helper: {
+        command: 'git-credential-shipfox',
+        socketPath: join(root, 'credential.sock'),
+        capability: 'job-capability',
+      },
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    expect(content).toContain('[credential "https://github.com/acme/repo/"]');
+  });
+
+  it('preserves a .git path when the repository name is only .git', async () => {
+    const configPath = join(root, 'git-cred.config');
+
+    await writeGitCredentialHelperConfig({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/.git',
+      helper: {
+        command: 'git-credential-shipfox',
+        socketPath: join(root, 'credential.sock'),
+        capability: 'job-capability',
+      },
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    expect(content).toContain('[credential "https://github.com/acme/.git"]');
+  });
+
   it.each([
     ['control characters', 'job\ncapability'],
     ['oversized values', 'x'.repeat(513)],

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -312,7 +312,9 @@ function gitConfigRepositoryUrl(repositoryUrl: string): string {
   const normalized = normalizeRepositoryUrl(repositoryUrl);
   const originalPath = new URL(repositoryUrl).pathname.replace(TRAILING_SLASHES_RE, '');
   if (!originalPath.toLowerCase().endsWith('.git')) return normalized;
-  return `${normalized.slice(0, -1)}${originalPath.slice(-4)}`;
+  const url = new URL(normalized);
+  url.pathname = originalPath;
+  return url.toString();
 }
 
 function validateGitCredentialHelper(helper: GitCredentialHelperConfig): void {

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -22,6 +22,7 @@ const GIT_CREDENTIAL_SECTION_RE = /^\[credential\]\s*(?:[;#].*)?$/i;
 const GIT_USE_HTTP_PATH_RE = /^usehttppath\s*=\s*(true|false)\s*(?:[;#].*)?$/i;
 const GIT_CREDENTIAL_KEYS_RE = /^(credential|http)\..*\.(helper|username|password|extraheader)$/i;
 const GIT_CONFIG_LINES_RE = /\r?\n/;
+const TRAILING_SLASHES_RE = /\/+$/u;
 const GIT_CREDENTIAL_KEY_RE =
   /^(?:credential|http)\.(.*)\.(?:helper|username|password|extraheader)$/i;
 
@@ -295,7 +296,7 @@ export function writeGitCredentialHelperConfig(params: {
   gitAuthor?: {name: string; email: string} | undefined;
 }): Promise<void> {
   const {configPath, repositoryUrl, helper, gitAuthor} = params;
-  const normalizedRepositoryUrl = normalizeRepositoryUrl(repositoryUrl);
+  const normalizedRepositoryUrl = gitConfigRepositoryUrl(repositoryUrl);
   validateGitCredentialHelper(helper);
   return withAmbientGitConfigLock(configPath, () =>
     updateGitCredentialHelperConfig({
@@ -305,6 +306,13 @@ export function writeGitCredentialHelperConfig(params: {
       gitAuthor,
     }),
   );
+}
+
+function gitConfigRepositoryUrl(repositoryUrl: string): string {
+  const normalized = normalizeRepositoryUrl(repositoryUrl);
+  const originalPath = new URL(repositoryUrl).pathname.replace(TRAILING_SLASHES_RE, '');
+  if (!originalPath.toLowerCase().endsWith('.git')) return normalized;
+  return `${normalized.slice(0, -1)}${originalPath.slice(-4)}`;
 }
 
 function validateGitCredentialHelper(helper: GitCredentialHelperConfig): void {
@@ -351,7 +359,10 @@ async function updateGitCredentialHelperConfig(params: {
       `${current}${current.endsWith('\n') || current === '' ? '' : '\n'}${additions}`,
       {flag: 'wx', mode: 0o600},
     );
-    await unsetGitCredentialValues(temporaryConfigPath, params.repositoryUrl);
+    await unsetGitCredentialValues(
+      temporaryConfigPath,
+      normalizeRepositoryUrl(params.repositoryUrl),
+    );
     const withoutOldHelper = await readFile(temporaryConfigPath, 'utf8');
     await writeFile(temporaryConfigPath, `${withoutOldHelper}${helperLines.join('\n')}\n`, {
       flag: 'w',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1401,6 +1401,9 @@ importers:
 
   e2e/setup/integrations:
     dependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/core-dto
       '@shipfox/api-integration-github-dto':
         specifier: workspace:*
         version: link:../../../libs/api/integration/github-dto


### PR DESCRIPTION
## Summary

Adds deterministic end-to-end evidence for renewable Git checkout credentials before production activation.

- Adds an opt-in seconds-lived Test VCS provider and challenge-capable smart-HTTP fixture.
- Covers renewal on rejection and refresh-at, multi-checkout, read/write isolation, stale rejection, dynamic redaction, author configuration without credential persistence, concurrent same-scope minting, and terminal provider failure.
- Wires local E2E runners to the built credential helper while keeping the capability disabled by default.

## Motivation

Long-running workflows can outlive a provider credential. This suite proves the renewal seams and failure boundaries with a deterministic fixture before enabling the capability in production.

## Validation

- Dedicated renewable-credentials E2E suite: 5/5 scenarios passed.
- Provider-failure isolation E2E: 1/1 passed.
- Affected-package typecheck: 200/200; check: 99/99; dependency-cruiser: 62/62.
- Focused unit tests, harness tests, database-boundary verification, and diff checks passed.

## Remaining activation gate

The real GitHub canary for helper compatibility and initial L2 reuse remains to be run with live credentials. The local suite covers the acceptance criteria that do not require an hour-long GitHub wait.

Refs ENG-1752

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
For ENG-1752, adds deterministic end-to-end proof for renewable Git credentials using an opt-in Test VCS provider. Write-side rejection retries now renew credentials before pushing again, while the provider and runner capability remain disabled by default.

- Covers refresh-at and rejection renewal, multi-checkout, scope isolation, stale rejection, redaction, author configuration, concurrent minting, and provider failure.
- Adds a seconds-lived Test VCS smart-HTTP fixture, setup routes, failure controls, and local runner support for the built credential helper.
- Fixes Git credential matching for repository URLs with or without `.git`, preserves nested Turbo test arguments, and aligns branch validation with Git ref rules.
- Local scenarios and affected package checks pass; a live GitHub canary remains for helper compatibility and initial L2 reuse.

<sup>Written for commit 1a60e390966856ec97cec0281fdab32363488d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

