### PR TITLE
Type unknown-shaped tool outputs as CEL dyn end to end

### DIFF
--- a/.changeset/dynamic-tool-output-types.md
+++ b/.changeset/dynamic-tool-output-types.md
@@ -1,7 +1,8 @@
 ---
 "@shipfox/expression": minor
 "@shipfox/api-definitions": patch
-"@shipfox/api-workflows-dto": patch
+"@shipfox/api-workflows-dto": minor
+"@shipfox/api-workflows": patch
 ---
 
-Types unknown-shaped tool and JSON outputs as CEL `dyn` while preserving their runtime values.
+Adds CEL `dyn` support for unknown-shaped tool and JSON outputs, preserves their native runtime values, and keeps listener snapshots compatible during rolling deploys.

--- a/.changeset/dynamic-tool-output-types.md
+++ b/.changeset/dynamic-tool-output-types.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/expression": minor
+"@shipfox/api-definitions": patch
+"@shipfox/api-workflows-dto": patch
+---
+
+Types unknown-shaped tool and JSON outputs as CEL `dyn` while preserving their runtime values.

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -58,13 +58,14 @@ execution_name: 'Deploy #${{ run.number }}'
 | `bool` | `true` |
 | `list` | `["main", "release"]` |
 | `map` | `{"env": "prod"}` |
+| `dyn` | A value whose shape is not known when the expression is checked |
 | `timestamp` | `timestamp("2026-01-01T00:00:00Z")` |
 
 ## Operators
 
 | Operator | Example | Result |
 | --- | --- | --- |
-| `==`, `!=` | `trigger.event == "push"` | Compares two values of the same type |
+| `==`, `!=` | `trigger.event == "push"` | Compares compatible values; `dyn` is checked at evaluation time |
 | `<`, `<=`, `>`, `>=` | `run.created_at > timestamp("2026-01-01T00:00:00Z")` | Orders numbers, strings, and timestamps |
 | `&&`, `\|\|`, `!` | `job.key == "deploy" && !step.is_retry` | Combines boolean values |
 | `in` | `"prod" in inputs.environments` | True when a list contains the value |
@@ -74,8 +75,9 @@ execution_name: 'Deploy #${{ run.number }}'
 | `? :` | `run.number == 1 ? "first" : "rerun"` | The middle value when true, the last when false |
 | `( )` | `(a \|\| b) && c` | Groups an expression against precedence |
 
-Comparing values of different types is an error rather than a false result, and
-`int` and `double` count as different types. A predicate that errors never
+Static checking rejects incompatible known types rather than treating them as a
+false result. Dynamic values are checked when the expression runs, and numeric
+comparisons support both `int` and `double`. A predicate that errors never
 passes.
 
 ## Functions and macros
@@ -100,7 +102,7 @@ passes.
 | `timestamp(string)` | `timestamp("2026-01-01T00:00:00Z")` | A timestamp from an RFC 3339 string |
 | `range(start, stop, step)` | `range(1, 3, 1)` | An inclusive list of integers |
 | `toJson(value)` | `toJson(event.pull_request.labels)` | The value serialized as compact JSON text |
-| `fromJson(string)` | `fromJson(event.payload)` | The JSON text parsed into a CEL value |
+| `fromJson(string)` | `fromJson(event.payload)` | The JSON text parsed into a dynamic CEL value |
 
 `list.first()` and `list.last()` keep the element's type. Calling either method
 on an empty list causes an evaluation error. Workflow job and step conditions
@@ -111,6 +113,10 @@ record that outcome as errored rather than rejected.
 at most 1,000,000 UTF-8 bytes in one evaluation. `fromJson()` expects a valid
 JSON string and converts safe integer numbers to CEL integers. `toJson()` writes
 integers outside the range JSON numbers represent exactly as quoted strings.
+
+Lookups through an open map, schema-less tool output, or an unknown JSON Schema
+are `dyn`. They can be used with field access, methods, and comparisons, but a
+runtime failure still makes the surrounding predicate fail.
 
 The [CEL language
 definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md#standard-definitions)

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -146,10 +146,10 @@ jobs:
 <JobFields />
 
 Job `outputs` values are templates. A value that contains exactly one expression
-preserves its inferred non-string type, including arrays and objects. An
-expression without an inferred type resolves to a string. Mixed literal and
-expression templates also resolve to strings. A downstream job must declare a
-direct `needs` edge before it reads the output.
+preserves its inferred non-string type, including dynamic values, arrays, and
+objects. An expression without an inferred type resolves to a string. Mixed
+literal and expression templates also resolve to strings. A downstream job must
+declare a direct `needs` edge before it reads the output.
 
 ### Job checkout fields
 
@@ -207,6 +207,13 @@ The `with` block contains JSON-compatible tool inputs. String values can use
 workflow expressions. Tool outputs use a mapping from output names to one
 expression over `result` or `vars`.
 
+Mappings are checked against the provider catalog's `outputSchema`. A closed
+object whose properties are all required keeps typed field access. Open objects,
+optional properties, and unknown schema shapes resolve to `map` or `dyn`, so a
+mapped value is declared as schema-less JSON and can retain a number, boolean,
+object, or list at runtime. A tool without an `outputSchema` keeps its reserved
+`result` root open.
+
 Tool-step authoring requires a validation API deployment that supports these
 fields. Deploy the editor schema and validation API together; rolling back the
 validation API after tool-step definitions are saved makes those definitions
@@ -244,7 +251,9 @@ A gate must define `success`, `on_failure`, or both.
 
 Run, agent, and checkout steps use output declarations. A declaration can be its
 type directly (for example, `sha: string`) or an object with required `type`.
-Only `json` declarations can include `schema`.
+Only `json` declarations can include `schema`. A schema-less `json` declaration
+is dynamic: typed expressions can use its value, but its exact fields are not
+known until runtime.
 
 Tool steps use output mappings instead. Each mapping value must be exactly one
 `${{ }}` expression over the tool `result` or workflow `vars`.

--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -13,9 +13,10 @@ Code that turns a checked workflow document into the model used by definitions.
   `gate.on_failure.restart_from` against earlier named steps in the same job.
   Tool-step gates validate against the no-`exit_code` report environment.
 - **Tool steps**: `normalizeToolStep` splits `family.method` tool ids, parses
-  `with` interpolation trees and `outputs` mappings (typed from the catalog
-  `outputSchema`), records the `steps.<key>` type overlay, and validates the
-  connection, tool, and inputs against the optional integration context.
+  `with` interpolation trees and `outputs` mappings, types known closed catalog
+  schemas, keeps open or unknown shapes dynamic, records the `steps.<key>` type
+  overlay, and validates the connection, tool, and inputs against the optional
+  integration context.
 - **`InvalidWorkflowModelError`**: Reports semantic workflow errors found during
   normalization.
 
@@ -102,6 +103,12 @@ For now, run-step gates can use typed roots such as `step.exit_code`,
 roots that are available by step reporting. Guard optional output keys with
 `has(step.outputs.pass)` before reading them so missing keys fail as a normal
 false predicate instead of an uncheckable evaluation error.
+
+Tool output mappings use the catalog `outputSchema` when it proves a closed,
+all-required shape. Open objects, optional properties, and provider schemas with
+an unknown shape produce `map` or `dyn` values, so mapped outputs are persisted
+as schema-less JSON while retaining numeric, boolean, and structured values at
+runtime. A tool without an output schema keeps its reserved `result` root open.
 
 `on_failure.restart_from` must name an earlier step in the same job. The runtime
 host does not execute restart semantics yet. This module only records the

--- a/libs/api/definitions/src/core/workflow-model/normalize-tool-step.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-tool-step.test.ts
@@ -256,6 +256,7 @@ describe('normalizeToolStep', () => {
             ready: '$' + '{{ result.ready }}',
             payload: '$' + '{{ result.payload }}',
             items: '$' + '{{ result.items }}',
+            whole: '$' + '{{ result }}',
           }),
           gate: {
             success:
@@ -273,6 +274,7 @@ describe('normalizeToolStep', () => {
       ready: {check: 'typed', resultType: {kind: 'dyn'}},
       payload: {check: 'typed', resultType: {kind: 'dyn'}},
       items: {check: 'typed', resultType: {kind: 'dyn'}},
+      whole: {check: 'typed', resultType: {kind: 'dyn'}},
     });
     expect(step.outputs).toEqual({
       text: {type: 'json'},
@@ -280,6 +282,7 @@ describe('normalizeToolStep', () => {
       ready: {type: 'json'},
       payload: {type: 'json'},
       items: {type: 'json'},
+      whole: {type: 'json'},
     });
     expect(step.gate?.success).toMatchObject({check: 'typed', resultType: 'bool'});
   });

--- a/libs/api/definitions/src/core/workflow-model/normalize-tool-step.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-tool-step.test.ts
@@ -96,6 +96,18 @@ const integrationValidationContext = {
               required: ['issueId', 'body'],
             },
           },
+          {
+            id: 'dynamic_reader',
+            description: 'Read an unknown payload',
+            sensitivity: 'read',
+            sensitive: false,
+            requiredScope: 'read',
+            inputSchema: {
+              type: 'object',
+              properties: {id: {type: 'string'}},
+              required: ['id'],
+            },
+          },
         ],
       },
     ],
