### PR TITLE
Snapshot renewable inference eligibility before credential minting

### DIFF
--- a/.changeset/frozen-claim-capability.md
+++ b/.changeset/frozen-claim-capability.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-agent": patch
+"@shipfox/api-runners-dto": minor
+"@shipfox/api-runners": patch
+"@shipfox/api-workflows": patch
+---
+
+Snapshots renewable inference eligibility at job claim and rejects runtime credentials after cancellation or attempt replacement.

--- a/libs/api/agent-dto/src/inter-module.test.ts
+++ b/libs/api/agent-dto/src/inter-module.test.ts
@@ -46,6 +46,7 @@ describe('agentInterModuleContract', () => {
       provider: 'shipfox' as const,
       model: 'managed-model',
       thinking: 'high' as const,
+      renewableInference: true,
     };
 
     const parsed = agentInterModuleContract.methods.resolveRuntimeCredentials.input.parse(input);

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -86,6 +86,7 @@ export const agentInterModuleContract = defineInterModuleContract({
         runId: z.string().uuid(),
         stepAttemptId: z.string().uuid(),
         jobIdentity: managedProviderJobIdentitySchema.optional(),
+        renewableInference: z.boolean().optional(),
         harness: harnessSchema,
         provider: modelProviderRefSchema,
         model: z.string(),

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -103,6 +103,7 @@ describe('resolveRuntimeCredentials', () => {
         provider: 'shipfox',
         model: 'responses-model',
         thinking: 'high',
+        renewableInference: true,
       },
       {managedProvider: managedProvider(resolveCredentials)},
     );
@@ -113,6 +114,7 @@ describe('resolveRuntimeCredentials', () => {
       stepAttemptId,
       jobIdentity,
       model: 'responses-model',
+      renewableInference: true,
     });
     expect(result).toEqual({
       harness: 'pi',

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -31,6 +31,7 @@ export interface ResolveRuntimeCredentialsParams {
   runId: string;
   stepAttemptId: string;
   jobIdentity?: ManagedProviderJobIdentity | undefined;
+  renewableInference?: boolean | undefined;
   harness: Harness;
   provider: ModelProviderRef;
   model: string;
@@ -98,6 +99,9 @@ async function resolveManagedCredentials(
     stepAttemptId: params.stepAttemptId,
     ...(params.jobIdentity === undefined ? {} : {jobIdentity: params.jobIdentity}),
     model: params.model,
+    ...(params.renewableInference === undefined
+      ? {}
+      : {renewableInference: params.renewableInference}),
   });
   recordRuntimeConfigResolution(params, {source: 'instance', outcome: 'resolved'});
   return toResponse(params, managedRuntimeConfig.credentials, undefined, {

--- a/libs/api/definitions/src/db/workflow-lineage-migration.test.ts
+++ b/libs/api/definitions/src/db/workflow-lineage-migration.test.ts
@@ -57,7 +57,9 @@ async function insertDefinition(
 }
 
 describe('workflow lineage schema migration (0003)', () => {
-  test('adds nullable lineage storage without backfilling existing definitions', async () => {
+  test('adds nullable lineage storage without backfilling existing definitions', {
+    timeout: 30_000,
+  }, async () => {
     const scratch = `api_test_lineage_${randomUUID().replaceAll('-', '')}`;
     const admin = await connectTo(ADMIN_DATABASE);
     let target: pg.Client | undefined;

--- a/libs/api/runners-dto/src/inter-module.test.ts
+++ b/libs/api/runners-dto/src/inter-module.test.ts
@@ -1,6 +1,15 @@
 import {runnersInterModuleContract} from './inter-module.js';
 
 describe('runnersInterModuleContract', () => {
+  test('carries the claim-time renewable inference snapshot with an active lease', () => {
+    const result = runnersInterModuleContract.methods.getLeaseState.output.parse({
+      active: true,
+      renewableInference: false,
+    });
+
+    expect(result).toEqual({active: true, renewableInference: false});
+  });
+
   test('exposes bounded JSON capability results', () => {
     const result =
       runnersInterModuleContract.methods.getEffectiveRunnerToolCapabilities.output.parse({

--- a/libs/api/runners-dto/src/inter-module.ts
+++ b/libs/api/runners-dto/src/inter-module.ts
@@ -13,7 +13,10 @@ export const runnersInterModuleContract = defineInterModuleContract({
         jobExecutionId: idSchema,
         runnerSessionId: idSchema,
       }),
-      output: z.object({active: z.boolean()}),
+      output: z.object({
+        active: z.boolean(),
+        renewableInference: z.boolean().optional(),
+      }),
     },
     getEffectiveRunnerToolCapabilities: {
       input: z.object({runnerSessionId: idSchema}),

--- a/libs/api/runners/drizzle/0013_safe_whizzer.sql
+++ b/libs/api/runners/drizzle/0013_safe_whizzer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runners_running_jobs" ADD COLUMN "renewable_inference" boolean;

--- a/libs/api/runners/drizzle/meta/0013_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2210 @@
+{
+  "id": "7eb463da-dea0-40b8-ac74-f4517394c5c8",
+  "prevId": "e33083f0-0f7d-400e-91ef-d3bad47cc869",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.runners_admin_command_results": {
+      "name": "runners_admin_command_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key_fingerprint": {
+          "name": "idempotency_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_admin_command_results_actor_key_unique": {
+          "name": "runners_admin_command_results_actor_key_unique",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_ephemeral_registration_tokens": {
+      "name": "runners_ephemeral_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_ephemeral_registration_tokens_hashed_token_unique": {
+          "name": "runners_ephemeral_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_reservation_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_active_provider_runner_idx": {
+          "name": "runners_ephemeral_registration_tokens_active_provider_runner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_terminal_idx": {
+          "name": "runners_ephemeral_registration_tokens_terminal_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"consumed_at\", \"expires_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_manual_registration_tokens": {
+      "name": "runners_manual_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_manual_registration_tokens_hashed_token_unique": {
+          "name": "runners_manual_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_manual_registration_tokens_workspace_id_idx": {
+          "name": "runners_manual_registration_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_outbox": {
+      "name": "runners_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_outbox_pending_idx": {
+          "name": "runners_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_outbox_dispatched_retention_idx": {
+          "name": "runners_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_pending_jobs": {
+      "name": "runners_pending_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_pending_jobs_workspace_created_idx": {
+          "name": "runners_pending_jobs_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_pending_jobs_job_id_idx": {
+          "name": "runners_pending_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_pending_jobs_job_execution_id_unique": {
+          "name": "runners_pending_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_capability_snapshots": {
+      "name": "runners_provisioner_capability_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_slots": {
+          "name": "available_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting": {
+          "name": "starting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "running": {
+          "name": "running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "advertised_at": {
+          "name": "advertised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_capability_snapshots_workspace_active_idx": {
+          "name": "runners_provisioner_capability_snapshots_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "advertised_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_capability_snapshots_provisioner_idx": {
+          "name": "runners_provisioner_capability_snapshots_provisioner_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_tokens": {
+      "name": "runners_provisioner_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_provisioner_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_tokens_hashed_token_unique": {
+          "name": "runners_provisioner_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_tokens_workspace_last_seen_idx": {
+          "name": "runners_provisioner_tokens_workspace_last_seen_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_provisioner_tokens_scope_workspace_ck": {
+          "name": "runners_provisioner_tokens_scope_workspace_ck",
+          "value": "(scope = 'workspace' AND workspace_id IS NOT NULL) OR (scope = 'installation' AND workspace_id IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_reservations": {
+      "name": "runners_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "runners_reservation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'launch'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runners_reservations_workspace_expires_idx": {
+          "name": "runners_reservations_workspace_expires_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_reservations_expires_idx": {
+          "name": "runners_reservations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_reservations_count_positive_ck": {
+          "name": "runners_reservations_count_positive_ck",
+          "value": "\"runners_reservations\".\"count\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_activation_tokens": {
+      "name": "runners_runner_activation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_activation_tokens_hashed_token_unique": {
+          "name": "runners_runner_activation_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_activation_tokens_runner_instance_idx": {
+          "name": "runners_runner_activation_tokens_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_bootstrap_tokens": {
+      "name": "runners_runner_bootstrap_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_bootstrap_tokens_hashed_token_unique": {
+          "name": "runners_runner_bootstrap_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_bootstrap_tokens_runner_instance_idx": {
+          "name": "runners_runner_bootstrap_tokens_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_control_sessions": {
+      "name": "runners_runner_control_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_control_sessions_hashed_token_unique": {
+          "name": "runners_runner_control_sessions_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_control_sessions_active_runner_instance_unique": {
+          "name": "runners_runner_control_sessions_active_runner_instance_unique",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"closed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_control_sessions_runner_instance_idx": {
+          "name": "runners_runner_control_sessions_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_instances": {
+      "name": "runners_runner_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intended_reservation_id": {
+          "name": "intended_reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_kind": {
+          "name": "launch_kind",
+          "type": "runners_provider_runner_launch_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "state": {
+          "name": "state",
+          "type": "runners_provider_runner_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_claimed_at": {
+          "name": "first_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopping_at": {
+          "name": "stopping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_authorized_at": {
+          "name": "termination_authorized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "runners_termination_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_released_at": {
+          "name": "reservation_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_instances_provisioner_runner_unique": {
+          "name": "runners_runner_instances_provisioner_runner_unique",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runners_runner_instances\".\"provider_runner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_workspace_state_updated_idx": {
+          "name": "runners_runner_instances_workspace_state_updated_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_stale_reaper_idx": {
+          "name": "runners_runner_instances_stale_reaper_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_provisioner_intended_reservation_idx": {
+          "name": "runners_runner_instances_provisioner_intended_reservation_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intended_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"intended_reservation_id\" is not null and \"runners_runner_instances\".\"reservation_released_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_intended_reservation_idx": {
+          "name": "runners_runner_instances_intended_reservation_idx",
+          "columns": [
+            {
+              "expression": "intended_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"intended_reservation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_provisioner_reservation_idx": {
+          "name": "runners_runner_instances_provisioner_reservation_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"reservation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_active_template_counts_idx": {
+          "name": "runners_runner_instances_active_template_counts_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" in ('starting', 'running') and \"template_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_token_kind": {
+          "name": "registration_token_kind",
+          "type": "runners_runner_session_registration_token_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_capabilities": {
+          "name": "tool_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_capabilities_reported_at": {
+          "name": "tool_capabilities_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_capabilities": {
+          "name": "lifecycle_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_capabilities_reported_at": {
+          "name": "lifecycle_capabilities_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_claims": {
+          "name": "max_claims",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claims_used": {
+          "name": "claims_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_job_completed_at": {
+          "name": "last_job_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_sessions_provider_runner_updated_idx": {
+          "name": "runners_runner_sessions_provider_runner_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_sessions_stale_idle_idx": {
+          "name": "runners_runner_sessions_stale_idle_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_sessions\".\"revoked_at\" IS NULL AND \"runners_runner_sessions\".\"claims_used\" = 0 AND \"runners_runner_sessions\".\"registration_token_kind\" IN ('ephemeral', 'activation')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_sessions_active_activation_unique": {
+          "name": "runners_runner_sessions_active_activation_unique",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runners_runner_sessions\".\"registration_token_kind\" = 'activation' AND \"runners_runner_sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_runner_sessions_claims_ck": {
+          "name": "runners_runner_sessions_claims_ck",
+          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" in ('ephemeral', 'activation') AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NOT NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'activation' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_running_jobs": {
+      "name": "runners_running_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renewable_inference": {
+          "name": "renewable_inference",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_heartbeat_at": {
+          "name": "first_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "runners_job_stop_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_running_jobs_no_first_heartbeat_started_idx": {
+          "name": "runners_running_jobs_no_first_heartbeat_started_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"first_heartbeat_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_last_heartbeat_at_idx": {
+          "name": "runners_running_jobs_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_provider_runner_started_idx": {
+          "name": "runners_running_jobs_provider_runner_started_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_cancellation_requested_idx": {
+          "name": "runners_running_jobs_cancellation_requested_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cancellation_requested_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_job_id_idx": {
+          "name": "runners_running_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_running_jobs_job_execution_id_unique": {
+          "name": "runners_running_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provider_runner_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.runners_provisioner_scope": {
+      "name": "runners_provisioner_scope",
+      "schema": "public",
+      "values": ["workspace", "installation"]
+    },
+    "public.runners_reservation_kind": {
+      "name": "runners_reservation_kind",
+      "schema": "public",
+      "values": ["bound", "launch"]
+    },
+    "public.runners_provider_runner_launch_kind": {
+      "name": "runners_provider_runner_launch_kind",
+      "schema": "public",
+      "values": ["demand", "warm", "manual"]
+    },
+    "public.runners_provider_runner_state": {
+      "name": "runners_provider_runner_state",
+      "schema": "public",
+      "values": ["starting", "running", "stopping", "stopped", "failed", "terminated"]
+    },
+    "public.runners_termination_reason": {
+      "name": "runners_termination_reason",
+      "schema": "public",
+      "values": [
+        "registration-deadline",
+        "activation-timeout",
+        "runner-unresponsive",
+        "lease-expired",
+        "session-exhausted",
+        "stopping-timeout",
+        "provider-health-failed",
+        "job-cancelled",
+        "job-timeout",
+        "terminal-state"
+      ]
+    },
+    "public.runners_runner_session_registration_token_kind": {
+      "name": "runners_runner_session_registration_token_kind",
+      "schema": "public",
+      "values": ["manual", "ephemeral", "activation"]
+    },
+    "public.runners_runner_session_scope": {
+      "name": "runners_runner_session_scope",
+      "schema": "public",
+      "values": ["workspace"]
+    },
+    "public.runners_job_stop_reason": {
+      "name": "runners_job_stop_reason",
+      "schema": "public",
+      "values": ["run_cancelled", "timed_out"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/runners/drizzle/meta/_journal.json
+++ b/libs/api/runners/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1788181714093,
       "tag": "0012_condemned_wendell_rand",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1788446446529,
+      "tag": "0013_safe_whizzer",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -23,6 +23,7 @@ export {
   enqueueJobExecution,
   expireStuckJobExecutions,
   getJobExecutionCleanupStats,
+  getJobLeaseState,
   getWorkspaceJobCounts,
   isJobLeaseActive,
   listActiveRunningJobExecutions,

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -19,6 +19,7 @@ import {
   expireStuckJobExecutions,
   getJobExecutionCleanupStats,
   getJobExecutionQueueDepth,
+  getJobLeaseState,
   isJobLeaseActive,
   reconcileTerminalJobExecution,
   recordHeartbeat,
@@ -335,6 +336,73 @@ describe('claimPendingJobExecution', () => {
       .from(runningJobExecutions)
       .where(eq(runningJobExecutions.jobExecutionId, claimed?.jobExecutionId as string));
     expect(running?.firstHeartbeatAt).toBeNull();
+  });
+
+  it('snapshots renewable inference eligibility at claim and ignores later heartbeat changes', async () => {
+    await db()
+      .update(runnerSessions)
+      .set({
+        toolCapabilities: {
+          features: {renewable_git: false, renewable_inference: true},
+          harnesses: {},
+        },
+        toolCapabilitiesReportedAt: new Date('2025-01-01T00:00:00.000Z'),
+      })
+      .where(eq(runnerSessions.id, runnerSessionId));
+    const created = await pendingJobFactory.create({workspaceId});
+
+    const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+    const [running] = await db()
+      .select({renewableInference: runningJobExecutions.renewableInference})
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, created.jobExecutionId));
+
+    expect(running?.renewableInference).toBe(true);
+
+    await recordHeartbeat({
+      jobExecutionId: claimed?.jobExecutionId as string,
+      runnerSessionId,
+      toolCapabilities: null,
+    });
+
+    await expect(
+      getJobLeaseState({
+        jobId: created.jobId,
+        jobExecutionId: created.jobExecutionId,
+        runnerSessionId,
+      }),
+    ).resolves.toEqual({active: true, renewableInference: true});
+  });
+
+  it('snapshots false for a claim without renewable inference capability', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+
+    await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+
+    const [running] = await db()
+      .select({renewableInference: runningJobExecutions.renewableInference})
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, created.jobExecutionId));
+    expect(running?.renewableInference).toBe(false);
+  });
+
+  it('omits the renewable snapshot for legacy running rows', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+    const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+    expect(claimed?.jobExecutionId).toBe(created.jobExecutionId);
+
+    await db()
+      .update(runningJobExecutions)
+      .set({renewableInference: null})
+      .where(eq(runningJobExecutions.jobExecutionId, created.jobExecutionId));
+
+    await expect(
+      getJobLeaseState({
+        jobId: created.jobId,
+        jobExecutionId: created.jobExecutionId,
+        runnerSessionId,
+      }),
+    ).resolves.toEqual({active: true});
   });
 
   it('reports an active lease only for the session that claimed the job', async () => {

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -346,7 +346,7 @@ describe('claimPendingJobExecution', () => {
           features: {renewable_git: false, renewable_inference: true},
           harnesses: {},
         },
-        toolCapabilitiesReportedAt: new Date('2025-01-01T00:00:00.000Z'),
+        toolCapabilitiesReportedAt: new Date(),
       })
       .where(eq(runnerSessions.id, runnerSessionId));
     const created = await pendingJobFactory.create({workspaceId});
@@ -372,6 +372,29 @@ describe('claimPendingJobExecution', () => {
         runnerSessionId,
       }),
     ).resolves.toEqual({active: true, renewableInference: true});
+  });
+
+  it('does not authorize renewable inference from a stale capability report', async () => {
+    await db()
+      .update(runnerSessions)
+      .set({
+        toolCapabilities: {
+          features: {renewable_git: false, renewable_inference: true},
+          harnesses: {},
+        },
+        toolCapabilitiesReportedAt: new Date('2025-01-01T00:00:00.000Z'),
+      })
+      .where(eq(runnerSessions.id, runnerSessionId));
+    const created = await pendingJobFactory.create({workspaceId});
+
+    await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+
+    const [running] = await db()
+      .select({renewableInference: runningJobExecutions.renewableInference})
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, created.jobExecutionId));
+
+    expect(running?.renewableInference).toBe(false);
   });
 
   it('snapshots false for a claim without renewable inference capability', async () => {

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -513,6 +513,7 @@ interface ClaimPendingJobExecutionParams {
 interface ClaimRunnerContext {
   provisionerId: string | null;
   providerRunnerId: string | null;
+  renewableInference: boolean | null;
   runnerInstanceCondition: ReturnType<typeof eq> | undefined;
 }
 
@@ -531,14 +532,20 @@ export async function claimPendingJobExecution(
   let queueTimeObservation: JobExecutionQueueTimeObservation | null = null;
   let firstClaimReservationReleaseCount = 0;
   const result = await db().transaction(async (tx) => {
-    const {provisionerId, providerRunnerId, runnerInstanceCondition} =
+    const {provisionerId, providerRunnerId, renewableInference, runnerInstanceCondition} =
       await loadClaimRunnerContextTx(tx, params);
 
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
     // for rows sharing a created_at within a batch. Lock only the FIFO candidate before
     // attempting its execution advisory lock; putting pg_try_advisory_xact_lock in this
     // predicate would evaluate it while scanning and temporarily lock many queue entries.
-    const pendingClaim = await claimPendingCandidateTx(tx, params, provisionerId, providerRunnerId);
+    const pendingClaim = await claimPendingCandidateTx(
+      tx,
+      params,
+      provisionerId,
+      providerRunnerId,
+      renewableInference,
+    );
     if (!pendingClaim) return null;
     const {row, claimed} = pendingClaim;
 
@@ -609,25 +616,31 @@ async function loadClaimRunnerContextTx(
   let runnerInstanceId: string | null = null;
   let provisionerId: string | null = null;
   let providerRunnerId: string | null = null;
+  const sessionQuery = tx
+    .select({
+      maxClaims: runnerSessions.maxClaims,
+      claimsUsed: runnerSessions.claimsUsed,
+      revokedAt: runnerSessions.revokedAt,
+      runnerInstanceId: runnerSessions.runnerInstanceId,
+      provisionerId: runnerSessions.provisionerId,
+      providerRunnerId: runnerSessions.providerRunnerId,
+      toolCapabilities: runnerSessions.toolCapabilities,
+    })
+    .from(runnerSessions)
+    .where(eq(runnerSessions.id, params.runnerSessionId))
+    .limit(1);
+  const [session] =
+    params.maxClaims === null ? await sessionQuery : await sessionQuery.for('update');
+  let renewableInference: boolean | null = null;
   if (params.maxClaims !== null) {
-    const [session] = await tx
-      .select({
-        maxClaims: runnerSessions.maxClaims,
-        claimsUsed: runnerSessions.claimsUsed,
-        revokedAt: runnerSessions.revokedAt,
-        runnerInstanceId: runnerSessions.runnerInstanceId,
-        provisionerId: runnerSessions.provisionerId,
-        providerRunnerId: runnerSessions.providerRunnerId,
-      })
-      .from(runnerSessions)
-      .where(eq(runnerSessions.id, params.runnerSessionId))
-      .limit(1)
-      .for('update');
     assertClaimSessionAvailable(session, params.runnerSessionId);
     runnerInstanceId = session.runnerInstanceId;
     provisionerId = session.provisionerId;
     providerRunnerId = session.providerRunnerId;
   }
+  // The execution owns this claim-time value. Do not derive it from report freshness.
+  if (session)
+    renewableInference = session.toolCapabilities?.features?.renewable_inference === true;
   const runnerInstanceCondition = claimRunnerInstanceCondition(
     runnerInstanceId,
     provisionerId,
@@ -636,7 +649,7 @@ async function loadClaimRunnerContextTx(
   if (runnerInstanceCondition && provisionerId) {
     await lockClaimRunnerReservationIdsTx(tx, provisionerId, runnerInstanceCondition);
   }
-  return {provisionerId, providerRunnerId, runnerInstanceCondition};
+  return {provisionerId, providerRunnerId, renewableInference, runnerInstanceCondition};
 }
 
 function assertClaimSessionAvailable<
@@ -694,6 +707,7 @@ async function claimPendingCandidateTx(
   params: ClaimPendingJobExecutionParams,
   provisionerId: string | null,
   providerRunnerId: string | null,
+  renewableInference: boolean | null,
 ): Promise<{
   row: typeof pendingJobExecutions.$inferSelect;
   claimed: {claimedAt: Date};
@@ -731,6 +745,7 @@ async function claimPendingCandidateTx(
       jobExecutionId: row.jobExecutionId,
       projectId: row.projectId,
       runnerSessionId: params.runnerSessionId,
+      renewableInference,
       provisionerId,
       providerRunnerId,
       requiredLabels: row.requiredLabels,
@@ -1164,8 +1179,25 @@ export async function isJobLeaseActive(params: {
   jobExecutionId: string;
   runnerSessionId: string;
 }): Promise<boolean> {
+  const state = await getJobLeaseState(params);
+  return state.active;
+}
+
+export interface JobLeaseState {
+  active: boolean;
+  renewableInference?: boolean;
+}
+
+export async function getJobLeaseState(params: {
+  jobId?: string;
+  jobExecutionId: string;
+  runnerSessionId: string;
+}): Promise<JobLeaseState> {
   const [row] = await db()
-    .select({id: runningJobExecutions.id})
+    .select({
+      id: runningJobExecutions.id,
+      renewableInference: runningJobExecutions.renewableInference,
+    })
     .from(runningJobExecutions)
     .where(
       and(
@@ -1176,7 +1208,11 @@ export async function isJobLeaseActive(params: {
     )
     .limit(1);
 
-  return row !== undefined;
+  if (!row) return {active: false};
+  return {
+    active: true,
+    ...(row.renewableInference === null ? {} : {renewableInference: row.renewableInference}),
+  };
 }
 
 export async function recordHeartbeat(params: {

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -25,11 +25,13 @@ import {
   type SQL,
   sql,
 } from 'drizzle-orm';
+import {config} from '#config.js';
 import {
   EmptyRequiredLabelsError,
   RunnerSessionExhaustedError,
   RunningJobExecutionNotFoundError,
 } from '#core/errors.js';
+import {effectiveRunnerToolCapabilities} from '#core/runner-tool-capabilities.js';
 import {
   type JobExecutionQueueTimeObservation,
   jobExecutionEnqueuedCount,
@@ -625,6 +627,7 @@ async function loadClaimRunnerContextTx(
       provisionerId: runnerSessions.provisionerId,
       providerRunnerId: runnerSessions.providerRunnerId,
       toolCapabilities: runnerSessions.toolCapabilities,
+      toolCapabilitiesReportedAt: runnerSessions.toolCapabilitiesReportedAt,
     })
     .from(runnerSessions)
     .where(eq(runnerSessions.id, params.runnerSessionId))
@@ -638,9 +641,16 @@ async function loadClaimRunnerContextTx(
     provisionerId = session.provisionerId;
     providerRunnerId = session.providerRunnerId;
   }
-  // The execution owns this claim-time value. Do not derive it from report freshness.
-  if (session)
-    renewableInference = session.toolCapabilities?.features?.renewable_inference === true;
+  // Snapshot only the freshness-aware state at claim time. Later heartbeat reports must not
+  // change the execution's eligibility.
+  if (session) {
+    const effectiveCapabilities = effectiveRunnerToolCapabilities({
+      toolCapabilities: session.toolCapabilities,
+      reportedAt: session.toolCapabilitiesReportedAt,
+      staleAfterSeconds: config.RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS,
+    });
+    renewableInference = effectiveCapabilities.features?.renewable_inference === true;
+  }
   const runnerInstanceCondition = claimRunnerInstanceCondition(
     runnerInstanceId,
     provisionerId,

--- a/libs/api/runners/src/db/schema/running-job-executions.ts
+++ b/libs/api/runners/src/db/schema/running-job-executions.ts
@@ -1,6 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
-import {check, index, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {boolean, check, index, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 import {runnerSessions} from './runner-sessions.js';
 
@@ -22,6 +22,7 @@ export const runningJobExecutions = pgTable(
     runnerSessionId: uuid('runner_session_id')
       .notNull()
       .references(() => runnerSessions.id),
+    renewableInference: boolean('renewable_inference'),
     provisionerId: uuid('provisioner_id'),
     providerRunnerId: text('provider_runner_id'),
     requiredLabels: text('required_labels').array().notNull(),

--- a/libs/api/runners/src/presentation/inter-module.ts
+++ b/libs/api/runners/src/presentation/inter-module.ts
@@ -1,13 +1,13 @@
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {defineInterModulePresentation, type InterModulePresentation} from '@shipfox/inter-module';
 import {getEffectiveRunnerToolCapabilities} from '#core/runner-tool-capabilities.js';
-import {getWorkspaceJobCounts, isJobLeaseActive} from '#db/job-executions.js';
+import {getJobLeaseState, getWorkspaceJobCounts} from '#db/job-executions.js';
 
 export function createRunnersInterModulePresentation(): InterModulePresentation<
   typeof runnersInterModuleContract
 > {
   return defineInterModulePresentation(runnersInterModuleContract, {
-    getLeaseState: async (input) => ({active: await isJobLeaseActive(input)}),
+    getLeaseState: getJobLeaseState,
     getEffectiveRunnerToolCapabilities: async (input) => {
       const result = await getEffectiveRunnerToolCapabilities(input);
       return {capabilities: result.capabilities, reportFresh: result.reportFresh};

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -194,6 +194,90 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     expect(res.json().credentials.api_key).toBe('sk-gated-workspace-secret');
   });
 
+  test('forwards the claim-time renewable inference snapshot to credential resolution', async () => {
+    const {run, job, step} = await createRunningAgentStep();
+    await saveWorkspaceCredential(run.workspaceId, 'sk-renewable-workspace-secret');
+    const token = await mintActiveLeaseToken({jobId: job.id, renewableInference: true});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: runtimeConfigUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(resolveRuntimeCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({renewableInference: true}),
+    );
+  });
+
+  test('does not return credentials when the step is cancelled during resolution', async () => {
+    const {job, step} = await createRunningAgentStep();
+    const runtimeConfig: Awaited<ReturnType<AgentInterModuleClient['resolveRuntimeCredentials']>> =
+      {
+        harness: 'pi',
+        provider_id: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'xhigh',
+        credentials: {api_key: 'sk-cancelled-runtime-secret'},
+      };
+    let releaseResolution!: () => void;
+    const resolution = new Promise<typeof runtimeConfig>((resolve) => {
+      releaseResolution = () => resolve(runtimeConfig);
+    });
+    resolveRuntimeCredentials.mockImplementationOnce(() => resolution);
+    const token = await mintActiveLeaseToken({jobId: job.id});
+    const responsePromise = app.inject({
+      method: 'GET',
+      url: runtimeConfigUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    await vi.waitFor(() => expect(resolveRuntimeCredentials).toHaveBeenCalledTimes(1));
+    await db().update(stepsTable).set({status: 'cancelled'}).where(eq(stepsTable.id, step.id));
+    releaseResolution();
+
+    const res = await responsePromise;
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('step-not-running');
+    expect(res.json().credentials).toBeUndefined();
+  });
+
+  test('does not return credentials when the step advances to a new attempt during resolution', async () => {
+    const {job, step} = await createRunningAgentStep();
+    const runtimeConfig: Awaited<ReturnType<AgentInterModuleClient['resolveRuntimeCredentials']>> =
+      {
+        harness: 'pi',
+        provider_id: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'xhigh',
+        credentials: {api_key: 'sk-superseded-runtime-secret'},
+      };
+    let releaseResolution!: () => void;
+    const resolution = new Promise<typeof runtimeConfig>((resolve) => {
+      releaseResolution = () => resolve(runtimeConfig);
+    });
+    resolveRuntimeCredentials.mockImplementationOnce(() => resolution);
+    const token = await mintActiveLeaseToken({jobId: job.id});
+    const responsePromise = app.inject({
+      method: 'GET',
+      url: runtimeConfigUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    await vi.waitFor(() => expect(resolveRuntimeCredentials).toHaveBeenCalledTimes(1));
+    await db()
+      .update(stepsTable)
+      .set({currentAttempt: step.currentAttempt + 1})
+      .where(eq(stepsTable.id, step.id));
+    releaseResolution();
+
+    const res = await responsePromise;
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('step-attempt-mismatch');
+    expect(res.json().credentials).toBeUndefined();
+  });
+
   test('returns 404 when the lease token is no longer the active job lease', async () => {
     const {run, job, step} = await createRunningAgentStep();
     await insertRunningJobLease({

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -84,12 +84,13 @@ export function createAgentRuntimeConfigRoute(params: {
     },
     handler: async (request, reply) => {
       const {step_id: stepId, attempt} = request.query;
-      const {step, workspaceId, projectId} = await loadRunningLeasedStep({
+      const loadedStep = await loadRunningLeasedStep({
         runners: params.runners,
         request,
         stepId,
         attempt,
       });
+      const {step, workspaceId, projectId, renewableInference} = loadedStep;
 
       if (step.type !== 'agent') {
         throw new ClientError('Step is not an agent step', 'step-not-agent', {status: 409});
@@ -128,6 +129,14 @@ export function createAgentRuntimeConfigRoute(params: {
         provider: agentConfig.provider,
         model: agentConfig.model,
         thinking: agentConfig.thinking,
+        ...(renewableInference === undefined ? {} : {renewableInference}),
+      });
+
+      await loadRunningLeasedStep({
+        runners: params.runners,
+        request,
+        stepId,
+        attempt,
       });
 
       reply.header('cache-control', 'no-store');

--- a/libs/api/workflows/src/presentation/routes/leased-step.ts
+++ b/libs/api/workflows/src/presentation/routes/leased-step.ts
@@ -20,20 +20,23 @@ export interface LoadedRunningLeasedStep {
   run: WorkflowRunOriginState;
   /** The server-frozen subject for a successful persisted checkout renewal. */
   checkoutRenewalSubject?: CheckoutRenewalSubject;
+  /** The capability snapshot captured when the runner claimed this execution. */
+  renewableInference?: boolean;
 }
 
 export async function assertLeasedJobActive(
   runners: RunnersInterModuleClient,
   leasedJob: Pick<LeasedJobContext, 'jobId' | 'jobExecutionId' | 'runnerSessionId'>,
-): Promise<void> {
-  const {active: leaseIsActive} = await runners.getLeaseState({
+): Promise<Awaited<ReturnType<RunnersInterModuleClient['getLeaseState']>>> {
+  const leaseState = await runners.getLeaseState({
     jobId: leasedJob.jobId,
     jobExecutionId: leasedJob.jobExecutionId,
     runnerSessionId: leasedJob.runnerSessionId,
   });
-  if (!leaseIsActive) {
+  if (!leaseState.active) {
     throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
   }
+  return leaseState;
 }
 
 export async function loadRunningLeasedStep(params: {
@@ -45,7 +48,11 @@ export async function loadRunningLeasedStep(params: {
 }): Promise<LoadedRunningLeasedStep> {
   const leasedJob = requireLeasedJobContext(params.request);
 
-  await assertLeasedJobActive(params.runners, leasedJob);
+  const leaseState = await assertLeasedJobActive(params.runners, leasedJob);
+  const renewableInference =
+    leaseState.renewableInference === undefined
+      ? {}
+      : {renewableInference: leaseState.renewableInference};
 
   const step = await getStepByIdForJobExecution({
     stepId: params.stepId,
@@ -78,6 +85,7 @@ export async function loadRunningLeasedStep(params: {
           triggerReference: scope.triggerReference,
           run: scope.run,
           checkoutRenewalSubject,
+          ...renewableInference,
         };
       }
     }
@@ -91,5 +99,6 @@ export async function loadRunningLeasedStep(params: {
     projectId: scope.projectId,
     triggerReference: scope.triggerReference,
     run: scope.run,
+    ...renewableInference,
   };
 }

--- a/libs/api/workflows/test/fixtures/active-lease-token.ts
+++ b/libs/api/workflows/test/fixtures/active-lease-token.ts
@@ -14,6 +14,7 @@ export interface MintActiveLeaseTokenParams {
     projectId?: string;
     workspaceId?: string;
   };
+  renewableInference?: boolean | undefined;
 }
 
 export async function mintActiveLeaseToken(params: MintActiveLeaseTokenParams): Promise<string> {
@@ -29,6 +30,7 @@ export async function mintActiveLeaseToken(params: MintActiveLeaseTokenParams): 
     jobId: params.jobId,
     jobExecutionId: jobExecution.id,
     runnerSessionId,
+    renewableInference: params.renewableInference,
   });
 
   return await mintLeaseToken({
@@ -50,6 +52,7 @@ export interface InsertRunningJobLeaseParams {
   jobExecutionId: string;
   projectId: string;
   runnerSessionId: string;
+  renewableInference?: boolean | undefined;
 }
 
 export function insertRunningJobLease(params: InsertRunningJobLeaseParams): Promise<void> {

--- a/libs/api/workflows/test/fixtures/runners-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/runners-inter-module.ts
@@ -1,6 +1,10 @@
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 
 const activeLeases = new Set<string>();
+const leaseStates = new Map<
+  string,
+  Awaited<ReturnType<RunnersInterModuleClient['getLeaseState']>>
+>();
 const toolCapabilities = new Map<
   string,
   Awaited<ReturnType<RunnersInterModuleClient['getEffectiveRunnerToolCapabilities']>>
@@ -18,8 +22,16 @@ export function registerActiveRunnerLease(params: {
   jobId: string;
   jobExecutionId: string;
   runnerSessionId: string;
+  renewableInference?: boolean | undefined;
 }): void {
-  activeLeases.add(leaseKey(params));
+  const key = leaseKey(params);
+  activeLeases.add(key);
+  leaseStates.set(key, {
+    active: true,
+    ...(params.renewableInference === undefined
+      ? {}
+      : {renewableInference: params.renewableInference}),
+  });
 }
 
 export function setRunnerToolCapabilities(
@@ -31,11 +43,13 @@ export function setRunnerToolCapabilities(
 
 export function resetRunnersTestClient(): void {
   activeLeases.clear();
+  leaseStates.clear();
   toolCapabilities.clear();
 }
 
 export const runnersTestClient: RunnersInterModuleClient = {
-  getLeaseState: async (params) => ({active: activeLeases.has(leaseKey(params))}),
+  getLeaseState: async (params) =>
+    leaseStates.get(leaseKey(params)) ?? {active: activeLeases.has(leaseKey(params))},
   getEffectiveRunnerToolCapabilities: async ({runnerSessionId}) =>
     toolCapabilities.get(runnerSessionId) ?? {capabilities: {harnesses: {}}, reportFresh: false},
   getWorkspaceJobCounts: async ({workspaceIds}) => ({

--- a/libs/client/shell/test/external/fixture/package.json
+++ b/libs/client/shell/test/external/fixture/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "jsdom": "29.1.1",
+    "postcss": "8.5.26",
     "typescript": "7.0.2",
     "vite": "8.0.16",
     "vitest": "4.1.9"


### PR DESCRIPTION
Snapshot renewable inference eligibility before credential minting

Running steps now use the capability state captured when the job is claimed. The runtime credential route passes that server-owned snapshot to managed providers and checks the current lease, step status, and attempt again after resolution.

This preserves legacy behavior for older claim rows and providers, while preventing heartbeat freshness from revoking an active step's eligibility or cancellation and attempt replacement from returning newly minted credentials. Runner behavior and Cloud renewable issuance remain unchanged.

Closes ENG-1940

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running steps now decide renewable credential eligibility from the capability state captured at claim time instead of live heartbeat freshness, and stale capability reports can no longer authorize eligibility. The runtime credential route passes the server-owned snapshot to managed providers and re-reads the lease, step status, and attempt after resolution.

- Heartbeat freshness can no longer revoke eligibility for an already running step.
- Cancellation or a new step attempt still prevents a newly minted token from being returned.
- Stale capability reports cannot grant eligibility at claim time.
- Older claim rows and providers without a snapshot keep the legacy path.
- Runner behavior and Cloud renewable issuance are unchanged.
- Adds `postcss` to the external client test fixture dependencies.

**Migration**
- Adds a nullable `renewable_inference` column to `runners_running_jobs`.

<sup>Written for commit ed043e0521efb5a1f54c8c05926d6d4095d42d5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

