### PR TITLE
[runner-agent] Enable renewable Claude authentication

### DIFF
--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -81,7 +81,7 @@
     }
   },
   "scripts": {
-    "build": "shipfox-swc --copy-files",
+    "build": "shipfox-swc --copy-files && chmod +x dist/core/claude-auth-helper.js",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "test": "shipfox-vitest-run",
@@ -106,6 +106,7 @@
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/runner-execution": "workspace:*",
     "@shipfox/runner-protocol": "workspace:*",
+    "@shipfox/runner-workspace": "workspace:*",
     "pi-mcp-adapter": "catalog:",
     "pi-web-access": "catalog:",
     "typebox": "catalog:",

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -458,6 +458,7 @@ describe('claudeHarnessAdapter', () => {
   });
 
   it('uses the renewable Claude helper without passing static auth to the child', async () => {
+    const previousApiKey = process.env.ANTHROPIC_API_KEY;
     const previousAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
     process.env.ANTHROPIC_API_KEY = 'parent-api-key';
     process.env.ANTHROPIC_AUTH_TOKEN = 'parent-auth-token';
@@ -481,6 +482,8 @@ describe('claudeHarnessAdapter', () => {
         }),
       );
     } finally {
+      if (previousApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = previousApiKey;
       if (previousAuthToken === undefined) delete process.env.ANTHROPIC_AUTH_TOKEN;
       else process.env.ANTHROPIC_AUTH_TOKEN = previousAuthToken;
     }

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -67,8 +67,15 @@ import {
 } from '@shipfox/api-agent-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {claudeHarnessAdapter} from '#core/claude-adapter.js';
+import {CLAUDE_AUTH_HELPER_PATH} from '#core/claude-auth-helper.js';
+import {
+  CLAUDE_CREDENTIAL_CAPABILITY_ENV,
+  CLAUDE_CREDENTIAL_HELPER_TTL_MS,
+  CLAUDE_CREDENTIAL_SOCKET_ENV,
+  CLAUDE_CREDENTIAL_TIMEOUT_ENV,
+} from '#core/claude-credential-broker.js';
 import {AgentConfigError, AgentPermissionModeError} from '#core/errors.js';
-import type {HarnessInvocation} from '#core/harness.js';
+import type {HarnessInvocation, InferenceCredentialSource} from '#core/harness.js';
 import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 
 // Mirrors claudeModelCapabilities() family normalization in the adapter.
@@ -181,6 +188,7 @@ function lastQueryOptions(): {
   sessionStoreFlush?: string;
   resume?: string;
   forkSession?: boolean;
+  settings?: {apiKeyHelper?: string};
 } {
   const call = queryMock.mock.calls[0] as
     | [
@@ -447,6 +455,50 @@ describe('claudeHarnessAdapter', () => {
     });
     expect(lastQueryOptions()).not.toHaveProperty('tools');
     expect(lastQueryOptions().env).not.toHaveProperty('ANTHROPIC_MODEL');
+  });
+
+  it('uses the renewable Claude helper without passing static auth to the child', async () => {
+    const previousAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    process.env.ANTHROPIC_API_KEY = 'parent-api-key';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'parent-auth-token';
+    queryMock.mockReturnValue(makeQuery([successMessage]));
+    const credentialSource: InferenceCredentialSource = {
+      resolve: vi.fn().mockResolvedValue({token: 'managed-token', generation: 'generation-1'}),
+      close: vi.fn(),
+    };
+
+    try {
+      await claudeHarnessAdapter.run(
+        invocation({
+          provider: 'shipfox',
+          model: 'claude-opus-4-8',
+          credentials: {api_key: 'managed-token'},
+          claude: {
+            base_url: 'https://inference.shipfox.dev/v1',
+            auth_token: 'managed-token',
+          },
+          credentialSource,
+        }),
+      );
+    } finally {
+      if (previousAuthToken === undefined) delete process.env.ANTHROPIC_AUTH_TOKEN;
+      else process.env.ANTHROPIC_AUTH_TOKEN = previousAuthToken;
+    }
+
+    expect(lastQueryOptions().settings).toEqual({apiKeyHelper: CLAUDE_AUTH_HELPER_PATH});
+    expect(lastQueryOptions().env).toMatchObject({
+      [CLAUDE_CREDENTIAL_SOCKET_ENV]: expect.any(String),
+      [CLAUDE_CREDENTIAL_CAPABILITY_ENV]: expect.any(String),
+      [CLAUDE_CREDENTIAL_TIMEOUT_ENV]: expect.any(String),
+      CLAUDE_CODE_API_KEY_HELPER_TTL_MS: String(CLAUDE_CREDENTIAL_HELPER_TTL_MS),
+      ANTHROPIC_BASE_URL: 'https://inference.shipfox.dev/v1',
+      ANTHROPIC_SMALL_FAST_MODEL: 'claude-opus-4-8',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-opus-4-8',
+      CLAUDE_CODE_SUBAGENT_MODEL: 'claude-opus-4-8',
+    });
+    expect(lastQueryOptions().env).not.toHaveProperty('ANTHROPIC_API_KEY');
+    expect(lastQueryOptions().env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
+    expect(credentialSource.resolve).not.toHaveBeenCalled();
   });
 
   it('accepts a managed provider with the per-step claude runtime block', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -24,6 +24,13 @@ import {
 import {logger} from '@shipfox/node-opentelemetry';
 import {z} from 'zod';
 import {config} from '#config.js';
+import {CLAUDE_AUTH_HELPER_PATH} from '#core/claude-auth-helper.js';
+import {
+  CLAUDE_CREDENTIAL_HELPER_TTL_MS,
+  type ClaudeCredentialBroker,
+  claudeCredentialHelperEnvironment,
+  createClaudeCredentialBroker,
+} from '#core/claude-credential-broker.js';
 import {
   type ClaudeToolCatalogErrorClass,
   type ClaudeToolCatalogFailure,
@@ -333,6 +340,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   let response = '';
   let toolContext: ClaudeToolContext | undefined;
   let turnsCompleted = false;
+  let credentialBroker: ClaudeCredentialBroker | undefined;
   const controller = new AbortController();
   const abortQuery = () => {
     controller.abort();
@@ -346,6 +354,14 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     activeToolDiagnostics = toolContext.diagnostics;
     toolContext.diagnostics.logManifest();
     configDir = await createClaudeConfigDir(agentStateDir);
+    if (invocation.credentialSource !== undefined && invocation.claude !== undefined) {
+      credentialBroker = createClaudeCredentialBroker({
+        credentialSource: invocation.credentialSource,
+        signal,
+        socketDirectory: agentStateDir,
+      });
+      await credentialBroker.start();
+    }
 
     const inputMessages = new ClaudeInputStream();
     messages = inputMessages;
@@ -362,7 +378,17 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         abortController: controller,
         ...toolContext.selectedToolOptions,
         ...claudeSystemPromptOption(),
-        env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
+        ...(credentialBroker === undefined
+          ? {}
+          : {settings: {apiKeyHelper: CLAUDE_AUTH_HELPER_PATH}}),
+        env: claudeEnvironment(
+          auth,
+          configDir,
+          gitConfigGlobal,
+          override,
+          effectiveModel,
+          credentialBroker,
+        ),
         ...(toolContext.mcpServers === undefined ? {} : {mcpServers: toolContext.mcpServers}),
         ...claudeSessionQueryOptions(sessionInvocation, sessionStore),
         includePartialMessages: false,
@@ -421,6 +447,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     messages?.close();
     signal.removeEventListener('abort', abortQuery);
     claudeQuery?.close();
+    await credentialBroker?.close();
     if (configDir !== undefined) await cleanupClaudeConfigDir(configDir);
   }
 }
@@ -1474,11 +1501,25 @@ function claudeEnvironment(
   configDir: string,
   gitConfigGlobal: string | undefined,
   override: ClaudeAnthropicOverride | undefined,
+  effectiveModel: string,
+  credentialBroker: ClaudeCredentialBroker | undefined,
 ): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    ANTHROPIC_API_KEY: auth.apiKey,
-    ...(auth.authToken !== undefined ? {ANTHROPIC_AUTH_TOKEN: auth.authToken} : {}),
+  const environment: NodeJS.ProcessEnv = {...process.env};
+  if (credentialBroker === undefined) {
+    environment.ANTHROPIC_API_KEY = auth.apiKey;
+    if (auth.authToken !== undefined) environment.ANTHROPIC_AUTH_TOKEN = auth.authToken;
+  } else {
+    delete environment.ANTHROPIC_API_KEY;
+    delete environment.ANTHROPIC_AUTH_TOKEN;
+    Object.assign(environment, claudeCredentialHelperEnvironment(credentialBroker), {
+      CLAUDE_CODE_API_KEY_HELPER_TTL_MS: String(CLAUDE_CREDENTIAL_HELPER_TTL_MS),
+      ANTHROPIC_SMALL_FAST_MODEL: effectiveModel,
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: effectiveModel,
+      CLAUDE_CODE_SUBAGENT_MODEL: effectiveModel,
+    });
+  }
+
+  Object.assign(environment, {
     ...(override !== undefined
       ? {
           ANTHROPIC_BASE_URL: override.baseUrl,
@@ -1492,7 +1533,8 @@ function claudeEnvironment(
     CLAUDE_AGENT_SDK_CLIENT_APP: '@shipfox/runner-agent',
     CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
     ...(gitConfigGlobal ? {GIT_CONFIG_GLOBAL: gitConfigGlobal} : {}),
-  };
+  });
+  return environment;
 }
 
 function claudeAnthropicOverride(

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -447,7 +447,11 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     messages?.close();
     signal.removeEventListener('abort', abortQuery);
     claudeQuery?.close();
-    await credentialBroker?.close();
+    try {
+      await credentialBroker?.close();
+    } catch (error) {
+      logger().warn({err: error}, 'Failed to remove Claude credential broker');
+    }
     if (configDir !== undefined) await cleanupClaudeConfigDir(configDir);
   }
 }

--- a/libs/runner/agent/src/core/claude-auth-helper.ts
+++ b/libs/runner/agent/src/core/claude-auth-helper.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+  assertCredentialSocketTimeout,
+  requestCredentialSocketTransport,
+} from '@shipfox/runner-workspace';
+import {
+  CLAUDE_CREDENTIAL_CAPABILITY_ENV,
+  CLAUDE_CREDENTIAL_HELPER_TIMEOUT_MS,
+  CLAUDE_CREDENTIAL_SOCKET_ENV,
+  CLAUDE_CREDENTIAL_TIMEOUT_ENV,
+} from '#core/claude-credential-broker.js';
+
+export const CLAUDE_AUTH_HELPER_PATH = fileURLToPath(
+  new URL('./claude-auth-helper.js', import.meta.url),
+);
+
+interface WritableOutput {
+  write(chunk: string): unknown;
+}
+
+export async function runClaudeAuthHelper(params?: {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly output?: WritableOutput;
+}): Promise<void> {
+  const env = params?.env ?? process.env;
+  const socketPath = requiredEnvironment(env, CLAUDE_CREDENTIAL_SOCKET_ENV);
+  const capability = requiredEnvironment(env, CLAUDE_CREDENTIAL_CAPABILITY_ENV);
+  const timeoutMs = helperTimeout(env[CLAUDE_CREDENTIAL_TIMEOUT_ENV]);
+  const response = await requestCredentialSocketTransport(
+    socketPath,
+    {capability, operation: 'get'},
+    {timeoutMs, shouldRetry: () => false},
+  );
+  if (!response.ok || typeof response.token !== 'string' || response.token.length === 0) {
+    throw new Error('Claude credential broker rejected the request');
+  }
+
+  (params?.output ?? process.stdout).write(`${response.token}\n`);
+}
+
+export async function main(params?: {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly output?: WritableOutput;
+  readonly stderr?: WritableOutput;
+  readonly setExitCode?: (code: number) => void;
+}): Promise<void> {
+  try {
+    await runClaudeAuthHelper(params);
+  } catch (error) {
+    (params?.setExitCode ?? ((code: number) => (process.exitCode = code)))(1);
+    (params?.stderr ?? process.stderr).write(
+      `claude-auth-helper failed: ${error instanceof Error ? error.name : 'UnknownError'}\n`,
+    );
+  }
+}
+
+function requiredEnvironment(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Claude credential helper environment is missing ${name}`);
+  }
+  return value;
+}
+
+function helperTimeout(rawValue: string | undefined): number {
+  if (rawValue === undefined) return CLAUDE_CREDENTIAL_HELPER_TIMEOUT_MS;
+  const value = Number(rawValue);
+  try {
+    assertCredentialSocketTimeout(value);
+  } catch {
+    throw new Error('Claude credential helper timeout is invalid');
+  }
+  return value;
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint !== undefined && resolve(entrypoint) === CLAUDE_AUTH_HELPER_PATH) {
+  await main();
+}

--- a/libs/runner/agent/src/core/claude-credential-broker.test.ts
+++ b/libs/runner/agent/src/core/claude-credential-broker.test.ts
@@ -1,0 +1,175 @@
+import {mkdtemp, rm, stat} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {main, runClaudeAuthHelper} from '#core/claude-auth-helper.js';
+import {
+  CLAUDE_CREDENTIAL_HELPER_TTL_MS,
+  claudeCredentialHelperEnvironment,
+  createClaudeCredentialBroker,
+} from '#core/claude-credential-broker.js';
+import type {InferenceCredential, InferenceCredentialSource} from '#core/harness.js';
+
+function outputBuffer(): {output: {write(chunk: string): void}; read: () => string} {
+  let value = '';
+  return {
+    output: {
+      write(chunk: string) {
+        value += chunk;
+      },
+    },
+    read: () => value,
+  };
+}
+
+async function withBroker<T>(
+  source: InferenceCredentialSource,
+  operation: (broker: ReturnType<typeof createClaudeCredentialBroker>) => Promise<T>,
+  options: {monotonicNow?: () => number} = {},
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-claude-credential-'));
+  const broker = createClaudeCredentialBroker({
+    credentialSource: source,
+    signal: new AbortController().signal,
+    socketDirectory: root,
+    ...options,
+  });
+  try {
+    await broker.start();
+    return await operation(broker);
+  } finally {
+    await broker.close();
+    await rm(root, {recursive: true, force: true});
+  }
+}
+
+function helperCall(broker: ReturnType<typeof createClaudeCredentialBroker>): Promise<string> {
+  const buffer = outputBuffer();
+  return runClaudeAuthHelper({
+    env: claudeCredentialHelperEnvironment(broker),
+    output: buffer.output,
+  }).then(() => buffer.read());
+}
+
+describe('Claude renewable credential broker and helper', () => {
+  it('writes only the current credential to helper stdout', async () => {
+    const source: InferenceCredentialSource = {
+      resolve: vi.fn().mockResolvedValue({token: 'jwt-1', generation: 'generation-1'}),
+      close: vi.fn(),
+    };
+
+    await withBroker(source, async (broker) => {
+      await expect(helperCall(broker)).resolves.toBe('jwt-1\n');
+      expect(source.resolve).toHaveBeenCalledWith();
+    });
+  });
+
+  it('uses rejection renewal before the helper deadline and scheduled renewal at the deadline', async () => {
+    let now = 100;
+    const credentials: InferenceCredential[] = [
+      {token: 'jwt-1', generation: 'generation-1'},
+      {token: 'jwt-2', generation: 'generation-2'},
+      {token: 'jwt-3', generation: 'generation-3'},
+    ];
+    let index = 0;
+    const resolve = vi.fn<InferenceCredentialSource['resolve']>((_options) => {
+      const credential = credentials[index++] ?? {token: 'jwt-fallback', generation: 'fallback'};
+      return Promise.resolve(credential);
+    });
+    const source: InferenceCredentialSource = {resolve, close: vi.fn()};
+
+    await withBroker(
+      source,
+      async (broker) => {
+        await expect(helperCall(broker)).resolves.toBe('jwt-1\n');
+
+        now += CLAUDE_CREDENTIAL_HELPER_TTL_MS - 1;
+        await expect(helperCall(broker)).resolves.toBe('jwt-2\n');
+
+        now += CLAUDE_CREDENTIAL_HELPER_TTL_MS;
+        await expect(helperCall(broker)).resolves.toBe('jwt-3\n');
+      },
+      {monotonicNow: () => now},
+    );
+
+    expect(resolve).toHaveBeenNthCalledWith(1);
+    expect(resolve).toHaveBeenNthCalledWith(2, {rejectedGeneration: 'generation-1'});
+    expect(resolve).toHaveBeenNthCalledWith(3);
+  });
+
+  it('shares concurrent early rejection renewals', async () => {
+    let now = 100;
+    let releaseRenewal!: (credential: InferenceCredential) => void;
+    let renewalStarted = false;
+    const resolve = vi.fn<InferenceCredentialSource['resolve']>((options) => {
+      if (options?.rejectedGeneration === 'generation-1' && !renewalStarted) {
+        renewalStarted = true;
+        return new Promise((resolveRenewal) => {
+          releaseRenewal = resolveRenewal;
+        });
+      }
+      return Promise.resolve({token: 'jwt-1', generation: 'generation-1'});
+    });
+    const source: InferenceCredentialSource = {resolve, close: vi.fn()};
+
+    await withBroker(
+      source,
+      async (broker) => {
+        await helperCall(broker);
+        now += 1;
+        const first = helperCall(broker);
+        const second = helperCall(broker);
+        await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(2));
+        releaseRenewal({token: 'jwt-2', generation: 'generation-2'});
+        await expect(Promise.all([first, second])).resolves.toEqual(['jwt-2\n', 'jwt-2\n']);
+      },
+      {monotonicNow: () => now},
+    );
+
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports helper failures without returning credential material', async () => {
+    const source: InferenceCredentialSource = {
+      resolve: vi.fn().mockRejectedValue(new Error('renewal failed jwt-secret')),
+      close: vi.fn(),
+    };
+
+    await withBroker(source, async (broker) => {
+      const stderr = outputBuffer();
+      let exitCode: number | undefined;
+      await main({
+        env: claudeCredentialHelperEnvironment(broker),
+        stderr: stderr.output,
+        setExitCode: (code) => {
+          exitCode = code;
+        },
+      });
+      expect(exitCode).toBe(1);
+      expect(stderr.read()).toBe('claude-auth-helper failed: Error\n');
+      expect(stderr.read()).not.toContain('jwt-secret');
+    });
+  });
+
+  it('removes the per-step socket on close', async () => {
+    const source: InferenceCredentialSource = {
+      resolve: vi.fn().mockResolvedValue({token: 'jwt-1', generation: 'generation-1'}),
+      close: vi.fn(),
+    };
+    const root = await mkdtemp(join(tmpdir(), 'shipfox-claude-credential-'));
+    const broker = createClaudeCredentialBroker({
+      credentialSource: source,
+      signal: new AbortController().signal,
+      socketDirectory: root,
+    });
+
+    try {
+      await broker.start();
+      await expect(stat(broker.socketPath)).resolves.toBeDefined();
+      await broker.close();
+      await expect(stat(broker.socketPath)).rejects.toMatchObject({code: 'ENOENT'});
+    } finally {
+      await broker.close();
+      await rm(root, {recursive: true, force: true});
+    }
+  });
+});

--- a/libs/runner/agent/src/core/claude-credential-broker.test.ts
+++ b/libs/runner/agent/src/core/claude-credential-broker.test.ts
@@ -172,4 +172,30 @@ describe('Claude renewable credential broker and helper', () => {
       await rm(root, {recursive: true, force: true});
     }
   });
+
+  it('removes the per-step socket when the step aborts', async () => {
+    const source: InferenceCredentialSource = {
+      resolve: vi.fn().mockResolvedValue({token: 'jwt-1', generation: 'generation-1'}),
+      close: vi.fn(),
+    };
+    const root = await mkdtemp(join(tmpdir(), 'shipfox-claude-credential-'));
+    const controller = new AbortController();
+    const broker = createClaudeCredentialBroker({
+      credentialSource: source,
+      signal: controller.signal,
+      socketDirectory: root,
+    });
+
+    try {
+      await broker.start();
+      await expect(stat(broker.socketPath)).resolves.toBeDefined();
+      controller.abort();
+      await vi.waitFor(() =>
+        expect(stat(broker.socketPath)).rejects.toMatchObject({code: 'ENOENT'}),
+      );
+    } finally {
+      await broker.close();
+      await rm(root, {recursive: true, force: true});
+    }
+  });
 });

--- a/libs/runner/agent/src/core/claude-credential-broker.ts
+++ b/libs/runner/agent/src/core/claude-credential-broker.ts
@@ -112,6 +112,9 @@ export function createClaudeCredentialBroker(options: {
           ownerCreated = true;
         }
         await transport.start();
+        if (closed || options.signal.aborted) {
+          throw new CredentialSocketError('Claude credential broker is closed', 'ECANCELED');
+        }
         started = true;
       } catch (error) {
         await transport.close().catch(() => undefined);

--- a/libs/runner/agent/src/core/claude-credential-broker.ts
+++ b/libs/runner/agent/src/core/claude-credential-broker.ts
@@ -1,0 +1,219 @@
+import {randomUUID} from 'node:crypto';
+import {mkdir, rm, writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {CredentialSocketTransportRequest} from '@shipfox/runner-workspace';
+import {
+  CredentialSocketError,
+  createCredentialSocketTransportServer,
+  MAX_CREDENTIAL_SOCKET_PATH_BYTES,
+  RUNNER_FALLBACK_CREDENTIAL_SOCKET_DIR,
+  runnerFallbackCredentialSocketOwnerPath,
+  runnerFallbackCredentialSocketPath,
+} from '@shipfox/runner-workspace';
+import type {InferenceCredential, InferenceCredentialSource} from '#core/harness.js';
+
+export const CLAUDE_CREDENTIAL_SOCKET_ENV = 'SHIPFOX_CLAUDE_CREDENTIAL_SOCKET';
+export const CLAUDE_CREDENTIAL_CAPABILITY_ENV = 'SHIPFOX_CLAUDE_CREDENTIAL_CAPABILITY';
+export const CLAUDE_CREDENTIAL_TIMEOUT_ENV = 'SHIPFOX_CLAUDE_CREDENTIAL_TIMEOUT_MS';
+
+/** Claude Code's helper cache interval. The broker renews before this expires on rejection. */
+export const CLAUDE_CREDENTIAL_HELPER_TTL_MS = 120_000;
+
+/** Keep helper calls below Claude Code's ten-second slow-helper notice. */
+export const CLAUDE_CREDENTIAL_HELPER_TIMEOUT_MS = 9_000;
+
+export interface ClaudeCredentialBroker {
+  readonly socketPath: string;
+  readonly capability: string;
+  start(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export function createClaudeCredentialBroker(options: {
+  readonly credentialSource: InferenceCredentialSource;
+  readonly signal: AbortSignal;
+  readonly socketDirectory: string;
+  readonly monotonicNow?: () => number;
+}): ClaudeCredentialBroker {
+  const capability = randomUUID();
+  const localSocketPath = join(options.socketDirectory, `claude-credential-${capability}.sock`);
+  const usesFallbackSocket =
+    Buffer.byteLength(localSocketPath, 'utf8') > MAX_CREDENTIAL_SOCKET_PATH_BYTES;
+  const socketPath = usesFallbackSocket
+    ? runnerFallbackCredentialSocketPath(capability)
+    : localSocketPath;
+  const ownerPath = usesFallbackSocket
+    ? runnerFallbackCredentialSocketOwnerPath(capability)
+    : undefined;
+  const monotonicNow = options.monotonicNow ?? (() => performance.now());
+  let current: InferenceCredential | undefined;
+  let nextRefreshAt = 0;
+  let credentialFlight: Promise<InferenceCredential> | undefined;
+  let started = false;
+  let closed = false;
+  let ownerCreated = false;
+  let closeFlight: Promise<void> | undefined;
+
+  const transport = createCredentialSocketTransportServer({
+    socketPath,
+    capability,
+    timeoutMs: CLAUDE_CREDENTIAL_HELPER_TIMEOUT_MS,
+    handleRequest,
+  });
+
+  async function handleRequest(request: CredentialSocketTransportRequest, signal: AbortSignal) {
+    if (request.operation !== 'get') return {ok: false, code: 'unsupported-operation'};
+    try {
+      return await resolveCredentialForRequest(signal);
+    } catch (error) {
+      if (signal.aborted) throw error;
+      logger().warn(
+        {reason: error instanceof Error ? error.name : 'UnknownError'},
+        'Claude credential helper request failed',
+      );
+      return {ok: false, code: 'credential-unavailable'};
+    }
+  }
+
+  async function resolveCredentialForRequest(signal: AbortSignal) {
+    const startedAt = monotonicNow();
+    const rejectedGeneration =
+      current !== undefined && startedAt < nextRefreshAt ? current.generation : undefined;
+    const previousGeneration = current?.generation;
+    const credential = await awaitUnlessCanceled(resolveCredential(rejectedGeneration), signal);
+    if (credential.token.length === 0 || credential.generation.length === 0) {
+      throw new Error('Resolved Claude credential was incomplete');
+    }
+
+    current = credential;
+    if (previousGeneration === undefined || credential.generation !== previousGeneration) {
+      nextRefreshAt = monotonicNow() + CLAUDE_CREDENTIAL_HELPER_TTL_MS;
+    }
+    return {ok: true, token: credential.token};
+  }
+
+  const broker: ClaudeCredentialBroker = {
+    socketPath,
+    capability,
+    start: async () => {
+      if (started) return;
+      if (closed || options.signal.aborted) {
+        throw new CredentialSocketError('Claude credential broker is closed', 'ECANCELED');
+      }
+
+      try {
+        if (ownerPath !== undefined) {
+          await mkdir(RUNNER_FALLBACK_CREDENTIAL_SOCKET_DIR, {recursive: true, mode: 0o700});
+          await writeFile(ownerPath, `${process.pid}:${randomUUID()}`, {
+            flag: 'wx',
+            mode: 0o600,
+          });
+          ownerCreated = true;
+        }
+        await transport.start();
+        started = true;
+      } catch (error) {
+        await transport.close().catch(() => undefined);
+        await removeOwnedSocket();
+        throw error;
+      }
+    },
+    close: () => {
+      if (closeFlight !== undefined) return closeFlight;
+      closeFlight = closeBroker();
+      return closeFlight;
+    },
+  };
+
+  const closeOnAbort = () => {
+    void broker.close().catch((error) => {
+      logger().warn(
+        {reason: error instanceof Error ? error.name : 'UnknownError'},
+        'Claude credential broker cleanup failed',
+      );
+    });
+  };
+  options.signal.addEventListener('abort', closeOnAbort, {once: true});
+  if (options.signal.aborted) closeOnAbort();
+
+  return broker;
+
+  function resolveCredential(rejectedGeneration: string | undefined): Promise<InferenceCredential> {
+    if (credentialFlight !== undefined) return credentialFlight;
+
+    const next = Promise.resolve().then(() =>
+      rejectedGeneration === undefined
+        ? options.credentialSource.resolve()
+        : options.credentialSource.resolve({rejectedGeneration}),
+    );
+    const flight = next.finally(() => {
+      if (credentialFlight === flight) credentialFlight = undefined;
+    });
+    credentialFlight = flight;
+    void flight.catch(() => undefined);
+    return flight;
+  }
+
+  async function closeBroker(): Promise<void> {
+    if (closed) return;
+    closed = true;
+    options.signal.removeEventListener('abort', closeOnAbort);
+    try {
+      await transport.close();
+    } finally {
+      started = false;
+      await removeOwnedSocket();
+    }
+  }
+
+  async function removeOwnedSocket(): Promise<void> {
+    const removals = [rm(socketPath, {force: true})];
+    if (ownerCreated && ownerPath !== undefined) {
+      removals.push(rm(ownerPath, {force: true}));
+    }
+    await Promise.allSettled(removals);
+    ownerCreated = false;
+  }
+}
+
+export function claudeCredentialHelperEnvironment(
+  broker: Pick<ClaudeCredentialBroker, 'socketPath' | 'capability'>,
+): Record<string, string> {
+  return {
+    [CLAUDE_CREDENTIAL_SOCKET_ENV]: broker.socketPath,
+    [CLAUDE_CREDENTIAL_CAPABILITY_ENV]: broker.capability,
+    [CLAUDE_CREDENTIAL_TIMEOUT_ENV]: String(CLAUDE_CREDENTIAL_HELPER_TIMEOUT_MS),
+  };
+}
+
+function awaitUnlessCanceled<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  void operation.catch(() => undefined);
+  if (signal.aborted) {
+    throw new CredentialSocketError('Claude credential request was canceled', 'ECANCELED');
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      callback();
+    };
+    const onAbort = () =>
+      finish(() =>
+        reject(new CredentialSocketError('Claude credential request was canceled', 'ECANCELED')),
+      );
+
+    signal.addEventListener('abort', onAbort, {once: true});
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    void operation.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6813,6 +6813,9 @@ importers:
       '@shipfox/runner-protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@shipfox/runner-workspace':
+        specifier: workspace:*
+        version: link:../workspace
       pi-mcp-adapter:
         specifier: 'catalog:'
         version: 2.11.0(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0)(zod@4.4.3)


### PR DESCRIPTION
Managed Claude sessions previously passed a static managed token through ANTHROPIC_AUTH_TOKEN, so sessions that outlived the token could fail after idle time. This PR connects managed Claude sessions to the renewable source through a per-step Unix-socket broker and a stateless executable apiKeyHelper.

The broker reuses bounded capability framing, coalesces scheduled and rejection-driven resolutions, and closes socket state with the step. The adapter removes inherited Anthropic authentication variables and pins auxiliary model roles to the requested model; static and direct-provider paths remain unchanged. The build emits an executable helper, with coverage for timing, concurrency, failure redaction, cleanup, adapter configuration, and the emitted helper round trip.

This is upstream-only and does not advertise the capability or change Cloud AMI behavior.

Validation: runner-agent tests (375), package check/build, build-only TypeScript check, dependency and lockfile audits, published-artifact validation, emitted-helper integration, and git diff checks passed. The package type script still reports the existing TS7016 declaration error for @shipfox/vitest in vitest.config.ts; the production build type check passes.

Closes ENG-1948

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed Claude sessions previously passed a static managed token through `ANTHROPIC_AUTH_TOKEN`, so sessions that outlived the token could fail after idle time. They now renew credentials through a per-step Unix-socket broker and a stateless `apiKeyHelper`, so long-running managed sessions keep working.

Static and direct-provider auth paths are unchanged. The adapter removes inherited Anthropic auth variables when the broker is active and pins auxiliary model roles to the requested model. The broker falls back to a shared socket directory when the per-step path is too long and removes its socket and owner files on close or abort. The build now emits the helper as an executable. This is upstream-only and does not advertise the capability or change Cloud AMI behavior. Closes ENG-1948.

<sup>Written for commit 02d6dae639b2874fd8d608f803ce1940e544555c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

