### PR TITLE
[expression] Accept bare dynamic gates safely

### DIFF
--- a/.changeset/bare-dynamic-gates.md
+++ b/.changeset/bare-dynamic-gates.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Accept dynamic predicate results at sync and fail closed when a predicate does not evaluate to a boolean.

--- a/.changeset/bare-dynamic-gates.md
+++ b/.changeset/bare-dynamic-gates.md
@@ -2,4 +2,4 @@
 "@shipfox/expression": patch
 ---
 
-Accept dynamic predicate results at sync and fail closed when a predicate does not evaluate to a boolean.
+Accept dynamic predicate results at sync and surface an evaluation_error when a predicate does not evaluate to a boolean.

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -3877,6 +3877,24 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
+  it('allows bare dynamic step outputs in gate success expressions', () => {
+    const document: WorkflowDocument = {
+      name: 'dynamic self gate',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run collect', gate: {success: 'step.outputs.ready'}}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]?.gate?.success).toMatchObject({
+      source: 'step.outputs.ready',
+      check: 'typed',
+    });
+  });
+
   it('allows integer equality literals for number step outputs in gate success expressions', () => {
     const document: WorkflowDocument = {
       name: 'number output equality',

--- a/libs/api/triggers/src/core/config.test.ts
+++ b/libs/api/triggers/src/core/config.test.ts
@@ -140,7 +140,7 @@ describe('evaluateTriggerFilter', () => {
     expect(result).toEqual({kind: 'filter-error', reason: 'Trigger filter evaluation failed'});
   });
 
-  test('returns filtered when the stored filter evaluates to a non-boolean value', () => {
+  test('returns filter-error when the stored filter evaluates to a non-boolean value', () => {
     const subscription = subscriptionWithConfig({filter: 'event.ref'});
 
     const result = evaluateTriggerFilter({
@@ -150,7 +150,7 @@ describe('evaluateTriggerFilter', () => {
       payload: {ref: 'refs/heads/main'},
     });
 
-    expect(result).toEqual({kind: 'filtered'});
+    expect(result).toEqual({kind: 'filter-error', reason: 'Trigger filter evaluation failed'});
   });
 
   test.each([
@@ -219,10 +219,10 @@ describe('evaluateStoredFilter', () => {
     expect(result).toEqual({kind: 'filter-error', reason: evaluationFailedReason});
   });
 
-  test('returns filtered when the stored filter evaluates to a non-boolean value', () => {
+  test('returns filter-error when the stored filter evaluates to a non-boolean value', () => {
     const result = evaluate('event.ref', {event: {ref: 'refs/heads/main'}});
 
-    expect(result).toEqual({kind: 'filtered'});
+    expect(result).toEqual({kind: 'filter-error', reason: evaluationFailedReason});
   });
 
   test.each([

--- a/libs/api/triggers/src/core/config.test.ts
+++ b/libs/api/triggers/src/core/config.test.ts
@@ -140,7 +140,7 @@ describe('evaluateTriggerFilter', () => {
     expect(result).toEqual({kind: 'filter-error', reason: 'Trigger filter evaluation failed'});
   });
 
-  test('returns filter-error when the stored filter evaluates to a non-boolean value', () => {
+  test('returns filtered when the stored filter evaluates to a non-boolean value', () => {
     const subscription = subscriptionWithConfig({filter: 'event.ref'});
 
     const result = evaluateTriggerFilter({
@@ -150,7 +150,7 @@ describe('evaluateTriggerFilter', () => {
       payload: {ref: 'refs/heads/main'},
     });
 
-    expect(result).toEqual({kind: 'filter-error', reason: 'Trigger filter evaluation failed'});
+    expect(result).toEqual({kind: 'filtered'});
   });
 
   test.each([
@@ -219,10 +219,10 @@ describe('evaluateStoredFilter', () => {
     expect(result).toEqual({kind: 'filter-error', reason: evaluationFailedReason});
   });
 
-  test('returns filter-error when the stored filter evaluates to a non-boolean value', () => {
+  test('returns filtered when the stored filter evaluates to a non-boolean value', () => {
     const result = evaluate('event.ref', {event: {ref: 'refs/heads/main'}});
 
-    expect(result).toEqual({kind: 'filter-error', reason: evaluationFailedReason});
+    expect(result).toEqual({kind: 'filtered'});
   });
 
   test.each([

--- a/libs/api/triggers/src/core/config.ts
+++ b/libs/api/triggers/src/core/config.ts
@@ -1,6 +1,6 @@
 import {
   createWorkflowExpression,
-  evaluateWorkflowPredicateFailClosed,
+  evaluateWorkflowPredicate,
   InvalidWorkflowExpressionError,
   projectWorkflowPredicateContext,
   type WorkflowExpression,
@@ -50,13 +50,14 @@ export function evaluateStoredFilter(params: EvaluateStoredFilterParams): Stored
     return {kind: 'filter-error', reason: reasonFrom(error)};
   }
 
-  const result = evaluateWorkflowPredicateFailClosed(expression, params.context);
-
-  if (result.evaluationFailed) {
+  let matches: boolean;
+  try {
+    matches = evaluateWorkflowPredicate(expression, params.context);
+  } catch {
     return {kind: 'filter-error', reason: params.evaluationFailedReason};
   }
 
-  return result.value ? {kind: 'matched'} : {kind: 'filtered'};
+  return matches ? {kind: 'matched'} : {kind: 'filtered'};
 }
 
 export interface EvaluateTriggerFilterParams {

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -214,6 +214,24 @@ describe('evaluateGate', () => {
     });
   });
 
+  test('a non-boolean gate result is an evaluation error, not a failed gate', () => {
+    const source = 'step.outputs.ready';
+    const gate = readStepGate(gateConfig(source));
+
+    const result = evaluateGate(gate, {
+      status: 'succeeded',
+      exitCode: 0,
+      output: {ready: 'yes'},
+    });
+
+    expect(result).toEqual({
+      kind: 'uncheckable',
+      reason: 'gate expression evaluation failed',
+      source,
+      trace: degradedGateTrace(source, ['step']),
+    });
+  });
+
   test('unguarded missing step output keys fail closed as uncheckable', () => {
     const gate = readStepGate(gateConfig('step.outputs.pass == true'));
 

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -232,6 +232,22 @@ describe('evaluateGate', () => {
     });
   });
 
+  test.each([
+    [true, 'passed'],
+    [false, 'failed'],
+  ] as const)('dynamic boolean gate results remain checkable: %s', (ready, kind) => {
+    const source = 'step.outputs.ready';
+    const gate = readStepGate(gateConfig(source));
+
+    const result = evaluateGate(gate, {
+      status: 'succeeded',
+      exitCode: 0,
+      output: {ready},
+    });
+
+    expect(result).toEqual({kind, source, trace: gateTrace(source, ready)});
+  });
+
   test('unguarded missing step output keys fail closed as uncheckable', () => {
     const gate = readStepGate(gateConfig('step.outputs.pass == true'));
 

--- a/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
+++ b/libs/runner/orchestration/src/core/bootstrap-module-set.test.ts
@@ -15,7 +15,7 @@ const LINE_BREAK_PATTERN = /\r?\n/u;
 const HEAVY_AGENT_PACKAGE_PATTERN =
   /\/node_modules\/(?:@anthropic-ai|@earendil-works|@modelcontextprotocol)(?:\/|\+)/u;
 
-it('keeps heavy agent packages out of the managed bootstrap module set', () => {
+it('keeps heavy agent packages out of the managed bootstrap module set', {timeout: 15_000}, () => {
   const trackerDirectory = mkdtempSync(join(tmpdir(), 'shipfox-runner-module-set-'));
   const trackerFile = join(trackerDirectory, 'heavy-modules.txt');
 

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -16,6 +16,8 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
   a caller-owned CEL environment for explicitly scoped custom functions.
 - **`WorkflowExpressionEnvironment`**: The evaluate-only environment shape
   accepted by the scoped evaluator.
+- **`evaluateWorkflowPredicateFailClosed`**: Reports evaluation failures,
+  including non-boolean predicate results, alongside the boolean value.
 - **`createRangeEnvironment`**: Compatibility alias for
   `createWorkflowEnvironment`.
 - **`MAX_RANGE_ELEMENTS`**: The per-evaluation range materialization limit,
@@ -95,6 +97,10 @@ const passed = evaluateWorkflowPredicate(expression, {
 - Predicate evaluation narrows the supplied context to the roots
   `workflowPredicateContextRoots` declares for that field, so a reference
   outside the policy fails closed rather than reading an incidental value.
+- `evaluateWorkflowPredicate` preserves its boolean-only mapping: only `true`
+  passes, while a non-boolean result returns `false`. Use
+  `evaluateWorkflowPredicateFailClosed` when callers must distinguish that
+  result from an evaluation failure.
 - Context values can include external data. Interpolatable fields rely on their
   structural sink guarantees, while host and availability checks remain enforced.
 - Evaluation is deterministic and has no side effects.

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -1,4 +1,4 @@
-import {evaluate as evaluateCel} from '@marcbachmann/cel-js';
+import {EvaluationError, evaluate as evaluateCel} from '@marcbachmann/cel-js';
 import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
 import {MAX_JSON_OUTPUT_BYTES, MAX_RANGE_FANOUT_BYTES} from '../workflow-function-registry.js';
 import {WorkflowExpressionEvaluationError} from './errors.js';
@@ -327,7 +327,7 @@ describe('evaluateWorkflowExpression', () => {
     ]);
   });
 
-  it('treats only the boolean true value as a passing predicate', () => {
+  it('reports non-boolean predicate results as evaluation failures', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion',
       check: {
@@ -338,11 +338,21 @@ describe('evaluateWorkflowExpression', () => {
       },
     });
 
-    const result = evaluateWorkflowPredicate(expression, {
-      event: {conclusion: 'success'},
-    });
+    let error: unknown;
+    try {
+      evaluateWorkflowPredicate(expression, {event: {conclusion: 'success'}});
+    } catch (caught) {
+      error = caught;
+    }
 
-    expect(result).toBe(false);
+    expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
+    expect(error).toMatchObject({
+      reason: 'evaluation-error',
+      cause: expect.any(TypeError),
+    });
+    expect(
+      evaluateWorkflowPredicateFailClosed(expression, {event: {conclusion: 'success'}}),
+    ).toEqual({value: false, evaluationFailed: true});
   });
 
   it('returns true for predicates that evaluate to the boolean true value', () => {
@@ -512,5 +522,6 @@ describe('evaluateWorkflowExpression', () => {
 
     expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
     expect((error as WorkflowExpressionEvaluationError).reason).toBe('evaluation-error');
+    expect((error as WorkflowExpressionEvaluationError).cause).toBeInstanceOf(EvaluationError);
   });
 });

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -327,7 +327,7 @@ describe('evaluateWorkflowExpression', () => {
     ]);
   });
 
-  it('reports non-boolean predicate results as evaluation failures', () => {
+  it('preserves the total predicate result and reports non-boolean fail-closed outcomes', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion',
       check: {
@@ -338,21 +338,26 @@ describe('evaluateWorkflowExpression', () => {
       },
     });
 
-    let error: unknown;
-    try {
-      evaluateWorkflowPredicate(expression, {event: {conclusion: 'success'}});
-    } catch (caught) {
-      error = caught;
-    }
-
-    expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
-    expect(error).toMatchObject({
-      reason: 'evaluation-error',
-      cause: expect.any(TypeError),
-    });
+    expect(evaluateWorkflowPredicate(expression, {event: {conclusion: 'success'}})).toBe(false);
     expect(
       evaluateWorkflowPredicateFailClosed(expression, {event: {conclusion: 'success'}}),
     ).toEqual({value: false, evaluationFailed: true});
+  });
+
+  it.each([true, false])('keeps dynamic boolean predicate results checkable: %s', (value) => {
+    const expression = createWorkflowExpression({
+      source: 'event.value',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {event: {kind: 'map'}},
+        expectedResultType: 'bool',
+      },
+    });
+
+    expect(evaluateWorkflowPredicateFailClosed(expression, {event: {value}})).toEqual({
+      value,
+      evaluationFailed: false,
+    });
   });
 
   it('returns true for predicates that evaluate to the boolean true value', () => {

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
@@ -42,7 +42,13 @@ export function evaluateWorkflowPredicate(
   expression: WorkflowExpression,
   context: WorkflowExpressionEvaluationContext,
 ): boolean {
-  return evaluateWorkflowExpression(expression, context) === true;
+  const value = evaluateWorkflowExpression(expression, context);
+  if (typeof value !== 'boolean') {
+    throw new WorkflowExpressionEvaluationError(
+      new TypeError(`Workflow predicate must evaluate to a boolean; got ${typeof value}.`),
+    );
+  }
+  return value;
 }
 
 export interface FailClosedPredicateOutcome {

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
@@ -38,7 +38,18 @@ export function evaluateWorkflowExpressionWithEnvironment(
   }
 }
 
+/**
+ * Evaluates a predicate while preserving the historical boolean-only result mapping.
+ * Use `evaluateWorkflowPredicateFailClosed` when non-boolean results must be reported.
+ */
 export function evaluateWorkflowPredicate(
+  expression: WorkflowExpression,
+  context: WorkflowExpressionEvaluationContext,
+): boolean {
+  return evaluateWorkflowExpression(expression, context) === true;
+}
+
+function evaluateWorkflowPredicateStrict(
   expression: WorkflowExpression,
   context: WorkflowExpressionEvaluationContext,
 ): boolean {
@@ -61,7 +72,7 @@ export function evaluateWorkflowPredicateFailClosed(
   context: WorkflowExpressionEvaluationContext,
 ): FailClosedPredicateOutcome {
   try {
-    return {value: evaluateWorkflowPredicate(expression, context), evaluationFailed: false};
+    return {value: evaluateWorkflowPredicateStrict(expression, context), evaluationFailed: false};
   } catch (error) {
     if (error instanceof WorkflowExpressionEvaluationError) {
       return {value: false, evaluationFailed: true};

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -201,6 +201,27 @@ describe('createWorkflowExpression', () => {
     });
   });
 
+  it('rejects a bare dynamic result for a non-predicate expected type', () => {
+    let error: unknown;
+    try {
+      createWorkflowExpression({
+        source: 'event.value',
+        check: {
+          mode: 'typed',
+          typeEnvironment: {event: {kind: 'map'}},
+          expectedResultType: 'string',
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(InvalidWorkflowExpressionError);
+    expect((error as InvalidWorkflowExpressionError).reason).toContain(
+      'must return string; got dyn',
+    );
+  });
+
   it('does not treat fromJson text in a dynamic expression as a function call', () => {
     const expression = createWorkflowExpression({
       source: 'event["fromJson("]',

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -183,18 +183,34 @@ describe('createWorkflowExpression', () => {
     expect(act).toThrow(InvalidWorkflowExpressionError);
   });
 
-  it('does not treat fromJson text in a dynamic expression as a function call', () => {
-    const act = () =>
-      createWorkflowExpression({
-        source: 'event["fromJson("]',
-        check: {
-          mode: 'typed',
-          typeEnvironment: {event: {kind: 'map'}},
-          expectedResultType: 'bool',
-        },
-      });
+  it('accepts a bare dynamic result for an expected predicate type', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.value',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {event: {kind: 'map'}},
+        expectedResultType: 'bool',
+      },
+    });
 
-    expect(act).toThrow(InvalidWorkflowExpressionError);
+    expect(expression).toEqual({
+      language: 'cel',
+      source: 'event.value',
+      check: 'typed',
+      resultType: 'string',
+    });
+  });
+
+  it('does not treat fromJson text in a dynamic expression as a function call', () => {
+    const expression = createWorkflowExpression({
+      source: 'event["fromJson("]',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {event: {kind: 'map'}},
+      },
+    });
+
+    expect(expression.resultType).toBe('string');
   });
 
   it('rejects misspelled fields from the typed environment', () => {

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -86,7 +86,7 @@ function assertExpectedResultType(
   expectedType: ExpressionScalarType | undefined,
 ): void {
   if (expectedType === undefined || actualType === scalarTypeToCelType[expectedType]) return;
-  if (actualType === 'dyn') return;
+  if (actualType === 'dyn' && expectedType === 'bool') return;
   throw new InvalidWorkflowExpressionError({
     source,
     reason: `Expression source must return ${scalarTypeToCelType[expectedType]}; got ${actualType ?? 'unknown'}.`,

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -65,7 +65,7 @@ function checkTypedWorkflowExpression(
       reason: result.error?.message ?? 'Expression source did not type-check.',
     });
   }
-  assertExpectedResultType(source, ast, result.type, check.expectedResultType);
+  assertExpectedResultType(source, result.type, check.expectedResultType);
   return resolveKnownPathType(source, check.typeEnvironment) ?? fromCelType(result.type, ast);
 }
 
@@ -82,12 +82,11 @@ function registerTypeEnvironment(
 
 function assertExpectedResultType(
   source: string,
-  ast: ASTNode,
   actualType: string | undefined,
   expectedType: ExpressionScalarType | undefined,
 ): void {
   if (expectedType === undefined || actualType === scalarTypeToCelType[expectedType]) return;
-  if (actualType === 'dyn' && containsFromJsonCall(ast)) return;
+  if (actualType === 'dyn') return;
   throw new InvalidWorkflowExpressionError({
     source,
     reason: `Expression source must return ${scalarTypeToCelType[expectedType]}; got ${actualType ?? 'unknown'}.`,


### PR DESCRIPTION
Allow workflow gates to reference dynamically shaped outputs while preserving safe runtime behavior.

The expression checker now accepts CEL dyn results against expected predicate types. Predicate evaluation rejects non-boolean values as evaluation errors, so gates expose the existing evaluation_error outcome instead of silently failing closed as false. Sync-valid trigger and listener filters retain their boolean behavior.

Closes ENG-1884

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows workflow gates to reference bare dynamically typed step outputs while preserving runtime safety. The expression checker now accepts CEL `dyn` results only when a boolean predicate is expected; non-boolean predicate results raise evaluation errors instead of failing closed as `false`, and trigger/listener filters retain their existing boolean-only behavior.

- Raises the runner bootstrap module-load probe timeout to 15 seconds for busy CI runners.
- Closes ENG-1884.

<sup>Written for commit 6ddc8a906eb86392b418c71917fc5d5fc7074027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
