### PR TITLE
Persist agent tool protocol errors and session termination diagnostics

### DIFF
--- a/.changeset/quiet-tools-record.md
+++ b/.changeset/quiet-tools-record.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Persists structured agent tool protocol errors and session termination diagnostics.

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -172,6 +172,48 @@ describe('buildAgentToolsMcpServer', () => {
     }
   });
 
+  it('returns stable protocol details for a missing method', async () => {
+    const dispatch = vi.fn();
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools());
+
+    const result = await client.callTool(
+      {name: 'github_main__issue_read', arguments: {}},
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        code: 'invalid-request',
+        reason: 'missing_required_parameter',
+        tool: 'issue_read',
+        parameter: 'method',
+      },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns a stable tool-not-found reason without exposing it as a provider error', async () => {
+    const dispatch = vi.fn();
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools());
+
+    const result = await client.callTool(
+      {name: 'github_main__missing_tool', arguments: {}},
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        code: 'invalid-request',
+        reason: 'tool_not_found',
+        tool: 'github_main__missing_tool',
+      },
+    });
+  });
+
   it('ignores a stray method argument for standalone tools', async () => {
     const dispatch = vi.fn(async () => ({
       content: [{type: 'text' as const, text: 'called'}],

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -37,6 +37,21 @@ export interface IntegrationToolDispatchResult {
   authorization?: IntegrationToolCallAuthorization | undefined;
 }
 
+export type IntegrationToolProtocolErrorReason =
+  | 'tool_not_found'
+  | 'arguments_not_object'
+  | 'missing_required_parameter'
+  | 'invalid_parameter_type'
+  | 'unauthorized_method';
+
+export interface IntegrationToolProtocolError {
+  readonly [key: string]: unknown;
+  readonly code: 'invalid-request';
+  readonly reason: IntegrationToolProtocolErrorReason;
+  readonly tool?: string | undefined;
+  readonly parameter?: string | undefined;
+}
+
 export interface BuildAgentToolsMcpServerParams {
   authorizedTools: AuthorizedIntegrationToolMap;
   dispatch: IntegrationToolDispatcher;
@@ -78,7 +93,11 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
         outcome: 'invalid-request',
         errorCode: 'invalid-request',
       });
-      return toolError(`Unknown integration tool: ${request.params.name}`);
+      return toolError(`Unknown integration tool: ${request.params.name}`, {
+        code: 'invalid-request',
+        reason: 'tool_not_found',
+        tool: request.params.name,
+      });
     }
 
     const args = request.params.arguments ?? {};
@@ -90,7 +109,11 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
         outcome: 'invalid-request',
         errorCode: 'invalid-request',
       });
-      return toolError('Tool arguments must be an object');
+      return toolError('Tool arguments must be an object', {
+        code: 'invalid-request',
+        reason: 'arguments_not_object',
+        tool: authorizedTool.tool.id,
+      });
     }
 
     const methodValidation = validateMethod(authorizedTool, args);
@@ -102,7 +125,7 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
         outcome: 'invalid-request',
         errorCode: 'invalid-request',
       });
-      return toolError(methodValidation.message);
+      return toolError(methodValidation.message, methodValidation.details);
     }
     const method = methodValidation.method ?? NO_METHOD_LABEL;
 
