### PR TITLE
[api-integration-core] Activate GitHub repository authorization

### DIFF
--- a/.changeset/activate-github-repository-authorization.md
+++ b/.changeset/activate-github-repository-authorization.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Enforce GitHub repository authorization and expose repository-access settings in the integration module.

--- a/.changeset/activate-github-repository-authorization.md
+++ b/.changeset/activate-github-repository-authorization.md
@@ -2,4 +2,4 @@
 "@shipfox/api-integration-core": patch
 ---
 
-Enforce GitHub repository authorization and expose repository-access settings in the integration module.
+Enforce GitHub repository authorization and expose repository-access settings in the integration module. Remove `INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION` from deployments because enforcement is now unconditional for GitHub. Other providers remain outside this cutover until they declare repository authorization support.

--- a/.changeset/activate-github-repository-authorization.md
+++ b/.changeset/activate-github-repository-authorization.md
@@ -2,4 +2,4 @@
 "@shipfox/api-integration-core": patch
 ---
 
-Enforce GitHub repository authorization and expose repository-access settings in the integration module. Remove `INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION` from deployments because enforcement is now unconditional for GitHub. Other providers remain outside this cutover until they declare repository authorization support.
+Enforce GitHub repository authorization and expose repository-access settings in the integration module.

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -271,10 +271,6 @@ export function e2eEnv(sourceEnv) {
       sourceEnv.INTEGRATIONS_ENABLE_GITHUB_PROVIDER,
       'true',
     ),
