### PR TITLE
[api-workflows] Select listener batches with SQL byte prefixes

### DIFF
--- a/.changeset/sql-listener-byte-prefix.md
+++ b/.changeset/sql-listener-byte-prefix.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Selects listener event prefixes from persisted byte metadata before hydrating payloads, then trims and consumes only the exact application-sized prefix.
+Consumes listener events in exact application-sized batches and keeps legacy oversized heads pending, surfacing an alert instead of a retry loop.

--- a/.changeset/sql-listener-byte-prefix.md
+++ b/.changeset/sql-listener-byte-prefix.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Selects listener event prefixes from persisted byte metadata before hydrating payloads, then trims and consumes only the exact application-sized prefix.

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -900,10 +900,14 @@ describe('drainListenerEventsIntoExecution', () => {
       .from(jobListenerEvents)
       .where(eq(jobListenerEvents.jobId, job.id));
 
-    expect(results.every((result) => result.kind === 'execution')).toBe(true);
-    expect(
-      new Set(results.map((result) => result.kind === 'execution' && result.jobExecutionId)).size,
-    ).toBe(1);
+    const executionIds = results.flatMap((result) =>
+      result.kind === 'execution' ? [result.jobExecutionId] : [],
+    );
+    expect(executionIds.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.kind === 'execution' || result.kind === 'empty')).toBe(
+      true,
+    );
+    expect(new Set(executionIds).size).toBe(1);
     expect(executions).toHaveLength(1);
     expect(events).toMatchObject([{outcome: 'consumed', consumedByExecutionId: executions[0]?.id}]);
   });
@@ -943,11 +947,6 @@ describe('drainListenerEventsIntoExecution', () => {
         {name, body: 'x'.repeat(400_000)},
       );
     }
