### PR TITLE
Reject oversized listener fire deliveries

### DIFF
--- a/.changeset/reject-oversized-listener-fires.md
+++ b/.changeset/reject-oversized-listener-fires.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-agent-access-dto": patch
+"@shipfox/api-triggers": patch
+"@shipfox/api-triggers-dto": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": patch
+---
+
+Rejects oversized listener fire deliveries without suppressing matching resolve events.

--- a/.changeset/reject-oversized-listener-fires.md
+++ b/.changeset/reject-oversized-listener-fires.md
@@ -4,6 +4,7 @@
 "@shipfox/api-triggers-dto": patch
 "@shipfox/api-workflows": patch
 "@shipfox/api-workflows-dto": patch
+"@shipfox/client-triggers": minor
 ---
 
 Rejects oversized listener fire deliveries without suppressing matching resolve events.

--- a/libs/api/agent-access-dto/src/schemas/diagnostic-tools.ts
+++ b/libs/api/agent-access-dto/src/schemas/diagnostic-tools.ts
@@ -28,7 +28,12 @@ export type GetTriggerEventFacetsInputDto = z.infer<typeof getTriggerEventFacets
 
 const triggerOriginSchema = z.enum(['integration', 'manual', 'cron', 'dev']);
 const triggerOutcomeSchema = z.enum(['received', 'routed', 'discarded', 'failed', 'errored']);
