### PR TITLE
Prevent duplicate Temporal worker shutdown errors

### DIFF
--- a/.changeset/calm-workers-drain.md
+++ b/.changeset/calm-workers-drain.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/node-module": patch
+"@shipfox/node-temporal": minor
 ---
 
-Avoids duplicate Temporal worker shutdown requests when signal handling has already started draining workers.
+Adds state-aware Temporal worker shutdown requests and avoids duplicate requests after a worker has already stopped running.

--- a/.changeset/calm-workers-drain.md
+++ b/.changeset/calm-workers-drain.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-module": patch
+---
+
+Avoids duplicate Temporal worker shutdown requests when signal handling has already started draining workers.

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -506,6 +506,7 @@ function moduleWorker(overrides: Partial<ModuleWorker> = {}): ModuleWorker {
 
 function temporalWorker(runResult: Promise<void> = new Promise(() => undefined)) {
   return {
+    getState: vi.fn().mockReturnValue('RUNNING'),
     run: vi.fn(() => runResult),
     shutdown: vi.fn(),
   };
@@ -735,6 +736,33 @@ describe('startModuleWorkers', () => {
       {err: failure, taskQueue: 'runtime-queue'},
       'Worker stopped unexpectedly',
     );
+  });
+
+  it('waits for a draining worker without shutting it down again', async () => {
+    const shutdownFailure = new Error('Not running. Current state: DRAINING');
+    const connection = {close: vi.fn().mockResolvedValue(undefined)};
+    let resolveRun: () => void = () => undefined;
+    const runPromise = new Promise<void>((resolve) => {
+      resolveRun = resolve;
+    });
+    const worker = temporalWorker(runPromise);
+    worker.getState.mockReturnValue('DRAINING');
+    worker.shutdown.mockImplementation(() => {
+      throw shutdownFailure;
+    });
+    mocks.createTemporalWorkerConnection.mockResolvedValue(connection);
+    mocks.createTemporalWorker.mockResolvedValueOnce(worker);
+    const handle = await startModuleWorkers({workers: [moduleWorker()]});
+
+    const stop = handle.stop();
+    await flushMicrotasks();
+
+    expect(connection.close).not.toHaveBeenCalled();
+    resolveRun();
+    await expect(stop).resolves.toBeUndefined();
+    expect(worker.shutdown).not.toHaveBeenCalled();
+    expect(connection.close).toHaveBeenCalledOnce();
+    expect(mocks.closeTemporalClient).toHaveBeenCalledOnce();
   });
 
   it('stops every worker, logs deliberate-stop failures, and closes Temporal resources in order', async () => {

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   createTemporalClient: vi.fn(),
   createTemporalWorker: vi.fn(),
   createTemporalWorkerConnection: vi.fn(),
+  requestTemporalWorkerShutdown: vi.fn(),
   workflowStart: vi.fn(),
   markErrorReported: vi.fn(),
   reportError: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock('@shipfox/node-temporal', () => ({
   createTemporalClient: mocks.createTemporalClient,
   createTemporalWorker: mocks.createTemporalWorker,
   createTemporalWorkerConnection: mocks.createTemporalWorkerConnection,
+  requestTemporalWorkerShutdown: mocks.requestTemporalWorkerShutdown,
   temporalClient: () => ({workflow: {start: mocks.workflowStart}}),
 }));
 
@@ -512,6 +514,11 @@ function temporalWorker(runResult: Promise<void> = new Promise(() => undefined))
   };
 }
 
+function mockRequestTemporalWorkerShutdown(worker: ReturnType<typeof temporalWorker>): void {
+  if (worker.getState() !== 'RUNNING') return;
+  worker.shutdown();
+}
+
 function alreadyStartedError(): Error {
   const error = new Error('already started');
   error.name = 'WorkflowExecutionAlreadyStartedError';
@@ -529,6 +536,7 @@ describe('startModuleWorkers', () => {
     mocks.createTemporalClient.mockReset();
     mocks.createTemporalWorker.mockReset();
     mocks.createTemporalWorkerConnection.mockReset();
+    mocks.requestTemporalWorkerShutdown.mockReset();
     mocks.workflowStart.mockReset();
     mocks.logger.error.mockReset();
     mocks.logger.info.mockReset();
@@ -537,6 +545,7 @@ describe('startModuleWorkers', () => {
     mocks.createTemporalClient.mockResolvedValue({});
     mocks.createTemporalWorkerConnection.mockResolvedValue({close: vi.fn()});
     mocks.createTemporalWorker.mockResolvedValue(temporalWorker());
+    mocks.requestTemporalWorkerShutdown.mockImplementation(mockRequestTemporalWorkerShutdown);
     mocks.workflowStart.mockResolvedValue({});
   });
 
@@ -738,15 +747,22 @@ describe('startModuleWorkers', () => {
     );
   });
 
-  it('waits for a draining worker without shutting it down again', async () => {
-    const shutdownFailure = new Error('Not running. Current state: DRAINING');
+  it.each([
+    'INITIALIZED',
+    'STOPPING',
+    'DRAINING',
+    'DRAINED',
+    'STOPPED',
+    'FAILED',
+  ] as const)('waits for a worker in the %s state without shutting it down again', async (state) => {
+    const shutdownFailure = new Error(`Not running. Current state: ${state}`);
     const connection = {close: vi.fn().mockResolvedValue(undefined)};
     let resolveRun: () => void = () => undefined;
     const runPromise = new Promise<void>((resolve) => {
       resolveRun = resolve;
     });
     const worker = temporalWorker(runPromise);
-    worker.getState.mockReturnValue('DRAINING');
+    worker.getState.mockReturnValue(state);
     worker.shutdown.mockImplementation(() => {
       throw shutdownFailure;
     });

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -488,20 +488,7 @@ async function stopModuleWorkers(options: {
   workers: StartedModuleWorker[];
   connection: NativeConnection;
 }): Promise<void> {
-  const errors: unknown[] = [];
-  for (const {worker, taskQueue} of options.workers) {
-    try {
-      worker.shutdown();
-    } catch (error) {
-      logger().error({err: error, taskQueue}, 'Failed to shut down module worker');
-      reportError(error, {
-        boundary: 'module.worker',
-        operation: 'shutdown',
-        tags: {taskQueue},
-      });
-      errors.push(error);
-    }
-  }
+  const errors = options.workers.flatMap(requestModuleWorkerShutdown);
 
   const results = await Promise.allSettled(
     options.workers.map(({runPromise}) => runPromise ?? Promise.resolve()),
@@ -538,6 +525,27 @@ async function stopModuleWorkers(options: {
     }
   }
   throwLifecycleErrors(errors, 'Failed to stop module workers');
+}
+
+function requestModuleWorkerShutdown({worker, taskQueue}: StartedModuleWorker): unknown[] {
+  try {
+    if (workerIsStoppingOrStopped(worker)) return [];
+    worker.shutdown();
+    return [];
+  } catch (error) {
+    logger().error({err: error, taskQueue}, 'Failed to shut down module worker');
+    reportError(error, {
+      boundary: 'module.worker',
+      operation: 'shutdown',
+      tags: {taskQueue},
+    });
+    return [error];
+  }
+}
+
+function workerIsStoppingOrStopped(worker: Worker): boolean {
+  const state = worker.getState();
+  return state === 'STOPPING' || state === 'DRAINING' || state === 'DRAINED' || state === 'STOPPED';
 }
 
 function throwLifecycleErrors(errors: unknown[], message: string): void {

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -8,6 +8,7 @@ import {
   createTemporalWorker,
   createTemporalWorkerConnection,
   type NativeConnection,
+  requestTemporalWorkerShutdown,
   temporalClient,
   type Worker,
 } from '@shipfox/node-temporal';
@@ -529,8 +530,7 @@ async function stopModuleWorkers(options: {
 
 function requestModuleWorkerShutdown({worker, taskQueue}: StartedModuleWorker): unknown[] {
   try {
-    if (workerIsStoppingOrStopped(worker)) return [];
-    worker.shutdown();
+    requestTemporalWorkerShutdown(worker);
     return [];
   } catch (error) {
     logger().error({err: error, taskQueue}, 'Failed to shut down module worker');
@@ -541,11 +541,6 @@ function requestModuleWorkerShutdown({worker, taskQueue}: StartedModuleWorker): 
     });
     return [error];
   }
-}
-
-function workerIsStoppingOrStopped(worker: Worker): boolean {
-  const state = worker.getState();
-  return state === 'STOPPING' || state === 'DRAINING' || state === 'DRAINED' || state === 'STOPPED';
 }
 
 function throwLifecycleErrors(errors: unknown[], message: string): void {

--- a/libs/shared/node/temporal/README.md
+++ b/libs/shared/node/temporal/README.md
@@ -10,11 +10,12 @@ Temporal client and worker helpers for Shipfox Node services.
 - **`isTemporalHealthy()`**: Checks the Temporal connection health service.
 - **`createTemporalWorkerConnection()`**: Creates a Temporal worker connection for a caller that owns its lifecycle.
 - **`createTemporalWorker(options)`**: Creates a worker with Shipfox defaults.
+- **`requestTemporalWorkerShutdown(worker)`**: Requests shutdown only when the worker is running.
 - **Prebuilt workflow bundles**: Builds and loads production workflow artifacts without bundling at worker startup.
 - **OpenTelemetry propagation**: Connects client, workflow, and activity spans through the official Temporal interceptors.
 - **Temporal metrics**: Exposes the SDK's native Prometheus metrics from the worker process.
 
-## Installation
+## Installation and setup
 
 ```sh
 pnpm add @shipfox/node-temporal
@@ -27,6 +28,7 @@ import {
   createTemporalClient,
   createTemporalWorker,
   createTemporalWorkerConnection,
+  requestTemporalWorkerShutdown,
   temporalClient,
 } from '@shipfox/node-temporal';
 
@@ -56,7 +58,9 @@ const worker = await createTemporalWorker({
   activities: {syncActivity},
 });
 
-await worker.shutdown();
+const run = worker.run();
+requestTemporalWorkerShutdown(worker);
+await run;
 await connection.close();
 ```
 

--- a/libs/shared/node/temporal/src/index.ts
+++ b/libs/shared/node/temporal/src/index.ts
@@ -27,4 +27,5 @@ export {
   type CreateWorkerOptions,
   createTemporalWorker,
   createTemporalWorkerConnection,
+  requestTemporalWorkerShutdown,
 } from './worker.js';

--- a/libs/shared/node/temporal/src/worker.test.ts
+++ b/libs/shared/node/temporal/src/worker.test.ts
@@ -1,6 +1,10 @@
-import type {NativeConnection} from '@temporalio/worker';
+import type {NativeConnection, State, Worker} from '@temporalio/worker';
 import type {CreateWorkerOptions} from './worker.js';
-import {createTemporalWorker, createTemporalWorkerConnection} from './worker.js';
+import {
+  createTemporalWorker,
+  createTemporalWorkerConnection,
+  requestTemporalWorkerShutdown,
+} from './worker.js';
 
 const mocks = vi.hoisted(() => ({
   nativeConnectionConnect: vi.fn(),
@@ -58,6 +62,13 @@ function workerOptions(overrides: Partial<CreateWorkerOptions> = {}): CreateWork
   };
 }
 
+function temporalWorker(state: State): Worker {
+  return {
+    getState: vi.fn().mockReturnValue(state),
+    shutdown: vi.fn(),
+  } as unknown as Worker;
+}
+
 describe('createTemporalWorkerConnection', () => {
   beforeEach(() => {
     mocks.nativeConnectionConnect.mockReset();
@@ -94,6 +105,31 @@ describe('createTemporalWorkerConnection', () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).cause).toBe(failure);
     });
+  });
+});
+
+describe('requestTemporalWorkerShutdown', () => {
+  it('requests shutdown for a running worker', () => {
+    const worker = temporalWorker('RUNNING');
+
+    requestTemporalWorkerShutdown(worker);
+
+    expect(worker.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'INITIALIZED',
+    'STOPPING',
+    'DRAINING',
+    'DRAINED',
+    'STOPPED',
+    'FAILED',
+  ] as const)('does not request shutdown for a worker in the %s state', (state) => {
+    const worker = temporalWorker(state);
+
+    requestTemporalWorkerShutdown(worker);
+
+    expect(worker.shutdown).not.toHaveBeenCalled();
   });
 });
 

--- a/libs/shared/node/temporal/src/worker.ts
+++ b/libs/shared/node/temporal/src/worker.ts
@@ -101,3 +101,8 @@ export async function createTemporalWorker(options: CreateWorkerOptions): Promis
 
   return worker;
 }
+
+export function requestTemporalWorkerShutdown(worker: Worker): void {
+  if (worker.getState() !== 'RUNNING') return;
+  worker.shutdown();
+}


### PR DESCRIPTION
## Why

The Temporal runtime and API server both handle termination signals. Temporal can leave a worker in any non-running state before server lifecycle cleanup requests shutdown. Calling `shutdown()` again then raises `IllegalStateError`, which produces misleading Sentry events during cleanup.

## What changed

`@shipfox/node-temporal` now owns a state-aware shutdown request that only calls the SDK for a `RUNNING` worker. Module cleanup uses that boundary while preserving run-promise waiting, shared-resource ordering, and genuine lifecycle error reporting. Regression coverage exercises every Temporal worker state, and the Changeset covers both published packages.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/node-temporal... --filter=@shipfox/node-module... --filter=@shipfox/api-server`
- `mise exec -- turbo verify --filter=@shipfox/prose-policy`
- `mise exec -- pnpm changeset status`
- `mise exec -- git diff --check`

Sentry: https://shipfox.sentry.io/issues/136638576/