### PR TITLE
[docs] Standardize Shipfox product definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,19 @@
   <a href="CONTRIBUTING.md"><b>Contributing</b></a>
 </p>
 
-**The agent platform for engineering teams.**
+## Your AI software factory
 
-Shipfox turns engineering work into automated workflows built from AI agents and
-shell commands. Workflows live as YAML in your repository and react to events
-across your stack. Shipfox handles orchestration, secure tool access, isolated
-execution, and monitoring.
+**Shipfox is an AI software factory for engineering teams.**
+
+**Ship more work. Manage less of it.**
+
+Delegate recurring work across code, delivery, documentation, and operations.
+Shipfox keeps it moving with AI agents and brings your team in where human
+judgment matters.
+
+Workflows live as YAML in your repository and react to events across your stack.
+Shipfox handles orchestration, secure tool access, isolated execution, and
+monitoring.
 
 [Get your first workflow running now](https://www.shipfox.io/docs/getting-started).
 

--- a/apps/docs/WRITING.md
+++ b/apps/docs/WRITING.md
@@ -31,6 +31,32 @@ page. Split a page when its subject requires more than one reader mode.
 
 ## Product terminology
 
+### Product definition and workflows
+
+The canonical product category is **AI software factory**. Start every
+machine-facing Shipfox summary with this sentence:
+
+> Shipfox is an AI software factory for engineering teams.
+
+Keep the sentence unchanged across public metadata, structured data, and
+machine-readable summaries. Add surface-specific supporting detail after it.
+
+Use this product headline on public overview surfaces:
+
+> Your AI software factory
+
+Use this primary tagline with the headline:
+
+> Ship more work. Manage less of it.
+
+Use this supporting copy when the surface has room for the full pitch:
+
+> Delegate recurring work across code, delivery, documentation, and operations. Shipfox keeps it moving with AI agents and brings your team in where human judgment matters.
+
+Use **workflow** for the Shipfox concept. Use **pipeline** only when quoting or
+contrasting an external system, or when explaining that it is an informal
+synonym for workflow. Keep literal names from external systems unchanged.
+
 Use **integration connection** for the workspace resource created when an
 integration is connected. Do not use **connection** by itself for this resource,
 especially in titles, navigation, prerequisites, and other text that readers may
@@ -615,7 +641,6 @@ the reader to run it, and never let it appear to document shipped behavior.
   permits it.
 - Do not imply that separate jobs share a filesystem, process environment, logs,
   or undeclared results.
-- Use "workflow", never "pipeline" except when quoting another system.
 
 ## Page-type review checklist
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,14 +1,20 @@
 ---
 title: "Shipfox · Your AI Software Factory"
 sidebarTitle: "Home"
-description: "The agent platform for engineering teams. Define agents in git, trigger them on any event from your stack, and give them secure access to your tools and teammates."
+description: "Shipfox is an AI software factory for engineering teams. Delegate recurring work across code, delivery, documentation, and operations."
 ---
 
-## Agent platform for engineering teams
+## Your AI software factory
 
-Shipfox lets you automate real engineering work with agents you trust in production.
+**Ship more work. Manage less of it.**
 
-You describe what the agent does. Shipfox handles everything around it: orchestration, secure access to your tools, execution next to your code, monitoring, and central control.
+Delegate recurring work across code, delivery, documentation, and operations.
+Shipfox keeps it moving with AI agents and brings your team in where human
+judgment matters.
+
+You describe what each agent does. Shipfox handles everything around it:
+orchestration, secure access to your tools, execution next to your code,
+monitoring, and central control.
 
 Agents live in your repository as [YAML](/reference/workflow-schema). Copy this
 workflow into your repository, push it, then start it from the dashboard:

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -1,4 +1,9 @@
 import {canonicalDocsUrl} from '@/lib/machine-readable';
+import {
+  PRODUCT_DEFINITION,
+  PRODUCT_SUPPORTING_COPY,
+  PRODUCT_TAGLINE,
+} from '@/lib/product-definition';
 import {source} from '@/lib/source';
 
 export const revalidate = false;
@@ -87,7 +92,7 @@ export function GET() {
   const lines: string[] = [
     '# Shipfox Documentation',
     '',
-    '> Shipfox is a continuous shipping platform for engineering teams. Define YAML workflows in your repo, run shell and AI agent steps on your own runners, and trigger pipelines from GitHub, Sentry, and more.',
+    `> ${PRODUCT_DEFINITION} ${PRODUCT_TAGLINE} ${PRODUCT_SUPPORTING_COPY}`,
     '',
   ];
 

--- a/apps/docs/src/lib/product-definition.test.ts
+++ b/apps/docs/src/lib/product-definition.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import test from 'node:test';
+import {fileURLToPath} from 'node:url';
+import {getLLMText} from './get-llm-text';
+import {buildPageMetadata} from './page-metadata';
+import {
+  PRODUCT_CATEGORY,
+  PRODUCT_DEFINITION,
+  PRODUCT_HEADLINE,
+  PRODUCT_SUPPORTING_COPY,
+  PRODUCT_TAGLINE,
+} from './product-definition';
+
+const repositoryRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+const FIRST_SENTENCE_PATTERN = /^.*?\.(?:\s|$)/;
+const HOME_DESCRIPTION_PATTERN = /^description: "(.+)"$/m;
+const LLMS_PRODUCT_PITCH_PATTERN =
+  /\$\{PRODUCT_DEFINITION\} \$\{PRODUCT_TAGLINE\} \$\{PRODUCT_SUPPORTING_COPY\}/;
+type TestPage = Parameters<typeof getLLMText>[0];
+
+function firstSentence(value: string): string {
+  const sentence = value.match(FIRST_SENTENCE_PATTERN)?.[0].trim();
+  assert.ok(sentence, `Expected a complete first sentence in: ${value}`);
+  return sentence;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+test('keeps crawler-facing docs surfaces on the canonical product definition', async () => {
+  const [homeSource, llmsRoute] = await Promise.all([
+    readFile(`${repositoryRoot}/apps/docs/content/docs/index.mdx`, 'utf8'),
+    readFile(`${repositoryRoot}/apps/docs/src/app/llms.txt/route.ts`, 'utf8'),
+  ]);
+
+  const description = homeSource.match(HOME_DESCRIPTION_PATTERN)?.[1];
+  assert.ok(description);
+  assert.equal(firstSentence(description), PRODUCT_DEFINITION);
+  assert.ok(homeSource.includes(`## ${PRODUCT_HEADLINE}`));
+  assert.ok(homeSource.includes(`**${PRODUCT_TAGLINE}**`));
+  assert.ok(normalizeWhitespace(homeSource).includes(PRODUCT_SUPPORTING_COPY));
+
+  const metadata = buildPageMetadata({
+    url: '/',
+    data: {title: 'Shipfox', description},
+  });
+  assert.equal(firstSentence(String(metadata.description)), PRODUCT_DEFINITION);
+  assert.equal(firstSentence(String(metadata.openGraph?.description)), PRODUCT_DEFINITION);
+
+  assert.ok(llmsRoute.includes('PRODUCT_DEFINITION,'));
+  assert.ok(llmsRoute.includes('PRODUCT_TAGLINE,'));
+  assert.ok(llmsRoute.includes('PRODUCT_SUPPORTING_COPY,'));
+  assert.match(llmsRoute, LLMS_PRODUCT_PITCH_PATTERN);
+  assert.ok(!llmsRoute.includes('trigger pipelines'));
+
+  const homeMarkdown = await getLLMText({
+    url: '/',
+    data: {
+      title: 'Shipfox',
+      description,
+      getText: async () => 'Docs home',
+    },
+  } as unknown as TestPage);
+  assert.ok(homeMarkdown.includes(`Description: ${PRODUCT_DEFINITION}`));
+});
+
+test('records the canonical product pitch in the docs writing guide', async () => {
+  const writingGuide = await readFile(`${repositoryRoot}/apps/docs/WRITING.md`, 'utf8');
+
+  assert.ok(writingGuide.includes(`canonical product category is **${PRODUCT_CATEGORY}**`));
+  assert.ok(writingGuide.includes(`> ${PRODUCT_DEFINITION}`));
+  assert.ok(writingGuide.includes(`> ${PRODUCT_HEADLINE}`));
+  assert.ok(writingGuide.includes(`> ${PRODUCT_TAGLINE}`));
+  assert.ok(writingGuide.includes(`> ${PRODUCT_SUPPORTING_COPY}`));
+});

--- a/apps/docs/src/lib/product-definition.ts
+++ b/apps/docs/src/lib/product-definition.ts
@@ -1,0 +1,10 @@
+export const PRODUCT_CATEGORY = 'AI software factory';
+
+export const PRODUCT_DEFINITION = `Shipfox is an ${PRODUCT_CATEGORY} for engineering teams.`;
+
+export const PRODUCT_HEADLINE = 'Your AI software factory';
+
+export const PRODUCT_TAGLINE = 'Ship more work. Manage less of it.';
+
+export const PRODUCT_SUPPORTING_COPY =
+  'Delegate recurring work across code, delivery, documentation, and operations. Shipfox keeps it moving with AI agents and brings your team in where human judgment matters.';


### PR DESCRIPTION
## Summary

Standardize the Shipfox docs on one primary definition: "Shipfox is an AI software factory for engineering teams."

The docs homepage and public README pair that definition with the approved "Your AI software factory" headline, "Ship more work. Manage less of it." tagline, and supporting explanation. Metadata, machine-readable Markdown, and `llms.txt` now start from the same definition. The writing guide records the pitch and keeps `workflow` as the canonical Shipfox term, while deterministic coverage prevents the docs-owned surfaces from drifting.

This PR covers the `ShipfoxHQ/shipfox` side of ENG-1932. The Cloud landing metadata, structured data, hero tagline, root `llms.txt`, and discovery coverage remain for the companion `ShipfoxHQ/cloud` pull request.

## Validation

- `mise exec -- pnpm --dir apps/docs test`
- `mise exec -- pnpm --dir apps/docs check`
- `mise exec -- pnpm --dir apps/docs type`
- `mise exec -- turbo verify --filter=@shipfox/prose-policy`
- `mise exec -- git diff origin/main...HEAD --check`

Part of ENG-1932
