### PR TITLE
[api-integration-github] Stop invalid installation-token cache reads

### DIFF
--- a/.changeset/quiet-github-token-cache.md
+++ b/.changeset/quiet-github-token-cache.md
@@ -2,4 +2,4 @@
 '@shipfox/api-integration-github': patch
 ---
 
-Stop probing an invalid legacy Secrets key when reading shared GitHub installation tokens.
+Fix shared GitHub installation-token cache reads for API requests.

--- a/.changeset/quiet-github-token-cache.md
+++ b/.changeset/quiet-github-token-cache.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-integration-github': patch
+---
+
+Stop probing an invalid legacy Secrets key when reading shared GitHub installation tokens.

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -13,7 +13,6 @@ export const TRANSIENT_BACKOFF_MAX_MS = 5 * 60 * 1000;
 export const TERMINAL_BACKOFF_MS = 15 * 60 * 1000;
 export const GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT = 'compatibility';
 export const GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY = 'BACKOFF';
-export const GITHUB_LEGACY_INSTALLATION_TOKEN_KEY = 'envelope';
 
 const providerErrorReasons = [
   'repository-not-found',

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -1,9 +1,11 @@
 import {createHash} from 'node:crypto';
+import {secretKeySchema} from '@shipfox/api-secrets-dto';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {
   backoffActive,
   encodeInstallationTokenEnvelope,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+  GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
   githubInstallationTokenBackoffKey,
   githubInstallationTokenKey,
   needsRefresh,
@@ -38,6 +40,9 @@ function createStore(): InstallationTokenSecretStore & {
     failWrites: false,
     failReads: false,
     read(readWorkspaceId: string, readInstallationId: number, key: string) {
+      if (!secretKeySchema.safeParse(key).success) {
+        return Promise.reject(new Error(`invalid secret key: ${key}`));
+      }
       if (store.failReads) return Promise.reject(new Error('read failed'));
       return Promise.resolve(values.get(`${readWorkspaceId}:${readInstallationId}:${key}`) ?? null);
     },
@@ -47,6 +52,9 @@ function createStore(): InstallationTokenSecretStore & {
       key: string,
       envelope: Parameters<InstallationTokenSecretStore['write']>[3],
     ) {
+      if (!secretKeySchema.safeParse(key).success) {
+        return Promise.reject(new Error(`invalid secret key: ${key}`));
+      }
       if (store.failWrites) return Promise.reject(new Error('write failed'));
       values.set(
         `${writeWorkspaceId}:${writeInstallationId}:${key}`,
@@ -110,10 +118,10 @@ describe('SharedInstallationTokenCache', () => {
     );
   });
 
-  it('reads the legacy compatibility envelope', async () => {
+  it('reads the fixed-key compatibility envelope without invalid secret reads', async () => {
     const store = createStore();
     store.values.set(
-      `${workspaceId}:${installationId}:envelope`,
+      `${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY}`,
       encodeInstallationTokenEnvelope({
         backoffUntil: new Date('2026-06-10T11:05:00.000Z'),
         backoffReason: 'rate-limited',
@@ -127,6 +135,7 @@ describe('SharedInstallationTokenCache', () => {
       shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
     ).rejects.toMatchObject({reason: 'rate-limited', status: 429});
     expect(mint).not.toHaveBeenCalled();
+    expect(errorMonitoring.reportError).not.toHaveBeenCalled();
   });
 
   beforeEach(() => {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -16,7 +16,6 @@ import {
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
   GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
   GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
-  GITHUB_LEGACY_INSTALLATION_TOKEN_KEY,
   githubInstallationTokenBackoffKey,
   githubInstallationTokenBackoffKeys,
   githubInstallationTokenKey,
@@ -521,35 +520,30 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   ): Promise<InstallationTokenEnvelope | undefined> {
     const isCompatibilityProfile =
       profileKey === githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT);
-    const {profileResult, backoffResults, fixedEnvelopeResult, legacyResult} =
-      await readSecretValues(
-        this.options.secretStore,
-        workspaceId,
-        installationId,
-        profileKey,
-        backoffKeys,
-      );
+    const {profileResult, backoffResults, fixedEnvelopeResult} = await readSecretValues(
+      this.options.secretStore,
+      workspaceId,
+      installationId,
+      profileKey,
+      backoffKeys,
+    );
     reportSecretReadFailure(profileResult, reportReadFailure);
     for (const backoffResult of backoffResults) {
       reportSecretReadFailure(backoffResult, reportReadFailure);
     }
     reportSecretReadFailure(fixedEnvelopeResult, reportReadFailure);
-    reportSecretReadFailure(legacyResult, reportReadFailure);
 
     const profileRaw = settledRaw(profileResult);
     const backoffRaws = backoffResults.map(settledRaw);
     const fixedEnvelopeRaw = settledRaw(fixedEnvelopeResult);
-    const legacyRaw = settledRaw(legacyResult);
     let profile = parseRawEnvelope(profileRaw, installationId);
     let backoff = latestBackoff(
       backoffRaws.map((backoffRaw) => parseRawEnvelope(backoffRaw, installationId)),
       this.now(),
     );
     const fixedEnvelope = parseRawEnvelope(fixedEnvelopeRaw, installationId);
-    const legacy = parseRawEnvelope(legacyRaw, installationId);
-    const compatibilityEnvelope = fixedEnvelope ?? legacy;
     if (isCompatibilityProfile && profile === undefined && profileRaw === null) {
-      profile = compatibilityEnvelope;
+      profile = fixedEnvelope;
     }
     if (
       isCompatibilityProfile &&
@@ -557,7 +551,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       backoffRaws.length === 1 &&
       backoffRaws[0] === null
     ) {
-      backoff = compatibilityEnvelope;
+      backoff = fixedEnvelope;
     }
     if (!profile && !backoff) return undefined;
     return {
@@ -597,7 +591,6 @@ interface InstallationTokenSecretReads {
   profileResult: SettledSecretRead;
   backoffResults: readonly SettledSecretRead[];
   fixedEnvelopeResult: SettledSecretRead;
-  legacyResult: SettledSecretRead;
 }
 
 async function readSecretValues(
@@ -616,22 +609,15 @@ async function readSecretValues(
     installationId,
     GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
   );
-  const legacyRead = secretStore.read(
-    workspaceId,
-    installationId,
-    GITHUB_LEGACY_INSTALLATION_TOKEN_KEY,
-  );
-  const [profileResult, fixedEnvelopeResult, legacyResult] = await Promise.allSettled([
+  const [profileResult, fixedEnvelopeResult] = await Promise.allSettled([
     profileRead,
     fixedEnvelopeRead,
-    legacyRead,
   ]);
   const backoffResults = await Promise.allSettled(backoffReads);
   return {
     profileResult,
     backoffResults,
     fixedEnvelopeResult,
-    legacyResult,
   };
 }
 


### PR DESCRIPTION
## Summary

Staging reports `SecretKeyValidationError` while reading shared GitHub installation tokens because the cache probes the lowercase `envelope` key, which the Secrets key schema does not accept.

Remove that impossible legacy read while preserving the valid uppercase `ENVELOPE` compatibility path. The cache test store now applies the production key schema so future invalid key probes fail locally, and successful token mints can clear profile backoff normally.

Sentry: https://shipfox.sentry.io/issues/143741573/

## Validation

- `mise exec -- turbo check type test build depcruise --filter=@shipfox/api-integration-github...` — 120/120 tasks; 425 package tests
- `mise exec -- pnpm check:published-artifacts`
- `mise exec -- pnpm exec changeset status`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops shared GitHub installation-token cache reads from probing the invalid lowercase `envelope` Secrets key, which caused staging errors on every read. Compatibility reads now use the valid fixed key, so successful token mints can clear profile backoff without reporting spurious errors.

- Applies the production `secretKeySchema` to the test store so invalid key probes fail locally.
- Removes the obsolete legacy key and adds regression coverage for clean compatibility reads.

<sup>Written for commit caab282f605c70b30d7745fd92d859d93b9b6200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

