### PR TITLE
[docs] Publish canonical discovery signals

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,6 +21,7 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@shipfox/config": "workspace:*",
     "@shipfox/workflow-document": "workspace:*",
     "fumadocs-core": "catalog:",
     "fumadocs-mdx": "catalog:",

--- a/apps/docs/src/app/(home)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(home)/[[...slug]]/page.tsx
@@ -5,7 +5,7 @@ import {notFound} from 'next/navigation';
 import {PageFeedback} from '@/app/components/page-feedback';
 import {source} from '@/lib/source';
 import {getMDXComponents} from '@/mdx-components';
-import {toUrl, url} from '@/url';
+import {toMarkdownUrl, toUrl, url} from '@/url';
 
 export default async function Page(props: {params: Promise<{slug?: string[]}>}) {
   const params = await props.params;
@@ -42,6 +42,7 @@ export async function generateMetadata(props: {
   if (!page) notFound();
 
   const title = `${page.data.title} | Shipfox`;
+  const canonicalUrl = toUrl(page.url);
   // toUrl carries the /docs basePath, which Next does not apply to manually
   // built metadata URLs.
   const image = toUrl('/shipfox-og.jpg');
@@ -49,9 +50,14 @@ export async function generateMetadata(props: {
     title,
     description: page.data.description,
     metadataBase: new URL(url),
+    alternates: {
+      canonical: canonicalUrl,
+      types: {'text/markdown': toMarkdownUrl(page.url)},
+    },
     openGraph: {
       title,
       description: page.data.description,
+      url: canonicalUrl,
       images: [
         {
           url: image,

--- a/apps/docs/src/app/(home)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(home)/[[...slug]]/page.tsx
@@ -3,9 +3,9 @@ import {DocsBody, DocsDescription, DocsPage, DocsTitle} from 'fumadocs-ui/page';
 import type {Metadata} from 'next';
 import {notFound} from 'next/navigation';
 import {PageFeedback} from '@/app/components/page-feedback';
+import {buildPageMetadata} from '@/lib/page-metadata';
 import {source} from '@/lib/source';
 import {getMDXComponents} from '@/mdx-components';
-import {toMarkdownUrl, toUrl, url} from '@/url';
 
 export default async function Page(props: {params: Promise<{slug?: string[]}>}) {
   const params = await props.params;
@@ -41,45 +41,5 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
-  const title = `${page.data.title} | Shipfox`;
-  const canonicalUrl = toUrl(page.url);
-  // toUrl carries the /docs basePath, which Next does not apply to manually
-  // built metadata URLs.
-  const image = toUrl('/shipfox-og.jpg');
-  return {
-    title,
-    description: page.data.description,
-    metadataBase: new URL(url),
-    alternates: {
-      canonical: canonicalUrl,
-      types: {'text/markdown': toMarkdownUrl(page.url)},
-    },
-    openGraph: {
-      title,
-      description: page.data.description,
-      url: canonicalUrl,
-      images: [
-        {
-          url: image,
-          width: 1200,
-          height: 630,
-          alt: 'Shipfox: Your AI software factory',
-        },
-      ],
-      siteName: 'Shipfox',
-      type: 'website',
-      locale: 'en_US',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      images: [
-        {
-          url: image,
-          width: 1200,
-          height: 630,
-          alt: 'Shipfox: Your AI software factory',
-        },
-      ],
-    },
-  };
+  return buildPageMetadata(page);
 }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -18,9 +18,6 @@ const commitMono = localFont({
 export default function Layout({children}: {children: ReactNode}) {
   return (
     <html lang="en" className={commitMono.variable} suppressHydrationWarning>
-      <head>
-        <link rel="alternate" type="text/markdown" href="/llms.txt" />
-      </head>
       <body className="flex flex-col min-h-screen">
         <DocsAnalyticsTracker />
         {/* The search client fetches this URL as-is; Next does not apply basePath to

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -35,7 +35,7 @@ export function loadConfig(update?: Partial<NodeJS.ProcessEnv>): DocsConfig {
       }),
     },
     update,
-  ) as DocsConfig;
+  ) as unknown as DocsConfig;
 }
 
 // Next replaces this public env access with the `env` value from next.config.mjs

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -5,6 +5,7 @@ export type DocsConfig = {
   VERCEL_URL: string | undefined;
   NEXT_PUBLIC_VERCEL_ENV: 'development' | 'preview' | 'production' | undefined;
   NEXT_PUBLIC_VERCEL_URL: string | undefined;
+  NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: string | undefined;
   NEXT_PUBLIC_BASE_PATH: string;
 };
 
@@ -29,6 +30,10 @@ export function loadConfig(update?: Partial<NodeJS.ProcessEnv>): DocsConfig {
         default: undefined,
         desc: 'Public hostname of the current Vercel deployment used when the server variable is unavailable.',
       }),
+      NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: host({
+        default: undefined,
+        desc: 'Public hostname of the Vercel project production deployment used for canonical docs URLs.',
+      }),
       NEXT_PUBLIC_BASE_PATH: str({
         default: '',
         desc: 'Path prefix applied to externally generated docs URLs, such as /docs in production.',
@@ -39,9 +44,17 @@ export function loadConfig(update?: Partial<NodeJS.ProcessEnv>): DocsConfig {
 }
 
 // Next replaces this public env access with the `env` value from next.config.mjs
-// at build time. Pass that value explicitly so the runtime config keeps the
-// production `/docs` prefix after validation.
+// at build time. Pass these values explicitly so the runtime config keeps the
+// production path and canonical origin after validation.
 const nextBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+const nextProjectProductionUrl = process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
 export const config = loadConfig(
-  nextBasePath === undefined ? undefined : {NEXT_PUBLIC_BASE_PATH: nextBasePath},
+  nextBasePath === undefined && nextProjectProductionUrl === undefined
+    ? undefined
+    : {
+        ...(nextBasePath === undefined ? {} : {NEXT_PUBLIC_BASE_PATH: nextBasePath}),
+        ...(nextProjectProductionUrl === undefined
+          ? {}
+          : {NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: nextProjectProductionUrl}),
+      },
 );

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -1,6 +1,14 @@
 import {createConfig, host, str} from '@shipfox/config';
 
-export function loadConfig(update?: Partial<NodeJS.ProcessEnv>) {
+export type DocsConfig = {
+  VERCEL_ENV: 'development' | 'preview' | 'production' | undefined;
+  VERCEL_URL: string | undefined;
+  NEXT_PUBLIC_VERCEL_ENV: 'development' | 'preview' | 'production' | undefined;
+  NEXT_PUBLIC_VERCEL_URL: string | undefined;
+  NEXT_PUBLIC_BASE_PATH: string;
+};
+
+export function loadConfig(update?: Partial<NodeJS.ProcessEnv>): DocsConfig {
   return createConfig(
     {
       VERCEL_ENV: str({
@@ -27,7 +35,13 @@ export function loadConfig(update?: Partial<NodeJS.ProcessEnv>) {
       }),
     },
     update,
-  );
+  ) as DocsConfig;
 }
 
-export const config = loadConfig();
+// Next replaces this public env access with the `env` value from next.config.mjs
+// at build time. Pass that value explicitly so the runtime config keeps the
+// production `/docs` prefix after validation.
+const nextBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+export const config = loadConfig(
+  nextBasePath === undefined ? undefined : {NEXT_PUBLIC_BASE_PATH: nextBasePath},
+);

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -1,0 +1,33 @@
+import {createConfig, host, str} from '@shipfox/config';
+
+export function loadConfig(update?: Partial<NodeJS.ProcessEnv>) {
+  return createConfig(
+    {
+      VERCEL_ENV: str({
+        choices: ['development', 'preview', 'production'],
+        default: undefined,
+        desc: 'Vercel deployment environment used to choose the canonical docs origin.',
+      }),
+      VERCEL_URL: host({
+        default: undefined,
+        desc: 'Hostname of the current Vercel deployment used for preview docs URLs.',
+      }),
+      NEXT_PUBLIC_VERCEL_ENV: str({
+        choices: ['development', 'preview', 'production'],
+        default: undefined,
+        desc: 'Public Vercel deployment environment used when the server variable is unavailable.',
+      }),
+      NEXT_PUBLIC_VERCEL_URL: host({
+        default: undefined,
+        desc: 'Public hostname of the current Vercel deployment used when the server variable is unavailable.',
+      }),
+      NEXT_PUBLIC_BASE_PATH: str({
+        default: '',
+        desc: 'Path prefix applied to externally generated docs URLs, such as /docs in production.',
+      }),
+    },
+    update,
+  );
+}
+
+export const config = loadConfig();

--- a/apps/docs/src/lib/page-metadata.ts
+++ b/apps/docs/src/lib/page-metadata.ts
@@ -1,0 +1,58 @@
+import type {Metadata} from 'next';
+import {basePath, toMarkdownUrl, toUrl, url} from '@/url';
+
+type DocsPage = {
+  url: string;
+  data: {
+    title: string;
+    description?: string;
+  };
+};
+
+export function buildPageMetadata(
+  page: DocsPage,
+  origin: string = url,
+  prefix: string = basePath,
+): Metadata {
+  const title = `${page.data.title} | Shipfox`;
+  const canonicalUrl = toUrl(page.url, origin, prefix);
+  // toUrl carries the /docs basePath, which Next does not apply to manually
+  // built metadata URLs.
+  const image = toUrl('/shipfox-og.jpg', origin, prefix);
+  return {
+    title,
+    description: page.data.description,
+    metadataBase: new URL(origin),
+    alternates: {
+      canonical: canonicalUrl,
+      types: {'text/markdown': toMarkdownUrl(page.url, origin, prefix)},
+    },
+    openGraph: {
+      title,
+      description: page.data.description,
+      url: canonicalUrl,
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: 'Shipfox: Your AI software factory',
+        },
+      ],
+      siteName: 'Shipfox',
+      type: 'website',
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: 'Shipfox: Your AI software factory',
+        },
+      ],
+    },
+  };
+}

--- a/apps/docs/src/url.test.ts
+++ b/apps/docs/src/url.test.ts
@@ -14,6 +14,16 @@ describe('resolveDocsOrigin', () => {
     );
   });
 
+  it('uses the configured Vercel production host when available', () => {
+    assert.equal(
+      resolveDocsOrigin({
+        VERCEL_ENV: 'production',
+        NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: 'docs-route-check.shipfox.test',
+      }),
+      'https://docs-route-check.shipfox.test',
+    );
+  });
+
   it('uses the deployment host for preview builds', () => {
     assert.equal(
       resolveDocsOrigin({

--- a/apps/docs/src/url.test.ts
+++ b/apps/docs/src/url.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {PUBLIC_DOCS_ORIGIN, resolveDocsOrigin, toMarkdownUrl, toUrl} from './url';
+
+describe('resolveDocsOrigin', () => {
+  it('uses the public docs origin for production builds', () => {
+    assert.equal(
+      resolveDocsOrigin({
+        VERCEL_ENV: 'production',
+        VERCEL_URL: 'shipfox-docs-git-main.vercel.app',
+      }),
+      PUBLIC_DOCS_ORIGIN,
+    );
+  });
+
+  it('uses the deployment host for preview builds', () => {
+    assert.equal(
+      resolveDocsOrigin({
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'shipfox-docs-git-feature.vercel.app',
+      }),
+      'https://shipfox-docs-git-feature.vercel.app',
+    );
+  });
+
+  it('falls back to the local docs origin', () => {
+    assert.equal(resolveDocsOrigin({}), 'http://localhost:3500');
+  });
+});
+
+describe('docs URLs', () => {
+  it('uses index.md for the docs home Markdown alternate', () => {
+    assert.equal(toMarkdownUrl('/'), `${toUrl('/')}index.md`);
+  });
+
+  it('adds the Markdown suffix to page-specific alternates', () => {
+    assert.equal(toMarkdownUrl('/getting-started'), `${toUrl('/getting-started')}.md`);
+  });
+});

--- a/apps/docs/src/url.test.ts
+++ b/apps/docs/src/url.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'node:test';
+import {buildPageMetadata} from './lib/page-metadata';
 import {PUBLIC_DOCS_ORIGIN, resolveDocsOrigin, toMarkdownUrl, toUrl} from './url';
 
 describe('resolveDocsOrigin', () => {
@@ -30,10 +31,59 @@ describe('resolveDocsOrigin', () => {
 
 describe('docs URLs', () => {
   it('uses index.md for the docs home Markdown alternate', () => {
-    assert.equal(toMarkdownUrl('/'), `${toUrl('/')}index.md`);
+    assert.equal(toMarkdownUrl('/'), toUrl('/index.md'));
   });
 
   it('adds the Markdown suffix to page-specific alternates', () => {
     assert.equal(toMarkdownUrl('/getting-started'), `${toUrl('/getting-started')}.md`);
+  });
+
+  it('builds canonical and Markdown URLs with the production path prefix', () => {
+    const productionOrigin = resolveDocsOrigin({
+      VERCEL_ENV: 'production',
+      VERCEL_URL: 'shipfox-docs-git-main.vercel.app',
+    });
+
+    assert.equal(toUrl('/', productionOrigin, '/docs'), `${PUBLIC_DOCS_ORIGIN}/docs`);
+    assert.equal(
+      toMarkdownUrl('/', productionOrigin, '/docs'),
+      `${PUBLIC_DOCS_ORIGIN}/docs/index.md`,
+    );
+    assert.equal(
+      toUrl('/getting-started', productionOrigin, '/docs'),
+      `${PUBLIC_DOCS_ORIGIN}/docs/getting-started`,
+    );
+    assert.equal(
+      toMarkdownUrl('/getting-started', productionOrigin, '/docs'),
+      `${PUBLIC_DOCS_ORIGIN}/docs/getting-started.md`,
+    );
+  });
+
+  it('uses canonical and Markdown alternates in home and nested page metadata', () => {
+    const homeMetadata = buildPageMetadata(
+      {url: '/', data: {title: 'Shipfox', description: 'Home page'}},
+      PUBLIC_DOCS_ORIGIN,
+      '/docs',
+    );
+    const nestedMetadata = buildPageMetadata(
+      {url: '/getting-started', data: {title: 'Getting started', description: 'First steps'}},
+      PUBLIC_DOCS_ORIGIN,
+      '/docs',
+    );
+
+    assert.equal(homeMetadata.alternates?.canonical, `${PUBLIC_DOCS_ORIGIN}/docs`);
+    assert.equal(
+      homeMetadata.alternates?.types?.['text/markdown'],
+      `${PUBLIC_DOCS_ORIGIN}/docs/index.md`,
+    );
+    assert.equal(
+      nestedMetadata.alternates?.canonical,
+      `${PUBLIC_DOCS_ORIGIN}/docs/getting-started`,
+    );
+    assert.equal(
+      nestedMetadata.alternates?.types?.['text/markdown'],
+      `${PUBLIC_DOCS_ORIGIN}/docs/getting-started.md`,
+    );
+    assert.equal(nestedMetadata.openGraph?.url, `${PUBLIC_DOCS_ORIGIN}/docs/getting-started`);
   });
 });

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -6,7 +6,11 @@ export const PUBLIC_DOCS_ORIGIN = 'https://www.shipfox.io';
 type DocsEnvironment = Partial<
   Pick<
     DocsConfig,
-    'VERCEL_ENV' | 'VERCEL_URL' | 'NEXT_PUBLIC_VERCEL_ENV' | 'NEXT_PUBLIC_VERCEL_URL'
+    | 'VERCEL_ENV'
+    | 'VERCEL_URL'
+    | 'NEXT_PUBLIC_VERCEL_ENV'
+    | 'NEXT_PUBLIC_VERCEL_URL'
+    | 'NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL'
   >
 >;
 
@@ -17,7 +21,10 @@ function originFromDeploymentHost(host: string): string {
 
 export function resolveDocsOrigin(environment: DocsEnvironment = config): string {
   const deploymentEnvironment = environment.VERCEL_ENV ?? environment.NEXT_PUBLIC_VERCEL_ENV;
-  if (deploymentEnvironment === 'production') return PUBLIC_DOCS_ORIGIN;
+  if (deploymentEnvironment === 'production') {
+    const productionHost = environment.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
+    return productionHost ? originFromDeploymentHost(productionHost) : PUBLIC_DOCS_ORIGIN;
+  }
 
   const deploymentHost = environment.VERCEL_URL ?? environment.NEXT_PUBLIC_VERCEL_URL;
   if (deploymentHost) return originFromDeploymentHost(deploymentHost);

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -1,19 +1,24 @@
-let host = 'localhost:3500';
-let protocol = 'http';
+const LOCAL_DOCS_ORIGIN = 'http://localhost:3500';
+export const PUBLIC_DOCS_ORIGIN = 'https://www.shipfox.io';
 
-if (process.env.NEXT_PUBLIC_VERCEL_ENV) {
-  protocol = 'https';
-  if (
-    process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' &&
-    process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
-  ) {
-    host = process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
-  } else if (process.env.NEXT_PUBLIC_VERCEL_URL) {
-    host = process.env.NEXT_PUBLIC_VERCEL_URL;
-  }
+type DocsEnvironment = Record<string, string | undefined>;
+
+function originFromDeploymentHost(host: string): string {
+  const value = host.includes('://') ? host : `https://${host}`;
+  return new URL(value).origin;
 }
 
-export const url = `${protocol}://${host}`;
+export function resolveDocsOrigin(environment: DocsEnvironment = process.env): string {
+  const deploymentEnvironment = environment.VERCEL_ENV ?? environment.NEXT_PUBLIC_VERCEL_ENV;
+  if (deploymentEnvironment === 'production') return PUBLIC_DOCS_ORIGIN;
+
+  const deploymentHost = environment.VERCEL_URL ?? environment.NEXT_PUBLIC_VERCEL_URL;
+  if (deploymentHost) return originFromDeploymentHost(deploymentHost);
+
+  return LOCAL_DOCS_ORIGIN;
+}
+
+export const url = resolveDocsOrigin();
 
 // Set from `basePath` in next.config.mjs (via NEXT_PUBLIC_BASE_PATH): `/docs` in
 // production, empty in local dev. Every absolute URL we emit for external consumers
@@ -24,4 +29,9 @@ export const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 export const toUrl = (path: string) => {
   const suffix = path === '/' ? '' : path;
   return new URL(`${basePath}${suffix}`, url).toString();
+};
+
+export const toMarkdownUrl = (path: string) => {
+  const markdownPath = path === '/' ? '/index.md' : `${path}.md`;
+  return toUrl(markdownPath);
 };

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -1,9 +1,8 @@
-import {config, type loadConfig} from './config';
+import {config, type DocsConfig} from './config';
 
 const LOCAL_DOCS_ORIGIN = 'http://localhost:3500';
 export const PUBLIC_DOCS_ORIGIN = 'https://www.shipfox.io';
 
-type DocsConfig = ReturnType<typeof loadConfig>;
 type DocsEnvironment = Partial<
   Pick<
     DocsConfig,

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -1,14 +1,22 @@
+import {config, type loadConfig} from './config';
+
 const LOCAL_DOCS_ORIGIN = 'http://localhost:3500';
 export const PUBLIC_DOCS_ORIGIN = 'https://www.shipfox.io';
 
-type DocsEnvironment = Record<string, string | undefined>;
+type DocsConfig = ReturnType<typeof loadConfig>;
+type DocsEnvironment = Partial<
+  Pick<
+    DocsConfig,
+    'VERCEL_ENV' | 'VERCEL_URL' | 'NEXT_PUBLIC_VERCEL_ENV' | 'NEXT_PUBLIC_VERCEL_URL'
+  >
+>;
 
 function originFromDeploymentHost(host: string): string {
   const value = host.includes('://') ? host : `https://${host}`;
   return new URL(value).origin;
 }
 
-export function resolveDocsOrigin(environment: DocsEnvironment = process.env): string {
+export function resolveDocsOrigin(environment: DocsEnvironment = config): string {
   const deploymentEnvironment = environment.VERCEL_ENV ?? environment.NEXT_PUBLIC_VERCEL_ENV;
   if (deploymentEnvironment === 'production') return PUBLIC_DOCS_ORIGIN;
 
@@ -24,14 +32,14 @@ export const url = resolveDocsOrigin();
 // production, empty in local dev. Every absolute URL we emit for external consumers
 // (llms.txt, sitemap, robots, OG metadata) must carry the prefix; Next only applies
 // basePath to in-app routing, not to strings we build ourselves.
-export const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+export const basePath = config.NEXT_PUBLIC_BASE_PATH;
 
-export const toUrl = (path: string) => {
+export const toUrl = (path: string, origin: string = url, prefix: string = basePath) => {
   const suffix = path === '/' ? '' : path;
-  return new URL(`${basePath}${suffix}`, url).toString();
+  return new URL(`${prefix}${suffix}`, origin).toString();
 };
 
-export const toMarkdownUrl = (path: string) => {
+export const toMarkdownUrl = (path: string, origin: string = url, prefix: string = basePath) => {
   const markdownPath = path === '/' ? '/index.md' : `${path}.md`;
-  return toUrl(markdownPath);
+  return toUrl(markdownPath, origin, prefix);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,9 @@ importers:
 
   apps/docs:
     dependencies:
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../libs/shared/common/config
       '@shipfox/workflow-document':
         specifier: workspace:*
         version: link:../../libs/shared/workflow/document


### PR DESCRIPTION
## Summary

Make `https://www.shipfox.io/docs` the single production identity for docs metadata and machine-readable discovery. Production builds now use the public origin while previews retain their deployment host. Each docs page emits one canonical URL and its page-specific `.md` alternate; sitemap, robots, `llms.txt`, `llms-full.txt`, schema, and social URLs use the same origin.

This is the Shipfox docs side of ENG-1928. The companion Cloud landing PR is https://github.com/ShipfoxHQ/cloud/pull/364; it adds domain-root sitemap, robots, `llms.txt`, and environment-aware public docs links.

Validated with the affected-package Turbo checks, production and preview builds, and a production-shaped matrix covering all 103 public HTML pages and their Markdown alternates.

Part of ENG-1928

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Production docs metadata and discovery URLs previously used the deployment host; they now use the configured Vercel production hostname, falling back to `https://www.shipfox.io`, while previews keep their deployment host and local builds use `http://localhost:3500`. This completes the docs side of ENG-1928.

- Each docs page emits one canonical URL and a page-specific `.md` alternate; sitemap, robots, `llms.txt`, `llms-full.txt`, schema, and social URLs share that origin.
- Replaces the layout-wide `llms.txt` alternate with per-page Markdown links.
- Routes Vercel inputs and the injected production `/docs` base path through typed config from `@shipfox/config`, with coverage for production, preview, and local URL resolution.

<sup>Written for commit 2a819af404aeca8a95325a769009d3094ce2a706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

