### PR TITLE
Make workflow job execution events self-sufficient

### DIFF
--- a/.changeset/self-sufficient-job-execution-events.md
+++ b/.changeset/self-sufficient-job-execution-events.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+---
+
+Adds runner identity to the `runners.job.claimed` projection on `job_executions`, and adds `workspaceId`, `projectId`, `definitionId`, `jobKey`, `queuedAt`, `startedAt`, and runner identity to `workflows.job_execution.terminated` and `jobKey`, `definitionId`, and `runNumber` to `workflows.job_execution.queued`, so a consumer can build a complete usage record from a single event.

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -233,6 +233,78 @@ describe('workflowsJobExecutionTerminatedSchema', () => {
 
     expect(workflowsJobExecutionTerminatedSchema.parse(input)).toEqual(input);
   });
+
+  it('keeps identity, timestamps, and runner identity optional for events written before they existed', () => {
+    const result = workflowsJobExecutionTerminatedSchema.parse(validJobExecutionTerminated);
+
+    expect(result.workspaceId).toBeUndefined();
+    expect(result.projectId).toBeUndefined();
+    expect(result.definitionId).toBeUndefined();
+    expect(result.jobKey).toBeUndefined();
+    expect(result.queuedAt).toBeUndefined();
+    expect(result.startedAt).toBeUndefined();
+    expect(result.runnerLabels).toBeUndefined();
+    expect(result.templateKey).toBeUndefined();
+    expect(result.provisionerId).toBeUndefined();
+    expect(result.provisionerScope).toBeUndefined();
+    expect(result.providerKind).toBeUndefined();
+    expect(result.launchKind).toBeUndefined();
+  });
+
+  it('makes a claimed execution self-sufficient: identity, queued, started, and runner identity all present', () => {
+    const input = {
+      ...validJobExecutionTerminated,
+      workspaceId: 'ws-1',
+      projectId: 'project-1',
+      definitionId: 'def-1',
+      jobKey: 'build',
+      queuedAt: '2026-08-11T08:00:00.000Z',
+      startedAt: '2026-08-11T08:00:05.000Z',
+      runnerLabels: ['linux', 'x64'],
+      templateKey: 'standard',
+      provisionerId: crypto.randomUUID(),
+      provisionerScope: 'installation' as const,
+      providerKind: 'ec2',
+      launchKind: 'demand' as const,
+    };
+
+    expect(workflowsJobExecutionTerminatedSchema.strict().parse(input)).toEqual(input);
+  });
+
+  it('accepts null started_at and null runner identity for a never-claimed execution', () => {
+    const input = {
+      ...validJobExecutionTerminated,
+      workspaceId: 'ws-1',
+      projectId: 'project-1',
+      definitionId: 'def-1',
+      jobKey: 'build',
+      queuedAt: '2026-08-11T08:00:00.000Z',
+      startedAt: null,
+      runnerLabels: null,
+      templateKey: null,
+      provisionerId: null,
+      provisionerScope: null,
+      providerKind: null,
+      launchKind: null,
+    };
+
+    expect(workflowsJobExecutionTerminatedSchema.strict().parse(input)).toEqual(input);
+  });
+
+  it('rejects a provisioner scope or launch kind outside the known set', () => {
+    expect(() =>
+      workflowsJobExecutionTerminatedSchema.parse({
+        ...validJobExecutionTerminated,
+        provisionerScope: 'region',
+      }),
+    ).toThrow();
+    expect(() =>
+      workflowsJobExecutionTerminatedSchema.parse({
+        ...validJobExecutionTerminated,
+        launchKind: 'scheduled',
+      }),
+    ).toThrow();
+  });
 });
 
 describe('workflowsWorkflowRunTerminatedSchema', () => {
@@ -372,6 +444,27 @@ describe('workflowsStepRestartEnqueuedSchema', () => {
     const parse = () => workflowsStepRestartEnqueuedSchema.parse(input);
 
     expect(parse).toThrow();
+  });
+});
+
+describe('workflowsJobExecutionQueuedSchema', () => {
+  it('accepts the job key, definition id, and run number added for self-sufficient usage records', () => {
+    const input = {
+      ...validJobExecutionQueued,
+      jobKey: 'build',
+      definitionId: 'def-1',
+      runNumber: 12,
+    };
+
+    expect(workflowsJobExecutionQueuedSchema.strict().parse(input)).toEqual(input);
+  });
+
+  it('keeps the job key, definition id, and run number optional for events written before they existed', () => {
+    const result = workflowsJobExecutionQueuedSchema.parse(validJobExecutionQueued);
+
+    expect(result.jobKey).toBeUndefined();
+    expect(result.definitionId).toBeUndefined();
+    expect(result.runNumber).toBeUndefined();
   });
 });
 

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -263,9 +263,9 @@ describe('workflowsJobExecutionTerminatedSchema', () => {
       runnerLabels: ['linux', 'x64'],
       templateKey: 'standard',
       provisionerId: crypto.randomUUID(),
-      provisionerScope: 'installation' as const,
+      provisionerScope: 'installation',
       providerKind: 'ec2',
-      launchKind: 'demand' as const,
+      launchKind: 'demand',
     };
 
     expect(workflowsJobExecutionTerminatedSchema.strict().parse(input)).toEqual(input);
@@ -291,17 +291,31 @@ describe('workflowsJobExecutionTerminatedSchema', () => {
     expect(workflowsJobExecutionTerminatedSchema.strict().parse(input)).toEqual(input);
   });
 
-  it('rejects a provisioner scope or launch kind outside the known set', () => {
+  it('accepts a provisioner scope or launch kind the runners module has not shipped here yet', () => {
+    // Not a closed enum: the runners module owns and validates these values, on its own
+    // release cadence. A value this package doesn't recognize yet must still parse, or a
+    // runners-side addition would dead-letter every terminated event for executions claimed
+    // with it (the dispatcher validates every outbox payload against this schema).
+    const input = {
+      ...validJobExecutionTerminated,
+      provisionerScope: 'region',
+      launchKind: 'scheduled',
+    };
+
+    expect(workflowsJobExecutionTerminatedSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects an empty provisioner scope or launch kind', () => {
     expect(() =>
       workflowsJobExecutionTerminatedSchema.parse({
         ...validJobExecutionTerminated,
-        provisionerScope: 'region',
+        provisionerScope: '',
       }),
     ).toThrow();
     expect(() =>
       workflowsJobExecutionTerminatedSchema.parse({
         ...validJobExecutionTerminated,
-        launchKind: 'scheduled',
+        launchKind: '',
       }),
     ).toThrow();
   });

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -5,12 +5,6 @@ import {logOutcomeSchema} from './schemas/log-outcome.js';
 
 const nonEmptyStringSchema = z.string().nonempty();
 
-// Mirrors the runners module's own (unexported) event-contract enums. Kept local
-// rather than imported: this package owns its own public contract independently
-// of runners-dto's.
-const jobExecutionProvisionerScopeSchema = z.enum(['installation', 'workspace']);
-const jobExecutionLaunchKindSchema = z.enum(['demand', 'warm', 'manual']);
-
 export const WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED =
   'workflows.workflow_run_attempt.created' as const;
 // Terminal fact for a workflow run, written in the same transaction as the status flip.
@@ -111,8 +105,11 @@ export const workflowsJobExecutionTerminatedSchema = z.object({
   cancellationReason: workflowStopReasonSchema.nullable().optional(),
   statusReasonMessage: z.string().nullable().optional(),
   // Optional so consumers can continue to read events written before these fields existed. New
-  // outbox events always include the identity fields; the timestamps and runner identity are
-  // null when the execution was never queued, never claimed, or claimed by no known provisioner.
+  // outbox events always include the identity fields. The timestamps and runner identity are
+  // null when the execution was never queued or never claimed, and can also be null for a
+  // claimed execution when the runners.job.claimed projection has not landed yet at termination
+  // time (async, at-least-once, first-write-wins like startedAt today) — a rare race the Usage
+  // context tolerates by treating a late claim as filling display fields only.
   // Added so a consumer can build a complete usage record from this one event.
   workspaceId: nonEmptyStringSchema.optional(),
   projectId: nonEmptyStringSchema.optional(),
@@ -123,9 +120,13 @@ export const workflowsJobExecutionTerminatedSchema = z.object({
   runnerLabels: z.array(nonEmptyStringSchema).min(1).nullable().optional(),
   templateKey: nonEmptyStringSchema.nullable().optional(),
   provisionerId: nonEmptyStringSchema.nullable().optional(),
-  provisionerScope: jobExecutionProvisionerScopeSchema.nullable().optional(),
+  // Not a closed enum: the runners module owns and validates this value (also true of
+  // providerKind below). A schema this package doesn't need to keep in lockstep with a
+  // release it doesn't control, since the dispatcher validates every outbox payload against
+  // this schema and dead-letters after repeated failures.
+  provisionerScope: nonEmptyStringSchema.nullable().optional(),
   providerKind: nonEmptyStringSchema.nullable().optional(),
-  launchKind: jobExecutionLaunchKindSchema.nullable().optional(),
+  launchKind: nonEmptyStringSchema.nullable().optional(),
 });
 export type WorkflowsJobExecutionTerminatedEventDto = z.infer<
   typeof workflowsJobExecutionTerminatedSchema

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -5,6 +5,12 @@ import {logOutcomeSchema} from './schemas/log-outcome.js';
 
 const nonEmptyStringSchema = z.string().nonempty();
 
+// Mirrors the runners module's own (unexported) event-contract enums. Kept local
+// rather than imported: this package owns its own public contract independently
+// of runners-dto's.
+const jobExecutionProvisionerScopeSchema = z.enum(['installation', 'workspace']);
+const jobExecutionLaunchKindSchema = z.enum(['demand', 'warm', 'manual']);
+
 export const WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED =
   'workflows.workflow_run_attempt.created' as const;
 // Terminal fact for a workflow run, written in the same transaction as the status flip.
@@ -81,6 +87,11 @@ export const workflowsJobExecutionQueuedSchema = z.object({
   projectId: nonEmptyStringSchema,
   requiredLabels: z.array(nonEmptyStringSchema).min(1),
   queuedAt: z.string().datetime(),
+  // Optional so consumers can continue to read events written before these fields
+  // existed. New outbox events always include the value.
+  jobKey: nonEmptyStringSchema.optional(),
+  definitionId: nonEmptyStringSchema.optional(),
+  runNumber: z.number().int().positive().optional(),
 });
 export type WorkflowsJobExecutionQueuedEventDto = z.infer<typeof workflowsJobExecutionQueuedSchema>;
 
@@ -99,6 +110,22 @@ export const workflowsJobExecutionTerminatedSchema = z.object({
   // Optional so consumers can continue to read terminal events emitted before this field existed.
   cancellationReason: workflowStopReasonSchema.nullable().optional(),
   statusReasonMessage: z.string().nullable().optional(),
+  // Optional so consumers can continue to read events written before these fields existed. New
+  // outbox events always include the identity fields; the timestamps and runner identity are
+  // null when the execution was never queued, never claimed, or claimed by no known provisioner.
+  // Added so a consumer can build a complete usage record from this one event.
+  workspaceId: nonEmptyStringSchema.optional(),
+  projectId: nonEmptyStringSchema.optional(),
+  definitionId: nonEmptyStringSchema.optional(),
+  jobKey: nonEmptyStringSchema.optional(),
+  queuedAt: z.string().datetime().nullable().optional(),
+  startedAt: z.string().datetime().nullable().optional(),
+  runnerLabels: z.array(nonEmptyStringSchema).min(1).nullable().optional(),
+  templateKey: nonEmptyStringSchema.nullable().optional(),
+  provisionerId: nonEmptyStringSchema.nullable().optional(),
+  provisionerScope: jobExecutionProvisionerScopeSchema.nullable().optional(),
+  providerKind: nonEmptyStringSchema.nullable().optional(),
+  launchKind: jobExecutionLaunchKindSchema.nullable().optional(),
 });
 export type WorkflowsJobExecutionTerminatedEventDto = z.infer<
   typeof workflowsJobExecutionTerminatedSchema

--- a/libs/api/workflows/drizzle/0008_job_execution_runner_identity.sql
+++ b/libs/api/workflows/drizzle/0008_job_execution_runner_identity.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "workflows_job_executions" ADD COLUMN "runner_labels" jsonb;--> statement-breakpoint
+ALTER TABLE "workflows_job_executions" ADD COLUMN "template_key" text;--> statement-breakpoint
+ALTER TABLE "workflows_job_executions" ADD COLUMN "provisioner_id" uuid;--> statement-breakpoint
+ALTER TABLE "workflows_job_executions" ADD COLUMN "provisioner_scope" text;--> statement-breakpoint
+ALTER TABLE "workflows_job_executions" ADD COLUMN "provider_kind" text;--> statement-breakpoint
+ALTER TABLE "workflows_job_executions" ADD COLUMN "launch_kind" text;

--- a/libs/api/workflows/drizzle/meta/0008_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2252 @@
+{
+  "id": "2fc16196-749b-4ee9-9614-07bc1ac1d555",
+  "prevId": "79c175d9-6279-44bb-a948-c990294eb627",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_checkout_renewal_subjects": {
+      "name": "workflows_checkout_renewal_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_checkout_renewal_subject_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_repository_id": {
+          "name": "external_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions_contents": {
+          "name": "permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_crs_step_id_attempt_uq": {
+          "name": "workflows_crs_step_id_attempt_uq",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_crs_workflow_run_attempt_id_idx": {
+          "name": "workflows_crs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_checkout_renewal_subjects_step_id_workflows_steps_id_fk": {
+          "name": "workflows_checkout_renewal_subjects_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_checkout_renewal_subjects",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_checkout_renewal_subjects_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_checkout_renewal_subjects_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_checkout_renewal_subjects",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_crs_attempt_positive_ck": {
+          "name": "workflows_crs_attempt_positive_ck",
+          "value": "\"workflows_checkout_renewal_subjects\".\"attempt\" > 0"
+        },
+        "workflows_crs_promoted_at_ck": {
+          "name": "workflows_crs_promoted_at_ck",
+          "value": "(\"workflows_checkout_renewal_subjects\".\"status\" = 'pending' and \"workflows_checkout_renewal_subjects\".\"promoted_at\" is null) or (\"workflows_checkout_renewal_subjects\".\"status\" = 'promoted' and \"workflows_checkout_renewal_subjects\".\"promoted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_executions": {
+      "name": "workflows_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_scope": {
+          "name": "provisioner_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_kind": {
+          "name": "launch_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason_message": {
+          "name": "status_reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_job_executions_job_id_idx": {
+          "name": "workflows_job_executions_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_running_idx": {
+          "name": "workflows_job_executions_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_executions\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_job_sequence_uq": {
+          "name": "workflows_job_executions_job_sequence_uq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_executions_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_executions_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_executions",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_listener_events": {
+      "name": "workflows_job_listener_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "workflows_job_listener_event_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "workflows_job_listener_event_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "workflows_job_listener_event_outcome_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_ref": {
+          "name": "event_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_payload_bytes": {
+          "name": "stored_payload_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "normalized_event_bytes": {
+          "name": "normalized_event_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by_execution_id": {
+          "name": "consumed_by_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_job_listener_events_job_event_ref_unique": {
+          "name": "workflows_job_listener_events_job_event_ref_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_job_received_idx": {
+          "name": "workflows_job_listener_events_job_received_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_pending_order_idx": {
+          "name": "workflows_job_listener_events_pending_order_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_listener_events\".\"consumed_by_execution_id\" IS NULL AND \"workflows_job_listener_events\".\"outcome\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_consumed_order_idx": {
+          "name": "workflows_job_listener_events_consumed_order_idx",
+          "columns": [
+            {
+              "expression": "consumed_by_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_listener_events\".\"consumed_by_execution_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_listener_events_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_listener_events_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["consumed_by_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_job_listener_events_byte_counts_ck": {
+          "name": "workflows_job_listener_events_byte_counts_ck",
+          "value": "\"workflows_job_listener_events\".\"stored_payload_bytes\" >= 0 AND \"workflows_job_listener_events\".\"normalized_event_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "workflows_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over": {
+          "name": "carried_over",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checkout_persist_credentials": {
+          "name": "checkout_persist_credentials",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkout_permissions_contents": {
+          "name": "checkout_permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_timeout_ms": {
+          "name": "execution_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_timeout_ms": {
+          "name": "listening_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions": {
+          "name": "max_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_resolve": {
+          "name": "on_resolve",
+          "type": "workflows_job_on_resolve",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_debounce_ms": {
+          "name": "batch_debounce_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_size": {
+          "name": "batch_max_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_wait_ms": {
+          "name": "batch_max_wait_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listener_status": {
+          "name": "listener_status",
+          "type": "workflows_listener_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "workflows_resolution_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_on": {
+          "name": "listening_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_until": {
+          "name": "listening_until",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_jobs_workflow_run_attempt_id_idx": {
+          "name": "workflows_jobs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_jobs_active_listeners_idx": {
+          "name": "workflows_jobs_active_listeners_idx",
+          "columns": [
+            {
+              "expression": "listener_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_jobs\".\"listener_status\" = 'listening'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_order": {
+          "name": "execution_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_outcome": {
+          "name": "log_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_feedback": {
+          "name": "restart_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invocations": {
+          "name": "invocations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        },
+        "workflows_step_attempts_job_execution_id_execution_order_uq": {
+          "name": "workflows_step_attempts_job_execution_id_execution_order_uq",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id", "execution_order"]
+        },
+        "workflows_step_attempts_id_step_id_job_execution_id_uq": {
+          "name": "workflows_step_attempts_id_step_id_job_execution_id_uq",
+          "nullsNotDistinct": false,
+          "columns": ["id", "step_id", "job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_execution_order_positive_ck": {
+          "name": "workflows_step_attempts_execution_order_positive_ck",
+          "value": "\"workflows_step_attempts\".\"execution_order\" > 0"
+        },
+        "workflows_step_attempts_status_dispatched_ck": {
+          "name": "workflows_step_attempts_status_dispatched_ck",
+          "value": "\"workflows_step_attempts\".\"status\" NOT IN ('pending', 'skipped')"
+        },
+        "workflows_step_attempts_log_outcome_ck": {
+          "name": "workflows_step_attempts_log_outcome_ck",
+          "value": "\"workflows_step_attempts\".\"log_outcome\" IS NULL OR \"workflows_step_attempts\".\"log_outcome\" IN ('drained', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_step_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_plan": {
+          "name": "config_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authored_config": {
+          "name": "authored_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_execution_id_idx": {
+          "name": "workflows_steps_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_steps_id_job_execution_id_uq": {
+          "name": "workflows_steps_id_job_execution_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_steps_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_steps_current_attempt_positive_ck": {
+          "name": "workflows_steps_current_attempt_positive_ck",
+          "value": "\"workflows_steps\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_tool_invocations": {
+      "name": "workflows_tool_invocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_attempt_id": {
+          "name": "step_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_tool_invocation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "call_index": {
+          "name": "call_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_tool_invocations_job_execution_id_idx": {
+          "name": "workflows_tool_invocations_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_tool_invocations_due_at_unsettled_idx": {
+          "name": "workflows_tool_invocations_due_at_unsettled_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_tool_invocations\".\"status\" <> 'settled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_tool_invocations_step_id_workflows_steps_id_fk": {
+          "name": "workflows_tool_invocations_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_attempt_id_workflows_step_attempts_id_fk": {
+          "name": "workflows_tool_invocations_step_attempt_id_workflows_step_attempts_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_step_attempts",
+          "columnsFrom": ["step_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_tool_invocations_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_tool_invocations_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_attempt_id_step_id_job_execution_id_workflows_step_attempts_fk": {
+          "name": "workflows_tool_invocations_step_attempt_id_step_id_job_execution_id_workflows_step_attempts_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_step_attempts",
+          "columnsFrom": ["step_attempt_id", "step_id", "job_execution_id"],
+          "columnsTo": ["id", "step_id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_tool_invocations_step_attempt_id_uq": {
+          "name": "workflows_tool_invocations_step_attempt_id_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_attempt_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_tool_invocations_call_index_nonnegative_ck": {
+          "name": "workflows_tool_invocations_call_index_nonnegative_ck",
+          "value": "\"workflows_tool_invocations\".\"call_index\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_attempts": {
+      "name": "workflows_workflow_run_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rerun_mode": {
+          "name": "rerun_mode",
+          "type": "workflows_rerun_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rerun_by_user_id": {
+          "name": "rerun_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_tool_materialization": {
+          "name": "agent_tool_materialization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wra_workflow_run_attempt_unique": {
+          "name": "workflows_wra_workflow_run_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wra_one_active_attempt_unique": {
+          "name": "workflows_wra_one_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows_workflow_run_attempts\".\"status\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_workflow_run_attempts",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["workflow_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wra_attempt_positive_ck": {
+          "name": "workflows_wra_attempt_positive_ck",
+          "value": "\"workflows_workflow_run_attempts\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_counters": {
+      "name": "workflows_workflow_run_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_wrrc_definition_id_unique": {
+          "name": "workflows_wrrc_definition_id_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "dev_source": {
+          "name": "dev_source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_provider": {
+          "name": "trigger_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2592000000
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_definition_number_unique": {
+          "name": "workflows_wr_definition_number_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_origin_created_id_idx": {
+          "name": "workflows_wr_project_origin_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_running_idx": {
+          "name": "workflows_wr_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wr_current_attempt_positive_ck": {
+          "name": "workflows_wr_current_attempt_positive_ck",
+          "value": "\"workflows_workflow_runs\".\"current_attempt\" > 0"
+        },
+        "workflows_wr_origin_ck": {
+          "name": "workflows_wr_origin_ck",
+          "value": "\"workflows_workflow_runs\".\"origin\" in ('synced', 'dev')"
+        },
+        "workflows_wr_dev_source_ck": {
+          "name": "workflows_wr_dev_source_ck",
+          "value": "(\n        (\"workflows_workflow_runs\".\"origin\" = 'synced' and \"workflows_workflow_runs\".\"dev_source\" is null)\n        or (\n          \"workflows_workflow_runs\".\"origin\" = 'dev'\n          and \"workflows_workflow_runs\".\"dev_source\" is not null\n          and jsonb_typeof(\"workflows_workflow_runs\".\"dev_source\") = 'object'\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_checkout_renewal_subject_status": {
+      "name": "workflows_checkout_renewal_subject_status",
+      "schema": "public",
+      "values": ["pending", "promoted"]
+    },
+    "public.workflows_job_execution_status": {
+      "name": "workflows_job_execution_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_job_listener_event_disposition": {
+      "name": "workflows_job_listener_event_disposition",
+      "schema": "public",
+      "values": ["fire", "resolve"]
+    },
+    "public.workflows_job_listener_event_outcome": {
+      "name": "workflows_job_listener_event_outcome",
+      "schema": "public",
+      "values": ["pending", "consumed", "honored", "rejected", "abandoned"]
+    },
+    "public.workflows_job_listener_event_outcome_reason": {
+      "name": "workflows_job_listener_event_outcome_reason",
+      "schema": "public",
+      "values": ["payload_too_large", "until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_checkout_contents": {
+      "name": "workflows_checkout_contents",
+      "schema": "public",
+      "values": ["read", "write"]
+    },
+    "public.workflows_job_mode": {
+      "name": "workflows_job_mode",
+      "schema": "public",
+      "values": ["one_shot", "listening"]
+    },
+    "public.workflows_job_on_resolve": {
+      "name": "workflows_job_on_resolve",
+      "schema": "public",
+      "values": ["finish", "cancel"]
+    },
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_job_status_reason": {
+      "name": "workflows_job_status_reason",
+      "schema": "public",
+      "values": [
+        "dependency_not_completed",
+        "condition_false",
+        "default_gate_rejected",
+        "condition_rejected",
+        "condition_errored",
+        "user_cancelled",
+        "run_cancelled",
+        "timed_out",
+        "runner_lost",
+        "output_too_large",
+        "step_failed",
+        "unknown",
+        "output_invalid"
+      ]
+    },
+    "public.workflows_listener_status": {
+      "name": "workflows_listener_status",
+      "schema": "public",
+      "values": ["inactive", "listening", "resolved"]
+    },
+    "public.workflows_resolution_reason": {
+      "name": "workflows_resolution_reason",
+      "schema": "public",
+      "values": ["until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_step_status_reason": {
+      "name": "workflows_step_status_reason",
+      "schema": "public",
+      "values": ["default_gate_rejected", "condition_rejected", "condition_errored"]
+    },
+    "public.workflows_tool_invocation_status": {
+      "name": "workflows_tool_invocation_status",
+      "schema": "public",
+      "values": ["queued", "in_flight", "settled"]
+    },
+    "public.workflows_rerun_mode": {
+      "name": "workflows_rerun_mode",
+      "schema": "public",
+      "values": ["all", "failed"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788444128396,
       "tag": "0007_left_sharon_ventura",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788515520229,
+      "tag": "0008_job_execution_runner_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -108,6 +108,12 @@ const listenerPriorExecutionSelection = {
   sequence: jobExecutions.sequence,
   name: jobExecutions.name,
   runner: jobExecutions.runner,
+  runnerLabels: jobExecutions.runnerLabels,
+  templateKey: jobExecutions.templateKey,
+  provisionerId: jobExecutions.provisionerId,
+  provisionerScope: jobExecutions.provisionerScope,
+  providerKind: jobExecutions.providerKind,
+  launchKind: jobExecutions.launchKind,
   status: jobExecutions.status,
   statusReason: jobExecutions.statusReason,
   statusReasonMessage: jobExecutions.statusReasonMessage,
@@ -658,6 +664,14 @@ export async function settleListenerJobExecution(params: {
       finishedAt: execution.finishedAt,
       statusReason: execution.statusReason,
       statusReasonMessage: execution.statusReasonMessage,
+      queuedAt: execution.queuedAt,
+      startedAt: execution.startedAt,
+      runnerLabels: execution.runnerLabels,
+      templateKey: execution.templateKey,
+      provisionerId: execution.provisionerId,
+      provisionerScope: execution.provisionerScope,
+      providerKind: execution.providerKind,
+      launchKind: execution.launchKind,
     });
     await bulkUpdateStepStatuses(
       {jobExecutionId: params.jobExecutionId, status: params.status},
@@ -837,6 +851,14 @@ async function persistMaterializedListenerExecution(
       finishedAt: execution.finishedAt,
       statusReason: execution.statusReason,
       statusReasonMessage: execution.statusReasonMessage,
+      queuedAt: execution.queuedAt,
+      startedAt: execution.startedAt,
+      runnerLabels: execution.runnerLabels,
+      templateKey: execution.templateKey,
+      provisionerId: execution.provisionerId,
+      provisionerScope: execution.provisionerScope,
+      providerKind: execution.providerKind,
+      launchKind: execution.launchKind,
     });
   }
 
@@ -900,6 +922,14 @@ async function persistRejectedMaterializedListenerExecution(
     finishedAt: execution.finishedAt,
     statusReason: execution.statusReason,
     statusReasonMessage: execution.statusReasonMessage,
+    queuedAt: execution.queuedAt,
+    startedAt: execution.startedAt,
+    runnerLabels: execution.runnerLabels,
+    templateKey: execution.templateKey,
+    provisionerId: execution.provisionerId,
+    provisionerScope: execution.provisionerScope,
+    providerKind: execution.providerKind,
+    launchKind: execution.launchKind,
   });
   await tx
     .update(jobListenerEvents)

--- a/libs/api/workflows/src/db/schema/job-executions.ts
+++ b/libs/api/workflows/src/db/schema/job-executions.ts
@@ -40,6 +40,16 @@ export const jobExecutions = pgTable(
     // exposes the parent job's static name/key as the effective name.
     name: text('name'),
     runner: jsonb('runner').$type<string[]>(),
+    // Runner identity from the claimed event (first-write-wins, beside startedAt).
+    // Plain columns, not a foreign key or a local enum: the values are opaque ids
+    // and enum-shaped strings owned and validated by the runners module's own
+    // event contract, not by this table.
+    runnerLabels: jsonb('runner_labels').$type<string[]>(),
+    templateKey: text('template_key'),
+    provisionerId: uuid('provisioner_id'),
+    provisionerScope: text('provisioner_scope'),
+    providerKind: text('provider_kind'),
+    launchKind: text('launch_kind'),
     status: jobExecutionStatusEnum('status').notNull().default('pending'),
     statusReason: jobStatusReasonEnum('status_reason'),
     statusReasonMessage: text('status_reason_message'),

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -28,6 +28,7 @@ import {
   getStepsByJobId,
   markStepRunning,
   queueJobExecution,
+  recordJobExecutionStartedAt,
   resolveJobExecutionAfterLeaseExpiry,
   updateJobExecutionStatus,
 } from '../workflow-runs.js';
@@ -85,6 +86,9 @@ describe('workflow run job executions', () => {
       projectId,
       requiredLabels: ['ubuntu-latest'],
       queuedAt: queued.queuedAt?.toISOString(),
+      jobKey: job.key,
+      definitionId,
+      runNumber: run.number,
     });
   });
 
@@ -133,6 +137,167 @@ describe('workflow run job executions', () => {
         workflowRunId: run.id,
         status: 'cancelled',
         statusReason: 'run_cancelled',
+      }),
+    ]);
+  });
+
+  test('carries identity, queued, started, and runner identity in the terminated event for a claimed execution', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({jobs: {build: {steps: [{run: 'echo build'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+
+    const queued = await queueJobExecution({jobExecutionId: execution.id});
+    const startedAt = new Date('2026-08-11T08:00:05.000Z');
+    const provisionerId = crypto.randomUUID();
+    await recordJobExecutionStartedAt({
+      jobExecutionId: execution.id,
+      startedAt,
+      runnerIdentity: {
+        runnerLabels: ['ubuntu-latest', 'x64'],
+        templateKey: 'standard',
+        provisionerId,
+        provisionerScope: 'installation',
+        providerKind: 'ec2',
+        launchKind: 'demand',
+      },
+    });
+
+    await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'failed',
+      expectedVersion: execution.version,
+      statusReason: 'unknown',
+    });
+
+    expect(await jobExecutionTerminatedEvents(execution.id)).toEqual([
+      expect.objectContaining({
+        jobId: job.id,
+        jobExecutionId: execution.id,
+        workflowRunId: run.id,
+        workspaceId,
+        projectId,
+        definitionId,
+        jobKey: job.key,
+        status: 'failed',
+        statusReason: 'unknown',
+        queuedAt: queued.queuedAt?.toISOString(),
+        startedAt: startedAt.toISOString(),
+        runnerLabels: ['ubuntu-latest', 'x64'],
+        templateKey: 'standard',
+        provisionerId,
+        provisionerScope: 'installation',
+        providerKind: 'ec2',
+        launchKind: 'demand',
+      }),
+    ]);
+  });
+
+  test('carries a null started_at and null runner identity in the terminated event for a never-claimed execution', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({jobs: {build: {steps: [{run: 'echo build'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+
+    const queued = await queueJobExecution({jobExecutionId: execution.id});
+
+    await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'cancelled',
+      expectedVersion: execution.version,
+      statusReason: 'run_cancelled',
+    });
+
+    expect(await jobExecutionTerminatedEvents(execution.id)).toEqual([
+      expect.objectContaining({
+        jobExecutionId: execution.id,
+        status: 'cancelled',
+        queuedAt: queued.queuedAt?.toISOString(),
+        startedAt: null,
+        runnerLabels: null,
+        templateKey: null,
+        provisionerId: null,
+        provisionerScope: null,
+        providerKind: null,
+        launchKind: null,
+      }),
+    ]);
+  });
+
+  test('carries queued, started, and runner identity in the terminated event after a lease expires', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({jobs: {build: {steps: [{run: 'echo build'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+
+    const queued = await queueJobExecution({jobExecutionId: execution.id});
+    const startedAt = new Date('2026-08-11T08:00:05.000Z');
+    await recordJobExecutionStartedAt({
+      jobExecutionId: execution.id,
+      startedAt,
+      runnerIdentity: {
+        runnerLabels: ['ubuntu-latest'],
+        templateKey: 'standard',
+        provisionerId: null,
+        provisionerScope: 'installation',
+        providerKind: 'ec2',
+        launchKind: 'demand',
+      },
+    });
+
+    await resolveJobExecutionAfterLeaseExpiry({
+      jobExecutionId: execution.id,
+      expectedVersion: execution.version,
+    });
+
+    expect(await jobExecutionTerminatedEvents(execution.id)).toEqual([
+      expect.objectContaining({
+        jobExecutionId: execution.id,
+        status: 'failed',
+        statusReason: 'runner_lost',
+        queuedAt: queued.queuedAt?.toISOString(),
+        startedAt: startedAt.toISOString(),
+        runnerLabels: ['ubuntu-latest'],
+        templateKey: 'standard',
+        provisionerScope: 'installation',
+        providerKind: 'ec2',
+        launchKind: 'demand',
       }),
     ]);
   });

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -1,4 +1,8 @@
-import {WORKFLOWS_JOB_EXECUTION_QUEUED} from '@shipfox/api-workflows-dto';
+import {
+  WORKFLOWS_JOB_EXECUTION_QUEUED,
+  WORKFLOWS_JOB_EXECUTION_TERMINATED,
+  workflowsJobExecutionTerminatedSchema,
+} from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
 import {
   InterpolationUnresolvableError,
@@ -246,6 +250,98 @@ describe('workflow run job executions', () => {
         launchKind: null,
       }),
     ]);
+  });
+
+  test('carries a null queued_at, started_at, and runner identity in the terminated event for an execution cancelled before it was ever queued', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({jobs: {build: {steps: [{run: 'echo build'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+
+    await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'cancelled',
+      expectedVersion: execution.version,
+      statusReason: 'run_cancelled',
+    });
+
+    expect(await jobExecutionTerminatedEvents(execution.id)).toEqual([
+      expect.objectContaining({
+        jobExecutionId: execution.id,
+        status: 'cancelled',
+        queuedAt: null,
+        startedAt: null,
+        runnerLabels: null,
+        templateKey: null,
+        provisionerId: null,
+        provisionerScope: null,
+        providerKind: null,
+        launchKind: null,
+      }),
+    ]);
+  });
+
+  test('writes a terminated payload that round-trips through its own strict event schema', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({jobs: {build: {steps: [{run: 'echo build'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+
+    await queueJobExecution({jobExecutionId: execution.id});
+    await recordJobExecutionStartedAt({
+      jobExecutionId: execution.id,
+      startedAt: new Date('2026-08-11T08:00:05.000Z'),
+      runnerIdentity: {
+        runnerLabels: ['ubuntu-latest'],
+        templateKey: 'standard',
+        provisionerId: crypto.randomUUID(),
+        provisionerScope: 'installation',
+        providerKind: 'ec2',
+        launchKind: 'demand',
+      },
+    });
+    await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'succeeded',
+      expectedVersion: execution.version,
+    });
+
+    const [event] = await db()
+      .select({payload: workflowsOutbox.payload})
+      .from(workflowsOutbox)
+      .where(
+        and(
+          eq(workflowsOutbox.eventType, WORKFLOWS_JOB_EXECUTION_TERMINATED),
+          sql`${workflowsOutbox.payload}->>'jobExecutionId' = ${execution.id}`,
+        ),
+      );
+    if (!event) throw new Error('Expected a terminated event');
+
+    expect(() => workflowsJobExecutionTerminatedSchema.strict().parse(event.payload)).not.toThrow();
   });
 
   test('carries queued, started, and runner identity in the terminated event after a lease expires', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -289,6 +289,14 @@ async function updateJobExecutionStatusAtVersion(
       finishedAt: row.finishedAt,
       statusReason: row.statusReason,
       statusReasonMessage: row.statusReasonMessage,
+      queuedAt: row.queuedAt,
+      startedAt: row.startedAt,
+      runnerLabels: row.runnerLabels,
+      templateKey: row.templateKey,
+      provisionerId: row.provisionerId,
+      provisionerScope: row.provisionerScope,
+      providerKind: row.providerKind,
+      launchKind: row.launchKind,
     });
   }
   return {
@@ -390,13 +398,25 @@ export async function queueJobExecution(params: {jobExecutionId: string}): Promi
   return result.execution;
 }
 
+export interface JobExecutionRunnerIdentity {
+  runnerLabels: string[] | null;
+  templateKey: string | null;
+  provisionerId: string | null;
+  provisionerScope: string | null;
+  providerKind: string | null;
+  launchKind: string | null;
+}
+
 export async function recordJobExecutionStartedAt(params: {
   jobExecutionId: string;
   startedAt: Date;
+  // Present when the caller is projecting a runner claim; absent for callers
+  // that only need to stamp the start time (e.g. tests exercising display state).
+  runnerIdentity?: JobExecutionRunnerIdentity;
 }): Promise<void> {
   const updated = await db()
     .update(jobExecutions)
-    .set({startedAt: params.startedAt})
+    .set({startedAt: params.startedAt, ...params.runnerIdentity})
     .where(and(eq(jobExecutions.id, params.jobExecutionId), isNull(jobExecutions.startedAt)))
     .returning({id: jobExecutions.id});
 

--- a/libs/api/workflows/src/db/workflow-runs/outbox.ts
+++ b/libs/api/workflows/src/db/workflow-runs/outbox.ts
@@ -5,7 +5,6 @@ import {
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
-  type WorkflowsJobExecutionTerminatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {eq} from 'drizzle-orm';
 import type {JobStatusReason} from '#core/entities/job.js';
@@ -54,9 +53,10 @@ export async function writeJobExecutionTerminatedOutbox(
     finishedAt?: Date | null | undefined;
     statusReason: JobStatusReason | null;
     statusReasonMessage?: string | null | undefined;
-    // Runner identity and lifecycle timestamps carried on the job_executions row,
-    // so the terminated event is a self-sufficient usage record: null when the
-    // execution was never queued, never claimed, or claimed by no known provisioner.
+    // Runner identity and lifecycle timestamps carried on the job_executions row, so the
+    // terminated event is a self-sufficient usage record. Null when the execution was never
+    // queued or never claimed, and startedAt/runner identity can also be null for a claimed
+    // execution if the runners.job.claimed projection has not landed yet (see events.ts).
     queuedAt: Date | null;
     startedAt: Date | null;
     runnerLabels: string[] | null;
@@ -100,15 +100,9 @@ export async function writeJobExecutionTerminatedOutbox(
       runnerLabels: params.runnerLabels,
       templateKey: params.templateKey,
       provisionerId: params.provisionerId,
-      // Stored as plain text (see the job_executions schema); cast to the DTO's
-      // closed set here, at the one place this value crosses into the strict
-      // event contract. A value outside the set can only come from a producer
-      // migration ahead of this package, so it is passed through rather than
-      // dropped or thrown on.
-      provisionerScope:
-        params.provisionerScope as WorkflowsJobExecutionTerminatedEventDto['provisionerScope'],
+      provisionerScope: params.provisionerScope,
       providerKind: params.providerKind,
-      launchKind: params.launchKind as WorkflowsJobExecutionTerminatedEventDto['launchKind'],
+      launchKind: params.launchKind,
     },
   });
 }

--- a/libs/api/workflows/src/db/workflow-runs/outbox.ts
+++ b/libs/api/workflows/src/db/workflow-runs/outbox.ts
@@ -5,6 +5,7 @@ import {
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
+  type WorkflowsJobExecutionTerminatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {eq} from 'drizzle-orm';
 import type {JobStatusReason} from '#core/entities/job.js';
@@ -37,6 +38,9 @@ export async function writeJobExecutionQueuedOutbox(
       projectId: identity.projectId,
       requiredLabels: params.requiredLabels,
       queuedAt: params.queuedAt.toISOString(),
+      jobKey: identity.jobKey,
+      definitionId: identity.definitionId,
+      runNumber: identity.runNumber,
     },
   });
 }
@@ -50,6 +54,17 @@ export async function writeJobExecutionTerminatedOutbox(
     finishedAt?: Date | null | undefined;
     statusReason: JobStatusReason | null;
     statusReasonMessage?: string | null | undefined;
+    // Runner identity and lifecycle timestamps carried on the job_executions row,
+    // so the terminated event is a self-sufficient usage record: null when the
+    // execution was never queued, never claimed, or claimed by no known provisioner.
+    queuedAt: Date | null;
+    startedAt: Date | null;
+    runnerLabels: string[] | null;
+    templateKey: string | null;
+    provisionerId: string | null;
+    provisionerScope: string | null;
+    providerKind: string | null;
+    launchKind: string | null;
   },
 ): Promise<void> {
   if (
@@ -68,14 +83,32 @@ export async function writeJobExecutionTerminatedOutbox(
       jobExecutionId: params.jobExecutionId,
       workflowRunId: identity.workflowRunId,
       workflowRunAttemptId: identity.workflowRunAttemptId,
+      workspaceId: identity.workspaceId,
+      projectId: identity.projectId,
+      definitionId: identity.definitionId,
+      jobKey: identity.jobKey,
       status: params.status,
       finishedAt: (params.finishedAt ?? new Date()).toISOString(),
+      queuedAt: params.queuedAt ? params.queuedAt.toISOString() : null,
+      startedAt: params.startedAt ? params.startedAt.toISOString() : null,
       statusReason: params.statusReason,
       cancellationReason:
         params.statusReason === 'run_cancelled' || params.statusReason === 'timed_out'
           ? params.statusReason
           : null,
       statusReasonMessage: params.statusReasonMessage ?? null,
+      runnerLabels: params.runnerLabels,
+      templateKey: params.templateKey,
+      provisionerId: params.provisionerId,
+      // Stored as plain text (see the job_executions schema); cast to the DTO's
+      // closed set here, at the one place this value crosses into the strict
+      // event contract. A value outside the set can only come from a producer
+      // migration ahead of this package, so it is passed through rather than
+      // dropped or thrown on.
+      provisionerScope:
+        params.provisionerScope as WorkflowsJobExecutionTerminatedEventDto['provisionerScope'],
+      providerKind: params.providerKind,
+      launchKind: params.launchKind as WorkflowsJobExecutionTerminatedEventDto['launchKind'],
     },
   });
 }

--- a/libs/api/workflows/src/db/workflow-runs/run-graph.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-graph.ts
@@ -90,6 +90,14 @@ export async function persistMaterializedRunGraph(
         finishedAt: jobExecution.finishedAt,
         statusReason: jobExecution.statusReason,
         statusReasonMessage: jobExecution.statusReasonMessage,
+        queuedAt: jobExecution.queuedAt,
+        startedAt: jobExecution.startedAt,
+        runnerLabels: jobExecution.runnerLabels,
+        templateKey: jobExecution.templateKey,
+        provisionerId: jobExecution.provisionerId,
+        provisionerScope: jobExecution.provisionerScope,
+        providerKind: jobExecution.providerKind,
+        launchKind: jobExecution.launchKind,
       });
     }
   }

--- a/libs/api/workflows/src/db/workflow-runs/run-status.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-status.ts
@@ -150,6 +150,14 @@ async function terminateRunAttempt(
         finishedAt: jobExecutions.finishedAt,
         statusReason: jobExecutions.statusReason,
         statusReasonMessage: jobExecutions.statusReasonMessage,
+        queuedAt: jobExecutions.queuedAt,
+        startedAt: jobExecutions.startedAt,
+        runnerLabels: jobExecutions.runnerLabels,
+        templateKey: jobExecutions.templateKey,
+        provisionerId: jobExecutions.provisionerId,
+        provisionerScope: jobExecutions.provisionerScope,
+        providerKind: jobExecutions.providerKind,
+        launchKind: jobExecutions.launchKind,
       });
     for (const jobExecution of terminatedExecutions) {
       await writeJobExecutionTerminatedOutbox(tx, {
@@ -159,6 +167,14 @@ async function terminateRunAttempt(
         finishedAt: jobExecution.finishedAt,
         statusReason: jobExecution.statusReason,
         statusReasonMessage: jobExecution.statusReasonMessage,
+        queuedAt: jobExecution.queuedAt,
+        startedAt: jobExecution.startedAt,
+        runnerLabels: jobExecution.runnerLabels,
+        templateKey: jobExecution.templateKey,
+        provisionerId: jobExecution.provisionerId,
+        provisionerScope: jobExecution.provisionerScope,
+        providerKind: jobExecution.providerKind,
+        launchKind: jobExecution.launchKind,
       });
       await bulkUpdateStepStatuses(
         {jobExecutionId: jobExecution.id, status: spec.terminalStatus},

--- a/libs/api/workflows/src/db/workflow-runs/shared.ts
+++ b/libs/api/workflows/src/db/workflow-runs/shared.ts
@@ -60,19 +60,25 @@ export async function getWorkflowContextForJob(
   tx: Tx,
 ): Promise<{
   jobId: string;
+  jobKey: string;
   workflowRunId: string;
   workflowRunAttemptId: string;
   workspaceId: string;
   projectId: string;
+  definitionId: string;
+  runNumber: number;
   vars: Record<string, string> | null;
 }> {
   const rows = await tx
     .select({
       jobId: jobs.id,
+      jobKey: jobs.key,
       workflowRunId: workflowRuns.id,
       workflowRunAttemptId: workflowRunAttempts.id,
       workspaceId: workflowRuns.workspaceId,
       projectId: workflowRuns.projectId,
+      definitionId: workflowRuns.definitionId,
+      runNumber: workflowRuns.number,
       vars: workflowRunAttempts.vars,
     })
     .from(jobs)

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
@@ -1,6 +1,19 @@
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
 import {getJobExecutionsByJobId, getJobsByWorkflowRunId} from '#db/index.js';
+import {jobExecutions} from '#db/schema/job-executions.js';
 import {workflowRunFactory} from '#test/index.js';
 import {onRunnerJobClaimed} from './on-runner-job-claimed.js';
+
+async function getJobExecutionRow(jobExecutionId: string) {
+  const [row] = await db()
+    .select()
+    .from(jobExecutions)
+    .where(eq(jobExecutions.id, jobExecutionId))
+    .limit(1);
+  if (!row) throw new Error(`Expected job execution row ${jobExecutionId}`);
+  return row;
+}
 
 const signalMock = vi.fn();
 const getHandleMock = vi.fn(() => ({signal: signalMock}));
@@ -16,7 +29,7 @@ describe('onRunnerJobClaimed', () => {
     signalMock.mockResolvedValue(undefined);
   });
 
-  it('stamps started_at on the job execution from the claim event payload', async () => {
+  it('stamps started_at and runner identity on the job execution from the claim event payload', async () => {
     const run = await workflowRunFactory.create();
     const job = (await getJobsByWorkflowRunId(run.id))[0];
     expect(job).toBeDefined();
@@ -32,10 +45,24 @@ describe('onRunnerJobClaimed', () => {
       jobId: job.id,
       jobExecutionId: jobExecution.id,
       claimedAt: claimedAt.toISOString(),
+      runnerLabels: ['linux', 'x64'],
+      templateKey: 'standard',
+      provisionerId: crypto.randomUUID(),
+      provisionerScope: 'installation',
+      providerKind: 'ec2',
+      launchKind: 'demand',
     });
 
     const after = (await getJobExecutionsByJobId(job.id))[0];
     expect(after?.startedAt?.getTime()).toBe(claimedAt.getTime());
+    const row = await getJobExecutionRow(jobExecution.id);
+    expect(row).toMatchObject({
+      runnerLabels: ['linux', 'x64'],
+      templateKey: 'standard',
+      provisionerScope: 'installation',
+      providerKind: 'ec2',
+      launchKind: 'demand',
+    });
     expect(getHandleMock).toHaveBeenCalledWith(`job:${job.id}`);
     expect(signalMock).toHaveBeenCalledWith('job-claimed', {
       jobExecutionId: jobExecution.id,
@@ -43,7 +70,35 @@ describe('onRunnerJobClaimed', () => {
     });
   });
 
-  it('is idempotent: a redelivered event keeps the first started_at (coalesce)', async () => {
+  it('stamps null runner identity when the claim carries no known provisioner', async () => {
+    const run = await workflowRunFactory.create();
+    const job = (await getJobsByWorkflowRunId(run.id))[0];
+    expect(job).toBeDefined();
+    if (!job) return;
+    const jobExecution = (await getJobExecutionsByJobId(job.id))[0];
+    expect(jobExecution).toBeDefined();
+    if (!jobExecution) return;
+
+    await onRunnerJobClaimed({
+      workflowRunId: run.id,
+      workflowRunAttemptId: job.workflowRunAttemptId,
+      jobId: job.id,
+      jobExecutionId: jobExecution.id,
+      claimedAt: '2026-06-22T10:05:00.000Z',
+    });
+
+    const row = await getJobExecutionRow(jobExecution.id);
+    expect(row).toMatchObject({
+      runnerLabels: null,
+      templateKey: null,
+      provisionerId: null,
+      provisionerScope: null,
+      providerKind: null,
+      launchKind: null,
+    });
+  });
+
+  it('is idempotent: a redelivered event keeps the first started_at and runner identity (coalesce)', async () => {
     const run = await workflowRunFactory.create();
     const job = (await getJobsByWorkflowRunId(run.id))[0];
     expect(job).toBeDefined();
@@ -60,6 +115,10 @@ describe('onRunnerJobClaimed', () => {
       jobId: job.id,
       jobExecutionId: jobExecution.id,
       claimedAt: first.toISOString(),
+      runnerLabels: ['linux'],
+      templateKey: 'standard',
+      provisionerScope: 'installation',
+      launchKind: 'demand',
     });
     await onRunnerJobClaimed({
       workflowRunId: run.id,
@@ -67,10 +126,21 @@ describe('onRunnerJobClaimed', () => {
       jobId: job.id,
       jobExecutionId: jobExecution.id,
       claimedAt: second.toISOString(),
+      runnerLabels: ['windows'],
+      templateKey: 'other',
+      provisionerScope: 'workspace',
+      launchKind: 'warm',
     });
 
     const after = (await getJobExecutionsByJobId(job.id))[0];
     expect(after?.startedAt?.getTime()).toBe(first.getTime());
+    const row = await getJobExecutionRow(jobExecution.id);
+    expect(row).toMatchObject({
+      runnerLabels: ['linux'],
+      templateKey: 'standard',
+      provisionerScope: 'installation',
+      launchKind: 'demand',
+    });
   });
 
   it('discards a claim signal when the job workflow already terminated', async () => {

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
@@ -38,6 +38,7 @@ describe('onRunnerJobClaimed', () => {
     expect(jobExecution).toBeDefined();
     if (!jobExecution) return;
     const claimedAt = new Date('2026-06-22T10:05:00.000Z');
+    const provisionerId = crypto.randomUUID();
 
     await onRunnerJobClaimed({
       workflowRunId: run.id,
@@ -47,7 +48,7 @@ describe('onRunnerJobClaimed', () => {
       claimedAt: claimedAt.toISOString(),
       runnerLabels: ['linux', 'x64'],
       templateKey: 'standard',
-      provisionerId: crypto.randomUUID(),
+      provisionerId,
       provisionerScope: 'installation',
       providerKind: 'ec2',
       launchKind: 'demand',
@@ -59,6 +60,7 @@ describe('onRunnerJobClaimed', () => {
     expect(row).toMatchObject({
       runnerLabels: ['linux', 'x64'],
       templateKey: 'standard',
+      provisionerId,
       provisionerScope: 'installation',
       providerKind: 'ec2',
       launchKind: 'demand',

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.ts
@@ -22,6 +22,14 @@ export async function onRunnerJobClaimed(payload: RunnerJobClaimedEvent): Promis
   await recordJobExecutionStartedAt({
     jobExecutionId: payload.jobExecutionId,
     startedAt: new Date(payload.claimedAt),
+    runnerIdentity: {
+      runnerLabels: payload.runnerLabels ?? null,
+      templateKey: payload.templateKey ?? null,
+      provisionerId: payload.provisionerId ?? null,
+      provisionerScope: payload.provisionerScope ?? null,
+      providerKind: payload.providerKind ?? null,
+      launchKind: payload.launchKind ?? null,
+    },
   });
 
   const handle = temporalClient().workflow.getHandle(`job:${payload.jobId}`);


### PR DESCRIPTION
Workflow job-execution events now carry enough context for usage consumers to build a complete record without re-querying workflow state. The workflows projection stores runner identity at claim time, and the queued and terminated outbox payloads include workflow identity and lifecycle context. New fields remain backward-compatible for older events and nullable when an execution was never claimed.

Closes ENG-1907

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes workflow job-execution events self-sufficient so usage consumers can build a complete record from a single event without re-querying workflow state (ENG-1907).

- `runners.job.claimed` now stores runner identity (`runnerLabels`, `templateKey`, `provisionerId`, `provisionerScope`, `providerKind`, `launchKind`) on `job_executions` beside `started_at`, first-write-wins.
- `workflows.job_execution.terminated` now carries workspace, project, definition, job key, queued/started timestamps, and runner identity; timestamps and runner identity are null when the execution was never queued or never claimed.
- `workflows.job_execution.queued` now carries `jobKey`, `definitionId`, and `runNumber`.
- `provisionerScope` and `launchKind` are open strings, not closed enums, so new values from the runners module won't dead-letter terminated events.
- All new event fields are optional, so older events parse cleanly; this is a minor release of `@shipfox/api-workflows` and `@shipfox/api-workflows-dto`.

<sup>Written for commit 16d459fc1347ac5fabd6301e7d16c496583addb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

