### PR TITLE
[client-workflows] Make workflow payload failures actionable

### DIFF
--- a/.changeset/clear-payload-errors.md
+++ b/.changeset/clear-payload-errors.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": minor
+---
+
+Explains workflow payload failures with actionable size, configuration, and rerun guidance.

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -267,6 +267,8 @@ export class WorkflowDiagnosticTooLargeError extends Error {
     readonly measuredBytes: number,
   ) {
     const overshootBytes = measuredBytes - limitBytes;
+    // The client reads this prefix to identify trigger-event failures persisted before structured
+    // payload fields existed. Keep the field-bearing prefix stable for legacy record compatibility.
     super(
       `Workflow diagnostic field "${field}" exceeds the size limit of ${limitBytes} bytes ` +
         `(measured ${measuredBytes} bytes; overshoot ${overshootBytes} bytes).`,

--- a/libs/client/workflows/src/components/job-detail/diagnostic-unavailable.tsx
+++ b/libs/client/workflows/src/components/job-detail/diagnostic-unavailable.tsx
@@ -1,20 +1,27 @@
 import {Text} from '@shipfox/react-ui/typography';
-import type {WorkflowDiagnosticField} from '#core/workflow-run.js';
+import type {
+  WorkflowDiagnosticField,
+  WorkflowDiagnosticUnavailableReason,
+} from '#core/workflow-run.js';
 
 export function DiagnosticUnavailableField({
   field,
   storedBytes,
+  reason,
 }: {
   field: WorkflowDiagnosticField;
   storedBytes: number;
+  reason: WorkflowDiagnosticUnavailableReason;
 }) {
+  const copy = diagnosticUnavailableCopy(reason);
+
   return (
     <div className="flex min-w-0 flex-col gap-tight rounded-6 border border-tag-warning-border bg-tag-warning-bg p-panel-compact">
       <Text size="xs" bold className="text-foreground-neutral-base">
-        {diagnosticFieldLabel(field)} unavailable
+        {diagnosticFieldLabel(field)} {copy.titleSuffix}
       </Text>
       <Text size="xs" className="text-tag-warning-text">
-        The stored value is too large to display ({storedBytes.toLocaleString()} bytes).
+        {copy.description} Measured {storedBytes.toLocaleString()} bytes.
       </Text>
     </div>
   );
@@ -23,10 +30,33 @@ export function DiagnosticUnavailableField({
 export function DiagnosticUnavailableAnnouncement({count}: {count: number}) {
   return (
     <span role="status" aria-live="polite" className="sr-only">
-      {count} diagnostic {count === 1 ? 'field is' : 'fields are'} unavailable because the stored
-      value{count === 1 ? ' is' : 's are'} too large to display.
+      {count} workflow detail {count === 1 ? 'is' : 'values are'} not available in full.
     </span>
   );
+}
+
+function diagnosticUnavailableCopy(reason: WorkflowDiagnosticUnavailableReason): {
+  titleSuffix: string;
+  description: string;
+} {
+  switch (reason) {
+    case 'legacy_value_exceeds_inline_limit':
+      return {
+        titleSuffix: 'is unavailable in this view',
+        description: 'This value was recorded by an older server and exceeds the display limit.',
+      };
+    case 'value_exceeds_inline_limit':
+      return {
+        titleSuffix: 'exceeds the display limit',
+        description:
+          'The complete value is preserved for workflow execution but is not shown here.',
+      };
+    case 'value_truncated_at_write_limit':
+      return {
+        titleSuffix: 'was not fully recorded',
+        description: 'Shipfox preserved the workflow outcome and omitted the oversized detail.',
+      };
+  }
 }
 
 export function diagnosticFieldLabel(field: WorkflowDiagnosticField): string {

--- a/libs/client/workflows/src/components/job-detail/diagnostic-unavailable.tsx
+++ b/libs/client/workflows/src/components/job-detail/diagnostic-unavailable.tsx
@@ -3,6 +3,7 @@ import type {
   WorkflowDiagnosticField,
   WorkflowDiagnosticUnavailableReason,
 } from '#core/workflow-run.js';
+import {workflowPayloadFieldLabel} from '#core/workflow-run.js';
 
 export function DiagnosticUnavailableField({
   field,
@@ -18,10 +19,11 @@ export function DiagnosticUnavailableField({
   return (
     <div className="flex min-w-0 flex-col gap-tight rounded-6 border border-tag-warning-border bg-tag-warning-bg p-panel-compact">
       <Text size="xs" bold className="text-foreground-neutral-base">
-        {diagnosticFieldLabel(field)} {copy.titleSuffix}
+        {workflowPayloadFieldLabel(field)} {copy.titleSuffix}
       </Text>
       <Text size="xs" className="text-tag-warning-text">
-        {copy.description} Measured {storedBytes.toLocaleString()} bytes.
+        {copy.description} Measured{' '}
+        <span className="font-code">{storedBytes.toLocaleString()} bytes</span>.
       </Text>
     </div>
   );
@@ -43,7 +45,7 @@ function diagnosticUnavailableCopy(reason: WorkflowDiagnosticUnavailableReason):
     case 'legacy_value_exceeds_inline_limit':
       return {
         titleSuffix: 'is unavailable in this view',
-        description: 'This value was recorded by an older server and exceeds the display limit.',
+        description: 'The complete value exceeds the display limit and is not shown here.',
       };
     case 'value_exceeds_inline_limit':
       return {
@@ -56,38 +58,5 @@ function diagnosticUnavailableCopy(reason: WorkflowDiagnosticUnavailableReason):
         titleSuffix: 'was not fully recorded',
         description: 'Shipfox preserved the workflow outcome and omitted the oversized detail.',
       };
-  }
-}
-
-export function diagnosticFieldLabel(field: WorkflowDiagnosticField): string {
-  switch (field) {
-    case 'authored_config':
-      return 'Authored configuration';
-    case 'config':
-      return 'Resolved configuration';
-    case 'evaluation_trace':
-    case 'job_evaluation_trace':
-    case 'execution_evaluation_trace':
-      return 'Evaluation';
-    case 'output':
-      return 'Step output';
-    case 'outputs':
-      return 'Outputs';
-    case 'response':
-      return 'Response';
-    case 'error':
-      return 'Failure details';
-    case 'gate_result':
-      return 'Gate result';
-    case 'restart_feedback':
-      return 'Restart feedback';
-    case 'job_outputs':
-      return 'Job outputs';
-    case 'execution_outputs':
-      return 'Execution outputs';
-    case 'condition':
-      return 'Condition';
-    case 'trigger_events':
-      return 'Trigger events';
   }
 }

--- a/libs/client/workflows/src/components/job-detail/job-context-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-context-panel.tsx
@@ -283,6 +283,7 @@ function ContextUnavailableFields({
           key={field.field}
           field={field.field}
           storedBytes={field.storedBytes}
+          reason={field.reason}
         />
       ))}
       <DiagnosticUnavailableAnnouncement count={fields.length} />

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
@@ -105,6 +105,26 @@ describe('toSelectedAttemptError', () => {
 
     expect(error).toMatchObject({reason, category: 'user'});
   });
+
+  test('preserves structured payload limits from a historical attempt', () => {
+    const error = toSelectedAttemptError({type: 'run'} as Step, {
+      message: 'Resolved configuration exceeds execution payload limit',
+      reason: 'execution_payload_too_large',
+      field: 'resolved_config',
+      retryable: false,
+      limitBytes: 65_536,
+      measured_bytes: 75_644,
+      overshootBytes: 10_108,
+    });
+
+    expect(error).toMatchObject({
+      field: 'resolved_config',
+      retryable: false,
+      limitBytes: 65_536,
+      measuredBytes: 75_644,
+      overshootBytes: 10_108,
+    });
+  });
 });
 
 describe('skippedJobDescription', () => {
@@ -176,6 +196,55 @@ describe('materialized output failure descriptions', () => {
 
     expect(emptyStateForJob(job, execution)).toMatchObject({
       description: 'Job outputs cannot define more than 10 entries (found 11)',
+    });
+  });
+
+  test('identifies a legacy trigger payload failure before the first step', () => {
+    const job = workflowJob({
+      status: 'failed',
+      status_reason: 'output_too_large',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'failed',
+          status_reason: 'output_too_large',
+          status_reason_message:
+            'Workflow diagnostic field "trigger_events" measured 97834 bytes, exceeding the 65536 byte limit.',
+          steps: [],
+        }),
+      ],
+    });
+    const execution = job.jobExecutions[0];
+    if (!execution) throw new Error('Expected a job execution');
+
+    const emptyState = emptyStateForJob(job, execution);
+    expect(emptyState).toMatchObject({
+      title: 'Trigger events exceeded a legacy payload limit',
+      description:
+        'The trigger events for this execution exceeded a legacy payload limit. Re-running failed jobs preserves the same events, so reduce the listener batch or start a new run from a smaller event payload.',
+    });
+    expect(emptyState?.description).not.toContain('job output');
+  });
+
+  test('keeps bounded fallback copy for old output failures without a message', () => {
+    const job = workflowJob({
+      status: 'failed',
+      status_reason: 'output_too_large',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'failed',
+          status_reason: 'output_too_large',
+          status_reason_message: null,
+          steps: [],
+        }),
+      ],
+    });
+    const execution = job.jobExecutions[0];
+    if (!execution) throw new Error('Expected a job execution');
+
+    expect(emptyStateForJob(job, execution)).toMatchObject({
+      title: 'Job failed before its first step started',
+      description:
+        'The materialized job output exceeded its configured size limit. Review the failure details before re-running the workflow.',
     });
   });
 

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
@@ -1,4 +1,3 @@
-import type {Step} from '#core/workflow-run.js';
 import {
   workflowJob,
   workflowJobExecutionDto,
@@ -10,7 +9,6 @@ import {
   jobSucceededSummary,
   outputFailureDescriptionForExecution,
   skippedJobDescription,
-  toSelectedAttemptError,
 } from './job-empty-states.js';
 
 describe('jobSucceededSummary', () => {
@@ -31,99 +29,6 @@ describe('jobSucceededSummary', () => {
     if (!execution) throw new Error('Expected a job execution');
 
     expect(jobSucceededSummary(job, execution)).toBe('1 step succeeded');
-  });
-});
-
-describe('toSelectedAttemptError', () => {
-  test('preserves managed-provider metadata from a historical attempt', () => {
-    const error = toSelectedAttemptError({type: 'agent'} as Step, {
-      message: 'This instance only supports provider `shipfox`.',
-      code: 'workspace-providers-disabled',
-      managedProviderId: 'shipfox',
-      reason: 'agent_config_invalid',
-      agentConfigIssue: 'provider_unsupported',
-    });
-
-    expect(error).toMatchObject({
-      code: 'workspace-providers-disabled',
-      managedProviderId: 'shipfox',
-      reason: 'agent_config_invalid',
-      agentConfigIssue: 'provider_unsupported',
-    });
-  });
-
-  test.each([
-    'setup',
-    'checkout',
-    'agent',
-    'run',
-  ] as const)('derives the error category for %s steps', (type) => {
-    for (const reason of [
-      'checkout_auth_failed',
-      'checkout_unavailable',
-      'checkout_failed',
-      'checkout_path_invalid',
-      'checkout_destination_occupied',
-      'git_unavailable',
-      'workspace_prep_failed',
-      'setup_aborted',
-    ] as const) {
-      const error = toSelectedAttemptError({type} as Step, {
-        message: 'Checkout failed',
-        reason,
-      });
-
-      expect(error).toMatchObject({
-        reason,
-        category: 'setup',
-      });
-    }
-  });
-
-  test.each([
-    ['setup', 'setup'],
-    ['checkout', 'setup'],
-    ['agent', 'user'],
-    ['run', 'user'],
-  ] as const)('keeps config failures in the expected category for %s steps', (type, category) => {
-    const error = toSelectedAttemptError({type} as Step, {
-      message: 'Command failed',
-      reason: 'config_unresolvable',
-    });
-
-    expect(error).toMatchObject({reason: 'config_unresolvable', category});
-  });
-
-  test.each([
-    'execution_payload_too_large',
-    'step_result_too_large',
-  ] as const)('preserves bounded failure reason %s', (reason) => {
-    const error = toSelectedAttemptError({type: 'run'} as Step, {
-      message: 'Bounded workflow value exceeded its limit',
-      reason,
-    });
-
-    expect(error).toMatchObject({reason, category: 'user'});
-  });
-
-  test('preserves structured payload limits from a historical attempt', () => {
-    const error = toSelectedAttemptError({type: 'run'} as Step, {
-      message: 'Resolved configuration exceeds execution payload limit',
-      reason: 'execution_payload_too_large',
-      field: 'resolved_config',
-      retryable: false,
-      limitBytes: 65_536,
-      measured_bytes: 75_644,
-      overshootBytes: 10_108,
-    });
-
-    expect(error).toMatchObject({
-      field: 'resolved_config',
-      retryable: false,
-      limitBytes: 65_536,
-      measuredBytes: 75_644,
-      overshootBytes: 10_108,
-    });
   });
 });
 
@@ -208,7 +113,7 @@ describe('materialized output failure descriptions', () => {
           status: 'failed',
           status_reason: 'output_too_large',
           status_reason_message:
-            'Workflow diagnostic field "trigger_events" measured 97834 bytes, exceeding the 65536 byte limit.',
+            'Workflow diagnostic field "trigger_events" exceeds the size limit of 65536 bytes (measured 97834 bytes; overshoot 32298 bytes).',
           steps: [],
         }),
       ],

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -1,13 +1,7 @@
-import {deriveStepErrorCategory} from '@shipfox/api-workflows-dto';
 import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import type {Job, JobExecution, Step, StepError} from '#core/workflow-run.js';
-import {
-  AGENT_CONFIG_ISSUES,
-  deriveJobDisplayStatus,
-  deriveJobExecutionDisplayStatus,
-  STEP_ERROR_REASONS,
-} from '#core/workflow-run.js';
+import {deriveJobDisplayStatus, deriveJobExecutionDisplayStatus} from '#core/workflow-run.js';
 import type {StepListEmptyState} from '../step-list/index.js';
 import {formatJobExecutionTime} from './job-execution-time-text.js';
 
@@ -283,92 +277,6 @@ export function CarriedOverStepPanel() {
       variant="panel"
     />
   );
-}
-
-export function toSelectedAttemptError(
-  step: Step,
-  error: Record<string, unknown> | null,
-): StepError | null {
-  if (error === null) return null;
-
-  const parsedReason = parsedStepErrorReason(error.reason);
-  const rawAgentConfigIssue = error.agentConfigIssue ?? error.agent_config_issue;
-  const agentConfigIssue = parsedAgentConfigIssue(rawAgentConfigIssue);
-  const exitCode = error.exitCode ?? error.exit_code;
-  const resolvedReason = parsedReason ?? (agentConfigIssue ? 'agent_config_invalid' : undefined);
-
-  if (resolvedReason === undefined) return null;
-
-  const stringFields = selectedErrorStringFields(error);
-  const managedProviderId = selectedManagedProviderId(error);
-  const sizeFields = selectedErrorSizeFields(error);
-  const retryable = typeof error.retryable === 'boolean' ? error.retryable : undefined;
-
-  return {
-    message: typeof error.message === 'string' ? error.message : '',
-    ...stringFields,
-    ...sizeFields,
-    ...(managedProviderId === undefined ? {} : {managedProviderId}),
-    ...(retryable === undefined ? {} : {retryable}),
-    exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
-    signal: typeof error.signal === 'string' ? error.signal : undefined,
-    reason: resolvedReason,
-    agentConfigIssue,
-    category: deriveStepErrorCategory(step.type, resolvedReason),
-  };
-}
-
-function selectedErrorSizeFields(
-  error: Record<string, unknown>,
-): Pick<StepError, 'limitBytes' | 'measuredBytes' | 'overshootBytes'> {
-  const limitBytes = selectedPositiveNumber(error, 'limitBytes', 'limit_bytes');
-  const measuredBytes = selectedPositiveNumber(error, 'measuredBytes', 'measured_bytes');
-  const overshootBytes = selectedPositiveNumber(error, 'overshootBytes', 'overshoot_bytes');
-  return {
-    ...(limitBytes === undefined ? {} : {limitBytes}),
-    ...(measuredBytes === undefined ? {} : {measuredBytes}),
-    ...(overshootBytes === undefined ? {} : {overshootBytes}),
-  };
-}
-
-function selectedPositiveNumber(
-  error: Record<string, unknown>,
-  camelCaseKey: string,
-  snakeCaseKey: string,
-): number | undefined {
-  const value = error[camelCaseKey] ?? error[snakeCaseKey];
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
-}
-
-function selectedErrorStringFields(
-  error: Record<string, unknown>,
-): Pick<StepError, 'code' | 'field' | 'source'> {
-  return {
-    ...(typeof error.code === 'string' ? {code: error.code} : {}),
-    ...(typeof error.field === 'string' ? {field: error.field} : {}),
-    ...(typeof error.source === 'string' ? {source: error.source} : {}),
-  };
-}
-
-function parsedStepErrorReason(value: unknown): NonNullable<StepError['reason']> | undefined {
-  if (typeof value !== 'string') return undefined;
-  if (!STEP_ERROR_REASONS.has(value as StepError['reason'] & string)) return undefined;
-  return value as NonNullable<StepError['reason']>;
-}
-
-function parsedAgentConfigIssue(
-  value: unknown,
-): NonNullable<StepError['agentConfigIssue']> | undefined {
-  if (typeof value !== 'string') return undefined;
-  if (!AGENT_CONFIG_ISSUES.has(value as NonNullable<StepError['agentConfigIssue']>))
-    return undefined;
-  return value as NonNullable<StepError['agentConfigIssue']>;
-}
-
-function selectedManagedProviderId(error: Record<string, unknown>): string | undefined {
-  if (typeof error.managedProviderId === 'string') return error.managedProviderId;
-  if (typeof error.managed_provider_id === 'string') return error.managed_provider_id;
-  return undefined;
 }
 
 export function isAgentConfigFailure(step: Step, error: StepError | null): boolean {

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -15,6 +15,9 @@ const MATERIALIZED_OUTPUT_FAILURE_DESCRIPTION =
   'A materialized job output could not be persisted: it exceeded a size or entry cap, contained a non-JSON-safe value, or referenced an unresolved value. Check the output mapping and values before re-running the workflow.';
 const OUTPUT_TOO_LARGE_FAILURE_DESCRIPTION =
   'The materialized job output exceeded its configured size limit. Review the failure details before re-running the workflow.';
+const LEGACY_TRIGGER_PAYLOAD_FAILURE_DESCRIPTION =
+  'The trigger events for this execution exceeded a legacy payload limit. Re-running failed jobs preserves the same events, so reduce the listener batch or start a new run from a smaller event payload.';
+const LEGACY_DIAGNOSTIC_FIELD_RE = /^Workflow diagnostic field "([^"]+)"/u;
 
 export function outputFailureDescriptionForExecution(
   jobExecution: JobExecution,
@@ -102,13 +105,10 @@ export function emptyStateForJob(
   }
 
   if (displayStatus === 'failed') {
+    const reason = jobExecution.statusReason ?? job.statusReason;
     return {
-      title: 'Job failed before its first step started',
-      description: preStepFailureDescription(
-        jobExecution.statusReason ?? job.statusReason,
-        runner,
-        jobExecution.statusReasonMessage,
-      ),
+      title: preStepFailureTitle(reason, jobExecution.statusReasonMessage),
+      description: preStepFailureDescription(reason, runner, jobExecution.statusReasonMessage),
       status: displayStatus,
     };
   }
@@ -231,6 +231,9 @@ function preStepFailureDescription(
     case 'step_failed':
       return `The execution failed before step details were recorded.${runnerCopy} Review run annotations before re-running the workflow.`;
     case 'output_too_large':
+      if (legacyDiagnosticField(statusReasonMessage) === 'trigger_events') {
+        return LEGACY_TRIGGER_PAYLOAD_FAILURE_DESCRIPTION;
+      }
       return statusReasonMessage || OUTPUT_TOO_LARGE_FAILURE_DESCRIPTION;
     case 'output_invalid':
       return statusReasonMessage || MATERIALIZED_OUTPUT_FAILURE_DESCRIPTION;
@@ -248,6 +251,22 @@ function preStepFailureDescription(
     default:
       return `The execution ended because ${humanizeFailureReason(reason)}.${runnerCopy} Resolve that condition before re-running the workflow.`;
   }
+}
+
+function preStepFailureTitle(reason: string | null, statusReasonMessage: string | null): string {
+  if (
+    reason === 'output_too_large' &&
+    legacyDiagnosticField(statusReasonMessage) === 'trigger_events'
+  ) {
+    return 'Trigger events exceeded a legacy payload limit';
+  }
+  return 'Job failed before its first step started';
+}
+
+function legacyDiagnosticField(message: string | null): string | undefined {
+  if (!message) return undefined;
+  const match = LEGACY_DIAGNOSTIC_FIELD_RE.exec(message);
+  return match?.[1];
 }
 
 function humanizeFailureReason(reason: string): string {
@@ -282,17 +301,43 @@ export function toSelectedAttemptError(
 
   const stringFields = selectedErrorStringFields(error);
   const managedProviderId = selectedManagedProviderId(error);
+  const sizeFields = selectedErrorSizeFields(error);
+  const retryable = typeof error.retryable === 'boolean' ? error.retryable : undefined;
 
   return {
     message: typeof error.message === 'string' ? error.message : '',
     ...stringFields,
+    ...sizeFields,
     ...(managedProviderId === undefined ? {} : {managedProviderId}),
+    ...(retryable === undefined ? {} : {retryable}),
     exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
     signal: typeof error.signal === 'string' ? error.signal : undefined,
     reason: resolvedReason,
     agentConfigIssue,
     category: deriveStepErrorCategory(step.type, resolvedReason),
   };
+}
+
+function selectedErrorSizeFields(
+  error: Record<string, unknown>,
+): Pick<StepError, 'limitBytes' | 'measuredBytes' | 'overshootBytes'> {
+  const limitBytes = selectedPositiveNumber(error, 'limitBytes', 'limit_bytes');
+  const measuredBytes = selectedPositiveNumber(error, 'measuredBytes', 'measured_bytes');
+  const overshootBytes = selectedPositiveNumber(error, 'overshootBytes', 'overshoot_bytes');
+  return {
+    ...(limitBytes === undefined ? {} : {limitBytes}),
+    ...(measuredBytes === undefined ? {} : {measuredBytes}),
+    ...(overshootBytes === undefined ? {} : {overshootBytes}),
+  };
+}
+
+function selectedPositiveNumber(
+  error: Record<string, unknown>,
+  camelCaseKey: string,
+  snakeCaseKey: string,
+): number | undefined {
+  const value = error[camelCaseKey] ?? error[snakeCaseKey];
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
 function selectedErrorStringFields(

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -32,7 +32,10 @@ const ATTEMPT_ID = '66666666-6666-4666-8666-666666666666';
 const EXECUTION_ID = '77777777-7777-4777-8777-777777777777';
 const INSPECTOR_TRIGGER_NAME = 'Open inspector';
 const INVOCATION_LOG_DESCRIPTION = /The full result remains available in the invocation log\./u;
-const REDUCE_DIAGNOSTIC_COPY = /reduce.*diagnostic/iu;
+const REDUCE_AUTHORED_VALUE_DESCRIPTION =
+  "Reduce the authored value or its upstream input before starting a new run. Re-running failed jobs preserves this attempt's inputs; re-running all jobs can recompute upstream outputs.";
+const REDUCE_STEP_RESULT_DESCRIPTION =
+  "Reduce the user-controlled result before re-running. Re-running failed jobs preserves this attempt's inputs.";
 
 describe('StepInspectorSheet', () => {
   afterEach(() => {
@@ -179,7 +182,13 @@ describe('StepInspectorSheet', () => {
     await renderPanel({entry: toolStepEntry({status: 'succeeded'})});
     await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
 
-    expect(await screen.findByRole('region', {name: 'Authored configuration'})).toBeInTheDocument();
+    const configuration = await screen.findByRole('region', {name: 'Configuration'});
+    expect(
+      within(configuration).getByRole('tab', {name: 'Authored configuration'}),
+    ).toBeInTheDocument();
+    expect(
+      within(configuration).getByRole('tab', {name: 'Resolved configuration'}),
+    ).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Invocations'})).toHaveTextContent('Succeeded');
     expect(screen.getByText('provider response')).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Attempt diagnostics'})).toHaveTextContent(
@@ -244,7 +253,7 @@ describe('StepInspectorSheet', () => {
     const unavailable = await screen.findByRole('region', {name: 'Unavailable diagnostics'});
     expect(unavailable).toHaveTextContent('Resolved configuration is unavailable in this view');
     expect(unavailable).toHaveTextContent(
-      'This value was recorded by an older server and exceeds the display limit.',
+      'The complete value exceeds the display limit and is not shown here.',
     );
     expect(unavailable).toHaveTextContent('Step output exceeds the display limit');
     expect(unavailable).toHaveTextContent(
@@ -255,6 +264,7 @@ describe('StepInspectorSheet', () => {
       'Shipfox preserved the workflow outcome and omitted the oversized detail.',
     );
     expect(unavailable).toHaveTextContent('300,000 bytes');
+    expect(within(unavailable).getByText('300,000 bytes')).toHaveClass('font-code');
   });
 
   it('explains deterministic payload failures and opens bounded configuration detail', async () => {
@@ -288,11 +298,9 @@ describe('StepInspectorSheet', () => {
     expect(screen.getByText('Affected value')).toBeInTheDocument();
     expect(screen.getByText(`${(75_644).toLocaleString()} bytes`)).toBeInTheDocument();
     expect(screen.getByText(`${(65_536).toLocaleString()} bytes`)).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Reduce the authored value or its upstream input before starting a new run. Re-running failed jobs preserves this attempt's inputs; re-running all jobs can recompute upstream outputs.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Over by')).toBeInTheDocument();
+    expect(screen.getByText(`${(10_108).toLocaleString()} bytes`)).toBeInTheDocument();
+    expect(screen.getByText(REDUCE_AUTHORED_VALUE_DESCRIPTION)).toBeInTheDocument();
     expect(screen.queryByText('Agent dispatch failed')).toBeNull();
 
     const inputs = await screen.findByRole('region', {name: 'Inputs'});
@@ -300,6 +308,144 @@ describe('StepInspectorSheet', () => {
     expect(within(inputs).getByRole('tab', {name: 'Resolved configuration'})).toBeInTheDocument();
     await user.click(screen.getByRole('button', {name: 'View configuration'}));
     expect(inputs).toHaveFocus();
+  });
+
+  it('uses the step status reason for mixed-version configuration failures', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      fetchImpl: vi.fn(async () =>
+        jsonResponse(stepDetailResponse({authored_config: {run: 'pnpm test'}, config: null})),
+      ),
+    });
+
+    const entry = stepEntry(
+      'execution_payload_too_large',
+      undefined,
+      {field: 'authored_config'},
+      true,
+    );
+    entry.step.statusReason = 'execution_payload_too_large';
+    await renderPanel({entry});
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    const inputs = await screen.findByRole('region', {name: 'Inputs'});
+    await user.click(screen.getByRole('button', {name: 'View configuration'}));
+    expect(inputs).toHaveFocus();
+  });
+
+  it('opens resolved tool configuration when authored configuration is unavailable', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      fetchImpl: vi.fn(async () =>
+        jsonResponse(
+          stepDetailResponse({
+            authored_config: null,
+            config: {tool: {provider: 'slack', with: {channel: '#releases'}}},
+          }),
+        ),
+      ),
+    });
+
+    await renderPanel({
+      entry: toolStepEntry({
+        status: 'failed',
+        reason: 'execution_payload_too_large',
+        field: 'resolved_config',
+      }),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    const configuration = await screen.findByRole('region', {name: 'Configuration'});
+    expect(within(configuration).queryByRole('tab', {name: 'Authored configuration'})).toBeNull();
+    expect(
+      within(configuration).getByRole('tab', {name: 'Resolved configuration'}),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: 'View configuration'}));
+    expect(configuration).toHaveFocus();
+  });
+
+  it('does not link unrelated payload failures to configuration', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      fetchImpl: vi.fn(async () =>
+        jsonResponse(
+          stepDetailResponse({
+            authored_config: {run: 'pnpm test'},
+            config: {run: 'pnpm test --filter=client'},
+          }),
+        ),
+      ),
+    });
+
+    await renderPanel({
+      entry: stepEntry('step_result_too_large', undefined, {field: 'output'}),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    await screen.findByRole('region', {name: 'Inputs'});
+    expect(screen.queryByRole('button', {name: 'View configuration'})).toBeNull();
+  });
+
+  it('explains a user-controlled oversized step response', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({
+      entry: stepEntry('step_result_too_large', undefined, {field: 'response'}),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(await screen.findByText('Response exceeds the step result limit')).toBeInTheDocument();
+    expect(screen.getByText(REDUCE_STEP_RESULT_DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it('explains an oversized generated step detail without asking the user to reduce it', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({
+      entry: stepEntry('step_result_too_large', undefined, {field: 'gate_result'}),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(
+      await screen.findByText('Gate result exceeds the step result limit'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Shipfox recorded the step outcome, but this generated detail exceeded its retention limit. Review the bounded details available below.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(REDUCE_STEP_RESULT_DESCRIPTION)).toBeNull();
+  });
+
+  it('explains an oversized listener batch without suggesting a failed-job rerun', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({
+      entry: stepEntry('execution_payload_too_large', undefined, {field: 'listener_batch'}),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(
+      await screen.findByText('Trigger events exceed the execution limit'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Adjust the listener batch or source event before starting a new run. Re-running failed jobs preserves the same trigger events.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the server message when structured payload details are absent', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({entry: stepEntry('execution_payload_too_large')});
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(await screen.findByText('Agent dispatch failed')).toBeInTheDocument();
   });
 
   it('does not ask users to reduce an internal diagnostic', async () => {
@@ -317,7 +463,8 @@ describe('StepInspectorSheet', () => {
         'The workflow outcome was preserved, but this server could not retain all troubleshooting details. Review the bounded details available below.',
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText(REDUCE_DIAGNOSTIC_COPY)).toBeNull();
+    expect(screen.queryByText(REDUCE_AUTHORED_VALUE_DESCRIPTION)).toBeNull();
+    expect(screen.queryByText(REDUCE_STEP_RESULT_DESCRIPTION)).toBeNull();
   });
 
   it('shows the session descriptor without transcript data', async () => {
@@ -756,6 +903,7 @@ function stepEntry(
   reason: StepErrorReason = 'agent_invocation_failed',
   code?: string,
   errorOverrides: Partial<NonNullable<WorkflowRunStepDetailDto['error']>> = {},
+  omitErrorReason = false,
 ): StepListEntryModel {
   const jobId = '44444444-4444-4444-8444-444444444444';
   const job = workflowJob({
@@ -778,7 +926,7 @@ function stepEntry(
             config: {run: 'pnpm test'},
             error: {
               message: 'Agent dispatch failed',
-              reason,
+              ...(omitErrorReason ? {} : {reason}),
               ...(code ? {code} : {}),
               ...errorOverrides,
             },

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -386,6 +386,19 @@ describe('StepInspectorSheet', () => {
     expect(screen.queryByRole('button', {name: 'View configuration'})).toBeNull();
   });
 
+  it('does not link an oversized condition to configuration', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({
+      entry: stepEntry('execution_payload_too_large', undefined, {field: 'condition'}),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(await screen.findByText('Condition exceeds the execution limit')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View configuration'})).toBeNull();
+  });
+
   it('explains a user-controlled oversized step response', async () => {
     const user = userEvent.setup();
     configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -32,6 +32,7 @@ const ATTEMPT_ID = '66666666-6666-4666-8666-666666666666';
 const EXECUTION_ID = '77777777-7777-4777-8777-777777777777';
 const INSPECTOR_TRIGGER_NAME = 'Open inspector';
 const INVOCATION_LOG_DESCRIPTION = /The full result remains available in the invocation log\./u;
+const REDUCE_DIAGNOSTIC_COPY = /reduce.*diagnostic/iu;
 
 describe('StepInspectorSheet', () => {
   afterEach(() => {
@@ -224,12 +225,12 @@ describe('StepInspectorSheet', () => {
               {
                 field: 'output',
                 stored_bytes: 300_000,
-                reason: 'legacy_value_exceeds_inline_limit',
+                reason: 'value_exceeds_inline_limit',
               },
               {
                 field: 'evaluation_trace',
                 stored_bytes: 70_000,
-                reason: 'legacy_value_exceeds_inline_limit',
+                reason: 'value_truncated_at_write_limit',
               },
             ],
           }),
@@ -241,10 +242,82 @@ describe('StepInspectorSheet', () => {
     await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
 
     const unavailable = await screen.findByRole('region', {name: 'Unavailable diagnostics'});
-    expect(unavailable).toHaveTextContent('Resolved configuration unavailable');
-    expect(unavailable).toHaveTextContent('Step output unavailable');
-    expect(unavailable).toHaveTextContent('Evaluation unavailable');
+    expect(unavailable).toHaveTextContent('Resolved configuration is unavailable in this view');
+    expect(unavailable).toHaveTextContent(
+      'This value was recorded by an older server and exceeds the display limit.',
+    );
+    expect(unavailable).toHaveTextContent('Step output exceeds the display limit');
+    expect(unavailable).toHaveTextContent(
+      'The complete value is preserved for workflow execution but is not shown here.',
+    );
+    expect(unavailable).toHaveTextContent('Evaluation was not fully recorded');
+    expect(unavailable).toHaveTextContent(
+      'Shipfox preserved the workflow outcome and omitted the oversized detail.',
+    );
     expect(unavailable).toHaveTextContent('300,000 bytes');
+  });
+
+  it('explains deterministic payload failures and opens bounded configuration detail', async () => {
+    const user = userEvent.setup();
+    const largeAuthoredValue = 'x'.repeat(75_644);
+    configureApiClient({
+      fetchImpl: vi.fn(async () =>
+        jsonResponse(
+          stepDetailResponse({
+            authored_config: {prompt: largeAuthoredValue},
+            config: {prompt: largeAuthoredValue},
+          }),
+        ),
+      ),
+    });
+
+    await renderPanel({
+      entry: stepEntry('execution_payload_too_large', undefined, {
+        field: 'resolved_config',
+        retryable: false,
+        limit_bytes: 65_536,
+        measured_bytes: 75_644,
+        overshoot_bytes: 10_108,
+      }),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(
+      await screen.findByText('Resolved configuration exceeds the execution limit'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Affected value')).toBeInTheDocument();
+    expect(screen.getByText(`${(75_644).toLocaleString()} bytes`)).toBeInTheDocument();
+    expect(screen.getByText(`${(65_536).toLocaleString()} bytes`)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Reduce the authored value or its upstream input before starting a new run. Re-running failed jobs preserves this attempt's inputs; re-running all jobs can recompute upstream outputs.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Agent dispatch failed')).toBeNull();
+
+    const inputs = await screen.findByRole('region', {name: 'Inputs'});
+    expect(within(inputs).getByRole('tab', {name: 'Authored configuration'})).toBeInTheDocument();
+    expect(within(inputs).getByRole('tab', {name: 'Resolved configuration'})).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: 'View configuration'}));
+    expect(inputs).toHaveFocus();
+  });
+
+  it('does not ask users to reduce an internal diagnostic', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      fetchImpl: vi.fn(() => new Promise<Response>(() => undefined)),
+    });
+
+    await renderPanel({entry: stepEntry('diagnostic_too_large')});
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(await screen.findByText('Step details could not be recorded')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The workflow outcome was preserved, but this server could not retain all troubleshooting details. Review the bounded details available below.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(REDUCE_DIAGNOSTIC_COPY)).toBeNull();
   });
 
   it('shows the session descriptor without transcript data', async () => {
@@ -682,6 +755,7 @@ function PanelHarness({
 function stepEntry(
   reason: StepErrorReason = 'agent_invocation_failed',
   code?: string,
+  errorOverrides: Partial<NonNullable<WorkflowRunStepDetailDto['error']>> = {},
 ): StepListEntryModel {
   const jobId = '44444444-4444-4444-8444-444444444444';
   const job = workflowJob({
@@ -702,7 +776,12 @@ function stepEntry(
             status: 'failed',
             type: 'agent',
             config: {run: 'pnpm test'},
-            error: {message: 'Agent dispatch failed', reason, ...(code ? {code} : {})},
+            error: {
+              message: 'Agent dispatch failed',
+              reason,
+              ...(code ? {code} : {}),
+              ...errorOverrides,
+            },
             evaluation_trace: [
               {
                 expression: 'inputs.message',

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -22,7 +22,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {cn, formatDuration} from '@shipfox/react-ui/utils';
 import {Link} from '@tanstack/react-router';
-import type {ReactNode} from 'react';
+import {type ReactNode, useId} from 'react';
 import type {
   EvaluationTraceEntry,
   JobStatusReason,
@@ -122,6 +122,7 @@ function StepFailureCallout({
   workflowRunId,
   runAttempt,
   onViewLogs,
+  onViewConfiguration,
 }: {
   step: Step;
   attempt: StepAttempt;
@@ -131,13 +132,16 @@ function StepFailureCallout({
   workflowRunId: string;
   runAttempt: number;
   onViewLogs: (() => void) | undefined;
+  onViewConfiguration: (() => void) | undefined;
 }) {
   const reason = error?.reason ?? step.statusReason ?? 'unknown';
-  const toolGuidance = toolFailureGuidance(reason, step, attempt, error);
-  const title = toolGuidance?.title ?? failureTitle(reason);
-  const description = toolGuidance?.description ?? failureDescription(reason, step, error);
+  const guidance =
+    workflowPayloadFailureGuidance(reason, error) ??
+    toolFailureGuidance(reason, step, attempt, error);
+  const title = guidance?.title ?? failureTitle(reason);
+  const description = guidance?.description ?? failureDescription(reason, step, error);
   const failureCode = step.type === 'tool' ? (error?.code ?? reason) : reason;
-  const sourceLink = sourceLinkForFailure(reason) && step.sourceLocation;
+  const showSourceLink = Boolean(sourceLinkForFailure(reason) && step.sourceLocation);
 
   if (step.type === 'agent' && reason === 'agent_config_invalid') {
     return (
@@ -160,50 +164,116 @@ function StepFailureCallout({
         <CalloutTitle>{title}</CalloutTitle>
         <CalloutDescription>
           <div className="flex min-w-0 flex-wrap items-center gap-x-inline gap-y-tight">
-            <div className="flex min-w-0 flex-col gap-tight">
+            <div className="flex min-w-0 flex-1 flex-col gap-tight">
               <span>{description}</span>
-              {error?.message ? (
-                <span className="text-foreground-neutral-muted">{error.message}</span>
-              ) : null}
+              <FailureMessage reason={reason} message={error?.message} />
+              <WorkflowPayloadSizeDetails reason={reason} error={error} />
             </div>
             <Code as="span" variant="label" className="text-tag-error-text">
               {failureCode}
             </Code>
-            {sourceLink ? (
-              <Link
-                to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
-                params={{workspaceSlug, projectSlug, workflowRunId}}
-                search={
-                  workflowRunSearchParams(
-                    {tab: 'source'},
-                    {stepId: step.id, stepAttemptId: attempt.id, runAttempt},
-                  ) as never
-                }
-                className="font-medium text-foreground-highlight-interactive underline-offset-2 hover:underline"
-              >
-                View in source
-              </Link>
-            ) : null}
-            {toolGuidance?.recoveryLabel ? (
-              <Link
-                to="/w/$workspaceSlug/settings/integrations"
-                params={{workspaceSlug}}
-                className="font-medium text-foreground-highlight-interactive underline-offset-2 hover:underline"
-              >
-                {toolGuidance.recoveryLabel}
-              </Link>
-            ) : null}
+            <FailureRecoveryLinks
+              showSourceLink={showSourceLink}
+              recoveryLabel={guidance?.recoveryLabel}
+              step={step}
+              attempt={attempt}
+              workspaceSlug={workspaceSlug}
+              projectSlug={projectSlug}
+              workflowRunId={workflowRunId}
+              runAttempt={runAttempt}
+            />
           </div>
         </CalloutDescription>
       </CalloutContent>
-      {step.type === 'tool' && onViewLogs ? (
-        <CalloutActions>
-          <Button type="button" size="2xs" variant="secondary" onClick={onViewLogs}>
-            View invocation log
-          </Button>
-        </CalloutActions>
-      ) : null}
+      <StepFailureActions
+        onViewConfiguration={onViewConfiguration}
+        onViewLogs={step.type === 'tool' ? onViewLogs : undefined}
+      />
     </Callout>
+  );
+}
+
+function FailureMessage({
+  reason,
+  message,
+}: {
+  reason: string | JobStatusReason;
+  message: string | undefined;
+}) {
+  if (!message || isWorkflowPayloadFailure(reason)) return null;
+  return <span className="text-foreground-neutral-muted">{message}</span>;
+}
+
+function FailureRecoveryLinks({
+  showSourceLink,
+  recoveryLabel,
+  step,
+  attempt,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  runAttempt,
+}: {
+  showSourceLink: boolean;
+  recoveryLabel: string | undefined;
+  step: Step;
+  attempt: StepAttempt;
+  workspaceSlug: string;
+  projectSlug: string;
+  workflowRunId: string;
+  runAttempt: number;
+}) {
+  return (
+    <>
+      {showSourceLink ? (
+        <Link
+          to="/w/$workspaceSlug/p/$projectSlug/runs/$workflowRunId"
+          params={{workspaceSlug, projectSlug, workflowRunId}}
+          search={
+            workflowRunSearchParams(
+              {tab: 'source'},
+              {stepId: step.id, stepAttemptId: attempt.id, runAttempt},
+            ) as never
+          }
+          className="font-medium text-foreground-highlight-interactive underline-offset-2 hover:underline"
+        >
+          View in source
+        </Link>
+      ) : null}
+      {recoveryLabel ? (
+        <Link
+          to="/w/$workspaceSlug/settings/integrations"
+          params={{workspaceSlug}}
+          className="font-medium text-foreground-highlight-interactive underline-offset-2 hover:underline"
+        >
+          {recoveryLabel}
+        </Link>
+      ) : null}
+    </>
+  );
+}
+
+function StepFailureActions({
+  onViewConfiguration,
+  onViewLogs,
+}: {
+  onViewConfiguration: (() => void) | undefined;
+  onViewLogs: (() => void) | undefined;
+}) {
+  if (!onViewConfiguration && !onViewLogs) return null;
+  return (
+    <CalloutActions>
+      {onViewConfiguration ? (
+        <Button type="button" size="2xs" variant="secondary" onClick={onViewConfiguration}>
+          View configuration
+        </Button>
+      ) : null}
+      {onViewLogs ? (
+        <Button type="button" size="2xs" variant="secondary" onClick={onViewLogs}>
+          View invocation log
+        </Button>
+      ) : null}
+    </CalloutActions>
   );
 }
 
@@ -236,6 +306,18 @@ function StepInspector({
 }) {
   const detail = query.data;
   const hasAnnotations = annotationCount !== undefined && annotationCount > 0;
+  const configurationSectionId = useId();
+  const hasConfigurationDetail = Boolean(
+    detail && inspectorHasInputValues(detail.authoredConfig, detail.config),
+  );
+  const onViewConfiguration =
+    hasConfigurationDetail && isConfigurationPayloadFailure(error)
+      ? () => {
+          const section = document.getElementById(configurationSectionId);
+          section?.scrollIntoView?.({behavior: 'smooth', block: 'nearest'});
+          section?.focus({preventScroll: true});
+        }
+      : undefined;
 
   return (
     <div className="flex min-w-0 flex-col gap-section">
@@ -249,6 +331,7 @@ function StepInspector({
           workflowRunId={workflowRunId}
           runAttempt={runAttempt}
           onViewLogs={onViewLogs}
+          onViewConfiguration={onViewConfiguration}
         />
       ) : null}
       <InspectorQueryContent
@@ -258,6 +341,7 @@ function StepInspector({
         attempt={attempt}
         showFailure={showFailure}
         hasAnnotations={hasAnnotations}
+        configurationSectionId={configurationSectionId}
       />
       {hasAnnotations ? (
         <Link
@@ -283,6 +367,7 @@ function InspectorQueryContent({
   attempt,
   showFailure,
   hasAnnotations,
+  configurationSectionId,
 }: {
   query: ReturnType<typeof useStepAttemptDetailQuery>;
   detail: ReturnType<typeof useStepAttemptDetailQuery>['data'];
@@ -290,6 +375,7 @@ function InspectorQueryContent({
   attempt: StepAttempt;
   showFailure: boolean;
   hasAnnotations: boolean;
+  configurationSectionId: string;
 }) {
   if (query.isPending) return <InspectorLoading />;
   if (query.isError && detail === undefined) {
@@ -330,6 +416,7 @@ function InspectorQueryContent({
         attempt={attempt}
         showFailure={showFailure}
         hasAnnotations={hasAnnotations}
+        configurationSectionId={configurationSectionId}
       />
     </div>
   );
@@ -366,12 +453,14 @@ function InspectorDetailContent({
   attempt,
   showFailure,
   hasAnnotations,
+  configurationSectionId,
 }: {
   detail: NonNullable<ReturnType<typeof useStepAttemptDetailQuery>['data']>;
   step: Step;
   attempt: StepAttempt;
   showFailure: boolean;
   hasAnnotations: boolean;
+  configurationSectionId: string;
 }) {
   const trace = detail.evaluationTrace ?? null;
   const resolvedConfig = detail.config ?? null;
@@ -392,10 +481,15 @@ function InspectorDetailContent({
     <div className="flex min-w-0 flex-col gap-group">
       {detail.session ? <SessionChip session={detail.session} /> : null}
       {isToolStep ? (
-        <ToolStepDetails detail={detail} attempt={presentedAttempt} showFailure={showFailure} />
+        <ToolStepDetails
+          detail={detail}
+          attempt={presentedAttempt}
+          showFailure={showFailure}
+          configurationSectionId={configurationSectionId}
+        />
       ) : null}
       {!isToolStep && hasInputValues ? (
-        <InspectorSection title="Inputs">
+        <InspectorSection title="Inputs" id={configurationSectionId}>
           <ConfigCode authoredConfig={detail.authoredConfig} resolvedConfig={resolvedConfig} />
         </InspectorSection>
       ) : null}
@@ -441,6 +535,7 @@ function UnavailableDiagnosticsSection({
           key={`${field.field}-${field.storedBytes}`}
           field={field.field}
           storedBytes={field.storedBytes}
+          reason={field.reason}
         />
       ))}
       <DiagnosticUnavailableAnnouncement count={fields.length} />
@@ -513,17 +608,19 @@ function ToolStepDetails({
   detail,
   attempt,
   showFailure,
+  configurationSectionId,
 }: {
   detail: StepAttemptDetail;
   attempt: StepAttempt;
   showFailure: boolean;
+  configurationSectionId: string;
 }) {
   const result = toolResult(attempt);
   const mappedOutputs = toolMappedOutputs(attempt);
   return (
     <>
       {countConfigValues(detail.authoredConfig) > 0 ? (
-        <InspectorSection title="Authored configuration">
+        <InspectorSection title="Authored configuration" id={configurationSectionId}>
           <ConfigCode authoredConfig={detail.authoredConfig} resolvedConfig={null} />
         </InspectorSection>
       ) : null}
@@ -739,9 +836,22 @@ function SessionChip({session}: {session: NonNullable<StepAttemptDetail['session
   );
 }
 
-function InspectorSection({title, children}: {title: string; children: ReactNode}) {
+function InspectorSection({
+  title,
+  children,
+  id,
+}: {
+  title: string;
+  children: ReactNode;
+  id?: string | undefined;
+}) {
   return (
-    <section className="flex min-w-0 flex-col gap-inline" aria-label={title}>
+    <section
+      id={id}
+      tabIndex={id ? -1 : undefined}
+      className="flex min-w-0 flex-col gap-inline rounded-6 focus:outline-none focus:ring-2 focus:ring-border-interactive-base focus:ring-offset-4"
+      aria-label={title}
+    >
       <Text size="xs" bold className="text-foreground-neutral-base">
         {title}
       </Text>
@@ -1013,13 +1123,13 @@ function failureDescription(
   }
 }
 
-interface ToolFailureGuidance {
+interface FailureGuidance {
   title: string;
   description: string;
   recoveryLabel?: string | undefined;
 }
 
-const TOOL_FAILURE_GUIDANCE_BY_CODE: Readonly<Record<string, ToolFailureGuidance>> = {
+const TOOL_FAILURE_GUIDANCE_BY_CODE: Readonly<Record<string, FailureGuidance>> = {
   'access-denied': {
     title: 'Tool access was denied',
     description:
@@ -1034,7 +1144,7 @@ const TOOL_FAILURE_GUIDANCE_BY_CODE: Readonly<Record<string, ToolFailureGuidance
   },
 };
 
-const SUCCESSFUL_TOOL_OUTPUT_FAILURE_GUIDANCE: ToolFailureGuidance = {
+const SUCCESSFUL_TOOL_OUTPUT_FAILURE_GUIDANCE: FailureGuidance = {
   title: 'Tool call succeeded, but the step failed',
   description:
     'The integration returned a result, but Shipfox could not map or store it because it did not satisfy the output contract or size limit. The full result remains available in the invocation log.',
@@ -1045,12 +1155,141 @@ function toolFailureGuidance(
   step: Step,
   attempt: StepAttempt,
   error: StepError | null,
-): ToolFailureGuidance | null {
+): FailureGuidance | null {
   if (step.type !== 'tool') return null;
   if (toolCallSucceededBeforeFailure(reason, attempt)) {
     return SUCCESSFUL_TOOL_OUTPUT_FAILURE_GUIDANCE;
   }
   return error?.code ? (TOOL_FAILURE_GUIDANCE_BY_CODE[error.code] ?? null) : null;
+}
+
+function isWorkflowPayloadFailure(reason: string | JobStatusReason): boolean {
+  return (
+    reason === 'execution_payload_too_large' ||
+    reason === 'step_result_too_large' ||
+    reason === 'diagnostic_too_large'
+  );
+}
+
+function isConfigurationPayloadFailure(error: StepError | null): boolean {
+  if (error?.reason !== 'execution_payload_too_large') return false;
+  return (
+    error.field === 'authored_config' ||
+    error.field === 'resolved_config' ||
+    error.field === 'config_plan' ||
+    error.field === 'condition'
+  );
+}
+
+function workflowPayloadFailureGuidance(
+  reason: string | JobStatusReason,
+  error: StepError | null,
+): FailureGuidance | null {
+  const fieldLabel = workflowPayloadFieldLabel(error?.field);
+  if (reason === 'execution_payload_too_large') {
+    if (error?.field === 'listener_batch') {
+      return {
+        title: 'Trigger events exceed the execution limit',
+        description:
+          'Adjust the listener batch or source event before starting a new run. Re-running failed jobs preserves the same trigger events.',
+      };
+    }
+    return {
+      title: `${fieldLabel} exceeds the execution limit`,
+      description:
+        "Reduce the authored value or its upstream input before starting a new run. Re-running failed jobs preserves this attempt's inputs; re-running all jobs can recompute upstream outputs.",
+    };
+  }
+  if (reason === 'step_result_too_large') {
+    const resultFieldLabel = error?.field ? workflowPayloadFieldLabel(error.field) : 'Step result';
+    return {
+      title: `${resultFieldLabel} exceeds the step result limit`,
+      description:
+        "Reduce the user-controlled result before re-running. Re-running failed jobs preserves this attempt's inputs.",
+    };
+  }
+  if (reason === 'diagnostic_too_large') {
+    return {
+      title: 'Step details could not be recorded',
+      description:
+        'The workflow outcome was preserved, but this server could not retain all troubleshooting details. Review the bounded details available below.',
+    };
+  }
+  return null;
+}
+
+function WorkflowPayloadSizeDetails({
+  reason,
+  error,
+}: {
+  reason: string | JobStatusReason;
+  error: StepError | null;
+}) {
+  if (!isWorkflowPayloadFailure(reason) || !error) return null;
+  const measuredBytes = validByteCount(error.measuredBytes);
+  const limitBytes = validByteCount(error.limitBytes);
+  if (!error.field && measuredBytes === null && limitBytes === null) return null;
+
+  return (
+    <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-inline gap-y-tight text-xs text-foreground-neutral-muted">
+      {error.field ? (
+        <>
+          <dt>Affected value</dt>
+          <dd className="text-foreground-neutral-base">{workflowPayloadFieldLabel(error.field)}</dd>
+        </>
+      ) : null}
+      {measuredBytes !== null ? (
+        <>
+          <dt>Measured</dt>
+          <dd className="font-code text-foreground-neutral-base">
+            {measuredBytes.toLocaleString()} bytes
+          </dd>
+        </>
+      ) : null}
+      {limitBytes !== null ? (
+        <>
+          <dt>Limit</dt>
+          <dd className="font-code text-foreground-neutral-base">
+            {limitBytes.toLocaleString()} bytes
+          </dd>
+        </>
+      ) : null}
+    </dl>
+  );
+}
+
+function validByteCount(value: number | undefined): number | null {
+  return value !== undefined && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function workflowPayloadFieldLabel(field: string | undefined): string {
+  switch (field) {
+    case 'authored_config':
+      return 'Authored configuration';
+    case 'resolved_config':
+      return 'Resolved configuration';
+    case 'config_plan':
+      return 'Configuration plan';
+    case 'condition':
+      return 'Condition input';
+    case 'listener_batch':
+    case 'trigger_events':
+      return 'Trigger events';
+    case 'response':
+      return 'Response';
+    case 'output':
+      return 'Step output';
+    case 'outputs':
+      return 'Outputs';
+    case 'error':
+      return 'Failure details';
+    case 'gate_result':
+      return 'Gate result';
+    case 'restart_feedback':
+      return 'Restart feedback';
+    default:
+      return 'Workflow value';
+  }
 }
 
 function sourceLinkForFailure(reason: string | JobStatusReason): boolean {

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -33,7 +33,11 @@ import type {
   StepError,
   WorkflowDiagnosticUnavailableField,
 } from '#core/workflow-run.js';
-import {presentStepAttemptDiagnostics} from '#core/workflow-run.js';
+import {
+  isWorkflowConfigurationPayloadField,
+  presentStepAttemptDiagnostics,
+  workflowPayloadFieldLabel,
+} from '#core/workflow-run.js';
 import {useStepAttemptDetailQuery} from '#hooks/api/step-attempt-detail.js';
 import {workflowRunSearchParams} from '#routes/inputs.js';
 import {humanizeStatus, type StepListEntryModel} from '../step-list/step-list-model.js';
@@ -42,7 +46,6 @@ import {
   DiagnosticUnavailableAnnouncement,
   DiagnosticUnavailableField,
 } from './diagnostic-unavailable.js';
-import {toSelectedAttemptError} from './job-empty-states.js';
 import {JsonCode, type JsonCodeEntry, JsonCodeTabs} from './json-code.js';
 
 export interface StepInspectorSheetProps {
@@ -70,7 +73,7 @@ export function StepInspectorSheet({
   annotationCount,
   onViewLogs,
 }: StepInspectorSheetProps) {
-  const error = selectedStepError(entry.step, entry.error);
+  const error = entry.stepError ?? entry.step.error;
   const inspectorQuery = useStepAttemptDetailQuery(entry.step.id, entry.attempt, {
     enabled: open,
     polling: open && entry.status === 'running',
@@ -166,7 +169,7 @@ function StepFailureCallout({
           <div className="flex min-w-0 flex-wrap items-center gap-x-inline gap-y-tight">
             <div className="flex min-w-0 flex-1 flex-col gap-tight">
               <span>{description}</span>
-              <FailureMessage reason={reason} message={error?.message} />
+              <FailureMessage reason={reason} error={error} />
               <WorkflowPayloadSizeDetails reason={reason} error={error} />
             </div>
             <Code as="span" variant="label" className="text-tag-error-text">
@@ -195,13 +198,14 @@ function StepFailureCallout({
 
 function FailureMessage({
   reason,
-  message,
+  error,
 }: {
   reason: string | JobStatusReason;
-  message: string | undefined;
+  error: StepError | null;
 }) {
-  if (!message || isWorkflowPayloadFailure(reason)) return null;
-  return <span className="text-foreground-neutral-muted">{message}</span>;
+  if (!error?.message) return null;
+  if (isWorkflowPayloadFailure(reason) && hasWorkflowPayloadDetails(error)) return null;
+  return <span className="text-foreground-neutral-muted">{error.message}</span>;
 }
 
 function FailureRecoveryLinks({
@@ -307,11 +311,12 @@ function StepInspector({
   const detail = query.data;
   const hasAnnotations = annotationCount !== undefined && annotationCount > 0;
   const configurationSectionId = useId();
+  const reason = error?.reason ?? step.statusReason;
   const hasConfigurationDetail = Boolean(
     detail && inspectorHasInputValues(detail.authoredConfig, detail.config),
   );
   const onViewConfiguration =
-    hasConfigurationDetail && isConfigurationPayloadFailure(error)
+    hasConfigurationDetail && isConfigurationPayloadFailure(reason, error)
       ? () => {
           const section = document.getElementById(configurationSectionId);
           section?.scrollIntoView?.({behavior: 'smooth', block: 'nearest'});
@@ -617,11 +622,12 @@ function ToolStepDetails({
 }) {
   const result = toolResult(attempt);
   const mappedOutputs = toolMappedOutputs(attempt);
+  const hasConfiguration = inspectorHasInputValues(detail.authoredConfig, detail.config);
   return (
     <>
-      {countConfigValues(detail.authoredConfig) > 0 ? (
-        <InspectorSection title="Authored configuration" id={configurationSectionId}>
-          <ConfigCode authoredConfig={detail.authoredConfig} resolvedConfig={null} />
+      {hasConfiguration ? (
+        <InspectorSection title="Configuration" id={configurationSectionId}>
+          <ConfigCode authoredConfig={detail.authoredConfig} resolvedConfig={detail.config} />
         </InspectorSection>
       ) : null}
       <InspectorSection title="Arguments">
@@ -849,7 +855,7 @@ function InspectorSection({
     <section
       id={id}
       tabIndex={id ? -1 : undefined}
-      className="flex min-w-0 flex-col gap-inline rounded-6 focus:outline-none focus:ring-2 focus:ring-border-interactive-base focus:ring-offset-4"
+      className="flex min-w-0 flex-col gap-inline rounded-6 focus:outline-none focus:ring-2 focus:ring-border-highlights-interactive focus:ring-offset-4"
       aria-label={title}
     >
       <Text size="xs" bold className="text-foreground-neutral-base">
@@ -970,13 +976,6 @@ function EmptyInspector() {
       No additional troubleshooting details were recorded.
     </Text>
   );
-}
-
-function selectedStepError(
-  step: Step,
-  attemptError: Record<string, unknown> | null,
-): StepError | null {
-  return toSelectedAttemptError(step, attemptError) ?? step.error;
 }
 
 function failureTitle(reason: string | JobStatusReason): string {
@@ -1171,13 +1170,12 @@ function isWorkflowPayloadFailure(reason: string | JobStatusReason): boolean {
   );
 }
 
-function isConfigurationPayloadFailure(error: StepError | null): boolean {
-  if (error?.reason !== 'execution_payload_too_large') return false;
+function isConfigurationPayloadFailure(
+  reason: string | JobStatusReason | null,
+  error: StepError | null,
+): boolean {
   return (
-    error.field === 'authored_config' ||
-    error.field === 'resolved_config' ||
-    error.field === 'config_plan' ||
-    error.field === 'condition'
+    reason === 'execution_payload_too_large' && isWorkflowConfigurationPayloadField(error?.field)
   );
 }
 
@@ -1202,6 +1200,17 @@ function workflowPayloadFailureGuidance(
   }
   if (reason === 'step_result_too_large') {
     const resultFieldLabel = error?.field ? workflowPayloadFieldLabel(error.field) : 'Step result';
+    if (
+      error?.field === 'error' ||
+      error?.field === 'gate_result' ||
+      error?.field === 'restart_feedback'
+    ) {
+      return {
+        title: `${resultFieldLabel} exceeds the step result limit`,
+        description:
+          'Shipfox recorded the step outcome, but this generated detail exceeded its retention limit. Review the bounded details available below.',
+      };
+    }
     return {
       title: `${resultFieldLabel} exceeds the step result limit`,
       description:
@@ -1228,7 +1237,10 @@ function WorkflowPayloadSizeDetails({
   if (!isWorkflowPayloadFailure(reason) || !error) return null;
   const measuredBytes = validByteCount(error.measuredBytes);
   const limitBytes = validByteCount(error.limitBytes);
-  if (!error.field && measuredBytes === null && limitBytes === null) return null;
+  const overshootBytes = validByteCount(error.overshootBytes);
+  if (!error.field && measuredBytes === null && limitBytes === null && overshootBytes === null) {
+    return null;
+  }
 
   return (
     <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-inline gap-y-tight text-xs text-foreground-neutral-muted">
@@ -1254,42 +1266,29 @@ function WorkflowPayloadSizeDetails({
           </dd>
         </>
       ) : null}
+      {overshootBytes !== null ? (
+        <>
+          <dt>Over by</dt>
+          <dd className="font-code text-foreground-neutral-base">
+            {overshootBytes.toLocaleString()} bytes
+          </dd>
+        </>
+      ) : null}
     </dl>
+  );
+}
+
+function hasWorkflowPayloadDetails(error: StepError): boolean {
+  return (
+    error.field !== undefined ||
+    validByteCount(error.measuredBytes) !== null ||
+    validByteCount(error.limitBytes) !== null ||
+    validByteCount(error.overshootBytes) !== null
   );
 }
 
 function validByteCount(value: number | undefined): number | null {
   return value !== undefined && Number.isFinite(value) && value >= 0 ? value : null;
-}
-
-function workflowPayloadFieldLabel(field: string | undefined): string {
-  switch (field) {
-    case 'authored_config':
-      return 'Authored configuration';
-    case 'resolved_config':
-      return 'Resolved configuration';
-    case 'config_plan':
-      return 'Configuration plan';
-    case 'condition':
-      return 'Condition input';
-    case 'listener_batch':
-    case 'trigger_events':
-      return 'Trigger events';
-    case 'response':
-      return 'Response';
-    case 'output':
-      return 'Step output';
-    case 'outputs':
-      return 'Outputs';
-    case 'error':
-      return 'Failure details';
-    case 'gate_result':
-      return 'Gate result';
-    case 'restart_feedback':
-      return 'Restart feedback';
-    default:
-      return 'Workflow value';
-  }
 }
 
 function sourceLinkForFailure(reason: string | JobStatusReason): boolean {

--- a/libs/client/workflows/src/components/step-list/step-list-model.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.ts
@@ -165,6 +165,7 @@ function toStepEntries(step: StepModel, carriedOverJob: boolean): StepListEntryM
       outputs: null,
       response: null,
       error: null,
+      stepError: null,
       gateResult: null,
       restartFeedback: null,
       invocations: [],

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -386,6 +386,11 @@ describe('WorkflowRunSummary', () => {
     const rerunButton = await screen.findByRole('button', {name: 'Re-run jobs'});
     expect(rerunButton).toHaveClass('bg-background-neutral-base');
     await user.click(rerunButton);
+    expect(
+      await screen.findByText(
+        "Re-running failed jobs preserves this attempt's inputs and successful job outputs. Re-run all jobs to recompute them.",
+      ),
+    ).toBeInTheDocument();
     expect(await screen.findByRole('menuitem', {name: 'Re-run all jobs'})).toBeInTheDocument();
     await user.click(await screen.findByRole('menuitem', {name: 'Re-run failed jobs'}));
 

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '@shipfox/react-ui/dropdown-menu';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
@@ -336,7 +337,11 @@ function WorkflowRunActionSlot({
           Re-run jobs
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-320">
+        <DropdownMenuLabel className="whitespace-normal px-row py-row text-xs font-normal leading-18 text-foreground-neutral-muted">
+          Re-running failed jobs preserves this attempt&apos;s inputs and successful job outputs.
+          Re-run all jobs to recompute them.
+        </DropdownMenuLabel>
         <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun('all')}>
           Re-run all jobs
         </DropdownMenuItem>

--- a/libs/client/workflows/src/core/entities/step-attempt.test.ts
+++ b/libs/client/workflows/src/core/entities/step-attempt.test.ts
@@ -106,6 +106,7 @@ function compactAttempt(): StepAttempt {
     outputs: {mapped: 'compact'},
     response: 'compact response',
     error: {message: 'compact error'},
+    stepError: null,
     gateResult: {kind: 'passed', passed: true, source: 'compact', exitCode: 0},
     restartFeedback: 'compact feedback',
     invocations: [

--- a/libs/client/workflows/src/core/entities/step-attempt.ts
+++ b/libs/client/workflows/src/core/entities/step-attempt.ts
@@ -1,4 +1,5 @@
 import {type Duration, intervalToDuration} from 'date-fns';
+import type {StepError} from './step.js';
 import type {WorkflowDiagnosticUnavailableField} from './workflow-diagnostics.js';
 
 export type StepGateResult =
@@ -57,6 +58,7 @@ interface StepAttemptFields {
   outputs: Record<string, unknown> | null;
   response: string | null;
   error: Record<string, unknown> | null;
+  stepError: StepError | null;
   gateResult: StepGateResult;
   restartFeedback: string | null;
   invocations: StepAttemptInvocation[];
@@ -76,6 +78,7 @@ export class StepAttempt {
   outputs!: Record<string, unknown> | null;
   response!: string | null;
   error!: Record<string, unknown> | null;
+  stepError!: StepError | null;
   gateResult!: StepGateResult;
   restartFeedback!: string | null;
   invocations!: StepAttemptInvocation[];

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -77,6 +77,10 @@ export interface StepError {
   managedProviderId?: string | undefined;
   field?: string | undefined;
   source?: string | undefined;
+  retryable?: boolean | undefined;
+  limitBytes?: number | undefined;
+  measuredBytes?: number | undefined;
+  overshootBytes?: number | undefined;
   exitCode: number | null;
   signal: string | undefined;
   reason: StepErrorReason | undefined;

--- a/libs/client/workflows/src/core/entities/workflow-diagnostics.test.ts
+++ b/libs/client/workflows/src/core/entities/workflow-diagnostics.test.ts
@@ -1,0 +1,7 @@
+import {workflowPayloadFieldLabel} from './workflow-diagnostics.js';
+
+describe('workflow payload field labels', () => {
+  it.each(['toString', '__proto__'])('falls back for the inherited key %s', (field) => {
+    expect(workflowPayloadFieldLabel(field)).toBe('Workflow value');
+  });
+});

--- a/libs/client/workflows/src/core/entities/workflow-diagnostics.ts
+++ b/libs/client/workflows/src/core/entities/workflow-diagnostics.ts
@@ -15,6 +15,50 @@ export type WorkflowDiagnosticField =
   | 'condition'
   | 'trigger_events';
 
+export type WorkflowPayloadField =
+  | WorkflowDiagnosticField
+  | 'resolved_config'
+  | 'config_plan'
+  | 'listener_batch';
+
+const WORKFLOW_PAYLOAD_FIELD_LABELS = {
+  authored_config: 'Authored configuration',
+  config: 'Resolved configuration',
+  resolved_config: 'Resolved configuration',
+  config_plan: 'Configuration plan',
+  evaluation_trace: 'Evaluation',
+  job_evaluation_trace: 'Evaluation',
+  execution_evaluation_trace: 'Evaluation',
+  output: 'Step output',
+  outputs: 'Outputs',
+  response: 'Response',
+  error: 'Failure details',
+  gate_result: 'Gate result',
+  restart_feedback: 'Restart feedback',
+  job_outputs: 'Job outputs',
+  execution_outputs: 'Execution outputs',
+  condition: 'Condition',
+  trigger_events: 'Trigger events',
+  listener_batch: 'Trigger events',
+} satisfies Record<WorkflowPayloadField, string>;
+
+const CONFIGURATION_PAYLOAD_FIELDS = new Set<WorkflowPayloadField>([
+  'authored_config',
+  'config',
+  'resolved_config',
+  'config_plan',
+  'condition',
+]);
+
+export function workflowPayloadFieldLabel(field: string | undefined): string {
+  if (field === undefined || !(field in WORKFLOW_PAYLOAD_FIELD_LABELS)) return 'Workflow value';
+  return WORKFLOW_PAYLOAD_FIELD_LABELS[field as WorkflowPayloadField];
+}
+
+export function isWorkflowConfigurationPayloadField(field: string | undefined): boolean {
+  return field !== undefined && CONFIGURATION_PAYLOAD_FIELDS.has(field as WorkflowPayloadField);
+}
+
 export type WorkflowDiagnosticUnavailableReason =
   | 'legacy_value_exceeds_inline_limit'
   | 'value_exceeds_inline_limit'

--- a/libs/client/workflows/src/core/entities/workflow-diagnostics.ts
+++ b/libs/client/workflows/src/core/entities/workflow-diagnostics.ts
@@ -47,11 +47,12 @@ const CONFIGURATION_PAYLOAD_FIELDS = new Set<WorkflowPayloadField>([
   'config',
   'resolved_config',
   'config_plan',
-  'condition',
 ]);
 
 export function workflowPayloadFieldLabel(field: string | undefined): string {
-  if (field === undefined || !(field in WORKFLOW_PAYLOAD_FIELD_LABELS)) return 'Workflow value';
+  if (field === undefined || !Object.hasOwn(WORKFLOW_PAYLOAD_FIELD_LABELS, field)) {
+    return 'Workflow value';
+  }
   return WORKFLOW_PAYLOAD_FIELD_LABELS[field as WorkflowPayloadField];
 }
 

--- a/libs/client/workflows/src/core/entities/workflow-job-detail.ts
+++ b/libs/client/workflows/src/core/entities/workflow-job-detail.ts
@@ -12,6 +12,11 @@ export type {
   WorkflowDiagnosticField,
   WorkflowDiagnosticUnavailableField,
   WorkflowDiagnosticUnavailableReason,
+  WorkflowPayloadField,
+} from './workflow-diagnostics.js';
+export {
+  isWorkflowConfigurationPayloadField,
+  workflowPayloadFieldLabel,
 } from './workflow-diagnostics.js';
 
 /** A bounded page returned by one of the selected-job cursor endpoints. */

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -74,7 +74,12 @@ export type {
   WorkflowJobPage,
   WorkflowJobStepAttemptSummary,
   WorkflowJobStepSummary,
+  WorkflowPayloadField,
   WorkflowStepAttemptPage,
+} from './entities/workflow-job-detail.js';
+export {
+  isWorkflowConfigurationPayloadField,
+  workflowPayloadFieldLabel,
 } from './entities/workflow-job-detail.js';
 export type {
   DevRunLaunch,

--- a/libs/client/workflows/src/hooks/api/workflow-job-detail-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-job-detail-mapper.ts
@@ -308,6 +308,7 @@ function toLegacyStepAttempt(
     outputs: null,
     response: null,
     error: attempt.error ? {...attempt.error} : null,
+    stepError: attempt.error,
     gateResult: attempt.gateResult,
     restartFeedback: null,
     invocations: [],

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.test.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.test.ts
@@ -106,6 +106,22 @@ describe('workflow run step error mapping', () => {
     expect(current?.measuredBytes).toBe(0);
     expect(historical?.measuredBytes).toBe(0);
   });
+
+  test('preserves an unclassified historical attempt error', () => {
+    const error = mappedAttemptError('run', {
+      message: 'Legacy runner failed before it recorded a reason',
+      code: 'legacy-runner-failure',
+      source: 'runner',
+    });
+
+    expect(error).toMatchObject({
+      message: 'Legacy runner failed before it recorded a reason',
+      code: 'legacy-runner-failure',
+      source: 'runner',
+    });
+    expect(error?.reason).toBeUndefined();
+    expect(error?.category).toBeUndefined();
+  });
 });
 
 function mappedAttemptError(type: string, error: Record<string, unknown>) {

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.test.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.test.ts
@@ -1,0 +1,120 @@
+import {workflowStepAttemptDto, workflowStepDto} from '#test/fixtures/workflow-run.js';
+import {toStep} from './workflow-run-mapper.js';
+
+describe('workflow run step error mapping', () => {
+  test('preserves managed-provider metadata from a historical attempt', () => {
+    const error = mappedAttemptError('agent', {
+      message: 'This instance only supports provider `shipfox`.',
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_unsupported',
+    });
+
+    expect(error).toMatchObject({
+      code: 'workspace-providers-disabled',
+      managedProviderId: 'shipfox',
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_unsupported',
+    });
+  });
+
+  test.each([
+    'setup',
+    'checkout',
+    'agent',
+    'run',
+  ] as const)('derives the error category for %s steps', (type) => {
+    for (const reason of [
+      'checkout_auth_failed',
+      'checkout_unavailable',
+      'checkout_failed',
+      'checkout_path_invalid',
+      'checkout_destination_occupied',
+      'git_unavailable',
+      'workspace_prep_failed',
+      'setup_aborted',
+    ] as const) {
+      expect(mappedAttemptError(type, {message: 'Checkout failed', reason})).toMatchObject({
+        reason,
+        category: 'setup',
+      });
+    }
+  });
+
+  test.each([
+    ['setup', 'setup'],
+    ['checkout', 'setup'],
+    ['agent', 'user'],
+    ['run', 'user'],
+  ] as const)('keeps config failures in the expected category for %s steps', (type, category) => {
+    expect(
+      mappedAttemptError(type, {message: 'Command failed', reason: 'config_unresolvable'}),
+    ).toMatchObject({reason: 'config_unresolvable', category});
+  });
+
+  test.each([
+    'execution_payload_too_large',
+    'step_result_too_large',
+  ] as const)('preserves bounded failure reason %s', (reason) => {
+    expect(
+      mappedAttemptError('run', {
+        message: 'Bounded workflow value exceeded its limit',
+        reason,
+      }),
+    ).toMatchObject({reason, category: 'user'});
+  });
+
+  test('normalizes historical size fields once at the API boundary', () => {
+    const error = mappedAttemptError('run', {
+      message: 'Resolved configuration exceeds execution payload limit',
+      reason: 'execution_payload_too_large',
+      field: 'resolved_config',
+      retryable: false,
+      limitBytes: 65_536,
+      limit_bytes: 0,
+      measured_bytes: -5,
+      overshoot_bytes: Number.POSITIVE_INFINITY,
+    });
+
+    expect(error).toMatchObject({
+      field: 'resolved_config',
+      retryable: false,
+      limitBytes: 65_536,
+    });
+    expect(error).not.toHaveProperty('measuredBytes');
+    expect(error).not.toHaveProperty('overshootBytes');
+  });
+
+  test('keeps zero byte counts consistent across current and historical errors', () => {
+    const current = toStep(
+      workflowStepDto({
+        type: 'run',
+        error: {
+          message: 'Payload failed',
+          reason: 'execution_payload_too_large',
+          measured_bytes: 0,
+        },
+      }),
+    ).error;
+    const historical = mappedAttemptError('run', {
+      message: 'Payload failed',
+      reason: 'execution_payload_too_large',
+      measured_bytes: 0,
+    });
+
+    expect(current?.measuredBytes).toBe(0);
+    expect(historical?.measuredBytes).toBe(0);
+  });
+});
+
+function mappedAttemptError(type: string, error: Record<string, unknown>) {
+  const step = toStep(
+    workflowStepDto({
+      type,
+      error: null,
+      attempts: [workflowStepAttemptDto({error})],
+    }),
+  );
+  return step.attempts[0]?.stepError ?? null;
+}

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -36,6 +36,7 @@ import {
   type Step,
   StepAttempt,
   type StepAttemptSession,
+  type StepError,
   type StepGateResult,
   toWorkflowRunOverviewExecutionDuration,
   type WorkflowExecutionEvent,
@@ -648,27 +649,34 @@ export function toStep(dto: WorkflowRunStepDetailDto): Step {
     evaluationTrace: toEvaluationTrace(dto.evaluation_trace),
     agentConfig: toAgentStepConfig(dto),
     toolConfig: toToolStepConfig(dto),
-    error: dto.error
-      ? {
-          message: dto.error.message,
-          ...(dto.error.code === undefined ? {} : {code: dto.error.code}),
-          ...(dto.error.managed_provider_id === undefined
-            ? {}
-            : {managedProviderId: dto.error.managed_provider_id}),
-          ...(dto.error.field === undefined ? {} : {field: dto.error.field}),
-          ...(dto.error.source === undefined ? {} : {source: dto.error.source}),
-          exitCode: dto.error.exit_code ?? null,
-          signal: dto.error.signal,
-          reason: dto.error.reason,
-          agentConfigIssue: dto.error.agent_config_issue,
-          category: dto.error.category,
-        }
-      : null,
+    error: toStepError(dto.error),
     position: dto.position,
     currentAttempt: dto.current_attempt,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
     attempts: dto.attempts.map((attempt) => toStepAttempt(attempt, dto.job_execution_id)),
+  };
+}
+
+function toStepError(error: WorkflowRunStepDetailDto['error']): StepError | null {
+  if (!error) return null;
+  return {
+    message: error.message,
+    ...(error.code === undefined ? {} : {code: error.code}),
+    ...(error.managed_provider_id === undefined
+      ? {}
+      : {managedProviderId: error.managed_provider_id}),
+    ...(error.field === undefined ? {} : {field: error.field}),
+    ...(error.source === undefined ? {} : {source: error.source}),
+    ...(error.retryable === undefined ? {} : {retryable: error.retryable}),
+    ...(error.limit_bytes === undefined ? {} : {limitBytes: error.limit_bytes}),
+    ...(error.measured_bytes === undefined ? {} : {measuredBytes: error.measured_bytes}),
+    ...(error.overshoot_bytes === undefined ? {} : {overshootBytes: error.overshoot_bytes}),
+    exitCode: error.exit_code ?? null,
+    signal: error.signal,
+    reason: error.reason,
+    agentConfigIssue: error.agent_config_issue,
+    category: error.category,
   };
 }
 

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -717,7 +717,6 @@ function toAttemptStepError(
   const rawAgentConfigIssue = error.agentConfigIssue ?? error.agent_config_issue;
   const agentConfigIssue = parsedAgentConfigIssue(rawAgentConfigIssue);
   const reason = parsedReason ?? (agentConfigIssue ? 'agent_config_invalid' : undefined);
-  if (reason === undefined) return null;
 
   const exitCode = error.exitCode ?? error.exit_code;
   const managedProviderId = selectedString(error, 'managedProviderId', 'managed_provider_id');
@@ -733,7 +732,7 @@ function toAttemptStepError(
     signal: typeof error.signal === 'string' ? error.signal : undefined,
     reason,
     agentConfigIssue,
-    category: deriveStepErrorCategory(stepType, reason),
+    category: reason === undefined ? undefined : deriveStepErrorCategory(stepType, reason),
   };
 }
 

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -21,11 +21,13 @@ import type {
   WorkflowRunStepDetailDto,
 } from '@shipfox/api-workflows-dto';
 import {
+  deriveStepErrorCategory,
   WORKFLOW_RUN_OVERVIEW_COMPLETE_EDGE_LIMIT,
   WORKFLOW_RUN_OVERVIEW_COMPLETE_JOB_LIMIT,
   WORKFLOW_RUN_OVERVIEW_LARGE_JOB_PAGE_LIMIT,
 } from '@shipfox/api-workflows-dto';
 import {
+  AGENT_CONFIG_ISSUES,
   defaultJobExecution,
   deriveJobExecutionDisplayStatus,
   type EvaluationTraceEntry,
@@ -33,6 +35,7 @@ import {
   JobExecution,
   type JobListening,
   type JobStatus,
+  STEP_ERROR_REASONS,
   type Step,
   StepAttempt,
   type StepAttemptSession,
@@ -654,7 +657,7 @@ export function toStep(dto: WorkflowRunStepDetailDto): Step {
     currentAttempt: dto.current_attempt,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
-    attempts: dto.attempts.map((attempt) => toStepAttempt(attempt, dto.job_execution_id)),
+    attempts: dto.attempts.map((attempt) => toStepAttempt(attempt, dto.job_execution_id, dto.type)),
   };
 }
 
@@ -669,9 +672,7 @@ function toStepError(error: WorkflowRunStepDetailDto['error']): StepError | null
     ...(error.field === undefined ? {} : {field: error.field}),
     ...(error.source === undefined ? {} : {source: error.source}),
     ...(error.retryable === undefined ? {} : {retryable: error.retryable}),
-    ...(error.limit_bytes === undefined ? {} : {limitBytes: error.limit_bytes}),
-    ...(error.measured_bytes === undefined ? {} : {measuredBytes: error.measured_bytes}),
-    ...(error.overshoot_bytes === undefined ? {} : {overshootBytes: error.overshoot_bytes}),
+    ...toStepErrorSizeFields(error),
     exitCode: error.exit_code ?? null,
     signal: error.signal,
     reason: error.reason,
@@ -680,7 +681,11 @@ function toStepError(error: WorkflowRunStepDetailDto['error']): StepError | null
   };
 }
 
-export function toStepAttempt(dto: StepAttemptDto, jobExecutionId: string): StepAttempt {
+export function toStepAttempt(
+  dto: StepAttemptDto,
+  jobExecutionId: string,
+  stepType = 'run',
+): StepAttempt {
   return new StepAttempt({
     id: dto.id,
     stepId: dto.step_id,
@@ -693,12 +698,105 @@ export function toStepAttempt(dto: StepAttemptDto, jobExecutionId: string): Step
     outputs: dto.outputs ?? dto.output ?? null,
     response: dto.response ?? null,
     error: dto.error ?? null,
+    stepError: toAttemptStepError(stepType, dto.error),
     gateResult: toStepGateResult(dto.gate_result),
     restartFeedback: dto.restart_feedback ?? null,
     invocations: dto.invocations.map(toStepAttemptInvocation),
     startedAt: dto.started_at,
     finishedAt: dto.finished_at ?? null,
   });
+}
+
+function toAttemptStepError(
+  stepType: string,
+  error: Record<string, unknown> | null | undefined,
+): StepError | null {
+  if (!error) return null;
+
+  const parsedReason = parsedStepErrorReason(error.reason);
+  const rawAgentConfigIssue = error.agentConfigIssue ?? error.agent_config_issue;
+  const agentConfigIssue = parsedAgentConfigIssue(rawAgentConfigIssue);
+  const reason = parsedReason ?? (agentConfigIssue ? 'agent_config_invalid' : undefined);
+  if (reason === undefined) return null;
+
+  const exitCode = error.exitCode ?? error.exit_code;
+  const managedProviderId = selectedString(error, 'managedProviderId', 'managed_provider_id');
+  const retryable = typeof error.retryable === 'boolean' ? error.retryable : undefined;
+
+  return {
+    message: typeof error.message === 'string' ? error.message : '',
+    ...selectedStepErrorStringFields(error),
+    ...toStepErrorSizeFields(error),
+    ...(managedProviderId === undefined ? {} : {managedProviderId}),
+    ...(retryable === undefined ? {} : {retryable}),
+    exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
+    signal: typeof error.signal === 'string' ? error.signal : undefined,
+    reason,
+    agentConfigIssue,
+    category: deriveStepErrorCategory(stepType, reason),
+  };
+}
+
+interface StepErrorSizeSource {
+  limitBytes?: unknown;
+  limit_bytes?: unknown;
+  measuredBytes?: unknown;
+  measured_bytes?: unknown;
+  overshootBytes?: unknown;
+  overshoot_bytes?: unknown;
+}
+
+function toStepErrorSizeFields(
+  error: StepErrorSizeSource,
+): Pick<StepError, 'limitBytes' | 'measuredBytes' | 'overshootBytes'> {
+  const limitBytes = selectedByteCount(error.limitBytes, error.limit_bytes);
+  const measuredBytes = selectedByteCount(error.measuredBytes, error.measured_bytes);
+  const overshootBytes = selectedByteCount(error.overshootBytes, error.overshoot_bytes);
+  return {
+    ...(limitBytes === undefined ? {} : {limitBytes}),
+    ...(measuredBytes === undefined ? {} : {measuredBytes}),
+    ...(overshootBytes === undefined ? {} : {overshootBytes}),
+  };
+}
+
+function selectedByteCount(camelCaseValue: unknown, snakeCaseValue: unknown): number | undefined {
+  const value = camelCaseValue ?? snakeCaseValue;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function selectedStepErrorStringFields(
+  error: Record<string, unknown>,
+): Pick<StepError, 'code' | 'field' | 'source'> {
+  return {
+    ...(typeof error.code === 'string' ? {code: error.code} : {}),
+    ...(typeof error.field === 'string' ? {field: error.field} : {}),
+    ...(typeof error.source === 'string' ? {source: error.source} : {}),
+  };
+}
+
+function selectedString(
+  error: Record<string, unknown>,
+  camelCaseKey: string,
+  snakeCaseKey: string,
+): string | undefined {
+  const value = error[camelCaseKey] ?? error[snakeCaseKey];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function parsedStepErrorReason(value: unknown): NonNullable<StepError['reason']> | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (!STEP_ERROR_REASONS.has(value as StepError['reason'] & string)) return undefined;
+  return value as NonNullable<StepError['reason']>;
+}
+
+function parsedAgentConfigIssue(
+  value: unknown,
+): NonNullable<StepError['agentConfigIssue']> | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (!AGENT_CONFIG_ISSUES.has(value as NonNullable<StepError['agentConfigIssue']>)) {
+    return undefined;
+  }
+  return value as NonNullable<StepError['agentConfigIssue']>;
 }
 
 export function toStepAttemptDetail(dto: StepAttemptDetailResponseDto) {


### PR DESCRIPTION
## Summary

Workflow payload failures currently expose internal diagnostic terminology and generic retry guidance. This change maps structured byte limits into the client, distinguishes diagnostic display and write failures from execution limits, and links to authored and resolved configuration when it is available.

The rerun menu now explains that failed-job reruns preserve attempt inputs and successful outputs, while full reruns recompute them. Legacy oversized `trigger_events` records also render as trigger failures instead of job-output failures.

## Validation

`mise exec -- turbo check type test --filter='@shipfox/client-workflows...'`

`mise exec -- pnpm --filter @shipfox/prose-policy verify`

Closes ENG-1970

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes workflow payload failures actionable by distinguishing display limits from execution limits, adding size details and configuration links, and clarifying rerun behavior. Historical attempt errors are now normalized at the API boundary so they expose the same structured payload details as current failures, with invalid size values dropped and zero byte counts preserved consistently.

- Adds a rerun menu label explaining that failed-job reruns preserve attempt inputs and successful job outputs.
- Renders oversized trigger events from legacy records as trigger failures instead of job-output failures.
- Shows byte counts and affected value names for payload limit failures.
- Links to authored or resolved configuration when a configuration payload exceeds the limit.
- Distinguishes three diagnostic unavailability reasons: older server record, display limit, and write limit.

<sup>Written for commit f738e042a23b459a35147de7f153784bfa582ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