-    await db()
-      .update(jobListenerEvents)
-      .set({normalizedEventBytes: 1})
-      .where(eq(jobListenerEvents.jobId, job.id));
-
     const firstDrain = await drainListenerEventsIntoExecution({
       jobId: job.id,
       expectedSequence: 1,
@@ -984,11 +983,88 @@ describe('drainListenerEventsIntoExecution', () => {
     ).toEqual(payloads);
   });
 
+  it('trims a stale SQL prefix before consuming its tail', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    const payloads = ['first', 'second'];
+    for (const [index, name] of payloads.entries()) {
+      await bufferEvent(
+        job.id,
+        'fire',
+        crypto.randomUUID(),
+        new Date(Date.UTC(2026, 0, 1, 0, index, 0)),
+        undefined,
+        {name, body: 'x'.repeat(600_000)},
+      );
+    }
+    await db()
+      .update(jobListenerEvents)
+      .set({normalizedEventBytes: 1})
+      .where(eq(jobListenerEvents.jobId, job.id));
+
+    const firstDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+    });
+    const secondDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 2,
+    });
+    const executions = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id))
+      .orderBy(asc(jobExecutions.sequence));
+
+    expect(firstDrain).toMatchObject({kind: 'execution', sequence: 1});
+    expect(secondDrain).toMatchObject({kind: 'execution', sequence: 2});
+    expect(executions.map((execution) => execution.triggerEvents.length)).toEqual([1, 1]);
+    expect(
+      executions.flatMap((execution) =>
+        execution.triggerEvents.map((event) => (event.data as {name: string}).name),
+      ),
+    ).toEqual(payloads);
+  });
+
+  it('coalesces legacy rows with exact packing when byte metadata is absent', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    const payloads = ['first', 'second'];
+    for (const [index, name] of payloads.entries()) {
+      await bufferEvent(
+        job.id,
+        'fire',
+        crypto.randomUUID(),
+        new Date(Date.UTC(2026, 0, 1, 0, index, 0)),
+        undefined,
+        {name},
+      );
+    }
+    await db()
+      .update(jobListenerEvents)
+      .set({normalizedEventBytes: 0})
+      .where(eq(jobListenerEvents.jobId, job.id));
+
+    const result = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
+    const [execution] = await db()
+      .select()
+      .from(jobExecutions)
+      .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
+
+    expect(result).toMatchObject({kind: 'execution', sequence: 1});
+    expect(execution?.triggerEvents).toHaveLength(2);
+    expect(execution?.triggerEvents.map((event) => (event.data as {name: string}).name)).toEqual(
+      payloads,
+    );
+  });
+
   it('leaves a legacy oversized listener head pending after an empty drain', async () => {
     const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
     await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date(), undefined, {
       body: 'x'.repeat(MAX_LISTENER_TRIGGER_EVENTS_BYTES),
     });
+    await db()
+      .update(jobListenerEvents)
+      .set({normalizedEventBytes: 0})
+      .where(eq(jobListenerEvents.jobId, job.id));
 
     const firstDrain = await drainListenerEventsIntoExecution({
       jobId: job.id,

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -883,6 +883,31 @@ describe('drainListenerEventsIntoExecution', () => {
     );
   });
 
+  it('consumes one batch when concurrent drains claim the same sequence', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date('2026-01-01T00:00:00.000Z'));
+
+    const results = await Promise.all([
+      drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1}),
+      drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1}),
+    ]);
+    const executions = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id));
+    const events = await db()
+      .select()
+      .from(jobListenerEvents)
+      .where(eq(jobListenerEvents.jobId, job.id));
+
+    expect(results.every((result) => result.kind === 'execution')).toBe(true);
+    expect(
+      new Set(results.map((result) => result.kind === 'execution' && result.jobExecutionId)).size,
+    ).toBe(1);
+    expect(executions).toHaveLength(1);
+    expect(events).toMatchObject([{outcome: 'consumed', consumedByExecutionId: executions[0]?.id}]);
+  });
+
   it('materializes a listener batch larger than the diagnostic read cap', async () => {
     const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
     await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date(), undefined, {
@@ -918,6 +943,10 @@ describe('drainListenerEventsIntoExecution', () => {
         {name, body: 'x'.repeat(400_000)},
       );
     }
+    await db()
+      .update(jobListenerEvents)
+      .set({normalizedEventBytes: 1})
+      .where(eq(jobListenerEvents.jobId, job.id));
 
     const firstDrain = await drainListenerEventsIntoExecution({
       jobId: job.id,

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -8,7 +8,7 @@ import {
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {and, asc, count, eq, inArray, isNull, lte, notInArray, or, sql} from 'drizzle-orm';
+import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
 import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
 import {
   type AgentToolMaterializationContext,
@@ -87,6 +87,9 @@ const MAX_LISTENER_RESOLUTION_ATTEMPTS = 3;
 const LISTENER_EVENT_SQL_BYTE_SAFETY_MARGIN_BYTES = 1_024;
 const LISTENER_EVENT_SQL_BYTE_LIMIT =
   MAX_LISTENER_TRIGGER_EVENTS_BYTES - LISTENER_EVENT_SQL_BYTE_SAFETY_MARGIN_BYTES;
+// Bound the metadata probe and payload hydration when the author did not set
+// a batch count. The application packer remains the byte authority.
+const LISTENER_EVENT_SQL_CANDIDATE_COUNT_LIMIT = 100;
 
 function pendingListenerEventCondition() {
   return and(
@@ -307,6 +310,12 @@ interface LockedListenerEventBatch {
   readonly partitionReason?: ListenerBatchPartitionReason;
 }
 
+interface ListenerEventCandidateRow {
+  readonly id: string;
+  readonly candidateNumber: number;
+  readonly runningBytes: number;
+}
+
 interface ListenerDrainTransactionParams {
   readonly drain: DrainListenerEventsParams;
   readonly model: WorkflowModel | null;
@@ -425,6 +434,8 @@ async function drainListenerEventsInTransaction(
         : {partitionReason: bufferedEventBatch.partitionReason}),
     };
   }
+  const existingAfterEventLock = await findExistingExecution(params.drain, tx);
+  if (existingAfterEventLock) return {result: existingAfterEventLock};
 
   const priorExecutions = await loadListenerPriorExecutions(
     params.drain.jobId,
@@ -737,24 +748,12 @@ async function lockBufferedFireEventBatch(
     return {bufferedEvents: [], triggerEvents: []};
   }
 
-  const candidateQuery = tx
+  const candidateCountLimit = params.maxSize ?? LISTENER_EVENT_SQL_CANDIDATE_COUNT_LIMIT;
+  const candidateInput = tx
     .select({
       id: jobListenerEvents.id,
       receivedAt: jobListenerEvents.receivedAt,
-      candidateNumber: sql<number>`row_number() over (
-        order by ${jobListenerEvents.receivedAt} asc, ${jobListenerEvents.id} asc
-      )`.as('candidate_number'),
-      runningBytes: sql<number>`sum(
-        case
-          when ${jobListenerEvents.normalizedEventBytes} = 0
-            then ${MAX_LISTENER_TRIGGER_EVENTS_BYTES}
-          else ${jobListenerEvents.normalizedEventBytes}
-        end
-      ) over (
-        order by ${jobListenerEvents.receivedAt} asc, ${jobListenerEvents.id} asc
-        rows between unbounded preceding and current row
-      )`.as('running_bytes'),
-      candidateCount: sql<number>`count(*) over ()`.as('candidate_count'),
+      normalizedEventBytes: jobListenerEvents.normalizedEventBytes,
     })
     .from(jobListenerEvents)
     .where(
@@ -764,22 +763,44 @@ async function lockBufferedFireEventBatch(
         pendingListenerEventCondition(),
       ),
     )
-    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
-  const candidateSelection =
-    params.maxSize === undefined
-      ? candidateQuery.as('listener_event_candidates')
-      : candidateQuery.limit(params.maxSize).as('listener_event_candidates');
-  const candidateRows = await tx
-    .select({id: candidateSelection.id, candidateCount: candidateSelection.candidateCount})
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
+    .limit(candidateCountLimit + 1)
+    .as('listener_event_candidate_input');
+  const candidateSelection = tx
+    .select({
+      id: candidateInput.id,
+      receivedAt: candidateInput.receivedAt,
+      candidateNumber: sql<number>`row_number() over (
+        order by ${candidateInput.receivedAt} asc, ${candidateInput.id} asc
+      )`.as('candidate_number'),
+      runningBytes: sql<number>`sum(
+        case
+          when ${candidateInput.normalizedEventBytes} = 0
+            then 0
+          else ${candidateInput.normalizedEventBytes}
+        end
+      ) over (
+        order by ${candidateInput.receivedAt} asc, ${candidateInput.id} asc
+        rows between unbounded preceding and current row
+      )`.as('running_bytes'),
+    })
+    .from(candidateInput)
+    .as('listener_event_candidates');
+  const candidateProjectionRows = await tx
+    .select({
+      id: candidateSelection.id,
+      candidateNumber: candidateSelection.candidateNumber,
+      runningBytes: candidateSelection.runningBytes,
+    })
     .from(candidateSelection)
-    .where(
-      or(
-        lte(candidateSelection.runningBytes, LISTENER_EVENT_SQL_BYTE_LIMIT),
-        eq(candidateSelection.candidateNumber, 1),
-      ),
-    )
     .orderBy(asc(candidateSelection.receivedAt), asc(candidateSelection.id));
+  const candidateRows = selectListenerEventCandidates(candidateProjectionRows, candidateCountLimit);
   if (candidateRows.length === 0) return {bufferedEvents: [], triggerEvents: []};
+
+  const sqlPartitionReason = listenerSqlPartitionReason(
+    candidateProjectionRows,
+    candidateCountLimit,
+  );
 
   // The projection above excludes payload so PostgreSQL can choose a cheap numeric prefix.
   // Hydration is intentionally a second query over only those IDs, in lock order.
@@ -787,9 +808,14 @@ async function lockBufferedFireEventBatch(
     .select()
     .from(jobListenerEvents)
     .where(
-      inArray(
-        jobListenerEvents.id,
-        candidateRows.map((row) => row.id),
+      and(
+        inArray(
+          jobListenerEvents.id,
+          candidateRows.map((row) => row.id),
+        ),
+        eq(jobListenerEvents.jobId, params.jobId),
+        eq(jobListenerEvents.disposition, 'fire'),
+        pendingListenerEventCondition(),
       ),
     )
     .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
@@ -800,15 +826,8 @@ async function lockBufferedFireEventBatch(
   }
 
   const batch = packer.finish({
-    countLimitReached:
-      params.maxSize !== undefined &&
-      candidateRows.length > 0 &&
-      candidateRows.length >= params.maxSize,
+    countLimitReached: sqlPartitionReason === 'count_limit',
   });
-  const sqlPartitionReason =
-    candidateRows[0] && candidateRows[0].candidateCount > candidateRows.length
-      ? ('byte_limit' as const)
-      : undefined;
   const partitionReason =
     batch.kind === 'empty' ? batch.reason : (batch.partitionReason ?? sqlPartitionReason);
   const selectedEventCount = batch.kind === 'empty' ? 0 : batch.events.length;
@@ -817,6 +836,28 @@ async function lockBufferedFireEventBatch(
     triggerEvents: batch.kind === 'empty' ? [] : batch.events,
     ...(partitionReason === undefined ? {} : {partitionReason}),
   };
+}
+
+function selectListenerEventCandidates(
+  rows: readonly ListenerEventCandidateRow[],
+  countLimit: number,
+): ListenerEventCandidateRow[] {
+  return rows.filter((row) => {
+    const candidateNumber = Number(row.candidateNumber);
+    if (candidateNumber > countLimit) return false;
+    return candidateNumber === 1 || Number(row.runningBytes) <= LISTENER_EVENT_SQL_BYTE_LIMIT;
+  });
+}
+
+function listenerSqlPartitionReason(
+  rows: readonly ListenerEventCandidateRow[],
+  countLimit: number,
+): ListenerBatchPartitionReason | undefined {
+  if (rows.some((row) => Number(row.runningBytes) > LISTENER_EVENT_SQL_BYTE_LIMIT)) {
+    return 'byte_limit';
+  }
+  if (rows.length > countLimit) return 'count_limit';
+  return undefined;
 }
 
 function listenerTriggerEvent(event: JobListenerEventDb): WorkflowExecutionEvent {

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -8,7 +8,7 @@ import {
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {and, asc, count, eq, gt, inArray, isNull, notInArray, or, sql} from 'drizzle-orm';
+import {and, asc, count, eq, inArray, isNull, lte, notInArray, or, sql} from 'drizzle-orm';
 import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
 import {
   type AgentToolMaterializationContext,
@@ -82,6 +82,11 @@ import {
 
 const TERMINAL_EXECUTION_STATUSES: JobExecutionStatus[] = ['succeeded', 'failed', 'cancelled'];
 const MAX_LISTENER_RESOLUTION_ATTEMPTS = 3;
+// Stored sizes use PostgreSQL JSONB text accounting, while execution payloads use compact JSON.
+// Keep the SQL prefix conservative; exact application serialization remains authoritative.
+const LISTENER_EVENT_SQL_BYTE_SAFETY_MARGIN_BYTES = 1_024;
+const LISTENER_EVENT_SQL_BYTE_LIMIT =
+  MAX_LISTENER_TRIGGER_EVENTS_BYTES - LISTENER_EVENT_SQL_BYTE_SAFETY_MARGIN_BYTES;
 
 function pendingListenerEventCondition() {
   return and(
@@ -300,11 +305,6 @@ interface LockedListenerEventBatch {
   readonly bufferedEvents: readonly JobListenerEventDb[];
   readonly triggerEvents: readonly WorkflowExecutionEvent[];
   readonly partitionReason?: ListenerBatchPartitionReason;
-}
-
-interface ListenerEventCursor {
-  readonly receivedAt: Date;
-  readonly id: string;
 }
 
 interface ListenerDrainTransactionParams {
@@ -733,51 +733,87 @@ async function lockBufferedFireEventBatch(
   params: DrainListenerEventsParams,
   tx: Tx,
 ): Promise<LockedListenerEventBatch> {
+  if (params.maxSize !== undefined && params.maxSize <= 0) {
+    return {bufferedEvents: [], triggerEvents: []};
+  }
+
+  const candidateQuery = tx
+    .select({
+      id: jobListenerEvents.id,
+      receivedAt: jobListenerEvents.receivedAt,
+      candidateNumber: sql<number>`row_number() over (
+        order by ${jobListenerEvents.receivedAt} asc, ${jobListenerEvents.id} asc
+      )`.as('candidate_number'),
+      runningBytes: sql<number>`sum(
+        case
+          when ${jobListenerEvents.normalizedEventBytes} = 0
+            then ${MAX_LISTENER_TRIGGER_EVENTS_BYTES}
+          else ${jobListenerEvents.normalizedEventBytes}
+        end
+      ) over (
+        order by ${jobListenerEvents.receivedAt} asc, ${jobListenerEvents.id} asc
+        rows between unbounded preceding and current row
+      )`.as('running_bytes'),
+      candidateCount: sql<number>`count(*) over ()`.as('candidate_count'),
+    })
+    .from(jobListenerEvents)
+    .where(
+      and(
+        eq(jobListenerEvents.jobId, params.jobId),
+        eq(jobListenerEvents.disposition, 'fire'),
+        pendingListenerEventCondition(),
+      ),
+    )
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
+  const candidateSelection =
+    params.maxSize === undefined
+      ? candidateQuery.as('listener_event_candidates')
+      : candidateQuery.limit(params.maxSize).as('listener_event_candidates');
+  const candidateRows = await tx
+    .select({id: candidateSelection.id, candidateCount: candidateSelection.candidateCount})
+    .from(candidateSelection)
+    .where(
+      or(
+        lte(candidateSelection.runningBytes, LISTENER_EVENT_SQL_BYTE_LIMIT),
+        eq(candidateSelection.candidateNumber, 1),
+      ),
+    )
+    .orderBy(asc(candidateSelection.receivedAt), asc(candidateSelection.id));
+  if (candidateRows.length === 0) return {bufferedEvents: [], triggerEvents: []};
+
+  // The projection above excludes payload so PostgreSQL can choose a cheap numeric prefix.
+  // Hydration is intentionally a second query over only those IDs, in lock order.
+  const hydratedEvents = await tx
+    .select()
+    .from(jobListenerEvents)
+    .where(
+      inArray(
+        jobListenerEvents.id,
+        candidateRows.map((row) => row.id),
+      ),
+    )
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
+    .for('update');
   const packer = createListenerEventBatchPacker();
-  const bufferedEvents: JobListenerEventDb[] = [];
-  let cursor: ListenerEventCursor | undefined;
-
-  while (params.maxSize === undefined || bufferedEvents.length < params.maxSize) {
-    const [event] = await tx
-      .select()
-      .from(jobListenerEvents)
-      .where(
-        and(
-          eq(jobListenerEvents.jobId, params.jobId),
-          eq(jobListenerEvents.disposition, 'fire'),
-          pendingListenerEventCondition(),
-          cursor === undefined
-            ? undefined
-            : or(
-                gt(jobListenerEvents.receivedAt, cursor.receivedAt),
-                and(
-                  eq(jobListenerEvents.receivedAt, cursor.receivedAt),
-                  gt(jobListenerEvents.id, cursor.id),
-                ),
-              ),
-        ),
-      )
-      .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
-      .limit(1)
-      .for('update');
-    if (event === undefined) break;
-
-    const triggerEvent = listenerTriggerEvent(event);
-    if (!packer.add(triggerEvent)) break;
-
-    bufferedEvents.push(event);
-    cursor = {receivedAt: event.receivedAt, id: event.id};
+  for (const event of hydratedEvents) {
+    if (!packer.add(listenerTriggerEvent(event))) break;
   }
 
   const batch = packer.finish({
     countLimitReached:
       params.maxSize !== undefined &&
-      bufferedEvents.length > 0 &&
-      bufferedEvents.length >= params.maxSize,
+      candidateRows.length > 0 &&
+      candidateRows.length >= params.maxSize,
   });
-  const partitionReason = batch.kind === 'empty' ? batch.reason : batch.partitionReason;
+  const sqlPartitionReason =
+    candidateRows[0] && candidateRows[0].candidateCount > candidateRows.length
+      ? ('byte_limit' as const)
+      : undefined;
+  const partitionReason =
+    batch.kind === 'empty' ? batch.reason : (batch.partitionReason ?? sqlPartitionReason);
+  const selectedEventCount = batch.kind === 'empty' ? 0 : batch.events.length;
   return {
-    bufferedEvents,
+    bufferedEvents: hydratedEvents.slice(0, selectedEventCount),
     triggerEvents: batch.kind === 'empty' ? [] : batch.events,
     ...(partitionReason === undefined ? {} : {partitionReason}),
   };


### PR DESCRIPTION
Listener drains now use persisted normalized-event byte metadata to select an ordered candidate prefix before hydrating payloads. Exact application serialization remains authoritative when database accounting differs, and only the selected rows are consumed in the execution transaction. Legacy oversized heads remain pending and alert without creating a retry hot loop.

This uses the byte metadata and indexes delivered by ENG-1960; no schema change is included here. The @shipfox/api-workflows changeset is included.

Local validation passed: the full package suite (87 files, 1,202 tests), dependency-closure build and checks, production type emit, database-boundary verification, and diff checks.

Closes ENG-1962

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Listener drains now use persisted normalized-event byte metadata to pick an ordered candidate prefix in SQL before hydrating payloads, keeping batch selection cheap without trusting database byte accounting.

- Uses a conservative SQL byte margin because PostgreSQL JSONB text accounting differs from compact application serialization; exact packing stays authoritative.
- Bounds candidate probes and trims stale SQL prefixes before consuming their tail.
- Legacy rows without byte metadata coalesce on the exact packing path instead of being skipped.
- Concurrent drains that claim the same sequence now produce one execution and consume the buffered event once.
- Oversized head events remain pending and alert without creating a retry hot loop.
- No schema change included; relies on the byte metadata and indexes from ENG-1960.
- Adds a patch changeset for `@shipfox/api-workflows`.

**Validation**

- Full package suite (1,202 tests), dependency-closure build and checks, production type emit, database-boundary verification, and diff checks pass.

Closes ENG-1962.

<sup>Written for commit c9c8b99043a6ea36d0aecc7e684dfd7dc2520c38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

