### PR TITLE
Roll out renewable Git credentials

### DIFF
--- a/.changeset/managed-renewable-git.md
+++ b/.changeset/managed-renewable-git.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Advertises renewable Git support from verified managed runner images and warns self-hosted users when persisted checkout credentials cannot renew.

--- a/.changeset/managed-renewable-git.md
+++ b/.changeset/managed-renewable-git.md
@@ -1,4 +1,5 @@
 ---
+"@shipfox/client-workflows": patch
 "@shipfox/api-workflows": patch
 ---
 

--- a/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
@@ -80,9 +80,9 @@ authenticated Git command. See [Checkout
 fields](/reference/workflow-schema#checkout-fields).
 
 Verified managed runner images renew persisted Git credentials during long jobs.
-An older self-hosted runner keeps using static credentials and the job shows an
-upgrade warning; update that runner image when the workflow needs Git access
-beyond the credential lifetime.
+An older self-hosted runner uses static credentials. The job shows an upgrade
+warning. Update that runner image when the workflow needs Git access beyond the
+credential lifetime.
 
 Git commands inside a container started by a user step do not receive the host
 runner's credential helper or Unix socket. Supply a credential explicitly to

--- a/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
@@ -78,3 +78,12 @@ The checkout credential remains available to later steps by default. Set
 `persist-credentials: false` only when no later step should perform an
 authenticated Git command. See [Checkout
 fields](/reference/workflow-schema#checkout-fields).
+
+Verified managed runner images renew persisted Git credentials during long jobs.
+An older self-hosted runner keeps using static credentials and the job shows an
+upgrade warning; update that runner image when the workflow needs Git access
+beyond the credential lifetime.
+
+Git commands inside a container started by a user step do not receive the host
+runner's credential helper or Unix socket. Supply a credential explicitly to
+that container when it needs authenticated Git access.

--- a/apps/docs/content/docs/reference/runner.mdx
+++ b/apps/docs/content/docs/reference/runner.mdx
@@ -45,7 +45,7 @@ labels](/reference/runner-labels).
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp directory | Parent directory for per-job workspaces. The runner only creates and cleans per-job child directories under this root. |
-| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` in source-run mode; `true` in verified managed images | Enables automatic renewal for `persist_credentials: true` Git checkouts. Managed images set this only after verifying the helper and production dependency closure. Do not add it to provider-rendered runner environment data. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` in source-run mode; `true` in verified managed images | Enables automatic renewal for `persist-credentials: true` Git checkouts. Managed images set this only after verifying the helper and production dependency closure. Do not set it on a self-hosted or unverified image, or add it to provider-rendered runner environment data. |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | How often the runner asks the API for new jobs. Backs off toward `SHIPFOX_POLL_MAX_INTERVAL_MS` while idle or after errors. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Largest interval the poll backoff can reach. |
 | `SHIPFOX_POLL_MAX_DURATION_MS` | `300000` | How long the runner keeps polling without claiming a job before it exits. Use `0` for runners that should poll forever. |
@@ -65,9 +65,13 @@ labels](/reference/runner-labels).
 ## Renewable Git credentials
 
 Verified managed runner images advertise renewable Git credentials after their
-installation checks pass. A checkout with `persist_credentials: true` can then
+installation checks pass. A checkout with `persist-credentials: true` can then
 renew its exact repository credential during a long job without workflow-supplied
 tokens or retry logic.
+
+Only a verified managed image may advertise this capability. Do not set the flag
+on a self-hosted or unverified image. The helper and production-closure checks
+must pass before a runner enables it.
 
 Older self-hosted runners remain compatible and continue with static checkout
 credentials. If a persisted checkout is dispatched to one, the job shows a

--- a/apps/docs/content/docs/reference/runner.mdx
+++ b/apps/docs/content/docs/reference/runner.mdx
@@ -45,6 +45,7 @@ labels](/reference/runner-labels).
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp directory | Parent directory for per-job workspaces. The runner only creates and cleans per-job child directories under this root. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` in source-run mode; `true` in verified managed images | Enables automatic renewal for `persist_credentials: true` Git checkouts. Managed images set this only after verifying the helper and production dependency closure. Do not add it to provider-rendered runner environment data. |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | How often the runner asks the API for new jobs. Backs off toward `SHIPFOX_POLL_MAX_INTERVAL_MS` while idle or after errors. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Largest interval the poll backoff can reach. |
 | `SHIPFOX_POLL_MAX_DURATION_MS` | `300000` | How long the runner keeps polling without claiming a job before it exits. Use `0` for runners that should poll forever. |
@@ -60,6 +61,23 @@ labels](/reference/runner-labels).
 | `SHIPFOX_LOG_SPOOL_MAX_BYTES` | `67108864` | Maximum unacknowledged log bytes kept on disk per step attempt while the API is unreachable. Past it, output is dropped with a gap marker. |
 | `SHIPFOX_LOG_DRAIN_TIMEOUT_MS` | `5000` | How long the runner waits at job end for in-flight uploads before deleting the workspace. |
 | `SHIPFOX_AGENT_SESSION_FLUSH_BYTES` | `4194304` | Upload window and per-entry drop threshold for agent-session logs. An entry above it is dropped with a gap marker. |
+
+## Renewable Git credentials
+
+Verified managed runner images advertise renewable Git credentials after their
+installation checks pass. A checkout with `persist_credentials: true` can then
+renew its exact repository credential during a long job without workflow-supplied
+tokens or retry logic.
+
+Older self-hosted runners remain compatible and continue with static checkout
+credentials. If a persisted checkout is dispatched to one, the job shows a
+warning that the credential may expire and recommends upgrading the runner image.
+Scheduling is not blocked by the missing capability.
+
+Git commands started inside a container from a user step do not inherit the host
+runner's helper or Unix socket. Supply an explicit credential to that container
+when it needs authenticated Git access. Mounting the job workspace alone does not
+change this boundary.
 
 ## Agent steps
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -117,9 +117,14 @@ COPY --from=build /prod ./
 RUN ln -s /app/dist/git-credential-helper.js /usr/local/bin/git-credential-shipfox
 
 # Verify the production dependency closure contains every Pi extension entry and the
-# WASM-backed SVG image-preparation assets before the image can be published. This
-# runs against the deployed flat layout, not the pnpm development tree.
+# WASM-backed SVG image-preparation assets, plus the Git credential helper, before
+# the image can be published. This runs against the deployed flat layout, not the
+# pnpm development tree.
 RUN node ./dist/verify-installation.js
+
+# This image has passed the installation gate, so managed containers may advertise
+# renewable Git credentials. Source-run and older images retain the flag's false default.
+ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true
 
 USER shipfox
 

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -20,7 +20,10 @@ the per-job directory. The credential scope follows the job's checkout
 permissions. The credentials are fetched only after the job is claimed, never
 persisted to `.git/config`, and never appear in logs or step errors. When a job
 persists checkout credentials for agent steps, the runner writes a 0600 per-job
-Git config file scoped to the repository URL and removes it during job cleanup.
+Git credential-helper configuration scoped to the repository URL and removes it during job cleanup.
+Current managed images use the renewable helper. Older or source-run self-hosted runners use
+static checkout credentials, and a job annotation warns when those credentials may expire during
+a long job.
 A setup failure (missing `git`, a denied credential, or an unreachable provider)
 fails the job before any step runs, with a machine-readable reason recorded on
 the step.
@@ -74,6 +77,7 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_RUNNER_PROVIDER_KIND` | N/A | Provider kind the managed runner declares during enrollment, such as `ec2` or `docker`. Required with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`. |
 | `SHIPFOX_RUNNER_PROTOCOL_VERSION` | `1` | Protocol version the managed runner declares during enrollment. |
 | `SHIPFOX_RUNNER_LABELS` | N/A | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` | Enables the runner-local renewable Git credential broker. Verified managed images set this to `true`; keep the source-run default until the image and API rollout is ready. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | Base poll interval when requesting jobs. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Maximum backoff interval when no jobs are available or the API errors. |

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -19,8 +19,8 @@ short-lived checkout credentials and shallow-clones the project repository into
 the per-job directory. The credential scope follows the job's checkout
 permissions. The credentials are fetched only after the job is claimed, never
 persisted to `.git/config`, and never appear in logs or step errors. When a job
