### PR TITLE
Expose workflow run attempts to expressions

### DIFF
--- a/.changeset/run-attempt-context.md
+++ b/.changeset/run-attempt-context.md
@@ -3,4 +3,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Exposes the current workflow run attempt as `run.attempt` in expressions and reruns.
+Exposes the current workflow run attempt as `run.attempt` in expressions and reruns. Deploy compatible workers before adopting this field in persisted expressions because older builds omit it and cause those expressions to fail closed.

--- a/.changeset/run-attempt-context.md
+++ b/.changeset/run-attempt-context.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/expression": minor
+"@shipfox/api-workflows": patch
+---
+
+Exposes the current workflow run attempt as `run.attempt` in expressions and reruns.

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
@@ -165,6 +165,13 @@ describe('validatePredicateExpression', () => {
     expect(result.expression).toMatchObject({source});
   });
 
+  it('accepts run.attempt in the typed predicate context', () => {
+    const result = validate({field: 'job.if', source: 'run.attempt >= 1'});
+
+    expect(result.issues).toEqual([]);
+    expect(result.expression).toMatchObject({source: 'run.attempt >= 1', check: 'typed'});
+  });
+
   it.each([
     [
       'step.success',

--- a/libs/api/workflows/src/core/listener-execution-materialization.test.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.test.ts
@@ -22,6 +22,7 @@ describe('materializeListenerExecution', () => {
       run: {
         id: crypto.randomUUID(),
         number: 1,
+        currentAttempt: 1,
         name: 'Review run',
         workflowName: 'Review run',
         definitionId: crypto.randomUUID(),

--- a/libs/api/workflows/src/core/listener-execution-materialization.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.ts
@@ -33,6 +33,7 @@ export interface MaterializeListenerExecutionParams {
     WorkflowRun,
     | 'id'
     | 'number'
+    | 'currentAttempt'
     | 'name'
     | 'workflowName'
     | 'definitionId'

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -105,6 +105,7 @@ describe('assembleWorkflowRunContext', () => {
   const run = {
     id: 'run-1',
     number: 1,
+    currentAttempt: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -133,6 +134,7 @@ describe('assembleWorkflowRunContext', () => {
       run: {
         id: 'run-1',
         number: 1n,
+        attempt: 1n,
         name: 'Build',
         project_id: 'proj-1',
         workspace_id: 'workspace-1',
@@ -149,6 +151,12 @@ describe('assembleWorkflowRunContext', () => {
       event: {ref: 'refs/heads/main'},
       inputs: {deploy: true},
     });
+
+    const expression = createWorkflowExpression({
+      source: 'run.attempt == 1',
+      check: {mode: 'syntax'},
+    });
+    expect(evaluateWorkflowExpression(expression, context)).toBe(true);
   });
 
   it.each([
@@ -175,6 +183,7 @@ describe('assembleCreationContext', () => {
   const run = {
     id: 'run-1',
     number: 1,
+    currentAttempt: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -245,6 +254,7 @@ describe('assembleExecutionCreationContext', () => {
   const run = {
     id: 'run-1',
     number: 1,
+    currentAttempt: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -369,6 +379,7 @@ describe('assembleJobActivationContext', () => {
   const run = {
     id: 'run-1',
     number: 1,
+    currentAttempt: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -487,6 +498,7 @@ describe('listener filter snapshots', () => {
   const run = {
     id: 'run-1',
     number: 1,
+    currentAttempt: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -809,10 +821,11 @@ describe('listener filter snapshots', () => {
 
     const [matcher] = applyListenerFilterSnapshots(plan.on, context);
     const jobs = matcher?.filter_snapshot?.jobs as Record<string, {executions: {index: unknown}[]}>;
-    const snapshotRun = matcher?.filter_snapshot?.run as {number: unknown};
+    const snapshotRun = matcher?.filter_snapshot?.run as {number: unknown; attempt: unknown};
 
     expect(typeof jobs.build?.executions[0]?.index).toBe('number');
     expect(typeof snapshotRun.number).toBe('number');
+    expect(typeof snapshotRun.attempt).toBe('number');
     expect(() => JSON.stringify(matcher?.filter_snapshot)).not.toThrow();
   });
 });
@@ -1240,6 +1253,7 @@ describe('assembleExecutionResolutionContext', () => {
   const run = {
     id: 'run-1',
     number: 1,
+    currentAttempt: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -159,6 +159,21 @@ describe('assembleWorkflowRunContext', () => {
     expect(evaluateWorkflowExpression(expression, context)).toBe(true);
   });
 
+  it('rehydrates a later run attempt as a CEL integer', () => {
+    const context = assembleWorkflowRunContext({
+      run: {...run, currentAttempt: 2},
+      triggerPayload: {source: 'manual', event: 'fire', subscriptionId: 'sub-1', userId: 'user-1'},
+    });
+
+    expect(context.run).toMatchObject({number: 1n, attempt: 2n});
+    expect(
+      evaluateWorkflowExpression(
+        createWorkflowExpression({source: 'run.attempt == 2', check: {mode: 'syntax'}}),
+        context,
+      ),
+    ).toBe(true);
+  });
+
   it.each([
     {
       source: 'manual' as const,
@@ -497,8 +512,8 @@ describe('assembleJobActivationContext', () => {
 describe('listener filter snapshots', () => {
   const run = {
     id: 'run-1',
-    number: 1,
-    currentAttempt: 1,
+    number: 7,
+    currentAttempt: 2,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -801,7 +816,7 @@ describe('listener filter snapshots', () => {
         {
           source: 'github',
           event: 'pull_request',
-          filter: 'jobs.build.executions[0].index == 0 && run.number == 1',
+          filter: 'jobs.build.executions[0].index == 0 && run.number == 7',
         },
       ],
       until: null,
@@ -824,8 +839,8 @@ describe('listener filter snapshots', () => {
     const snapshotRun = matcher?.filter_snapshot?.run as {number: unknown; attempt: unknown};
 
     expect(typeof jobs.build?.executions[0]?.index).toBe('number');
-    expect(typeof snapshotRun.number).toBe('number');
-    expect(typeof snapshotRun.attempt).toBe('number');
+    expect(snapshotRun.number).toBe(7);
+    expect(snapshotRun.attempt).toBe(2);
     expect(() => JSON.stringify(matcher?.filter_snapshot)).not.toThrow();
   });
 });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -33,6 +33,7 @@ export interface AssembleWorkflowRunContextParams {
     WorkflowRun,
     | 'id'
     | 'number'
+    | 'currentAttempt'
     | 'name'
     | 'workflowName'
     | 'definitionId'
@@ -61,6 +62,10 @@ export function assembleWorkflowRunContext(
       id: params.run.id,
       number:
         options.skipCelNativeRehydration === true ? params.run.number : BigInt(params.run.number),
+      attempt:
+        options.skipCelNativeRehydration === true
+          ? params.run.currentAttempt
+          : BigInt(params.run.currentAttempt),
       name: params.run.name,
       project_id: params.run.projectId,
       workspace_id: params.run.workspaceId,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -45,7 +45,10 @@ describe('workflow run queries', () => {
       return buildModel({
         runName: `Run ${template('inputs.env')}`,
         jobs: {
-          build: {steps: [{run: 'echo build'}]},
+          build: {
+            runnerTemplates: [template('run.attempt == 1 ? "attempt-1" : "attempt-2"')],
+            steps: [{run: 'echo build'}],
+          },
           test: {needs: 'build', steps: [{run: 'echo test'}]},
           deploy: {needs: 'test', steps: [{run: 'echo deploy'}]},
           notify: {steps: [{run: 'echo notify'}]},
@@ -613,6 +616,12 @@ describe('workflow run queries', () => {
       expect(second.currentAttempt).toBe(2);
       expect(second.id).toBe(source.id);
       expect(third).toMatchObject({id: source.id, currentAttempt: 3});
+
+      const secondJobs = await getJobsByWorkflowRunId(second.id);
+      const secondBuild = secondJobs.find((job) => job.key === 'build');
+      if (!secondBuild) throw new Error('Missing second-attempt build job');
+      const [secondBuildExecution] = await getJobExecutionsByJobId(secondBuild.id);
+      expect(secondBuildExecution?.runner).toEqual(['attempt-2', 'ubuntu-latest']);
 
       const sourceContext = assembleWorkflowRunContext({
         run: source,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -3,6 +3,7 @@ import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {AgentToolMaterializationSnapshot} from '#core/agent-tools.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
+import {assembleWorkflowRunContext} from '#core/step-config/assemble-run-context.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {
   buildModel,
@@ -612,6 +613,19 @@ describe('workflow run queries', () => {
       expect(second.currentAttempt).toBe(2);
       expect(second.id).toBe(source.id);
       expect(third).toMatchObject({id: source.id, currentAttempt: 3});
+
+      const sourceContext = assembleWorkflowRunContext({
+        run: source,
+        triggerPayload: source.triggerPayload,
+        inputs: source.inputs,
+      });
+      const secondContext = assembleWorkflowRunContext({
+        run: second,
+        triggerPayload: second.triggerPayload,
+        inputs: second.inputs,
+      });
+      expect(sourceContext.run).toMatchObject({id: source.id, attempt: 1n});
+      expect(secondContext.run).toMatchObject({id: source.id, attempt: 2n});
     });
 
     test('pins the current attempt as the source across consecutive failed reruns', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -92,16 +92,16 @@ export async function createRerunWorkflowRun(
 
     const sourceGraph = await loadRerunSourceGraph(tx, sourceJobs);
 
-    const sourceRun = toWorkflowRun(sourceRow);
+    const runForAttempt = {...toWorkflowRun(sourceRow), currentAttempt: attempt};
     const graphJobs = materializeRerunGraphJobs({
       mode: params.mode,
-      sourceRun,
+      sourceRun: runForAttempt,
       sourceAttempt: sourceAttemptRow,
       sourceJobs,
       ...sourceGraph,
     });
     await persistMaterializedRunGraph(tx, {
-      run: sourceRun,
+      run: runForAttempt,
       workflowRunAttempt: newAttemptRow,
       materializedJobs: graphJobs,
       ...rerunSessionCarryOver(sourceAttemptRow.id, params.mode),

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
@@ -88,6 +88,7 @@ export const workflowContextDocs = [
     fields: {
       id: 'Identifier of the run.',
       number: 'Sequential run number within the workflow definition.',
+      attempt: 'Attempt number of the current run, starting at one.',
       name: 'Resolved run name, or the workflow name when `run_name` is not set.',
       project_id: 'Identifier of the project that owns the run.',
       workspace_id: 'Identifier of the workspace that owns the run.',

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -175,6 +175,7 @@ describe('workflow context registry', () => {
         fields: {
           id: 'string',
           number: 'int',
+          attempt: 'int',
           name: 'string',
           project_id: 'string',
           workspace_id: 'string',
@@ -186,6 +187,12 @@ describe('workflow context registry', () => {
     expect(() =>
       createWorkflowExpression({
         source: 'run.number > 0',
+        check: {mode: 'typed', typeEnvironment: runTypeEnvironment},
+      }),
+    ).not.toThrow();
+    expect(() =>
+      createWorkflowExpression({
+        source: 'run.attempt > 0',
         check: {mode: 'typed', typeEnvironment: runTypeEnvironment},
       }),
     ).not.toThrow();

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -116,6 +116,7 @@ const runTypeEnvironment = {
     fields: {
       id: 'string',
       number: 'int',
+      attempt: 'int',
       name: 'string',
       project_id: 'string',
       workspace_id: 'string',


### PR DESCRIPTION
Expose the current workflow attempt as `run.attempt` in the typed and runtime workflow expression context. The value remains CEL-native for expression evaluation and JSON-safe in listener snapshots, with coverage for predicate validation and stable run IDs across reruns.

Closes ENG-1938

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the current workflow run attempt as `run.attempt` in the typed and runtime expression context, so workflow conditions can react to reruns. Previously the attempt was not reachable from expressions. The value stays CEL-native (`int`) during evaluation and JSON-safe in listener filter snapshots. Closes ENG-1938.

**Notes**
- Reruns keep the same run ID while `run.attempt` increments, so expressions can distinguish the source run from its retries.
- Typed predicate validation now accepts `run.attempt`, for example in `job.if`.
- Deploy compatible workers before adopting `run.attempt` in persisted expressions; older builds omit it and would make those expressions fail closed.

<sup>Written for commit 80b90f5c682632589b556608bd6ddbd30efbda6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

