### PR TITLE
Stabilize flow fixtures and timeout diagnostics

### DIFF
--- a/e2e/observe/definitions/src/index.test.ts
+++ b/e2e/observe/definitions/src/index.test.ts
@@ -8,6 +8,8 @@ const DEFINITION_SYNC_FAILED_RE =
 const DEFINITION_TIMEOUT_RE =
   /Timed out waiting for definition: configPath=.shipfox\/workflows\/missing.yml/u;
 const DEFINITION_TIMEOUT_OBSERVED_RE = /definitions=\[id=22222222/u;
+const DEFINITION_TIMEOUT_SYNC_TIMESTAMPS_RE =
+  /syncStartedAt=2026-07-02T08:00:00.000Z syncLastSyncAt=2026-07-02T08:00:00.000Z/u;
 
 function definition(params: Partial<DefinitionDto> = {}): DefinitionDto {
   return {
@@ -160,6 +162,33 @@ describe('waitForDefinition', () => {
 
     await expect(result).rejects.toThrow(DEFINITION_TIMEOUT_RE);
     await expect(result).rejects.toThrow(DEFINITION_TIMEOUT_OBSERVED_RE);
+  });
+
+  test('reports sync timestamps so a timeout shows how long the sync has run', async () => {
+    const result = waitForDefinition({
+      configPath: '.shipfox/workflows/missing.yml',
+      fetch: () =>
+        response(
+          listResponse({
+            sync: {
+              ref: 'main',
+              status: 'syncing',
+              last_sync_at: '2026-07-02T08:00:00.000Z',
+              started_at: '2026-07-02T08:00:00.000Z',
+              finished_at: null,
+              last_error_code: null,
+              last_error_message: null,
+              diagnostics: [],
+            },
+          }),
+        ),
+      initialDelayMs: 1,
+      projectId,
+      timeoutMs: 10,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(DEFINITION_TIMEOUT_SYNC_TIMESTAMPS_RE);
   });
 
   test('passes abort signals through polling', async () => {

--- a/e2e/observe/definitions/src/index.ts
+++ b/e2e/observe/definitions/src/index.ts
@@ -1,6 +1,10 @@
 import type {DefinitionDto, DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
 import {type ApiFetch, createApiClient, pollUntil} from '@shipfox/e2e-core';
 
+// No budget here is really safe: the server holds a sync in `syncing` for as long as its
+// Temporal workflow is recovering, and provider activities retry 5 times with 5s/10s/20s/40s
+// backoff. Callers that do not test the sync itself should seed definitions over the API
+// instead of waiting on one.
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_INITIAL_DELAY_MS = 250;
 const DEFAULT_MAX_DELAY_MS = 4_000;
@@ -71,6 +75,10 @@ function formatObserved(response: DefinitionListResponseDto | null, selector: De
     ? [
         `syncStatus=${response.sync.status}`,
         `syncRef=${response.sync.ref ?? 'null'}`,
+        // A stuck sync and a sync that only just restarted both read `syncing`; the
+        // timestamps say which one a timeout actually observed.
+        `syncStartedAt=${response.sync.started_at ?? 'null'}`,
+        `syncLastSyncAt=${response.sync.last_sync_at}`,
         `syncErrorCode=${response.sync.last_error_code ?? 'null'}`,
         `syncErrorMessage=${response.sync.last_error_message ?? 'null'}`,
       ].join(' ')

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -23,7 +23,7 @@ import {
   postWebhookDelivery,
   type WebhookDiagnosticsRequest,
 } from './webhook.js';
-import {seedAndWaitForDefinition} from './workflow-project.js';
+import {seedProjectWithApiDefinition} from './workflow-project.js';
 
 export const LISTENER_JOB = 'listen';
 const FIRE_SOURCE_PLACEHOLDER = '__FIRE_WEBHOOK_SOURCE__';
@@ -105,7 +105,7 @@ export async function setupListenerCase(params: {
     }),
   ]);
 
-  const {definition} = await seedAndWaitForDefinition({
+  const {definition} = await seedProjectWithApiDefinition({
     suite: params.suite,
     token,
     name: params.testName,

--- a/e2e/suites/flow/workflows/src/slack-agent-tools.ts
+++ b/e2e/suites/flow/workflows/src/slack-agent-tools.ts
@@ -7,7 +7,7 @@ import {
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import {triggerSlackAppMentionAndAwaitRun} from '#slack-events.js';
 import type {SuiteContext} from '#suite-context.js';
-import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {seedProjectWithApiDefinition} from '#workflow-project.js';
 
 const TERMINAL_TIMEOUT_MS = 60_000;
 
@@ -38,7 +38,9 @@ export async function runSlackToolsWorkflow(params: {
   });
 
   try {
-    const {project} = await seedAndWaitForDefinition({
+    // This scenario proves Slack tooling, not definition sync, so it takes the definition
+    // straight from the API rather than waiting on gitea and Temporal to produce one.
+    const {project} = await seedProjectWithApiDefinition({
       suite: params.suite,
       token,
       name: scenario,

--- a/e2e/suites/flow/workflows/src/workflow-project.ts
+++ b/e2e/suites/flow/workflows/src/workflow-project.ts
@@ -28,13 +28,6 @@ export interface WorkflowProjectFile {
  */
 export type DefinitionDelivery = 'vcs' | 'api';
 
-// A job checks out the project repository unless it opts out, so an `api` delivery still
-// needs the repo to hold a commit and therefore a default branch.
-const CHECKOUT_PLACEHOLDER_FILE: WorkflowProjectFile = {
-  path: 'README.md',
-  content: '# Shipfox E2E fixture repository\n',
-};
-
 export interface SeededWorkflowProject {
   project: ProjectResponseDto;
   repo: string;
@@ -101,20 +94,24 @@ export async function seedWorkflowProject(params: {
       ...(giteaIssue === undefined ? {} : {__GITEA_ISSUE_NUMBER__: String(giteaIssue.number)}),
     },
   });
-  await commitFiles({
-    org: params.suite.org,
-    repo: params.repo,
-    message: `seed ${params.name}`,
-    files: [
-      // An `api` delivery deliberately leaves the workflow file out of the repo. A synced
-      // VCS definition at the same path is a second row with the same triggers, so it
-      // subscribes twice and one event starts two runs.
-      params.definitionDelivery === 'api'
-        ? CHECKOUT_PLACEHOLDER_FILE
-        : {path: params.configPath, content: renderedWorkflowYaml},
-      ...(params.extraFiles ?? []).map((file) => ({path: file.path, content: file.content})),
-    ],
-  });
+  const files = [
+    // An `api` delivery deliberately leaves the workflow file out of the repo. A synced
+    // VCS definition at the same path is a second row with the same triggers, so it
+    // subscribes twice and one event starts two runs. `createRepo` already initializes
+    // the repository with a default branch for jobs that check it out.
+    ...(params.definitionDelivery === 'api'
+      ? []
+      : [{path: params.configPath, content: renderedWorkflowYaml}]),
+    ...(params.extraFiles ?? []).map((file) => ({path: file.path, content: file.content})),
+  ];
+  if (files.length > 0) {
+    await commitFiles({
+      org: params.suite.org,
+      repo: params.repo,
+      message: `seed ${params.name}`,
+      files,
+    });
+  }
 
   const project = await createProject({
     workspaceId: params.suite.workspaceId,

--- a/e2e/suites/flow/workflows/src/workflow-project.ts
+++ b/e2e/suites/flow/workflows/src/workflow-project.ts
@@ -1,5 +1,6 @@
 import type {DefinitionResponseDto} from '@shipfox/api-definitions-dto';
 import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
+import {createApiClient} from '@shipfox/e2e-core';
 import {type CreatedIssue, commitFiles, createIssue, createRepo} from '@shipfox/e2e-driver-gitea';
 import {waitForDefinition} from '@shipfox/e2e-observe-definitions';
 import {createProject, giteaExternalRepositoryId} from './create-project.js';
@@ -17,6 +18,22 @@ export interface WorkflowProjectFile {
   path: string;
   content: string;
 }
+
+/**
+ * How a seeded project gets its definition.
+ *
+ * `vcs` commits the workflow file and waits for the definition sync to apply it, which is
+ * what a test of the sync itself needs. `api` posts the same YAML to `POST /definitions`,
+ * for tests that only need a definition to exist before they exercise something else.
+ */
+export type DefinitionDelivery = 'vcs' | 'api';
+
+// A job checks out the project repository unless it opts out, so an `api` delivery still
+// needs the repo to hold a commit and therefore a default branch.
+const CHECKOUT_PLACEHOLDER_FILE: WorkflowProjectFile = {
+  path: 'README.md',
+  content: '# Shipfox E2E fixture repository\n',
+};
 
 export interface SeededWorkflowProject {
   project: ProjectResponseDto;
@@ -65,6 +82,7 @@ export async function seedWorkflowProject(params: {
   replacements?: Record<string, string> | undefined;
   extraFiles?: WorkflowProjectFile[] | undefined;
   giteaIssue?: {title: string; body: string} | undefined;
+  definitionDelivery?: DefinitionDelivery | undefined;
 }): Promise<SeededWorkflowProject> {
   await createRepo({org: params.suite.org, name: params.repo});
   const giteaIssue =
@@ -88,7 +106,12 @@ export async function seedWorkflowProject(params: {
     repo: params.repo,
     message: `seed ${params.name}`,
     files: [
-      {path: params.configPath, content: renderedWorkflowYaml},
+      // An `api` delivery deliberately leaves the workflow file out of the repo. A synced
+      // VCS definition at the same path is a second row with the same triggers, so it
+      // subscribes twice and one event starts two runs.
+      params.definitionDelivery === 'api'
+        ? CHECKOUT_PLACEHOLDER_FILE
+        : {path: params.configPath, content: renderedWorkflowYaml},
       ...(params.extraFiles ?? []).map((file) => ({path: file.path, content: file.content})),
     ],
   });
@@ -117,4 +140,51 @@ export async function seedAndWaitForDefinition(params: Parameters<typeof seedWor
     token: params.token,
   });
   return {...seeded, definition};
+}
+
+/**
+ * Seeds a project and creates its definition over the API in one round trip.
+ *
+ * Prefer this over `seedAndWaitForDefinition` unless the definition sync is the subject of
+ * the test. Waiting for a sync makes an arrangement step depend on gitea, the outbox, and
+ * a Temporal workflow whose provider activities retry with 5s/10s/20s/40s backoff, so a
+ * transient failure holds the sync in `syncing` far longer than the arrangement is worth
+ * waiting for. `POST /definitions` runs the same parsing and integration validation
+ * synchronously, so a workflow this suite got wrong fails as a 400 naming the problem
+ * instead of a poll timing out with no error to report.
+ */
+export async function seedProjectWithApiDefinition(
+  params: Parameters<typeof seedWorkflowProject>[0],
+): Promise<ReadyWorkflowProject> {
+  const seeded = await seedWorkflowProject({...params, definitionDelivery: 'api'});
+  const definition = await createApiClient({
+    token: params.token,
+  }).requestJson<DefinitionResponseDto>('post', '/definitions', {
+    json: {
+      project_id: seeded.project.id,
+      source: 'manual',
+      yaml: seeded.renderedWorkflowYaml,
+    },
+  });
+  assertResolvedReferences(definition, params.name);
+  return {...seeded, definition};
+}
+
+/**
+ * A workflow naming a connection, tool, or method the workspace does not have is only a
+ * warning, because a definition stays authorable while its integration is being connected.
+ * A seeded fixture has no such excuse: its trigger would never fire and its tools would
+ * never be offered, so the run fails minutes later with nothing pointing back at the
+ * arrangement. Failing on the diagnostic names the missing reference instead.
+ */
+function assertResolvedReferences(definition: DefinitionResponseDto, scenario: string): void {
+  const unresolved = (definition.diagnostics ?? []).filter((diagnostic) =>
+    diagnostic.code.startsWith('unknown-'),
+  );
+  if (unresolved.length === 0) return;
+
+  const detail = unresolved
+    .map((diagnostic) => `${diagnostic.code} at ${diagnostic.path ?? 'unknown path'}`)
+    .join(', ');
+  throw new Error(`Seeded ${scenario} definition references unresolved integrations: ${detail}`);
 }


### PR DESCRIPTION
Workflow-flow fixtures were waiting on the asynchronous VCS definition-sync path even for scenarios whose behavior starts after a definition exists. A transient provider retry could leave the arrangement in `syncing` until the scenario timed out, obscuring the cause.

This adds an opt-in API delivery path for non-sync scenarios. It still creates a repository with a default-branch placeholder for checkout, posts the rendered YAML through `POST /definitions`, and rejects unresolved integration diagnostics at setup. The existing VCS path remains for sync coverage. Definition wait timeouts now include sync start and last-sync timestamps, with a regression test.

Local validation passed for the forced `check`, `type`, `build`, `depcruise`, and `test` tasks on `@shipfox/e2e-flow-workflows` (59 tests) and the `@shipfox/e2e-observe-definitions` dependency closure (70 tasks). The broader flow dependency closure was otherwise green but hit the unrelated real-Git `@shipfox/runner-execution` fixture because this environment globally enables GPG signing without the test key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workflow fixtures that don't test definition sync now seed definitions through the API instead of waiting on the asynchronous VCS sync path, and timeout diagnostics now include sync timestamps.

- `seedProjectWithApiDefinition` posts the rendered YAML to `POST /definitions` and fails fast when diagnostics reference unresolved integrations.
- The API path leaves the workflow file out of the repo so a synced VCS definition can't double-subscribe the same triggers; `createRepo` still provides a default branch for checkout.
- `runSlackToolsWorkflow` and `setupListenerCase` now use the API path since they exercise Slack tooling and webhooks rather than sync.
- Added a regression test asserting timeout messages carry the sync start and last-sync values.

<sup>Written for commit 8843f28950e823523ef2e3c43e23437fccd7a913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

