### PR TITLE
[client-shell] Support standard chrome on root-scoped routes

### DIFF
--- a/.changeset/root-layout-runtime.md
+++ b/.changeset/root-layout-runtime.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": minor
+---
+
+Adds a root-safe application layout with shared Shipfox chrome, route frames, and session-banner behavior.

--- a/.changeset/root-layout-runtime.md
+++ b/.changeset/root-layout-runtime.md
@@ -2,4 +2,4 @@
 "@shipfox/client-shell": minor
 ---
 
-Adds a root-safe application layout with shared Shipfox chrome, route frames, and session-banner behavior.
+Adds the `ApplicationLayout` runtime component for authenticated root-scoped routes, with shared Shipfox chrome, route frames, and session-banner behavior.

--- a/libs/client/shell/README.md
+++ b/libs/client/shell/README.md
@@ -1,0 +1,134 @@
+# Shipfox Client Shell
+
+Browser shell and compile-time composition contracts for Shipfox client applications.
+
+## What it does
+
+- **`defineClientFeature()` and authoring types** define Node-safe routes,
+  layouts, providers, navigation entries, settings sections, and runtime
+  configuration fragments.
+- **`@shipfox/client-shell/runtime`** provides the browser provider stack,
+  router helpers, authentication state, chrome slots, route frames, and layout
+  navigation registry.
+- **`ApplicationLayout`** renders the standard authenticated application
+  header, navigation strip, route frame, account menu, and session banner for a
+  root-parented feature that has no active workspace.
+- **`@shipfox/client-shell/vite`** validates the feature graph and generates the
+  application's typed TanStack Router tree.
+- **`@shipfox/client-shell/testing`** provides the shell provider stack for
+  package tests and Storybook stories.
+
+## Installation and setup
+
+```sh
+pnpm add @shipfox/client-shell
+```
+
+Install the package's React, TanStack Router, React Query, Jotai, Vite, and Zod
+peer dependencies at the versions required by the consuming application. A
+composed application supplies browser chrome slots through `composeClientApp()`
+or `ChromeProvider`.
+
+## Usage
+
+Use `ApplicationLayout` for an authenticated feature layout parented at the
+root anchor. Filter navigation by the application's authorization policy before
+passing it to the shell.
+
+```tsx
+import {defineClientFeature} from '@shipfox/client-shell';
+import {
+  ApplicationLayout,
+  defineRoute,
+  useLayoutNavigation,
+} from '@shipfox/client-shell/runtime';
+
+export const administrationFeature = defineClientFeature({
+  id: 'acme.administration',
+  layouts: [
+    {
+      id: 'acme.administration',
+      path: '/admin',
+      parent: 'root',
+      impl: './routes/admin-layout',
+    },
+  ],
+  navigation: [
+    {
+      id: 'admin.overview',
+      scope: 'layout',
+      layout: 'acme.administration',
+      label: 'Overview',
+      to: '/admin/overview',
+      exact: true,
+      minimumRole: 'administrator',
+    },
+  ],
+});
+
+function AdminLayout() {
+  const entries = useLayoutNavigation('acme.administration');
+  const currentRole = 'administrator';
+  const visibleEntries = entries.filter((entry) =>
+    entry.minimumRole === undefined || entry.minimumRole === currentRole,
+  );
+
+  return (
+    <ApplicationLayout
+      context={<span>Administration</span>}
+      navigation={{
+        ariaLabel: 'Administration sections',
+        entries: visibleEntries,
+      }}
+    />
+  );
+}
+
+export default defineRoute({
+  staticData: {frame: 'content'},
+  component: AdminLayout,
+});
+```
+
+`ApplicationLayout` renders its `children` when provided and otherwise renders
+the current route's `Outlet`.
+
+## Routes
+
+The root, workspace, project, workspace-settings, and project-settings anchors
+are the stable shell parents. Feature-owned layouts can attach below an anchor
+and become parents for routes from other features. See
+[ADR 0001](../../../docs/adr/0001-client-composition-contract.md) for the
+composition and collision rules.
+
+## Behavior notes
+
+- `ApplicationLayout` follows the shared authentication state but never
+  requires an active workspace or project.
+- Layout navigation accepts only `scope: 'layout'` entries. The shell uses
+  `exact` for active-link matching and treats `minimumRole` as opaque metadata.
+- The 40px navigation strip remains mounted when `entries` is empty. It scrolls
+  horizontally without a visible scrollbar when links exceed the viewport.
+- The shared header owns the Docs link, user identity, theme selection, account
+  menu slot, and logout action.
+- The shared frame resolves the deepest route's `content`, `data`, or `focused`
+  declaration and accounts for the measured session-banner height.
+- Consumers import browser components from `@shipfox/client-shell/runtime`.
+  The package root remains safe for build-time feature evaluation.
+
+## Development
+
+```sh
+mise exec -- turbo check --filter=@shipfox/client-shell
+mise exec -- turbo type --filter=@shipfox/client-shell
+mise exec -- turbo test --filter=@shipfox/client-shell
+mise exec -- turbo build --filter=@shipfox/client-shell
+mise exec -- turbo test:external --filter=@shipfox/client-shell
+```
+
+The external-consumer fixture builds, tests, and type-checks the package from
+packed tarballs.
+
+## License
+
+MIT

