### PR TITLE
[@shipfox/api-integration-core] Preserve tool errors with output schemas

### DIFF
--- a/.changeset/mcp-error-schema.md
+++ b/.changeset/mcp-error-schema.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Allows integration tool errors to satisfy declared MCP output schemas.

--- a/libs/api/integration/core/src/core/tool-call-service.ts
+++ b/libs/api/integration/core/src/core/tool-call-service.ts
@@ -640,13 +640,13 @@ const credentialErrorNamePattern = /Token|Credential|Secret|AccessToken/;
 
 function errorResult(error: unknown): IntegrationToolCallError {
   if (error instanceof IntegrationProviderError) {
+    const retryAfterSeconds = retryAfterSecondsValue(error.retryAfterSeconds);
+    const status = statusCode(error.status);
     return {
       code: error.reason,
       message: error.message,
-      ...(error.retryAfterSeconds === undefined
-        ? {}
-        : {retryAfterSeconds: error.retryAfterSeconds}),
-      ...(error.status === undefined ? {} : {status: error.status}),
+      ...(retryAfterSeconds === undefined ? {} : {retryAfterSeconds}),
+      ...(status === undefined ? {} : {status}),
     };
   }
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
@@ -240,7 +240,7 @@ describe('agent tools gateway route', () => {
     const providerError = new IntegrationProviderError(
       'provider-rejected',
       'commit_id is missing',
-      undefined,
+      30,
       422,
     );
     const app = await createGatewayApp({
@@ -283,7 +283,35 @@ describe('agent tools gateway route', () => {
     expect(result).toEqual({
       isError: true,
       content: [{type: 'text', text: 'commit_id is missing'}],
-      structuredContent: {code: 'provider-rejected', status: 422},
+      structuredContent: {code: 'provider-rejected', retryAfterSeconds: 30, status: 422},
+    });
+  });
+
+  it('omits invalid provider retry hints before MCP validation', async () => {
+    const lease = leaseContext({workspaceId: 'workspace-1'});
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    leases.set('invalid-retry-lease', lease);
+    const providerError = new IntegrationProviderError('rate-limited', 'Try again later', -1, 429);
+    const app = await createGatewayApp({
+      registry: registryWithAgentTools([catalogTool()], {callError: providerError}),
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([integration])},
+      }),
+      getIntegrationConnectionById: async () =>
+        connection({
+          id: integration.connectionId,
+          workspaceId: lease.workspaceId,
+          slug: integration.connectionSlug,
+        }),
+    });
+
+    const result = await callIssueReadTool(app, 'invalid-retry-lease');
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Try again later'}],
+      structuredContent: {code: 'rate-limited', status: 429},
     });
   });
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
@@ -125,6 +125,10 @@ describe('agent tools gateway route', () => {
     await client.close();
 
     expect(tools.tools.map((tool) => tool.name)).toEqual(['github_main__issue_read']);
+    expect(tools.tools[0]?.outputSchema).toMatchObject({
+      type: 'object',
+      anyOf: expect.any(Array),
+    });
     expect(result.isError).not.toBe(true);
     expect(result.structuredContent).toMatchObject({
       status: 'dispatched',
@@ -182,6 +186,7 @@ describe('agent tools gateway route', () => {
     );
 
     await client.connect(transport as unknown as Transport);
+    await client.listTools();
     const result = await client.callTool(
       {
         name: 'github_main__issue_read',
@@ -265,6 +270,7 @@ describe('agent tools gateway route', () => {
     );
 
     await client.connect(transport as unknown as Transport);
+    await client.listTools();
     const result = await client.callTool(
       {
         name: 'github_main__issue_read',
@@ -312,6 +318,7 @@ describe('agent tools gateway route', () => {
     );
 
     await client.connect(transport as unknown as Transport);
+    await client.listTools();
     const result = await client.callTool(
       {
         name: 'github_main__issue_read',
@@ -365,6 +372,7 @@ async function callIssueReadTool(app: FastifyInstance, leaseToken: string) {
   );
 
   await client.connect(transport as unknown as Transport);
+  await client.listTools();
   const result = await client.callTool(
     {
       name: 'github_main__issue_read',

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -1,6 +1,12 @@
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
 import {CallToolResultSchema} from '@modelcontextprotocol/sdk/types.js';
+import {giteaAgentToolCatalog} from '@shipfox/api-integration-gitea';
+import {githubAgentToolCatalog} from '@shipfox/api-integration-github';
+import {jiraAgentToolCatalog} from '@shipfox/api-integration-jira';
+import {linearAgentToolCatalog} from '@shipfox/api-integration-linear';
+import {slackAgentToolCatalog} from '@shipfox/api-integration-slack';
+import type {AgentToolCatalogEntry, AgentToolJsonSchema} from '@shipfox/api-integration-spi';
 import {INVALID_METHOD_LABEL, NO_METHOD_LABEL} from '#core/tool-call-audit.js';
 import {
   catalogTool,
@@ -13,7 +19,10 @@ import {
 } from '#test/agent-tools-gateway-helpers.js';
 import {createIntegrationToolDispatcher} from './dispatch.js';
 import {buildAgentToolsMcpServer, type IntegrationToolDispatchInput} from './mcp-server.js';
-import type {AuthorizedIntegrationToolMap} from './resolve-authorized-tools.js';
+import type {
+  AuthorizedIntegrationTool,
+  AuthorizedIntegrationToolMap,
+} from './resolve-authorized-tools.js';
 
 describe('buildAgentToolsMcpServer', () => {
   it('lists namespaced tools and dispatches authorized method-family calls', async () => {
@@ -332,6 +341,104 @@ describe('buildAgentToolsMcpServer', () => {
       },
     ]);
   });
+
+  it('passes structured errors through the SDK for tools with output schemas', async () => {
+    const authorizedTools = defaultAuthorizedTools();
+    const authorizedTool = authorizedTools.get('github_main__issue_read');
+    if (!authorizedTool) throw new Error('Expected default authorized tool');
+    authorizedTools.set('github_main__issue_read', {
+      ...authorizedTool,
+      outputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {issue: {type: 'string'}},
+        required: ['issue'],
+      },
+    });
+    const dispatch = vi.fn(async () => ({
+      isError: true,
+      content: [{type: 'text' as const, text: 'commit_id is missing'}],
+      structuredContent: {code: 'provider-rejected', status: 422},
+    }));
+    const {client, close} = await connectClient(dispatch, authorizedTools);
+
+    const tools = await client.listTools();
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      },
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(tools.tools[0]?.outputSchema).toMatchObject({
+      type: 'object',
+      anyOf: expect.any(Array),
+    });
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'commit_id is missing'}],
+      structuredContent: {code: 'provider-rejected', status: 422},
+    });
+  });
+
+  it('accepts success and structured error projections for every declared provider output schema', async () => {
+    const catalogTools = declaredOutputSchemaTools();
+    expect(catalogTools.length).toBeGreaterThan(0);
+    const authorizedTools = new Map(
+      catalogTools.map(
+        ({mcpName, provider, entry}, index) =>
+          [mcpName, authorizedToolForCatalog(mcpName, provider, entry, index)] as const,
+      ),
+    );
+    const results = new Map<string, ReturnType<typeof toolResult>>();
+    const dispatch = vi.fn((input: IntegrationToolDispatchInput) => {
+      const result = results.get(input.authorizedTool.mcpName);
+      if (!result) throw new Error(`Missing fixture for ${input.authorizedTool.mcpName}`);
+      return Promise.resolve(result);
+    });
+    const {client, close} = await connectClient(dispatch, authorizedTools);
+
+    const tools = await client.listTools();
+    expect(tools.tools).toHaveLength(catalogTools.length);
+
+    for (const {mcpName, entry} of catalogTools) {
+      const arguments_ = toolArguments(entry);
+      const success = structuredContentFixture(entry.outputSchema);
+      results.set(mcpName, toolResult(success));
+
+      const listedTool = tools.tools.find((tool) => tool.name === mcpName);
+      expect(listedTool?.outputSchema).toEqual(
+        expect.objectContaining({
+          type: 'object',
+          anyOf: expect.arrayContaining([entry.outputSchema]),
+        }),
+      );
+
+      const successResult = await client.callTool(
+        {name: mcpName, arguments: arguments_},
+        CallToolResultSchema,
+      );
+      expect(successResult).toMatchObject({structuredContent: success});
+
+      for (const error of [
+        {code: 'provider-rejected'},
+        {code: 'provider-rejected', status: 422},
+        {code: 'provider-timeout', status: 503, retryAfterSeconds: 3},
+      ]) {
+        results.set(mcpName, toolResult(error, true));
+
+        const errorResult = await client.callTool(
+          {name: mcpName, arguments: arguments_},
+          CallToolResultSchema,
+        );
+        expect(errorResult).toMatchObject({isError: true, structuredContent: error});
+      }
+    }
+
+    await close();
+  });
 });
 
 async function connectClient(
@@ -408,4 +515,163 @@ function standaloneTools(): AuthorizedIntegrationToolMap {
       },
     ],
   ]);
+}
+
+type DeclaredOutputSchemaTool = {
+  provider: string;
+  entry: AgentToolCatalogEntry & {outputSchema: AgentToolJsonSchema};
+  mcpName: string;
+};
+
+function declaredOutputSchemaTools(): DeclaredOutputSchemaTool[] {
+  const providerCatalogs: Array<[string, readonly AgentToolCatalogEntry[]]> = [
+    ['gitea', giteaAgentToolCatalog],
+    ['github', githubAgentToolCatalog],
+    ['jira', jiraAgentToolCatalog],
+    ['linear', linearAgentToolCatalog],
+    ['slack', slackAgentToolCatalog],
+  ];
+  return providerCatalogs.flatMap(([provider, catalog]) =>
+    catalog.filter(hasOutputSchema).map((entry) => ({
+      provider,
+      entry,
+      mcpName: `${provider}__${entry.id}`,
+    })),
+  );
+}
+
+function hasOutputSchema(
+  entry: AgentToolCatalogEntry,
+): entry is AgentToolCatalogEntry & {outputSchema: AgentToolJsonSchema} {
+  return entry.outputSchema !== undefined;
+}
+
+function authorizedToolForCatalog(
+  mcpName: string,
+  provider: string,
+  entry: AgentToolCatalogEntry,
+  index: number,
+): AuthorizedIntegrationTool {
+  const tool = materializedTool({
+    id: entry.id,
+    sensitivity: entry.sensitivity,
+    sensitive: entry.sensitive,
+    requiredScope: Array.isArray(entry.requiredScope) ? entry.requiredScope : [entry.requiredScope],
+    inputSchema: entry.inputSchema,
+    outputSchema: entry.outputSchema,
+    methods: entry.methods?.map((method) => ({
+      id: method.id,
+      token: `${entry.id}.${method.id}`,
+      description: method.description,
+      sensitivity: method.sensitivity,
+      sensitive: method.sensitive,
+      requiredScope: Array.isArray(method.requiredScope)
+        ? method.requiredScope
+        : [method.requiredScope],
+    })),
+  });
+  const connectionId = `connection-${provider}-${index}`;
+  const connectionSlug = `${provider}-${index}`;
+  const integration = materializedIntegration({
+    connectionId,
+    connectionSlug,
+    provider,
+    tools: [tool],
+  });
+
+  return {
+    mcpName,
+    integration,
+    tool,
+    connection: connection({id: connectionId, provider, slug: connectionSlug}),
+    description: entry.description,
+    inputSchema: entry.inputSchema,
+    outputSchema: entry.outputSchema,
+    catalogEntry: entry,
+  };
+}
+
+function toolArguments(entry: AgentToolCatalogEntry): Record<string, unknown> {
+  const method = entry.methods?.[0]?.id;
+  return method === undefined ? {} : {method};
+}
+
+function structuredContentFixture(schema: Record<string, unknown>): Record<string, unknown> {
+  const fixture = valueFixture(schema);
+  if (!isRecord(fixture)) throw new Error('Expected an object output schema fixture');
+  return fixture;
+}
+
+function valueFixture(schema: Record<string, unknown>): unknown {
+  const literal = schemaLiteral(schema);
+  if (literal !== undefined) return literal.value;
+
+  const branch = schemaBranch(schema);
+  if (branch) return valueFixture(branch);
+
+  switch (schema.type) {
+    case 'object':
+      return objectFixture(schema);
+    case 'array':
+      return [];
+    case 'boolean':
+      return true;
+    case 'integer':
+    case 'number':
+      return 1;
+    case 'string':
+      return 'fixture';
+    case 'null':
+      return null;
+    default:
+      return {};
+  }
+}
+
+function schemaLiteral(schema: Record<string, unknown>): {value: unknown} | undefined {
+  if (Object.hasOwn(schema, 'const')) return {value: schema.const};
+
+  const enumValues = schema.enum;
+  return Array.isArray(enumValues) && enumValues.length > 0 ? {value: enumValues[0]} : undefined;
+}
+
+function schemaBranch(schema: Record<string, unknown>): Record<string, unknown> | undefined {
+  for (const keyword of ['anyOf', 'oneOf'] as const) {
+    const branches = schema[keyword];
+    const firstBranch = Array.isArray(branches) ? branches.find(isRecord) : undefined;
+    if (firstBranch) return firstBranch;
+  }
+  return undefined;
+}
+
+function objectFixture(schema: Record<string, unknown>): Record<string, unknown> {
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((name): name is string => typeof name === 'string')
+    : [];
+  return Object.fromEntries(
+    required.map((name) => [
+      name,
+      valueFixture(isRecord(properties[name]) ? properties[name] : {}),
+    ]),
+  );
+}
+
+function toolResult(
+  structuredContent: Record<string, unknown>,
+  isError = false,
+): {
+  isError?: true;
+  content: [{type: 'text'; text: string}];
+  structuredContent: Record<string, unknown>;
+} {
+  return {
+    ...(isError ? {isError: true as const} : {}),
+    content: [{type: 'text', text: JSON.stringify(structuredContent)}],
+    structuredContent,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -383,6 +383,103 @@ describe('buildAgentToolsMcpServer', () => {
     });
   });
 
+  it('keeps output schema references rooted when adding an error branch', async () => {
+    const authorizedTools = defaultAuthorizedTools();
+    const authorizedTool = authorizedTools.get('github_main__issue_read');
+    if (!authorizedTool) throw new Error('Expected default authorized tool');
+    const outputSchema = {
+      $id: 'urn:shipfox:integration-tool-output',
+      $defs: {
+        issue: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {id: {type: 'string'}},
+          required: ['id'],
+        },
+      },
+      type: 'object',
+      additionalProperties: false,
+      properties: {issue: {$ref: '#/$defs/issue'}},
+      required: ['issue'],
+    };
+    authorizedTools.set('github_main__issue_read', {
+      ...authorizedTool,
+      outputSchema,
+    });
+    const dispatch = vi.fn(async () => ({
+      content: [{type: 'text' as const, text: 'issue returned'}],
+      structuredContent: {issue: {id: 'issue-1'}},
+    }));
+    const {client, close} = await connectClient(dispatch, authorizedTools);
+
+    const tools = await client.listTools();
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      },
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(tools.tools[0]?.outputSchema).toEqual(
+      expect.objectContaining({
+        $id: outputSchema.$id,
+        $defs: outputSchema.$defs,
+        anyOf: expect.arrayContaining([
+          expect.objectContaining({
+            properties: outputSchema.properties,
+            required: outputSchema.required,
+          }),
+        ]),
+      }),
+    );
+    expect(result).toMatchObject({structuredContent: {issue: {id: 'issue-1'}}});
+  });
+
+  it('validates error projections emitted by the integration dispatcher', async () => {
+    const entry = catalogTool();
+    const mcpName = 'github_main__issue_read';
+    const authorizedTool = authorizedToolForCatalog(mcpName, 'github', entry, 0);
+    const errorCases = [
+      {
+        providerResult: toolResult({code: 'provider-rejected'}, true),
+        expected: {code: 'provider-rejected'},
+      },
+      {
+        providerResult: toolResult({code: 'provider-rejected', status: 422}, true),
+        expected: {code: 'provider-rejected', status: 422},
+      },
+      {
+        providerResult: toolResult(
+          {code: 'provider-timeout', status: 503, retryAfterSeconds: 3},
+          true,
+        ),
+        expected: {code: 'provider-timeout', status: 503, retryAfterSeconds: 3},
+      },
+    ];
+
+    for (const {providerResult, expected} of errorCases) {
+      const dispatch = createIntegrationToolDispatcher({
+        registry: registryWithAgentTools([entry], {result: providerResult}),
+        lease: leaseContext({workspaceId: 'workspace-1'}),
+      });
+      const {client, close} = await connectClient(dispatch, new Map([[mcpName, authorizedTool]]));
+
+      await client.listTools();
+      const result = await client.callTool(
+        {
+          name: mcpName,
+          arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+        },
+        CallToolResultSchema,
+      );
+      await close();
+
+      expect(result).toMatchObject({isError: true, structuredContent: expected});
+    }
+  });
+
   it('accepts success and structured error projections for every declared provider output schema', async () => {
     const catalogTools = declaredOutputSchemaTools();
     expect(catalogTools.length).toBeGreaterThan(0);

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -54,6 +54,7 @@ const integrationToolErrorOutputSchema = {
   },
   required: ['code'],
 } as const;
+const outputSchemaRootKeywords = ['$defs', 'definitions', '$id', '$schema'] as const;
 
 export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams): Server {
   const server = new Server(
@@ -168,9 +169,19 @@ function outputSchemaWithIntegrationToolError(
   outputSchema: Record<string, unknown>,
 ): Record<string, unknown> {
   // MCP clients validate structuredContent even when the tool result is an error.
+  const rootSchemaKeywords = Object.fromEntries(
+    outputSchemaRootKeywords
+      .filter((keyword) => Object.hasOwn(outputSchema, keyword))
+      .map((keyword) => [keyword, outputSchema[keyword]]),
+  );
+  const successSchema = {...outputSchema};
+  for (const keyword of outputSchemaRootKeywords) {
+    delete successSchema[keyword];
+  }
   return {
+    ...rootSchemaKeywords,
     type: 'object',
-    anyOf: [outputSchema, integrationToolErrorOutputSchema],
+    anyOf: [successSchema, integrationToolErrorOutputSchema],
   };
 }
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -43,6 +43,18 @@ export interface BuildAgentToolsMcpServerParams {
   recordCall?: IntegrationToolCallRecorder | undefined;
 }
 
+const integrationToolErrorOutputSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    code: {type: 'string'},
+    status: {type: 'integer', minimum: 100, maximum: 599},
+    retryAfterSeconds: {type: 'number', minimum: 0},
+    reason: {type: 'string'},
+  },
+  required: ['code'],
+} as const;
+
 export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams): Server {
   const server = new Server(
     {name: 'shipfox-integration-tools', version: '0.0.0'},
@@ -59,7 +71,7 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
       },
       ...(authorizedTool.outputSchema
         ? {
-            outputSchema: authorizedTool.outputSchema as {
+            outputSchema: outputSchemaWithIntegrationToolError(authorizedTool.outputSchema) as {
               type: 'object';
               properties?: Record<string, object> | undefined;
               required?: string[] | undefined;
@@ -150,6 +162,16 @@ function unpackDispatchResult(dispatched: CallToolResult | IntegrationToolDispat
     };
   }
   return {result: dispatched as CallToolResult};
+}
+
+function outputSchemaWithIntegrationToolError(
+  outputSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  // MCP clients validate structuredContent even when the tool result is an error.
+  return {
+    type: 'object',
+    anyOf: [outputSchema, integrationToolErrorOutputSchema],
+  };
 }
 
 function toolCallErrorDetails(result: CallToolResult): {

--- a/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
+++ b/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
@@ -131,7 +131,18 @@ export function catalogTool(overrides: Partial<AgentToolCatalogEntry> = {}): Age
     sensitive: false,
     requiredScope: [],
     inputSchema: {type: 'object', properties: {}, additionalProperties: false},
-    outputSchema: {type: 'object', additionalProperties: true},
+    outputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        status: {const: 'dispatched'},
+        provider: {type: 'string'},
+        connection_id: {type: 'string'},
+        tool_id: {type: 'string'},
+        method: {type: 'string'},
+      },
+      required: ['status', 'provider', 'connection_id', 'tool_id'],
+    },
     methods: [
       {
         id: 'get',


### PR DESCRIPTION
MCP clients validate structuredContent against cached tool output schemas even when isError is true. Strict integration success schemas therefore converted provider failures into MCP -32602 validation errors.

The gateway keeps each declared success schema strict and adds a bounded structured error projection. Provider messages and terminal codes remain unchanged. The SDK contract covers success and supported error projections across every provider catalog with a declared output schema.

Closes ENG-1937

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes integration tool errors being masked as MCP `-32602` validation errors for tools with declared output schemas. MCP clients validate `structuredContent` against the cached output schema even when `isError` is true, so strict success schemas rejected error shapes and provider failures surfaced as argument errors; the gateway now wraps declared output schemas in `anyOf` with a shared error schema, keeping success schemas strict and leaving provider messages and terminal codes unchanged. Closes ENG-1937.

**Bug Fixes**
- The shared error schema requires only `code` and accepts `status`, `retryAfterSeconds`, and the planned `reason`; root keywords like `$id` and `$defs` are preserved when the error branch is added.
- Invalid provider retry hints are dropped before MCP validation.
- Contract tests run success and every error projection through the SDK `Client` for all declared provider output schemas.

<sup>Written for commit df7fa574dc81e417c4c3adc00500f1944432a04f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