@@ -185,26 +208,49 @@ function recordToolCall(
 function validateMethod(
   authorizedTool: AuthorizedIntegrationTool,
   args: Record<string, unknown>,
-): {kind: 'ok'; method?: string | undefined} | {kind: 'error'; message: string} {
+):
+  | {kind: 'ok'; method?: string | undefined}
+  | {kind: 'error'; message: string; details: IntegrationToolProtocolError} {
   if (!authorizedTool.tool.methods) return {kind: 'ok'};
 
   const method = args.method;
   if (typeof method !== 'string') {
-    return {kind: 'error', message: 'Method-family tools require a string method argument'};
+    return {
+      kind: 'error',
+      message: 'Method-family tools require a string method argument',
+      details: {
+        code: 'invalid-request',
+        reason: Object.hasOwn(args, 'method')
+          ? 'invalid_parameter_type'
+          : 'missing_required_parameter',
+        tool: authorizedTool.tool.id,
+        parameter: 'method',
+      },
+    };
   }
 
   const allowedMethods = new Set(authorizedTool.tool.methods.map((candidate) => candidate.id));
   if (!allowedMethods.has(method)) {
-    return {kind: 'error', message: `Unauthorized integration tool method: ${method}`};
+    return {
+      kind: 'error',
+      message: `Unauthorized integration tool method: ${method}`,
+      details: {
+        code: 'invalid-request',
+        reason: 'unauthorized_method',
+        tool: authorizedTool.tool.id,
+        parameter: 'method',
+      },
+    };
   }
 
   return {kind: 'ok', method};
 }
 
-function toolError(message: string): CallToolResult {
+function toolError(message: string, details: IntegrationToolProtocolError): CallToolResult {
   return {
     isError: true,
     content: [{type: 'text', text: message}],
+    structuredContent: details,
   };
 }
 

--- a/libs/runner/agent/src/core/agent-session-diagnostics.test.ts
+++ b/libs/runner/agent/src/core/agent-session-diagnostics.test.ts
@@ -1,0 +1,207 @@
+import {
+  AgentSessionDiagnostics,
+  type AgentSessionFailureClass,
+  stableDiagnosticFingerprint,
+} from '#core/agent-session-diagnostics.js';
+
+function diagnostics(
+  overrides: Partial<ConstructorParameters<typeof AgentSessionDiagnostics>[0]> = {},
+): AgentSessionDiagnostics {
+  return new AgentSessionDiagnostics({
+    harness: 'pi',
+    invocation: {
+      jobExecutionId: 'job-1',
+      stepId: 'step-1',
+      attempt: 2,
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      session: {mode: 'resume'},
+    },
+    metadataMode: 'warm',
+    ...overrides,
+  });
+}
+
+describe('AgentSessionDiagnostics', () => {
+  it('retains one structured protected record for calls, errors, writes, and budgets', () => {
+    const record = diagnostics({
+      providerTools: [
+        {
+          name: 'pull_request_read',
+          description: 'Read a pull request.',
+          inputSchema: {type: 'object', properties: {method: {type: 'string'}}},
+          outputSchema: {type: 'object'},
+        },
+      ],
+      directToolNames: ['pull_request_read'],
+      proxyFallback: true,
+    });
+    record.recordSessionId('session-1');
+    record.recordTurnStart();
+    record.recordToolCall({
+      toolCallId: 'call-1',
+      toolName: 'pull_request_read',
+      args: {repo: 'platform', method: 'get'},
+    });
+    record.recordToolResult({
+      toolCallId: 'call-1',
+      isError: true,
+      details: {
+        message: 'wording one',
+        structuredContent: {
+          code: 'invalid-request',
+          reason: 'missing_required_parameter',
+          tool: 'pull_request_read',
+          parameter: 'method',
+        },
+      },
+    });
+    record.recordOutputWrite({
+      key: 'summary',
+      value: 'done',
+      result: {ok: true},
+    });
+    record.recordOutputWrite({
+      key: 'summary',
+      value: 'done',
+      result: {ok: true, idempotent: true},
+    });
+    record.finish('completed');
+
+    expect(record.storeEntry()).toMatchObject({
+      type: 'shipfox_agent_diagnostics',
+      data: {
+        kind: 'agent_session_diagnostics',
+        version: 1,
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        sessionId: 'session-1',
+        registration: {
+          metadataMode: 'warm',
+          directToolNames: ['pull_request_read'],
+          proxyFallback: true,
+        },
+        providerTools: [
+          {
+            name: 'pull_request_read',
+            description: 'Read a pull request.',
+            inputSchema: {type: 'object', properties: {method: {type: 'string'}}},
+            outputSchema: {type: 'object'},
+          },
+        ],
+        toolCalls: [
+          {
+            toolName: 'pull_request_read',
+            normalizedArgs: {method: 'get', repo: 'platform'},
+            argsFingerprint: expect.any(String),
+          },
+        ],
+        toolResults: [
+          expect.objectContaining({
+            isError: true,
+            error: {
+              code: 'invalid-request',
+              reason: 'missing_required_parameter',
+              tool: 'pull_request_read',
+              parameter: 'method',
+            },
+            resultFingerprint: expect.any(String),
+          }),
+        ],
+        outputWrites: [
+          {status: 'accepted', key: 'summary', valueFingerprint: expect.any(String)},
+          {status: 'idempotent', key: 'summary', valueFingerprint: expect.any(String)},
+        ],
+        termination: {reason: 'completed'},
+        budgets: {
+          turns: {consumed: 1, remaining: null},
+          toolCalls: {consumed: 1, remaining: null},
+          timeMs: {consumed: expect.any(Number), remaining: null},
+          tokens: {consumed: 0, remaining: null},
+        },
+      },
+    });
+  });
+
+  it('keeps repetition fingerprints stable when provider prose changes', () => {
+    const record = diagnostics();
+    for (const [index, message] of [
+      'first wording',
+      'rephrased wording',
+      'third wording',
+    ].entries()) {
+      const toolCallId = `call-${index}`;
+      record.recordToolCall({toolCallId, toolName: 'pull_request_read', args: {method: 'get'}});
+      record.recordToolResult({
+        toolCallId,
+        isError: true,
+        details: {
+          message,
+          structuredContent: {
+            code: 'invalid-request',
+            reason: 'missing_required_parameter',
+            tool: 'pull_request_read',
+            parameter: 'method',
+          },
+        },
+      });
+    }
+
+    const snapshot = record.snapshot();
+    expect(snapshot.toolResults.map((result) => result.resultFingerprint)).toEqual([
+      snapshot.toolResults[0]?.resultFingerprint,
+      snapshot.toolResults[0]?.resultFingerprint,
+      snapshot.toolResults[0]?.resultFingerprint,
+    ]);
+    expect(snapshot.failureClasses).toContain('agent_tool_loop_detected');
+    expect(
+      stableDiagnosticFingerprint({code: 'invalid-request', reason: 'missing_required_parameter'}),
+    ).toBe(
+      stableDiagnosticFingerprint({reason: 'missing_required_parameter', code: 'invalid-request'}),
+    );
+  });
+
+  it('fills exact arguments when a progress event precedes the assistant tool call', () => {
+    const record = diagnostics();
+    record.recordToolCall({toolCallId: 'call-1', toolName: 'pull_request_read', args: {}});
+    record.updateToolCallArguments('call-1', {method: 'get', repo: 'platform'});
+
+    expect(record.snapshot().toolCalls).toMatchObject([
+      {
+        toolCallId: 'call-1',
+        normalizedArgs: {method: 'get', repo: 'platform'},
+      },
+    ]);
+  });
+
+  it.each<AgentSessionFailureClass>([
+    'required_output_missing',
+    'agent_tool_loop_detected',
+    'output_conflict',
+    'integration_tool_catalog_unavailable',
+  ])('supports the typed failure class %s', (failureClass) => {
+    const record = diagnostics({
+      catalogFailures:
+        failureClass === 'integration_tool_catalog_unavailable'
+          ? [{server: 'shipfox_integration_tools', errorClass: 'timeout'}]
+          : undefined,
+    });
+    if (failureClass === 'output_conflict') {
+      record.recordOutputWrite({
+        key: 'summary',
+        value: 'first',
+        result: {ok: false, code: 'output_conflict'},
+      });
+    } else if (failureClass !== 'integration_tool_catalog_unavailable') {
+      record.markFailure(failureClass);
+    }
+    record.finish(failureClass, failureClass);
+
+    expect(record.snapshot().failureClasses).toContain(failureClass);
+    expect(record.snapshot().termination).toMatchObject({
+      reason: failureClass,
+      failureClass,
+    });
+  });
+});

--- a/libs/runner/agent/src/core/agent-session-diagnostics.test.ts
+++ b/libs/runner/agent/src/core/agent-session-diagnostics.test.ts
@@ -162,6 +162,55 @@ describe('AgentSessionDiagnostics', () => {
     );
   });
 
+  it('does not classify an unrecognized provider code only because it has a reason', () => {
+    const record = diagnostics();
+    record.recordToolResult({
+      isError: false,
+      details: {code: 'provider-specific-code', reason: 'provider wording'},
+    });
+
+    expect(record.snapshot().toolResults[0]).toMatchObject({isError: false});
+    expect(record.snapshot().toolResults[0]).not.toHaveProperty('error');
+  });
+
+  it('bounds model-controlled diagnostic values while retaining full-value fingerprints', () => {
+    const hugeArgs = {payload: 'secret-'.repeat(5000)};
+    const hugeKey = 'output-'.repeat(5000);
+    const record = diagnostics({
+      providerTools: Array.from({length: 100}, (_, index) => ({
+        name: `tool-${index}`,
+        description: 'description-'.repeat(500),
+        inputSchema: {properties: {payload: 'schema-'.repeat(5000)}},
+      })),
+    });
+    record.recordToolCall({toolCallId: 'call-1', toolName: 'tool-1', args: hugeArgs});
+    record.recordOutputWrite({
+      key: hugeKey,
+      value: hugeArgs.payload,
+      result: {
+        ok: false,
+        code: 'output_schema_mismatch',
+        reason: 'schema-'.repeat(5000),
+      },
+    });
+
+    const snapshot = record.snapshot();
+    const call = snapshot.toolCalls[0];
+    const write = snapshot.outputWrites[0];
+    expect(call?.normalizedArgs).toMatchObject({payload: expect.any(String)});
+    expect((call?.normalizedArgs as {payload: string}).payload).not.toBe(hugeArgs.payload);
+    expect(call?.argsFingerprint).toBe(stableDiagnosticFingerprint(hugeArgs));
+    expect(write).toMatchObject({
+      key: expect.any(String),
+      keyFingerprint: stableDiagnosticFingerprint(hugeKey),
+      code: 'output_schema_mismatch',
+      reason: expect.any(String),
+    });
+    expect(write?.key).not.toBe(hugeKey);
+    expect(Buffer.byteLength(JSON.stringify(snapshot), 'utf8')).toBeLessThanOrEqual(128 * 1024);
+    expect(snapshot.providerTools.length).toBeLessThanOrEqual(64);
+  });
+
   it('fills exact arguments when a progress event precedes the assistant tool call', () => {
     const record = diagnostics();
     record.recordToolCall({toolCallId: 'call-1', toolName: 'pull_request_read', args: {}});

--- a/libs/runner/agent/src/core/agent-session-diagnostics.ts
+++ b/libs/runner/agent/src/core/agent-session-diagnostics.ts
@@ -1,0 +1,664 @@
+import {createHash} from 'node:crypto';
+import type {HarnessInvocation} from '#core/harness.js';
+
+export const AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE = 'shipfox_agent_diagnostics';
+export const AGENT_SESSION_DIAGNOSTICS_VERSION = 1 as const;
+
+export type AgentSessionHarness = 'pi' | 'claude';
+export type AgentSessionMetadataMode = 'cold' | 'warm';
+
+/** Stable classes used to group a failed agent session without parsing prose. */
+export type AgentSessionFailureClass =
+  | 'required_output_missing'
+  | 'agent_tool_loop_detected'
+  | 'output_conflict'
+  | 'integration_tool_catalog_unavailable';
+
+export type AgentSessionTerminationReason =
+  | 'completed'
+  | 'aborted'
+  | 'required_output_missing'
+  | 'agent_tool_loop_detected'
+  | 'output_conflict'
+  | 'integration_tool_catalog_unavailable'
+  | 'error';
+
+export interface AgentSessionToolDescriptor {
+  readonly name: string;
+  readonly description?: string | undefined;
+  readonly inputSchema: unknown;
+  readonly outputSchema?: unknown | undefined;
+}
+
+export interface AgentSessionCatalogFailure {
+  readonly server: string;
+  readonly errorClass: 'http' | 'timeout' | 'transport' | 'unknown';
+  readonly status?: number | undefined;
+}
+
+export interface AgentSessionRegistration {
+  readonly metadataMode: AgentSessionMetadataMode;
+  readonly directToolNames: readonly string[];
+  readonly proxyFallback: boolean;
+}
+
+export interface AgentSessionToolCall {
+  readonly sequence: number;
+  readonly toolCallId?: string | undefined;
+  readonly toolName: string;
+  /** Protected session artifacts may retain the exact normalized arguments. */
+  readonly normalizedArgs: unknown;
+  readonly argsFingerprint: string;
+}
+
+export interface AgentSessionToolResult {
+  readonly sequence: number;
+  readonly toolCallId?: string | undefined;
+  readonly toolName?: string | undefined;
+  readonly isError: boolean;
+  readonly resultFingerprint: string;
+  readonly structuredResultFingerprint?: string | undefined;
+  readonly error?: AgentToolErrorDetails | undefined;
+}
+
+export type AgentSessionOutputWriteStatus = 'accepted' | 'idempotent' | 'conflicting' | 'rejected';
+
+export interface AgentSessionOutputWrite {
+  readonly sequence: number;
+  readonly key: string;
+  readonly status: AgentSessionOutputWriteStatus;
+  readonly valueFingerprint: string;
+  readonly code?: string | undefined;
+}
+
+export interface AgentSessionBudget {
+  readonly consumed: number;
+  /** No agent budget is configured at this boundary today. */
+  readonly remaining: number | null;
+}
+
+export interface AgentSessionBudgets {
+  readonly turns: AgentSessionBudget;
+  readonly toolCalls: AgentSessionBudget;
+  readonly timeMs: AgentSessionBudget;
+  readonly tokens: AgentSessionBudget;
+}
+
+export interface AgentToolErrorDetails {
+  readonly code: string;
+  readonly reason?: string | undefined;
+  readonly tool?: string | undefined;
+  readonly parameter?: string | undefined;
+  readonly status?: number | undefined;
+}
+
+export interface AgentSessionTermination {
+  readonly reason: AgentSessionTerminationReason;
+  readonly failureClass?: AgentSessionFailureClass | undefined;
+}
+
+export interface AgentSessionDiagnosticEntry {
+  readonly kind: 'agent_session_diagnostics';
+  readonly version: typeof AGENT_SESSION_DIAGNOSTICS_VERSION;
+  readonly harness: AgentSessionHarness;
+  readonly provider: string;
+  readonly model: string;
+  readonly sessionId?: string | undefined;
+  readonly registration: AgentSessionRegistration;
+  readonly providerTools: readonly AgentSessionToolDescriptor[];
+  readonly catalogFailures: readonly AgentSessionCatalogFailure[];
+  readonly toolCalls: readonly AgentSessionToolCall[];
+  readonly toolResults: readonly AgentSessionToolResult[];
+  readonly outputWrites: readonly AgentSessionOutputWrite[];
+  readonly failureClasses: readonly AgentSessionFailureClass[];
+  readonly termination: AgentSessionTermination;
+  readonly budgets: AgentSessionBudgets;
+}
+
+export interface AgentSessionDiagnosticStoreEntry {
+  readonly [key: string]: unknown;
+  readonly type: typeof AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE;
+  readonly uuid: string;
+  readonly data: AgentSessionDiagnosticEntry;
+}
+
+interface AgentSessionDiagnosticsParams {
+  readonly harness: AgentSessionHarness;
+  readonly invocation: Pick<
+    HarnessInvocation,
+    'jobExecutionId' | 'stepId' | 'attempt' | 'provider' | 'model' | 'session'
+  >;
+  readonly metadataMode: AgentSessionMetadataMode;
+  readonly directToolNames?: readonly string[] | undefined;
+  readonly proxyFallback?: boolean | undefined;
+  readonly providerTools?: readonly AgentSessionToolDescriptor[] | undefined;
+  readonly catalogFailures?: readonly AgentSessionCatalogFailure[] | undefined;
+}
+
+interface RecordToolResultParams {
+  readonly toolCallId?: string | undefined;
+  readonly toolName?: string | undefined;
+  readonly isError: boolean;
+  readonly details?: unknown;
+  readonly structuredContent?: unknown;
+}
+
+const MAX_DIAGNOSTIC_TOOL_CALLS = 256;
+const MAX_DIAGNOSTIC_TOOL_RESULTS = 256;
+const MAX_DIAGNOSTIC_OUTPUT_WRITES = 256;
+const MAX_DIAGNOSTIC_FAILURE_CLASSES = 4;
+const MAX_DIAGNOSTIC_CATALOG_FAILURES = 32;
+const MAX_REPEATED_TOOL_FAILURES = 3;
+const STABLE_ERROR_CODES = new Set([
+  'invalid-request',
+  'unknown',
+  'provider-timeout',
+  'cancelled',
+  'credentials-unavailable',
+  'repository-required',
+  'repository-not-granted',
+  'repository-ambiguous',
+  'repository-authorization-unavailable',
+  'search-qualifier-conflict',
+  'repository-not-found',
+  'installation-not-found',
+  'file-not-found',
+  'ref-not-found',
+  'ref-invalid',
+  'access-denied',
+  'rate-limited',
+  'timeout',
+  'provider-unavailable',
+  'provider-rejected',
+  'malformed-provider-response',
+  'content-too-large',
+  'too-many-files',
+  'required_output_missing',
+  'agent_tool_loop_detected',
+  'output_conflict',
+  'output_schema_mismatch',
+  'output_value_too_large',
+  'output_total_too_large',
+  'invalid_output_key',
+  'undeclared_output',
+]);
+
+/**
+ * Collects protected, structured session facts. Nothing from this class is
+ * sent to normal logs or metric labels; adapters decide when to append the
+ * snapshot to their native protected transcript.
+ */
+export class AgentSessionDiagnostics {
+  readonly #harness: AgentSessionHarness;
+  readonly #provider: string;
+  readonly #model: string;
+  readonly #entryUuid: string;
+  readonly #startedAt = Date.now();
+  readonly #registration: AgentSessionRegistration;
+  #providerTools: readonly AgentSessionToolDescriptor[];
+  readonly #catalogFailures: AgentSessionCatalogFailure[];
+  readonly #toolCalls: AgentSessionToolCall[] = [];
+  readonly #toolResults: AgentSessionToolResult[] = [];
+  readonly #outputWrites: AgentSessionOutputWrite[] = [];
+  readonly #toolCallById = new Map<string, AgentSessionToolCall>();
+  readonly #repeatedFailures = new Map<string, number>();
+  readonly #failureClasses: AgentSessionFailureClass[] = [];
+  #sessionId: string | undefined;
+  #sequence = 0;
+  #turnsConsumed = 0;
+  #toolCallsConsumed = 0;
+  #tokensConsumed = 0;
+  #terminationReason: AgentSessionTerminationReason | undefined;
+  #terminationFailureClass: AgentSessionFailureClass | undefined;
+
+  constructor(params: AgentSessionDiagnosticsParams) {
+    this.#harness = params.harness;
+    this.#provider = params.invocation.provider;
+    this.#model = params.invocation.model;
+    this.#entryUuid = diagnosticEntryUuid(params);
+    this.#registration = {
+      metadataMode: params.metadataMode,
+      directToolNames: [...new Set(params.directToolNames ?? [])],
+      proxyFallback: params.proxyFallback ?? false,
+    };
+    this.#providerTools = (params.providerTools ?? []).map(normalizeToolDescriptor);
+    this.#catalogFailures = (params.catalogFailures ?? [])
+      .slice(0, MAX_DIAGNOSTIC_CATALOG_FAILURES)
+      .map(normalizeCatalogFailure);
+    if (this.#catalogFailures.length > 0) {
+      this.markFailure('integration_tool_catalog_unavailable');
+    }
+  }
+
+  get entryUuid(): string {
+    return this.#entryUuid;
+  }
+
+  get terminationReason(): AgentSessionTerminationReason | undefined {
+    return this.#terminationReason;
+  }
+
+  get failureClasses(): readonly AgentSessionFailureClass[] {
+    return this.#failureClasses;
+  }
+
+  recordSessionId(sessionId: string | undefined): void {
+    if (sessionId !== undefined && sessionId !== '') this.#sessionId = sessionId;
+  }
+
+  recordProviderTools(tools: readonly AgentSessionToolDescriptor[]): void {
+    if (tools.length === 0) return;
+    this.#providerTools = tools.map(normalizeToolDescriptor);
+  }
+
+  recordToolCall(params: {toolCallId?: string | undefined; toolName: string; args: unknown}): void {
+    const normalizedArgs = normalizeDiagnosticValue(params.args);
+    const call: AgentSessionToolCall = {
+      sequence: this.#nextSequence(),
+      ...(params.toolCallId === undefined ? {} : {toolCallId: params.toolCallId}),
+      toolName: params.toolName,
+      normalizedArgs,
+      argsFingerprint: stableDiagnosticFingerprint(normalizedArgs),
+    };
+    this.#toolCallsConsumed += 1;
+    if (this.#toolCalls.length < MAX_DIAGNOSTIC_TOOL_CALLS) this.#toolCalls.push(call);
+    if (params.toolCallId !== undefined) this.#toolCallById.set(params.toolCallId, call);
+  }
+
+  updateToolCallArguments(toolCallId: string, args: unknown): void {
+    const existing = this.#toolCallById.get(toolCallId);
+    if (existing === undefined) return;
+    const normalizedArgs = normalizeDiagnosticValue(args);
+    const updated = {
+      ...existing,
+      normalizedArgs,
+      argsFingerprint: stableDiagnosticFingerprint(normalizedArgs),
+    };
+    this.#toolCallById.set(toolCallId, updated);
+    const index = this.#toolCalls.findIndex((call) => call.toolCallId === toolCallId);
+    if (index >= 0) this.#toolCalls[index] = updated;
+  }
+
+  recordToolResult(params: RecordToolResultParams): void {
+    const call =
+      params.toolCallId === undefined ? undefined : this.#toolCallById.get(params.toolCallId);
+    const result = createToolResult(params, call, this.#nextSequence());
+    if (this.#toolResults.length < MAX_DIAGNOSTIC_TOOL_RESULTS) this.#toolResults.push(result);
+    this.#recordToolResultFailure(result, call, params.toolName);
+  }
+
+  recordOutputWrite(params: {
+    key: string;
+    value: string;
+    result: {
+      readonly ok: boolean;
+      readonly idempotent?: boolean | undefined;
+      readonly code?: string | undefined;
+    };
+  }): void {
+    const status = outputWriteStatus(params.result);
+    if (status === 'conflicting') this.markFailure('output_conflict');
+    if (this.#outputWrites.length >= MAX_DIAGNOSTIC_OUTPUT_WRITES) return;
+    this.#outputWrites.push({
+      sequence: this.#nextSequence(),
+      key: params.key,
+      status,
+      valueFingerprint: stableDiagnosticFingerprint(params.value),
+      ...(params.result.code === undefined ? {} : {code: params.result.code}),
+    });
+  }
+
+  recordCatalogFailure(failure: AgentSessionCatalogFailure): void {
+    if (
+      !this.#catalogFailures.some(
+        (candidate) =>
+          candidate.server === failure.server && candidate.errorClass === failure.errorClass,
+      ) &&
+      this.#catalogFailures.length < MAX_DIAGNOSTIC_CATALOG_FAILURES
+    ) {
+      this.#catalogFailures.push(normalizeCatalogFailure(failure));
+    }
+    this.markFailure('integration_tool_catalog_unavailable');
+  }
+
+  recordTurnStart(): void {
+    this.#turnsConsumed += 1;
+  }
+
+  recordUsage(usage: unknown): void {
+    if (!isRecord(usage)) return;
+    const total = firstFiniteNumber(usage, ['total_tokens', 'totalTokens', 'total']);
+    if (total !== undefined) {
+      this.#tokensConsumed += total;
+      return;
+    }
+    this.#tokensConsumed +=
+      (firstFiniteNumber(usage, ['input_tokens', 'inputTokens', 'input']) ?? 0) +
+      (firstFiniteNumber(usage, ['output_tokens', 'outputTokens', 'output']) ?? 0);
+  }
+
+  markFailure(failureClass: AgentSessionFailureClass): void {
+    if (
+      !this.#failureClasses.includes(failureClass) &&
+      this.#failureClasses.length < MAX_DIAGNOSTIC_FAILURE_CLASSES
+    ) {
+      this.#failureClasses.push(failureClass);
+    }
+  }
+
+  finish(reason: AgentSessionTerminationReason, failureClass?: AgentSessionFailureClass): void {
+    if (failureClass !== undefined) this.markFailure(failureClass);
+    if (this.#terminationReason !== undefined) return;
+    this.#terminationReason = reason;
+    this.#terminationFailureClass =
+      failureClass ?? (isFailureClass(reason) ? reason : this.#failureClasses[0]);
+  }
+
+  snapshot(): AgentSessionDiagnosticEntry {
+    const terminationReason = this.#terminationReason ?? 'error';
+    return {
+      kind: 'agent_session_diagnostics',
+      version: AGENT_SESSION_DIAGNOSTICS_VERSION,
+      harness: this.#harness,
+      provider: this.#provider,
+      model: this.#model,
+      ...(this.#sessionId === undefined ? {} : {sessionId: this.#sessionId}),
+      registration: this.#registration,
+      providerTools: this.#providerTools,
+      catalogFailures: [...this.#catalogFailures],
+      toolCalls: [...this.#toolCalls],
+      toolResults: [...this.#toolResults],
+      outputWrites: [...this.#outputWrites],
+      failureClasses: [...this.#failureClasses],
+      termination: {
+        reason: terminationReason,
+        ...(this.#terminationFailureClass === undefined
+          ? {}
+          : {failureClass: this.#terminationFailureClass}),
+      },
+      budgets: {
+        turns: budget(this.#turnsConsumed),
+        toolCalls: budget(this.#toolCallsConsumed),
+        timeMs: budget(Math.max(0, Date.now() - this.#startedAt)),
+        tokens: budget(this.#tokensConsumed),
+      },
+    };
+  }
+
+  storeEntry(): AgentSessionDiagnosticStoreEntry {
+    return {
+      type: AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE,
+      uuid: this.#entryUuid,
+      data: this.snapshot(),
+    };
+  }
+
+  #nextSequence(): number {
+    const sequence = this.#sequence;
+    this.#sequence += 1;
+    return sequence;
+  }
+
+  #recordToolResultFailure(
+    result: AgentSessionToolResult,
+    call: AgentSessionToolCall | undefined,
+    toolName: string | undefined,
+  ): void {
+    if (result.error?.code === 'output_conflict') this.markFailure('output_conflict');
+    if (!result.isError) return;
+    const repetitionKey = [
+      call?.toolName ?? toolName ?? 'unknown',
+      call?.argsFingerprint ?? 'unknown',
+      result.resultFingerprint,
+    ].join(':');
+    const repetitions = (this.#repeatedFailures.get(repetitionKey) ?? 0) + 1;
+    this.#repeatedFailures.set(repetitionKey, repetitions);
+    if (repetitions >= MAX_REPEATED_TOOL_FAILURES) {
+      this.markFailure('agent_tool_loop_detected');
+    }
+  }
+}
+
+function createToolResult(
+  params: RecordToolResultParams,
+  call: AgentSessionToolCall | undefined,
+  sequence: number,
+): AgentSessionToolResult {
+  const outputFailure = isOutputFailure(params.details);
+  const error = stableToolErrorDetails(
+    {
+      details: params.details,
+      structuredContent: params.structuredContent,
+    },
+    params.isError || outputFailure,
+  );
+  const isError = params.isError || outputFailure || error !== undefined;
+  const structuredResult = structuredResultForFingerprint(
+    params.structuredContent ?? params.details,
+  );
+  return {
+    sequence,
+    ...(params.toolCallId === undefined ? {} : {toolCallId: params.toolCallId}),
+    ...(params.toolName === undefined && call === undefined
+      ? {}
+      : {toolName: params.toolName ?? call?.toolName}),
+    isError,
+    resultFingerprint: stableDiagnosticFingerprint({isError, error, structuredResult}),
+    ...(structuredResult === undefined
+      ? {}
+      : {structuredResultFingerprint: stableDiagnosticFingerprint(structuredResult)}),
+    ...(error === undefined ? {} : {error}),
+  };
+}
+
+function outputWriteStatus(result: {
+  readonly ok: boolean;
+  readonly idempotent?: boolean | undefined;
+  readonly code?: string | undefined;
+}): AgentSessionOutputWriteStatus {
+  if (!result.ok) return result.code === 'output_conflict' ? 'conflicting' : 'rejected';
+  return result.idempotent === true ? 'idempotent' : 'accepted';
+}
+
+export function stableDiagnosticFingerprint(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+/**
+ * Extract only the bounded, machine-readable portion of a tool failure. In
+ * particular, provider prose and result payloads never become an error label.
+ */
+export function stableToolErrorDetails(
+  value: unknown,
+  allowUnrecognizedCode = false,
+): AgentToolErrorDetails | undefined {
+  const seen = new WeakSet<object>();
+  for (const record of recordCandidates(value)) {
+    const error = stableToolErrorForRecord(record, allowUnrecognizedCode, seen);
+    if (error !== undefined) return error;
+  }
+  return undefined;
+}
+
+function stableToolErrorForRecord(
+  record: Record<string, unknown>,
+  allowUnrecognizedCode: boolean,
+  seen: WeakSet<object>,
+): AgentToolErrorDetails | undefined {
+  if (seen.has(record)) return undefined;
+  seen.add(record);
+  const code = stringField(record, 'code');
+  if (
+    code !== undefined &&
+    (allowUnrecognizedCode ||
+      STABLE_ERROR_CODES.has(code) ||
+      stringField(record, 'reason') !== undefined)
+  ) {
+    return {
+      code,
+      ...optionalStringField('reason', record.reason),
+      ...optionalStringField('tool', record.tool),
+      ...optionalStringField('parameter', record.parameter),
+      ...optionalStatusField(record.status),
+    };
+  }
+  if (isRecord(record.structuredContent)) {
+    const nested = stableToolErrorForRecord(record.structuredContent, allowUnrecognizedCode, seen);
+    if (nested !== undefined) return nested;
+  }
+  if (isRecord(record.mcpResult)) {
+    const nested = stableToolErrorForRecord(record.mcpResult, allowUnrecognizedCode, seen);
+    if (nested !== undefined) return nested;
+  }
+  if (isRecord(record.details)) {
+    const nested = stableToolErrorForRecord(record.details, allowUnrecognizedCode, seen);
+    if (nested !== undefined) return nested;
+  }
+  const adapterError = stringField(record, 'error');
+  if (adapterError === undefined) return undefined;
+  return adapterToolError(adapterError, record);
+}
+
+function adapterToolError(
+  adapterError: string,
+  record: Record<string, unknown>,
+): AgentToolErrorDetails {
+  if (adapterError === 'tool_not_found' || adapterError === 'tool_not_found_after_reconnect') {
+    return {
+      code: 'invalid-request',
+      reason: 'tool_not_found',
+      ...optionalStringField('tool', record.requestedTool),
+    };
+  }
+  if (adapterError === 'tool_error' || adapterError === 'call_failed') {
+    return {code: 'tool_error', reason: 'provider_error'};
+  }
+  return {code: 'tool_error', reason: adapterError};
+}
+
+function diagnosticEntryUuid(params: AgentSessionDiagnosticsParams): string {
+  return [
+    AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE,
+    params.harness,
+    params.invocation.jobExecutionId ?? 'unknown',
+    params.invocation.stepId ?? 'unknown',
+    String(params.invocation.attempt ?? 0),
+  ].join(':');
+}
+
+function normalizeToolDescriptor(tool: AgentSessionToolDescriptor): AgentSessionToolDescriptor {
+  return {
+    name: tool.name,
+    ...(tool.description === undefined ? {} : {description: tool.description}),
+    inputSchema: normalizeDiagnosticValue(tool.inputSchema),
+    ...(tool.outputSchema === undefined
+      ? {}
+      : {outputSchema: normalizeDiagnosticValue(tool.outputSchema)}),
+  };
+}
+
+function normalizeCatalogFailure(failure: AgentSessionCatalogFailure): AgentSessionCatalogFailure {
+  return {
+    server: failure.server,
+    errorClass: failure.errorClass,
+    ...(failure.status === undefined ? {} : {status: failure.status}),
+  };
+}
+
+function budget(consumed: number): AgentSessionBudget {
+  return {consumed: Math.max(0, Math.floor(consumed)), remaining: null};
+}
+
+function structuredResultForFingerprint(value: unknown): unknown {
+  if (!isRecord(value)) return undefined;
+  const structuredContent = value.structuredContent;
+  if (structuredContent !== undefined) return normalizeDiagnosticValue(structuredContent);
+  const mcpResult = value.mcpResult;
+  if (isRecord(mcpResult) && mcpResult.structuredContent !== undefined) {
+    return normalizeDiagnosticValue(mcpResult.structuredContent);
+  }
+  if (value.ok === false && isRecord(value.details)) {
+    return normalizeDiagnosticValue(value.details);
+  }
+  return undefined;
+}
+
+function isOutputFailure(value: unknown): boolean {
+  return isRecord(value) && value.ok === false;
+}
+
+function recordCandidates(value: unknown): readonly Record<string, unknown>[] {
+  if (!isRecord(value)) return [];
+  const candidates: Record<string, unknown>[] = [value];
+  if (isRecord(value.details)) candidates.push(value.details);
+  if (isRecord(value.structuredContent)) candidates.push(value.structuredContent);
+  if (isRecord(value.mcpResult)) {
+    candidates.push(value.mcpResult);
+    if (isRecord(value.mcpResult.structuredContent)) {
+      candidates.push(value.mcpResult.structuredContent);
+    }
+    if (isRecord(value.mcpResult.details)) candidates.push(value.mcpResult.details);
+  }
+  return candidates;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function optionalStringField(key: string, value: unknown): Record<string, string> {
+  return typeof value === 'string' && value.length > 0 ? {[key]: value} : {};
+}
+
+function optionalStatusField(value: unknown): Record<string, number> {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599
+    ? {status: value}
+    : {};
+}
+
+function firstFiniteNumber(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  }
+  return undefined;
+}
+
+function isFailureClass(value: AgentSessionTerminationReason): value is AgentSessionFailureClass {
+  return value !== 'completed' && value !== 'aborted' && value !== 'error';
+}
+
+/** Sort object keys while preserving arrays and exact scalar argument values. */
+export function normalizeDiagnosticValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const normalized = value.map((item) => normalizeDiagnosticValue(item, seen));
+    seen.delete(value);
+    return normalized;
+  }
+  const record = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    normalized[key] = normalizeDiagnosticValue(record[key], seen);
+  }
+  seen.delete(value);
+  return normalized;
+}
+
+function stableJson(value: unknown): string {
+  try {
+    return JSON.stringify(normalizeDiagnosticValue(value)) ?? 'undefined';
+  } catch {
+    return String(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/libs/runner/agent/src/core/agent-session-diagnostics.ts
+++ b/libs/runner/agent/src/core/agent-session-diagnostics.ts
@@ -27,7 +27,9 @@ export interface AgentSessionToolDescriptor {
   readonly name: string;
   readonly description?: string | undefined;
   readonly inputSchema: unknown;
+  readonly inputSchemaFingerprint?: string | undefined;
   readonly outputSchema?: unknown | undefined;
+  readonly outputSchemaFingerprint?: string | undefined;
 }
 
 export interface AgentSessionCatalogFailure {
@@ -46,7 +48,7 @@ export interface AgentSessionToolCall {
   readonly sequence: number;
   readonly toolCallId?: string | undefined;
   readonly toolName: string;
-  /** Protected session artifacts may retain the exact normalized arguments. */
+  /** Protected session artifacts retain bounded normalized arguments and a full-value fingerprint. */
   readonly normalizedArgs: unknown;
   readonly argsFingerprint: string;
 }
@@ -66,9 +68,11 @@ export type AgentSessionOutputWriteStatus = 'accepted' | 'idempotent' | 'conflic
 export interface AgentSessionOutputWrite {
   readonly sequence: number;
   readonly key: string;
+  readonly keyFingerprint: string;
   readonly status: AgentSessionOutputWriteStatus;
   readonly valueFingerprint: string;
   readonly code?: string | undefined;
+  readonly reason?: string | undefined;
 }
 
 export interface AgentSessionBudget {
@@ -148,6 +152,13 @@ const MAX_DIAGNOSTIC_TOOL_RESULTS = 256;
 const MAX_DIAGNOSTIC_OUTPUT_WRITES = 256;
 const MAX_DIAGNOSTIC_FAILURE_CLASSES = 4;
 const MAX_DIAGNOSTIC_CATALOG_FAILURES = 32;
+const MAX_DIAGNOSTIC_PROVIDER_TOOLS = 64;
+const MAX_DIAGNOSTIC_CORRELATIONS = 512;
+const MAX_DIAGNOSTIC_VALUE_BYTES = 4 * 1024;
+const MAX_DIAGNOSTIC_VALUE_DEPTH = 8;
+const MAX_DIAGNOSTIC_COLLECTION_ITEMS = 64;
+const MAX_DIAGNOSTIC_STRING_BYTES = 256;
+const MAX_DIAGNOSTIC_ENTRY_BYTES = 128 * 1024;
 const MAX_REPEATED_TOOL_FAILURES = 3;
 const STABLE_ERROR_CODES = new Set([
   'invalid-request',
@@ -213,15 +224,17 @@ export class AgentSessionDiagnostics {
 
   constructor(params: AgentSessionDiagnosticsParams) {
     this.#harness = params.harness;
-    this.#provider = params.invocation.provider;
-    this.#model = params.invocation.model;
+    this.#provider = boundedDiagnosticString(params.invocation.provider);
+    this.#model = boundedDiagnosticString(params.invocation.model);
     this.#entryUuid = diagnosticEntryUuid(params);
     this.#registration = {
       metadataMode: params.metadataMode,
-      directToolNames: [...new Set(params.directToolNames ?? [])],
+      directToolNames: boundedUniqueStrings(params.directToolNames ?? []),
       proxyFallback: params.proxyFallback ?? false,
     };
-    this.#providerTools = (params.providerTools ?? []).map(normalizeToolDescriptor);
+    this.#providerTools = (params.providerTools ?? [])
+      .slice(0, MAX_DIAGNOSTIC_PROVIDER_TOOLS)
+      .map(normalizeToolDescriptor);
     this.#catalogFailures = (params.catalogFailures ?? [])
       .slice(0, MAX_DIAGNOSTIC_CATALOG_FAILURES)
       .map(normalizeCatalogFailure);
@@ -243,46 +256,71 @@ export class AgentSessionDiagnostics {
   }
 
   recordSessionId(sessionId: string | undefined): void {
-    if (sessionId !== undefined && sessionId !== '') this.#sessionId = sessionId;
+    if (sessionId !== undefined && sessionId !== '') {
+      this.#sessionId = boundedDiagnosticString(sessionId);
+    }
   }
 
   recordProviderTools(tools: readonly AgentSessionToolDescriptor[]): void {
     if (tools.length === 0) return;
-    this.#providerTools = tools.map(normalizeToolDescriptor);
+    this.#providerTools = tools
+      .slice(0, MAX_DIAGNOSTIC_PROVIDER_TOOLS)
+      .map(normalizeToolDescriptor);
+  }
+
+  recordProviderToolNames(toolNames: readonly string[]): void {
+    const knownTools = new Map(this.#providerTools.map((tool) => [tool.name, tool]));
+    for (const toolName of toolNames) {
+      if (knownTools.size >= MAX_DIAGNOSTIC_PROVIDER_TOOLS) break;
+      const name = boundedDiagnosticString(toolName);
+      if (name === '' || knownTools.has(name)) continue;
+      knownTools.set(name, {name, inputSchema: null});
+    }
+    this.#providerTools = [...knownTools.values()];
   }
 
   recordToolCall(params: {toolCallId?: string | undefined; toolName: string; args: unknown}): void {
     const normalizedArgs = normalizeDiagnosticValue(params.args);
+    const toolCallId =
+      params.toolCallId === undefined ? undefined : boundedDiagnosticString(params.toolCallId);
     const call: AgentSessionToolCall = {
       sequence: this.#nextSequence(),
-      ...(params.toolCallId === undefined ? {} : {toolCallId: params.toolCallId}),
-      toolName: params.toolName,
-      normalizedArgs,
+      ...(toolCallId === undefined ? {} : {toolCallId}),
+      toolName: boundedDiagnosticString(params.toolName),
+      normalizedArgs: boundedDiagnosticValue(normalizedArgs),
       argsFingerprint: stableDiagnosticFingerprint(normalizedArgs),
     };
     this.#toolCallsConsumed += 1;
     if (this.#toolCalls.length < MAX_DIAGNOSTIC_TOOL_CALLS) this.#toolCalls.push(call);
-    if (params.toolCallId !== undefined) this.#toolCallById.set(params.toolCallId, call);
+    if (toolCallId !== undefined) {
+      setBoundedMap(this.#toolCallById, toolCallId, call, MAX_DIAGNOSTIC_CORRELATIONS);
+    }
   }
 
   updateToolCallArguments(toolCallId: string, args: unknown): void {
-    const existing = this.#toolCallById.get(toolCallId);
+    const boundedToolCallId = boundedDiagnosticString(toolCallId);
+    const existing = this.#toolCallById.get(boundedToolCallId);
     if (existing === undefined) return;
     const normalizedArgs = normalizeDiagnosticValue(args);
     const updated = {
       ...existing,
-      normalizedArgs,
+      normalizedArgs: boundedDiagnosticValue(normalizedArgs),
       argsFingerprint: stableDiagnosticFingerprint(normalizedArgs),
     };
-    this.#toolCallById.set(toolCallId, updated);
-    const index = this.#toolCalls.findIndex((call) => call.toolCallId === toolCallId);
+    setBoundedMap(this.#toolCallById, boundedToolCallId, updated, MAX_DIAGNOSTIC_CORRELATIONS);
+    const index = this.#toolCalls.findIndex((call) => call.toolCallId === boundedToolCallId);
     if (index >= 0) this.#toolCalls[index] = updated;
   }
 
   recordToolResult(params: RecordToolResultParams): void {
-    const call =
-      params.toolCallId === undefined ? undefined : this.#toolCallById.get(params.toolCallId);
-    const result = createToolResult(params, call, this.#nextSequence());
+    const toolCallId =
+      params.toolCallId === undefined ? undefined : boundedDiagnosticString(params.toolCallId);
+    const call = toolCallId === undefined ? undefined : this.#toolCallById.get(toolCallId);
+    const result = createToolResult(
+      {...params, ...(toolCallId === undefined ? {} : {toolCallId})},
+      call,
+      this.#nextSequence(),
+    );
     if (this.#toolResults.length < MAX_DIAGNOSTIC_TOOL_RESULTS) this.#toolResults.push(result);
     this.#recordToolResultFailure(result, call, params.toolName);
   }
@@ -294,6 +332,7 @@ export class AgentSessionDiagnostics {
       readonly ok: boolean;
       readonly idempotent?: boolean | undefined;
       readonly code?: string | undefined;
+      readonly reason?: string | undefined;
     };
   }): void {
     const status = outputWriteStatus(params.result);
@@ -301,10 +340,16 @@ export class AgentSessionDiagnostics {
     if (this.#outputWrites.length >= MAX_DIAGNOSTIC_OUTPUT_WRITES) return;
     this.#outputWrites.push({
       sequence: this.#nextSequence(),
-      key: params.key,
+      key: boundedDiagnosticString(params.key),
+      keyFingerprint: stableDiagnosticFingerprint(params.key),
       status,
       valueFingerprint: stableDiagnosticFingerprint(params.value),
-      ...(params.result.code === undefined ? {} : {code: params.result.code}),
+      ...(params.result.code === undefined
+        ? {}
+        : {code: boundedDiagnosticString(params.result.code)}),
+      ...(params.result.reason === undefined
+        ? {}
+        : {reason: boundedDiagnosticString(params.result.reason)}),
     });
   }
 
@@ -356,7 +401,7 @@ export class AgentSessionDiagnostics {
 
   snapshot(): AgentSessionDiagnosticEntry {
     const terminationReason = this.#terminationReason ?? 'error';
-    return {
+    return boundedDiagnosticEntry({
       kind: 'agent_session_diagnostics',
       version: AGENT_SESSION_DIAGNOSTICS_VERSION,
       harness: this.#harness,
@@ -382,7 +427,7 @@ export class AgentSessionDiagnostics {
         timeMs: budget(Math.max(0, Date.now() - this.#startedAt)),
         tokens: budget(this.#tokensConsumed),
       },
-    };
+    });
   }
 
   storeEntry(): AgentSessionDiagnosticStoreEntry {
@@ -407,12 +452,12 @@ export class AgentSessionDiagnostics {
     if (result.error?.code === 'output_conflict') this.markFailure('output_conflict');
     if (!result.isError) return;
     const repetitionKey = [
-      call?.toolName ?? toolName ?? 'unknown',
+      call?.toolName ?? boundedDiagnosticString(toolName ?? 'unknown'),
       call?.argsFingerprint ?? 'unknown',
       result.resultFingerprint,
     ].join(':');
     const repetitions = (this.#repeatedFailures.get(repetitionKey) ?? 0) + 1;
-    this.#repeatedFailures.set(repetitionKey, repetitions);
+    setBoundedMap(this.#repeatedFailures, repetitionKey, repetitions, MAX_DIAGNOSTIC_CORRELATIONS);
     if (repetitions >= MAX_REPEATED_TOOL_FAILURES) {
       this.markFailure('agent_tool_loop_detected');
     }
@@ -436,12 +481,13 @@ function createToolResult(
   const structuredResult = structuredResultForFingerprint(
     params.structuredContent ?? params.details,
   );
+  const toolName = params.toolName ?? call?.toolName;
   return {
     sequence,
-    ...(params.toolCallId === undefined ? {} : {toolCallId: params.toolCallId}),
-    ...(params.toolName === undefined && call === undefined
+    ...(params.toolCallId === undefined
       ? {}
-      : {toolName: params.toolName ?? call?.toolName}),
+      : {toolCallId: boundedDiagnosticString(params.toolCallId)}),
+    ...(toolName === undefined ? {} : {toolName: boundedDiagnosticString(toolName)}),
     isError,
     resultFingerprint: stableDiagnosticFingerprint({isError, error, structuredResult}),
     ...(structuredResult === undefined
@@ -488,14 +534,9 @@ function stableToolErrorForRecord(
   if (seen.has(record)) return undefined;
   seen.add(record);
   const code = stringField(record, 'code');
-  if (
-    code !== undefined &&
-    (allowUnrecognizedCode ||
-      STABLE_ERROR_CODES.has(code) ||
-      stringField(record, 'reason') !== undefined)
-  ) {
+  if (code !== undefined && (allowUnrecognizedCode || STABLE_ERROR_CODES.has(code))) {
     return {
-      code,
+      code: boundedDiagnosticString(code),
       ...optionalStringField('reason', record.reason),
       ...optionalStringField('tool', record.tool),
       ...optionalStringField('parameter', record.parameter),
@@ -533,35 +574,45 @@ function adapterToolError(
   if (adapterError === 'tool_error' || adapterError === 'call_failed') {
     return {code: 'tool_error', reason: 'provider_error'};
   }
-  return {code: 'tool_error', reason: adapterError};
+  return {code: 'tool_error', reason: boundedDiagnosticString(adapterError)};
 }
 
 function diagnosticEntryUuid(params: AgentSessionDiagnosticsParams): string {
   return [
     AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE,
     params.harness,
-    params.invocation.jobExecutionId ?? 'unknown',
-    params.invocation.stepId ?? 'unknown',
+    boundedDiagnosticString(params.invocation.jobExecutionId ?? 'unknown'),
+    boundedDiagnosticString(params.invocation.stepId ?? 'unknown'),
     String(params.invocation.attempt ?? 0),
   ].join(':');
 }
 
 function normalizeToolDescriptor(tool: AgentSessionToolDescriptor): AgentSessionToolDescriptor {
+  const inputSchema = normalizeDiagnosticValue(tool.inputSchema);
+  const outputSchema =
+    tool.outputSchema === undefined ? undefined : normalizeDiagnosticValue(tool.outputSchema);
   return {
-    name: tool.name,
-    ...(tool.description === undefined ? {} : {description: tool.description}),
-    inputSchema: normalizeDiagnosticValue(tool.inputSchema),
-    ...(tool.outputSchema === undefined
+    name: boundedDiagnosticString(tool.name),
+    ...(tool.description === undefined
       ? {}
-      : {outputSchema: normalizeDiagnosticValue(tool.outputSchema)}),
+      : {description: boundedDiagnosticString(tool.description)}),
+    inputSchema: boundedDiagnosticValue(inputSchema),
+    inputSchemaFingerprint: stableDiagnosticFingerprint(inputSchema),
+    ...(outputSchema === undefined
+      ? {}
+      : {
+          outputSchema: boundedDiagnosticValue(outputSchema),
+          outputSchemaFingerprint: stableDiagnosticFingerprint(outputSchema),
+        }),
   };
 }
 
 function normalizeCatalogFailure(failure: AgentSessionCatalogFailure): AgentSessionCatalogFailure {
+  const status = statusValue(failure.status);
   return {
-    server: failure.server,
+    server: boundedDiagnosticString(failure.server),
     errorClass: failure.errorClass,
-    ...(failure.status === undefined ? {} : {status: failure.status}),
+    ...(status === undefined ? {} : {status}),
   };
 }
 
@@ -608,13 +659,20 @@ function stringField(record: Record<string, unknown>, key: string): string | und
 }
 
 function optionalStringField(key: string, value: unknown): Record<string, string> {
-  return typeof value === 'string' && value.length > 0 ? {[key]: value} : {};
+  return typeof value === 'string' && value.length > 0
+    ? {[key]: boundedDiagnosticString(value)}
+    : {};
 }
 
 function optionalStatusField(value: unknown): Record<string, number> {
+  const status = statusValue(value);
+  return status === undefined ? {} : {status};
+}
+
+function statusValue(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599
-    ? {status: value}
-    : {};
+    ? value
+    : undefined;
 }
 
 function firstFiniteNumber(
@@ -630,6 +688,110 @@ function firstFiniteNumber(
 
 function isFailureClass(value: AgentSessionTerminationReason): value is AgentSessionFailureClass {
   return value !== 'completed' && value !== 'aborted' && value !== 'error';
+}
+
+function boundedDiagnosticEntry(entry: AgentSessionDiagnosticEntry): AgentSessionDiagnosticEntry {
+  let bounded = entry;
+  while (diagnosticJsonBytes(bounded) > MAX_DIAGNOSTIC_ENTRY_BYTES) {
+    if (bounded.toolCalls.length > 0) {
+      bounded = {...bounded, toolCalls: bounded.toolCalls.slice(1)};
+      continue;
+    }
+    if (bounded.toolResults.length > 0) {
+      bounded = {...bounded, toolResults: bounded.toolResults.slice(1)};
+      continue;
+    }
+    if (bounded.outputWrites.length > 0) {
+      bounded = {...bounded, outputWrites: bounded.outputWrites.slice(1)};
+      continue;
+    }
+    if (bounded.providerTools.length > 0) {
+      bounded = {...bounded, providerTools: bounded.providerTools.slice(1)};
+      continue;
+    }
+    if (bounded.catalogFailures.length > 0) {
+      bounded = {...bounded, catalogFailures: bounded.catalogFailures.slice(1)};
+      continue;
+    }
+    break;
+  }
+  return bounded;
+}
+
+function boundedDiagnosticValue(value: unknown): unknown {
+  return boundNormalizedDiagnosticValue(normalizeDiagnosticValue(value), 0);
+}
+
+function boundNormalizedDiagnosticValue(value: unknown, depth: number): unknown {
+  if (typeof value === 'string') return boundedDiagnosticString(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (depth >= MAX_DIAGNOSTIC_VALUE_DEPTH) return '[truncated]';
+
+  if (Array.isArray(value)) {
+    const bounded = value
+      .slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)
+      .map((item) => boundNormalizedDiagnosticValue(item, depth + 1));
+    while (diagnosticJsonBytes(bounded) > MAX_DIAGNOSTIC_VALUE_BYTES && bounded.length > 0) {
+      bounded.pop();
+    }
+    return bounded;
+  }
+
+  const record = value as Record<string, unknown>;
+  const bounded: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort().slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)) {
+    bounded[boundedDiagnosticString(key)] = boundNormalizedDiagnosticValue(record[key], depth + 1);
+  }
+  while (diagnosticJsonBytes(bounded) > MAX_DIAGNOSTIC_VALUE_BYTES) {
+    const lastKey = Object.keys(bounded).at(-1);
+    if (lastKey === undefined) break;
+    delete bounded[lastKey];
+  }
+  return bounded;
+}
+
+function boundedDiagnosticString(value: string, maxBytes = MAX_DIAGNOSTIC_STRING_BYTES): string {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  const suffix = '...[truncated]';
+  const suffixBytes = Buffer.byteLength(suffix, 'utf8');
+  const prefixBytes = Math.max(0, maxBytes - suffixBytes);
+  let prefix = '';
+  for (const character of value) {
+    const next = `${prefix}${character}`;
+    if (Buffer.byteLength(next, 'utf8') > prefixBytes) break;
+    prefix = next;
+  }
+  return `${prefix}${suffix}`;
+}
+
+function boundedUniqueStrings(values: readonly string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const bounded = boundedDiagnosticString(value);
+    if (seen.has(bounded)) continue;
+    seen.add(bounded);
+    result.push(bounded);
+    if (result.length >= MAX_DIAGNOSTIC_PROVIDER_TOOLS) break;
+  }
+  return result;
+}
+
+function setBoundedMap<K, V>(map: Map<K, V>, key: K, value: V, maxSize: number): void {
+  if (!map.has(key) && map.size >= maxSize) {
+    const oldest = map.keys().next();
+    if (!oldest.done) map.delete(oldest.value);
+  }
+  map.set(key, value);
+}
+
+function diagnosticJsonBytes(value: unknown): number {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? 0 : Buffer.byteLength(serialized, 'utf8');
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
 }
 
 /** Sort object keys while preserving arrays and exact scalar argument values. */

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -630,12 +630,10 @@ describe('claudeHarnessAdapter', () => {
     await expect(result).rejects.toMatchObject({failurePhase: 'output_gate_failed'});
     await expect(rejection).resolves.toMatchObject({
       isError: true,
-      structuredContent: {
+      structuredContent: expect.objectContaining({
         code: 'undeclared_output',
-        reason: 'undeclared_output',
-        tool: 'set_output',
-        parameter: 'undeclared',
-      },
+        details: {code: 'undeclared_output', key: 'undeclared'},
+      }),
     });
   });
 
@@ -1194,6 +1192,44 @@ describe('claudeHarnessAdapter', () => {
       }),
       'Claude integration tool outcome',
     );
+  });
+
+  it('persists diagnostics when resumed-session tool preparation fails before Claude starts', async () => {
+    const transcriptFile = join(testCwd, 'downloaded-session.jsonl');
+    writeFileSync(transcriptFile, '{"type":"user","uuid":"prior"}\n');
+    const bridge = mcpBridge([], {
+      activateHttp: vi.fn().mockRejectedValue(new Error('bridge bind failed')),
+    });
+
+    const result = claudeHarnessAdapter.run(
+      invocation({
+        mcpServers: [bridge],
+        requestedIntegrationTools: [{connectionSlug: 'linear_shipfox', toolId: 'get_team'}],
+        session: {
+          mode: 'resume',
+          file: transcriptFile,
+          harnessSessionId: 'prior-session-id',
+        },
+      }),
+    );
+
+    await expect(result).rejects.toMatchObject({
+      name: 'AgentInvocationError',
+      sessionFile: transcriptFile,
+      sessionId: 'prior-session-id',
+    });
+    const entries = readFileSync(transcriptFile, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(entries.at(-1)).toMatchObject({
+      type: 'shipfox_agent_diagnostics',
+      data: {
+        harness: 'claude',
+        sessionId: 'prior-session-id',
+        termination: {reason: 'error'},
+      },
+    });
   });
 
   it('continues after a catalog failure and records its taxonomy', async () => {
@@ -1961,7 +1997,7 @@ describe('claudeHarnessAdapter', () => {
         [{type: 'assistant', uuid: 'next', message: {content: []}}],
       );
       return makeQuery([
-        {...initWithTools([sdkTool]), session_id: 'prior-session-id'},
+        {...initWithTools([sdkTool, 'Read']), session_id: 'prior-session-id'},
         assistantToolUse(sdkTool, 'call-1'),
         userToolResult('call-1'),
         successMessage,
@@ -1994,12 +2030,13 @@ describe('claudeHarnessAdapter', () => {
         directToolNames: [sdkTool],
         proxyFallback: false,
       },
-      providerTools: [
-        {
+      providerTools: expect.arrayContaining([
+        expect.objectContaining({
           name: sdkTool,
           inputSchema: {type: 'object'},
-        },
-      ],
+        }),
+        expect.objectContaining({name: 'Read', inputSchema: null}),
+      ]),
       toolCalls: [
         {
           toolCallId: 'call-1',
@@ -2072,16 +2109,35 @@ describe('claudeHarnessAdapter', () => {
 
   it('aborts the SDK controller and closes the query when the signal fires', async () => {
     const ac = new AbortController();
-    const blockingQuery = makeBlockingQuery([initMessage]);
+    const transcriptFile = join(testCwd, 'aborted-session.jsonl');
+    writeFileSync(transcriptFile, '{"type":"user","uuid":"prior"}\n');
+    const blockingQuery = makeBlockingQuery([{...initMessage, session_id: 'prior-session-id'}]);
     queryMock.mockReturnValue(blockingQuery);
 
-    const result = claudeHarnessAdapter.run(invocation({signal: ac.signal}));
+    const result = claudeHarnessAdapter.run(
+      invocation({
+        signal: ac.signal,
+        session: {
+          mode: 'resume',
+          file: transcriptFile,
+          harnessSessionId: 'prior-session-id',
+        },
+      }),
+    );
     await vi.waitFor(() => expect(queryMock).toHaveBeenCalled());
     ac.abort();
 
     await expect(result).rejects.toThrow('did not emit a result');
     expect(lastQueryOptions().abortController.signal.aborted).toBe(true);
     expect(blockingQuery.close).toHaveBeenCalled();
+    const entries = readFileSync(transcriptFile, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(entries.at(-1)).toMatchObject({
+      type: 'shipfox_agent_diagnostics',
+      data: {termination: {reason: 'aborted'}},
+    });
   });
 
   it('propagates SDK generator failures', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -614,6 +614,31 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions()).not.toHaveProperty('tools');
   });
 
+  it('marks rejected Claude output writes as structured tool errors', async () => {
+    let rejection: unknown;
+    queryMock.mockImplementation((params: {options: Record<string, unknown>}) => {
+      const servers = params.options.mcpServers as
+        | Record<string, {tools?: Array<{handler?: (args: unknown) => Promise<unknown>}>}>
+        | undefined;
+      const handler = servers?.shipfox_outputs?.tools?.[0]?.handler;
+      rejection = handler?.({key: 'undeclared', value: 'value'});
+      return makeQuery([successMessage, successMessage, successMessage]);
+    });
+
+    const result = claudeHarnessAdapter.run(invocation({outputs: {summary: {type: 'string'}}}));
+
+    await expect(result).rejects.toMatchObject({failurePhase: 'output_gate_failed'});
+    await expect(rejection).resolves.toMatchObject({
+      isError: true,
+      structuredContent: {
+        code: 'undeclared_output',
+        reason: 'undeclared_output',
+        tool: 'set_output',
+        parameter: 'undeclared',
+      },
+    });
+  });
+
   it('keeps the output tool enabled when Claude tools are explicitly selected', async () => {
     queryMock.mockReturnValue(makeQuery([successMessage, successMessage, successMessage]));
 
@@ -1809,9 +1834,22 @@ describe('claudeHarnessAdapter', () => {
       sessionFile: transcriptFile,
       sessionId: 'prior-session-id',
     });
-    expect(readFileSync(transcriptFile, 'utf8')).toBe(
-      '{"type":"user","uuid":"prior"}\n{"type":"assistant","uuid":"next","message":{"content":[]}}\n',
-    );
+    const persistedEntries = readFileSync(transcriptFile, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(persistedEntries.slice(0, 2)).toEqual([
+      {type: 'user', uuid: 'prior'},
+      {type: 'assistant', uuid: 'next', message: {content: []}},
+    ]);
+    expect(persistedEntries.at(-1)).toMatchObject({
+      type: 'shipfox_agent_diagnostics',
+      data: expect.objectContaining({
+        harness: 'claude',
+        sessionId: 'prior-session-id',
+        termination: {reason: 'completed'},
+      }),
+    });
     expect(lastQueryOptions()).toMatchObject({
       persistSession: true,
       sessionStoreFlush: 'batched',
@@ -1887,14 +1925,101 @@ describe('claudeHarnessAdapter', () => {
       sessionFile: join(testCwd, 'runner-agent', 'sessions', 'claude-session.jsonl'),
       sessionId: 'session-1',
     });
-    expect(readFileSync(result.sessionFile as string, 'utf8')).toBe(
-      '{"type":"user","uuid":"first","message":{"content":"Fix it."}}\n',
-    );
+    const persistedEntries = readFileSync(result.sessionFile as string, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(persistedEntries[0]).toEqual({
+      type: 'user',
+      uuid: 'first',
+      message: {content: 'Fix it.'},
+    });
+    expect(persistedEntries.at(-1)).toMatchObject({
+      type: 'shipfox_agent_diagnostics',
+      data: expect.objectContaining({
+        harness: 'claude',
+        sessionId: 'session-1',
+        termination: {reason: 'completed'},
+      }),
+    });
     expect(lastQueryOptions()).toMatchObject({
       persistSession: true,
       settingSources: [],
     });
     expect(lastQueryOptions()).not.toHaveProperty('resume');
+  });
+
+  it('persists provider-facing tool inventory and ordered call diagnostics', async () => {
+    const integrationTool = 'linear_shipfox__get_team';
+    const sdkTool = `mcp__shipfox_integration_tools__${integrationTool}`;
+    const transcriptFile = join(testCwd, 'diagnostics-session.jsonl');
+    writeFileSync(transcriptFile, '{"type":"user","uuid":"prior"}\n');
+    const bridge = mcpBridge([integrationTool]);
+    queryMock.mockImplementation((params: {options: {sessionStore?: TestSessionStore}}) => {
+      void params.options.sessionStore?.append(
+        {projectKey: 'project', sessionId: 'prior-session-id'},
+        [{type: 'assistant', uuid: 'next', message: {content: []}}],
+      );
+      return makeQuery([
+        {...initWithTools([sdkTool]), session_id: 'prior-session-id'},
+        assistantToolUse(sdkTool, 'call-1'),
+        userToolResult('call-1'),
+        successMessage,
+      ]);
+    });
+
+    const result = await claudeHarnessAdapter.run(
+      invocation({
+        mcpServers: [bridge],
+        requestedIntegrationTools: [{connectionSlug: 'linear_shipfox', toolId: 'get_team'}],
+        session: {
+          mode: 'resume',
+          file: transcriptFile,
+          harnessSessionId: 'prior-session-id',
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({sessionFile: transcriptFile, sessionId: 'prior-session-id'});
+    const entries = readFileSync(transcriptFile, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    const diagnosticEntry = entries.find((entry) => entry.type === 'shipfox_agent_diagnostics') as
+      | {data: Record<string, unknown>}
+      | undefined;
+    expect(diagnosticEntry?.data).toMatchObject({
+      registration: {
+        metadataMode: 'warm',
+        directToolNames: [sdkTool],
+        proxyFallback: false,
+      },
+      providerTools: [
+        {
+          name: sdkTool,
+          inputSchema: {type: 'object'},
+        },
+      ],
+      toolCalls: [
+        {
+          toolCallId: 'call-1',
+          toolName: integrationTool,
+          normalizedArgs: {secret: 'not logged'},
+        },
+      ],
+      toolResults: [
+        {
+          toolCallId: 'call-1',
+          toolName: integrationTool,
+          isError: false,
+        },
+      ],
+      budgets: {
+        turns: {consumed: 1, remaining: null},
+        toolCalls: {consumed: 1, remaining: null},
+      },
+      termination: {reason: 'completed'},
+    });
   });
 
   it('resumes a Claude fork without committing it', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -329,7 +329,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   let claudeQuery: Query | undefined;
   let messages: ClaudeInputStream | undefined;
   let sessionStore: ClaudeSessionStore | undefined;
-  let sessionId: string | undefined;
+  let sessionId = sessionInvocation?.harnessSessionId;
   let response = '';
   let toolContext: ClaudeToolContext | undefined;
   let turnsCompleted = false;
@@ -340,13 +340,13 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   };
 
   try {
+    assertClaudeNotAborted(signal);
+    sessionStore = await createClaudeSessionStore(sessionInvocation);
     toolContext = await createClaudeToolContext(invocation, managedMcpServers);
     activeToolDiagnostics = toolContext.diagnostics;
     toolContext.diagnostics.logManifest();
     configDir = await createClaudeConfigDir(agentStateDir);
 
-    assertClaudeNotAborted(signal);
-    sessionStore = await createClaudeSessionStore(sessionInvocation);
     const inputMessages = new ClaudeInputStream();
     messages = inputMessages;
     claudeQuery = query({
@@ -415,6 +415,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
       agentStateDir,
       session: sessionInvocation,
       sessionStore,
+      aborted: signal.aborted,
     });
   } finally {
     messages?.close();
@@ -490,12 +491,14 @@ async function handleClaudeAgentFailure(params: {
   agentStateDir: string;
   session: HarnessInvocation['session'];
   sessionStore: ClaudeSessionStore | undefined;
+  aborted: boolean;
 }): Promise<never> {
   const failurePhase = params.diagnostics.finish({
     outputGate: outputGateForError(params.error),
     missingOutputCount: params.collector.missingRequired().length,
     executionFailed: true,
     executionCompleted: params.executionCompleted,
+    aborted: params.aborted,
   });
   await params.diagnostics.appendToSessionStore(params.sessionStore, params.sessionId);
   return await rethrowClaudeSessionError({
@@ -1023,7 +1026,14 @@ function setOutputTool(
         result: {
           ok: result.ok,
           ...(result.ok && result.idempotent === true ? {idempotent: true} : {}),
-          ...(!result.ok ? {code: result.code} : {}),
+          ...(!result.ok
+            ? {
+                code: result.code,
+                ...(result.details.schemaError === undefined
+                  ? {}
+                  : {reason: result.details.schemaError}),
+              }
+            : {}),
         },
       });
       return {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -1025,7 +1025,9 @@ function setOutputTool(
         value: args.value,
         result: {
           ok: result.ok,
-          ...(result.ok && result.idempotent === true ? {idempotent: true} : {}),
+          ...(result.ok && 'idempotent' in result && result.idempotent === true
+            ? {idempotent: true}
+            : {}),
           ...(!result.ok
             ? {
                 code: result.code,

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -310,7 +310,10 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   const hasDeclaredOutputs =
     invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
   const useOutputTools = hasDeclaredOutputs;
-  const managedMcpServers = useOutputTools ? [outputMcpServer(collector)] : [];
+  let activeToolDiagnostics: ClaudeToolDiagnostics | undefined;
+  const managedMcpServers = useOutputTools
+    ? [outputMcpServer(collector, () => activeToolDiagnostics)]
+    : [];
 
   await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
@@ -338,6 +341,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
 
   try {
     toolContext = await createClaudeToolContext(invocation, managedMcpServers);
+    activeToolDiagnostics = toolContext.diagnostics;
     toolContext.diagnostics.logManifest();
     configDir = await createClaudeConfigDir(agentStateDir);
 
@@ -382,15 +386,16 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     });
     response = turnResponse;
     turnsCompleted = true;
+    toolContext.diagnostics.finish({
+      outputGate: hasDeclaredOutputs ? 'passed' : 'not_required',
+    });
+    await toolContext.diagnostics.appendToSessionStore(sessionStore, sessionId);
     const persistedSession = await persistClaudeSessionIfNeeded({
       shouldPersistSession,
       agentStateDir,
       session: sessionInvocation,
       sessionStore,
       sessionId,
-    });
-    toolContext.diagnostics.finish({
-      outputGate: hasDeclaredOutputs ? 'passed' : 'not_required',
     });
     return claudeHarnessResult(response, collector.snapshot(), persistedSession);
   } catch (error) {
@@ -458,6 +463,13 @@ async function createClaudeToolContext(
     selectedToolNames,
     omissions: integrationTools.omissions,
     catalogFailures: integrationTools.catalogFailures,
+    providerTools: [
+      ...integrationTools.providerTools.map(providerFacingClaudeTool),
+      ...managedMcpServers.flatMap((server) => server.providerTools),
+    ],
+    metadataMode: invocation.session?.mode === 'resume' ? 'warm' : 'cold',
+    directToolNames: integrationTools.resolvedSdkToolNames,
+    proxyFallback: false,
     requiredOutputCount: Object.keys(invocation.outputs ?? {}).length,
   });
   return {
@@ -485,6 +497,7 @@ async function handleClaudeAgentFailure(params: {
     executionFailed: true,
     executionCompleted: params.executionCompleted,
   });
+  await params.diagnostics.appendToSessionStore(params.sessionStore, params.sessionId);
   return await rethrowClaudeSessionError({
     error: classifyClaudeAgentError({
       error: params.error,
@@ -666,6 +679,7 @@ interface ClaudeManagedMcpServer {
   readonly name: string;
   readonly config: ReturnType<typeof createSdkMcpServer>;
   readonly requiredToolNames: readonly string[];
+  readonly providerTools: readonly ClaudeProviderTool[];
 }
 
 interface ClaudeIntegrationMcpServer {
@@ -676,6 +690,7 @@ interface ClaudeIntegrationMcpServer {
     readonly alwaysLoad: true;
     readonly headers: Readonly<Record<string, string>>;
   };
+  readonly providerTools: readonly ClaudeProviderTool[];
   readonly resolvedToolNames: readonly string[];
   readonly listToolsFailed: boolean;
   readonly catalogFailure?: ClaudeToolCatalogFailure;
@@ -683,12 +698,24 @@ interface ClaudeIntegrationMcpServer {
 
 interface PreparedClaudeIntegrationTools {
   readonly servers: readonly ClaudeIntegrationMcpServer[];
+  readonly providerTools: readonly ClaudeProviderTool[];
   readonly resolvedToolNames: readonly string[];
   readonly resolvedSdkToolNames: readonly string[];
   readonly expectedSdkToolNames: readonly string[];
   readonly sdkToolToIntegrationTool: ReadonlyMap<string, string>;
   readonly omissions: readonly ClaudeToolOmission[];
   readonly catalogFailures: readonly ClaudeToolCatalogFailure[];
+}
+
+interface ClaudeProviderTool {
+  readonly name: string;
+  readonly description?: string | undefined;
+  readonly inputSchema: unknown;
+  readonly outputSchema?: unknown | undefined;
+}
+
+function providerFacingClaudeTool(tool: ClaudeProviderTool): ClaudeProviderTool {
+  return {...tool, name: claudeSdkToolName(tool.name)};
 }
 
 async function prepareClaudeIntegrationTools(
@@ -737,6 +764,7 @@ async function prepareClaudeIntegrationTools(
           alwaysLoad: true,
           headers: {Authorization: `Bearer ${authToken}`},
         },
+        providerTools: listed.tools,
         resolvedToolNames: listed.toolNames,
         listToolsFailed: listed.failed,
         ...(catalogFailure === undefined ? {} : {catalogFailure}),
@@ -764,6 +792,7 @@ async function prepareClaudeIntegrationTools(
   );
   return {
     servers: preparedServers,
+    providerTools: preparedServers.flatMap((server) => server.providerTools),
     resolvedToolNames,
     resolvedSdkToolNames,
     expectedSdkToolNames,
@@ -786,6 +815,7 @@ function omissionReason(
 }
 
 interface ClaudeToolCatalogResult {
+  readonly tools: readonly ClaudeProviderTool[];
   readonly toolNames: readonly string[];
   readonly failed: boolean;
   readonly failureReason?: ClaudeToolCatalogFailureReason;
@@ -815,7 +845,18 @@ async function listClaudeIntegrationToolNames(
         onTimeout: () => controller.abort(new Error(CLAUDE_MCP_METADATA_TIMEOUT_MESSAGE)),
       },
     );
-    return {toolNames: result.tools.map((tool) => tool.name), failed: false};
+    return {
+      tools: result.tools.map((tool) => ({
+        name: tool.name,
+        ...(tool.description === undefined ? {} : {description: tool.description}),
+        inputSchema: tool.inputSchema,
+        ...('outputSchema' in tool && tool.outputSchema !== undefined
+          ? {outputSchema: tool.outputSchema}
+          : {}),
+      })),
+      toolNames: result.tools.map((tool) => tool.name),
+      failed: false,
+    };
   } catch (error) {
     if (signal.aborted) throw error;
     const failureReason = catalogFailureReason(error);
@@ -832,6 +873,7 @@ async function listClaudeIntegrationToolNames(
       'Claude integration tool catalog could not be resolved before invocation',
     );
     return {
+      tools: [],
       toolNames: [],
       failed: true,
       failureReason,
@@ -919,12 +961,31 @@ function uniqueStrings(values: readonly string[]): string[] {
 
 type ClaudeMcpTools = NonNullable<Parameters<typeof createSdkMcpServer>[0]['tools']>;
 
-function outputMcpServer(collector: OutputCollector): ClaudeManagedMcpServer {
+function outputMcpServer(
+  collector: OutputCollector,
+  diagnostics: () => ClaudeToolDiagnostics | undefined,
+): ClaudeManagedMcpServer {
+  const toolDescription = 'Set one structured output value for this workflow step.';
   return managedMcpServer({
     name: OUTPUT_MCP_SERVER_NAME,
     version: '1.0.0',
     instructions: collector.guidanceText(),
-    tools: [setOutputTool(collector)],
+    tools: [setOutputTool(collector, diagnostics)],
+    providerTools: [
+      {
+        name: `mcp__${OUTPUT_MCP_SERVER_NAME}__set_output`,
+        description: toolDescription,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            key: {type: 'string'},
+            value: {type: 'string'},
+          },
+          required: ['key', 'value'],
+          additionalProperties: false,
+        },
+      },
+    ],
   });
 }
 
@@ -933,6 +994,7 @@ function managedMcpServer<Tools extends ClaudeMcpTools>(params: {
   version: string;
   instructions: string;
   tools: Tools;
+  providerTools?: readonly ClaudeProviderTool[] | undefined;
 }): ClaudeManagedMcpServer {
   return {
     name: params.name,
@@ -940,10 +1002,14 @@ function managedMcpServer<Tools extends ClaudeMcpTools>(params: {
     requiredToolNames: params.tools.map(
       (managedTool) => `mcp__${params.name}__${managedTool.name}`,
     ),
+    providerTools: params.providerTools ?? [],
   };
 }
 
-function setOutputTool(collector: OutputCollector) {
+function setOutputTool(
+  collector: OutputCollector,
+  diagnostics: () => ClaudeToolDiagnostics | undefined,
+) {
   return tool(
     'set_output',
     'Set one structured output value for this workflow step.',
@@ -951,6 +1017,15 @@ function setOutputTool(collector: OutputCollector) {
     async (args) => {
       await Promise.resolve();
       const result = collector.trySet(args.key, args.value);
+      diagnostics()?.recordOutputWrite({
+        key: args.key,
+        value: args.value,
+        result: {
+          ok: result.ok,
+          ...(result.ok && result.idempotent === true ? {idempotent: true} : {}),
+          ...(!result.ok ? {code: result.code} : {}),
+        },
+      });
       return {
         content: [
           {
@@ -1006,6 +1081,7 @@ async function runClaudeTurns(params: {
       missingRequired: () => params.collector.missingRequired(),
       guidanceForMissing: (missing) => params.collector.guidanceTextFor(missing),
       runTurn: async (message) => {
+        params.toolDiagnostics.recordTurnStart();
         params.messages.push(userMessage(message));
         response =
           (

--- a/libs/runner/agent/src/core/claude-tool-diagnostics.ts
+++ b/libs/runner/agent/src/core/claude-tool-diagnostics.ts
@@ -3,6 +3,15 @@ import {
   agentIntegrationMcpToolName,
 } from '@shipfox/api-agent-dto';
 import {logger} from '@shipfox/node-opentelemetry';
+import {
+  type AgentSessionCatalogFailure,
+  type AgentSessionDiagnosticStoreEntry,
+  AgentSessionDiagnostics,
+  type AgentSessionFailureClass,
+  type AgentSessionMetadataMode,
+  type AgentSessionTerminationReason,
+  type AgentSessionToolDescriptor,
+} from '#core/agent-session-diagnostics.js';
 import type {AgentInvocationFailurePhase} from '#core/errors.js';
 import type {HarnessInvocation, RequestedIntegrationTool} from '#core/harness.js';
 
@@ -34,7 +43,10 @@ export interface ClaudeToolCatalogFailure {
 }
 
 interface ClaudeToolDiagnosticsParams {
-  readonly invocation: Pick<HarnessInvocation, 'jobExecutionId' | 'stepId' | 'attempt'>;
+  readonly invocation: Pick<
+    HarnessInvocation,
+    'jobExecutionId' | 'stepId' | 'attempt' | 'provider' | 'model' | 'session'
+  >;
   readonly requestedTools: readonly RequestedIntegrationTool[];
   readonly resolvedToolNames?: readonly string[];
   readonly expectedSdkToolNames?: readonly string[];
@@ -42,6 +54,10 @@ interface ClaudeToolDiagnosticsParams {
   readonly selectedToolNames?: readonly string[] | undefined;
   readonly omissions?: readonly ClaudeToolOmission[];
   readonly catalogFailures?: readonly ClaudeToolCatalogFailure[];
+  readonly providerTools?: readonly AgentSessionToolDescriptor[] | undefined;
+  readonly metadataMode?: AgentSessionMetadataMode | undefined;
+  readonly directToolNames?: readonly string[] | undefined;
+  readonly proxyFallback?: boolean | undefined;
   readonly requiredOutputCount: number;
 }
 
@@ -59,6 +75,7 @@ export class ClaudeToolDiagnostics {
   readonly #sdkToolToIntegrationTool: ReadonlyMap<string, string>;
   readonly #selectedToolNames: readonly string[] | undefined;
   readonly #catalogFailures: readonly ClaudeToolCatalogFailure[];
+  readonly #sessionDiagnostics: AgentSessionDiagnostics;
   readonly #omissions = new Map<string, ClaudeToolOmissionReason>();
   readonly #requiredOutputCount: number;
   readonly #advertisedToolNames = new Set<string>();
@@ -66,9 +83,11 @@ export class ClaudeToolDiagnostics {
   readonly #attemptedToolNames = new Set<string>();
   readonly #failedToolNames = new Set<string>();
   readonly #toolUseIds = new Map<string, string>();
+  readonly #diagnosticToolUseIds = new Set<string>();
   #advertisementObserved = false;
   #sdkToolListObserved = false;
   #outcomeLogged = false;
+  #sessionDiagnosticsAppended = false;
   #failurePhase: AgentInvocationFailurePhase | undefined;
 
   constructor(params: ClaudeToolDiagnosticsParams) {
@@ -92,6 +111,16 @@ export class ClaudeToolDiagnostics {
     this.#selectedToolNames = params.selectedToolNames;
     this.#catalogFailures = (params.catalogFailures ?? []).slice(0, MAX_DIAGNOSTIC_ENTRIES);
     this.#requiredOutputCount = params.requiredOutputCount;
+    this.#sessionDiagnostics = new AgentSessionDiagnostics({
+      harness: 'claude',
+      invocation: params.invocation,
+      metadataMode:
+        params.metadataMode ?? (params.invocation.session?.mode === 'resume' ? 'warm' : 'cold'),
+      directToolNames: params.directToolNames,
+      proxyFallback: params.proxyFallback,
+      providerTools: params.providerTools,
+      catalogFailures: (params.catalogFailures ?? []).map(catalogFailureForSession),
+    });
     for (const omission of params.omissions ?? []) {
       this.#addOmission(omission.toolName, omission.reason);
     }
@@ -99,6 +128,14 @@ export class ClaudeToolDiagnostics {
 
   get failurePhase(): AgentInvocationFailurePhase | undefined {
     return this.#failurePhase;
+  }
+
+  get sessionDiagnostics(): AgentSessionDiagnostics {
+    return this.#sessionDiagnostics;
+  }
+
+  recordTurnStart(): void {
+    this.#sessionDiagnostics.recordTurnStart();
   }
 
   recordPreparationFailure(reason: ClaudeToolOmissionReason): void {
@@ -137,6 +174,7 @@ export class ClaudeToolDiagnostics {
   }
 
   recordMessage(message: unknown): void {
+    if (isRecord(message)) this.#sessionDiagnostics.recordUsage(message.usage);
     if (isInitMessage(message)) {
       this.#recordInit(message);
       return;
@@ -144,7 +182,7 @@ export class ClaudeToolDiagnostics {
     if (!isRecord(message)) return;
 
     if (message.type === 'tool_progress') {
-      this.#recordToolUse(message.tool_name, message.tool_use_id);
+      this.#recordToolUse(message.tool_name, message.tool_use_id, undefined);
       return;
     }
     if (message.type === 'assistant') {
@@ -166,6 +204,9 @@ export class ClaudeToolDiagnostics {
       this.#recordSdkRegistrationOmissions();
     }
     this.#failurePhase = this.#classify(params);
+    const failureClass = this.#sessionFailureClass(params);
+    if (failureClass !== undefined) this.#sessionDiagnostics.markFailure(failureClass);
+    this.#sessionDiagnostics.finish(sessionTerminationReason(params, failureClass), failureClass);
     if (!this.#hasIntegrationTools()) return this.#failurePhase;
 
     safeLog(
@@ -200,8 +241,53 @@ export class ClaudeToolDiagnostics {
     return this.#failurePhase;
   }
 
+  recordOutputWrite(params: {
+    key: string;
+    value: string;
+    result: {
+      readonly ok: boolean;
+      readonly idempotent?: boolean | undefined;
+      readonly code?: string | undefined;
+    };
+  }): void {
+    this.#sessionDiagnostics.recordOutputWrite(params);
+  }
+
+  async appendToSessionStore(
+    sessionStore:
+      | {
+          append(
+            key: {projectKey: string; sessionId: string},
+            entries: AgentSessionDiagnosticStoreEntry[],
+          ): Promise<void>;
+        }
+      | undefined,
+    sessionId: string | undefined,
+  ): Promise<void> {
+    if (this.#sessionDiagnosticsAppended || sessionStore === undefined || sessionId === undefined) {
+      return;
+    }
+    try {
+      await sessionStore.append({projectKey: '', sessionId}, [
+        this.#sessionDiagnostics.storeEntry(),
+      ]);
+      this.#sessionDiagnosticsAppended = true;
+    } catch {
+      safeLog(
+        {
+          event: 'runner.agent_session_diagnostics_persist_failed',
+          harness: 'claude',
+        },
+        'Claude session diagnostics could not be appended to the protected transcript',
+      );
+    }
+  }
+
   #recordInit(message: Record<string, unknown>): void {
     this.#advertisementObserved = true;
+    if (typeof message.session_id === 'string') {
+      this.#sessionDiagnostics.recordSessionId(message.session_id);
+    }
     if (!Array.isArray(message.tools)) return;
     this.#sdkToolListObserved = true;
     const advertised = new Set(
@@ -224,27 +310,46 @@ export class ClaudeToolDiagnostics {
     if (!isRecord(message) || !Array.isArray(message.content)) return;
     for (const block of message.content) {
       if (!isRecord(block) || block.type !== 'tool_use') continue;
-      this.#recordToolUse(block.name, block.id);
+      this.#recordToolUse(block.name, block.id, block.input);
     }
   }
 
   #recordToolResults(message: unknown): void {
     if (!isRecord(message) || !Array.isArray(message.content)) return;
     for (const block of message.content) {
-      if (!isRecord(block) || block.type !== 'tool_result' || block.is_error !== true) continue;
+      if (!isRecord(block) || block.type !== 'tool_result') continue;
       if (typeof block.tool_use_id !== 'string') continue;
       const toolName = this.#toolUseIds.get(block.tool_use_id);
-      if (toolName !== undefined) this.#failedToolNames.add(toolName);
+      if (block.is_error === true && toolName !== undefined) this.#failedToolNames.add(toolName);
+      this.#sessionDiagnostics.recordToolResult({
+        toolCallId: block.tool_use_id,
+        ...(toolName === undefined ? {} : {toolName}),
+        isError: block.is_error === true,
+        details: block,
+        structuredContent: structuredClaudeToolResult(block.content),
+      });
     }
   }
 
-  #recordToolUse(name: unknown, toolUseId: unknown): void {
+  #recordToolUse(name: unknown, toolUseId: unknown, input: unknown): void {
     if (typeof name !== 'string' || !this.#expectedSdkToolNames.has(name)) return;
     const integrationName = this.#sdkToolToIntegrationTool.get(name);
     if (integrationName === undefined) return;
     this.#omissions.delete(integrationName);
     this.#attemptedToolNames.add(integrationName);
-    if (typeof toolUseId === 'string') this.#toolUseIds.set(toolUseId, integrationName);
+    if (typeof toolUseId === 'string') {
+      this.#toolUseIds.set(toolUseId, integrationName);
+      if (!this.#diagnosticToolUseIds.has(toolUseId)) {
+        this.#diagnosticToolUseIds.add(toolUseId);
+        this.#sessionDiagnostics.recordToolCall({
+          toolCallId: toolUseId,
+          toolName: integrationName,
+          args: input === undefined ? {} : input,
+        });
+      } else if (input !== undefined) {
+        this.#sessionDiagnostics.updateToolCallArguments(toolUseId, input);
+      }
+    }
   }
 
   #classify(params: {
@@ -278,6 +383,19 @@ export class ClaudeToolDiagnostics {
     return undefined;
   }
 
+  #sessionFailureClass(params: {
+    outputGate: ClaudeToolOutputGate;
+    executionFailed?: boolean;
+  }): AgentSessionFailureClass | undefined {
+    if (params.outputGate === 'failed') return 'required_output_missing';
+    const observed = this.#sessionDiagnostics.failureClasses[0];
+    if (observed !== undefined) return observed;
+    if (params.executionFailed === true && this.#catalogFailures.length > 0) {
+      return 'integration_tool_catalog_unavailable';
+    }
+    return undefined;
+  }
+
   #addOmission(toolName: string, reason: ClaudeToolOmissionReason): void {
     if (!this.#requestedToolNames.includes(toolName) || this.#omissions.has(toolName)) return;
     this.#omissions.set(toolName, reason);
@@ -306,12 +424,44 @@ export class ClaudeToolDiagnostics {
   }
 }
 
+function sessionTerminationReason(
+  params: {outputGate: ClaudeToolOutputGate; executionFailed?: boolean},
+  failureClass: AgentSessionFailureClass | undefined,
+): AgentSessionTerminationReason {
+  if (params.executionFailed === true) return failureClass ?? 'error';
+  return params.outputGate === 'failed' ? 'error' : 'completed';
+}
+
 export function integrationToolName(tool: RequestedIntegrationTool): string {
   return agentIntegrationMcpToolName(tool.connectionSlug, tool.toolId);
 }
 
 export function claudeSdkToolName(integrationName: string): string {
   return `mcp__${AGENT_INTEGRATION_MCP_SERVER_NAME}__${integrationName}`;
+}
+
+function catalogFailureForSession(failure: ClaudeToolCatalogFailure): AgentSessionCatalogFailure {
+  return {
+    server: failure.server,
+    errorClass: failure.errorClass,
+    ...(failure.errorStatus === undefined ? {} : {status: failure.errorStatus}),
+  };
+}
+
+function structuredClaudeToolResult(content: unknown): unknown {
+  if (!Array.isArray(content)) return undefined;
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.structuredContent !== undefined) return block.structuredContent;
+    if (block.type !== 'text' || typeof block.text !== 'string') continue;
+    try {
+      const parsed: unknown = JSON.parse(block.text);
+      if (isRecord(parsed) && ('code' in parsed || 'reason' in parsed)) return parsed;
+    } catch {
+      // Ordinary provider text is intentionally excluded from diagnostics.
+    }
+  }
+  return undefined;
 }
 
 function isInitMessage(message: unknown): message is Record<string, unknown> {

--- a/libs/runner/agent/src/core/claude-tool-diagnostics.ts
+++ b/libs/runner/agent/src/core/claude-tool-diagnostics.ts
@@ -121,6 +121,9 @@ export class ClaudeToolDiagnostics {
       providerTools: params.providerTools,
       catalogFailures: (params.catalogFailures ?? []).map(catalogFailureForSession),
     });
+    if (params.invocation.session?.harnessSessionId !== undefined) {
+      this.#sessionDiagnostics.recordSessionId(params.invocation.session.harnessSessionId);
+    }
     for (const omission of params.omissions ?? []) {
       this.#addOmission(omission.toolName, omission.reason);
     }
@@ -197,6 +200,7 @@ export class ClaudeToolDiagnostics {
     missingOutputCount?: number;
     executionFailed?: boolean;
     executionCompleted?: boolean;
+    aborted?: boolean;
   }): AgentInvocationFailurePhase | undefined {
     if (this.#outcomeLogged) return this.#failurePhase;
     this.#outcomeLogged = true;
@@ -248,6 +252,7 @@ export class ClaudeToolDiagnostics {
       readonly ok: boolean;
       readonly idempotent?: boolean | undefined;
       readonly code?: string | undefined;
+      readonly reason?: string | undefined;
     };
   }): void {
     this.#sessionDiagnostics.recordOutputWrite(params);
@@ -293,6 +298,7 @@ export class ClaudeToolDiagnostics {
     const advertised = new Set(
       message.tools.filter((tool): tool is string => typeof tool === 'string'),
     );
+    this.#sessionDiagnostics.recordProviderToolNames([...advertised]);
     for (const toolName of this.#expectedSdkToolNames) {
       const integrationName = this.#sdkToolToIntegrationTool.get(toolName);
       if (integrationName === undefined) continue;
@@ -425,9 +431,10 @@ export class ClaudeToolDiagnostics {
 }
 
 function sessionTerminationReason(
-  params: {outputGate: ClaudeToolOutputGate; executionFailed?: boolean},
+  params: {outputGate: ClaudeToolOutputGate; executionFailed?: boolean; aborted?: boolean},
   failureClass: AgentSessionFailureClass | undefined,
 ): AgentSessionTerminationReason {
+  if (params.aborted === true) return 'aborted';
   if (params.executionFailed === true) return failureClass ?? 'error';
   return params.outputGate === 'failed' ? 'error' : 'completed';
 }

--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -213,7 +213,7 @@ describe('OutputCollector', () => {
       details: {code: 'output_conflict', key: 'summary'},
     });
     expect(collector.snapshot()).toEqual({summary: 'done'});
-    expect(collector.isComplete).toBe(true);
+    expect(collector.isComplete()).toBe(true);
   });
 
   it('returns the validation error and exact JSON Schema for a rejected json output', () => {

--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -75,6 +75,8 @@ describe('OutputCollector', () => {
 
     expect(result).toMatchObject({
       ok: false,
+      isError: true,
+      code: 'undeclared_output',
       feedback: expect.stringContaining(
         'Output "extra" is not declared by the step output schema. Use one of these exact keys: count.',
       ),
@@ -98,7 +100,12 @@ describe('OutputCollector', () => {
     const result = collector.trySet('bad key', 'value');
 
     expect(result.ok).toBe(false);
-    expect(result).toMatchObject({feedback: expect.stringContaining('Output key "bad key"')});
+    expect(result).toMatchObject({
+      ok: false,
+      isError: true,
+      code: 'invalid_output_key',
+      feedback: expect.stringContaining('Output key "bad key"'),
+    });
   });
 
   it('lists declared keys without repeating schemas when a typed step receives an invalid key', () => {
@@ -109,6 +116,8 @@ describe('OutputCollector', () => {
 
     expect(result).toMatchObject({
       ok: false,
+      isError: true,
+      code: 'invalid_output_key',
       feedback: expect.stringContaining(
         'Output key "bad key" is invalid. Use letters, numbers, underscores, or hyphens, and start with a letter or underscore. Use one of these exact keys: findings.',
       ),
@@ -192,6 +201,21 @@ describe('OutputCollector', () => {
     });
   });
 
+  it('accepts an identical repeated write but rejects a conflicting write', () => {
+    const collector = new OutputCollector({summary: {type: 'string'}});
+
+    expect(collector.trySet('summary', 'done')).toEqual({ok: true});
+    expect(collector.trySet('summary', 'done')).toEqual({ok: true, idempotent: true});
+    expect(collector.trySet('summary', 'changed')).toMatchObject({
+      ok: false,
+      isError: true,
+      code: 'output_conflict',
+      details: {code: 'output_conflict', key: 'summary'},
+    });
+    expect(collector.snapshot()).toEqual({summary: 'done'});
+    expect(collector.isComplete).toBe(true);
+  });
+
   it('returns the validation error and exact JSON Schema for a rejected json output', () => {
     const schema = {
       type: 'array',
@@ -208,6 +232,8 @@ describe('OutputCollector', () => {
 
     expect(result).toMatchObject({
       ok: false,
+      isError: true,
+      code: 'output_schema_mismatch',
       feedback: expect.stringContaining('Output "findings" does not match its JSON Schema.'),
     });
     expect(result).toMatchObject({
@@ -224,7 +250,7 @@ describe('OutputCollector', () => {
 
     const result = collector.trySet('large', 'x'.repeat(measuredBytes));
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: false,
       isError: true,
       code: 'output_value_too_large',
@@ -284,7 +310,7 @@ describe('OutputCollector', () => {
       Buffer.byteLength(`overflow=${overflowValue}\n`, 'utf8');
 
     expect(first).toEqual({ok: true});
-    expect(second).toEqual({
+    expect(second).toMatchObject({
       ok: false,
       isError: true,
       code: 'output_total_too_large',
@@ -443,6 +469,7 @@ describe('runOutputTurnLoop', () => {
     expect(error).toBeInstanceOf(RequiredOutputsMissingError);
     expect(error).toMatchObject({
       message: 'Agent step finished without required outputs: findings',
+      code: 'required_output_missing',
     });
     expect(error).toMatchObject({message: expect.not.stringContaining(outputSpecification)});
     expect(error).toMatchObject({message: expect.not.stringContaining(guidance)});

--- a/libs/runner/agent/src/core/output-collector.ts
+++ b/libs/runner/agent/src/core/output-collector.ts
@@ -41,6 +41,8 @@ export type SetOutputResult =
 export const MAX_OUTPUT_REPROMPTS = 2;
 
 export class RequiredOutputsMissingError extends Error {
+  readonly code = 'required_output_missing' as const;
+
   constructor(public readonly missing: readonly string[]) {
     super(`Agent step finished without required outputs: ${missing.join(', ')}`);
     this.name = 'RequiredOutputsMissingError';

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -339,11 +339,14 @@ describe('piHarnessAdapter', () => {
     await piHarnessAdapter.run(invocation());
 
     const options = createAgentSessionServicesMock.mock.calls[0]?.[0];
-    expect(options.resourceLoaderOptions.extensionFactories).toEqual([
-      expect.objectContaining({
-        name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
-      }),
-    ]);
+    expect(options.resourceLoaderOptions.extensionFactories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
+        }),
+        expect.objectContaining({name: 'shipfox-pi-session-diagnostics'}),
+      ]),
+    );
     expect(bindExtensionsMock).toHaveBeenCalledTimes(1);
     expect(bindExtensionsMock).toHaveBeenCalledWith(expect.objectContaining({mode: 'print'}));
   });
@@ -448,14 +451,17 @@ describe('piHarnessAdapter', () => {
     );
     expect(
       createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions.extensionFactories,
-    ).toEqual([
-      expect.objectContaining({
-        name: PI_TOOL_ERROR_NORMALIZER_EXTENSION_NAME,
-      }),
-      expect.objectContaining({
-        name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
-      }),
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: PI_TOOL_ERROR_NORMALIZER_EXTENSION_NAME,
+        }),
+        expect.objectContaining({
+          name: PI_TOOL_SVG_NORMALIZER_EXTENSION_NAME,
+        }),
+        expect.objectContaining({name: 'shipfox-pi-session-diagnostics'}),
+      ]),
+    );
     expect(extensionShutdownMock).toHaveBeenCalledWith({type: 'session_shutdown', reason: 'quit'});
     expect(disposeMock).toHaveBeenCalledAfter(extensionShutdownMock);
     expect(existsSync(configPath)).toBe(false);

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -30,6 +30,11 @@ import {
 } from '@shipfox/api-agent-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {Type} from 'typebox';
+import {
+  type AgentSessionCatalogFailure,
+  AgentSessionDiagnostics,
+  type AgentSessionToolDescriptor,
+} from '#core/agent-session-diagnostics.js';
 import {assertRunnerEgressAllowed} from '#core/egress.js';
 import {
   AgentConfigError,
@@ -54,6 +59,7 @@ import {
   isPiExtensionAvailable,
   piExtensionDirectories,
 } from '#core/pi-extensions.js';
+import {createPiSessionDiagnosticsExtension} from '#core/pi-session-diagnostics.js';
 import {createPiToolErrorNormalizerExtension} from '#core/pi-tool-error-normalizer.js';
 import {createPiToolSvgNormalizerExtension} from '#core/pi-tool-svg-normalizer.js';
 import {PrerequisiteLedger} from '#core/prerequisite-ledger.js';
@@ -76,6 +82,9 @@ const PI_BUILTIN_TOOL_NAMES = new Set([
 ]);
 const PI_MCP_METADATA_TIMEOUT_MS = 10_000;
 const PI_MCP_CONFIG_ARG_WAIT_TIMEOUT_MS = 30_000;
+const PI_MCP_METADATA_TIMEOUT_MESSAGE = 'Pi integration tool catalog lookup timed out.';
+const CATALOG_TIMEOUT_PATTERN = /timed out|timeout/i;
+const MAX_DIAGNOSTIC_STRING_LENGTH = 256;
 
 let piMcpConfigArgTail = Promise.resolve();
 
@@ -128,6 +137,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   let forkedFromExistingSession = false;
   let mcpConfig: PiMcpConfig | undefined;
   let customTools: ToolDefinition[] = [];
+  let diagnostics: AgentSessionDiagnostics | undefined;
 
   try {
     const directTools =
@@ -138,6 +148,22 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       toolSurface === 'discovery'
         ? await createPiMcpConfig(agentStateDir, invocation.mcpServers, signal)
         : undefined;
+    const sessionDiagnostics = new AgentSessionDiagnostics({
+      harness: 'pi',
+      invocation,
+      metadataMode: invocationSession?.mode === 'resume' ? 'warm' : 'cold',
+      directToolNames: [
+        ...directTools.map(({definition}) => definition.name),
+        ...(mcpConfig?.directToolNames ?? []),
+      ],
+      proxyFallback: mcpConfig?.proxyFallback ?? false,
+      providerTools: [
+        ...directTools.map(({definition}) => piMcpToolDescriptor(definition)),
+        ...(mcpConfig?.providerTools ?? []),
+      ],
+      catalogFailures: mcpConfig?.catalogFailures,
+    });
+    diagnostics = sessionDiagnostics;
     customTools = createPiCustomTools({
       collector,
       hasDeclaredOutputs,
@@ -148,6 +174,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       mcpConfig,
       modelRuntime,
       hasDirectTools: directTools.length > 0,
+      diagnostics: sessionDiagnostics,
     });
     const created = await createPiSession({
       services: prepared.services,
@@ -174,6 +201,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       prerequisiteLedger,
       sessionInvocation: invocationSession,
       forkedFromExistingSession,
+      diagnostics: sessionDiagnostics,
     });
   } catch (error) {
     if (invocationSession?.mode === 'fork') {
@@ -181,7 +209,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     }
     throw error;
   } finally {
-    await closePiSession({session, mcpConfig});
+    await closePiSession({session, mcpConfig, diagnostics});
   }
 }
 
@@ -243,6 +271,7 @@ async function runPiSession(params: {
   prerequisiteLedger: PrerequisiteLedger;
   sessionInvocation: HarnessInvocation['session'];
   forkedFromExistingSession: boolean;
+  diagnostics: AgentSessionDiagnostics;
 }): Promise<HarnessResult> {
   const abortSession = () => {
     Promise.resolve(params.session.abort()).catch(() => undefined);
@@ -267,6 +296,15 @@ async function runActivePiSession(
     onError: (error) => logger().warn({err: error}, 'Pi extension failed'),
   });
   installPiCompletionHooks(params);
+  params.diagnostics.recordSessionId(params.session.sessionId);
+  const registeredTools = params.session.getAllTools?.() ?? [];
+  params.diagnostics.recordProviderTools(
+    registeredTools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.parameters,
+    })),
+  );
   if (params.signal.aborted) throw new Error('Agent step aborted during pi session creation');
 
   const forwarder = startForwarding(
@@ -317,30 +355,15 @@ async function runPiOutputTurns(
       completionMissing: () => params.prerequisiteLedger.missing(),
       guidanceForMissing: (missing) => params.collector.guidanceTextFor(missing),
     });
+    params.diagnostics.finish('completed');
   } catch (error) {
-    const response = params.session.getLastAssistantText() ?? '';
-    if (error instanceof RequiredOutputsMissingError) {
-      throw new AgentInvocationError(
-        error.message,
-        response,
-        sessionArtifact.sessionFile,
-        sessionArtifact.sessionId,
-      );
-    }
-    if (error instanceof AgentInvocationError) {
-      throw new AgentInvocationError(
-        error.message,
-        error.response,
-        sessionArtifact.sessionFile,
-        sessionArtifact.sessionId,
-      );
-    }
-    throw new AgentInvocationError(
-      error instanceof Error ? error.message : String(error),
-      response,
-      sessionArtifact.sessionFile,
-      sessionArtifact.sessionId,
-    );
+    throw wrapPiOutputError({
+      error,
+      response: params.session.getLastAssistantText() ?? '',
+      sessionArtifact,
+      diagnostics: params.diagnostics,
+      aborted: params.signal.aborted,
+    });
   }
   const outputs = params.collector.snapshot();
   return {
@@ -348,6 +371,45 @@ async function runPiOutputTurns(
     ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
     ...sessionArtifact,
   };
+}
+
+function wrapPiOutputError(params: {
+  error: unknown;
+  response: string;
+  sessionArtifact: {sessionFile?: string; sessionId?: string};
+  diagnostics: AgentSessionDiagnostics;
+  aborted: boolean;
+}): AgentInvocationError {
+  if (params.error instanceof RequiredOutputsMissingError) {
+    params.diagnostics.finish('required_output_missing', 'required_output_missing');
+    return new AgentInvocationError(
+      params.error.message,
+      params.response,
+      params.sessionArtifact.sessionFile,
+      params.sessionArtifact.sessionId,
+      'output_gate_failed',
+    );
+  }
+  if (params.error instanceof AgentInvocationError) {
+    params.diagnostics.finish(
+      params.aborted ? 'aborted' : 'error',
+      params.error.failurePhase === 'output_gate_failed' ? 'required_output_missing' : undefined,
+    );
+    return new AgentInvocationError(
+      params.error.message,
+      params.error.response,
+      params.sessionArtifact.sessionFile,
+      params.sessionArtifact.sessionId,
+      params.error.failurePhase,
+    );
+  }
+  params.diagnostics.finish(params.aborted ? 'aborted' : 'error');
+  return new AgentInvocationError(
+    params.error instanceof Error ? params.error.message : String(params.error),
+    params.response,
+    params.sessionArtifact.sessionFile,
+    params.sessionArtifact.sessionId,
+  );
 }
 
 function resumablePiSessionArtifact(
@@ -438,6 +500,7 @@ async function preparePiSessionServices(params: {
   mcpConfig: PiMcpConfig | undefined;
   modelRuntime: ModelRuntimeInstance;
   hasDirectTools: boolean;
+  diagnostics: AgentSessionDiagnostics;
 }): Promise<{
   services: Awaited<ReturnType<typeof createAgentSessionServices>>;
 }> {
@@ -468,6 +531,7 @@ async function preparePiSessionServices(params: {
             ? []
             : [createPiToolErrorNormalizerExtension()]),
           createPiToolSvgNormalizerExtension(),
+          createPiSessionDiagnosticsExtension(params.diagnostics),
         ],
       },
     }),
@@ -668,6 +732,9 @@ interface PiMcpConfig {
   readonly directory: string;
   readonly path: string;
   readonly directToolNames: readonly string[];
+  readonly providerTools: readonly AgentSessionToolDescriptor[];
+  readonly catalogFailures: readonly AgentSessionCatalogFailure[];
+  readonly proxyFallback: boolean;
 }
 
 type PiMcpTool = ListToolsResult['tools'][number];
@@ -676,6 +743,17 @@ type PiMcpBridge = NonNullable<HarnessInvocation['mcpServers']>[number];
 interface PiIntegrationTool {
   readonly bridge: PiMcpBridge;
   readonly definition: PiMcpTool;
+}
+
+function piMcpToolDescriptor(tool: PiMcpTool): AgentSessionToolDescriptor {
+  return {
+    name: tool.name,
+    ...(tool.description === undefined ? {} : {description: tool.description}),
+    inputSchema: tool.inputSchema,
+    ...('outputSchema' in tool && tool.outputSchema !== undefined
+      ? {outputSchema: tool.outputSchema}
+      : {}),
+  };
 }
 
 function resolvePiToolSurface(invocation: HarnessInvocation): HarnessToolSurface {
@@ -731,7 +809,7 @@ async function createPiMcpConfig(
   try {
     const preparedServers = await Promise.all(
       mcpServers.map(async (server) => {
-        const [url, tools] = await Promise.all([
+        const [url, catalog] = await Promise.all([
           server.activateHttp(),
           listPiMcpTools(server, signal, false),
         ]);
@@ -746,7 +824,9 @@ async function createPiMcpConfig(
               exposeResources: false,
             },
           ] as const,
-          directToolNames: tools.map((tool) => tool.name),
+          directToolNames: catalog.tools.map((tool) => tool.name),
+          providerTools: catalog.tools.map(piMcpToolDescriptor),
+          ...(catalog.failure === undefined ? {} : {catalogFailure: catalog.failure}),
         };
       }),
     );
@@ -761,6 +841,11 @@ async function createPiMcpConfig(
       directory,
       path,
       directToolNames: preparedServers.flatMap((server) => server.directToolNames),
+      providerTools: preparedServers.flatMap((server) => server.providerTools),
+      catalogFailures: preparedServers.flatMap((server) =>
+        server.catalogFailure === undefined ? [] : [server.catalogFailure],
+      ),
+      proxyFallback: true,
     };
   } catch (error) {
     try {
@@ -782,8 +867,8 @@ async function createPiIntegrationToolCatalog(
   const catalog = (
     await Promise.all(
       mcpServers.map(async (server) => {
-        const tools = await listPiMcpTools(server, signal, true);
-        return tools.map((definition) => ({bridge: server, definition}));
+        const catalog = await listPiMcpTools(server, signal, true);
+        return catalog.tools.map((definition) => ({bridge: server, definition}));
       }),
     )
   ).flat();
@@ -831,10 +916,16 @@ async function listPiMcpTools(
   server: PiMcpBridge,
   signal: AbortSignal,
   failClosed: boolean,
-): Promise<readonly PiMcpTool[]> {
+): Promise<{
+  readonly tools: readonly PiMcpTool[];
+  readonly failure?: AgentSessionCatalogFailure | undefined;
+}> {
   const controller = new AbortController();
   const onAbort = () => controller.abort(signal.reason);
-  const timeout = setTimeout(() => controller.abort(), PI_MCP_METADATA_TIMEOUT_MS);
+  const timeout = setTimeout(
+    () => controller.abort(new Error(PI_MCP_METADATA_TIMEOUT_MESSAGE)),
+    PI_MCP_METADATA_TIMEOUT_MS,
+  );
   if (signal.aborted) onAbort();
   else signal.addEventListener('abort', onAbort, {once: true});
 
@@ -843,15 +934,31 @@ async function listPiMcpTools(
       signal: controller.signal,
       timeout: PI_MCP_METADATA_TIMEOUT_MS,
     });
-    return result.tools;
+    return {
+      tools: result.tools,
+    };
   } catch (error) {
     if (signal.aborted) throw error;
+    const status = catalogErrorStatus(error);
+    const errorClass = catalogErrorClass(error, status, controller.signal.aborted);
     if (failClosed) throw integrationToolCatalogUnavailable(server.name, error);
     logger().warn(
-      {err: error, server: server.name},
+      {
+        event: 'runner.agent_pi_tool_catalog_unavailable',
+        server: boundedDiagnosticString(server.name),
+        errorClass,
+        ...(status === undefined ? {} : {status}),
+      },
       'Failed to list Pi MCP direct tools; keeping the MCP proxy fallback',
     );
-    return [];
+    return {
+      tools: [],
+      failure: {
+        server: server.name,
+        errorClass,
+        ...(status === undefined ? {} : {status}),
+      },
+    };
   } finally {
     clearTimeout(timeout);
     signal.removeEventListener('abort', onAbort);
@@ -940,11 +1047,39 @@ function piToolContent(content: CallToolResult['content']): AgentToolResult<unkn
   });
 }
 
+function catalogErrorStatus(error: unknown): number | undefined {
+  if (!isRecord(error)) return undefined;
+  const status = error.status ?? error.statusCode ?? error.code;
+  return typeof status === 'number' && Number.isInteger(status) && status >= 100 && status <= 599
+    ? status
+    : undefined;
+}
+
+function boundedDiagnosticString(value: string): string {
+  return value.length <= MAX_DIAGNOSTIC_STRING_LENGTH
+    ? value
+    : value.slice(0, MAX_DIAGNOSTIC_STRING_LENGTH);
+}
+
+function catalogErrorClass(
+  error: unknown,
+  status: number | undefined,
+  timedOut: boolean,
+): AgentSessionCatalogFailure['errorClass'] {
+  if (status !== undefined) return 'http';
+  if (timedOut) return 'timeout';
+  if (error instanceof Error && CATALOG_TIMEOUT_PATTERN.test(error.message)) return 'timeout';
+  if (error instanceof TypeError) return 'transport';
+  return 'unknown';
+}
+
 async function closePiSession(params: {
   session: Awaited<ReturnType<typeof createAgentSessionFromServices>>['session'] | undefined;
   mcpConfig: PiMcpConfig | undefined;
+  diagnostics: AgentSessionDiagnostics | undefined;
 }): Promise<void> {
-  const {session, mcpConfig} = params;
+  const {session, mcpConfig, diagnostics} = params;
+  diagnostics?.finish(diagnostics.terminationReason ?? 'error');
   if (session !== undefined) {
     try {
       await session.extensionRunner.emit({type: 'session_shutdown', reason: 'quit'});
@@ -1263,4 +1398,8 @@ function credentialValue(
     );
   }
   return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -1176,10 +1176,6 @@ function parseMcpProxyArgs(value: unknown): unknown {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function setOutputTool(collector: OutputCollector) {
   return defineTool({
     name: PI_OUTPUT_TOOL_NAME,

--- a/libs/runner/agent/src/core/pi-session-diagnostics.test.ts
+++ b/libs/runner/agent/src/core/pi-session-diagnostics.test.ts
@@ -1,0 +1,99 @@
+import type {ExtensionAPI} from '@earendil-works/pi-coding-agent';
+import {AgentSessionDiagnostics} from '#core/agent-session-diagnostics.js';
+import {
+  createPiSessionDiagnosticsExtension,
+  PI_SESSION_DIAGNOSTICS_EXTENSION_NAME,
+} from '#core/pi-session-diagnostics.js';
+
+function diagnostics(): AgentSessionDiagnostics {
+  return new AgentSessionDiagnostics({
+    harness: 'pi',
+    invocation: {
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      session: {mode: 'resume'},
+    },
+    metadataMode: 'warm',
+  });
+}
+
+describe('Pi session diagnostics extension', () => {
+  it('persists protocol failures and upgrades proxy/output failures to isError', async () => {
+    const record = diagnostics();
+    const handlers = new Map<string, (event: never) => unknown>();
+    const appendEntry = vi.fn();
+    const extension = createPiSessionDiagnosticsExtension(record);
+    const pi = {
+      on: (event: string, handler: (event: never) => unknown) => handlers.set(event, handler),
+      appendEntry,
+    } as unknown as ExtensionAPI;
+
+    expect(extension.name).toBe(PI_SESSION_DIAGNOSTICS_EXTENSION_NAME);
+    if (extension.factory === undefined) throw new Error('Expected extension factory');
+    await extension.factory(pi);
+
+    handlers.get('tool_call')?.({
+      toolCallId: 'proxy-call',
+      toolName: 'mcp',
+      input: {name: 'pull_request_read', args: {method: 'get'}},
+    } as never);
+    const proxyResult = handlers.get('tool_result')?.({
+      toolCallId: 'proxy-call',
+      toolName: 'mcp',
+      input: {name: 'pull_request_read'},
+      content: [{type: 'text', text: 'Method is required: wording can change'}],
+      details: {
+        mode: 'call',
+        error: 'tool_error',
+        mcpResult: {
+          isError: true,
+          structuredContent: {
+            code: 'invalid-request',
+            reason: 'missing_required_parameter',
+            tool: 'pull_request_read',
+            parameter: 'method',
+          },
+        },
+      },
+      isError: false,
+    } as never) as {isError?: boolean} | undefined;
+    const outputResult = handlers.get('tool_result')?.({
+      toolCallId: 'output-call',
+      toolName: 'set_output',
+      input: {key: 'summary', value: 'second'},
+      content: [{type: 'text', text: 'conflicting output'}],
+      details: {
+        ok: false,
+        isError: true,
+        code: 'output_conflict',
+        details: {code: 'output_conflict', key: 'summary'},
+      },
+      isError: false,
+    } as never) as {isError?: boolean} | undefined;
+    record.finish('error', 'output_conflict');
+    handlers.get('session_shutdown')?.({} as never);
+
+    expect(proxyResult).toEqual({isError: true});
+    expect(outputResult).toEqual({isError: true});
+    expect(appendEntry).toHaveBeenCalledWith('shipfox_agent_diagnostics', expect.any(Object));
+    const entry = appendEntry.mock.calls[0]?.[1] as {
+      toolResults: Array<{isError: boolean; error?: unknown}>;
+      outputWrites: Array<{key: string; status: string}>;
+      termination: unknown;
+    };
+    expect(entry.toolResults[0]).toMatchObject({
+      isError: true,
+      error: {
+        code: 'invalid-request',
+        reason: 'missing_required_parameter',
+        tool: 'pull_request_read',
+        parameter: 'method',
+      },
+    });
+    expect(entry.toolResults[1]).toMatchObject({isError: true, error: {code: 'output_conflict'}});
+    expect(entry.outputWrites).toEqual([
+      expect.objectContaining({key: 'summary', status: 'conflicting'}),
+    ]);
+    expect(entry.termination).toEqual({reason: 'error', failureClass: 'output_conflict'});
+  });
+});

--- a/libs/runner/agent/src/core/pi-session-diagnostics.test.ts
+++ b/libs/runner/agent/src/core/pi-session-diagnostics.test.ts
@@ -29,7 +29,7 @@ describe('Pi session diagnostics extension', () => {
     } as unknown as ExtensionAPI;
 
     expect(extension.name).toBe(PI_SESSION_DIAGNOSTICS_EXTENSION_NAME);
-    if (extension.factory === undefined) throw new Error('Expected extension factory');
+    if (typeof extension === 'function') throw new Error('Expected an inline extension object');
     await extension.factory(pi);
 
     handlers.get('tool_call')?.({

--- a/libs/runner/agent/src/core/pi-session-diagnostics.ts
+++ b/libs/runner/agent/src/core/pi-session-diagnostics.ts
@@ -35,16 +35,18 @@ export function createPiSessionDiagnosticsExtension(
       });
 
       pi.on('tool_result', (event) => {
+        const structuredContent = structuredContentFromToolResult(event.details);
         diagnostics.recordToolResult({
           toolCallId: event.toolCallId,
           toolName: event.toolName,
           isError: event.isError,
           details: event.details,
+          ...(structuredContent === undefined ? {} : {structuredContent}),
         });
         recordOutputWrite(diagnostics, event.toolName, event.input, event.details);
 
         const stableError = stableToolErrorDetails(
-          event.details,
+          {details: event.details, structuredContent},
           event.isError || isRejectedOutput(event.details),
         );
         if (event.isError || isRejectedOutput(event.details) || stableError !== undefined) {
@@ -83,6 +85,7 @@ function recordOutputWrite(
 ): void {
   if (toolName !== 'set_output' || !isRecord(input) || typeof input.key !== 'string') return;
   if (!isRecord(details) || typeof details.ok !== 'boolean') return;
+  const reason = outputFailureReason(details);
   diagnostics.recordOutputWrite({
     key: input.key,
     value: typeof input.value === 'string' ? input.value : '',
@@ -90,8 +93,26 @@ function recordOutputWrite(
       ok: details.ok,
       ...(typeof details.idempotent === 'boolean' ? {idempotent: details.idempotent} : {}),
       ...(typeof details.code === 'string' ? {code: details.code} : {}),
+      ...(reason === undefined ? {} : {reason}),
     },
   });
+}
+
+function outputFailureReason(details: Record<string, unknown>): string | undefined {
+  if (typeof details.reason === 'string') return details.reason;
+  return isRecord(details.details) && typeof details.details.schemaError === 'string'
+    ? details.details.schemaError
+    : undefined;
+}
+
+function structuredContentFromToolResult(value: unknown, seen = new Set<object>()): unknown {
+  if (!isRecord(value)) return undefined;
+  if (seen.has(value)) return undefined;
+  seen.add(value);
+  if (value.structuredContent !== undefined) return value.structuredContent;
+  const nestedMcpResult = structuredContentFromToolResult(value.mcpResult, seen);
+  if (nestedMcpResult !== undefined) return nestedMcpResult;
+  return structuredContentFromToolResult(value.details, seen);
 }
 
 function isRejectedOutput(value: unknown): boolean {

--- a/libs/runner/agent/src/core/pi-session-diagnostics.ts
+++ b/libs/runner/agent/src/core/pi-session-diagnostics.ts
@@ -1,0 +1,111 @@
+import type {ExtensionAPI, InlineExtension} from '@earendil-works/pi-coding-agent';
+import {logger} from '@shipfox/node-opentelemetry';
+import {
+  AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE,
+  type AgentSessionDiagnostics,
+  stableToolErrorDetails,
+} from '#core/agent-session-diagnostics.js';
+
+export const PI_SESSION_DIAGNOSTICS_EXTENSION_NAME = 'shipfox-pi-session-diagnostics';
+
+/**
+ * Captures Pi tool lifecycle events in memory and writes one structured custom
+ * entry to the protected native transcript during session shutdown. The hook
+ * also upgrades adapter-level protocol failures to Pi's `isError` signal.
+ */
+export function createPiSessionDiagnosticsExtension(
+  diagnostics: AgentSessionDiagnostics,
+): InlineExtension {
+  return {
+    name: PI_SESSION_DIAGNOSTICS_EXTENSION_NAME,
+    hidden: true,
+    factory: (pi: ExtensionAPI) => {
+      let persisted = false;
+
+      pi.on('turn_start', () => {
+        diagnostics.recordTurnStart();
+      });
+
+      pi.on('tool_call', (event) => {
+        diagnostics.recordToolCall({
+          toolCallId: event.toolCallId,
+          toolName: event.toolName,
+          args: event.input,
+        });
+      });
+
+      pi.on('tool_result', (event) => {
+        diagnostics.recordToolResult({
+          toolCallId: event.toolCallId,
+          toolName: event.toolName,
+          isError: event.isError,
+          details: event.details,
+        });
+        recordOutputWrite(diagnostics, event.toolName, event.input, event.details);
+
+        const stableError = stableToolErrorDetails(
+          event.details,
+          event.isError || isRejectedOutput(event.details),
+        );
+        if (event.isError || isRejectedOutput(event.details) || stableError !== undefined) {
+          return {isError: true};
+        }
+        return undefined;
+      });
+
+      pi.on('turn_end', (event) => {
+        diagnostics.recordUsage(event.message);
+      });
+
+      pi.on('agent_end', (event) => {
+        diagnostics.recordUsage(event);
+      });
+
+      pi.on('session_shutdown', () => {
+        if (persisted) return;
+        persisted = true;
+        try {
+          pi.appendEntry(AGENT_SESSION_DIAGNOSTICS_ENTRY_TYPE, diagnostics.snapshot());
+        } catch {
+          // Diagnostics must never change the agent outcome or shutdown path.
+          safeLog('Failed to persist Pi agent session diagnostics');
+        }
+      });
+    },
+  };
+}
+
+function recordOutputWrite(
+  diagnostics: AgentSessionDiagnostics,
+  toolName: string,
+  input: unknown,
+  details: unknown,
+): void {
+  if (toolName !== 'set_output' || !isRecord(input) || typeof input.key !== 'string') return;
+  if (!isRecord(details) || typeof details.ok !== 'boolean') return;
+  diagnostics.recordOutputWrite({
+    key: input.key,
+    value: typeof input.value === 'string' ? input.value : '',
+    result: {
+      ok: details.ok,
+      ...(typeof details.idempotent === 'boolean' ? {idempotent: details.idempotent} : {}),
+      ...(typeof details.code === 'string' ? {code: details.code} : {}),
+    },
+  });
+}
+
+function isRejectedOutput(value: unknown): boolean {
+  return isRecord(value) && value.ok === false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function safeLog(message: string): void {
+  try {
+    logger().warn({event: 'runner.agent_session_diagnostics'}, message);
+  } catch {
+    // Diagnostics must not affect Pi shutdown.
+  }
+}


### PR DESCRIPTION
Persist structured, bounded diagnostics for agent tool failures and session termination in protected native session artifacts. The adapters retain machine-readable provider tool, call, result, output, failure, termination, and budget facts so protocol failures remain diagnosable without relying on prose or normal logs.

Closes ENG-1936

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists bounded, structured diagnostics for agent tool failures and session termination in protected session artifacts, so protocol failures stay diagnosable without parsing prose or relying on normal logs.

**Diagnostics**
- Records tool calls, results, output writes, budgets, and termination reason in a new `shipfox_agent_diagnostics` entry in Claude transcripts and Pi sessions.
- Bounds retained tool data and correlation state; raw result payloads are excluded.
- Repeating identical tool failures three or more times is classified as `agent_tool_loop_detected`.
- Records Claude tool inventory and aborted or pre-session failures.

**Protocol errors**
- MCP server returns `structuredContent` error codes such as `invalid-request`; output rejections use stable codes like `undeclared_output` and `output_conflict`.
- Output values are immutable: identical rewrites are accepted as idempotent, conflicting rewrites are rejected.
- Output rejections are surfaced to the agent as `isError` tool results instead of plain text.

Closes ENG-1936.

<sup>Written for commit fad0718a8abaca87cff008a6a2f68d4e5f649977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

