### PR TITLE
Add the workflow admission policy seam

### DIFF
--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -7,6 +7,7 @@ export {
   type DefaultModulesOptions,
   type DefaultRunnersModuleFactory,
   type DefaultRunnersModuleOptions,
+  type DefaultWorkflowsModuleOptions,
   defaultModules,
 } from './modules.js';
 export {createLoginMethodsRoute} from './routes/login-methods.js';

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -20,6 +20,7 @@ import type {
   DefaultAgentModuleFactory,
   DefaultAgentModuleOptions,
   DefaultModulesOptions,
+  DefaultWorkflowsModuleOptions,
 } from './modules.js';
 import {defaultModules} from './modules.js';
 
@@ -760,6 +761,17 @@ describe('defaultModules', () => {
       auth: expect.any(Object),
       installationProvisioning: {policy},
     });
+  });
+
+  it('composes Workflows admission options', async () => {
+    const policy = {admit: vi.fn().mockResolvedValue({allowed: true})};
+    const options: DefaultWorkflowsModuleOptions = {admission: {policy}};
+
+    await defaultModules({workflowsModuleOptions: options});
+
+    expect(mocks.createWorkflowsModule).toHaveBeenCalledWith(
+      expect.objectContaining({admission: {policy}}),
+    );
   });
 
   it('extends the default module list with the composed Workspaces client', async () => {

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -26,7 +26,7 @@ import {
   secretsInterModuleContract,
 } from '@shipfox/api-secrets-dto/inter-module';
 import {createTriggersModule} from '@shipfox/api-triggers';
-import {createWorkflowsModule} from '@shipfox/api-workflows';
+import {type CreateWorkflowsModuleOptions, createWorkflowsModule} from '@shipfox/api-workflows';
 import {
   type WorkflowsModuleClient,
   workflowsInterModuleContract,
@@ -50,6 +50,7 @@ export interface DefaultModulesOptions {
   authModuleOptions?: DefaultAuthModuleOptions | undefined;
   agentModuleOptions?: DefaultAgentModuleOptions | undefined;
   runnersModuleOptions?: DefaultRunnersModuleOptions | undefined;
+  workflowsModuleOptions?: DefaultWorkflowsModuleOptions | undefined;
   authModuleFactory?: DefaultAuthModuleFactory | undefined;
   agentModuleFactory?: DefaultAgentModuleFactory | undefined;
   runnersModuleFactory?: DefaultRunnersModuleFactory | undefined;
@@ -96,6 +97,9 @@ export type DefaultRunnersModuleOptions = Pick<
   CreateRunnersModuleOptions,
   'installationProvisioning'
 >;
+
+/** Options for the standard Workflows module. */
+export type DefaultWorkflowsModuleOptions = Pick<CreateWorkflowsModuleOptions, 'admission'>;
 
 /** Full replacement escape hatch for the standard Runners module. */
 export type DefaultRunnersModuleFactory = (options: {auth: AuthInterModuleClient}) => ShipfoxModule;
@@ -307,6 +311,7 @@ export async function defaultModules(
     projectsModule,
     definitionsModule,
     createWorkflowsModule({
+      ...options.workflowsModuleOptions,
       annotations: annotationsClient,
       agent: agentClient,
       definitions: definitionsClient,

--- a/libs/api/triggers/src/core/create-dev-run.test.ts
+++ b/libs/api/triggers/src/core/create-dev-run.test.ts
@@ -776,6 +776,27 @@ describe('createDevRun', () => {
     expect(await subscriptionsForWorkspace(params.workspaceId)).toHaveLength(0);
   });
 
+  test('records an admission denial reason as a terminal dev event', async () => {
+    const params = buildParams();
+    const reason = 'billing-payment-method-required';
+    resolveDefinitionAtRef.mockResolvedValue(resolvedDefinition(undefined));
+    startDevRun.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startDevRun,
+        'admission-denied',
+        {workspaceId: params.workspaceId, reason},
+      ),
+    );
+
+    await expect(createDevRun(params)).rejects.toMatchObject({code: 'admission-denied'});
+
+    const [event] = await eventsForWorkspace(params.workspaceId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    const [decision] = await decisionsForEvent(event.id);
+    expect(decision).toMatchObject({decision: 'dispatch-error', reason});
+  });
+
   test('journals a retryable dev failure and rethrows the original error', async () => {
     const params = buildParams();
     resolveDefinitionAtRef.mockResolvedValue(resolvedDefinition(undefined));

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -59,6 +59,14 @@ function definitionNotFound(_definitionId: string) {
   );
 }
 
+function admissionDenied(workspaceId: string) {
+  return createInterModuleKnownError(
+    workflowsInterModuleContract.methods.startRunFromTrigger,
+    'admission-denied',
+    {workspaceId, reason: 'billing-payment-method-required'},
+  );
+}
+
 function projectMismatch() {
   return createInterModuleKnownError(
     workflowsInterModuleContract.methods.startRunFromTrigger,
@@ -976,6 +984,29 @@ describe('dispatchIntegrationEvent trigger history', () => {
     expect(errored?.reason).toContain('definition-not-found');
     expect(triggered?.decision).toBe('triggered');
     expect(triggered?.runId).toBe(run.id);
+  });
+
+  test('records an admission denial reason as a terminal integration event', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(admissionDenied(workspaceId));
+
+    await dispatch({workspaceId, eventRef});
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    const [decision] = await decisionsForEvent(event.id);
+    expect(decision).toMatchObject({
+      decision: 'dispatch-error',
+      reason: 'billing-payment-method-required',
+    });
   });
 
   test('marks the event errored when every subscription errors permanently', async () => {

--- a/libs/api/triggers/src/core/fire-cron.test.ts
+++ b/libs/api/triggers/src/core/fire-cron.test.ts
@@ -102,6 +102,36 @@ describe('fireCronSubscription', () => {
     expect(decisions[0]?.reason).toContain('definition-not-found');
   });
 
+  test('records an admission denial reason as a terminal cron event', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'cron',
+      event: 'tick',
+      config: {},
+    });
+    const reason = 'billing-payment-method-required';
+    runWorkflow.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startRunFromTrigger,
+        'admission-denied',
+        {workspaceId: subscription.workspaceId, reason},
+      ),
+    );
+
+    await expect(
+      fireCronSubscription({
+        workflows,
+        subscriptionId: subscription.id,
+        scheduledSlot: SLOT,
+      }),
+    ).resolves.toEqual({outcome: 'errored'});
+
+    const [event] = await eventsForWorkspace(subscription.workspaceId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    const [decision] = await decisionsForEvent(event.id);
+    expect(decision).toMatchObject({decision: 'dispatch-error', reason});
+  });
+
   test('omits inputs when the subscription has no configured inputs', async () => {
     const subscription = await triggerSubscriptionFactory.create({
       source: 'cron',

--- a/libs/api/triggers/src/core/fire-manual.test.ts
+++ b/libs/api/triggers/src/core/fire-manual.test.ts
@@ -132,6 +132,37 @@ describe('fireManualSubscription (trigger history)', () => {
     expect(decisions[0]?.reason).toContain('definition-not-found');
   });
 
+  test('records an admission denial reason as a terminal manual event', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'manual',
+      event: 'fire',
+      config: {},
+    });
+    const reason = 'billing-payment-method-required';
+    runWorkflow.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startRunFromTrigger,
+        'admission-denied',
+        {workspaceId: subscription.workspaceId, reason},
+      ),
+    );
+
+    await expect(
+      fireManualSubscription({
+        workflows,
+        subscriptionId: subscription.id,
+        callerWorkspaceId: subscription.workspaceId,
+        userId: crypto.randomUUID(),
+      }),
+    ).rejects.toMatchObject({code: 'admission-denied'});
+
+    const [event] = await eventsForWorkspace(subscription.workspaceId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    const [decision] = await decisionsForEvent(event.id);
+    expect(decision).toMatchObject({decision: 'dispatch-error', reason});
+  });
+
   test('falls back to fire in history when a bad row stores a NULL event', async () => {
     const subscription = await triggerSubscriptionFactory.create({
       source: 'manual',

--- a/libs/api/triggers/src/core/record-trigger-history.test.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.test.ts
@@ -1,3 +1,5 @@
+import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {jobListenerSubscriptionFactory, triggerSubscriptionFactory} from '#test/index.js';
 
 const runWorkflow = vi.fn();
@@ -272,5 +274,15 @@ describe('toReason', () => {
     const reason = toReason(new Error('definition deleted'));
 
     expect(reason).toBe('definition deleted');
+  });
+
+  test('persists the policy reason for an admission denial', () => {
+    const error = createInterModuleKnownError(
+      workflowsInterModuleContract.methods.startRunFromTrigger,
+      'admission-denied',
+      {workspaceId: crypto.randomUUID(), reason: 'billing-payment-method-required'},
+    );
+
+    expect(toReason(error)).toBe('billing-payment-method-required');
   });
 });

--- a/libs/api/triggers/src/core/record-trigger-history.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.ts
@@ -1,3 +1,5 @@
+import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {JobListenerSubscription} from '#core/entities/job-listener-subscription.js';
@@ -27,11 +29,24 @@ const MAX_REASON_LENGTH = 2000;
 export function toReason(error: unknown): string {
   let message: string;
   try {
-    message = error instanceof Error ? error.message : String(error);
+    message = admissionReason(error) ?? (error instanceof Error ? error.message : String(error));
   } catch {
     message = '[unprintable thrown value]';
   }
   return message.slice(0, MAX_REASON_LENGTH);
+}
+
+function admissionReason(error: unknown): string | undefined {
+  const methods = [
+    workflowsInterModuleContract.methods.startRunFromTrigger,
+    workflowsInterModuleContract.methods.startDevRun,
+    workflowsInterModuleContract.methods.deliverEventToJobListener,
+  ] as const;
+  for (const method of methods) {
+    if (!isInterModuleKnownError(method, error) || error.code !== 'admission-denied') continue;
+    return error.details.reason;
+  }
+  return undefined;
 }
 
 export interface TriggerRun {

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
@@ -346,6 +346,32 @@ describe('routeEventToJobListeners', () => {
     });
   });
 
+  it('records an admission denial reason without retrying listener delivery', async () => {
+    const workspaceId = crypto.randomUUID();
+    const reason = 'billing-payment-method-required';
+    await jobListenerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'pull_request_review',
+    });
+    const error = createInterModuleKnownError(
+      workflowsInterModuleContract.methods.deliverEventToJobListener,
+      'admission-denied',
+      {workspaceId, reason},
+    );
+    deliverEventToListener.mockRejectedValueOnce(error);
+
+    const result = await route({workspaceId});
+
+    expect(listenerDispatchErrored).toHaveBeenCalledWith(expect.anything(), reason);
+    expect(result).toMatchObject({
+      engagedCount: 1,
+      acceptedJobCount: 0,
+      deliveredCount: 0,
+      transientErrored: false,
+    });
+  });
+
   it('delivers only when a listener filter matches the payload and snapshot', async () => {
     const workspaceId = crypto.randomUUID();
     const jobId = crypto.randomUUID();

--- a/libs/api/triggers/src/core/workflows-client.test.ts
+++ b/libs/api/triggers/src/core/workflows-client.test.ts
@@ -179,11 +179,14 @@ describe('WorkflowsModuleClient consumer parity', () => {
     'workspace-not-found',
     'workspace-suspended',
     'workspace-deleted',
+    'admission-denied',
   ] as const)('treats a %s listener delivery as permanent', (code) => {
     const error = createInterModuleKnownError(
       workflowsInterModuleContract.methods.deliverEventToJobListener,
       code,
-      {workspaceId: input.workspaceId},
+      code === 'admission-denied'
+        ? {workspaceId: input.workspaceId, reason: 'billing-payment-method-required'}
+        : {workspaceId: input.workspaceId},
     );
 
     expect(isPermanentDeliverEventToJobListenerError(error)).toBe(true);

--- a/libs/api/triggers/src/presentation/routes/create-dev-run.test.ts
+++ b/libs/api/triggers/src/presentation/routes/create-dev-run.test.ts
@@ -422,6 +422,34 @@ describe('POST /dev-runs', () => {
     });
   });
 
+  test('maps admission denial to 409 with required action details', async () => {
+    const reason = 'billing-payment-method-required';
+    const requiredAction = {
+      reason,
+      message: 'Add a payment method to continue.',
+      url: '/settings/billing',
+    };
+    createDevRunMock.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startDevRun,
+        'admission-denied',
+        {workspaceId, reason, requiredAction},
+      ),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/dev-runs',
+      payload: VALID_BODY,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      code: 'admission-denied',
+      details: {workspace_id: workspaceId, reason, required_action: requiredAction},
+    });
+  });
+
   test.each([
     ['workspace-deleted', 404, 'workspace-deleted', 'Workspace is deleted'],
     ['workspace-not-found', 404, 'workspace-not-found', 'Workspace not found'],

--- a/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
@@ -157,6 +157,36 @@ describe('POST /:definitionId/fire-manual', () => {
     });
   });
 
+  test('maps admission denial to 409 with required action details', async () => {
+    const definitionId = crypto.randomUUID();
+    const reason = 'billing-payment-method-required';
+    const requiredAction = {
+      reason,
+      message: 'Add a payment method to continue.',
+      url: '/settings/billing',
+    };
+    await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});
+    fireManualSubscriptionMock.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startRunFromTrigger,
+        'admission-denied',
+        {workspaceId, reason, requiredAction},
+      ),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/${definitionId}/fire-manual`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      code: 'admission-denied',
+      details: {workspace_id: workspaceId, reason, required_action: requiredAction},
+    });
+  });
+
   test('maps missing workspace to 404', async () => {
     const definitionId = crypto.randomUUID();
     await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});

--- a/libs/api/triggers/src/presentation/routes/fire-manual.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.ts
@@ -33,6 +33,11 @@ export function createFireManualTriggerRoute(workflows: WorkflowsModuleClient) {
       body: fireManualTriggerBodySchema,
       response: {
         201: fireManualTriggerResponseSchema,
+        409: z.object({
+          code: z.string(),
+          message: z.string().optional(),
+          details: z.unknown().optional(),
+        }),
         422: z.object({
           code: z.string(),
           details: startRunErrorDetailsSchema.optional(),

--- a/libs/api/triggers/src/presentation/routes/map-start-run-error.ts
+++ b/libs/api/triggers/src/presentation/routes/map-start-run-error.ts
@@ -25,6 +25,24 @@ export function mapStartRunError(error: unknown, method: StartRunMethod): Client
         status: 404,
         cause: error,
       });
+    case 'admission-denied':
+      return new ClientError('Workflow admission denied', 'admission-denied', {
+        status: 409,
+        details: {
+          workspace_id: error.details.workspaceId,
+          reason: error.details.reason,
+          ...(error.details.requiredAction === undefined
+            ? {}
+            : {
+                required_action: {
+                  reason: error.details.requiredAction.reason,
+                  message: error.details.requiredAction.message,
+                  url: error.details.requiredAction.url,
+                },
+              }),
+        },
+        cause: error,
+      });
     case 'agent-config-unresolvable':
       return new ClientError(
         'Agent configuration cannot be resolved',

--- a/libs/api/workflows-dto/src/inter-module.test.ts
+++ b/libs/api/workflows-dto/src/inter-module.test.ts
@@ -311,6 +311,18 @@ describe('workflowsInterModuleContract', () => {
     ['workspace-not-found', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['workspace-suspended', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['workspace-deleted', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    [
+      'admission-denied',
+      {
+        workspaceId: '00000000-0000-4000-8000-000000000010',
+        reason: 'billing-payment-method-required',
+        requiredAction: {
+          reason: 'billing-payment-method-required',
+          message: 'Add a payment method to continue.',
+          url: '/settings/billing',
+        },
+      },
+    ],
     ['definition-not-found', {definitionId: '00000000-0000-4000-8000-000000000001'}],
     ['project-mismatch', {}],
     ['agent-config-unresolvable', {definitionId: '00000000-0000-4000-8000-000000000001'}],
@@ -438,6 +450,13 @@ describe('workflowsInterModuleContract', () => {
     ['workspace-not-found', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['workspace-suspended', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['workspace-deleted', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    [
+      'admission-denied',
+      {
+        workspaceId: '00000000-0000-4000-8000-000000000010',
+        reason: 'billing-payment-method-required',
+      },
+    ],
     ['agent-config-unresolvable', {definitionId: '00000000-0000-4000-8000-000000000001'}],
     ['agent-integration-materialization-failed', {}],
     [
@@ -461,6 +480,13 @@ describe('workflowsInterModuleContract', () => {
     ['workspace-not-found', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['workspace-suspended', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['workspace-deleted', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    [
+      'admission-denied',
+      {
+        workspaceId: '00000000-0000-4000-8000-000000000010',
+        reason: 'billing-payment-method-required',
+      },
+    ],
   ] as const)('defines the %s listener-delivery failure', (code, details) => {
     const schema = workflowsInterModuleContract.methods.deliverEventToJobListener.errors[code];
 

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -49,6 +49,17 @@ import {
 } from './schemas/workflow-run-overview.js';
 
 const idSchema = z.string().uuid();
+const admissionDeniedDetailsSchema = z.object({
+  workspaceId: idSchema,
+  reason: z.string(),
+  requiredAction: z
+    .object({
+      reason: z.string(),
+      message: z.string(),
+      url: z.string(),
+    })
+    .optional(),
+});
 const workflowRunTriggerReferenceSchema = z.object({
   project: z.object({id: idSchema}).nullable(),
   repository: z.string().nullable(),
@@ -196,6 +207,7 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         'workspace-not-found': z.object({workspaceId: idSchema}),
         'workspace-suspended': z.object({workspaceId: idSchema}),
         'workspace-deleted': z.object({workspaceId: idSchema}),
+        'admission-denied': admissionDeniedDetailsSchema,
         'definition-not-found': z.object({definitionId: idSchema}),
         'project-mismatch': z.object({}),
         'agent-config-unresolvable': z.object({definitionId: idSchema}),
@@ -248,6 +260,7 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         'workspace-not-found': z.object({workspaceId: idSchema}),
         'workspace-suspended': z.object({workspaceId: idSchema}),
         'workspace-deleted': z.object({workspaceId: idSchema}),
+        'admission-denied': admissionDeniedDetailsSchema,
         'agent-config-unresolvable': z.object({definitionId: idSchema}),
         'agent-integration-materialization-failed': z.object({}),
         'interpolation-unresolvable': z.object({
@@ -301,6 +314,7 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         'workspace-not-found': z.object({workspaceId: idSchema}),
         'workspace-suspended': z.object({workspaceId: idSchema}),
         'workspace-deleted': z.object({workspaceId: idSchema}),
+        'admission-denied': admissionDeniedDetailsSchema,
       },
     },
     getStepLogContext: {

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -1,6 +1,7 @@
 import type {WorkflowExecutionPayloadFieldDto} from '@shipfox/api-workflows-dto';
 import type {JobStatus} from './entities/job.js';
 import type {WorkflowRunStatus} from './entities/workflow-run.js';
+import type {RequiredAction} from './workspace-admission.js';
 
 export class DefinitionNotFoundError extends Error {
   constructor(definitionId: string) {
@@ -36,6 +37,17 @@ export class WorkspaceNotFoundError extends Error {
   constructor(readonly workspaceId: string) {
     super(`Workspace not found: ${workspaceId}`);
     this.name = 'WorkspaceNotFoundError';
+  }
+}
+
+export class WorkflowAdmissionDeniedError extends Error {
+  constructor(
+    readonly workspaceId: string,
+    readonly reason: string,
+    readonly requiredAction?: RequiredAction | undefined,
+  ) {
+    super(`Workflow admission denied: ${reason}`);
+    this.name = 'WorkflowAdmissionDeniedError';
   }
 }
 

--- a/libs/api/workflows/src/core/index.ts
+++ b/libs/api/workflows/src/core/index.ts
@@ -26,6 +26,7 @@ export {
   SourceRunNotFoundError,
   StepNotFoundError,
   StepNotRunningError,
+  WorkflowAdmissionDeniedError,
   WorkflowDiagnosticTooLargeError,
   WorkflowExecutionPayloadTooLargeError,
   WorkflowRunNotCancellableError,
@@ -60,3 +61,10 @@ export {
   type ScheduleRuntimeDagInput,
   scheduleRuntimeDag,
 } from './workflow-scheduling/index.js';
+export type {
+  RequiredAction,
+  WorkflowAdmissionCheck,
+  WorkflowAdmissionDecision,
+  WorkflowAdmissionInput,
+  WorkflowAdmissionPolicy,
+} from './workspace-admission.js';

--- a/libs/api/workflows/src/core/workspace-admission.test.ts
+++ b/libs/api/workflows/src/core/workspace-admission.test.ts
@@ -1,7 +1,15 @@
 import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
-import {WorkspaceDeletedError, WorkspaceNotFoundError, WorkspaceSuspendedError} from './errors.js';
-import {assertWorkspaceAdmitsNewJobs} from './workspace-admission.js';
+import {
+  type WorkflowAdmissionDeniedError,
+  WorkspaceDeletedError,
+  WorkspaceNotFoundError,
+  WorkspaceSuspendedError,
+} from './errors.js';
+import {
+  assertWorkspaceAdmitsNewJobs,
+  WORKFLOW_ADMISSION_POLICY_TIMEOUT_MS,
+} from './workspace-admission.js';
 
 const workspaceId = '00000000-0000-4000-8000-000000000001';
 
@@ -12,6 +20,83 @@ describe('assertWorkspaceAdmitsNewJobs', () => {
     await assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId);
 
     expect(getWorkspaceOperatingState).toHaveBeenCalledWith({workspaceId});
+  });
+
+  test('passes the workflow context to an admission policy', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'active'});
+    const admit = vi.fn().mockResolvedValue({allowed: true});
+
+    await assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId, {
+      policy: {admit},
+      source: 'manual',
+      definitionId: 'definition-1',
+    });
+
+    expect(admit).toHaveBeenCalledWith({
+      workspaceId,
+      source: 'manual',
+      definitionId: 'definition-1',
+    });
+  });
+
+  test('rejects an explicit policy denial with its required action', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'active'});
+    const requiredAction = {
+      reason: 'billing-payment-method-required',
+      message: 'Add a payment method to continue.',
+      url: '/settings/billing',
+    };
+    const admit = vi.fn().mockResolvedValue({
+      allowed: false,
+      reason: requiredAction.reason,
+      requiredAction,
+    });
+
+    await expect(
+      assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId, {
+        policy: {admit},
+        source: 'github',
+        definitionId: 'definition-1',
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowAdmissionDeniedError',
+      workspaceId,
+      reason: requiredAction.reason,
+      requiredAction,
+    } satisfies Partial<WorkflowAdmissionDeniedError>);
+  });
+
+  test('runs the operating-state gate before the policy', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'suspended'});
+    const admit = vi.fn().mockResolvedValue({allowed: false, reason: 'policy-denied'});
+
+    await expect(
+      assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId, {
+        policy: {admit},
+        source: 'manual',
+        definitionId: 'definition-1',
+      }),
+    ).rejects.toBeInstanceOf(WorkspaceSuspendedError);
+    expect(admit).not.toHaveBeenCalled();
+  });
+
+  test('treats a hanging policy as a transient timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'active'});
+      const admit = vi.fn().mockReturnValue(new Promise<never>(() => undefined));
+      const check = assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId, {
+        policy: {admit},
+        source: 'manual',
+        definitionId: 'definition-1',
+      });
+      const rejection = expect(check).rejects.toThrow('Workflow admission policy timed out');
+
+      await vi.advanceTimersByTimeAsync(WORKFLOW_ADMISSION_POLICY_TIMEOUT_MS);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test.each([

--- a/libs/api/workflows/src/core/workspace-admission.ts
+++ b/libs/api/workflows/src/core/workspace-admission.ts
@@ -3,11 +3,46 @@ import {
   workspacesInterModuleContract,
 } from '@shipfox/api-workspaces-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
-import {WorkspaceDeletedError, WorkspaceNotFoundError, WorkspaceSuspendedError} from './errors.js';
+import {
+  WorkflowAdmissionDeniedError,
+  WorkspaceDeletedError,
+  WorkspaceNotFoundError,
+  WorkspaceSuspendedError,
+} from './errors.js';
+
+export interface WorkflowAdmissionInput {
+  workspaceId: string;
+  source: string;
+  definitionId: string;
+}
+
+export interface RequiredAction {
+  reason: string;
+  message: string;
+  url: string;
+}
+
+export type WorkflowAdmissionDecision =
+  | {allowed: true}
+  | {allowed: false; reason: string; requiredAction?: RequiredAction | undefined};
+
+export interface WorkflowAdmissionPolicy {
+  admit(input: WorkflowAdmissionInput): Promise<WorkflowAdmissionDecision>;
+}
+
+export interface WorkflowAdmissionCheck {
+  policy?: WorkflowAdmissionPolicy | undefined;
+  source: string;
+  definitionId: string;
+}
+
+/** The host policy must not hold an admission path open indefinitely. */
+export const WORKFLOW_ADMISSION_POLICY_TIMEOUT_MS = 5_000;
 
 export async function assertWorkspaceAdmitsNewJobs(
   workspaces: Pick<WorkspacesInterModuleClient, 'getWorkspaceOperatingState'>,
   workspaceId: string,
+  admission?: WorkflowAdmissionCheck | undefined,
 ): Promise<void> {
   let state: Awaited<ReturnType<WorkspacesInterModuleClient['getWorkspaceOperatingState']>>;
   try {
@@ -27,14 +62,52 @@ export async function assertWorkspaceAdmitsNewJobs(
 
   const {status} = state;
   switch (status) {
-    case 'active':
+    case 'active': {
+      if (admission?.policy === undefined) return;
+
+      const decision = await admitWithTimeout(admission.policy, {
+        workspaceId,
+        source: admission.source,
+        definitionId: admission.definitionId,
+      });
+      if (!decision.allowed) {
+        throw new WorkflowAdmissionDeniedError(
+          workspaceId,
+          decision.reason,
+          decision.requiredAction,
+        );
+      }
       return;
+    }
     case 'suspended':
       throw new WorkspaceSuspendedError(workspaceId);
     case 'deleted':
       throw new WorkspaceDeletedError(workspaceId);
     default:
       return assertNever(status);
+  }
+}
+
+async function admitWithTimeout(
+  policy: WorkflowAdmissionPolicy,
+  input: WorkflowAdmissionInput,
+): Promise<WorkflowAdmissionDecision> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      policy.admit(input),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `Workflow admission policy timed out after ${WORKFLOW_ADMISSION_POLICY_TIMEOUT_MS}ms`,
+            ),
+          );
+        }, WORKFLOW_ADMISSION_POLICY_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -75,6 +75,7 @@ export async function getJobById(id: string): Promise<Job | undefined> {
 export interface JobScope {
   workspaceId: string;
   projectId: string;
+  definitionId: string;
   triggerReference: WorkflowRunTriggerReference | null;
   /** The run's origin state, so checkout fallbacks can read the dev source. */
   run: WorkflowRunOriginState;
@@ -85,6 +86,7 @@ export async function getJobScope(jobId: string): Promise<JobScope | undefined> 
     .select({
       workspaceId: workflowRuns.workspaceId,
       projectId: workflowRuns.projectId,
+      definitionId: workflowRuns.definitionId,
       triggerReference: workflowRuns.triggerReference,
       origin: workflowRuns.origin,
       devSource: workflowRuns.devSource,
@@ -99,6 +101,7 @@ export async function getJobScope(jobId: string): Promise<JobScope | undefined> 
   return {
     workspaceId: row.workspaceId,
     projectId: row.projectId,
+    definitionId: row.definitionId,
     triggerReference: row.triggerReference,
     run: toWorkflowRunOriginState(row),
   };

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -28,6 +28,7 @@ import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inte
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {config} from '#config.js';
 import {createToolStepExecutor} from '#core/tool-step/tool-step-executor.js';
+import type {WorkflowAdmissionPolicy} from '#core/workspace-admission.js';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 import {registerWorkflowsServiceMetrics} from '#metrics/index.js';
 import {
@@ -62,6 +63,7 @@ export {
   isPermanentRunWorkflowError,
   ProjectMismatchError,
   runWorkflow,
+  WorkflowAdmissionDeniedError,
   WorkflowDiagnosticTooLargeError,
   WorkflowExecutionPayloadTooLargeError,
   WorkflowRunNotCancellableError,
@@ -69,6 +71,12 @@ export {
   WorkflowStepAttemptInvocationLimitError,
   WorkflowStepResultTooLargeError,
 } from '#core/index.js';
+export type {
+  RequiredAction,
+  WorkflowAdmissionDecision,
+  WorkflowAdmissionInput,
+  WorkflowAdmissionPolicy,
+} from '#core/workspace-admission.js';
 export {
   closeDb,
   type DeliverEventToListenerParams,
@@ -87,6 +95,10 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto & RunnersEventMap>();
 
+export interface CreateWorkflowsModuleOptions {
+  admission?: {policy: WorkflowAdmissionPolicy} | undefined;
+}
+
 export function createWorkflowsModule({
   agent,
   definitions,
@@ -98,7 +110,8 @@ export function createWorkflowsModule({
   runners,
   secrets,
   workspaces,
-}: {
+  admission,
+}: CreateWorkflowsModuleOptions & {
   agent: AgentInterModuleClient;
   definitions: DefinitionsInterModuleClient;
   annotations: AnnotationsInterModuleClient;
@@ -125,6 +138,7 @@ export function createWorkflowsModule({
       runners,
       secrets,
       workspaces,
+      admission,
     }),
     metrics: registerWorkflowsServiceMetrics,
     ...(config.WORKFLOWS_TOOL_STEP_EXECUTOR_ENABLED ? {services: [toolStepExecutor.service]} : {}),
@@ -162,6 +176,7 @@ export function createWorkflowsModule({
         runners,
         secrets,
         workspaces,
+        admission,
       }),
     ],
   };

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -10,6 +10,7 @@ import {decodeNumberIdCursor} from '@shipfox/node-drizzle';
 import type {WorkflowRun} from '#core/entities/workflow-run.js';
 import {
   InvalidJobRunnerLabelsError,
+  WorkflowAdmissionDeniedError,
   WorkflowDiagnosticTooLargeError,
   WorkflowExecutionPayloadTooLargeError,
   WorkflowSourceSnapshotTooLargeError,
@@ -904,6 +905,15 @@ describe('Workflows inter-module presentation', () => {
 
   test.each([
     ['definition-not-found', () => new DefinitionNotFoundError(input.definitionId)],
+    [
+      'admission-denied',
+      () =>
+        new WorkflowAdmissionDeniedError(input.workspaceId, 'billing-payment-method-required', {
+          reason: 'billing-payment-method-required',
+          message: 'Add a payment method to continue.',
+          url: '/settings/billing',
+        }),
+    ],
     ['project-mismatch', () => new ProjectMismatchError(input.projectId, input.definitionId)],
     ['agent-config-unresolvable', () => new AgentConfigUnresolvableError(input.definitionId)],
     [
@@ -950,6 +960,52 @@ describe('Workflows inter-module presentation', () => {
     const error = new WorkflowDiagnosticTooLargeError('config', 64 * 1024, 64 * 1024 + 1);
 
     expect(toStartRunKnownError(error, input.definitionId)).toBe(error);
+  });
+
+  test('denies a start-run before loading the workflow definition', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'active'});
+    const admit = vi.fn().mockResolvedValue({
+      allowed: false,
+      reason: 'billing-payment-method-required',
+      requiredAction: {
+        reason: 'billing-payment-method-required',
+        message: 'Add a payment method to continue.',
+        url: '/settings/billing',
+      },
+    });
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+      admission: {policy: {admit}},
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.startRunFromTrigger(input, {
+        signal: new AbortController().signal,
+      }),
+    ).catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(workflowsInterModuleContract.methods.startRunFromTrigger, error) &&
+        error.code,
+    ).toBe('admission-denied');
+    expect(error).toMatchObject({
+      details: {
+        workspaceId: input.workspaceId,
+        reason: 'billing-payment-method-required',
+        requiredAction: {url: '/settings/billing'},
+      },
+    });
+    expect(admit).toHaveBeenCalledWith({
+      workspaceId: input.workspaceId,
+      source: 'manual',
+      definitionId: input.definitionId,
+    });
   });
 
   test('maps a missing workspace from the Workspace contract for start-run', async () => {
@@ -1051,6 +1107,45 @@ describe('Workflows inter-module presentation', () => {
     const error = new WorkflowDiagnosticTooLargeError('evaluation_trace', 64 * 1024, 64 * 1024 + 1);
 
     expect(toStartDevRunKnownError(error)).toBe(error);
+  });
+
+  test('denies a dev run before creating the run', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'active'});
+    const admit = vi
+      .fn()
+      .mockResolvedValue({allowed: false, reason: 'billing-payment-method-required'});
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+      admission: {policy: {admit}},
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.startDevRun(devInput, {
+        signal: new AbortController().signal,
+      }),
+    ).catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(workflowsInterModuleContract.methods.startDevRun, error) &&
+        error.code,
+    ).toBe('admission-denied');
+    expect(error).toMatchObject({
+      details: {
+        workspaceId: devInput.workspaceId,
+        reason: 'billing-payment-method-required',
+      },
+    });
+    expect(admit).toHaveBeenCalledWith({
+      workspaceId: devInput.workspaceId,
+      source: 'manual',
+      definitionId: devInput.workflowId,
+    });
   });
 
   test.each([
@@ -1206,6 +1301,59 @@ describe('Workflows inter-module presentation', () => {
     ).toBe('workspace-not-found');
   });
 
+  test('denies fire listener deliveries before materialization', async () => {
+    const jobId = '00000000-0000-4000-8000-000000000006';
+    const workspaceId = '00000000-0000-4000-8000-000000000007';
+    const definitionId = '00000000-0000-4000-8000-000000000008';
+    const admit = vi
+      .fn()
+      .mockResolvedValue({allowed: false, reason: 'billing-payment-method-required'});
+    mocks.getJobScope.mockResolvedValue({workspaceId, projectId: input.projectId, definitionId});
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {
+        getWorkspaceOperatingState: vi.fn().mockResolvedValue({status: 'active'}),
+      } as never,
+      admission: {policy: {admit}},
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.deliverEventToJobListener(
+        {
+          ...input,
+          jobId,
+          disposition: 'fire',
+          eventRef: 'event-1',
+          deliveryId: 'delivery-1',
+          source: 'github',
+          event: 'push',
+          provider: 'github',
+          payload: {},
+          receivedAt: '2026-07-20T12:00:00.000Z',
+        },
+        {signal: new AbortController().signal},
+      ),
+    ).catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(
+        workflowsInterModuleContract.methods.deliverEventToJobListener,
+        error,
+      ) && error.code,
+    ).toBe('admission-denied');
+    expect(admit).toHaveBeenCalledWith({
+      workspaceId,
+      source: 'github',
+      definitionId,
+    });
+    expect(mocks.deliverEventToListener).not.toHaveBeenCalled();
+  });
+
   test.each([
     ['suspended', 'workspace-suspended'],
     ['deleted', 'workspace-deleted'],
@@ -1307,6 +1455,9 @@ describe('Workflows inter-module presentation', () => {
     const jobId = '00000000-0000-4000-8000-000000000006';
     mocks.getJobScope.mockResolvedValue({workspaceId: input.workspaceId});
     const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'suspended'});
+    const admit = vi
+      .fn()
+      .mockResolvedValue({allowed: false, reason: 'billing-payment-method-required'});
     const presentation = createWorkflowsInterModulePresentation({
       agent: {} as never,
       definitions: {} as never,
@@ -1315,6 +1466,7 @@ describe('Workflows inter-module presentation', () => {
       runners: {} as never,
       secrets: {} as never,
       workspaces: {getWorkspaceOperatingState} as never,
+      admission: {policy: {admit}},
     });
 
     await expect(
@@ -1335,6 +1487,7 @@ describe('Workflows inter-module presentation', () => {
     ).resolves.toEqual({buffered: true, skipped: false});
     expect(mocks.getJobScope).not.toHaveBeenCalled();
     expect(getWorkspaceOperatingState).not.toHaveBeenCalled();
+    expect(admit).not.toHaveBeenCalled();
     expect(mocks.deliverEventToListener).toHaveBeenCalled();
   });
 

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -37,6 +37,7 @@ import type {Step} from '#core/entities/step.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {
   InvalidJobRunnerLabelsError,
+  WorkflowAdmissionDeniedError,
   WorkflowExecutionPayloadTooLargeError,
   WorkflowSourceSnapshotTooLargeError,
   WorkspaceDeletedError,
@@ -53,7 +54,10 @@ import {
   runWorkflow,
 } from '#core/index.js';
 import {resolveWorkflowRunTriggerReference} from '#core/resolve-trigger-reference.js';
-import {assertWorkspaceAdmitsNewJobs} from '#core/workspace-admission.js';
+import {
+  assertWorkspaceAdmitsNewJobs,
+  type WorkflowAdmissionPolicy,
+} from '#core/workspace-admission.js';
 import {
   getJobScope,
   getLatestRunAttempt,
@@ -116,6 +120,7 @@ export function createWorkflowsInterModulePresentation(params: {
   runners: RunnersInterModuleClient;
   integrations: IntegrationsModuleClient;
   projects: ProjectsModuleClient;
+  admission?: {policy: WorkflowAdmissionPolicy} | undefined;
 }): InterModulePresentation<typeof workflowsInterModuleContract> {
   /**
    * Shared lease + running-agent-step resolution for the lease-authed
@@ -179,7 +184,11 @@ export function createWorkflowsInterModulePresentation(params: {
   return defineInterModulePresentation(workflowsInterModuleContract, {
     startRunFromTrigger: async (input) => {
       try {
-        await assertWorkspaceAdmitsNewJobs(params.workspaces, input.workspaceId);
+        await assertWorkspaceAdmitsNewJobs(params.workspaces, input.workspaceId, {
+          policy: params.admission?.policy,
+          source: input.triggerPayload.source,
+          definitionId: input.definitionId,
+        });
         const run = await runWorkflow(
           params.definitions,
           {
@@ -203,7 +212,11 @@ export function createWorkflowsInterModulePresentation(params: {
     },
     startDevRun: async (input) => {
       try {
-        await assertWorkspaceAdmitsNewJobs(params.workspaces, input.workspaceId);
+        await assertWorkspaceAdmitsNewJobs(params.workspaces, input.workspaceId, {
+          policy: params.admission?.policy,
+          source: input.triggerPayload.source,
+          definitionId: input.workflowId,
+        });
         const run = await runDevWorkflow(
           params.agent,
           {
@@ -242,7 +255,11 @@ export function createWorkflowsInterModulePresentation(params: {
       try {
         const scope = input.disposition === 'fire' ? await getJobScope(input.jobId) : undefined;
         if (scope) {
-          await assertWorkspaceAdmitsNewJobs(params.workspaces, scope.workspaceId);
+          await assertWorkspaceAdmitsNewJobs(params.workspaces, scope.workspaceId, {
+            policy: params.admission?.policy,
+            source: input.source,
+            definitionId: scope.definitionId,
+          });
         }
 
         let triggerReference: WorkflowRunTriggerReference | null = null;
@@ -907,6 +924,13 @@ function toWorkspaceAdmissionKnownError(
   if (error instanceof WorkspaceNotFoundError) {
     return createInterModuleKnownError(method, 'workspace-not-found', {
       workspaceId: error.workspaceId,
+    });
+  }
+  if (error instanceof WorkflowAdmissionDeniedError) {
+    return createInterModuleKnownError(method, 'admission-denied', {
+      workspaceId: error.workspaceId,
+      reason: error.reason,
+      ...(error.requiredAction === undefined ? {} : {requiredAction: error.requiredAction}),
     });
   }
   return undefined;

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -209,6 +209,7 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
     expect(scope).toEqual({
       workspaceId: run.workspaceId,
       projectId: run.projectId,
+      definitionId: run.definitionId,
       triggerReference: null,
       run: {origin: 'synced', devSource: null},
     });

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -8,6 +8,7 @@ import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-modu
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
+import type {WorkflowAdmissionPolicy} from '#core/workspace-admission.js';
 import {createAgentRuntimeConfigRoute} from './agent-runtime-config.js';
 import {cancelRunRoute} from './cancel-run.js';
 import {createCheckoutTokenRoute} from './checkout-token.js';
@@ -43,6 +44,7 @@ type WorkflowRouteClients = {
   runners: RunnersInterModuleClient;
   secrets: SecretsInterModuleClient;
   workspaces: WorkspacesInterModuleClient;
+  admission?: {policy: WorkflowAdmissionPolicy} | undefined;
 };
 
 type LeaseTokenRouteClients = Omit<WorkflowRouteClients, 'workspaces'>;
@@ -91,7 +93,7 @@ export function createWorkflowRoutes(params: WorkflowRouteClients): RouteGroup[]
         getRunRoute(params.projects),
         getStepAttemptDetailRoute(params.projects),
         cancelRunRoute(params.projects),
-        rerunRunRoute(params.projects, params.workspaces),
+        rerunRunRoute(params.projects, params.workspaces, params.admission),
       ],
     },
     createLeaseTokenRouteGroup(params),

--- a/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
@@ -10,12 +10,13 @@ import {
   workspacesInterModuleContract,
 } from '@shipfox/api-workspaces-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
-import {ClientError} from '@shipfox/node-fastify';
+import {ClientError, errorHandler} from '@shipfox/node-fastify';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
+import type {WorkflowAdmissionPolicy} from '#core/workspace-admission.js';
 import {db} from '#db/db.js';
 import {steps} from '#db/schema/steps.js';
 import {
@@ -41,6 +42,8 @@ const projects = {
 } as unknown as ProjectsModuleClient;
 const getWorkspaceOperatingState = vi.fn();
 const workspaces = {getWorkspaceOperatingState} as unknown as WorkspacesInterModuleClient;
+const admit = vi.fn<WorkflowAdmissionPolicy['admit']>();
+const admission = {policy: {admit}};
 const startMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@shipfox/node-temporal', async (importOriginal) => ({
@@ -77,6 +80,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
 
   beforeAll(async () => {
     app = Fastify();
+    app.setErrorHandler(errorHandler);
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
     app.addHook('onRequest', (request, _reply, done) => {
@@ -90,7 +94,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
       );
       done();
     });
-    app.post('/api/workflows/runs/:id/rerun', rerunRunRoute(projects, workspaces));
+    app.post('/api/workflows/runs/:id/rerun', rerunRunRoute(projects, workspaces, admission));
     await app.ready();
   });
 
@@ -112,6 +116,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
       }),
     );
     getWorkspaceOperatingState.mockResolvedValue({status: 'active'});
+    admit.mockResolvedValue({allowed: true});
   });
 
   async function createTerminalRun(status: 'succeeded' | 'failed' = 'failed') {
@@ -296,6 +301,38 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('workspace-suspended');
     expect(getWorkspaceOperatingState).toHaveBeenCalledWith({workspaceId});
+  });
+
+  test('returns an admission denial with required action before creating a new attempt', async () => {
+    const source = await createTerminalRun('failed');
+    const requiredAction = {
+      reason: 'billing-payment-method-required',
+      message: 'Add a payment method to continue.',
+      url: '/settings/billing',
+    };
+    admit.mockResolvedValue({allowed: false, reason: requiredAction.reason, requiredAction});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${source.id}/rerun`,
+      payload: {mode: 'all'},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      code: 'admission-denied',
+      details: {
+        workspace_id: source.workspaceId,
+        reason: requiredAction.reason,
+        required_action: requiredAction,
+      },
+    });
+    expect(admit).toHaveBeenCalledWith({
+      workspaceId: source.workspaceId,
+      source: source.triggerSource,
+      definitionId: source.definitionId,
+    });
+    await expect(getWorkflowRunById(source.id)).resolves.toMatchObject({currentAttempt: 1});
   });
 
   test('returns workspace-deleted before creating a new attempt', async () => {

--- a/libs/api/workflows/src/presentation/routes/rerun-run.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.ts
@@ -8,18 +8,29 @@ import {
   NoFailedJobsError,
   RunNotTerminalError,
   SourceRunNotFoundError,
+  WorkflowAdmissionDeniedError,
   WorkspaceDeletedError,
   WorkspaceNotFoundError,
   WorkspaceSuspendedError,
 } from '#core/errors.js';
-import {assertWorkspaceAdmitsNewJobs} from '#core/workspace-admission.js';
+import {
+  assertWorkspaceAdmitsNewJobs,
+  type WorkflowAdmissionPolicy,
+} from '#core/workspace-admission.js';
 import {createRerunWorkflowRun} from '#db/index.js';
 import {toRunDto} from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 
+const errorResponseSchema = z.object({
+  code: z.string(),
+  message: z.string().optional(),
+  details: z.unknown().optional(),
+});
+
 export function rerunRunRoute(
   projects: ProjectsModuleClient,
   workspaces: WorkspacesInterModuleClient,
+  admission?: {policy: WorkflowAdmissionPolicy} | undefined,
 ) {
   return defineRoute({
     method: 'POST',
@@ -32,6 +43,7 @@ export function rerunRunRoute(
       body: rerunWorkflowRunBodySchema,
       response: {
         200: workflowRunResponseSchema,
+        409: errorResponseSchema,
       },
     },
     errorHandler: (error) => {
@@ -62,13 +74,24 @@ export function rerunRunRoute(
           cause: error,
         });
       }
+      if (error instanceof WorkflowAdmissionDeniedError) {
+        throw new ClientError('Workflow admission denied', 'admission-denied', {
+          status: 409,
+          details: admissionDeniedDetails(error),
+          cause: error,
+        });
+      }
       throw error;
     },
     handler: async (request) => {
       const {id} = request.params;
       const sourceRun = await requireAccessibleRun({request, id, projects});
 
-      await assertWorkspaceAdmitsNewJobs(workspaces, sourceRun.workspaceId);
+      await assertWorkspaceAdmitsNewJobs(workspaces, sourceRun.workspaceId, {
+        policy: admission?.policy,
+        source: sourceRun.triggerSource,
+        definitionId: sourceRun.definitionId,
+      });
 
       const actor = requireUserContext(request);
       const run = await createRerunWorkflowRun({
@@ -80,4 +103,20 @@ export function rerunRunRoute(
       return toRunDto(run, run.currentAttempt);
     },
   });
+}
+
+function admissionDeniedDetails(error: WorkflowAdmissionDeniedError) {
+  return {
+    workspace_id: error.workspaceId,
+    reason: error.reason,
+    ...(error.requiredAction === undefined
+      ? {}
+      : {
+          required_action: {
+            reason: error.requiredAction.reason,
+            message: error.requiredAction.message,
+            url: error.requiredAction.url,
+          },
+        }),
+  };
 }

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -33,6 +33,8 @@ const fixtureTemplate = join(externalRoot, 'fixture');
 const REGISTRY_SHIPFOX_PACKAGE_PATTERN = /^@shipfox\+[^@]+@\d/u;
 const EXPECTED_COLLISION_DIAGNOSTIC =
   'Route "/auth/login" is contributed by both features "shipfox.auth" and "fixture.unapproved-collision". Set override: true to replace it explicitly.';
+// PostCSS 8.5.27 omitted the NodeProps import required by its declarations.
+const FIXTURE_OVERRIDES = {postcss: '8.5.23'};
 const arguments_ = process.argv.slice(2).filter((argument) => argument !== '--');
 const linkMode = arguments_.includes('--link');
 
@@ -209,12 +211,13 @@ async function configureFixture(root, consumerPackages, packageSpecs) {
   const consumerDependencies = Object.fromEntries(
     consumerPackages.map((name) => [name, packageSpecs[name]]),
   );
+  const overrides = {...packageSpecs, ...FIXTURE_OVERRIDES};
   manifest.dependencies = {...manifest.dependencies, ...consumerDependencies};
   await Promise.all([
     writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`),
     writeFile(
       join(root, 'pnpm-workspace.yaml'),
-      renderFixtureWorkspaceConfig({repositoryRoot, overrides: packageSpecs}),
+      renderFixtureWorkspaceConfig({repositoryRoot, overrides}),
     ),
   ]);
 }


### PR DESCRIPTION
## Summary

Adds an optional workflow admission policy to the server-side Workflows seam and threads it through the default server composition.

The policy gates manual, scheduled, integration, listener-fire, dev-run, and rerun admissions beside the existing workspace operating-state gate. Explicit denials return stable `admission-denied` details, become terminal trigger-history entries without retries, and preserve required-action data through HTTP and inter-module boundaries. Resolve deliveries and no-policy compositions remain unchanged.

## Motivation

Billing and other application owners need one server-enforced admission seam without coupling their rules to Workflows or Triggers.

Validation: affected-package `turbo check`, `turbo type`, `turbo test`, and `turbo build` all passed. Workflows dependency-cruiser also passed with no violations.

Release packaging and packed-consumer verification are tracked separately in ENG-1910.

Closes ENG-1908

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional admission policy to the Workflows module so application owners (e.g., billing) can deny runs before they start, without coupling their rules to Workflows or Triggers. The policy gates manual, scheduled, integration, listener-fire, dev-run, and rerun admissions; denials return a stable `admission-denied` error with reason and optional required action, and become terminal trigger-history entries without retries. No-policy compositions behave exactly as before.

**Details**

- The policy is threaded through `defaultModules` via `workflowsModuleOptions.admission` and through the HTTP routes and inter-module contracts.
- Explicit denials map to HTTP 409 with `workspace_id`, `reason`, and optional `required_action`.
- Trigger history records the denial reason without retrying, for manual, cron, integration, dev-run, and listener deliveries.
- The policy runs after the workspace operating-state gate and times out after 5 seconds.
- Pins PostCSS to 8.5.23 in the packed-consumer fixture so the external contract checks aren't broken by a malformed transitive declaration.

<sup>Written for commit d9f79f495d17c25c9c76b8d1104825e7cd0752ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

