### PR TITLE
[docs] Keep production docs URLs canonical on Vercel

### DIFF
--- a/apps/docs/src/url.test.ts
+++ b/apps/docs/src/url.test.ts
@@ -14,6 +14,16 @@ describe('resolveDocsOrigin', () => {
     );
   });
 
+  it('uses the public docs origin when the production host is a Vercel deployment', () => {
+    assert.equal(
+      resolveDocsOrigin({
+        VERCEL_ENV: 'production',
+        NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: 'shipfox-docs-git-main.vercel.app',
+      }),
+      PUBLIC_DOCS_ORIGIN,
+    );
+  });
+
   it('uses the configured Vercel production host when available', () => {
     assert.equal(
       resolveDocsOrigin({

--- a/apps/docs/src/url.ts
+++ b/apps/docs/src/url.ts
@@ -4,6 +4,7 @@ export {canonicalDocsOrigin} from './lib/canonical-docs-origin';
 
 const LOCAL_DOCS_ORIGIN = 'http://localhost:3500';
 export const PUBLIC_DOCS_ORIGIN = 'https://www.shipfox.io';
+const VERCEL_DEPLOYMENT_HOST_PATTERN = /\.vercel\.app$/i;
 
 type DocsEnvironment = Partial<
   Pick<
@@ -25,7 +26,13 @@ export function resolveDocsOrigin(environment: DocsEnvironment = config): string
   const deploymentEnvironment = environment.VERCEL_ENV ?? environment.NEXT_PUBLIC_VERCEL_ENV;
   if (deploymentEnvironment === 'production') {
     const productionHost = environment.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
-    return productionHost ? originFromDeploymentHost(productionHost) : PUBLIC_DOCS_ORIGIN;
+    if (productionHost) {
+      const productionOrigin = originFromDeploymentHost(productionHost);
+      if (!VERCEL_DEPLOYMENT_HOST_PATTERN.test(new URL(productionOrigin).hostname)) {
+        return productionOrigin;
+      }
+    }
+    return PUBLIC_DOCS_ORIGIN;
   }
 
   const deploymentHost = environment.VERCEL_URL ?? environment.NEXT_PUBLIC_VERCEL_URL;


### PR DESCRIPTION
The docs build can run in a production Vercel deployment while Vercel's project production URL still points to a `*.vercel.app` deployment host. That host is not canonical, and machine-readable Markdown rejects it during static generation.

This change treats Vercel deployment hosts as non-canonical for production origin resolution, falls back to the public docs origin, and continues honoring configured custom production domains.

Validation passed:

- `mise exec -- pnpm --filter=@shipfox/docs test:unit` (46 tests)
- `mise exec -- turbo check type --filter=@shipfox/docs...`
- `mise exec -- turbo test --filter=@shipfox/docs...` (103 HTML pages, 103 Markdown pages, 11 excluded routes)
- `mise exec -- turbo build --filter=@shipfox/docs...`
- `mise exec -- git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the production docs build on Vercel by treating `*.vercel.app` deployment hosts as non-canonical for origin resolution, so the build falls back to the public docs origin instead of failing the canonical URL guard during static generation. Custom production domains are still honored.

<sup>Written for commit 77cba031b49f73c996a3c89fcd82ea7f94c81b8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

