### PR TITLE
[@shipfox/expression] Bound evaluation traces by serialized byte budget

### DIFF
--- a/.changeset/bounded-trace-budget.md
+++ b/.changeset/bounded-trace-budget.md
@@ -2,4 +2,4 @@
 "@shipfox/expression": patch
 ---
 
-Bounds evaluation traces by serialized UTF-8 bytes while preserving deterministic prefixes and dropped-entry counts.
+Bounds evaluation traces to stay within the observation size budget while keeping deterministic prefixes and accurate dropped-entry counts.

--- a/.changeset/bounded-trace-budget.md
+++ b/.changeset/bounded-trace-budget.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Bounds evaluation traces by serialized UTF-8 bytes while preserving deterministic prefixes and dropped-entry counts.

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -66,6 +66,7 @@ export {evaluatePlannedPredicateAtSite} from './plan/evaluate-planned-predicate.
 export {
   capTraceEntries,
   capTraceValue,
+  EVALUATION_TRACE_MAX_BYTES,
   EVALUATION_TRACE_MAX_ENTRIES,
   EVALUATION_TRACE_VALUE_CAP_BYTES,
   type EvaluationTraceEntry,

--- a/libs/shared/expression/src/plan/evaluation-trace.test.ts
+++ b/libs/shared/expression/src/plan/evaluation-trace.test.ts
@@ -1,12 +1,16 @@
 import {
   capTraceEntries,
   capTraceValue,
+  EVALUATION_TRACE_MAX_BYTES,
   EVALUATION_TRACE_MAX_ENTRIES,
   EVALUATION_TRACE_VALUE_CAP_BYTES,
   evaluationTraceEntry,
 } from './evaluation-trace.js';
 
 describe('evaluation trace', () => {
+  const serializedByteLength = (value: unknown) =>
+    new TextEncoder().encode(JSON.stringify(value)).byteLength;
+
   it('caps values by UTF-8 bytes with an explicit marker', () => {
     const result = capTraceValue('x'.repeat(EVALUATION_TRACE_VALUE_CAP_BYTES + 1));
 
@@ -63,6 +67,77 @@ describe('evaluation trace', () => {
 
     expect(capped).toHaveLength(EVALUATION_TRACE_MAX_ENTRIES);
     expect(capped.at(-1)).toEqual({truncated: true, dropped: 3});
+  });
+
+  it('bounds the serialized trace and counts byte-dropped entries', () => {
+    const entries = Array.from({length: EVALUATION_TRACE_MAX_ENTRIES}, (_, index) =>
+      evaluationTraceEntry({
+        expression: `run.value_${index}`,
+        roots: ['run'],
+        fillTarget: 'run-creation',
+        evaluatedAt: 'run-creation',
+        value: 'é'.repeat(EVALUATION_TRACE_VALUE_CAP_BYTES),
+      }),
+    );
+
+    const capped = capTraceEntries(entries);
+
+    expect(serializedByteLength(capped)).toBeLessThanOrEqual(EVALUATION_TRACE_MAX_BYTES);
+    expect(capped.slice(0, -1)).toEqual(entries.slice(0, capped.length - 1));
+    expect(capTraceEntries(entries)).toEqual(capped);
+    expect(capped.at(-1)).toEqual({
+      truncated: true,
+      dropped: entries.length - capped.length + 1,
+    });
+  });
+
+  it('retains an entry at the exact serialized byte boundary', () => {
+    const entry = evaluationTraceEntry({
+      expression: 'run.exact',
+      roots: ['run'],
+      fillTarget: 'run-creation',
+      evaluatedAt: 'run-creation',
+      value: 'é',
+    });
+    const exactBudget = serializedByteLength([entry]);
+
+    const capped = capTraceEntries([entry], exactBudget);
+
+    expect(capped).toEqual([entry]);
+    expect(serializedByteLength(capped)).toBe(exactBudget);
+  });
+
+  it('uses UTF-8 bytes and preserves the omitted count with a dropped marker', () => {
+    const entries = [
+      evaluationTraceEntry({
+        expression: 'run.first_é',
+        roots: ['run'],
+        fillTarget: 'run-creation',
+        evaluatedAt: 'run-creation',
+        value: 'é',
+      }),
+      evaluationTraceEntry({
+        expression: 'run.second',
+        roots: ['run'],
+        fillTarget: 'run-creation',
+        evaluatedAt: 'run-creation',
+        value: 'second',
+      }),
+      evaluationTraceEntry({
+        expression: 'run.third',
+        roots: ['run'],
+        fillTarget: 'run-creation',
+        evaluatedAt: 'run-creation',
+        value: 'third',
+      }),
+    ];
+    const droppedMarker = {truncated: true as const, dropped: 6};
+    const exactBudget = serializedByteLength([entries[0], droppedMarker]);
+
+    const capped = capTraceEntries([...entries, {truncated: true, dropped: 4}], exactBudget);
+
+    expect(capped).toEqual([entries[0], droppedMarker]);
+    expect(serializedByteLength(capped)).toBe(exactBudget);
   });
 
   it('absorbs existing dropped markers when capping again', () => {

--- a/libs/shared/expression/src/plan/evaluation-trace.ts
+++ b/libs/shared/expression/src/plan/evaluation-trace.ts
@@ -3,6 +3,7 @@ import type {RoutedExpression} from './route-expression.js';
 
 export const EVALUATION_TRACE_VALUE_CAP_BYTES = 1024;
 export const EVALUATION_TRACE_MAX_ENTRIES = 256;
+export const EVALUATION_TRACE_MAX_BYTES = 64 * 1024;
 
 const TRACE_TRUNCATION_MARKER = '...[truncated]';
 const textEncoder = new TextEncoder();
@@ -93,10 +94,16 @@ export function predicateTraceEntry(input: PredicateTraceEntryInput): Evaluation
   });
 }
 
+/**
+ * Keeps the largest deterministic prefix that fits the entry and serialized UTF-8 byte limits.
+ * Existing dropped markers are folded into the final marker so repeated capping remains idempotent.
+ */
 export function capTraceEntries<Entry extends EvaluationTraceRowEntry>(
   entries: readonly Entry[],
+  maxBytes = EVALUATION_TRACE_MAX_BYTES,
 ): readonly (Exclude<Entry, EvaluationTraceLimitEntry> | EvaluationTraceLimitEntry)[] {
   const traceEntries: Exclude<Entry, EvaluationTraceLimitEntry>[] = [];
+  const traceEntryBytes: number[] = [];
   let dropped = 0;
 
   for (const entry of entries) {
@@ -106,17 +113,54 @@ export function capTraceEntries<Entry extends EvaluationTraceRowEntry>(
     }
 
     traceEntries.push(entry as Exclude<Entry, EvaluationTraceLimitEntry>);
+    traceEntryBytes.push(serializedJsonByteLength(entry));
   }
+
+  let traceBytes = 2;
+  for (const entryBytes of traceEntryBytes) {
+    traceBytes = appendSerializedEntryBytes(traceBytes, entryBytes);
+  }
+
+  const noMarkerFits =
+    dropped === 0 && traceEntries.length <= EVALUATION_TRACE_MAX_ENTRIES && traceBytes <= maxBytes;
+  if (noMarkerFits) return traceEntries;
 
   const keepCount = EVALUATION_TRACE_MAX_ENTRIES - 1;
-  if (traceEntries.length + (dropped > 0 ? 1 : 0) <= EVALUATION_TRACE_MAX_ENTRIES) {
-    return dropped === 0 ? traceEntries : [...traceEntries, {truncated: true, dropped}];
+  const retained: Exclude<Entry, EvaluationTraceLimitEntry>[] = [];
+  let retainedBytes = 2;
+  for (let index = 0; index < Math.min(keepCount, traceEntries.length); index += 1) {
+    const entry = traceEntries[index];
+    const entryBytes = traceEntryBytes[index];
+    if (entry === undefined || entryBytes === undefined) break;
+
+    const candidateBytes = appendSerializedEntryBytes(retainedBytes, entryBytes);
+    const candidateDropped = dropped + traceEntries.length - (index + 1);
+    if (traceWithDroppedMarkerBytes(candidateBytes, candidateDropped) > maxBytes) break;
+
+    retained.push(entry);
+    retainedBytes = candidateBytes;
   }
 
-  return [
-    ...traceEntries.slice(0, keepCount),
-    {truncated: true, dropped: dropped + traceEntries.length - keepCount},
-  ];
+  dropped += traceEntries.length - retained.length;
+  if (traceWithDroppedMarkerBytes(retainedBytes, dropped) > maxBytes) return [];
+
+  return [...retained, {truncated: true, dropped}];
+}
+
+function serializedJsonByteLength(value: unknown): number {
+  const serialized = JSON.stringify(value);
+  return textEncoder.encode(serialized ?? '').byteLength;
+}
+
+function appendSerializedEntryBytes(currentBytes: number, entryBytes: number): number {
+  return currentBytes + entryBytes + (currentBytes === 2 ? 0 : 1);
+}
+
+function traceWithDroppedMarkerBytes(prefixBytes: number, dropped: number): number {
+  return appendSerializedEntryBytes(
+    prefixBytes,
+    serializedJsonByteLength({truncated: true, dropped}),
+  );
 }
 
 function isEvaluationTraceLimitEntry(


### PR DESCRIPTION
Workflow evaluation traces could satisfy the per-entry and entry-count limits while still exceeding the observation budget. This keeps trace construction within the 64 KiB serialized UTF-8 ceiling, preserving deterministic prefixes and omitted-entry accounting across repeated capping.

Closes ENG-1969

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds workflow evaluation traces by serialized byte size so they stay within the 64 KiB observation budget. Previously, traces could satisfy per-entry and entry-count limits yet still exceed the budget; now capping also enforces a serialized UTF-8 ceiling, keeping deterministic prefixes and correct dropped-entry counts.

Closes ENG-1969

<sup>Written for commit 55671332c5462139d91f1056aa021fff6e0ad4bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

