### PR TITLE
[@shipfox/api-integration-github] Restore pull request comment permissions

### DIFF
--- a/.changeset/friendly-mice-comment.md
+++ b/.changeset/friendly-mice-comment.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/api-integration-github': patch
+---
+
+Restores GitHub pull request timeline comment publishing for scoped installation tokens.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -55,7 +55,10 @@ const expectedCatalogRows = [
     category: 'issues',
     sensitivity: 'write',
     sensitive: false,
-    requiredScope: [{permission: 'issues', access: 'write'}],
+    requiredScope: [
+      {permission: 'issues', access: 'write'},
+      {permission: 'pull_requests', access: 'write'},
+    ],
   },
   {
     id: 'issue_write',
@@ -1213,6 +1216,50 @@ describe('github agent tool catalog', () => {
     expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
       contents: 'write',
       issues: 'read',
+    });
+  });
+
+  it('requests issue and pull request write access for issue comments', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {id: 7}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {
+          issues: 'write' as const,
+          pull_requests: 'write' as const,
+        },
+      }),
+    );
+    const addIssueComment = githubAgentToolCatalog.find(
+      (entry) => entry.id === 'add_issue_comment',
+    );
+    if (!addIssueComment) throw new Error('Missing add_issue_comment tool');
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [addIssueComment],
+      scope: undefined,
+    });
+    const result = await session.call({
+      toolId: 'add_issue_comment',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        issue_number: 1,
+        body: 'Comment',
+      },
+    });
+
+    expect(result).toMatchObject({structuredContent: {id: 7}});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
+      issues: 'write',
+      pull_requests: 'write',
     });
   });
 

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -66,6 +66,10 @@ interface GithubAgentToolCatalogInput {
 const scopes = {
   issuesRead: [{permission: 'issues', access: 'read'}],
   issuesWrite: [{permission: 'issues', access: 'write'}],
+  issueAndPullRequestCommentsWrite: [
+    {permission: 'issues', access: 'write'},
+    {permission: 'pull_requests', access: 'write'},
+  ],
   pullRequestsRead: [{permission: 'pull_requests', access: 'read'}],
   pullRequestsWrite: [{permission: 'pull_requests', access: 'write'}],
   actionsRead: [{permission: 'actions', access: 'read'}],
@@ -501,7 +505,7 @@ export const githubAgentToolCatalog = [
       'Add a comment and/or reaction to a specific issue or issue comment in a GitHub repository. Use this tool with pull requests as well, but only if the user is not asking specifically to add or react to review comments. At least one of body or reaction is required.',
     sensitivity: 'write',
     sensitive: false,
-    requiredScope: scopes.issuesWrite,
+    requiredScope: scopes.issueAndPullRequestCommentsWrite,
     inputSchema: repositoryInputSchema(
       {
         issue_number: integerSchema('Issue or pull request number to comment on or react to'),


### PR DESCRIPTION
## Summary

- Request both issue and pull request write permissions when `add_issue_comment` is selected.
- Cover the derived installation-token profile with a regression test.
- Add a patch Changeset for the restored publishing behavior.

## Why

GitHub uses the same REST endpoint for issue and pull request timeline comments, but target authorization differs. The narrowed token profile only requested `issues: write`, so comments on pull requests failed with `403 Resource not accessible by integration`.

Keeping the existing tool ID restores previously supported pull request comments for existing workflows. #1649 proposes the narrower alternative of a dedicated pull request comment tool; reviewers can choose between backward compatibility here and separate target-specific tools there.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/api-integration-github...` (111 tasks passed)
- `mise exec -- pnpm changeset status`
- `mise exec -- git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub pull request timeline comments failing with `403 Resource not accessible by integration` for scoped installation tokens. The `add_issue_comment` tool now requests both `issues: write` and `pull_requests: write` because the timeline comment endpoint is shared between issues and pull requests, while previously only `issues: write` was requested.

- Adds a regression test asserting the installation-token profile includes both permissions.
- Adds a patch Changeset for the restored publishing behavior.

<sup>Written for commit 234670921738ea9d4034d1845e6486ecefe40cf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

