### PR TITLE
Prove GitHub repository authorization end to end

### DIFF
--- a/.changeset/github-auth-proof.md
+++ b/.changeset/github-auth-proof.md
@@ -1,0 +1,8 @@
+---
+'@shipfox/api-integration-github': minor
+'@shipfox/api-integration-github-dto': minor
+'@shipfox/api-integration-core': patch
+'@shipfox/api-projects-dto': minor
+---
+
+Adds GitHub authorization state and E2E project metadata for selected and all repository access.

--- a/.changeset/github-auth-proof.md
+++ b/.changeset/github-auth-proof.md
@@ -5,4 +5,4 @@
 '@shipfox/api-projects-dto': minor
 ---
 
-Adds GitHub authorization state and E2E project metadata for selected and all repository access.
+Adds GitHub authorization state for selected and all repository access.

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -271,6 +271,10 @@ export function e2eEnv(sourceEnv) {
       sourceEnv.INTEGRATIONS_ENABLE_GITHUB_PROVIDER,
       'true',
     ),
+    INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION: valueOr(
+      sourceEnv.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
+      'true',
+    ),
     INTEGRATIONS_ENABLE_LINEAR_PROVIDER: valueOr(
       sourceEnv.INTEGRATIONS_ENABLE_LINEAR_PROVIDER,
       'true',

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -82,6 +82,7 @@ describe('e2eEnv', () => {
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
     assert.equal(env.INTEGRATIONS_ENABLE_LINEAR_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_GITHUB_PROVIDER, 'true');
+    assert.equal(env.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_SLACK_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '600');
@@ -113,6 +114,7 @@ describe('e2eEnv', () => {
       LINEAR_MCP_ENDPOINT: 'http://127.0.0.1:16120/mcp',
       GITHUB_API_BASE_URL: 'http://127.0.0.1:16121',
       GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE: 'disabled',
+      INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION: 'false',
       SLACK_API_BASE_URL: 'http://127.0.0.1:16122',
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
@@ -129,6 +131,7 @@ describe('e2eEnv', () => {
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:16120/mcp');
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
     assert.equal(env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE, 'disabled');
+    assert.equal(env.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION, 'false');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:16122');
     assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '600');
     assert.equal(env.INTEGRATIONS_TEST_VCS_PORT, '16115');

--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -3,6 +3,8 @@ import type {Page} from '@shipfox/playwright';
 
 type Locator = ReturnType<Page['locator']>;
 type FixtureUse<T> = (fixture: T) => Promise<void>;
+const SELECTED_REPOSITORY_MODE_RE = /Only your projects' repositories/u;
+const ALL_REPOSITORY_MODE_RE = /Every repository this integration can access/u;
 
 export class IntegrationsCatalogueScreen {
   private readonly shell: SettingsShell;
@@ -113,6 +115,44 @@ export class ProviderInstallScreen {
   }
 }
 
+export class ConnectionDetailsScreen {
+  constructor(private readonly page: Page) {}
+
+  async goto(workspaceSlug: string, connectionSlug: string): Promise<void> {
+    await this.page.goto(
+      `/w/${workspaceSlug}/settings/integrations/${encodeURIComponent(connectionSlug)}`,
+    );
+  }
+
+  heading(): Locator {
+    return this.page.getByRole('heading', {name: 'Repository access'});
+  }
+
+  selectedMode(): Locator {
+    return this.page.getByRole('radio', {name: SELECTED_REPOSITORY_MODE_RE});
+  }
+
+  allMode(): Locator {
+    return this.page.getByRole('radio', {name: ALL_REPOSITORY_MODE_RE});
+  }
+
+  projectsRepositoriesHeading(): Locator {
+    return this.page.getByRole('heading', {name: "Your projects' repositories"});
+  }
+
+  repository(name: string): Locator {
+    return this.page.getByText(name, {exact: true});
+  }
+
+  saveButton(): Locator {
+    return this.page.getByRole('button', {name: 'Save changes'});
+  }
+
+  providerNotice(): Locator {
+    return this.page.getByRole('link', {name: 'Change repositories on GitHub'});
+  }
+}
+
 export class SentryCallbackScreen {
   constructor(private readonly page: Page) {}
 
@@ -147,6 +187,7 @@ export class SentryCallbackScreen {
 
 export interface IntegrationsScreenFixtures {
   integrationsCatalogue: IntegrationsCatalogueScreen;
+  connectionDetails: ConnectionDetailsScreen;
   providerInstall: ProviderInstallScreen;
   sentryCallback: SentryCallbackScreen;
   sourceControlSetup: SourceControlSetupScreen;
@@ -158,6 +199,9 @@ export const integrationsScreens = {
     use: FixtureUse<IntegrationsCatalogueScreen>,
   ) => {
     await use(new IntegrationsCatalogueScreen(page));
+  },
+  connectionDetails: async ({page}: {page: Page}, use: FixtureUse<ConnectionDetailsScreen>) => {
+    await use(new ConnectionDetailsScreen(page));
   },
   providerInstall: async ({page}: {page: Page}, use: FixtureUse<ProviderInstallScreen>) => {
     await use(new ProviderInstallScreen(page));

--- a/e2e/setup/integrations/src/index.test.ts
+++ b/e2e/setup/integrations/src/index.test.ts
@@ -61,6 +61,31 @@ describe('integrations E2E setup helper', () => {
     });
   });
 
+  it('can create a disabled GitHub connection for setup sequencing', async () => {
+    requestJson.mockResolvedValueOnce({id: 'connection-id'});
+    const {createGithubConnection} = await import('./index.js');
+
+    await createGithubConnection({
+      workspaceId: '00000000-0000-4000-8000-000000000001',
+      installationId: 1234,
+      accountLogin: 'shipfox-e2e',
+      displayName: 'GitHub Shipfox E2E',
+      installerUserId: '00000000-0000-4000-8000-000000000002',
+      lifecycleStatus: 'disabled',
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/integrations/github-connections', {
+      json: {
+        workspace_id: '00000000-0000-4000-8000-000000000001',
+        installation_id: 1234,
+        account_login: 'shipfox-e2e',
+        display_name: 'GitHub Shipfox E2E',
+        installer_user_id: '00000000-0000-4000-8000-000000000002',
+        lifecycle_status: 'disabled',
+      },
+    });
+  });
+
   it('creates Test VCS connections and repositories through the protected setup routes', async () => {
     requestJson.mockResolvedValueOnce({id: 'connection-id'}).mockResolvedValueOnce({
       external_repository_id: 'test-vcs:e2e-owner/repository',

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -69,6 +69,7 @@ export interface CreateGithubConnectionParams {
   accountLogin: string;
   displayName: string;
   installerUserId: string;
+  lifecycleStatus?: 'active' | 'disabled' | undefined;
 }
 
 function githubConnectionBody(
@@ -80,6 +81,7 @@ function githubConnectionBody(
     account_login: params.accountLogin,
     display_name: params.displayName,
     installer_user_id: params.installerUserId,
+    ...(params.lifecycleStatus === undefined ? {} : {lifecycle_status: params.lifecycleStatus}),
   };
 }
 

--- a/e2e/setup/projects/src/index.ts
+++ b/e2e/setup/projects/src/index.ts
@@ -10,6 +10,9 @@ export interface CreateProjectParams {
   slug?: string | undefined;
   sourceConnectionId?: string | undefined;
   sourceExternalRepositoryId?: string | undefined;
+  sourceRepositoryOwner?: string | undefined;
+  sourceRepositoryName?: string | undefined;
+  sourceDefaultBranch?: string | undefined;
 }
 
 const DEFAULT_PROJECT_NAME = 'E2E Project';
@@ -26,6 +29,9 @@ export async function createProject(
       params.slug ?? withSlugSuffix(slugifyName(name, {fallback: 'project'}), ++projectSequence),
     source_connection_id: params.sourceConnectionId,
     source_external_repository_id: params.sourceExternalRepositoryId,
+    source_repository_owner: params.sourceRepositoryOwner,
+    source_repository_name: params.sourceRepositoryName,
+    source_default_branch: params.sourceDefaultBranch,
   };
   return await requestJson<E2eCreateProjectResponseDto>('post', '/__e2e/projects', {
     json: body,

--- a/e2e/suites/client/integrations/package.json
+++ b/e2e/suites/client/integrations/package.json
@@ -31,6 +31,8 @@
     "@shipfox/e2e-harness": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/e2e-screens-integrations": "workspace:*",
+    "@shipfox/e2e-setup-integrations": "workspace:*",
+    "@shipfox/e2e-setup-projects": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/suites/client/integrations/tests/repository-access.e2e.ts
+++ b/e2e/suites/client/integrations/tests/repository-access.e2e.ts
@@ -1,0 +1,49 @@
+import {createGithubConnection} from '@shipfox/e2e-setup-integrations';
+import {createProject} from '@shipfox/e2e-setup-projects';
+import {expect, test} from './test.js';
+
+test('settings exposes project-backed GitHub repositories and persists access mode', async ({
+  connectionDetails,
+  createReadyWorkspace,
+}) => {
+  const {workspaceId, workspaceSlug} = await createReadyWorkspace({
+    name: 'Repository Access Settings Workspace',
+  });
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const connection = await createGithubConnection({
+    workspaceId,
+    installationId: Number.parseInt(uniqueId.slice(0, 7), 16) + 1,
+    accountLogin: `e${uniqueId.slice(0, 5)}`,
+    displayName: `GitHub Settings ${uniqueId}`,
+    installerUserId: crypto.randomUUID(),
+  });
+  await createProject({
+    workspaceId,
+    name: `GitHub Settings Project ${uniqueId}`,
+    sourceConnectionId: connection.id,
+    sourceExternalRepositoryId: 'github:42',
+    sourceRepositoryOwner: 'shipfox',
+    sourceRepositoryName: 'e2e',
+    sourceDefaultBranch: 'main',
+  });
+
+  // The project-backed list comes from local project state; no repository grant mutation is
+  // needed to populate it.
+  await connectionDetails.goto(workspaceSlug, connection.slug);
+
+  await expect(connectionDetails.heading()).toBeVisible();
+  await expect(connectionDetails.selectedMode()).toBeChecked();
+  await expect(connectionDetails.projectsRepositoriesHeading()).toBeVisible();
+  await expect(connectionDetails.repository('shipfox/e2e')).toBeVisible();
+  await expect(connectionDetails.providerNotice()).toBeVisible();
+
+  await connectionDetails.allMode().check();
+  await connectionDetails.saveButton().click();
+  await expect(connectionDetails.allMode()).toBeChecked();
+  await expect(connectionDetails.projectsRepositoriesHeading()).toHaveCount(0);
+
+  await connectionDetails.selectedMode().check();
+  await connectionDetails.saveButton().click();
+  await expect(connectionDetails.selectedMode()).toBeChecked();
+  await expect(connectionDetails.repository('shipfox/e2e')).toBeVisible();
+});

--- a/e2e/suites/client/integrations/tests/repository-access.e2e.ts
+++ b/e2e/suites/client/integrations/tests/repository-access.e2e.ts
@@ -41,9 +41,15 @@ test('settings exposes project-backed GitHub repositories and persists access mo
   await connectionDetails.saveButton().click();
   await expect(connectionDetails.allMode()).toBeChecked();
   await expect(connectionDetails.projectsRepositoriesHeading()).toHaveCount(0);
+  await connectionDetails.goto(workspaceSlug, connection.slug);
+  await expect(connectionDetails.allMode()).toBeChecked();
+  await expect(connectionDetails.projectsRepositoriesHeading()).toHaveCount(0);
 
   await connectionDetails.selectedMode().check();
   await connectionDetails.saveButton().click();
+  await expect(connectionDetails.selectedMode()).toBeChecked();
+  await expect(connectionDetails.repository('shipfox/e2e')).toBeVisible();
+  await connectionDetails.goto(workspaceSlug, connection.slug);
   await expect(connectionDetails.selectedMode()).toBeChecked();
   await expect(connectionDetails.repository('shipfox/e2e')).toBeVisible();
 });

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -64,6 +64,7 @@
     "@shipfox/e2e-setup-agent": "workspace:*",
     "@shipfox/e2e-setup-integrations": "workspace:*",
     "@shipfox/e2e-setup-auth": "workspace:*",
+    "@shipfox/e2e-setup-projects": "workspace:*",
     "@shipfox/e2e-setup-secrets": "workspace:*",
     "@shipfox/e2e-setup-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",

--- a/e2e/suites/flow/workflows/src/github-api.test.ts
+++ b/e2e/suites/flow/workflows/src/github-api.test.ts
@@ -165,4 +165,38 @@ describe('GitHub API mock', () => {
       await mock.stop();
     }
   });
+
+  it('serves pull request review thread queries with the expected GraphQL shape', async () => {
+    const mock = await startGithubApiMock({endpoint: new URL('http://127.0.0.1:0')});
+
+    try {
+      const response = await fetch(new URL('/graphql', mock.endpoint), {
+        method: 'POST',
+        headers: {
+          authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: 'query GetPullRequestReviewThreads { reviewThreads { nodes { id } } }',
+          variables: {owner: 'shipfox', repo: 'platform', pullNumber: 2},
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [],
+                pageInfo: {hasNextPage: false, endCursor: null},
+              },
+            },
+          },
+        },
+      });
+    } finally {
+      await mock.stop();
+    }
+  });
 });

--- a/e2e/suites/flow/workflows/src/github-api.test.ts
+++ b/e2e/suites/flow/workflows/src/github-api.test.ts
@@ -1,5 +1,7 @@
 import {
+  GITHUB_GRAPHQL_RESULT_MARKER,
   GITHUB_READ_RESULT_MARKER,
+  GITHUB_SEARCH_RESULT_MARKER,
   GITHUB_STATEFUL_INSTALLATION_TOKEN,
   GITHUB_STATELESS_INSTALLATION_TOKEN,
   GITHUB_WRITE_RESULT_MARKER,
@@ -77,6 +79,86 @@ describe('GitHub API mock', () => {
           owner: 'shipfox',
           repo: 'e2e',
           body: {title: 'Synthetic issue'},
+        },
+      ]);
+    } finally {
+      await mock.stop();
+    }
+  });
+
+  it('serves repository metadata, scoped checkout mints, search, and GraphQL requests', async () => {
+    const mock = await startGithubApiMock({endpoint: new URL('http://127.0.0.1:0')});
+
+    try {
+      const mint = await fetch(new URL('/app/installations/1234/access_tokens', mock.endpoint), {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer app-jwt',
+          'content-type': 'application/json',
+          'x-github-stateless-s2s-token': 'enabled',
+        },
+        body: JSON.stringify({repository_ids: [42], permissions: {contents: 'read'}}),
+      });
+      const repository = await fetch(new URL('/repositories/42', mock.endpoint), {
+        headers: {authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`},
+      });
+      const search = await fetch(
+        new URL('/search/issues?q=is%3Aopen%20repo%3Ashipfox%2Fe2e', mock.endpoint),
+        {headers: {authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`}},
+      );
+      const graphql = await fetch(new URL('/graphql', mock.endpoint), {
+        method: 'POST',
+        headers: {
+          authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: 'mutation ResolveReviewThread { resolveReviewThread { thread { id } } }',
+          variables: {input: {threadId: 'thread-42'}},
+        }),
+      });
+
+      expect(mint.status).toBe(201);
+      expect(repository.status).toBe(200);
+      expect(search.status).toBe(200);
+      expect(graphql.status).toBe(200);
+      await expect(mint.json()).resolves.toMatchObject({
+        repositories: [{id: 42, full_name: 'shipfox/e2e'}],
+      });
+      await expect(repository.json()).resolves.toMatchObject({id: 42, full_name: 'shipfox/e2e'});
+      await expect(search.json()).resolves.toMatchObject({
+        items: [{marker: GITHUB_SEARCH_RESULT_MARKER}],
+      });
+      await expect(graphql.json()).resolves.toMatchObject({
+        data: {
+          resolveReviewThread: {
+            thread: {id: 'thread-42', marker: GITHUB_GRAPHQL_RESULT_MARKER},
+          },
+        },
+      });
+      expect(mock.calls).toEqual([
+        {
+          kind: 'mint-token',
+          authorization: 'Bearer app-jwt',
+          tokenFormatOverride: 'enabled',
+          installationId: 1234,
+          body: {repository_ids: [42], permissions: {contents: 'read'}},
+        },
+        {
+          kind: 'resolve-repository',
+          authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+          repositoryId: 42,
+        },
+        {
+          kind: 'search-issues',
+          authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+          query: 'is:open repo:shipfox/e2e',
+        },
+        {
+          kind: 'graphql',
+          authorization: `bearer ${GITHUB_STATELESS_INSTALLATION_TOKEN}`,
+          query: 'mutation ResolveReviewThread { resolveReviewThread { thread { id } } }',
+          variables: {input: {threadId: 'thread-42'}},
         },
       ]);
     } finally {

--- a/e2e/suites/flow/workflows/src/github-api.ts
+++ b/e2e/suites/flow/workflows/src/github-api.ts
@@ -15,10 +15,15 @@ export const GITHUB_STATELESS_INSTALLATION_TOKEN =
 export const GITHUB_STATEFUL_INSTALLATION_TOKEN = `ghs_${'d'.repeat(36)}`;
 export const GITHUB_READ_RESULT_MARKER = 'github-read-result-marker';
 export const GITHUB_WRITE_RESULT_MARKER = 'github-write-result-marker';
+export const GITHUB_SEARCH_RESULT_MARKER = 'github-search-result-marker';
+export const GITHUB_GRAPHQL_RESULT_MARKER = 'github-graphql-result-marker';
 
 const INSTALLATION_TOKEN_PATH = /^\/app\/installations\/(\d+)\/access_tokens$/u;
+const REPOSITORY_PATH = /^\/repositories\/(\d+)$/u;
 const ISSUE_PATH = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)$/u;
 const ISSUES_PATH = /^\/repos\/([^/]+)\/([^/]+)\/issues$/u;
+const SEARCH_ISSUES_PATH = /^\/search\/issues$/u;
+const GRAPHQL_PATH = /^\/graphql$/u;
 
 export type GithubApiMockCall =
   | {
@@ -27,6 +32,22 @@ export type GithubApiMockCall =
       tokenFormatOverride: string | undefined;
       installationId: number;
       body: Record<string, unknown>;
+    }
+  | {
+      kind: 'resolve-repository';
+      authorization: string | undefined;
+      repositoryId: number;
+    }
+  | {
+      kind: 'search-issues';
+      authorization: string | undefined;
+      query: string | null;
+    }
+  | {
+      kind: 'graphql';
+      authorization: string | undefined;
+      query: string;
+      variables: Record<string, unknown>;
     }
   | {
       kind: 'read-issue';
@@ -51,6 +72,7 @@ export interface GithubApiMock {
 
 export interface GithubApiMockOptions {
   endpoint?: URL | undefined;
+  installationId?: number | undefined;
   installationToken?: string | undefined;
 }
 
@@ -58,6 +80,7 @@ export async function startGithubApiMock(
   options: GithubApiMockOptions = {},
 ): Promise<GithubApiMock> {
   const calls: GithubApiMockCall[] = [];
+  const installationId = options.installationId;
   const installationToken = options.installationToken ?? GITHUB_STATELESS_INSTALLATION_TOKEN;
   const endpoint = options.endpoint ?? new URL(requiredGithubApiBaseUrl());
   let boundEndpoint = endpoint;
@@ -65,6 +88,7 @@ export async function startGithubApiMock(
     void handleGithubRequest({
       calls,
       endpoint: boundEndpoint,
+      installationId,
       installationToken,
       request,
       response,
@@ -90,68 +114,246 @@ export async function startGithubApiMock(
   };
 }
 
+interface GithubRequestContext {
+  calls: GithubApiMockCall[];
+  endpoint: URL;
+  installationId: number | undefined;
+  installationToken: string;
+  request: IncomingMessage;
+  response: ServerResponse;
+  requestUrl: URL;
+  authorization: string | undefined;
+}
+
 async function handleGithubRequest(params: {
   calls: GithubApiMockCall[];
   endpoint: URL;
+  installationId: number | undefined;
   installationToken: string;
   request: IncomingMessage;
   response: ServerResponse;
 }): Promise<void> {
   const requestUrl = new URL(params.request.url ?? '/', params.endpoint);
-  const authorization = params.request.headers.authorization;
+  const context: GithubRequestContext = {
+    ...params,
+    requestUrl,
+    authorization: params.request.headers.authorization,
+  };
   const mintMatch = requestUrl.pathname.match(INSTALLATION_TOKEN_PATH);
+  if (requestMatches(params.request, 'POST', mintMatch)) {
+    await handleMintRequest(context, mintMatch);
+    return;
+  }
+  const repositoryMatch = requestUrl.pathname.match(REPOSITORY_PATH);
+  if (requestMatches(params.request, 'GET', repositoryMatch)) {
+    handleRepositoryRequest(context, repositoryMatch);
+    return;
+  }
   const issueMatch = requestUrl.pathname.match(ISSUE_PATH);
+  if (requestMatches(params.request, 'GET', issueMatch)) {
+    handleIssueRequest(context, issueMatch);
+    return;
+  }
   const createIssueMatch = requestUrl.pathname.match(ISSUES_PATH);
-
-  if (params.request.method === 'POST' && mintMatch) {
-    params.calls.push({
-      kind: 'mint-token',
-      authorization,
-      tokenFormatOverride: singleHeader(params.request.headers['x-github-stateless-s2s-token']),
-      installationId: Number(mintMatch[1]),
-      body: await readJsonBody(params.request),
-    });
-    sendJson(params.response, 201, {
-      token: params.installationToken,
-      expires_at: '2099-01-01T00:00:00.000Z',
-      permissions: {issues: 'write'},
-      repository_selection: 'all',
-    });
+  if (requestMatches(params.request, 'POST', createIssueMatch)) {
+    await handleCreateIssueRequest(context, createIssueMatch);
     return;
   }
-
-  if (params.request.method === 'GET' && issueMatch) {
-    params.calls.push({
-      kind: 'read-issue',
-      authorization,
-      owner: decodeURIComponent(issueMatch[1] ?? ''),
-      repo: decodeURIComponent(issueMatch[2] ?? ''),
-      issueNumber: Number(issueMatch[3]),
-    });
-    sendJson(params.response, 200, {
-      number: Number(issueMatch[3]),
-      title: 'Synthetic GitHub issue',
-      marker: GITHUB_READ_RESULT_MARKER,
-    });
+  const searchIssuesMatch = requestUrl.pathname.match(SEARCH_ISSUES_PATH);
+  if (requestMatches(params.request, 'GET', searchIssuesMatch)) {
+    handleSearchIssuesRequest(context);
     return;
   }
-
-  if (params.request.method === 'POST' && createIssueMatch) {
-    params.calls.push({
-      kind: 'create-issue',
-      authorization,
-      owner: decodeURIComponent(createIssueMatch[1] ?? ''),
-      repo: decodeURIComponent(createIssueMatch[2] ?? ''),
-      body: await readJsonBody(params.request),
-    });
-    sendJson(params.response, 201, {
-      number: 2,
-      marker: GITHUB_WRITE_RESULT_MARKER,
-    });
+  const graphqlMatch = requestUrl.pathname.match(GRAPHQL_PATH);
+  if (requestMatches(params.request, 'POST', graphqlMatch)) {
+    await handleGraphqlRequest(context);
     return;
   }
 
   sendJson(params.response, 404, {message: 'Not Found'});
+}
+
+function requestMatches(
+  request: IncomingMessage,
+  method: string,
+  match: RegExpMatchArray | null,
+): match is RegExpMatchArray {
+  return request.method === method && match !== null;
+}
+
+async function handleMintRequest(
+  params: GithubRequestContext,
+  match: RegExpMatchArray,
+): Promise<void> {
+  const body = await readJsonBody(params.request);
+  const installationId = Number(match[1]);
+  if (params.installationId !== undefined && params.installationId !== installationId) {
+    sendJson(params.response, 404, {message: 'Not Found'});
+    return;
+  }
+  params.calls.push({
+    kind: 'mint-token',
+    authorization: params.authorization,
+    tokenFormatOverride: singleHeader(params.request.headers['x-github-stateless-s2s-token']),
+    installationId,
+    body,
+  });
+  const repositories = scopedRepositories(body, params.endpoint);
+  sendJson(params.response, 201, {
+    token: params.installationToken,
+    expires_at: '2099-01-01T00:00:00.000Z',
+    permissions: permissionsFromMint(body),
+    repository_selection: 'all',
+    ...(repositories === undefined ? {} : {repositories}),
+  });
+}
+
+function handleRepositoryRequest(params: GithubRequestContext, match: RegExpMatchArray): void {
+  const repositoryId = Number(match[1]);
+  if (isCurrentInstallationAuthorization(params)) {
+    params.calls.push({
+      kind: 'resolve-repository',
+      authorization: params.authorization,
+      repositoryId,
+    });
+  }
+  sendJson(params.response, 200, repositoryPayload(repositoryId, params.endpoint));
+}
+
+function handleIssueRequest(params: GithubRequestContext, match: RegExpMatchArray): void {
+  if (isCurrentInstallationAuthorization(params)) {
+    params.calls.push({
+      kind: 'read-issue',
+      authorization: params.authorization,
+      owner: decodeURIComponent(match[1] ?? ''),
+      repo: decodeURIComponent(match[2] ?? ''),
+      issueNumber: Number(match[3]),
+    });
+  }
+  sendJson(params.response, 200, {
+    number: Number(match[3]),
+    title: 'Synthetic GitHub issue',
+    marker: GITHUB_READ_RESULT_MARKER,
+  });
+}
+
+async function handleCreateIssueRequest(
+  params: GithubRequestContext,
+  match: RegExpMatchArray,
+): Promise<void> {
+  const body = await readJsonBody(params.request);
+  if (isCurrentInstallationAuthorization(params)) {
+    params.calls.push({
+      kind: 'create-issue',
+      authorization: params.authorization,
+      owner: decodeURIComponent(match[1] ?? ''),
+      repo: decodeURIComponent(match[2] ?? ''),
+      body,
+    });
+  }
+  sendJson(params.response, 201, {
+    number: 2,
+    marker: GITHUB_WRITE_RESULT_MARKER,
+  });
+}
+
+function handleSearchIssuesRequest(params: GithubRequestContext): void {
+  if (isCurrentInstallationAuthorization(params)) {
+    params.calls.push({
+      kind: 'search-issues',
+      authorization: params.authorization,
+      query: params.requestUrl.searchParams.get('q'),
+    });
+  }
+  sendJson(params.response, 200, {
+    total_count: 1,
+    incomplete_results: false,
+    items: [{marker: GITHUB_SEARCH_RESULT_MARKER}],
+  });
+}
+
+async function handleGraphqlRequest(params: GithubRequestContext): Promise<void> {
+  const body = await readJsonBody(params.request);
+  const query = typeof body.query === 'string' ? body.query : '';
+  const variables = isRecord(body.variables) ? body.variables : {};
+  if (isCurrentInstallationAuthorization(params)) {
+    params.calls.push({kind: 'graphql', authorization: params.authorization, query, variables});
+  }
+  sendJson(params.response, 200, {
+    data: {
+      resolveReviewThread: {
+        thread: {
+          id: isRecord(variables.input) ? variables.input.threadId : 'synthetic-thread-id',
+          isResolved: true,
+          marker: GITHUB_GRAPHQL_RESULT_MARKER,
+        },
+      },
+    },
+  });
+}
+
+function isCurrentInstallationAuthorization(params: GithubRequestContext): boolean {
+  if (params.installationId === undefined) return true;
+  return (
+    params.authorization === `bearer ${params.installationToken}` ||
+    params.authorization === `token ${params.installationToken}`
+  );
+}
+
+function permissionsFromMint(body: Record<string, unknown>): Record<string, string> {
+  return isRecord(body.permissions)
+    ? (body.permissions as Record<string, string>)
+    : {issues: 'write'};
+}
+
+function scopedRepositories(
+  body: Record<string, unknown>,
+  endpoint: URL,
+): Record<string, unknown>[] | undefined {
+  if (Array.isArray(body.repository_ids)) {
+    return body.repository_ids
+      .filter((value): value is number => typeof value === 'number')
+      .map((repositoryId) => repositoryPayload(repositoryId, endpoint));
+  }
+  if (Array.isArray(body.repositories)) {
+    return body.repositories
+      .filter((value): value is string => typeof value === 'string')
+      .map((repositoryName) => {
+        const [ownerPart, namePart] = repositoryName.split('/', 2);
+        const owner = namePart === undefined ? 'shipfox' : ownerPart;
+        const name = namePart ?? ownerPart;
+        return repositoryPayload(
+          owner === 'shipfox' && name === 'e2e' ? 42 : 43,
+          endpoint,
+          owner,
+          name,
+        );
+      });
+  }
+  return undefined;
+}
+
+function repositoryPayload(
+  repositoryId: number,
+  endpoint: URL,
+  owner = 'shipfox',
+  name = repositoryId === 42 ? 'e2e' : 'outside',
+): Record<string, unknown> {
+  return {
+    id: repositoryId,
+    owner: {login: owner},
+    name,
+    full_name: `${owner}/${name}`,
+    default_branch: 'main',
+    private: true,
+    visibility: 'private',
+    clone_url: new URL(`/repos/${owner}/${name}.git`, endpoint).toString(),
+    html_url: `https://github.com/${owner}/${name}`,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function singleHeader(value: string | string[] | undefined): string | undefined {

--- a/e2e/suites/flow/workflows/src/github-api.ts
+++ b/e2e/suites/flow/workflows/src/github-api.ts
@@ -279,17 +279,36 @@ async function handleGraphqlRequest(params: GithubRequestContext): Promise<void>
   if (isCurrentInstallationAuthorization(params)) {
     params.calls.push({kind: 'graphql', authorization: params.authorization, query, variables});
   }
-  sendJson(params.response, 200, {
-    data: {
-      resolveReviewThread: {
-        thread: {
-          id: isRecord(variables.input) ? variables.input.threadId : 'synthetic-thread-id',
-          isResolved: true,
-          marker: GITHUB_GRAPHQL_RESULT_MARKER,
+  if (query.includes('resolveReviewThread')) {
+    sendJson(params.response, 200, {
+      data: {
+        resolveReviewThread: {
+          thread: {
+            id: isRecord(variables.input) ? variables.input.threadId : 'synthetic-thread-id',
+            isResolved: true,
+            marker: GITHUB_GRAPHQL_RESULT_MARKER,
+          },
         },
       },
-    },
-  });
+    });
+    return;
+  }
+  if (query.includes('reviewThreads')) {
+    sendJson(params.response, 200, {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [],
+              pageInfo: {hasNextPage: false, endCursor: null},
+            },
+          },
+        },
+      },
+    });
+    return;
+  }
+  sendJson(params.response, 200, {data: {}});
 }
 
 function isCurrentInstallationAuthorization(params: GithubRequestContext): boolean {

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -177,10 +177,7 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
       expect(providerRequests.every((request) => request.assertion_failures.length === 0)).toBe(
         true,
       );
-      // Source metadata lookups can finish after definition sync reports terminal, so keep
-      // background repository-resolution calls out of the agent-tool request trace.
-      const agentToolCalls = githubApi.calls.filter((call) => call.kind !== 'resolve-repository');
-      expect(agentToolCalls).toEqual([
+      expect(githubAgentToolCalls(githubApi)).toEqual([
         {
           kind: 'mint-token',
           authorization: expect.stringMatching(BEARER_AUTHORIZATION),
@@ -257,7 +254,7 @@ test('enforces selected GitHub authorization for deterministic tools', async ({
 
     expect(result.terminal.status).toBe('succeeded');
     expect(result.terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
-    expect(fixture.githubApi.calls).toEqual([
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([
       {
         kind: 'mint-token',
         authorization: expect.any(String),
@@ -301,7 +298,7 @@ test('denies a selected GitHub tool target outside Shipfox projects', async ({su
       'Repository is not authorized for this integration connection',
     );
     expect(result.failureLogs).not.toContain(fixture.installationToken);
-    expect(fixture.githubApi.calls).toEqual([]);
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
     await fixture.githubApi.stop();
   }
@@ -329,7 +326,7 @@ test('requires an explicit repository for selected GitHub search', async ({suite
       'Selected repository access requires owner and repo parameters',
     );
     expect(result.failureLogs).not.toContain(fixture.installationToken);
-    expect(fixture.githubApi.calls).toEqual([]);
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
     await fixture.githubApi.stop();
   }
@@ -357,7 +354,7 @@ test('rejects GitHub search qualifiers before provider dispatch', async ({suite}
       'Search query cannot contain repo:, org:, or user: qualifiers',
     );
     expect(result.failureLogs).not.toContain(fixture.installationToken);
-    expect(fixture.githubApi.calls).toEqual([]);
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
     await fixture.githubApi.stop();
   }
@@ -384,7 +381,7 @@ test('allows an all-mode GitHub tool target outside Shipfox projects', async ({
     });
 
     expect(result.terminal.status).toBe('succeeded');
-    expect(fixture.githubApi.calls).toEqual([
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([
       {
         kind: 'mint-token',
         authorization: expect.any(String),
@@ -423,7 +420,7 @@ test('mints a GitHub checkout token for a selected project repository by ID', as
 
     expect(result.terminal.status).toBe('failed');
     expect(result.failureLogs).not.toContain(fixture.installationToken);
-    expect(fixture.githubApi.calls).toEqual([
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([
       {
         kind: 'mint-token',
         authorization: expect.any(String),
@@ -463,7 +460,7 @@ test('denies a selected GitHub checkout target outside Shipfox projects', async 
       'Checkout step failed because Shipfox could not grant repository access.',
     );
     expect(result.failureLogs).not.toContain(fixture.installationToken);
-    expect(fixture.githubApi.calls).toEqual([]);
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
     await fixture.githubApi.stop();
   }
@@ -488,7 +485,7 @@ test('mints a GitHub checkout token for an all-mode repository name', async ({su
 
     expect(result.terminal.status).toBe('failed');
     expect(result.failureLogs).not.toContain(fixture.installationToken);
-    expect(fixture.githubApi.calls).toEqual([
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([
       {
         kind: 'mint-token',
         authorization: expect.any(String),
@@ -749,6 +746,12 @@ jobs:
 
 function shortId(): string {
   return crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+}
+
+function githubAgentToolCalls(githubApi: GithubApiMock): GithubApiMock['calls'] {
+  // Source metadata lookups can finish after definition sync reports terminal, so keep
+  // background repository-resolution calls out of the agent-tool request trace.
+  return githubApi.calls.filter((call) => call.kind !== 'resolve-repository');
 }
 
 async function runGithubToolsWorkflow(params: {

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -177,7 +177,10 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
       expect(providerRequests.every((request) => request.assertion_failures.length === 0)).toBe(
         true,
       );
-      expect(githubApi.calls).toEqual([
+      // Source metadata lookups can finish after definition sync reports terminal, so keep
+      // background repository-resolution calls out of the agent-tool request trace.
+      const agentToolCalls = githubApi.calls.filter((call) => call.kind !== 'resolve-repository');
+      expect(agentToolCalls).toEqual([
         {
           kind: 'mint-token',
           authorization: expect.stringMatching(BEARER_AUTHORIZATION),

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -1,28 +1,38 @@
+import type {DefinitionResponseDto} from '@shipfox/api-definitions-dto';
+import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {createAnthropicFakeModelProviderConfig} from '@shipfox/e2e-setup-agent';
 import {createGithubConnection} from '@shipfox/e2e-setup-integrations';
+import {createProject as createE2eProject} from '@shipfox/e2e-setup-projects';
 import {
   attachLocalRunnerLog,
   collectStepLogAttachmentRequests,
   fetchLogAttachment,
 } from '#attachments.js';
 import {
+  GITHUB_GRAPHQL_RESULT_MARKER,
   GITHUB_READ_RESULT_MARKER,
+  GITHUB_SEARCH_RESULT_MARKER,
   GITHUB_STATEFUL_INSTALLATION_TOKEN,
   GITHUB_STATELESS_INSTALLATION_TOKEN,
   GITHUB_WRITE_RESULT_MARKER,
+  type GithubApiMock,
   startGithubApiMock,
 } from '#github-api.js';
+import {waitForDefinitionSyncTerminal} from '#polling.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import type {SuiteContext} from '#suite-context.js';
 import {fireManualAndAwaitRun} from '#triggers.js';
-import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {renderWorkflowYaml, seedAndWaitForDefinition} from '#workflow-project.js';
 import {expect, test} from './fixtures.js';
 
 const CLAUDE_AGENT_MODEL = 'deterministic-github-tools-agent';
 const TERMINAL_TIMEOUT_MS = 60_000;
+const GITHUB_REPOSITORY_ID = 42;
+const GITHUB_REPOSITORY_EXTERNAL_ID = `github:${GITHUB_REPOSITORY_ID}`;
+const GITHUB_OUTSIDE_REPOSITORY_NAME = 'shipfox/outside';
 const BEARER_AUTHORIZATION = /^bearer /iu;
 const GITHUB_TOKEN_CASES = [
   {
@@ -43,7 +53,10 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
   test(`runs selected GitHub tools with a ${tokenCase.format} token`, async ({suite}, testInfo) => {
     const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
     const installationId = Number.parseInt(uniqueId.slice(0, 7), 16) + 1;
-    const githubApi = await startGithubApiMock({installationToken: tokenCase.token});
+    const githubApi = await startGithubApiMock({
+      installationId,
+      installationToken: tokenCase.token,
+    });
     let fakeModelProvider: Awaited<ReturnType<typeof startFakeOpenAiModelProvider>> | undefined;
 
     try {
@@ -57,9 +70,28 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
         accountLogin: `e${uniqueId.slice(0, 5)}`,
         displayName: `GitHub E2E ${uniqueId}`,
         installerUserId: crypto.randomUUID(),
+        lifecycleStatus: 'disabled',
       });
+      const project = await createE2eProject({
+        workspaceId: suite.workspaceId,
+        name: `GitHub E2E project ${uniqueId}`,
+        sourceConnectionId: connection.id,
+        sourceExternalRepositoryId: 'github:42',
+        sourceRepositoryOwner: 'shipfox',
+        sourceRepositoryName: 'e2e',
+        sourceDefaultBranch: 'main',
+      });
+      await activateGithubConnection(suite, connection.id);
+      await waitForDefinitionSyncTerminal({
+        projectId: project.id,
+        token: suite.sessionToken,
+        timeoutMs: TERMINAL_TIMEOUT_MS,
+      });
+      githubApi.calls.length = 0;
       const issueReadTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_read`;
       const issueWriteTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_write`;
+      const searchIssuesTool = `mcp__shipfox_integration_tools__${connection.slug}__search_issues`;
+      const reviewThreadTool = `mcp__shipfox_integration_tools__${connection.slug}__pull_request_review_thread_write`;
       const addIssueCommentTool = `mcp__shipfox_integration_tools__${connection.slug}__add_issue_comment`;
       const fakeAnthropic = await createAnthropicFakeModelProviderConfig({
         workspaceId: suite.workspaceId,
@@ -73,23 +105,22 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
             repo: 'e2e',
             issue_number: 1,
           }),
+          toolCall(searchIssuesTool, {
+            query: 'is:open',
+            owner: 'shipfox',
+            repo: 'e2e',
+          }),
+          toolCall(reviewThreadTool, {
+            method: 'resolve',
+            owner: 'shipfox',
+            repo: 'e2e',
+            thread_id: 'PRRT_kwDO_e2e',
+          }),
           toolCall(issueWriteTool, {
             method: 'create',
             owner: 'shipfox',
             repo: 'e2e',
             title: 'Synthetic GitHub issue',
-          }),
-          toolCall(issueReadTool, {
-            method: 'get_comments',
-            owner: 'shipfox',
-            repo: 'e2e',
-            issue_number: 1,
-          }),
-          toolCall(addIssueCommentTool, {
-            owner: 'shipfox',
-            repo: 'e2e',
-            issue_number: 1,
-            body: 'This tool was not selected',
           }),
           message('done'),
         ],
@@ -97,6 +128,8 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
           {kind: 'model', equals: CLAUDE_AGENT_MODEL},
           {kind: 'tool_present', name: issueReadTool},
           {kind: 'tool_present', name: issueWriteTool},
+          {kind: 'tool_present', name: searchIssuesTool},
+          {kind: 'tool_present', name: reviewThreadTool},
           {kind: 'tool_absent', name: addIssueCommentTool},
           {
             kind: 'message_content_includes',
@@ -105,17 +138,17 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
           },
           {
             kind: 'message_content_includes',
-            value: GITHUB_WRITE_RESULT_MARKER,
+            value: GITHUB_SEARCH_RESULT_MARKER,
             minRequestIndex: 2,
           },
           {
             kind: 'message_content_includes',
-            value: 'Unauthorized integration tool method: get_comments',
+            value: GITHUB_GRAPHQL_RESULT_MARKER,
             minRequestIndex: 3,
           },
           {
             kind: 'message_content_includes',
-            value: 'No such tool available:',
+            value: GITHUB_WRITE_RESULT_MARKER,
             minRequestIndex: 4,
           },
         ],
@@ -150,7 +183,7 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
           authorization: expect.stringMatching(BEARER_AUTHORIZATION),
           tokenFormatOverride: 'enabled',
           installationId,
-          body: {permissions: {issues: 'write'}},
+          body: {permissions: {issues: 'write', pull_requests: 'write'}},
         },
         {
           kind: 'read-issue',
@@ -158,6 +191,17 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
           owner: 'shipfox',
           repo: 'e2e',
           issueNumber: 1,
+        },
+        {
+          kind: 'search-issues',
+          authorization: tokenCase.authorization,
+          query: 'is:open repo:shipfox/e2e',
+        },
+        {
+          kind: 'graphql',
+          authorization: tokenCase.authorization,
+          query: expect.stringContaining('resolveReviewThread'),
+          variables: {input: {threadId: 'PRRT_kwDO_e2e'}},
         },
         {
           kind: 'create-issue',
@@ -182,6 +226,526 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
       ]);
     }
   });
+}
+
+test('enforces selected GitHub authorization for deterministic tools', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-selected-tool',
+      workflowYaml: deterministicToolWorkflow({
+        connection: fixture.connection.slug,
+        tool: 'issue_read.get',
+        with: {owner: 'shipfox', repo: 'e2e', issue_number: 1},
+        outputs: {marker: `\${{ result.marker }}`},
+        verification: {
+          env: {MARKER: `\${{ steps.github.outputs.marker }}`},
+          run: `test "$MARKER" = "${GITHUB_READ_RESULT_MARKER}"`,
+        },
+      }),
+    });
+
+    expect(result.terminal.status).toBe('succeeded');
+    expect(result.terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
+    expect(fixture.githubApi.calls).toEqual([
+      {
+        kind: 'mint-token',
+        authorization: expect.any(String),
+        tokenFormatOverride: 'enabled',
+        installationId: fixture.installationId,
+        body: {permissions: {issues: 'read'}},
+      },
+      {
+        kind: 'read-issue',
+        authorization: `bearer ${fixture.installationToken}`,
+        owner: 'shipfox',
+        repo: 'e2e',
+        issueNumber: 1,
+      },
+    ]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('denies a selected GitHub tool target outside Shipfox projects', async ({suite}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-selected-tool-denied',
+      workflowYaml: deterministicToolWorkflow({
+        connection: fixture.connection.slug,
+        tool: 'issue_read.get',
+        with: {owner: 'shipfox', repo: 'outside', issue_number: 1},
+      }),
+    });
+
+    expect(result.terminal.status).toBe('failed');
+    expect(result.terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('failed');
+    expect(result.failureLogs).toContain(
+      'Repository is not authorized for this integration connection',
+    );
+    expect(result.failureLogs).not.toContain(fixture.installationToken);
+    expect(fixture.githubApi.calls).toEqual([]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('requires an explicit repository for selected GitHub search', async ({suite}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-search-repository-required',
+      workflowYaml: deterministicToolWorkflow({
+        connection: fixture.connection.slug,
+        tool: 'search_issues',
+        with: {query: 'is:open'},
+      }),
+    });
+
+    expect(result.terminal.status).toBe('failed');
+    expect(result.failureLogs).toContain(
+      'Selected repository access requires owner and repo parameters',
+    );
+    expect(result.failureLogs).not.toContain(fixture.installationToken);
+    expect(fixture.githubApi.calls).toEqual([]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('rejects GitHub search qualifiers before provider dispatch', async ({suite}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-search-qualifier',
+      workflowYaml: deterministicToolWorkflow({
+        connection: fixture.connection.slug,
+        tool: 'search_issues',
+        with: {query: 'repo:outside', owner: 'shipfox', repo: 'e2e'},
+      }),
+    });
+
+    expect(result.terminal.status).toBe('failed');
+    expect(result.failureLogs).toContain(
+      'Search query cannot contain repo:, org:, or user: qualifiers',
+    );
+    expect(result.failureLogs).not.toContain(fixture.installationToken);
+    expect(fixture.githubApi.calls).toEqual([]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('allows an all-mode GitHub tool target outside Shipfox projects', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    await setRepositoryAccessMode(suite, fixture.connection.id, 'all');
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-all-tool',
+      workflowYaml: deterministicToolWorkflow({
+        connection: fixture.connection.slug,
+        tool: 'issue_read.get',
+        with: {owner: 'shipfox', repo: 'outside', issue_number: 1},
+      }),
+    });
+
+    expect(result.terminal.status).toBe('succeeded');
+    expect(fixture.githubApi.calls).toEqual([
+      {
+        kind: 'mint-token',
+        authorization: expect.any(String),
+        tokenFormatOverride: 'enabled',
+        installationId: fixture.installationId,
+        body: {permissions: {issues: 'read'}},
+      },
+      {
+        kind: 'read-issue',
+        authorization: `bearer ${fixture.installationToken}`,
+        owner: 'shipfox',
+        repo: 'outside',
+        issueNumber: 1,
+      },
+    ]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('mints a GitHub checkout token for a selected project repository by ID', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-checkout-selected-id',
+      workflowYaml: checkoutWorkflow({}),
+      project: fixture.project,
+    });
+
+    expect(result.terminal.status).toBe('failed');
+    expect(result.failureLogs).not.toContain(fixture.installationToken);
+    expect(fixture.githubApi.calls).toEqual([
+      {
+        kind: 'mint-token',
+        authorization: expect.any(String),
+        tokenFormatOverride: 'enabled',
+        installationId: fixture.installationId,
+        body: {
+          repository_ids: [GITHUB_REPOSITORY_ID],
+          permissions: {contents: 'read'},
+        },
+      },
+    ]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('denies a selected GitHub checkout target outside Shipfox projects', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-checkout-selected-denied',
+      workflowYaml: checkoutWorkflow({
+        connection: fixture.connection.slug,
+        repository: GITHUB_OUTSIDE_REPOSITORY_NAME,
+      }),
+    });
+
+    expect(result.terminal.status).toBe('failed');
+    expect(result.failureLogs).toContain(
+      'Checkout step failed because Shipfox could not grant repository access.',
+    );
+    expect(result.failureLogs).not.toContain(fixture.installationToken);
+    expect(fixture.githubApi.calls).toEqual([]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('mints a GitHub checkout token for an all-mode repository name', async ({suite}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    await setRepositoryAccessMode(suite, fixture.connection.id, 'all');
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-checkout-all-name',
+      workflowYaml: checkoutWorkflow({
+        connection: fixture.connection.slug,
+        repository: GITHUB_OUTSIDE_REPOSITORY_NAME,
+      }),
+    });
+
+    expect(result.terminal.status).toBe('failed');
+    expect(result.failureLogs).not.toContain(fixture.installationToken);
+    expect(fixture.githubApi.calls).toEqual([
+      {
+        kind: 'mint-token',
+        authorization: expect.any(String),
+        tokenFormatOverride: 'enabled',
+        installationId: fixture.installationId,
+        body: {
+          repositories: ['outside'],
+          permissions: {contents: 'read'},
+        },
+      },
+    ]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+async function createGithubFixture(suite: SuiteContext, uniqueId: string): Promise<GithubFixture> {
+  const installationId = Number.parseInt(uniqueId.slice(0, 7), 16) + 1;
+  const installationToken = `ghs_${uniqueId}.${'e'.repeat(36)}.${'f'.repeat(36)}`;
+  const githubApi = await startGithubApiMock({installationId, installationToken});
+
+  try {
+    const connection = await createGithubConnection({
+      workspaceId: suite.workspaceId,
+      installationId,
+      accountLogin: `e${uniqueId.slice(0, 5)}`,
+      displayName: `GitHub authorization ${uniqueId}`,
+      installerUserId: crypto.randomUUID(),
+      lifecycleStatus: 'disabled',
+    });
+    const project = await createE2eProject({
+      workspaceId: suite.workspaceId,
+      name: `GitHub authorization project ${uniqueId}`,
+      sourceConnectionId: connection.id,
+      sourceExternalRepositoryId: GITHUB_REPOSITORY_EXTERNAL_ID,
+      sourceRepositoryOwner: 'shipfox',
+      sourceRepositoryName: 'e2e',
+      sourceDefaultBranch: 'main',
+    });
+    await activateGithubConnection(suite, connection.id);
+    await waitForDefinitionSyncTerminal({
+      projectId: project.id,
+      token: suite.sessionToken,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
+    });
+    githubApi.calls.length = 0;
+    return {connection, githubApi, installationId, installationToken, project};
+  } catch (error) {
+    await githubApi.stop();
+    throw error;
+  }
+}
+
+interface GithubFixture {
+  connection: {id: string; slug: string};
+  githubApi: GithubApiMock;
+  installationId: number;
+  installationToken: string;
+  project: ProjectResponseDto;
+}
+
+async function activateGithubConnection(suite: SuiteContext, connectionId: string): Promise<void> {
+  const client = createApiClient({token: suite.sessionToken});
+  await client.request('patch', `/integration-connections/${connectionId}`, {
+    json: {lifecycle_status: 'active'},
+  });
+}
+
+async function setRepositoryAccessMode(
+  suite: SuiteContext,
+  connectionId: string,
+  mode: 'selected' | 'all',
+): Promise<void> {
+  const client = createApiClient({token: suite.sessionToken});
+  await client.request('put', `/integration-connections/${connectionId}/repository-access`, {
+    json: {mode},
+  });
+}
+
+async function runGithubWorkflow(params: {
+  suite: SuiteContext;
+  testInfo: {
+    attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
+  };
+  uniqueId: string;
+  scenario: string;
+  workflowYaml: string;
+  project?: ProjectResponseDto | undefined;
+  replacements?: Record<string, string> | undefined;
+}): Promise<{
+  terminal: Awaited<ReturnType<typeof waitForRunTerminalOrFailedRunner>>;
+  failureLogs: string;
+}> {
+  const token = params.suite.sessionToken;
+  const client = createApiClient({token});
+  const runnerLabel = `e2e-${params.scenario}-${params.uniqueId}`;
+  const repo = `${params.scenario}-${params.uniqueId}`;
+  const localRunner = await startSuiteLocalRunner({
+    workspaceId: params.suite.workspaceId,
+    userToken: token,
+    name: `E2E ${params.scenario} ${params.uniqueId}`,
+    runnerLabel,
+    extraEnv: {SHIPFOX_POLL_MAX_DURATION_MS: String(TERMINAL_TIMEOUT_MS)},
+  });
+
+  let failureLogs = '';
+  try {
+    const definition =
+      params.project === undefined
+        ? (
+            await seedAndWaitForDefinition({
+              suite: params.suite,
+              token,
+              name: params.scenario,
+              repo,
+              runnerLabel,
+              workflowYaml: params.workflowYaml,
+              configPath: `.shipfox/workflows/${params.scenario}.yml`,
+              replacements: params.replacements,
+            })
+          ).definition
+        : await createManualDefinition({
+            client,
+            project: params.project,
+            workflowYaml: renderWorkflowYaml({
+              suite: params.suite,
+              repo,
+              runnerLabel,
+              workflowYaml: params.workflowYaml,
+              replacements: params.replacements,
+            }),
+          });
+    const runId = await fireManualAndAwaitRun({
+      client,
+      definitionId: definition.id,
+      inputs: {},
+      scenario: params.scenario,
+    });
+    const terminal = await waitForRunTerminalOrFailedRunner({
+      runId,
+      token,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
+      runner: localRunner.runner,
+    });
+
+    if (terminal.status !== 'succeeded') {
+      for (const request of collectStepLogAttachmentRequests(terminal)) {
+        const attachment = await fetchLogAttachment(request, token);
+        failureLogs += `\n${attachment.body}`;
+        await params.testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        });
+      }
+    }
+    return {terminal, failureLogs};
+  } finally {
+    await attachLocalRunnerLog(
+      (attachment) =>
+        params.testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        }),
+      localRunner.logFile,
+    );
+    await stopLocalRunner(localRunner.runner).catch((error: unknown) => {
+      process.stderr.write(`${params.scenario}-e2e: stopLocalRunner failed: ${String(error)}\n`);
+    });
+  }
+}
+
+async function createManualDefinition(params: {
+  client: ReturnType<typeof createApiClient>;
+  project: ProjectResponseDto;
+  workflowYaml: string;
+}): Promise<DefinitionResponseDto> {
+  return await params.client.requestJson<DefinitionResponseDto>('post', '/definitions', {
+    json: {
+      project_id: params.project.id,
+      source: 'manual',
+      yaml: params.workflowYaml,
+    },
+  });
+}
+
+function deterministicToolWorkflow(params: {
+  connection: string;
+  tool: string;
+  with: Record<string, string | number>;
+  outputs?: Record<string, string> | undefined;
+  verification?: {env: Record<string, string>; run: string} | undefined;
+}): string {
+  const outputs =
+    params.outputs === undefined ? '' : `\n        outputs: ${JSON.stringify(params.outputs)}`;
+  const verification =
+    params.verification === undefined
+      ? ''
+      : `\n      - key: verify\n        env: ${JSON.stringify(params.verification.env)}\n        run: ${JSON.stringify(params.verification.run)}`;
+  return `
+name: GitHub deterministic tool
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  tools:
+    steps:
+      - key: github
+        tool: ${params.tool}
+        connection: ${params.connection}
+        with: ${JSON.stringify(params.with)}${outputs}${verification}
+`;
+}
+
+function checkoutWorkflow(params: {
+  connection?: string | undefined;
+  repository?: string | undefined;
+}): string {
+  if (params.connection === undefined || params.repository === undefined) {
+    return `
+name: GitHub checkout
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  checkout:
+    checkout:
+      permissions:
+        contents: read
+    steps:
+      - key: fail-after-checkout
+        run: exit 1
+`;
+  }
+
+  return `
+name: GitHub checkout
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  checkout:
+    checkout: false
+    steps:
+      - key: repository
+        checkout:
+          connection: ${JSON.stringify(params.connection)}
+          repository: ${JSON.stringify(params.repository)}
+          permissions:
+            contents: read
+`;
+}
+
+function shortId(): string {
+  return crypto.randomUUID().replaceAll('-', '').slice(0, 10);
 }
 
 async function runGithubToolsWorkflow(params: {
@@ -275,7 +839,11 @@ jobs:
         prompt: Use the selected GitHub tools.
         integrations:
           - connection: ${connectionSlug}
-            include: [issue_read.get, issue_write.create]
+            include:
+              - issue_read.get
+              - issue_write.create
+              - search_issues
+              - pull_request_review_thread_write.resolve
             allow_write: true
 `;
 }

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -76,7 +76,7 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
         workspaceId: suite.workspaceId,
         name: `GitHub E2E project ${uniqueId}`,
         sourceConnectionId: connection.id,
-        sourceExternalRepositoryId: 'github:42',
+        sourceExternalRepositoryId: GITHUB_REPOSITORY_EXTERNAL_ID,
         sourceRepositoryOwner: 'shipfox',
         sourceRepositoryName: 'e2e',
         sourceDefaultBranch: 'main',

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -10,6 +10,7 @@ import {
   type TestVcsStats,
   testVcsExternalRepositoryId,
 } from '@shipfox/e2e-setup-integrations';
+import {createProject as createE2eProject} from '@shipfox/e2e-setup-projects';
 import {attachLocalRunnerLog} from '#attachments.js';
 import {createProject} from '#create-project.js';
 import {ON_REJECTION_WORKFLOW} from '#renewable-credentials-workflows.js';
@@ -398,6 +399,20 @@ async function seedTestVcsWorkflow(params: {
     connectionId: params.connectionId,
     externalRepositoryId: repository.external_repository_id,
   });
+  if (params.secondaryRepositoryName !== undefined) {
+    await createE2eProject({
+      workspaceId: params.suite.workspaceId,
+      name: `Test VCS ${params.secondaryRepositoryName}`,
+      sourceConnectionId: params.connectionId,
+      sourceExternalRepositoryId: testVcsExternalRepositoryId(
+        params.owner,
+        params.secondaryRepositoryName,
+      ),
+      sourceRepositoryOwner: params.owner,
+      sourceRepositoryName: params.secondaryRepositoryName,
+      sourceDefaultBranch: 'main',
+    });
+  }
   const definition = await waitForDefinition({
     projectId: project.id,
     configPath: params.configPath,

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
@@ -213,6 +213,21 @@ describe('resolveAuthorizedIntegrationTools', () => {
 
     expect(narrowed).toEqual(schema);
   });
+
+  it('removes top-level oneOf from non-method tool schemas for Claude', () => {
+    const schema = {
+      type: 'object',
+      properties: {query: {type: 'string'}},
+      oneOf: [{required: ['owner', 'repo']}],
+    };
+
+    const narrowed = narrowMethodEnum(schema, []);
+
+    expect(narrowed).toEqual({
+      type: 'object',
+      properties: {query: {type: 'string'}},
+    });
+  });
 });
 
 describe('MCP tool names', () => {

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
@@ -159,7 +159,7 @@ function addAuthorizedTool(
     connection,
     // Live catalog metadata supplies dispatch classification; frozen step config remains the allowlist.
     description: catalogTool?.description ?? tool.id,
-    inputSchema: tool.methods ? toolInputSchema(tool) : tool.inputSchema,
+    inputSchema: toolInputSchema(tool),
     outputSchema: tool.outputSchema ?? catalogTool?.outputSchema,
     ...(catalogTool === undefined ? {} : {catalogEntry: catalogTool}),
   });

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -131,7 +131,7 @@ async function loadGithubModuleParts(
             externalAccountId: input.installationId,
             slug,
             displayName: input.displayName,
-            lifecycleStatus: 'active',
+            lifecycleStatus: input.lifecycleStatus ?? 'active',
             capabilities: providerCapabilities,
           },
           {tx},
@@ -161,6 +161,9 @@ async function loadGithubModuleParts(
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,
+    repositoryAuthorization: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION
+      ? 'enforced'
+      : 'unclassified',
     invalidateRepositoryAuthorizationCache: options.invalidateRepositoryAuthorizationCache,
     coreDb: db,
     deleteSecrets: options.secrets?.deleteSecrets,

--- a/libs/api/integration/github-dto/src/schemas/github.ts
+++ b/libs/api/integration/github-dto/src/schemas/github.ts
@@ -1,4 +1,7 @@
-import {integrationConnectionDtoSchema} from '@shipfox/api-integration-core-dto';
+import {
+  integrationConnectionDtoSchema,
+  updateIntegrationConnectionLifecycleStatusSchema,
+} from '@shipfox/api-integration-core-dto';
 import {z} from 'zod';
 
 export const createGithubInstallBodySchema = z.object({
@@ -28,6 +31,7 @@ export const createE2eGithubConnectionBodySchema = z.object({
   account_login: z.string().min(1),
   display_name: z.string().min(1),
   installer_user_id: z.string().uuid(),
+  lifecycle_status: updateIntegrationConnectionLifecycleStatusSchema.optional(),
 });
 export type CreateE2eGithubConnectionBodyDto = z.infer<typeof createE2eGithubConnectionBodySchema>;
 

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -802,9 +802,20 @@ describe('github agent tool catalog', () => {
     const searchPullRequestsSchema = inputSchemaFor('search_pull_requests');
 
     expect(listIssueTypesSchema.required).toEqual(['owner']);
+    const repositoryProperties = {
+      owner: {description: 'Repository owner', type: 'string'},
+      repo: {description: 'Repository name', type: 'string'},
+    };
     const searchRepositoryPairSchema = [
-      {required: ['owner', 'repo']},
-      {not: {anyOf: [{required: ['owner']}, {required: ['repo']}]}},
+      {properties: repositoryProperties, required: ['owner', 'repo']},
+      {
+        not: {
+          anyOf: [
+            {properties: repositoryProperties, required: ['owner']},
+            {properties: repositoryProperties, required: ['repo']},
+          ],
+        },
+      },
     ];
     expect(searchIssuesSchema.oneOf).toEqual(searchRepositoryPairSchema);
     expect(searchPullRequestsSchema.oneOf).toEqual(searchRepositoryPairSchema);

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -485,12 +485,7 @@ export const githubAgentToolCatalog = [
         ...pageProperties,
       },
       ['query'],
-      {
-        oneOf: [
-          {required: ['owner', 'repo']},
-          {not: {anyOf: [{required: ['owner']}, {required: ['repo']}]}},
-        ],
-      },
+      searchRepositoryPairConstraints(),
     ),
     outputSchema: objectSchema({issues: arraySchema(openObjectSchema('GitHub issue'))}, ['issues']),
   }),
@@ -667,12 +662,7 @@ export const githubAgentToolCatalog = [
         ...pageProperties,
       },
       ['query'],
-      {
-        oneOf: [
-          {required: ['owner', 'repo']},
-          {not: {anyOf: [{required: ['owner']}, {required: ['repo']}]}},
-        ],
-      },
+      searchRepositoryPairConstraints(),
     ),
     outputSchema: objectSchema(
       {pull_requests: arraySchema(openObjectSchema('GitHub pull request'))},
@@ -1169,6 +1159,22 @@ function objectSchema(
     properties,
     ...(required.length > 0 ? {required} : {}),
     ...extraSchema,
+  };
+}
+
+function searchRepositoryPairConstraints(): Pick<AgentToolJsonSchema, 'oneOf'> {
+  return {
+    oneOf: [
+      {properties: repositoryProperties, required: ['owner', 'repo']},
+      {
+        not: {
+          anyOf: [
+            {properties: repositoryProperties, required: ['owner']},
+            {properties: repositoryProperties, required: ['repo']},
+          ],
+        },
+      },
+    ],
   };
 }
 

--- a/libs/api/integration/github/src/core/install.ts
+++ b/libs/api/integration/github/src/core/install.ts
@@ -1,5 +1,8 @@
 import type {UserContextMembership} from '@shipfox/api-auth-context';
-import type {IntegrationConnection} from '@shipfox/api-integration-spi';
+import type {
+  IntegrationConnection,
+  IntegrationConnectionLifecycleStatus,
+} from '@shipfox/api-integration-spi';
 import type {GithubApiClient, GithubInstallationDetails} from '#api/client.js';
 import {
   GithubInstallationAlreadyLinkedError,
@@ -13,6 +16,7 @@ export interface ConnectGithubInstallationInput {
   installationId: string;
   displayName: string;
   installerUserId: string;
+  lifecycleStatus?: IntegrationConnectionLifecycleStatus | undefined;
   installation: {
     installationId: string;
     accountLogin: string;

--- a/libs/api/integration/github/src/index.test.ts
+++ b/libs/api/integration/github/src/index.test.ts
@@ -22,6 +22,26 @@ vi.mock('#core/webhook-processor.js', () => ({
 }));
 
 describe('createGithubIntegrationProvider', () => {
+  it.each([
+    ['unclassified', 'unclassified'],
+    ['enforced', 'enforced'],
+  ] as const)('preserves the composed repository authorization state: %s', (_label, state) => {
+    const provider = createGithubIntegrationProvider({
+      github: {} as never,
+      getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+      connectGithubInstallation: vi.fn() as never,
+      coreDb: vi.fn() as never,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+      publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
+      publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
+      repositoryAuthorization: state,
+    });
+
+    expect(provider.repositoryAuthorization).toBe(state);
+  });
+
   it('shares installation-token cleanup with the direct and composed processors', async () => {
     const deleteSecrets = vi.fn(() => Promise.resolve(1));
     const provider = createGithubIntegrationProvider({

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -1,5 +1,6 @@
 import {githubEventCatalog} from '@shipfox/api-integration-github-dto';
 import type {
+  AgentToolRepositoryAuthorizationState,
   GetIntegrationConnectionByIdFn,
   IntegrationConnection,
   PublishIntegrationEventReceivedFn,
@@ -105,6 +106,8 @@ export interface CreateGithubIntegrationProviderOptions
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  /** The composed integrations module controls when repository authorization is live. */
+  repositoryAuthorization?: AgentToolRepositoryAuthorizationState | undefined;
   /** Invalidates local repository authorization decisions after a committed webhook mutation. */
   invalidateRepositoryAuthorizationCache?: ((connectionId: string) => void) | undefined;
   getGithubInstallationByConnectionId?: typeof getGithubInstallationByConnectionId | undefined;
@@ -193,8 +196,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
   return {
     provider: 'github' as const,
     displayName: 'GitHub',
-    // Classification is dark until the final repository-authorization cutover.
-    repositoryAuthorization: 'unclassified' as const,
+    repositoryAuthorization: options.repositoryAuthorization ?? 'unclassified',
     eventCatalog: githubEventCatalog,
     adapters: {
       source_control: new GithubSourceControlProvider(github, undefined, checkoutTokenCache),

--- a/libs/api/integration/github/src/presentation/e2eRoutes/create-connection.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/create-connection.ts
@@ -45,6 +45,7 @@ export function createE2eGithubConnectionRoute(options: CreateE2eGithubConnectio
           installationId,
           displayName: body.display_name,
           installerUserId: body.installer_user_id,
+          ...(body.lifecycle_status === undefined ? {} : {lifecycleStatus: body.lifecycle_status}),
           installation: {
             installationId,
             accountLogin: body.account_login,

--- a/libs/api/integration/github/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/index.test.ts
@@ -93,6 +93,38 @@ describe('GitHub E2E routes', () => {
     expect(res.json()).toMatchObject({code: 'validation-error'});
   });
 
+  it('passes an optional disabled lifecycle status to connection setup', async () => {
+    const connectGithubInstallation = vi.fn(() => Promise.resolve(connection()));
+    const app = await createApp({
+      routes: [
+        createGithubE2eRoutes({
+          getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectGithubInstallation,
+          connectionCapabilities: ['source_control', 'agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/github-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        installation_id: 1234,
+        account_login: 'shipfox-e2e',
+        display_name: 'GitHub Shipfox E2E',
+        installer_user_id: '00000000-0000-4000-8000-000000000004',
+        lifecycle_status: 'disabled',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(connectGithubInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({lifecycleStatus: 'disabled'}),
+    );
+  });
+
   it('rejects an installation connected to another workspace', async () => {
     const connectGithubInstallation = vi.fn(() => Promise.resolve(connection()));
     const app = await createApp({

--- a/libs/api/projects-dto/src/e2e/project.ts
+++ b/libs/api/projects-dto/src/e2e/project.ts
@@ -2,13 +2,30 @@ import {displayNameSchema, slugSchema} from '@shipfox/api-common-dto';
 import {z} from 'zod';
 import {projectResponseSchema} from '../schemas/project.js';
 
-export const e2eCreateProjectBodySchema = z.object({
-  workspace_id: z.string().uuid(),
-  name: displayNameSchema,
-  slug: slugSchema.optional(),
-  source_connection_id: z.string().uuid().optional(),
-  source_external_repository_id: z.string().min(1).max(255).optional(),
-});
+export const e2eCreateProjectBodySchema = z
+  .object({
+    workspace_id: z.string().uuid(),
+    name: displayNameSchema,
+    slug: slugSchema.optional(),
+    source_connection_id: z.string().uuid().optional(),
+    source_external_repository_id: z.string().min(1).max(255).optional(),
+    // Test-only source metadata lets E2E fixtures exercise project-backed repository views
+    // without calling a real provider during setup.
+    source_repository_owner: z.string().min(1).max(255).optional(),
+    source_repository_name: z.string().min(1).max(255).optional(),
+    source_default_branch: z.string().min(1).max(255).optional(),
+  })
+  .superRefine((body, context) => {
+    const hasOwner = body.source_repository_owner !== undefined;
+    const hasName = body.source_repository_name !== undefined;
+    if (hasOwner !== hasName) {
+      context.addIssue({
+        code: 'custom',
+        path: ['source_repository_owner'],
+        message: 'Source repository owner and name must be provided together',
+      });
+    }
+  });
 
 export type E2eCreateProjectBodyDto = z.infer<typeof e2eCreateProjectBodySchema>;
 

--- a/libs/api/projects-dto/src/e2e/project.ts
+++ b/libs/api/projects-dto/src/e2e/project.ts
@@ -25,6 +25,13 @@ export const e2eCreateProjectBodySchema = z
         message: 'Source repository owner and name must be provided together',
       });
     }
+    if (body.source_default_branch !== undefined && (!hasOwner || !hasName)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['source_default_branch'],
+        message: 'Source repository default branch requires owner and name',
+      });
+    }
   });
 
 export type E2eCreateProjectBodyDto = z.infer<typeof e2eCreateProjectBodySchema>;

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -31,6 +31,13 @@ export interface CreateProjectParams {
   workspaceId: string;
   sourceConnectionId: string;
   sourceExternalRepositoryId: string;
+  sourceRepository?:
+    | {
+        owner: string;
+        name: string;
+        defaultBranch: string;
+      }
+    | undefined;
   name: string;
   slug: string;
 }
@@ -105,6 +112,13 @@ export async function createProject(params: CreateProjectParams): Promise<Projec
             workspaceId: params.workspaceId,
             sourceConnectionId: params.sourceConnectionId,
             sourceExternalRepositoryId: params.sourceExternalRepositoryId,
+            ...(params.sourceRepository === undefined
+              ? {}
+              : {
+                  sourceRepositoryOwner: params.sourceRepository.owner,
+                  sourceRepositoryName: params.sourceRepository.name,
+                  sourceDefaultBranch: params.sourceRepository.defaultBranch,
+                }),
             name: params.name,
             slug: params.slug,
           })

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
@@ -129,6 +129,22 @@ describe('projects E2E routes', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  test('requires source repository owner and name when a default branch is provided', async () => {
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: crypto.randomUUID(),
+        name: 'GitHub E2E Project',
+        source_default_branch: 'main',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
   test('returns conflict for duplicate explicit source values', async () => {
     const workspaceId = crypto.randomUUID();
     const sourceConnectionId = crypto.randomUUID();

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
@@ -1,6 +1,6 @@
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {sql} from 'drizzle-orm';
-import {db} from '#db/index.js';
+import {db, getProjectById} from '#db/index.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
 import {projectsE2eRoutes} from './index.js';
 
@@ -78,6 +78,55 @@ describe('projects E2E routes', () => {
       connection_id: sourceConnectionId,
       external_repository_id: 'e2e:explicit',
     });
+  });
+
+  test('preserves explicit source metadata for provider-backed fixtures', async () => {
+    const workspaceId = crypto.randomUUID();
+    const sourceConnectionId = crypto.randomUUID();
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: workspaceId,
+        name: 'GitHub E2E Project',
+        source_connection_id: sourceConnectionId,
+        source_external_repository_id: 'github:42',
+        source_repository_owner: 'shipfox',
+        source_repository_name: 'e2e',
+        source_default_branch: 'main',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      source: {
+        connection_id: sourceConnectionId,
+        external_repository_id: 'github:42',
+      },
+    });
+    await expect(getProjectById(res.json().id)).resolves.toMatchObject({
+      sourceRepositoryOwner: 'shipfox',
+      sourceRepositoryName: 'e2e',
+      sourceDefaultBranch: 'main',
+    });
+  });
+
+  test('requires source repository owner and name together', async () => {
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: crypto.randomUUID(),
+        name: 'GitHub E2E Project',
+        source_repository_owner: 'shipfox',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
   });
 
   test('returns conflict for duplicate explicit source values', async () => {

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
@@ -7,6 +7,7 @@ import {
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {ProjectAlreadyExistsError, ProjectSlugConflictError} from '#core/index.js';
 import {createProject} from '#db/index.js';
+import {updateProjectSourceRepository} from '#db/projects.js';
 import {toProjectDto} from '#presentation/dto/index.js';
 
 function syntheticExternalRepositoryId(): string {
@@ -14,6 +15,28 @@ function syntheticExternalRepositoryId(): string {
 }
 
 const MAX_GENERATED_SLUG_ATTEMPTS = 5;
+
+async function hydrateSourceRepository(
+  project: Awaited<ReturnType<typeof createProject>>,
+  source: {
+    owner?: string | undefined;
+    name?: string | undefined;
+    defaultBranch?: string | undefined;
+  },
+): Promise<typeof project> {
+  if (source.owner === undefined || source.name === undefined) return project;
+
+  const hydratedProject = await updateProjectSourceRepository({
+    workspaceId: project.workspaceId,
+    sourceConnectionId: project.sourceConnectionId,
+    sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+    sourceRepositoryOwner: source.owner,
+    sourceRepositoryName: source.name,
+    sourceDefaultBranch: source.defaultBranch ?? 'main',
+  });
+  if (!hydratedProject) throw new Error('E2E project source metadata update failed');
+  return hydratedProject;
+}
 
 function generatedProjectSlug(slugBase: string): string {
   const suffix = Number.parseInt(randomUUID().replaceAll('-', '').slice(0, 8), 16);
@@ -53,14 +76,21 @@ export const createE2eProjectRoute = defineRoute({
 
     for (let attempt = 0; attempt < MAX_GENERATED_SLUG_ATTEMPTS; attempt += 1) {
       try {
-        const project = await createProject({
-          workspaceId: request.body.workspace_id,
-          name: request.body.name,
-          slug,
-          sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
-          sourceExternalRepositoryId:
-            request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
-        });
+        const project = await hydrateSourceRepository(
+          await createProject({
+            workspaceId: request.body.workspace_id,
+            name: request.body.name,
+            slug,
+            sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
+            sourceExternalRepositoryId:
+              request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
+          }),
+          {
+            owner: request.body.source_repository_owner,
+            name: request.body.source_repository_name,
+            defaultBranch: request.body.source_default_branch,
+          },
+        );
 
         reply.code(201);
         return toProjectDto(project);

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
@@ -7,7 +7,6 @@ import {
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {ProjectAlreadyExistsError, ProjectSlugConflictError} from '#core/index.js';
 import {createProject} from '#db/index.js';
-import {updateProjectSourceRepository} from '#db/projects.js';
 import {toProjectDto} from '#presentation/dto/index.js';
 
 function syntheticExternalRepositoryId(): string {
@@ -15,28 +14,6 @@ function syntheticExternalRepositoryId(): string {
 }
 
 const MAX_GENERATED_SLUG_ATTEMPTS = 5;
-
-async function hydrateSourceRepository(
-  project: Awaited<ReturnType<typeof createProject>>,
-  source: {
-    owner?: string | undefined;
-    name?: string | undefined;
-    defaultBranch?: string | undefined;
-  },
-): Promise<typeof project> {
-  if (source.owner === undefined || source.name === undefined) return project;
-
-  const hydratedProject = await updateProjectSourceRepository({
-    workspaceId: project.workspaceId,
-    sourceConnectionId: project.sourceConnectionId,
-    sourceExternalRepositoryId: project.sourceExternalRepositoryId,
-    sourceRepositoryOwner: source.owner,
-    sourceRepositoryName: source.name,
-    sourceDefaultBranch: source.defaultBranch ?? 'main',
-  });
-  if (!hydratedProject) throw new Error('E2E project source metadata update failed');
-  return hydratedProject;
-}
 
 function generatedProjectSlug(slugBase: string): string {
   const suffix = Number.parseInt(randomUUID().replaceAll('-', '').slice(0, 8), 16);
@@ -76,21 +53,24 @@ export const createE2eProjectRoute = defineRoute({
 
     for (let attempt = 0; attempt < MAX_GENERATED_SLUG_ATTEMPTS; attempt += 1) {
       try {
-        const project = await hydrateSourceRepository(
-          await createProject({
-            workspaceId: request.body.workspace_id,
-            name: request.body.name,
-            slug,
-            sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
-            sourceExternalRepositoryId:
-              request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
-          }),
-          {
-            owner: request.body.source_repository_owner,
-            name: request.body.source_repository_name,
-            defaultBranch: request.body.source_default_branch,
-          },
-        );
+        const sourceRepository =
+          request.body.source_repository_owner === undefined ||
+          request.body.source_repository_name === undefined
+            ? undefined
+            : {
+                owner: request.body.source_repository_owner,
+                name: request.body.source_repository_name,
+                defaultBranch: request.body.source_default_branch ?? 'main',
+              };
+        const project = await createProject({
+          workspaceId: request.body.workspace_id,
+          name: request.body.name,
+          slug,
+          sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
+          sourceExternalRepositoryId:
+            request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
+          sourceRepository,
+        });
 
         reply.code(201);
         return toProjectDto(project);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1699,6 +1699,12 @@ importers:
       '@shipfox/e2e-screens-integrations':
         specifier: workspace:*
         version: link:../../../screens/integrations
+      '@shipfox/e2e-setup-integrations':
+        specifier: workspace:*
+        version: link:../../../setup/integrations
+      '@shipfox/e2e-setup-projects':
+        specifier: workspace:*
+        version: link:../../../setup/projects
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../../tools/playwright
@@ -1948,6 +1954,9 @@ importers:
       '@shipfox/e2e-setup-integrations':
         specifier: workspace:*
         version: link:../../../setup/integrations
+      '@shipfox/e2e-setup-projects':
+        specifier: workspace:*
+        version: link:../../../setup/projects
       '@shipfox/e2e-setup-secrets':
         specifier: workspace:*
         version: link:../../../setup/secrets

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -34,6 +34,7 @@
         "DEFINITION_*",
         "GITEA_BASE_URL",
         "HOST",
+        "INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION",
         "INTEGRATIONS_ENABLE_SLACK_PROVIDER",
         "OBJECT_STORAGE_S3_ENDPOINT",
         "OTEL_*",
@@ -108,6 +109,7 @@
       "dependsOn": ["^build"],
       "passThroughEnv": [
         "ADMIN_BOOTSTRAP_TOKEN",
+        "INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION",
         "SLACK_API_BASE_URL",
         "SLACK_SIGNING_SECRET"
       ]


### PR DESCRIPTION
This change proves the enabled GitHub repository authorization path end to end while keeping production rollout dark-launched. The E2E harness explicitly enables the gate and uses project-backed GitHub fixtures to exercise selected and all repository access, deterministic and agent tool calls, search validation, indirect review-thread calls, checkout token scopes, and credential-safe failures. The integrations settings journey verifies project-derived repositories and selected/all persistence.

The provider now receives its authorization state from the composed integrations gate, and the test-only setup routes can seed repository metadata without provider lookups during fixture creation. Claude-compatible tool schemas preserve the authorization boundary for search tools.

Validation:
- GitHub flow E2E: 10 passed
- Integrations settings E2E: 15 passed
- Affected check/type/test matrix: 313/313 Turbo tasks
- Dependency, lockfile, database-boundary, prose, published-artifact, harness, and diff checks passed

Closes ENG-1847

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proves the GitHub repository authorization path end to end while keeping the production rollout dark-launched. The E2E harness enables the gate and uses project-backed GitHub fixtures to exercise selected and all repository access, deterministic and agent tool calls, search validation, indirect review-thread calls, checkout token scopes, and credential-safe failures.

- The provider receives its authorization state from the composed integrations gate; E2E setup can seed disabled connections and repository metadata, and background metadata lookups stay out of the agent-tool trace.
- Claude-compatible tool schemas strip method and repository-pair constraints, preserving the authorization boundary for search tools.
- Integrations settings journey verifies project-derived repositories and selected/all persistence.

Closes ENG-1847.

<sup>Written for commit 63e7b1b01426b8e10f0d3faa4717a3418a3be23f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

