### PR TITLE
[api-workflows] Name tool output mapping failures

### DIFF
--- a/.changeset/bounded-expression-diagnostics.md
+++ b/.changeset/bounded-expression-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Exposes bounded CEL evaluation diagnostics without runtime operands.

--- a/.changeset/named-mapping-errors.md
+++ b/.changeset/named-mapping-errors.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/api-workflows": patch
+"@shipfox/expression": minor
 ---
 
-Names mapped tool outputs in runtime errors with their mapping key and CEL cause.
+Names mapped tool outputs in runtime errors with their mapping key and safe CEL cause.

--- a/.changeset/named-mapping-errors.md
+++ b/.changeset/named-mapping-errors.md
@@ -1,6 +1,5 @@
 ---
 "@shipfox/api-workflows": patch
-"@shipfox/expression": minor
 ---
 
-Names mapped tool outputs in runtime errors with their mapping key and safe CEL cause.
+Names mapped tool output failures with their mapping key and a bounded CEL diagnostic.

--- a/.changeset/named-mapping-errors.md
+++ b/.changeset/named-mapping-errors.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Names mapped tool outputs in runtime errors with their mapping key and CEL cause.

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -713,6 +713,55 @@ describe('tool step executor', () => {
     ).toBeDefined();
   });
 
+  test.each([
+    {
+      description: 'a missing key',
+      source: 'result.teams[0].nmae',
+      result: {teams: [{id: 'team-1'}]},
+      cause: 'No such key: nmae',
+    },
+    {
+      description: 'an out-of-range index',
+      source: 'result.teams[1].id',
+      result: {teams: [{id: 'team-1'}]},
+      cause: 'No such key: index out of bounds, index 1 >= size 1',
+    },
+  ])('names the mapping key and CEL cause for $description', async ({source, result, cause}) => {
+    const {jobId} = await arrangeToolStep('read', {
+      outputMappings: {
+        team_id: createWorkflowExpression({source, check: {mode: 'syntax'}}),
+      },
+    });
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result,
+      content: [],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle({
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    const [step] = await getStepsByJobId(jobId);
+    expect(step).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'output_invalid',
+        reason: 'output_invalid',
+        message: `Tool output mapping "team_id" failed: ${cause}`,
+      },
+    });
+  });
+
   test('preserves a __proto__ output mapping as ordinary output data', async () => {
     const outputMappings: Record<string, unknown> = {};
     Object.defineProperty(outputMappings, '__proto__', {

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -796,13 +796,7 @@ function errorMessage(error: unknown): string {
 }
 
 function mappingEvaluationErrorMessage(error: unknown): string {
-  if (!(error instanceof WorkflowExpressionEvaluationError) || error.cause === undefined) {
-    return errorMessage(error);
-  }
-  if (isRecord(error.cause) && typeof error.cause.summary === 'string') {
-    return error.cause.summary;
-  }
-  return errorMessage(error.cause);
+  return error instanceof WorkflowExpressionEvaluationError ? error.summary : errorMessage(error);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -4,7 +4,11 @@ import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto
 import {MAX_RECORD_DATA_BYTES, type ServerLogRecord} from '@shipfox/api-logs-dto';
 import type {LogsModuleClient} from '@shipfox/api-logs-dto/inter-module';
 import {logsInterModuleContract} from '@shipfox/api-logs-dto/inter-module';
-import {evaluateWorkflowExpression, type WorkflowExpression} from '@shipfox/expression';
+import {
+  evaluateWorkflowExpression,
+  type WorkflowExpression,
+  WorkflowExpressionEvaluationError,
+} from '@shipfox/expression';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {reportError} from '@shipfox/node-error-monitoring';
 import type {ModuleService} from '@shipfox/node-module';
@@ -438,13 +442,22 @@ function mapToolOutputs(
     if (!isRecord(rawExpression) || typeof rawExpression.source !== 'string') {
       throw new Error(`Tool output mapping "${key}" is invalid`);
     }
+    let value: unknown;
+    try {
+      value = evaluateWorkflowExpression(rawExpression as unknown as WorkflowExpression, {
+        result,
+        vars: workflowContext.vars ?? {},
+      });
+    } catch (error) {
+      throw new Error(
+        `Tool output mapping "${key}" failed: ${mappingEvaluationErrorMessage(error)}`,
+        {cause: error},
+      );
+    }
     Object.defineProperty(output, key, {
       configurable: true,
       enumerable: true,
-      value: evaluateWorkflowExpression(rawExpression as unknown as WorkflowExpression, {
-        result,
-        vars: workflowContext.vars ?? {},
-      }),
+      value,
       writable: true,
     });
   }
@@ -780,6 +793,16 @@ function reportUnexpectedToolError(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function mappingEvaluationErrorMessage(error: unknown): string {
+  if (!(error instanceof WorkflowExpressionEvaluationError) || error.cause === undefined) {
+    return errorMessage(error);
+  }
+  if (isRecord(error.cause) && typeof error.cause.summary === 'string') {
+    return error.cause.summary;
+  }
+  return errorMessage(error.cause);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/libs/shared/expression/src/evaluator/errors.ts
+++ b/libs/shared/expression/src/evaluator/errors.ts
@@ -4,9 +4,17 @@ export const workflowExpressionEvaluationErrorCode = 'workflow-expression-evalua
 
 export type WorkflowExpressionEvaluationFailureReason = 'missing-path' | 'evaluation-error';
 
+const MAX_WORKFLOW_EXPRESSION_EVALUATION_SUMMARY_LENGTH = 200;
+const SAFE_CEL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+const SAFE_CEL_ERROR_CODE = /^[a-z][a-z0-9_]{0,63}$/;
+const SAFE_INDEX_OUT_OF_BOUNDS_SUMMARY =
+  /^No such key: index out of bounds, index (-?\d{1,9}) (< 0|>= size \d{1,9})$/;
+
 export class WorkflowExpressionEvaluationError extends Error {
   readonly code = workflowExpressionEvaluationErrorCode;
   readonly reason: WorkflowExpressionEvaluationFailureReason;
+  /** A bounded diagnostic with runtime values removed before persistence. */
+  readonly summary: string;
 
   constructor(cause: unknown) {
     super('Workflow expression evaluation failed', {cause});
@@ -16,5 +24,48 @@ export class WorkflowExpressionEvaluationError extends Error {
       (cause.code === 'no_such_key' || cause.code === 'unknown_variable')
         ? 'missing-path'
         : 'evaluation-error';
+    this.summary = boundedWorkflowExpressionEvaluationSummary(cause);
   }
+}
+
+function boundedWorkflowExpressionEvaluationSummary(cause: unknown): string {
+  const summary = workflowExpressionEvaluationSummary(cause);
+  return summary.length <= MAX_WORKFLOW_EXPRESSION_EVALUATION_SUMMARY_LENGTH
+    ? summary
+    : `${summary.slice(0, MAX_WORKFLOW_EXPRESSION_EVALUATION_SUMMARY_LENGTH - 1)}…`;
+}
+
+function workflowExpressionEvaluationSummary(cause: unknown): string {
+  if (!(cause instanceof EvaluationError)) return 'CEL evaluation failed';
+
+  if (cause.code === 'no_such_key') {
+    return missingKeySummary(cause);
+  }
+
+  if (cause.code === 'index_out_of_bounds') {
+    return indexOutOfBoundsSummary(cause);
+  }
+
+  const code = safeCelErrorCode(cause.code);
+  return code === undefined ? 'CEL evaluation failed' : `CEL evaluation failed (${code})`;
+}
+
+function missingKeySummary(error: EvaluationError): string {
+  if (error.node?.op !== '.' && error.node?.op !== '.?') return 'No such key';
+
+  const key = error.node.args[1];
+  return typeof key === 'string' && SAFE_CEL_IDENTIFIER.test(key)
+    ? `No such key: ${key}`
+    : 'No such key';
+}
+
+function indexOutOfBoundsSummary(error: EvaluationError): string {
+  const match = SAFE_INDEX_OUT_OF_BOUNDS_SUMMARY.exec(error.summary);
+  return match === null
+    ? 'No such key: index out of bounds'
+    : `No such key: index out of bounds, index ${match[1]} ${match[2]}`;
+}
+
+function safeCelErrorCode(code: string): string | undefined {
+  return SAFE_CEL_ERROR_CODE.test(code) ? code : undefined;
 }

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -513,4 +513,24 @@ describe('evaluateWorkflowExpression', () => {
     expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
     expect((error as WorkflowExpressionEvaluationError).reason).toBe('evaluation-error');
   });
+
+  it('exposes a bounded diagnostic without runtime operands', () => {
+    const expression = createWorkflowExpression({
+      source: 'duration(result.secret)',
+      check: {mode: 'syntax'},
+    });
+
+    let error: unknown;
+    try {
+      evaluateWorkflowExpression(expression, {result: {secret: 'topsecret'}});
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
+    expect((error as WorkflowExpressionEvaluationError).summary).toBe(
+      'CEL evaluation failed (invalid_duration)',
+    );
+    expect((error as WorkflowExpressionEvaluationError).summary).not.toContain('topsecret');
+  });
 });


### PR DESCRIPTION
Tool output mapping evaluation failures now identify the mapping key and concise CEL cause, making output_invalid errors actionable for missing keys and out-of-range indexes. The original evaluator error remains attached as the cause, and invalid mapping configuration behavior is unchanged.

Validated with the focused tool-step executor suite (23 tests), affected-package Turbo check/type/test/build gates (including 1,069 workflow tests), Changeset status, and git diff --check.

Closes ENG-1885

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tool output mapping failures now identify the mapping key and a bounded CEL diagnostic with runtime operands removed, making `output_invalid` errors actionable for missing keys and out-of-range indexes. Invalid mapping configuration behavior is unchanged, and the original evaluator error remains attached as the cause. Closes ENG-1885.

**Bug Fixes**
- Adds regression coverage for diagnostic sanitization and length bounds.
- Splits changesets across `@shipfox/api-workflows` and `@shipfox/expression` to match each package's actual change.

<sup>Written for commit 202acfc6cab4f034e0c9ca99acf183d496bfaaea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

