### PR TITLE
feat(github): add pull request comment tool

### DIFF
--- a/.changeset/pr-conversation-comment-tool.md
+++ b/.changeset/pr-conversation-comment-tool.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-integration-github': minor
+---
+
+Add a dedicated pull request conversation comment tool that requests pull request write access.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -118,6 +118,13 @@ const expectedCatalogRows = [
     requiredScope: [{permission: 'pull_requests', access: 'write'}],
   },
   {
+    id: 'add_pull_request_comment',
+    category: 'pull_requests',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: [{permission: 'pull_requests', access: 'write'}],
+  },
+  {
     id: 'create_commit',
     category: 'repository',
     sensitivity: 'write',
@@ -422,6 +429,11 @@ const githubOperationRouteCases = [
     toolId: 'create_pull_request',
     args: {},
     expectedRoute: 'POST /repos/{owner}/{repo}/pulls',
+  },
+  {
+    toolId: 'add_pull_request_comment',
+    args: {pull_number: 1, body: 'Comment'},
+    expectedRoute: 'POST /repos/{owner}/{repo}/issues/{pull_number}/comments',
   },
   {
     toolId: 'create_commit',
@@ -792,6 +804,7 @@ describe('github agent tool catalog', () => {
   it('keeps reviewed input constraints aligned with GitHub operations', () => {
     const listIssueTypesSchema = inputSchemaFor('list_issue_types');
     const addIssueCommentSchema = inputSchemaFor('add_issue_comment');
+    const addPullRequestCommentSchema = inputSchemaFor('add_pull_request_comment');
     const updatePullRequestSchema = inputSchemaFor('update_pull_request');
     const addReplySchema = inputSchemaFor('add_reply_to_pull_request_comment');
     const pullRequestReadSchema = inputSchemaFor('pull_request_read');
@@ -814,6 +827,7 @@ describe('github agent tool catalog', () => {
       {required: ['issue_number', 'reaction']},
       {required: ['comment_id', 'reaction']},
     ]);
+    expect(addPullRequestCommentSchema.required).toEqual(['owner', 'repo', 'pull_number', 'body']);
     expect(addReplySchema.anyOf).toEqual([
       {required: ['pull_number', 'body']},
       {required: ['reaction']},
@@ -2215,6 +2229,97 @@ describe('github agent tool catalog', () => {
     expect(result).toEqual({
       content: [{type: 'text', text: '{"id":7}'}],
       structuredContent: {id: 7},
+    });
+  });
+
+  it('posts a pull request conversation comment with pull request write permission', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {id: 8}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {pull_requests: 'write' as const},
+      }),
+    );
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+    const tool = githubAgentToolCatalog.find((entry) => entry.id === 'add_pull_request_comment');
+    if (!tool) throw new Error('Missing add_pull_request_comment tool');
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [tool],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'add_pull_request_comment',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 1,
+        body: 'Comment',
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/issues/{pull_number}/comments',
+      {owner: 'shipfox', repo: 'platform', pull_number: 1, body: 'Comment'},
+    );
+    expect(result).toEqual({
+      content: [{type: 'text', text: '{"id":8}'}],
+      structuredContent: {id: 8},
+    });
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
+      pull_requests: 'write',
+    });
+  });
+
+  it('rejects a pull request conversation comment without pull request write permission', async () => {
+    const request = vi.fn();
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {
+        getInstallationAccessToken: vi.fn(() =>
+          Promise.resolve({
+            token: 'installation-token',
+            expiresAt: new Date(),
+            permissions: {issues: 'write' as const},
+          }),
+        ),
+      },
+      createClient: vi.fn(() => ({request})),
+    });
+    const tool = githubAgentToolCatalog.find((entry) => entry.id === 'add_pull_request_comment');
+    if (!tool) throw new Error('Missing add_pull_request_comment tool');
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [tool],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'add_pull_request_comment',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 1,
+        body: 'Comment',
+      },
+    });
+
+    expect(request).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'GitHub installation token is missing permission for this operation: add_pull_request_comment requires pull_requests: write',
+        },
+      ],
+      structuredContent: {code: 'access-denied'},
     });
   });
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -502,6 +502,8 @@ export function githubOperationRoute(
       return 'GET /search/issues';
     case 'create_pull_request.':
       return `POST ${repoPath}/pulls`;
+    case 'add_pull_request_comment.':
+      return `POST ${repoPath}/issues/${pull}/comments`;
     case 'create_commit.':
       return GITHUB_GRAPHQL_ROUTE;
     case 'create_branch.':

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -498,7 +498,7 @@ export const githubAgentToolCatalog = [
     id: 'add_issue_comment',
     category: 'issues',
     description:
-      'Add a comment and/or reaction to a specific issue or issue comment in a GitHub repository. Use this tool with pull requests as well, but only if the user is not asking specifically to add or react to review comments. At least one of body or reaction is required.',
+      'Add a comment and/or reaction to a specific issue or issue comment in a GitHub repository. For pull request conversation comments, use add_pull_request_comment. At least one of body or reaction is required.',
     sensitivity: 'write',
     sensitive: false,
     requiredScope: scopes.issuesWrite,
@@ -701,6 +701,23 @@ export const githubAgentToolCatalog = [
     outputSchema: objectSchema({pull_request: openObjectSchema('Created GitHub pull request')}, [
       'pull_request',
     ]),
+  }),
+  tool({
+    id: 'add_pull_request_comment',
+    category: 'pull_requests',
+    description:
+      'Add a conversation comment to a pull request. This does not create an inline review comment or reply to a review comment.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: scopes.pullRequestsWrite,
+    inputSchema: repositoryInputSchema(
+      {
+        pull_number: integerSchema('Pull request number'),
+        body: stringSchema('Comment content'),
+      },
+      ['pull_number', 'body'],
+    ),
+    outputSchema: openObjectSchema('Created pull request conversation comment'),
   }),
   tool({
     id: 'create_commit',


### PR DESCRIPTION
## Summary

- add a dedicated `add_pull_request_comment` tool for pull request conversation comments
- request `pull_requests: write` for that tool while keeping issue comments scoped to `issues: write`
- cover the catalog, route, input schema, token profile, successful call, and missing-permission rejection
- guide agents away from using `add_issue_comment` for pull requests

## Why

`add_issue_comment` currently accepts both issues and pull requests but always derives an `issues: write` installation-token profile. GitHub accepts either Issues or Pull requests write permission for the shared REST endpoint, but the resource-ambiguous tool makes permission behavior unclear. A dedicated pull request conversation tool keeps the selector and token authority aligned without granting pull request write access to issue-only workflows.

## Validation

- `pnpm --filter @shipfox/api-integration-github check`
- `pnpm --filter @shipfox/api-integration-github type`
- `pnpm --filter @shipfox/api-integration-github build`
- `pnpm --filter @shipfox/api-integration-github depcruise`
- isolated `src/core/agent-tools.test.ts`: 176 tests passed
- `pnpm --filter @shipfox/docs test`

The broader dependency test graph was also attempted; it reached an unrelated local PostgreSQL prerequisite (`role "shipfox" does not exist`). CI remains the full database-backed verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated `add_pull_request_comment` tool so pull request conversation comments request `pull_requests: write` access instead of reusing `add_issue_comment`, which always derived `issues: write`. This keeps the tool selector and installation token authority aligned without granting pull request write access to issue-only workflows.

- `add_issue_comment` no longer advertises itself for pull requests; its description now directs agents to the new tool.
- Adds the catalog entry, route, input schema, and tests for the new tool, including the missing-permission rejection.

<sup>Written for commit 5aeb1ae807a180fb589b35fe2cdb41a0dadf6aca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

