### PR TITLE
[docs] Update Cloud model reference catalog

### DIFF
--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -67,8 +67,8 @@ reference](/reference/workflow-schema#agent-step-fields).
 | Kimi K2.7 Code | `kimi-k2.7-code` |
 | Kimi K2.6 | `kimi-k2.6` |
 | Qwen3.8 2.4T A95B | `qwen3.8-2.4t-a95b` |
-| Qwen3.6 35 B A3B | `qwen3.6-35b-a3b` |
-| Qwen3.5 397 B A17B | `qwen3.5-397b-a17b` |
+| Qwen3 Coder Plus | `qwen3-coder-plus` |
+| Qwen3 Max | `qwen3-max` |
 | MiMo V2.5 Pro | `mimo-v2.5-pro` |
 | MiniMax M2.7 | `minimax-m2.7` |
 | MiniMax M3 | `minimax-m3` |

--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -38,6 +38,7 @@ reference](/reference/workflow-schema#agent-step-fields).
 
 | Model | `model` ID |
 | --- | --- |
+| Claude Fable 5.1 | `claude-fable-5.1` |
 | Claude Fable 5 | `claude-fable-5` |
 | Claude Opus 5 | `claude-opus-5` |
 | Claude Opus 4.8 | `claude-opus-4.8` |


### PR DESCRIPTION
Keep the Shipfox Cloud managed-model reference aligned with the current catalog. The page documents Claude Fable 5.1 and the renamed Qwen3 Coder Plus and Qwen3 Max entries with their exact `claude-fable-5.1`, `qwen3-coder-plus`, and `qwen3-max` workflow IDs.