### PR TITLE
[api-workflows] Partition listener batches by serialized execution bytes

### DIFF
--- a/.changeset/bounded-listener-batches.md
+++ b/.changeset/bounded-listener-batches.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Partitions listener batches by serialized execution bytes and preserves pending tails.
+Accepts listener executions that fit the bounded execution payload limit and keeps overflow trigger events pending.

--- a/.changeset/bounded-listener-batches.md
+++ b/.changeset/bounded-listener-batches.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Partitions listener batches by serialized execution bytes and preserves pending tails.

--- a/libs/api/workflows/src/core/listener-event-batching.test.ts
+++ b/libs/api/workflows/src/core/listener-event-batching.test.ts
@@ -1,0 +1,53 @@
+import type {WorkflowExecutionEvent} from './entities/job-execution.js';
+import {
+  packListenerEventBatch,
+  serializedListenerEventsByteLength,
+} from './listener-event-batching.js';
+
+function event(data: unknown): WorkflowExecutionEvent {
+  return {
+    source: 'github',
+    event: 'push',
+    delivery_id: 'delivery-1',
+    received_at: '2026-01-01T00:00:00.000Z',
+    project: null,
+    repository: null,
+    ref: null,
+    commit: null,
+    data,
+  };
+}
+
+describe('packListenerEventBatch', () => {
+  test('returns the largest ordered prefix that fits the byte limit', () => {
+    const first = event({value: 'first'});
+    const second = event({value: 'second'});
+    const maxBytes = serializedListenerEventsByteLength([first]);
+
+    const result = packListenerEventBatch([first, second], {
+      countLimitReached: false,
+      maxBytes,
+    });
+
+    expect(result).toEqual({kind: 'selected', events: [first], partitionReason: 'byte_limit'});
+  });
+
+  test('reports a count partition when all count-limited rows fit', () => {
+    const result = packListenerEventBatch([event('first'), event('second')], {
+      countLimitReached: true,
+    });
+
+    expect(result).toMatchObject({kind: 'selected', partitionReason: 'count_limit'});
+  });
+
+  test('returns empty when the first event cannot fit', () => {
+    const first = event('first');
+
+    const result = packListenerEventBatch([first], {
+      countLimitReached: false,
+      maxBytes: serializedListenerEventsByteLength([]),
+    });
+
+    expect(result).toEqual({kind: 'empty', reason: 'byte_limit'});
+  });
+});

--- a/libs/api/workflows/src/core/listener-event-batching.ts
+++ b/libs/api/workflows/src/core/listener-event-batching.ts
@@ -1,0 +1,48 @@
+import {MAX_JSON_OUTPUT_BYTES} from '@shipfox/expression';
+import type {WorkflowExecutionEvent} from './entities/job-execution.js';
+
+/** Maximum UTF-8 bytes in the normalized trigger-event array sent to execution. */
+export const MAX_LISTENER_TRIGGER_EVENTS_BYTES = MAX_JSON_OUTPUT_BYTES;
+
+export type ListenerBatchPartitionReason = 'byte_limit' | 'count_limit';
+
+export type ListenerEventBatch =
+  | {readonly kind: 'empty'; readonly reason: 'byte_limit'}
+  | {
+      readonly kind: 'selected';
+      readonly events: readonly WorkflowExecutionEvent[];
+      readonly partitionReason?: ListenerBatchPartitionReason;
+    };
+
+export function packListenerEventBatch(
+  events: readonly WorkflowExecutionEvent[],
+  params: {readonly countLimitReached: boolean; readonly maxBytes?: number},
+): ListenerEventBatch {
+  const selected: WorkflowExecutionEvent[] = [];
+  const maxBytes = params.maxBytes ?? MAX_LISTENER_TRIGGER_EVENTS_BYTES;
+
+  for (const event of events) {
+    const candidate = [...selected, event];
+    if (serializedListenerEventsByteLength(candidate) > maxBytes) {
+      return selected.length === 0
+        ? {kind: 'empty', reason: 'byte_limit'}
+        : {kind: 'selected', events: selected, partitionReason: 'byte_limit'};
+    }
+    selected.push(event);
+  }
+
+  return {
+    kind: 'selected',
+    events: selected,
+    ...(params.countLimitReached ? {partitionReason: 'count_limit' as const} : {}),
+  };
+}
+
+export function serializedListenerEventsByteLength(
+  events: readonly WorkflowExecutionEvent[],
+): number {
+  const serialized = JSON.stringify(events);
+  return serialized === undefined
+    ? Number.POSITIVE_INFINITY
+    : Buffer.byteLength(serialized, 'utf8');
+}

--- a/libs/api/workflows/src/core/listener-event-batching.ts
+++ b/libs/api/workflows/src/core/listener-event-batching.ts
@@ -14,28 +14,71 @@ export type ListenerEventBatch =
       readonly partitionReason?: ListenerBatchPartitionReason;
     };
 
