### PR TITLE
Harden repository audits and resumed agent workspaces

### DIFF
--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -2122,6 +2122,118 @@ describe('runJobSteps', () => {
     expect(events.indexOf(`commit:${agent.id}`)).toBeLessThan(events.indexOf(`report:${agent.id}`));
   });
 
+  it('preserves the existing workspace when resuming without a checkout', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep({
+      session: {id: SESSION_ID, key: 'main', mode: 'resume', segment: 0},
+    });
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'shipfox-runner-session-'));
+    const transcriptFile = join(transcriptDir, 'session.jsonl');
+    writeFileSync(transcriptFile, 'session transcript');
+    requestSessionTranscriptMock.mockResolvedValueOnce({
+      blob: gzipSync(Buffer.from('session transcript')),
+      segment: 0,
+      harness: 'pi',
+    });
+    executeAgentStepMock.mockResolvedValueOnce({
+      success: true,
+      response: 'done',
+      sessionFile: transcriptFile,
+      sessionId: 'native-session-1',
+      error: null,
+      exit_code: 0,
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+
+    try {
+      await runLoop({agentStateDir: transcriptDir, signal: new AbortController().signal});
+    } finally {
+      rmSync(transcriptDir, {recursive: true, force: true});
+    }
+
+    expect(executeAgentStepMock).toHaveBeenCalledWith(
+      agent,
+      expect.objectContaining({
+        prompt:
+          'Resuming session "main". The existing workspace is intact from the previous turn.\n\nFix it.',
+      }),
+    );
+  });
+
+  it('only claims a fresh workspace for the first resumed step after checkout', async () => {
+    const setup = buildSetupStep();
+    const firstAgent = buildAgentStep({
+      id: '00000000-0000-0000-0000-0000000000c1',
+      session: {id: SESSION_ID, key: 'main', mode: 'resume', segment: 0},
+    });
+    const secondAgent = buildAgentStep({
+      id: '00000000-0000-0000-0000-0000000000c2',
+      session: {
+        id: '00000000-0000-0000-0000-0000000000e1',
+        key: 'follow-up',
+        mode: 'resume',
+        segment: 0,
+      },
+    });
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'shipfox-runner-session-'));
+    const transcriptFile = join(transcriptDir, 'session.jsonl');
+    writeFileSync(transcriptFile, 'session transcript');
+    executeSetupStepMock.mockResolvedValueOnce({
+      result: {
+        success: true,
+        checkout: {
+          repository: 'acme/repo',
+          ref: 'refs/heads/main',
+          commit: 'abc123',
+          path: '/work',
+        },
+        error: null,
+        exit_code: 0,
+      },
+    });
+    requestSessionTranscriptMock.mockResolvedValue({
+      blob: gzipSync(Buffer.from('session transcript')),
+      segment: 0,
+      harness: 'pi',
+    });
+    executeAgentStepMock.mockResolvedValue({
+      success: true,
+      response: 'done',
+      sessionFile: transcriptFile,
+      sessionId: 'native-session-1',
+      error: null,
+      exit_code: 0,
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(firstAgent, 1))
+      .mockResolvedValueOnce(stepResponse(secondAgent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+
+    try {
+      await runLoop({agentStateDir: transcriptDir, signal: new AbortController().signal});
+    } finally {
+      rmSync(transcriptDir, {recursive: true, force: true});
+    }
+
+    expect(executeAgentStepMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        prompt: expect.stringContaining(
+          'This is a new execution in a fresh workspace checked out at refs/heads/main.',
+        ),
+      }),
+    );
+    expect(executeAgentStepMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        prompt:
+          'Resuming session "follow-up". The existing workspace is intact from the previous turn.\n\nFix it.',
+      }),
+    );
+  });
+
   it('commits a loadable failed harness result before reporting it', async () => {
     const setup = buildSetupStep();
     const agent = buildAgentStep({

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -2234,6 +2234,76 @@ describe('runJobSteps', () => {
     );
   });
 
+  it('consumes the checkout marker when a resumed session has no transcript', async () => {
+    const setup = buildSetupStep();
+    const firstAgent = buildAgentStep({
+      id: '00000000-0000-0000-0000-0000000000c3',
+      session: {id: SESSION_ID, key: 'main', mode: 'resume', segment: 0},
+    });
+    const secondAgent = buildAgentStep({
+      id: '00000000-0000-0000-0000-0000000000c4',
+      session: {
+        id: '00000000-0000-0000-0000-0000000000e2',
+        key: 'follow-up',
+        mode: 'resume',
+        segment: 0,
+      },
+    });
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'shipfox-runner-session-'));
+    const transcriptFile = join(transcriptDir, 'session.jsonl');
+    writeFileSync(transcriptFile, 'session transcript');
+    executeSetupStepMock.mockResolvedValueOnce({
+      result: {
+        success: true,
+        checkout: {
+          repository: 'acme/repo',
+          ref: 'refs/heads/main',
+          commit: 'abc123',
+          path: '/work',
+        },
+        error: null,
+        exit_code: 0,
+      },
+    });
+    requestSessionTranscriptMock
+      .mockResolvedValueOnce({blob: null, segment: 0})
+      .mockResolvedValueOnce({
+        blob: gzipSync(Buffer.from('session transcript')),
+        segment: 0,
+        harness: 'pi',
+      });
+    executeAgentStepMock.mockResolvedValue({
+      success: true,
+      response: 'done',
+      sessionFile: transcriptFile,
+      sessionId: 'native-session-1',
+      error: null,
+      exit_code: 0,
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(firstAgent, 1))
+      .mockResolvedValueOnce(stepResponse(secondAgent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+
+    try {
+      await runLoop({agentStateDir: transcriptDir, signal: new AbortController().signal});
+    } finally {
+      rmSync(transcriptDir, {recursive: true, force: true});
+    }
+
+    expect(executeAgentStepMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({session: {mode: 'resume'}}),
+    );
+    expect(executeAgentStepMock.mock.calls[0]?.[1]).not.toHaveProperty('prompt');
+    expect(executeAgentStepMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        prompt:
+          'Resuming session "follow-up". The existing workspace is intact from the previous turn.\n\nFix it.',
+      }),
+    );
+  });
+
   it('commits a loadable failed harness result before reporting it', async () => {
     const setup = buildSetupStep();
     const agent = buildAgentStep({

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1008,12 +1008,12 @@ async function executeAgentStepBranch(params: {
   params.onStream(sessionStream);
   params.registerStreamSecrets(sessionStream);
   const {executeAgentStep} = await loadRunnerAgentStep();
-  const resumePrompt = buildResumePrompt(session, params.checkoutRef, input.step.config.prompt);
   consumeCheckoutRefIfUsed({
     consume: input.consumeCheckoutRef,
     checkoutRef: params.checkoutRef,
-    resumePrompt,
+    session,
   });
+  const resumePrompt = buildResumePrompt(session, params.checkoutRef, input.step.config.prompt);
   const result = await executeAgentStep(input.step, {
     signal: input.signal,
     cwd: params.stepCwd,
@@ -1150,9 +1150,9 @@ function buildResumePrompt(
 function consumeCheckoutRefIfUsed(params: {
   consume: (() => void) | undefined;
   checkoutRef: string | undefined;
-  resumePrompt: string | undefined;
+  session: AgentSessionState;
 }): void {
-  if (params.resumePrompt === undefined || params.checkoutRef === undefined) return;
+  if (params.checkoutRef === undefined || params.session.mode !== 'resume') return;
   params.consume?.();
 }
 

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -208,6 +208,9 @@ async function runJobStepIteration(
     ambientGitConfigPath: state.ambientGitConfigPath,
     ambientGitConfigSecrets: state.ambientGitConfigSecrets,
     checkoutRef: state.checkoutRef,
+    consumeCheckoutRef: () => {
+      state.checkoutRef = undefined;
+    },
     jobId: params.jobId,
     stepLabel,
     logsDir: params.logsDir,
@@ -620,6 +623,7 @@ export async function executeStep(params: {
   ambientGitConfigPath?: string | undefined;
   ambientGitConfigSecrets?: string[] | undefined;
   checkoutRef?: string | undefined;
+  consumeCheckoutRef?: (() => void) | undefined;
   gitConfigPath: string;
   jobId: string;
   stepLabel: string;
@@ -1004,16 +1008,18 @@ async function executeAgentStepBranch(params: {
   params.onStream(sessionStream);
   params.registerStreamSecrets(sessionStream);
   const {executeAgentStep} = await loadRunnerAgentStep();
+  const resumePrompt = buildResumePrompt(session, params.checkoutRef, input.step.config.prompt);
+  consumeCheckoutRefIfUsed({
+    consume: input.consumeCheckoutRef,
+    checkoutRef: params.checkoutRef,
+    resumePrompt,
+  });
   const result = await executeAgentStep(input.step, {
     signal: input.signal,
     cwd: params.stepCwd,
     agentStateDir: input.agentStateDir,
     ...(session.invocation === undefined ? {} : {session: session.invocation}),
-    ...(session.preamble && typeof input.step.config.prompt === 'string'
-      ? {
-          prompt: `${resumePreamble(session, params.checkoutRef)}\n\n${input.step.config.prompt}`,
-        }
-      : {}),
+    ...(resumePrompt === undefined ? {} : {prompt: resumePrompt}),
     ...(input.ambientGitConfigPath ? {gitConfigGlobal: input.ambientGitConfigPath} : {}),
     runtime: {
       harness: runtimeConfig.harness,
@@ -1126,11 +1132,28 @@ async function prepareAgentSession(
 }
 
 function resumePreamble(session: AgentSessionState, checkoutRef: string | undefined): string {
-  const workspace =
-    checkoutRef === undefined
-      ? ''
-      : ` This is a new execution in a fresh workspace checked out at ${checkoutRef}.`;
-  return `Resuming session "${session.key ?? ''}".${workspace} Files and processes from earlier parts of this conversation no longer exist unless they were committed.`;
+  if (checkoutRef === undefined) {
+    return `Resuming session "${session.key ?? ''}". The existing workspace is intact from the previous turn.`;
+  }
+  return `Resuming session "${session.key ?? ''}". This is a new execution in a fresh workspace checked out at ${checkoutRef}. Files and processes from earlier parts of this conversation no longer exist unless they were committed.`;
+}
+
+function buildResumePrompt(
+  session: AgentSessionState,
+  checkoutRef: string | undefined,
+  prompt: unknown,
+): string | undefined {
+  if (!session.preamble || typeof prompt !== 'string') return undefined;
+  return `${resumePreamble(session, checkoutRef)}\n\n${prompt}`;
+}
+
+function consumeCheckoutRefIfUsed(params: {
+  consume: (() => void) | undefined;
+  checkoutRef: string | undefined;
+  resumePrompt: string | undefined;
+}): void {
+  if (params.resumePrompt === undefined || params.checkoutRef === undefined) return;
+  params.consume?.();
 }
 
 function sessionCommitSdkVersion(harness: string): string {

--- a/tools/api-database-policy/turbo.json
+++ b/tools/api-database-policy/turbo.json
@@ -2,6 +2,13 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/api-contexts.cjs",
+        "$TURBO_ROOT$/api-databases.cjs"
+      ]
+    },
     "verify": {
       "inputs": [
         "$TURBO_DEFAULT$",

--- a/tools/api-database-policy/turbo.json
+++ b/tools/api-database-policy/turbo.json
@@ -6,7 +6,14 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/api-contexts.cjs",
-        "$TURBO_ROOT$/api-databases.cjs"
+        "$TURBO_ROOT$/api-databases.cjs",
+        "$TURBO_ROOT$/libs/api/**/package.json",
+        "$TURBO_ROOT$/libs/api/**/drizzle.config.ts",
+        "$TURBO_ROOT$/libs/api/**/drizzle/**",
+        "$TURBO_ROOT$/libs/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/libs/shared/node/**/package.json",
+        "$TURBO_ROOT$/libs/shared/node/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/apps/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
       ]
     },
     "verify": {

--- a/tools/client-architecture-policy/turbo.json
+++ b/tools/client-architecture-policy/turbo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/libs/client/**/*.{ts,tsx}",
+        "$TURBO_ROOT$/libs/shared/react/ui/**/*.{ts,tsx}"
+      ]
+    },
+    "verify": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/libs/client/**/*.{ts,tsx}",
+        "$TURBO_ROOT$/libs/shared/react/ui/**/*.{ts,tsx}"
+      ]
+    }
+  }
+}

--- a/tools/dependency-policy/turbo.json
+++ b/tools/dependency-policy/turbo.json
@@ -2,6 +2,15 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/pnpm-lock.yaml",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/{apps,dev,e2e,infra,libs,tools,turbo}/**/package.json"
+      ]
+    },
     "verify": {
       "inputs": [
         "$TURBO_DEFAULT$",

--- a/tools/dependency-policy/turbo.json
+++ b/tools/dependency-policy/turbo.json
@@ -5,6 +5,7 @@
     "test": {
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.syncpackrc.json",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/pnpm-lock.yaml",
         "$TURBO_ROOT$/pnpm-workspace.yaml",

--- a/tools/repository-documentation-policy/src/repository-documentation.ts
+++ b/tools/repository-documentation-policy/src/repository-documentation.ts
@@ -22,6 +22,13 @@ export type DocumentationViolation =
       kind: 'orphan';
       file: string;
       reason: string;
+    }
+  | {
+      kind: 'missing-repository-root-input';
+      file: string;
+      package: string;
+      task: RepositoryPolicyTask;
+      reason: string;
     };
 
 export interface DocumentationCheckResult {
@@ -85,6 +92,9 @@ export type GuidanceFileKind =
   | 'package'
   | 'policy'
   | 'subsystem';
+
+const repositoryPolicyTasks = ['test', 'verify'] as const;
+type RepositoryPolicyTask = (typeof repositoryPolicyTasks)[number];
 
 export function guidanceFileKind(relativePath: string): GuidanceFileKind {
   if (relativePath === 'docs/README.md') return 'documentation-map';
@@ -166,7 +176,65 @@ export async function checkRepositoryDocumentation(
     }
   }
 
-  return {checkedFiles, violations};
+  return {
+    checkedFiles,
+    violations: [...violations, ...(await checkRepositoryToolTurboInputs(rootDirectory))],
+  };
+}
+
+export async function checkRepositoryToolTurboInputs(
+  rootDirectory = repositoryRoot,
+): Promise<DocumentationViolation[]> {
+  const toolsDirectory = path.join(rootDirectory, 'tools');
+  const entries = await readdir(toolsDirectory, {withFileTypes: true}).catch(() => []);
+  const violations: DocumentationViolation[] = [];
+
+  for (const directoryName of entries
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith('-policy'))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((entry) => entry.name)) {
+    violations.push(...(await checkRepositoryPolicyPackage(toolsDirectory, directoryName)));
+  }
+
+  return violations;
+}
+
+async function checkRepositoryPolicyPackage(
+  toolsDirectory: string,
+  directoryName: string,
+): Promise<DocumentationViolation[]> {
+  const packageDirectory = path.join(toolsDirectory, directoryName);
+  const manifest = await readJsonObject(path.join(packageDirectory, 'package.json'));
+  const scripts = manifest && isRecord(manifest.scripts) ? manifest.scripts : undefined;
+  if (scripts === undefined || typeof scripts.verify !== 'string') return [];
+
+  const tasks = repositoryPolicyTasks.filter((task) => typeof scripts[task] === 'string');
+  const turboConfig = await readJsonObject(path.join(packageDirectory, 'turbo.json'));
+  return tasks.flatMap((task) => {
+    const violation = missingRepositoryRootInput(turboConfig, directoryName, task);
+    return violation === undefined ? [] : [violation];
+  });
+}
+
+function missingRepositoryRootInput(
+  turboConfig: Record<string, unknown> | undefined,
+  directoryName: string,
+  task: RepositoryPolicyTask,
+): DocumentationViolation | undefined {
+  const taskConfig = turboConfig && isRecord(turboConfig.tasks) ? turboConfig.tasks[task] : null;
+  const inputs = isRecord(taskConfig) ? taskConfig.inputs : undefined;
+  const hasRepositoryRootInput =
+    Array.isArray(inputs) &&
+    inputs.some((input) => typeof input === 'string' && input.includes('$TURBO_ROOT$'));
+  if (hasRepositoryRootInput) return undefined;
+
+  return {
+    kind: 'missing-repository-root-input',
+    file: `tools/${directoryName}/turbo.json`,
+    package: `tools/${directoryName}`,
+    task,
+    reason: `The ${task} task must declare at least one $TURBO_ROOT$ input so repository changes invalidate its cache.`,
+  };
 }
 
 interface DocumentationFileCheckOptions {
@@ -438,7 +506,23 @@ function formatViolation(violation: DocumentationViolation): string {
   if (violation.kind === 'orphan') {
     return `- ${violation.file}: ${violation.reason}`;
   }
+  if (violation.kind === 'missing-repository-root-input') {
+    return `- ${violation.package}#${violation.task}: ${violation.reason}`;
+  }
   return `- ${violation.source}:${violation.line} -> ${violation.target}: ${violation.reason}`;
+}
+
+async function readJsonObject(file: string): Promise<Record<string, unknown> | undefined> {
+  try {
+    const value: unknown = JSON.parse(await readFile(file, 'utf8'));
+    return isRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tools/repository-documentation-policy/test/repository-documentation.test.ts
+++ b/tools/repository-documentation-policy/test/repository-documentation.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   checkRepositoryDocumentation,
+  checkRepositoryToolTurboInputs,
   collectDocumentationFiles,
   extractMarkdownLinks,
 } from '../src/repository-documentation.js';
@@ -128,6 +129,55 @@ describe('repository documentation policy', () => {
     try {
       assert.deepEqual(await collectDocumentationFiles(root), ['README.md']);
       assert.deepEqual((await checkRepositoryDocumentation(root)).violations, []);
+    } finally {
+      await rm(root, {recursive: true});
+    }
+  });
+
+  test('requires repository policy tasks to declare repository-root inputs', async () => {
+    const root = await fixture({
+      'tools/client-architecture-policy/package.json': JSON.stringify({
+        name: '@shipfox/client-architecture-policy',
+        scripts: {test: 'test', verify: 'verify'},
+      }),
+      'tools/client-architecture-policy/turbo.json': JSON.stringify({
+        tasks: {
+          test: {inputs: ['$TURBO_ROOT$/libs/client/**/*.ts']},
+          verify: {inputs: ['$TURBO_ROOT$/libs/client/**/*.ts']},
+        },
+      }),
+    });
+    try {
+      assert.deepEqual(await checkRepositoryToolTurboInputs(root), []);
+    } finally {
+      await rm(root, {recursive: true});
+    }
+  });
+
+  test('reports repository policy tasks without repository-root inputs', async () => {
+    const root = await fixture({
+      'tools/client-architecture-policy/package.json': JSON.stringify({
+        name: '@shipfox/client-architecture-policy',
+        scripts: {test: 'test', verify: 'verify'},
+      }),
+      'tools/client-architecture-policy/turbo.json': JSON.stringify({
+        tasks: {
+          test: {inputs: ['$TURBO_DEFAULT$']},
+          verify: {inputs: ['$TURBO_ROOT$/libs/client/**/*.ts']},
+        },
+      }),
+    });
+    try {
+      assert.deepEqual(await checkRepositoryToolTurboInputs(root), [
+        {
+          kind: 'missing-repository-root-input',
+          file: 'tools/client-architecture-policy/turbo.json',
+          package: 'tools/client-architecture-policy',
+          task: 'test',
+          reason:
+            'The test task must declare at least one $TURBO_ROOT$ input so repository changes invalidate its cache.',
+        },
+      ]);
     } finally {
       await rm(root, {recursive: true});
     }

--- a/tools/repository-documentation-policy/turbo.json
+++ b/tools/repository-documentation-policy/turbo.json
@@ -2,13 +2,26 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/{AGENTS.md,CLAUDE.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,DESIGN.md,README.md,SECURITY.md,WRITING.md}",
+        "$TURBO_ROOT$/.agents/**/*.md",
+        "$TURBO_ROOT$/docs/**/*.md",
+        "$TURBO_ROOT$/{apps,dev,e2e,infra,libs,tools}/**/*.md",
+        "$TURBO_ROOT$/tools/*/package.json",
+        "$TURBO_ROOT$/tools/*/turbo.json"
+      ]
+    },
     "verify": {
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/{AGENTS.md,CLAUDE.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,DESIGN.md,README.md,SECURITY.md,WRITING.md}",
         "$TURBO_ROOT$/.agents/**/*.md",
         "$TURBO_ROOT$/docs/**/*.md",
-        "$TURBO_ROOT$/{apps,dev,e2e,infra,libs,tools}/**/*.md"
+        "$TURBO_ROOT$/{apps,dev,e2e,infra,libs,tools}/**/*.md",
+        "$TURBO_ROOT$/tools/*/package.json",
+        "$TURBO_ROOT$/tools/*/turbo.json"
       ]
     }
   }

--- a/tools/repository-documentation-policy/turbo.json
+++ b/tools/repository-documentation-policy/turbo.json
@@ -5,10 +5,6 @@
     "test": {
       "inputs": [
         "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/{AGENTS.md,CLAUDE.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,DESIGN.md,README.md,SECURITY.md,WRITING.md}",
-        "$TURBO_ROOT$/.agents/**/*.md",
-        "$TURBO_ROOT$/docs/**/*.md",
-        "$TURBO_ROOT$/{apps,dev,e2e,infra,libs,tools}/**/*.md",
         "$TURBO_ROOT$/tools/*/package.json",
         "$TURBO_ROOT$/tools/*/turbo.json"
       ]


### PR DESCRIPTION
Repository policy audits read files outside their own packages, so their Turbo
cache keys must include the repository paths they inspect. This adds explicit
inputs for the client architecture audit and enforces repository-root inputs
for repository policy tasks. The repository documentation policy also tracks
policy manifests and Turbo configs so the enforcement cannot go stale.

Resumed runner agents share the checkout after the first resumed step. The
runner now consumes the checkout marker when the first resumed step builds its
prompt, and later resumes explicitly retain the existing workspace. Regression
coverage protects both no-checkout resumes and multiple resumed agents after
one checkout.

The convention-based policy check is intentional: it keeps the repository
contract deterministic without depending on source-pattern detection.

Validation completed with targeted Turbo check, type, test, and verify runs for
the changed policy and runner packages, plus the downstream package-release
type check. A client audit cache probe also confirmed a client source edit
causes a cache miss and reports the violation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden repository policy caching and resumed agent workspace handling so policy audits can't go stale and resumed runs keep their checkout.

**Repository policy caching**
- Declares repository-root Turbo inputs for `api-database-policy`, `dependency-policy`, and the new `client-architecture-policy` config.
- The repository documentation policy now requires every `tools/*-policy` package to declare a `$TURBO_ROOT$` input for `test` and `verify` tasks.
- The documentation policy's own inputs include policy manifests and Turbo configs so its enforcement can't go stale.

**Resumed agent workspaces**
- The runner consumes the checkout marker for the first resumed session even when no transcript exists, so later resumed steps retain the existing workspace instead of claiming a fresh checkout.
- Regression tests cover no-checkout resumes and multiple resumed agents after one checkout.

<sup>Written for commit 99c49e1669f54dc9b364cff0bdba5e5a59a445fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