-persists checkout credentials for agent steps, the runner writes a 0600 per-job
-Git credential-helper configuration scoped to the repository URL and removes it during job cleanup.
+persists checkout credentials for agent steps, the runner writes a 0600 per-job Git
+credential-helper configuration. It is scoped to the repository URL and removed during job cleanup.
 Current managed images use the renewable helper. Older or source-run self-hosted runners use
 static checkout credentials, and a job annotation warns when those credentials may expire during
 a long job.
@@ -77,7 +77,7 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_RUNNER_PROVIDER_KIND` | N/A | Provider kind the managed runner declares during enrollment, such as `ec2` or `docker`. Required with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`. |
 | `SHIPFOX_RUNNER_PROTOCOL_VERSION` | `1` | Protocol version the managed runner declares during enrollment. |
 | `SHIPFOX_RUNNER_LABELS` | N/A | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
-| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` | Enables the runner-local renewable Git credential broker. Verified managed images set this to `true`; keep the source-run default until the image and API rollout is ready. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` | Enables the runner-local renewable Git credential broker. Verified managed images set this to `true` after the helper and production-closure checks pass. Keep `false` on self-hosted or unverified images. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | Base poll interval when requesting jobs. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Maximum backoff interval when no jobs are available or the API errors. |

--- a/apps/runner/src/verify-installation.ts
+++ b/apps/runner/src/verify-installation.ts
@@ -3,18 +3,20 @@ import {assertPiHarnessExtensionsAvailable} from '@shipfox/runner-agent/pi-exten
 import {assertPiImageRasterizerAvailable} from '@shipfox/runner-agent/pi-image-rasterizer';
 
 const require = createRequire(import.meta.url);
-const RUNNER_AGENT_RUNTIME_EXPORTS = [
+const RUNNER_RUNTIME_EXPORTS = [
   '@shipfox/runner-agent/pi-image-rasterizer',
   '@shipfox/runner-agent/tool-capabilities',
   '@shipfox/runner-agent/step',
+  '@shipfox/runner-execution/git-credential-helper',
+  './git-credential-helper.js',
 ] as const;
 
-for (const specifier of RUNNER_AGENT_RUNTIME_EXPORTS) {
+for (const specifier of RUNNER_RUNTIME_EXPORTS) {
   try {
     require.resolve(specifier);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    throw new Error(`Unable to resolve runner agent export "${specifier}": ${reason}`);
+    throw new Error(`Unable to resolve runner runtime export "${specifier}": ${reason}`);
   }
 }
 

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -150,7 +150,7 @@ that container needs an explicitly supplied credential.
 Roll out a verified image through a candidate and one managed canary before fleet promotion:
 
 1. Build and publish the architecture-specific candidate from the target `main` revision.
-2. Start one managed runner from that candidate and run the long-lived Git checkout challenge.
+2. Start one managed runner in an isolated non-production worker-plane account from that candidate and run the long-lived Git checkout challenge.
 3. Monitor `workflows_checkout_token_requests` for initial and renewal outcomes,
    `github_checkout_token_cache_lookups` for cache and stale-serving outcomes,
    `github_checkout_token_mint_duration` for provider mint latency, and the runner job logs.

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -135,6 +135,34 @@ The image derives its tool capabilities from its baked runner runtime and sends 
 enrollment. Providers do not inject capabilities, workspace IDs, workspace registration tokens,
 or activation tokens into user data.
 
+The image owns `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT`. The container image sets it only after the
+production-closure verifier passes. The AMI service unit sets it only after `install-runner.sh`
+has run that same verifier, so a partial image bake cannot advertise the helper. Provider-rendered
+environment files must not set this flag.
+
+Older self-managed images remain compatible: they use static checkout credentials. When a persisted
+checkout reaches one, the API writes an upgrade warning to the job annotations without blocking
+scheduling. Git commands started inside a user container do not receive the host helper or socket;
+that container needs an explicitly supplied credential.
+
+## Renewable Git rollout
+
+Roll out a verified image through a candidate and one managed canary before fleet promotion:
+
+1. Build and publish the architecture-specific candidate from the target `main` revision.
+2. Start one managed runner from that candidate and run the long-lived Git checkout challenge.
+3. Monitor `workflows_checkout_token_requests` for initial and renewal outcomes,
+   `github_checkout_token_cache_lookups` for cache and stale-serving outcomes,
+   `github_checkout_token_mint_duration` for provider mint latency, and the runner job logs.
+4. Promote the image only after renewal requests, L2 outcomes, provider mints, and job results are
+   stable for the canary window. Confirm no managed runner below the supported capability remains.
+5. Roll back by deploying the static runner image or disabling the image advertisement first. Keep
+   server renewal delivery available until no new runner advertises the capability.
+
+The image build and canary prove different boundaries. A passing Packer or Docker build proves the
+helper is packaged. The canary proves the managed runner selects it against the deployed API and
+provider. Neither check makes a live rollout green without its monitoring evidence.
+
 `shipfox-runner.service` powers off immediately when the runner exits. Its SIGTERM drain budget is 90 seconds, after which systemd can force-kill the process and the backend re-reserves the job. The image accepts `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` for compatibility but does not arm an age-based timer or fallback poweroff from that key. Before an orchestration-owned exit, the runner writes one bounded `runner.shutdown_intent` event to the structured logger and the direct EC2 console descriptor, identifying a success, controlled exit, or fatal failure. AWS builds also enable a Spot IMDSv2 watcher that stops the runner, allows it to drain briefly, then powers off.
 
 With `InstanceInitiatedShutdownBehavior=terminate` and Spot `InstanceInterruptionBehavior=terminate`, provider-side settings convert these poweroffs into EC2 termination. The systemd lifecycle action is the fast path. The durable backstop remains tagged-instance reconciliation, the backend staleness reaper, and terminate-on-shutdown because privileged job steps or a wedged kernel can prevent normal process exit.

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -11,6 +11,8 @@ User=shipfox
 EnvironmentFile=-/etc/environment
 EnvironmentFile=/etc/shipfox/runner.env
 Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
+# The image installs this unit only after install-runner.sh verifies the deployed helper.
+Environment=SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true
 ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh
 WorkingDirectory=/opt/runner
 ExecStart=/opt/shipfox-runner/scripts/runtime/run-runner.sh /usr/local/bin/node dist/index.js

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -12,8 +12,9 @@ cd "$(dirname "$lockfile")"
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner
-# Verify the deployed production closure contains every Pi extension entry before the image is
-# published. This runs against the deployed flat layout, not the pnpm development tree.
+# Verify the deployed production closure contains every Pi extension entry and the Git credential
+# helper before the image is published. This runs against the deployed flat layout, not the pnpm
+# development tree.
 node /opt/runner/dist/verify-installation.js
 chown -R shipfox:shipfox /opt/runner
 

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -2,6 +2,7 @@
 set -eu
 
 root_dir=${RUNNER_IMAGE_ROOT:-/}
+runner_dir=${RUNNER_IMAGE_RUNNER_DIR:-/opt/runner}
 workspace="$root_dir/tmp/shipfox-runner-workspace"
 lockfile="$(find "$workspace" -name pnpm-lock.yaml -print -quit)"
 if [ -z "$lockfile" ]; then
@@ -11,12 +12,17 @@ fi
 cd "$(dirname "$lockfile")"
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
-pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner
+pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false "$runner_dir"
 # Verify the deployed production closure contains every Pi extension entry and the Git credential
 # helper before the image is published. This runs against the deployed flat layout, not the pnpm
 # development tree.
-node /opt/runner/dist/verify-installation.js
-chown -R shipfox:shipfox /opt/runner
+node "$runner_dir/dist/verify-installation.js"
+# The runner package is the deployed root rather than an installed dependency, so its package bin
+# is not linked onto PATH by pnpm. Keep Git's name-based helper resolution usable in production.
+mkdir -p "$root_dir/usr/local/bin"
+ln -sfn "$runner_dir/dist/git-credential-helper.js" \
+  "$root_dir/usr/local/bin/git-credential-shipfox"
+chown -R shipfox:shipfox "$runner_dir"
 
 # Ubuntu's tmpfiles.d/tmp.conf applies `D /tmp 1777 root root 30d` during boot.
 # Remove the dependency tree before the AMI is snapshotted so tmpfiles does not

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -926,6 +926,7 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Unit', 'SuccessAction')).toBe('poweroff-immediate');
     expect(systemdDirective(unit, 'Unit', 'FailureAction')).toBe('poweroff-immediate');
     expect(systemdDirective(unit, 'Service', 'StandardOutput')).toBe('journal+console');
+    expect(unit).toContain('Environment=SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true');
     expect(unit).not.toContain('--enable-source-maps');
   });
 