+export interface ListenerEventBatchPacker {
+  readonly events: readonly WorkflowExecutionEvent[];
+  add(event: WorkflowExecutionEvent): boolean;
+  finish(params: {readonly countLimitReached: boolean}): ListenerEventBatch;
+}
+
+export function createListenerEventBatchPacker(params?: {
+  readonly maxBytes?: number;
+}): ListenerEventBatchPacker {
+  const selected: WorkflowExecutionEvent[] = [];
+  const maxBytes = params?.maxBytes ?? MAX_LISTENER_TRIGGER_EVENTS_BYTES;
+  let serializedBytes = Buffer.byteLength('[]', 'utf8');
+  let partitionReason: ListenerBatchPartitionReason | undefined;
+
+  return {
+    get events() {
+      return selected;
+    },
+    add(event) {
+      if (partitionReason !== undefined) return false;
+
+      const serialized = JSON.stringify(event);
+      const eventBytes =
+        serialized === undefined ? Number.POSITIVE_INFINITY : Buffer.byteLength(serialized, 'utf8');
+      const candidateBytes =
+        serializedBytes + eventBytes + (selected.length === 0 ? 0 : Buffer.byteLength(',', 'utf8'));
+      if (candidateBytes > maxBytes) {
+        partitionReason = 'byte_limit';
+        return false;
+      }
+
+      selected.push(event);
+      serializedBytes = candidateBytes;
+      return true;
+    },
+    finish(finishParams) {
+      if (selected.length === 0 && partitionReason === 'byte_limit') {
+        return {kind: 'empty', reason: 'byte_limit'};
+      }
+
+      const resultPartitionReason =
+        partitionReason ?? (finishParams.countLimitReached ? 'count_limit' : undefined);
+      return {
+        kind: 'selected',
+        events: selected,
+        ...(resultPartitionReason === undefined ? {} : {partitionReason: resultPartitionReason}),
+      };
+    },
+  };
+}
+
 export function packListenerEventBatch(
   events: readonly WorkflowExecutionEvent[],
   params: {readonly countLimitReached: boolean; readonly maxBytes?: number},
 ): ListenerEventBatch {
-  const selected: WorkflowExecutionEvent[] = [];
-  const maxBytes = params.maxBytes ?? MAX_LISTENER_TRIGGER_EVENTS_BYTES;
+  const packer =
+    params.maxBytes === undefined
+      ? createListenerEventBatchPacker()
+      : createListenerEventBatchPacker({maxBytes: params.maxBytes});
 
   for (const event of events) {
-    const candidate = [...selected, event];
-    if (serializedListenerEventsByteLength(candidate) > maxBytes) {
-      return selected.length === 0
-        ? {kind: 'empty', reason: 'byte_limit'}
-        : {kind: 'selected', events: selected, partitionReason: 'byte_limit'};
-    }
-    selected.push(event);
+    if (!packer.add(event)) break;
   }
 
-  return {
-    kind: 'selected',
-    events: selected,
-    ...(params.countLimitReached ? {partitionReason: 'count_limit' as const} : {}),
-  };
+  return packer.finish({countLimitReached: params.countLimitReached});
 }
 
 export function serializedListenerEventsByteLength(

--- a/libs/api/workflows/src/core/listener-prior-execution-context.test.ts
+++ b/libs/api/workflows/src/core/listener-prior-execution-context.test.ts
@@ -1,0 +1,85 @@
+import {workflowModel} from '#test/index.js';
+import {listenerPriorExecutionEventsRequired} from './listener-prior-execution-context.js';
+
+function template(source: string): string {
+  return `\${{ ${source} }}`;
+}
+
+describe('listenerPriorExecutionEventsRequired', () => {
+  test('omits prior event arrays when no authored expression needs executions', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          success: 'vars.should_succeed == "true"',
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+
+    expect(listenerPriorExecutionEventsRequired({model, jobKey: 'review'})).toBe(false);
+  });
+
+  test('keeps prior event arrays for job success expressions over executions', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          success: 'executions.all(e, e.status == "succeeded")',
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+
+    expect(listenerPriorExecutionEventsRequired({model, jobKey: 'review'})).toBe(true);
+  });
+
+  test('keeps prior event arrays for a persisted success expression absent from the model', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+
+    expect(
+      listenerPriorExecutionEventsRequired({
+        model,
+        jobKey: 'review',
+        success: 'executions[0].events[0].data.action == "opened"',
+      }),
+    ).toBe(true);
+  });
+
+  test('keeps prior event arrays for deferred execution names and runner selectors', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          executionName: template('executions[0].events[0].data.name'),
+          runnerTemplates: [template('executions[0].events[0].data.runner')],
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+
+    expect(listenerPriorExecutionEventsRequired({model, jobKey: 'review'})).toBe(true);
+  });
+
+  test('keeps prior event arrays for deferred workflow environment config', () => {
+    const model = workflowModel({
+      env: {REGION: template('executions[0].events[0].data.region')},
+      jobs: {
+        review: {
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+
+    expect(listenerPriorExecutionEventsRequired({model, jobKey: 'review'})).toBe(true);
+  });
+
+  test('keeps the full shape when the persisted model has no matching job', () => {
+    expect(listenerPriorExecutionEventsRequired({model: workflowModel(), jobKey: 'missing'})).toBe(
+      true,
+    );
+  });
+});

--- a/libs/api/workflows/src/core/listener-prior-execution-context.ts
+++ b/libs/api/workflows/src/core/listener-prior-execution-context.ts
@@ -1,0 +1,82 @@
+import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import {
+  extractExactContextRoots,
+  type ResolvedFieldSegment,
+  type WorkflowExpression,
+} from '@shipfox/expression';
+
+/**
+ * Returns whether listener materialization or resolution needs event bodies from
+ * prior executions. The default success predicate only reads execution status,
+ * so it does not by itself require the event arrays.
+ */
+export function listenerPriorExecutionEventsRequired(params: {
+  readonly model: WorkflowModel | null;
+  readonly jobKey: string;
+  readonly success?: string | null | undefined;
+}): boolean {
+  const job = params.model?.jobs.find((candidate) => candidate.key === params.jobKey);
+  if (job === undefined) return true;
+
+  const roots = new Set<string>();
+  try {
+    if (params.success !== undefined && params.success !== null) {
+      addExpressionRoots(params.success, roots);
+    }
+    if (job.success !== undefined) addExpressionRoots(job.success, roots);
+    collectExpressionRoots(params.model?.templates?.env, roots, new Set());
+    collectExpressionRoots(job, roots, new Set());
+  } catch {
+    // A malformed or future model must keep the full context shape rather than
+    // risk evaluating an expression against missing historical data.
+    return true;
+  }
+
+  return roots.has('executions');
+}
+
+function collectExpressionRoots(value: unknown, roots: Set<string>, visited: Set<object>): void {
+  if (value === null || typeof value !== 'object') return;
+  if (isWorkflowExpression(value)) {
+    addExpressionRoots(value.source, roots);
+    return;
+  }
+  if (isDeferredSegment(value)) {
+    for (const root of value.roots) roots.add(root);
+    addExpressionRoots(value.expression.source, roots);
+    return;
+  }
+  if (visited.has(value)) return;
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    for (const child of value) collectExpressionRoots(child, roots, visited);
+    return;
+  }
+  for (const child of Object.values(value)) collectExpressionRoots(child, roots, visited);
+}
+
+function addExpressionRoots(source: string, roots: Set<string>): void {
+  for (const root of extractExactContextRoots(source)) roots.add(root);
+}
+
+function isWorkflowExpression(value: object): value is WorkflowExpression {
+  const candidate = value as {language?: unknown; source?: unknown};
+  return candidate.language === 'cel' && typeof candidate.source === 'string';
+}
+
+function isDeferredSegment(
+  value: object,
+): value is Extract<ResolvedFieldSegment, {kind: 'deferred'}> {
+  const candidate = value as {
+    kind?: unknown;
+    expression?: unknown;
+    roots?: unknown;
+  };
+  return (
+    candidate.kind === 'deferred' &&
+    candidate.expression !== null &&
+    typeof candidate.expression === 'object' &&
+    Array.isArray(candidate.roots)
+  );
+}

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -9,6 +9,7 @@ import type {JobListeningTrigger, JobStatus} from '#core/entities/job.js';
 import type {JobExecutionStatus} from '#core/entities/job-execution.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
+import {MAX_LISTENER_TRIGGER_EVENTS_BYTES} from '#core/listener-event-batching.js';
 import {db} from '#db/db.js';
 import {deliverEventToListener} from '#db/job-listener-events.js';
 import {
@@ -88,6 +89,7 @@ function bufferEvent(
   eventRef = crypto.randomUUID(),
   receivedAt = new Date('2026-01-01T00:00:00.000Z'),
   triggerReference?: WorkflowRunTriggerReference | null,
+  payload: unknown = {action: 'opened'},
 ) {
   return deliverEventToListener({
     jobId,
@@ -98,7 +100,7 @@ function bufferEvent(
     event: 'pull_request',
     provider: 'github',
     triggerReference,
-    payload: {action: 'opened'},
+    payload,
     receivedAt,
   });
 }
@@ -826,6 +828,108 @@ describe('drainListenerEventsIntoExecution', () => {
     );
   });
 
+  it('materializes a listener batch larger than the diagnostic read cap', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date(), undefined, {
+      body: 'x'.repeat(WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES + 10_000),
+    });
+
+    const result = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
+    const [execution] = await db()
+      .select()
+      .from(jobExecutions)
+      .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
+    const serializedBytes = Buffer.byteLength(
+      JSON.stringify(execution?.triggerEvents ?? []),
+      'utf8',
+    );
+
+    expect(result).toMatchObject({kind: 'execution', status: 'pending'});
+    expect(execution?.triggerEvents).toHaveLength(1);
+    expect(serializedBytes).toBeGreaterThan(WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES);
+    expect(serializedBytes).toBeLessThanOrEqual(MAX_LISTENER_TRIGGER_EVENTS_BYTES);
+  });
+
+  it('partitions a byte-limited listener batch without consuming its tail', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    const payloads = ['first', 'second', 'third'];
+    for (const [index, name] of payloads.entries()) {
+      await bufferEvent(
+        job.id,
+        'fire',
+        crypto.randomUUID(),
+        new Date(Date.UTC(2026, 0, 1, 0, index, 0)),
+        undefined,
+        {name, body: 'x'.repeat(400_000)},
+      );
+    }
+
+    const firstDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+    });
+    const afterFirstDrain = await db()
+      .select()
+      .from(jobListenerEvents)
+      .where(eq(jobListenerEvents.jobId, job.id));
+    const secondDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 2,
+    });
+    const executions = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id))
+      .orderBy(asc(jobExecutions.sequence));
+    const afterSecondDrain = await db()
+      .select()
+      .from(jobListenerEvents)
+      .where(eq(jobListenerEvents.jobId, job.id));
+
+    expect(firstDrain).toMatchObject({kind: 'execution', sequence: 1});
+    expect(secondDrain).toMatchObject({kind: 'execution', sequence: 2});
+    expect(executions.map((execution) => execution.triggerEvents.length)).toEqual([2, 1]);
+    expect(afterFirstDrain.filter((event) => event.consumedByExecutionId === null)).toHaveLength(1);
+    expect(afterSecondDrain.filter((event) => event.consumedByExecutionId === null)).toHaveLength(
+      0,
+    );
+    expect(
+      executions.flatMap((execution) =>
+        execution.triggerEvents.map((event) => (event.data as {name: string}).name),
+      ),
+    ).toEqual(payloads);
+  });
+
+  it('leaves a legacy oversized listener head pending after an empty drain', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date(), undefined, {
+      body: 'x'.repeat(MAX_LISTENER_TRIGGER_EVENTS_BYTES),
+    });
+
+    const firstDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+    });
+    const secondDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+    });
+    const events = await db()
+      .select()
+      .from(jobListenerEvents)
+      .where(eq(jobListenerEvents.jobId, job.id));
+    const executions = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id));
+
+    expect(firstDrain).toEqual({kind: 'empty'});
+    expect(secondDrain).toEqual({kind: 'empty'});
+    expect(events).toHaveLength(1);
+    expect(events[0]?.consumedByExecutionId).toBeNull();
+    expect(executions).toHaveLength(0);
+  });
+
   it('materializes runner labels separately for each listener firing', async () => {
     const job = await createListeningJobFromModel({
       jobs: {
@@ -1082,40 +1186,5 @@ describe('drainListenerEventsIntoExecution', () => {
       .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
     expect(result).toMatchObject({kind: 'execution', status: 'failed'});
     expect(execution?.status).toBe('failed');
-  });
-
-  it('consumes a listener batch when its diagnostic payload is oversized', async () => {
-    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
-    await bufferEvent(job.id);
-    await db()
-      .update(jobListenerEvents)
-      .set({payload: 'x'.repeat(WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES)})
-      .where(
-        and(
-          eq(jobListenerEvents.jobId, job.id),
-          isNull(jobListenerEvents.consumedByExecutionId),
-          eq(jobListenerEvents.disposition, 'fire'),
-        ),
-      );
-
-    const result = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
-    const [execution] = await db()
-      .select()
-      .from(jobExecutions)
-      .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
-    const events = await db()
-      .select()
-      .from(jobListenerEvents)
-      .where(eq(jobListenerEvents.jobId, job.id));
-
-    expect(result).toMatchObject({kind: 'execution', status: 'failed'});
-    expect(execution).toMatchObject({
-      status: 'failed',
-      statusReason: 'output_too_large',
-      triggerEvents: [],
-      evaluationTrace: null,
-    });
-    expect(events).toHaveLength(1);
-    expect(events[0]?.consumedByExecutionId).toBe(execution?.id);
   });
 });

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -8,7 +8,7 @@ import {
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
+import {and, asc, count, eq, gt, inArray, isNull, notInArray, or, sql} from 'drizzle-orm';
 import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
 import {
   type AgentToolMaterializationContext,
@@ -25,9 +25,9 @@ import {normalizeWorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import {InterpolationUnresolvableError, WorkflowDiagnosticTooLargeError} from '#core/errors.js';
 import {type DeriveJobSuccessResult, deriveJobSuccess} from '#core/job-transition/index.js';
 import {
+  createListenerEventBatchPacker,
   type ListenerBatchPartitionReason,
   MAX_LISTENER_TRIGGER_EVENTS_BYTES,
-  packListenerEventBatch,
 } from '#core/listener-event-batching.js';
 import {
   type MaterializedListenerExecution,
@@ -265,6 +265,17 @@ interface DrainedListenerEvents {
   readonly partitionReason?: ListenerBatchPartitionReason;
 }
 
+interface LockedListenerEventBatch {
+  readonly bufferedEvents: readonly JobListenerEventDb[];
+  readonly triggerEvents: readonly WorkflowExecutionEvent[];
+  readonly partitionReason?: ListenerBatchPartitionReason;
+}
+
+interface ListenerEventCursor {
+  readonly receivedAt: Date;
+  readonly id: string;
+}
+
 interface ListenerDrainTransactionParams {
   readonly drain: DrainListenerEventsParams;
   readonly model: WorkflowModel | null;
@@ -370,18 +381,16 @@ async function drainListenerEventsInTransaction(
   const resolveRequested = await hasPendingResolveEvent(params.drain.jobId, tx);
   if (resolveRequested) return {result: {kind: 'resolve-requested'}};
 
-  const bufferedEvents = await lockBufferedFireEvents(params.drain, tx);
-  if (bufferedEvents.length === 0) return {result: {kind: 'empty'}};
-
-  const batch = packListenerEventBatch(listenerTriggerEvents(bufferedEvents), {
-    countLimitReached:
-      params.drain.maxSize !== undefined && bufferedEvents.length >= params.drain.maxSize,
-  });
-  if (batch.kind === 'empty') {
-    return {result: {kind: 'empty'}, partitionReason: batch.reason};
+  const bufferedEventBatch = await lockBufferedFireEventBatch(params.drain, tx);
+  if (bufferedEventBatch.bufferedEvents.length === 0) {
+    return {
+      result: {kind: 'empty'},
+      ...(bufferedEventBatch.partitionReason === undefined
+        ? {}
+        : {partitionReason: bufferedEventBatch.partitionReason}),
+    };
   }
 
-  const selectedBufferedEvents = bufferedEvents.slice(0, batch.events.length);
   const target = await loadListenerMaterializationTarget(params.drain.jobId, tx);
   const priorExecutions = await loadListenerPriorExecutions(
     params.drain.jobId,
@@ -396,7 +405,7 @@ async function drainListenerEventsInTransaction(
     vars: params.vars,
     variableResolutionError: params.variableResolutionError,
     sequence: params.drain.expectedSequence,
-    triggerEvents: batch.events,
+    triggerEvents: bufferedEventBatch.triggerEvents,
     priorExecutions,
     resolveAgentDefaults:
       params.drain.resolveAgentDefaults ??
@@ -409,7 +418,7 @@ async function drainListenerEventsInTransaction(
   const execution = await persistMaterializedListenerExecution(tx, {
     jobId: params.drain.jobId,
     sequence: params.drain.expectedSequence,
-    bufferedEventIds: selectedBufferedEvents.map((event) => event.id),
+    bufferedEventIds: bufferedEventBatch.bufferedEvents.map((event) => event.id),
     materialized,
   });
 
@@ -419,8 +428,10 @@ async function drainListenerEventsInTransaction(
 
   return {
     result: drainExecutionResult(execution),
-    batchSize: selectedBufferedEvents.length,
-    ...(batch.partitionReason === undefined ? {} : {partitionReason: batch.partitionReason}),
+    batchSize: bufferedEventBatch.bufferedEvents.length,
+    ...(bufferedEventBatch.partitionReason === undefined
+      ? {}
+      : {partitionReason: bufferedEventBatch.partitionReason}),
   };
 }
 
@@ -678,43 +689,72 @@ async function hasBufferedFireEvent(jobId: string, tx: Tx): Promise<boolean> {
   return fireEvent !== undefined;
 }
 
-async function lockBufferedFireEvents(
+async function lockBufferedFireEventBatch(
   params: DrainListenerEventsParams,
   tx: Tx,
-): Promise<JobListenerEventDb[]> {
-  const bufferedQuery = tx
-    .select()
-    .from(jobListenerEvents)
-    .where(
-      and(
-        eq(jobListenerEvents.jobId, params.jobId),
-        eq(jobListenerEvents.disposition, 'fire'),
-        isNull(jobListenerEvents.consumedByExecutionId),
-      ),
-    )
-    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
-  return await (params.maxSize === undefined
-    ? bufferedQuery
-    : bufferedQuery.limit(params.maxSize)
-  ).for('update');
+): Promise<LockedListenerEventBatch> {
+  const packer = createListenerEventBatchPacker();
+  const bufferedEvents: JobListenerEventDb[] = [];
+  let cursor: ListenerEventCursor | undefined;
+
+  while (params.maxSize === undefined || bufferedEvents.length < params.maxSize) {
+    const [event] = await tx
+      .select()
+      .from(jobListenerEvents)
+      .where(
+        and(
+          eq(jobListenerEvents.jobId, params.jobId),
+          eq(jobListenerEvents.disposition, 'fire'),
+          isNull(jobListenerEvents.consumedByExecutionId),
+          cursor === undefined
+            ? undefined
+            : or(
+                gt(jobListenerEvents.receivedAt, cursor.receivedAt),
+                and(
+                  eq(jobListenerEvents.receivedAt, cursor.receivedAt),
+                  gt(jobListenerEvents.id, cursor.id),
+                ),
+              ),
+        ),
+      )
+      .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
+      .limit(1)
+      .for('update');
+    if (event === undefined) break;
+
+    const triggerEvent = listenerTriggerEvent(event);
+    if (!packer.add(triggerEvent)) break;
+
+    bufferedEvents.push(event);
+    cursor = {receivedAt: event.receivedAt, id: event.id};
+  }
+
+  const batch = packer.finish({
+    countLimitReached:
+      params.maxSize !== undefined &&
+      bufferedEvents.length > 0 &&
+      bufferedEvents.length >= params.maxSize,
+  });
+  const partitionReason = batch.kind === 'empty' ? batch.reason : batch.partitionReason;
+  return {
+    bufferedEvents,
+    triggerEvents: batch.kind === 'empty' ? [] : batch.events,
+    ...(partitionReason === undefined ? {} : {partitionReason}),
+  };
 }
 
-function listenerTriggerEvents(
-  bufferedEvents: readonly JobListenerEventDb[],
-): WorkflowExecutionEvent[] {
-  return bufferedEvents.map((event) =>
-    normalizeWorkflowExecutionEvent({
-      source: event.source,
-      event: event.event,
-      delivery_id: event.deliveryId,
-      received_at: event.receivedAt.toISOString(),
-      project: event.triggerReference?.project ?? null,
-      repository: event.triggerReference?.repository ?? null,
-      ref: event.triggerReference?.ref ?? null,
-      commit: event.triggerReference?.commit ?? null,
-      data: event.payload,
-    }),
-  );
+function listenerTriggerEvent(event: JobListenerEventDb): WorkflowExecutionEvent {
+  return normalizeWorkflowExecutionEvent({
+    source: event.source,
+    event: event.event,
+    delivery_id: event.deliveryId,
+    received_at: event.receivedAt.toISOString(),
+    project: event.triggerReference?.project ?? null,
+    repository: event.triggerReference?.repository ?? null,
+    ref: event.triggerReference?.ref ?? null,
+    commit: event.triggerReference?.commit ?? null,
+    data: event.payload,
+  });
 }
 
 async function persistMaterializedListenerExecution(

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -1,5 +1,5 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
-import {readPersistedWorkflowModel} from '@shipfox/api-definitions-dto';
+import {readPersistedWorkflowModel, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
@@ -7,9 +7,13 @@ import {
   WORKFLOWS_JOB_ACTIVATED,
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
 import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
-import {loadAgentToolMaterializationContext} from '#core/agent-tools.js';
+import {
+  type AgentToolMaterializationContext,
+  loadAgentToolMaterializationContext,
+} from '#core/agent-tools.js';
 import {assertWorkflowDiagnosticSize} from '#core/diagnostics.js';
 import {isJobTerminal, type JobStatus, type ResolutionReason} from '#core/entities/job.js';
 import type {
@@ -21,9 +25,15 @@ import {normalizeWorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import {InterpolationUnresolvableError, WorkflowDiagnosticTooLargeError} from '#core/errors.js';
 import {type DeriveJobSuccessResult, deriveJobSuccess} from '#core/job-transition/index.js';
 import {
+  type ListenerBatchPartitionReason,
+  MAX_LISTENER_TRIGGER_EVENTS_BYTES,
+  packListenerEventBatch,
+} from '#core/listener-event-batching.js';
+import {
   type MaterializedListenerExecution,
   materializeListenerExecution,
 } from '#core/listener-execution-materialization.js';
+import {listenerPriorExecutionEventsRequired} from '#core/listener-prior-execution-context.js';
 import {
   applyListenerFilterSnapshots,
   assembleListenerSnapshotContext,
@@ -32,13 +42,19 @@ import {
   planListenerFilterSnapshots,
 } from '#core/step-config/assemble-run-context.js';
 import {
+  recordListenerBatchPartition,
   recordListenerEventsCoalesced,
   recordWorkflowJobExecutionStatusChanged,
   recordWorkflowListenerResolved,
 } from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
 import {writeWorkflowsOutboxEvent} from './outbox-writes.js';
-import {type JobExecutionDb, jobExecutions, toJobExecution} from './schema/job-executions.js';
+import {
+  type JobExecutionDb,
+  type JobExecutionDbWithoutTriggerEvents,
+  jobExecutions,
+  toJobExecution,
+} from './schema/job-executions.js';
 import {type JobListenerEventDb, jobListenerEvents} from './schema/job-listener-events.js';
 import {jobs, toJob} from './schema/jobs.js';
 import {steps} from './schema/steps.js';
@@ -54,6 +70,26 @@ import {
 
 const TERMINAL_EXECUTION_STATUSES: JobExecutionStatus[] = ['succeeded', 'failed', 'cancelled'];
 const MAX_LISTENER_RESOLUTION_ATTEMPTS = 3;
+
+const listenerPriorExecutionSelection = {
+  id: jobExecutions.id,
+  jobId: jobExecutions.jobId,
+  sequence: jobExecutions.sequence,
+  name: jobExecutions.name,
+  runner: jobExecutions.runner,
+  status: jobExecutions.status,
+  statusReason: jobExecutions.statusReason,
+  statusReasonMessage: jobExecutions.statusReasonMessage,
+  outputs: jobExecutions.outputs,
+  evaluationTrace: jobExecutions.evaluationTrace,
+  version: jobExecutions.version,
+  createdAt: jobExecutions.createdAt,
+  updatedAt: jobExecutions.updatedAt,
+  queuedAt: jobExecutions.queuedAt,
+  startedAt: jobExecutions.startedAt,
+  finishedAt: jobExecutions.finishedAt,
+  timedOutAt: jobExecutions.timedOutAt,
+} satisfies Record<keyof JobExecutionDbWithoutTriggerEvents, unknown>;
 
 export interface ActivateJobListenerParams {
   jobId: string;
@@ -223,6 +259,21 @@ export interface DrainListenerEventsParams {
   secrets?: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'> | undefined;
 }
 
+interface DrainedListenerEvents {
+  readonly result: DrainListenerEventsResult;
+  readonly batchSize?: number;
+  readonly partitionReason?: ListenerBatchPartitionReason;
+}
+
+interface ListenerDrainTransactionParams {
+  readonly drain: DrainListenerEventsParams;
+  readonly model: WorkflowModel | null;
+  readonly includePriorExecutionTriggerEvents: boolean;
+  readonly vars: Record<string, string> | undefined;
+  readonly variableResolutionError: InterpolationUnresolvableError | undefined;
+  readonly agentToolContext: AgentToolMaterializationContext | undefined;
+}
+
 export async function drainListenerEventsIntoExecution(
   params: DrainListenerEventsParams,
 ): Promise<DrainListenerEventsResult> {
@@ -247,6 +298,10 @@ export async function drainListenerEventsIntoExecution(
       ? null
       : readPersistedWorkflowModel(materializationTarget.attempt.model);
   const modelJob = model?.jobs.find((job) => job.key === materializationTarget.job.key);
+  const includePriorExecutionTriggerEvents = listenerPriorExecutionEventsRequired({
+    model,
+    jobKey: materializationTarget.job.key,
+  });
   let vars: Record<string, string> | undefined;
   let variableResolutionError: InterpolationUnresolvableError | undefined;
   if (model !== null && modelJob !== undefined) {
@@ -275,61 +330,98 @@ export async function drainListenerEventsIntoExecution(
         })
       : undefined;
 
-  const drained = await db().transaction(async (tx) => {
-    const existing = await findExistingExecution(params, tx);
-    if (existing) return {result: existing};
-
-    const resolveRequested = await hasPendingResolveEvent(params.jobId, tx);
-    if (resolveRequested) return {result: {kind: 'resolve-requested' as const}};
-
-    const bufferedEvents = await lockBufferedFireEvents(params, tx);
-    if (bufferedEvents.length === 0) return {result: {kind: 'empty' as const}};
-
-    const target = await loadListenerMaterializationTarget(params.jobId, tx);
-    const priorExecutions = await loadListenerPriorExecutions(
-      params.jobId,
-      target.job.name ?? target.job.key,
+  const drained = await db().transaction((tx) =>
+    drainListenerEventsInTransaction(
+      {
+        drain: params,
+        model,
+        includePriorExecutionTriggerEvents,
+        vars,
+        variableResolutionError,
+        agentToolContext,
+      },
       tx,
+    ),
+  );
+
+  if (drained.partitionReason !== undefined) {
+    recordListenerBatchPartition(drained.partitionReason);
+  }
+  if (drained.result.kind === 'empty' && drained.partitionReason === 'byte_limit') {
+    logger().warn(
+      {jobId: params.jobId, limitBytes: MAX_LISTENER_TRIGGER_EVENTS_BYTES},
+      'Listener event batch head exceeds the execution byte limit; leaving it buffered',
     );
-    const materialized = await materializeListenerExecution({
-      model,
-      run: toWorkflowRun(target.run),
-      job: toJob(target.job),
-      vars,
-      variableResolutionError,
-      sequence: params.expectedSequence,
-      triggerEvents: listenerTriggerEvents(bufferedEvents),
-      priorExecutions,
-      resolveAgentDefaults:
-        params.resolveAgentDefaults ??
-        (params.agent
-          ? createAgentDefaultsResolver(params.agent, target.run.workspaceId)
-          : undefined),
-      agentToolContext,
-      agentToolSnapshot: target.attempt.agentToolMaterialization,
-    });
-    const execution = await persistMaterializedListenerExecution(tx, {
-      jobId: params.jobId,
-      sequence: params.expectedSequence,
-      bufferedEventIds: bufferedEvents.map((event) => event.id),
-      materialized,
-    });
-
-    if (materialized.status === 'failed' || execution.status === 'failed') {
-      recordWorkflowJobExecutionStatusChanged(execution.status);
-    }
-
-    return {
-      result: drainExecutionResult(execution),
-      batchSize: bufferedEvents.length,
-    };
-  });
-
+  }
   if (drained.result.kind === 'execution' && drained.batchSize !== undefined) {
     recordListenerEventsCoalesced(drained.batchSize);
   }
 
   return drained.result;
+}
+
+async function drainListenerEventsInTransaction(
+  params: ListenerDrainTransactionParams,
+  tx: Tx,
+): Promise<DrainedListenerEvents> {
+  const existing = await findExistingExecution(params.drain, tx);
+  if (existing) return {result: existing};
+
+  const resolveRequested = await hasPendingResolveEvent(params.drain.jobId, tx);
+  if (resolveRequested) return {result: {kind: 'resolve-requested'}};
+
+  const bufferedEvents = await lockBufferedFireEvents(params.drain, tx);
+  if (bufferedEvents.length === 0) return {result: {kind: 'empty'}};
+
+  const batch = packListenerEventBatch(listenerTriggerEvents(bufferedEvents), {
+    countLimitReached:
+      params.drain.maxSize !== undefined && bufferedEvents.length >= params.drain.maxSize,
+  });
+  if (batch.kind === 'empty') {
+    return {result: {kind: 'empty'}, partitionReason: batch.reason};
+  }
+
+  const selectedBufferedEvents = bufferedEvents.slice(0, batch.events.length);
+  const target = await loadListenerMaterializationTarget(params.drain.jobId, tx);
+  const priorExecutions = await loadListenerPriorExecutions(
+    params.drain.jobId,
+    target.job.name ?? target.job.key,
+    tx,
+    params.includePriorExecutionTriggerEvents,
+  );
+  const materialized = await materializeListenerExecution({
+    model: params.model,
+    run: toWorkflowRun(target.run),
+    job: toJob(target.job),
+    vars: params.vars,
+    variableResolutionError: params.variableResolutionError,
+    sequence: params.drain.expectedSequence,
+    triggerEvents: batch.events,
+    priorExecutions,
+    resolveAgentDefaults:
+      params.drain.resolveAgentDefaults ??
+      (params.drain.agent
+        ? createAgentDefaultsResolver(params.drain.agent, target.run.workspaceId)
+        : undefined),
+    agentToolContext: params.agentToolContext,
+    agentToolSnapshot: target.attempt.agentToolMaterialization,
+  });
+  const execution = await persistMaterializedListenerExecution(tx, {
+    jobId: params.drain.jobId,
+    sequence: params.drain.expectedSequence,
+    bufferedEventIds: selectedBufferedEvents.map((event) => event.id),
+    materialized,
+  });
+
+  if (materialized.status === 'failed' || execution.status === 'failed') {
+    recordWorkflowJobExecutionStatusChanged(execution.status);
+  }
+
+  return {
+    result: drainExecutionResult(execution),
+    batchSize: selectedBufferedEvents.length,
+    ...(batch.partitionReason === undefined ? {} : {partitionReason: batch.partitionReason}),
+  };
 }
 
 export interface ListenerBufferPeek {
@@ -407,10 +499,19 @@ async function deriveJobListenerResolutionDecision(
   const jobRow = target?.job;
   if (!jobRow) throw new Error(`Job not found: ${jobId}`);
 
+  const model =
+    target.attempt.model === null ? null : readPersistedWorkflowModel(target.attempt.model);
+  const includePriorExecutionTriggerEvents = listenerPriorExecutionEventsRequired({
+    model,
+    jobKey: jobRow.key,
+    success: jobRow.success,
+  });
+
   const [executionRows, dependencyJobs] = await Promise.all([
-    db()
-      .select()
-      .from(jobExecutions)
+    (includePriorExecutionTriggerEvents
+      ? db().select().from(jobExecutions)
+      : db().select(listenerPriorExecutionSelection).from(jobExecutions)
+    )
       .where(eq(jobExecutions.jobId, jobId))
       .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id)),
     getDirectDependencyJobContexts(jobId),
@@ -626,7 +727,6 @@ async function persistMaterializedListenerExecution(
   },
 ): Promise<JobExecutionDb> {
   try {
-    assertWorkflowDiagnosticSize('trigger_events', params.materialized.triggerEvents);
     assertWorkflowDiagnosticSize('execution_evaluation_trace', params.materialized.evaluationTrace);
     for (const step of params.materialized.steps) {
       assertWorkflowDiagnosticSize('config', step.config);
@@ -771,10 +871,12 @@ async function loadListenerPriorExecutions(
   jobId: string,
   fallbackName: string,
   tx: Tx,
+  includeTriggerEvents: boolean,
 ): Promise<JobExecution[]> {
-  const priorExecutions = await tx
-    .select()
-    .from(jobExecutions)
+  const priorExecutions = await (includeTriggerEvents
+    ? tx.select().from(jobExecutions)
+    : tx.select(listenerPriorExecutionSelection).from(jobExecutions)
+  )
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
   return priorExecutions.map((execution) => toJobExecution(execution, fallbackName));

--- a/libs/api/workflows/src/db/schema/job-executions.ts
+++ b/libs/api/workflows/src/db/schema/job-executions.ts
@@ -67,9 +67,13 @@ export const jobExecutions = pgTable(
 );
 
 export type JobExecutionDb = typeof jobExecutions.$inferSelect;
+export type JobExecutionDbWithoutTriggerEvents = Omit<JobExecutionDb, 'triggerEvents'>;
 export type JobExecutionCreateDb = typeof jobExecutions.$inferInsert;
 
-export function toJobExecution(row: JobExecutionDb, fallbackName: string): JobExecution {
+export function toJobExecution(
+  row: JobExecutionDb | JobExecutionDbWithoutTriggerEvents,
+  fallbackName: string,
+): JobExecution {
   return {
     id: row.id,
     jobId: row.jobId,
@@ -83,9 +87,10 @@ export function toJobExecution(row: JobExecutionDb, fallbackName: string): JobEx
     // Keep legacy/corrupt JSONB rows readable. The diagnostic context route
     // reports an invalid trigger-events shape as an empty collection rather
     // than allowing a mapper `.map` failure to abort the read.
-    triggerEvents: Array.isArray(row.triggerEvents)
-      ? row.triggerEvents.map(normalizeWorkflowExecutionEvent)
-      : [],
+    triggerEvents:
+      'triggerEvents' in row && Array.isArray(row.triggerEvents)
+        ? row.triggerEvents.map(normalizeWorkflowExecutionEvent)
+        : [],
     outputs: row.outputs,
     evaluationTrace: row.evaluationTrace ?? null,
     version: row.version,

--- a/libs/api/workflows/src/metrics/instance.test.ts
+++ b/libs/api/workflows/src/metrics/instance.test.ts
@@ -125,6 +125,20 @@ describe('workflow tool invocation metrics', () => {
   });
 });
 
+describe('listener batch metrics', () => {
+  test('records bounded partition reasons', () => {
+    metrics.recordListenerBatchPartition('byte_limit');
+    metrics.recordListenerBatchPartition('count_limit');
+
+    expect(counterAdd('workflows_listener_batch_partitions')).toHaveBeenNthCalledWith(1, 1, {
+      reason: 'byte_limit',
+    });
+    expect(counterAdd('workflows_listener_batch_partitions')).toHaveBeenNthCalledWith(2, 1, {
+      reason: 'count_limit',
+    });
+  });
+});
+
 describe('workflow-run detail measurement metrics', () => {
   test('records bounded labels and read measurements', () => {
     metrics.recordWorkflowRunDetailRead({

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -123,6 +123,12 @@ const listenerEventsCoalesced = meter.createHistogram<Record<string, never>>(
   },
 );
 
+const listenerBatchPartitions = meter.createCounter<{
+  reason: 'byte_limit' | 'count_limit';
+}>('workflows_listener_batch_partitions', {
+  description: 'Listener firing batch partitions by bounded limit',
+});
+
 const toolInvocationDuration = meter.createHistogram<{
   provider: string;
   outcome: 'success' | 'error';
@@ -271,6 +277,10 @@ export function recordWorkflowListenerResolved(reason: ResolutionReason): void {
 
 export function recordListenerEventsCoalesced(batchSize: number): void {
   listenerEventsCoalesced.record(batchSize);
+}
+
+export function recordListenerBatchPartition(reason: 'byte_limit' | 'count_limit'): void {
+  listenerBatchPartitions.add(1, {reason});
 }
 
 export function recordWorkflowToolInvocationDuration(


### PR DESCRIPTION
## Summary

Listener trigger events now form the largest ordered prefix that fits the normalized 1,000,000-byte execution payload limit. The drain consumes only that prefix, leaving the remainder pending for the existing loop. Prior execution trigger-event bodies are omitted from resolution reads unless workflow expressions reference `executions`.

The previous diagnostic-size check rejected otherwise valid listener executions and consumed the whole locked batch. This change removes that mismatch, handles legacy oversized heads without a hot loop, and records bounded partition reasons.

The compatibility change remains free of Temporal history changes. Durable per-event byte metadata and terminal `abandoned` outcomes remain in ENG-1960.

Refs ENG-1959

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Partitions listener trigger batches by serialized execution bytes so valid executions no longer fail the diagnostic size check, and skips loading prior execution trigger events unless workflow expressions reference `executions`. No Temporal history changes.

**Bug Fixes**
- Listener executions larger than the diagnostic read cap now materialize normally instead of failing.
- Legacy oversized batch heads stay pending without a hot loop, and the remaining tail is consumed by later drains.

**Refactors**
- Prior execution trigger-event bodies are omitted from resolution reads unless expressions reference `executions`.
- Records bounded partition reasons (`byte_limit`, `count_limit`) in metrics.

<sup>Written for commit c4de006b9f1276ebe0ca4386aa4c4b57054d6fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