--- a/libs/client/shell/src/components/application-frame.tsx
+++ b/libs/client/shell/src/components/application-frame.tsx
@@ -1,0 +1,185 @@
+import {Button} from '@shipfox/react-ui/button';
+import {FullPageLoader} from '@shipfox/react-ui/loader';
+import {Logo} from '@shipfox/react-ui/logo';
+import {Link, Navigate, useLocation, useMatches} from '@tanstack/react-router';
+import {
+  type CSSProperties,
+  type PropsWithChildren,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type {NavTabEntry} from '#contract.js';
+import {useMaybeActiveWorkspace} from '#runtime/active-workspace.js';
+import {useAuthState} from '#runtime/auth.js';
+import {useChrome} from '#runtime/chrome-context.js';
+import {ReportErrorBoundary} from '#runtime/report-error-boundary.js';
+import type {RouteFrame} from '#runtime/route-frame.js';
+import {WorkspaceUnavailablePage} from '#runtime/workspace-setup.js';
+import {FOCUSED_FRAME_CONTENT_CLASS_NAME} from './focused-frame.js';
+import {NavTabs} from './nav-tabs.js';
+import {UserMenu} from './user-menu.js';
+
+declare module '@tanstack/react-router' {
+  interface StaticDataRouteOption {
+    frame?: RouteFrame;
+  }
+}
+
+const frameClassNames: Record<RouteFrame, string> = {
+  content: 'mx-auto w-full max-w-[1120px] px-frame py-frame',
+  data: 'flex min-h-0 w-full flex-1 flex-col px-frame py-frame',
+  focused: `${FOCUSED_FRAME_CONTENT_CLASS_NAME} px-frame py-frame`,
+};
+
+/**
+ * Minimum height of the reserved SessionBanner strip, in pixels. The layout
+ * reserves this much for the slot and the app-content viewport arithmetic
+ * starts from it; the rendered strip height is measured and feeds the
+ * arithmetic so taller banners keep the content area consistent.
+ */
+const SESSION_BANNER_HEIGHT_PX = 40;
+
+interface ApplicationFrameNavigation {
+  ariaLabel: string;
+  entries: readonly NavTabEntry[];
+  params?: Record<string, unknown> | undefined;
+  projectScoped?: boolean | undefined;
+}
+
+export function ApplicationFrame({
+  children,
+  compactLogo = false,
+  context,
+  navigation,
+  requireWorkspace = false,
+}: PropsWithChildren<{
+  compactLogo?: boolean | undefined;
+  context: ReactNode;
+  navigation?: ApplicationFrameNavigation | undefined;
+  requireWorkspace?: boolean | undefined;
+}>) {
+  const auth = useAuthState();
+  const workspace = useMaybeActiveWorkspace();
+  const location = useLocation();
+  const matches = useMatches();
+  const {SessionBanner} = useChrome();
+  const sessionBannerStripRef = useRef<HTMLDivElement | null>(null);
+  const [bannerFailed, setBannerFailed] = useState(false);
+  const [bannerHeightPx, setBannerHeightPx] = useState(() =>
+    SessionBanner ? SESSION_BANNER_HEIGHT_PX : 0,
+  );
+  // Retry the banner only when the route or the slot identity changes; the key
+  // stays referentially stable across the onError/onRecovered state toggles so
+  // a persistently failing slot latches instead of being retried in a loop.
+  const bannerRetryKey = useMemo(
+    () => ({href: location.href, slot: SessionBanner}),
+    [location.href, SessionBanner],
+  );
+
+  // Keep the app-content deduction aligned with the rendered strip height.
+  useEffect(() => {
+    if (!SessionBanner || bannerFailed) return;
+    const strip = sessionBannerStripRef.current;
+    if (!strip) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setBannerHeightPx(entry.contentRect.height);
+    });
+    observer.observe(strip);
+    return () => observer.disconnect();
+  }, [SessionBanner, bannerFailed]);
+
+  if (auth.isLoading) return <FullPageLoader />;
+  if (!auth.isAuthenticated) {
+    return (
+      <Navigate to={'/auth/login' as never} search={{redirect: location.href} as never} replace />
+    );
+  }
+  if (requireWorkspace && !workspace) return <WorkspaceUnavailablePage />;
+
+  const frame = matches.reduce<RouteFrame>(
+    (current, match) => match.staticData.frame ?? current,
+    'content',
+  );
+  const reservedHeightPx = SessionBanner && !bannerFailed ? bannerHeightPx : 0;
+  const chromeHeightPx = 56 + (navigation ? 40 : 0) + reservedHeightPx;
+  const appContentHeight = `calc(100dvh - ${chromeHeightPx}px)`;
+  const isFullBleedFrame = frame === 'data';
+  const mainClassName = isFullBleedFrame
+    ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
+    : 'flex-1 overflow-auto';
+
+  return (
+    <div className="h-screen w-full flex flex-col bg-background-subtle-base">
+      {SessionBanner ? (
+        <ReportErrorBoundary
+          label="Failed to render session banner."
+          retryKey={bannerRetryKey}
+          onError={() => setBannerFailed(true)}
+          onRecovered={() => setBannerFailed(false)}
+        >
+          <div
+            ref={sessionBannerStripRef}
+            className="flex shrink-0 items-center bg-background-subtle-base"
+            style={{minHeight: SESSION_BANNER_HEIGHT_PX}}
+          >
+            <SessionBanner />
+          </div>
+        </ReportErrorBoundary>
+      ) : undefined}
+      <ApplicationHeader compactLogo={compactLogo} context={context} />
+      {navigation ? (
+        <NavTabs
+          ariaLabel={navigation.ariaLabel}
+          entries={navigation.entries}
+          params={navigation.params}
+          projectScoped={navigation.projectScoped}
+        />
+      ) : undefined}
+      <main
+        className={mainClassName}
+        style={{'--app-content-h': appContentHeight} as CSSProperties}
+      >
+        <div className={frameClassNames[frame]}>{children}</div>
+      </main>
+    </div>
+  );
+}
+
+function ApplicationHeader({compactLogo, context}: {compactLogo: boolean; context: ReactNode}) {
+  return (
+    <header className="sticky top-0 z-30 h-56 px-row flex items-center gap-cluster bg-background-subtle-base border-b border-border-neutral-base shrink-0">
+      <Link
+        to="/"
+        aria-label="Shipfox home"
+        className="rounded-6 focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
+      >
+        {compactLogo ? (
+          <>
+            <Logo variant="mark" alt="" className="sm:hidden" />
+            <Logo variant="wordmark" alt="" className="hidden sm:block" />
+          </>
+        ) : (
+          <Logo variant="wordmark" alt="" />
+        )}
+      </Link>
+      <span className="h-20 w-px bg-border-neutral-base" aria-hidden="true" />
+      {context}
+      <div className="flex-1" />
+      <Button asChild variant="transparent" size="sm" className="text-foreground-neutral-subtle">
+        <a
+          href="https://shipfox.io/docs"
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label="Docs (opens in new tab)"
+        >
+          Docs
+        </a>
+      </Button>
+      <UserMenu />
+    </header>
+  );
+}

--- a/libs/client/shell/src/components/application-frame.tsx
+++ b/libs/client/shell/src/components/application-frame.tsx
@@ -1,12 +1,14 @@
 import {Button} from '@shipfox/react-ui/button';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {Logo} from '@shipfox/react-ui/logo';
