### PR TITLE
Authorize Gitea checkout targets through the local repository contract

### DIFF
--- a/.changeset/enforce-gitea-checkout-authorization.md
+++ b/.changeset/enforce-gitea-checkout-authorization.md
@@ -1,7 +1,7 @@
 ---
 "@shipfox/api-integration-core": minor
-"@shipfox/api-integration-gitea": patch
-"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-gitea": minor
+"@shipfox/api-integration-github": minor
 "@shipfox/api-integration-spi": minor
 ---
 

--- a/.changeset/enforce-gitea-checkout-authorization.md
+++ b/.changeset/enforce-gitea-checkout-authorization.md
@@ -1,8 +1,8 @@
 ---
-"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-core": minor
 "@shipfox/api-integration-gitea": patch
 "@shipfox/api-integration-github": patch
-"@shipfox/api-integration-spi": patch
+"@shipfox/api-integration-spi": minor
 ---
 
-Enforce repository authorization for GitHub and Gitea checkout targets while keeping tool authorization classification separate.
+Enforce repository authorization for GitHub and Gitea checkout targets.

--- a/.changeset/enforce-gitea-checkout-authorization.md
+++ b/.changeset/enforce-gitea-checkout-authorization.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-gitea": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-spi": patch
+---
+
+Enforce repository authorization for GitHub and Gitea checkout targets while keeping tool authorization classification separate.

--- a/libs/api/integration/core/src/core/providers/registry.test.ts
+++ b/libs/api/integration/core/src/core/providers/registry.test.ts
@@ -113,6 +113,29 @@ describe('integration provider registry', () => {
     expect(result).toThrow(IntegrationCapabilityUnavailableError);
   });
 
