### PR TITLE
Upgrade bundled Claude Code to 2.1.246

### DIFF
--- a/.changeset/fable-claude-sdk.md
+++ b/.changeset/fable-claude-sdk.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": patch
+---
+
+Updates Claude session parsing for system events introduced by Claude Agent SDK 0.3.246.

--- a/apps/runner/src/verify-installation.ts
+++ b/apps/runner/src/verify-installation.ts
@@ -1,4 +1,5 @@
 import {createRequire} from 'node:module';
+import {assertBundledClaudeCodeVersion} from '@shipfox/runner-agent/claude-code';
 import {assertPiHarnessExtensionsAvailable} from '@shipfox/runner-agent/pi-extensions';
 import {assertPiImageRasterizerAvailable} from '@shipfox/runner-agent/pi-image-rasterizer';
 
@@ -24,5 +25,6 @@ for (const specifier of RUNNER_RUNTIME_EXPORTS) {
 // than the pnpm development tree. Imports the leaf module, not a package barrel: the runner barrels
 // validate the runtime environment at module load, which no image build can satisfy. A throw prints
 // the offending package and exits nonzero, which is the whole contract here.
+assertBundledClaudeCodeVersion();
 assertPiHarnessExtensionsAvailable();
 await assertPiImageRasterizerAvailable();

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1538,6 +1538,10 @@ describe('runner container entrypoint', () => {
     );
 
     expect(dockerfile).toContain('RUN node ./dist/verify-installation.js');
+    expect(verifyInstallation).toContain(
+      "import {assertBundledClaudeCodeVersion} from '@shipfox/runner-agent/claude-code';",
+    );
+    expect(verifyInstallation).toContain('assertBundledClaudeCodeVersion();');
     expect(verifyInstallation).toContain("'@shipfox/runner-execution/git-credential-helper'");
     expect(verifyInstallation).toContain("'./git-credential-helper.js'");
     expect(dockerfile).toContain('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true');

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -24,6 +24,8 @@ export const PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES = new Set<string>([
   'thinking_tokens',
   'status',
   'session_state_changed',
+  'background_tasks_changed',
+  'control_request_progress',
   'task_progress',
   'hook_progress',
   'hook_started',

--- a/libs/api/logs/test/fixtures/claude-session/sdk-system-subtypes.json
+++ b/libs/api/logs/test/fixtures/claude-session/sdk-system-subtypes.json
@@ -1,10 +1,12 @@
 {
   "package": "@anthropic-ai/claude-agent-sdk",
-  "version": "0.3.200",
+  "version": "0.3.246",
   "subtypes": [
     "api_retry",
+    "background_tasks_changed",
     "commands_changed",
     "compact_boundary",
+    "control_request_progress",
     "elicitation_complete",
     "files_persisted",
     "hook_progress",

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -49,6 +49,16 @@
         "default": "./dist/core/pi-extensions.js"
       }
     },
+    "./claude-code": {
+      "workspace-source": {
+        "types": "./src/claude-code.ts",
+        "default": "./src/claude-code.ts"
+      },
+      "default": {
+        "types": "./dist/claude-code.d.ts",
+        "default": "./dist/claude-code.js"
+      }
+    },
     "./tool-capabilities": {
       "workspace-source": {
         "types": "./src/core/tool-capabilities.ts",

--- a/libs/runner/agent/src/claude-code.ts
+++ b/libs/runner/agent/src/claude-code.ts
@@ -1,0 +1,4 @@
+export {
+  assertBundledClaudeCodeVersion,
+  MINIMUM_CLAUDE_CODE_VERSION,
+} from '#core/claude-code.js';

--- a/libs/runner/agent/src/core/claude-code.test.ts
+++ b/libs/runner/agent/src/core/claude-code.test.ts
@@ -1,0 +1,80 @@
+import {
+  assertBundledClaudeCodeVersion,
+  isSupportedClaudeCodeVersion,
+  MINIMUM_CLAUDE_CODE_VERSION,
+  readBundledClaudeCodeVersion,
+} from '#core/claude-code.js';
+
+describe('Claude Code compatibility', () => {
+  it('reports the version of the bundled Claude Code binary', () => {
+    expect(readBundledClaudeCodeVersion()).toBe(MINIMUM_CLAUDE_CODE_VERSION);
+    expect(() => assertBundledClaudeCodeVersion()).not.toThrow();
+  });
+
+  it.each([
+    ['2.1.245', false],
+    ['2.1.246', true],
+    ['2.1.300', true],
+    ['2.2.0', true],
+    ['not-a-version', false],
+  ])('checks support for Claude Code %s', (version, supported) => {
+    expect(isSupportedClaudeCodeVersion(version)).toBe(supported);
+  });
+
+  it('resolves the SDK binary through the SDK package directory', () => {
+    let resolvedSpecifier: string | undefined;
+
+    expect(
+      readBundledClaudeCodeVersion({
+        platform: 'darwin',
+        arch: 'arm64',
+        resolve: (specifier) => {
+          resolvedSpecifier = specifier;
+          return '/tmp/claude';
+        },
+        execute: () => '2.1.246 (Claude Code)',
+      }),
+    ).toBe('2.1.246');
+    expect(resolvedSpecifier).toBe('@anthropic-ai/claude-agent-sdk-darwin-arm64/claude');
+  });
+
+  it('tries the musl SDK binary after the glibc binary on Linux', () => {
+    const resolvedSpecifiers: string[] = [];
+
+    expect(
+      readBundledClaudeCodeVersion({
+        platform: 'linux',
+        arch: 'x64',
+        preferMusl: false,
+        resolve: (specifier) => {
+          resolvedSpecifiers.push(specifier);
+          if (specifier.endsWith('-musl/claude')) return '/tmp/claude';
+          throw new Error('glibc binary unavailable');
+        },
+        execute: () => '2.1.246 (Claude Code)',
+      }),
+    ).toBe('2.1.246');
+    expect(resolvedSpecifiers).toEqual([
+      '@anthropic-ai/claude-agent-sdk-linux-x64/claude',
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude',
+    ]);
+  });
+
+  it('fails when the bundled binary reports an invalid version', () => {
+    expect(() =>
+      readBundledClaudeCodeVersion({
+        resolve: () => '/tmp/claude',
+        execute: () => 'Claude Code unavailable',
+      }),
+    ).toThrow('Unable to parse bundled Claude Code version');
+  });
+
+  it('fails when the bundled binary is older than the minimum', () => {
+    expect(() =>
+      assertBundledClaudeCodeVersion({
+        resolve: () => '/tmp/claude',
+        execute: () => '2.1.245 (Claude Code)',
+      }),
+    ).toThrow(`requires ${MINIMUM_CLAUDE_CODE_VERSION} or newer`);
+  });
+});

--- a/libs/runner/agent/src/core/claude-code.test.ts
+++ b/libs/runner/agent/src/core/claude-code.test.ts
@@ -7,7 +7,6 @@ import {
 
 describe('Claude Code compatibility', () => {
   it('reports the version of the bundled Claude Code binary', () => {
-    expect(readBundledClaudeCodeVersion()).toBe(MINIMUM_CLAUDE_CODE_VERSION);
     expect(() => assertBundledClaudeCodeVersion()).not.toThrow();
   });
 
@@ -16,6 +15,8 @@ describe('Claude Code compatibility', () => {
     ['2.1.246', true],
     ['2.1.300', true],
     ['2.2.0', true],
+    ['2.1.246-beta.1', false],
+    ['2.1.246.1', false],
     ['not-a-version', false],
   ])('checks support for Claude Code %s', (version, supported) => {
     expect(isSupportedClaudeCodeVersion(version)).toBe(supported);

--- a/libs/runner/agent/src/core/claude-code.ts
+++ b/libs/runner/agent/src/core/claude-code.ts
@@ -1,0 +1,158 @@
+import {execFileSync} from 'node:child_process';
+import {createRequire} from 'node:module';
+
+const CLAUDE_AGENT_SDK_PACKAGE = '@anthropic-ai/claude-agent-sdk';
+const MINIMUM_CLAUDE_CODE_VERSION_PARTS = [2, 1, 246] as const;
+const CLAUDE_CODE_VERSION_PATTERN = /\b(\d+)\.(\d+)\.(\d+)\b/u;
+const require = createRequire(import.meta.url);
+
+export const MINIMUM_CLAUDE_CODE_VERSION = MINIMUM_CLAUDE_CODE_VERSION_PARTS.join('.');
+
+type ClaudeCodeVersion = readonly [number, number, number];
+type PackageResolver = (specifier: string) => string;
+type ClaudeCodeExecutor = (executable: string) => string;
+
+type ClaudeCodeCheckParams = {
+  resolve?: PackageResolver;
+  execute?: ClaudeCodeExecutor;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  preferMusl?: boolean;
+};
+
+/**
+ * Verifies that the Claude Code binary bundled by the Agent SDK meets the runner's minimum
+ * version. This runs against the deployed production closure during runner image builds.
+ */
+export function assertBundledClaudeCodeVersion(params: ClaudeCodeCheckParams = {}): void {
+  const version = readBundledClaudeCodeVersion(params);
+  if (isSupportedClaudeCodeVersion(version)) return;
+
+  throw new Error(
+    `Bundled Claude Code version ${version} is not supported; requires ${MINIMUM_CLAUDE_CODE_VERSION} or newer.`,
+  );
+}
+
+export function readBundledClaudeCodeVersion(params: ClaudeCodeCheckParams = {}): string {
+  const executable = resolveBundledClaudeCodeExecutable(params);
+  let output: string;
+
+  try {
+    output = (params.execute ?? executeClaudeCode)(executable);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to execute bundled Claude Code at "${executable}": ${reason}`);
+  }
+
+  const version = parseClaudeCodeVersion(output);
+  if (version === undefined) {
+    const reportedOutput = output.trim().replace(/\s+/gu, ' ');
+    throw new Error(
+      `Unable to parse bundled Claude Code version from "${reportedOutput}"; expected a semantic version.`,
+    );
+  }
+
+  return formatClaudeCodeVersion(version);
+}
+
+export function isSupportedClaudeCodeVersion(version: string): boolean {
+  const parsedVersion = parseClaudeCodeVersion(version);
+  return (
+    parsedVersion !== undefined &&
+    compareClaudeCodeVersions(parsedVersion, MINIMUM_CLAUDE_CODE_VERSION_PARTS) >= 0
+  );
+}
+
+function resolveBundledClaudeCodeExecutable(params: ClaudeCodeCheckParams): string {
+  const platform = params.platform ?? process.platform;
+  const arch = params.arch ?? process.arch;
+  const specifiers = claudeCodeBinarySpecifiers({
+    platform,
+    arch,
+    ...(params.preferMusl === undefined ? {} : {preferMusl: params.preferMusl}),
+  });
+  const resolve = params.resolve ?? sdkPackageResolver();
+  const reasons: string[] = [];
+
+  for (const specifier of specifiers) {
+    try {
+      return resolve(specifier);
+    } catch (error) {
+      reasons.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  const detail = reasons.length === 0 ? '' : ` ${reasons.join(' ')}`;
+  throw new Error(
+    `Unable to resolve bundled Claude Code for ${platform}-${arch}; tried ${specifiers.join(', ')}.${detail}`,
+  );
+}
+
+function sdkPackageResolver(): PackageResolver {
+  let sdkEntry: string;
+  try {
+    sdkEntry = require.resolve(CLAUDE_AGENT_SDK_PACKAGE);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to resolve Claude Agent SDK package: ${reason}`);
+  }
+
+  const sdkRequire = createRequire(sdkEntry);
+  return (specifier) => sdkRequire.resolve(specifier);
+}
+
+function claudeCodeBinarySpecifiers(params: {
+  platform: NodeJS.Platform;
+  arch: string;
+  preferMusl?: boolean;
+}): string[] {
+  const {platform, arch} = params;
+  const binary = platform === 'win32' ? 'claude.exe' : 'claude';
+
+  if (platform === 'android') {
+    return [`${CLAUDE_AGENT_SDK_PACKAGE}-linux-${arch}-android/${binary}`];
+  }
+
+  if (platform === 'linux') {
+    const libcSuffixes = (params.preferMusl ?? prefersMusl()) ? ['-musl', ''] : ['', '-musl'];
+    return libcSuffixes.map(
+      (suffix) => `${CLAUDE_AGENT_SDK_PACKAGE}-linux-${arch}${suffix}/${binary}`,
+    );
+  }
+
+  return [`${CLAUDE_AGENT_SDK_PACKAGE}-${platform}-${arch}/${binary}`];
+}
+
+function prefersMusl(): boolean {
+  if (process.platform !== 'linux' || typeof process.report?.getReport !== 'function') return false;
+
+  try {
+    const report = process.report.getReport() as {header?: {glibcVersionRuntime?: string}};
+    return report.header?.glibcVersionRuntime === undefined;
+  } catch {
+    return false;
+  }
+}
+
+function executeClaudeCode(executable: string): string {
+  return execFileSync(executable, ['--version'], {encoding: 'utf8', timeout: 10_000});
+}
+
+function parseClaudeCodeVersion(output: string): ClaudeCodeVersion | undefined {
+  const match = CLAUDE_CODE_VERSION_PATTERN.exec(output);
+  if (match === null) return undefined;
+
+  const version = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+  return version.every((part) => Number.isSafeInteger(part)) ? version : undefined;
+}
+
+function formatClaudeCodeVersion(version: ClaudeCodeVersion): string {
+  return version.join('.');
+}
+
+function compareClaudeCodeVersions(version: ClaudeCodeVersion, other: ClaudeCodeVersion): number {
+  for (const difference of [version[0] - other[0], version[1] - other[1], version[2] - other[2]]) {
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}

--- a/libs/runner/agent/src/core/claude-code.ts
+++ b/libs/runner/agent/src/core/claude-code.ts
@@ -3,7 +3,7 @@ import {createRequire} from 'node:module';
 
 const CLAUDE_AGENT_SDK_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 const MINIMUM_CLAUDE_CODE_VERSION_PARTS = [2, 1, 246] as const;
-const CLAUDE_CODE_VERSION_PATTERN = /\b(\d+)\.(\d+)\.(\d+)\b/u;
+const CLAUDE_CODE_VERSION_PATTERN = /(?:^|\s)(\d+)\.(\d+)\.(\d+)(?=\s|$|\()/u;
 const require = createRequire(import.meta.url);
 
 export const MINIMUM_CLAUDE_CODE_VERSION = MINIMUM_CLAUDE_CODE_VERSION_PARTS.join('.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.1
     '@anthropic-ai/claude-agent-sdk':
-      specifier: 0.3.200
-      version: 0.3.200
+      specifier: 0.3.246
+      version: 0.3.246
     '@anthropic-ai/sdk':
       specifier: 0.110.0
       version: 0.110.0
@@ -3792,7 +3792,7 @@ importers:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 'catalog:'
-        version: 0.3.200(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.246(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@shipfox/api-auth-dto':
         specifier: workspace:*
         version: link:../auth-dto
@@ -6758,7 +6758,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 'catalog:'
-        version: 0.3.200(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.246(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: 'catalog:'
         version: 0.110.0(zod@4.4.3)
@@ -8564,52 +8564,52 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.200':
-    resolution: {integrity: sha512-8UzzInVdRPDNIOvrAxYbHHJD/u13WSBx9fvEeuZnsZ6rZh0qnSI1QwU8Due0V2+m+ZnT3cEonmXDvo2ee/icWg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.246':
+    resolution: {integrity: sha512-pYDv2RT+UVOvEapMEWKf7Gm5a87Si1Zf+XR23IMGYbG5mESatNJ8Gz2PmkrwfTezZknb0ljWZe8zgcTFITM3dA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.200':
-    resolution: {integrity: sha512-DCwlQoO8HWGuFElE+Q5pYkiBTalXjjMATRAxXyc94fI6m1ZRqyba66dOea+zTmzHPpOb6zSoHYNLiXy7EjNpcg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.246':
+    resolution: {integrity: sha512-yl+gMMFUQ8++SBaxUe2JxBqU0LOJO4HZTsWWTOrH5kRlTRhdQDF/lESsoNXCHgfF/+77YNKgef0h+rl/D12Jfg==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.200':
-    resolution: {integrity: sha512-ak0l+zpz3dKPjnBegUhOs1Y5xFveEQ1AVqmq6s8Q7qd3vO4SrDPiUOpxRkjkqWyGD8r8w+ezG+unf3U9IZ6DRg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.246':
+    resolution: {integrity: sha512-AeiDXveuA9dVRDouSRiQzL40P3dOuJPfZOlwwsFNbVUN0D+06WtwgmeWYnyRG4dxsM67Pf4lYcRZ0x9pfEZUwQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.200':
-    resolution: {integrity: sha512-NAEonp086ZOsf+3o/9Y5JRclO6C4n4ceiSuCpSDV6SSUOLBmCRi7r/PJOoMsIWwMshC6fnnkDKZamTpHjr75eg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.246':
+    resolution: {integrity: sha512-t7AEewD7bcjZYMmrfFLjsUSxPo4z+5J5O5cC9V2zOvAhNkefdMeGWI2/1cdqZxuaOiFVt46byjlZuiNNunF+bQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.200':
-    resolution: {integrity: sha512-Sf5TTCO3bc5ty7FX5F19WT3xbtU+f1biYD9+dDJ7YHyYFWuiPlWcnCJ8El8RSwCTuvz3OexJLwCqGHRWOC3eBg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.246':
+    resolution: {integrity: sha512-+3PrWX3qXgakO3tZImr7keKFry5XIkbHBEaUxgi3/RtPmxGwS+JdVAr0xxzOoC2F6Y66Kn0lUnztRnZHORBc+Q==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.200':
-    resolution: {integrity: sha512-0R/In8G4fZLFFEIA1SqXRRf9mzDGx7roHpMawNdTT1QlG4XftGTlKMxfukt/YcxwzsNPWg4hJSkEDxsb+3J6FA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.246':
+    resolution: {integrity: sha512-BIbBlJ6x7Cys6UFvahUfce26H+U+Q4tLWjKRD39AaV7JvRav8/vfdFytzWq6E+h9hT1OOWYuPYx2gMn5vDhZhQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.200':
-    resolution: {integrity: sha512-iJx10bdrk3afa/Oq9QHRh2HaINT/xnsm5OrFNNLbix2CoOEY5lA7f0lk/s0OMiWnfXdv5vvtADpgZ5tvUoQykA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.246':
+    resolution: {integrity: sha512-JV8b28OJ8d+EMVEVIWlN3aEkT8uSehO3ZN/PJzXFG7Jgn56oVYUew4aY9vK4jao/4E4mdfzvs358w4HcTBUzVw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.200':
-    resolution: {integrity: sha512-Mka8YDpDIiSJcbrdoBhzX3S0n9DYcoYaEjS7lxwX3GyPi5PvXV4UBuXzj++7ieV/KS4w32Sm3mHQRpeVwnJZ0A==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.246':
+    resolution: {integrity: sha512-omI65bYGynLpE1Ybijk56K1wBnt0H6WujNwlg1LzIdeHrYmpUxoqncK92xKH5kb9XWUz3byHqArbv7wsT+M/2A==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.200':
-    resolution: {integrity: sha512-o13TM3boFIJE4oZdQDFw5TQfiev1sBoxwzKM2QGj/NPtxriGTP0PKNAQsGZvTsiEOIIH5rzPr/H81xVkkAw23g==}
+  '@anthropic-ai/claude-agent-sdk@0.3.246':
+    resolution: {integrity: sha512-FtR0HoHHNqeqJWjZN8qLUAzZVFUI9ztXYNPPwv98Ecmv9qq2QTauI8IzkY26CC0mleWAqb9RQEW2C0OtiUliug==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -18304,44 +18304,44 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.200':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.246':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.200(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.246(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.110.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.200
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.200
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.246
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.246
 
   '@anthropic-ai/sdk@0.110.0(zod@4.4.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ catalogMode: strict
 
 catalog:
   "@actions/core": "^3.0.0"
-  "@anthropic-ai/claude-agent-sdk": "0.3.200"
+  "@anthropic-ai/claude-agent-sdk": "0.3.246"
   "@anthropic-ai/sdk": "0.110.0"
   "@argos-ci/cli": "^5.0.0"
   "@argos-ci/playwright": "^7.0.0"


### PR DESCRIPTION
Pins Claude Agent SDK 0.3.246, which bundles the Claude Code version required for renewable inference credentials.

The runner image installation gate checks the actual platform binary before enabling managed runner behavior. Claude session parsing also tracks the new SDK system-event types without turning transient progress into user-visible rows.

Local builds, type checks, lint checks, runner-agent tests, runner-image tests, API log parser compatibility tests, dependency policies, published-artifact verification, and the frozen install pass. The full API logs suite still requires the local Garage service; its isolated parser compatibility test passes.

The staging candidate-image canary remains the separate ENG-1946 follow-up.

Closes ENG-1942

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `@anthropic-ai/claude-agent-sdk` to 0.3.246, which bundles the Claude Code version required for renewable inference credentials. The runner image build now fails if the bundled Claude Code binary is older than 2.1.246, and the check also rejects prerelease and extra-component versions. Claude session parsing treats two new SDK system event types as progress-only. The staging candidate-image canary remains a separate follow-up (ENG-1946). Closes ENG-1942.

<sup>Written for commit 9d53cf2b19b2a14fccbe4e768470a6b53c8413f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