@@ -1531,8 +1532,18 @@ describe('runner container entrypoint', () => {
       new URL('../../../../apps/runner/Dockerfile', import.meta.url),
       'utf8',
     );
+    const verifyInstallation = await readFile(
+      new URL('../../../../apps/runner/src/verify-installation.ts', import.meta.url),
+      'utf8',
+    );
 
     expect(dockerfile).toContain('RUN node ./dist/verify-installation.js');
+    expect(verifyInstallation).toContain("'@shipfox/runner-execution/git-credential-helper'");
+    expect(verifyInstallation).toContain("'./git-credential-helper.js'");
+    expect(dockerfile).toContain('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true');
+    expect(dockerfile.indexOf('RUN node ./dist/verify-installation.js')).toBeLessThan(
+      dockerfile.indexOf('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true'),
+    );
     expect(dockerfile).toContain('ENTRYPOINT ["tini", "--"]');
     expect(dockerfile).toContain('CMD ["node", "./dist/index.js"]');
     expect(dockerfile).not.toContain('--enable-source-maps');

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,5 +1,5 @@
 import {execFileSync, spawnSync} from 'node:child_process';
-import {chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, readFile, readlink, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {findProducedAmiId, parsePackerAmiArtifact} from '#aws.js';
@@ -2012,7 +2012,7 @@ describe('runner image composition', () => {
 });
 
 describe('runner installation', () => {
-  it('removes the dependency tree from the image build staging area', async () => {
+  it('verifies the staged runtime and installs the helper on the runner PATH', async () => {
     const script = new URL('../scripts/build/install-runner.sh', import.meta.url);
     const fixture = await createRunnerInstallFixture();
 
@@ -2024,8 +2024,34 @@ describe('runner installation', () => {
 
       expect(await pathExists(fixture.workspace)).toBe(false);
       expect(await readFile(fixture.commandLog, 'utf8')).toContain(
-        'pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner',
+        `pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false ${fixture.runnerDirectory}`,
       );
+      expect(await readFile(fixture.commandLog, 'utf8')).toContain(
+        `node ${fixture.runnerDirectory}/dist/verify-installation.js`,
+      );
+      expect(await readlink(fixture.helperPath)).toBe(
+        `${fixture.runnerDirectory}/dist/git-credential-helper.js`,
+      );
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it.each([
+    'helper',
+    'entrypoint',
+  ] as const)('fails the staged runtime check when the %s is missing', async (missingRuntime) => {
+    const script = new URL('../scripts/build/install-runner.sh', import.meta.url);
+    const fixture = await createRunnerInstallFixture({missingRuntime});
+
+    try {
+      expect(() =>
+        execFileSync('/bin/sh', [script.pathname], {
+          env: fixture.environment,
+          stdio: 'pipe',
+        }),
+      ).toThrow();
+      expect(await pathExists(fixture.workspace)).toBe(true);
     } finally {
       await rm(fixture.root, {force: true, recursive: true});
     }
@@ -2224,13 +2250,18 @@ printf 'swapon %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
   };
 }
 
-async function createRunnerInstallFixture() {
+async function createRunnerInstallFixture(
+  options: {missingRuntime?: 'helper' | 'entrypoint'} = {},
+) {
   const root = await mkdtemp(join(tmpdir(), 'shipfox-runner-install-'));
   const commandDirectory = join(root, 'commands');
   const workspace = join(root, 'tmp/shipfox-runner-workspace');
   const commandLog = join(root, 'command.log');
+  const runnerDirectory = join(root, 'opt/runner');
+  const helperPath = join(root, 'usr/local/bin/git-credential-shipfox');
 
   await mkdir(join(workspace, 'package'), {recursive: true});
+  await mkdir(join(runnerDirectory, 'dist'), {recursive: true});
   await mkdir(commandDirectory, {recursive: true});
   await writeFile(join(workspace, 'package/pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
   await writeExecutable(join(commandDirectory, 'corepack'), '#!/bin/sh\nexit 0\n');
@@ -2239,9 +2270,28 @@ async function createRunnerInstallFixture() {
     `#!/bin/sh
 set -eu
 printf 'pnpm %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+mkdir -p "$RUNNER_IMAGE_RUNNER_DIR/dist"
+: > "$RUNNER_IMAGE_RUNNER_DIR/dist/index.js"
+if [ "\${RUNNER_IMAGE_MISSING_RUNTIME:-}" != helper ]; then
+  printf '#!/bin/sh\\n' > "$RUNNER_IMAGE_RUNNER_DIR/dist/git-credential-helper.js"
+  chmod 755 "$RUNNER_IMAGE_RUNNER_DIR/dist/git-credential-helper.js"
+fi
+if [ "\${RUNNER_IMAGE_MISSING_RUNTIME:-}" = entrypoint ]; then
+  rm -f "$RUNNER_IMAGE_RUNNER_DIR/dist/index.js"
+fi
 `,
   );
-  await writeExecutable(join(commandDirectory, 'node'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(
+    join(commandDirectory, 'node'),
+    `#!/bin/sh
+set -eu
+printf 'node %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
+if [ "$1" = "$RUNNER_IMAGE_RUNNER_DIR/dist/verify-installation.js" ]; then
+  test -f "$RUNNER_IMAGE_RUNNER_DIR/dist/index.js"
+  test -x "$RUNNER_IMAGE_RUNNER_DIR/dist/git-credential-helper.js"
+fi
+`,
+  );
   await writeExecutable(join(commandDirectory, 'chown'), '#!/bin/sh\nexit 0\n');
 
   return {
@@ -2251,8 +2301,12 @@ printf 'pnpm %s\\n' "$*" >> "$RUNNER_IMAGE_COMMAND_LOG"
       PATH: `${commandDirectory}:${process.env.PATH ?? ''}`,
       RUNNER_IMAGE_COMMAND_LOG: commandLog,
       RUNNER_IMAGE_ROOT: root,
+      RUNNER_IMAGE_MISSING_RUNTIME: options.missingRuntime ?? '',
+      RUNNER_IMAGE_RUNNER_DIR: runnerDirectory,
     },
+    helperPath,
     root,
+    runnerDirectory,
     workspace,
   };
 }

--- a/libs/api/workflows/src/core/agent-tool-capability-warning.ts
+++ b/libs/api/workflows/src/core/agent-tool-capability-warning.ts
@@ -12,6 +12,7 @@ import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-modu
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {recordWorkflowAgentToolWarningFailed} from '#metrics/instance.js';
+import {annotationTargetFromLease} from './annotation-target.js';
 import type {Step} from './entities/step.js';
 
 const TOOL_LIST_LIMIT = 10;
@@ -171,23 +172,6 @@ function markdownInlineCode(value: string): string {
 function warningReason(params: {reportFresh: boolean; harnessKnown: boolean}): WarningReason {
   if (params.harnessKnown) return 'known-absence';
   return params.reportFresh ? 'harness-not-advertised' : 'unknown-or-stale';
-}
-
-function annotationTargetFromLease(
-  lease: LeasedJobContext,
-): Omit<
-  Parameters<AnnotationsInterModuleClient['replaceOrRemoveAnnotation']>[0],
-  'originStepId' | 'originStepAttempt' | 'context' | 'annotation'
-> {
-  return {
-    workspaceId: lease.workspaceId,
-    projectId: lease.projectId,
-    workflowRunId: lease.workflowRunId,
-    workflowRunAttempt: lease.workflowRunAttempt ?? 1,
-    workflowRunAttemptId: lease.workflowRunAttemptId,
-    jobId: lease.jobId,
-    jobExecutionId: lease.jobExecutionId,
-  };
 }
 
 function isAnnotationBudgetError(error: unknown): boolean {

--- a/libs/api/workflows/src/core/annotation-target.ts
+++ b/libs/api/workflows/src/core/annotation-target.ts
@@ -1,0 +1,19 @@
+import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {LeasedJobContext} from '@shipfox/api-auth-context';
+
+export function annotationTargetFromLease(
+  lease: LeasedJobContext,
+): Omit<
+  Parameters<AnnotationsInterModuleClient['replaceOrRemoveAnnotation']>[0],
+  'originStepId' | 'originStepAttempt' | 'context' | 'annotation'
+> {
+  return {
+    workspaceId: lease.workspaceId,
+    projectId: lease.projectId,
+    workflowRunId: lease.workflowRunId,
+    workflowRunAttempt: lease.workflowRunAttempt ?? 1,
+    workflowRunAttemptId: lease.workflowRunAttemptId,
+    jobId: lease.jobId,
+    jobExecutionId: lease.jobExecutionId,
+  };
+}

--- a/libs/api/workflows/src/core/checkout-capability-warning.test.ts
+++ b/libs/api/workflows/src/core/checkout-capability-warning.test.ts
@@ -51,6 +51,29 @@ describe('warnRenewableGitCapabilityMismatchOnDispatch', () => {
     );
   });
 
+  it('warns when a fresh runner report explicitly disables renewable Git', async () => {
+    const leaseIdentity = lease();
+    const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
+    getEffectiveRunnerToolCapabilities.mockResolvedValue({
+      capabilities: {features: {renewable_git: false}, harnesses: {}},
+      reportFresh: true,
+    });
+
+    await warnRenewableGitCapabilityMismatchOnDispatch({
+      annotations,
+      runners,
+      leaseIdentity,
+      step,
+    });
+
+    expect(annotation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: `renewable-git-capability:${step.id}`,
+        annotation: expect.objectContaining({op: 'replace'}),
+      }),
+    );
+  });
+
   it('removes an existing warning when the runner advertises renewable Git', async () => {
     const leaseIdentity = lease();
     const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
@@ -110,6 +133,41 @@ describe('warnRenewableGitCapabilityMismatchOnDispatch', () => {
         step,
       }),
     ).resolves.toBeUndefined();
+
+    expect(annotation).not.toHaveBeenCalled();
+  });
+
+  it('does not make an annotation write failure affect dispatch', async () => {
+    const leaseIdentity = lease();
+    const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
+    annotation.mockRejectedValueOnce(new Error('annotation write failed'));
+
+    await expect(
+      warnRenewableGitCapabilityMismatchOnDispatch({
+        annotations,
+        runners,
+        leaseIdentity,
+        step,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(annotation).toHaveBeenCalledOnce();
+  });
+
+  it('does not project a warning from a stale capability report', async () => {
+    const leaseIdentity = lease();
+    const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
+    getEffectiveRunnerToolCapabilities.mockResolvedValue({
+      capabilities: {features: {renewable_git: true}, harnesses: {}},
+      reportFresh: false,
+    });
+
+    await warnRenewableGitCapabilityMismatchOnDispatch({
+      annotations,
+      runners,
+      leaseIdentity,
+      step,
+    });
 
     expect(annotation).not.toHaveBeenCalled();
   });

--- a/libs/api/workflows/src/core/checkout-capability-warning.test.ts
+++ b/libs/api/workflows/src/core/checkout-capability-warning.test.ts
@@ -1,0 +1,165 @@
+import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {JobLeaseTokenClaims} from '@shipfox/api-auth-dto';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
+import {warnRenewableGitCapabilityMismatchOnDispatch} from './checkout-capability-warning.js';
+import type {Step} from './entities/step.js';
+
+const annotation = vi.fn<AnnotationsInterModuleClient['replaceOrRemoveAnnotation']>();
+const annotations: AnnotationsInterModuleClient = {
+  replaceOrRemoveAnnotation: annotation,
+  listAnnotationsForRunAttempt: vi.fn(),
+};
+const getEffectiveRunnerToolCapabilities =
+  vi.fn<RunnersInterModuleClient['getEffectiveRunnerToolCapabilities']>();
+const runners = {
+  getEffectiveRunnerToolCapabilities,
+} as unknown as RunnersInterModuleClient;
+
+beforeEach(() => {
+  annotation.mockClear();
+  annotation.mockResolvedValue({});
+  getEffectiveRunnerToolCapabilities.mockClear();
+  getEffectiveRunnerToolCapabilities.mockResolvedValue({
+    capabilities: {harnesses: {}},
+    reportFresh: true,
+  });
+});
+
+describe('warnRenewableGitCapabilityMismatchOnDispatch', () => {
+  it('warns when a persisted checkout runner does not advertise renewable Git', async () => {
+    const leaseIdentity = lease();
+    const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
+
+    await warnRenewableGitCapabilityMismatchOnDispatch({
+      annotations,
+      runners,
+      leaseIdentity,
+      step,
+    });
+
+    expect(annotation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobExecutionId: leaseIdentity.jobExecutionId,
+        originStepId: step.id,
+        context: `renewable-git-capability:${step.id}`,
+        annotation: expect.objectContaining({
+          op: 'replace',
+          style: 'warning',
+          body: expect.stringContaining('may expire during a long job'),
+        }),
+      }),
+    );
+  });
+
+  it('removes an existing warning when the runner advertises renewable Git', async () => {
+    const leaseIdentity = lease();
+    const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
+    getEffectiveRunnerToolCapabilities.mockResolvedValue({
+      capabilities: {features: {renewable_git: true}, harnesses: {}},
+      reportFresh: true,
+    });
+
+    await warnRenewableGitCapabilityMismatchOnDispatch({
+      annotations,
+      runners,
+      leaseIdentity,
+      step,
+    });
+
+    expect(annotation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: `renewable-git-capability:${step.id}`,
+        annotation: {op: 'remove'},
+      }),
+    );
+  });
+
+  it('does not inspect capabilities for non-persisted or non-checkout steps', async () => {
+    const leaseIdentity = lease();
+
+    await warnRenewableGitCapabilityMismatchOnDispatch({
+      annotations,
+      runners,
+      leaseIdentity,
+      step: checkoutStep({
+        jobExecutionId: leaseIdentity.jobExecutionId,
+        config: {checkout: {persist_credentials: false}},
+      }),
+    });
+    await warnRenewableGitCapabilityMismatchOnDispatch({
+      annotations,
+      runners,
+      leaseIdentity,
+      step: checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId, type: 'run'}),
+    });
+
+    expect(getEffectiveRunnerToolCapabilities).not.toHaveBeenCalled();
+    expect(annotation).not.toHaveBeenCalled();
+  });
+
+  it('does not make a capability lookup failure affect dispatch', async () => {
+    const leaseIdentity = lease();
+    const step = checkoutStep({jobExecutionId: leaseIdentity.jobExecutionId});
+    getEffectiveRunnerToolCapabilities.mockRejectedValue(new Error('runner lookup failed'));
+
+    await expect(
+      warnRenewableGitCapabilityMismatchOnDispatch({
+        annotations,
+        runners,
+        leaseIdentity,
+        step,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(annotation).not.toHaveBeenCalled();
+  });
+});
+
+function lease(): JobLeaseTokenClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    aud: 'runner-job-lease',
+    iat: now,
+    exp: now + 60,
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    workflowRunId: crypto.randomUUID(),
+    workflowRunAttempt: 1,
+    workflowRunAttemptId: crypto.randomUUID(),
+    jobId: crypto.randomUUID(),
+    jobExecutionId: crypto.randomUUID(),
+    runnerSessionId: crypto.randomUUID(),
+    currentStepId: crypto.randomUUID(),
+    currentStepAttempt: 1,
+  };
+}
+
+function checkoutStep(params: Partial<Step> = {}): Step {
+  return {
+    id: crypto.randomUUID(),
+    jobExecutionId: crypto.randomUUID(),
+    key: 'checkout',
+    name: 'Checkout',
+    sourceLocation: null,
+    status: 'running',
+    statusReason: null,
+    evaluationTrace: null,
+    type: 'checkout',
+    config: {
+      checkout: {
+        repository: 'acme/repository',
+        persist_credentials: true,
+      },
+    },
+    condition: null,
+    configPlan: null,
+    authoredConfig: null,
+    error: null,
+    position: 0,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...params,
+  };
+}

--- a/libs/api/workflows/src/core/checkout-capability-warning.ts
+++ b/libs/api/workflows/src/core/checkout-capability-warning.ts
@@ -1,0 +1,88 @@
+import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {LeasedJobContext} from '@shipfox/api-auth-context';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
+import {logger} from '@shipfox/node-opentelemetry';
+import {getCheckoutPolicy} from './checkout.js';
+import type {Step} from './entities/step.js';
+
+export async function warnRenewableGitCapabilityMismatchOnDispatch(params: {
+  annotations: AnnotationsInterModuleClient;
+  runners: RunnersInterModuleClient;
+  leaseIdentity: LeasedJobContext;
+  step: Step;
+}): Promise<void> {
+  if (!isPersistedCheckout(params.step)) return;
+
+  let capabilities: Awaited<
+    ReturnType<RunnersInterModuleClient['getEffectiveRunnerToolCapabilities']>
+  >;
+  try {
+    capabilities = await params.runners.getEffectiveRunnerToolCapabilities({
+      runnerSessionId: params.leaseIdentity.runnerSessionId,
+    });
+  } catch (error) {
+    logger().warn(
+      {error, jobExecutionId: params.leaseIdentity.jobExecutionId, stepId: params.step.id},
+      'Failed to read runner capabilities for renewable Git warning',
+    );
+    return;
+  }
+
+  const context = `renewable-git-capability:${params.step.id}`;
+  const renewableGitAdvertised = capabilities.capabilities.features?.renewable_git === true;
+  const annotation = renewableGitAdvertised
+    ? {op: 'remove' as const}
+    : {
+        op: 'replace' as const,
+        style: 'warning' as const,
+        body: [
+          '**Renewable Git credentials are unavailable on this runner**',
+          '',
+          'This job persists Git credentials, but the matched runner did not advertise renewable Git support. Its checkout credential may expire during a long job.',
+          'Upgrade the self-managed runner to a current Shipfox runner image to enable automatic renewal. The job continues with static checkout credentials for now.',
+          '',
+          'See the [Runner configuration reference](/reference/runner) for the supported runner setup.',
+        ].join('\n'),
+      };
+
+  try {
+    await params.annotations.replaceOrRemoveAnnotation({
+      ...annotationTargetFromLease(params.leaseIdentity),
+      originStepId: params.step.id,
+      originStepAttempt: params.step.currentAttempt,
+      context,
+      annotation,
+    });
+  } catch (error) {
+    logger().warn(
+      {
+        error,
+        jobExecutionId: params.leaseIdentity.jobExecutionId,
+        stepId: params.step.id,
+      },
+      'Failed to write renewable Git capability warning annotation',
+    );
+  }
+}
+
+function isPersistedCheckout(step: Step): boolean {
+  if (step.type !== 'setup' && step.type !== 'checkout') return false;
+  return getCheckoutPolicy(step.config)?.persistCredentials === true;
+}
+
+function annotationTargetFromLease(
+  lease: LeasedJobContext,
+): Omit<
+  Parameters<AnnotationsInterModuleClient['replaceOrRemoveAnnotation']>[0],
+  'originStepId' | 'originStepAttempt' | 'context' | 'annotation'
+> {
+  return {
+    workspaceId: lease.workspaceId,
+    projectId: lease.projectId,
+    workflowRunId: lease.workflowRunId,
+    workflowRunAttempt: lease.workflowRunAttempt ?? 1,
+    workflowRunAttemptId: lease.workflowRunAttemptId,
+    jobId: lease.jobId,
+    jobExecutionId: lease.jobExecutionId,
+  };
+}

--- a/libs/api/workflows/src/core/checkout-capability-warning.ts
+++ b/libs/api/workflows/src/core/checkout-capability-warning.ts
@@ -1,9 +1,17 @@
-import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import {
+  type AnnotationsInterModuleClient,
+  annotationsInterModuleContract,
+} from '@shipfox/annotations-dto/inter-module';
 import type {LeasedJobContext} from '@shipfox/api-auth-context';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {logger} from '@shipfox/node-opentelemetry';
+import {recordWorkflowCheckoutCapabilityWarningFailed} from '#metrics/instance.js';
+import {annotationTargetFromLease} from './annotation-target.js';
 import {getCheckoutPolicy} from './checkout.js';
 import type {Step} from './entities/step.js';
+
+type WarningFailureReason = 'budget' | 'lookup' | 'write';
 
 export async function warnRenewableGitCapabilityMismatchOnDispatch(params: {
   annotations: AnnotationsInterModuleClient;
@@ -21,12 +29,17 @@ export async function warnRenewableGitCapabilityMismatchOnDispatch(params: {
       runnerSessionId: params.leaseIdentity.runnerSessionId,
     });
   } catch (error) {
+    recordWarningWriteFailure('lookup');
     logger().warn(
       {error, jobExecutionId: params.leaseIdentity.jobExecutionId, stepId: params.step.id},
       'Failed to read runner capabilities for renewable Git warning',
     );
     return;
   }
+
+  // A stale report means the runner's current capability is unknown. Treating the empty fallback
+  // as an explicit absence would replace a valid annotation during a heartbeat race.
+  if (!capabilities.reportFresh) return;
 
   const context = `renewable-git-capability:${params.step.id}`;
   const renewableGitAdvertised = capabilities.capabilities.features?.renewable_git === true;
@@ -41,7 +54,7 @@ export async function warnRenewableGitCapabilityMismatchOnDispatch(params: {
           'This job persists Git credentials, but the matched runner did not advertise renewable Git support. Its checkout credential may expire during a long job.',
           'Upgrade the self-managed runner to a current Shipfox runner image to enable automatic renewal. The job continues with static checkout credentials for now.',
           '',
-          'See the [Runner configuration reference](/reference/runner) for the supported runner setup.',
+          'See the [Runner configuration reference](https://www.shipfox.io/docs/reference/runner) for the supported runner setup.',
         ].join('\n'),
       };
 
@@ -54,9 +67,12 @@ export async function warnRenewableGitCapabilityMismatchOnDispatch(params: {
       annotation,
     });
   } catch (error) {
+    const reason = isAnnotationBudgetError(error) ? 'budget' : 'write';
+    recordWarningWriteFailure(reason);
     logger().warn(
       {
         error,
+        reason,
         jobExecutionId: params.leaseIdentity.jobExecutionId,
         stepId: params.step.id,
       },
@@ -70,19 +86,13 @@ function isPersistedCheckout(step: Step): boolean {
   return getCheckoutPolicy(step.config)?.persistCredentials === true;
 }
 
-function annotationTargetFromLease(
-  lease: LeasedJobContext,
-): Omit<
-  Parameters<AnnotationsInterModuleClient['replaceOrRemoveAnnotation']>[0],
-  'originStepId' | 'originStepAttempt' | 'context' | 'annotation'
-> {
-  return {
-    workspaceId: lease.workspaceId,
-    projectId: lease.projectId,
-    workflowRunId: lease.workflowRunId,
-    workflowRunAttempt: lease.workflowRunAttempt ?? 1,
-    workflowRunAttemptId: lease.workflowRunAttemptId,
-    jobId: lease.jobId,
-    jobExecutionId: lease.jobExecutionId,
-  };
+function isAnnotationBudgetError(error: unknown): boolean {
+  return isInterModuleKnownError(
+    annotationsInterModuleContract.methods.replaceOrRemoveAnnotation,
+    error,
+  );
+}
+
+function recordWarningWriteFailure(reason: WarningFailureReason): void {
+  recordWorkflowCheckoutCapabilityWarningFailed(reason);
 }

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -102,6 +102,12 @@ const agentToolWarningFailedCount = meter.createCounter<{
   description: 'Agent tool capability warning failures by bounded reason',
 });
 
+const checkoutCapabilityWarningFailedCount = meter.createCounter<{
+  reason: 'budget' | 'lookup' | 'write';
+}>('workflows_checkout_capability_warning_failed', {
+  description: 'Checkout capability warning failures by bounded reason',
+});
+
 const failureAnnotationFailedCount = meter.createCounter<{
   reason: 'lookup' | 'budget' | 'write';
 }>('workflows_failure_annotation_failed', {
@@ -288,6 +294,12 @@ export function recordWorkflowToolInvocationLogAppendFailure(reason: 'known' | '
 
 export function recordWorkflowAgentToolWarningFailed(reason: 'budget' | 'lookup' | 'write'): void {
   agentToolWarningFailedCount.add(1, {reason});
+}
+
+export function recordWorkflowCheckoutCapabilityWarningFailed(
+  reason: 'budget' | 'lookup' | 'write',
+): void {
+  checkoutCapabilityWarningFailedCount.add(1, {reason});
 }
 
 export function recordWorkflowFailureAnnotationFailed(reason: 'lookup' | 'budget' | 'write'): void {

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -1,3 +1,4 @@
+import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
 import {
   type IntegrationsModuleClient,
@@ -24,8 +25,12 @@ import {createWorkflowRun, getJobsByWorkflowRunId, getStepsByJobId} from '#db/wo
 import {projectFactory} from '#test/factories/project.js';
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
-import {fakeLeaseTokenAuthMethod, mintLeaseToken} from '#test/fixtures/lease-token.js';
-import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {
+  fakeLeaseTokenAuthMethod,
+  getLeaseTokenClaims,
+  mintLeaseToken,
+} from '#test/fixtures/lease-token.js';
+import {runnersTestClient, setRunnerToolCapabilities} from '#test/fixtures/runners-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 const {captureExceptionMock, savePendingCheckoutRenewalSubjectMock} = vi.hoisted(() => ({
@@ -58,6 +63,12 @@ const integrations = {
   createCheckoutCredentials,
 } as Pick<IntegrationsModuleClient, 'createCheckoutSpec' | 'createCheckoutCredentials'>;
 
+const annotationWrites = vi.fn<AnnotationsInterModuleClient['replaceOrRemoveAnnotation']>();
+const annotations = {
+  replaceOrRemoveAnnotation: annotationWrites.mockResolvedValue({}),
+  listAnnotationsForRunAttempt: vi.fn(),
+} satisfies AnnotationsInterModuleClient;
+
 const {logger, lines: logLines, clear: clearLogLines} = createCapturingLogger();
 
 const githubSpec = (token: string) => ({
@@ -75,7 +86,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
       routes: [
         createLeaseTokenRouteGroup({
           agent: {} as never,
-          annotations: {} as never,
+          annotations,
           auth: {} as never,
           integrations: integrations as never,
           projects: projects as never,
@@ -96,6 +107,7 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
     resolveCheckoutTarget.mockReset();
     savePendingCheckoutRenewalSubjectMock.mockClear();
     captureExceptionMock.mockReset();
+    annotationWrites.mockClear();
     clearLogLines();
   });
 
@@ -181,6 +193,82 @@ describe('POST /runs/jobs/current/steps/:stepId/checkout-token', () => {
       target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
       permissions: {contents: 'read'},
     });
+  });
+
+  test('writes the renewable Git warning after persisted credentials are issued', async () => {
+    const {project, job, step} = await createRunningCheckoutStep({kind: 'checkout'});
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
+    });
+    createCheckoutSpec.mockResolvedValue(githubSpec('ghs-warning-token'));
+    const token = await mintActiveLeaseToken({jobId: job.id});
+    const lease = getLeaseTokenClaims(token);
+    if (!lease) throw new Error('Expected minted lease token to verify');
+    setRunnerToolCapabilities(lease.runnerSessionId, {
+      capabilities: {harnesses: {}},
+      reportFresh: true,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: checkoutUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const retry = await app.inject({
+      method: 'POST',
+      url: checkoutUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(retry.statusCode).toBe(200);
+    expect(annotationWrites).toHaveBeenCalledTimes(2);
+    expect(annotationWrites).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobExecutionId: lease.jobExecutionId,
+        originStepId: step.id,
+        context: `renewable-git-capability:${step.id}`,
+        annotation: expect.objectContaining({
+          op: 'replace',
+          body: expect.stringContaining('may expire during a long job'),
+        }),
+      }),
+    );
+  });
+
+  test('does not warn when the checkout response has no credentials', async () => {
+    const {project, job, step} = await createRunningCheckoutStep({kind: 'checkout'});
+    getProjectById.mockResolvedValue({project});
+    resolveCheckoutTarget.mockResolvedValue({
+      projectId: project.id,
+      connectionId: project.sourceConnectionId,
+      target: {kind: 'external-id', externalRepositoryId: project.sourceExternalRepositoryId},
+    });
+    createCheckoutSpec.mockResolvedValue({
+      repositoryUrl: 'https://github.com/acme/public-repo.git',
+      ref: 'main',
+    });
+    const token = await mintActiveLeaseToken({jobId: job.id});
+    const lease = getLeaseTokenClaims(token);
+    if (!lease) throw new Error('Expected minted lease token to verify');
+    setRunnerToolCapabilities(lease.runnerSessionId, {
+      capabilities: {harnesses: {}},
+      reportFresh: true,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: checkoutUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).not.toHaveProperty('auth');
+    expect(annotationWrites).not.toHaveBeenCalled();
   });
 
   test('rejects a renewal generation while the checkout step is still running', async () => {

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -1,3 +1,4 @@
+import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
 import {
   type IntegrationsModuleClient,
   integrationsInterModuleContract,
@@ -18,6 +19,7 @@ import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {captureException} from '@shipfox/node-error-monitoring';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {createStepCheckoutSpec, renewStepCheckoutCredentials} from '#core/checkout.js';
+import {warnRenewableGitCapabilityMismatchOnDispatch} from '#core/checkout-capability-warning.js';
 import type {CheckoutRenewalSubject} from '#core/entities/checkout-renewal-subject.js';
 import {
   CheckoutConfigInvalidError,
@@ -34,6 +36,7 @@ import {
 } from './leased-step.js';
 
 export function createCheckoutTokenRoute(clients: {
+  annotations: AnnotationsInterModuleClient;
   runners: RunnersInterModuleClient;
   integrations: IntegrationsModuleClient;
   projects: ProjectsModuleClient;
@@ -86,6 +89,14 @@ export function createCheckoutTokenRoute(clients: {
           warn: (context, message) => request.log.warn(context, message),
           error: (context, message) => request.log.error(context, message),
         });
+        if (response.auth?.persist === true) {
+          await warnRenewableGitCapabilityMismatchOnDispatch({
+            annotations: clients.annotations,
+            runners: clients.runners,
+            leaseIdentity: loaded.leasedJob,
+            step: loaded.step,
+          });
+        }
         recordWorkflowCheckoutTokenRequest(mode, 'success');
         reply.header('cache-control', 'no-store');
         return response;

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -54,6 +54,7 @@ export function createLeaseTokenRouteGroup(params: LeaseTokenRouteClients): Rout
       createNextStepRoute(params),
       createReportStepRoute(params.runners),
       createCheckoutTokenRoute({
+        annotations: params.annotations,
         integrations: params.integrations,
         projects: params.projects,
         runners: params.runners,

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -1,4 +1,5 @@
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {eq} from 'drizzle-orm';
 import {JobNotFoundError} from '#core/errors.js';
@@ -45,7 +46,7 @@ async function recordStepResult(
 
 function setRunnerToolCapabilities(
   runnerSessionId: string,
-  capabilities: {harnesses: {pi?: {tools: string[]}; claude?: {tools: string[]}}},
+  capabilities: RunnerToolCapabilitiesDto,
 ): void {
   setTestRunnerToolCapabilities(runnerSessionId, {capabilities, reportFresh: true});
 }
@@ -250,6 +251,55 @@ describe('POST /runs/jobs/current/steps/next', () => {
       expect.objectContaining({
         jobExecutionId: lease.jobExecutionId,
         annotation: expect.objectContaining({op: 'replace'}),
+      }),
+    );
+  });
+
+  test('writes the renewable Git upgrade warning only on fresh dispatch', async () => {
+    annotationWrites.mockClear();
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const step = steps[0];
+    if (!step) throw new Error('Expected a step');
+    await db()
+      .update(stepsTable)
+      .set({
+        type: 'checkout',
+        config: {
+          checkout: {
+            repository: 'acme/repository',
+            persist_credentials: true,
+          },
+        },
+      })
+      .where(eq(stepsTable.id, step.id));
+    const token = await mintActiveLeaseToken({jobId});
+    const lease = getLeaseTokenClaims(token);
+    if (!lease) throw new Error('Expected minted lease token to verify');
+    setRunnerToolCapabilities(lease.runnerSessionId, {harnesses: {}});
+
+    const first = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: {authorization: `Bearer ${token}`},
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(annotationWrites).toHaveBeenCalledTimes(1);
+    expect(annotationWrites).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobExecutionId: lease.jobExecutionId,
+        originStepId: step.id,
+        context: `renewable-git-capability:${step.id}`,
+        annotation: expect.objectContaining({
+          op: 'replace',
+          body: expect.stringContaining('may expire during a long job'),
+        }),
       }),
     );
   });

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -255,7 +255,7 @@ describe('POST /runs/jobs/current/steps/next', () => {
     );
   });
 
-  test('writes the renewable Git upgrade warning only on fresh dispatch', async () => {
+  test('defers the renewable Git upgrade warning until credentials are resolved', async () => {
     annotationWrites.mockClear();
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const step = steps[0];
@@ -290,18 +290,7 @@ describe('POST /runs/jobs/current/steps/next', () => {
 
     expect(first.statusCode).toBe(200);
     expect(second.statusCode).toBe(200);
-    expect(annotationWrites).toHaveBeenCalledTimes(1);
-    expect(annotationWrites).toHaveBeenCalledWith(
-      expect.objectContaining({
-        jobExecutionId: lease.jobExecutionId,
-        originStepId: step.id,
-        context: `renewable-git-capability:${step.id}`,
-        annotation: expect.objectContaining({
-          op: 'replace',
-          body: expect.stringContaining('may expire during a long job'),
-        }),
-      }),
-    );
+    expect(annotationWrites).not.toHaveBeenCalled();
   });
 
   test('returns 404 for a valid token without an active lease', async () => {

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -6,7 +6,6 @@ import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-modu
 import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {warnAgentToolCapabilityMismatchOnDispatch} from '#core/agent-tool-capability-warning.js';
-import {warnRenewableGitCapabilityMismatchOnDispatch} from '#core/checkout-capability-warning.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {nextStepForLeasedJobExecution} from '#core/job-execution.js';
 import {toStepDto} from '#presentation/dto/step.js';
@@ -67,12 +66,6 @@ export function createNextStepRoute(params: {
         });
         if (next.dispatched) {
           await warnAgentToolCapabilityMismatchOnDispatch({
-            annotations: params.annotations,
-            runners: params.runners,
-            leaseIdentity: leasedJob,
-            step: next.step,
-          });
-          await warnRenewableGitCapabilityMismatchOnDispatch({
             annotations: params.annotations,
             runners: params.runners,
             leaseIdentity: leasedJob,

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -6,6 +6,7 @@ import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-modu
 import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {warnAgentToolCapabilityMismatchOnDispatch} from '#core/agent-tool-capability-warning.js';
+import {warnRenewableGitCapabilityMismatchOnDispatch} from '#core/checkout-capability-warning.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {nextStepForLeasedJobExecution} from '#core/job-execution.js';
 import {toStepDto} from '#presentation/dto/step.js';
@@ -66,6 +67,12 @@ export function createNextStepRoute(params: {
         });
         if (next.dispatched) {
           await warnAgentToolCapabilityMismatchOnDispatch({
+            annotations: params.annotations,
+            runners: params.runners,
+            leaseIdentity: leasedJob,
+            step: next.step,
+          });
+          await warnRenewableGitCapabilityMismatchOnDispatch({
             annotations: params.annotations,
             runners: params.runners,
             leaseIdentity: leasedJob,

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -45,6 +45,10 @@ const MINTED_CONTEXTS = [
     key: ({originStepId}: MintedContextSource) => `agent-tool-capability:${originStepId}`,
     fallbackTitle: 'Agent tool capability',
   },
+  {
+    key: ({originStepId}: MintedContextSource) => `renewable-git-capability:${originStepId}`,
+    fallbackTitle: 'Renewable Git capability',
+  },
 ] as const;
 
 type MintedContextSource = Pick<RunAnnotationRecord, 'context' | 'jobId' | 'originStepId'>;

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
@@ -1,4 +1,5 @@
-import {screen, within} from '@testing-library/react';
+import {act, screen, within} from '@testing-library/react';
+import {useState} from 'react';
 import {
   buildRunAnnotationList,
   type RunAnnotationRecord,
@@ -48,6 +49,30 @@ describe('RunAnnotationList', () => {
     renderList([annotation({id: 'a1', context: `agent-tool-capability:${BUILD_STEP_ID}`})]);
 
     expect(await screen.findByRole('heading', {level: 3, name: 'build'})).toBeInTheDocument();
+  });
+
+  test('heads the renewable Git context with the emitting job', async () => {
+    renderList([annotation({id: 'a1', context: `renewable-git-capability:${BUILD_STEP_ID}`})]);
+
+    expect(await screen.findByRole('heading', {level: 3, name: 'build'})).toBeInTheDocument();
+  });
+
+  test('announces annotations added after the initial snapshot once', async () => {
+    let updateEntries: (entries: RunAnnotationRecord[]) => void = () => undefined;
+    function Harness() {
+      const [entries, setEntries] = useState([annotation({id: 'a1', sequence: 1})]);
+      updateEntries = setEntries;
+      return renderListElement(entries);
+    }
+
+    renderWithRouter(<Harness />);
+    await screen.findByRole('heading', {level: 3, name: 'default'});
+
+    act(() => {
+      updateEntries([annotation({id: 'a1', sequence: 1}), annotation({id: 'a2', sequence: 2})]);
+    });
+
+    expect(await screen.findByText('A new annotation was added to this run.')).toBeInTheDocument();
   });
 
   test('leaves a step-chosen context that only looks minted as the heading', async () => {
@@ -142,11 +167,24 @@ function renderList(
     derivedAnnotations,
     query = listQuery(),
   }: {
-    derivedAnnotations?: readonly DerivedRunAnnotation[];
+    derivedAnnotations?: readonly DerivedRunAnnotation[] | undefined;
     query?: RunAnnotationListQuery;
   } = {},
 ) {
-  return renderWithRouter(
+  return renderWithRouter(renderListElement(annotations, {derivedAnnotations, query}));
+}
+
+function renderListElement(
+  annotations: RunAnnotationRecord[],
+  {
+    derivedAnnotations,
+    query = listQuery(),
+  }: {
+    derivedAnnotations?: readonly DerivedRunAnnotation[] | undefined;
+    query?: RunAnnotationListQuery;
+  } = {},
+) {
+  return (
     <RunAnnotationList
       query={query}
       entries={buildRunAnnotationList({annotations, jobs})}
@@ -156,7 +194,7 @@ function renderList(
       workflowRunId={RUN_ID}
       runAttempt={1}
       filtered={false}
-    />,
+    />
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -5,7 +5,7 @@ import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {PanelBody, PanelRow} from '@shipfox/react-ui/panel';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
-import {type ReactNode, useState} from 'react';
+import {type ReactNode, useEffect, useRef, useState} from 'react';
 import type {RunAnnotationEntry, RunAnnotationStyle} from '#core/run-annotation.js';
 import {RunAnnotationItem, RunDerivedAnnotationItem} from './run-annotation-item.js';
 import {RunAnnotationsEmpty} from './run-annotations-empty.js';
@@ -167,11 +167,43 @@ export function RunAnnotationList({
 
   return (
     <>
+      <RunAnnotationLiveRegion entries={entries} />
       {query.isError ? <RunAnnotationStaleError query={query} /> : null}
 
       {content}
       {footer}
     </>
+  );
+}
+
+function RunAnnotationLiveRegion({entries}: {entries: readonly RunAnnotationEntry[]}): ReactNode {
+  const latestSequence = useRef<number | undefined>(undefined);
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    const previousSequence = latestSequence.current;
+    const highestSequence = entries.reduce(
+      (highest, entry) => Math.max(highest, entry.annotation.sequence),
+      previousSequence ?? 0,
+    );
+    latestSequence.current = highestSequence;
+    if (previousSequence === undefined) return;
+
+    const addedCount = entries.filter(
+      ({annotation}) => annotation.sequence > previousSequence,
+    ).length;
+    if (addedCount === 0) return;
+    setAnnouncement(
+      addedCount === 1
+        ? 'A new annotation was added to this run.'
+        : `${addedCount} new annotations were added to this run.`,
+    );
+  }, [entries]);
+
+  return (
+    <div role="status" aria-live="polite" className="sr-only">
+      {announcement}
+    </div>
   );
 }
 

--- a/libs/runner/agent/src/config.ts
+++ b/libs/runner/agent/src/config.ts
@@ -23,7 +23,7 @@ export const config = createConfig({
     default: '',
   }),
   SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT: bool({
-    desc: 'Enables the runner-local renewable Git credential broker. Keep this disabled until the runner deployment is ready for renewable checkout credentials.',
+    desc: 'Enables the runner-local renewable Git credential broker. Source-run defaults remain disabled; verified managed images set this after the helper and production closure are checked.',
     default: false,
   }),
 });

--- a/libs/runner/orchestration/src/core/credential-lifecycle.ts
+++ b/libs/runner/orchestration/src/core/credential-lifecycle.ts
@@ -51,14 +51,14 @@ export function createJobCredentialLifecycle(options: {
 
   const broker = createCredentialBroker({
     classifyFailure: classifyCredentialFailure,
-    renew: async ({repositoryUrl, subject, rejectedGeneration}) => {
+    renew: async ({repositoryUrl, subject, rejectedGeneration, signal}) => {
       const checkout = parseCheckoutSubject(subject);
       let response: CheckoutTokenResponseDto;
       try {
         response = await requestCheckoutToken(options.leaseClient, {
           stepId: checkout.stepId,
           attempt: checkout.attempt,
-          signal: renewalSignal,
+          signal: signal === undefined ? renewalSignal : AbortSignal.any([renewalSignal, signal]),
           ...(rejectedGeneration === undefined ? {} : {rejectedGeneration}),
         });
       } catch (error) {

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -352,7 +352,7 @@ describe('runJob', () => {
     expect(mockReleaseCredentialLock).toHaveBeenCalledOnce();
   });
 
-  it('degrades to static checkout credentials when the broker cannot start', async () => {
+  it('refuses an opted-in job when the broker cannot start', async () => {
     const startError = new Error('socket unavailable');
     mockRunnerToolCapabilities.mockReturnValueOnce({
       features: {renewable_git: true},
@@ -362,10 +362,7 @@ describe('runJob', () => {
 
     await runJob(JOB, WORKSPACE_ROOT);
 
-    expect(mockRunJobSteps).toHaveBeenCalledOnce();
-    expect(mockRunJobSteps.mock.calls[0]?.[0]).not.toHaveProperty('credentialHelper');
-    expect(mockRunJobSteps.mock.calls[0]?.[0]).not.toHaveProperty('registerCheckoutCredential');
-    expect(mockRunJobSteps.mock.calls[0]?.[0]).not.toHaveProperty('credentialFailureEvents');
+    expect(mockRunJobSteps).not.toHaveBeenCalled();
     expect(mockCredentialLifecycle.close).toHaveBeenCalledOnce();
     expect(mockCleanupJobCredentials).toHaveBeenCalledOnce();
   });

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -462,9 +462,9 @@ export async function runJob(
         await candidate.start();
         credentialLifecycle = candidate;
       } catch (error) {
-        logger().warn(
+        logger().error(
           {err: error, jobId: job.job_id},
-          'Renewable Git broker unavailable; continuing with static checkout credentials',
+          'Renewable Git broker unavailable; refusing opted-in job',
         );
         await candidate?.close().catch((closeError) => {
           logger().warn(
@@ -472,6 +472,7 @@ export async function runJob(
             'Failed to close unavailable job credential broker',
           );
         });
+        return;
       }
     }
     await runJobSteps({

--- a/libs/runner/workspace/src/credential-broker.test.ts
+++ b/libs/runner/workspace/src/credential-broker.test.ts
@@ -1,5 +1,6 @@
 import {
   CredentialBroker,
+  type CredentialRenewalRequest,
   MAX_CREDENTIAL_FAILURE_EVENTS,
   normalizeRepositoryUrl,
   TransientCredentialRenewalError,
@@ -194,11 +195,13 @@ describe('credential broker', () => {
     expect(renew).toHaveBeenNthCalledWith(1, {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
+      signal: expect.any(AbortSignal),
     });
     expect(renew).toHaveBeenNthCalledWith(2, {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
       rejectedGeneration: 'generation-a',
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -224,6 +227,7 @@ describe('credential broker', () => {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
       rejectedGeneration: 'generation-a',
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -280,11 +284,13 @@ describe('credential broker', () => {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
       rejectedGeneration: 'generation-a',
+      signal: expect.any(AbortSignal),
     });
     expect(renew).toHaveBeenNthCalledWith(2, {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
       rejectedGeneration: 'generation-b',
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -385,6 +391,7 @@ describe('credential broker', () => {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
       rejectedGeneration: 'generation-a',
+      signal: expect.any(AbortSignal),
     });
 
     await broker.reject(repository);
@@ -413,6 +420,7 @@ describe('credential broker', () => {
       repositoryUrl: 'https://gitea.example/Org/Repo/',
       subject: 'checkout',
       rejectedGeneration: 'generation-a',
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -453,7 +461,11 @@ describe('credential broker', () => {
   });
 
   it('times out a renewal and applies backoff', async () => {
-    const renew = vi.fn(() => new Promise<never>(() => undefined));
+    let renewalSignal: AbortSignal | undefined;
+    const renew = vi.fn(({signal}: CredentialRenewalRequest) => {
+      renewalSignal = signal;
+      return new Promise<never>(() => undefined);
+    });
     const broker = new CredentialBroker({
       renew,
       now: () => 5_000,
@@ -466,6 +478,7 @@ describe('credential broker', () => {
       username: 'runner',
       token: 'token-a',
     });
+    expect(renewalSignal?.aborted).toBe(true);
     await expect(broker.lookup(repository)).resolves.toEqual({
       username: 'runner',
       token: 'token-a',

--- a/libs/runner/workspace/src/credential-broker.ts
+++ b/libs/runner/workspace/src/credential-broker.ts
@@ -27,6 +27,7 @@ export type CredentialRenewalRequest = {
   repositoryUrl: string;
   subject: string;
   rejectedGeneration?: string;
+  signal?: AbortSignal;
 };
 
 export type CredentialRenewal = (
@@ -373,19 +374,21 @@ export class CredentialBroker {
     rejectedGeneration: string | undefined,
   ): Promise<BrokerCredentialInput> {
     let timer: ReturnType<typeof setTimeout> | undefined;
+    const controller = new AbortController();
     try {
       const renewal = Promise.resolve().then(() =>
         this.options.renew({
           repositoryUrl: entry.url,
           subject: entry.subject,
           ...(rejectedGeneration === undefined ? {} : {rejectedGeneration}),
+          signal: controller.signal,
         }),
       );
       const timeout = new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new TransientCredentialRenewalError('Credential renewal timed out')),
-          this.renewalTimeoutMsValue,
-        );
+        timer = setTimeout(() => {
+          controller.abort('renewal-timeout');
+          reject(new TransientCredentialRenewalError('Credential renewal timed out'));
+        }, this.renewalTimeoutMsValue);
       });
       return await Promise.race([renewal, timeout]);
     } finally {


### PR DESCRIPTION
Managed runner images now advertise renewable Git credentials only after the production-closure verifier confirms the helper is present. Older self-hosted runners stay on static credentials and receive an upgrade annotation when a persisted checkout is dispatched.

This completes the production selection and packaging step for ENG-1753 while preserving mixed-version compatibility. The documentation records the user-started container credential boundary, canary signals, and API-first rollback order. A patch Changeset covers `@shipfox/api-workflows`.

Validation passed for the changed API tests (18/18), runner-image tests (73/73), docs checks, affected-package checks, type checks, dependency-boundary checks, builds, and the runner runtime verifier. The full API suite reached 1,091 passing tests but hit an unrelated Temporal timeout and Vitest worker-start error in existing tests; the targeted changed tests pass.

Live managed-image canary and fleet rollout remain deployment follow-up because they require the deployed API and provider environment.

Closes ENG-1753

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verified managed runner images now advertise renewable Git credentials for persisted checkouts; older self-hosted runners keep static credentials and get a non-blocking upgrade warning when a persisted checkout is dispatched. This completes ENG-1753 and preserves mixed-version scheduling.

- The API warns only on fresh dispatches where persisted credentials are actually issued, and ignores capability lookup or annotation failures.
- A runner that advertises renewable Git now refuses the job if its credential broker cannot start, instead of degrading to static credentials.
- Renewal requests carry an `AbortSignal` so an in-flight renewal is cancelled when the broker times out.
- The run annotation list announces newly added annotations to screen readers.
- Documentation covers the user-started container credential boundary; the patch Changeset covers `@shipfox/api-workflows` and `@shipfox/client-workflows`.
- Live canary and fleet rollout remain deployment follow-up and require the deployed API and provider environment.

<sup>Written for commit 549dea9d575badf058bca1b315255148bcf86050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