-const triggerDecisionOutcomeSchema = z.enum(['triggered', 'filter-error', 'dispatch-error']);
+const triggerDecisionOutcomeSchema = z.enum([
+  'triggered',
+  'filter-error',
+  'dispatch-error',
+  'rejected',
+]);
 const triggerDecisionSchema = z
   .object({
     id: idSchema,
@@ -135,7 +140,10 @@ const triggerDecisionJsonSchema = {
   properties: {
     id: uuid,
     subscription_kind: {type: 'string', enum: ['trigger', 'listener', 'dev']},
-    outcome: {type: 'string', enum: ['triggered', 'filter-error', 'dispatch-error']},
+    outcome: {
+      type: 'string',
+      enum: ['triggered', 'filter-error', 'dispatch-error', 'rejected'],
+    },
     reason: nullable(text),
     workflow_definition_id: nullable(uuid),
     project_id: nullable(uuid),

--- a/libs/api/agent-access/src/core/diagnostic-tools.test.ts
+++ b/libs/api/agent-access/src/core/diagnostic-tools.test.ts
@@ -165,6 +165,39 @@ describe('trigger diagnostic tools', () => {
     expect(result.replays.map((item) => item.id)).toEqual([uuid(22), uuid(21)]);
   });
 
+  test('accepts rejected listener decisions in the trigger event tool result', async () => {
+    const mocks = clients();
+    mocks.getTriggerEvent.mockResolvedValue({
+      ...event(),
+      decisions: [
+        {
+          ...decision(1),
+          subscriptionKind: 'listener' as const,
+          workflowDefinitionId: null,
+          projectId: null,
+          decision: 'rejected' as const,
+          runId: null,
+          reason: 'payload-too-large',
+        },
+      ],
+      replays: [],
+      decisionsTotalCount: 1,
+      replaysTotalCount: 0,
+    });
+
+    const response = await tool(mocks, 'get_trigger_event').execute({
+      context,
+      arguments: {event_id: eventId},
+    });
+    const result = success<TriggerResult>(response);
+
+    expect(result.decisions[0]).toMatchObject({
+      outcome: 'rejected',
+      reason: 'payload-too-large',
+    });
+    expect(getTriggerEventResultJsonSchema.properties.decisions.items).toBeDefined();
+  });
+
   test('keeps an escaping-heavy capped payload valid JSON and reports its original byte size', async () => {
     const mocks = clients();
     const payload = {message: '\\"\n\\\\🙂'.repeat(8_000)};

--- a/libs/api/triggers-dto/src/schemas/trigger-events.ts
+++ b/libs/api/triggers-dto/src/schemas/trigger-events.ts
@@ -12,7 +12,12 @@ export const triggerEventOutcomeSchema = z.enum([
 ]);
 export type TriggerEventOutcomeDto = z.infer<typeof triggerEventOutcomeSchema>;
 
-export const triggerDecisionOutcomeSchema = z.enum(['triggered', 'filter-error', 'dispatch-error']);
+export const triggerDecisionOutcomeSchema = z.enum([
+  'triggered',
+  'filter-error',
+  'dispatch-error',
+  'rejected',
+]);
 export type TriggerDecisionOutcomeDto = z.infer<typeof triggerDecisionOutcomeSchema>;
 
 export const triggerDecisionSubscriptionKindSchema = z.enum(['trigger', 'listener', 'dev']);

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -637,6 +637,42 @@ describe('dispatchIntegrationEvent', () => {
     });
   });
 
+  test('records rejected listener-only matches as errored without triggering a listener', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const subscription = await jobListenerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+    });
+    deliverEventToListener.mockResolvedValueOnce({
+      buffered: false,
+      skipped: false,
+      rejection: {
+        reason: 'payload-too-large',
+        eventId: crypto.randomUUID(),
+        measuredBytes: 786_433,
+        limitBytes: 786_432,
+      },
+    });
+
+    await dispatch({workspaceId, eventRef});
+
+    expect(runWorkflow).not.toHaveBeenCalled();
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    expect(event.matchedCount).toBe(1);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      subscriptionKind: 'listener',
+      subscriptionId: subscription.id,
+      decision: 'rejected',
+      reason: 'payload-too-large',
+    });
+  });
+
   test('treats listener replay conflicts as routed idempotent success', async () => {
     const workspaceId = crypto.randomUUID();
     const eventRef = crypto.randomUUID();

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -34,7 +34,8 @@ export interface DispatchIntegrationEventParams {
 // and re-thrown so the outbox
 // replays the whole event and converges (succeeded siblings dedup on the idempotency key). The
 // event reaches a terminal outcome only when no transient error remains: `routed` if any run
-// was created or any listening job matched, `discarded` if nothing matched, otherwise `errored`.
+// was created or any listening job accepted a delivery, `discarded` if nothing matched, otherwise
+// `errored`.
 // History is best-effort; the thrown transient error, not the recorded outcome, drives the retry.
 export async function dispatchIntegrationEvent(
   params: DispatchIntegrationEventParams,

--- a/libs/api/triggers/src/core/entities/decision.ts
+++ b/libs/api/triggers/src/core/entities/decision.ts
@@ -1,6 +1,11 @@
 import type {JobListenerMatcherKind} from './job-listener-subscription.js';
 
-export const triggerDecisionOutcomes = ['triggered', 'filter-error', 'dispatch-error'] as const;
+export const triggerDecisionOutcomes = [
+  'triggered',
+  'filter-error',
+  'dispatch-error',
+  'rejected',
+] as const;
 export type TriggerDecisionOutcome = (typeof triggerDecisionOutcomes)[number];
 export type TriggerDecisionSubscriptionKind = 'trigger' | 'listener' | 'dev';
 

--- a/libs/api/triggers/src/core/record-trigger-history.test.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.test.ts
@@ -20,6 +20,7 @@ vi.mock('#db/event-history.js', () => ({
   upsertDevDispatchErrorDecision: (...args: unknown[]) => upsertDevDispatchErrorDecision(...args),
   upsertDispatchErrorDecision: vi.fn(),
   upsertFilterErrorDecision: vi.fn(),
+  upsertListenerDeliveryRejectedDecision: vi.fn(),
   upsertListenerTriggeredDecision: vi.fn(),
   upsertListenerDispatchErrorDecision: vi.fn(),
   upsertListenerFilterErrorDecision: vi.fn(),
@@ -76,6 +77,9 @@ describe('trigger history is best-effort and never blocks triggering', () => {
     ).resolves.toBeUndefined();
     await expect(
       recorder.listenerFilterErrored(listenerSubscription, 'bad filter'),
+    ).resolves.toBeUndefined();
+    await expect(
+      recorder.listenerDeliveryRejected(listenerSubscription, 'payload-too-large'),
     ).resolves.toBeUndefined();
     await expect(recorder.discarded()).resolves.toBeUndefined();
     await expect(recorder.routed(1)).resolves.toBeUndefined();

--- a/libs/api/triggers/src/core/record-trigger-history.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.ts
@@ -14,6 +14,7 @@ import {
   upsertDevTriggeredDecision,
   upsertDispatchErrorDecision,
   upsertFilterErrorDecision,
+  upsertListenerDeliveryRejectedDecision,
   upsertListenerDispatchErrorDecision,
   upsertListenerFilterErrorDecision,
   upsertListenerTriggeredDecision,
@@ -55,6 +56,10 @@ export interface TriggerHistoryRecorder {
   listenerTriggered(subscription: JobListenerSubscription): Promise<void>;
   listenerFilterErrored(subscription: JobListenerSubscription, reason: string): Promise<void>;
   listenerDispatchErrored(subscription: JobListenerSubscription, reason: string): Promise<void>;
+  listenerDeliveryRejected(
+    subscription: JobListenerSubscription,
+    reason: 'payload-too-large',
+  ): Promise<void>;
   discarded(): Promise<void>;
   routed(matchedCount: number): Promise<void>;
   failed(matchedCount: number): Promise<void>;
@@ -152,6 +157,12 @@ export async function beginTriggerHistory(
       record(
         'listener-dispatch-error-decision',
         (id) => upsertListenerDispatchErrorDecision({receivedEventId: id, subscription, reason}),
+        subscription.id,
+      ),
+    listenerDeliveryRejected: (subscription, reason) =>
+      record(
+        'listener-rejected-decision',
+        (id) => upsertListenerDeliveryRejectedDecision({receivedEventId: id, subscription, reason}),
         subscription.id,
       ),
     discarded: () => record('discard-event', (id) => markReceivedEventDiscarded(id)),

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
@@ -9,11 +9,15 @@ const findMatchingJobListenerSubscriptions = vi.fn();
 const listenerTriggered = vi.fn();
 const listenerFilterErrored = vi.fn();
 const listenerDispatchErrored = vi.fn();
+const listenerDeliveryRejected = vi.fn();
 const loggerWarn = vi.fn();
+const listenerDeliveryRejectionsCount = vi.hoisted(() => ({add: vi.fn()}));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
   logger: () => ({warn: loggerWarn}),
 }));
+
+vi.mock('#metrics/instance.js', () => ({listenerDeliveryRejectionsCount}));
 
 vi.mock('#db/job-listener-subscriptions.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('#db/job-listener-subscriptions.js')>();
@@ -74,6 +78,7 @@ function buildHistory(): TriggerHistoryRecorder {
     listenerTriggered,
     listenerFilterErrored,
     listenerDispatchErrored,
+    listenerDeliveryRejected,
     discarded: vi.fn(),
     routed: vi.fn(),
     failed: vi.fn(),
@@ -89,6 +94,8 @@ describe('routeEventToJobListeners', () => {
     listenerTriggered.mockReset();
     listenerFilterErrored.mockReset();
     listenerDispatchErrored.mockReset();
+    listenerDeliveryRejected.mockReset();
+    listenerDeliveryRejectionsCount.add.mockReset();
     loggerWarn.mockReset();
     deliverEventToListener.mockResolvedValue({buffered: true, skipped: false});
     resolveWorkflowRunTriggerReference.mockResolvedValue(null);
@@ -275,6 +282,44 @@ describe('routeEventToJobListeners', () => {
 
     expect(result).toMatchObject({
       engagedCount: 0,
+      matchedJobCount: 1,
+      acceptedJobCount: 0,
+      deliveredCount: 0,
+      transientErrored: false,
+    });
+  });
+
+  it('records rejected deliveries without signaling listener execution', async () => {
+    const workspaceId = crypto.randomUUID();
+    const subscription = await jobListenerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'pull_request_review',
+    });
+    deliverEventToListener.mockResolvedValueOnce({
+      buffered: false,
+      skipped: false,
+      rejection: {
+        reason: 'payload-too-large',
+        eventId: crypto.randomUUID(),
+        measuredBytes: 786_433,
+        limitBytes: 786_432,
+      },
+    });
+
+    const result = await route({workspaceId});
+
+    expect(listenerDeliveryRejected).toHaveBeenCalledTimes(1);
+    expect(listenerDeliveryRejected).toHaveBeenCalledWith(
+      expect.objectContaining({id: subscription.id}),
+      'payload-too-large',
+    );
+    expect(listenerTriggered).not.toHaveBeenCalled();
+    expect(listenerDeliveryRejectionsCount.add).toHaveBeenCalledWith(1, {
+      reason: 'payload_too_large',
+    });
+    expect(result).toMatchObject({
+      engagedCount: 1,
       matchedJobCount: 1,
       acceptedJobCount: 0,
       deliveredCount: 0,

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.ts
@@ -5,6 +5,7 @@ import {
 import {projectWorkflowPredicateContext, rehydrateJsonExpressionRecord} from '@shipfox/expression';
 import {logger} from '@shipfox/node-opentelemetry';
 import {findMatchingJobListenerSubscriptions} from '#db/job-listener-subscriptions.js';
+import {listenerDeliveryRejectionsCount} from '#metrics/instance.js';
 import {evaluateStoredFilter, type StoredFilterEvaluation} from './config.js';
 import type {JobListenerSubscription} from './entities/job-listener-subscription.js';
 import {type TriggerHistoryRecorder, toReason} from './record-trigger-history.js';
@@ -32,8 +33,9 @@ export interface RouteEventToJobListenersParams {
 export interface RouteEventToJobListenersResult {
   /**
    * Listener outcomes that should contribute to received_event.matched_count:
-   * filter errors, accepted deliveries, and dispatch errors. Stale skipped jobs
-   * are intentionally excluded because they did not produce an auditable decision.
+   * filter errors, accepted deliveries, rejected deliveries, and dispatch errors.
+   * Stale skipped jobs are intentionally excluded because they did not produce an
+   * auditable decision.
    */
   engagedCount: number;
   /**
@@ -84,7 +86,11 @@ export async function routeEventToJobListeners(
   );
 
   return {
-    engagedCount: filterErrorCount + delivery.acceptedJobCount + delivery.dispatchErrorCount,
+    engagedCount:
+      filterErrorCount +
+      delivery.acceptedJobCount +
+      delivery.rejectedJobCount +
+      delivery.dispatchErrorCount,
     matchedJobCount: effectiveMatchByJobId.size,
     acceptedJobCount: delivery.acceptedJobCount,
     deliveredCount: delivery.deliveredCount,
@@ -121,6 +127,7 @@ async function collectEffectiveListenerMatches(
 interface ListenerDeliveryState {
   acceptedJobCount: number;
   deliveredCount: number;
+  rejectedJobCount: number;
   dispatchErrorCount: number;
   sawTransientError: boolean;
   firstTransientError: unknown;
@@ -136,6 +143,7 @@ async function deliverEventToMatchedListeners(
   const state: ListenerDeliveryState = {
     acceptedJobCount: 0,
     deliveredCount: 0,
+    rejectedJobCount: 0,
     dispatchErrorCount: 0,
     sawTransientError: false,
     firstTransientError: undefined,
@@ -168,11 +176,17 @@ async function deliverEventToMatchedListener(
       payload: params.payload,
       receivedAt: params.receivedAt.toISOString(),
     });
-    if (!result.skipped) {
-      state.acceptedJobCount += 1;
-      await params.history.listenerTriggered(subscription);
+    if (result.rejection !== undefined) {
+      state.rejectedJobCount += 1;
+      await params.history.listenerDeliveryRejected(subscription, result.rejection.reason);
+      listenerDeliveryRejectionsCount.add(1, {reason: 'payload_too_large'});
+    } else {
+      if (!result.skipped) {
+        state.acceptedJobCount += 1;
+        await params.history.listenerTriggered(subscription);
+      }
+      if (result.buffered) state.deliveredCount += 1;
     }
-    if (result.buffered) state.deliveredCount += 1;
   } catch (error) {
     state.dispatchErrorCount += 1;
     await params.history.listenerDispatchErrored(subscription, toReason(error));

--- a/libs/api/triggers/src/db/event-history.test.ts
+++ b/libs/api/triggers/src/db/event-history.test.ts
@@ -14,6 +14,7 @@ import {
   upsertDevTriggeredDecision,
   upsertDispatchErrorDecision,
   upsertFilterErrorDecision,
+  upsertListenerDeliveryRejectedDecision,
   upsertListenerDispatchErrorDecision,
   upsertListenerFilterErrorDecision,
   upsertListenerTriggeredDecision,
@@ -568,5 +569,49 @@ describe('decision upserts', () => {
     expect(rows[0]?.subscriptionKind).toBe('listener');
     expect(rows[0]?.decision).toBe('filter-error');
     expect(rows[0]?.reason).toBe('Listener filter evaluation failed');
+  });
+
+  it('records a stable listener delivery rejection decision', async () => {
+    const receivedEventId = await insertReceivedEvent(buildEventParams());
+    const subscription = buildListenerSubscription();
+
+    await upsertListenerDeliveryRejectedDecision({
+      receivedEventId,
+      subscription,
+      reason: 'payload-too-large',
+    });
+
+    const rows = await decisionsFor(receivedEventId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      subscriptionKind: 'listener',
+      subscriptionId: subscription.id,
+      decision: 'rejected',
+      runId: null,
+      runName: null,
+      reason: 'payload-too-large',
+    });
+  });
+
+  it('promotes listener rejection to triggered and never downgrades it', async () => {
+    const receivedEventId = await insertReceivedEvent(buildEventParams());
+    const subscription = buildListenerSubscription();
+
+    await upsertListenerDeliveryRejectedDecision({
+      receivedEventId,
+      subscription,
+      reason: 'payload-too-large',
+    });
+    await upsertListenerTriggeredDecision({receivedEventId, subscription});
+    await upsertListenerDeliveryRejectedDecision({
+      receivedEventId,
+      subscription,
+      reason: 'payload-too-large',
+    });
+
+    const rows = await decisionsFor(receivedEventId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.decision).toBe('triggered');
+    expect(rows[0]?.reason).toBeNull();
   });
 });

--- a/libs/api/triggers/src/db/event-history.ts
+++ b/libs/api/triggers/src/db/event-history.ts
@@ -224,6 +224,35 @@ export interface UpsertListenerFailedDecisionParams {
   reason: string;
 }
 
+export interface UpsertListenerDeliveryRejectedDecisionParams {
+  receivedEventId: string;
+  subscription: JobListenerSubscription;
+  reason: 'payload-too-large';
+}
+
+export async function upsertListenerDeliveryRejectedDecision(
+  params: UpsertListenerDeliveryRejectedDecisionParams,
+): Promise<void> {
+  await db()
+    .insert(triggersDecisions)
+    .values({
+      ...listenerDecisionIdentity(params),
+      decision: 'rejected',
+      runId: null,
+      runName: null,
+      reason: params.reason,
+    })
+    .onConflictDoUpdate({
+      target: [
+        triggersDecisions.receivedEventId,
+        triggersDecisions.subscriptionKind,
+        triggersDecisions.subscriptionId,
+      ],
+      set: {decision: 'rejected', runId: null, runName: null, reason: params.reason},
+      setWhere: ne(triggersDecisions.decision, 'triggered'),
+    });
+}
+
 export async function upsertListenerFilterErrorDecision(
   params: UpsertListenerFailedDecisionParams,
 ): Promise<void> {

--- a/libs/api/triggers/src/db/schema/decisions.test.ts
+++ b/libs/api/triggers/src/db/schema/decisions.test.ts
@@ -104,6 +104,29 @@ describe('toTriggerDecision', () => {
 
     expect(result.decision).toBe('dispatch-error');
   });
+
+  test('maps rejected rows to the rejected outcome', () => {
+    const row = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      receivedEventId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      subscriptionKind: 'listener',
+      subscriptionId: '019e98ab-b90f-7265-b13c-8b441c991382',
+      subscriptionName: 'listener on[0] github/push',
+      workflowDefinitionId: null,
+      projectId: null,
+      workflowRunId: '019e98ab-b90f-7265-b13c-8b441c991383',
+      jobId: '019e98ab-b90f-7265-b13c-8b441c991384',
+      matcherKind: 'on',
+      matcherOrdinal: 0,
+      decision: 'rejected',
+      runId: null,
+      runName: null,
+      reason: 'payload-too-large',
+      createdAt: new Date('2026-06-09T10:00:02.000Z'),
+    } as unknown as TriggerDecisionDb;
+
+    expect(toTriggerDecision(row).decision).toBe('rejected');
+  });
 });
 
 describe('triggers_decisions schema', () => {

--- a/libs/api/triggers/src/db/schema/decisions.ts
+++ b/libs/api/triggers/src/db/schema/decisions.ts
@@ -79,7 +79,12 @@ export function toTriggerDecision(row: TriggerDecisionDb): TriggerDecision {
 
 function toTriggerDecisionOutcome(decision: string): TriggerDecision['decision'] {
   if (decision === 'errored') return 'dispatch-error';
-  if (decision === 'triggered' || decision === 'filter-error' || decision === 'dispatch-error') {
+  if (
+    decision === 'triggered' ||
+    decision === 'filter-error' ||
+    decision === 'dispatch-error' ||
+    decision === 'rejected'
+  ) {
     return decision;
   }
   return 'dispatch-error';

--- a/libs/api/triggers/src/metrics/index.ts
+++ b/libs/api/triggers/src/metrics/index.ts
@@ -4,6 +4,7 @@ export {
   devRunsCount,
   eventOutcomeCount,
   eventReceivedCount,
+  listenerDeliveryRejectionsCount,
   subscriptionTriggeredCount,
 } from './instance.js';
 export {registerTriggersServiceMetrics} from './service.js';

--- a/libs/api/triggers/src/metrics/instance.ts
+++ b/libs/api/triggers/src/metrics/instance.ts
@@ -14,6 +14,12 @@ export const subscriptionTriggeredCount = meter.createCounter<{
   description: 'Subscriptions that resulted in a workflow run, by provider',
 });
 
+export const listenerDeliveryRejectionsCount = meter.createCounter<{
+  reason: 'payload_too_large';
+}>('triggers_listener_delivery_rejections', {
+  description: 'Listener delivery rejections by bounded reason',
+});
+
 export const eventOutcomeCount = meter.createCounter<{
   provider: string;
   outcome: 'discarded' | 'routed' | 'failed' | 'errored';

--- a/libs/api/workflows-dto/src/inter-module.test.ts
+++ b/libs/api/workflows-dto/src/inter-module.test.ts
@@ -255,6 +255,16 @@ describe('workflowsInterModuleContract', () => {
       payload: {ref: 'refs/heads/main'},
       receivedAt: '2026-07-20T12:00:00.000Z',
     });
+    const rejection = workflowsInterModuleContract.methods.deliverEventToJobListener.output.parse({
+      buffered: false,
+      skipped: false,
+      rejection: {
+        reason: 'payload-too-large',
+        eventId: 'listener-event-1',
+        measuredBytes: 786_433,
+        limitBytes: 786_432,
+      },
+    });
     const reference =
       workflowsInterModuleContract.methods.resolveWorkflowRunTriggerReference.input.parse({
         workspaceId: '00000000-0000-4000-8000-000000000001',
@@ -271,6 +281,7 @@ describe('workflowsInterModuleContract', () => {
     expect(start.idempotencyKey).toBe('subscription-1:event-1');
     expect(start.triggerConnectionId).toBe('00000000-0000-4000-8000-000000000005');
     expect(delivery.disposition).toBe('fire');
+    expect(rejection.rejection?.reason).toBe('payload-too-large');
     expect(reference.triggerConnectionId).toBe('00000000-0000-4000-8000-000000000005');
     expect(delivery.triggerConnectionId).toBe('00000000-0000-4000-8000-000000000005');
   });

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -296,7 +296,18 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         payload: z.unknown(),
         receivedAt: z.string().datetime(),
       }),
-      output: z.object({buffered: z.boolean(), skipped: z.boolean()}),
+      output: z.object({
+        buffered: z.boolean(),
+        skipped: z.boolean(),
+        rejection: z
+          .object({
+            reason: z.literal('payload-too-large'),
+            eventId: z.string().min(1),
+            measuredBytes: z.number().int().positive(),
+            limitBytes: z.number().int().positive(),
+          })
+          .optional(),
+      }),
       errors: {
         'workspace-not-found': z.object({workspaceId: idSchema}),
         'workspace-suspended': z.object({workspaceId: idSchema}),

--- a/libs/api/workflows/src/core/listener-event-batching.ts
+++ b/libs/api/workflows/src/core/listener-event-batching.ts
@@ -4,6 +4,9 @@ import type {WorkflowExecutionEvent} from './entities/job-execution.js';
 /** Maximum UTF-8 bytes in the normalized trigger-event array sent to execution. */
 export const MAX_LISTENER_TRIGGER_EVENTS_BYTES = MAX_JSON_OUTPUT_BYTES;
 
+/** Maximum normalized bytes in one fire event accepted into a listener buffer. */
+export const MAX_LISTENER_FIRE_EVENT_BYTES = 768 * 1024;
+
 export type ListenerBatchPartitionReason = 'byte_limit' | 'count_limit';
 
 export type ListenerEventBatch =

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -13,6 +13,7 @@ export {
   type DeliverEventToListenerParams,
   type DeliverEventToListenerResult,
   deliverEventToListener,
+  type ListenerDeliveryRejection,
 } from './job-listener-events.js';
 export type {
   ActivateJobListenerParams,

--- a/libs/api/workflows/src/db/job-listener-events.test.ts
+++ b/libs/api/workflows/src/db/job-listener-events.test.ts
@@ -1,12 +1,15 @@
+import {WEBHOOK_MAX_RAW_BODY_BYTES} from '@shipfox/api-integration-core-dto';
 import {WORKFLOWS_JOB_EVENT_DELIVERED} from '@shipfox/api-workflows-dto';
 import {eq} from 'drizzle-orm';
+import {diagnosticValueByteLength} from '#core/diagnostics.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
+import {MAX_LISTENER_FIRE_EVENT_BYTES} from '#core/listener-event-batching.js';
 import {db} from '#db/db.js';
 import {jobListenerEvents} from '#db/schema/job-listener-events.js';
 import {jobs} from '#db/schema/jobs.js';
 import {workflowsOutbox} from '#db/schema/outbox.js';
 
-const {deliverEventToListener} = await import('./job-listener-events.js');
+const {deliverEventToListener, normalizeListenerEvent} = await import('./job-listener-events.js');
 const {jobFactory} = await import('#test/index.js');
 
 interface DeliverOverrides {
@@ -15,6 +18,7 @@ interface DeliverOverrides {
   eventRef?: string;
   provider?: string;
   triggerReference?: WorkflowRunTriggerReference | null;
+  payload?: unknown;
 }
 
 function deliver(overrides: DeliverOverrides = {}) {
@@ -27,7 +31,7 @@ function deliver(overrides: DeliverOverrides = {}) {
     event: 'pull_request_review',
     provider: overrides.provider ?? 'github',
     triggerReference: overrides.triggerReference,
-    payload: {action: 'submitted'},
+    payload: overrides.payload ?? {action: 'submitted'},
     receivedAt: new Date('2026-01-01T00:00:00.000Z'),
   });
 }
@@ -73,6 +77,77 @@ describe('deliverEventToListener', () => {
     });
     expect(row?.storedPayloadBytes).toBeGreaterThan(0);
     expect(row?.normalizedEventBytes).toBeGreaterThan(row?.storedPayloadBytes ?? 0);
+  });
+
+  it('rejects oversized fire events with metadata and no payload or outbox signal', async () => {
+    const job = await jobFactory.create({}, {transient: {status: 'pending'}});
+    const eventRef = crypto.randomUUID();
+    const payload = {body: 'x'.repeat(MAX_LISTENER_FIRE_EVENT_BYTES)};
+
+    const first = await deliver({jobId: job.id, eventRef, payload});
+    const second = await deliver({jobId: job.id, eventRef, payload});
+
+    const [row] = await listEvents(job.id);
+    const outboxRows = await db()
+      .select()
+      .from(workflowsOutbox)
+      .where(eq(workflowsOutbox.eventType, WORKFLOWS_JOB_EVENT_DELIVERED));
+    const matchingOutbox = outboxRows.find(
+      (candidate) =>
+        (candidate.payload as Record<string, unknown>).jobId === job.id &&
+        (candidate.payload as Record<string, unknown>).eventRef === eventRef,
+    );
+
+    expect(first).toMatchObject({
+      buffered: false,
+      skipped: false,
+      rejection: {
+        reason: 'payload-too-large',
+        eventId: expect.any(String),
+        measuredBytes: expect.any(Number),
+        limitBytes: MAX_LISTENER_FIRE_EVENT_BYTES,
+      },
+    });
+    expect(second).toEqual(first);
+    expect(row).toMatchObject({
+      outcome: 'rejected',
+      outcomeReason: 'payload_too_large',
+      payload: null,
+      storedPayloadBytes: diagnosticValueByteLength(payload),
+    });
+    expect(row?.normalizedEventBytes).toBeGreaterThan(MAX_LISTENER_FIRE_EVENT_BYTES);
+    expect(matchingOutbox).toBeUndefined();
+  });
+
+  it('accepts an oversized resolve event for later honoring', async () => {
+    const job = await jobFactory.create({}, {transient: {status: 'pending'}});
+    const payload = {body: 'x'.repeat(MAX_LISTENER_FIRE_EVENT_BYTES)};
+
+    const result = await deliver({jobId: job.id, disposition: 'resolve', payload});
+
+    const [row] = await listEvents(job.id);
+    expect(result).toEqual({buffered: true, skipped: false});
+    expect(row).toMatchObject({outcome: 'pending', payload});
+    expect(row?.normalizedEventBytes).toBeGreaterThan(MAX_LISTENER_FIRE_EVENT_BYTES);
+  });
+
+  it('keeps the maximum first-party webhook payload within the fire-event contract', () => {
+    const payload = {
+      body: 'x'.repeat(WEBHOOK_MAX_RAW_BODY_BYTES - Buffer.byteLength('{"body":""}')),
+    };
+    const normalizedEventBytes = diagnosticValueByteLength([
+      normalizeListenerEvent({
+        source: 'github',
+        event: 'push',
+        deliveryId: 'delivery-1',
+        triggerReference: null,
+        payload,
+        receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ]);
+
+    expect(Buffer.byteLength(JSON.stringify(payload), 'utf8')).toBe(WEBHOOK_MAX_RAW_BODY_BYTES);
+    expect(normalizedEventBytes).toBeLessThanOrEqual(MAX_LISTENER_FIRE_EVENT_BYTES);
   });
 
   it('persists the normalized trigger reference with the listener event', async () => {

--- a/libs/api/workflows/src/db/job-listener-events.ts
+++ b/libs/api/workflows/src/db/job-listener-events.ts
@@ -11,6 +11,7 @@ import type {
   JobListenerEventOutcomeReason,
 } from '#core/entities/job-listener-event.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
+import {MAX_LISTENER_FIRE_EVENT_BYTES} from '#core/listener-event-batching.js';
 import {recordListenerEventReceived} from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
 import {writeWorkflowsOutboxEvent} from './outbox-writes.js';
@@ -33,6 +34,14 @@ export interface DeliverEventToListenerParams {
 export interface DeliverEventToListenerResult {
   buffered: boolean;
   skipped: boolean;
+  rejection?: ListenerDeliveryRejection;
+}
+
+export interface ListenerDeliveryRejection {
+  reason: 'payload-too-large';
+  eventId: string;
+  measuredBytes: number;
+  limitBytes: number;
 }
 
 export interface FinalizedListenerEventCounts {
@@ -97,51 +106,118 @@ export async function finalizePendingListenerEvents(
 export async function deliverEventToListener(
   params: DeliverEventToListenerParams,
 ): Promise<DeliverEventToListenerResult> {
-  const result = await db().transaction(async (tx) => {
-    const [job] = await tx
-      .select({id: jobs.id, status: jobs.status})
-      .from(jobs)
-      .where(eq(jobs.id, params.jobId))
-      .for('update')
-      .limit(1);
+  const storedPayloadBytes = diagnosticValueByteLength(params.payload);
+  const normalizedEventBytes = diagnosticValueByteLength([normalizeListenerEvent(params)]);
+  const rejectsFireEvent =
+    params.disposition === 'fire' && normalizedEventBytes > MAX_LISTENER_FIRE_EVENT_BYTES;
 
-    if (!job || isJobTerminal(job.status)) return {buffered: false, skipped: true};
-
-    const rows = await tx
-      .insert(jobListenerEvents)
-      .values({
-        jobId: params.jobId,
-        disposition: params.disposition,
-        eventRef: params.eventRef,
-        deliveryId: params.deliveryId,
-        source: params.source,
-        event: params.event,
-        triggerReference: params.triggerReference ?? null,
-        outcome: 'pending',
-        outcomeReason: null,
-        payload: params.payload,
-        storedPayloadBytes: diagnosticValueByteLength(params.payload),
-        normalizedEventBytes: diagnosticValueByteLength([normalizeListenerEvent(params)]),
-        receivedAt: params.receivedAt,
-      })
-      .onConflictDoNothing({target: [jobListenerEvents.jobId, jobListenerEvents.eventRef]})
-      .returning({id: jobListenerEvents.id});
-
-    if (!rows[0]) return {buffered: false, skipped: false};
-    await writeWorkflowsOutboxEvent(tx, {
-      type: WORKFLOWS_JOB_EVENT_DELIVERED,
-      payload: {
-        jobId: params.jobId,
-        disposition: params.disposition,
-        eventRef: params.eventRef,
-        eventName: params.event,
-      },
-    });
-    return {buffered: true, skipped: false};
-  });
+  const result = await db().transaction((tx) =>
+    persistListenerEvent(tx, params, {
+      rejectsFireEvent,
+      storedPayloadBytes,
+      normalizedEventBytes,
+    }),
+  );
 
   if (!result.buffered) return result;
 
   recordListenerEventReceived(params.provider);
   return result;
+}
+
+async function persistListenerEvent(
+  tx: Tx,
+  params: DeliverEventToListenerParams,
+  sizes: {
+    rejectsFireEvent: boolean;
+    storedPayloadBytes: number;
+    normalizedEventBytes: number;
+  },
+): Promise<DeliverEventToListenerResult> {
+  const [job] = await tx
+    .select({id: jobs.id, status: jobs.status})
+    .from(jobs)
+    .where(eq(jobs.id, params.jobId))
+    .for('update')
+    .limit(1);
+
+  if (!job || isJobTerminal(job.status)) return {buffered: false, skipped: true};
+
+  const rows = await tx
+    .insert(jobListenerEvents)
+    .values({
+      jobId: params.jobId,
+      disposition: params.disposition,
+      eventRef: params.eventRef,
+      deliveryId: params.deliveryId,
+      source: params.source,
+      event: params.event,
+      triggerReference: params.triggerReference ?? null,
+      outcome: sizes.rejectsFireEvent ? 'rejected' : 'pending',
+      outcomeReason: sizes.rejectsFireEvent ? 'payload_too_large' : null,
+      payload: sizes.rejectsFireEvent ? null : params.payload,
+      storedPayloadBytes: sizes.storedPayloadBytes,
+      normalizedEventBytes: sizes.normalizedEventBytes,
+      receivedAt: params.receivedAt,
+    })
+    .onConflictDoNothing({target: [jobListenerEvents.jobId, jobListenerEvents.eventRef]})
+    .returning({id: jobListenerEvents.id});
+
+  if (!rows[0]) return findExistingListenerEvent(tx, params);
+  if (sizes.rejectsFireEvent) {
+    return {
+      buffered: false,
+      skipped: false,
+      rejection: createListenerDeliveryRejection(rows[0].id, sizes.normalizedEventBytes),
+    };
+  }
+
+  await writeWorkflowsOutboxEvent(tx, {
+    type: WORKFLOWS_JOB_EVENT_DELIVERED,
+    payload: {
+      jobId: params.jobId,
+      disposition: params.disposition,
+      eventRef: params.eventRef,
+      eventName: params.event,
+    },
+  });
+  return {buffered: true, skipped: false};
+}
+
+async function findExistingListenerEvent(
+  tx: Tx,
+  params: Pick<DeliverEventToListenerParams, 'jobId' | 'eventRef'>,
+): Promise<DeliverEventToListenerResult> {
+  const [existing] = await tx
+    .select({
+      id: jobListenerEvents.id,
+      outcome: jobListenerEvents.outcome,
+      normalizedEventBytes: jobListenerEvents.normalizedEventBytes,
+    })
+    .from(jobListenerEvents)
+    .where(
+      and(
+        eq(jobListenerEvents.jobId, params.jobId),
+        eq(jobListenerEvents.eventRef, params.eventRef),
+      ),
+    )
+    .limit(1);
+  if (existing?.outcome !== 'rejected') return {buffered: false, skipped: false};
+  return {
+    buffered: false,
+    skipped: false,
+    rejection: createListenerDeliveryRejection(existing.id, existing.normalizedEventBytes),
+  };
+}
+
+function createListenerDeliveryRejection(
+  eventId: string,
+  measuredBytes: number,
+): ListenerDeliveryRejection {
+  return {
+    reason: 'payload-too-large',
+    eventId,
+    measuredBytes,
+    limitBytes: MAX_LISTENER_FIRE_EVENT_BYTES,
+  };
 }

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -9,7 +9,10 @@ import type {JobListeningTrigger, JobStatus} from '#core/entities/job.js';
 import type {JobExecutionStatus} from '#core/entities/job-execution.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
-import {MAX_LISTENER_TRIGGER_EVENTS_BYTES} from '#core/listener-event-batching.js';
+import {
+  MAX_LISTENER_FIRE_EVENT_BYTES,
+  MAX_LISTENER_TRIGGER_EVENTS_BYTES,
+} from '#core/listener-event-batching.js';
 import {db} from '#db/db.js';
 import {deliverEventToListener} from '#db/job-listener-events.js';
 import {
@@ -502,8 +505,16 @@ describe('resolveJobListener', () => {
 
   it('honors resolve events and abandons fire events when resolved until', async () => {
     const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    const oversizedPayload = {body: 'x'.repeat(MAX_LISTENER_FIRE_EVENT_BYTES)};
     await bufferEvent(job.id, 'fire');
-    await bufferEvent(job.id, 'resolve');
+    const resolveResult = await bufferEvent(
+      job.id,
+      'resolve',
+      crypto.randomUUID(),
+      new Date(),
+      undefined,
+      oversizedPayload,
+    );
 
     await resolveJobListener({jobId: job.id, reason: 'until'});
 
@@ -525,10 +536,11 @@ describe('resolveJobListener', () => {
           outcome: 'honored',
           outcomeReason: null,
           consumedByExecutionId: null,
-          payload: {action: 'opened'},
+          payload: oversizedPayload,
         }),
       ]),
     );
+    expect(resolveResult).toEqual({buffered: true, skipped: false});
   });
 
   it.each([

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -77,6 +77,7 @@ export {
   deliverEventToListener,
   getStepById,
   getStepByIdForJobExecution,
+  type ListenerDeliveryRejection,
   migrationsPath,
   workflowsOutbox,
 } from '#db/index.js';

--- a/libs/client/triggers/src/core/trigger-event.ts
+++ b/libs/client/triggers/src/core/trigger-event.ts
@@ -10,7 +10,11 @@ export const triggerEventOutcomes = [
   'errored',
 ] as const satisfies readonly TriggerEventOutcome[];
 
-export type TriggerEventDecisionOutcome = 'triggered' | 'filter-error' | 'dispatch-error';
+export type TriggerEventDecisionOutcome =
+  | 'triggered'
+  | 'filter-error'
+  | 'dispatch-error'
+  | 'rejected';
 
 export interface TriggerEventSource {
   provider: string | null;

--- a/libs/client/triggers/src/hooks/api/trigger-event-mapper.test.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-event-mapper.test.ts
@@ -49,7 +49,7 @@ describe('trigger event mapper', () => {
 
   test('maps matched workflow results into their domain contract', () => {
     const detail = toTriggerEventDetail({
-      ...triggerEventDto(),
+      ...triggerEventDto({matched_count: 2}),
       connection_name: 'Shipfox',
       payload: {ref: 'main'},
       decisions: [
@@ -71,6 +71,24 @@ describe('trigger event mapper', () => {
           reason: null,
           created_at: '2026-06-01T00:00:01.000Z',
         },
+        {
+          id: '99999999-9999-4999-8999-999999999999',
+          received_event_id: EVENT_ID,
+          subscription_kind: 'listener',
+          subscription_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          subscription_name: 'Notify',
+          workflow_definition_id: null,
+          project_id: null,
+          workflow_run_id: null,
+          job_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          matcher_kind: 'on',
+          matcher_ordinal: 0,
+          decision: 'rejected',
+          run_id: null,
+          run_name: null,
+          reason: 'payload-too-large',
+          created_at: '2026-06-01T00:00:01.000Z',
+        },
       ],
       replays: [],
     } satisfies TriggerEventDetailResponseDto);
@@ -84,6 +102,15 @@ describe('trigger event mapper', () => {
         runId: '88888888-8888-4888-8888-888888888888',
         runName: 'deploy #1',
         reason: null,
+      },
+      {
+        id: '99999999-9999-4999-8999-999999999999',
+        subscriptionName: 'Notify',
+        decision: 'rejected',
+        projectId: null,
+        runId: null,
+        runName: null,
+        reason: 'payload-too-large',
       },
     ]);
   });


### PR DESCRIPTION
Oversized listener fire payloads could enter the Workflows listener buffer even when their normalized form exceeded the execution boundary, risking queue poisoning.

This change rejects normalized fire deliveries above 768 KiB with metadata-only persistence, keeps resolve deliveries uncapped so matching `until` signals still become `honored`, and records bounded rejected listener decisions and metrics while preserving `errored` for rejected-only events. The inter-module and diagnostic contracts now expose the additive outcome, with first-party payload-size conformance coverage. A Changeset is included for the affected published packages.

Validated locally with filtered checks and types, the full Workflows, Triggers, Workflows DTO, and Agent Access suites, database-boundary verification, Changeset status, and `git diff --check`.

Closes ENG-1961

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects oversized listener fire deliveries before they enter the Workflows listener buffer. Fire deliveries with normalized payloads above 768 KiB are now persisted as metadata-only `rejected` events, while resolve deliveries stay uncapped so matching `until` signals still become `honored`.

**Behavior changes**
- Rejected fire deliveries write no outbox signal, emit a rejection metric instead of the received metric, and count as engaged but not accepted.
- Adds a `rejected` trigger decision outcome and `triggers_listener_delivery_rejections` counter; events with only rejected listener matches remain `errored`.
- The inter-module delivery contract now returns an optional `rejection` field, and the client trigger mapper surfaces the new `rejected` outcome to match the API.
- The Changeset patches all affected published packages.

<sup>Written for commit a909a037cef76a37d9b3d1a4f21042c83c88a133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