-import {Link, Navigate, useLocation, useMatches} from '@tanstack/react-router';
+import {Link, useLocation, useMatches, useNavigate} from '@tanstack/react-router';
 import {
+  type ComponentType,
   type CSSProperties,
   type PropsWithChildren,
   type ReactNode,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -66,8 +68,6 @@ export function ApplicationFrame({
   const location = useLocation();
   const matches = useMatches();
   const {SessionBanner} = useChrome();
-  const sessionBannerStripRef = useRef<HTMLDivElement | null>(null);
-  const [bannerFailed, setBannerFailed] = useState(false);
   const [bannerHeightPx, setBannerHeightPx] = useState(() =>
     SessionBanner ? SESSION_BANNER_HEIGHT_PX : 0,
   );
@@ -79,24 +79,9 @@ export function ApplicationFrame({
     [location.href, SessionBanner],
   );
 
-  // Keep the app-content deduction aligned with the rendered strip height.
-  useEffect(() => {
-    if (!SessionBanner || bannerFailed) return;
-    const strip = sessionBannerStripRef.current;
-    if (!strip) return;
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) setBannerHeightPx(entry.contentRect.height);
-    });
-    observer.observe(strip);
-    return () => observer.disconnect();
-  }, [SessionBanner, bannerFailed]);
-
   if (auth.isLoading) return <FullPageLoader />;
   if (!auth.isAuthenticated) {
-    return (
-      <Navigate to={'/auth/login' as never} search={{redirect: location.href} as never} replace />
-    );
+    return <GuestRedirect href={location.href} />;
   }
   if (requireWorkspace && !workspace) return <WorkspaceUnavailablePage />;
 
@@ -104,7 +89,7 @@ export function ApplicationFrame({
     (current, match) => match.staticData.frame ?? current,
     'content',
   );
-  const reservedHeightPx = SessionBanner && !bannerFailed ? bannerHeightPx : 0;
+  const reservedHeightPx = SessionBanner ? bannerHeightPx : 0;
   const chromeHeightPx = 56 + (navigation ? 40 : 0) + reservedHeightPx;
   const appContentHeight = `calc(100dvh - ${chromeHeightPx}px)`;
   const isFullBleedFrame = frame === 'data';
@@ -115,20 +100,11 @@ export function ApplicationFrame({
   return (
     <div className="h-screen w-full flex flex-col bg-background-subtle-base">
       {SessionBanner ? (
-        <ReportErrorBoundary
-          label="Failed to render session banner."
+        <SessionBannerStrip
+          sessionBanner={SessionBanner}
           retryKey={bannerRetryKey}
-          onError={() => setBannerFailed(true)}
-          onRecovered={() => setBannerFailed(false)}
-        >
-          <div
-            ref={sessionBannerStripRef}
-            className="flex shrink-0 items-center bg-background-subtle-base"
-            style={{minHeight: SESSION_BANNER_HEIGHT_PX}}
-          >
-            <SessionBanner />
-          </div>
-        </ReportErrorBoundary>
+          onHeightChange={setBannerHeightPx}
+        />
       ) : undefined}
       <ApplicationHeader compactLogo={compactLogo} context={context} />
       {navigation ? (
@@ -149,13 +125,72 @@ export function ApplicationFrame({
   );
 }
 
+function GuestRedirect({href}: {href: string}) {
+  const navigate = useNavigate();
+  const [search] = useState(() => ({redirect: href}));
+  useEffect(() => {
+    void navigate({to: '/auth/login' as never, search: search as never, replace: true});
+  }, [navigate, search]);
+  return null;
+}
+
+function SessionBannerStrip({
+  sessionBanner,
+  onHeightChange,
+  retryKey,
+}: {
+  sessionBanner: ComponentType;
+  onHeightChange: (heightPx: number) => void;
+  retryKey: unknown;
+}) {
+  const SessionBanner = sessionBanner;
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const [bannerFailed, setBannerFailed] = useState(false);
+
+  // Reset stale or failed measurements before paint when the slot state changes.
+  useLayoutEffect(() => {
+    onHeightChange(bannerFailed ? 0 : SESSION_BANNER_HEIGHT_PX);
+  }, [bannerFailed, onHeightChange]);
+
+  // The strip exists only after authentication succeeds, so observation starts
+  // when the guarded browser chrome actually mounts.
+  useEffect(() => {
+    if (bannerFailed || typeof ResizeObserver === 'undefined') return;
+    const strip = stripRef.current;
+    if (!strip) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) onHeightChange(entry.contentRect.height);
+    });
+    observer.observe(strip);
+    return () => observer.disconnect();
+  }, [bannerFailed, onHeightChange]);
+
+  return (
+    <ReportErrorBoundary
+      label="Failed to render session banner."
+      retryKey={retryKey}
+      onError={() => setBannerFailed(true)}
+      onRecovered={() => setBannerFailed(false)}
+    >
+      <div
+        ref={stripRef}
+        className="flex shrink-0 items-center bg-background-subtle-base"
+        style={{minHeight: SESSION_BANNER_HEIGHT_PX}}
+      >
+        <SessionBanner />
+      </div>
+    </ReportErrorBoundary>
+  );
+}
+
 function ApplicationHeader({compactLogo, context}: {compactLogo: boolean; context: ReactNode}) {
   return (
     <header className="sticky top-0 z-30 h-56 px-row flex items-center gap-cluster bg-background-subtle-base border-b border-border-neutral-base shrink-0">
       <Link
         to="/"
         aria-label="Shipfox home"
-        className="rounded-6 focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
+        className="shrink-0 rounded-6 focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
       >
         {compactLogo ? (
           <>
@@ -166,20 +201,22 @@ function ApplicationHeader({compactLogo, context}: {compactLogo: boolean; contex
           <Logo variant="wordmark" alt="" />
         )}
       </Link>
-      <span className="h-20 w-px bg-border-neutral-base" aria-hidden="true" />
-      {context}
-      <div className="flex-1" />
-      <Button asChild variant="transparent" size="sm" className="text-foreground-neutral-subtle">
-        <a
-          href="https://shipfox.io/docs"
-          target="_blank"
-          rel="noreferrer noopener"
-          aria-label="Docs (opens in new tab)"
-        >
-          Docs
-        </a>
-      </Button>
-      <UserMenu />
+      <span className="h-20 w-px shrink-0 bg-border-neutral-base" aria-hidden="true" />
+      <div className="flex min-w-0 items-center gap-cluster overflow-hidden">{context}</div>
+      <div className="min-w-0 flex-1" />
+      <div className="flex shrink-0 items-center gap-cluster">
+        <Button asChild variant="transparent" size="sm" className="text-foreground-neutral-subtle">
+          <a
+            href="https://shipfox.io/docs"
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label="Docs (opens in new tab)"
+          >
+            Docs
+          </a>
+        </Button>
+        <UserMenu />
+      </div>
     </header>
   );
 }

--- a/libs/client/shell/src/components/application-layout.test.tsx
+++ b/libs/client/shell/src/components/application-layout.test.tsx
@@ -1,10 +1,11 @@
 import {DropdownMenuItem} from '@shipfox/react-ui/dropdown-menu';
 import type {AnyRouter} from '@tanstack/react-router';
-import {act, fireEvent, screen, within} from '@testing-library/react';
+import {act, fireEvent, screen, waitFor, within} from '@testing-library/react';
 import {atom, useAtomValue} from 'jotai';
+import type {ComponentType} from 'react';
 import {defineClientFeature} from '#contract.js';
-import type {AuthStateValue} from '#runtime/auth.js';
-import type {ChromeSlots} from '#runtime/chrome-context.js';
+import {type AuthStateValue, authStateAtom} from '#runtime/auth.js';
+import {ChromeProvider, type ChromeSlots, useChrome} from '#runtime/chrome-context.js';
 import {defineRoute} from '#runtime/define-route.js';
 import {useLayoutNavigation} from '#runtime/layout-navigation.js';
 import {renderComposedShell} from '#test/render.js';
@@ -16,6 +17,22 @@ const ROOT_AUTH: AuthStateValue = {
   workspaces: [],
   isLoading: false,
   isAuthenticated: true,
+  hasWorkspace: false,
+};
+
+const LOADING_AUTH: AuthStateValue = {
+  status: 'loading',
+  workspaces: [],
+  isLoading: true,
+  isAuthenticated: false,
+  hasWorkspace: false,
+};
+
+const GUEST_AUTH: AuthStateValue = {
+  status: 'guest',
+  workspaces: [],
+  isLoading: false,
+  isAuthenticated: false,
   hasWorkspace: false,
 };
 
@@ -56,6 +73,39 @@ const emptyAdminFeature = defineClientFeature({
   routes: [{path: '/empty-admin/overview', parent: 'acme.empty-admin', impl: 'empty-overview'}],
 });
 
+const authFeature = defineClientFeature({
+  id: 'acme.auth',
+  routes: [{path: '/auth/login', parent: 'root', impl: 'login'}],
+});
+
+const tenantAdminFeature = defineClientFeature({
+  id: 'acme.tenant-admin',
+  layouts: [
+    {
+      id: 'acme.tenant-admin',
+      path: '/tenant/$tenantSlug/admin',
+      parent: 'root',
+      impl: 'tenant-layout',
+    },
+  ],
+  routes: [
+    {
+      path: '/tenant/$tenantSlug/admin/overview',
+      parent: 'acme.tenant-admin',
+      impl: 'tenant-overview',
+    },
+  ],
+  navigation: [
+    {
+      id: 'tenant-admin.overview',
+      scope: 'layout',
+      layout: 'acme.tenant-admin',
+      label: 'Tenant overview',
+      to: '/tenant/$tenantSlug/admin/overview',
+    },
+  ],
+});
+
 function AdminLayout() {
   const entries = useLayoutNavigation('acme.admin');
   return (
@@ -81,6 +131,28 @@ function EmptyAdminLayout() {
   );
 }
 
+function TenantAdminLayout() {
+  const entries = useLayoutNavigation('acme.tenant-admin');
+  return (
+    <ApplicationLayout
+      context={<span>Tenant administration</span>}
+      navigation={{ariaLabel: 'Tenant administration sections', entries}}
+    />
+  );
+}
+
+function AdminLayoutWithChildren() {
+  const entries = useLayoutNavigation('acme.admin');
+  return (
+    <ApplicationLayout
+      context={<span>Administration</span>}
+      navigation={{ariaLabel: 'Administration sections', entries}}
+    >
+      <div>Inline administration content</div>
+    </ApplicationLayout>
+  );
+}
+
 function routeHeading(specifier: string) {
   const labels: Record<string, string> = {
     overview: 'Overview page',
@@ -88,37 +160,65 @@ function routeHeading(specifier: string) {
     users: 'Users page',
     user: 'User page',
     'empty-overview': 'Empty overview',
+    'tenant-overview': 'Tenant overview page',
   };
   return labels[specifier] ?? specifier;
 }
 
 function renderAdmin({
+  auth = ROOT_AUTH,
   chrome,
   frame = 'content',
+  layoutComponent,
   path = '/admin/overview',
 }: {
+  auth?: AuthStateValue;
   chrome?: Partial<ChromeSlots>;
   frame?: 'content' | 'data' | 'focused';
+  layoutComponent?: ComponentType;
   path?: string;
 } = {}) {
-  const features = path.startsWith('/empty-admin') ? [emptyAdminFeature] : [adminFeature];
+  const feature = path.startsWith('/empty-admin') ? emptyAdminFeature : adminFeature;
   return renderComposedShell({
-    auth: ROOT_AUTH,
-    features,
+    auth,
+    features: [feature, authFeature],
     initialPath: path,
     ...(chrome ? {chrome} : {}),
     resolveImpl: (specifier) => {
       if (specifier === 'layout') {
-        return defineRoute({staticData: {frame: 'content'}, component: AdminLayout});
+        return defineRoute({
+          staticData: {frame: 'content'},
+          component: layoutComponent ?? AdminLayout,
+        });
       }
       if (specifier === 'empty-layout') {
         return defineRoute({staticData: {frame: 'content'}, component: EmptyAdminLayout});
+      }
+      if (specifier === 'login') {
+        return defineRoute({
+          staticData: {frame: 'content'},
+          component: () => <h1>Login page</h1>,
+        });
       }
       return defineRoute({
         staticData: {frame},
         component: () => <h1>{routeHeading(specifier)}</h1>,
       });
     },
+  });
+}
+
+function renderTenantAdmin() {
+  return renderComposedShell({
+    auth: ROOT_AUTH,
+    features: [tenantAdminFeature],
+    initialPath: '/tenant/acme/admin/overview',
+    resolveImpl: (specifier) =>
+      defineRoute({
+        staticData: {frame: 'content'},
+        component:
+          specifier === 'tenant-layout' ? TenantAdminLayout : () => <h1>Tenant overview page</h1>,
+      }),
   });
 }
 
@@ -141,6 +241,26 @@ describe('ApplicationLayout', () => {
         .map((tab) => tab.textContent),
     ).toEqual(['Overview', 'Users']);
     expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+  });
+
+  test('keeps account controls reachable when header context is long', async () => {
+    await renderAdmin();
+
+    const context = (await screen.findByText('Administration')).parentElement;
+    expect(context).toHaveClass('min-w-0', 'overflow-hidden');
+    expect(screen.getByRole('link', {name: 'Docs (opens in new tab)'}).parentElement).toHaveClass(
+      'shrink-0',
+    );
+    expect(screen.getByRole('button', {name: 'User menu'})).toBeVisible();
+  });
+
+  test('resolves layout navigation parameters from a dynamic root route', async () => {
+    await renderTenantAdmin();
+
+    expect(await screen.findByRole('tab', {name: 'Tenant overview'})).toHaveAttribute(
+      'href',
+      '/tenant/acme/admin/overview',
+    );
   });
 
   test.each([
@@ -240,6 +360,55 @@ describe('ApplicationLayout', () => {
     }
   });
 
+  test('keeps the 40px fallback when ResizeObserver is unavailable', async () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+
+    try {
+      await renderAdmin({chrome: {SessionBanner: () => <div>Root session banner</div>}});
+
+      expect(await screen.findByText('Root session banner')).toBeVisible();
+      expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 136px)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('installs banner measurement after authentication finishes loading', async () => {
+    let resize: ResizeObserverCallback | undefined;
+    class ResizeObserverProbe {
+      constructor(callback: ResizeObserverCallback) {
+        resize = callback;
+      }
+      observe(): void {
+        // The test only needs to confirm observation starts after authentication.
+      }
+      unobserve(): void {
+        // The test only needs to confirm observation starts after authentication.
+      }
+      disconnect(): void {
+        // The test only needs to confirm observation starts after authentication.
+      }
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverProbe);
+
+    try {
+      const {store} = await renderAdmin({
+        auth: LOADING_AUTH,
+        chrome: {SessionBanner: () => <div>Root session banner</div>},
+      });
+
+      expect(await screen.findByRole('status', {name: 'Loading'})).toBeVisible();
+      expect(screen.queryByText('Administration')).not.toBeInTheDocument();
+
+      act(() => store.set(authStateAtom, ROOT_AUTH));
+
+      expect(await screen.findByText('Administration')).toBeVisible();
+      await waitFor(() => expect(resize).toBeTypeOf('function'));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   test('contains and retries a failing session banner when the route changes', async () => {
     const failure = new Error('Root session banner failed');
     const reportErrorSpy = vi.fn();
@@ -271,6 +440,61 @@ describe('ApplicationLayout', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  test('measures a failed banner again after its slot is removed and re-added', async () => {
+    const failure = new Error('Root session banner failed');
+    const reportErrorSpy = vi.fn();
+    const bannerFailedAtom = atom(true);
+    vi.stubGlobal('reportError', reportErrorSpy);
+    function RecoverableSessionBanner() {
+      if (useAtomValue(bannerFailedAtom)) throw failure;
+      return <div>Recovered root session banner</div>;
+    }
+    const bannerSlotAtom = atom<{slot?: ComponentType}>({slot: RecoverableSessionBanner});
+    function DynamicChromeAdminLayout() {
+      const chrome = useChrome();
+      const {slot} = useAtomValue(bannerSlotAtom);
+      return (
+        <ChromeProvider chrome={slot ? {...chrome, SessionBanner: slot} : chrome}>
+          <AdminLayout />
+        </ChromeProvider>
+      );
+    }
+
+    try {
+      const {store} = await renderAdmin({layoutComponent: DynamicChromeAdminLayout});
+
+      expect(await screen.findByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+      act(() => {
+        store.set(bannerSlotAtom, {});
+        store.set(bannerFailedAtom, false);
+      });
+      act(() => store.set(bannerSlotAtom, {slot: RecoverableSessionBanner}));
+
+      expect(await screen.findByText('Recovered root session banner')).toBeVisible();
+      expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 136px)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('redirects guests to login with the original root route', async () => {
+    const {router} = await renderAdmin({auth: GUEST_AUTH});
+
+    expect(await screen.findByRole('heading', {name: 'Login page'})).toBeVisible();
+    await waitFor(() =>
+      expect((router as AnyRouter).state.location.href).toBe(
+        '/auth/login?redirect=%2Fadmin%2Foverview',
+      ),
+    );
+  });
+
+  test('renders supplied children instead of the nested route outlet', async () => {
+    await renderAdmin({layoutComponent: AdminLayoutWithChildren});
+
+    expect(await screen.findByText('Inline administration content')).toBeVisible();
+    expect(screen.queryByRole('heading', {name: 'Overview page'})).not.toBeInTheDocument();
   });
 
   test.each([

--- a/libs/client/shell/src/components/application-layout.test.tsx
+++ b/libs/client/shell/src/components/application-layout.test.tsx
@@ -1,0 +1,287 @@
+import {DropdownMenuItem} from '@shipfox/react-ui/dropdown-menu';
+import type {AnyRouter} from '@tanstack/react-router';
+import {act, fireEvent, screen, within} from '@testing-library/react';
+import {atom, useAtomValue} from 'jotai';
+import {defineClientFeature} from '#contract.js';
+import type {AuthStateValue} from '#runtime/auth.js';
+import type {ChromeSlots} from '#runtime/chrome-context.js';
+import {defineRoute} from '#runtime/define-route.js';
+import {useLayoutNavigation} from '#runtime/layout-navigation.js';
+import {renderComposedShell} from '#test/render.js';
+import {ApplicationLayout} from './application-layout.js';
+
+const ROOT_AUTH: AuthStateValue = {
+  status: 'authenticated',
+  user: {id: 'user', email: 'root@example.com'},
+  workspaces: [],
+  isLoading: false,
+  isAuthenticated: true,
+  hasWorkspace: false,
+};
+
+const adminFeature = defineClientFeature({
+  id: 'acme.admin',
+  layouts: [{id: 'acme.admin', path: '/admin', parent: 'root', impl: 'layout'}],
+  routes: [
+    {path: '/admin/overview', parent: 'acme.admin', impl: 'overview'},
+    {path: '/admin/overview/details', parent: 'acme.admin', impl: 'overview-details'},
+    {path: '/admin/users', parent: 'acme.admin', impl: 'users'},
+    {path: '/admin/users/$userId', parent: 'acme.admin', impl: 'user'},
+  ],
+  navigation: [
+    {
+      id: 'admin.overview',
+      scope: 'layout',
+      layout: 'acme.admin',
+      label: 'Overview',
+      to: '/admin/overview',
+      exact: true,
+      order: 100,
+    },
+    {
+      id: 'admin.users',
+      scope: 'layout',
+      layout: 'acme.admin',
+      label: 'Users',
+      to: '/admin/users',
+      minimumRole: 'opaque-root-role',
+      order: 200,
+    },
+  ],
+});
+
+const emptyAdminFeature = defineClientFeature({
+  id: 'acme.empty-admin',
+  layouts: [{id: 'acme.empty-admin', path: '/empty-admin', parent: 'root', impl: 'empty-layout'}],
+  routes: [{path: '/empty-admin/overview', parent: 'acme.empty-admin', impl: 'empty-overview'}],
+});
+
+function AdminLayout() {
+  const entries = useLayoutNavigation('acme.admin');
+  return (
+    <ApplicationLayout
+      context={
+        <>
+          <span>Administration</span>
+          <span>Instance administrator</span>
+        </>
+      }
+      navigation={{ariaLabel: 'Administration sections', entries}}
+    />
+  );
+}
+
+function EmptyAdminLayout() {
+  const entries = useLayoutNavigation('acme.empty-admin');
+  return (
+    <ApplicationLayout
+      context={<span>Empty administration</span>}
+      navigation={{ariaLabel: 'Empty administration sections', entries}}
+    />
+  );
+}
+
+function routeHeading(specifier: string) {
+  const labels: Record<string, string> = {
+    overview: 'Overview page',
+    'overview-details': 'Overview details',
+    users: 'Users page',
+    user: 'User page',
+    'empty-overview': 'Empty overview',
+  };
+  return labels[specifier] ?? specifier;
+}
+
+function renderAdmin({
+  chrome,
+  frame = 'content',
+  path = '/admin/overview',
+}: {
+  chrome?: Partial<ChromeSlots>;
+  frame?: 'content' | 'data' | 'focused';
+  path?: string;
+} = {}) {
+  const features = path.startsWith('/empty-admin') ? [emptyAdminFeature] : [adminFeature];
+  return renderComposedShell({
+    auth: ROOT_AUTH,
+    features,
+    initialPath: path,
+    ...(chrome ? {chrome} : {}),
+    resolveImpl: (specifier) => {
+      if (specifier === 'layout') {
+        return defineRoute({staticData: {frame: 'content'}, component: AdminLayout});
+      }
+      if (specifier === 'empty-layout') {
+        return defineRoute({staticData: {frame: 'content'}, component: EmptyAdminLayout});
+      }
+      return defineRoute({
+        staticData: {frame},
+        component: () => <h1>{routeHeading(specifier)}</h1>,
+      });
+    },
+  });
+}
+
+describe('ApplicationLayout', () => {
+  test('renders standard chrome and opaque layout navigation without a workspace', async () => {
+    await renderAdmin();
+
+    expect(await screen.findByRole('heading', {name: 'Overview page'})).toBeVisible();
+    expect(screen.getByText('Administration')).toBeVisible();
+    expect(screen.getByText('Instance administrator')).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Shipfox home'})).toBeVisible();
+    const docsLink = screen.getByRole('link', {name: 'Docs (opens in new tab)'});
+    expect(docsLink).toHaveAttribute('href', 'https://shipfox.io/docs');
+    expect(docsLink).toHaveAttribute('target', '_blank');
+    expect(docsLink).toHaveAttribute('rel', 'noreferrer noopener');
+    const navigation = screen.getByRole('tablist', {name: 'Administration sections'});
+    expect(
+      within(navigation)
+        .getAllByRole('tab')
+        .map((tab) => tab.textContent),
+    ).toEqual(['Overview', 'Users']);
+    expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+  });
+
+  test.each([
+    ['/admin/overview/details', 'Overview', false],
+    ['/admin/users/user-1', 'Users', true],
+  ])('uses exact matching for %s', async (path, label, selected) => {
+    await renderAdmin({path});
+
+    const tab = await screen.findByRole('tab', {name: label});
+    expect(tab).toHaveAttribute('aria-selected', String(selected));
+  });
+
+  test('reserves an empty navigation strip', async () => {
+    await renderAdmin({path: '/empty-admin/overview'});
+
+    expect(await screen.findByRole('heading', {name: 'Empty overview'})).toBeVisible();
+    const navigation = screen.getByRole('tablist', {name: 'Empty administration sections'});
+    expect(navigation).toBeEmptyDOMElement();
+    expect(navigation).toHaveClass(
+      'h-40',
+      'overflow-x-auto',
+      'whitespace-nowrap',
+      '[scrollbar-width:none]',
+      '[&::-webkit-scrollbar]:hidden',
+    );
+  });
+
+  test('keeps overflowing navigation usable at a 375px viewport width', async () => {
+    await renderAdmin();
+
+    const navigation = await screen.findByRole('tablist', {name: 'Administration sections'});
+    Object.defineProperties(navigation, {
+      clientWidth: {configurable: true, value: 375},
+      scrollWidth: {configurable: true, value: 640},
+    });
+
+    expect(navigation.scrollWidth).toBeGreaterThan(navigation.clientWidth);
+    expect(navigation).toHaveClass(
+      'overflow-x-auto',
+      'whitespace-nowrap',
+      '[scrollbar-width:none]',
+      '[&::-webkit-scrollbar]:hidden',
+    );
+    for (const tab of within(navigation).getAllByRole('tab')) {
+      expect(tab).toHaveClass('shrink-0', 'whitespace-nowrap');
+    }
+  });
+
+  test('uses the shared account entry, theme controls, and logout action', async () => {
+    function AccountMenuEntry() {
+      return <DropdownMenuItem>Root account action</DropdownMenuItem>;
+    }
+    await renderAdmin({chrome: {AccountMenuEntry}});
+
+    fireEvent.pointerDown(await screen.findByRole('button', {name: 'User menu'}));
+
+    expect(await screen.findByRole('menuitem', {name: 'Root account action'})).toBeVisible();
+    expect(screen.getByText('root@example.com')).toBeVisible();
+    expect(screen.getByText('Theme')).toBeVisible();
+    expect(screen.getAllByRole('menuitemradio').map((item) => item.textContent)).toEqual([
+      'Light',
+      'Dark',
+      'System',
+    ]);
+    expect(screen.getByRole('menuitem', {name: 'Logout'})).toHaveAttribute('href', '/auth/logout');
+  });
+
+  test('updates content height when the shared session banner changes height', async () => {
+    let resize: ResizeObserverCallback | undefined;
+    class ResizeObserverProbe {
+      constructor(callback: ResizeObserverCallback) {
+        resize = callback;
+      }
+      observe(): void {
+        // The test invokes the captured callback directly.
+      }
+      unobserve(): void {
+        // The test invokes the captured callback directly.
+      }
+      disconnect(): void {
+        // The test invokes the captured callback directly.
+      }
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverProbe);
+
+    try {
+      await renderAdmin({chrome: {SessionBanner: () => <div>Root session banner</div>}});
+
+      const main = await screen.findByRole('main');
+      expect(main).toHaveStyle('--app-content-h: calc(100dvh - 136px)');
+      act(() => {
+        resize?.([{contentRect: {height: 72}} as ResizeObserverEntry], {} as ResizeObserver);
+      });
+      expect(main).toHaveStyle('--app-content-h: calc(100dvh - 168px)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('contains and retries a failing session banner when the route changes', async () => {
+    const failure = new Error('Root session banner failed');
+    const reportErrorSpy = vi.fn();
+    const bannerFailedAtom = atom(true);
+    vi.stubGlobal('reportError', reportErrorSpy);
+    function RecoverableSessionBanner() {
+      if (useAtomValue(bannerFailedAtom)) throw failure;
+      return <div>Recovered root session banner</div>;
+    }
+
+    try {
+      const {router, store} = await renderAdmin({
+        chrome: {SessionBanner: RecoverableSessionBanner},
+      });
+
+      expect(await screen.findByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+      expect(reportErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cause: failure,
+          message: 'Failed to render session banner.',
+        }),
+      );
+
+      store.set(bannerFailedAtom, false);
+      await (router as AnyRouter).navigate({to: '/admin/users' as never});
+
+      expect(await screen.findByText('Recovered root session banner')).toBeVisible();
+      expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 136px)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test.each([
+    ['content', 'overflow-auto', 'max-w-[1120px]'],
+    ['data', 'overflow-hidden', 'flex-1'],
+    ['focused', 'overflow-auto', 'max-w-[640px]'],
+  ] as const)('uses the deepest %s route frame', async (frame, mainClass, frameClass) => {
+    await renderAdmin({frame});
+
+    const main = await screen.findByRole('main');
+    expect(main).toHaveClass(mainClass);
+    expect(main.firstElementChild).toHaveClass(frameClass);
+  });
+});

--- a/libs/client/shell/src/components/application-layout.tsx
+++ b/libs/client/shell/src/components/application-layout.tsx
@@ -1,0 +1,21 @@
+import {Outlet} from '@tanstack/react-router';
+import type {PropsWithChildren, ReactNode} from 'react';
+import type {LayoutNavigationEntry} from '#contract.js';
+import {ApplicationFrame} from './application-frame.js';
+
+export interface ApplicationLayoutProps extends PropsWithChildren {
+  context: ReactNode;
+  navigation: {
+    ariaLabel: string;
+    entries: readonly LayoutNavigationEntry[];
+  };
+}
+
+/** Standard application chrome for authenticated routes outside a workspace. */
+export function ApplicationLayout({children, context, navigation}: ApplicationLayoutProps) {
+  return (
+    <ApplicationFrame compactLogo context={context} navigation={navigation}>
+      {children ?? <Outlet />}
+    </ApplicationFrame>
+  );
+}

--- a/libs/client/shell/src/components/main-layout.test.tsx
+++ b/libs/client/shell/src/components/main-layout.test.tsx
@@ -1,5 +1,5 @@
 import type {AnyRouter} from '@tanstack/react-router';
-import {screen} from '@testing-library/react';
+import {fireEvent, screen, waitFor, within} from '@testing-library/react';
 import {atom, useAtomValue} from 'jotai';
 import {defineClientFeature} from '#contract.js';
 import type {ChromeSlots} from '#runtime/chrome-context.js';
@@ -12,20 +12,100 @@ function overviewFeature() {
     routes: [
       {path: '/w/$workspaceSlug/overview', parent: 'workspaceLayout', impl: 'overview'},
       {path: '/w/$workspaceSlug/projects', parent: 'workspaceLayout', impl: 'projects'},
+      {
+        path: '/w/$workspaceSlug/p/$projectSlug/runs',
+        parent: 'projectLayout',
+        impl: 'runs',
+      },
+      {
+        path: '/w/$workspaceSlug/p/$projectSlug/activity',
+        parent: 'projectLayout',
+        impl: 'activity',
+      },
+    ],
+    navigation: [
+      {
+        id: 'overview',
+        scope: 'workspace',
+        label: 'Overview',
+        to: '/w/$workspaceSlug/overview',
+      },
+      {
+        id: 'projects',
+        scope: 'workspace',
+        label: 'Projects',
+        to: '/w/$workspaceSlug/projects',
+      },
+      {
+        id: 'runs',
+        scope: 'project',
+        label: 'Runs',
+        to: '/w/$workspaceSlug/p/$projectSlug/runs',
+      },
+      {
+        id: 'activity',
+        scope: 'project',
+        label: 'Activity',
+        to: '/w/$workspaceSlug/p/$projectSlug/activity',
+      },
     ],
   });
 }
 
-function renderMainLayout(chrome: Partial<ChromeSlots> = {}, hideProjectNavigation = false) {
+function renderMainLayout(
+  chrome: Partial<ChromeSlots> = {},
+  hideProjectNavigation = false,
+  initialPath = '/w/workspace/overview',
+) {
   return renderComposedShell({
     features: [overviewFeature()],
-    initialPath: '/w/workspace/overview',
-    resolveImpl: () =>
-      defineRoute({staticData: {frame: 'content'}, component: () => <h1>Overview</h1>}),
+    initialPath,
+    resolveImpl: (specifier) =>
+      defineRoute({
+        staticData: {frame: 'content'},
+        component: () => <h1>{specifier}</h1>,
+      }),
     chrome,
     workspaceSetup: async () => ({hideProjectNavigation}),
   });
 }
+
+describe('MainLayout navigation', () => {
+  test.each([
+    {
+      initialPath: '/w/workspace/overview',
+      labels: ['Overview', 'Projects'],
+      targetLabel: 'Projects',
+      targetPath: '/w/workspace/projects',
+    },
+    {
+      initialPath: '/w/workspace/p/project/runs',
+      labels: ['Runs', 'Activity'],
+      targetLabel: 'Activity',
+      targetPath: '/w/workspace/p/project/activity',
+    },
+  ])('filters and resolves navigation at $initialPath', async ({
+    initialPath,
+    labels,
+    targetLabel,
+    targetPath,
+  }) => {
+    const {router} = await renderMainLayout({}, false, initialPath);
+
+    const navigation = await screen.findByRole('tablist');
+    expect(
+      within(navigation)
+        .getAllByRole('tab')
+        .map((tab) => tab.textContent),
+    ).toEqual(labels);
+    const target = within(navigation).getByRole('tab', {name: targetLabel});
+    expect(target).toHaveAttribute('href', targetPath);
+
+    fireEvent.click(target);
+
+    await waitFor(() => expect((router as AnyRouter).state.location.pathname).toBe(targetPath));
+  });
+});
 
 describe('MainLayout session banner', () => {
   test('renders no banner strip when the slot is absent', async () => {

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -1,37 +1,8 @@
-import {FullPageLoader} from '@shipfox/react-ui/loader';
-import {Navigate, Outlet, useLocation, useMatches} from '@tanstack/react-router';
-import {type CSSProperties, useEffect, useMemo, useRef, useState} from 'react';
+import {Outlet} from '@tanstack/react-router';
 import type {NavTabEntry} from '#contract.js';
-import {useMaybeActiveWorkspace} from '#runtime/active-workspace.js';
-import {useAuthState} from '#runtime/auth.js';
-import {useChrome} from '#runtime/chrome-context.js';
-import {ReportErrorBoundary} from '#runtime/report-error-boundary.js';
-import type {RouteFrame} from '#runtime/route-frame.js';
 import {parseWorkspaceProjectParams, useRouteParams} from '#runtime/route-inputs.js';
-import {WorkspaceUnavailablePage} from '#runtime/workspace-setup.js';
-import {FOCUSED_FRAME_CONTENT_CLASS_NAME} from './focused-frame.js';
-import {NavBar} from './nav-bar.js';
-import {NavTabs} from './nav-tabs.js';
-
-declare module '@tanstack/react-router' {
-  interface StaticDataRouteOption {
-    frame?: RouteFrame;
-  }
-}
-
-const frameClassNames: Record<RouteFrame, string> = {
-  content: 'mx-auto w-full max-w-[1120px] px-frame py-frame',
-  data: 'flex min-h-0 w-full flex-1 flex-col px-frame py-frame',
-  focused: `${FOCUSED_FRAME_CONTENT_CLASS_NAME} px-frame py-frame`,
-};
-
-/**
- * Minimum height of the reserved SessionBanner strip, in pixels. The layout
- * reserves this much for the slot and the app-content viewport arithmetic
- * starts from it; the rendered strip height is measured and feeds the
- * arithmetic so taller banners keep the content area consistent.
- */
-const SESSION_BANNER_HEIGHT_PX = 40;
+import {ApplicationFrame} from './application-frame.js';
+import {NavBarContext} from './nav-bar.js';
 
 export function MainLayout({
   navigation,
@@ -40,87 +11,28 @@ export function MainLayout({
   navigation: readonly NavTabEntry[];
   hideProjectNavigation?: boolean;
 }) {
-  const auth = useAuthState();
-  const workspace = useMaybeActiveWorkspace();
-  const location = useLocation();
-  const {projectSlug} = useRouteParams(parseWorkspaceProjectParams);
-  const matches = useMatches();
-  const {SessionBanner} = useChrome();
-  const sessionBannerStripRef = useRef<HTMLDivElement | null>(null);
-  const [bannerFailed, setBannerFailed] = useState(false);
-  const [bannerHeightPx, setBannerHeightPx] = useState(() =>
-    SessionBanner ? SESSION_BANNER_HEIGHT_PX : 0,
-  );
-  // Retry the banner only when the route or the slot identity changes; the key
-  // stays referentially stable across the onError/onRecovered state toggles so
-  // a persistently failing slot latches instead of being retried in a loop.
-  const bannerRetryKey = useMemo(
-    () => ({href: location.href, slot: SessionBanner}),
-    [location.href, SessionBanner],
-  );
+  const params = useRouteParams(parseWorkspaceProjectParams);
+  const {projectSlug} = params;
+  const scope = projectSlug ? 'project' : 'workspace';
+  const entries = navigation.filter((entry) => entry.scope === scope);
 
-  // Keep the app-content deduction aligned with the rendered strip height.
-  useEffect(() => {
-    if (!SessionBanner || bannerFailed) return;
-    const strip = sessionBannerStripRef.current;
-    if (!strip) return;
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) setBannerHeightPx(entry.contentRect.height);
-    });
-    observer.observe(strip);
-    return () => observer.disconnect();
-  }, [SessionBanner, bannerFailed]);
-
-  if (auth.isLoading) return <FullPageLoader />;
-  if (!auth.isAuthenticated) {
-    return (
-      <Navigate to={'/auth/login' as never} search={{redirect: location.href} as never} replace />
-    );
-  }
-  if (!workspace) return <WorkspaceUnavailablePage />;
-  const frame = matches.reduce<RouteFrame>(
-    (current, match) => match.staticData.frame ?? current,
-    'content',
-  );
-  const reservedHeightPx = bannerFailed ? 0 : bannerHeightPx;
-  const appContentHeight = hideProjectNavigation
-    ? `calc(100dvh - ${56 + reservedHeightPx}px)`
-    : `calc(100dvh - ${96 + reservedHeightPx}px)`;
-  const isFullBleedFrame = frame === 'data';
-  const mainClassName = isFullBleedFrame
-    ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
-    : 'flex-1 overflow-auto';
   return (
-    <div className="h-screen w-full flex flex-col bg-background-subtle-base">
-      {SessionBanner ? (
-        <ReportErrorBoundary
-          label="Failed to render session banner."
-          retryKey={bannerRetryKey}
-          onError={() => setBannerFailed(true)}
-          onRecovered={() => setBannerFailed(false)}
-        >
-          <div
-            ref={sessionBannerStripRef}
-            className="flex shrink-0 items-center bg-background-subtle-base"
-            style={{minHeight: SESSION_BANNER_HEIGHT_PX}}
-          >
-            <SessionBanner />
-          </div>
-        </ReportErrorBoundary>
-      ) : undefined}
-      <NavBar hideProjectNavigation={hideProjectNavigation} />
-      {hideProjectNavigation ? undefined : (
-        <NavTabs entries={navigation} scope={projectSlug ? 'project' : 'workspace'} />
-      )}
-      <main
-        className={mainClassName}
-        style={{'--app-content-h': appContentHeight} as CSSProperties}
-      >
-        <div className={frameClassNames[frame]}>
-          <Outlet />
-        </div>
-      </main>
-    </div>
+    <ApplicationFrame
+      compactLogo={hideProjectNavigation}
+      context={<NavBarContext hideProjectNavigation={hideProjectNavigation} />}
+      navigation={
+        hideProjectNavigation
+          ? undefined
+          : {
+              ariaLabel: `${projectSlug ? 'Project' : 'Workspace'} sections`,
+              entries,
+              params,
+              projectScoped: !!projectSlug,
+            }
+      }
+      requireWorkspace
+    >
+      <Outlet />
+    </ApplicationFrame>
   );
 }

--- a/libs/client/shell/src/components/nav-bar.tsx
+++ b/libs/client/shell/src/components/nav-bar.tsx
@@ -1,31 +1,12 @@
-import {Button} from '@shipfox/react-ui/button';
-import {Logo} from '@shipfox/react-ui/logo';
-import {Link} from '@tanstack/react-router';
 import {useActiveWorkspace} from '#runtime/active-workspace.js';
 import {useChrome} from '#runtime/chrome-context.js';
-import {UserMenu} from './user-menu.js';
 import {WorkspaceCrumb} from './workspace-crumb.js';
 
-export function NavBar({hideProjectNavigation = false}: {hideProjectNavigation?: boolean}) {
+export function NavBarContext({hideProjectNavigation = false}: {hideProjectNavigation?: boolean}) {
   const workspace = useActiveWorkspace();
   const {ProjectBreadcrumb, WorkspaceSetupIndicator} = useChrome();
   return (
-    <header className="sticky top-0 z-30 h-56 px-row flex items-center gap-cluster bg-background-subtle-base border-b border-border-neutral-base shrink-0">
-      <Link
-        to="/"
-        aria-label="Shipfox home"
-        className="rounded-6 focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
-      >
-        {hideProjectNavigation ? (
-          <>
-            <Logo variant="mark" alt="" className="sm:hidden" />
-            <Logo variant="wordmark" alt="" className="hidden sm:block" />
-          </>
-        ) : (
-          <Logo variant="wordmark" alt="" />
-        )}
-      </Link>
-      <span className="h-20 w-px bg-border-neutral-base" aria-hidden="true" />
+    <>
       <WorkspaceCrumb workspace={workspace} compact={hideProjectNavigation} />
       {hideProjectNavigation ? undefined : (
         <>
@@ -36,18 +17,6 @@ export function NavBar({hideProjectNavigation = false}: {hideProjectNavigation?:
           {WorkspaceSetupIndicator ? <WorkspaceSetupIndicator /> : undefined}
         </>
       )}
-      <div className="flex-1" />
-      <Button asChild variant="transparent" size="sm" className="text-foreground-neutral-subtle">
-        <a
-          href="https://shipfox.io/docs"
-          target="_blank"
-          rel="noreferrer noopener"
-          aria-label="Docs (opens in new tab)"
-        >
-          Docs
-        </a>
-      </Button>
-      <UserMenu />
-    </header>
+    </>
   );
 }

--- a/libs/client/shell/src/components/nav-tabs.test.tsx
+++ b/libs/client/shell/src/components/nav-tabs.test.tsx
@@ -27,7 +27,13 @@ const entries: readonly NavTabEntry[] = [
 ];
 
 function WorkspaceTabs() {
-  return <NavTabs ariaLabel="Workspace sections" entries={entries} />;
+  return (
+    <NavTabs
+      ariaLabel="Workspace sections"
+      entries={entries}
+      params={{workspaceSlug: 'workspace'}}
+    />
+  );
 }
 
 const projectEntries: readonly NavTabEntry[] = [
@@ -68,6 +74,8 @@ describe('NavTabs', () => {
     expect(projectsTab).toHaveAttribute('aria-selected', 'false');
     expect(settingsTab).toHaveClass('text-foreground-neutral-base');
     expect(settingsTab).toHaveAttribute('aria-selected', 'true');
+    expect(projectsTab).toHaveAttribute('href', '/w/workspace/projects');
+    expect(settingsTab).toHaveAttribute('href', '/w/workspace/settings');
   });
 
   test('uses a quiet branded marker for the active project section', async () => {
@@ -76,7 +84,12 @@ describe('NavTabs', () => {
       getParentRoute: () => rootRoute,
       path: '/w/$workspaceSlug/p/$projectSlug/runs',
       component: () => (
-        <NavTabs ariaLabel="Project sections" entries={projectEntries} projectScoped />
+        <NavTabs
+          ariaLabel="Project sections"
+          entries={projectEntries}
+          params={{workspaceSlug: 'workspace', projectSlug: 'project'}}
+          projectScoped
+        />
       ),
     });
     const router = createRouter({
@@ -94,5 +107,6 @@ describe('NavTabs', () => {
     expect(runsTab).toHaveClass('shrink-0', 'whitespace-nowrap');
     expect(runsTab).toHaveClass('border-b', 'border-border-highlights-interactive');
     expect(runsTab).not.toHaveClass('border-b-2');
+    expect(runsTab).toHaveAttribute('href', '/w/workspace/p/project/runs');
   });
 });

--- a/libs/client/shell/src/components/nav-tabs.test.tsx
+++ b/libs/client/shell/src/components/nav-tabs.test.tsx
@@ -27,7 +27,7 @@ const entries: readonly NavTabEntry[] = [
 ];
 
 function WorkspaceTabs() {
-  return <NavTabs entries={entries} scope="workspace" />;
+  return <NavTabs ariaLabel="Workspace sections" entries={entries} />;
 }
 
 const projectEntries: readonly NavTabEntry[] = [
@@ -75,7 +75,9 @@ describe('NavTabs', () => {
     const runsRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/w/$workspaceSlug/p/$projectSlug/runs',
-      component: () => <NavTabs entries={projectEntries} scope="project" />,
+      component: () => (
+        <NavTabs ariaLabel="Project sections" entries={projectEntries} projectScoped />
+      ),
     });
     const router = createRouter({
       history: createMemoryHistory({initialEntries: ['/w/workspace/p/project/runs']}),

--- a/libs/client/shell/src/components/nav-tabs.tsx
+++ b/libs/client/shell/src/components/nav-tabs.tsx
@@ -1,19 +1,19 @@
 import {Link} from '@tanstack/react-router';
 import {useReducedMotion} from 'framer-motion';
 import type {NavTabEntry} from '#contract.js';
-import {parseWorkspaceProjectParams, useRouteParams} from '#runtime/route-inputs.js';
 
 export function NavTabs({
+  ariaLabel,
   entries,
-  scope,
+  params,
+  projectScoped = false,
 }: {
+  ariaLabel: string;
   entries: readonly NavTabEntry[];
-  scope: NavTabEntry['scope'];
+  params?: Record<string, unknown> | undefined;
+  projectScoped?: boolean | undefined;
 }) {
-  const params = useRouteParams(parseWorkspaceProjectParams);
   const reduced = useReducedMotion();
-  const tabs = entries.filter((entry) => entry.scope === scope);
-  const projectScoped = scope === 'project';
   const tabClassName = `h-40 inline-flex shrink-0 items-center whitespace-nowrap px-tight ${projectScoped ? 'text-xs' : 'text-sm'} font-medium transition-colors ${reduced ? '' : 'transition-[border-color]'}`;
   const activeProps = {
     className: projectScoped
@@ -29,14 +29,14 @@ export function NavTabs({
   return (
     <div
       role="tablist"
-      aria-label={`${scope === 'project' ? 'Project' : 'Workspace'} sections`}
+      aria-label={ariaLabel}
       className="sticky top-56 z-20 flex h-40 items-end gap-cluster overflow-x-auto whitespace-nowrap border-b border-border-neutral-base bg-background-subtle-base px-row [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
-      {tabs.map((entry) => (
+      {entries.map((entry) => (
         <Link
           key={entry.id}
           to={entry.to as never}
-          params={params as never}
+          {...(params ? {params: params as never} : {})}
           role="tab"
           activeOptions={{exact: entry.exact ?? false}}
           activeProps={activeProps}

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -1,3 +1,7 @@
+export {
+  ApplicationLayout,
+  type ApplicationLayoutProps,
+} from '#components/application-layout.js';
 export {AuthActions, AuthShell, type AuthShellProps} from '#components/auth-shell.js';
 export {
   FOCUSED_FRAME_CONTENT_CLASS_NAME,

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-layout.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-layout.tsx
@@ -1,20 +1,16 @@
-import {Link, Outlet} from '@tanstack/react-router';
-import {useLayoutNavigation} from '@shipfox/client-shell/runtime';
-import {defineRoute} from '@shipfox/client-shell/runtime';
+import {
+  ApplicationLayout,
+  defineRoute,
+  useLayoutNavigation,
+} from '@shipfox/client-shell/runtime';
 
 function ExternalAdminLayout() {
   const entries = useLayoutNavigation('fixture.admin-layout');
   return (
-    <>
-      <nav aria-label="External administration sections">
-        {entries.map((entry) => (
-          <Link key={entry.id} to={entry.to as never}>
-            {entry.label}
-          </Link>
-        ))}
-      </nav>
-      <Outlet />
-    </>
+    <ApplicationLayout
+      context={<span>External administration</span>}
+      navigation={{ariaLabel: 'External administration sections', entries}}
+    />
   );
 }
 

--- a/libs/client/shell/test/render.tsx
+++ b/libs/client/shell/test/render.tsx
@@ -13,6 +13,7 @@ import {navigationEntries, settingsEntries} from '#runtime/registries.js';
 import type {WorkspaceSetupGate} from '#runtime/workspace-setup.js';
 
 export async function renderComposedShell({
+  auth: authOverride,
   features,
   initialPath,
   resolveImpl,
@@ -20,6 +21,7 @@ export async function renderComposedShell({
   workspaceSetup,
   clientAnalytics,
 }: {
+  auth?: AuthStateValue;
   features: readonly ClientFeature[];
   initialPath: string;
   resolveImpl: ResolveRouteImpl;
@@ -40,15 +42,17 @@ export async function renderComposedShell({
   });
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
   const store = createStore();
-  const auth: AuthStateValue = {
-    status: 'authenticated',
-    workspaces: [
-      {id: 'workspace', name: 'Workspace', slug: 'workspace', membershipId: 'membership'},
-    ],
-    isLoading: false,
-    isAuthenticated: true,
-    hasWorkspace: true,
-  };
+  const auth: AuthStateValue =
+    authOverride ??
+    ({
+      status: 'authenticated',
+      workspaces: [
+        {id: 'workspace', name: 'Workspace', slug: 'workspace', membershipId: 'membership'},
+      ],
+      isLoading: false,
+      isAuthenticated: true,
+      hasWorkspace: true,
+    } satisfies AuthStateValue);
   const chrome: ChromeSlots = {
     ProjectBreadcrumb: () => null,
     projectSlugResolver: async () => 'project',


### PR DESCRIPTION
## Summary

Expose a browser-runtime ApplicationLayout for authenticated root-parented features that need standard Shipfox chrome without an active workspace or project.

MainLayout and the new layout now share the private header, account utilities, navigation, route-frame, and measured session-banner implementation. Consumers continue to own authorization policy and pass already-filtered layout navigation entries.

## Motivation

Cloud Administration currently recreates the application shell for its root-parented /admin layout. This public seam lets it adopt the upstream chrome without deep imports or workspace-specific state, preventing the two layouts from drifting.

## Validation

- mise exec -- turbo check type test build --filter=@shipfox/client-shell... (107 tasks passed)
- mise exec -- turbo test:external --filter=@shipfox/client-shell (165 tasks passed; 196 public entry points verified from packed tarballs)
- prose policy, focused Vale, and git diff --check passed

The repository-wide client architecture check remains blocked on current main by the existing inline-query-policy violation in libs/client/workflows/src/hooks/api/workflow-filter-options.ts. This branch does not change that file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes `ApplicationLayout` from `@shipfox/client-shell/runtime` so authenticated root-parented features can render standard Shipfox chrome without an active workspace or project. `MainLayout` and the new layout share the header, account utilities, navigation strip, route frames, and measured session-banner behavior; consumers own authorization policy and pass already-filtered navigation entries.

**New Features**
- `ApplicationLayout` renders the current route's `Outlet` unless `children` are provided, and redirects guests to login with the original route preserved.
- Cloud Administration and the external-consumer fixture can adopt the shared chrome for `/admin`-style root routes instead of recreating the application shell.

**Refactors**
- `MainLayout` delegates to the shared `ApplicationFrame`, which owns the header, session-banner measurement, and authentication gates.
- `NavBar` becomes `NavBarContext` and renders only the workspace/project context; `NavTabs` receives `ariaLabel`, `params`, and `projectScoped` instead of reading scope from route params.

<sup>Written for commit 0de61c4c1ab005242d90971d34dc9d14575a4862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

