### PR TITLE
[client-workflows] Explain run annotations and unexecuted jobs

### DIFF
--- a/.changeset/enriched-run-annotations.md
+++ b/.changeset/enriched-run-annotations.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": minor
+---
+
+Load enriched run annotations and no-execution job explanations from their bounded workflow APIs.

--- a/.changeset/enriched-run-annotations.md
+++ b/.changeset/enriched-run-annotations.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": minor
 ---
 
-Load enriched run annotations and no-execution job explanations from their bounded workflow APIs.
+Loads enriched run annotations and no-execution job explanations from the required bounded workflow APIs.

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -159,6 +159,7 @@ export function JobDetailView({
   const annotations = useRunAnnotationsQuery({
     workflowRunId,
     runAttempt: detailData?.runAttempt.attempt,
+    loadAllPages: true,
   });
   const jobAnnotationSummary = summarizeLoadedJobAnnotations(annotations, jobId);
   const inspectorResetKey = `${jobId}:${search.jobExecutionId ?? ''}`;

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -443,10 +443,14 @@ function summarizeLoadedJobAnnotations(
   annotations: ReturnType<typeof useRunAnnotationsQuery>,
   jobId: string,
 ): RunAnnotationSummary | undefined {
-  if (!annotations.annotations) return undefined;
-  return summarizeJobAnnotations(annotations.annotations, jobId, {
-    truncated: annotations.summary?.truncated ?? false,
-  });
+  if (!annotations.entries) return undefined;
+  return summarizeJobAnnotations(
+    annotations.entries.map((entry) => entry.annotation),
+    jobId,
+    {
+      truncated: annotations.summary?.truncated ?? false,
+    },
+  );
 }
 
 function resolveAnnotationExecutionId(

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -35,19 +35,15 @@ const ANNOTATION_ROW_CLASS =
 const MINTED_CONTEXTS = [
   {
     key: ({originStepId}: MintedContextSource) => `failure:step:${originStepId}`,
-    fallbackTitle: 'Step failure',
   },
   {
     key: ({jobId}: MintedContextSource) => `failure:job:${jobId}`,
-    fallbackTitle: 'Job failure',
   },
   {
     key: ({originStepId}: MintedContextSource) => `agent-tool-capability:${originStepId}`,
-    fallbackTitle: 'Agent tool capability',
   },
   {
     key: ({originStepId}: MintedContextSource) => `renewable-git-capability:${originStepId}`,
-    fallbackTitle: 'Renewable Git capability',
   },
 ] as const;
 
@@ -81,11 +77,8 @@ export function RunAnnotationItem({
 }: RunAnnotationItemProps) {
   const {annotation, origin} = entry;
   const canLink = Boolean(origin && workspaceSlug && projectSlug);
-  // A minted context is never the heading, not even as a last resort: a run that no longer
-  // contains the emitting job resolves no name, and printing the routing key would put a bare
-  // uuid where the row's subject belongs.
   const minted = mintedContext(annotation);
-  const title = minted ? (entry.jobName ?? minted.fallbackTitle) : annotation.context;
+  const title = minted ? entry.jobName : annotation.context;
 
   return (
     <AnnotationRow>

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -126,6 +126,7 @@ export function RunAnnotationItem({
 
 export interface RunDerivedAnnotationItemProps {
   style: RunAnnotationStyle;
+  statusLabel: 'Skipped' | 'Failed';
   jobName: string;
   body: string;
 }
@@ -133,12 +134,17 @@ export interface RunDerivedAnnotationItemProps {
 /**
  * A terminal job that never created an execution record.
  *
- * It has no step to link to and no context of its own, so it is titled by its job and says
- * plainly that no execution exists. It renders in the same row as every other annotation, since
- * a job that failed before it started is a diagnostic like any other, and often the first one
- * worth reading.
+ * It has no step to link to and no context of its own, so it is titled by its job and names the
+ * terminal status that prompted the explanation. It renders in the same row as every other
+ * annotation, since a job that failed before it started is a diagnostic like any other, and often
+ * the first one worth reading.
  */
-export function RunDerivedAnnotationItem({style, jobName, body}: RunDerivedAnnotationItemProps) {
+export function RunDerivedAnnotationItem({
+  style,
+  statusLabel,
+  jobName,
+  body,
+}: RunDerivedAnnotationItemProps) {
   return (
     <AnnotationRow>
       <AnnotationCard
@@ -151,7 +157,7 @@ export function RunDerivedAnnotationItem({style, jobName, body}: RunDerivedAnnot
             size="xs"
             className="min-w-0 truncate font-code text-foreground-neutral-subtle"
           >
-            no execution recorded
+            {statusLabel}
           </Text>
         }
         body={body}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-item.tsx
@@ -22,8 +22,8 @@ const ANNOTATION_ROW_CLASS =
   'items-start justify-start gap-cluster hover:bg-background-neutral-base';
 
 /**
- * The contexts the server mints itself, each rebuilt exactly as its producer builds it, with the
- * heading to use when the job that would normally name the row cannot be resolved.
+ * The contexts the server mints itself, each rebuilt exactly as its producer builds it. The
+ * server-provided emitting job names these rows.
  *
  * These are routing keys rather than something a reader chose, so they never become the heading.
  * Rebuilt whole rather than matched by prefix: `context` is caller-chosen with no reserved

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
@@ -2,16 +2,10 @@ import {act, screen, within} from '@testing-library/react';
 import {useState} from 'react';
 import {
   buildRunAnnotationList,
+  type RunAnnotationEntry,
   type RunAnnotationRecord,
   type RunAnnotationStyle,
 } from '#core/run-annotation.js';
-import type {Job} from '#core/workflow-run.js';
-import {
-  workflowJob,
-  workflowJobExecutionDto,
-  workflowStepAttemptDto,
-  workflowStepDto,
-} from '#test/fixtures/workflow-run.js';
 import {renderWithRouter} from '#test/render.js';
 import {
   type DerivedRunAnnotation,
@@ -85,15 +79,13 @@ describe('RunAnnotationList', () => {
     ).toBeInTheDocument();
   });
 
-  test('names a minted context whose job the run no longer resolves', async () => {
-    // A job missing from the run snapshot resolves no name and no step link, so the routing key
-    // would otherwise be the only text on the row.
+  test('uses the server-provided job name even when the overview does not contain the job', async () => {
     renderList([
       annotation({id: 'a1', context: `failure:step:${BUILD_STEP_ID}`, jobId: MISSING_JOB_ID}),
     ]);
 
     expect(
-      await screen.findByRole('heading', {level: 3, name: 'Step failure'}),
+      await screen.findByRole('heading', {level: 3, name: 'archived job'}),
     ).toBeInTheDocument();
     expect(screen.queryByText(`failure:step:${BUILD_STEP_ID}`)).not.toBeInTheDocument();
   });
@@ -138,7 +130,7 @@ describe('RunAnnotationList', () => {
     renderList(entries, {derivedAnnotations: [derived({id: 'd1', jobName: 'deploy production'})]});
 
     expect(await screen.findByRole('button', {name: SHOW_MORE_PATTERN})).toHaveTextContent(
-      'Show 1 more of 27',
+      'Show 2 more of 27',
     );
   });
 
@@ -159,6 +151,16 @@ describe('RunAnnotationList', () => {
     await screen.findByRole('heading', {level: 3, name: 'smoke check'});
     expect(screen.queryByRole('link', {name: OPEN_STEP_PATTERN})).not.toBeInTheDocument();
   });
+
+  test('keeps loaded annotations visible when job explanations fail', async () => {
+    renderList([annotation({id: 'a1', context: 'smoke check'})], {
+      jobExplanationsQuery: listQuery({isError: true, error: new Error('Unavailable')}),
+    });
+
+    expect(await screen.findByRole('heading', {level: 3, name: 'smoke check'})).toBeInTheDocument();
+    expect(screen.getByText('Could not load job explanations.')).toBeInTheDocument();
+    expect(screen.queryByText('This run has no annotations to show.')).not.toBeInTheDocument();
+  });
 });
 
 function renderList(
@@ -166,12 +168,16 @@ function renderList(
   {
     derivedAnnotations,
     query = listQuery(),
+    jobExplanationsQuery = listQuery(),
   }: {
     derivedAnnotations?: readonly DerivedRunAnnotation[] | undefined;
     query?: RunAnnotationListQuery;
+    jobExplanationsQuery?: RunAnnotationListQuery;
   } = {},
 ) {
-  return renderWithRouter(renderListElement(annotations, {derivedAnnotations, query}));
+  return renderWithRouter(
+    renderListElement(annotations, {derivedAnnotations, query, jobExplanationsQuery}),
+  );
 }
 
 function renderListElement(
@@ -179,15 +185,18 @@ function renderListElement(
   {
     derivedAnnotations,
     query = listQuery(),
+    jobExplanationsQuery = listQuery(),
   }: {
     derivedAnnotations?: readonly DerivedRunAnnotation[] | undefined;
     query?: RunAnnotationListQuery;
+    jobExplanationsQuery?: RunAnnotationListQuery;
   } = {},
 ) {
   return (
     <RunAnnotationList
       query={query}
-      entries={buildRunAnnotationList({annotations, jobs})}
+      jobExplanationsQuery={jobExplanationsQuery}
+      entries={buildRunAnnotationList({entries: annotations.map(annotationEntry)})}
       derivedAnnotations={derivedAnnotations}
       workspaceSlug="acme"
       projectSlug="platform"
@@ -229,6 +238,8 @@ function annotation(overrides: Partial<RunAnnotationRecord> & {id: string}): Run
 
 function derived(overrides: Partial<DerivedRunAnnotation> & {id: string}): DerivedRunAnnotation {
   return {
+    jobId: '44444444-4444-4444-8444-00000000000d',
+    jobPosition: 1,
     style: 'warning',
     jobName: 'deploy production',
     body: 'Skipped before an execution was created.',
@@ -236,26 +247,23 @@ function derived(overrides: Partial<DerivedRunAnnotation> & {id: string}): Deriv
   };
 }
 
-const jobs: Job[] = [
-  workflowJob({
-    id: BUILD_JOB_ID,
-    key: 'build',
-    name: 'build',
-    position: 0,
-    job_executions: [
-      workflowJobExecutionDto({
-        id: BUILD_EXECUTION_ID,
-        job_id: BUILD_JOB_ID,
-        steps: [
-          workflowStepDto({
-            id: BUILD_STEP_ID,
-            name: 'run smoke checks',
-            attempts: [
-              workflowStepAttemptDto({id: BUILD_ATTEMPT_ID, step_id: BUILD_STEP_ID, attempt: 1}),
-            ],
-          }),
-        ],
-      }),
-    ],
-  }),
-];
+function annotationEntry(annotation: RunAnnotationRecord): RunAnnotationEntry {
+  const missingJob = annotation.jobId === MISSING_JOB_ID;
+  return {
+    annotation,
+    jobName: missingJob ? 'archived job' : 'build',
+    jobPosition: missingJob ? 1 : 0,
+    executionSequence: 1,
+    executionLabel: null,
+    stepLabel: 'run smoke checks',
+    attemptLabel: 'attempt 1',
+    origin: missingJob
+      ? null
+      : {
+          jobId: annotation.jobId,
+          jobExecutionId: annotation.jobExecutionId,
+          stepId: annotation.originStepId,
+          stepAttemptId: BUILD_ATTEMPT_ID,
+        },
+  };
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
@@ -131,7 +131,7 @@ describe('RunAnnotationList', () => {
       derivedAnnotations: [derived({id: 'd1', jobName: 'deploy production'})],
     });
 
-    await screen.findByText('no execution recorded');
+    await screen.findByText('Skipped');
     const headings = screen.getAllByRole('heading', {level: 3});
 
     expect(headings.map((heading) => heading.textContent)).toEqual([
@@ -206,7 +206,9 @@ describe('RunAnnotationList', () => {
     });
 
     expect(await screen.findByRole('heading', {level: 3, name: 'smoke check'})).toBeInTheDocument();
-    expect(screen.getByText('Could not load job explanations.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Some details about skipped or failed jobs could not be loaded.'),
+    ).toBeInTheDocument();
     expect(screen.queryByText('This run has no annotations to show.')).not.toBeInTheDocument();
   });
 
@@ -221,7 +223,18 @@ describe('RunAnnotationList', () => {
       await screen.findByRole('button', {name: 'Retry loading annotations'}),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: 'Retry loading job explanations'}),
+      screen.getByRole('button', {name: 'Retry loading skipped and failed job details'}),
+    ).toBeInTheDocument();
+  });
+
+  test('explains when loaded skipped and failed job details may be stale', async () => {
+    renderList([], {
+      derivedAnnotations: [],
+      jobExplanationsQuery: listQuery({isError: true, error: new Error('Unavailable')}),
+    });
+
+    expect(
+      await screen.findByText('Some details about skipped or failed jobs may be out of date.'),
     ).toBeInTheDocument();
   });
 });
@@ -307,9 +320,10 @@ function derived(overrides: Partial<DerivedRunAnnotation> & {id: string}): Deriv
   return {
     jobId: '44444444-4444-4444-8444-00000000000d',
     jobPosition: 1,
-    style: 'warning',
+    style: 'default',
+    statusLabel: 'Skipped',
     jobName: 'deploy production',
-    body: 'Skipped before an execution was created.',
+    body: 'A required job did not succeed, so this job did not run.',
     ...overrides,
   };
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.test.tsx
@@ -2,10 +2,10 @@ import {act, screen, within} from '@testing-library/react';
 import {useState} from 'react';
 import {
   buildRunAnnotationList,
-  type RunAnnotationEntry,
   type RunAnnotationRecord,
   type RunAnnotationStyle,
 } from '#core/run-annotation.js';
+import {runAnnotationEntryFixture} from '#test/fixtures/workflow-run.js';
 import {renderWithRouter} from '#test/render.js';
 import {
   type DerivedRunAnnotation,
@@ -22,6 +22,7 @@ const RUN_ID = '11111111-1111-4111-8111-111111111111';
 
 const SHOW_MORE_PATTERN = /Show \d+ more of \d+/;
 const OPEN_STEP_PATTERN = /Open step/;
+const NEW_ANNOTATION_PATTERN = /new annotation/u;
 
 describe('RunAnnotationList', () => {
   test('heads a row with the block the emitting step named', async () => {
@@ -67,6 +68,27 @@ describe('RunAnnotationList', () => {
     });
 
     expect(await screen.findByText('A new annotation was added to this run.')).toBeInTheDocument();
+  });
+
+  test('does not announce the first loaded page as newly added', async () => {
+    let updateEntries: (entries: RunAnnotationRecord[]) => void = () => undefined;
+    function Harness() {
+      const [entries, setEntries] = useState<RunAnnotationRecord[] | undefined>(undefined);
+      updateEntries = setEntries;
+      return renderListElement(entries, {
+        derivedAnnotations: [],
+        query: listQuery({isPending: entries === undefined}),
+      });
+    }
+
+    renderWithRouter(<Harness />);
+    await screen.findByLabelText('Loading annotations');
+    act(() => {
+      updateEntries([annotation({id: 'a1', sequence: 1})]);
+    });
+
+    await screen.findByRole('heading', {level: 3, name: 'default'});
+    expect(screen.queryByText(NEW_ANNOTATION_PATTERN)).not.toBeInTheDocument();
   });
 
   test('leaves a step-chosen context that only looks minted as the heading', async () => {
@@ -118,7 +140,7 @@ describe('RunAnnotationList', () => {
     ]);
   });
 
-  test('counts a derived row in the total the render window reports', async () => {
+  test('counts a derived row in the total the independent render windows report', async () => {
     const entries = Array.from({length: 26}, (_unused, index) =>
       annotation({
         id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(index).padStart(12, '0')}`,
@@ -130,8 +152,34 @@ describe('RunAnnotationList', () => {
     renderList(entries, {derivedAnnotations: [derived({id: 'd1', jobName: 'deploy production'})]});
 
     expect(await screen.findByRole('button', {name: SHOW_MORE_PATTERN})).toHaveTextContent(
-      'Show 2 more of 27',
+      'Show 1 more of 27',
     );
+  });
+
+  test('keeps visible annotations mounted when explanations arrive', async () => {
+    const entries = Array.from({length: 30}, (_unused, index) =>
+      annotation({
+        id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(index).padStart(12, '0')}`,
+        context: `context-${index}`,
+        sequence: index + 1,
+      }),
+    );
+    let updateExplanations: (entries: readonly DerivedRunAnnotation[]) => void = () => undefined;
+    function Harness() {
+      const [explanations, setExplanations] = useState<readonly DerivedRunAnnotation[]>([]);
+      updateExplanations = setExplanations;
+      return renderListElement(entries, {derivedAnnotations: explanations});
+    }
+
+    renderWithRouter(<Harness />);
+    await screen.findByRole('heading', {level: 3, name: 'context-24'});
+
+    act(() => {
+      updateExplanations([derived({id: 'd1', jobName: 'deploy production'})]);
+    });
+
+    expect(screen.getByRole('heading', {level: 3, name: 'deploy production'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {level: 3, name: 'context-24'})).toBeInTheDocument();
   });
 
   test('links a row back to the step that emitted it', async () => {
@@ -161,6 +209,21 @@ describe('RunAnnotationList', () => {
     expect(screen.getByText('Could not load job explanations.')).toBeInTheDocument();
     expect(screen.queryByText('This run has no annotations to show.')).not.toBeInTheDocument();
   });
+
+  test('names each resource retry button', async () => {
+    renderList([], {
+      derivedAnnotations: [],
+      query: listQuery({isError: true, error: new Error('Unavailable')}),
+      jobExplanationsQuery: listQuery({isError: true, error: new Error('Unavailable')}),
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Retry loading annotations'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Retry loading job explanations'}),
+    ).toBeInTheDocument();
+  });
 });
 
 function renderList(
@@ -181,7 +244,7 @@ function renderList(
 }
 
 function renderListElement(
-  annotations: RunAnnotationRecord[],
+  annotations: RunAnnotationRecord[] | undefined,
   {
     derivedAnnotations,
     query = listQuery(),
@@ -196,7 +259,11 @@ function renderListElement(
     <RunAnnotationList
       query={query}
       jobExplanationsQuery={jobExplanationsQuery}
-      entries={buildRunAnnotationList({entries: annotations.map(annotationEntry)})}
+      entries={
+        annotations
+          ? buildRunAnnotationList({entries: annotations.map(annotationEntry)})
+          : undefined
+      }
       derivedAnnotations={derivedAnnotations}
       workspaceSlug="acme"
       projectSlug="platform"
@@ -247,23 +314,12 @@ function derived(overrides: Partial<DerivedRunAnnotation> & {id: string}): Deriv
   };
 }
 
-function annotationEntry(annotation: RunAnnotationRecord): RunAnnotationEntry {
+function annotationEntry(annotation: RunAnnotationRecord) {
   const missingJob = annotation.jobId === MISSING_JOB_ID;
-  return {
-    annotation,
+  return runAnnotationEntryFixture(annotation, {
     jobName: missingJob ? 'archived job' : 'build',
     jobPosition: missingJob ? 1 : 0,
-    executionSequence: 1,
-    executionLabel: null,
     stepLabel: 'run smoke checks',
-    attemptLabel: 'attempt 1',
-    origin: missingJob
-      ? null
-      : {
-          jobId: annotation.jobId,
-          jobExecutionId: annotation.jobExecutionId,
-          stepId: annotation.originStepId,
-          stepAttemptId: BUILD_ATTEMPT_ID,
-        },
-  };
+    origin: missingJob ? null : {stepAttemptId: BUILD_ATTEMPT_ID},
+  });
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -40,9 +40,28 @@ export interface DerivedRunAnnotation {
   jobId: string;
   jobPosition: number;
   style: RunAnnotationStyle;
+  statusLabel: 'Skipped' | 'Failed';
   jobName: string;
   body: string;
 }
+
+interface RunAnnotationResourceErrorCopy {
+  loadMessage: string;
+  refreshMessage: string;
+  retryLabel: string;
+}
+
+const ANNOTATION_RESOURCE_ERROR_COPY: RunAnnotationResourceErrorCopy = {
+  loadMessage: 'Could not load annotations.',
+  refreshMessage: 'Could not refresh annotations.',
+  retryLabel: 'Retry loading annotations',
+};
+
+const JOB_DETAILS_RESOURCE_ERROR_COPY: RunAnnotationResourceErrorCopy = {
+  loadMessage: 'Some details about skipped or failed jobs could not be loaded.',
+  refreshMessage: 'Some details about skipped or failed jobs may be out of date.',
+  retryLabel: 'Retry loading skipped and failed job details',
+};
 
 /**
  * How many rows from each independently loaded resource render at once.
@@ -102,14 +121,14 @@ export function RunAnnotationList({
       {query.isError ? (
         <RunAnnotationResourceError
           query={query}
-          subject="annotations"
+          copy={ANNOTATION_RESOURCE_ERROR_COPY}
           hasStaleContent={entries !== undefined}
         />
       ) : null}
       {jobExplanationsQuery.isError ? (
         <RunAnnotationResourceError
           query={jobExplanationsQuery}
-          subject="job explanations"
+          copy={JOB_DETAILS_RESOURCE_ERROR_COPY}
           hasStaleContent={derivedAnnotations !== undefined}
         />
       ) : null}
@@ -206,6 +225,7 @@ function RunAnnotationListContent({
           <RunDerivedAnnotationItem
             key={annotation.id}
             style={annotation.style}
+            statusLabel={annotation.statusLabel}
             jobName={annotation.jobName}
             body={annotation.body}
           />
@@ -398,25 +418,23 @@ function RunAnnotationsFilteredEmpty({
  */
 function RunAnnotationResourceError({
   query,
-  subject,
+  copy,
   hasStaleContent,
 }: {
   query: QueryLoadErrorQuery;
-  subject: string;
+  copy: RunAnnotationResourceErrorCopy;
   hasStaleContent: boolean;
 }) {
   return (
     <div className="border-b border-border-neutral-base bg-background-neutral-base px-row py-row">
       <Callout role="status" aria-live="polite" type="error" variant="secondary">
         <CalloutContent className="flex items-center justify-between gap-inline">
-          <Text size="xs">
-            Could not {hasStaleContent ? 'refresh' : 'load'} {subject}.
-          </Text>
+          <Text size="xs">{hasStaleContent ? copy.refreshMessage : copy.loadMessage}</Text>
           <Button
             type="button"
             size="2xs"
             variant="secondary"
-            aria-label={`Retry loading ${subject}`}
+            aria-label={copy.retryLabel}
             className="[@media(pointer:coarse)]:min-h-44"
             isLoading={query.isFetching}
             onClick={() => {

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -45,11 +45,12 @@ export interface DerivedRunAnnotation {
 }
 
 /**
- * How many annotations render at once.
+ * How many rows from each independently loaded resource render at once.
  *
  * Each server resource pages independently and every row mounts a Markdown pipeline, so the
- * fetch budget is not a render budget. The window grows on demand and another server page only
- * loads once the reader has actually seen everything already fetched.
+ * fetch budget is not a render budget. Each window grows on demand and another server page only
+ * loads once the reader has actually seen everything already fetched. Keeping the windows
+ * separate prevents a newly arriving explanation from evicting an annotation already on screen.
  */
 const RENDER_WINDOW = 25;
 
@@ -77,16 +78,16 @@ export function RunAnnotationList({
   filtered,
   onClearFilters,
 }: RunAnnotationListProps) {
-  const [visibleCount, setVisibleCount] = useState(RENDER_WINDOW);
+  const [visibleEntryCount, setVisibleEntryCount] = useState(RENDER_WINDOW);
+  const [visibleExplanationCount, setVisibleExplanationCount] = useState(RENDER_WINDOW);
   const resolvedEntries = entries ?? [];
   const resolvedDerivedAnnotations = derivedAnnotations ?? [];
   const isWaitingForContent =
     (query.isPending && entries === undefined) ||
     (jobExplanationsQuery.isPending && derivedAnnotations === undefined);
 
-  const visibleDerivedAnnotations = resolvedDerivedAnnotations.slice(0, visibleCount);
-  const annotationWindow = Math.max(0, visibleCount - visibleDerivedAnnotations.length);
-  const visibleEntries = resolvedEntries.slice(0, annotationWindow);
+  const visibleDerivedAnnotations = resolvedDerivedAnnotations.slice(0, visibleExplanationCount);
+  const visibleEntries = resolvedEntries.slice(0, visibleEntryCount);
   const totalCount = resolvedEntries.length + resolvedDerivedAnnotations.length;
   const hiddenCount = totalCount - visibleDerivedAnnotations.length - visibleEntries.length;
   const hasContent = totalCount > 0;
@@ -97,7 +98,7 @@ export function RunAnnotationList({
     jobExplanationsQuery.isError;
   return (
     <>
-      <RunAnnotationLiveRegion entries={resolvedEntries} />
+      {entries === undefined ? null : <RunAnnotationLiveRegion entries={entries} />}
       {query.isError ? (
         <RunAnnotationResourceError
           query={query}
@@ -134,7 +135,16 @@ export function RunAnnotationList({
         totalCount={totalCount}
         query={query}
         jobExplanationsQuery={jobExplanationsQuery}
-        onShowMore={() => setVisibleCount((current) => current + RENDER_WINDOW)}
+        onShowMore={() => {
+          const explanationsToReveal = Math.min(
+            RENDER_WINDOW,
+            Math.max(0, resolvedDerivedAnnotations.length - visibleExplanationCount),
+          );
+          setVisibleExplanationCount((current) => current + explanationsToReveal);
+          setVisibleEntryCount(
+            (current) => current + Math.max(0, RENDER_WINDOW - explanationsToReveal),
+          );
+        }}
       />
     </>
   );
@@ -406,6 +416,7 @@ function RunAnnotationResourceError({
             type="button"
             size="2xs"
             variant="secondary"
+            aria-label={`Retry loading ${subject}`}
             className="[@media(pointer:coarse)]:min-h-44"
             isLoading={query.isFetching}
             onClick={() => {

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotation-list.tsx
@@ -1,4 +1,4 @@
-import {QueryLoadError, type QueryLoadErrorQuery} from '@shipfox/client-ui';
+import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout, CalloutContent} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
@@ -20,7 +20,8 @@ export interface RunAnnotationListQuery extends QueryLoadErrorQuery {
 export interface RunAnnotationListProps {
   query: RunAnnotationListQuery;
   entries: RunAnnotationEntry[] | undefined;
-  /** Synthetic terminal-job diagnostics for jobs that never created an execution record. */
+  jobExplanationsQuery: RunAnnotationListQuery;
+  /** Terminal-job diagnostics for jobs that never created an execution record. */
   derivedAnnotations?: readonly DerivedRunAnnotation[] | undefined;
   workflowRunId: string;
   workspaceSlug?: string | undefined;
@@ -36,6 +37,8 @@ export interface RunAnnotationListProps {
 
 export interface DerivedRunAnnotation {
   id: string;
+  jobId: string;
+  jobPosition: number;
   style: RunAnnotationStyle;
   jobName: string;
   body: string;
@@ -44,9 +47,9 @@ export interface DerivedRunAnnotation {
 /**
  * How many annotations render at once.
  *
- * A page holds up to 500 rows and each one mounts a Markdown pipeline, so the fetch budget is
- * not a render budget. The window grows on demand and the server page only loads once the
- * reader has actually seen everything already fetched.
+ * Each server resource pages independently and every row mounts a Markdown pipeline, so the
+ * fetch budget is not a render budget. The window grows on demand and another server page only
+ * loads once the reader has actually seen everything already fetched.
  */
 const RENDER_WINDOW = 25;
 
@@ -63,7 +66,8 @@ const RENDER_WINDOW = 25;
 export function RunAnnotationList({
   query,
   entries,
-  derivedAnnotations = [],
+  jobExplanationsQuery,
+  derivedAnnotations,
   workflowRunId,
   workspaceSlug,
   projectSlug,
@@ -74,106 +78,196 @@ export function RunAnnotationList({
   onClearFilters,
 }: RunAnnotationListProps) {
   const [visibleCount, setVisibleCount] = useState(RENDER_WINDOW);
+  const resolvedEntries = entries ?? [];
+  const resolvedDerivedAnnotations = derivedAnnotations ?? [];
+  const isWaitingForContent =
+    (query.isPending && entries === undefined) ||
+    (jobExplanationsQuery.isPending && derivedAnnotations === undefined);
 
-  if (query.isPending) return <RunAnnotationListSkeleton />;
-
-  if (query.isError && entries === undefined) {
-    return (
-      <QueryLoadError query={query} subject="annotations" icon="fileDamageLine" variant="panel" />
-    );
-  }
-
-  if (entries === undefined) return <RunAnnotationListSkeleton />;
-
-  const visible = entries.slice(0, visibleCount);
-  const hiddenCount = entries.length - visible.length;
-  const totalCount = entries.length + derivedAnnotations.length;
+  const visibleDerivedAnnotations = resolvedDerivedAnnotations.slice(0, visibleCount);
+  const annotationWindow = Math.max(0, visibleCount - visibleDerivedAnnotations.length);
+  const visibleEntries = resolvedEntries.slice(0, annotationWindow);
+  const totalCount = resolvedEntries.length + resolvedDerivedAnnotations.length;
+  const hiddenCount = totalCount - visibleDerivedAnnotations.length - visibleEntries.length;
   const hasContent = totalCount > 0;
-  let content: ReactNode;
+  const hasUnknownContent =
+    entries === undefined ||
+    derivedAnnotations === undefined ||
+    query.isError ||
+    jobExplanationsQuery.isError;
+  return (
+    <>
+      <RunAnnotationLiveRegion entries={resolvedEntries} />
+      {query.isError ? (
+        <RunAnnotationResourceError
+          query={query}
+          subject="annotations"
+          hasStaleContent={entries !== undefined}
+        />
+      ) : null}
+      {jobExplanationsQuery.isError ? (
+        <RunAnnotationResourceError
+          query={jobExplanationsQuery}
+          subject="job explanations"
+          hasStaleContent={derivedAnnotations !== undefined}
+        />
+      ) : null}
+
+      <RunAnnotationListContent
+        hasContent={hasContent}
+        hasUnknownContent={hasUnknownContent}
+        isWaitingForContent={isWaitingForContent}
+        filtered={filtered}
+        filteredJobName={filteredJobName}
+        filteredSeverity={filteredSeverity}
+        incomplete={query.hasNextPage || jobExplanationsQuery.hasNextPage}
+        onClearFilters={onClearFilters}
+        derivedAnnotations={visibleDerivedAnnotations}
+        entries={visibleEntries}
+        workspaceSlug={workspaceSlug}
+        projectSlug={projectSlug}
+        workflowRunId={workflowRunId}
+        runAttempt={runAttempt}
+      />
+      <RunAnnotationPagination
+        hiddenCount={hiddenCount}
+        totalCount={totalCount}
+        query={query}
+        jobExplanationsQuery={jobExplanationsQuery}
+        onShowMore={() => setVisibleCount((current) => current + RENDER_WINDOW)}
+      />
+    </>
+  );
+}
+
+function RunAnnotationListContent({
+  hasContent,
+  hasUnknownContent,
+  isWaitingForContent,
+  filtered,
+  filteredJobName,
+  filteredSeverity,
+  incomplete,
+  onClearFilters,
+  derivedAnnotations,
+  entries,
+  workspaceSlug,
+  projectSlug,
+  workflowRunId,
+  runAttempt,
+}: {
+  hasContent: boolean;
+  hasUnknownContent: boolean;
+  isWaitingForContent: boolean;
+  filtered: boolean;
+  filteredJobName: string | undefined;
+  filteredSeverity: string | undefined;
+  incomplete: boolean;
+  onClearFilters: (() => void) | undefined;
+  derivedAnnotations: readonly DerivedRunAnnotation[];
+  entries: readonly RunAnnotationEntry[];
+  workspaceSlug: string | undefined;
+  projectSlug: string | undefined;
+  workflowRunId: string;
+  runAttempt: number | undefined;
+}): ReactNode {
+  if (hasUnknownContent && !hasContent) {
+    return isWaitingForContent ? <RunAnnotationListSkeleton /> : null;
+  }
   if (!hasContent) {
-    content = filtered ? (
+    return filtered ? (
       <RunAnnotationsFilteredEmpty
         jobName={filteredJobName}
         severity={filteredSeverity}
-        incomplete={query.hasNextPage}
+        incomplete={incomplete}
         onClearFilters={onClearFilters}
       />
     ) : (
       <RunAnnotationsEmpty />
     );
-  } else {
-    content = (
-      <PanelBody asChild>
-        <ol>
-          {/* A job that failed before it ever created an execution is the most upstream thing
-              in the run, and it has no step to link to. It leads rather than trailing behind a
-              render window that could bury it. */}
-          {derivedAnnotations.map((annotation) => (
-            <RunDerivedAnnotationItem
-              key={annotation.id}
-              style={annotation.style}
-              jobName={annotation.jobName}
-              body={annotation.body}
-            />
-          ))}
-          {visible.map((entry) => (
-            <RunAnnotationItem
-              key={entry.annotation.id}
-              entry={entry}
-              workspaceSlug={workspaceSlug}
-              projectSlug={projectSlug}
-              workflowRunId={workflowRunId}
-              runAttempt={runAttempt}
-            />
-          ))}
-        </ol>
-      </PanelBody>
-    );
   }
+  return (
+    <PanelBody asChild>
+      <ol>
+        {/* A job that failed before it ever created an execution is the most upstream thing
+            in the run, and it has no step to link to. It leads rather than trailing behind a
+            render window that could bury it. */}
+        {derivedAnnotations.map((annotation) => (
+          <RunDerivedAnnotationItem
+            key={annotation.id}
+            style={annotation.style}
+            jobName={annotation.jobName}
+            body={annotation.body}
+          />
+        ))}
+        {entries.map((entry) => (
+          <RunAnnotationItem
+            key={entry.annotation.id}
+            entry={entry}
+            workspaceSlug={workspaceSlug}
+            projectSlug={projectSlug}
+            workflowRunId={workflowRunId}
+            runAttempt={runAttempt}
+          />
+        ))}
+      </ol>
+    </PanelBody>
+  );
+}
 
-  let footer: ReactNode = null;
+function RunAnnotationPagination({
+  hiddenCount,
+  totalCount,
+  query,
+  jobExplanationsQuery,
+  onShowMore,
+}: {
+  hiddenCount: number;
+  totalCount: number;
+  query: RunAnnotationListQuery;
+  jobExplanationsQuery: RunAnnotationListQuery;
+  onShowMore: () => void;
+}): ReactNode {
   if (hiddenCount > 0) {
-    footer = (
+    return (
       <RunAnnotationListFooter>
         <Button
           type="button"
           size="sm"
           variant="secondary"
           className="[@media(pointer:coarse)]:min-h-44"
-          onClick={() => setVisibleCount((current) => current + RENDER_WINDOW)}
+          onClick={onShowMore}
         >
           Show {Math.min(hiddenCount, RENDER_WINDOW)} more of {totalCount}
         </Button>
       </RunAnnotationListFooter>
     );
-  } else if (query.hasNextPage) {
-    footer = (
-      <RunAnnotationListFooter>
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          className="[@media(pointer:coarse)]:min-h-44"
-          isLoading={query.isFetchingNextPage}
-          onClick={() => {
-            void query.fetchNextPage();
-          }}
-        >
-          Load more annotations
-        </Button>
-      </RunAnnotationListFooter>
-    );
   }
-
+  if (!query.hasNextPage && !jobExplanationsQuery.hasNextPage) return null;
   return (
-    <>
-      <RunAnnotationLiveRegion entries={entries} />
-      {query.isError ? <RunAnnotationStaleError query={query} /> : null}
-
-      {content}
-      {footer}
-    </>
+    <RunAnnotationListFooter>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        className="[@media(pointer:coarse)]:min-h-44"
+        isLoading={query.isFetchingNextPage || jobExplanationsQuery.isFetchingNextPage}
+        onClick={() => void fetchNextAnnotationPages(query, jobExplanationsQuery)}
+      >
+        Load more annotations
+      </Button>
+    </RunAnnotationListFooter>
   );
+}
+
+async function fetchNextAnnotationPages(
+  query: RunAnnotationListQuery,
+  jobExplanationsQuery: RunAnnotationListQuery,
+): Promise<void> {
+  await Promise.all([
+    ...(query.hasNextPage ? [query.fetchNextPage()] : []),
+    ...(jobExplanationsQuery.hasNextPage ? [jobExplanationsQuery.fetchNextPage()] : []),
+  ]);
 }
 
 function RunAnnotationLiveRegion({entries}: {entries: readonly RunAnnotationEntry[]}): ReactNode {
@@ -286,19 +380,28 @@ function RunAnnotationsFilteredEmpty({
 }
 
 /**
- * A failed poll keeps the annotations already on screen and marks them stale rather than
- * clearing. Polite rather than assertive: the poll runs every 4s and a flapping API would
- * otherwise interrupt a screen reader on every cycle.
+ * A failed resource stays distinct from an empty result and keeps any loaded rows on screen.
+ * Polite rather than assertive: a flapping API must not interrupt a screen reader on every poll.
  *
  * A band inside the panel rather than a bordered notice, because the hairline below it already
  * separates it from the rows and a second frame would be a box inside a box.
  */
-function RunAnnotationStaleError({query}: {query: QueryLoadErrorQuery}) {
+function RunAnnotationResourceError({
+  query,
+  subject,
+  hasStaleContent,
+}: {
+  query: QueryLoadErrorQuery;
+  subject: string;
+  hasStaleContent: boolean;
+}) {
   return (
     <div className="border-b border-border-neutral-base bg-background-neutral-base px-row py-row">
       <Callout role="status" aria-live="polite" type="error" variant="secondary">
         <CalloutContent className="flex items-center justify-between gap-inline">
-          <Text size="xs">Could not refresh annotations.</Text>
+          <Text size="xs">
+            Could not {hasStaleContent ? 'refresh' : 'load'} {subject}.
+          </Text>
           <Button
             type="button"
             size="2xs"

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
@@ -105,9 +105,10 @@ export const Playground: Story = {
             id: 'derived-deploy',
             jobId: '44444444-4444-4444-8444-00000000000d',
             jobPosition: 2,
-            style: 'warning',
+            style: 'default',
+            statusLabel: 'Skipped',
             jobName: 'deploy production',
-            body: 'Skipped before an execution was created.\n\nReview its dependencies or condition before re-running.\nReason: `dependency_failed`',
+            body: 'A required job did not succeed, so this job did not run.',
           },
         ]}
       />

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
@@ -3,11 +3,11 @@ import type {Meta, StoryObj} from '@storybook/react';
 import type {ReactNode} from 'react';
 import {
   buildRunAnnotationList,
-  type RunAnnotationEntry,
   type RunAnnotationRecord,
   type RunAnnotationStyle,
   summarizeRunAnnotations,
 } from '#core/run-annotation.js';
+import {runAnnotationEntryFixture} from '#test/fixtures/workflow-run.js';
 import {RunAnnotationCountChip} from './run-annotation-count-chip.js';
 import {
   type DerivedRunAnnotation,
@@ -341,7 +341,7 @@ function annotation(
   };
 }
 
-function annotationEntry(annotation: RunAnnotationRecord): RunAnnotationEntry {
+function annotationEntry(annotation: RunAnnotationRecord) {
   const testJob = annotation.jobId === TEST_JOB_ID;
   let jobName = testJob ? 'test' : 'build';
   let stepLabel = testJob ? 'vitest' : 'run smoke checks';
@@ -349,19 +349,12 @@ function annotationEntry(annotation: RunAnnotationRecord): RunAnnotationEntry {
     jobName = 'Hello world on Anthropic models with Claude';
     stepLabel = UNNAMED_AGENT_STEP;
   }
-  return {
-    annotation,
+  return runAnnotationEntryFixture(annotation, {
     jobName,
     jobPosition: testJob ? 1 : 0,
-    executionSequence: 1,
-    executionLabel: null,
     stepLabel,
-    attemptLabel: 'attempt 1',
     origin: {
-      jobId: annotation.jobId,
-      jobExecutionId: annotation.jobExecutionId,
-      stepId: annotation.originStepId,
       stepAttemptId: testJob ? '66666666-6666-4666-8666-00000000000c' : BUILD_ATTEMPT_ID,
     },
-  };
+  });
 }

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-annotations.stories.tsx
@@ -3,17 +3,11 @@ import type {Meta, StoryObj} from '@storybook/react';
 import type {ReactNode} from 'react';
 import {
   buildRunAnnotationList,
+  type RunAnnotationEntry,
   type RunAnnotationRecord,
   type RunAnnotationStyle,
   summarizeRunAnnotations,
 } from '#core/run-annotation.js';
-import type {Job} from '#core/workflow-run.js';
-import {
-  workflowJob,
-  workflowJobExecutionDto,
-  workflowStepAttemptDto,
-  workflowStepDto,
-} from '#test/fixtures/workflow-run.js';
 import {RunAnnotationCountChip} from './run-annotation-count-chip.js';
 import {
   type DerivedRunAnnotation,
@@ -32,7 +26,6 @@ const TEST_EXECUTION_ID = '77777777-7777-4777-8777-00000000000c';
 const BUILD_STEP_ID = '55555555-5555-4555-8555-00000000000b';
 const TEST_STEP_ID = '55555555-5555-4555-8555-00000000000c';
 const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
-const TEST_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000c';
 
 const LONG_BODY = [
   '### Failing specs',
@@ -110,6 +103,8 @@ export const Playground: Story = {
         derivedAnnotations={[
           {
             id: 'derived-deploy',
+            jobId: '44444444-4444-4444-8444-00000000000d',
+            jobPosition: 2,
             style: 'warning',
             jobName: 'deploy production',
             body: 'Skipped before an execution was created.\n\nReview its dependencies or condition before re-running.\nReason: `dependency_failed`',
@@ -199,7 +194,6 @@ export const DataStates: Story = {
                 body: 'Reason: `agent_config_invalid`',
               }),
             ]}
-            jobs={jobsWithUnnamedAgentStep}
           />
         </StateExample>
       </div>
@@ -257,9 +251,9 @@ function AnnotationsFrame({
  */
 function AnnotationsList({
   annotations,
-  derivedAnnotations,
-  jobs: jobsOverride,
+  derivedAnnotations = [],
   query = storyQuery(),
+  jobExplanationsQuery = storyQuery(),
   filtered = false,
   filteredJobName,
   filteredSeverity,
@@ -267,15 +261,13 @@ function AnnotationsList({
 }: {
   annotations: RunAnnotationRecord[];
   derivedAnnotations?: readonly DerivedRunAnnotation[];
-  jobs?: Job[];
   query?: RunAnnotationListQuery;
+  jobExplanationsQuery?: RunAnnotationListQuery;
   filtered?: boolean;
   filteredJobName?: string;
   filteredSeverity?: string;
   summary?: ReturnType<typeof summarizeRunAnnotations>;
 }) {
-  const resolvedJobs = jobsOverride ?? jobs;
-
   return (
     <Panel>
       {summary ? (
@@ -290,10 +282,11 @@ function AnnotationsList({
       ) : null}
       <RunAnnotationList
         query={query}
+        jobExplanationsQuery={jobExplanationsQuery}
         entries={
           query.data === undefined
             ? undefined
-            : buildRunAnnotationList({annotations, jobs: resolvedJobs})
+            : buildRunAnnotationList({entries: annotations.map(annotationEntry)})
         }
         derivedAnnotations={derivedAnnotations}
         workspaceSlug={WORKSPACE_SLUG}
@@ -348,72 +341,27 @@ function annotation(
   };
 }
 
-const jobs: Job[] = [
-  workflowJob({
-    id: BUILD_JOB_ID,
-    key: 'build',
-    name: 'build',
-    position: 0,
-    job_executions: [
-      workflowJobExecutionDto({
-        id: BUILD_EXECUTION_ID,
-        job_id: BUILD_JOB_ID,
-        steps: [
-          workflowStepDto({
-            id: BUILD_STEP_ID,
-            name: 'run smoke checks',
-            attempts: [
-              workflowStepAttemptDto({id: BUILD_ATTEMPT_ID, step_id: BUILD_STEP_ID, attempt: 1}),
-            ],
-          }),
-        ],
-      }),
-    ],
-  }),
-  workflowJob({
-    id: TEST_JOB_ID,
-    key: 'test',
-    name: 'test',
-    position: 1,
-    job_executions: [
-      workflowJobExecutionDto({
-        id: TEST_EXECUTION_ID,
-        job_id: TEST_JOB_ID,
-        steps: [
-          workflowStepDto({
-            id: TEST_STEP_ID,
-            name: 'vitest',
-            attempts: [
-              workflowStepAttemptDto({id: TEST_ATTEMPT_ID, step_id: TEST_STEP_ID, attempt: 1}),
-            ],
-          }),
-        ],
-      }),
-    ],
-  }),
-];
-
-const jobsWithUnnamedAgentStep: Job[] = [
-  jobs[0] as Job,
-  workflowJob({
-    id: TEST_JOB_ID,
-    key: 'test',
-    name: 'Hello world on Anthropic models with Claude',
-    position: 1,
-    job_executions: [
-      workflowJobExecutionDto({
-        id: TEST_EXECUTION_ID,
-        job_id: TEST_JOB_ID,
-        steps: [
-          workflowStepDto({
-            id: TEST_STEP_ID,
-            name: UNNAMED_AGENT_STEP,
-            attempts: [
-              workflowStepAttemptDto({id: TEST_ATTEMPT_ID, step_id: TEST_STEP_ID, attempt: 1}),
-            ],
-          }),
-        ],
-      }),
-    ],
-  }),
-];
+function annotationEntry(annotation: RunAnnotationRecord): RunAnnotationEntry {
+  const testJob = annotation.jobId === TEST_JOB_ID;
+  let jobName = testJob ? 'test' : 'build';
+  let stepLabel = testJob ? 'vitest' : 'run smoke checks';
+  if (annotation.id === 'unnamed') {
+    jobName = 'Hello world on Anthropic models with Claude';
+    stepLabel = UNNAMED_AGENT_STEP;
+  }
+  return {
+    annotation,
+    jobName,
+    jobPosition: testJob ? 1 : 0,
+    executionSequence: 1,
+    executionLabel: null,
+    stepLabel,
+    attemptLabel: 'attempt 1',
+    origin: {
+      jobId: annotation.jobId,
+      jobExecutionId: annotation.jobExecutionId,
+      stepId: annotation.originStepId,
+      stepAttemptId: testJob ? '66666666-6666-4666-8666-00000000000c' : BUILD_ATTEMPT_ID,
+    },
+  };
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.test.ts
@@ -4,7 +4,7 @@ import {presentRunJobExplanation} from './run-job-explanation.js';
 
 describe('presentRunJobExplanation', () => {
   test.each([
-    ['dependency_not_completed', 'A required job did not succeed, so this job did not run.'],
+    ['dependency_not_completed', 'A required job did not complete, so this job did not run.'],
     ['default_gate_rejected', 'A required job did not succeed, so this job did not run.'],
     ['condition_false', 'Its condition evaluated to false, so this job did not run.'],
     ['condition_rejected', 'Its condition evaluated to false, so this job did not run.'],
@@ -80,7 +80,6 @@ describe('presentRunJobExplanation', () => {
     expect(presentation.body).toContain(
       "Shipfox could not evaluate this job's success condition. Review the condition and the values it references.",
     );
-    expect(presentation.body).not.toContain('Check runner availability');
   });
 
   test('does not invent recovery advice when a failed job has no reason', () => {

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.test.ts
@@ -1,0 +1,123 @@
+import type {EvaluationTraceValueEntry} from '#core/entities/step-attempt.js';
+import type {RunJobExplanation} from '#core/run-annotation.js';
+import {presentRunJobExplanation} from './run-job-explanation.js';
+
+describe('presentRunJobExplanation', () => {
+  test.each([
+    ['dependency_not_completed', 'A required job did not succeed, so this job did not run.'],
+    ['default_gate_rejected', 'A required job did not succeed, so this job did not run.'],
+    ['condition_false', 'Its condition evaluated to false, so this job did not run.'],
+    ['condition_rejected', 'Its condition evaluated to false, so this job did not run.'],
+  ] as const)('presents the expected %s skip neutrally', (statusReason, body) => {
+    const presentation = presentRunJobExplanation(explanation({statusReason}));
+
+    expect(presentation).toEqual({style: 'default', statusLabel: 'Skipped', body});
+  });
+
+  test('makes a condition evaluation error actionable', () => {
+    const presentation = presentRunJobExplanation(
+      explanation({
+        statusReason: 'condition_errored',
+        evaluationTrace: [evaluationTrace({degraded: true})],
+      }),
+    );
+
+    expect(presentation).toMatchObject({
+      style: 'warning',
+      statusLabel: 'Skipped',
+      body: expect.stringContaining(
+        "Shipfox could not evaluate this job's condition. Review the condition and the values it references.",
+      ),
+    });
+    expect(presentation.body).toContain('Condition evaluation:');
+    expect(presentation.body).toContain('`job.if` evaluated `needs.build.result == "succeeded"`');
+  });
+
+  test.each([
+    ['user_cancelled', 'This job did not run because it was cancelled.'],
+    ['run_cancelled', 'This job did not run because the run was cancelled.'],
+  ] as const)('presents the expected %s cancellation neutrally', (statusReason, body) => {
+    const presentation = presentRunJobExplanation(explanation({statusReason}));
+
+    expect(presentation).toEqual({style: 'default', statusLabel: 'Skipped', body});
+  });
+
+  test('calls attention to a skipped job with no recorded reason', () => {
+    const presentation = presentRunJobExplanation(explanation({statusReason: 'unknown'}));
+
+    expect(presentation).toEqual({
+      style: 'warning',
+      statusLabel: 'Skipped',
+      body: 'This job did not run. Shipfox did not record a reason.',
+    });
+  });
+
+  test('explains a rejected job success condition', () => {
+    const presentation = presentRunJobExplanation(
+      explanation({
+        status: 'failed',
+        statusReason: 'step_failed',
+        evaluationTrace: [evaluationTrace({field: 'job.success', value: 'false'})],
+      }),
+    );
+
+    expect(presentation).toMatchObject({
+      style: 'error',
+      statusLabel: 'Failed',
+      body: expect.stringContaining('Its success condition evaluated to false.'),
+    });
+  });
+
+  test('makes a degraded job success condition actionable', () => {
+    const presentation = presentRunJobExplanation(
+      explanation({
+        status: 'failed',
+        statusReason: 'unknown',
+        evaluationTrace: [evaluationTrace({field: 'job.success', value: '', degraded: true})],
+      }),
+    );
+
+    expect(presentation.body).toContain(
+      "Shipfox could not evaluate this job's success condition. Review the condition and the values it references.",
+    );
+    expect(presentation.body).not.toContain('Check runner availability');
+  });
+
+  test('does not invent recovery advice when a failed job has no reason', () => {
+    const presentation = presentRunJobExplanation(
+      explanation({status: 'failed', statusReason: 'unknown'}),
+    );
+
+    expect(presentation).toEqual({
+      style: 'error',
+      statusLabel: 'Failed',
+      body: 'This job failed without running any work. Shipfox did not record a reason.',
+    });
+  });
+});
+
+function explanation(overrides: Partial<RunJobExplanation> = {}): RunJobExplanation {
+  return {
+    jobId: '44444444-4444-4444-8444-00000000000d',
+    jobName: 'deploy',
+    jobPosition: 1,
+    status: 'skipped',
+    statusReason: 'condition_rejected',
+    evaluationTrace: null,
+    ...overrides,
+  };
+}
+
+function evaluationTrace(
+  overrides: Partial<EvaluationTraceValueEntry> = {},
+): EvaluationTraceValueEntry {
+  return {
+    expression: 'needs.build.result == "succeeded"',
+    roots: ['needs'],
+    fillTarget: 'job.if',
+    evaluatedAt: '2026-09-04T10:00:00.000Z',
+    field: 'job.if',
+    value: 'false',
+    ...overrides,
+  };
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.ts
@@ -1,0 +1,99 @@
+import type {RunAnnotationStyle, RunJobExplanation} from '#core/run-annotation.js';
+
+export interface RunJobExplanationPresentation {
+  style: RunAnnotationStyle;
+  statusLabel: 'Skipped' | 'Failed';
+  body: string;
+}
+
+const EXPECTED_SKIP_REASONS = new Set<RunJobExplanation['statusReason']>([
+  'dependency_not_completed',
+  'default_gate_rejected',
+  'condition_false',
+  'condition_rejected',
+  'user_cancelled',
+  'run_cancelled',
+]);
+
+export function presentRunJobExplanation(
+  explanation: RunJobExplanation,
+): RunJobExplanationPresentation {
+  const traceSummary = formatConditionEvaluation(explanation.evaluationTrace);
+  const summary =
+    explanation.status === 'skipped'
+      ? skippedJobSummary(explanation.statusReason)
+      : failedJobSummary(explanation);
+
+  return {
+    style: explanationStyle(explanation),
+    statusLabel: explanation.status === 'skipped' ? 'Skipped' : 'Failed',
+    body: [summary, traceSummary].filter(Boolean).join('\n\n'),
+  };
+}
+
+function explanationStyle(explanation: RunJobExplanation): RunAnnotationStyle {
+  if (explanation.status === 'failed') return 'error';
+  return EXPECTED_SKIP_REASONS.has(explanation.statusReason) ? 'default' : 'warning';
+}
+
+function skippedJobSummary(reason: RunJobExplanation['statusReason']): string {
+  switch (reason) {
+    case 'dependency_not_completed':
+    case 'default_gate_rejected':
+      return 'A required job did not succeed, so this job did not run.';
+    case 'condition_false':
+    case 'condition_rejected':
+      return 'Its condition evaluated to false, so this job did not run.';
+    case 'condition_errored':
+      return "Shipfox could not evaluate this job's condition. Review the condition and the values it references.";
+    case 'user_cancelled':
+      return 'This job did not run because it was cancelled.';
+    case 'run_cancelled':
+      return 'This job did not run because the run was cancelled.';
+    case null:
+    case 'unknown':
+      return 'This job did not run. Shipfox did not record a reason.';
+    default:
+      return 'This job did not run.';
+  }
+}
+
+function failedJobSummary(explanation: RunJobExplanation): string {
+  const successConditionTrace = explanation.evaluationTrace?.filter(
+    (entry) => !('dropped' in entry) && entry.field === 'job.success',
+  );
+
+  if (!successConditionTrace?.length && explanation.statusReason === 'step_failed') {
+    return 'Its success condition evaluated to false.';
+  }
+  if (
+    !successConditionTrace?.length &&
+    explanation.statusReason !== null &&
+    explanation.statusReason !== 'unknown'
+  ) {
+    return 'This job failed without running any work.';
+  }
+  if (!successConditionTrace?.length) {
+    return 'This job failed without running any work. Shipfox did not record a reason.';
+  }
+  if (successConditionTrace.some((entry) => !('dropped' in entry) && entry.degraded)) {
+    return "Shipfox could not evaluate this job's success condition. Review the condition and the values it references.";
+  }
+  return 'Its success condition evaluated to false.';
+}
+
+function formatConditionEvaluation(trace: RunJobExplanation['evaluationTrace']): string | null {
+  if (!trace?.length) return null;
+
+  return [
+    'Condition evaluation:',
+    ...trace.map((entry) => {
+      if ('dropped' in entry) {
+        return `- ${entry.dropped} additional evaluation${entry.dropped === 1 ? '' : 's'} not recorded`;
+      }
+      const value =
+        entry.value === undefined || entry.value === '' ? '(empty)' : `\`${entry.value}\``;
+      return `- \`${entry.field}\` evaluated \`${entry.expression}\` to ${value}${entry.degraded ? ' (degraded)' : ''}`;
+    }),
+  ].join('\n');
+}

--- a/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.ts
+++ b/libs/client/workflows/src/components/workflow-run-tabs/run-job-explanation.ts
@@ -39,6 +39,7 @@ function explanationStyle(explanation: RunJobExplanation): RunAnnotationStyle {
 function skippedJobSummary(reason: RunJobExplanation['statusReason']): string {
   switch (reason) {
     case 'dependency_not_completed':
+      return 'A required job did not complete, so this job did not run.';
     case 'default_gate_rejected':
       return 'A required job did not succeed, so this job did not run.';
     case 'condition_false':

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.stories.tsx
@@ -1,6 +1,8 @@
 import type {AnnotationDto} from '@shipfox/annotations-dto';
 import type {
+  WorkflowRunAnnotationItemDto,
   WorkflowRunDetailResponseDto,
+  WorkflowRunJobExplanationDto,
   WorkflowRunJobOverviewDto,
   WorkflowRunOverviewResponseDto,
 } from '@shipfox/api-workflows-dto';
@@ -30,10 +32,27 @@ const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
 function responseForPath(
   path: string,
   annotations: readonly AnnotationDto[],
+  explanations: readonly WorkflowRunJobExplanationDto[],
   workflowSize: 'complete' | 'large',
 ) {
-  if (path === '/annotations') {
-    return {body: {annotations, has_more: false, next_cursor: null}, status: 200};
+  if (path === `/workflows/runs/${RUN_ID}/annotations`) {
+    return {body: {items: annotations.map(annotationItemDto), next_cursor: null}, status: 200};
+  }
+  if (path === `/workflows/runs/${RUN_ID}/job-explanations`) {
+    return {body: {items: explanations, next_cursor: null}, status: 200};
+  }
+  if (path === '/annotations/summary') {
+    return {
+      body: {
+        total: annotations.length,
+        error: annotations.filter(({style}) => style === 'error').length,
+        warning: annotations.filter(({style}) => style === 'warning').length,
+        info: annotations.filter(({style}) => style === 'info').length,
+        success: annotations.filter(({style}) => style === 'success').length,
+        step_counts: [],
+      },
+      status: 200,
+    };
   }
   if (path === `/workflows/runs/${RUN_ID}/attempts`) {
     return {body: RUN_ATTEMPTS_RESPONSE, status: 200};
@@ -170,7 +189,8 @@ const RUN_OVERVIEW_RESPONSE: WorkflowRunOverviewResponseDto = {
         id: '44444444-4444-4444-8444-00000000000d',
         key: 'notify',
         name: 'notify',
-        status: 'succeeded',
+        status: 'skipped',
+        status_reason: 'condition_rejected',
         position: 2,
         dependencies: ['deploy'],
       }),
@@ -226,6 +246,7 @@ function overviewJobDto(
 
 /** Stable identity: a fresh `[]` per render would retrigger the API-client effect every render. */
 const NO_ANNOTATIONS: AnnotationDto[] = [];
+const NO_JOB_EXPLANATIONS: WorkflowRunJobExplanationDto[] = [];
 
 const RUN_ANNOTATIONS: AnnotationDto[] = [
   annotationDto({
@@ -251,9 +272,23 @@ const RUN_ANNOTATIONS: AnnotationDto[] = [
   }),
 ];
 
+const RUN_JOB_EXPLANATIONS: WorkflowRunJobExplanationDto[] = [
+  {
+    job_id: '44444444-4444-4444-8444-00000000000d',
+    job_label: 'notify',
+    job_position: 2,
+    status: 'skipped',
+    status_reason: 'condition_rejected',
+    evaluation_trace: null,
+  },
+];
+
 const withRunApi: Decorator = (Story, context) => (
   <RunWorkspaceStoryProviders
     annotations={(context.parameters.annotations ?? NO_ANNOTATIONS) as AnnotationDto[]}
+    explanations={
+      (context.parameters.explanations ?? NO_JOB_EXPLANATIONS) as WorkflowRunJobExplanationDto[]
+    }
     workflowSize={context.parameters.workflowSize === 'large' ? 'large' : 'complete'}
   >
     <Story />
@@ -306,7 +341,7 @@ export const WideViewport: Story = {};
  * its rows sit against the run header and the frame gutters.
  */
 export const Annotations: Story = {
-  parameters: {annotations: RUN_ANNOTATIONS},
+  parameters: {annotations: RUN_ANNOTATIONS, explanations: RUN_JOB_EXPLANATIONS},
   args: {tab: 'annotations'},
 };
 
@@ -328,12 +363,32 @@ function annotationDto(overrides: Partial<AnnotationDto> & {id: string}): Annota
   };
 }
 
+function annotationItemDto(annotation: AnnotationDto): WorkflowRunAnnotationItemDto {
+  return {
+    annotation,
+    origin: {
+      job_id: annotation.job_id,
+      job_label: 'build',
+      job_position: 0,
+      job_execution_id: annotation.job_execution_id,
+      execution_sequence: 1,
+      execution_label: null,
+      step_id: annotation.origin_step_id,
+      step_label: 'run smoke checks',
+      step_attempt_id: BUILD_ATTEMPT_ID,
+      step_attempt: annotation.origin_step_attempt,
+    },
+  };
+}
+
 function RunWorkspaceStoryProviders({
   annotations,
+  explanations,
   workflowSize,
   children,
 }: {
   annotations: AnnotationDto[];
+  explanations: WorkflowRunJobExplanationDto[];
   workflowSize: 'complete' | 'large';
   children: ReactNode;
 }) {
@@ -351,7 +406,7 @@ function RunWorkspaceStoryProviders({
         else if (input instanceof URL) url = input.href;
         else url = String(input);
         const path = new URL(url, 'https://api.example.test').pathname;
-        const response = responseForPath(path, annotations, workflowSize);
+        const response = responseForPath(path, annotations, explanations, workflowSize);
         return new Response(JSON.stringify(response.body), {
           status: response.status,
           headers: {'content-type': 'application/json'},
@@ -363,7 +418,7 @@ function RunWorkspaceStoryProviders({
     return () => {
       configureApiClient({baseUrl: '', fetchImpl: undefined});
     };
-  }, [annotations, workflowSize]);
+  }, [annotations, explanations, workflowSize]);
 
   if (!configured) return null;
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -1,5 +1,9 @@
 import type {AnnotationDto} from '@shipfox/annotations-dto';
-import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
+import type {
+  WorkflowRunAnnotationItemDto,
+  WorkflowRunDetailResponseDto,
+  WorkflowRunJobExplanationDto,
+} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,6 +11,7 @@ import {
   workflowJobDto,
   workflowJobExecutionDto,
   workflowRunDetailDto,
+  workflowRunOverviewResponseDto,
   workflowStepAttemptDto,
   workflowStepDto,
 } from '#test/fixtures/workflow-run.js';
@@ -24,6 +29,7 @@ const ANNOTATION_ID_ONE = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001';
 const ANNOTATION_ID_TWO = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002';
 const TASK_NINE_PATTERN = /Task nine/;
 const SHOW_MORE_PATTERN = /Show \d+ more/;
+const CONDITION_REJECTED_PATTERN = /condition_rejected/;
 
 describe('WorkflowRunView', () => {
   beforeEach(() => {
@@ -185,20 +191,60 @@ describe('WorkflowRunView', () => {
   });
 
   test('shows a failed annotations read as an error, never as an empty run', async () => {
+    const detail = workflowRunViewDetailDto();
     configureApiClient({
-      fetchImpl: vi.fn((input: RequestInfo | URL) =>
-        Promise.resolve(
-          requestUrl(input).includes('/annotations')
-            ? jsonResponse({code: 'internal'}, {status: 500})
-            : jsonResponse(workflowRunViewDetailDto()),
-        ),
-      ),
+      fetchImpl: vi.fn((input: RequestInfo | URL) => {
+        const path = new URL(requestUrl(input), 'https://api.example.test').pathname;
+        if (path === `/workflows/runs/${RUN_ID}/annotations`) {
+          return Promise.resolve(jsonResponse({code: 'internal'}, {status: 500}));
+        }
+        return Promise.resolve(jsonResponse(runResourceResponse(path, detail)));
+      }),
     });
 
     renderView({tab: 'annotations'});
 
-    expect(await screen.findByRole('button', {name: 'Retry loading annotations'})).toBeVisible();
+    expect(await screen.findByText('Could not load annotations.')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeVisible();
     expect(screen.queryByText('This run has no annotations to show.')).not.toBeInTheDocument();
+  });
+
+  test('renders server-owned explanations for jobs that never created an execution', async () => {
+    configureRunFetch([], {}, {}, [
+      {
+        job_id: DEPLOY_JOB_ID,
+        job_label: 'deploy',
+        job_position: 1,
+        status: 'skipped',
+        status_reason: 'condition_rejected',
+        evaluation_trace: null,
+      },
+    ]);
+
+    renderView({tab: 'annotations'});
+
+    expect(await screen.findByRole('heading', {level: 3, name: 'deploy'})).toBeInTheDocument();
+    const explanation = (await screen.findByRole('heading', {level: 3, name: 'deploy'})).closest(
+      'li',
+    );
+    expect(explanation).toHaveTextContent('Skipped before an execution was created.');
+    expect(explanation).toHaveTextContent(CONDITION_REJECTED_PATTERN);
+  });
+
+  test('opens annotations without loading the legacy full run tree', async () => {
+    const fetchImpl = configureRunFetch([
+      annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage'}),
+    ]);
+
+    renderView({tab: 'annotations'});
+
+    await screen.findByRole('heading', {level: 3, name: 'coverage'});
+    expect(
+      fetchImpl.mock.calls.some(([input]) => {
+        const url = new URL(requestUrl(input as RequestInfo | URL), 'https://api.example.test');
+        return url.pathname === `/workflows/runs/${RUN_ID}`;
+      }),
+    ).toBe(false);
   });
 
   test('bounds how many annotation bodies render at once', async () => {
@@ -239,7 +285,7 @@ describe('WorkflowRunView', () => {
     configureRunFetch(
       [annotationDto({id: ANNOTATION_ID_ONE, context: 'coverage', style: 'info'})],
       {},
-      {has_more: true, next_cursor: 'next-page'},
+      {next_cursor: 'next-page'},
     );
 
     renderView({tab: 'annotations', selection: {severity: 'error'}});
@@ -287,21 +333,22 @@ describe('WorkflowRunView', () => {
   });
 
   test('renders the captured workflow source in the Source section', async () => {
+    const detail = workflowRunViewDetailDto({
+      source_snapshot: {format: 'yaml', content: 'jobs:\n  build:\n    steps: []'},
+    });
     configureApiClient({
       fetchImpl: vi.fn((input: RequestInfo | URL) => {
-        const detail = workflowRunViewDetailDto({
-          source_snapshot: {format: 'yaml', content: 'jobs:\n  build:\n    steps: []'},
-        });
+        const path = new URL(requestUrl(input), 'https://api.example.test').pathname;
         return Promise.resolve(
           jsonResponse(
-            requestUrl(input).includes('/source')
+            path === `/workflows/runs/${RUN_ID}/source`
               ? {
                   kind: 'available',
                   workflow_run_id: RUN_ID,
                   workflow_run_attempt: detail.run_attempt.attempt,
                   source_snapshot: detail.source_snapshot,
                 }
-              : detail,
+              : runResourceResponse(path, detail),
           ),
         );
       }),
@@ -350,48 +397,56 @@ function requestUrl(input: RequestInfo | URL): string {
   return input instanceof URL ? input.href : input.url;
 }
 
-/** Routes the run detail and the annotations read, which are two independent fetches. */
+/** Routes the independently loaded run workspace resources. */
 function configureRunFetch(
   annotations: AnnotationDto[] = [],
   runOverrides: Partial<WorkflowRunDetailResponseDto> = {},
-  annotationPageOverrides: Partial<{has_more: boolean; next_cursor: string | null}> = {},
+  annotationPageOverrides: Partial<{next_cursor: string | null}> = {},
+  explanations: WorkflowRunJobExplanationDto[] = [],
 ) {
-  configureApiClient({
-    fetchImpl: vi.fn((input: RequestInfo | URL) => {
-      const url = requestUrl(input);
-      const detail = workflowRunViewDetailDto(runOverrides);
-      if (url.includes('/annotations')) {
-        return Promise.resolve(
-          jsonResponse({
-            annotations,
-            has_more: false,
-            next_cursor: null,
-            ...annotationPageOverrides,
-          }),
-        );
-      }
-      if (url.includes('/source')) {
-        return Promise.resolve(
-          jsonResponse(
-            detail.source_snapshot
-              ? {
-                  kind: 'available',
-                  workflow_run_id: RUN_ID,
-                  workflow_run_attempt: detail.run_attempt.attempt,
-                  source_snapshot: detail.source_snapshot,
-                }
-              : {
-                  kind: 'unavailable',
-                  workflow_run_id: RUN_ID,
-                  workflow_run_attempt: detail.run_attempt.attempt,
-                  reason: detail.origin === 'dev' ? 'temporary_run' : 'pre_snapshot_run',
-                },
-          ),
-        );
-      }
-      return Promise.resolve(jsonResponse(detail));
-    }),
+  const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+    const path = new URL(requestUrl(input), 'https://api.example.test').pathname;
+    const detail = workflowRunViewDetailDto(runOverrides);
+    if (path === `/workflows/runs/${RUN_ID}/annotations`) {
+      return Promise.resolve(
+        jsonResponse({
+          items: annotations.map(annotationItemDto),
+          next_cursor: null,
+          ...annotationPageOverrides,
+        }),
+      );
+    }
+    if (path === `/workflows/runs/${RUN_ID}/job-explanations`) {
+      return Promise.resolve(jsonResponse({items: explanations, next_cursor: null}));
+    }
+    if (path === '/annotations/summary') {
+      return Promise.resolve(jsonResponse(annotationSummaryDto(annotations)));
+    }
+    if (path === `/workflows/runs/${RUN_ID}/source`) {
+      return Promise.resolve(
+        jsonResponse(
+          detail.source_snapshot
+            ? {
+                kind: 'available',
+                workflow_run_id: RUN_ID,
+                workflow_run_attempt: detail.run_attempt.attempt,
+                source_snapshot: detail.source_snapshot,
+              }
+            : {
+                kind: 'unavailable',
+                workflow_run_id: RUN_ID,
+                workflow_run_attempt: detail.run_attempt.attempt,
+                reason: detail.origin === 'dev' ? 'temporary_run' : 'pre_snapshot_run',
+              },
+        ),
+      );
+    }
+    return Promise.resolve(jsonResponse(runResourceResponse(path, detail)));
   });
+  configureApiClient({
+    fetchImpl,
+  });
+  return fetchImpl;
 }
 
 function annotationDto(overrides: Partial<AnnotationDto> & {id: string}): AnnotationDto {
@@ -406,6 +461,54 @@ function annotationDto(overrides: Partial<AnnotationDto> & {id: string}): Annota
     body: 'Body',
     ...overrides,
   };
+}
+
+function annotationItemDto(annotation: AnnotationDto): WorkflowRunAnnotationItemDto {
+  return {
+    annotation,
+    origin: {
+      job_id: annotation.job_id,
+      job_label: 'build',
+      job_position: 0,
+      job_execution_id: annotation.job_execution_id,
+      execution_sequence: 1,
+      execution_label: null,
+      step_id: annotation.origin_step_id,
+      step_label: 'checkout',
+      step_attempt_id: BUILD_ATTEMPT_ID,
+      step_attempt: annotation.origin_step_attempt,
+    },
+  };
+}
+
+function annotationSummaryDto(annotations: readonly AnnotationDto[]) {
+  return {
+    total: annotations.length,
+    error: annotations.filter(({style}) => style === 'error').length,
+    warning: annotations.filter(({style}) => style === 'warning').length,
+    info: annotations.filter(({style}) => style === 'info').length,
+    success: annotations.filter(({style}) => style === 'success').length,
+    step_counts: [],
+  };
+}
+
+function runResourceResponse(path: string, detail: WorkflowRunDetailResponseDto) {
+  if (path === `/workflows/runs/${RUN_ID}/head`) {
+    return {
+      current_attempt: detail.current_attempt,
+      latest_attempt: detail.latest_attempt,
+      current_status: detail.status,
+      updated_at: detail.updated_at,
+    };
+  }
+  if (path === `/workflows/runs/${RUN_ID}/overview`) {
+    return workflowRunOverviewResponseDto(detail);
+  }
+  if (path === `/workflows/runs/${RUN_ID}/job-explanations`) {
+    return {items: [], next_cursor: null};
+  }
+  if (path === '/annotations/summary') return annotationSummaryDto([]);
+  return detail;
 }
 
 function workflowRunViewDetailDto(
@@ -455,7 +558,13 @@ function workflowRunViewDetailDto(
         status: 'running',
         position: 1,
         dependencies: ['build'],
-        steps: [workflowStepDto({name: 'deploy', status: 'running'})],
+        job_executions: [
+          workflowJobExecutionDto({
+            job_id: DEPLOY_JOB_ID,
+            status: 'running',
+            steps: [workflowStepDto({name: 'deploy', status: 'running'})],
+          }),
+        ],
       }),
     ],
     ...overrides,

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -30,7 +30,6 @@ const ANNOTATION_ID_ONE = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001';
 const ANNOTATION_ID_TWO = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002';
 const TASK_NINE_PATTERN = /Task nine/;
 const SHOW_MORE_PATTERN = /Show \d+ more/;
-const CONDITION_REJECTED_PATTERN = /condition_rejected/;
 
 describe('WorkflowRunView', () => {
   beforeEach(() => {
@@ -245,8 +244,11 @@ describe('WorkflowRunView', () => {
     const explanation = (await screen.findByRole('heading', {level: 3, name: 'deploy'})).closest(
       'li',
     );
-    expect(explanation).toHaveTextContent('Skipped before an execution was created.');
-    expect(explanation).toHaveTextContent(CONDITION_REJECTED_PATTERN);
+    expect(explanation).toHaveTextContent('Skipped');
+    expect(explanation).toHaveTextContent(
+      'Its condition evaluated to false, so this job did not run.',
+    );
+    expect(explanation).not.toHaveTextContent('condition_rejected');
   });
 
   test('filters to a job that exists only in job explanations', async () => {
@@ -270,7 +272,27 @@ describe('WorkflowRunView', () => {
       level: 3,
       name: 'archived deploy',
     });
-    expect(explanation.closest('li')).toHaveTextContent('Skipped before an execution was created.');
+    expect(explanation.closest('li')).toHaveTextContent(
+      'Its condition evaluated to false, so this job did not run.',
+    );
+  });
+
+  test('does not present an expected skip as a warning', async () => {
+    configureRunFetch([], {}, {}, [
+      {
+        job_id: DEPLOY_JOB_ID,
+        job_label: 'deploy',
+        job_position: 1,
+        status: 'skipped',
+        status_reason: 'condition_rejected',
+        evaluation_trace: null,
+      },
+    ]);
+
+    renderView({tab: 'annotations', selection: {severity: 'warning'}});
+
+    expect(await screen.findByText('No matching annotations')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {level: 3, name: 'deploy'})).not.toBeInTheDocument();
   });
 
   test('loads the next job-explanation page from the shared control', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -22,6 +22,7 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const BUILD_JOB_ID = '77777777-7777-4777-8777-777777777777';
 const DEPLOY_JOB_ID = '88888888-8888-4888-8888-888888888888';
+const ARCHIVED_JOB_ID = '88888888-8888-4888-8888-000000000003';
 const BUILD_EXECUTION_ID = '99999999-9999-4999-8999-000000000001';
 const BUILD_STEP_ID = '55555555-5555-4555-8555-000000000001';
 const BUILD_ATTEMPT_ID = '66666666-6666-4666-8666-000000000001';
@@ -191,12 +192,25 @@ describe('WorkflowRunView', () => {
   });
 
   test('shows a failed annotations read as an error, never as an empty run', async () => {
+    const user = userEvent.setup();
     const detail = workflowRunViewDetailDto();
     configureApiClient({
       fetchImpl: vi.fn((input: RequestInfo | URL) => {
         const path = new URL(requestUrl(input), 'https://api.example.test').pathname;
         if (path === `/workflows/runs/${RUN_ID}/annotations`) {
           return Promise.resolve(jsonResponse({code: 'internal'}, {status: 500}));
+        }
+        if (path === '/annotations/summary') {
+          return Promise.resolve(
+            jsonResponse({
+              total: 3,
+              error: 2,
+              warning: 1,
+              info: 0,
+              success: 0,
+              step_counts: [],
+            }),
+          );
         }
         return Promise.resolve(jsonResponse(runResourceResponse(path, detail)));
       }),
@@ -205,7 +219,11 @@ describe('WorkflowRunView', () => {
     renderView({tab: 'annotations'});
 
     expect(await screen.findByText('Could not load annotations.')).toBeVisible();
-    expect(screen.getByRole('button', {name: 'Retry'})).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Retry loading annotations'})).toBeVisible();
+    expect(screen.getByText('3 annotations')).toBeVisible();
+    await user.click(screen.getByRole('combobox', {name: 'Filter annotations by job'}));
+    expect(await screen.findByRole('option', {name: 'build'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'deploy'})).toBeInTheDocument();
     expect(screen.queryByText('This run has no annotations to show.')).not.toBeInTheDocument();
   });
 
@@ -229,6 +247,61 @@ describe('WorkflowRunView', () => {
     );
     expect(explanation).toHaveTextContent('Skipped before an execution was created.');
     expect(explanation).toHaveTextContent(CONDITION_REJECTED_PATTERN);
+  });
+
+  test('filters to a job that exists only in job explanations', async () => {
+    configureRunFetch([], {}, {}, [
+      {
+        job_id: ARCHIVED_JOB_ID,
+        job_label: 'archived deploy',
+        job_position: 3,
+        status: 'skipped',
+        status_reason: 'condition_rejected',
+        evaluation_trace: null,
+      },
+    ]);
+
+    renderView({tab: 'annotations', selection: {jobId: ARCHIVED_JOB_ID}});
+
+    expect(
+      await screen.findByRole('combobox', {name: 'Filter annotations by job'}),
+    ).toHaveTextContent('archived deploy');
+    const explanation = await screen.findByRole('heading', {
+      level: 3,
+      name: 'archived deploy',
+    });
+    expect(explanation.closest('li')).toHaveTextContent('Skipped before an execution was created.');
+  });
+
+  test('loads the next job-explanation page from the shared control', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = configureRunFetch([], {}, {}, [], {
+      cursor: 'jobs-page-2',
+      items: [
+        {
+          job_id: ARCHIVED_JOB_ID,
+          job_label: 'archived deploy',
+          job_position: 3,
+          status: 'failed',
+          status_reason: 'unknown',
+          evaluation_trace: null,
+        },
+      ],
+    });
+
+    renderView({tab: 'annotations'});
+    await user.click(await screen.findByRole('button', {name: 'Load more annotations'}));
+
+    expect(
+      await screen.findByRole('heading', {level: 3, name: 'archived deploy'}),
+    ).toBeInTheDocument();
+    expect(
+      requestUrls(fetchImpl).some(
+        (url) =>
+          url.pathname === `/workflows/runs/${RUN_ID}/job-explanations` &&
+          url.searchParams.get('cursor') === 'jobs-page-2',
+      ),
+    ).toBe(true);
   });
 
   test('opens annotations without loading the legacy full run tree', async () => {
@@ -403,9 +476,11 @@ function configureRunFetch(
   runOverrides: Partial<WorkflowRunDetailResponseDto> = {},
   annotationPageOverrides: Partial<{next_cursor: string | null}> = {},
   explanations: WorkflowRunJobExplanationDto[] = [],
+  nextExplanationPage?: {cursor: string; items: WorkflowRunJobExplanationDto[]} | undefined,
 ) {
   const fetchImpl = vi.fn((input: RequestInfo | URL) => {
-    const path = new URL(requestUrl(input), 'https://api.example.test').pathname;
+    const url = new URL(requestUrl(input), 'https://api.example.test');
+    const path = url.pathname;
     const detail = workflowRunViewDetailDto(runOverrides);
     if (path === `/workflows/runs/${RUN_ID}/annotations`) {
       return Promise.resolve(
@@ -417,7 +492,9 @@ function configureRunFetch(
       );
     }
     if (path === `/workflows/runs/${RUN_ID}/job-explanations`) {
-      return Promise.resolve(jsonResponse({items: explanations, next_cursor: null}));
+      return Promise.resolve(
+        jsonResponse(jobExplanationsPage(url, explanations, nextExplanationPage)),
+      );
     }
     if (path === '/annotations/summary') {
       return Promise.resolve(jsonResponse(annotationSummaryDto(annotations)));
@@ -447,6 +524,23 @@ function configureRunFetch(
     fetchImpl,
   });
   return fetchImpl;
+}
+
+function jobExplanationsPage(
+  url: URL,
+  firstPage: WorkflowRunJobExplanationDto[],
+  nextPage: {cursor: string; items: WorkflowRunJobExplanationDto[]} | undefined,
+) {
+  if (nextPage && url.searchParams.get('cursor') === nextPage.cursor) {
+    return {items: nextPage.items, next_cursor: null};
+  }
+  return {items: firstPage, next_cursor: nextPage?.cursor ?? null};
+}
+
+function requestUrls(fetchImpl: ReturnType<typeof vi.fn>): URL[] {
+  return fetchImpl.mock.calls.map(
+    ([input]) => new URL(requestUrl(input as RequestInfo | URL), 'https://api.example.test'),
+  );
 }
 
 function annotationDto(overrides: Partial<AnnotationDto> & {id: string}): AnnotationDto {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -16,11 +16,14 @@ import {toast} from '@shipfox/react-ui/toast';
 import {Text} from '@shipfox/react-ui/typography';
 import {useNavigate} from '@tanstack/react-router';
 import {type ReactNode, useEffect, useMemo, useRef, useState} from 'react';
-import {buildRunAnnotationList, type RunAnnotationSummary} from '#core/run-annotation.js';
 import {
-  type EvaluationTraceEntry,
+  buildRunAnnotationList,
+  type RunAnnotationEntry,
+  type RunAnnotationSummary,
+  type RunJobExplanation,
+} from '#core/run-annotation.js';
+import {
   isWorkflowRunTerminal,
-  type Job,
   type StepSourceLocation,
   type WorkflowRunDetail,
   type WorkflowRunOverview,
@@ -31,6 +34,7 @@ import {
 import {withoutWorkflowRunSelectionSearch} from '#core/workflow-run-url-state.js';
 import {useWorkflowRunAnnotationSummaryQuery} from '#hooks/api/annotations.js';
 import {useRunAnnotationsQuery} from '#hooks/api/run-annotations.js';
+import {useRunJobExplanationsQuery} from '#hooks/api/run-job-explanations.js';
 import {toWorkflowRunLineageHeadFromRecord} from '#hooks/api/workflow-run-mapper.js';
 import {
   useWorkflowRunLineageHeadQuery,
@@ -89,7 +93,7 @@ export interface WorkflowRunViewProps {
   activeJob?: WorkflowRunOverviewJob | undefined;
   jobSearch?: WorkflowJobSearch | undefined;
   jobContent?: ReactNode | undefined;
-  /** Run-level legacy bridge data, retained only for mixed-deployment run sections. */
+  /** Legacy full-tree bridge, retained only when bounded selection resolution fails. */
   legacyQuery?: ReturnType<typeof useWorkflowRunAttemptQuery> | undefined;
 }
 
@@ -117,7 +121,8 @@ export function WorkflowRunView({
     {workflowRunId: string; attempt: number} | undefined
   >();
   const explicitAttempt = routeAttempt ?? pinnedWorkflowRunAttempt(pinnedAttempt, workflowRunId);
-  const hasLegacyJobSelection = containsLegacyJobSelection(selection);
+  const hasLegacyJobSelection =
+    activeSection === 'summary' && containsLegacyJobSelection(selection);
 
   useEffect(() => {
     if (routeAttempt !== undefined) setPinnedAttempt(undefined);
@@ -165,7 +170,6 @@ export function WorkflowRunView({
   });
   const legacyBridgeEnabled = shouldLoadLegacyBridge({
     activeJobId,
-    activeSection,
     hasLegacyJobSelection,
     selectionQueryIsError: selectionQuery.isError,
   });
@@ -188,6 +192,12 @@ export function WorkflowRunView({
   );
   const rerunMutation = useRerunWorkflowRunMutation(projectId);
   const annotationsQuery = useRunAnnotationsQuery({
+    workflowRunId,
+    runAttempt: overviewAttempt,
+    enabled: shouldLoadRunAnnotations(activeSection, activeJobId),
+    live: shouldLiveRunAnnotations(activeSection, activeJobId, overviewQuery.data, overviewStatus),
+  });
+  const jobExplanationsQuery = useRunJobExplanationsQuery({
     workflowRunId,
     runAttempt: overviewAttempt,
     enabled: shouldLoadRunAnnotations(activeSection, activeJobId),
@@ -219,6 +229,7 @@ export function WorkflowRunView({
           listRun={listRun}
           legacyQuery={legacyQuery}
           annotations={annotationsQuery}
+          jobExplanations={jobExplanationsQuery}
           annotationSummaryQuery={annotationSummaryQuery}
           rerunMutation={rerunMutation}
           runAttempt={overviewAttempt}
@@ -326,17 +337,15 @@ function workflowRunActionsReady({
 
 function shouldLoadLegacyBridge({
   activeJobId,
-  activeSection,
   hasLegacyJobSelection,
   selectionQueryIsError,
 }: {
   activeJobId: string | undefined;
-  activeSection: RunWorkspaceSection;
   hasLegacyJobSelection: boolean;
   selectionQueryIsError: boolean;
 }): boolean {
   if (activeJobId !== undefined) return false;
-  return activeSection === 'annotations' || (hasLegacyJobSelection && selectionQueryIsError);
+  return hasLegacyJobSelection && selectionQueryIsError;
 }
 
 function shouldLoadAnnotationSummary({
@@ -465,6 +474,7 @@ function RunViewContent({
   listRun,
   legacyQuery,
   annotations,
+  jobExplanations,
   annotationSummaryQuery,
   rerunMutation,
   runAttempt,
@@ -485,6 +495,7 @@ function RunViewContent({
   listRun: ReturnType<typeof useWorkflowRunListItem>;
   legacyQuery: ReturnType<typeof useWorkflowRunAttemptQuery> | undefined;
   annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  jobExplanations: ReturnType<typeof useRunJobExplanationsQuery>;
   annotationSummaryQuery: ReturnType<typeof useWorkflowRunAnnotationSummaryQuery>;
   rerunMutation: ReturnType<typeof useRerunWorkflowRunMutation>;
   runAttempt: number | undefined;
@@ -503,7 +514,7 @@ function RunViewContent({
   const resolvedSelection =
     legacyRun && selection ? resolveWorkflowRunSelection({run: legacyRun, selection}) : undefined;
   const resolvedJobId = selectionQuery.data?.jobId ?? resolvedSelection?.job?.id;
-  const selectedJobId = containsLegacyJobSelection(selection) ? resolvedJobId : undefined;
+  const selectedJobId = selectedRunJobId({activeSection, selection, resolvedJobId});
   const highlightedLineRange =
     selectionQuery.data?.sourceLocation ?? resolvedSelection?.step?.sourceLocation ?? null;
   const annotationSummary = annotationSummaryQuery.data ?? annotations.summary;
@@ -639,6 +650,7 @@ function RunViewContent({
       shellRun={shellRun}
       legacyQuery={legacyQuery}
       annotations={annotations}
+      jobExplanations={jobExplanations}
       annotationSummary={annotationSummary}
       rerunPending={rerunMutation.isPending}
       activeSection={activeSection}
@@ -659,6 +671,20 @@ function RunViewContent({
   );
 }
 
+function selectedRunJobId({
+  activeSection,
+  selection,
+  resolvedJobId,
+}: {
+  activeSection: RunWorkspaceSection;
+  selection: WorkflowRunsSearch | undefined;
+  resolvedJobId: string | undefined;
+}): string | undefined {
+  if (activeSection === 'annotations') return selection?.jobId;
+  if (containsLegacyJobSelection(selection)) return resolvedJobId;
+  return undefined;
+}
+
 function RunViewLayout({
   workspaceSlug,
   projectSlug,
@@ -669,6 +695,7 @@ function RunViewLayout({
   shellRun,
   legacyQuery,
   annotations,
+  jobExplanations,
   annotationSummary,
   rerunPending,
   activeSection,
@@ -695,6 +722,7 @@ function RunViewLayout({
   shellRun: WorkflowRunShell | undefined;
   legacyQuery: ReturnType<typeof useWorkflowRunAttemptQuery> | undefined;
   annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  jobExplanations: ReturnType<typeof useRunJobExplanationsQuery>;
   annotationSummary: RunAnnotationSummary | undefined;
   rerunPending: boolean;
   activeSection: RunWorkspaceSection;
@@ -778,10 +806,10 @@ function RunViewLayout({
               overview={overview}
               sourceQuery={sourceQuery}
               shellRun={shellRun}
-              legacyQuery={legacyQuery}
               jobContent={jobContent}
               activeSection={activeSection}
               annotations={annotations}
+              jobExplanations={jobExplanations}
               annotationSummary={annotationSummary}
               workspaceSlug={workspaceSlug}
               projectSlug={projectSlug}
@@ -805,10 +833,10 @@ function RunWorkspaceContent({
   overview,
   sourceQuery,
   shellRun,
-  legacyQuery,
   jobContent,
   activeSection,
   annotations,
+  jobExplanations,
   annotationSummary,
   workspaceSlug,
   projectSlug,
@@ -826,10 +854,10 @@ function RunWorkspaceContent({
   overview: WorkflowRunOverview | undefined;
   sourceQuery: ReturnType<typeof useWorkflowRunSourceQuery>;
   shellRun: WorkflowRunShell | undefined;
-  legacyQuery: ReturnType<typeof useWorkflowRunAttemptQuery> | undefined;
   jobContent: ReactNode | undefined;
   activeSection: RunWorkspaceSection;
   annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  jobExplanations: ReturnType<typeof useRunJobExplanationsQuery>;
   annotationSummary: RunAnnotationSummary | undefined;
   workspaceSlug: string | undefined;
   projectSlug: string | undefined;
@@ -869,15 +897,15 @@ function RunWorkspaceContent({
     );
   }
 
-  const sectionFallback = workspaceSectionFallback({activeSection, legacyQuery, sourceQuery});
+  const sectionFallback = workspaceSectionFallback({activeSection, sourceQuery});
   if (sectionFallback) return sectionFallback;
 
   return (
     <RunSectionContent
       section={activeSection}
       run={overview}
-      legacyRun={legacyQuery?.data}
       annotations={annotations}
+      jobExplanations={jobExplanations}
       annotationSummary={annotationSummary}
       workspaceSlug={workspaceSlug}
       projectSlug={projectSlug}
@@ -895,31 +923,11 @@ function RunWorkspaceContent({
 
 function workspaceSectionFallback({
   activeSection,
-  legacyQuery,
   sourceQuery,
 }: {
   activeSection: RunWorkspaceSection;
-  legacyQuery: ReturnType<typeof useWorkflowRunAttemptQuery> | undefined;
   sourceQuery: ReturnType<typeof useWorkflowRunSourceQuery>;
 }): ReactNode | undefined {
-  if (
-    activeSection === 'annotations' &&
-    (!legacyQuery || legacyQuery.isPending || legacyQuery.data === undefined)
-  ) {
-    if (legacyQuery?.isError) {
-      return (
-        <div className="min-h-0 flex-1 overflow-auto p-panel">
-          <QueryLoadError query={legacyQuery} subject="workflow run details" icon="pulseLine" />
-        </div>
-      );
-    }
-    return (
-      <div className="min-h-0 flex-1 overflow-auto p-panel">
-        <WorkflowRunContentSkeleton />
-      </div>
-    );
-  }
-
   if (activeSection === 'source' && (sourceQuery.isPending || sourceQuery.data === undefined)) {
     if (sourceQuery.isError) {
       return (
@@ -975,8 +983,8 @@ function shouldRedirectLegacyJob({
 function RunSectionContent({
   section,
   run,
-  legacyRun,
   annotations,
+  jobExplanations,
   annotationSummary,
   workspaceSlug,
   projectSlug,
@@ -991,8 +999,8 @@ function RunSectionContent({
 }: {
   section: RunWorkspaceSection;
   run: WorkflowRunOverview;
-  legacyRun: WorkflowRunDetail | undefined;
   annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  jobExplanations: ReturnType<typeof useRunJobExplanationsQuery>;
   annotationSummary: RunAnnotationSummary | undefined;
   workspaceSlug: string | undefined;
   projectSlug: string | undefined;
@@ -1039,17 +1047,11 @@ function RunSectionContent({
   }
 
   if (section === 'annotations') {
-    if (!legacyRun) {
-      return (
-        <div className="min-h-0 flex-1 overflow-auto p-panel">
-          <WorkflowRunContentSkeleton />
-        </div>
-      );
-    }
     return (
       <RunAnnotationsSection
-        run={legacyRun}
+        run={run}
         annotations={annotations}
+        jobExplanations={jobExplanations}
         annotationSummary={annotationSummary}
         workspaceSlug={workspaceSlug}
         projectSlug={projectSlug}
@@ -1130,6 +1132,7 @@ function WorkflowSourceStaleError({query}: {query: ReturnType<typeof useWorkflow
 function RunAnnotationsSection({
   run,
   annotations,
+  jobExplanations,
   annotationSummary,
   workspaceSlug,
   projectSlug,
@@ -1138,8 +1141,9 @@ function RunAnnotationsSection({
   onSelectAnnotationJob,
   onClearAnnotationFilters,
 }: {
-  run: WorkflowRunDetail;
+  run: WorkflowRunOverview;
   annotations: ReturnType<typeof useRunAnnotationsQuery>;
+  jobExplanations: ReturnType<typeof useRunJobExplanationsQuery>;
   annotationSummary: RunAnnotationSummary | undefined;
   workspaceSlug: string | undefined;
   projectSlug: string | undefined;
@@ -1148,49 +1152,55 @@ function RunAnnotationsSection({
   onSelectAnnotationJob: (jobId: string | undefined) => void;
   onClearAnnotationFilters: () => void;
 }) {
-  const selectedJob = run.jobs.find((job) => job.id === selectedJobId);
   const severity = selection?.severity;
-  const records = annotations.annotations;
+  const annotationEntries = annotations.entries;
+  const explanations = jobExplanations.explanations;
+  const jobs = useMemo(
+    () => annotationJobOptions(run, annotationEntries, explanations),
+    [annotationEntries, explanations, run],
+  );
+  const selectedJob = jobs.find((job) => job.id === selectedJobId);
 
   const entries = useMemo(
     () =>
-      records
+      annotationEntries
         ? buildRunAnnotationList({
-            annotations: records,
-            jobs: run.jobs,
+            entries: annotationEntries,
             severity,
-            jobId: selectedJob?.id,
+            jobId: selectedJobId,
           })
         : undefined,
-    [records, run.jobs, selectedJob?.id, severity],
+    [annotationEntries, selectedJobId, severity],
   );
   const derivedAnnotations = useMemo<readonly DerivedRunAnnotation[] | undefined>(() => {
-    if (!records) return undefined;
-    const jobsWithAnnotations = new Set(records.map((annotation) => annotation.jobId));
-
-    return run.jobs
-      .filter((job) => {
-        const style = job.status === 'failed' ? 'error' : 'warning';
+    if (!explanations) return undefined;
+    return explanations
+      .filter((explanation) => {
+        const style = explanation.status === 'failed' ? 'error' : 'warning';
         return (
-          (!selectedJob || selectedJob.id === job.id) &&
-          !jobsWithAnnotations.has(job.id) &&
-          (job.status === 'failed' || job.status === 'skipped') &&
-          job.jobExecutions.length === 0 &&
+          (!selectedJobId || selectedJobId === explanation.jobId) &&
           matchesDerivedAnnotationFilters(style, selection)
         );
       })
-      .map((job) => ({
-        id: `derived-${job.id}`,
-        style: job.status === 'failed' ? 'error' : 'warning',
-        jobName: job.displayName,
-        body: derivedJobAnnotation(job),
-      }));
-  }, [records, run.jobs, selectedJob, selection]);
-  const hasSynthesizedJobAnnotations = run.jobs.some(
-    (job) =>
-      (job.status === 'failed' || job.status === 'skipped') && job.jobExecutions.length === 0,
-  );
-  const annotationTotal = Math.max(annotationSummary?.total ?? 0, records?.length ?? 0);
+      .map((explanation) => ({
+        id: `derived-${explanation.jobId}`,
+        jobId: explanation.jobId,
+        jobPosition: explanation.jobPosition,
+        style: explanation.status === 'failed' ? ('error' as const) : ('warning' as const),
+        jobName: explanation.jobName,
+        body: derivedJobAnnotation(explanation),
+      }))
+      .sort(
+        (left, right) =>
+          left.jobPosition - right.jobPosition || left.jobId.localeCompare(right.jobId),
+      );
+  }, [explanations, selectedJobId, selection]);
+  const annotationTotal = Math.max(annotationSummary?.total ?? 0, annotationEntries?.length ?? 0);
+  const hasKnownDiagnostics =
+    annotationTotal > 0 ||
+    (explanations?.length ?? 0) > 0 ||
+    annotations.query.hasNextPage ||
+    jobExplanations.query.hasNextPage;
 
   return (
     <section
@@ -1211,7 +1221,7 @@ function RunAnnotationsSection({
               search={selection}
             />
             <AnnotationJobFilter
-              jobs={run.jobs}
+              jobs={jobs}
               selectedJobId={selectedJob?.id}
               onSelect={onSelectAnnotationJob}
             />
@@ -1223,6 +1233,7 @@ function RunAnnotationsSection({
             // list never inherits a "show more" position from different data.
             key={`${run.id}:${run.runAttempt.attempt}:${severity ?? 'all'}:${selectedJob?.id ?? 'all'}`}
             query={annotations.query}
+            jobExplanationsQuery={jobExplanations.query}
             entries={entries}
             derivedAnnotations={derivedAnnotations}
             workspaceSlug={workspaceSlug}
@@ -1230,10 +1241,8 @@ function RunAnnotationsSection({
             workflowRunId={run.id}
             runAttempt={run.runAttempt.attempt}
             // A run with no annotations at all offers no filter to clear, whatever the URL says.
-            filtered={Boolean(
-              (severity || selectedJob) && (annotationTotal > 0 || hasSynthesizedJobAnnotations),
-            )}
-            filteredJobName={selectedJob?.displayName}
+            filtered={Boolean((severity || selectedJobId) && hasKnownDiagnostics)}
+            filteredJobName={selectedJob?.name}
             filteredSeverity={severity}
             onClearFilters={onClearAnnotationFilters}
           />
@@ -1251,12 +1260,12 @@ function matchesDerivedAnnotationFilters(
 }
 
 /** The row is titled by its job, so the body opens with what happened rather than repeating it. */
-function derivedJobAnnotation(job: Job): string {
-  const reason = job.statusReason ? `Reason: \`${job.statusReason}\`` : null;
-  const traceSummary = formatConditionEvaluation(job.evaluationTrace);
+function derivedJobAnnotation(explanation: RunJobExplanation): string {
+  const reason = explanation.statusReason ? `Reason: \`${explanation.statusReason}\`` : null;
+  const traceSummary = formatConditionEvaluation(explanation.evaluationTrace);
   const details = [reason, traceSummary].filter(Boolean).join('\n');
 
-  if (job.status === 'skipped') {
+  if (explanation.status === 'skipped') {
     return [
       'Skipped before an execution was created.',
       '',
@@ -1276,9 +1285,7 @@ function derivedJobAnnotation(job: Job): string {
     .join('\n');
 }
 
-function formatConditionEvaluation(
-  trace: readonly EvaluationTraceEntry[] | null | undefined,
-): string | null {
+function formatConditionEvaluation(trace: RunJobExplanation['evaluationTrace']): string | null {
   if (!trace?.length) return null;
 
   return [
@@ -1296,19 +1303,52 @@ function formatConditionEvaluation(
 
 const ALL_ANNOTATION_JOBS = 'all-jobs';
 
+interface AnnotationJobOption {
+  id: string;
+  name: string;
+  position: number;
+}
+
+function annotationJobOptions(
+  run: WorkflowRunOverview,
+  entries: readonly RunAnnotationEntry[] | undefined,
+  explanations: readonly RunJobExplanation[] | undefined,
+): AnnotationJobOption[] {
+  const options = new Map<string, AnnotationJobOption>();
+  const overviewJobs = run.jobs.kind === 'complete' ? run.jobs.items : run.jobs.firstPage.items;
+  for (const job of overviewJobs) {
+    options.set(job.id, {id: job.id, name: job.displayName, position: job.position});
+  }
+  for (const entry of entries ?? []) {
+    options.set(entry.annotation.jobId, {
+      id: entry.annotation.jobId,
+      name: entry.jobName,
+      position: entry.jobPosition,
+    });
+  }
+  for (const explanation of explanations ?? []) {
+    options.set(explanation.jobId, {
+      id: explanation.jobId,
+      name: explanation.jobName,
+      position: explanation.jobPosition,
+    });
+  }
+
+  return [...options.values()].sort(
+    (left, right) => left.position - right.position || left.id.localeCompare(right.id),
+  );
+}
+
 function AnnotationJobFilter({
   jobs,
   selectedJobId,
   onSelect,
 }: {
-  jobs: Job[];
+  jobs: readonly AnnotationJobOption[];
   selectedJobId: string | undefined;
   onSelect: (jobId: string | undefined) => void;
 }) {
-  const sortedJobs = [...jobs].sort(
-    (left, right) => left.position - right.position || left.id.localeCompare(right.id),
-  );
-  const selectedJobName = jobs.find((job) => job.id === selectedJobId)?.displayName;
+  const selectedJobName = jobs.find((job) => job.id === selectedJobId)?.name;
 
   return (
     <Select
@@ -1327,9 +1367,9 @@ function AnnotationJobFilter({
       </SelectTrigger>
       <SelectContent align="end">
         <SelectItem value={ALL_ANNOTATION_JOBS}>All jobs</SelectItem>
-        {sortedJobs.map((job) => (
+        {jobs.map((job) => (
           <SelectItem key={job.id} value={job.id}>
-            {job.displayName}
+            {job.name}
           </SelectItem>
         ))}
       </SelectContent>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -63,6 +63,7 @@ import {
   RunAnnotationList,
   RunAnnotationSummaryLine,
 } from '../workflow-run-tabs/index.js';
+import {presentRunJobExplanation} from '../workflow-run-tabs/run-job-explanation.js';
 import {WorkflowSourceContent} from '../workflow-source-panel/index.js';
 import {RunWorkspaceNav} from './run-workspace-nav.js';
 import {WorkflowRunLargeJobs} from './workflow-run-large-jobs.js';
@@ -1176,20 +1177,19 @@ function RunAnnotationsSection({
   const derivedAnnotations = useMemo<readonly DerivedRunAnnotation[] | undefined>(() => {
     if (!explanations) return undefined;
     return explanations
-      .filter((explanation) => {
-        const style = explanation.status === 'failed' ? 'error' : 'warning';
+      .map((explanation) => ({explanation, presentation: presentRunJobExplanation(explanation)}))
+      .filter(({explanation, presentation}) => {
         return (
           (!effectiveJobId || effectiveJobId === explanation.jobId) &&
-          matchesDerivedAnnotationFilters(style, selection)
+          matchesDerivedAnnotationFilters(presentation.style, selection)
         );
       })
-      .map((explanation) => ({
+      .map(({explanation, presentation}) => ({
         id: `derived-${explanation.jobId}`,
         jobId: explanation.jobId,
         jobPosition: explanation.jobPosition,
-        style: explanation.status === 'failed' ? ('error' as const) : ('warning' as const),
+        ...presentation,
         jobName: explanation.jobName,
-        body: derivedJobAnnotation(explanation),
       }))
       .sort(
         (left, right) =>
@@ -1254,52 +1254,10 @@ function RunAnnotationsSection({
 }
 
 function matchesDerivedAnnotationFilters(
-  style: 'warning' | 'error',
+  style: DerivedRunAnnotation['style'],
   selection: WorkflowRunsSearch | undefined,
 ): boolean {
   return !selection?.severity || style === selection.severity;
-}
-
-/** The row is titled by its job, so the body opens with what happened rather than repeating it. */
-function derivedJobAnnotation(explanation: RunJobExplanation): string {
-  const reason = explanation.statusReason ? `Reason: \`${explanation.statusReason}\`` : null;
-  const traceSummary = formatConditionEvaluation(explanation.evaluationTrace);
-  const details = [reason, traceSummary].filter(Boolean).join('\n');
-
-  if (explanation.status === 'skipped') {
-    return [
-      'Skipped before an execution was created.',
-      '',
-      'Review its dependencies or condition before re-running.',
-      details,
-    ]
-      .filter(Boolean)
-      .join('\n');
-  }
-  return [
-    'Failed before an execution was created.',
-    '',
-    'Check runner availability and workflow configuration before re-running.',
-    details,
-  ]
-    .filter(Boolean)
-    .join('\n');
-}
-
-function formatConditionEvaluation(trace: RunJobExplanation['evaluationTrace']): string | null {
-  if (!trace?.length) return null;
-
-  return [
-    'Condition evaluation:',
-    ...trace.map((entry) => {
-      if ('dropped' in entry) {
-        return `- ${entry.dropped} additional evaluation${entry.dropped === 1 ? '' : 's'} not recorded`;
-      }
-      const value =
-        entry.value === undefined || entry.value === '' ? '(empty)' : `\`${entry.value}\``;
-      return `- \`${entry.field}\` evaluated \`${entry.expression}\` to ${value}${entry.degraded ? ' (degraded)' : ''}`;
-    }),
-  ].join('\n');
 }
 
 const ALL_ANNOTATION_JOBS = 'all-jobs';

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1160,6 +1160,7 @@ function RunAnnotationsSection({
     [annotationEntries, explanations, run],
   );
   const selectedJob = jobs.find((job) => job.id === selectedJobId);
+  const effectiveJobId = selectedJob?.id;
 
   const entries = useMemo(
     () =>
@@ -1167,10 +1168,10 @@ function RunAnnotationsSection({
         ? buildRunAnnotationList({
             entries: annotationEntries,
             severity,
-            jobId: selectedJobId,
+            jobId: effectiveJobId,
           })
         : undefined,
-    [annotationEntries, selectedJobId, severity],
+    [annotationEntries, effectiveJobId, severity],
   );
   const derivedAnnotations = useMemo<readonly DerivedRunAnnotation[] | undefined>(() => {
     if (!explanations) return undefined;
@@ -1178,7 +1179,7 @@ function RunAnnotationsSection({
       .filter((explanation) => {
         const style = explanation.status === 'failed' ? 'error' : 'warning';
         return (
-          (!selectedJobId || selectedJobId === explanation.jobId) &&
+          (!effectiveJobId || effectiveJobId === explanation.jobId) &&
           matchesDerivedAnnotationFilters(style, selection)
         );
       })
@@ -1194,7 +1195,7 @@ function RunAnnotationsSection({
         (left, right) =>
           left.jobPosition - right.jobPosition || left.jobId.localeCompare(right.jobId),
       );
-  }, [explanations, selectedJobId, selection]);
+  }, [effectiveJobId, explanations, selection]);
   const annotationTotal = Math.max(annotationSummary?.total ?? 0, annotationEntries?.length ?? 0);
   const hasKnownDiagnostics =
     annotationTotal > 0 ||
@@ -1241,7 +1242,7 @@ function RunAnnotationsSection({
             workflowRunId={run.id}
             runAttempt={run.runAttempt.attempt}
             // A run with no annotations at all offers no filter to clear, whatever the URL says.
-            filtered={Boolean((severity || selectedJobId) && hasKnownDiagnostics)}
+            filtered={Boolean((severity || effectiveJobId) && hasKnownDiagnostics)}
             filteredJobName={selectedJob?.name}
             filteredSeverity={severity}
             onClearFilters={onClearAnnotationFilters}

--- a/libs/client/workflows/src/core/run-annotation.test.ts
+++ b/libs/client/workflows/src/core/run-annotation.test.ts
@@ -1,18 +1,12 @@
 import {
-  workflowJob,
-  workflowJobExecutionDto,
-  workflowStepAttemptDto,
-  workflowStepDto,
-} from '#test/fixtures/workflow-run.js';
-import {
   buildRunAnnotationList,
   highestRunAnnotationSeverity,
+  type RunAnnotationEntry,
   type RunAnnotationRecord,
   type RunAnnotationStyle,
   summarizeJobAnnotations,
   summarizeRunAnnotations,
 } from './run-annotation.js';
-import type {Job} from './workflow-run.js';
 
 const BUILD_JOB_ID = '44444444-4444-4444-8444-00000000000b';
 const TEST_JOB_ID = '44444444-4444-4444-8444-00000000000c';
@@ -96,7 +90,7 @@ describe('buildRunAnnotationList', () => {
       annotation({id: 'e', style: 'info', sequence: 5}),
     ];
 
-    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+    const entries = buildRunAnnotationList({entries: annotationEntries(annotations)});
 
     expect(entries.map((entry) => entry.annotation.id)).toEqual(['b', 'd', 'e', 'a', 'c']);
   });
@@ -108,7 +102,7 @@ describe('buildRunAnnotationList', () => {
       annotation({id: 'early-job', style: 'error', sequence: 9, jobId: BUILD_JOB_ID}),
     ];
 
-    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+    const entries = buildRunAnnotationList({entries: annotationEntries(annotations)});
 
     expect(entries.map((entry) => entry.annotation.id)).toEqual(['early-job', 'late-job']);
   });
@@ -131,7 +125,7 @@ describe('buildRunAnnotationList', () => {
       }),
     ];
 
-    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+    const entries = buildRunAnnotationList({entries: annotationEntries(annotations)});
 
     expect(entries.map((entry) => entry.annotation.id)).toEqual([
       'first-execution',
@@ -139,10 +133,10 @@ describe('buildRunAnnotationList', () => {
     ]);
   });
 
-  test('resolves provenance and an origin the run can route back to', () => {
+  test('preserves server provenance and an origin the run can route back to', () => {
     const annotations = [annotation({id: 'a', style: 'error'})];
 
-    const [entry] = buildRunAnnotationList({annotations, jobs: jobs()});
+    const [entry] = buildRunAnnotationList({entries: annotationEntries(annotations)});
 
     expect(entry?.jobName).toBe('build');
     expect(entry?.stepLabel).toBe('compile');
@@ -167,27 +161,22 @@ describe('buildRunAnnotationList', () => {
       }),
     ];
 
-    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+    const entries = buildRunAnnotationList({entries: annotationEntries(annotations)});
     const byId = new Map(entries.map((entry) => [entry.annotation.id, entry]));
 
     expect(byId.get('single')?.executionLabel).toBeNull();
     expect(byId.get('multi')?.executionLabel).toBe('execution #2');
   });
 
-  test('keeps an annotation whose step the run attempt no longer holds, without an origin', () => {
-    const annotations = [
-      annotation({
-        id: 'orphan',
-        style: 'error',
-        originStepId: '55555555-5555-4555-8555-0000000000ff',
-      }),
-    ];
-
-    const [entry] = buildRunAnnotationList({annotations, jobs: jobs()});
+  test('keeps an annotation without a routable step-attempt origin', () => {
+    const annotations = [annotation({id: 'orphan', style: 'error'})];
+    const [entry] = buildRunAnnotationList({
+      entries: annotations.map((record) => annotationEntry(record, {origin: null})),
+    });
 
     expect(entry?.annotation.id).toBe('orphan');
     expect(entry?.jobName).toBe('build');
-    expect(entry?.stepLabel).toBeNull();
+    expect(entry?.stepLabel).toBe('compile');
     expect(entry?.origin).toBeNull();
   });
 
@@ -201,7 +190,7 @@ describe('buildRunAnnotationList', () => {
       annotation({id: 'known-job', style: 'error'}),
     ];
 
-    const entries = buildRunAnnotationList({annotations, jobs: jobs()});
+    const entries = buildRunAnnotationList({entries: annotationEntries(annotations)});
 
     expect(entries.map((entry) => entry.annotation.id)).toEqual(['known-job', 'unknown-job']);
   });
@@ -214,12 +203,12 @@ describe('buildRunAnnotationList', () => {
     ];
 
     expect(
-      buildRunAnnotationList({annotations, jobs: jobs(), severity: 'error'}).map(
+      buildRunAnnotationList({entries: annotationEntries(annotations), severity: 'error'}).map(
         (entry) => entry.annotation.id,
       ),
     ).toEqual(['build-error', 'test-error']);
     expect(
-      buildRunAnnotationList({annotations, jobs: jobs(), jobId: BUILD_JOB_ID}).map(
+      buildRunAnnotationList({entries: annotationEntries(annotations), jobId: BUILD_JOB_ID}).map(
         (entry) => entry.annotation.id,
       ),
     ).toEqual(['build-error', 'build-info']);
@@ -228,7 +217,9 @@ describe('buildRunAnnotationList', () => {
   test('never selects an unstyled annotation with a severity filter', () => {
     const annotations = [annotation({id: 'plain', style: 'default'})];
 
-    expect(buildRunAnnotationList({annotations, jobs: jobs(), severity: 'info'})).toEqual([]);
+    expect(
+      buildRunAnnotationList({entries: annotationEntries(annotations), severity: 'info'}),
+    ).toEqual([]);
   });
 });
 
@@ -247,69 +238,31 @@ function annotation(
   };
 }
 
-function jobs(): Job[] {
-  return [
-    workflowJob({
-      id: BUILD_JOB_ID,
-      key: 'build',
-      name: 'build',
-      position: 0,
-      job_executions: [
-        workflowJobExecutionDto({
-          id: BUILD_EXECUTION_ID,
-          job_id: BUILD_JOB_ID,
-          sequence: 1,
-          steps: [
-            workflowStepDto({
-              id: BUILD_STEP_ID,
-              job_execution_id: BUILD_EXECUTION_ID,
-              name: 'compile',
-              attempts: [
-                workflowStepAttemptDto({
-                  id: BUILD_ATTEMPT_ID,
-                  step_id: BUILD_STEP_ID,
-                  attempt: 1,
-                  status: 'succeeded',
-                }),
-              ],
-            }),
-          ],
-        }),
-      ],
-    }),
-    workflowJob({
-      id: TEST_JOB_ID,
-      key: 'test',
-      name: 'test',
-      position: 1,
-      job_executions: [
-        workflowJobExecutionDto({
-          id: TEST_EXECUTION_ONE_ID,
-          job_id: TEST_JOB_ID,
-          sequence: 1,
-          steps: [
-            workflowStepDto({
-              id: TEST_STEP_ID,
-              job_execution_id: TEST_EXECUTION_ONE_ID,
-              name: 'run tests',
-              attempts: [],
-            }),
-          ],
-        }),
-        workflowJobExecutionDto({
-          id: TEST_EXECUTION_TWO_ID,
-          job_id: TEST_JOB_ID,
-          sequence: 2,
-          steps: [
-            workflowStepDto({
-              id: TEST_STEP_ID,
-              job_execution_id: TEST_EXECUTION_TWO_ID,
-              name: 'run tests',
-              attempts: [],
-            }),
-          ],
-        }),
-      ],
-    }),
-  ];
+function annotationEntry(
+  record: RunAnnotationRecord,
+  overrides: Partial<RunAnnotationEntry> = {},
+): RunAnnotationEntry {
+  const testJob = record.jobId === TEST_JOB_ID;
+  const secondExecution = record.jobExecutionId === TEST_EXECUTION_TWO_ID;
+  const jobPosition = record.jobId === BUILD_JOB_ID ? 0 : Number.MAX_SAFE_INTEGER;
+  return {
+    annotation: record,
+    jobName: testJob ? 'test' : 'build',
+    jobPosition: testJob ? 1 : jobPosition,
+    executionSequence: secondExecution ? 2 : 1,
+    executionLabel: testJob ? `execution #${secondExecution ? 2 : 1}` : null,
+    stepLabel: testJob ? 'run tests' : 'compile',
+    attemptLabel: 'attempt 1',
+    origin: {
+      jobId: record.jobId,
+      jobExecutionId: record.jobExecutionId,
+      stepId: record.originStepId,
+      stepAttemptId: BUILD_ATTEMPT_ID,
+    },
+    ...overrides,
+  };
+}
+
+function annotationEntries(records: RunAnnotationRecord[]): RunAnnotationEntry[] {
+  return records.map((record) => annotationEntry(record));
 }

--- a/libs/client/workflows/src/core/run-annotation.test.ts
+++ b/libs/client/workflows/src/core/run-annotation.test.ts
@@ -1,3 +1,4 @@
+import {runAnnotationEntryFixture} from '#test/fixtures/workflow-run.js';
 import {
   buildRunAnnotationList,
   highestRunAnnotationSeverity,
@@ -245,22 +246,17 @@ function annotationEntry(
   const testJob = record.jobId === TEST_JOB_ID;
   const secondExecution = record.jobExecutionId === TEST_EXECUTION_TWO_ID;
   const jobPosition = record.jobId === BUILD_JOB_ID ? 0 : Number.MAX_SAFE_INTEGER;
-  return {
-    annotation: record,
+  return runAnnotationEntryFixture(record, {
     jobName: testJob ? 'test' : 'build',
     jobPosition: testJob ? 1 : jobPosition,
     executionSequence: secondExecution ? 2 : 1,
     executionLabel: testJob ? `execution #${secondExecution ? 2 : 1}` : null,
     stepLabel: testJob ? 'run tests' : 'compile',
-    attemptLabel: 'attempt 1',
     origin: {
-      jobId: record.jobId,
-      jobExecutionId: record.jobExecutionId,
-      stepId: record.originStepId,
       stepAttemptId: BUILD_ATTEMPT_ID,
     },
     ...overrides,
-  };
+  });
 }
 
 function annotationEntries(records: RunAnnotationRecord[]): RunAnnotationEntry[] {

--- a/libs/client/workflows/src/core/run-annotation.ts
+++ b/libs/client/workflows/src/core/run-annotation.ts
@@ -1,4 +1,5 @@
-import type {Job} from './workflow-run.js';
+import type {JobStatusReason} from './entities/job.js';
+import type {EvaluationTraceEntry} from './entities/step-attempt.js';
 
 export type RunAnnotationStyle = 'default' | 'info' | 'success' | 'warning' | 'error';
 
@@ -62,13 +63,24 @@ export interface RunAnnotationOrigin {
 
 export interface RunAnnotationEntry {
   annotation: RunAnnotationRecord;
-  jobName: string | null;
+  jobName: string;
+  jobPosition: number;
+  executionSequence: number;
   /** Only set when the job ran more than once, so a single-execution job stays uncluttered. */
   executionLabel: string | null;
-  stepLabel: string | null;
+  stepLabel: string;
   attemptLabel: string;
-  /** `null` when the run attempt no longer contains the emitting step, so no link is offered. */
+  /** `null` when the emitting step attempt has not been created, so no link is offered. */
   origin: RunAnnotationOrigin | null;
+}
+
+export interface RunJobExplanation {
+  jobId: string;
+  jobName: string;
+  jobPosition: number;
+  status: 'failed' | 'skipped';
+  statusReason: JobStatusReason | null;
+  evaluationTrace: EvaluationTraceEntry[] | null;
 }
 
 export function annotationSeverity(style: RunAnnotationStyle): RunAnnotationSeverity | null {
@@ -97,8 +109,7 @@ export function summarizeRunAnnotations(
 }
 
 export interface BuildRunAnnotationListInput {
-  annotations: readonly RunAnnotationRecord[];
-  jobs: readonly Job[];
+  entries: readonly RunAnnotationEntry[];
   severity?: RunAnnotationSeverity | undefined;
   jobId?: string | undefined;
 }
@@ -111,22 +122,20 @@ export interface BuildRunAnnotationListInput {
  * sequence before using it, and ends on the id so the order never depends on input order.
  */
 export function buildRunAnnotationList({
-  annotations,
-  jobs,
+  entries,
   severity,
   jobId,
 }: BuildRunAnnotationListInput): RunAnnotationEntry[] {
-  const index = indexJobs(jobs);
-  const entries: RunAnnotationEntry[] = [];
+  const visible: RunAnnotationEntry[] = [];
 
-  for (const annotation of annotations) {
-    if (jobId && annotation.jobId !== jobId) continue;
-    const annotationSeverityValue = annotationSeverity(annotation.style);
+  for (const entry of entries) {
+    if (jobId && entry.annotation.jobId !== jobId) continue;
+    const annotationSeverityValue = annotationSeverity(entry.annotation.style);
     if (severity && annotationSeverityValue !== severity) continue;
-    entries.push(toEntry(annotation, index));
+    visible.push(entry);
   }
 
-  return entries.sort((left, right) => compareEntries(left, right, index));
+  return visible.sort(compareEntries);
 }
 
 /** Counts annotations owned by one job, for the job page's bounded reference chip. */
@@ -148,97 +157,18 @@ export function highestRunAnnotationSeverity(
   return RUN_ANNOTATION_SEVERITIES.find((severity) => summary[severity] > 0) ?? null;
 }
 
-interface JobIndexEntry {
-  position: number;
-  name: string;
-  executionCount: number;
-  executions: Map<string, JobExecutionIndexEntry>;
-}
-
-interface JobExecutionIndexEntry {
-  sequence: number;
-  steps: Map<string, {label: string; attemptIds: Map<number, string>}>;
-}
-
-function indexJobs(jobs: readonly Job[]): Map<string, JobIndexEntry> {
-  const index = new Map<string, JobIndexEntry>();
-
-  for (const job of jobs) {
-    const executions = new Map<string, JobExecutionIndexEntry>();
-    for (const execution of job.jobExecutions) {
-      const steps = new Map<string, {label: string; attemptIds: Map<number, string>}>();
-      for (const step of execution.steps) {
-        const attemptIds = new Map<number, string>();
-        for (const attempt of step.attempts) attemptIds.set(attempt.attempt, attempt.id);
-        steps.set(step.id, {label: step.name || step.key || step.id, attemptIds});
-      }
-      executions.set(execution.id, {sequence: execution.sequence, steps});
-    }
-
-    index.set(job.id, {
-      position: job.position,
-      name: job.displayName,
-      executionCount: job.jobExecutions.length,
-      executions,
-    });
-  }
-
-  return index;
-}
-
-function toEntry(
-  annotation: RunAnnotationRecord,
-  index: Map<string, JobIndexEntry>,
-): RunAnnotationEntry {
-  const job = index.get(annotation.jobId);
-  const execution = job?.executions.get(annotation.jobExecutionId);
-  const step = execution?.steps.get(annotation.originStepId);
-  const stepAttemptId = step?.attemptIds.get(annotation.originStepAttempt);
-
-  return {
-    annotation,
-    jobName: job?.name ?? null,
-    executionLabel:
-      execution && job && job.executionCount > 1 ? `execution #${execution.sequence}` : null,
-    stepLabel: step?.label ?? null,
-    attemptLabel: `attempt ${annotation.originStepAttempt}`,
-    origin: stepAttemptId
-      ? {
-          jobId: annotation.jobId,
-          jobExecutionId: annotation.jobExecutionId,
-          stepId: annotation.originStepId,
-          stepAttemptId,
-        }
-      : null,
-  };
-}
-
-function compareEntries(
-  left: RunAnnotationEntry,
-  right: RunAnnotationEntry,
-  index: Map<string, JobIndexEntry>,
-): number {
+function compareEntries(left: RunAnnotationEntry, right: RunAnnotationEntry): number {
   const bySeverity = SEVERITY_RANK[left.annotation.style] - SEVERITY_RANK[right.annotation.style];
   if (bySeverity !== 0) return bySeverity;
 
-  const byJob = jobPosition(left, index) - jobPosition(right, index);
+  const byJob = left.jobPosition - right.jobPosition;
   if (byJob !== 0) return byJob;
 
-  const byExecution = executionSequence(left, index) - executionSequence(right, index);
+  const byExecution = left.executionSequence - right.executionSequence;
   if (byExecution !== 0) return byExecution;
 
   const bySequence = left.annotation.sequence - right.annotation.sequence;
   if (bySequence !== 0) return bySequence;
 
   return left.annotation.id.localeCompare(right.annotation.id);
-}
-
-/** An unmatched job sorts last rather than first, so known provenance leads the list. */
-function jobPosition(entry: RunAnnotationEntry, index: Map<string, JobIndexEntry>): number {
-  return index.get(entry.annotation.jobId)?.position ?? Number.MAX_SAFE_INTEGER;
-}
-
-function executionSequence(entry: RunAnnotationEntry, index: Map<string, JobIndexEntry>): number {
-  const job = index.get(entry.annotation.jobId);
-  return job?.executions.get(entry.annotation.jobExecutionId)?.sequence ?? Number.MAX_SAFE_INTEGER;
 }

--- a/libs/client/workflows/src/hooks/api/run-annotation-mapper.test.ts
+++ b/libs/client/workflows/src/hooks/api/run-annotation-mapper.test.ts
@@ -1,0 +1,104 @@
+import type {
+  WorkflowRunAnnotationItemDto,
+  WorkflowRunJobExplanationDto,
+} from '@shipfox/api-workflows-dto';
+import {toRunAnnotationEntry, toRunJobExplanation} from './run-annotation-mapper.js';
+
+const JOB_ID = '44444444-4444-4444-8444-00000000000b';
+const EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
+const STEP_ID = '55555555-5555-4555-8555-00000000000b';
+
+describe('run annotation mappers', () => {
+  test('maps server-owned annotation provenance without reconstructing a run tree', () => {
+    const entry = toRunAnnotationEntry(annotationItem({step_attempt_id: null}));
+
+    expect(entry).toMatchObject({
+      jobName: 'Build web',
+      jobPosition: 3,
+      executionSequence: 2,
+      executionLabel: 'execution #2',
+      stepLabel: 'Publish URL',
+      attemptLabel: 'attempt 4',
+      origin: null,
+    });
+  });
+
+  test('maps a routable step attempt and a no-execution job explanation', () => {
+    const stepAttemptId = '66666666-6666-4666-8666-00000000000b';
+    const entry = toRunAnnotationEntry(annotationItem({step_attempt_id: stepAttemptId}));
+    const explanation = toRunJobExplanation(jobExplanation());
+
+    expect(entry.origin).toEqual({
+      jobId: JOB_ID,
+      jobExecutionId: EXECUTION_ID,
+      stepId: STEP_ID,
+      stepAttemptId,
+    });
+    expect(explanation).toMatchObject({
+      jobId: JOB_ID,
+      jobName: 'Build web',
+      jobPosition: 3,
+      status: 'skipped',
+      statusReason: 'condition_rejected',
+      evaluationTrace: [
+        {
+          expression: `\${{ inputs.publish }}`,
+          fillTarget: 'jobs.build.if',
+          field: 'if',
+          value: 'false',
+        },
+      ],
+    });
+  });
+});
+
+function annotationItem(
+  originOverrides: Partial<WorkflowRunAnnotationItemDto['origin']> = {},
+): WorkflowRunAnnotationItemDto {
+  return {
+    annotation: {
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001',
+      job_id: JOB_ID,
+      job_execution_id: EXECUTION_ID,
+      origin_step_id: STEP_ID,
+      origin_step_attempt: 4,
+      context: 'release URL',
+      style: 'info',
+      sequence: 9,
+      body: 'Published https://example.test',
+    },
+    origin: {
+      job_id: JOB_ID,
+      job_label: 'Build web',
+      job_position: 3,
+      job_execution_id: EXECUTION_ID,
+      execution_sequence: 2,
+      execution_label: 'execution #2',
+      step_id: STEP_ID,
+      step_label: 'Publish URL',
+      step_attempt_id: null,
+      step_attempt: 4,
+      ...originOverrides,
+    },
+  };
+}
+
+function jobExplanation(): WorkflowRunJobExplanationDto {
+  return {
+    job_id: JOB_ID,
+    job_label: 'Build web',
+    job_position: 3,
+    status: 'skipped',
+    status_reason: 'condition_rejected',
+    evaluation_trace: [
+      {
+        expression: `\${{ inputs.publish }}`,
+        roots: ['inputs'],
+        fill_target: 'jobs.build.if',
+        evaluated_at: '2026-09-04T12:00:00.000Z',
+        field: 'if',
+        value: 'false',
+      },
+    ],
+  };
+}

--- a/libs/client/workflows/src/hooks/api/run-annotation-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/run-annotation-mapper.ts
@@ -1,9 +1,24 @@
-import type {AnnotationDto, ReadAnnotationsResponseDto} from '@shipfox/annotations-dto';
-import type {RunAnnotationRecord} from '#core/run-annotation.js';
+import type {AnnotationDto} from '@shipfox/annotations-dto';
+import type {
+  WorkflowRunAnnotationItemDto,
+  WorkflowRunAnnotationsResponseDto,
+  WorkflowRunJobExplanationDto,
+  WorkflowRunJobExplanationsResponseDto,
+} from '@shipfox/api-workflows-dto';
+import type {
+  RunAnnotationEntry,
+  RunAnnotationRecord,
+  RunJobExplanation,
+} from '#core/run-annotation.js';
+import {toEvaluationTrace} from './workflow-run-mapper.js';
 
 export interface RunAnnotationPage {
-  annotations: RunAnnotationRecord[];
-  hasMore: boolean;
+  entries: RunAnnotationEntry[];
+  nextCursor: string | null;
+}
+
+export interface RunJobExplanationPage {
+  explanations: RunJobExplanation[];
   nextCursor: string | null;
 }
 
@@ -21,10 +36,52 @@ export function toRunAnnotation(dto: AnnotationDto): RunAnnotationRecord {
   };
 }
 
-export function toRunAnnotationPage(response: ReadAnnotationsResponseDto): RunAnnotationPage {
+export function toRunAnnotationEntry(item: WorkflowRunAnnotationItemDto): RunAnnotationEntry {
+  const {annotation, origin} = item;
   return {
-    annotations: response.annotations.map(toRunAnnotation),
-    hasMore: response.has_more,
+    annotation: toRunAnnotation(annotation),
+    jobName: origin.job_label,
+    jobPosition: origin.job_position,
+    executionSequence: origin.execution_sequence,
+    executionLabel: origin.execution_label,
+    stepLabel: origin.step_label,
+    attemptLabel: `attempt ${origin.step_attempt}`,
+    origin: origin.step_attempt_id
+      ? {
+          jobId: origin.job_id,
+          jobExecutionId: origin.job_execution_id,
+          stepId: origin.step_id,
+          stepAttemptId: origin.step_attempt_id,
+        }
+      : null,
+  };
+}
+
+export function toRunAnnotationPage(
+  response: Pick<WorkflowRunAnnotationsResponseDto, 'items' | 'next_cursor'>,
+): RunAnnotationPage {
+  return {
+    entries: response.items.map(toRunAnnotationEntry),
+    nextCursor: response.next_cursor,
+  };
+}
+
+export function toRunJobExplanation(dto: WorkflowRunJobExplanationDto): RunJobExplanation {
+  return {
+    jobId: dto.job_id,
+    jobName: dto.job_label,
+    jobPosition: dto.job_position,
+    status: dto.status,
+    statusReason: dto.status_reason,
+    evaluationTrace: toEvaluationTrace(dto.evaluation_trace),
+  };
+}
+
+export function toRunJobExplanationPage(
+  response: Pick<WorkflowRunJobExplanationsResponseDto, 'items' | 'next_cursor'>,
+): RunJobExplanationPage {
+  return {
+    explanations: response.items.map(toRunJobExplanation),
     nextCursor: response.next_cursor,
   };
 }

--- a/libs/client/workflows/src/hooks/api/run-annotations.test.tsx
+++ b/libs/client/workflows/src/hooks/api/run-annotations.test.tsx
@@ -1,0 +1,137 @@
+import type {
+  WorkflowRunAnnotationItemDto,
+  WorkflowRunJobExplanationDto,
+} from '@shipfox/api-workflows-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {act, cleanup, renderHook, waitFor} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {useRunAnnotationsQuery} from './run-annotations.js';
+import {useRunJobExplanationsQuery} from './run-job-explanations.js';
+
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+const JOB_ID = '44444444-4444-4444-8444-00000000000b';
+const EXECUTION_ID = '77777777-7777-4777-8777-00000000000b';
+const STEP_ID = '55555555-5555-4555-8555-00000000000b';
+const STEP_ATTEMPT_ID = '66666666-6666-4666-8666-00000000000b';
+
+describe('run annotation resource hooks', () => {
+  afterEach(() => {
+    cleanup();
+    configureApiClient({baseUrl: '', fetchImpl: undefined});
+  });
+
+  test('loads and independently pages enriched annotations and job explanations', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.pathname.endsWith('/job-explanations')) {
+        return Promise.resolve(jsonResponse({items: [jobExplanation()], next_cursor: null}));
+      }
+      const secondPage = url.searchParams.get('cursor') === 'annotation-page-2';
+      return Promise.resolve(
+        jsonResponse({
+          items: secondPage ? [annotationItem('second')] : [annotationItem('first')],
+          next_cursor: secondPage ? null : 'annotation-page-2',
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderWithQueryClient(() => ({
+      annotations: useRunAnnotationsQuery({workflowRunId: RUN_ID, runAttempt: 2}),
+      explanations: useRunJobExplanationsQuery({workflowRunId: RUN_ID, runAttempt: 2}),
+    }));
+
+    await waitFor(() => {
+      expect(result.current.annotations.entries).toHaveLength(1);
+      expect(result.current.explanations.explanations).toHaveLength(1);
+    });
+    expect(requestUrls(fetchImpl)).toEqual([
+      `https://api.example.test/workflows/runs/${RUN_ID}/annotations?attempt=2&limit=100`,
+      `https://api.example.test/workflows/runs/${RUN_ID}/job-explanations?attempt=2&limit=100`,
+    ]);
+    expect(result.current.annotations.summary).toMatchObject({total: 1, truncated: true});
+    expect(result.current.explanations.explanations?.[0]).toMatchObject({
+      jobName: 'Deploy',
+      statusReason: 'condition_rejected',
+    });
+
+    await act(() => result.current.annotations.query.fetchNextPage());
+
+    await waitFor(() =>
+      expect(result.current.annotations.entries?.map(({annotation}) => annotation.context)).toEqual(
+        ['first', 'second'],
+      ),
+    );
+    expect(requestUrls(fetchImpl).at(-1)).toBe(
+      `https://api.example.test/workflows/runs/${RUN_ID}/annotations?attempt=2&limit=100&cursor=annotation-page-2`,
+    );
+    expect(result.current.annotations.summary).toMatchObject({total: 2, truncated: false});
+  });
+});
+
+function renderWithQueryClient<T>(callback: () => T) {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(callback, {wrapper});
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+  });
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (typeof input === 'string') return new URL(input);
+  return input instanceof URL ? input : new URL(input.url);
+}
+
+function requestUrls(fetchImpl: ReturnType<typeof vi.fn>): string[] {
+  return fetchImpl.mock.calls.map(([input]) => requestUrl(input as RequestInfo | URL).href);
+}
+
+function annotationItem(context: string): WorkflowRunAnnotationItemDto {
+  return {
+    annotation: {
+      id:
+        context === 'first'
+          ? 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001'
+          : 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002',
+      job_id: JOB_ID,
+      job_execution_id: EXECUTION_ID,
+      origin_step_id: STEP_ID,
+      origin_step_attempt: 1,
+      context,
+      style: 'info',
+      sequence: context === 'first' ? 1 : 2,
+      body: 'Body',
+    },
+    origin: {
+      job_id: JOB_ID,
+      job_label: 'Build',
+      job_position: 0,
+      job_execution_id: EXECUTION_ID,
+      execution_sequence: 1,
+      execution_label: null,
+      step_id: STEP_ID,
+      step_label: 'Compile',
+      step_attempt_id: STEP_ATTEMPT_ID,
+      step_attempt: 1,
+    },
+  };
+}
+
+function jobExplanation(): WorkflowRunJobExplanationDto {
+  return {
+    job_id: JOB_ID,
+    job_label: 'Deploy',
+    job_position: 1,
+    status: 'skipped',
+    status_reason: 'condition_rejected',
+    evaluation_trace: null,
+  };
+}

--- a/libs/client/workflows/src/hooks/api/run-annotations.test.tsx
+++ b/libs/client/workflows/src/hooks/api/run-annotations.test.tsx
@@ -87,7 +87,47 @@ describe('run annotation resource hooks', () => {
       WORKFLOW_RESOURCE_ERROR_POLL_MS,
     );
     expect(refetchInterval(options, 2, null)).toBe(false);
+    expect(refetchOnWindowFocus(options, 1)).toBe(true);
     expect(refetchOnWindowFocus(options, 2)).toBe(false);
+  });
+
+  test.each([
+    ['annotations', runAnnotationsQueryOptions],
+    ['job explanations', runJobExplanationsQueryOptions],
+  ] as const)('settles terminal %s resources', (_name, optionsFor) => {
+    const options = optionsFor({workflowRunId: RUN_ID, runAttempt: 2, live: false});
+
+    expect(options.staleTime).toBe(Infinity);
+    expect(refetchInterval(options, 1, null)).toBe(false);
+    expect(refetchOnWindowFocus(options, 1)).toBe(false);
+  });
+
+  test('stops automatic aggregation when the API repeats a cursor', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      const repeatedPage = url.searchParams.get('cursor') === 'repeat-cursor';
+      return Promise.resolve(
+        jsonResponse({
+          items: [annotationItem(repeatedPage ? 'second' : 'first')],
+          next_cursor: 'repeat-cursor',
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderWithQueryClient(() =>
+      useRunAnnotationsQuery({
+        workflowRunId: RUN_ID,
+        runAttempt: 2,
+        loadAllPages: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.entries).toHaveLength(2));
+    expect(result.current.query.hasNextPage).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.current.entries).toHaveLength(2);
+    expect(result.current.summary).toMatchObject({total: 2, truncated: true});
   });
 });
 

--- a/libs/client/workflows/src/hooks/api/run-annotations.test.tsx
+++ b/libs/client/workflows/src/hooks/api/run-annotations.test.tsx
@@ -6,8 +6,15 @@ import {configureApiClient} from '@shipfox/client-api';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {act, cleanup, renderHook, waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
-import {useRunAnnotationsQuery} from './run-annotations.js';
-import {useRunJobExplanationsQuery} from './run-job-explanations.js';
+import {runAnnotationsQueryOptions, useRunAnnotationsQuery} from './run-annotations.js';
+import {
+  runJobExplanationsQueryOptions,
+  useRunJobExplanationsQuery,
+} from './run-job-explanations.js';
+import {
+  WORKFLOW_RESOURCE_ACTIVE_POLL_MS,
+  WORKFLOW_RESOURCE_ERROR_POLL_MS,
+} from './workflow-resource-query.js';
 
 const RUN_ID = '11111111-1111-4111-8111-111111111111';
 const JOB_ID = '44444444-4444-4444-8444-00000000000b';
@@ -68,7 +75,39 @@ describe('run annotation resource hooks', () => {
     );
     expect(result.current.annotations.summary).toMatchObject({total: 2, truncated: false});
   });
+
+  test.each([
+    ['annotations', runAnnotationsQueryOptions],
+    ['job explanations', runJobExplanationsQueryOptions],
+  ] as const)('keeps a recoverable first-page polling policy for %s', (_name, optionsFor) => {
+    const options = optionsFor({workflowRunId: RUN_ID, runAttempt: 2, live: true});
+
+    expect(refetchInterval(options, 1, null)).toBe(WORKFLOW_RESOURCE_ACTIVE_POLL_MS);
+    expect(refetchInterval(options, 1, new Error('Unavailable'))).toBe(
+      WORKFLOW_RESOURCE_ERROR_POLL_MS,
+    );
+    expect(refetchInterval(options, 2, null)).toBe(false);
+    expect(refetchOnWindowFocus(options, 2)).toBe(false);
+  });
 });
+
+function refetchInterval(
+  options: {refetchInterval?: unknown},
+  pageCount: number,
+  error: Error | null,
+) {
+  if (typeof options.refetchInterval !== 'function') return options.refetchInterval;
+  return options.refetchInterval({
+    state: {data: {pages: Array.from({length: pageCount}, () => ({}))}, error},
+  } as never);
+}
+
+function refetchOnWindowFocus(options: {refetchOnWindowFocus?: unknown}, pageCount: number) {
+  if (typeof options.refetchOnWindowFocus !== 'function') return options.refetchOnWindowFocus;
+  return options.refetchOnWindowFocus({
+    state: {data: {pages: Array.from({length: pageCount}, () => ({}))}},
+  } as never);
+}
 
 function renderWithQueryClient<T>(callback: () => T) {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});

--- a/libs/client/workflows/src/hooks/api/run-annotations.ts
+++ b/libs/client/workflows/src/hooks/api/run-annotations.ts
@@ -5,21 +5,17 @@ import {
 import {checkedApiRequest} from '@shipfox/client-api';
 import {
   type InfiniteData,
-  infiniteQueryOptions,
   type UseInfiniteQueryOptions,
   useInfiniteQuery,
 } from '@tanstack/react-query';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {
   type RunAnnotationEntry,
   type RunAnnotationSummary,
   summarizeRunAnnotations,
 } from '#core/run-annotation.js';
 import {type RunAnnotationPage, toRunAnnotationPage} from './run-annotation-mapper.js';
-import {
-  WORKFLOW_RESOURCE_ACTIVE_POLL_MS,
-  WORKFLOW_RESOURCE_STALE_TIME_MS,
-} from './workflow-resource-query.js';
+import {paginatedWorkflowResourceQueryOptions} from './workflow-resource-query.js';
 
 export const runAnnotationsQueryKeys = {
   all: ['run-annotations'] as const,
@@ -71,6 +67,8 @@ export interface RunAnnotationsQueryInput {
   enabled?: boolean | undefined;
   /** Poll while the run attempt is non-terminal, then settle. */
   live?: boolean | undefined;
+  /** Fetch every page for consumers that need an exact run-wide aggregate. */
+  loadAllPages?: boolean | undefined;
 }
 
 export function runAnnotationsQueryOptions({
@@ -81,15 +79,12 @@ export function runAnnotationsQueryOptions({
 }: RunAnnotationsQueryInput): RunAnnotationsQueryOptions {
   const enabled = Boolean(workflowRunId) && runAttempt !== undefined && enabledOption;
 
-  // Polling stops once the reader has paged past the first page: the cursor bounding page 2 was
-  // computed from page 1's last row, so a refetch that shifts that boundary can drop a range of
-  // annotations into a between-pages gap.
-  return infiniteQueryOptions({
+  return paginatedWorkflowResourceQueryOptions({
     queryKey: workflowRunId
       ? runAnnotationsQueryKeys.list(workflowRunId, runAttempt)
       : ([...runAnnotationsQueryKeys.all, 'list'] as const),
     enabled,
-    initialPageParam: undefined as string | undefined,
+    live,
     queryFn: ({pageParam, signal}) =>
       listRunAnnotations({
         workflowRunId: workflowRunId ?? '',
@@ -97,15 +92,6 @@ export function runAnnotationsQueryOptions({
         cursor: pageParam,
         signal,
       }),
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    staleTime: WORKFLOW_RESOURCE_STALE_TIME_MS,
-    refetchOnWindowFocus: true,
-    refetchInterval: (query) => {
-      if (!live || query.state.error !== null) return false;
-      const pages = query.state.data?.pages;
-      return pages && pages.length > 1 ? false : WORKFLOW_RESOURCE_ACTIVE_POLL_MS;
-    },
-    refetchIntervalInBackground: false,
   });
 }
 
@@ -127,6 +113,19 @@ export interface RunAnnotationsQueryResult {
 export function useRunAnnotationsQuery(input: RunAnnotationsQueryInput): RunAnnotationsQueryResult {
   const query = useInfiniteQuery(runAnnotationsQueryOptions(input));
   const pages = query.data?.pages;
+
+  useEffect(() => {
+    if (!input.loadAllPages || !query.hasNextPage || query.isFetchingNextPage || query.isError) {
+      return;
+    }
+    void query.fetchNextPage();
+  }, [
+    input.loadAllPages,
+    query.fetchNextPage,
+    query.hasNextPage,
+    query.isError,
+    query.isFetchingNextPage,
+  ]);
 
   const entries = useMemo(
     () => (pages ? pages.flatMap((page) => page.entries) : undefined),

--- a/libs/client/workflows/src/hooks/api/run-annotations.ts
+++ b/libs/client/workflows/src/hooks/api/run-annotations.ts
@@ -1,4 +1,7 @@
-import {READ_ANNOTATIONS_MAX_LIMIT, readAnnotationsResponseSchema} from '@shipfox/annotations-dto';
+import {
+  WORKFLOW_RUN_ANNOTATIONS_PAGE_LIMIT,
+  workflowRunAnnotationsResponseSchema,
+} from '@shipfox/api-workflows-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {
   type InfiniteData,
@@ -8,14 +11,15 @@ import {
 } from '@tanstack/react-query';
 import {useMemo} from 'react';
 import {
-  type RunAnnotationRecord,
+  type RunAnnotationEntry,
   type RunAnnotationSummary,
   summarizeRunAnnotations,
 } from '#core/run-annotation.js';
 import {type RunAnnotationPage, toRunAnnotationPage} from './run-annotation-mapper.js';
-
-/** Matches the run detail poll, so annotations and run state never disagree by more than a tick. */
-const ACTIVE_POLL_MS = 4_000;
+import {
+  WORKFLOW_RESOURCE_ACTIVE_POLL_MS,
+  WORKFLOW_RESOURCE_STALE_TIME_MS,
+} from './workflow-resource-query.js';
 
 export const runAnnotationsQueryKeys = {
   all: ['run-annotations'] as const,
@@ -47,16 +51,17 @@ async function listRunAnnotations({
   signal?: AbortSignal;
 }): Promise<RunAnnotationPage> {
   const params = new URLSearchParams({
-    workflow_run_id: workflowRunId,
     attempt: String(runAttempt),
-    limit: String(READ_ANNOTATIONS_MAX_LIMIT),
+    limit: String(WORKFLOW_RUN_ANNOTATIONS_PAGE_LIMIT),
   });
   if (cursor) params.set('cursor', cursor);
 
   return toRunAnnotationPage(
-    await checkedApiRequest(readAnnotationsResponseSchema, `/annotations?${params.toString()}`, {
-      signal,
-    }),
+    await checkedApiRequest(
+      workflowRunAnnotationsResponseSchema,
+      `/workflows/runs/${workflowRunId}/annotations?${params.toString()}`,
+      {signal},
+    ),
   );
 }
 
@@ -93,12 +98,12 @@ export function runAnnotationsQueryOptions({
         signal,
       }),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    staleTime: 2_000,
+    staleTime: WORKFLOW_RESOURCE_STALE_TIME_MS,
     refetchOnWindowFocus: true,
     refetchInterval: (query) => {
-      if (!live) return false;
+      if (!live || query.state.error !== null) return false;
       const pages = query.state.data?.pages;
-      return pages && pages.length > 1 ? false : ACTIVE_POLL_MS;
+      return pages && pages.length > 1 ? false : WORKFLOW_RESOURCE_ACTIVE_POLL_MS;
     },
     refetchIntervalInBackground: false,
   });
@@ -115,7 +120,7 @@ export interface RunAnnotationsQueryResult {
     >
   >;
   /** `undefined` until the first page resolves, so counts never render a speculative zero. */
-  annotations: RunAnnotationRecord[] | undefined;
+  entries: RunAnnotationEntry[] | undefined;
   summary: RunAnnotationSummary | undefined;
 }
 
@@ -123,17 +128,20 @@ export function useRunAnnotationsQuery(input: RunAnnotationsQueryInput): RunAnno
   const query = useInfiniteQuery(runAnnotationsQueryOptions(input));
   const pages = query.data?.pages;
 
-  const annotations = useMemo(
-    () => (pages ? pages.flatMap((page) => page.annotations) : undefined),
+  const entries = useMemo(
+    () => (pages ? pages.flatMap((page) => page.entries) : undefined),
     [pages],
   );
   const summary = useMemo(
     () =>
-      annotations
-        ? summarizeRunAnnotations(annotations, {truncated: pages?.at(-1)?.hasMore ?? false})
+      entries
+        ? summarizeRunAnnotations(
+            entries.map((entry) => entry.annotation),
+            {truncated: pages?.at(-1)?.nextCursor !== null},
+          )
         : undefined,
-    [annotations, pages],
+    [entries, pages],
   );
 
-  return {query, annotations, summary};
+  return {query, entries, summary};
 }

--- a/libs/client/workflows/src/hooks/api/run-job-explanations.ts
+++ b/libs/client/workflows/src/hooks/api/run-job-explanations.ts
@@ -1,0 +1,129 @@
+import {
+  WORKFLOW_RUN_JOB_EXPLANATIONS_PAGE_LIMIT,
+  workflowRunJobExplanationsResponseSchema,
+} from '@shipfox/api-workflows-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {
+  type InfiniteData,
+  infiniteQueryOptions,
+  type UseInfiniteQueryOptions,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import type {RunJobExplanation} from '#core/run-annotation.js';
+import {type RunJobExplanationPage, toRunJobExplanationPage} from './run-annotation-mapper.js';
+import {
+  WORKFLOW_RESOURCE_ACTIVE_POLL_MS,
+  WORKFLOW_RESOURCE_STALE_TIME_MS,
+} from './workflow-resource-query.js';
+
+export const runJobExplanationsQueryKeys = {
+  all: ['run-job-explanations'] as const,
+  list: (workflowRunId: string, runAttempt?: number | undefined) =>
+    [...runJobExplanationsQueryKeys.all, 'list', workflowRunId, runAttempt ?? null] as const,
+};
+
+type RunJobExplanationsQueryKey =
+  | ReturnType<typeof runJobExplanationsQueryKeys.list>
+  | readonly ['run-job-explanations', 'list'];
+
+type RunJobExplanationsQueryOptions = UseInfiniteQueryOptions<
+  RunJobExplanationPage,
+  Error,
+  InfiniteData<RunJobExplanationPage, string | undefined>,
+  RunJobExplanationsQueryKey,
+  string | undefined
+>;
+
+async function listRunJobExplanations({
+  workflowRunId,
+  runAttempt,
+  cursor,
+  signal,
+}: {
+  workflowRunId: string;
+  runAttempt: number;
+  cursor?: string | undefined;
+  signal?: AbortSignal;
+}): Promise<RunJobExplanationPage> {
+  const params = new URLSearchParams({
+    attempt: String(runAttempt),
+    limit: String(WORKFLOW_RUN_JOB_EXPLANATIONS_PAGE_LIMIT),
+  });
+  if (cursor) params.set('cursor', cursor);
+
+  return toRunJobExplanationPage(
+    await checkedApiRequest(
+      workflowRunJobExplanationsResponseSchema,
+      `/workflows/runs/${workflowRunId}/job-explanations?${params.toString()}`,
+      {signal},
+    ),
+  );
+}
+
+export interface RunJobExplanationsQueryInput {
+  workflowRunId: string | undefined;
+  runAttempt: number | undefined;
+  enabled?: boolean | undefined;
+  /** Poll while the run attempt is non-terminal, then settle. */
+  live?: boolean | undefined;
+}
+
+export function runJobExplanationsQueryOptions({
+  workflowRunId,
+  runAttempt,
+  enabled: enabledOption = true,
+  live = false,
+}: RunJobExplanationsQueryInput): RunJobExplanationsQueryOptions {
+  const enabled = Boolean(workflowRunId) && runAttempt !== undefined && enabledOption;
+
+  return infiniteQueryOptions({
+    queryKey: workflowRunId
+      ? runJobExplanationsQueryKeys.list(workflowRunId, runAttempt)
+      : ([...runJobExplanationsQueryKeys.all, 'list'] as const),
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({pageParam, signal}) =>
+      listRunJobExplanations({
+        workflowRunId: workflowRunId ?? '',
+        runAttempt: runAttempt ?? 1,
+        cursor: pageParam,
+        signal,
+      }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: WORKFLOW_RESOURCE_STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+    refetchInterval: (query) => {
+      if (!live || query.state.error !== null) return false;
+      const pages = query.state.data?.pages;
+      return pages && pages.length > 1 ? false : WORKFLOW_RESOURCE_ACTIVE_POLL_MS;
+    },
+    refetchIntervalInBackground: false,
+  });
+}
+
+export interface RunJobExplanationsQueryResult {
+  query: ReturnType<
+    typeof useInfiniteQuery<
+      RunJobExplanationPage,
+      Error,
+      InfiniteData<RunJobExplanationPage, string | undefined>,
+      RunJobExplanationsQueryKey,
+      string | undefined
+    >
+  >;
+  explanations: RunJobExplanation[] | undefined;
+}
+
+export function useRunJobExplanationsQuery(
+  input: RunJobExplanationsQueryInput,
+): RunJobExplanationsQueryResult {
+  const query = useInfiniteQuery(runJobExplanationsQueryOptions(input));
+  const pages = query.data?.pages;
+  const explanations = useMemo(
+    () => (pages ? pages.flatMap((page) => page.explanations) : undefined),
+    [pages],
+  );
+
+  return {query, explanations};
+}

--- a/libs/client/workflows/src/hooks/api/run-job-explanations.ts
+++ b/libs/client/workflows/src/hooks/api/run-job-explanations.ts
@@ -5,17 +5,13 @@ import {
 import {checkedApiRequest} from '@shipfox/client-api';
 import {
   type InfiniteData,
-  infiniteQueryOptions,
   type UseInfiniteQueryOptions,
   useInfiniteQuery,
 } from '@tanstack/react-query';
 import {useMemo} from 'react';
 import type {RunJobExplanation} from '#core/run-annotation.js';
 import {type RunJobExplanationPage, toRunJobExplanationPage} from './run-annotation-mapper.js';
-import {
-  WORKFLOW_RESOURCE_ACTIVE_POLL_MS,
-  WORKFLOW_RESOURCE_STALE_TIME_MS,
-} from './workflow-resource-query.js';
+import {paginatedWorkflowResourceQueryOptions} from './workflow-resource-query.js';
 
 export const runJobExplanationsQueryKeys = {
   all: ['run-job-explanations'] as const,
@@ -77,12 +73,12 @@ export function runJobExplanationsQueryOptions({
 }: RunJobExplanationsQueryInput): RunJobExplanationsQueryOptions {
   const enabled = Boolean(workflowRunId) && runAttempt !== undefined && enabledOption;
 
-  return infiniteQueryOptions({
+  return paginatedWorkflowResourceQueryOptions({
     queryKey: workflowRunId
       ? runJobExplanationsQueryKeys.list(workflowRunId, runAttempt)
       : ([...runJobExplanationsQueryKeys.all, 'list'] as const),
     enabled,
-    initialPageParam: undefined as string | undefined,
+    live,
     queryFn: ({pageParam, signal}) =>
       listRunJobExplanations({
         workflowRunId: workflowRunId ?? '',
@@ -90,15 +86,6 @@ export function runJobExplanationsQueryOptions({
         cursor: pageParam,
         signal,
       }),
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    staleTime: WORKFLOW_RESOURCE_STALE_TIME_MS,
-    refetchOnWindowFocus: true,
-    refetchInterval: (query) => {
-      if (!live || query.state.error !== null) return false;
-      const pages = query.state.data?.pages;
-      return pages && pages.length > 1 ? false : WORKFLOW_RESOURCE_ACTIVE_POLL_MS;
-    },
-    refetchIntervalInBackground: false,
   });
 }
 

--- a/libs/client/workflows/src/hooks/api/workflow-resource-query.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-resource-query.ts
@@ -85,9 +85,12 @@ export function paginatedWorkflowResourceQueryOptions<
     queryFn,
     enabled,
     initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    staleTime: WORKFLOW_RESOURCE_STALE_TIME_MS,
-    refetchOnWindowFocus: (query) => (query.state.data?.pages.length ?? 0) <= 1,
+    getNextPageParam: (lastPage, _pages, _lastPageParam, pageParams) => {
+      const nextCursor = lastPage.nextCursor ?? undefined;
+      return nextCursor && !pageParams.includes(nextCursor) ? nextCursor : undefined;
+    },
+    staleTime: live ? WORKFLOW_RESOURCE_STALE_TIME_MS : Infinity,
+    refetchOnWindowFocus: (query) => live && (query.state.data?.pages.length ?? 0) <= 1,
     refetchInterval: (query) => {
       if (!enabled || !live) return false;
       const pages = query.state.data?.pages;

--- a/libs/client/workflows/src/hooks/api/workflow-resource-query.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-resource-query.ts
@@ -1,6 +1,14 @@
-import type {QueryFunction, QueryKey, UseQueryOptions} from '@tanstack/react-query';
+import {
+  type InfiniteData,
+  infiniteQueryOptions,
+  type QueryFunction,
+  type QueryKey,
+  type UseInfiniteQueryOptions,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
 
 export const WORKFLOW_RESOURCE_ACTIVE_POLL_MS = 4_000;
+export const WORKFLOW_RESOURCE_ERROR_POLL_MS = 15_000;
 export const WORKFLOW_RESOURCE_STALE_TIME_MS = 2_000;
 
 type WorkflowResourceQueryOptions<TData, TQueryKey extends QueryKey> = Pick<
@@ -37,4 +45,57 @@ export function workflowResourceQueryOptions<TData, TQueryKey extends QueryKey>(
     },
     refetchIntervalInBackground: false,
   };
+}
+
+type PaginatedWorkflowResourceQueryOptions<
+  TPage extends {nextCursor: string | null},
+  TQueryKey extends QueryKey,
+> = UseInfiniteQueryOptions<
+  TPage,
+  Error,
+  InfiniteData<TPage, string | undefined>,
+  TQueryKey,
+  string | undefined
+>;
+
+/**
+ * Shared lifecycle for mutable cursor-paged run resources.
+ *
+ * Polling and focus refetch stop after page two has been derived from page one's cursor. Refetching
+ * page one after that point could shift its boundary and leave rows between the two cached pages.
+ * A live first page keeps a slower heartbeat after a transient error so it can recover without the
+ * reader having to notice and activate a retry control.
+ */
+export function paginatedWorkflowResourceQueryOptions<
+  TPage extends {nextCursor: string | null},
+  TQueryKey extends QueryKey,
+>({
+  queryKey,
+  queryFn,
+  enabled,
+  live,
+}: {
+  queryKey: TQueryKey;
+  queryFn: QueryFunction<TPage, TQueryKey, string | undefined>;
+  enabled: boolean;
+  live: boolean;
+}): PaginatedWorkflowResourceQueryOptions<TPage, TQueryKey> {
+  return infiniteQueryOptions({
+    queryKey,
+    queryFn,
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: WORKFLOW_RESOURCE_STALE_TIME_MS,
+    refetchOnWindowFocus: (query) => (query.state.data?.pages.length ?? 0) <= 1,
+    refetchInterval: (query) => {
+      if (!enabled || !live) return false;
+      const pages = query.state.data?.pages;
+      if (pages && pages.length > 1) return false;
+      return query.state.error === null
+        ? WORKFLOW_RESOURCE_ACTIVE_POLL_MS
+        : WORKFLOW_RESOURCE_ERROR_POLL_MS;
+    },
+    refetchIntervalInBackground: false,
+  });
 }

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -49,6 +49,7 @@ const JOB_DETAIL_PATH_RE = /^\/workflows\/runs\/jobs\/([^/]+)$/u;
 describe('WorkflowJobDetailPage', () => {
   beforeEach(() => {
     jobAnnotations.value = [];
+    jobAnnotations.nextPage = [];
   });
 
   test('lets the job detail route inherit its shell canvas', async () => {
@@ -108,6 +109,56 @@ describe('WorkflowJobDetailPage', () => {
 
     await screen.findByRole('heading', {name: 'release'});
     expect(screen.queryByRole('link', {name: ANNOTATION_LINK_PATTERN})).not.toBeInTheDocument();
+  });
+
+  test('loads every annotation page before settling the job count', async () => {
+    jobAnnotations.value = [
+      {
+        id: 'aaaaaaaa-1111-4aaa-8aaa-000000000001',
+        job_id: SIBLING_JOB_ID,
+        job_execution_id: EXECUTION_ID,
+        origin_step_id: STEP_ID,
+        origin_step_attempt: 1,
+        context: 'other job',
+        style: 'info',
+        sequence: 1,
+        body: 'Not this job.',
+      },
+    ];
+    jobAnnotations.nextPage = [
+      {
+        id: 'aaaaaaaa-1111-4aaa-8aaa-000000000002',
+        job_id: JOB_ID,
+        job_execution_id: EXECUTION_ID,
+        origin_step_id: STEP_ID,
+        origin_step_attempt: 2,
+        context: 'smoke check',
+        style: 'error',
+        sequence: 2,
+        body: 'Task nine failed.',
+      },
+    ];
+    const annotationRequests: URL[] = [];
+    configureApiClient({
+      fetchImpl: vi.fn((input: RequestInfo | URL) => {
+        const url = new URL((input as Request).url);
+        if (url.pathname === `/workflows/runs/${RUN_ID}/annotations`) {
+          annotationRequests.push(url);
+        }
+        return jobDetailFetch(input);
+      }),
+    });
+
+    renderJobPath(`?jobExecution=${EXECUTION_ID}&runAttempt=1`);
+
+    expect(
+      await screen.findByRole('link', {name: 'View 1 annotation, highest severity error'}),
+    ).toBeInTheDocument();
+    expect(
+      annotationRequests.some(
+        (request) => request.searchParams.get('cursor') === 'job-annotations-page-2',
+      ),
+    ).toBe(true);
   });
 
   test('resolves an exact job execution and step attempt from a deep link', async () => {
@@ -486,11 +537,16 @@ function renderJobPath(path = '', jobId = JOB_ID) {
 }
 
 /** Annotations for the job page, which renders their count and never their bodies. */
-const jobAnnotations: {value: AnnotationDto[]} = {value: []};
+const jobAnnotations: {value: AnnotationDto[]; nextPage: AnnotationDto[]} = {
+  value: [],
+  nextPage: [],
+};
 
-function annotationsResponse() {
+function annotationsResponse(cursor: string | null = null) {
+  const annotations =
+    cursor === 'job-annotations-page-2' ? jobAnnotations.nextPage : jobAnnotations.value;
   return {
-    items: jobAnnotations.value.map((annotation) => ({
+    items: annotations.map((annotation) => ({
       annotation,
       origin: {
         job_id: annotation.job_id,
@@ -505,7 +561,8 @@ function annotationsResponse() {
         step_attempt: annotation.origin_step_attempt,
       },
     })),
-    next_cursor: null,
+    next_cursor:
+      cursor === null && jobAnnotations.nextPage.length > 0 ? 'job-annotations-page-2' : null,
   };
 }
 
@@ -514,7 +571,7 @@ function jobDetailFetch(input: RequestInfo | URL) {
   const url = new URL(request.url);
 
   if (url.pathname.endsWith('/annotations')) {
-    return Promise.resolve(jsonResponse(annotationsResponse()));
+    return Promise.resolve(jsonResponse(annotationsResponse(url.searchParams.get('cursor'))));
   }
 
   if (url.pathname.endsWith('/attempts')) {

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -1,3 +1,4 @@
+import type {AnnotationDto} from '@shipfox/annotations-dto';
 import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {act, screen, waitFor} from '@testing-library/react';
@@ -485,10 +486,27 @@ function renderJobPath(path = '', jobId = JOB_ID) {
 }
 
 /** Annotations for the job page, which renders their count and never their bodies. */
-const jobAnnotations: {value: unknown[]} = {value: []};
+const jobAnnotations: {value: AnnotationDto[]} = {value: []};
 
 function annotationsResponse() {
-  return {annotations: jobAnnotations.value, has_more: false, next_cursor: null};
+  return {
+    items: jobAnnotations.value.map((annotation) => ({
+      annotation,
+      origin: {
+        job_id: annotation.job_id,
+        job_label: annotation.job_id === JOB_ID ? 'release' : 'sibling',
+        job_position: annotation.job_id === JOB_ID ? 0 : 1,
+        job_execution_id: annotation.job_execution_id,
+        execution_sequence: 2,
+        execution_label: 'execution #2',
+        step_id: annotation.origin_step_id,
+        step_label: 'release',
+        step_attempt_id: ATTEMPT_ID,
+        step_attempt: annotation.origin_step_attempt,
+      },
+    })),
+    next_cursor: null,
+  };
 }
 
 function jobDetailFetch(input: RequestInfo | URL) {

--- a/libs/client/workflows/test/fixtures/workflow-run.ts
+++ b/libs/client/workflows/test/fixtures/workflow-run.ts
@@ -20,6 +20,11 @@ import type {
 } from '@shipfox/api-workflows-dto';
 import {WORKFLOW_RUN_JOB_PREVIEW_LIMIT} from '@shipfox/api-workflows-dto';
 import type {
+  RunAnnotationEntry,
+  RunAnnotationOrigin,
+  RunAnnotationRecord,
+} from '#core/run-annotation.js';
+import type {
   Job,
   Step,
   StepAttempt,
@@ -51,6 +56,38 @@ let jobSummarySequence = 0;
 let jobExecutionSequence = 0;
 let stepSequence = 0;
 let attemptSequence = 0;
+
+type RunAnnotationEntryOverrides = Partial<Omit<RunAnnotationEntry, 'annotation' | 'origin'>> & {
+  origin?: Partial<RunAnnotationOrigin> | null | undefined;
+};
+
+/** An enriched annotation entry with server-owned provenance and focused per-case overrides. */
+export function runAnnotationEntryFixture(
+  annotation: RunAnnotationRecord,
+  overrides: RunAnnotationEntryOverrides = {},
+): RunAnnotationEntry {
+  const {origin: originOverride, ...entryOverrides} = overrides;
+  return {
+    annotation,
+    jobName: 'build',
+    jobPosition: 0,
+    executionSequence: 1,
+    executionLabel: null,
+    stepLabel: 'compile',
+    attemptLabel: `attempt ${annotation.originStepAttempt}`,
+    origin:
+      originOverride === null
+        ? null
+        : {
+            jobId: annotation.jobId,
+            jobExecutionId: annotation.jobExecutionId,
+            stepId: annotation.originStepId,
+            stepAttemptId: STEP_ID,
+            ...originOverride,
+          },
+    ...entryOverrides,
+  };
+}
 
 export type JobDtoOverrides = Partial<Omit<WorkflowRunJobDetailDto, 'job_executions'>> & {
   job_executions?: WorkflowRunJobDetailDto['job_executions'];


### PR DESCRIPTION
Run annotations were still consuming legacy, unbounded annotation data and could not explain jobs that never produced executions. This change moves the workflow run UI to the bounded enriched annotation and job-explanation APIs, preserving server-authored provenance while keeping the two resources independently pageable and failure-tolerant.

The annotation view now renders available partial data when one resource is delayed or fails, maintains legacy deep-link selection only as a fallback, and avoids loading full run details just to populate overview annotations. Expected dependency, condition, and cancellation skips appear as neutral rows with a plain-language reason; evaluation problems remain warnings and no-execution failures remain errors. Internal job-explanation terminology and generic runner-availability remediation are not shown to users.

Focused adapter, hook, component, story, and page coverage exercises mapping, polling, paging, filtering, copy, presentation severity, and mixed-resource states.

Compatibility: the Annotations view now requires API deployments that provide both bounded workflow routes. API-only rollbacks to a release before those routes are not supported for this surface.

Closes ENG-1874