### PR TITLE
[docs] Make machine-readable docs match rendered references

### DIFF
--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import {mkdirSync, writeFileSync} from 'node:fs';
+import {randomUUID} from 'node:crypto';
+import {existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {listHarnessDescriptors, MODEL_PROVIDER_CATALOG_SEED} from '@shipfox/api-agent-dto';
@@ -33,6 +34,8 @@ import {
   workflowContextNames,
 } from '@shipfox/expression';
 import {buildWorkflowJsonSchema, thinkingLevelsForHarness} from '@shipfox/workflow-document';
+import {GENERATED_MANIFEST_FILE} from '@/lib/generated-artifacts';
+import {inlineCode, tableValue} from '@/lib/markdown';
 import {registeredIntegrationProviders} from '@/lib/registered-integration-providers';
 import {
   contextFieldRows,
@@ -75,30 +78,40 @@ const integrationCatalogProviders = registeredIntegrationProviders
   .filter((provider) => provider.kind === 'catalog')
   .map((provider) => ({...provider, ...dtoCatalogBySlug[provider.slug]}));
 const regions = [
-  ['content/generated/reference/model-providers.mdx', renderModelProvidersTable],
+  {file: 'content/generated/reference/model-providers.mdx', render: renderModelProvidersTable},
   ...integrationCatalogProviders.flatMap((provider) => [
     ...(provider.eventCatalog
       ? [
-          [
-            `content/generated/integrations/${provider.slug}/events.mdx`,
-            () => renderEventCatalog(provider.eventCatalog),
-          ],
+          {
+            file: `content/generated/integrations/${provider.slug}/events.mdx`,
+            render: () => renderEventCatalog(provider.eventCatalog),
+          },
         ]
       : []),
     ...(provider.toolCatalog
       ? [
-          [
-            `content/generated/integrations/${provider.slug}/tools.mdx`,
-            () => renderToolCatalog(provider.toolCatalog, provider.toolSelectionCatalog),
-          ],
+          {
+            file: `content/generated/integrations/${provider.slug}/tools.mdx`,
+            render: () => renderToolCatalog(provider.toolCatalog, provider.toolSelectionCatalog),
+          },
         ]
       : []),
   ]),
-  ['content/generated/integrations/catalog.json', renderIntegrationCatalogData],
-  ['content/generated/reference/workflow-schema.mdx', renderWorkflowSchemaReference],
-  ['content/generated/reference/context-roots.mdx', renderContextRoots],
-  ['content/generated/reference/context-availability.mdx', renderContextAvailability],
-  ['content/generated/reference/context-properties.mdx', renderContextProperties],
+  {file: 'content/generated/integrations/catalog.json', render: renderIntegrationCatalogData},
+  {
+    file: 'content/generated/reference/workflow-schema.mdx',
+    render: renderWorkflowSchemaArtifact,
+    machineReadable: {
+      format: 'json',
+      file: 'content/generated/reference/workflow-schema.llm.json',
+    },
+  },
+  {file: 'content/generated/reference/context-roots.mdx', render: renderContextRoots},
+  {
+    file: 'content/generated/reference/context-availability.mdx',
+    render: renderContextAvailability,
+  },
+  {file: 'content/generated/reference/context-properties.mdx', render: renderContextProperties},
 ];
 
 const contextShapeDeps = {
@@ -370,9 +383,13 @@ function objects(value) {
   return Array.isArray(value) ? value.map(object) : [];
 }
 
-function renderWorkflowSchemaReference() {
-  const schema = buildWorkflowJsonSchema();
-  const workflowSchemaMarkdown = {};
+function renderWorkflowSchemaArtifact() {
+  const machineReadable = {};
+  const content = renderWorkflowSchemaReference(buildWorkflowJsonSchema(), machineReadable);
+  return {content, machineReadable};
+}
+
+function renderWorkflowSchemaReference(schema, workflowSchemaMarkdown) {
   const root = object(schema.properties);
   const jobs = object(object(root.jobs).additionalProperties);
   const steps = object(object(object(jobs.properties).steps).items);
@@ -546,10 +563,6 @@ function renderWorkflowSchemaReference() {
     .filter(Boolean)
     .join('\n\n');
 
-  writeFileSync(
-    join(docsRoot, 'content/generated/reference/workflow-schema.llm.json'),
-    `${JSON.stringify(workflowSchemaMarkdown, null, 2)}\n`,
-  );
   return output;
 }
 
@@ -567,54 +580,60 @@ function workflowComponent(markdown, name, properties, options = {}) {
 }
 
 function renderTypeTable(properties, options) {
-  const required = new Set(options.required ?? []);
-  const names = options.fields ?? Object.keys(properties);
-  const rows = names.flatMap((name) => {
-    const property = properties[name];
-    if (!property) return [];
-    return [
-      `    ${JSON.stringify(name)}: {`,
-      `      type: ${options.types?.[name] ?? typeFor(property)},`,
-      `      description: ${descriptionFor(property.description)},`,
-      ...(required.has(name) ? ['      required: true,'] : []),
-      ...(options.defaults?.[name] ? [`      default: ${codeType(options.defaults[name])},`] : []),
-      ...(options.nested?.[name]
-        ? [`      typeDescriptionLink: ${JSON.stringify(options.nested[name])},`]
-        : []),
+  const rows = workflowTableRows(properties, options);
+  return [
+    '<TypeTable',
+    '  type={{',
+    ...rows.flatMap((row) => [
+      `    ${JSON.stringify(row.name)}: {`,
+      `      type: ${row.typeExpression},`,
+      `      description: ${descriptionFor(row.description)},`,
+      ...(row.required ? ['      required: true,'] : []),
+      ...(row.defaultValue ? [`      default: ${codeType(row.defaultValue)},`] : []),
+      ...(row.nestedHref ? [`      typeDescriptionLink: ${JSON.stringify(row.nestedHref)},`] : []),
       '    },',
-    ];
-  });
-
-  return ['<TypeTable', '  type={{', ...rows, '  }}', '/>'].join('\n');
+    ]),
+    '  }}',
+    '/>',
+  ].join('\n');
 }
 
 function renderTypeTableMarkdown(properties, options) {
-  const required = new Set(options.required ?? []);
-  const names = options.fields ?? Object.keys(properties);
-  const rows = names.flatMap((name) => {
-    const property = properties[name];
-    if (!property) return [];
-
-    const type = options.types?.[name]
-      ? markdownTypeFromExpression(options.types[name])
-      : markdownTypeFromExpression(typeFor(property));
-    const linkedType = options.nested?.[name]
-      ? `[${inlineCode(type)}](${options.nested[name]})`
-      : inlineCode(type);
-    const defaultValue = options.defaults?.[name];
-    const defaultText = defaultValue ? inlineCode(defaultValue) : '-';
-    const description = typeof property.description === 'string' ? property.description : '';
-
-    return [
-      `| ${inlineCode(name)} | ${linkedType} | ${required.has(name) ? 'Required' : 'Optional'} | ${defaultText} | ${tableValue(description || '-')} |`,
-    ];
-  });
+  const rows = workflowTableRows(properties, options);
 
   return [
     '| Field | Type | Required | Default | Description |',
     '|---|---|---|---|---|',
-    ...rows,
+    ...rows.map((row) => {
+      const linkedType = row.nestedHref
+        ? `[${inlineCode(row.type)}](${row.nestedHref})`
+        : inlineCode(row.type);
+      const defaultText = row.defaultValue ? inlineCode(row.defaultValue) : '-';
+      return `| ${inlineCode(row.name)} | ${linkedType} | ${row.required ? 'Required' : 'Optional'} | ${defaultText} | ${tableValue(row.description || '-')} |`;
+    }),
   ].join('\n');
+}
+
+function workflowTableRows(properties, options) {
+  const required = new Set(options.required ?? []);
+  const names = options.fields ?? Object.keys(properties);
+  return names.flatMap((name) => {
+    const property = properties[name];
+    if (!property) return [];
+
+    const typeExpression = options.types?.[name] ?? typeFor(property);
+    return [
+      {
+        name,
+        typeExpression,
+        type: markdownTypeFromExpression(typeExpression),
+        required: required.has(name),
+        defaultValue: options.defaults?.[name],
+        nestedHref: options.nested?.[name],
+        description: typeof property.description === 'string' ? property.description : '',
+      },
+    ];
+  });
 }
 
 function markdownTypeFromExpression(expression) {
@@ -623,14 +642,6 @@ function markdownTypeFromExpression(expression) {
   );
   if (values.length > 0) return values.join(' | ');
   return expression;
-}
-
-function inlineCode(value) {
-  return `\`${tableValue(value)}\``;
-}
-
-function tableValue(value) {
-  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
 
 function typeFor(schema) {
@@ -721,11 +732,49 @@ function environmentFields() {
   };
 }
 
-for (const [file, render] of regions) {
-  const path = join(docsRoot, file);
-  mkdirSync(dirname(path), {recursive: true});
-  const next = `${render()}\n`;
-  writeFileSync(path, next);
+for (const region of regions) {
+  const path = join(docsRoot, region.file);
+  const rendered = region.render();
+  const content = typeof rendered === 'string' ? rendered : rendered.content;
+  writeGeneratedFile(path, `${content}\n`);
+
+  if (region.machineReadable) {
+    if (typeof rendered === 'string' || !rendered.machineReadable) {
+      throw new Error(`${region.file} did not return its machine-readable artifact.`);
+    }
+    writeGeneratedFile(
+      join(docsRoot, region.machineReadable.file),
+      `${JSON.stringify(rendered.machineReadable, null, 2)}\n`,
+    );
+  }
+
   // biome-ignore lint/suspicious/noConsole: CLI diagnostics
-  console.log(`✓ wrote ${file}`);
+  console.log(`✓ wrote ${region.file}`);
+}
+
+writeGeneratedFile(
+  join(docsRoot, GENERATED_MANIFEST_FILE),
+  `${JSON.stringify(
+    Object.fromEntries(
+      regions.map((region) => [
+        region.file,
+        region.machineReadable
+          ? {format: region.machineReadable.format, file: region.machineReadable.file}
+          : {format: 'markdown'},
+      ]),
+    ),
+    null,
+    2,
+  )}\n`,
+);
+
+function writeGeneratedFile(path, content) {
+  mkdirSync(dirname(path), {recursive: true});
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporaryPath, content);
+    renameSync(temporaryPath, path);
+  } finally {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  }
 }

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -372,6 +372,7 @@ function objects(value) {
 
 function renderWorkflowSchemaReference() {
   const schema = buildWorkflowJsonSchema();
+  const workflowSchemaMarkdown = {};
   const root = object(schema.properties);
   const jobs = object(object(root.jobs).additionalProperties);
   const steps = object(object(object(jobs.properties).steps).items);
@@ -388,10 +389,10 @@ function renderWorkflowSchemaReference() {
   const batch = object(listening.properties).batch;
   const session = objectSchemaFor(object(steps.properties).session);
 
-  return [
+  const output = [
     "import {TypeTable} from 'fumadocs-ui/components/type-table';",
     '',
-    component('TopLevelFields', root, {
+    workflowComponent(workflowSchemaMarkdown, 'TopLevelFields', root, {
       required: ['name', 'jobs'],
       nested: {
         env: '#environment-variables',
@@ -404,8 +405,10 @@ function renderWorkflowSchemaReference() {
         jobs: recordType('Job'),
       },
     }),
-    component('TriggerFields', object(trigger.properties), {required: strings(trigger.required)}),
-    component('JobFields', object(jobs.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'TriggerFields', object(trigger.properties), {
+      required: strings(trigger.required),
+    }),
+    workflowComponent(workflowSchemaMarkdown, 'JobFields', object(jobs.properties), {
       required: ['steps'],
       nested: {
         checkout: '#job-checkout-fields',
@@ -419,16 +422,20 @@ function renderWorkflowSchemaReference() {
         steps: codeType('Step[]'),
       },
     }),
-    component('JobCheckoutFields', object(jobCheckout.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'JobCheckoutFields', object(jobCheckout.properties), {
       nested: {permissions: '#checkout-permissions-fields'},
       types: {permissions: namedType('CheckoutPermissions')},
     }),
-    component('CheckoutFields', object(checkout.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'CheckoutFields', object(checkout.properties), {
       nested: {permissions: '#checkout-permissions-fields'},
       types: {permissions: namedType('CheckoutPermissions')},
     }),
-    component('CheckoutPermissionsFields', object(checkoutPermissions.properties)),
-    component('RunStepFields', object(steps.properties), {
+    workflowComponent(
+      workflowSchemaMarkdown,
+      'CheckoutPermissionsFields',
+      object(checkoutPermissions.properties),
+    ),
+    workflowComponent(workflowSchemaMarkdown, 'RunStepFields', object(steps.properties), {
       fields: ['key', 'if', 'name', 'run', 'gate', 'env', 'outputs'],
       required: ['run'],
       nested: {
@@ -442,7 +449,7 @@ function renderWorkflowSchemaReference() {
         outputs: recordType('Output'),
       },
     }),
-    component('ToolStepFields', object(steps.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'ToolStepFields', object(steps.properties), {
       fields: ['key', 'if', 'name', 'tool', 'connection', 'with', 'gate', 'outputs'],
       required: ['tool'],
       nested: {
@@ -455,7 +462,7 @@ function renderWorkflowSchemaReference() {
         outputs: recordType('string'),
       },
     }),
-    component('CheckoutStepFields', object(steps.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'CheckoutStepFields', object(steps.properties), {
       fields: ['key', 'if', 'name', 'checkout', 'gate', 'outputs'],
       required: ['checkout'],
       nested: {
@@ -469,7 +476,7 @@ function renderWorkflowSchemaReference() {
         outputs: recordType('Output'),
       },
     }),
-    component('AgentStepFields', object(steps.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'AgentStepFields', object(steps.properties), {
       fields: [
         'key',
         'if',
@@ -500,20 +507,27 @@ function renderWorkflowSchemaReference() {
         outputs: recordType('Output'),
       },
     }),
-    component('AgentIntegrationFields', object(integration.properties), {required: ['include']}),
-    component('AgentSessionFields', object(session.properties), {
+    workflowComponent(
+      workflowSchemaMarkdown,
+      'AgentIntegrationFields',
+      object(integration.properties),
+      {required: ['include']},
+    ),
+    workflowComponent(workflowSchemaMarkdown, 'AgentSessionFields', object(session.properties), {
       required: ['key'],
       defaults: {mode: 'resume'},
       types: {key: codeType('string')},
     }),
-    component('GateFields', object(gate.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'GateFields', object(gate.properties), {
       nested: {on_failure: '#gate-failure-fields'},
       types: {on_failure: namedType('GateFailure')},
     }),
-    component('GateFailureFields', object(gateFailure.properties), {required: ['restart_from']}),
-    component('StepOutputs', outputFields()),
-    component('ToolStepOutputs', toolOutputFields()),
-    component('ListeningFields', object(listening.properties), {
+    workflowComponent(workflowSchemaMarkdown, 'GateFailureFields', object(gateFailure.properties), {
+      required: ['restart_from'],
+    }),
+    workflowComponent(workflowSchemaMarkdown, 'StepOutputs', outputFields()),
+    workflowComponent(workflowSchemaMarkdown, 'ToolStepOutputs', toolOutputFields()),
+    workflowComponent(workflowSchemaMarkdown, 'ListeningFields', object(listening.properties), {
       required: ['on'],
       nested: {
         on: '#trigger-fields',
@@ -526,11 +540,17 @@ function renderWorkflowSchemaReference() {
         batch: namedType('ListeningBatch'),
       },
     }),
-    component('ListeningBatchFields', object(batch.properties)),
-    component('EnvironmentVariables', environmentFields()),
+    workflowComponent(workflowSchemaMarkdown, 'ListeningBatchFields', object(batch.properties)),
+    workflowComponent(workflowSchemaMarkdown, 'EnvironmentVariables', environmentFields()),
   ]
     .filter(Boolean)
     .join('\n\n');
+
+  writeFileSync(
+    join(docsRoot, 'content/generated/reference/workflow-schema.llm.json'),
+    `${JSON.stringify(workflowSchemaMarkdown, null, 2)}\n`,
+  );
+  return output;
 }
 
 function component(name, properties, options = {}) {
@@ -539,6 +559,11 @@ function component(name, properties, options = {}) {
     .map((line) => `    ${line}`)
     .join('\n');
   return [`export function ${name}() {`, '  return (', table, '  );', '}'].join('\n');
+}
+
+function workflowComponent(markdown, name, properties, options = {}) {
+  markdown[name] = renderTypeTableMarkdown(properties, options);
+  return component(name, properties, options);
 }
 
 function renderTypeTable(properties, options) {
@@ -561,6 +586,51 @@ function renderTypeTable(properties, options) {
   });
 
   return ['<TypeTable', '  type={{', ...rows, '  }}', '/>'].join('\n');
+}
+
+function renderTypeTableMarkdown(properties, options) {
+  const required = new Set(options.required ?? []);
+  const names = options.fields ?? Object.keys(properties);
+  const rows = names.flatMap((name) => {
+    const property = properties[name];
+    if (!property) return [];
+
+    const type = options.types?.[name]
+      ? markdownTypeFromExpression(options.types[name])
+      : markdownTypeFromExpression(typeFor(property));
+    const linkedType = options.nested?.[name]
+      ? `[${inlineCode(type)}](${options.nested[name]})`
+      : inlineCode(type);
+    const defaultValue = options.defaults?.[name];
+    const defaultText = defaultValue ? inlineCode(defaultValue) : '-';
+    const description = typeof property.description === 'string' ? property.description : '';
+
+    return [
+      `| ${inlineCode(name)} | ${linkedType} | ${required.has(name) ? 'Required' : 'Optional'} | ${defaultText} | ${tableValue(description || '-')} |`,
+    ];
+  });
+
+  return [
+    '| Field | Type | Required | Default | Description |',
+    '|---|---|---|---|---|',
+    ...rows,
+  ].join('\n');
+}
+
+function markdownTypeFromExpression(expression) {
+  const values = [...expression.matchAll(/<code>\{("(?:\\.|[^"\\])*")\}<\/code>/g)].map((match) =>
+    JSON.parse(match[1]),
+  );
+  if (values.length > 0) return values.join(' | ');
+  return expression;
+}
+
+function inlineCode(value) {
+  return `\`${tableValue(value)}\``;
+}
+
+function tableValue(value) {
+  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
 
 function typeFor(schema) {

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -5,6 +5,8 @@ import {
   INTEGRATION_CATALOG_CATEGORIES,
   INTEGRATION_CATALOG_ICONS,
 } from './src/lib/integration-catalog';
+import {stringifyMachineReadableComponent} from './src/lib/machine-readable';
+import {remarkGeneratedComponents} from './src/lib/remark-generated-components';
 
 export type {z} from 'zod';
 
@@ -29,7 +31,10 @@ export const docs = defineDocs({
         .optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      includeProcessedMarkdown: {
+        mdxAsPlaceholder: ['IntegrationCatalog'],
+        stringify: stringifyMachineReadableComponent,
+      },
     },
   },
   meta: {
@@ -38,5 +43,8 @@ export const docs = defineDocs({
 });
 
 export default defineConfig({
-  mdxOptions: {},
+  mdxOptions: {
+    remarkImageOptions: {useImport: false},
+    remarkPlugins: [remarkGeneratedComponents],
+  },
 });

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -1,5 +1,5 @@
+import {canonicalDocsUrl} from '@/lib/machine-readable';
 import {source} from '@/lib/source';
-import {toUrl} from '@/url';
 
 export const revalidate = false;
 
@@ -98,11 +98,13 @@ export function GET() {
     lines.push(`## ${SECTION_LABELS[sectionKey]}`, '');
 
     for (const page of sectionPages) {
-      const description = page.data.description as string | undefined;
-      const entry = description
-        ? `- [${page.data.title}](${toUrl(page.url)}): ${description}`
-        : `- [${page.data.title}](${toUrl(page.url)})`;
-      lines.push(entry);
+      const description = page.data.description;
+      if (typeof description !== 'string' || description.length === 0) {
+        throw new Error(
+          `Documentation page "${page.path}" (${page.url}) is missing a description.`,
+        );
+      }
+      lines.push(`- [${page.data.title}](${canonicalDocsUrl(page.url)}): ${description}`);
     }
 
     lines.push('');

--- a/apps/docs/src/lib/canonical-docs-origin.ts
+++ b/apps/docs/src/lib/canonical-docs-origin.ts
@@ -1,0 +1,1 @@
+export const canonicalDocsOrigin = 'https://www.shipfox.io/docs';

--- a/apps/docs/src/lib/generated-artifacts.ts
+++ b/apps/docs/src/lib/generated-artifacts.ts
@@ -1,0 +1,8 @@
+export const GENERATED_MANIFEST_FILE = 'content/generated/generated-artifacts.json';
+
+export interface GeneratedArtifactDescriptor {
+  format: 'markdown' | 'json';
+  file?: string;
+}
+
+export type GeneratedArtifactManifest = Readonly<Record<string, GeneratedArtifactDescriptor>>;

--- a/apps/docs/src/lib/get-llm-text.test.ts
+++ b/apps/docs/src/lib/get-llm-text.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {getLLMText} from './get-llm-text';
+import {canonicalDocsUrl} from './machine-readable';
 
 type TestPage = Parameters<typeof getLLMText>[0];
-const CANONICAL_HEADER_PATTERN =
-  /^# Test page\n\nCanonical URL: https:\/\/www\.shipfox\.io\/docs\//;
 const DESCRIPTION_PATTERN = /\n\nDescription: Test page description\n\n/;
 
 const pages = [
@@ -49,7 +48,7 @@ function testPage(url: string, body: string, description = 'Test page descriptio
 test('applies required generated facts to every reference page family', async () => {
   for (const page of pages) {
     const markdown = await getLLMText(testPage(page.url, page.body));
-    assert.match(markdown, CANONICAL_HEADER_PATTERN);
+    assert.equal(markdown.split('\n', 1)[0], `# Test page (${canonicalDocsUrl(page.url)})`);
     assert.match(markdown, DESCRIPTION_PATTERN);
     assert.ok(markdown.includes(page.body));
   }

--- a/apps/docs/src/lib/get-llm-text.test.ts
+++ b/apps/docs/src/lib/get-llm-text.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {getLLMText} from './get-llm-text';
+
+type TestPage = Parameters<typeof getLLMText>[0];
+const CANONICAL_HEADER_PATTERN =
+  /^# Test page\n\nCanonical URL: https:\/\/www\.shipfox\.io\/docs\//;
+const DESCRIPTION_PATTERN = /\n\nDescription: Test page description\n\n/;
+
+const pages = [
+  {
+    url: '/reference/workflow-schema',
+    body: ['## Top-level fields', '| `name` |', '## Agent step fields', '| `prompt` |'].join('\n'),
+  },
+  {
+    url: '/reference/contexts',
+    body: [
+      '## Available contexts',
+      '| Context | Holds |',
+      '## Context properties',
+      '| Property | Type | Description |',
+    ].join('\n'),
+  },
+  {
+    url: '/reference/model-providers',
+    body: ['## Supported providers', '| Provider | `provider` ID |'].join('\n'),
+  },
+  {
+    url: '/integrations/github/events',
+    body: ['## Event catalog', '### `push`'].join('\n'),
+  },
+  {
+    url: '/integrations/github/tools',
+    body: ['## Tool catalog', '##### Input'].join('\n'),
+  },
+] as const;
+
+function testPage(url: string, body: string, description = 'Test page description'): TestPage {
+  return {
+    url,
+    data: {
+      title: 'Test page',
+      description,
+      getText: async () => body,
+    },
+  } as unknown as TestPage;
+}
+
+test('applies required generated facts to every reference page family', async () => {
+  for (const page of pages) {
+    const markdown = await getLLMText(testPage(page.url, page.body));
+    assert.match(markdown, CANONICAL_HEADER_PATTERN);
+    assert.match(markdown, DESCRIPTION_PATTERN);
+    assert.ok(markdown.includes(page.body));
+  }
+});
+
+test('reports the source page when description or generated facts are missing', async () => {
+  await assert.rejects(getLLMText(testPage('/reference/contexts', '## Available contexts', '')), {
+    message: 'Documentation page "/reference/contexts" is missing a description.',
+  });
+  await assert.rejects(getLLMText(testPage('/reference/workflow-schema', '## Top-level fields')), {
+    message:
+      'Machine-readable Markdown for /reference/workflow-schema is missing generated fact: | `name` |',
+  });
+});

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,5 +1,4 @@
 import type {InferPageType} from 'fumadocs-core/source';
-import {getIntegrationCatalog} from '@/lib/integration-catalog-source';
 import {
   assertMachineReadableMarkdown,
   canonicalDocsUrl,
@@ -15,15 +14,18 @@ export async function getLLMText(page: InferPageType<typeof source>) {
   const processed = await page.data.getText('processed');
   const description = page.data.description;
   if (typeof description !== 'string' || description.length === 0) {
-    throw new Error(`Documentation page "${page.url}" is missing a description.`);
+    const source = page.path ? `${page.path} (${page.url})` : page.url;
+    throw new Error(`Documentation page "${source}" is missing a description.`);
   }
 
+  const integrationCatalog = processed.includes('IntegrationCatalog')
+    ? (await import('@/lib/integration-catalog-source')).getIntegrationCatalog()
+    : undefined;
   const body = serializeMachineReadableMarkdown(processed, {
-    integrationCatalog: processed.includes('IntegrationCatalog')
-      ? getIntegrationCatalog()
-      : undefined,
+    integrationCatalog,
     pageUrl: page.url,
     requiredFacts: requiredFactsForPage(page.url),
+    sourcePath: page.path,
   });
   const markdown = [
     `# ${page.data.title}`,
@@ -38,6 +40,7 @@ export async function getLLMText(page: InferPageType<typeof source>) {
   assertMachineReadableMarkdown(markdown, {
     pageUrl: page.url,
     requiredFacts: requiredFactsForPage(page.url),
+    sourcePath: page.path,
   });
   return markdown;
 }

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,10 +1,12 @@
 import type {InferPageType} from 'fumadocs-core/source';
+import {config} from '@/config';
 import {
   assertMachineReadableMarkdown,
   canonicalDocsUrl,
   serializeMachineReadableMarkdown,
 } from '@/lib/machine-readable';
 import type {source} from '@/lib/source';
+import {toUrl} from '@/url';
 
 const TRAILING_SLASH_PATTERN = /\/$/;
 const INTEGRATION_EVENTS_PAGE_PATTERN = /^\/integrations\/[^/]+\/events$/;
@@ -28,9 +30,7 @@ export async function getLLMText(page: InferPageType<typeof source>) {
     sourcePath: page.path,
   });
   const markdown = [
-    `# ${page.data.title}`,
-    '',
-    `Canonical URL: ${canonicalDocsUrl(page.url)}`,
+    `# ${page.data.title} (${machineReadablePageUrl(page.url)})`,
     '',
     `Description: ${description}`,
     '',
@@ -43,6 +43,11 @@ export async function getLLMText(page: InferPageType<typeof source>) {
     sourcePath: page.path,
   });
   return markdown;
+}
+
+function machineReadablePageUrl(pageUrl: string): string {
+  const deploymentEnvironment = config.VERCEL_ENV ?? config.NEXT_PUBLIC_VERCEL_ENV;
+  return deploymentEnvironment === 'production' ? toUrl(pageUrl) : canonicalDocsUrl(pageUrl);
 }
 
 function requiredFactsForPage(pageUrl: string): string[] {

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,10 +1,69 @@
 import type {InferPageType} from 'fumadocs-core/source';
+import {getIntegrationCatalog} from '@/lib/integration-catalog-source';
+import {
+  assertMachineReadableMarkdown,
+  canonicalDocsUrl,
+  serializeMachineReadableMarkdown,
+} from '@/lib/machine-readable';
 import type {source} from '@/lib/source';
-import {toUrl} from '@/url';
+
+const TRAILING_SLASH_PATTERN = /\/$/;
+const INTEGRATION_EVENTS_PAGE_PATTERN = /^\/integrations\/[^/]+\/events$/;
+const INTEGRATION_TOOLS_PAGE_PATTERN = /^\/integrations\/[^/]+\/tools$/;
 
 export async function getLLMText(page: InferPageType<typeof source>) {
   const processed = await page.data.getText('processed');
-  // toUrl carries the /docs basePath, matching the llms.txt route, so the
-  // full-text and per-page markdown advertise canonical URLs.
-  return `# ${page.data.title} (${toUrl(page.url)})\n\n${processed}`;
+  const description = page.data.description;
+  if (typeof description !== 'string' || description.length === 0) {
+    throw new Error(`Documentation page "${page.url}" is missing a description.`);
+  }
+
+  const body = serializeMachineReadableMarkdown(processed, {
+    integrationCatalog: processed.includes('IntegrationCatalog')
+      ? getIntegrationCatalog()
+      : undefined,
+    pageUrl: page.url,
+    requiredFacts: requiredFactsForPage(page.url),
+  });
+  const markdown = [
+    `# ${page.data.title}`,
+    '',
+    `Canonical URL: ${canonicalDocsUrl(page.url)}`,
+    '',
+    `Description: ${description}`,
+    '',
+    body,
+  ].join('\n');
+
+  assertMachineReadableMarkdown(markdown, {
+    pageUrl: page.url,
+    requiredFacts: requiredFactsForPage(page.url),
+  });
+  return markdown;
+}
+
+function requiredFactsForPage(pageUrl: string): string[] {
+  const path = pageUrl.replace(TRAILING_SLASH_PATTERN, '');
+  if (path === '/reference/workflow-schema') {
+    return ['## Top-level fields', '| `name` |', '## Agent step fields', '| `prompt` |'];
+  }
+  if (path === '/reference/contexts') {
+    return [
+      '## Available contexts',
+      '| Context | Holds |',
+      '## Context properties',
+      '| Property | Type | Description |',
+    ];
+  }
+  if (path === '/reference/model-providers') {
+    return ['## Supported providers', '| Provider | `provider` ID |'];
+  }
+  if (path === '/integrations') return ['## Integration catalog', '### GitHub'];
+  if (INTEGRATION_EVENTS_PAGE_PATTERN.test(path)) {
+    return ['## Event catalog', '### `'];
+  }
+  if (INTEGRATION_TOOLS_PAGE_PATTERN.test(path)) {
+    return ['## Tool catalog', '##### Input'];
+  }
+  return [];
 }

--- a/apps/docs/src/lib/machine-readable.test.ts
+++ b/apps/docs/src/lib/machine-readable.test.ts
@@ -184,4 +184,5 @@ test('fails deterministic checks for unresolved components and links', () => {
 test('uses safe Markdown code spans for values containing backticks', () => {
   assert.equal(inlineCode('value`with`backticks'), '``value`with`backticks``');
   assert.equal(inlineCode('`'), '`` ` ``');
+  assert.equal(inlineCode(' \t '), '`  \t  `');
 });

--- a/apps/docs/src/lib/machine-readable.test.ts
+++ b/apps/docs/src/lib/machine-readable.test.ts
@@ -127,6 +127,7 @@ test('replaces unusable imported image sources with descriptive text', () => {
 });
 
 test('fails deterministic checks for unresolved components and links', () => {
+  assert.doesNotThrow(() => assertMachineReadableMarkdown('# Test (https://www.shipfox.io/docs)'));
   assert.throws(
     () =>
       serializeMachineReadableMarkdown(

--- a/apps/docs/src/lib/machine-readable.test.ts
+++ b/apps/docs/src/lib/machine-readable.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {CatalogProvider} from './integration-catalog';
+import {
+  assertMachineReadableMarkdown,
+  canonicalDocsUrl,
+  canonicalizeDocumentationUrl,
+  rewriteMachineReadableLinks,
+  serializeMachineReadableMarkdown,
+} from './machine-readable';
+
+const github: CatalogProvider = {
+  slug: 'github',
+  name: 'GitHub',
+  summary: 'Connect repositories, receive events, and give agents scoped GitHub tools.',
+  capabilities: ['source_control', 'events', 'agent_tools'],
+  categories: ['source-control'],
+  aliases: ['git', 'vcs'],
+  icon: 'github',
+  overviewHref: '/integrations/github',
+  setupHref: '/integrations/github/setup',
+  eventCount: 18,
+  toolCount: 21,
+};
+
+test('builds canonical documentation URLs independently of the deployment host', () => {
+  assert.equal(
+    canonicalDocsUrl('/reference/workflow-schema'),
+    'https://www.shipfox.io/docs/reference/workflow-schema',
+  );
+  assert.equal(
+    canonicalizeDocumentationUrl('https://shipfox-docs.vercel.app/docs/reference/contexts'),
+    'https://www.shipfox.io/docs/reference/contexts',
+  );
+  assert.equal(
+    canonicalizeDocumentationUrl('https://docs.github.com/en/webhooks'),
+    'https://docs.github.com/en/webhooks',
+  );
+});
+
+test('rewrites documentation links and media while preserving code fences', () => {
+  const markdown = [
+    '[Workflow schema](/reference/workflow-schema#top-level-fields)',
+    '![Deployment topology](/img/diagrams/deployment-topology.png)',
+    '[GitHub](https://github.com/ShipfoxHQ/shipfox)',
+    '```yaml',
+    'url: /reference/workflow-schema',
+    '```',
+  ].join('\n');
+
+  const rewritten = rewriteMachineReadableLinks(markdown);
+
+  assert.ok(
+    rewritten.includes('https://www.shipfox.io/docs/reference/workflow-schema#top-level-fields'),
+  );
+  assert.ok(rewritten.includes('https://www.shipfox.io/docs/img/diagrams/deployment-topology.png'));
+  assert.ok(rewritten.includes('url: /reference/workflow-schema'));
+  assert.ok(rewritten.includes('https://github.com/ShipfoxHQ/shipfox'));
+  assert.equal(
+    rewriteMachineReadableLinks('[Fields](#top-level-fields)', '/reference/workflow-schema'),
+    '[Fields](https://www.shipfox.io/docs/reference/workflow-schema#top-level-fields)',
+  );
+});
+
+test('serializes integration catalog placeholders as complete Markdown facts', () => {
+  const markdown = serializeMachineReadableMarkdown(
+    '\0{"name":"IntegrationCatalog","children":"","attributes":{}}\0',
+    {
+      integrationCatalog: [github],
+      requiredFacts: ['## Integration catalog', '### GitHub'],
+    },
+  );
+
+  assert.ok(markdown.includes('| Slug | `github` |'));
+  assert.ok(
+    markdown.includes(
+      '| Events | 18 ([event catalog](https://www.shipfox.io/docs/integrations/github/events)) |',
+    ),
+  );
+  assert.ok(markdown.includes('| Agent tools | 21'));
+  assert.equal(markdown.includes('](/'), false);
+});
+
+test('replaces unusable imported image sources with descriptive text', () => {
+  const markdown = serializeMachineReadableMarkdown('<img alt="Run detail" src="__img0" />');
+
+  assert.equal(markdown, '[Image: Run detail]');
+});
+
+test('fails deterministic checks for unresolved components and links', () => {
+  assert.throws(() => assertMachineReadableMarkdown('<TopLevelFields />'), {
+    message: 'Machine-readable Markdown contains an unresolved MDX component: <TopLevelFields />',
+  });
+  assert.throws(() => assertMachineReadableMarkdown('[Contexts](/reference/contexts)'), {
+    message: 'Machine-readable Markdown contains a root-relative link or media URL.',
+  });
+  assert.throws(
+    () =>
+      assertMachineReadableMarkdown('## Workflow schema', {
+        pageUrl: '/reference/workflow-schema',
+        requiredFacts: ['| `name` |'],
+      }),
+    {
+      message:
+        'Machine-readable Markdown for /reference/workflow-schema is missing generated fact: | `name` |',
+    },
+  );
+});

--- a/apps/docs/src/lib/machine-readable.test.ts
+++ b/apps/docs/src/lib/machine-readable.test.ts
@@ -8,6 +8,7 @@ import {
   rewriteMachineReadableLinks,
   serializeMachineReadableMarkdown,
 } from './machine-readable';
+import {inlineCode} from './markdown';
 
 const github: CatalogProvider = {
   slug: 'github',
@@ -128,6 +129,9 @@ test('replaces unusable imported image sources with descriptive text', () => {
 
 test('fails deterministic checks for unresolved components and links', () => {
   assert.doesNotThrow(() => assertMachineReadableMarkdown('# Test (https://www.shipfox.io/docs)'));
+  assert.throws(() => assertMachineReadableMarkdown('https://www.shipfox.io/docs.foo'), {
+    message: 'Machine-readable Markdown contains a non-canonical Shipfox URL.',
+  });
   assert.throws(
     () =>
       serializeMachineReadableMarkdown(
@@ -175,4 +179,9 @@ test('fails deterministic checks for unresolved components and links', () => {
         'Machine-readable Markdown for https://www.shipfox.io/changelog contains a non-canonical Shipfox URL.',
     },
   );
+});
+
+test('uses safe Markdown code spans for values containing backticks', () => {
+  assert.equal(inlineCode('value`with`backticks'), '``value`with`backticks``');
+  assert.equal(inlineCode('`'), '`` ` ``');
 });

--- a/apps/docs/src/lib/machine-readable.test.ts
+++ b/apps/docs/src/lib/machine-readable.test.ts
@@ -36,6 +36,18 @@ test('builds canonical documentation URLs independently of the deployment host',
     canonicalizeDocumentationUrl('https://docs.github.com/en/webhooks'),
     'https://docs.github.com/en/webhooks',
   );
+  assert.equal(
+    canonicalizeDocumentationUrl('../contexts', '/reference/workflow-schema'),
+    'https://www.shipfox.io/docs/contexts',
+  );
+  assert.equal(
+    canonicalizeDocumentationUrl('https://www.shipfox.io/changelog'),
+    'https://www.shipfox.io/changelog',
+  );
+  assert.equal(
+    canonicalizeDocumentationUrl('https://other-app.vercel.app/reference/contexts'),
+    'https://other-app.vercel.app/reference/contexts',
+  );
 });
 
 test('rewrites documentation links and media while preserving code fences', () => {
@@ -60,6 +72,33 @@ test('rewrites documentation links and media while preserving code fences', () =
     rewriteMachineReadableLinks('[Fields](#top-level-fields)', '/reference/workflow-schema'),
     '[Fields](https://www.shipfox.io/docs/reference/workflow-schema#top-level-fields)',
   );
+
+  const fencedMarkers = [
+    '~~~yaml',
+    '[Inside](/reference/contexts)',
+    '```',
+    '[Still inside](/reference/workflow-schema)',
+    '~~~',
+    '[Outside](/reference/contexts)',
+  ].join('\n');
+  const rewrittenFencedMarkers = rewriteMachineReadableLinks(fencedMarkers);
+  assert.ok(rewrittenFencedMarkers.includes('[Still inside](/reference/workflow-schema)'));
+  assert.ok(
+    rewrittenFencedMarkers.includes('[Outside](https://www.shipfox.io/docs/reference/contexts)'),
+  );
+
+  const html = rewriteMachineReadableLinks(
+    [
+      '<a href="/reference/contexts">Contexts</a>',
+      '<img src="/img/diagrams/deployment-topology.png" alt="Topology">',
+      '<a href="https://shipfox-docs.vercel.app/docs/reference/contexts">Preview</a>',
+    ].join('\n'),
+  );
+  assert.ok(html.includes('href="https://www.shipfox.io/docs/reference/contexts"'));
+  assert.ok(
+    html.includes('src="https://www.shipfox.io/docs/img/diagrams/deployment-topology.png"'),
+  );
+  assert.ok(html.includes('alt="Topology"'));
 });
 
 test('serializes integration catalog placeholders as complete Markdown facts', () => {
@@ -88,6 +127,16 @@ test('replaces unusable imported image sources with descriptive text', () => {
 });
 
 test('fails deterministic checks for unresolved components and links', () => {
+  assert.throws(
+    () =>
+      serializeMachineReadableMarkdown(
+        '\0{"name":"UnknownComponent","children":"","attributes":{}}\0',
+      ),
+    {
+      message:
+        'Machine-readable Markdown contains an unresolved component placeholder: UnknownComponent',
+    },
+  );
   assert.throws(() => assertMachineReadableMarkdown('<TopLevelFields />'), {
     message: 'Machine-readable Markdown contains an unresolved MDX component: <TopLevelFields />',
   });
@@ -103,6 +152,26 @@ test('fails deterministic checks for unresolved components and links', () => {
     {
       message:
         'Machine-readable Markdown for /reference/workflow-schema is missing generated fact: | `name` |',
+    },
+  );
+  assert.throws(
+    () =>
+      assertMachineReadableMarkdown('## Contexts', {
+        pageUrl: 'https://shipfox-docs.vercel.app/reference/contexts',
+      }),
+    {
+      message:
+        'Machine-readable Markdown for https://shipfox-docs.vercel.app/reference/contexts contains a preview or local docs URL.',
+    },
+  );
+  assert.throws(
+    () =>
+      assertMachineReadableMarkdown('## Changelog', {
+        pageUrl: 'https://www.shipfox.io/changelog',
+      }),
+    {
+      message:
+        'Machine-readable Markdown for https://www.shipfox.io/changelog contains a non-canonical Shipfox URL.',
     },
   );
 });

--- a/apps/docs/src/lib/machine-readable.ts
+++ b/apps/docs/src/lib/machine-readable.ts
@@ -1,5 +1,5 @@
 import type {LLMsOptions} from 'fumadocs-core/mdx-plugins';
-import {canonicalDocsOrigin} from '../url';
+import {canonicalDocsOrigin} from './canonical-docs-origin';
 import {
   type CatalogProvider,
   catalogCapabilityLabels,

--- a/apps/docs/src/lib/machine-readable.ts
+++ b/apps/docs/src/lib/machine-readable.ts
@@ -1,0 +1,406 @@
+import type {LLMsOptions} from 'fumadocs-core/mdx-plugins';
+import {
+  type CatalogProvider,
+  catalogCapabilityLabels,
+  catalogCategoryLabels,
+} from './integration-catalog';
+
+export const CANONICAL_DOCS_ORIGIN = 'https://www.shipfox.io/docs';
+
+const INTERNAL_DOC_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  'shipfox.io',
+  'www.shipfox.io',
+  'shipfox-docs.vercel.app',
+]);
+const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const UNRESOLVED_MDX_COMPONENT_PATTERN = /<\/?[A-Z][A-Za-z0-9]*(?:\s[^<>]*)?\/?>(?:\s|$)/m;
+const ROOT_RELATIVE_LINK_PATTERN = /\]\(\s*\//;
+const ROOT_RELATIVE_ATTRIBUTE_PATTERN = /\b(?:href|src)=(['"])\//;
+const PREVIEW_DOC_URL_PATTERN =
+  /https?:\/\/(?:[^/\s]+\.vercel\.app|localhost(?::\d+)?|127\.0\.0\.1(?::\d+)?)(?:\/|$)/;
+const NON_CANONICAL_SHIPFOX_URL_PATTERN = /https:\/\/www\.shipfox\.io\/(?!docs(?:[/?#\s]|$))/;
+const UNUSABLE_IMAGE_SOURCE_PATTERN = /__img\d+/;
+const UNUSABLE_MDX_IMAGE_PATTERN =
+  /<img\b(?=[^>]*\bsrc\s*=\s*(?:["']__img\d+["']|\{__img\d+\}))[^>]*\/?>/gi;
+const UNUSABLE_MARKDOWN_IMAGE_PATTERN = /!\[([^\]]*)\]\(\s*<?__img\d+[^)]*\)?/gi;
+const MARKDOWN_LINK_DESTINATION_PATTERN = /(\]\(\s*)(<[^>\n]+>|[^)\s]+)([^)\n]*\))/g;
+const HTML_ATTRIBUTE_PATTERN = /\b(src|href)=(['"])([^'"]+)\2/g;
+const STEP_TITLE_PATTERN = /^\*\*(.*)\*\*$/s;
+const ALT_ATTRIBUTE_PATTERN = /\balt=(['"])(.*?)\1/i;
+
+export interface MachineReadableMarkdownOptions {
+  integrationCatalog?: readonly CatalogProvider[];
+  pageUrl?: string;
+  requiredFacts?: readonly string[];
+}
+
+export function canonicalDocsUrl(pageUrl: string): string {
+  return canonicalizeDocumentationUrl(pageUrl);
+}
+
+export function canonicalizeDocumentationUrl(destination: string, pageUrl?: string): string {
+  const value = destination.trim();
+  if (!value || value.startsWith('//')) {
+    return destination;
+  }
+
+  if (value.startsWith('#') || value.startsWith('?')) {
+    return pageUrl ? `${canonicalDocsUrl(pageUrl)}${value}` : destination;
+  }
+
+  if (value.startsWith('/')) return canonicalPath(value);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return destination;
+  }
+
+  if (!isInternalDocumentationHost(parsed.hostname)) return destination;
+  return canonicalPath(`${parsed.pathname}${parsed.search}${parsed.hash}`);
+}
+
+export function serializeIntegrationCatalog(providers: readonly CatalogProvider[]): string {
+  const sections = providers.map((provider) => {
+    const events = provider.eventCount
+      ? `${provider.eventCount} ([event catalog](/integrations/${provider.slug}/events))`
+      : '0';
+    const tools = provider.toolCount
+      ? `${provider.toolCount} ([tool catalog](/integrations/${provider.slug}/tools))`
+      : '0';
+
+    return [
+      `### ${provider.name}`,
+      '',
+      provider.summary,
+      '',
+      '| Field | Value |',
+      '|---|---|',
+      `| Slug | ${inlineCode(provider.slug)} |`,
+      `| Icon | ${inlineCode(provider.icon)} |`,
+      `| Capabilities | ${tableValue(provider.capabilities.map((value) => catalogCapabilityLabels[value]).join(', '))} |`,
+      `| Categories | ${tableValue(provider.categories.map((value) => catalogCategoryLabels[value]).join(', '))} |`,
+      `| Aliases | ${tableValue(provider.aliases.map(inlineCode).join(', '))} |`,
+      `| Events | ${tableValue(events)} |`,
+      `| Agent tools | ${tableValue(tools)} |`,
+      `| Overview | ${tableValue(`[${provider.name}](${provider.overviewHref})`)} |`,
+      `| Setup | ${tableValue(provider.setupHref ? `[Connect ${provider.name}](${provider.setupHref})` : 'Not available')} |`,
+    ].join('\n');
+  });
+
+  return [
+    '## Integration catalog',
+    '',
+    'Every integration listed here is available in the documentation and carries the capabilities, event, and agent-tool facts shown below.',
+    '',
+    sections.join('\n\n'),
+  ].join('\n');
+}
+
+export function serializeMachineReadableMarkdown(
+  markdown: string,
+  options: MachineReadableMarkdownOptions = {},
+): string {
+  let serialized = replacePlaceholders(markdown, options.integrationCatalog);
+  serialized = replaceUnusableImages(serialized);
+  serialized = rewriteMachineReadableLinks(serialized, options.pageUrl);
+  assertMachineReadableMarkdown(serialized, options);
+  return serialized.trim();
+}
+
+export function rewriteMachineReadableLinks(markdown: string, pageUrl?: string): string {
+  let inFence = false;
+
+  return markdown
+    .split('\n')
+    .map((line) => {
+      if (FENCE_PATTERN.test(line)) {
+        inFence = !inFence;
+        return line;
+      }
+      return inFence ? line : rewriteMachineReadableLine(line, pageUrl);
+    })
+    .join('\n');
+}
+
+export function assertMachineReadableMarkdown(
+  markdown: string,
+  {pageUrl, requiredFacts = []}: MachineReadableMarkdownOptions = {},
+): void {
+  const document = withoutFencedCode(markdown);
+  const page = pageUrl ? ` for ${pageUrl}` : '';
+
+  if (markdown.includes('\0'))
+    throw new Error(
+      `Machine-readable Markdown${page} contains an unresolved component placeholder.`,
+    );
+
+  const unresolvedComponent = document.match(UNRESOLVED_MDX_COMPONENT_PATTERN)?.[0];
+  if (unresolvedComponent) {
+    throw new Error(
+      `Machine-readable Markdown${page} contains an unresolved MDX component: ${unresolvedComponent}`,
+    );
+  }
+
+  if (ROOT_RELATIVE_LINK_PATTERN.test(document) || ROOT_RELATIVE_ATTRIBUTE_PATTERN.test(document)) {
+    throw new Error(`Machine-readable Markdown${page} contains a root-relative link or media URL.`);
+  }
+
+  if (PREVIEW_DOC_URL_PATTERN.test(document)) {
+    throw new Error(`Machine-readable Markdown${page} contains a preview or local docs URL.`);
+  }
+
+  if (NON_CANONICAL_SHIPFOX_URL_PATTERN.test(document)) {
+    throw new Error(`Machine-readable Markdown${page} contains a non-canonical Shipfox URL.`);
+  }
+
+  if (UNUSABLE_IMAGE_SOURCE_PATTERN.test(markdown)) {
+    throw new Error(`Machine-readable Markdown${page} contains an unusable image source.`);
+  }
+
+  for (const fact of requiredFacts) {
+    if (!markdown.includes(fact)) {
+      throw new Error(`Machine-readable Markdown${page} is missing generated fact: ${fact}`);
+    }
+  }
+}
+
+type StringifyCallback = NonNullable<LLMsOptions['stringify']>;
+type StringifyNode = Parameters<StringifyCallback>[0];
+type StringifyState = Parameters<StringifyCallback>[2];
+type StringifyInfo = Parameters<StringifyCallback>[3];
+type FlowParent = Parameters<StringifyState['containerFlow']>[0];
+type PhrasingParent = Parameters<StringifyState['containerPhrasing']>[0];
+
+interface MdxAttribute {
+  type: string;
+  name: string;
+  value: unknown;
+}
+
+interface MdxElementNode {
+  type: 'mdxJsxFlowElement' | 'mdxJsxTextElement';
+  name: string | null;
+  attributes: MdxAttribute[];
+  children: StringifyNode[];
+}
+
+export const stringifyMachineReadableComponent: StringifyCallback = (
+  node,
+  _parent,
+  state,
+  info,
+) => {
+  if (!isMdxElement(node)) return undefined;
+
+  switch (node.name) {
+    case 'Callout':
+      return blockquote(
+        childrenMarkdown(node, state, info),
+        calloutLabel(attributeValue(node, 'title'), attributeValue(node, 'type')),
+      );
+    case 'Steps':
+    case 'Cards':
+    case 'Accordions':
+    case 'Tabs':
+    case 'Frame':
+      return childrenMarkdown(node, state, info);
+    case 'Card':
+      return titledBlock(
+        attributeValue(node, 'title'),
+        attributeValue(node, 'href'),
+        childrenMarkdown(node, state, info),
+        '###',
+      );
+    case 'Accordion':
+      return titledBlock(
+        attributeValue(node, 'title'),
+        undefined,
+        childrenMarkdown(node, state, info),
+        '###',
+      );
+    case 'Step':
+      return stepMarkdown(node, state, info);
+    case 'Tab':
+      return titledBlock(
+        attributeValue(node, 'title') ?? attributeValue(node, 'label'),
+        undefined,
+        childrenMarkdown(node, state, info),
+        '####',
+      );
+    default:
+      return undefined;
+  }
+};
+
+function replacePlaceholders(markdown: string, providers?: readonly CatalogProvider[]): string {
+  return markdown.replace(/\0([\s\S]*?)\0/g, (_match, value: string) => {
+    let placeholder: unknown;
+    try {
+      placeholder = JSON.parse(value);
+    } catch {
+      throw new Error('Machine-readable Markdown contains an invalid component placeholder.');
+    }
+
+    if (!isPlaceholder(placeholder)) {
+      throw new Error('Machine-readable Markdown contains an invalid component placeholder.');
+    }
+
+    if (placeholder.name === 'IntegrationCatalog') {
+      if (!providers) {
+        throw new Error('Integration catalog data is unavailable for machine-readable Markdown.');
+      }
+      return serializeIntegrationCatalog(providers);
+    }
+
+    throw new Error(
+      `Machine-readable Markdown contains an unresolved component placeholder: ${placeholder.name}`,
+    );
+  });
+}
+
+function replaceUnusableImages(markdown: string): string {
+  const withMdxImages = markdown.replace(UNUSABLE_MDX_IMAGE_PATTERN, (tag) =>
+    imageDescription(tag),
+  );
+
+  return withMdxImages.replace(UNUSABLE_MARKDOWN_IMAGE_PATTERN, (_match, alt: string) => {
+    return imageDescription(alt ? `alt="${alt}"` : '');
+  });
+}
+
+function rewriteMachineReadableLine(line: string, pageUrl?: string): string {
+  const withLinks = line.replace(
+    MARKDOWN_LINK_DESTINATION_PATTERN,
+    (_match, prefix: string, destination: string, suffix: string) => {
+      const wrapped = destination.startsWith('<') && destination.endsWith('>');
+      const value = wrapped ? destination.slice(1, -1) : destination;
+      const rewritten = canonicalizeDocumentationUrl(value, pageUrl);
+      return `${prefix}${wrapped ? `<${rewritten}>` : rewritten}${suffix}`;
+    },
+  );
+
+  return withLinks.replace(
+    HTML_ATTRIBUTE_PATTERN,
+    (_match, name: string, quote: string, destination: string) =>
+      `${name}=${quote}${canonicalizeDocumentationUrl(destination, pageUrl)}${quote}`,
+  );
+}
+
+function canonicalPath(value: string): string {
+  const url = new URL(value, `${CANONICAL_DOCS_ORIGIN}/`);
+  let pathname = url.pathname;
+  if (pathname === '/docs') pathname = '/';
+  else if (pathname.startsWith('/docs/')) pathname = pathname.slice('/docs'.length);
+
+  return `${CANONICAL_DOCS_ORIGIN}${pathname === '/' ? '' : pathname}${url.search}${url.hash}`;
+}
+
+function isInternalDocumentationHost(hostname: string): boolean {
+  return INTERNAL_DOC_HOSTS.has(hostname) || hostname.endsWith('.vercel.app');
+}
+
+function withoutFencedCode(markdown: string): string {
+  let inFence = false;
+  return markdown
+    .split('\n')
+    .filter((line) => {
+      if (FENCE_PATTERN.test(line)) {
+        inFence = !inFence;
+        return false;
+      }
+      return !inFence;
+    })
+    .join('\n');
+}
+
+function childrenMarkdown(
+  node: MdxElementNode,
+  state: StringifyState,
+  info: StringifyInfo,
+): string {
+  return state.containerFlow({type: 'root', children: node.children} as FlowParent, info).trim();
+}
+
+function titledBlock(
+  title: string | undefined,
+  href: string | undefined,
+  content: string,
+  level: string,
+): string {
+  const cleanTitle = title?.trim().replace(/\s+/g, ' ');
+  let heading: string | undefined;
+  if (cleanTitle) {
+    heading = href
+      ? `${level} [${cleanTitle.replaceAll(']', '\\]')}](${href})`
+      : `${level} ${cleanTitle}`;
+  }
+
+  return [heading, content].filter(Boolean).join('\n\n');
+}
+
+function stepMarkdown(node: MdxElementNode, state: StringifyState, info: StringifyInfo): string {
+  const first = node.children[0];
+  if (first?.type !== 'paragraph' || first.children.length !== 1) {
+    return childrenMarkdown(node, state, info);
+  }
+
+  const onlyChild = first.children[0];
+  if (onlyChild?.type !== 'strong') return childrenMarkdown(node, state, info);
+
+  const title = state
+    .containerPhrasing(first as PhrasingParent, info)
+    .replace(STEP_TITLE_PATTERN, '$1')
+    .trim();
+  const content = state
+    .containerFlow({type: 'root', children: node.children.slice(1)} as FlowParent, info)
+    .trim();
+  return [`### ${title}`, content].filter(Boolean).join('\n\n');
+}
+
+function blockquote(content: string, label?: string): string {
+  const lines = content ? content.split('\n') : [];
+  if (label) lines.unshift(`**${label}**`);
+  if (lines.length === 0) return label ? `> **${label}**` : '';
+  return lines.map((line) => (line ? `> ${line}` : '>')).join('\n');
+}
+
+function calloutLabel(title?: string, type?: string): string | undefined {
+  const cleanTitle = title?.trim();
+  const cleanType = type?.trim();
+  if (cleanTitle && cleanType) return `${cleanTitle} (${cleanType})`;
+  return cleanTitle || cleanType;
+}
+
+function attributeValue(node: MdxElementNode, name: string): string | undefined {
+  const attribute = node.attributes.find(
+    (item) => item.type === 'mdxJsxAttribute' && item.name === name,
+  );
+  return attribute && typeof attribute.value === 'string' ? attribute.value : undefined;
+}
+
+function imageDescription(tag: string): string {
+  const alt = ALT_ATTRIBUTE_PATTERN.exec(tag)?.[2]?.trim();
+  return alt ? `[Image: ${alt}]` : '[Image]';
+}
+
+function tableValue(value: string): string {
+  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function inlineCode(value: string): string {
+  return `\`${tableValue(value)}\``;
+}
+
+function isMdxElement(node: StringifyNode): node is StringifyNode & MdxElementNode {
+  return node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement';
+}
+
+function isPlaceholder(value: unknown): value is {name: string} {
+  return (
+    typeof value === 'object' && value !== null && 'name' in value && typeof value.name === 'string'
+  );
+}

--- a/apps/docs/src/lib/machine-readable.ts
+++ b/apps/docs/src/lib/machine-readable.ts
@@ -22,7 +22,7 @@ const ROOT_RELATIVE_ATTRIBUTE_PATTERN = /\b(?:href|src)=(['"])\//;
 const PREVIEW_DOC_URL_PATTERN =
   /https?:\/\/(?:[^/\s]+\.vercel\.app|localhost(?::\d+)?|127\.0\.0\.1(?::\d+)?)(?:\/|$)/;
 const NON_CANONICAL_SHIPFOX_URL_PATTERN =
-  /https?:\/\/(?:www\.)?shipfox\.io\/(?!docs(?:[/?#\s)\]"'<>.,;:]|$))/;
+  /https?:\/\/(?:www\.)?shipfox\.io\/(?!docs(?:[/?#\s)\]"'<>]|[.,;:](?=$|[\s)\]"'<>])))/;
 const UNUSABLE_IMAGE_SOURCE_PATTERN = /__img\d+/;
 const UNUSABLE_MDX_IMAGE_PATTERN =
   /<img\b(?=[^>]*\bsrc\s*=\s*(?:["']__img\d+["']|\{__img\d+\}))[^>]*\/?>/gi;

--- a/apps/docs/src/lib/machine-readable.ts
+++ b/apps/docs/src/lib/machine-readable.ts
@@ -1,11 +1,11 @@
 import type {LLMsOptions} from 'fumadocs-core/mdx-plugins';
+import {canonicalDocsOrigin} from '../url';
 import {
   type CatalogProvider,
   catalogCapabilityLabels,
   catalogCategoryLabels,
 } from './integration-catalog';
-
-export const CANONICAL_DOCS_ORIGIN = 'https://www.shipfox.io/docs';
+import {inlineCode, tableValue} from './markdown';
 
 const INTERNAL_DOC_HOSTS = new Set([
   'localhost',
@@ -14,13 +14,14 @@ const INTERNAL_DOC_HOSTS = new Set([
   'www.shipfox.io',
   'shipfox-docs.vercel.app',
 ]);
-const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
 const UNRESOLVED_MDX_COMPONENT_PATTERN = /<\/?[A-Z][A-Za-z0-9]*(?:\s[^<>]*)?\/?>(?:\s|$)/m;
 const ROOT_RELATIVE_LINK_PATTERN = /\]\(\s*\//;
 const ROOT_RELATIVE_ATTRIBUTE_PATTERN = /\b(?:href|src)=(['"])\//;
 const PREVIEW_DOC_URL_PATTERN =
   /https?:\/\/(?:[^/\s]+\.vercel\.app|localhost(?::\d+)?|127\.0\.0\.1(?::\d+)?)(?:\/|$)/;
-const NON_CANONICAL_SHIPFOX_URL_PATTERN = /https:\/\/www\.shipfox\.io\/(?!docs(?:[/?#\s]|$))/;
+const NON_CANONICAL_SHIPFOX_URL_PATTERN = /https?:\/\/(?:www\.)?shipfox\.io\/(?!docs(?:[/?#\s]|$))/;
 const UNUSABLE_IMAGE_SOURCE_PATTERN = /__img\d+/;
 const UNUSABLE_MDX_IMAGE_PATTERN =
   /<img\b(?=[^>]*\bsrc\s*=\s*(?:["']__img\d+["']|\{__img\d+\}))[^>]*\/?>/gi;
@@ -30,10 +31,18 @@ const HTML_ATTRIBUTE_PATTERN = /\b(src|href)=(['"])([^'"]+)\2/g;
 const STEP_TITLE_PATTERN = /^\*\*(.*)\*\*$/s;
 const ALT_ATTRIBUTE_PATTERN = /\balt=(['"])(.*?)\1/i;
 
+type FenceCharacter = '`' | '~';
+
+interface FenceMarker {
+  character: FenceCharacter;
+  length: number;
+}
+
 export interface MachineReadableMarkdownOptions {
   integrationCatalog?: readonly CatalogProvider[];
   pageUrl?: string;
   requiredFacts?: readonly string[];
+  sourcePath?: string;
 }
 
 export function canonicalDocsUrl(pageUrl: string): string {
@@ -54,12 +63,13 @@ export function canonicalizeDocumentationUrl(destination: string, pageUrl?: stri
 
   let parsed: URL;
   try {
-    parsed = new URL(value);
+    parsed = pageUrl ? new URL(value, canonicalDocsUrl(pageUrl)) : new URL(value);
   } catch {
     return destination;
   }
 
   if (!isInternalDocumentationHost(parsed.hostname)) return destination;
+  if (!isCanonicalDocumentationPath(parsed.pathname)) return destination;
   return canonicalPath(`${parsed.pathname}${parsed.search}${parsed.hash}`);
 }
 
@@ -112,26 +122,32 @@ export function serializeMachineReadableMarkdown(
 }
 
 export function rewriteMachineReadableLinks(markdown: string, pageUrl?: string): string {
-  let inFence = false;
+  let fence: FenceMarker | undefined;
 
   return markdown
     .split('\n')
     .map((line) => {
-      if (FENCE_PATTERN.test(line)) {
-        inFence = !inFence;
+      const marker = fenceMarker(line);
+      if (!fence && marker) {
+        fence = marker;
         return line;
       }
-      return inFence ? line : rewriteMachineReadableLine(line, pageUrl);
+      if (fence && closesFence(line, fence)) {
+        fence = undefined;
+        return line;
+      }
+      return fence ? line : rewriteMachineReadableLine(line, pageUrl);
     })
     .join('\n');
 }
 
 export function assertMachineReadableMarkdown(
   markdown: string,
-  {pageUrl, requiredFacts = []}: MachineReadableMarkdownOptions = {},
+  {pageUrl, requiredFacts = [], sourcePath}: MachineReadableMarkdownOptions = {},
 ): void {
   const document = withoutFencedCode(markdown);
-  const page = pageUrl ? ` for ${pageUrl}` : '';
+  const label = pageLabel(pageUrl, sourcePath);
+  const page = label ? ` for ${label}` : '';
 
   if (markdown.includes('\0'))
     throw new Error(
@@ -149,15 +165,9 @@ export function assertMachineReadableMarkdown(
     throw new Error(`Machine-readable Markdown${page} contains a root-relative link or media URL.`);
   }
 
-  if (PREVIEW_DOC_URL_PATTERN.test(document)) {
-    throw new Error(`Machine-readable Markdown${page} contains a preview or local docs URL.`);
-  }
+  assertCanonicalUrls(document, pageUrl, page);
 
-  if (NON_CANONICAL_SHIPFOX_URL_PATTERN.test(document)) {
-    throw new Error(`Machine-readable Markdown${page} contains a non-canonical Shipfox URL.`);
-  }
-
-  if (UNUSABLE_IMAGE_SOURCE_PATTERN.test(markdown)) {
+  if (UNUSABLE_IMAGE_SOURCE_PATTERN.test(document)) {
     throw new Error(`Machine-readable Markdown${page} contains an unusable image source.`);
   }
 
@@ -291,30 +301,73 @@ function rewriteMachineReadableLine(line: string, pageUrl?: string): string {
 }
 
 function canonicalPath(value: string): string {
-  const url = new URL(value, `${CANONICAL_DOCS_ORIGIN}/`);
+  const url = new URL(value, `${canonicalDocsOrigin}/`);
   let pathname = url.pathname;
   if (pathname === '/docs') pathname = '/';
   else if (pathname.startsWith('/docs/')) pathname = pathname.slice('/docs'.length);
 
-  return `${CANONICAL_DOCS_ORIGIN}${pathname === '/' ? '' : pathname}${url.search}${url.hash}`;
+  return `${canonicalDocsOrigin}${pathname === '/' ? '' : pathname}${url.search}${url.hash}`;
 }
 
 function isInternalDocumentationHost(hostname: string): boolean {
-  return INTERNAL_DOC_HOSTS.has(hostname) || hostname.endsWith('.vercel.app');
+  return INTERNAL_DOC_HOSTS.has(hostname);
+}
+
+function pageLabel(pageUrl?: string, sourcePath?: string): string {
+  if (sourcePath && pageUrl) return `${sourcePath} (${pageUrl})`;
+  return sourcePath || pageUrl || '';
+}
+
+function assertCanonicalUrls(document: string, pageUrl: string | undefined, page: string): void {
+  const values = [pageUrl ?? '', document];
+  if (values.some((value) => PREVIEW_DOC_URL_PATTERN.test(value))) {
+    throw new Error(`Machine-readable Markdown${page} contains a preview or local docs URL.`);
+  }
+  if (values.some((value) => NON_CANONICAL_SHIPFOX_URL_PATTERN.test(value))) {
+    throw new Error(`Machine-readable Markdown${page} contains a non-canonical Shipfox URL.`);
+  }
+}
+
+function isCanonicalDocumentationPath(pathname: string): boolean {
+  return pathname === '/docs' || pathname.startsWith('/docs/');
 }
 
 function withoutFencedCode(markdown: string): string {
-  let inFence = false;
+  let fence: FenceMarker | undefined;
   return markdown
     .split('\n')
     .filter((line) => {
-      if (FENCE_PATTERN.test(line)) {
-        inFence = !inFence;
+      const marker = fenceMarker(line);
+      if (!fence && marker) {
+        fence = marker;
         return false;
       }
-      return !inFence;
+      if (fence && closesFence(line, fence)) {
+        fence = undefined;
+        return false;
+      }
+      return !fence;
     })
     .join('\n');
+}
+
+function fenceMarker(line: string): FenceMarker | undefined {
+  const marker = line.match(FENCE_OPEN_PATTERN)?.[1];
+  if (!marker) return undefined;
+  return {
+    character: marker[0] as FenceCharacter,
+    length: marker.length,
+  };
+}
+
+function closesFence(line: string, fence: FenceMarker): boolean {
+  const marker = fenceMarker(line);
+  return Boolean(
+    marker &&
+      FENCE_CLOSE_PATTERN.test(line) &&
+      marker.character === fence.character &&
+      marker.length >= fence.length,
+  );
 }
 
 function childrenMarkdown(
@@ -385,14 +438,6 @@ function attributeValue(node: MdxElementNode, name: string): string | undefined 
 function imageDescription(tag: string): string {
   const alt = ALT_ATTRIBUTE_PATTERN.exec(tag)?.[2]?.trim();
   return alt ? `[Image: ${alt}]` : '[Image]';
-}
-
-function tableValue(value: string): string {
-  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
-}
-
-function inlineCode(value: string): string {
-  return `\`${tableValue(value)}\``;
 }
 
 function isMdxElement(node: StringifyNode): node is StringifyNode & MdxElementNode {

--- a/apps/docs/src/lib/machine-readable.ts
+++ b/apps/docs/src/lib/machine-readable.ts
@@ -21,7 +21,8 @@ const ROOT_RELATIVE_LINK_PATTERN = /\]\(\s*\//;
 const ROOT_RELATIVE_ATTRIBUTE_PATTERN = /\b(?:href|src)=(['"])\//;
 const PREVIEW_DOC_URL_PATTERN =
   /https?:\/\/(?:[^/\s]+\.vercel\.app|localhost(?::\d+)?|127\.0\.0\.1(?::\d+)?)(?:\/|$)/;
-const NON_CANONICAL_SHIPFOX_URL_PATTERN = /https?:\/\/(?:www\.)?shipfox\.io\/(?!docs(?:[/?#\s]|$))/;
+const NON_CANONICAL_SHIPFOX_URL_PATTERN =
+  /https?:\/\/(?:www\.)?shipfox\.io\/(?!docs(?:[/?#\s)\]"'<>.,;:]|$))/;
 const UNUSABLE_IMAGE_SOURCE_PATTERN = /__img\d+/;
 const UNUSABLE_MDX_IMAGE_PATTERN =
   /<img\b(?=[^>]*\bsrc\s*=\s*(?:["']__img\d+["']|\{__img\d+\}))[^>]*\/?>/gi;

--- a/apps/docs/src/lib/markdown.ts
+++ b/apps/docs/src/lib/markdown.ts
@@ -1,4 +1,4 @@
-const WHITESPACE_ONLY_PATTERN = /^\s+$/;
+const WHITESPACE_ONLY_PATTERN = /^ +$/;
 const CODE_SPAN_PADDING_PATTERN = /^(?:\s|`)|(?:\s|`)$/u;
 
 export function tableValue(value: string): string {

--- a/apps/docs/src/lib/markdown.ts
+++ b/apps/docs/src/lib/markdown.ts
@@ -1,0 +1,7 @@
+export function tableValue(value: string): string {
+  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+export function inlineCode(value: string): string {
+  return `\`${tableValue(value)}\``;
+}

--- a/apps/docs/src/lib/markdown.ts
+++ b/apps/docs/src/lib/markdown.ts
@@ -1,7 +1,18 @@
+const WHITESPACE_ONLY_PATTERN = /^\s+$/;
+const CODE_SPAN_PADDING_PATTERN = /^(?:\s|`)|(?:\s|`)$/u;
+
 export function tableValue(value: string): string {
   return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
 
 export function inlineCode(value: string): string {
-  return `\`${tableValue(value)}\``;
+  const content = tableValue(value);
+  const maxBacktickRun = Math.max(0, ...Array.from(content.matchAll(/`+/g), ([run]) => run.length));
+  const delimiter = '`'.repeat(maxBacktickRun + 1);
+  const needsPadding =
+    content.length > 0 &&
+    !WHITESPACE_ONLY_PATTERN.test(content) &&
+    CODE_SPAN_PADDING_PATTERN.test(content);
+  const padding = needsPadding ? ' ' : '';
+  return `${delimiter}${padding}${content}${padding}${delimiter}`;
 }

--- a/apps/docs/src/lib/remark-generated-components.test.ts
+++ b/apps/docs/src/lib/remark-generated-components.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import {join} from 'node:path';
+import test from 'node:test';
+import {remarkGeneratedComponents} from './remark-generated-components';
+
+const docsRoot = process.cwd();
+
+const fixtures = [
+  {
+    directory: ['content', 'docs', 'reference'],
+    importStatement:
+      "import {TopLevelFields} from '../../generated/reference/workflow-schema.mdx';",
+    component: 'TopLevelFields',
+    fact: '| `name` |',
+  },
+  {
+    directory: ['content', 'docs', 'reference'],
+    importStatement:
+      "import ContextAvailability from '../../generated/reference/context-availability.mdx';",
+    component: 'ContextAvailability',
+    fact: '| Workflow key | Available contexts |',
+  },
+  {
+    directory: ['content', 'docs', 'reference'],
+    importStatement: "import ModelProviders from '../../generated/reference/model-providers.mdx';",
+    component: 'ModelProviders',
+    fact: '| Provider | `provider` ID |',
+  },
+  {
+    directory: ['content', 'docs', 'integrations', 'github'],
+    importStatement:
+      "import GithubEvents from '../../../generated/integrations/github/events.mdx';",
+    component: 'GithubEvents',
+    fact: '### `push`',
+  },
+  {
+    directory: ['content', 'docs', 'integrations', 'github'],
+    importStatement: "import GithubTools from '../../../generated/integrations/github/tools.mdx';",
+    component: 'GithubTools',
+    fact: '### issues',
+  },
+] as const;
+
+test('loads declared generated components with their machine-readable facts', async () => {
+  for (const fixture of fixtures) {
+    const tree = {
+      type: 'root',
+      children: [
+        {type: 'mdxjsEsm', value: fixture.importStatement},
+        {type: 'mdxJsxFlowElement', name: fixture.component, attributes: [], children: []},
+      ],
+    };
+
+    await remarkGeneratedComponents()(tree, {dirname: join(docsRoot, ...fixture.directory)});
+
+    const element = tree.children[1];
+    assert.ok(element && typeof element === 'object' && 'data' in element);
+    const text =
+      element.data &&
+      typeof element.data === 'object' &&
+      '_stringify' in element.data &&
+      element.data._stringify &&
+      typeof element.data._stringify === 'object' &&
+      'text' in element.data._stringify
+        ? element.data._stringify.text
+        : undefined;
+    assert.equal(typeof text, 'string');
+    if (typeof text !== 'string') throw new Error('Generated component text was not serialized.');
+    assert.ok(text.includes(fixture.fact));
+  }
+});

--- a/apps/docs/src/lib/remark-generated-components.test.ts
+++ b/apps/docs/src/lib/remark-generated-components.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import {join} from 'node:path';
+import {dirname, join} from 'node:path';
 import test from 'node:test';
+import {fileURLToPath} from 'node:url';
 import {remarkGeneratedComponents} from './remark-generated-components';
 
-const docsRoot = process.cwd();
+const docsRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
 
 const fixtures = [
   {

--- a/apps/docs/src/lib/remark-generated-components.ts
+++ b/apps/docs/src/lib/remark-generated-components.ts
@@ -1,5 +1,6 @@
 import {readFile} from 'node:fs/promises';
-import {basename, dirname, resolve, sep} from 'node:path';
+import {dirname, relative, resolve, sep} from 'node:path';
+import {GENERATED_MANIFEST_FILE, type GeneratedArtifactManifest} from './generated-artifacts';
 
 interface ImportedComponent {
   localName: string;
@@ -35,7 +36,8 @@ interface VFileLike {
 const IMPORT_PATTERN = /^\s*import\s+([\s\S]*?)\s+from\s+(['"])([^'"]+)\2\s*;?\s*$/gm;
 const IMPORT_ALIAS_PATTERN = /\s+as\s+/;
 const LOCAL_NAME_PATTERN = /^[A-Za-z_$][\w$]*$/;
-const WORKFLOW_MDX_PATTERN = /\.mdx$/;
+const GENERATED_MDX_COMPONENT_PATTERN = /<\/?[A-Z][A-Za-z0-9]*(?:\s[^<>]*)?\/?>(?:\s|$)/m;
+let generatedManifestPromise: Promise<GeneratedArtifactManifest> | undefined;
 
 export function remarkGeneratedComponents() {
   return async (tree: RootNode, file: VFileLike) => {
@@ -110,9 +112,24 @@ function resolveGeneratedImport(file: VFileLike, source: string): string | undef
 }
 
 async function readGeneratedComponent(target: string, localName: string): Promise<string> {
-  if (basename(target) === 'workflow-schema.mdx') {
-    const mapPath = target.replace(WORKFLOW_MDX_PATTERN, '.llm.json');
-    const map = JSON.parse(await readFile(mapPath, 'utf8')) as WorkflowMarkdownMap;
+  const {docsRoot, generatedRoot} = generatedPathsFor(target);
+  const source = relative(docsRoot, target).split(sep).join('/');
+  const artifact = (
+    await readGeneratedManifest(resolve(generatedRoot, 'generated-artifacts.json'))
+  )[source];
+  if (!artifact) {
+    throw new Error(
+      `Generated component "${localName}" from ${source} is not declared in ${GENERATED_MANIFEST_FILE}.`,
+    );
+  }
+
+  if (artifact.format === 'json') {
+    if (!artifact.file) {
+      throw new Error(`Generated component "${localName}" from ${source} has no JSON artifact.`);
+    }
+    const map = JSON.parse(
+      await readFile(resolve(docsRoot, artifact.file), 'utf8'),
+    ) as WorkflowMarkdownMap;
     const text = map[localName];
     if (typeof text !== 'string') {
       throw new Error(
@@ -122,7 +139,31 @@ async function readGeneratedComponent(target: string, localName: string): Promis
     return text.trim();
   }
 
-  return (await readFile(target, 'utf8')).trim();
+  const text = (await readFile(target, 'utf8')).trim();
+  if (GENERATED_MDX_COMPONENT_PATTERN.test(text)) {
+    throw new Error(
+      `Generated component "${localName}" from ${source} contains MDX but has no machine-readable artifact.`,
+    );
+  }
+  return text;
+}
+
+function readGeneratedManifest(path: string): Promise<GeneratedArtifactManifest> {
+  generatedManifestPromise ??= readFile(path, 'utf8').then(
+    (content) => JSON.parse(content) as GeneratedArtifactManifest,
+  );
+  return generatedManifestPromise;
+}
+
+function generatedPathsFor(target: string): {docsRoot: string; generatedRoot: string} {
+  const marker = `${sep}content${sep}generated${sep}`;
+  const markerIndex = target.indexOf(marker);
+  if (markerIndex < 0) {
+    throw new Error(`Generated component path is outside the docs generated directory: ${target}`);
+  }
+
+  const docsRoot = target.slice(0, markerIndex);
+  return {docsRoot, generatedRoot: resolve(docsRoot, 'content/generated')};
 }
 
 function walk(value: unknown, callback: (node: MdxEsmNode | MdxElementNode) => void): void {

--- a/apps/docs/src/lib/remark-generated-components.ts
+++ b/apps/docs/src/lib/remark-generated-components.ts
@@ -1,0 +1,147 @@
+import {readFile} from 'node:fs/promises';
+import {basename, dirname, resolve, sep} from 'node:path';
+
+interface ImportedComponent {
+  localName: string;
+  source: string;
+}
+
+interface WorkflowMarkdownMap {
+  [componentName: string]: string;
+}
+
+interface MdxEsmNode {
+  type: 'mdxjsEsm';
+  value: string;
+  children?: unknown[];
+}
+
+interface MdxElementNode {
+  type: 'mdxJsxFlowElement' | 'mdxJsxTextElement';
+  name: string | null;
+  children: unknown[];
+  data?: Record<string, unknown>;
+}
+
+interface RootNode {
+  children: unknown[];
+}
+
+interface VFileLike {
+  dirname?: string | null;
+  path?: string;
+}
+
+const IMPORT_PATTERN = /^\s*import\s+([\s\S]*?)\s+from\s+(['"])([^'"]+)\2\s*;?\s*$/gm;
+const IMPORT_ALIAS_PATTERN = /\s+as\s+/;
+const LOCAL_NAME_PATTERN = /^[A-Za-z_$][\w$]*$/;
+const WORKFLOW_MDX_PATTERN = /\.mdx$/;
+
+export function remarkGeneratedComponents() {
+  return async (tree: RootNode, file: VFileLike) => {
+    const imports = new Map<string, string>();
+    walk(tree, (node) => {
+      if (node.type !== 'mdxjsEsm') return;
+      for (const binding of generatedImports(node)) {
+        const target = resolveGeneratedImport(file, binding.source);
+        if (target) imports.set(binding.localName, target);
+      }
+    });
+
+    if (imports.size === 0) return;
+
+    const serialized = new Map<string, string>();
+    await Promise.all(
+      [...imports.entries()].map(async ([localName, target]) => {
+        serialized.set(localName, await readGeneratedComponent(target, localName));
+      }),
+    );
+
+    walk(tree, (node) => {
+      if (node.type !== 'mdxJsxFlowElement' && node.type !== 'mdxJsxTextElement') return;
+      const element = node;
+      if (!element.name) return;
+      const text = serialized.get(element.name);
+      if (!text) return;
+      element.data ??= {};
+      element.data._stringify = {text};
+    });
+  };
+}
+
+function generatedImports(node: MdxEsmNode): ImportedComponent[] {
+  const imports: ImportedComponent[] = [];
+  for (const match of node.value.matchAll(IMPORT_PATTERN)) {
+    const specifier = match[1]?.trim();
+    const source = match[3];
+    if (!specifier || !source) continue;
+
+    imports.push(...bindingsForSpecifier(specifier, source));
+  }
+  return imports;
+}
+
+function bindingsForSpecifier(specifier: string, source: string): ImportedComponent[] {
+  if (specifier.startsWith('{') && specifier.endsWith('}')) {
+    return specifier
+      .slice(1, -1)
+      .split(',')
+      .flatMap((item) => namedBinding(item, source));
+  }
+
+  const localName = specifier.split(',')[0]?.trim();
+  return localName && LOCAL_NAME_PATTERN.test(localName) ? [{localName, source}] : [];
+}
+
+function namedBinding(item: string, source: string): ImportedComponent[] {
+  const parts = item.trim().split(IMPORT_ALIAS_PATTERN);
+  const imported = parts[0]?.trim();
+  const localName = parts[1]?.trim() || imported;
+  return imported && localName ? [{localName, source}] : [];
+}
+
+function resolveGeneratedImport(file: VFileLike, source: string): string | undefined {
+  if (!source.startsWith('.') || !source.endsWith('.mdx')) return undefined;
+  const base = file.dirname ?? (file.path ? dirname(file.path) : undefined);
+  if (!base) return undefined;
+  const target = resolve(base, source);
+  const normalized = target.split(sep).join('/');
+  return normalized.includes('/content/generated/') ? target : undefined;
+}
+
+async function readGeneratedComponent(target: string, localName: string): Promise<string> {
+  if (basename(target) === 'workflow-schema.mdx') {
+    const mapPath = target.replace(WORKFLOW_MDX_PATTERN, '.llm.json');
+    const map = JSON.parse(await readFile(mapPath, 'utf8')) as WorkflowMarkdownMap;
+    const text = map[localName];
+    if (typeof text !== 'string') {
+      throw new Error(
+        `Generated workflow schema component "${localName}" has no machine-readable serialization.`,
+      );
+    }
+    return text.trim();
+  }
+
+  return (await readFile(target, 'utf8')).trim();
+}
+
+function walk(value: unknown, callback: (node: MdxEsmNode | MdxElementNode) => void): void {
+  if (!isRecord(value)) return;
+  if (isNode(value)) callback(value);
+  if (!Array.isArray(value.children)) return;
+  for (const child of value.children) walk(child, callback);
+}
+
+function isNode(value: unknown): value is MdxEsmNode | MdxElementNode {
+  if (!isRecord(value) || typeof value.type !== 'string') return false;
+  if (value.type === 'mdxjsEsm') return typeof value.value === 'string';
+  return (
+    (value.type === 'mdxJsxFlowElement' || value.type === 'mdxJsxTextElement') &&
+    (typeof value.name === 'string' || value.name === null) &&
+    Array.isArray(value.children)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -34,6 +34,12 @@ export function resolveDocsOrigin(environment: DocsEnvironment = config): string
 
 export const url = resolveDocsOrigin();
 
+// Machine-readable documentation is consumed outside the deployment that
+// generated it, so its canonical links always point at the public docs mount.
+// Keep this alongside the deployment URL configuration so the mount has one
+// owner even though preview and local links remain environment-specific.
+export const canonicalDocsOrigin = 'https://www.shipfox.io/docs';
+
 // Set from `basePath` in next.config.mjs (via NEXT_PUBLIC_BASE_PATH): `/docs` in
 // production, empty in local dev. Every absolute URL we emit for external consumers
 // (llms.txt, sitemap, robots, OG metadata) must carry the prefix; Next only applies

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -1,5 +1,7 @@
 import {config, type DocsConfig} from './config';
 
+export {canonicalDocsOrigin} from './lib/canonical-docs-origin';
+
 const LOCAL_DOCS_ORIGIN = 'http://localhost:3500';
 export const PUBLIC_DOCS_ORIGIN = 'https://www.shipfox.io';
 
@@ -33,12 +35,6 @@ export function resolveDocsOrigin(environment: DocsEnvironment = config): string
 }
 
 export const url = resolveDocsOrigin();
-
-// Machine-readable documentation is consumed outside the deployment that
-// generated it, so its canonical links always point at the public docs mount.
-// Keep this alongside the deployment URL configuration so the mount has one
-// owner even though preview and local links remain environment-specific.
-export const canonicalDocsOrigin = 'https://www.shipfox.io/docs';
 
 // Set from `basePath` in next.config.mjs (via NEXT_PUBLIC_BASE_PATH): `/docs` in
 // production, empty in local dev. Every absolute URL we emit for external consumers


### PR DESCRIPTION
Machine-readable reference pages now share the deterministic serialization path used by the full LLM export, so `.md` and `.mdx` endpoints reflect rendered content.

The serializer expands generated workflow, context, model-provider, and integration references; preserves authored MDX wrappers; emits canonical titles, descriptions, links, and media; and fails on unresolved components or missing generated facts.

Validation: `mise exec -- pnpm check`, `mise exec -- pnpm type`, `mise exec -- pnpm test`, and `mise exec -- pnpm build` from `apps/docs`.

Closes ENG-1929

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Machine-readable docs now use one deterministic serializer for per-page Markdown and `llms-full.txt`, so generated reference facts match rendered pages without unresolved MDX or deployment-relative URLs.

- Serializes workflow schemas, contexts, model providers, integration catalogs, events, and tools as Markdown headings and tables, with generated artifacts published through an atomic manifest.
- Converts presentation-only MDX wrappers while preserving authored content, fenced code, and code-span whitespace.
- Rewrites links and media to canonical `https://www.shipfox.io/docs` URLs, replacing unusable image sources with alt text.
- Requires page descriptions and validates generated facts, components, fences, and documentation URLs across representative page families.

Closes ENG-1929

<sup>Written for commit fce2682722461a72c185501b8aa07f81d7be6504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

