### PR TITLE
[integration-core] Make renewable credential E2E deterministic

### DIFF
--- a/.changeset/calm-foxes-renew.md
+++ b/.changeset/calm-foxes-renew.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/api-integration-core": patch
+"@shipfox/api-integration-core-dto": minor
 ---
 
-Makes Test VCS credential renewal checks deterministic.
+Adds Test VCS credential invalidation, refresh controls, and shared E2E setup DTOs.

--- a/.changeset/calm-foxes-renew.md
+++ b/.changeset/calm-foxes-renew.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Makes Test VCS credential renewal checks deterministic.

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -285,7 +285,7 @@ export function e2eEnv(sourceEnv) {
     ),
     INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS: valueOr(
       sourceEnv.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS,
-      '10',
+      '600',
     ),
     INTEGRATIONS_TEST_VCS_PORT: String(testVcsPort),
     LINEAR_MCP_ENDPOINT: linearMcpEndpoint,

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -84,7 +84,7 @@ describe('e2eEnv', () => {
     assert.equal(env.INTEGRATIONS_ENABLE_GITHUB_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_SLACK_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER, 'true');
-    assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '10');
+    assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '600');
     assert.equal(env.INTEGRATIONS_TEST_VCS_PORT, '55365');
     assert.equal(env.AUTH_ROOT_KEY, 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=');
     assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'true');
@@ -130,7 +130,7 @@ describe('e2eEnv', () => {
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
     assert.equal(env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE, 'disabled');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:16122');
-    assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '10');
+    assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '600');
     assert.equal(env.INTEGRATIONS_TEST_VCS_PORT, '16115');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
     assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'false');

