### PR TITLE
[@shipfox/docs] Add Gemini 3.8 Flash to the Cloud model reference

### DIFF
--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -48,6 +48,7 @@ reference](/reference/workflow-schema#agent-step-fields).
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` |
 | Claude Sonnet 4.5 | `claude-sonnet-4.5` |
 | Claude Haiku 4.5 | `claude-haiku-4.5` |
+| Gemini 3.8 Flash | `gemini-3.8-flash` |
 | GPT-5.6 Luna | `gpt-5.6-luna` |
 | GPT-5.6 Terra | `gpt-5.6-terra` |
 | GPT-5.6 Sol | `gpt-5.6-sol` |


### PR DESCRIPTION
Add Gemini 3.8 Flash to the managed Shipfox Cloud agent model reference so users can select the model with exact workflow ID `gemini-3.8-flash`. Validated locally with `mise exec -- turbo test --filter=@shipfox/docs...` and `mise exec -- turbo check type build --filter=@shipfox/docs...`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gemini 3.8 Flash to the Shipfox Cloud model reference so users can select it with workflow ID `gemini-3.8-flash`.

<sup>Written for commit 95eb7b7dbccff75b80d0a6cf492fdebecf3f5ce2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