-    INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION: valueOr(
-      sourceEnv.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
-      'true',
-    ),
     INTEGRATIONS_ENABLE_LINEAR_PROVIDER: valueOr(
       sourceEnv.INTEGRATIONS_ENABLE_LINEAR_PROVIDER,
       'true',

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -82,7 +82,6 @@ describe('e2eEnv', () => {
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
     assert.equal(env.INTEGRATIONS_ENABLE_LINEAR_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_GITHUB_PROVIDER, 'true');
-    assert.equal(env.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_SLACK_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_TEST_VCS_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '600');
@@ -114,7 +113,6 @@ describe('e2eEnv', () => {
       LINEAR_MCP_ENDPOINT: 'http://127.0.0.1:16120/mcp',
       GITHUB_API_BASE_URL: 'http://127.0.0.1:16121',
       GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE: 'disabled',
-      INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION: 'false',
       SLACK_API_BASE_URL: 'http://127.0.0.1:16122',
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
@@ -131,7 +129,6 @@ describe('e2eEnv', () => {
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:16120/mcp');
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
     assert.equal(env.GITHUB_INSTALLATION_TOKEN_FORMAT_OVERRIDE, 'disabled');
-    assert.equal(env.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION, 'false');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:16122');
     assert.equal(env.INTEGRATIONS_TEST_VCS_CREDENTIAL_TTL_SECONDS, '600');
     assert.equal(env.INTEGRATIONS_TEST_VCS_PORT, '16115');

--- a/libs/api/integration/core/src/config.test.ts
+++ b/libs/api/integration/core/src/config.test.ts
@@ -11,7 +11,6 @@ describe('integration provider config', () => {
 
     expect(config.INTEGRATIONS_ENABLE_CRON_PROVIDER).toBe(true);
     expect(config.INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER).toBe(true);
-    expect(config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION).toBe(false);
   });
 
   it('disables the Linear provider by default', async () => {
@@ -29,14 +28,5 @@ describe('integration provider config', () => {
     const {config} = await import('#config.js');
 
     expect(config.INTEGRATIONS_ENABLE_CRON_PROVIDER).toBe(false);
-  });
-
-  it('allows enabling repository authorization for a dark-launch environment', async () => {
-    vi.stubEnv('INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION', 'true');
-    vi.resetModules();
-
-    const {config} = await import('#config.js');
-
-    expect(config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION).toBe(true);
   });
 });

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -5,10 +5,6 @@ export const config = createConfig({
     desc: 'Enables the cron integration provider so workflow schedules can use the built-in cron source. It is enabled by default because it does not require provider setup.',
     default: true,
   }),
-  INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION: bool({
-    desc: 'Enables the provider-free repository authorization guard. It is disabled by default while repository authorization is rolled out.',
-    default: false,
-  }),
   INTEGRATIONS_ENABLE_GITEA_PROVIDER: bool({
     desc: 'Enables the Gitea integration provider so users can connect a Gitea instance.',
     default: false,

--- a/libs/api/integration/core/src/core/repository-authorizer.test.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.test.ts
@@ -530,7 +530,7 @@ describe('repository authorization', () => {
     const projects = createProjects({
       getProjectBySource: vi.fn().mockRejectedValue(new Error('must not be called')),
     });
-    const authorizer = createRepositoryAuthorizer({projects});
+    const authorizer = createRepositoryAuthorizer({projects, enabled: false});
 
     expect(authorizer.enabled).toBe(false);
     await expect(

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -154,8 +154,8 @@ export async function resolveRepositoryAuthorization({
 }
 
 /**
- * Creates the integration-owned dark-gated authorizer. A disabled authorizer
- * returns `undefined`, allowing its caller to preserve the existing behavior.
+ * Creates the integration-owned authorizer. A disabled authorizer returns
+ * `undefined`, allowing test callers to preserve the pre-enforcement behavior.
  */
 export function createRepositoryAuthorizer({
   projects,

--- a/libs/api/integration/core/src/core/repository-authorizer.ts
+++ b/libs/api/integration/core/src/core/repository-authorizer.ts
@@ -93,7 +93,8 @@ export interface ResolveRepositoryAuthorizationParams extends ResolveRepositoryA
 
 export interface CreateRepositoryAuthorizerOptions {
   projects?: ProjectsModuleClient | undefined;
-  enabled?: boolean | undefined;
+  /** Every composition must explicitly choose whether authorization is enabled. */
+  enabled: boolean;
   now?: (() => number) | undefined;
   maxCacheEntries?: number | undefined;
 }
@@ -154,12 +155,13 @@ export async function resolveRepositoryAuthorization({
 }
 
 /**
- * Creates the integration-owned authorizer. A disabled authorizer returns
- * `undefined`, allowing test callers to preserve the pre-enforcement behavior.
+ * Creates the integration-owned authorizer. The required `enabled` option keeps
+ * the disabled test seam explicit. A disabled authorizer returns `undefined`,
+ * allowing test callers to preserve the pre-enforcement behavior.
  */
 export function createRepositoryAuthorizer({
   projects,
-  enabled = false,
+  enabled,
   now = Date.now,
   maxCacheEntries = DEFAULT_REPOSITORY_AUTHORIZATION_CACHE_SIZE,
 }: CreateRepositoryAuthorizerOptions): RepositoryAuthorizer {

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -1,4 +1,5 @@
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import type {recordIntegrationCheckoutRepositoryAuthorization} from '#metrics/index.js';
 import type {IntegrationConnection} from './entities/connection.js';
 import {
   IntegrationCheckoutUnsupportedError,
@@ -45,6 +46,8 @@ describe('integration source-control service', () => {
     options: {
       omitCheckoutSpec?: boolean;
       repositoryAuthorizer?: RepositoryAuthorizer;
+      providerRepositoryAuthorization?: 'enforced' | 'unclassified';
+      recordRepositoryAuthorizationMetric?: typeof recordIntegrationCheckoutRepositoryAuthorization;
       getRepositoryAuthorizationMode?: () => 'selected' | 'all';
       connection?: IntegrationConnection;
     } = {},
@@ -88,6 +91,7 @@ describe('integration source-control service', () => {
         {
           provider: 'gitea',
           displayName: 'Gitea',
+          repositoryAuthorization: options.providerRepositoryAuthorization ?? 'enforced',
           adapters: {
             source_control: sourceControl,
           },
@@ -99,6 +103,7 @@ describe('integration source-control service', () => {
         return connectionId === activeConnection.id ? activeConnection : undefined;
       },
       repositoryAuthorizer: options.repositoryAuthorizer,
+      recordRepositoryAuthorizationMetric: options.recordRepositoryAuthorizationMetric,
       getRepositoryAuthorizationMode: options.getRepositoryAuthorizationMode,
     });
   }
@@ -320,6 +325,7 @@ describe('integration source-control service', () => {
       authorized: false,
       reason: 'repository_not_granted',
     } as const);
+    const recordRepositoryAuthorizationMetric = vi.fn();
     const service = createService(
       {createCheckoutSpec},
       {
@@ -327,6 +333,7 @@ describe('integration source-control service', () => {
           enabled: true,
           resolveRepositoryAuthorization,
         },
+        recordRepositoryAuthorizationMetric,
       },
     );
 
@@ -346,6 +353,41 @@ describe('integration source-control service', () => {
       capability: 'checkout',
     });
     expect(createCheckoutSpec).not.toHaveBeenCalled();
+    expect(recordRepositoryAuthorizationMetric).toHaveBeenCalledWith({
+      provider: 'gitea',
+      mode: 'selected',
+      decision: 'denied',
+      denial_reason: 'repository_not_granted',
+    });
+  });
+
+  it('does not authorize checkout for an unclassified provider', async () => {
+    const createCheckoutSpec = vi.fn(async () => ({
+      repositoryUrl: repository.cloneUrl,
+      ref: repository.defaultBranch,
+    }));
+    const resolveRepositoryAuthorization = vi.fn();
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        providerRepositoryAuthorization: 'unclassified',
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await expect(
+      service.createCheckoutSpec({
+        workspaceId,
+        connectionId: connection.id,
+        externalRepositoryId: repository.externalRepositoryId,
+      }),
+    ).resolves.toMatchObject({repositoryUrl: repository.cloneUrl});
+
+    expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
+    expect(createCheckoutSpec).toHaveBeenCalledOnce();
   });
 
   it('uses the persisted connection repository mode by default', async () => {

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -1,4 +1,11 @@
 import {normalizeCheckoutTarget} from '@shipfox/api-integration-spi';
+import {logger} from '@shipfox/node-opentelemetry';
+import {
+  type IntegrationCheckoutRepositoryAuthorizationDecision,
+  type IntegrationToolRepositoryAccessMode,
+  type IntegrationToolRepositoryDenialReason,
+  recordIntegrationCheckoutRepositoryAuthorization,
+} from '#metrics/index.js';
 import type {IntegrationConnection} from './entities/connection.js';
 import {
   IntegrationCheckoutUnsupportedError,
@@ -107,6 +114,10 @@ export interface CreateIntegrationSourceControlServiceOptions {
     connectionId: string,
   ) => Promise<IntegrationConnection | undefined>;
   repositoryAuthorizer?: RepositoryAuthorizer | undefined;
+  /** Test seam for asserting checkout authorization telemetry. */
+  recordRepositoryAuthorizationMetric?:
+    | typeof recordIntegrationCheckoutRepositoryAuthorization
+    | undefined;
   /** Trusted server-side seam for overriding the persisted per-connection repository mode. */
   getRepositoryAuthorizationMode?:
     | ((
@@ -119,6 +130,7 @@ export function createSourceControlIntegrationService({
   registry,
   getIntegrationConnectionById,
   repositoryAuthorizer,
+  recordRepositoryAuthorizationMetric = recordIntegrationCheckoutRepositoryAuthorization,
   getRepositoryAuthorizationMode = (connection) => connection.repositoryAccessMode,
 }: CreateIntegrationSourceControlServiceOptions): IntegrationSourceControlService {
   async function getConnection(connectionId: string): Promise<IntegrationConnection> {
@@ -228,6 +240,8 @@ export function createSourceControlIntegrationService({
         connection,
         input,
         repositoryAuthorizer,
+        providerRepositoryAuthorization: registry.get(connection.provider).repositoryAuthorization,
+        recordRepositoryAuthorizationMetric,
         getRepositoryAuthorizationMode,
       });
 
@@ -258,6 +272,8 @@ export function createSourceControlIntegrationService({
         connection,
         input,
         repositoryAuthorizer,
+        providerRepositoryAuthorization: registry.get(connection.provider).repositoryAuthorization,
+        recordRepositoryAuthorizationMetric,
         getRepositoryAuthorizationMode,
       });
 
@@ -286,25 +302,80 @@ async function authorizeCheckoutTarget(params: {
   connection: IntegrationConnection;
   input: CheckoutTargetInput & {workspaceId: string};
   repositoryAuthorizer: RepositoryAuthorizer | undefined;
+  providerRepositoryAuthorization: 'enforced' | 'unclassified' | undefined;
+  recordRepositoryAuthorizationMetric: typeof recordIntegrationCheckoutRepositoryAuthorization;
   getRepositoryAuthorizationMode: (
     connection: IntegrationConnection,
   ) => RepositoryAuthorizationMode | Promise<RepositoryAuthorizationMode>;
 }): Promise<CheckoutTarget> {
   const target = checkoutTarget(params.input);
-  if (params.repositoryAuthorizer === undefined) return target;
+  if (
+    params.repositoryAuthorizer === undefined ||
+    params.providerRepositoryAuthorization !== 'enforced'
+  ) {
+    return target;
+  }
+
+  const mode = await params.getRepositoryAuthorizationMode(params.connection);
 
   const authorization = await params.repositoryAuthorizer.resolveRepositoryAuthorization({
     workspaceId: params.input.workspaceId,
     connectionId: params.connection.id,
-    mode: await params.getRepositoryAuthorizationMode(params.connection),
+    mode,
     repository: target,
     capability: 'checkout',
   });
-  if (authorization === undefined) return target;
+  if (authorization === undefined) {
+    recordCheckoutAuthorizationMetric(params.recordRepositoryAuthorizationMetric, {
+      provider: params.connection.provider,
+      mode,
+      decision: 'not-enforced',
+      denial_reason: 'none',
+    });
+    return target;
+  }
   if (!authorization.authorized) {
+    recordCheckoutAuthorizationMetric(params.recordRepositoryAuthorizationMetric, {
+      provider: params.connection.provider,
+      mode,
+      decision: 'denied',
+      denial_reason: authorization.reason,
+    });
+    logger().warn(
+      {
+        workspaceId: params.input.workspaceId,
+        connectionId: params.connection.id,
+        provider: params.connection.provider,
+        repository: target,
+        denialReason: authorization.reason,
+      },
+      'Integration checkout repository authorization denied',
+    );
     throw new IntegrationRepositoryAuthorizationError(authorization.reason);
   }
+  recordCheckoutAuthorizationMetric(params.recordRepositoryAuthorizationMetric, {
+    provider: params.connection.provider,
+    mode,
+    decision: 'allowed',
+    denial_reason: 'none',
+  });
   return checkoutTargetFromAuthorization(authorization);
+}
+
+function recordCheckoutAuthorizationMetric(
+  recordMetric: typeof recordIntegrationCheckoutRepositoryAuthorization,
+  params: {
+    provider: string;
+    mode: IntegrationToolRepositoryAccessMode;
+    decision: IntegrationCheckoutRepositoryAuthorizationDecision;
+    denial_reason: IntegrationToolRepositoryDenialReason;
+  },
+): void {
+  try {
+    recordMetric(params);
+  } catch {
+    // Metrics must not change checkout authorization outcomes.
+  }
 }
 
 function checkoutTargetFromAuthorization(

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -1,7 +1,13 @@
 import type {StoredWebhookRequest, WebhookRequestProcessor} from '@shipfox/api-integration-spi';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {createOutboxRegistry, type ModuleService, startModuleServices} from '@shipfox/node-module';
-import {createIntegrationsContext, WebhookProcessorNotConfiguredError} from './index.js';
+import {
+  createIntegrationsContext,
+  createRepositoryAuthorizer,
+  WebhookProcessorNotConfiguredError,
+} from './index.js';
+
+const disabledRepositoryAuthorizer = createRepositoryAuthorizer({enabled: false});
 
 const request = {
   schema_version: 1,
@@ -36,6 +42,7 @@ describe('createIntegrationsContext', () => {
         },
       ],
       webhookDeliverySource: deliverySource,
+      repositoryAuthorizer: disabledRepositoryAuthorizer,
     });
 
     expect(context.module.services).toEqual([service]);
@@ -56,6 +63,7 @@ describe('createIntegrationsContext', () => {
   it('does not register a service without a delivery source', async () => {
     const context = await createIntegrationsContext({
       parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+      repositoryAuthorizer: disabledRepositoryAuthorizer,
     });
 
     expect(context.module.services).toBeUndefined();
@@ -76,6 +84,7 @@ describe('createIntegrationsContext', () => {
           services: [service],
         },
       ],
+      repositoryAuthorizer: disabledRepositoryAuthorizer,
     });
 
     expect(context.module.services).toEqual([service]);
@@ -91,6 +100,7 @@ describe('createIntegrationsContext', () => {
   it('rejects a queued request with no registered processor', async () => {
     const context = await createIntegrationsContext({
       parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+      repositoryAuthorizer: disabledRepositoryAuthorizer,
     });
 
     const result = context.webhookProcessor.process(request);
@@ -113,6 +123,7 @@ describe('createIntegrationsContext', () => {
           ],
         },
       ],
+      repositoryAuthorizer: disabledRepositoryAuthorizer,
     });
 
     await expect(result).rejects.toThrow(
@@ -130,52 +141,13 @@ describe('createIntegrationsContext', () => {
           throw sourceError;
         },
       },
+      repositoryAuthorizer: disabledRepositoryAuthorizer,
     });
 
     await expect(result).rejects.toThrow(sourceError);
   });
 
-  it('keeps the repository authorization gate disabled by default', async () => {
-    vi.stubEnv('INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION', 'false');
-    vi.resetModules();
-
-    const getProjectBySource = vi.fn();
-    const findProjectBySourceRepositoryName = vi.fn();
-    const projects = {
-      getProjectBySource,
-      findProjectBySourceRepositoryName,
-    } as unknown as ProjectsModuleClient;
-
-    try {
-      const {createIntegrationsContext: createContext} = await import('./index.js');
-      const context = await createContext({
-        parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
-        projects,
-      });
-
-      expect(context.repositoryAuthorizer.enabled).toBe(false);
-      expect(context.capabilities.repositoryAuthorizer).toBe(context.repositoryAuthorizer);
-      await expect(
-        context.repositoryAuthorizer.resolveRepositoryAuthorization({
-          workspaceId: 'workspace-1',
-          connectionId: 'connection-1',
-          mode: 'all',
-          repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
-          capability: 'checkout',
-        }),
-      ).resolves.toBeUndefined();
-      expect(getProjectBySource).not.toHaveBeenCalled();
-      expect(findProjectBySourceRepositoryName).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllEnvs();
-      vi.resetModules();
-    }
-  });
-
-  it('enables repository authorization through the integration context flag', async () => {
-    vi.stubEnv('INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION', 'true');
-    vi.resetModules();
-
+  it('enforces repository authorization by default', async () => {
     const getProjectBySource = vi.fn().mockResolvedValue({project: null});
     const projects = {
       getProjectBySource,
@@ -202,64 +174,58 @@ describe('createIntegrationsContext', () => {
       ref: 'main',
     });
 
-    try {
-      const {createIntegrationsContext: createContext} = await import('./index.js');
-      const context = await createContext({
-        parts: [
-          {
-            provider: {
-              provider: 'github',
-              displayName: 'GitHub',
-              adapters: {
-                source_control: {
-                  listRepositories: vi.fn(),
-                  resolveRepository: vi.fn(),
-                  listFiles: vi.fn(),
-                  fetchFile: vi.fn(),
-                  resolveTriggerReference: vi.fn().mockReturnValue(null),
-                  resolveRef: vi.fn(),
-                  createCheckoutSpec,
-                },
+    const context = await createIntegrationsContext({
+      parts: [
+        {
+          provider: {
+            provider: 'github',
+            displayName: 'GitHub',
+            adapters: {
+              source_control: {
+                listRepositories: vi.fn(),
+                resolveRepository: vi.fn(),
+                listFiles: vi.fn(),
+                fetchFile: vi.fn(),
+                resolveTriggerReference: vi.fn().mockReturnValue(null),
+                resolveRef: vi.fn(),
+                createCheckoutSpec,
               },
             },
           },
-        ],
-        projects,
-        getIntegrationConnectionById,
-      });
+        },
+      ],
+      projects,
+      getIntegrationConnectionById,
+    });
 
-      expect(context.repositoryAuthorizer.enabled).toBe(true);
-      await expect(
-        context.repositoryAuthorizer.resolveRepositoryAuthorization({
-          workspaceId: 'workspace-1',
-          connectionId: 'connection-1',
-          mode: 'selected',
-          repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
-          capability: 'checkout',
-        }),
-      ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
-      expect(getProjectBySource).toHaveBeenCalledWith({
-        workspaceId: 'workspace-1',
-        sourceConnectionId: 'connection-1',
-        sourceExternalRepositoryId: 'github:42',
-      });
-
-      await expect(
-        context.sourceControl.createCheckoutSpec({
-          workspaceId,
-          connectionId: connection.id,
-          target: {kind: 'external-id', externalRepositoryId: 'github:42'},
-        }),
-      ).rejects.toMatchObject({reason: 'repository_not_granted'});
-      expect(createCheckoutSpec).not.toHaveBeenCalled();
-      expect(getProjectBySource).toHaveBeenLastCalledWith({
+    expect(context.repositoryAuthorizer.enabled).toBe(true);
+    await expect(
+      context.repositoryAuthorizer.resolveRepositoryAuthorization({
         workspaceId,
-        sourceConnectionId: connection.id,
-        sourceExternalRepositoryId: 'github:42',
-      });
-    } finally {
-      vi.unstubAllEnvs();
-      vi.resetModules();
-    }
+        connectionId: connection.id,
+        mode: 'selected',
+        repository: {kind: 'external-id', externalRepositoryId: 'github:42'},
+        capability: 'checkout',
+      }),
+    ).resolves.toEqual({authorized: false, reason: 'repository_not_granted'});
+    expect(getProjectBySource).toHaveBeenCalledWith({
+      workspaceId,
+      sourceConnectionId: connection.id,
+      sourceExternalRepositoryId: 'github:42',
+    });
+
+    await expect(
+      context.sourceControl.createCheckoutSpec({
+        workspaceId,
+        connectionId: connection.id,
+        target: {kind: 'external-id', externalRepositoryId: 'github:42'},
+      }),
+    ).rejects.toMatchObject({reason: 'repository_not_granted'});
+    expect(createCheckoutSpec).not.toHaveBeenCalled();
+    expect(getProjectBySource).toHaveBeenLastCalledWith({
+      workspaceId,
+      sourceConnectionId: connection.id,
+      sourceExternalRepositoryId: 'github:42',
+    });
   });
 });

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -180,6 +180,7 @@ describe('createIntegrationsContext', () => {
           provider: {
             provider: 'github',
             displayName: 'GitHub',
+            repositoryAuthorization: 'enforced',
             adapters: {
               source_control: {
                 listRepositories: vi.fn(),

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -13,7 +13,6 @@ import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inte
 import {reportError} from '@shipfox/node-error-monitoring';
 import type {ModuleService, ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
-import {config} from '#config.js';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 import {WebhookProcessorNotConfiguredError} from '#core/errors.js';
 import {
@@ -286,7 +285,7 @@ export async function createIntegrationsContext(
     options.repositoryAuthorizer ??
     createRepositoryAuthorizer({
       projects: options.projects,
-      enabled: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION,
+      enabled: true,
     });
   const workspaces = options.workspaces;
   const parts: IntegrationModuleParts[] =

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -232,6 +232,11 @@ export interface CreateIntegrationsModuleOptions {
    */
   parts?: IntegrationModuleParts[] | undefined;
   secrets?: IntegrationProviderSecrets | undefined;
+  /**
+   * Required when `repositoryAuthorizer` is omitted because the production
+   * composition enables repository authorization unconditionally. Test callers
+   * that do not provide Projects must inject an explicit authorizer seam.
+   */
   projects?: ProjectsModuleClient | undefined;
   /** Test seam for composing repository authorization without configuration. */
   repositoryAuthorizer?: RepositoryAuthorizer | undefined;

--- a/libs/api/integration/core/src/metrics/instance.ts
+++ b/libs/api/integration/core/src/metrics/instance.ts
@@ -120,6 +120,30 @@ export function recordIntegrationAgentToolRepositoryAuthorization(params: {
   recordMetric(() => agentToolRepositoryAuthorizationCount.add(1, params));
 }
 
+export type IntegrationCheckoutRepositoryAuthorizationDecision =
+  | 'allowed'
+  | 'denied'
+  | 'not-enforced';
+
+const integrationCheckoutRepositoryAuthorizationCount = meter.createCounter<{
+  provider: string;
+  mode: IntegrationToolRepositoryAccessMode;
+  decision: IntegrationCheckoutRepositoryAuthorizationDecision;
+  denial_reason: IntegrationToolRepositoryDenialReason;
+}>('integrations_checkout_repository_authorization', {
+  description:
+    'Integration checkout repository authorization decisions by provider, mode, decision, and bounded denial reason',
+});
+
+export function recordIntegrationCheckoutRepositoryAuthorization(params: {
+  provider: string;
+  mode: IntegrationToolRepositoryAccessMode;
+  decision: IntegrationCheckoutRepositoryAuthorizationDecision;
+  denial_reason: IntegrationToolRepositoryDenialReason;
+}): void {
+  recordMetric(() => integrationCheckoutRepositoryAuthorizationCount.add(1, params));
+}
+
 export function normalizeIntegrationAgentToolCallErrorCode(
   value: unknown,
 ): IntegrationAgentToolCallErrorCode {

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -51,6 +51,7 @@ function createClient(
       {
         provider: 'gitea',
         displayName: 'Gitea',
+        repositoryAuthorization: 'enforced',
         adapters: {
           source_control: {
             listRepositories: vi.fn(),

--- a/libs/api/integration/core/src/presentation/routes/repository-access-read.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/repository-access-read.test.ts
@@ -2,6 +2,7 @@ import type {UserContextMembership} from '@shipfox/api-auth-context';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {vi} from '@shipfox/vitest/vi';
 import {upsertIntegrationConnection} from '#db/connections.js';
+import {createRepositoryAuthorizer} from '#index.js';
 import {createTestApp, sourceProvider, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('GET /integration-connections/:connectionId/repository-access', () => {
@@ -172,7 +173,10 @@ describe('GET /integration-connections/:connectionId/repository-access', () => {
   });
 
   it('returns a coded unavailable error without Projects wiring', async () => {
-    const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})]);
+    const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})], {
+      omitProjects: true,
+      repositoryAuthorizer: createRepositoryAuthorizer({enabled: false}),
+    });
     const connection = await createConnection();
 
     const response = await app.inject({

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -161,9 +161,7 @@ async function loadGithubModuleParts(
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,
-    repositoryAuthorization: config.INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION
-      ? 'enforced'
-      : 'unclassified',
+    repositoryAuthorization: 'enforced',
     invalidateRepositoryAuthorizationCache: options.invalidateRepositoryAuthorizationCache,
     coreDb: db,
     deleteSecrets: options.secrets?.deleteSecrets,

--- a/libs/api/integration/core/src/providers/modules.test.ts
+++ b/libs/api/integration/core/src/providers/modules.test.ts
@@ -160,6 +160,7 @@ describe('loadEnabledProviderModules', () => {
     const parts = await loadEnabledProviderModules();
     const githubPart = parts.find((part) => part.provider.provider === 'github');
     if (!githubPart?.e2eRoutes) throw new Error('GitHub E2E routes are not configured');
+    expect(githubPart.provider.repositoryAuthorization).toBe('enforced');
 
     const workspaceId = crypto.randomUUID();
     const installationId = Number.parseInt(crypto.randomUUID().replaceAll('-', '').slice(0, 8), 16);

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -12,6 +12,7 @@ import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {
   createIntegrationsModule,
+  createRepositoryAuthorizer,
   type IntegrationProvider,
   type RepositoryAuthorizer,
 } from '#index.js';
@@ -106,7 +107,8 @@ export async function createTestApp(
   const integrationsModule = await createIntegrationsModule({
     providers,
     projects: options.projects,
-    repositoryAuthorizer: options.repositoryAuthorizer,
+    repositoryAuthorizer:
+      options.repositoryAuthorizer ?? createRepositoryAuthorizer({enabled: false}),
   });
   const app = await createApp({
     auth: [createFakeUserAuth(memberships)],

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -104,11 +104,21 @@ export async function createTestApp(
   options: CreateTestAppOptions = {},
 ): Promise<FastifyInstance> {
   const memberships = options.memberships ?? authenticatedMemberships;
+  const repositoryAuthorizer =
+    options.repositoryAuthorizer ??
+    createRepositoryAuthorizer({
+      enabled: true,
+      projects:
+        options.projects ??
+        ({
+          getProjectBySource: async () => ({project: null}),
+          findProjectBySourceRepositoryName: async () => ({projects: []}),
+        } as unknown as ProjectsModuleClient),
+    });
   const integrationsModule = await createIntegrationsModule({
     providers,
     projects: options.projects,
-    repositoryAuthorizer:
-      options.repositoryAuthorizer ?? createRepositoryAuthorizer({enabled: false}),
+    repositoryAuthorizer,
   });
   const app = await createApp({
     auth: [createFakeUserAuth(memberships)],

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -108,12 +108,7 @@ export async function createTestApp(
     options.repositoryAuthorizer ??
     createRepositoryAuthorizer({
       enabled: true,
-      projects:
-        options.projects ??
-        ({
-          getProjectBySource: async () => ({project: null}),
-          findProjectBySourceRepositoryName: async () => ({projects: []}),
-        } as unknown as ProjectsModuleClient),
+      projects: options.projects ?? createDefaultTestProjects(),
     });
   const integrationsModule = await createIntegrationsModule({
     providers,
@@ -127,6 +122,41 @@ export async function createTestApp(
   });
   await app.ready();
   return app;
+}
+
+function createDefaultTestProjects(): ProjectsModuleClient {
+  const getProjectBySource: ProjectsModuleClient['getProjectBySource'] = async ({
+    workspaceId,
+    sourceConnectionId,
+    sourceExternalRepositoryId,
+  }) => ({
+    project: {
+      id: crypto.randomUUID(),
+      workspaceId,
+      sourceConnectionId,
+      sourceExternalRepositoryId,
+      name: 'Test project',
+    },
+  });
+  const findProjectBySourceRepositoryName: ProjectsModuleClient['findProjectBySourceRepositoryName'] =
+    async ({workspaceId, sourceConnectionId, sourceRepositoryOwner, sourceRepositoryName}) => ({
+      projects: [
+        {
+          id: crypto.randomUUID(),
+          workspaceId,
+          sourceConnectionId,
+          sourceExternalRepositoryId: `test:${sourceRepositoryOwner}/${sourceRepositoryName}`,
+          sourceRepositoryOwner,
+          sourceRepositoryName,
+          name: 'Test project',
+        },
+      ],
+    });
+
+  return {
+    getProjectBySource,
+    findProjectBySourceRepositoryName,
+  } as unknown as ProjectsModuleClient;
 }
 
 export function useIntegrationRouteTest() {

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -97,6 +97,8 @@ export interface CreateTestAppOptions {
   memberships?: ReadonlyArray<UserContextMembership> | undefined;
   projects?: ProjectsModuleClient | undefined;
   repositoryAuthorizer?: RepositoryAuthorizer | undefined;
+  /** Explicitly omits Projects wiring for tests of unavailable-module errors. */
+  omitProjects?: boolean | undefined;
 }
 
 export async function createTestApp(
@@ -104,15 +106,19 @@ export async function createTestApp(
   options: CreateTestAppOptions = {},
 ): Promise<FastifyInstance> {
   const memberships = options.memberships ?? authenticatedMemberships;
+  const projects = options.projects ?? createDefaultTestProjects();
+  if (options.omitProjects && options.repositoryAuthorizer === undefined) {
+    throw new Error('createTestApp omitProjects requires an explicit repositoryAuthorizer');
+  }
   const repositoryAuthorizer =
     options.repositoryAuthorizer ??
     createRepositoryAuthorizer({
       enabled: true,
-      projects: options.projects ?? createDefaultTestProjects(),
+      projects,
     });
   const integrationsModule = await createIntegrationsModule({
     providers,
-    projects: options.projects,
+    projects: options.omitProjects ? undefined : projects,
     repositoryAuthorizer,
   });
   const app = await createApp({

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -34,7 +34,6 @@
         "DEFINITION_*",
         "GITEA_BASE_URL",
         "HOST",
-        "INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION",
         "INTEGRATIONS_ENABLE_SLACK_PROVIDER",
         "OBJECT_STORAGE_S3_ENDPOINT",
         "OTEL_*",
@@ -109,7 +108,6 @@
       "dependsOn": ["^build"],
       "passThroughEnv": [
         "ADMIN_BOOTSTRAP_TOKEN",
-        "INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION",
         "SLACK_API_BASE_URL",
         "SLACK_SIGNING_SECRET"
       ]


### PR DESCRIPTION
GitHub repository authorization is now active in the production integration composition. GitHub exposes repository-access settings while the existing project-backed selected mode and explicit all-mode installation boundary remain in force. The dark-launch environment gate is removed, leaving ENG-1847's enabled-path coverage as the rollout proof.

Closes ENG-1848

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GitHub repository authorization is now always enforced in the integration core. The `INTEGRATIONS_ENABLE_REPOSITORY_AUTHORIZATION` dark-launch flag is removed from config, the e2e harness, and turbo passthrough, and GitHub connections now expose repository-access settings. Existing project-backed selected mode and explicit all-mode installation boundary remain unchanged. Closes ENG-1848.

**Notes**
- Tests now assert the authorizer is enabled by default; the e2e test app uses an enabled authorizer with stub projects.
- The authorizer's `enabled` option is now required, and tests that don't exercise enforcement inject a disabled authorizer.
- Checkout authorization decisions are recorded as a metric with provider, mode, decision, and denial reason; metric failures never change authorization outcomes.
- Providers that don't declare repository authorization support skip the authorizer; only GitHub is enforced in this cutover.

<sup>Written for commit 3c1843f19ffde90fc9b37ec0b19e0af8f8c7d649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