--- a/e2e/setup/integrations/src/index.test.ts
+++ b/e2e/setup/integrations/src/index.test.ts
@@ -71,7 +71,8 @@ describe('integrations E2E setup helper', () => {
     await createTestVcsConnection({
       workspaceId: '00000000-0000-4000-8000-000000000001',
       accountId: 'e2e-owner',
-      renewalMode: 'on-rejection',
+      renewalMode: 'refresh-at',
+      refreshAfterSeconds: 1,
     });
     await createTestVcsRepository({
       connectionId: 'connection-id',
@@ -87,7 +88,8 @@ describe('integrations E2E setup helper', () => {
         json: {
           workspace_id: '00000000-0000-4000-8000-000000000001',
           account_id: 'e2e-owner',
-          renewal_mode: 'on-rejection',
+          renewal_mode: 'refresh-at',
+          refresh_after_seconds: 1,
         },
       },
     );
@@ -116,6 +118,7 @@ describe('integrations E2E setup helper', () => {
       accepted_request_count: 2,
       rejected_request_count: 1,
       generations: ['generation-a', 'generation-b'],
+      invalidations: [],
       requests: [],
     });
     const {failNextTestVcsMints, getTestVcsStats} = await import('./index.js');

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -40,6 +40,11 @@ export interface TestVcsStats {
   accepted_request_count: number;
   rejected_request_count: number;
   generations: string[];
+  invalidations: Array<{
+    key: string;
+    repository: string;
+    generation: string;
+  }>;
   requests: Array<{
     method: string;
     path: string;
@@ -53,6 +58,7 @@ export interface CreateTestVcsConnectionParams {
   accountId: string;
   displayName?: string | undefined;
   renewalMode?: TestVcsRenewalMode | undefined;
+  refreshAfterSeconds?: number | undefined;
 }
 
 export interface CreateTestVcsRepositoryParams {
@@ -170,6 +176,9 @@ export async function createTestVcsConnection(
         account_id: params.accountId,
         ...(params.displayName === undefined ? {} : {display_name: params.displayName}),
         ...(params.renewalMode === undefined ? {} : {renewal_mode: params.renewalMode}),
+        ...(params.refreshAfterSeconds === undefined
+          ? {}
+          : {refresh_after_seconds: params.refreshAfterSeconds}),
       },
     },
   );

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -1,4 +1,10 @@
-import type {IntegrationConnectionDto, RepositoryDto} from '@shipfox/api-integration-core-dto';
+import type {
+  CreateE2eTestVcsConnectionBodyDto,
+  IntegrationConnectionDto,
+  RepositoryDto,
+  TestVcsRenewalModeDto,
+  TestVcsStatsDto,
+} from '@shipfox/api-integration-core-dto';
 import type {
   CreateE2eGithubConnectionBodyDto,
   CreateE2eGithubConnectionResponseDto,
@@ -13,7 +19,13 @@ import type {
 } from '@shipfox/api-integration-slack-dto';
 import {request, requestJson} from '@shipfox/e2e-core';
 
-export type {IntegrationConnectionDto, RepositoryDto} from '@shipfox/api-integration-core-dto';
+export type {
+  CreateE2eTestVcsConnectionBodyDto,
+  IntegrationConnectionDto,
+  RepositoryDto,
+  TestVcsRenewalModeDto,
+  TestVcsStatsDto,
+} from '@shipfox/api-integration-core-dto';
 export type {
   CreateE2eGithubConnectionBodyDto,
   CreateE2eGithubConnectionResponseDto,
@@ -27,31 +39,14 @@ export type {
   CreateE2eSlackConnectionResponseDto,
 } from '@shipfox/api-integration-slack-dto';
 
-export type TestVcsRenewalMode = 'refresh-at' | 'on-rejection';
+export type TestVcsRenewalMode = TestVcsRenewalModeDto;
 
 export interface TestVcsFile {
   path: string;
   content: string;
 }
 
-export interface TestVcsStats {
-  mint_count: number;
-  request_count: number;
-  accepted_request_count: number;
-  rejected_request_count: number;
-  generations: string[];
-  invalidations: Array<{
-    key: string;
-    repository: string;
-    generation: string;
-  }>;
-  requests: Array<{
-    method: string;
-    path: string;
-    status: 'accepted' | 'rejected';
-    generation?: string | undefined;
-  }>;
-}
+export type TestVcsStats = TestVcsStatsDto;
 
 export interface CreateTestVcsConnectionParams {
   workspaceId: string;
@@ -167,20 +162,19 @@ export async function createSlackConnection(
 export async function createTestVcsConnection(
   params: CreateTestVcsConnectionParams,
 ): Promise<IntegrationConnectionDto> {
+  const body: CreateE2eTestVcsConnectionBodyDto = {
+    workspace_id: params.workspaceId,
+    account_id: params.accountId,
+    renewal_mode: params.renewalMode ?? 'on-rejection',
+    ...(params.displayName === undefined ? {} : {display_name: params.displayName}),
+    ...(params.refreshAfterSeconds === undefined
+      ? {}
+      : {refresh_after_seconds: params.refreshAfterSeconds}),
+  };
   return await requestJson<IntegrationConnectionDto>(
     'post',
     '/__e2e/integrations/test-vcs/connections',
-    {
-      json: {
-        workspace_id: params.workspaceId,
-        account_id: params.accountId,
-        ...(params.displayName === undefined ? {} : {display_name: params.displayName}),
-        ...(params.renewalMode === undefined ? {} : {renewal_mode: params.renewalMode}),
-        ...(params.refreshAfterSeconds === undefined
-          ? {}
-          : {refresh_after_seconds: params.refreshAfterSeconds}),
-      },
-    },
+    {json: body},
   );
 }
 

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -18,6 +18,7 @@
     "#listener-jobs.js": "./src/listener-jobs.ts",
     "#linear-mcp.js": "./src/linear-mcp.ts",
     "#polling.js": "./src/polling.ts",
+    "#renewable-credentials-workflows.js": "./src/renewable-credentials-workflows.ts",
     "#run-scenario.js": "./src/run-scenario.ts",
     "#runner.js": "./src/runner.ts",
     "#scenarios.js": "./src/scenarios.ts",

--- a/e2e/suites/flow/workflows/src/renewable-credentials-workflows.ts
+++ b/e2e/suites/flow/workflows/src/renewable-credentials-workflows.ts
@@ -1,0 +1,57 @@
+const TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS = 2;
+
+export const ON_REJECTION_WORKFLOW = `
+name: Renewable Git on rejection
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    checkout:
+      permissions:
+        contents: write
+      persist-credentials: true
+    steps:
+      - key: verify-primary-checkout
+        run: |
+          test -d .git
+          command -v git-credential-shipfox
+          test -n "$GIT_CONFIG_GLOBAL"
+          test -f "$GIT_CONFIG_GLOBAL"
+          git config --global --list --show-origin
+          git config --global --get-urlmatch credential.helper "$(git remote get-url origin)" || true
+      - key: secondary-checkout
+        checkout:
+          connection: __TEST_VCS_CONNECTION__
+          repository: __TEST_VCS_SECONDARY_REPOSITORY__
+          ref: main
+          path: secondary
+          permissions:
+            contents: read
+          persist-credentials: true
+      - key: use-renewed-credentials
+        run: |
+          if git -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: primary-read' ls-remote origin main; then
+            echo 'expected the invalidated primary credential to be rejected' >&2
+            exit 1
+          fi
+          git ls-remote origin main
+          if git -C secondary -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: secondary-read' ls-remote origin main; then
+            echo 'expected the invalidated secondary credential to be rejected' >&2
+            exit 1
+          fi
+          git -C secondary ls-remote origin main
+          git config --local commit.gpgsign false
+          printf '\\nrenewed\\n' >> README.md
+          git add README.md
+          git commit -m "renewed credentials"
+          sleep ${TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS}
+          if git -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: primary-push' push origin HEAD:main; then
+            echo 'expected the invalidated primary credential to be rejected' >&2
+            exit 1
+          fi
+          git push origin HEAD:main
+          test "$(git log -1 --format=%ae)" = "test-vcs@shipfox.test"
+`;

--- a/e2e/suites/flow/workflows/tests/fixtures.ts
+++ b/e2e/suites/flow/workflows/tests/fixtures.ts
@@ -1,14 +1,41 @@
+import {createApiClient} from '@shipfox/e2e-core';
 import {test as base} from '@shipfox/e2e-core/playwright';
+import {
+  type CreateTestVcsConnectionParams,
+  createTestVcsConnection,
+  type IntegrationConnectionDto,
+} from '@shipfox/e2e-setup-integrations';
 import {markSuiteFailed, readSuiteContext, type SuiteContext} from '#suite-context.js';
 
 export interface SuiteFixtures {
   suite: SuiteContext;
+  createIsolatedTestVcsConnection: (
+    params: Omit<CreateTestVcsConnectionParams, 'workspaceId'>,
+  ) => Promise<IntegrationConnectionDto>;
   failureTracker: undefined;
 }
 
 export const test = base.extend<SuiteFixtures>({
   suite: async ({request: _request}, use) => {
     await use(readSuiteContext());
+  },
+  createIsolatedTestVcsConnection: async ({suite}, use) => {
+    const connectionIds: string[] = [];
+    try {
+      await use(async (params) => {
+        const connection = await createTestVcsConnection({
+          workspaceId: suite.workspaceId,
+          ...params,
+        });
+        connectionIds.push(connection.id);
+        return connection;
+      });
+    } finally {
+      const client = createApiClient({token: suite.sessionToken});
+      for (const connectionId of connectionIds.reverse()) {
+        await client.request('delete', `/integration-connections/${connectionId}`);
+      }
+    }
   },
   // Auto fixture: a worker touches the shared failure sentinel when its test does not
   // reach the expected status, so global teardown keeps the run's gitea org for

--- a/e2e/suites/flow/workflows/tests/fixtures.ts
+++ b/e2e/suites/flow/workflows/tests/fixtures.ts
@@ -33,7 +33,13 @@ export const test = base.extend<SuiteFixtures>({
     } finally {
       const client = createApiClient({token: suite.sessionToken});
       for (const connectionId of connectionIds.reverse()) {
-        await client.request('delete', `/integration-connections/${connectionId}`);
+        await client
+          .request('delete', `/integration-connections/${connectionId}`)
+          .catch((error: unknown) => {
+            process.stderr.write(
+              `renewable-credentials-e2e: deleting Test VCS connection ${connectionId} failed: ${String(error)}\n`,
+            );
+          });
       }
     }
   },

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -4,7 +4,6 @@ import {createApiClient} from '@shipfox/e2e-core';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {waitForDefinition} from '@shipfox/e2e-observe-definitions';
 import {
-  createTestVcsConnection,
   createTestVcsRepository,
   failNextTestVcsMints,
   getTestVcsStats,
@@ -13,6 +12,7 @@ import {
 } from '@shipfox/e2e-setup-integrations';
 import {attachLocalRunnerLog} from '#attachments.js';
 import {createProject} from '#create-project.js';
+import {ON_REJECTION_WORKFLOW} from '#renewable-credentials-workflows.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import type {SuiteContext} from '#suite-context.js';
 import {fireManualAndAwaitRun} from '#triggers.js';
@@ -22,63 +22,6 @@ const RUNNER_TERMINAL_TIMEOUT_MS = 180_000;
 const TEST_TIMEOUT_MS = 300_000;
 const TEST_VCS_TOKEN_PATTERN = /test-vcs-[0-9a-f-]{20,}/u;
 const TEST_VCS_REFRESH_WAIT_SECONDS = 2;
-const TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS = 2;
-
-const ON_REJECTION_WORKFLOW = `
-name: Renewable Git on rejection
-runner: __RUNNER_LABEL__
-triggers:
-  manual:
-    source: manual
-    event: fire
-jobs:
-  build:
-    checkout:
-      permissions:
-        contents: write
-      persist-credentials: true
-    steps:
-      - key: verify-primary-checkout
-        run: |
-          test -d .git
-          command -v git-credential-shipfox
-          test -n "$GIT_CONFIG_GLOBAL"
-          test -f "$GIT_CONFIG_GLOBAL"
-          git config --global --list --show-origin
-          git config --global --get-urlmatch credential.helper "$(git remote get-url origin)" || true
-      - key: secondary-checkout
-        checkout:
-          connection: __TEST_VCS_CONNECTION__
-          repository: __TEST_VCS_SECONDARY_REPOSITORY__
-          ref: main
-          path: secondary
-          permissions:
-            contents: read
-          persist-credentials: true
-      - key: use-renewed-credentials
-        run: |
-          if git -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: primary-read' ls-remote origin main; then
-            echo 'expected the invalidated primary credential to be rejected' >&2
-            exit 1
-          fi
-          git ls-remote origin main
-          if git -C secondary -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: secondary-read' ls-remote origin main; then
-            echo 'expected the invalidated secondary credential to be rejected' >&2
-            exit 1
-          fi
-          git -C secondary ls-remote origin main
-          git config --local commit.gpgsign false
-          printf '\\nrenewed\\n' >> README.md
-          git add README.md
-          git commit -m "renewed credentials"
-          sleep ${TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS}
-          if git -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: primary-push' push origin HEAD:main; then
-            echo 'expected the invalidated primary credential to be rejected' >&2
-            exit 1
-          fi
-          git push origin HEAD:main
-          test "$(git log -1 --format=%ae)" = "test-vcs@shipfox.test"
-`;
 
 const REFRESH_AT_WORKFLOW = `
 name: Renewable Git refresh at
@@ -176,12 +119,14 @@ jobs:
 
 test.describe.configure({mode: 'serial'});
 
-test('renews rejected credentials across multiple checkouts', async ({suite}, testInfo) => {
+test('renews rejected credentials across multiple checkouts', async ({
+  suite,
+  createIsolatedTestVcsConnection,
+}, testInfo) => {
   test.setTimeout(TEST_TIMEOUT_MS);
   const uniqueId = shortId();
   const accountId = `test-vcs-rejection-${uniqueId}`;
-  const connection = await createTestVcsConnection({
-    workspaceId: suite.workspaceId,
+  const connection = await createIsolatedTestVcsConnection({
     accountId,
     displayName: `Test VCS rejection ${uniqueId}`,
     renewalMode: 'on-rejection',
@@ -251,12 +196,14 @@ test('renews rejected credentials across multiple checkouts', async ({suite}, te
   await assertNoCredentialLeak(after, logFiles);
 });
 
-test('refreshes before Git needs an expired credential', async ({suite}, testInfo) => {
+test('refreshes before Git needs an expired credential', async ({
+  suite,
+  createIsolatedTestVcsConnection,
+}, testInfo) => {
   test.setTimeout(TEST_TIMEOUT_MS);
   const uniqueId = shortId();
   const accountId = `test-vcs-refresh-${uniqueId}`;
-  const connection = await createTestVcsConnection({
-    workspaceId: suite.workspaceId,
+  const connection = await createIsolatedTestVcsConnection({
     accountId,
     displayName: `Test VCS refresh-at ${uniqueId}`,
     renewalMode: 'refresh-at',

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -21,8 +21,8 @@ import {expect, test} from './fixtures.js';
 const RUNNER_TERMINAL_TIMEOUT_MS = 180_000;
 const TEST_TIMEOUT_MS = 300_000;
 const TEST_VCS_TOKEN_PATTERN = /test-vcs-[0-9a-f-]{20,}/u;
-const TEST_VCS_EXPIRY_WAIT_SECONDS = 11;
-const TEST_VCS_REFRESH_WAIT_SECONDS = 6;
+const TEST_VCS_REFRESH_WAIT_SECONDS = 2;
+const TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS = 2;
 
 const ON_REJECTION_WORKFLOW = `
 name: Renewable Git on rejection
@@ -57,14 +57,13 @@ jobs:
           persist-credentials: true
       - key: use-renewed-credentials
         run: |
-          sleep ${TEST_VCS_EXPIRY_WAIT_SECONDS}
-          if git ls-remote origin main; then
-            echo 'expected the expired primary credential to be rejected' >&2
+          if git -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: primary-read' ls-remote origin main; then
+            echo 'expected the invalidated primary credential to be rejected' >&2
             exit 1
           fi
           git ls-remote origin main
-          if git -C secondary ls-remote origin main; then
-            echo 'expected the expired secondary credential to be rejected' >&2
+          if git -C secondary -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: secondary-read' ls-remote origin main; then
+            echo 'expected the invalidated secondary credential to be rejected' >&2
             exit 1
           fi
           git -C secondary ls-remote origin main
@@ -72,9 +71,9 @@ jobs:
           printf '\\nrenewed\\n' >> README.md
           git add README.md
           git commit -m "renewed credentials"
-          sleep ${TEST_VCS_EXPIRY_WAIT_SECONDS}
-          if git push origin HEAD:main; then
-            echo 'expected the expired primary credential to be rejected' >&2
+          sleep ${TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS}
+          if git -c http.extraHeader='X-Shipfox-Test-Vcs-Invalidate-Generation: primary-push' push origin HEAD:main; then
+            echo 'expected the invalidated primary credential to be rejected' >&2
             exit 1
           fi
           git push origin HEAD:main
@@ -123,7 +122,6 @@ jobs:
           remote_url="$(git remote get-url origin)"
           test -z "$(git config --global --get-urlmatch credential.helper "$remote_url" || true)"
           test -z "$(git config --global --get-urlmatch http.extraHeader "$remote_url" || true)"
-          sleep ${TEST_VCS_EXPIRY_WAIT_SECONDS}
 `;
 
 const CONCURRENT_WORKFLOW = `
@@ -178,28 +176,33 @@ jobs:
 
 test.describe.configure({mode: 'serial'});
 
-test('renews on Git rejection across a long step and multiple checkouts', async ({
-  suite,
-}, testInfo) => {
+test('renews rejected credentials across multiple checkouts', async ({suite}, testInfo) => {
   test.setTimeout(TEST_TIMEOUT_MS);
   const uniqueId = shortId();
+  const accountId = `test-vcs-rejection-${uniqueId}`;
+  const connection = await createTestVcsConnection({
+    workspaceId: suite.workspaceId,
+    accountId,
+    displayName: `Test VCS rejection ${uniqueId}`,
+    renewalMode: 'on-rejection',
+  });
   const runnerLabel = `e2e-renewable-rejection-${uniqueId}`;
   const repositoryName = `renewal-${uniqueId}`;
   const secondaryRepositoryName = `renewal-secondary-${uniqueId}`;
   const configPath = `.shipfox/workflows/${repositoryName}.yml`;
-  const before = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+  const before = await getTestVcsStats({connectionId: connection.id});
 
   const secondary = await createTestVcsRepository({
-    connectionId: suite.testVcsConnectionId,
+    connectionId: connection.id,
     name: secondaryRepositoryName,
     files: [{path: 'README.md', content: '# Secondary test VCS repository\n'}],
   });
   const workflow = await seedTestVcsWorkflow({
     suite,
     token: suite.sessionToken,
-    connectionId: suite.testVcsConnectionId,
-    connectionSlug: suite.testVcsConnectionSlug,
-    owner: suite.testVcsAccountId,
+    connectionId: connection.id,
+    connectionSlug: connection.slug,
+    owner: connection.external_account_id,
     repositoryName,
     runnerLabel,
     configPath,
@@ -207,7 +210,7 @@ test('renews on Git rejection across a long step and multiple checkouts', async 
     secondaryRepositoryName,
   });
   expect(secondary.external_repository_id).toBe(
-    testVcsExternalRepositoryId(suite.testVcsAccountId, secondaryRepositoryName),
+    testVcsExternalRepositoryId(connection.external_account_id, secondaryRepositoryName),
   );
 
   const {terminal, logFiles} = await runWorkflow({
@@ -218,12 +221,31 @@ test('renews on Git rejection across a long step and multiple checkouts', async 
     runnerLabel,
     renewableGit: true,
   });
-  const after = await getTestVcsStats({connectionId: suite.testVcsConnectionId});
+  const after = await getTestVcsStats({connectionId: connection.id});
 
   expect(terminal.status).toBe('succeeded');
   expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('succeeded');
   expect(after.mint_count - before.mint_count).toBe(5);
-  expect(after.generations.length - before.generations.length).toBe(5);
+  const mintedGenerations = after.generations.slice(before.generations.length);
+  expect(mintedGenerations).toHaveLength(5);
+  expect(after.invalidations.slice(before.invalidations.length)).toEqual([
+    {
+      key: 'primary-read',
+      repository: `${connection.external_account_id}/${repositoryName}`,
+      generation: mintedGenerations[0],
+    },
+    {
+      key: 'secondary-read',
+      repository: `${connection.external_account_id}/${secondaryRepositoryName}`,
+      generation: mintedGenerations[1],
+    },
+    {
+      key: 'primary-push',
+      repository: `${connection.external_account_id}/${repositoryName}`,
+      generation: mintedGenerations[2],
+    },
+  ]);
+  assertInvalidatedCredentialsAreReplaced(before, after);
   expect(rejectedCredentialRequestCount(before, after)).toBeGreaterThanOrEqual(3);
   expect(after.accepted_request_count - before.accepted_request_count).toBeGreaterThan(0);
   await assertNoCredentialLeak(after, logFiles);
@@ -238,6 +260,7 @@ test('refreshes before Git needs an expired credential', async ({suite}, testInf
     accountId,
     displayName: `Test VCS refresh-at ${uniqueId}`,
     renewalMode: 'refresh-at',
+    refreshAfterSeconds: 1,
   });
   const runnerLabel = `e2e-renewable-refresh-${uniqueId}`;
   const repositoryName = `refresh-${uniqueId}`;
@@ -548,4 +571,30 @@ function rejectedCredentialRequestCount(before: TestVcsStats, after: TestVcsStat
   return after.requests.slice(before.request_count).filter((request) => {
     return request.status === 'rejected' && request.generation !== undefined;
   }).length;
+}
+
+function assertInvalidatedCredentialsAreReplaced(before: TestVcsStats, after: TestVcsStats): void {
+  const requests = after.requests.slice(before.request_count);
+  const invalidations = after.invalidations.slice(before.invalidations.length);
+  let cursor = 0;
+  for (const invalidation of invalidations) {
+    const repositoryPath = `/${invalidation.repository}.git/`;
+    const rejectedOffset = requests.slice(cursor).findIndex((request) => {
+      return (
+        request.status === 'rejected' &&
+        request.generation === invalidation.generation &&
+        request.path.startsWith(repositoryPath)
+      );
+    });
+    expect(rejectedOffset).toBeGreaterThanOrEqual(0);
+    const rejectedIndex = cursor + rejectedOffset;
+    const acceptedOffset = requests.slice(rejectedIndex + 1).findIndex((request) => {
+      return request.status === 'accepted' && request.path.startsWith(repositoryPath);
+    });
+    expect(acceptedOffset).toBeGreaterThanOrEqual(0);
+    const acceptedIndex = rejectedIndex + acceptedOffset + 1;
+    expect(requests[acceptedIndex]?.generation).toBeDefined();
+    expect(requests[acceptedIndex]?.generation).not.toBe(invalidation.generation);
+    cursor = acceptedIndex + 1;
+  }
 }

--- a/libs/api/integration/core-dto/src/schemas/index.ts
+++ b/libs/api/integration/core-dto/src/schemas/index.ts
@@ -53,3 +53,11 @@ export {
   updateIntegrationConnectionRepositoryAccessBodySchema,
   updateIntegrationConnectionRepositoryAccessResponseSchema,
 } from './integrations.js';
+export {
+  type CreateE2eTestVcsConnectionBodyDto,
+  createE2eTestVcsConnectionBodySchema,
+  type TestVcsRenewalModeDto,
+  type TestVcsStatsDto,
+  testVcsRenewalModeSchema,
+  testVcsStatsDtoSchema,
+} from './test-vcs.js';

--- a/libs/api/integration/core-dto/src/schemas/test-vcs.test.ts
+++ b/libs/api/integration/core-dto/src/schemas/test-vcs.test.ts
@@ -1,0 +1,46 @@
+import {createE2eTestVcsConnectionBodySchema, testVcsStatsDtoSchema} from './test-vcs.js';
+
+describe('Test VCS E2E DTOs', () => {
+  it('defaults connection renewal to on-rejection', () => {
+    const result = createE2eTestVcsConnectionBodySchema.parse({
+      workspace_id: '00000000-0000-4000-8000-000000000001',
+      account_id: 'e2e-owner',
+    });
+
+    expect(result.renewal_mode).toBe('on-rejection');
+  });
+
+  it('rejects a refresh delay for on-rejection renewal', () => {
+    const result = createE2eTestVcsConnectionBodySchema.safeParse({
+      workspace_id: '00000000-0000-4000-8000-000000000001',
+      account_id: 'e2e-owner',
+      renewal_mode: 'on-rejection',
+      refresh_after_seconds: 1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts redacted fixture observations', () => {
+    const result = testVcsStatsDtoSchema.parse({
+      mint_count: 1,
+      request_count: 1,
+      accepted_request_count: 0,
+      rejected_request_count: 1,
+      generations: ['generation-a'],
+      invalidations: [
+        {key: 'primary-read', repository: 'e2e-owner/repository', generation: 'generation-a'},
+      ],
+      requests: [
+        {
+          method: 'GET',
+          path: '/e2e-owner/repository.git/info/refs',
+          status: 'rejected',
+          generation: 'generation-a',
+        },
+      ],
+    });
+
+    expect(result.invalidations).toHaveLength(1);
+  });
+});

--- a/libs/api/integration/core-dto/src/schemas/test-vcs.ts
+++ b/libs/api/integration/core-dto/src/schemas/test-vcs.ts
@@ -1,0 +1,60 @@
+import {z} from 'zod';
+
+const testVcsRepositoryPartSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u);
+
+export const testVcsRenewalModeSchema = z.enum(['refresh-at', 'on-rejection']);
+export type TestVcsRenewalModeDto = z.infer<typeof testVcsRenewalModeSchema>;
+
+export const createE2eTestVcsConnectionBodySchema = z
+  .object({
+    workspace_id: z.string().uuid(),
+    account_id: testVcsRepositoryPartSchema,
+    display_name: z.string().min(1).max(200).optional(),
+    renewal_mode: testVcsRenewalModeSchema.default('on-rejection'),
+    refresh_after_seconds: z.number().positive().max(300).optional(),
+  })
+  .strict()
+  .refine(
+    (body) => body.refresh_after_seconds === undefined || body.renewal_mode === 'refresh-at',
+    {
+      message: 'refresh_after_seconds requires refresh-at renewal mode',
+      path: ['refresh_after_seconds'],
+    },
+  );
+export type CreateE2eTestVcsConnectionBodyDto = z.infer<
+  typeof createE2eTestVcsConnectionBodySchema
+>;
+
+const testVcsInvalidationSchema = z
+  .object({
+    key: z.string().min(1),
+    repository: z.string().min(1),
+    generation: z.string().min(1),
+  })
+  .strict();
+
+const testVcsRequestSchema = z
+  .object({
+    method: z.string(),
+    path: z.string(),
+    status: z.enum(['accepted', 'rejected']),
+    generation: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const testVcsStatsDtoSchema = z
+  .object({
+    mint_count: z.number().int().nonnegative(),
+    request_count: z.number().int().nonnegative(),
+    accepted_request_count: z.number().int().nonnegative(),
+    rejected_request_count: z.number().int().nonnegative(),
+    generations: z.array(z.string().min(1)),
+    invalidations: z.array(testVcsInvalidationSchema),
+    requests: z.array(testVcsRequestSchema),
+  })
+  .strict();
+export type TestVcsStatsDto = z.infer<typeof testVcsStatsDtoSchema>;

--- a/libs/api/integration/core/src/providers/modules.test.ts
+++ b/libs/api/integration/core/src/providers/modules.test.ts
@@ -85,7 +85,7 @@ describe('loadEnabledProviderModules', () => {
     expect(testVcsPart?.services).toHaveLength(1);
   });
 
-  it('checks Test VCS renewal timing before creating a connection', async () => {
+  it('validates Test VCS renewal configuration before creating a connection', async () => {
     vi.stubEnv('INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER', 'true');
     vi.stubEnv('INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS', '3');
     vi.resetModules();
@@ -100,16 +100,29 @@ describe('loadEnabledProviderModules', () => {
     const workspaceId = crypto.randomUUID();
     try {
       const app = await createApp({routes: testVcsPart.e2eRoutes, swagger: false});
-      const invalidPayloads = [
-        {renewal_mode: 'on-rejection', refresh_after_seconds: 1},
-        {renewal_mode: 'refresh-at', refresh_after_seconds: 3},
-        {renewal_mode: 'refresh-at', refresh_after_seconds: 4},
-      ];
-      for (const renewal of invalidPayloads) {
+      const mismatchedModeResponse = await app.inject({
+        method: 'POST',
+        url: '/integrations/test-vcs/connections',
+        payload: {
+          workspace_id: workspaceId,
+          account_id: 'e2e-owner',
+          renewal_mode: 'on-rejection',
+          refresh_after_seconds: 1,
+        },
+      });
+
+      expect(mismatchedModeResponse.statusCode).toBe(400);
+
+      for (const refreshAfterSeconds of [3, 4]) {
         const response = await app.inject({
           method: 'POST',
           url: '/integrations/test-vcs/connections',
-          payload: {workspace_id: workspaceId, account_id: 'e2e-owner', ...renewal},
+          payload: {
+            workspace_id: workspaceId,
+            account_id: 'e2e-owner',
+            renewal_mode: 'refresh-at',
+            refresh_after_seconds: refreshAfterSeconds,
+          },
         });
 
         expect(response.statusCode).toBe(400);

--- a/libs/api/integration/core/src/providers/modules.test.ts
+++ b/libs/api/integration/core/src/providers/modules.test.ts
@@ -85,6 +85,58 @@ describe('loadEnabledProviderModules', () => {
     expect(testVcsPart?.services).toHaveLength(1);
   });
 
+  it('checks Test VCS renewal timing before creating a connection', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER', 'true');
+    vi.stubEnv('INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS', '3');
+    vi.resetModules();
+
+    const {createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules();
+    const testVcsPart = parts.find((part) => part.provider.provider === 'test-vcs');
+    if (!testVcsPart?.e2eRoutes) throw new Error('Test VCS E2E routes are not configured');
+
+    const workspaceId = crypto.randomUUID();
+    try {
+      const app = await createApp({routes: testVcsPart.e2eRoutes, swagger: false});
+      const invalidPayloads = [
+        {renewal_mode: 'on-rejection', refresh_after_seconds: 1},
+        {renewal_mode: 'refresh-at', refresh_after_seconds: 3},
+        {renewal_mode: 'refresh-at', refresh_after_seconds: 4},
+      ];
+      for (const renewal of invalidPayloads) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/integrations/test-vcs/connections',
+          payload: {workspace_id: workspaceId, account_id: 'e2e-owner', ...renewal},
+        });
+
+        expect(response.statusCode).toBe(400);
+      }
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/test-vcs/connections',
+        payload: {
+          workspace_id: workspaceId,
+          account_id: 'e2e-owner',
+          renewal_mode: 'refresh-at',
+          refresh_after_seconds: 1,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+    } finally {
+      await db()
+        .delete(integrationsOutbox)
+        .where(sql`${integrationsOutbox.payload}->>'workspaceId' = ${workspaceId}`);
+      await db()
+        .delete(integrationConnections)
+        .where(eq(integrationConnections.workspaceId, workspaceId));
+    }
+  });
+
   it('publishes registry-derived capabilities for a GitHub connect flow', async () => {
     vi.stubEnv('INTEGRATIONS_ENABLE_GITHUB_PROVIDER', 'true');
     vi.resetModules();

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
@@ -65,6 +65,31 @@ describe('Test VCS smart HTTP fixture', () => {
     expect(isValidTestVcsBranchName('feature[')).toBe(false);
   });
 
+  it('rejects refresh timing whose minimum delay reaches credential expiry', async () => {
+    const fixture = createTestVcsFixture({port: 0});
+    try {
+      await fixture.start();
+      await fixture.createRepository({
+        owner: 'e2e-owner',
+        name: 'refresh-timing',
+        files: [{path: 'README.md', content: '# Test VCS\n'}],
+      });
+
+      expect(() =>
+        fixture.issueCredential({
+          owner: 'e2e-owner',
+          name: 'refresh-timing',
+          permissions: {contents: 'read'},
+          renewalMode: 'refresh-at',
+          ttlSeconds: 0.04,
+          refreshAfterSeconds: 0.01,
+        }),
+      ).toThrow('Test VCS refresh delay must precede credential expiry');
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it('requires a credential and accepts a fresh credential after expiry', async () => {
     const fixture = createTestVcsFixture({port: 0});
     const workingDirectory = await mkdtemp(join(tmpdir(), 'shipfox-test-vcs-git-'));

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
@@ -13,6 +13,7 @@ async function git(
   cwd: string,
   repositoryUrl: string,
   credentials: CheckoutCredentials,
+  invalidationKey?: string,
 ): Promise<string> {
   const authorization = Buffer.from(`${credentials.username}:${credentials.token}`).toString(
     'base64',
@@ -21,11 +22,17 @@ async function git(
     cwd,
     env: {
       ...process.env,
-      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_COUNT: invalidationKey === undefined ? '2' : '3',
       GIT_CONFIG_KEY_0: `http.${repositoryUrl}.extraHeader`,
       GIT_CONFIG_VALUE_0: `Authorization: Basic ${authorization}`,
       GIT_CONFIG_KEY_1: 'http.sslVerify',
       GIT_CONFIG_VALUE_1: 'false',
+      ...(invalidationKey === undefined
+        ? {}
+        : {
+            GIT_CONFIG_KEY_2: `http.${repositoryUrl}.extraHeader`,
+            GIT_CONFIG_VALUE_2: `X-Shipfox-Test-Vcs-Invalidate-Generation: ${invalidationKey}`,
+          }),
       GIT_TERMINAL_PROMPT: '0',
     },
   });
@@ -35,15 +42,21 @@ async function git(
 function credentials(
   fixture: ReturnType<typeof createTestVcsFixture>,
   repository: {owner: string; name: string},
-  generation = 'generation-a',
-): CheckoutCredentials {
-  return fixture.issueCredential({
+  options: {ttlSeconds?: number; rejectedGeneration?: string} = {},
+): CheckoutCredentials & {generation: string} {
+  const credential = fixture.issueCredential({
     ...repository,
     permissions: {contents: 'write'},
     renewalMode: 'on-rejection',
-    ttlSeconds: 1,
-    rejectedGeneration: generation === 'generation-a' ? undefined : 'generation-a',
+    ttlSeconds: options.ttlSeconds ?? 1,
+    ...(options.rejectedGeneration === undefined
+      ? {}
+      : {rejectedGeneration: options.rejectedGeneration}),
   });
+  if (credential.generation === undefined) {
+    throw new Error('Test VCS fixture credential has no generation');
+  }
+  return {...credential, generation: credential.generation};
 }
 
 describe('Test VCS smart HTTP fixture', () => {
@@ -82,7 +95,13 @@ describe('Test VCS smart HTTP fixture', () => {
         ),
       ).rejects.toThrow();
 
-      const second = credentials(fixture, {owner: 'e2e-owner', name: 'repository'}, 'generation-b');
+      const second = credentials(
+        fixture,
+        {owner: 'e2e-owner', name: 'repository'},
+        {
+          rejectedGeneration: first.generation,
+        },
+      );
       await expect(
         git(
           ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
@@ -98,6 +117,73 @@ describe('Test VCS smart HTTP fixture', () => {
       expect(stats.generations).toContain(first.generation);
       expect(stats.generations).toContain(second.generation);
       expect(stats.requests.every((request) => !request.path.includes(first.token))).toBe(true);
+    } finally {
+      await fixture.close();
+      await rm(workingDirectory, {recursive: true, force: true});
+    }
+  });
+
+  it('invalidates one credential generation through a one-shot Git header', async () => {
+    const fixture = createTestVcsFixture({port: 0});
+    const workingDirectory = await mkdtemp(join(tmpdir(), 'shipfox-test-vcs-git-'));
+    try {
+      await fixture.start();
+      const repository = await fixture.createRepository({
+        owner: 'e2e-owner',
+        name: 'repository',
+        files: [{path: 'README.md', content: '# Test VCS\n'}],
+      });
+      const first = credentials(
+        fixture,
+        {owner: 'e2e-owner', name: 'repository'},
+        {
+          ttlSeconds: 60,
+        },
+      );
+
+      await expect(
+        git(
+          ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
+          workingDirectory,
+          repository.cloneUrl,
+          first,
+          'primary-read',
+        ),
+      ).rejects.toThrow();
+      await expect(
+        git(
+          ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
+          workingDirectory,
+          repository.cloneUrl,
+          first,
+        ),
+      ).rejects.toThrow();
+
+      const second = credentials(
+        fixture,
+        {owner: 'e2e-owner', name: 'repository'},
+        {
+          ttlSeconds: 60,
+          rejectedGeneration: first.generation,
+        },
+      );
+      await expect(
+        git(
+          ['ls-remote', repository.cloneUrl, 'refs/heads/main'],
+          workingDirectory,
+          repository.cloneUrl,
+          second,
+          'primary-read',
+        ),
+      ).resolves.toContain('refs/heads/main');
+
+      expect(fixture.stats('e2e-owner').invalidations).toEqual([
+        {
+          key: 'primary-read',
+          repository: 'e2e-owner/repository',
+          generation: first.generation,
+        },
+      ]);
     } finally {
       await fixture.close();
       await rm(workingDirectory, {recursive: true, force: true});

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.test.ts
@@ -4,7 +4,11 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {promisify} from 'node:util';
 import type {CheckoutCredentials} from '@shipfox/api-integration-spi';
-import {createTestVcsFixture, isValidTestVcsBranchName} from '#providers/test-vcs-fixture.js';
+import {
+  createTestVcsFixture,
+  isValidTestVcsBranchName,
+  isValidTestVcsRefreshTiming,
+} from '#providers/test-vcs-fixture.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -63,6 +67,10 @@ describe('Test VCS smart HTTP fixture', () => {
   it('uses Git-compatible branch validation for the API schema', () => {
     expect(isValidTestVcsBranchName('feature]')).toBe(true);
     expect(isValidTestVcsBranchName('feature[')).toBe(false);
+  });
+
+  it('rejects a refresh deadline at the effective millisecond expiry', () => {
+    expect(isValidTestVcsRefreshTiming(0.0505, 0.05)).toBe(false);
   });
 
   it('rejects refresh timing whose minimum delay reaches credential expiry', async () => {

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.ts
@@ -31,6 +31,7 @@ const MAX_TEST_VCS_FILE_BYTES = MAX_REPOSITORY_FILE_BYTES * 2;
 const REPOSITORY_PART_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
 const GIT_TREE_FIELD_PATTERN = /\s+/u;
 const GIT_REPOSITORY_PATH_PATTERN = /^\/([^/]+)\/([^/]+)\.git(?:\/|$)/u;
+const MINIMUM_REFRESH_DELAY_MS = 50;
 
 export type TestVcsRenewalMode = 'refresh-at' | 'on-rejection';
 
@@ -101,6 +102,16 @@ export interface TestVcsFixture {
   resolveRef(input: {owner: string; name: string; ref: string}): Promise<ResolvedRef>;
   issueCredential(input: TestVcsCredentialInput): CheckoutCredentials;
   stats(owner?: string): TestVcsStats;
+}
+
+export function isValidTestVcsRefreshTiming(
+  ttlSeconds: number,
+  refreshAfterSeconds?: number,
+): boolean {
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) return false;
+  const requestedDelaySeconds = refreshAfterSeconds ?? ttlSeconds / 2;
+  if (!Number.isFinite(requestedDelaySeconds) || requestedDelaySeconds <= 0) return false;
+  return refreshDelayMilliseconds(ttlSeconds, refreshAfterSeconds) < ttlSeconds * 1000;
 }
 
 interface RepositoryRecord {
@@ -311,6 +322,12 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
       ) {
         throw new Error('Test VCS refresh delay must be between zero and the credential TTL');
       }
+      if (
+        input.renewalMode === 'refresh-at' &&
+        !isValidTestVcsRefreshTiming(input.ttlSeconds, input.refreshAfterSeconds)
+      ) {
+        throw new Error('Test VCS refresh delay must precede credential expiry');
+      }
       let generation = randomUUID();
       while (generation === input.rejectedGeneration) generation = randomUUID();
       const token = `test-vcs-${randomUUID()}`;
@@ -330,11 +347,7 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
           ? {
               mode: 'refresh-at',
               refreshAt: new Date(
-                now +
-                  Math.max(
-                    50,
-                    Math.floor((input.refreshAfterSeconds ?? input.ttlSeconds / 2) * 1000),
-                  ),
+                now + refreshDelayMilliseconds(input.ttlSeconds, input.refreshAfterSeconds),
               ),
             }
           : {mode: 'on-rejection'};
@@ -520,6 +533,16 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
   }
 
   return fixture;
+}
+
+function refreshDelayMilliseconds(
+  ttlSeconds: number,
+  refreshAfterSeconds?: number | undefined,
+): number {
+  return Math.max(
+    MINIMUM_REFRESH_DELAY_MS,
+    Math.floor((refreshAfterSeconds ?? ttlSeconds / 2) * 1000),
+  );
 }
 
 export function createTestVcsFixtureService(fixture: TestVcsFixture): ModuleService {

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.ts
@@ -111,7 +111,7 @@ export function isValidTestVcsRefreshTiming(
   if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) return false;
   const requestedDelaySeconds = refreshAfterSeconds ?? ttlSeconds / 2;
   if (!Number.isFinite(requestedDelaySeconds) || requestedDelaySeconds <= 0) return false;
-  return refreshDelayMilliseconds(ttlSeconds, refreshAfterSeconds) < ttlSeconds * 1000;
+  return refreshDelayMilliseconds(ttlSeconds, refreshAfterSeconds) < Math.floor(ttlSeconds * 1000);
 }
 
 interface RepositoryRecord {

--- a/libs/api/integration/core/src/providers/test-vcs-fixture.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-fixture.ts
@@ -24,6 +24,7 @@ import type {ModuleService} from '@shipfox/node-module';
 const execFileAsync = promisify(execFile);
 const TEST_VCS_USERNAME = 'x-access-token';
 const TEST_VCS_REALM = 'shipfox-test-vcs';
+const TEST_VCS_INVALIDATE_GENERATION_HEADER = 'x-shipfox-test-vcs-invalidate-generation';
 const GIT_BACKEND_TIMEOUT_MS = 60_000;
 const MAX_GIT_OUTPUT_BYTES = 8 * 1024 * 1024;
 const MAX_TEST_VCS_FILE_BYTES = MAX_REPOSITORY_FILE_BYTES * 2;
@@ -58,6 +59,7 @@ export interface TestVcsCredentialInput {
   permissions: CheckoutPermissions;
   renewalMode: TestVcsRenewalMode;
   ttlSeconds: number;
+  refreshAfterSeconds?: number | undefined;
   rejectedGeneration?: string | undefined;
 }
 
@@ -67,6 +69,11 @@ export interface TestVcsStats {
   acceptedRequestCount: number;
   rejectedRequestCount: number;
   generations: string[];
+  invalidations: Array<{
+    key: string;
+    repository: string;
+    generation: string;
+  }>;
   requests: Array<{
     method: string;
     path: string;
@@ -120,10 +127,20 @@ interface GitHttpRequest {
   owner?: string | undefined;
 }
 
+interface CredentialInvalidation {
+  owner: string;
+  name: string;
+  key: string;
+  generation: string;
+}
+
 export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
   const repositories = new Map<string, RepositoryRecord>();
   const credentials = new Map<string, CredentialRecord>();
   const requests: GitHttpRequest[] = [];
+  const invalidatedGenerations = new Set<string>();
+  const consumedInvalidationKeys = new Set<string>();
+  const invalidations: CredentialInvalidation[] = [];
   const children = new Set<ChildProcess>();
   const childExitPromises = new Map<ChildProcess, Promise<number>>();
   let rootPath: string | undefined;
@@ -172,6 +189,9 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
       repositories.clear();
       credentials.clear();
       requests.length = 0;
+      invalidatedGenerations.clear();
+      consumedInvalidationKeys.clear();
+      invalidations.length = 0;
     },
 
     async createRepository(input) {
@@ -283,6 +303,14 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
       if (!Number.isFinite(input.ttlSeconds) || input.ttlSeconds <= 0) {
         throw new Error('Test VCS credential TTL must be greater than zero');
       }
+      if (
+        input.refreshAfterSeconds !== undefined &&
+        (!Number.isFinite(input.refreshAfterSeconds) ||
+          input.refreshAfterSeconds <= 0 ||
+          input.refreshAfterSeconds >= input.ttlSeconds)
+      ) {
+        throw new Error('Test VCS refresh delay must be between zero and the credential TTL');
+      }
       let generation = randomUUID();
       while (generation === input.rejectedGeneration) generation = randomUUID();
       const token = `test-vcs-${randomUUID()}`;
@@ -301,7 +329,13 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
         input.renewalMode === 'refresh-at'
           ? {
               mode: 'refresh-at',
-              refreshAt: new Date(now + Math.max(50, Math.floor(input.ttlSeconds * 500))),
+              refreshAt: new Date(
+                now +
+                  Math.max(
+                    50,
+                    Math.floor((input.refreshAfterSeconds ?? input.ttlSeconds / 2) * 1000),
+                  ),
+              ),
             }
           : {mode: 'on-rejection'};
       return {
@@ -316,6 +350,10 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
     stats(owner) {
       const selected =
         owner === undefined ? requests : requests.filter((request) => request.owner === owner);
+      const selectedInvalidations =
+        owner === undefined
+          ? invalidations
+          : invalidations.filter((invalidation) => invalidation.owner === owner);
       const generations = [...credentials.values()]
         .filter((credential) => owner === undefined || credential.owner === owner)
         .map((credential) => credential.generation);
@@ -327,6 +365,11 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
         acceptedRequestCount: selected.filter((request) => request.status === 'accepted').length,
         rejectedRequestCount: selected.filter((request) => request.status === 'rejected').length,
         generations,
+        invalidations: selectedInvalidations.map(({owner, name, key, generation}) => ({
+          key,
+          repository: repositoryKey(owner, name),
+          generation,
+        })),
         requests: selected.map(({method, path, status, generation}) => ({
           method,
           path,
@@ -357,26 +400,23 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
       return;
     }
 
-    const credential = findCredential(request.headers.authorization);
-    const needsWrite =
-      requestUrl.pathname.endsWith('/git-receive-pack') ||
-      requestUrl.searchParams.get('service') === 'git-receive-pack';
-    const credentialUsable =
-      credential !== undefined &&
-      credential.owner === location.owner &&
-      credential.name === location.name &&
-      credential.expiresAt > Date.now() &&
-      (credential.permissions.contents === 'write' || !needsWrite);
+    const {presentedCredential, usableCredential} = authenticateGitRequest(
+      request,
+      requestUrl,
+      location,
+    );
     const requestRecord = {
       method: request.method ?? 'GET',
       path: request.url ?? '/',
       owner: location.owner,
     };
-    if (!credentialUsable) {
+    if (usableCredential === undefined) {
       requests.push({
         ...requestRecord,
         status: 'rejected',
-        ...(credential?.generation === undefined ? {} : {generation: credential.generation}),
+        ...(presentedCredential?.generation === undefined
+          ? {}
+          : {generation: presentedCredential.generation}),
       });
       request.resume();
       response.writeHead(401, {'www-authenticate': `Basic realm="${TEST_VCS_REALM}"`});
@@ -387,7 +427,7 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
     requests.push({
       ...requestRecord,
       status: 'accepted',
-      generation: credential.generation,
+      generation: usableCredential.generation,
     });
     await proxyToGitHttpBackend(
       request,
@@ -408,6 +448,53 @@ export function createTestVcsFixture(options: {port: number}): TestVcsFixture {
     return [...credentials.values()].find(
       (candidate) => candidate.username === username && candidate.token === token,
     );
+  }
+
+  function authenticateGitRequest(
+    request: IncomingMessage,
+    requestUrl: URL,
+    location: {owner: string; name: string},
+  ): {
+    presentedCredential: CredentialRecord | undefined;
+    usableCredential: CredentialRecord | undefined;
+  } {
+    const credential = findCredential(request.headers.authorization);
+    const needsWrite =
+      requestUrl.pathname.endsWith('/git-receive-pack') ||
+      requestUrl.searchParams.get('service') === 'git-receive-pack';
+    const credentialInScope =
+      credential !== undefined &&
+      credential.owner === location.owner &&
+      credential.name === location.name &&
+      credential.expiresAt > Date.now() &&
+      (credential.permissions.contents === 'write' || !needsWrite);
+    invalidateCredentialGeneration(
+      credentialInScope ? credential : undefined,
+      location,
+      request.headers[TEST_VCS_INVALIDATE_GENERATION_HEADER],
+    );
+    return {
+      presentedCredential: credential,
+      usableCredential:
+        credentialInScope && !invalidatedGenerations.has(credential.generation)
+          ? credential
+          : undefined,
+    };
+  }
+
+  function invalidateCredentialGeneration(
+    credential: CredentialRecord | undefined,
+    location: {owner: string; name: string},
+    header: string | string[] | undefined,
+  ): void {
+    if (credential === undefined) return;
+    const key = parseInvalidationKey(header);
+    if (key === undefined) return;
+    const scopedKey = `${repositoryKey(location.owner, location.name)}\u0000${key}`;
+    if (consumedInvalidationKeys.has(scopedKey)) return;
+    consumedInvalidationKeys.add(scopedKey);
+    invalidatedGenerations.add(credential.generation);
+    invalidations.push({...location, key, generation: credential.generation});
   }
 
   function requireRoot(): string {
@@ -515,6 +602,10 @@ function repositorySnapshot(input: {
 
 function repositoryKey(owner: string, name: string): string {
   return `${owner}/${name}`;
+}
+
+function parseInvalidationKey(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' && REPOSITORY_PART_PATTERN.test(value) ? value : undefined;
 }
 
 function assertRepositoryPart(value: string, label: string): void {

--- a/libs/api/integration/core/src/providers/test-vcs-runtime.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-runtime.ts
@@ -1,6 +1,8 @@
 import {
+  createE2eTestVcsConnectionBodySchema,
   integrationConnectionDtoSchema,
   repositoryDtoSchema,
+  testVcsStatsDtoSchema,
 } from '@shipfox/api-integration-core-dto';
 import type {IntegrationConnection as SpiIntegrationConnection} from '@shipfox/api-integration-spi';
 import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
@@ -24,6 +26,7 @@ import {
   createTestVcsFixture,
   createTestVcsFixtureService,
   isValidTestVcsBranchName,
+  isValidTestVcsRefreshTiming,
   type TestVcsFileInput,
   type TestVcsRenewalMode,
 } from '#providers/test-vcs-fixture.js';
@@ -40,23 +43,24 @@ const branchNameSchema = z
   .max(200)
   .refine(isValidTestVcsBranchName, {message: 'must be a valid Git branch name'});
 const fileSchema = z.object({path: z.string().min(1).max(512), content: z.string()}).strict();
-const renewalModeSchema = z.enum(['refresh-at', 'on-rejection']);
-const createConnectionBodySchema = z
-  .object({
-    workspace_id: z.string().uuid(),
-    account_id: repositoryPartSchema,
-    display_name: z.string().min(1).max(200).optional(),
-    renewal_mode: renewalModeSchema.default('on-rejection'),
-    refresh_after_seconds: z.number().positive().max(300).optional(),
-  })
-  .strict()
-  .refine(
-    (body) => body.refresh_after_seconds === undefined || body.renewal_mode === 'refresh-at',
-    {
-      message: 'refresh_after_seconds requires refresh-at renewal mode',
+const createConnectionBodySchema = createE2eTestVcsConnectionBodySchema.superRefine(
+  (body, context) => {
+    if (body.renewal_mode !== 'refresh-at') return;
+    if (
+      isValidTestVcsRefreshTiming(
+        config.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS,
+        body.refresh_after_seconds,
+      )
+    ) {
+      return;
+    }
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
       path: ['refresh_after_seconds'],
-    },
-  );
+      message: 'refresh_after_seconds must produce a deadline before credential expiry',
+    });
+  },
+);
 const createRepositoryBodySchema = z
   .object({
     connection_id: z.string().uuid(),
@@ -74,34 +78,6 @@ const commitFilesBodySchema = z
   })
   .strict();
 const statsQuerySchema = z.object({connection_id: z.string().uuid().optional()}).strict();
-const statsResponseSchema = z
-  .object({
-    mint_count: z.number().int().nonnegative(),
-    request_count: z.number().int().nonnegative(),
-    accepted_request_count: z.number().int().nonnegative(),
-    rejected_request_count: z.number().int().nonnegative(),
-    generations: z.array(z.string().min(1)),
-    invalidations: z.array(
-      z
-        .object({
-          key: z.string().min(1),
-          repository: z.string().min(1),
-          generation: z.string().min(1),
-        })
-        .strict(),
-    ),
-    requests: z.array(
-      z
-        .object({
-          method: z.string(),
-          path: z.string(),
-          status: z.enum(['accepted', 'rejected']),
-          generation: z.string().min(1).optional(),
-        })
-        .strict(),
-    ),
-  })
-  .strict();
 const failMintsBodySchema = z.object({count: z.number().int().min(1).max(10)}).strict();
 
 type TestVcsConnection = SpiIntegrationConnection<typeof TEST_VCS_PROVIDER>;
@@ -209,7 +185,7 @@ function createTestVcsRoutes(options: {
         description: 'Read redacted Test VCS fixture observations for E2E assertions.',
         schema: {
           querystring: statsQuerySchema,
-          response: {200: statsResponseSchema},
+          response: {200: testVcsStatsDtoSchema},
         },
         handler: async (request) => {
           const owner =

--- a/libs/api/integration/core/src/providers/test-vcs-runtime.ts
+++ b/libs/api/integration/core/src/providers/test-vcs-runtime.ts
@@ -47,8 +47,16 @@ const createConnectionBodySchema = z
     account_id: repositoryPartSchema,
     display_name: z.string().min(1).max(200).optional(),
     renewal_mode: renewalModeSchema.default('on-rejection'),
+    refresh_after_seconds: z.number().positive().max(300).optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (body) => body.refresh_after_seconds === undefined || body.renewal_mode === 'refresh-at',
+    {
+      message: 'refresh_after_seconds requires refresh-at renewal mode',
+      path: ['refresh_after_seconds'],
+    },
+  );
 const createRepositoryBodySchema = z
   .object({
     connection_id: z.string().uuid(),
@@ -73,6 +81,15 @@ const statsResponseSchema = z
     accepted_request_count: z.number().int().nonnegative(),
     rejected_request_count: z.number().int().nonnegative(),
     generations: z.array(z.string().min(1)),
+    invalidations: z.array(
+      z
+        .object({
+          key: z.string().min(1),
+          repository: z.string().min(1),
+          generation: z.string().min(1),
+        })
+        .strict(),
+    ),
     requests: z.array(
       z
         .object({
@@ -135,7 +152,12 @@ function createTestVcsRoutes(options: {
             displayName: request.body.display_name ?? `Test VCS ${request.body.account_id}`,
             capabilities: options.connectionCapabilities,
           });
-          options.sourceControl.configureConnection(connection.id, request.body.renewal_mode);
+          options.sourceControl.configureConnection(connection.id, {
+            renewalMode: request.body.renewal_mode,
+            ...(request.body.refresh_after_seconds === undefined
+              ? {}
+              : {refreshAfterSeconds: request.body.refresh_after_seconds}),
+          });
           reply.code(201);
           return toIntegrationConnectionDto(connection, {
             capabilities: options.connectionCapabilities,
@@ -201,6 +223,7 @@ function createTestVcsRoutes(options: {
             accepted_request_count: stats.acceptedRequestCount,
             rejected_request_count: stats.rejectedRequestCount,
             generations: stats.generations,
+            invalidations: stats.invalidations,
             requests: stats.requests,
           };
         },

--- a/libs/api/integration/core/src/providers/test-vcs.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.test.ts
@@ -139,6 +139,32 @@ describe('Test VCS source-control provider', () => {
     );
   });
 
+  it('isolates cached and in-flight credentials when a connection is reconfigured', async () => {
+    const issueCredential = vi.fn((input: {renewalMode: 'refresh-at' | 'on-rejection'}) =>
+      credential(input.renewalMode),
+    );
+    const provider = providerFixture({issueCredential});
+    provider.configureConnection(connection.id, {renewalMode: 'on-rejection'});
+
+    const previousPolicy = provider.createCheckoutCredentials(checkoutInput());
+    provider.configureConnection(connection.id, {
+      renewalMode: 'refresh-at',
+      refreshAfterSeconds: 1,
+    });
+    const currentPolicy = provider.createCheckoutCredentials(checkoutInput());
+
+    await expect(previousPolicy).resolves.toMatchObject({generation: 'on-rejection'});
+    await expect(currentPolicy).resolves.toMatchObject({generation: 'refresh-at'});
+    await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toMatchObject({
+      generation: 'refresh-at',
+    });
+    expect(issueCredential).toHaveBeenCalledTimes(2);
+    expect(issueCredential).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({renewalMode: 'refresh-at', refreshAfterSeconds: 1}),
+    );
+  });
+
   it('replaces a cached refresh-at credential after its refresh deadline', async () => {
     const dueForRefresh = {
       ...credential('generation-a'),
@@ -155,6 +181,33 @@ describe('Test VCS source-control provider', () => {
     await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toBe(refreshed);
 
     expect(issueCredential).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses a refresh-at credential until its future refresh deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      const initial = {
+        ...credential('generation-a'),
+        renewal: {
+          mode: 'refresh-at' as const,
+          refreshAt: new Date('2026-01-01T00:00:01.000Z'),
+        },
+      };
+      const refreshed = credential('generation-b');
+      const issueCredential = vi.fn().mockReturnValueOnce(initial).mockReturnValueOnce(refreshed);
+      const provider = providerFixture({issueCredential});
+
+      await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toBe(initial);
+      vi.advanceTimersByTime(999);
+      await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toBe(initial);
+      vi.advanceTimersByTime(1);
+      await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toBe(refreshed);
+
+      expect(issueCredential).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('supplies the provider author for write checkouts', async () => {

--- a/libs/api/integration/core/src/providers/test-vcs.test.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.test.ts
@@ -121,6 +121,42 @@ describe('Test VCS source-control provider', () => {
     expect(issueCredential).toHaveBeenCalledTimes(2);
   });
 
+  it('applies connection-specific refresh timing to minted credentials', async () => {
+    const issueCredential = vi.fn().mockReturnValue(credential('generation-a'));
+    const provider = providerFixture({issueCredential});
+    provider.configureConnection(connection.id, {
+      renewalMode: 'refresh-at',
+      refreshAfterSeconds: 1,
+    });
+
+    await provider.createCheckoutCredentials(checkoutInput());
+
+    expect(issueCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renewalMode: 'refresh-at',
+        refreshAfterSeconds: 1,
+      }),
+    );
+  });
+
+  it('replaces a cached refresh-at credential after its refresh deadline', async () => {
+    const dueForRefresh = {
+      ...credential('generation-a'),
+      renewal: {mode: 'refresh-at' as const, refreshAt: new Date(0)},
+    };
+    const refreshed = credential('generation-b');
+    const issueCredential = vi
+      .fn()
+      .mockReturnValueOnce(dueForRefresh)
+      .mockReturnValueOnce(refreshed);
+    const provider = providerFixture({issueCredential});
+
+    await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toBe(dueForRefresh);
+    await expect(provider.createCheckoutCredentials(checkoutInput())).resolves.toBe(refreshed);
+
+    expect(issueCredential).toHaveBeenCalledTimes(2);
+  });
+
   it('supplies the provider author for write checkouts', async () => {
     const provider = providerFixture({
       issueCredential: vi.fn().mockReturnValue(credential('write')),

--- a/libs/api/integration/core/src/providers/test-vcs.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.ts
@@ -41,16 +41,21 @@ export interface TestVcsSourceControlProviderOptions {
   credentialTtlSeconds: number;
 }
 
+export interface TestVcsConnectionConfiguration {
+  renewalMode: TestVcsRenewalMode;
+  refreshAfterSeconds?: number | undefined;
+}
+
 export class TestVcsSourceControlProvider implements SourceControlProvider<TestVcsConnection> {
-  private readonly renewalModes = new Map<string, TestVcsRenewalMode>();
+  private readonly connectionConfigurations = new Map<string, TestVcsConnectionConfiguration>();
   private readonly cachedCredentials = new Map<string, CheckoutCredentials>();
   private readonly mintFlights = new Map<string, Promise<CheckoutCredentials>>();
   private failNextMintCount = 0;
 
   constructor(private readonly options: TestVcsSourceControlProviderOptions) {}
 
-  configureConnection(connectionId: string, renewalMode: TestVcsRenewalMode): void {
-    this.renewalModes.set(connectionId, renewalMode);
+  configureConnection(connectionId: string, configuration: TestVcsConnectionConfiguration): void {
+    this.connectionConfigurations.set(connectionId, configuration);
   }
 
   failNextCredentialMints(count: number): void {
@@ -239,11 +244,15 @@ export class TestVcsSourceControlProvider implements SourceControlProvider<TestV
         'Test VCS credential minting is unavailable',
       );
     }
+    const configuration = this.connectionConfigurations.get(input.connection.id);
     const credential = this.options.fixture.issueCredential({
       ...locator,
       permissions: input.permissions,
-      renewalMode: this.renewalModes.get(input.connection.id) ?? 'on-rejection',
+      renewalMode: configuration?.renewalMode ?? 'on-rejection',
       ttlSeconds: this.options.credentialTtlSeconds,
+      ...(configuration?.refreshAfterSeconds === undefined
+        ? {}
+        : {refreshAfterSeconds: configuration.refreshAfterSeconds}),
       rejectedGeneration: input.rejectedGeneration,
     });
     this.cachedCredentials.set(cacheKey, credential);
@@ -347,5 +356,11 @@ function credentialCacheKey(
 }
 
 function isReusableCredential(credential: CheckoutCredentials, ttlSeconds: number): boolean {
+  if (
+    credential.renewal?.mode === 'refresh-at' &&
+    credential.renewal.refreshAt.getTime() <= Date.now()
+  ) {
+    return false;
+  }
   return credential.expiresAt.getTime() > Date.now() + Math.max(50, ttlSeconds * 500);
 }

--- a/libs/api/integration/core/src/providers/test-vcs.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.ts
@@ -55,7 +55,12 @@ export class TestVcsSourceControlProvider implements SourceControlProvider<TestV
   constructor(private readonly options: TestVcsSourceControlProviderOptions) {}
 
   configureConnection(connectionId: string, configuration: TestVcsConnectionConfiguration): void {
-    this.connectionConfigurations.set(connectionId, configuration);
+    this.connectionConfigurations.set(connectionId, {
+      renewalMode: configuration.renewalMode,
+      ...(configuration.refreshAfterSeconds === undefined
+        ? {}
+        : {refreshAfterSeconds: configuration.refreshAfterSeconds}),
+    });
   }
 
   failNextCredentialMints(count: number): void {
@@ -175,7 +180,15 @@ export class TestVcsSourceControlProvider implements SourceControlProvider<TestV
     const target = normalizeTarget(input);
     const locator = this.repositoryLocator(input.connection, target);
     this.requireRepository(locator);
-    const cacheKey = credentialCacheKey(input.connection, locator, input.permissions);
+    const configuration = this.connectionConfigurations.get(input.connection.id) ?? {
+      renewalMode: 'on-rejection',
+    };
+    const cacheKey = credentialCacheKey(
+      input.connection,
+      locator,
+      input.permissions,
+      configuration,
+    );
     for (;;) {
       const cached = this.cachedCredentials.get(cacheKey);
       if (
@@ -194,7 +207,7 @@ export class TestVcsSourceControlProvider implements SourceControlProvider<TestV
       }
 
       const operation = Promise.resolve()
-        .then(() => this.mintCredential(input, locator, cacheKey))
+        .then(() => this.mintCredential(input, locator, cacheKey, configuration))
         .finally(() => {
           if (this.mintFlights.get(cacheKey) === operation) this.mintFlights.delete(cacheKey);
         });
@@ -236,6 +249,7 @@ export class TestVcsSourceControlProvider implements SourceControlProvider<TestV
     input: CreateCheckoutCredentialsInput<TestVcsConnection>,
     locator: {owner: string; name: string},
     cacheKey: string,
+    configuration: TestVcsConnectionConfiguration,
   ): Promise<CheckoutCredentials> {
     if (this.failNextMintCount > 0) {
       this.failNextMintCount -= 1;
@@ -244,13 +258,12 @@ export class TestVcsSourceControlProvider implements SourceControlProvider<TestV
         'Test VCS credential minting is unavailable',
       );
     }
-    const configuration = this.connectionConfigurations.get(input.connection.id);
     const credential = this.options.fixture.issueCredential({
       ...locator,
       permissions: input.permissions,
-      renewalMode: configuration?.renewalMode ?? 'on-rejection',
+      renewalMode: configuration.renewalMode,
       ttlSeconds: this.options.credentialTtlSeconds,
-      ...(configuration?.refreshAfterSeconds === undefined
+      ...(configuration.refreshAfterSeconds === undefined
         ? {}
         : {refreshAfterSeconds: configuration.refreshAfterSeconds}),
       rejectedGeneration: input.rejectedGeneration,
@@ -345,13 +358,16 @@ function credentialCacheKey(
   connection: TestVcsConnection,
   locator: {owner: string; name: string},
   permissions: CheckoutPermissions,
+  configuration: TestVcsConnectionConfiguration,
 ): string {
   return JSON.stringify({
+    connectionId: connection.id,
     workspaceId: connection.workspaceId,
     provider: connection.provider,
     accountId: connection.externalAccountId,
     repository: `${locator.owner}/${locator.name}`,
     permissions,
+    configuration,
   });
 }
 


### PR DESCRIPTION
## Context

The renewable credential E2E scenario relied on a 10-second token expiry. CI scheduling could change which Git command observed expiry, so exact mint-count assertions raced against wall-clock timing.

## Change

The Test VCS fixture now supports a one-shot generation invalidation signal with redacted observations. The on-rejection scenario invalidates the primary read, secondary read, and primary push credentials in order. It proves that each rejected generation is replaced before the matching Git operation succeeds.

The refresh-at scenario uses an explicit early refresh deadline. Ordinary Test VCS credentials remain valid beyond the full workflow budget. Each repeated rejection scenario also gets an isolated connection, which keeps concurrent statistics independent.

## Verification

Affected package check, type, and unit-test tasks passed (394 tasks). The rejection scenario passed 10 of 10 repetitions with three Playwright workers. The complete workflow E2E suite passed all 50 tests.

Closes ENG-1933

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes renewable credential E2E tests deterministic by replacing wall-clock expiry waits with explicit invalidation and refresh deadlines. Tests now verify credential replacement without depending on CI timing.

- The Test VCS fixture accepts one-shot `X-Shipfox-Test-Vcs-Invalidate-Generation` headers and records redacted invalidations.
- The rejection workflow invalidates primary read, secondary read, and primary push credentials in order, then verifies each generation is replaced before the operation succeeds.
- Refresh-at delays use millisecond-precise deadlines that must precede credential expiry; caching is scoped by connection and renewal configuration.
- Isolated E2E connections are cleaned up after each test, and the default credential TTL increases from 10 to 600 seconds.
- Shared setup and stats DTOs now live in `@shipfox/api-integration-core-dto`, with validation for renewal settings and refresh timing.

Closes ENG-1933.

<sup>Written for commit 11182986e30c4f199e1a770ea039f2bc7f8b8f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