+  it('rejects checkout-capable source-control adapters without an authorization state', () => {
+    const result = () =>
+      createIntegrationProviderRegistry([
+        {
+          provider: 'gitea',
+          displayName: 'Gitea',
+          adapters: {
+            source_control: {
+              ...sourceControlAdapter(),
+              createCheckoutSpec: async () => ({
+                repositoryUrl: 'https://gitea.local/owner/repository.git',
+                ref: 'main',
+              }),
+            },
+          },
+        },
+      ]);
+
+    expect(result).toThrow(
+      'Source-control provider gitea must declare checkout repository authorization',
+    );
+  });
+
   it('rejects duplicate provider registrations', () => {
     const result = () =>
       createIntegrationProviderRegistry([

--- a/libs/api/integration/core/src/core/providers/registry.test.ts
+++ b/libs/api/integration/core/src/core/providers/registry.test.ts
@@ -136,6 +136,30 @@ describe('integration provider registry', () => {
     );
   });
 
+  it('rejects credential-capable source-control adapters without an authorization state', () => {
+    const result = () =>
+      createIntegrationProviderRegistry([
+        {
+          provider: 'gitea',
+          displayName: 'Gitea',
+          adapters: {
+            source_control: {
+              ...sourceControlAdapter(),
+              createCheckoutCredentials: async () => ({
+                username: 'x-access-token',
+                token: 'secret',
+                expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+              }),
+            },
+          },
+        },
+      ]);
+
+    expect(result).toThrow(
+      'Source-control provider gitea must declare checkout repository authorization',
+    );
+  });
+
   it('rejects duplicate provider registrations', () => {
     const result = () =>
       createIntegrationProviderRegistry([

--- a/libs/api/integration/core/src/core/providers/registry.ts
+++ b/libs/api/integration/core/src/core/providers/registry.ts
@@ -43,6 +43,7 @@ class MapIntegrationProviderRegistry implements IntegrationProviderRegistry {
         throw new Error(`Duplicate integration provider registered: ${provider.provider}`);
       }
 
+      assertCheckoutRepositoryAuthorization(provider);
       this.providers.set(provider.provider, normalizeProvider(provider));
     }
   }
@@ -85,6 +86,22 @@ function normalizeProvider(provider: IntegrationProvider): RegisteredIntegration
     adapters,
     capabilities: getIntegrationProviderCapabilities(adapters),
   };
+}
+
+function assertCheckoutRepositoryAuthorization(provider: IntegrationProvider): void {
+  const sourceControl = provider.adapters?.source_control;
+  if (
+    sourceControl === undefined ||
+    (sourceControl.createCheckoutSpec === undefined &&
+      sourceControl.createCheckoutCredentials === undefined) ||
+    sourceControl.checkoutRepositoryAuthorization !== undefined
+  ) {
+    return;
+  }
+
+  throw new Error(
+    `Source-control provider ${provider.provider} must declare checkout repository authorization`,
+  );
 }
 
 export function getIntegrationProviderCapabilities(

--- a/libs/api/integration/core/src/core/providers/source-control.ts
+++ b/libs/api/integration/core/src/core/providers/source-control.ts
@@ -2,6 +2,7 @@ export type {
   CheckoutCredentialRenewal,
   CheckoutCredentials,
   CheckoutPermissions,
+  CheckoutRepositoryAuthorizationState,
   CheckoutSpec,
   CheckoutTarget,
   CheckoutTargetInput,

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -7,7 +7,11 @@ import {
   IntegrationRepositoryAuthorizationError,
 } from './errors.js';
 import {createIntegrationProviderRegistry} from './providers/registry.js';
-import type {RepositorySnapshot, SourceControlProvider} from './providers/source-control.js';
+import type {
+  CheckoutRepositoryAuthorizationState,
+  RepositorySnapshot,
+  SourceControlProvider,
+} from './providers/source-control.js';
 import {
   createRepositoryAuthorizer,
   RepositoryAuthorizationTargetInvalidError,
@@ -47,6 +51,7 @@ describe('integration source-control service', () => {
       omitCheckoutSpec?: boolean;
       repositoryAuthorizer?: RepositoryAuthorizer;
       providerRepositoryAuthorization?: 'enforced' | 'unclassified';
+      checkoutRepositoryAuthorization?: CheckoutRepositoryAuthorizationState;
       recordRepositoryAuthorizationMetric?: typeof recordIntegrationCheckoutRepositoryAuthorization;
       getRepositoryAuthorizationMode?: () => 'selected' | 'all';
       connection?: IntegrationConnection;
@@ -77,6 +82,7 @@ describe('integration source-control service', () => {
         return {ref: input.ref, commit: 'a'.repeat(40)};
       },
       resolveTriggerReference: () => null,
+      checkoutRepositoryAuthorization: options.checkoutRepositoryAuthorization ?? 'enforced',
       createCheckoutSpec: async (input) => {
         await Promise.resolve();
         return {repositoryUrl: repository.cloneUrl, ref: input.ref ?? repository.defaultBranch};
@@ -361,7 +367,7 @@ describe('integration source-control service', () => {
     });
   });
 
-  it('does not authorize checkout for an unclassified provider', async () => {
+  it('does not authorize checkout for an unclassified source-control adapter', async () => {
     const createCheckoutSpec = vi.fn(async () => ({
       repositoryUrl: repository.cloneUrl,
       ref: repository.defaultBranch,
@@ -370,7 +376,7 @@ describe('integration source-control service', () => {
     const service = createService(
       {createCheckoutSpec},
       {
-        providerRepositoryAuthorization: 'unclassified',
+        checkoutRepositoryAuthorization: 'unclassified',
         repositoryAuthorizer: {
           enabled: true,
           resolveRepositoryAuthorization,
@@ -388,6 +394,38 @@ describe('integration source-control service', () => {
 
     expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
     expect(createCheckoutSpec).toHaveBeenCalledOnce();
+  });
+
+  it('authorizes checkout independently of the provider tool authorization state', async () => {
+    const createCheckoutSpec = vi.fn(async () => ({
+      repositoryUrl: repository.cloneUrl,
+      ref: repository.defaultBranch,
+    }));
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: false,
+      reason: 'repository_not_granted',
+    } as const);
+    const service = createService(
+      {createCheckoutSpec},
+      {
+        providerRepositoryAuthorization: 'unclassified',
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await expect(
+      service.createCheckoutSpec({
+        workspaceId,
+        connectionId: connection.id,
+        externalRepositoryId: repository.externalRepositoryId,
+      }),
+    ).rejects.toBeInstanceOf(IntegrationRepositoryAuthorizationError);
+
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledOnce();
+    expect(createCheckoutSpec).not.toHaveBeenCalled();
   });
 
   it('uses the persisted connection repository mode by default', async () => {

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -373,6 +373,7 @@ describe('integration source-control service', () => {
       ref: repository.defaultBranch,
     }));
     const resolveRepositoryAuthorization = vi.fn();
+    const recordRepositoryAuthorizationMetric = vi.fn();
     const service = createService(
       {createCheckoutSpec},
       {
@@ -381,6 +382,7 @@ describe('integration source-control service', () => {
           enabled: true,
           resolveRepositoryAuthorization,
         },
+        recordRepositoryAuthorizationMetric,
       },
     );
 
@@ -394,6 +396,34 @@ describe('integration source-control service', () => {
 
     expect(resolveRepositoryAuthorization).not.toHaveBeenCalled();
     expect(createCheckoutSpec).toHaveBeenCalledOnce();
+    expect(recordRepositoryAuthorizationMetric).toHaveBeenCalledWith({
+      provider: 'gitea',
+      mode: 'selected',
+      decision: 'not-enforced',
+      denial_reason: 'none',
+    });
+  });
+
+  it('records a not-enforced checkout metric when no authorizer is configured', async () => {
+    const createCheckoutSpec = vi.fn(async () => ({
+      repositoryUrl: repository.cloneUrl,
+      ref: repository.defaultBranch,
+    }));
+    const recordRepositoryAuthorizationMetric = vi.fn();
+    const service = createService({createCheckoutSpec}, {recordRepositoryAuthorizationMetric});
+
+    await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      externalRepositoryId: repository.externalRepositoryId,
+    });
+
+    expect(recordRepositoryAuthorizationMetric).toHaveBeenCalledWith({
+      provider: 'gitea',
+      mode: 'selected',
+      decision: 'not-enforced',
+      denial_reason: 'none',
+    });
   });
 
   it('authorizes checkout independently of the provider tool authorization state', async () => {
@@ -500,6 +530,40 @@ describe('integration source-control service', () => {
       repository: {kind: 'name', owner: 'acme', name: 'platform'},
       capability: 'checkout',
     });
+    expect(createCheckoutCredentials).not.toHaveBeenCalled();
+  });
+
+  it('authorizes checkout credentials independently of the provider tool authorization state', async () => {
+    const createCheckoutCredentials = vi.fn(async () => ({
+      username: 'x-access-token',
+      token: 'secret',
+      expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+    }));
+    const resolveRepositoryAuthorization = vi.fn().mockResolvedValue({
+      authorized: false,
+      reason: 'repository_not_granted',
+    } as const);
+    const service = createService(
+      {createCheckoutCredentials},
+      {
+        providerRepositoryAuthorization: 'unclassified',
+        repositoryAuthorizer: {
+          enabled: true,
+          resolveRepositoryAuthorization,
+        },
+      },
+    );
+
+    await expect(
+      service.createCheckoutCredentials({
+        workspaceId,
+        connectionId: connection.id,
+        externalRepositoryId: repository.externalRepositoryId,
+        permissions: {contents: 'read'},
+      }),
+    ).rejects.toBeInstanceOf(IntegrationRepositoryAuthorizationError);
+
+    expect(resolveRepositoryAuthorization).toHaveBeenCalledOnce();
     expect(createCheckoutCredentials).not.toHaveBeenCalled();
   });
 

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -313,6 +313,12 @@ async function authorizeCheckoutTarget(params: {
     params.repositoryAuthorizer === undefined ||
     params.checkoutRepositoryAuthorization !== 'enforced'
   ) {
+    recordCheckoutAuthorizationMetric(params.recordRepositoryAuthorizationMetric, {
+      provider: params.connection.provider,
+      mode: params.connection.repositoryAccessMode,
+      decision: 'not-enforced',
+      denial_reason: 'none',
+    });
     return target;
   }
 

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -240,7 +240,7 @@ export function createSourceControlIntegrationService({
         connection,
         input,
         repositoryAuthorizer,
-        providerRepositoryAuthorization: registry.get(connection.provider).repositoryAuthorization,
+        checkoutRepositoryAuthorization: sourceControl.checkoutRepositoryAuthorization,
         recordRepositoryAuthorizationMetric,
         getRepositoryAuthorizationMode,
       });
@@ -272,7 +272,7 @@ export function createSourceControlIntegrationService({
         connection,
         input,
         repositoryAuthorizer,
-        providerRepositoryAuthorization: registry.get(connection.provider).repositoryAuthorization,
+        checkoutRepositoryAuthorization: sourceControl.checkoutRepositoryAuthorization,
         recordRepositoryAuthorizationMetric,
         getRepositoryAuthorizationMode,
       });
@@ -302,7 +302,7 @@ async function authorizeCheckoutTarget(params: {
   connection: IntegrationConnection;
   input: CheckoutTargetInput & {workspaceId: string};
   repositoryAuthorizer: RepositoryAuthorizer | undefined;
-  providerRepositoryAuthorization: 'enforced' | 'unclassified' | undefined;
+  checkoutRepositoryAuthorization: 'enforced' | 'unclassified' | undefined;
   recordRepositoryAuthorizationMetric: typeof recordIntegrationCheckoutRepositoryAuthorization;
   getRepositoryAuthorizationMode: (
     connection: IntegrationConnection,
@@ -311,7 +311,7 @@ async function authorizeCheckoutTarget(params: {
   const target = checkoutTarget(params.input);
   if (
     params.repositoryAuthorizer === undefined ||
-    params.providerRepositoryAuthorization !== 'enforced'
+    params.checkoutRepositoryAuthorization !== 'enforced'
   ) {
     return target;
   }

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -183,6 +183,7 @@ describe('createIntegrationsContext', () => {
             repositoryAuthorization: 'enforced',
             adapters: {
               source_control: {
+                checkoutRepositoryAuthorization: 'enforced',
                 listRepositories: vi.fn(),
                 resolveRepository: vi.fn(),
                 listFiles: vi.fn(),

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -118,6 +118,7 @@ export type {
   CheckoutCredentialRenewal,
   CheckoutCredentials,
   CheckoutPermissions,
+  CheckoutRepositoryAuthorizationState,
   CheckoutSpec,
   CheckoutTarget,
   CheckoutTargetInput,

--- a/libs/api/integration/core/src/presentation/inter-module.test.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.test.ts
@@ -54,6 +54,7 @@ function createClient(
         repositoryAuthorization: 'enforced',
         adapters: {
           source_control: {
+            checkoutRepositoryAuthorization: 'enforced',
             listRepositories: vi.fn(),
             resolveRepository: vi.fn(resolveRepository),
             listFiles: vi.fn(),

--- a/libs/api/integration/core/src/providers/test-vcs.ts
+++ b/libs/api/integration/core/src/providers/test-vcs.ts
@@ -47,6 +47,8 @@ export interface TestVcsConnectionConfiguration {
 }
 
 export class TestVcsSourceControlProvider implements SourceControlProvider<TestVcsConnection> {
+  readonly checkoutRepositoryAuthorization = 'unclassified';
+
   private readonly connectionConfigurations = new Map<string, TestVcsConnectionConfiguration>();
   private readonly cachedCredentials = new Map<string, CheckoutCredentials>();
   private readonly mintFlights = new Map<string, Promise<CheckoutCredentials>>();

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -5,6 +5,7 @@ import {
   asRecord,
   buildProviderRepositoryId,
   type CheckoutCredentials,
+  type CheckoutRepositoryAuthorizationState,
   type CheckoutSpec,
   type CheckoutTarget,
   type CreateCheckoutCredentialsInput,
@@ -96,6 +97,8 @@ function giteaPushReference(
 export class GiteaSourceControlProvider
   implements SourceControlProvider<GiteaIntegrationConnection>
 {
+  readonly checkoutRepositoryAuthorization: CheckoutRepositoryAuthorizationState = 'enforced';
+
   constructor(private readonly gitea: GiteaApiClient) {}
 
   async listRepositories(

--- a/libs/api/integration/gitea/src/index.test.ts
+++ b/libs/api/integration/gitea/src/index.test.ts
@@ -18,7 +18,9 @@ describe('createGiteaIntegrationProvider', () => {
     expect(provider.provider).toBe('gitea');
     expect(provider.displayName).toBe('Gitea');
     expect(provider.eventCatalog?.events.map((event) => event.name)).toEqual(['push']);
+    expect(provider).not.toHaveProperty('repositoryAuthorization');
     expect(provider.adapters.source_control).toBeInstanceOf(GiteaSourceControlProvider);
+    expect(provider.adapters.source_control.checkoutRepositoryAuthorization).toBe('enforced');
     expect(provider.adapters.agent_tools).toBeInstanceOf(GiteaAgentToolsProvider);
     expect(provider.routes).toHaveLength(2);
     expect(provider.routes.map((group) => group.prefix)).toEqual([

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -4,6 +4,7 @@ import {
   asRecord,
   buildProviderRepositoryId,
   type CheckoutCredentials,
+  type CheckoutRepositoryAuthorizationState,
   type CheckoutSpec,
   type CheckoutTarget,
   type CreateCheckoutCredentialsInput,
@@ -103,6 +104,8 @@ function githubPushReference(
 export class GithubSourceControlProvider
   implements SourceControlProvider<GithubIntegrationConnection>
 {
+  readonly checkoutRepositoryAuthorization: CheckoutRepositoryAuthorizationState = 'enforced';
+
   constructor(
     private readonly github: GithubApiClient,
     private readonly appBotLogin: () => string | undefined = configuredGithubAppBotLogin,

--- a/libs/api/integration/github/src/index.test.ts
+++ b/libs/api/integration/github/src/index.test.ts
@@ -40,6 +40,7 @@ describe('createGithubIntegrationProvider', () => {
     });
 
     expect(provider.repositoryAuthorization).toBe(state);
+    expect(provider.adapters?.source_control?.checkoutRepositoryAuthorization).toBe('enforced');
   });
 
   it('shares installation-token cleanup with the direct and composed processors', async () => {

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -190,9 +190,13 @@ export interface TriggerReference {
   actor: string | null;
 }
 
+export type CheckoutRepositoryAuthorizationState = 'enforced' | 'unclassified';
+
 export interface SourceControlProvider<
   Connection extends IntegrationConnection = IntegrationConnection,
 > {
+  /** Whether integration core must authorize repository targets before checkout dispatch. */
+  checkoutRepositoryAuthorization?: CheckoutRepositoryAuthorizationState | undefined;
   listRepositories(input: ListRepositoriesInput<Connection>): Promise<RepositoryPage>;
   resolveRepository(input: ResolveRepositoryInput<Connection>): Promise<RepositorySnapshot>;
   listFiles(input: ListFilesInput<Connection>): Promise<FilePage>;


### PR DESCRIPTION
Gitea checkout targets now use the same local repository-target authorization contract as GitHub. Integration core authorizes external-ID and owner/name targets before provider dispatch while keeping provider tool and settings classification independent, so selected project-backed access can be enforced without a Gitea API lookup during authorization.

The shared long-lived Gitea checkout credential is intentionally unchanged and remains outside this issue’s scope. Gitea repository-tool classification and repository-access settings remain in ENG-1850; this PR intentionally keeps that provider-level boundary separate from checkout enforcement.

Closes ENG-1849