### PR TITLE
Define renewable inference credential contracts

### DIFF
--- a/.changeset/renewable-inference-contracts.md
+++ b/.changeset/renewable-inference-contracts.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-agent": minor
+"@shipfox/api-runners-dto": minor
+"@shipfox/api-workflows-dto": minor
+---
+
+Adds renewable inference credential metadata, capability, and failure-reason contracts while preserving legacy behavior.

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -65,6 +65,7 @@ const stepErrorReasonSchema = z.enum([
   'agent_session_held',
   'agent_session_harness_mismatch',
   'agent_session_unavailable',
+  'agent_inference_credentials_unavailable',
   'diagnostic_too_large',
   'tool_error',
   'tool_config_invalid',

--- a/libs/api/agent-dto/src/index.ts
+++ b/libs/api/agent-dto/src/index.ts
@@ -25,6 +25,7 @@ export {
   type CommitSessionTranscriptQueryDto,
   type CommitSessionTranscriptResponseDto,
   type CreateCustomModelProviderBodyDto,
+  type CredentialRenewalDto,
   type CustomAgentModelDto,
   type CustomModelProviderConfigDto,
   type CustomModelProviderHeaderDto,
@@ -35,6 +36,7 @@ export {
   commitSessionTranscriptQuerySchema,
   commitSessionTranscriptResponseSchema,
   createCustomModelProviderBodySchema,
+  credentialRenewalSchema,
   customAgentModelSchema,
   customModelProviderConfigDtoSchema,
   customModelProviderHeaderDtoSchema,
@@ -158,6 +160,7 @@ export {
   updateCustomModelProviderHeaderRequestSchema,
   updateModelProviderConfigBodySchema,
   updateModelProviderDefaultModelBodySchema,
+  validateRenewalWindow,
   type WorkspaceProvidersPolicy,
   workspaceProvidersPolicySchema,
 } from '#schemas/index.js';

--- a/libs/api/agent-dto/src/schemas/credential-renewal.test.ts
+++ b/libs/api/agent-dto/src/schemas/credential-renewal.test.ts
@@ -1,0 +1,35 @@
+import {z} from 'zod';
+import {credentialRenewalSchema, validateRenewalWindow} from './index.js';
+
+describe('credential renewal contracts', () => {
+  it('exports a renewal schema and validator for refresh-at credentials', () => {
+    const schema = z
+      .object({
+        expires_at: z.string().datetime({offset: true}),
+        renewal: credentialRenewalSchema,
+      })
+      .superRefine(validateRenewalWindow);
+    const input = {
+      expires_at: '2026-06-10T12:00:00.000Z',
+      renewal: {mode: 'refresh-at' as const, refresh_at: '2026-06-10T11:55:00.000Z'},
+    };
+
+    expect(schema.parse(input)).toEqual(input);
+  });
+
+  it('rejects a refresh-at renewal at or after expiry', () => {
+    const schema = z
+      .object({
+        expires_at: z.string().datetime({offset: true}),
+        renewal: credentialRenewalSchema,
+      })
+      .superRefine(validateRenewalWindow);
+
+    expect(
+      schema.safeParse({
+        expires_at: '2026-06-10T12:00:00.000Z',
+        renewal: {mode: 'refresh-at', refresh_at: '2026-06-10T12:00:00.000Z'},
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/libs/api/agent-dto/src/schemas/credential-renewal.test.ts
+++ b/libs/api/agent-dto/src/schemas/credential-renewal.test.ts
@@ -31,5 +31,33 @@ describe('credential renewal contracts', () => {
         renewal: {mode: 'refresh-at', refresh_at: '2026-06-10T12:00:00.000Z'},
       }).success,
     ).toBe(false);
+    expect(
+      schema.safeParse({
+        expires_at: '2026-06-10T12:00:00.000Z',
+        renewal: {mode: 'refresh-at', refresh_at: '2026-06-10T12:05:00.000Z'},
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects impossible calendar dates instead of relying on Date.parse normalization', () => {
+    const schema = z
+      .object({
+        expires_at: z.string().datetime({offset: true}),
+        renewal: credentialRenewalSchema,
+      })
+      .superRefine(validateRenewalWindow);
+
+    expect(
+      schema.safeParse({
+        expires_at: '2026-03-03T12:00:00.000Z',
+        renewal: {mode: 'refresh-at', refresh_at: '2026-02-30T11:55:00.000Z'},
+      }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({
+        expires_at: '2026-02-30T12:00:00.000Z',
+        renewal: {mode: 'refresh-at', refresh_at: '2026-02-28T11:55:00.000Z'},
+      }).success,
+    ).toBe(false);
   });
 });

--- a/libs/api/agent-dto/src/schemas/credential-renewal.ts
+++ b/libs/api/agent-dto/src/schemas/credential-renewal.ts
@@ -1,0 +1,33 @@
+import {z} from 'zod';
+
+export const credentialRenewalSchema = z.discriminatedUnion('mode', [
+  z.object({mode: z.literal('refresh-at'), refresh_at: z.string().datetime({offset: true})}),
+  z.object({mode: z.literal('on-rejection')}),
+]);
+
+export type CredentialRenewalDto = z.infer<typeof credentialRenewalSchema>;
+
+export function validateRenewalWindow<
+  T extends {
+    expires_at?: string | undefined;
+    renewal?: CredentialRenewalDto | undefined;
+  },
+>(auth: T, ctx: z.RefinementCtx): void {
+  if (auth.renewal?.mode !== 'refresh-at') return;
+
+  const refreshAt = Date.parse(auth.renewal.refresh_at);
+  const expiresAt = auth.expires_at === undefined ? Number.NaN : Date.parse(auth.expires_at);
+  if (!Number.isFinite(refreshAt) || !Number.isFinite(expiresAt)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['renewal', 'refresh_at'],
+      message: 'refresh_at and expires_at must be valid timestamps',
+    });
+  } else if (refreshAt >= expiresAt) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['renewal', 'refresh_at'],
+      message: 'refresh_at must be earlier than expires_at',
+    });
+  }
+}

--- a/libs/api/agent-dto/src/schemas/credential-renewal.ts
+++ b/libs/api/agent-dto/src/schemas/credential-renewal.ts
@@ -1,5 +1,7 @@
 import {z} from 'zod';
 
+const isoCalendarDatePrefix = /^(\d{4})-(\d{2})-(\d{2})T/;
+
 export const credentialRenewalSchema = z.discriminatedUnion('mode', [
   z.object({mode: z.literal('refresh-at'), refresh_at: z.string().datetime({offset: true})}),
   z.object({mode: z.literal('on-rejection')}),
@@ -17,7 +19,13 @@ export function validateRenewalWindow<
 
   const refreshAt = Date.parse(auth.renewal.refresh_at);
   const expiresAt = auth.expires_at === undefined ? Number.NaN : Date.parse(auth.expires_at);
-  if (!Number.isFinite(refreshAt) || !Number.isFinite(expiresAt)) {
+  if (
+    !hasValidCalendarDate(auth.renewal.refresh_at) ||
+    auth.expires_at === undefined ||
+    !hasValidCalendarDate(auth.expires_at) ||
+    !Number.isFinite(refreshAt) ||
+    !Number.isFinite(expiresAt)
+  ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['renewal', 'refresh_at'],
@@ -30,4 +38,23 @@ export function validateRenewalWindow<
       message: 'refresh_at must be earlier than expires_at',
     });
   }
+}
+
+function hasValidCalendarDate(value: string): boolean {
+  const match = isoCalendarDatePrefix.exec(value);
+  if (match === null) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1) return false;
+
+  const daysInMonth = [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][
+    month - 1
+  ];
+  return daysInMonth !== undefined && day <= daysInMonth;
+}
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
 }

--- a/libs/api/agent-dto/src/schemas/index.ts
+++ b/libs/api/agent-dto/src/schemas/index.ts
@@ -33,6 +33,11 @@ export {
   workspaceProvidersPolicySchema,
 } from './catalog.js';
 export {
+  type CredentialRenewalDto,
+  credentialRenewalSchema,
+  validateRenewalWindow,
+} from './credential-renewal.js';
+export {
   type CreateCustomModelProviderBodyDto,
   type CustomAgentModelDto,
   type CustomModelProviderConfigDto,

--- a/libs/api/agent-dto/src/schemas/managed-provider.ts
+++ b/libs/api/agent-dto/src/schemas/managed-provider.ts
@@ -89,6 +89,12 @@ export interface ManagedProviderRuntimeConfig {
   /** Gateway mount root, including path prefixes but no client API path, query, or fragment. */
   readonly baseUrl: string;
   readonly credentials: Record<string, string>;
+  readonly expiresAt?: Date | undefined;
+  readonly generation?: string | undefined;
+  readonly renewal?:
+    | {readonly mode: 'refresh-at'; readonly refreshAt: Date}
+    | {readonly mode: 'on-rejection'}
+    | undefined;
 }
 
 export interface ManagedModelProvider {
@@ -102,5 +108,6 @@ export interface ManagedModelProvider {
     runId: string;
     stepAttemptId: string;
     model: string;
+    renewableInference?: boolean | undefined;
   }) => Promise<ManagedProviderRuntimeConfig>;
 }

--- a/libs/api/agent-dto/src/schemas/runtime-config.test.ts
+++ b/libs/api/agent-dto/src/schemas/runtime-config.test.ts
@@ -72,6 +72,104 @@ describe('agentRuntimeCredentialsResponseSchema', () => {
     });
   });
 
+  it('parses renewable managed Claude runtime credentials', () => {
+    const parsed = agentRuntimeCredentialsResponseSchema.parse({
+      harness: 'claude',
+      provider_id: 'shipfox',
+      model: 'managed-claude',
+      thinking: 'high',
+      credentials: {api_key: 'managed-token'},
+      expires_at: '2026-06-10T12:00:00.000Z',
+      generation: '11111111-1111-4111-8111-111111111111',
+      renewal: {mode: 'refresh-at', refresh_at: '2026-06-10T11:55:00.000Z'},
+      claude: {
+        base_url: 'https://gateway.example.test',
+        auth_token: 'managed-token',
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      expires_at: '2026-06-10T12:00:00.000Z',
+      generation: '11111111-1111-4111-8111-111111111111',
+      renewal: {mode: 'refresh-at', refresh_at: '2026-06-10T11:55:00.000Z'},
+    });
+  });
+
+  it('requires all renewable metadata fields together', () => {
+    const input = {
+      harness: 'pi' as const,
+      provider_id: 'shipfox',
+      model: 'managed-claude',
+      thinking: 'high' as const,
+      credentials: {api_key: 'managed-token'},
+      expires_at: '2026-06-10T12:00:00.000Z',
+      generation: '11111111-1111-4111-8111-111111111111',
+      renewal: {mode: 'on-rejection' as const},
+    };
+
+    const withoutExpiry = (({expires_at: _expiresAt, ...value}) => value)(input);
+    const withoutGeneration = (({generation: _generation, ...value}) => value)(input);
+    const withoutRenewal = (({renewal: _renewal, ...value}) => value)(input);
+
+    expect(agentRuntimeCredentialsResponseSchema.safeParse(withoutExpiry).success).toBe(false);
+    expect(agentRuntimeCredentialsResponseSchema.safeParse(withoutGeneration).success).toBe(false);
+    expect(agentRuntimeCredentialsResponseSchema.safeParse(withoutRenewal).success).toBe(false);
+  });
+
+  it('requires an API key and matching Claude token for renewable credentials', () => {
+    const input = {
+      harness: 'claude' as const,
+      provider_id: 'shipfox',
+      model: 'managed-claude',
+      thinking: 'high' as const,
+      credentials: {api_key: 'managed-token'},
+      expires_at: '2026-06-10T12:00:00.000Z',
+      generation: '11111111-1111-4111-8111-111111111111',
+      renewal: {mode: 'on-rejection' as const},
+      claude: {
+        base_url: 'https://gateway.example.test',
+        auth_token: 'managed-token',
+      },
+    };
+
+    expect(
+      agentRuntimeCredentialsResponseSchema.safeParse({
+        ...input,
+        credentials: {authorization: 'managed-token'},
+      }).success,
+    ).toBe(false);
+    expect(
+      agentRuntimeCredentialsResponseSchema.safeParse({
+        ...input,
+        claude: {...input.claude, auth_token: 'different-token'},
+      }).success,
+    ).toBe(false);
+  });
+
+  it('requires a UUID generation and a refresh time before expiry', () => {
+    const input = {
+      harness: 'pi' as const,
+      provider_id: 'shipfox',
+      model: 'managed-claude',
+      thinking: 'high' as const,
+      credentials: {api_key: 'managed-token'},
+      expires_at: '2026-06-10T12:00:00.000Z',
+      generation: '11111111-1111-4111-8111-111111111111',
+      renewal: {mode: 'refresh-at' as const, refresh_at: '2026-06-10T11:55:00.000Z'},
+    };
+
+    expect(
+      agentRuntimeCredentialsResponseSchema.safeParse({...input, generation: 'generation-1'})
+        .success,
+    ).toBe(false);
+    expect(
+      agentRuntimeCredentialsResponseSchema.safeParse({
+        ...input,
+        renewal: {mode: 'refresh-at', refresh_at: '2026-06-10T12:00:00.000Z'},
+      }).success,
+    ).toBe(false);
+  });
+
   it('rejects a claude runtime block for a reserved provider id', () => {
     const parse = () =>
       agentRuntimeCredentialsResponseSchema.parse({

--- a/libs/api/agent-dto/src/schemas/runtime-config.ts
+++ b/libs/api/agent-dto/src/schemas/runtime-config.ts
@@ -1,5 +1,6 @@
 import {agentThinkingSchema, harnessSchema} from '@shipfox/workflow-document';
 import {z} from 'zod';
+import {credentialRenewalSchema, validateRenewalWindow} from './credential-renewal.js';
 import {customModelProviderRuntimeConfigSchema} from './custom-model-provider.js';
 import {isReservedModelProviderId, modelProviderRefSchema} from './model-provider-id.js';
 import {agentSessionDescriptorSchema} from './session-transcript.js';
@@ -25,11 +26,50 @@ export const agentRuntimeCredentialsResponseSchema = z
     model: z.string().min(1),
     thinking: agentThinkingSchema,
     credentials: z.record(credentialKeySchema, credentialValueSchema),
+    expires_at: z.string().datetime({offset: true}).optional(),
+    generation: z.string().uuid().optional(),
+    renewal: credentialRenewalSchema.optional(),
     custom_provider: customModelProviderRuntimeConfigSchema.optional(),
     claude: claudeRuntimeConfigSchema.optional(),
     session: agentSessionDescriptorSchema.optional(),
   })
   .superRefine((response, ctx) => {
+    validateRenewalWindow(response, ctx);
+
+    const hasExpiry = response.expires_at !== undefined;
+    const hasGeneration = response.generation !== undefined;
+    const hasRenewal = response.renewal !== undefined;
+    const hasRenewableMetadata = hasExpiry || hasGeneration || hasRenewal;
+
+    if (hasRenewableMetadata && !(hasExpiry && hasGeneration && hasRenewal)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['renewal'],
+        message: 'expires_at, generation, and renewal must be provided together.',
+      });
+    }
+
+    if (hasRenewableMetadata) {
+      if (response.credentials.api_key === undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['credentials', 'api_key'],
+          message: 'Renewable credentials must include credentials.api_key.',
+        });
+      }
+
+      if (
+        response.claude !== undefined &&
+        response.claude.auth_token !== response.credentials.api_key
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['claude', 'auth_token'],
+          message: 'claude.auth_token must match credentials.api_key.',
+        });
+      }
+    }
+
     if (response.claude !== undefined && isReservedModelProviderId(response.provider_id)) {
       ctx.addIssue({
         code: 'custom',

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -307,6 +307,66 @@ describe('resolveRuntimeCredentials', () => {
     });
   });
 
+  it('maps managed on-rejection credential metadata into the runtime response', async () => {
+    const expiresAt = new Date('2026-06-10T12:00:00.000Z');
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    resolveCredentials.mockResolvedValue({
+      api: 'anthropic-messages',
+      baseUrl: 'https://gateway.example.test/inference/v1/',
+      credentials: {api_key: 'managed-token'},
+      expiresAt,
+      generation,
+      renewal: {mode: 'on-rejection'},
+    });
+
+    const result = await resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'claude',
+        provider: 'shipfox',
+        model: 'claude-model',
+        thinking: 'high',
+      },
+      {managedProvider: managedProvider(resolveCredentials)},
+    );
+
+    expect(result).toMatchObject({
+      expires_at: expiresAt.toISOString(),
+      generation,
+      renewal: {mode: 'on-rejection'},
+    });
+  });
+
+  it('omits incomplete managed renewable credential metadata', async () => {
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    resolveCredentials.mockResolvedValue({
+      api: 'anthropic-messages',
+      baseUrl: 'https://gateway.example.test/inference/v1/',
+      credentials: {api_key: 'managed-token'},
+      generation: '11111111-1111-4111-8111-111111111111',
+    });
+
+    const result = await resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'claude',
+        provider: 'shipfox',
+        model: 'claude-model',
+        thinking: 'high',
+      },
+      {managedProvider: managedProvider(resolveCredentials)},
+    );
+
+    expect(result).not.toHaveProperty('expires_at');
+    expect(result).not.toHaveProperty('generation');
+    expect(result).not.toHaveProperty('renewal');
+  });
+
   it('keeps the catalog model ID when a managed model has no Claude model ID', async () => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     resolveCredentials.mockResolvedValue({

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -273,6 +273,40 @@ describe('resolveRuntimeCredentials', () => {
     });
   });
 
+  it('maps managed renewable credential metadata into the runtime response', async () => {
+    const expiresAt = new Date('2026-06-10T12:00:00.000Z');
+    const refreshAt = new Date('2026-06-10T11:55:00.000Z');
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
+    resolveCredentials.mockResolvedValue({
+      api: 'anthropic-messages',
+      baseUrl: 'https://gateway.example.test/inference/v1/',
+      credentials: {api_key: 'managed-token'},
+      expiresAt,
+      generation,
+      renewal: {mode: 'refresh-at', refreshAt},
+    });
+
+    const result = await resolveRuntimeCredentials(
+      {
+        workspaceId,
+        runId: crypto.randomUUID(),
+        stepAttemptId: crypto.randomUUID(),
+        harness: 'claude',
+        provider: 'shipfox',
+        model: 'claude-model',
+        thinking: 'high',
+      },
+      {managedProvider: managedProvider(resolveCredentials)},
+    );
+
+    expect(result).toMatchObject({
+      expires_at: expiresAt.toISOString(),
+      generation,
+      renewal: {mode: 'refresh-at', refresh_at: refreshAt.toISOString()},
+    });
+  });
+
   it('keeps the catalog model ID when a managed model has no Claude model ID', async () => {
     const resolveCredentials = vi.fn<ManagedModelProvider['resolveCredentials']>();
     resolveCredentials.mockResolvedValue({

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -249,6 +249,7 @@ function appendManagedProviderResponse(
   managedModel: ManagedModelProvider['models'][number] | undefined,
 ): void {
   if (managed === undefined) return;
+  appendManagedCredentialMetadata(response, managed.runtimeConfig);
   const modelDescriptor = toCustomAgentModelDto(
     managedModel ?? {id: params.model, label: params.model},
   );
@@ -272,4 +273,22 @@ function appendManagedProviderResponse(
     base_url: managedProviderAdapterBaseUrl(clientApi, managed.runtimeConfig.baseUrl),
     auth_token: authToken,
   };
+}
+
+function appendManagedCredentialMetadata(
+  response: AgentRuntimeCredentialsResponseDto,
+  runtimeConfig: ManagedProviderRuntimeConfig,
+): void {
+  if (runtimeConfig.expiresAt !== undefined) {
+    response.expires_at = runtimeConfig.expiresAt.toISOString();
+  }
+  if (runtimeConfig.generation !== undefined) {
+    response.generation = runtimeConfig.generation;
+  }
+  if (runtimeConfig.renewal !== undefined) {
+    response.renewal =
+      runtimeConfig.renewal.mode === 'refresh-at'
+        ? {mode: 'refresh-at', refresh_at: runtimeConfig.renewal.refreshAt.toISOString()}
+        : {mode: 'on-rejection'};
+  }
 }

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -279,16 +279,17 @@ function appendManagedCredentialMetadata(
   response: AgentRuntimeCredentialsResponseDto,
   runtimeConfig: ManagedProviderRuntimeConfig,
 ): void {
-  if (runtimeConfig.expiresAt !== undefined) {
-    response.expires_at = runtimeConfig.expiresAt.toISOString();
+  if (
+    runtimeConfig.expiresAt === undefined ||
+    runtimeConfig.generation === undefined ||
+    runtimeConfig.renewal === undefined
+  ) {
+    return;
   }
-  if (runtimeConfig.generation !== undefined) {
-    response.generation = runtimeConfig.generation;
-  }
-  if (runtimeConfig.renewal !== undefined) {
-    response.renewal =
-      runtimeConfig.renewal.mode === 'refresh-at'
-        ? {mode: 'refresh-at', refresh_at: runtimeConfig.renewal.refreshAt.toISOString()}
-        : {mode: 'on-rejection'};
-  }
+  response.expires_at = runtimeConfig.expiresAt.toISOString();
+  response.generation = runtimeConfig.generation;
+  response.renewal =
+    runtimeConfig.renewal.mode === 'refresh-at'
+      ? {mode: 'refresh-at', refresh_at: runtimeConfig.renewal.refreshAt.toISOString()}
+      : {mode: 'on-rejection'};
 }

--- a/libs/api/runners-dto/src/schemas/tool-capabilities.test.ts
+++ b/libs/api/runners-dto/src/schemas/tool-capabilities.test.ts
@@ -24,6 +24,16 @@ describe('runnerToolCapabilitiesSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts the renewable inference feature flag', () => {
+    const result = runnerToolCapabilitiesSchema.safeParse({
+      features: {renewable_git: true, renewable_inference: true},
+      harnesses: {},
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.features?.renewable_inference).toBe(true);
+  });
+
   it('requires renewable_git when protocol features are present', () => {
     const result = runnerToolCapabilitiesSchema.safeParse({
       features: {},

--- a/libs/api/runners-dto/src/schemas/tool-capabilities.ts
+++ b/libs/api/runners-dto/src/schemas/tool-capabilities.ts
@@ -3,6 +3,7 @@ import {z} from 'zod';
 export const runnerFeaturesSchema = z
   .object({
     renewable_git: z.boolean(),
+    renewable_inference: z.boolean().optional(),
   })
   .strict();
 

--- a/libs/api/workflows-dto/src/schemas/checkout-token.ts
+++ b/libs/api/workflows-dto/src/schemas/checkout-token.ts
@@ -1,3 +1,4 @@
+import {credentialRenewalSchema, validateRenewalWindow} from '@shipfox/api-agent-dto';
 import {z} from 'zod';
 
 const carryFields = {
@@ -11,36 +12,6 @@ const checkoutGitAuthorSchema = z.object({
   email: z.string().min(1),
 });
 
-const checkoutCredentialRenewalSchema = z.discriminatedUnion('mode', [
-  z.object({mode: z.literal('refresh-at'), refresh_at: z.string().datetime({offset: true})}),
-  z.object({mode: z.literal('on-rejection')}),
-]);
-
-function validateRenewalWindow<
-  T extends {
-    expires_at: string;
-    renewal?: {mode: 'refresh-at'; refresh_at: string} | {mode: 'on-rejection'} | undefined;
-  },
->(auth: T, ctx: z.RefinementCtx) {
-  if (auth.renewal?.mode !== 'refresh-at') return;
-
-  const refreshAt = Date.parse(auth.renewal.refresh_at);
-  const expiresAt = Date.parse(auth.expires_at);
-  if (!Number.isFinite(refreshAt) || !Number.isFinite(expiresAt)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['renewal', 'refresh_at'],
-      message: 'refresh_at and expires_at must be valid timestamps',
-    });
-  } else if (refreshAt >= expiresAt) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['renewal', 'refresh_at'],
-      message: 'refresh_at must be earlier than expires_at',
-    });
-  }
-}
-
 const checkoutTokenBasicAuthSchema = z
   .object({
     kind: z.literal('basic'),
@@ -48,7 +19,7 @@ const checkoutTokenBasicAuthSchema = z
     token: z.string().min(1),
     expires_at: z.string().datetime({offset: true}),
     generation: z.string().min(1).optional(),
-    renewal: checkoutCredentialRenewalSchema.optional(),
+    renewal: credentialRenewalSchema.optional(),
     ...carryFields,
   })
   .superRefine(validateRenewalWindow);
@@ -59,7 +30,7 @@ const checkoutTokenBearerAuthSchema = z
     token: z.string().min(1),
     expires_at: z.string().datetime({offset: true}),
     generation: z.string().min(1).optional(),
-    renewal: checkoutCredentialRenewalSchema.optional(),
+    renewal: credentialRenewalSchema.optional(),
     ...carryFields,
   })
   .superRefine(validateRenewalWindow);

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -135,6 +135,18 @@ describe('stepErrorDtoSchema', () => {
     });
   });
 
+  it('accepts an inference credential availability failure', () => {
+    const result = stepErrorDtoSchema.parse({
+      message: 'Inference credentials are unavailable.',
+      reason: 'agent_inference_credentials_unavailable',
+    });
+
+    expect(result).toEqual({
+      message: 'Inference credentials are unavailable.',
+      reason: 'agent_inference_credentials_unavailable',
+    });
+  });
+
   it.each([
     'agent_session_key_invalid',
     'agent_session_held',

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -35,6 +35,7 @@ export const stepErrorReasonSchema = z.enum([
   'agent_config_invalid',
   'agent_invocation_failed',
   'agent_harness_unavailable',
+  'agent_inference_credentials_unavailable',
   'agent_session_key_invalid',
   'agent_session_held',
   'agent_session_harness_mismatch',

--- a/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.test.ts
@@ -119,6 +119,13 @@ const STEP_FAILURE_CASES = [
       'Shipfox could not start the agent. Try again. If the problem continues, check the runner setup.',
   },
   {
+    reason: 'agent_inference_credentials_unavailable',
+    type: 'agent',
+    title: 'Inference credentials are unavailable',
+    description:
+      'Shipfox could not obtain inference credentials for this agent. Try again. If the problem continues, check the model provider configuration.',
+  },
+  {
     reason: 'agent_session_key_invalid',
     type: 'agent',
     title: 'Agent session configuration needs attention',

--- a/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-failure-annotations.ts
@@ -99,6 +99,11 @@ const STEP_FAILURE_COPY: Readonly<
     description:
       'Shipfox could not start the agent. Try again. If the problem continues, check the runner setup.',
   },
+  agent_inference_credentials_unavailable: {
+    title: 'Inference credentials are unavailable',
+    description:
+      'Shipfox could not obtain inference credentials for this agent. Try again. If the problem continues, check the model provider configuration.',
+  },
   agent_session_key_invalid: {
     title: 'Agent session configuration needs attention',
     description: 'Review the session key and mode before trying again.',

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -73,6 +73,12 @@ describe('StepInspectorSheet', () => {
       description: 'The resolved agent session key does not match the allowed key format.',
     },
     {
+      reason: 'agent_inference_credentials_unavailable',
+      title: 'Inference credentials are unavailable',
+      description:
+        'Shipfox could not obtain inference credentials for this agent. Try again. If the problem continues, check the model provider configuration.',
+    },
+    {
       reason: 'agent_session_held',
       title: 'Agent session is held by another attempt',
       description:

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -748,6 +748,8 @@ function failureTitle(reason: string | JobStatusReason): string {
       return 'Agent invocation failed';
     case 'agent_harness_unavailable':
       return 'Agent harness was unavailable';
+    case 'agent_inference_credentials_unavailable':
+      return 'Inference credentials are unavailable';
     case 'agent_session_key_invalid':
       return 'Agent session key is invalid';
     case 'agent_session_held':
@@ -815,6 +817,8 @@ function failureDescription(
       return 'The agent invocation failed after configuration was accepted.';
     case 'agent_harness_unavailable':
       return 'The runner could not start the agent harness.';
+    case 'agent_inference_credentials_unavailable':
+      return 'Shipfox could not obtain inference credentials for this agent. Try again. If the problem continues, check the model provider configuration.';
     case 'agent_session_key_invalid':
       return 'The resolved agent session key does not match the allowed key format.';
     case 'agent_session_held':

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -14,6 +14,7 @@ export type StepErrorReason =
   | 'agent_config_invalid'
   | 'agent_invocation_failed'
   | 'agent_harness_unavailable'
+  | 'agent_inference_credentials_unavailable'
   | 'agent_session_key_invalid'
   | 'agent_session_held'
   | 'agent_session_harness_mismatch'
@@ -43,6 +44,7 @@ export const STEP_ERROR_REASONS = new Set<StepErrorReason>([
   'agent_config_invalid',
   'agent_invocation_failed',
   'agent_harness_unavailable',
+  'agent_inference_credentials_unavailable',
   'agent_session_key_invalid',
   'agent_session_held',
   'agent_session_harness_mismatch',


### PR DESCRIPTION
Adds the compatibility-release contract surfaces needed for renewable managed inference credentials. The shared renewal schema and validator now live in agent-dto and are consumed by checkout without changing its wire contract. Runtime lease metadata, managed-provider compatibility, runner capability, and typed failure contracts are also defined, while legacy resolution remains unchanged.

This PR is intentionally limited to the U1 foundation: it does not persist eligibility, mint renewable tokens, change runner behavior, or activate the capability.

Validation: `turbo check type test` for the four affected packages, dependency-aware build and dependency-cruiser checks, and 902 package tests passed.

Closes ENG-1941

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the contract surfaces needed for renewable managed inference credentials without changing existing behavior.

- Moves the shared renewal schema and validator from `workflows-dto` into `agent-dto`; checkout's wire contract is unchanged.
- Adds optional `expires_at`, `generation`, and `renewal` fields to the runtime credentials response; they must be provided together, and renewable credentials must include `credentials.api_key`.
- Omits incomplete lease metadata from responses and rejects impossible calendar dates in renewal windows.
- Extends `ManagedProviderRuntimeConfig` with lease metadata and a `renewableInference` capability flag.
- Adds the `renewable_inference` runner feature flag and the `agent_inference_credentials_unavailable` step error reason, with server annotations, client troubleshooting copy, and E2E expectations.
- Does not persist eligibility, mint tokens, change runner behavior, or activate the capability.

Closes ENG-1941.

<sup>Written for commit 5ff2c545ba28e4464614ae61528d2d68a8210ffa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

