### PR TITLE
[runner-orchestration] Add a job-level inference secret registry

### DIFF
--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -462,6 +462,70 @@ describe('runJob', () => {
     ]);
   });
 
+  it('replaces inference generations without dropping other job secrets', async () => {
+    const observedSecrets: string[][] = [];
+    mockRunnerToolCapabilities.mockReturnValueOnce({
+      features: {renewable_git: true},
+      harnesses: {pi: {tools: ['read']}},
+    });
+    mockRunJobSteps.mockImplementationOnce((params) => {
+      params.subscribeSecrets?.((secrets) => observedSecrets.push(secrets));
+      params.registerSecrets?.(['checkout-token']);
+
+      const credentialLifecycleOptions = createJobCredentialLifecycleMock.mock.calls[0]?.[0] as {
+        replaceSecrets: (secrets: string[]) => void;
+      };
+      credentialLifecycleOptions.replaceSecrets(['git-token']);
+      params.replaceInferenceSecrets?.([
+        'inference-current',
+        'inference-previous',
+        'inference-oldest-retained',
+      ]);
+      credentialLifecycleOptions.replaceSecrets(['git-rotated']);
+      params.replaceInferenceSecrets?.([
+        'inference-newest',
+        'inference-current',
+        'inference-previous',
+        'inference-expired',
+      ]);
+      return Promise.resolve();
+    });
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    expect(observedSecrets).toEqual([
+      ['sf_mrt_runner-registration-token', JOB.lease_token, 'checkout-token'],
+      ['sf_mrt_runner-registration-token', JOB.lease_token, 'checkout-token', 'git-token'],
+      [
+        'sf_mrt_runner-registration-token',
+        JOB.lease_token,
+        'checkout-token',
+        'git-token',
+        'inference-current',
+        'inference-previous',
+        'inference-oldest-retained',
+      ],
+      [
+        'sf_mrt_runner-registration-token',
+        JOB.lease_token,
+        'checkout-token',
+        'git-rotated',
+        'inference-current',
+        'inference-previous',
+        'inference-oldest-retained',
+      ],
+      [
+        'sf_mrt_runner-registration-token',
+        JOB.lease_token,
+        'checkout-token',
+        'git-rotated',
+        'inference-newest',
+        'inference-current',
+        'inference-previous',
+      ],
+    ]);
+  });
+
   it('broadcasts registered secrets to each live subscriber independently', async () => {
     const firstSecrets: string[][] = [];
     const secondSecrets: string[][] = [];

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -58,6 +58,7 @@ const bootTimeline = createBootTimelineCollector();
 type RunnerBootPhaseTimeline = ReturnType<typeof createRunnerBootPhaseTimeline>;
 type RunnerShutdownReason = 'success' | 'controlled-exit' | 'fatal-failure';
 const RUNNER_LIFECYCLE_CAPABILITIES: ['local_execution_fence_v1'] = ['local_execution_fence_v1'];
+const MAX_INFERENCE_SECRET_GENERATIONS = 3;
 let bootPhaseTimeline: RunnerBootPhaseTimeline | undefined;
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
@@ -357,6 +358,7 @@ export async function runJob(
   const runnerSecrets = runnerSecret.length > 0 ? [runnerSecret] : [];
   const registeredSecrets = new Set<string>();
   const brokerSecrets = new Set<string>();
+  const inferenceSecrets = new Set<string>();
   const secrets = [...runnerSecrets, initialLeaseToken];
   const secretSubscribers = new Set<(secrets: string[]) => void>();
   const rotatingLeaseSecrets = () =>
@@ -382,6 +384,7 @@ export async function runJob(
         ...rotatingLeaseSecrets(),
         ...registeredSecrets,
         ...brokerSecrets,
+        ...inferenceSecrets,
       ]),
     );
     notifySecretSubscribers();
@@ -427,6 +430,23 @@ export async function runJob(
   const clearBrokerSecrets = () => {
     if (brokerSecrets.size === 0) return;
     brokerSecrets.clear();
+    rebuildSecrets();
+  };
+  const replaceInferenceSecrets = (replacement: string[]) => {
+    const next = new Set(
+      [...new Set(replacement.filter((secret) => secret.length > 0))].slice(
+        0,
+        MAX_INFERENCE_SECRET_GENERATIONS,
+      ),
+    );
+    if (
+      next.size === inferenceSecrets.size &&
+      [...next].every((secret) => inferenceSecrets.has(secret))
+    ) {
+      return;
+    }
+    inferenceSecrets.clear();
+    for (const secret of next) inferenceSecrets.add(secret);
     rebuildSecrets();
   };
 
@@ -485,6 +505,7 @@ export async function runJob(
         return () => secretSubscribers.delete(subscriber);
       },
       registerSecrets,
+      replaceInferenceSecrets,
       ...(credentialLifecycle
         ? {
             credentialHelper: credentialLifecycle.helper,

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -3259,6 +3259,89 @@ describe('runJobSteps', () => {
     );
   });
 
+  it('drops retired agent inference generations from later step results', async () => {
+    const firstAgent = buildAgentStep({id: '00000000-0000-0000-0000-0000000000f1'});
+    const secondAgent = buildAgentStep({id: '00000000-0000-0000-0000-0000000000f2'});
+    const retiredGeneration = 'inference-generation-retired';
+    const retainedGenerations = [
+      'inference-generation-current',
+      'inference-generation-previous',
+      'inference-generation-oldest-retained',
+    ] as const;
+    const [currentGeneration, previousGeneration, oldestGeneration] = retainedGenerations;
+    const jobSecrets: string[] = [];
+    const replaceInferenceSecrets = vi.fn((replacement: string[]) => {
+      jobSecrets.splice(0, jobSecrets.length, ...replacement);
+    });
+    const runtimeConfig = (apiKey: string | Record<string, string>) => ({
+      harness: 'pi',
+      provider_id: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+      credentials: typeof apiKey === 'string' ? {api_key: apiKey} : apiKey,
+    });
+    requestAgentRuntimeConfigMock
+      .mockResolvedValueOnce(runtimeConfig(retiredGeneration))
+      .mockResolvedValueOnce(
+        runtimeConfig({
+          current: currentGeneration,
+          previous: previousGeneration,
+          oldest: oldestGeneration,
+        }),
+      );
+    executeAgentStepMock
+      .mockResolvedValueOnce({
+        success: false,
+        response: `agent echoed ${retiredGeneration}`,
+        error: {
+          message: `provider returned ${retiredGeneration}`,
+          reason: 'agent_invocation_failed',
+        },
+        exit_code: null,
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        response: `agent echoed ${retiredGeneration} ${retainedGenerations.join(' ')}`,
+        error: {
+          message: `provider returned ${retiredGeneration} ${retainedGenerations.join(' ')}`,
+          reason: 'agent_invocation_failed',
+        },
+        exit_code: null,
+      });
+    const ac = new AbortController();
+    const executeAgent = (step: StepDto) =>
+      executeStep({
+        step,
+        attempt: 1,
+        cwd: '/work',
+        logsDir: LOGS_DIR,
+        agentStateDir: AGENT_STATE_DIR,
+        jobContext: JOB_CONTEXT,
+        leaseClient,
+        leaseToken: leaseTokenSource,
+        secrets: jobSecrets,
+        replaceInferenceSecrets,
+        signal: ac.signal,
+        workspacePrepared: true,
+        gitConfigPath: GIT_CONFIG_PATH,
+        jobId: JOB_ID,
+        stepLabel: 'implement',
+      });
+
+    const firstExecution = await executeAgent(firstAgent);
+    const secondExecution = await executeAgent(secondAgent);
+
+    expect(firstExecution.result.response).toBe('agent echoed ***');
+    expect(secondExecution.result.response).toBe(
+      `agent echoed ${retiredGeneration} ${retainedGenerations.map(() => '***').join(' ')}`,
+    );
+    expect(secondExecution.result.error?.message).toBe(
+      `provider returned ${retiredGeneration} ${retainedGenerations.map(() => '***').join(' ')}`,
+    );
+    expect(replaceInferenceSecrets).toHaveBeenNthCalledWith(1, [retiredGeneration]);
+    expect(replaceInferenceSecrets).toHaveBeenNthCalledWith(2, retainedGenerations);
+  });
+
   it('redacts runtime credential values from agent failures and responses', async () => {
     const agent = buildAgentStep();
     const hexCredential = Buffer.from('sk-runtime-secret').toString('hex');

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -251,6 +251,7 @@ function runLoop(params: {
   agentStateDir?: string;
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
   registerSecrets?: (secrets: string[]) => void;
+  replaceInferenceSecrets?: (secrets: string[]) => void;
   registerCheckoutCredential?: (credential: PersistedCheckoutCredential) => void;
   credentialFailureEvents?: CredentialFailureEventSource;
   credentialHelper?: {
@@ -268,6 +269,9 @@ function runLoop(params: {
     secrets: params.secrets ?? [],
     ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
     ...(params.registerSecrets ? {registerSecrets: params.registerSecrets} : {}),
+    ...(params.replaceInferenceSecrets
+      ? {replaceInferenceSecrets: params.replaceInferenceSecrets}
+      : {}),
     ...(params.registerCheckoutCredential
       ? {registerCheckoutCredential: params.registerCheckoutCredential}
       : {}),
@@ -3166,6 +3170,93 @@ describe('runJobSteps', () => {
     });
 
     expect(execution.result.error?.message).toBe('crashed with *** ***');
+  });
+
+  it('redacts the current inference generations from step results', async () => {
+    const run = buildRunStep();
+    const retainedGenerations = [
+      'inference-generation-current',
+      'inference-generation-previous',
+      'inference-generation-oldest-retained',
+    ];
+    executeRunStepMock.mockResolvedValueOnce({
+      success: false,
+      outputs: Object.fromEntries(
+        retainedGenerations.map((generation) => [generation, generation]),
+      ),
+      error: {message: `provider returned ${retainedGenerations.join(' ')}`},
+      exit_code: null,
+    });
+    const ac = new AbortController();
+
+    const execution = await executeStep({
+      step: run,
+      attempt: 1,
+      cwd: '/work',
+      logsDir: LOGS_DIR,
+      agentStateDir: AGENT_STATE_DIR,
+      jobContext: JOB_CONTEXT,
+      leaseClient,
+      leaseToken: leaseTokenSource,
+      secrets: [],
+      subscribeSecrets: (subscriber) => {
+        subscriber(['inference-generation-retired']);
+        subscriber(retainedGenerations);
+        return () => undefined;
+      },
+      signal: ac.signal,
+      workspacePrepared: true,
+      gitConfigPath: GIT_CONFIG_PATH,
+      jobId: JOB_ID,
+      stepLabel: 'run',
+    });
+
+    expect(execution.result).toEqual({
+      success: false,
+      outputs: Object.fromEntries(retainedGenerations.map((generation) => [generation, '***'])),
+      error: {message: `provider returned ${retainedGenerations.map(() => '***').join(' ')}`},
+      exit_code: null,
+    });
+  });
+
+  it('keeps crash redaction bounded to the latest inference generations', async () => {
+    const run = buildRunStep();
+    const retiredGeneration = 'inference-generation-retired';
+    const retainedGenerations = [
+      'inference-generation-current',
+      'inference-generation-previous',
+      'inference-generation-oldest-retained',
+    ];
+    executeRunStepMock.mockImplementationOnce(() => {
+      throw new Error(`crashed with ${retainedGenerations.join(' ')} ${retiredGeneration}`);
+    });
+    const ac = new AbortController();
+
+    const execution = await executeStep({
+      step: run,
+      attempt: 1,
+      cwd: '/work',
+      logsDir: LOGS_DIR,
+      agentStateDir: AGENT_STATE_DIR,
+      jobContext: JOB_CONTEXT,
+      leaseClient,
+      leaseToken: leaseTokenSource,
+      secrets: [],
+      subscribeSecrets: (subscriber) => {
+        subscriber([retiredGeneration]);
+        subscriber(retainedGenerations);
+        return () => undefined;
+      },
+      signal: ac.signal,
+      workspacePrepared: true,
+      gitConfigPath: GIT_CONFIG_PATH,
+      jobId: JOB_ID,
+      stepLabel: 'run',
+    });
+
+    expect(execution.result.error?.message).toBe(
+      `crashed with ${retainedGenerations.map(() => '***').join(' ')} ${retiredGeneration}`,
+    );
   });
 
   it('redacts runtime credential values from agent failures and responses', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -3262,6 +3262,7 @@ describe('runJobSteps', () => {
   it('redacts runtime credential values from agent failures and responses', async () => {
     const agent = buildAgentStep();
     const hexCredential = Buffer.from('sk-runtime-secret').toString('hex');
+    const replaceInferenceSecrets = vi.fn();
     executeAgentStepMock.mockResolvedValue({
       success: false,
       response: 'provider echoed sk-runtime-secret',
@@ -3283,6 +3284,7 @@ describe('runJobSteps', () => {
       leaseClient,
       leaseToken: leaseTokenSource,
       secrets: [],
+      replaceInferenceSecrets,
       signal: ac.signal,
       workspacePrepared: true,
       gitConfigPath: GIT_CONFIG_PATH,
@@ -3299,6 +3301,7 @@ describe('runJobSteps', () => {
       },
       exit_code: null,
     });
+    expect(replaceInferenceSecrets).toHaveBeenCalledWith(['sk-runtime-secret']);
   });
 
   it('redacts runtime credential values from successful agent response and outputs', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -107,8 +107,11 @@ export async function runJobSteps(params: {
   leaseToken: LeaseTokenSource;
   /** Secrets masked out of captured output before it reaches the spool. */
   secrets: string[];
+  /** Receives the complete job secret registry whenever one of its sets changes. */
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
   registerSecrets?: (secrets: string[]) => void;
+  /** Replaces the job's bounded current and previous inference credential generations. */
+  replaceInferenceSecrets?: (secrets: string[]) => void;
   registerCheckoutCredential?: (credential: PersistedCheckoutCredential) => void;
   credentialHelper?: GitCredentialHelperConfig | undefined;
   credentialFailureEvents?: CredentialFailureEventSource | undefined;
@@ -202,6 +205,9 @@ async function runJobStepIteration(
     leaseToken: params.leaseToken,
     secrets: params.secrets,
     ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
+    ...(params.replaceInferenceSecrets
+      ? {replaceInferenceSecrets: params.replaceInferenceSecrets}
+      : {}),
     signal: params.signal,
     workspacePrepared: state.workspacePrepared,
     checkoutDestinations: state.checkoutDestinations,
@@ -617,6 +623,7 @@ export async function executeStep(params: {
   leaseToken: LeaseTokenSource;
   secrets: string[];
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
+  replaceInferenceSecrets?: (secrets: string[]) => void;
   signal: AbortSignal;
   workspacePrepared: boolean;
   checkoutDestinations?: CheckoutDestinations | undefined;
@@ -649,8 +656,18 @@ export async function executeStep(params: {
   const unsubscribeSecrets: Array<() => void> = [];
   const secretState = {
     subscribedSecrets: [...secrets],
-    crashSecretVariants: buildSecretVariants(secrets),
+    crashSecrets: [...secrets],
+    inferenceSecrets: [] as string[],
   };
+  const replaceInferenceSecrets = params.replaceInferenceSecrets
+    ? (replacement: string[]) => {
+        params.replaceInferenceSecrets?.(replacement);
+        secretState.inferenceSecrets = [
+          ...new Set(replacement.filter((secret) => secret.length > 0)),
+        ];
+      }
+    : undefined;
+  const stepParams = withInferenceSecretReplacer(params, replaceInferenceSecrets);
   const registerStreamSecrets = createStreamSecretRegistrar({
     subscribeSecrets,
     secretState,
@@ -670,7 +687,7 @@ export async function executeStep(params: {
 
     if (step.type === 'setup') {
       const execution = await executeSetupStepBranch({
-        params: {...params, step},
+        params: {...stepParams, step},
         append,
         onStream: (createdStream) => {
           stream = createdStream;
@@ -698,7 +715,7 @@ export async function executeStep(params: {
 
     if (step.type === 'checkout') {
       const execution = await executeCheckoutStepBranch({
-        params: {...params, step},
+        params: {...stepParams, step},
         append,
         onStream: (createdStream) => {
           stream = createdStream;
@@ -723,7 +740,7 @@ export async function executeStep(params: {
     // be opened, run the agent without it rather than failing the step.
     if (step.type === 'agent') {
       const execution = await executeAgentStepBranch({
-        params: {...params, step},
+        params: {...stepParams, step},
         stepCwd,
         append,
         onStream: (createdStream) => {
@@ -738,7 +755,7 @@ export async function executeStep(params: {
     }
 
     const execution = await executeRunStepBranch({
-      params: {...params, step},
+      params: {...stepParams, step},
       stepCwd,
       append,
       onStream: (createdStream) => {
@@ -766,6 +783,14 @@ export async function executeStep(params: {
     for (const unsubscribe of unsubscribeSecrets) unsubscribe();
     runStream?.writeGroupEnd();
   }
+}
+
+function withInferenceSecretReplacer(
+  params: Parameters<typeof executeStep>[0],
+  replaceInferenceSecrets: ((secrets: string[]) => void) | undefined,
+): Parameters<typeof executeStep>[0] {
+  if (replaceInferenceSecrets === undefined) return params;
+  return {...params, replaceInferenceSecrets};
 }
 
 async function resolveStepWorkingDirectory(
@@ -810,7 +835,8 @@ function crashedStepExecution(params: {
       message: redactSecrets(
         params.error instanceof Error ? params.error.message : String(params.error),
         buildSecretVariants([
-          ...params.secretState.crashSecretVariants,
+          ...params.secretState.crashSecrets,
+          ...params.secretState.inferenceSecrets,
           ...params.secretState.subscribedSecrets,
           ...params.secrets,
         ]),
@@ -839,19 +865,20 @@ function createStreamSecretRegistrar(params: {
 }): (target: SecretAwareStream) => void {
   return (target) => {
     if (!target?.setSecrets && !target?.setRotatingSecrets && !target?.addSecrets) return;
-    const unsubscribe = params.subscribeSecrets?.((registeredSecrets) => {
-      params.secretState.subscribedSecrets = [
-        ...new Set([...params.secretState.subscribedSecrets, ...registeredSecrets]),
-      ];
+    const unsubscribe = params.subscribeSecrets?.((jobSecrets) => {
+      // Notifications are complete snapshots, not deltas. Replacing the snapshot keeps
+      // inference generations bounded in crash serialization while registered sets remain
+      // available through the job registry.
+      params.secretState.subscribedSecrets = [...jobSecrets];
       if (target.setSecrets) {
-        target.setSecrets(registeredSecrets);
+        target.setSecrets(jobSecrets);
         return;
       }
       if (target.setRotatingSecrets) {
-        target.setRotatingSecrets(registeredSecrets);
+        target.setRotatingSecrets(jobSecrets);
         return;
       }
-      target.addSecrets?.(registeredSecrets);
+      target.addSecrets?.(jobSecrets);
     });
     if (unsubscribe) params.unsubscribeSecrets.push(unsubscribe);
   };
@@ -961,7 +988,8 @@ async function executeCheckoutStepBranch(params: {
 
 interface StepSecretState {
   subscribedSecrets: string[];
-  crashSecretVariants: string[];
+  crashSecrets: string[];
+  inferenceSecrets: string[];
 }
 
 async function executeAgentStepBranch(params: {
@@ -1003,7 +1031,8 @@ async function executeAgentStepBranch(params: {
     ...(runtimeConfig.claude !== undefined ? [runtimeConfig.claude.auth_token] : []),
   ];
   const agentSecrets = [...input.secrets, ...runtimeSecretValues];
-  params.secretState.crashSecretVariants = buildSecretVariants(agentSecrets);
+  params.secretState.crashSecrets = [...input.secrets];
+  params.secretState.inferenceSecrets = [...new Set(runtimeSecretValues)];
   const sessionStream = createAgentSessionLogStream(input, agentSecrets, params.append);
   params.onStream(sessionStream);
   params.registerStreamSecrets(sessionStream);
@@ -1047,7 +1076,8 @@ async function executeAgentStepBranch(params: {
     result: maskAgentResult(
       result,
       buildSecretVariants([
-        ...agentSecrets,
+        ...params.secretState.crashSecrets,
+        ...params.secretState.inferenceSecrets,
         ...params.secretState.subscribedSecrets,
         ...input.secrets,
       ]),
@@ -1298,7 +1328,8 @@ async function executeRunStepBranch(params: {
     ...(input.ambientGitConfigSecrets ?? []),
     ...(secretMaterial?.secretValues ?? []),
   ];
-  params.secretState.crashSecretVariants = buildSecretVariants(runSecrets);
+  params.secretState.crashSecrets = [...runSecrets];
+  params.secretState.inferenceSecrets = [];
   const stepStream = createRunStepLogStream(input, runSecrets, params.append);
   params.onStream(stepStream);
   params.registerStreamSecrets(stepStream);
@@ -1315,7 +1346,12 @@ async function executeRunStepBranch(params: {
   });
   result = maskRunStepOutputs(
     result,
-    buildSecretVariants([...runSecrets, ...params.secretState.subscribedSecrets, ...input.secrets]),
+    buildSecretVariants([
+      ...params.secretState.crashSecrets,
+      ...params.secretState.inferenceSecrets,
+      ...params.secretState.subscribedSecrets,
+      ...input.secrets,
+    ]),
   );
   writeRunFailureContext(stepStream, result);
   return {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1030,6 +1030,7 @@ async function executeAgentStepBranch(params: {
     ...Object.values(runtimeConfig.credentials),
     ...(runtimeConfig.claude !== undefined ? [runtimeConfig.claude.auth_token] : []),
   ];
+  input.replaceInferenceSecrets?.(runtimeSecretValues);
   const agentSecrets = [...input.secrets, ...runtimeSecretValues];
   params.secretState.crashSecrets = [...input.secrets];
   params.secretState.inferenceSecrets = [...new Set(runtimeSecretValues)];

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -662,6 +662,9 @@ export async function executeStep(params: {
   const replaceInferenceSecrets = params.replaceInferenceSecrets
     ? (replacement: string[]) => {
         params.replaceInferenceSecrets?.(replacement);
+        const currentJobSecrets = [...params.secrets];
+        secretState.subscribedSecrets = currentJobSecrets;
+        secretState.crashSecrets = currentJobSecrets;
         secretState.inferenceSecrets = [
           ...new Set(replacement.filter((secret) => secret.length > 0)),
         ];


### PR DESCRIPTION
Rotated inference credentials need to join job redaction without overwriting lease, Git broker, or other registered secrets. This adds a bounded job-level inference set with replacement semantics and carries complete registry snapshots into step redaction, retaining the current and previous two generations. Result, error, and crash-path coverage verifies retired generations do not accumulate.

Validation: focused orchestration check, 183 tests, declaration emit, and build pass; affected check/build graphs pass. The affected test graph also exercises an unrelated runner-execution GPG fixture that fails because the local `Test <test@shipfox.io>` signing key is unavailable. The package type check remains blocked by the existing missing `@shipfox/vitest` declaration referenced by `vitest.config.ts`.

Closes ENG-1939

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded job-level inference secret registry so rotated inference credentials and agent runtime credentials get redacted from step output without overwriting lease, Git broker, or other registered secrets.

- Replaces inference generations atomically, retaining the current and previous two.
- Refreshes step and crash redaction snapshots so retired generations do not accumulate.

Closes ENG-1939.

<sup>Written for commit 622d2ca8f8ee4c6ffec2e13d40b00574d3c7e83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->