@@ -171,6 +183,49 @@ const integrationValidationContext = {
               },
             ],
           },
+          {
+            id: 'open_reader',
+            description: 'Read an open payload',
+            sensitivity: 'read',
+            sensitive: false,
+            requiredScope: 'read',
+            inputSchema: {
+              type: 'object',
+              properties: {owner: {type: 'string'}, repo: {type: 'string'}},
+              required: ['owner', 'repo'],
+            },
+            outputSchema: {
+              type: 'object',
+              properties: {count: {type: 'integer'}},
+              required: ['count'],
+            },
+          },
+          {
+            id: 'nested_open_reader',
+            description: 'Read a nested open payload',
+            sensitivity: 'read',
+            sensitive: false,
+            requiredScope: 'read',
+            inputSchema: {
+              type: 'object',
+              properties: {owner: {type: 'string'}, repo: {type: 'string'}},
+              required: ['owner', 'repo'],
+            },
+            outputSchema: {
+              type: 'object',
+              properties: {
+                items: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {title: {type: 'string'}},
+                  },
+                },
+              },
+              required: ['items'],
+              additionalProperties: false,
+            },
+          },
         ],
       },
     ],
@@ -187,6 +242,88 @@ const integrationValidationContext = {
 } satisfies IntegrationValidationContext;
 
 describe('normalizeToolStep', () => {
+  it('types schema-less mapped tool outputs as dyn', () => {
+    const model = normalize(
+      toolDocument(
+        toolStep({
+          key: 'dynamic',
+          tool: 'dynamic_reader',
+          connection: 'linear-main',
+          with: {id: 'ENG-1'},
+          outputs: mappingOutputs({
+            text: '$' + '{{ result.text }}',
+            count: '$' + '{{ result.count }}',
+            ready: '$' + '{{ result.ready }}',
+            payload: '$' + '{{ result.payload }}',
+            items: '$' + '{{ result.items }}',
+          }),
+          gate: {
+            success:
+              'step.outputs.count == 1.0 && step.outputs.ready == true && step.outputs.text.lowerAscii() == "ready"',
+          },
+        }),
+      ),
+      {integrationValidationContext},
+    );
+
+    const step = model.jobs[0]?.steps[0] as WorkflowModelToolStep;
+    expect(step.outputMappings).toMatchObject({
+      text: {check: 'typed', resultType: {kind: 'dyn'}},
+      count: {check: 'typed', resultType: {kind: 'dyn'}},
+      ready: {check: 'typed', resultType: {kind: 'dyn'}},
+      payload: {check: 'typed', resultType: {kind: 'dyn'}},
+      items: {check: 'typed', resultType: {kind: 'dyn'}},
+    });
+    expect(step.outputs).toEqual({
+      text: {type: 'json'},
+      count: {type: 'json'},
+      ready: {type: 'json'},
+      payload: {type: 'json'},
+      items: {type: 'json'},
+    });
+    expect(step.gate?.success).toMatchObject({check: 'typed', resultType: 'bool'});
+  });
+
+  it('keeps open object and nested open object mappings dynamic', () => {
+    const model = normalize(
+      {
+        name: 'open tool outputs',
+        jobs: {
+          use: {
+            steps: [
+              toolStep({
+                key: 'open',
+                tool: 'open_reader',
+                connection: 'github-main',
+                with: {owner: 'acme', repo: 'platform'},
+                outputs: mappingOutputs({count: '$' + '{{ result.count }}'}),
+                gate: {success: 'step.outputs.count >= 1.0'},
+              }),
+              toolStep({
+                key: 'nested',
+                tool: 'nested_open_reader',
+                connection: 'github-main',
+                with: {owner: 'acme', repo: 'platform'},
+                outputs: mappingOutputs({title: '$' + '{{ result.items[0].title }}'}),
+                gate: {success: 'step.outputs.title.lowerAscii() == "ready"'},
+              }),
+            ],
+          },
+        },
+      },
+      {integrationValidationContext},
+    );
+
+    const open = model.jobs[0]?.steps[0] as WorkflowModelToolStep;
+    const nested = model.jobs[0]?.steps[1] as WorkflowModelToolStep;
+    expect(open.outputMappings?.count).toMatchObject({check: 'typed', resultType: {kind: 'dyn'}});
+    expect(open.outputs).toEqual({count: {type: 'json'}});
+    expect(open.gate?.success).toMatchObject({check: 'typed', resultType: 'bool'});
+    expect(nested.outputMappings?.title).toMatchObject({check: 'typed', resultType: {kind: 'dyn'}});
+    expect(nested.outputs).toEqual({title: {type: 'json'}});
+    expect(nested.gate?.success).toMatchObject({check: 'typed', resultType: 'bool'});
+  });
+
   it('splits family.method ids and parses with templates and output mappings', () => {
     const model = normalize(
       {

--- a/libs/api/definitions/src/core/workflow-model/normalize-tool-step.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-tool-step.ts
@@ -126,7 +126,7 @@ export function normalizeToolStep(params: {
     // unknown field values are persisted as CEL dyn instead of syntax-only
     // expressions.
     resultTypeOverlay: {
-      result: outputSchema === undefined ? {kind: 'map'} : jsonSchemaToExpressionType(outputSchema),
+      result: outputSchema === undefined ? {kind: 'dyn'} : jsonSchemaToExpressionType(outputSchema),
     },
   });
   validateResolvedTool(params, tool, catalogEntry);

--- a/libs/api/definitions/src/core/workflow-model/normalize-tool-step.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-tool-step.ts
@@ -122,8 +122,12 @@ export function normalizeToolStep(params: {
   const outputMappings = normalizeOutputMappings({
     ...params,
     outputs: params.step.outputs,
-    resultTypeOverlay:
-      outputSchema === undefined ? undefined : {result: jsonSchemaToExpressionType(outputSchema)},
+    // Keep schema-less tool results open while still type-checking mappings so
+    // unknown field values are persisted as CEL dyn instead of syntax-only
+    // expressions.
+    resultTypeOverlay: {
+      result: outputSchema === undefined ? {kind: 'map'} : jsonSchemaToExpressionType(outputSchema),
+    },
   });
   validateResolvedTool(params, tool, catalogEntry);
 
@@ -504,6 +508,10 @@ function outputMappingsToDeclarations(
 }
 
 function expressionTypeToDeclaration(type: ExpressionType | undefined): OutputTypeDeclaration {
+  if (type === undefined || (typeof type === 'object' && type.kind === 'dyn')) {
+    return {type: 'json'};
+  }
+
   switch (type) {
     case 'string':
       return {type: 'string'};
@@ -520,9 +528,7 @@ function expressionTypeToDeclaration(type: ExpressionType | undefined): OutputTy
       // Structured (object/map/list) result types keep their shape in the
       // declaration schema so the step overlay re-derives list/object typing
       // for later expressions instead of degrading to schema-less JSON.
-      return type === undefined
-        ? {type: 'json'}
-        : {type: 'json', schema: expressionTypeToJsonSchema(type)};
+      return {type: 'json', schema: expressionTypeToJsonSchema(type)};
   }
 }
 
@@ -545,6 +551,8 @@ function expressionTypeToJsonSchema(type: ExpressionType): Readonly<Record<strin
       return {type: 'string'};
     default:
       switch (type.kind) {
+        case 'dyn':
+          return {};
         case 'object':
           return {
             type: 'object',

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -3799,6 +3799,7 @@ describe('normalizeWorkflowDocument', () => {
               env: {PAYLOAD: interpolation('steps.agent.outputs.payload')},
             },
           ],
+          outputs: {payload: interpolation('steps.agent.outputs.payload')},
         },
       },
     };
@@ -3834,6 +3835,20 @@ describe('normalizeWorkflowDocument', () => {
         },
       },
     });
+    expect(model.jobs[0]?.outputs?.payload).toEqual([
+      {
+        kind: 'deferred',
+        expression: {
+          language: 'cel',
+          source: 'steps.agent.outputs.payload',
+          check: 'typed',
+          resultType: {kind: 'dyn'},
+        },
+        roots: ['steps'],
+        fillTarget: 'execution-resolution',
+      },
+    ]);
+    expect(model.jobs[0]?.outputTypes).toEqual({payload: {kind: 'dyn'}});
   });
 
   it('rejects undeclared typed step output keys', () => {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -3781,6 +3781,61 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
+  it('types schema-less agent JSON outputs as dyn for later expressions', () => {
+    const document: WorkflowDocument = {
+      name: 'dynamic agent output',
+      jobs: {
+        build: {
+          steps: [
+            {
+              key: 'agent',
+              prompt: 'Inspect the change.',
+              outputs: {payload: {type: 'json'}},
+              gate: {success: 'step.outputs.payload == true'},
+            },
+            {
+              key: 'consume',
+              run: 'echo ok',
+              env: {PAYLOAD: interpolation('steps.agent.outputs.payload')},
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      outputs: {payload: {type: 'json'}},
+      gate: {
+        success: {
+          source: 'step.outputs.payload == true',
+          check: 'typed',
+          resultType: 'bool',
+        },
+      },
+    });
+    expect(model.jobs[0]?.steps[1]).toMatchObject({
+      kind: 'run',
+      templates: {
+        env: {
+          PAYLOAD: [
+            {
+              kind: 'deferred',
+              expression: {
+                source: 'steps.agent.outputs.payload',
+                check: 'typed',
+                resultType: {kind: 'dyn'},
+              },
+              roots: ['steps'],
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('rejects undeclared typed step output keys', () => {
     const document: WorkflowDocument = {
       name: 'bad typed output key',
@@ -6192,7 +6247,7 @@ describe('normalizeWorkflowDocument', () => {
               language: 'cel',
               source: 'execution.events[0].data.runner',
               check: 'typed',
-              resultType: 'string',
+              resultType: {kind: 'dyn'},
             },
             roots: ['execution'],
             fillTarget: 'execution-creation',

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -333,6 +333,25 @@ describe('workflowsJobActivatedSchema', () => {
     expect(result).toEqual(payload);
   });
 
+  it('accepts dynamic listener filter output types', () => {
+    const payload = {
+      ...validJobActivated,
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request_review',
+          filter: 'jobs.build.outputs.payload == true',
+          filter_snapshot: {jobs: {build: {outputs: {payload: true}}}},
+          filter_output_types: {build: {payload: {kind: 'dyn'}}},
+        },
+      ],
+    };
+
+    const result = workflowsJobActivatedSchema.parse(payload);
+
+    expect(result).toEqual(payload);
+  });
+
   it('keeps authoring-shaped matchers compatible when no snapshot is present', () => {
     const payload = {
       ...validJobActivated,

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -115,6 +115,7 @@ export type ListenerFilterExpressionType =
   | 'bool'
   | 'null'
   | 'timestamp'
+  | {kind: 'dyn'}
   | {kind: 'object'; fields: Record<string, ListenerFilterExpressionType>}
   | {kind: 'map'}
   | {kind: 'list'; element: ListenerFilterExpressionType};
@@ -122,6 +123,7 @@ export type ListenerFilterExpressionType =
 const listenerFilterExpressionTypeSchema: z.ZodType<ListenerFilterExpressionType> = z.lazy(() =>
   z.union([
     z.enum(['string', 'int', 'double', 'bool', 'null', 'timestamp']),
+    z.object({kind: z.literal('dyn')}),
     z.object({
       kind: z.literal('object'),
       fields: z.record(z.string(), listenerFilterExpressionTypeSchema),

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -1472,6 +1472,36 @@ describe('recordStepResult', () => {
     expect(attempt?.output).toEqual({meta: {registry: 'ghcr.io', size_bytes: 42}});
   });
 
+  test('preserves primitive and structured values for schema-less JSON outputs', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await db()
+      .update(stepsTable)
+      .set({
+        config: {
+          run: 'build',
+          outputs: {
+            count: {type: 'json'},
+            ready: {type: 'json'},
+            payload: {type: 'json'},
+          },
+        },
+      })
+      .where(eq(stepsTable.id, stepId));
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'succeeded',
+      output: {count: 42, ready: true, payload: {name: 'build'}},
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.output).toEqual({count: 42, ready: true, payload: {name: 'build'}});
+  });
+
   it.each([
     ['missing declared key', {}, 'outputs.count'],
     ['undeclared emitted key', {count: '1', extra: 'nope'}, 'outputs.extra'],

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -651,14 +651,30 @@ describe('listener filter snapshots', () => {
         outputTypes: {
           count: 'int',
           payload: {kind: 'dyn'},
-          nested: {kind: 'object', fields: {value: {kind: 'dyn'}}},
+          nested: {
+            kind: 'object',
+            fields: {value: {kind: 'dyn'}, createdAt: 'timestamp'},
+          },
           items: {kind: 'list', element: {kind: 'dyn'}},
+          nestedItems: {
+            kind: 'list',
+            element: {
+              kind: 'object',
+              fields: {value: {kind: 'dyn'}, count: 'int'},
+            },
+          },
         },
         executions: [],
       },
     ]);
 
-    expect(result).toEqual({build: {count: 'int'}});
+    expect(result).toEqual({
+      build: {
+        count: 'int',
+        nested: {kind: 'object', fields: {createdAt: 'timestamp'}},
+        nestedItems: {kind: 'list', element: {kind: 'object', fields: {count: 'int'}}},
+      },
+    });
   });
 
   it('omits snapshots for event-only filters and malformed filters', () => {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -644,6 +644,23 @@ describe('listener filter snapshots', () => {
     });
   });
 
+  it('omits dynamic listener output metadata for rolling-deploy compatibility', () => {
+    const result = listenerFilterOutputTypesForJobs([
+      {
+        job: {key: 'build', status: 'succeeded', outputs: {}},
+        outputTypes: {
+          count: 'int',
+          payload: {kind: 'dyn'},
+          nested: {kind: 'object', fields: {value: {kind: 'dyn'}}},
+          items: {kind: 'list', element: {kind: 'dyn'}},
+        },
+        executions: [],
+      },
+    ]);
+
+    expect(result).toEqual({build: {count: 'int'}});
+  });
+
   it('omits snapshots for event-only filters and malformed filters', () => {
     const plan = planListenerFilterSnapshots({
       on: [

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -394,10 +394,35 @@ export function listenerFilterOutputTypesForJobs(
   jobs: readonly JobContextInput[],
 ): ListenerFilterOutputTypes {
   return Object.fromEntries(
-    jobs.flatMap(({job, outputTypes}) =>
-      outputTypes === undefined ? [] : [[job.key, {...outputTypes}] as const],
-    ),
+    jobs.flatMap(({job, outputTypes}) => {
+      if (outputTypes === undefined) return [];
+
+      // `dyn` values need no CEL-native rehydration. Omitting their metadata
+      // keeps this persisted outbox shape readable by older trigger consumers
+      // during a rolling deploy, while typed sibling outputs retain theirs.
+      const compatibleOutputTypes = Object.fromEntries(
+        Object.entries(outputTypes).filter(([, type]) => !containsDynamicType(type)),
+      );
+      return Object.keys(compatibleOutputTypes).length === 0
+        ? []
+        : [[job.key, compatibleOutputTypes] as const];
+    }),
   );
+}
+
+function containsDynamicType(type: ExpressionType): boolean {
+  if (typeof type === 'string') return false;
+
+  switch (type.kind) {
+    case 'dyn':
+      return true;
+    case 'object':
+      return Object.values(type.fields).some(containsDynamicType);
+    case 'list':
+      return containsDynamicType(type.element);
+    case 'map':
+      return false;
+  }
 }
 
 function filterOutputTypesForPlan(

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -397,11 +397,14 @@ export function listenerFilterOutputTypesForJobs(
     jobs.flatMap(({job, outputTypes}) => {
       if (outputTypes === undefined) return [];
 
-      // `dyn` values need no CEL-native rehydration. Omitting their metadata
-      // keeps this persisted outbox shape readable by older trigger consumers
-      // during a rolling deploy, while typed sibling outputs retain theirs.
+      // `dyn` values need no CEL-native rehydration. Remove only their metadata
+      // branches so typed sibling outputs remain rehydratable while this
+      // persisted outbox shape stays readable by older trigger consumers.
       const compatibleOutputTypes = Object.fromEntries(
-        Object.entries(outputTypes).filter(([, type]) => !containsDynamicType(type)),
+        Object.entries(outputTypes).flatMap(([key, type]) => {
+          const compatibleType = withoutDynamicType(type);
+          return compatibleType === undefined ? [] : [[key, compatibleType] as const];
+        }),
       );
       return Object.keys(compatibleOutputTypes).length === 0
         ? []
@@ -410,18 +413,29 @@ export function listenerFilterOutputTypesForJobs(
   );
 }
 
-function containsDynamicType(type: ExpressionType): boolean {
-  if (typeof type === 'string') return false;
+function withoutDynamicType(type: ExpressionType): ExpressionType | undefined {
+  if (typeof type === 'string') return type;
 
   switch (type.kind) {
     case 'dyn':
-      return true;
-    case 'object':
-      return Object.values(type.fields).some(containsDynamicType);
-    case 'list':
-      return containsDynamicType(type.element);
+      return undefined;
     case 'map':
-      return false;
+      return type;
+    case 'list': {
+      const element = withoutDynamicType(type.element);
+      return element === undefined ? undefined : {kind: 'list', element};
+    }
+    case 'object': {
+      const fields = Object.fromEntries(
+        Object.entries(type.fields).flatMap(([key, fieldType]) => {
+          const compatibleType = withoutDynamicType(fieldType);
+          return compatibleType === undefined ? [] : [[key, compatibleType] as const];
+        }),
+      );
+      return Object.keys(type.fields).length > 0 && Object.keys(fields).length === 0
+        ? undefined
+        : {kind: 'object', fields};
+    }
   }
 }
 

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -1,7 +1,7 @@
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {MAX_RECORD_DATA_BYTES} from '@shipfox/api-logs-dto';
 import {type LogsModuleClient, logsInterModuleContract} from '@shipfox/api-logs-dto/inter-module';
-import {createWorkflowExpression} from '@shipfox/expression';
+import {createWorkflowExpression, type OutputDeclarations} from '@shipfox/expression';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {createOutboxRegistry} from '@shipfox/node-module';
 import {eq} from 'drizzle-orm';
@@ -150,6 +150,51 @@ describe('tool step executor', () => {
       output: {
         result: {identifier: 'ENG-1'},
         identifier: 'ENG-1',
+      },
+    });
+  });
+
+  test('preserves schema-less mapped tool output values', async () => {
+    const {jobId} = await arrangeToolStep('read', {
+      outputDeclarations: {
+        result: {type: 'json'},
+        count: {type: 'json'},
+        ready: {type: 'json'},
+        payload: {type: 'json'},
+      },
+      outputMappings: {
+        count: createWorkflowExpression({source: 'result.count', check: {mode: 'syntax'}}),
+        ready: createWorkflowExpression({source: 'result.ready', check: {mode: 'syntax'}}),
+        payload: createWorkflowExpression({source: 'result.payload', check: {mode: 'syntax'}}),
+      },
+    });
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result: {count: 42, ready: true, payload: {name: 'build'}},
+      content: [],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle({
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({
+      status: 'succeeded',
+      output: {
+        result: {count: 42, ready: true, payload: {name: 'build'}},
+        count: 42,
+        ready: true,
+        payload: {name: 'build'},
       },
     });
   });
@@ -985,6 +1030,7 @@ async function arrangeToolStep(
     arguments?: Record<string, unknown>;
     includeOutputs?: boolean;
     outputMappings?: Record<string, unknown>;
+    outputDeclarations?: OutputDeclarations;
     sensitive?: boolean;
   } = {},
 ): Promise<{
@@ -1027,8 +1073,10 @@ async function arrangeToolStep(
           ? {}
           : {
               outputs: {
-                result: {type: 'json'},
-                identifier: {type: 'string'},
+                ...(options.outputDeclarations ?? {
+                  result: {type: 'json'},
+                  identifier: {type: 'string'},
+                }),
               },
             }),
       },

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -199,6 +199,44 @@ describe('tool step executor', () => {
     });
   });
 
+  test.each([
+    ['null', {result: null, content: []}, null],
+    ['a scalar', {result: null, content: [{type: 'text', text: '42'}]}, 42],
+    ['an array', {result: null, content: [{type: 'text', text: '["one",2]'}]}, ['one', 2]],
+  ] as const)('preserves %s whole schema-less tool results', async (_label, providerOutput, result) => {
+    const {jobId} = await arrangeToolStep('read', {
+      outputDeclarations: {
+        result: {type: 'json'},
+        value: {type: 'json'},
+      },
+      outputMappings: {
+        value: createWorkflowExpression({source: 'result', check: {mode: 'syntax'}}),
+      },
+    });
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result: providerOutput.result,
+      content: [...providerOutput.content],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle({
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({status: 'succeeded'});
+    expect(attempt?.output).toEqual({result, value: result});
+  });
+
   test('recovers from a cycle failure and stops cleanly', async () => {
     const cycleRecovered = deferred();
     const waitForStop = deferred();

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -253,6 +253,47 @@ describe('workflow run job executions', () => {
     expect(persisted?.outputs).toEqual({findings: [{severity: 'high'}]});
   });
 
+  test.each([
+    ['a boolean', true],
+    ['an object', {name: 'build'}],
+  ] as const)('materializes %s dynamic job outputs without stringifying them', async (_label, value) => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({
+        jobs: {
+          build: {
+            steps: [{key: 'collect', run: 'echo build'}],
+            outputs: {payload: template('steps.collect.outputs.payload')},
+            outputTypes: {payload: {kind: 'dyn'}},
+          },
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+    await finishCollectedStep(job.id, {payload: value});
+
+    const resolved = await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'succeeded',
+      expectedVersion: execution.version,
+    });
+
+    expect(resolved.outputs).toEqual({payload: value});
+    const persisted = await getFirstJobExecutionByJobId(job.id);
+    expect(persisted?.outputs).toEqual({payload: value});
+  });
+
   test('persists job outputs in the raised size band when execution succeeds', async () => {
     const outputKeys = ['one', 'two', 'three'];
     const outputValues = Object.fromEntries(

--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -130,6 +130,26 @@ describe('OutputCollector', () => {
     expect(collector.snapshot()).toEqual({meta: '{"name":"api"}'});
   });
 
+  it('accepts schema-less json output values from agents', () => {
+    const collector = new OutputCollector({
+      count: {type: 'json'},
+      ready: {type: 'json'},
+      payload: {type: 'json'},
+      items: {type: 'json'},
+    });
+
+    expect(collector.trySet('count', '42')).toEqual({ok: true});
+    expect(collector.trySet('ready', 'true')).toEqual({ok: true});
+    expect(collector.trySet('payload', '{"name":"build"}')).toEqual({ok: true});
+    expect(collector.trySet('items', '["one",2]')).toEqual({ok: true});
+    expect(collector.snapshot()).toEqual({
+      count: '42',
+      ready: 'true',
+      payload: '{"name":"build"}',
+      items: '["one",2]',
+    });
+  });
+
   it('returns the validation error and exact JSON Schema for a rejected json output', () => {
     const schema = {
       type: 'array',

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -8,6 +8,8 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
   mode.
 - **`WorkflowExpression`**: Stores the CEL tag, source, and check level.
 - **`ExpressionTypeEnvironment`**: Lists names and field types for typed checks.
+- **`ExpressionType`**: Represents scalar, structured, open-map, and dynamic
+  (`dyn`) values in typed expression metadata.
 - **`evaluateWorkflowExpression`**: Runs a checked value against caller data.
 - **`createWorkflowEnvironment`**: Creates an isolated evaluator with the shared
   `list.first()`, `list.last()`, `range()`, `toJson()`, and `fromJson()`
@@ -94,6 +96,11 @@ const passed = evaluateWorkflowPredicate(expression, {
 
 - Use `syntax` when fields are not known yet.
 - Use `typed` when the caller knows the names and field types in scope.
+- `dyn` represents a value whose shape is not known at check time. It can be
+  used in any expected scalar position; the runtime still checks operations and
+  predicate results.
+- `fromJson()` results and lookups through open maps are `dyn`. Closed object
+  schemas continue to reject unknown fields during typed checking.
 - Predicate evaluation narrows the supplied context to the roots
   `workflowPredicateContextRoots` declares for that field, so a reference
   outside the policy fails closed rather than reading an incidental value.

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -1,3 +1,4 @@
+import {evaluateWorkflowPredicate} from '../evaluator/evaluate-workflow-expression.js';
 import {
   createWorkflowExpression,
   unsafeWorkflowExpressionFromSource,
@@ -446,6 +447,78 @@ describe('createWorkflowExpression', () => {
     });
 
     expect(expression.resultType).toBe('bool');
+  });
+
+  it.each([
+    [
+      'event.value < 1.0',
+      'int',
+      [
+        [0, true],
+        [1, false],
+        [2, false],
+      ],
+    ],
+    [
+      'event.value <= 1.0',
+      'int',
+      [
+        [0, true],
+        [1, true],
+        [2, false],
+      ],
+    ],
+    [
+      'event.value > 1',
+      'double',
+      [
+        [0.5, false],
+        [1, false],
+        [1.5, true],
+      ],
+    ],
+    [
+      'event.value >= 1',
+      'double',
+      [
+        [0.5, false],
+        [1, true],
+        [1.5, true],
+      ],
+    ],
+    [
+      '1.0 < event.value',
+      'int',
+      [
+        [0, false],
+        [1, false],
+        [2, true],
+      ],
+    ],
+    [
+      '1 <= event.value',
+      'double',
+      [
+        [0.5, false],
+        [1, true],
+        [1.5, true],
+      ],
+    ],
+  ] as const)('evaluates cross-type numeric ordering in %s', (source, scalarType, cases) => {
+    const expression = createWorkflowExpression({
+      source,
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {value: scalarType}},
+        },
+        expectedResultType: 'bool',
+      },
+    });
+
+    for (const [value, expected] of cases) {
+      expect(evaluateWorkflowPredicate(expression, {event: {value}})).toBe(expected);
+    }
   });
 
   it.each([

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -106,9 +106,9 @@ describe('createWorkflowExpression', () => {
     });
 
     expect(jsonExpression.resultType).toBe('string');
-    expect(parsedExpression.check).toBe('typed');
-    expect(parsedPredicateExpression.check).toBe('typed');
-    expect(dynamicJsonExpression.resultType).toBeUndefined();
+    expect(parsedExpression).toMatchObject({check: 'typed', resultType: {kind: 'dyn'}});
+    expect(parsedPredicateExpression).toMatchObject({check: 'typed', resultType: {kind: 'dyn'}});
+    expect(dynamicJsonExpression.resultType).toEqual({kind: 'dyn'});
     expect(rangeExpression.resultType).toBe('bool');
     expect(firstExpression.resultType).toBe('string');
     expect(lastExpression.resultType).toBe('string');
@@ -183,13 +183,20 @@ describe('createWorkflowExpression', () => {
     expect(act).toThrow(InvalidWorkflowExpressionError);
   });
 
-  it('accepts a bare dynamic result for an expected predicate type', () => {
+  it.each([
+    'string',
+    'int',
+    'double',
+    'bool',
+    'null',
+    'timestamp',
+  ] as const)('accepts a bare dynamic result for an expected %s type', (expectedResultType) => {
     const expression = createWorkflowExpression({
       source: 'event.value',
       check: {
         mode: 'typed',
         typeEnvironment: {event: {kind: 'map'}},
-        expectedResultType: 'bool',
+        expectedResultType,
       },
     });
 
@@ -197,29 +204,8 @@ describe('createWorkflowExpression', () => {
       language: 'cel',
       source: 'event.value',
       check: 'typed',
-      resultType: 'string',
+      resultType: {kind: 'dyn'},
     });
-  });
-
-  it('rejects a bare dynamic result for a non-predicate expected type', () => {
-    let error: unknown;
-    try {
-      createWorkflowExpression({
-        source: 'event.value',
-        check: {
-          mode: 'typed',
-          typeEnvironment: {event: {kind: 'map'}},
-          expectedResultType: 'string',
-        },
-      });
-    } catch (caught) {
-      error = caught;
-    }
-
-    expect(error).toBeInstanceOf(InvalidWorkflowExpressionError);
-    expect((error as InvalidWorkflowExpressionError).reason).toContain(
-      'must return string; got dyn',
-    );
   });
 
   it('does not treat fromJson text in a dynamic expression as a function call', () => {
@@ -231,7 +217,52 @@ describe('createWorkflowExpression', () => {
       },
     });
 
-    expect(expression.resultType).toBe('string');
+    expect(expression.resultType).toEqual({kind: 'dyn'});
+  });
+
+  it.each([
+    ['a dynamic variable', 'event', {event: {kind: 'dyn'}}],
+    ['a dynamic field', 'event.value', {event: {kind: 'object', fields: {value: {kind: 'dyn'}}}}],
+    [
+      'a dynamic list element',
+      'event.values[0]',
+      {
+        event: {
+          kind: 'object',
+          fields: {values: {kind: 'list', element: {kind: 'dyn'}}},
+        },
+      },
+    ],
+  ] as const)('preserves dyn for %s', (_label, source, typeEnvironment) => {
+    const expression = createWorkflowExpression({
+      source,
+      check: {mode: 'typed', typeEnvironment},
+    });
+
+    expect(expression.resultType).toEqual({kind: 'dyn'});
+  });
+
+  it.each([
+    ['a dynamic equality', 'event.value == "ready"', {event: {kind: 'dyn'}}],
+    ['a dynamic method call', 'event.value.lowerAscii() == "ready"', {event: {kind: 'dyn'}}],
+    ['a dynamic size call', 'event.value.size() == 2', {event: {kind: 'dyn'}}],
+    [
+      'a dynamic list element comparison',
+      'event.values[0] == "ready"',
+      {
+        event: {
+          kind: 'object',
+          fields: {values: {kind: 'list', element: {kind: 'dyn'}}},
+        },
+      },
+    ],
+  ] as const)('type-checks %s', (_label, source, typeEnvironment) => {
+    const expression = createWorkflowExpression({
+      source,
+      check: {mode: 'typed', typeEnvironment, expectedResultType: 'bool'},
+    });
+
+    expect(expression.resultType).toBe('bool');
   });
 
   it('rejects misspelled fields from the typed environment', () => {
@@ -390,6 +421,31 @@ describe('createWorkflowExpression', () => {
       check: 'typed',
       resultType: 'bool',
     });
+  });
+
+  it.each([
+    ['event.value < 1.0', 'int'],
+    ['event.value <= 1.0', 'int'],
+    ['event.value > 1', 'double'],
+    ['event.value >= 1', 'double'],
+    ['1.0 < event.value', 'int'],
+    ['1 <= event.value', 'double'],
+  ] satisfies readonly [
+    string,
+    ExpressionScalarType,
+  ][])('type-checks cross-type numeric ordering in %s', (source, scalarType) => {
+    const expression = createWorkflowExpression({
+      source,
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {value: scalarType}},
+        },
+        expectedResultType: 'bool',
+      },
+    });
+
+    expect(expression.resultType).toBe('bool');
   });
 
   it.each([
@@ -552,7 +608,7 @@ describe('createWorkflowExpression', () => {
     expect(act).toThrow(InvalidWorkflowExpressionError);
   });
 
-  it('treats dynamic open-map expression results as a scalar fallback', () => {
+  it('preserves dynamic open-map expression results as dyn', () => {
     const expression = createWorkflowExpression({
       source: 'step.outputs.pass',
       check: {
@@ -572,7 +628,7 @@ describe('createWorkflowExpression', () => {
       language: 'cel',
       source: 'step.outputs.pass',
       check: 'typed',
-      resultType: 'string',
+      resultType: {kind: 'dyn'},
     });
   });
 

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -1,4 +1,4 @@
-import {type ASTNode, Environment, parse as parseCel} from '@marcbachmann/cel-js';
+import {Environment, parse as parseCel} from '@marcbachmann/cel-js';
 import {registerWorkflowFunctions} from '../workflow-function-registry.js';
 import {InvalidWorkflowExpressionError} from './errors.js';
 import type {
@@ -37,10 +37,10 @@ export function createWorkflowExpression(
     });
   }
 
-  const ast = parseWorkflowExpression(source);
+  parseWorkflowExpression(source);
 
   if (params.check.mode === 'typed') {
-    resultType = checkTypedWorkflowExpression(source, ast, params.check);
+    resultType = checkTypedWorkflowExpression(source, params.check);
   }
 
   return {
@@ -53,7 +53,6 @@ export function createWorkflowExpression(
 
 function checkTypedWorkflowExpression(
   source: string,
-  ast: ASTNode,
   check: Extract<CreateWorkflowExpressionParams['check'], {mode: 'typed'}>,
 ): ExpressionType | undefined {
   const environment = createTypeCheckingEnvironment();
@@ -66,7 +65,7 @@ function checkTypedWorkflowExpression(
     });
   }
   assertExpectedResultType(source, result.type, check.expectedResultType);
-  return resolveKnownPathType(source, check.typeEnvironment) ?? fromCelType(result.type, ast);
+  return resolveKnownPathType(source, check.typeEnvironment) ?? fromCelType(result.type);
 }
 
 function registerTypeEnvironment(
@@ -86,7 +85,7 @@ function assertExpectedResultType(
   expectedType: ExpressionScalarType | undefined,
 ): void {
   if (expectedType === undefined || actualType === scalarTypeToCelType[expectedType]) return;
-  if (actualType === 'dyn' && expectedType === 'bool') return;
+  if (actualType === 'dyn') return;
   throw new InvalidWorkflowExpressionError({
     source,
     reason: `Expression source must return ${scalarTypeToCelType[expectedType]}; got ${actualType ?? 'unknown'}.`,
@@ -152,6 +151,7 @@ function toCelType(
   variableName: string,
 ): string | {schema: CelSchema} {
   if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'dyn') return 'dyn';
   if (type.kind === 'list') {
     return `list<${toCelListElementType(type.element, environment, [variableName])}>`;
   }
@@ -173,6 +173,7 @@ function toCelSchemaType(
   path: readonly string[],
 ): string | CelSchema {
   if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'dyn') return 'dyn';
   if (type.kind === 'list') {
     return `list<${toCelSchemaListElementType(type.element, environment, path)}>`;
   }
@@ -191,6 +192,7 @@ function toCelSchemaListElementType(
   path: readonly string[],
 ): string {
   if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'dyn') return 'dyn';
   if (type.kind === 'map') return 'map';
   if (type.kind === 'object') {
     const itemPath = [...path, 'item'];
@@ -215,6 +217,7 @@ function toCelListElementType(
   path: readonly string[],
 ): string {
   if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'dyn') return 'dyn';
   if (type.kind === 'map') return 'map';
   if (type.kind === 'object') {
     return toCelSchemaListElementType(type, environment, path);
@@ -222,7 +225,7 @@ function toCelListElementType(
   return `list<${toCelSchemaListElementType(type.element, environment, [...path, 'item'])}>`;
 }
 
-function fromCelType(type: string | undefined, ast: ASTNode): ExpressionType | undefined {
+function fromCelType(type: string | undefined): ExpressionType | undefined {
   if (type === undefined) return undefined;
 
   switch (type) {
@@ -241,8 +244,7 @@ function fromCelType(type: string | undefined, ast: ASTNode): ExpressionType | u
     case 'map':
       return {kind: 'map'};
     case 'dyn':
-      // Preserve legacy string fallback for open-map lookups; JSON values stay unknown.
-      return containsFromJsonCall(ast) ? undefined : 'string';
+      return {kind: 'dyn'};
     default:
       // cel-js currently exposes custom/list element result types as opaque strings.
       // Keep the outer list shape when present, but erase element detail rather than
@@ -252,31 +254,13 @@ function fromCelType(type: string | undefined, ast: ASTNode): ExpressionType | u
   }
 }
 
-function parseWorkflowExpression(source: string): ASTNode {
+function parseWorkflowExpression(source: string): void {
   try {
-    return parseCel(source).ast;
+    parseCel(source);
   } catch (error) {
     throw new InvalidWorkflowExpressionError({
       source,
       reason: error instanceof Error ? error.message : 'Expression source could not be parsed.',
     });
   }
-}
-
-function containsFromJsonCall(node: ASTNode): boolean {
-  if ((node.op === 'call' || node.op === 'rcall') && node.args[0] === 'fromJson') {
-    return true;
-  }
-
-  return containsFromJsonValue(node.args);
-}
-
-function containsFromJsonValue(value: unknown): boolean {
-  if (Array.isArray(value)) return value.some(containsFromJsonValue);
-  if (typeof value !== 'object' || value === null) return false;
-
-  const candidate = value as {readonly args?: unknown; readonly op?: unknown};
-  if (candidate.args === undefined || candidate.op === undefined) return false;
-
-  return containsFromJsonCall(candidate as ASTNode);
 }

--- a/libs/shared/expression/src/expression/workflow-expression.ts
+++ b/libs/shared/expression/src/expression/workflow-expression.ts
@@ -14,6 +14,9 @@ export type ExpressionScalarType = 'string' | 'int' | 'double' | 'bool' | 'null'
 export type ExpressionType =
   | ExpressionScalarType
   | {
+      kind: 'dyn';
+    }
+  | {
       kind: 'object';
       fields: Readonly<Record<string, ExpressionType>>;
     }

--- a/libs/shared/expression/src/outputs/output-declarations.test.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.test.ts
@@ -12,7 +12,7 @@ describe('outputDeclarationToExpressionType', () => {
     [{type: 'number' as const}, 'double'],
     [{type: 'boolean' as const}, 'bool'],
     [{type: 'json' as const}, {kind: 'dyn'}],
-    [{type: 'json' as const, schema: {}}, {kind: 'map'}],
+    [{type: 'json' as const, schema: {}}, {kind: 'dyn'}],
   ])('maps %j', (declaration, expected) => {
     const result = outputDeclarationToExpressionType(declaration);
 
@@ -87,7 +87,6 @@ describe('jsonSchemaToExpressionType', () => {
         properties: {},
       },
     ],
-    ['empty schema', {}],
     ['patternProperties', {type: 'object', patternProperties: {'^x': {type: 'string'}}}],
   ])('maps open object %s schema to map', (_label, schema) => {
     const result = jsonSchemaToExpressionType(schema);
@@ -104,6 +103,7 @@ describe('jsonSchemaToExpressionType', () => {
     ['not', {not: {type: 'string'}}],
     ['nullable', {type: 'string', nullable: true}],
     ['union type', {type: ['string', 'number']}],
+    ['empty schema', {}],
   ])('maps unknown-shaped %s schema to dyn', (_label, schema) => {
     const result = jsonSchemaToExpressionType(schema);
 
@@ -120,7 +120,7 @@ describe('jsonSchemaToExpressionType', () => {
     expect(result).toBe(expected);
   });
 
-  it('maps an unconstrained nested schema to an open map', () => {
+  it('maps an unconstrained nested schema to dyn', () => {
     const result = jsonSchemaToExpressionType({
       type: 'object',
       additionalProperties: false,
@@ -128,7 +128,7 @@ describe('jsonSchemaToExpressionType', () => {
       required: ['payload'],
     });
 
-    expect(result).toEqual({kind: 'object', fields: {payload: {kind: 'map'}}});
+    expect(result).toEqual({kind: 'object', fields: {payload: {kind: 'dyn'}}});
   });
 });
 
@@ -163,6 +163,33 @@ describe('coerceStepOutputs', () => {
         ready: true,
         payload: {name: 'build'},
         items: ['one', 2],
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        count: 42,
+        ready: true,
+        payload: {name: 'build'},
+        items: ['one', 2],
+      },
+    });
+  });
+
+  it('decodes string values for schema-less JSON outputs', () => {
+    const result = coerceStepOutputs({
+      declarations: {
+        count: {type: 'json'},
+        ready: {type: 'json'},
+        payload: {type: 'json'},
+        items: {type: 'json'},
+      },
+      output: {
+        count: '42',
+        ready: 'true',
+        payload: '{"name":"build"}',
+        items: '["one",2]',
       },
     });
 

--- a/libs/shared/expression/src/outputs/output-declarations.test.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.test.ts
@@ -11,7 +11,8 @@ describe('outputDeclarationToExpressionType', () => {
     [{type: 'string' as const}, 'string'],
     [{type: 'number' as const}, 'double'],
     [{type: 'boolean' as const}, 'bool'],
-    [{type: 'json' as const}, {kind: 'map'}],
+    [{type: 'json' as const}, {kind: 'dyn'}],
+    [{type: 'json' as const, schema: {}}, {kind: 'map'}],
   ])('maps %j', (declaration, expected) => {
     const result = outputDeclarationToExpressionType(declaration);
 
@@ -77,16 +78,57 @@ describe('jsonSchemaToExpressionType', () => {
         properties: {registry: {type: 'string'}},
       },
     ],
-    ['oneOf', {oneOf: [{type: 'string'}, {type: 'number'}]}],
-    ['anyOf', {anyOf: [{type: 'string'}, {type: 'number'}]}],
-    ['enum', {enum: ['a', 'b']}],
-    ['nullable', {type: 'string', nullable: true}],
+    [
+      'required property without a schema',
+      {
+        type: 'object',
+        additionalProperties: false,
+        required: ['registry'],
+        properties: {},
+      },
+    ],
+    ['empty schema', {}],
     ['patternProperties', {type: 'object', patternProperties: {'^x': {type: 'string'}}}],
-    ['union type', {type: ['string', 'number']}],
-  ])('falls back to map for %s schemas', (_label, schema) => {
+  ])('maps open object %s schema to map', (_label, schema) => {
     const result = jsonSchemaToExpressionType(schema);
 
     expect(result).toEqual({kind: 'map'});
+  });
+
+  it.each([
+    ['absent schema', undefined],
+    ['null schema', null],
+    ['oneOf', {oneOf: [{type: 'string'}, {type: 'number'}]}],
+    ['anyOf', {anyOf: [{type: 'string'}, {type: 'number'}]}],
+    ['allOf', {allOf: [{type: 'string'}, {type: 'number'}]}],
+    ['not', {not: {type: 'string'}}],
+    ['nullable', {type: 'string', nullable: true}],
+    ['union type', {type: ['string', 'number']}],
+  ])('maps unknown-shaped %s schema to dyn', (_label, schema) => {
+    const result = jsonSchemaToExpressionType(schema);
+
+    expect(result).toEqual({kind: 'dyn'});
+  });
+
+  it.each([
+    [{type: 'string', enum: ['ready']}, 'string'],
+    [{type: 'integer', const: 42}, 'int'],
+    [{type: 'number', enum: [1, 2]}, 'double'],
+  ])('preserves scalar schema %j despite enum/const', (schema, expected) => {
+    const result = jsonSchemaToExpressionType(schema);
+
+    expect(result).toBe(expected);
+  });
+
+  it('maps an unconstrained nested schema to an open map', () => {
+    const result = jsonSchemaToExpressionType({
+      type: 'object',
+      additionalProperties: false,
+      properties: {payload: {}},
+      required: ['payload'],
+    });
+
+    expect(result).toEqual({kind: 'object', fields: {payload: {kind: 'map'}}});
   });
 });
 
@@ -108,6 +150,33 @@ describe('validateJsonSchema', () => {
 });
 
 describe('coerceStepOutputs', () => {
+  it('passes through scalar and structured values for schema-less JSON outputs', () => {
+    const result = coerceStepOutputs({
+      declarations: {
+        count: {type: 'json'},
+        ready: {type: 'json'},
+        payload: {type: 'json'},
+        items: {type: 'json'},
+      },
+      output: {
+        count: 42,
+        ready: true,
+        payload: {name: 'build'},
+        items: ['one', 2],
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        count: 42,
+        ready: true,
+        payload: {name: 'build'},
+        items: ['one', 2],
+      },
+    });
+  });
+
   it('coerces declared scalar output values', () => {
     const result = coerceStepOutputs({
       declarations: {

--- a/libs/shared/expression/src/outputs/output-declarations.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.ts
@@ -45,7 +45,8 @@ const coercingAjv = new Ajv({
   addUsedSchema: false,
 });
 const jsonOutputValidatorCache = new Map<string, ValidateFunction>();
-const fallbackJsonType = {kind: 'map'} as const satisfies ExpressionType;
+const fallbackJsonType = {kind: 'dyn'} as const satisfies ExpressionType;
+const openObjectJsonType = {kind: 'map'} as const satisfies ExpressionType;
 
 export {workflowDocumentStepOutputTypes as outputTypes};
 
@@ -79,7 +80,12 @@ export function outputDeclarationsToExpressionFields(
 
 export function jsonSchemaToExpressionType(schema: unknown): ExpressionType {
   if (!isPlainRecord(schema)) return fallbackJsonType;
-  if (hasUnsupportedCombinator(schema)) return fallbackJsonType;
+  if (hasDynamicSchemaShape(schema)) return fallbackJsonType;
+  // An empty schema is the representation used when a dynamic value is nested
+  // inside a JSON declaration. Keep that nested value open on the next
+  // round-trip rather than making it another opaque leaf.
+  if (Object.keys(schema).length === 0) return openObjectJsonType;
+  if (schema.patternProperties !== undefined) return openObjectJsonType;
 
   const type = schema.type;
   if (Array.isArray(type)) return fallbackJsonType;
@@ -299,9 +305,10 @@ function closedObjectJsonSchemaToExpressionType(
     !isPlainRecord(properties) ||
     !Array.isArray(required) ||
     !required.every((field) => typeof field === 'string') ||
-    Object.keys(properties).some((field) => !required.includes(field))
+    Object.keys(properties).some((field) => !required.includes(field)) ||
+    required.some((field) => !Object.hasOwn(properties, field))
   ) {
-    return fallbackJsonType;
+    return openObjectJsonType;
   }
 
   return {
@@ -315,15 +322,12 @@ function closedObjectJsonSchemaToExpressionType(
   };
 }
 
-function hasUnsupportedCombinator(schema: Readonly<Record<string, unknown>>): boolean {
+function hasDynamicSchemaShape(schema: Readonly<Record<string, unknown>>): boolean {
   return (
     schema.oneOf !== undefined ||
     schema.anyOf !== undefined ||
     schema.allOf !== undefined ||
     schema.not !== undefined ||
-    schema.enum !== undefined ||
-    schema.const !== undefined ||
-    schema.patternProperties !== undefined ||
     schema.nullable === true
   );
 }

--- a/libs/shared/expression/src/outputs/output-declarations.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.ts
@@ -81,10 +81,6 @@ export function outputDeclarationsToExpressionFields(
 export function jsonSchemaToExpressionType(schema: unknown): ExpressionType {
   if (!isPlainRecord(schema)) return fallbackJsonType;
   if (hasDynamicSchemaShape(schema)) return fallbackJsonType;
-  // An empty schema is the representation used when a dynamic value is nested
-  // inside a JSON declaration. Keep that nested value open on the next
-  // round-trip rather than making it another opaque leaf.
-  if (Object.keys(schema).length === 0) return openObjectJsonType;
   if (schema.patternProperties !== undefined) return openObjectJsonType;
 
   const type = schema.type;


### PR DESCRIPTION
Unknown-shaped tool outputs currently lose their usable type information at the workflow boundary. This change carries an explicit CEL `dyn` type through expression checking and output declarations, so unknown values remain evaluable without being guessed as strings.

JSON Schema handling now distinguishes closed typed objects, open maps, and dynamic shapes. Schema-less tool and agent JSON outputs round-trip correctly and preserve numbers, booleans, and structured runtime values, with the workflow transport types and reference documentation updated alongside the release metadata.

Local package validation and focused type emission pass. The repository-wide affected type-emission command still reports existing TS2883 diagnostics in unchanged `apps/client/src/shipfox-app.gen.ts`.

Closes ENG-1887

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types unknown-shaped tool and JSON outputs as CEL `dyn` end to end, so schema-less tool and agent outputs keep numbers, booleans, and structured runtime values instead of being guessed as strings.

- `fromJson()` results and open-map lookups now return `dyn` instead of the legacy string fallback.
- JSON Schema mapping sends closed all-required objects to typed, open objects and optional properties to `map`, and unknown shapes (absent schemas, unions, combinators, `nullable`) to `dyn`; scalar `enum`/`const` keeps its scalar type.
- Schema-less `json` declarations now type as `dyn` and round-trip as schema-less JSON through runtime coercion; this also repairs authored agent step `type: json` outputs in gates.
- Numeric comparisons now type-check across `int` and `double`.
- Listener snapshots omit only `dyn` output metadata, keeping typed sibling outputs rehydratable for rolling-deploy compatibility.
- Misspelled fields under closed all-required schemas still fail at sync.
- Pre-existing TS2883 diagnostics remain in unchanged `apps/client/src/shipfox-app.gen.ts`.

<sup>Written for commit c38c8899afd7fe010e0c0a392e8c34765d4f910c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

